### PR TITLE
[codex] Forward unsafe iterator views through wrappers

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25863,9 +25863,38 @@ type debugIterator struct {
 	sourcesUsed int
 }
 
+type unsafeIteratorView interface {
+	UnsafeKey() []byte
+	UnsafeValue() []byte
+}
+
+func unsafeIteratorViewKey(it merging.Iterator) []byte {
+	if it == nil {
+		return nil
+	}
+	if u, ok := it.(unsafeIteratorView); ok {
+		return u.UnsafeKey()
+	}
+	return it.Key()
+}
+
+func unsafeIteratorViewValue(it merging.Iterator) []byte {
+	if it == nil {
+		return nil
+	}
+	if u, ok := it.(unsafeIteratorView); ok {
+		return u.UnsafeValue()
+	}
+	return it.Value()
+}
+
 func (it *debugIterator) DebugStats() (queueLen int, sourcesUsed int) {
 	return it.queueLen, it.sourcesUsed
 }
+
+func (it *debugIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *debugIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
 
 type leasedMergingIterator struct {
 	merging.Iterator
@@ -25873,6 +25902,10 @@ type leasedMergingIterator struct {
 	closeErr  error
 	release   func()
 }
+
+func (it *leasedMergingIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *leasedMergingIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
 
 func (it *leasedMergingIterator) Close() error {
 	it.closeOnce.Do(func() {
@@ -25889,6 +25922,12 @@ type foregroundTrackedIterator struct {
 	db        *DB
 	closeOnce sync.Once
 	closeErr  error
+}
+
+func (it *foregroundTrackedIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *foregroundTrackedIterator) UnsafeValue() []byte {
+	return unsafeIteratorViewValue(it.Iterator)
 }
 
 func (it *foregroundTrackedIterator) Close() error {
@@ -25983,6 +26022,20 @@ func (it *concatUnsafeIterator) Value() []byte {
 		panic("iterator invalid")
 	}
 	return it.cur.Value()
+}
+
+func (it *concatUnsafeIterator) UnsafeKey() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.cur.UnsafeKey()
+}
+
+func (it *concatUnsafeIterator) UnsafeValue() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.cur.UnsafeValue()
 }
 
 func (it *concatUnsafeIterator) KeyCopy(dst []byte) []byte {

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -1,0 +1,73 @@
+package caching
+
+import "testing"
+
+type unsafeForwardTestIterator struct {
+	key   []byte
+	value []byte
+	valid bool
+
+	keyCalls   int
+	valueCalls int
+}
+
+func (it *unsafeForwardTestIterator) Next() {
+	it.valid = false
+}
+
+func (it *unsafeForwardTestIterator) Valid() bool { return it.valid }
+
+func (it *unsafeForwardTestIterator) Key() []byte {
+	it.keyCalls++
+	return append([]byte(nil), it.key...)
+}
+
+func (it *unsafeForwardTestIterator) Value() []byte {
+	it.valueCalls++
+	return append([]byte(nil), it.value...)
+}
+
+func (it *unsafeForwardTestIterator) KeyCopy(dst []byte) []byte {
+	return append(dst[:0], it.key...)
+}
+
+func (it *unsafeForwardTestIterator) ValueCopy(dst []byte) []byte {
+	return append(dst[:0], it.value...)
+}
+
+func (it *unsafeForwardTestIterator) Close() error { return nil }
+
+func (it *unsafeForwardTestIterator) Error() error { return nil }
+
+func (it *unsafeForwardTestIterator) Domain() ([]byte, []byte) { return nil, nil }
+
+func (it *unsafeForwardTestIterator) UnsafeKey() []byte { return it.key }
+
+func (it *unsafeForwardTestIterator) UnsafeValue() []byte { return it.value }
+
+func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
+	base := &unsafeForwardTestIterator{
+		key:   []byte("key"),
+		value: []byte("value"),
+		valid: true,
+	}
+
+	for name, view := range map[string]unsafeIteratorView{
+		"debug":      &debugIterator{Iterator: base},
+		"leased":     &leasedMergingIterator{Iterator: base},
+		"foreground": (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView),
+	} {
+		key := view.UnsafeKey()
+		if len(key) == 0 || &key[0] != &base.key[0] {
+			t.Fatalf("%s UnsafeKey did not forward the backing key view", name)
+		}
+		value := view.UnsafeValue()
+		if len(value) == 0 || &value[0] != &base.value[0] {
+			t.Fatalf("%s UnsafeValue did not forward the backing value view", name)
+		}
+	}
+
+	if base.keyCalls != 0 || base.valueCalls != 0 {
+		t.Fatalf("safe Key/Value fallback called: key=%d value=%d", base.keyCalls, base.valueCalls)
+	}
+}


### PR DESCRIPTION
## Summary
- Forward `UnsafeKey` / `UnsafeValue` through cached iterator wrappers instead of falling back to safe `Key` / `Value` copies.
- Keep wrapper fallback behavior for iterators that do not expose unsafe views.
- Add a focused regression test proving debug, leased, and foreground wrappers preserve the underlying unsafe view and do not call safe-copy methods.

## Benchmark evidence
Before this PR, top-of-stack read-suite profiling (`/tmp/gomap_read_suite_top_0Ja360`) showed prefix scan dominated by safe key copies:
- Prefix Scan: `476,002 ops/s`
- `TreeDB/db.(*DBIterator).KeyCopy`: `60,351 alloc objects`, `42.19%` of prefix-scan allocation objects

After this PR (`/tmp/gomap_iter_unsafe_UJaIM5`):
- Prefix Scan: `799,669 ops/s`
- Prefix alloc objects: `78,173` total, down from `143,031`
- `TreeDB/db.(*DBIterator).KeyCopy` is gone from the top allocation sites

Full scan stayed in the same noisy range and did not show a comparable code-hot wrapper-copy allocation; remaining full-scan allocation sites were mostly profiling overhead plus small node key scratch growth.

## Validation
- `go test ./TreeDB/caching -run 'TestIteratorWrappersForwardUnsafeViews|TestIterator|TestAcquireSnapshot_AllocsBoundedAfterWarmPath'`
- `go test ./TreeDB/caching`
