### PR TITLE
[codex] Arena-copy published GetMany values

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22792,14 +22792,42 @@ type getManyProbeRef struct {
 	shard int
 }
 
-func copyGetManyValueToRefs(out [][]byte, refs []getManyProbeRef, val []byte) {
+const (
+	getManyValueGuessBytes         = 128
+	getManyMaxArenaInitialCapBytes = 1 << 20
+)
+
+var getManyEmptyValue = []byte{}
+
+type getManyValueCopyArena struct {
+	buf []byte
+}
+
+func newGetManyValueCopyArena(n int) getManyValueCopyArena {
+	arenaCap := n * getManyValueGuessBytes
+	if arenaCap < 0 {
+		arenaCap = 0
+	}
+	if arenaCap > getManyMaxArenaInitialCapBytes {
+		arenaCap = getManyMaxArenaInitialCapBytes
+	}
+	return getManyValueCopyArena{buf: make([]byte, 0, arenaCap)}
+}
+
+func (arena *getManyValueCopyArena) copyToRefs(out [][]byte, refs []getManyProbeRef, val []byte) {
 	if val == nil {
 		return
 	}
+	if len(val) == 0 {
+		for _, ref := range refs {
+			out[ref.idx] = getManyEmptyValue
+		}
+		return
+	}
 	for _, ref := range refs {
-		cpy := make([]byte, len(val))
-		copy(cpy, val)
-		out[ref.idx] = cpy
+		start := len(arena.buf)
+		arena.buf = append(arena.buf, val...)
+		out[ref.idx] = arena.buf[start:len(arena.buf):len(arena.buf)]
 	}
 }
 
@@ -22834,6 +22862,7 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 	db.noteRootDomainGetManyNative(len(keys), len(unique))
 
 	results := make([]rootDomainProbeResult, len(unique))
+	arena := newGetManyValueCopyArena(len(keys))
 	start := 0
 	for start < len(unique) {
 		end := start + 1
@@ -22849,8 +22878,8 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 		start = end
 	}
 
-	backendIdx := make([]int, 0, len(unique))
-	backendKeys := make([][]byte, 0, len(unique))
+	var backendIdx []int
+	var backendKeys [][]byte
 	for i, res := range results {
 		groupEnd := len(refs)
 		if i+1 < len(groupStarts) {
@@ -22859,23 +22888,28 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 		groupRefs := refs[groupStarts[i]:groupEnd]
 		switch {
 		case !res.found:
+			if backendIdx == nil {
+				backendCap := len(unique) - i
+				backendIdx = make([]int, 0, backendCap)
+				backendKeys = make([][]byte, 0, backendCap)
+			}
 			backendIdx = append(backendIdx, i)
 			backendKeys = append(backendKeys, unique[i].key)
 		case res.flags&node.FlagTombstone != 0:
 		case res.flags&node.FlagPointer != 0:
 			if res.val != nil {
-				copyGetManyValueToRefs(out, groupRefs, res.val)
+				arena.copyToRefs(out, groupRefs, res.val)
 				break
 			}
 			readVal, err := db.readValueLog(unique[i].key, res.ptr)
 			if err != nil {
 				return nil, err
 			}
-			copyGetManyValueToRefs(out, groupRefs, readVal)
+			arena.copyToRefs(out, groupRefs, readVal)
 		case res.val == nil:
-			copyGetManyValueToRefs(out, groupRefs, []byte{})
+			arena.copyToRefs(out, groupRefs, getManyEmptyValue)
 		default:
-			copyGetManyValueToRefs(out, groupRefs, res.val)
+			arena.copyToRefs(out, groupRefs, res.val)
 		}
 	}
 	if len(backendKeys) > 0 {
@@ -22892,7 +22926,7 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 			if uniqueIdx+1 < len(groupStarts) {
 				groupEnd = groupStarts[uniqueIdx+1]
 			}
-			copyGetManyValueToRefs(out, refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i])
+			arena.copyToRefs(out, refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i])
 		}
 	}
 	return out, nil
@@ -23152,22 +23186,10 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 	// instead of allocating per key. The limit below bounds only the initial
 	// arena capacity; subsequent appends may still grow the backing array, so
 	// multiple underlying allocations may be retained.
