### PR TITLE
[codex] Pool cached snapshot wrappers

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6318,6 +6318,7 @@ type DB struct {
 	// memtables is an RCU-style snapshot of (mutable, queue, queueRanges).
 	// Readers load it atomically to avoid holding db.mu around memtable access.
 	memtables                        atomic.Pointer[memtableView]
+	snapshotPool                     sync.Pool
 	rootDomainVersion                atomic.Uint64
 	rootPointStates                  []rootDomainState
 	rootSystemState                  rootDomainState

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -77,6 +77,25 @@ type backendSnapshotProvider interface {
 	AcquireSnapshot() *backenddb.Snapshot
 }
 
+func (db *DB) getSnapshotWrapper() *Snapshot {
+	if db == nil {
+		return &Snapshot{}
+	}
+	if v := db.snapshotPool.Get(); v != nil {
+		if snap, ok := v.(*Snapshot); ok && snap != nil {
+			return snap
+		}
+	}
+	return &Snapshot{}
+}
+
+func (db *DB) putSnapshotWrapper(snap *Snapshot) {
+	if db == nil || snap == nil {
+		return
+	}
+	db.snapshotPool.Put(snap)
+}
+
 // AcquireSnapshot returns a cached snapshot that includes queued memtable writes.
 func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
@@ -166,7 +185,10 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	snap := &Snapshot{db: db, view: view, backend: backendSnap}
+	snap := db.getSnapshotWrapper()
+	snap.db = db
+	snap.view = view
+	snap.backend = backendSnap
 	snap.backendRoot = backendSnapshotLookup{db: db, snapshot: backendSnap}
 	snap.backendRootOK = true
 	if state := backendSnap.State(); state != nil {
@@ -184,6 +206,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if snap.publishedRoots == nil {
 		db.rootPublishStats.backendFallbacks.Add(1)
 	}
+	snap.closed.Store(false)
 	return snap
 }
 
@@ -209,6 +232,7 @@ func (s *Snapshot) Close() error {
 		return nil
 	}
 
+	db := s.db
 	var err error
 	if s.backend != nil {
 		err = s.backend.Close()
@@ -228,6 +252,7 @@ func (s *Snapshot) Close() error {
 	s.backendSystemOK = false
 	s.rootVersion = 0
 	s.db = nil
+	db.putSnapshotWrapper(s)
 	return err
 }
 

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -207,8 +207,8 @@ func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
-	if allocs > 1.1 {
-		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 1.1 after warm path", allocs)
+	if allocs > 0.1 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.1 after warm path", allocs)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is the next stacked read-suite follow-on after #1348. It targets `random_read_parallel_acquire_snapshot`, where the allocation profile showed cached `AcquireSnapshot` allocating one wrapper object per snapshot acquire.

The backend `TreeDB/db` snapshot already uses `SnapshotPool`; this PR applies the same close-and-reuse model to the cached snapshot wrapper.

## Profile evidence

Baseline from the read-suite exact allocation profile on #1347 head:

```text
./bin/unified-bench -dbs treedb -profile fast \
  -test random_read_parallel_acquire_snapshot \
  -keys 200000 -batchsize 4000 -valsize 128 -read-workers 12 \
  -path-label native-fastpath -profile-dir /tmp/gomap_read_suite_alloc_uJQbyM \
  -progress=false -format markdown -allocsprofilerate 1
```

Before:

- throughput: `1,731,424` reads/s
- alloc space: ~`613.8MB`
- top source: `TreeDB/caching.(*DB).AcquireSnapshot`, ~`600.0MB` / `97.75%`
- alloc objects: ~`2,429,586`, with `AcquireSnapshot` at `2,400,002` objects
- instrumentation: `snapshot.acquire.avg_us=4.172`

After this PR, same shape:

```text
./bin/unified-bench -dbs treedb -profile fast \
  -test random_read_parallel_acquire_snapshot \
  -keys 200000 -batchsize 4000 -valsize 128 -read-workers 12 \
  -path-label native-fastpath -profile-dir /tmp/gomap_snapshot_pool_cGyVwX \
  -progress=false -format markdown -allocsprofilerate 1
```

After:

- throughput: `2,822,592` reads/s
- alloc space: `11.54MB` total, mostly pprof/gzip overhead
- alloc objects: `16,396` total, mostly pprof/trace overhead
- instrumentation: `snapshot.acquire.avg_us=1.376`

## Validation

- `go test ./TreeDB/caching -run 'TestAcquireSnapshot_AllocsBoundedAfterWarmPath|TestSnapshotClose_Idempotent|TestSnapshotGetAppendPublished'`
- `GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/caching -run 'TestAcquireSnapshot_AllocsBoundedAfterWarmPath|TestSnapshotClose_Idempotent|TestSnapshotGetAppendPublished'`
- `go test ./TreeDB/caching`
- focused benchmark/profile above