-	const (
-		getManyValueGuessBytes         = 128
-		getManyMaxArenaInitialCapBytes = 1 << 20
-	)
-	arenaCap := len(keys) * getManyValueGuessBytes
-	if arenaCap < 0 {
-		arenaCap = 0
-	}
-	if arenaCap > getManyMaxArenaInitialCapBytes {
-		arenaCap = getManyMaxArenaInitialCapBytes
-	}
-	arena := make([]byte, 0, arenaCap)
-	emptyValue := []byte{}
+	arena := newGetManyValueCopyArena(len(keys))
 	for i, key := range keys {
-		start := len(arena)
-		nextArena, found, err := db.getMemtableAppend(key, arena)
+		start := len(arena.buf)
+		nextArena, found, err := db.getMemtableAppend(key, arena.buf)
 		if err != nil {
 			if err == tree.ErrKeyNotFound {
 				// Tombstone in cache layers: treat as a missing key and do not fall
@@ -23182,12 +23204,12 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 			}
 		}
 		if found {
-			arena = nextArena
-			if len(arena) == start {
-				out[i] = emptyValue
+			arena.buf = nextArena
+			if len(arena.buf) == start {
+				out[i] = getManyEmptyValue
 				continue
 			}
-			out[i] = arena[start:len(arena):len(arena)]
+			out[i] = arena.buf[start:len(arena.buf):len(arena.buf)]
 			continue
 		}
 		backendIdx = append(backendIdx, i)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23183,9 +23183,9 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 	//
 	// The cache layer may need to resolve value-log pointers for memtable hits;
 	// by using the append path, those decodes can write directly into this arena
-	// instead of allocating per key. The limit below bounds only the initial
-	// arena capacity; subsequent appends may still grow the backing array, so
-	// multiple underlying allocations may be retained.
+	// instead of allocating per key. newGetManyValueCopyArena caps only the
+	// initial arena capacity; subsequent appends may still grow the backing
+	// array, so multiple underlying allocations may be retained.
 	arena := newGetManyValueCopyArena(len(keys))
 	for i, key := range keys {
 		start := len(arena.buf)

--- a/TreeDB/caching/point_read_shard_queue_test.go
+++ b/TreeDB/caching/point_read_shard_queue_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -576,9 +577,49 @@ func TestGetMany_DuplicateHitsReuseSingleProbeWithoutResultAliasing(t *testing.T
 	if ct.iterCalls != 1 {
 		t.Fatalf("expected one iterator probe, got %d", ct.iterCalls)
 	}
+
+	beforeAppend := append([]byte(nil), got[1]...)
+	_ = append(got[0], []byte("-suffix")...)
+	if !bytes.Equal(got[1], beforeAppend) {
+		t.Fatalf("append to duplicate output corrupted another output: got=%q want=%q", got[1], beforeAppend)
+	}
 	got[0][0] = 'X'
 	if string(got[1]) != "value" || string(got[2]) != "value" {
 		t.Fatalf("duplicate outputs must not alias: %#v", got)
+	}
+}
+
+func TestGetMany_PublishedRootPointShardsPreservesEmptyValue(t *testing.T) {
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+
+	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new memtable: %v", err)
+	}
+	ct := &countingTable{inner: mt}
+	key := []byte("empty")
+	ct.SetEntry(key, []byte{}, page.ValuePtr{}, node.FlagInline)
+	db.memtables.Store(&memtableView{
+		rootPointShards: []rootDomainSnapshot{
+			{immutables: []memtable.Table{ct}},
+		},
+	})
+
+	got, err := db.GetMany([][]byte{key, key})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(GetMany)=%d want 2", len(got))
+	}
+	for i := range got {
+		if got[i] == nil || len(got[i]) != 0 {
+			t.Fatalf("got[%d]=%q want empty non-nil value", i, got[i])
+		}
 	}
 }
 
@@ -614,6 +655,16 @@ func TestGetMany_DuplicateMissesCollapseToSingleBackendKey(t *testing.T) {
 	}
 	if len(backend.lastGetMany) != 1 || string(backend.lastGetMany[0]) != "missing" {
 		t.Fatalf("expected one deduped backend key, got %#v", backend.lastGetMany)
+	}
+
+	beforeAppend := append([]byte(nil), got[1]...)
+	_ = append(got[0], []byte("-suffix")...)
+	if !bytes.Equal(got[1], beforeAppend) {
+		t.Fatalf("append to duplicate backend output corrupted another output: got=%q want=%q", got[1], beforeAppend)
+	}
+	got[0][0] = 'X'
+	if string(got[1]) != "backend" || string(got[2]) != "backend" {
+		t.Fatalf("duplicate backend outputs must not alias: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is a follow-on to #1347 for the next read-suite allocation hotspot: `random_read_batch` on TreeDB published-root point shards.

The profile showed `getManyFromPublishedRootPointShards` allocating one returned value slice per requested key. This PR changes that path to use the same arena-copy shape as the fallback `GetMany` path, with capacity-capped returned slices so caller append/mutation semantics stay safe.

## Profile evidence

Baseline on #1347 head, exact allocation profile:

```text
./bin/unified-bench -dbs treedb -profile fast \
  -test random_read_batch -keys 200000 -batchsize 4000 -valsize 128 \
  -read-workers 12 -path-label native-fastpath \
  -profile-dir /tmp/gomap_read_suite_alloc_uJQbyM \
  -progress=false -format markdown -allocsprofilerate 1
```

Before:

- throughput: `235,883` reads/s
- alloc objects: `228,441` total
- top object source: `getManyFromPublishedRootPointShards`, `200,400` flat objects / `87.73%`

After this PR, same shape:

```text
./bin/unified-bench -dbs treedb -profile fast \
  -test random_read_batch -keys 200000 -batchsize 4000 -valsize 128 \
  -read-workers 12 -path-label native-fastpath \
  -profile-dir /tmp/gomap_read_batch_arena2_2PEaZN \
  -progress=false -format markdown -allocsprofilerate 1
```

After:

- throughput: `990,830` reads/s
- alloc objects: `15,208` total
- `getManyFromPublishedRootPointShards`: `400` flat objects / `2.63%`

Allocated bytes are still dominated by returned-value bytes and per-batch scratch slices, which are expected under safe-copy `GetMany` semantics.

## Validation

- `go test ./TreeDB/caching -run 'TestGetMany_(UsesPublishedRootPointShardsAsAuthority|DuplicateHitsReuseSingleProbeWithoutResultAliasing|PublishedRootPointShardsPreservesEmptyValue|DuplicateMissesCollapseToSingleBackendKey)$'`
- `go test ./TreeDB/caching` (ran before the final rebase; this change did not conflict with the base repair)
- focused `random_read_batch` allocation profile above
