### PR TITLE
[codex] Forward unsafe iterator views through wrappers

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25863,6 +25863,9 @@ type debugIterator struct {
 }
 
 type unsafeIteratorView interface {
+	// UnsafeKey and UnsafeValue return views owned by the iterator and valid
+	// only until the iterator moves or closes. Wrappers may return safe Key/Value
+	// copies when the wrapped iterator does not expose unsafe views.
 	UnsafeKey() []byte
 	UnsafeValue() []byte
 }
@@ -26025,14 +26028,14 @@ func (it *concatUnsafeIterator) Value() []byte {
 
 func (it *concatUnsafeIterator) UnsafeKey() []byte {
 	if !it.valid {
-		return nil
+		panic("iterator invalid")
 	}
 	return it.cur.UnsafeKey()
 }
 
 func (it *concatUnsafeIterator) UnsafeValue() []byte {
 	if !it.valid {
-		return nil
+		panic("iterator invalid")
 	}
 	return it.cur.UnsafeValue()
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25858,8 +25858,10 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 
 type debugIterator struct {
 	merging.Iterator
-	queueLen    int
-	sourcesUsed int
+	queueLen     int
+	sourcesUsed  int
+	keyScratch   []byte
+	valueScratch []byte
 }
 
 type unsafeIteratorView interface {
@@ -25870,44 +25872,62 @@ type unsafeIteratorView interface {
 	UnsafeValue() []byte
 }
 
-func unsafeIteratorViewKey(it merging.Iterator) []byte {
+func unsafeIteratorViewKey(it merging.Iterator, scratch *[]byte) []byte {
 	if it == nil {
 		return nil
 	}
 	if u, ok := it.(unsafeIteratorView); ok {
 		return u.UnsafeKey()
 	}
-	return it.Key()
+	if scratch == nil {
+		return it.Key()
+	}
+	*scratch = it.KeyCopy((*scratch)[:0])
+	return *scratch
 }
 
-func unsafeIteratorViewValue(it merging.Iterator) []byte {
+func unsafeIteratorViewValue(it merging.Iterator, scratch *[]byte) []byte {
 	if it == nil {
 		return nil
 	}
 	if u, ok := it.(unsafeIteratorView); ok {
 		return u.UnsafeValue()
 	}
-	return it.Value()
+	if scratch == nil {
+		return it.Value()
+	}
+	*scratch = it.ValueCopy((*scratch)[:0])
+	return *scratch
 }
 
 func (it *debugIterator) DebugStats() (queueLen int, sourcesUsed int) {
 	return it.queueLen, it.sourcesUsed
 }
 
-func (it *debugIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+func (it *debugIterator) UnsafeKey() []byte {
+	return unsafeIteratorViewKey(it.Iterator, &it.keyScratch)
+}
 
-func (it *debugIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
+func (it *debugIterator) UnsafeValue() []byte {
+	return unsafeIteratorViewValue(it.Iterator, &it.valueScratch)
+}
 
 type leasedMergingIterator struct {
 	merging.Iterator
-	closeOnce sync.Once
-	closeErr  error
-	release   func()
+	closeOnce    sync.Once
+	closeErr     error
+	release      func()
+	keyScratch   []byte
+	valueScratch []byte
 }
 
-func (it *leasedMergingIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+func (it *leasedMergingIterator) UnsafeKey() []byte {
+	return unsafeIteratorViewKey(it.Iterator, &it.keyScratch)
+}
 
-func (it *leasedMergingIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
+func (it *leasedMergingIterator) UnsafeValue() []byte {
+	return unsafeIteratorViewValue(it.Iterator, &it.valueScratch)
+}
 
 func (it *leasedMergingIterator) Close() error {
 	it.closeOnce.Do(func() {
@@ -25921,15 +25941,19 @@ func (it *leasedMergingIterator) Close() error {
 
 type foregroundTrackedIterator struct {
 	merging.Iterator
-	db        *DB
-	closeOnce sync.Once
-	closeErr  error
+	db           *DB
+	closeOnce    sync.Once
+	closeErr     error
+	keyScratch   []byte
+	valueScratch []byte
 }
 
-func (it *foregroundTrackedIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+func (it *foregroundTrackedIterator) UnsafeKey() []byte {
+	return unsafeIteratorViewKey(it.Iterator, &it.keyScratch)
+}
 
 func (it *foregroundTrackedIterator) UnsafeValue() []byte {
-	return unsafeIteratorViewValue(it.Iterator)
+	return unsafeIteratorViewValue(it.Iterator, &it.valueScratch)
 }
 
 func (it *foregroundTrackedIterator) Close() error {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25862,9 +25862,38 @@ type debugIterator struct {
 	sourcesUsed int
 }
 
+type unsafeIteratorView interface {
+	UnsafeKey() []byte
+	UnsafeValue() []byte
+}
+
+func unsafeIteratorViewKey(it merging.Iterator) []byte {
+	if it == nil {
+		return nil
+	}
+	if u, ok := it.(unsafeIteratorView); ok {
+		return u.UnsafeKey()
+	}
+	return it.Key()
+}
+
+func unsafeIteratorViewValue(it merging.Iterator) []byte {
+	if it == nil {
+		return nil
+	}
+	if u, ok := it.(unsafeIteratorView); ok {
+		return u.UnsafeValue()
+	}
+	return it.Value()
+}
+
 func (it *debugIterator) DebugStats() (queueLen int, sourcesUsed int) {
 	return it.queueLen, it.sourcesUsed
 }
+
+func (it *debugIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *debugIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
 
 type leasedMergingIterator struct {
 	merging.Iterator
@@ -25872,6 +25901,10 @@ type leasedMergingIterator struct {
 	closeErr  error
 	release   func()
 }
+
+func (it *leasedMergingIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *leasedMergingIterator) UnsafeValue() []byte { return unsafeIteratorViewValue(it.Iterator) }
 
 func (it *leasedMergingIterator) Close() error {
 	it.closeOnce.Do(func() {
@@ -25888,6 +25921,12 @@ type foregroundTrackedIterator struct {
 	db        *DB
 	closeOnce sync.Once
 	closeErr  error
+}
+
+func (it *foregroundTrackedIterator) UnsafeKey() []byte { return unsafeIteratorViewKey(it.Iterator) }
+
+func (it *foregroundTrackedIterator) UnsafeValue() []byte {
+	return unsafeIteratorViewValue(it.Iterator)
 }
 
 func (it *foregroundTrackedIterator) Close() error {
@@ -25982,6 +26021,20 @@ func (it *concatUnsafeIterator) Value() []byte {
 		panic("iterator invalid")
 	}
 	return it.cur.Value()
+}
+
+func (it *concatUnsafeIterator) UnsafeKey() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.cur.UnsafeKey()
+}
+
+func (it *concatUnsafeIterator) UnsafeValue() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.cur.UnsafeValue()
 }
 
 func (it *concatUnsafeIterator) KeyCopy(dst []byte) []byte {

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -7,8 +7,10 @@ type unsafeForwardTestIterator struct {
 	value []byte
 	valid bool
 
-	keyCalls   int
-	valueCalls int
+	keyCalls       int
+	valueCalls     int
+	keyCopyCalls   int
+	valueCopyCalls int
 }
 
 func (it *unsafeForwardTestIterator) Next() {
@@ -28,10 +30,12 @@ func (it *unsafeForwardTestIterator) Value() []byte {
 }
 
 func (it *unsafeForwardTestIterator) KeyCopy(dst []byte) []byte {
+	it.keyCopyCalls++
 	return append(dst[:0], it.key...)
 }
 
 func (it *unsafeForwardTestIterator) ValueCopy(dst []byte) []byte {
+	it.valueCopyCalls++
 	return append(dst[:0], it.value...)
 }
 
@@ -67,7 +71,13 @@ func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
 		}
 	}
 
-	if base.keyCalls != 0 || base.valueCalls != 0 {
-		t.Fatalf("safe Key/Value fallback called: key=%d value=%d", base.keyCalls, base.valueCalls)
+	if base.keyCalls != 0 || base.valueCalls != 0 || base.keyCopyCalls != 0 || base.valueCopyCalls != 0 {
+		t.Fatalf(
+			"safe iterator fallback called: key=%d value=%d keyCopy=%d valueCopy=%d",
+			base.keyCalls,
+			base.valueCalls,
+			base.keyCopyCalls,
+			base.valueCopyCalls,
+		)
 	}
 }

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -49,6 +49,49 @@ func (it *unsafeForwardTestIterator) UnsafeKey() []byte { return it.key }
 
 func (it *unsafeForwardTestIterator) UnsafeValue() []byte { return it.value }
 
+type safeFallbackTestIterator struct {
+	key   []byte
+	value []byte
+	valid bool
+
+	keyCalls       int
+	valueCalls     int
+	keyCopyCalls   int
+	valueCopyCalls int
+}
+
+func (it *safeFallbackTestIterator) Next() {
+	it.valid = false
+}
+
+func (it *safeFallbackTestIterator) Valid() bool { return it.valid }
+
+func (it *safeFallbackTestIterator) Key() []byte {
+	it.keyCalls++
+	return append([]byte(nil), it.key...)
+}
+
+func (it *safeFallbackTestIterator) Value() []byte {
+	it.valueCalls++
+	return append([]byte(nil), it.value...)
+}
+
+func (it *safeFallbackTestIterator) KeyCopy(dst []byte) []byte {
+	it.keyCopyCalls++
+	return append(dst[:0], it.key...)
+}
+
+func (it *safeFallbackTestIterator) ValueCopy(dst []byte) []byte {
+	it.valueCopyCalls++
+	return append(dst[:0], it.value...)
+}
+
+func (it *safeFallbackTestIterator) Close() error { return nil }
+
+func (it *safeFallbackTestIterator) Error() error { return nil }
+
+func (it *safeFallbackTestIterator) Domain() ([]byte, []byte) { return nil, nil }
+
 func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
 	base := &unsafeForwardTestIterator{
 		key:   []byte("key"),
@@ -79,5 +122,61 @@ func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
 			base.keyCopyCalls,
 			base.valueCopyCalls,
 		)
+	}
+}
+
+func TestIteratorWrappersFallbackToSafeCopiesWithoutUnsafeViews(t *testing.T) {
+	base := &safeFallbackTestIterator{
+		key:   []byte("key"),
+		value: []byte("value"),
+		valid: true,
+	}
+
+	for name, view := range map[string]unsafeIteratorView{
+		"debug":      &debugIterator{Iterator: base},
+		"leased":     &leasedMergingIterator{Iterator: base},
+		"foreground": (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView),
+	} {
+		key := view.UnsafeKey()
+		if string(key) != "key" {
+			t.Fatalf("%s UnsafeKey fallback=%q want key", name, key)
+		}
+		if len(key) != 0 && &key[0] == &base.key[0] {
+			t.Fatalf("%s UnsafeKey fallback returned backing key view", name)
+		}
+		value := view.UnsafeValue()
+		if string(value) != "value" {
+			t.Fatalf("%s UnsafeValue fallback=%q want value", name, value)
+		}
+		if len(value) != 0 && &value[0] == &base.value[0] {
+			t.Fatalf("%s UnsafeValue fallback returned backing value view", name)
+		}
+	}
+
+	if base.keyCalls != 3 || base.valueCalls != 3 || base.keyCopyCalls != 0 || base.valueCopyCalls != 0 {
+		t.Fatalf(
+			"safe iterator fallback calls: key=%d value=%d keyCopy=%d valueCopy=%d",
+			base.keyCalls,
+			base.valueCalls,
+			base.keyCopyCalls,
+			base.valueCopyCalls,
+		)
+	}
+}
+
+func TestConcatUnsafeIteratorPanicsWhenInvalid(t *testing.T) {
+	it := &concatUnsafeIterator{}
+	for name, fn := range map[string]func(){
+		"UnsafeKey":   func() { _ = it.UnsafeKey() },
+		"UnsafeValue": func() { _ = it.UnsafeValue() },
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic")
+				}
+			}()
+			fn()
+		})
 	}
 }

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -1,0 +1,73 @@
+package caching
+
+import "testing"
+
+type unsafeForwardTestIterator struct {
+	key   []byte
+	value []byte
+	valid bool
+
+	keyCalls   int
+	valueCalls int
+}
+
+func (it *unsafeForwardTestIterator) Next() {
+	it.valid = false
+}
+
+func (it *unsafeForwardTestIterator) Valid() bool { return it.valid }
+
+func (it *unsafeForwardTestIterator) Key() []byte {
+	it.keyCalls++
+	return append([]byte(nil), it.key...)
+}
+
+func (it *unsafeForwardTestIterator) Value() []byte {
+	it.valueCalls++
+	return append([]byte(nil), it.value...)
+}
+
+func (it *unsafeForwardTestIterator) KeyCopy(dst []byte) []byte {
+	return append(dst[:0], it.key...)
+}
+
+func (it *unsafeForwardTestIterator) ValueCopy(dst []byte) []byte {
+	return append(dst[:0], it.value...)
+}
+
+func (it *unsafeForwardTestIterator) Close() error { return nil }
+
+func (it *unsafeForwardTestIterator) Error() error { return nil }
+
+func (it *unsafeForwardTestIterator) Domain() ([]byte, []byte) { return nil, nil }
+
+func (it *unsafeForwardTestIterator) UnsafeKey() []byte { return it.key }
+
+func (it *unsafeForwardTestIterator) UnsafeValue() []byte { return it.value }
+
+func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
+	base := &unsafeForwardTestIterator{
+		key:   []byte("key"),
+		value: []byte("value"),
+		valid: true,
+	}
+
+	for name, view := range map[string]unsafeIteratorView{
+		"debug":      &debugIterator{Iterator: base},
+		"leased":     &leasedMergingIterator{Iterator: base},
+		"foreground": (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView),
+	} {
+		key := view.UnsafeKey()
+		if len(key) == 0 || &key[0] != &base.key[0] {
+			t.Fatalf("%s UnsafeKey did not forward the backing key view", name)
+		}
+		value := view.UnsafeValue()
+		if len(value) == 0 || &value[0] != &base.value[0] {
+			t.Fatalf("%s UnsafeValue did not forward the backing value view", name)
+		}
+	}
+
+	if base.keyCalls != 0 || base.valueCalls != 0 {
+		t.Fatalf("safe Key/Value fallback called: key=%d value=%d", base.keyCalls, base.valueCalls)
+	}
+}

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -167,9 +167,18 @@ func TestIteratorWrappersFallbackToSafeCopiesWithoutUnsafeViews(t *testing.T) {
 		}
 	}
 
-	if base.keyCalls != 3 || base.valueCalls != 3 || base.keyCopyCalls != 0 || base.valueCopyCalls != 0 {
+	if base.keyCalls != 0 || base.valueCalls != 0 {
 		t.Fatalf(
-			"safe iterator fallback calls: key=%d value=%d keyCopy=%d valueCopy=%d",
+			"safe iterator fallback used allocating accessors: key=%d value=%d keyCopy=%d valueCopy=%d",
+			base.keyCalls,
+			base.valueCalls,
+			base.keyCopyCalls,
+			base.valueCopyCalls,
+		)
+	}
+	if base.keyCopyCalls == 0 || base.valueCopyCalls == 0 {
+		t.Fatalf(
+			"safe iterator fallback did not use copy accessors: key=%d value=%d keyCopy=%d valueCopy=%d",
 			base.keyCalls,
 			base.valueCalls,
 			base.keyCopyCalls,

--- a/TreeDB/caching/iterator_unsafe_forward_test.go
+++ b/TreeDB/caching/iterator_unsafe_forward_test.go
@@ -98,19 +98,26 @@ func TestIteratorWrappersForwardUnsafeViews(t *testing.T) {
 		value: []byte("value"),
 		valid: true,
 	}
+	foreground, ok := (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView)
+	if !ok {
+		t.Fatalf("foreground iterator type=%T does not implement unsafeIteratorView", foreground)
+	}
 
-	for name, view := range map[string]unsafeIteratorView{
-		"debug":      &debugIterator{Iterator: base},
-		"leased":     &leasedMergingIterator{Iterator: base},
-		"foreground": (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView),
+	for _, tc := range []struct {
+		name string
+		view unsafeIteratorView
+	}{
+		{name: "debug", view: &debugIterator{Iterator: base}},
+		{name: "leased", view: &leasedMergingIterator{Iterator: base}},
+		{name: "foreground", view: foreground},
 	} {
-		key := view.UnsafeKey()
+		key := tc.view.UnsafeKey()
 		if len(key) == 0 || &key[0] != &base.key[0] {
-			t.Fatalf("%s UnsafeKey did not forward the backing key view", name)
+			t.Fatalf("%s UnsafeKey did not forward the backing key view", tc.name)
 		}
-		value := view.UnsafeValue()
+		value := tc.view.UnsafeValue()
 		if len(value) == 0 || &value[0] != &base.value[0] {
-			t.Fatalf("%s UnsafeValue did not forward the backing value view", name)
+			t.Fatalf("%s UnsafeValue did not forward the backing value view", tc.name)
 		}
 	}
 
@@ -131,25 +138,32 @@ func TestIteratorWrappersFallbackToSafeCopiesWithoutUnsafeViews(t *testing.T) {
 		value: []byte("value"),
 		valid: true,
 	}
+	foreground, ok := (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView)
+	if !ok {
+		t.Fatalf("foreground iterator type=%T does not implement unsafeIteratorView", foreground)
+	}
 
-	for name, view := range map[string]unsafeIteratorView{
-		"debug":      &debugIterator{Iterator: base},
-		"leased":     &leasedMergingIterator{Iterator: base},
-		"foreground": (&DB{}).wrapForegroundIterator(base).(unsafeIteratorView),
+	for _, tc := range []struct {
+		name string
+		view unsafeIteratorView
+	}{
+		{name: "debug", view: &debugIterator{Iterator: base}},
+		{name: "leased", view: &leasedMergingIterator{Iterator: base}},
+		{name: "foreground", view: foreground},
 	} {
-		key := view.UnsafeKey()
+		key := tc.view.UnsafeKey()
 		if string(key) != "key" {
-			t.Fatalf("%s UnsafeKey fallback=%q want key", name, key)
+			t.Fatalf("%s UnsafeKey fallback=%q want key", tc.name, key)
 		}
 		if len(key) != 0 && &key[0] == &base.key[0] {
-			t.Fatalf("%s UnsafeKey fallback returned backing key view", name)
+			t.Fatalf("%s UnsafeKey fallback returned backing key view", tc.name)
 		}
-		value := view.UnsafeValue()
+		value := tc.view.UnsafeValue()
 		if string(value) != "value" {
-			t.Fatalf("%s UnsafeValue fallback=%q want value", name, value)
+			t.Fatalf("%s UnsafeValue fallback=%q want value", tc.name, value)
 		}
 		if len(value) != 0 && &value[0] == &base.value[0] {
-			t.Fatalf("%s UnsafeValue fallback returned backing value view", name)
+			t.Fatalf("%s UnsafeValue fallback returned backing value view", tc.name)
 		}
 	}
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1708,7 +1708,7 @@ func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
 	}
 	domain.indexedAsyncMu.Unlock()
 	if !waitStart.IsZero() {
-		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(time.Since(waitStart)))
+		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(collectionObservedElapsedSince(waitStart)))
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4967,10 +4967,10 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
 		t.Fatal("timed out waiting for backpressure flush to wait on in-flight async publish")
 	}
-	releaseWait()
-	if got := mgr.StatsSnapshot().IndexedAsyncFlushBackpressure; got == 0 {
+	if got := col.writeDomain.indexedAsyncFlushBackpressure.Load(); got == 0 {
 		t.Fatal("async backpressure did not wait for in-flight publishing unit")
 	}
+	releaseWait()
 
 	publishDone := make(chan error, 1)
 	go func() {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4948,6 +4948,7 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	}
 
 	backpressureDone := make(chan error, 1)
+	waitEntered, releaseWait := collectionWaitIndexedAsyncFlushGateForTest(t)
 	go func() {
 		col.writeDomain.mu.Lock()
 		_, _, _, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
@@ -4959,17 +4960,14 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 		col.writeDomain.mu.Unlock()
 		backpressureDone <- err
 	}()
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if mgr.StatsSnapshot().IndexedAsyncFlushBackpressure > 0 {
-			break
-		}
-		select {
-		case err := <-backpressureDone:
-			t.Fatalf("backpressure flush returned before in-flight async publish drained: %v", err)
-		case <-time.After(time.Millisecond):
-		}
+	select {
+	case <-waitEntered:
+	case err := <-backpressureDone:
+		t.Fatalf("backpressure flush returned before in-flight async publish drained: %v", err)
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for backpressure flush to wait on in-flight async publish")
 	}
+	releaseWait()
 	if got := mgr.StatsSnapshot().IndexedAsyncFlushBackpressure; got == 0 {
 		t.Fatal("async backpressure did not wait for in-flight publishing unit")
 	}


### PR DESCRIPTION
## Summary
- Forward `UnsafeKey` / `UnsafeValue` through cached iterator wrappers instead of falling back to safe `Key` / `Value` copies.
- Keep wrapper fallback behavior for iterators that do not expose unsafe views.
- Add a focused regression test proving debug, leased, and foreground wrappers preserve the underlying unsafe view and do not call safe-copy methods.

## Benchmark evidence
Before this PR, profiling on the read-suite stack (`/tmp/gomap_read_suite_top_0Ja360`) showed prefix scan dominated by safe key copies:
- Prefix Scan: `476,002 ops/s`
- `TreeDB/db.(*DBIterator).KeyCopy`: `60,351 alloc objects`, `42.19%` of prefix-scan allocation objects

After this PR, restacked directly on #1348 (`/tmp/gomap_iter_unsafe_restack_xWNrU5`):
- Prefix Scan: `812,992 ops/s`
- Prefix alloc objects: `78,065` total, down from `143,031`
- `TreeDB/db.(*DBIterator).KeyCopy` is gone from the top allocation sites

Full scan stayed in the same noisy range and did not show a comparable code-hot wrapper-copy allocation; remaining full-scan allocation sites were mostly profiling overhead plus node key scratch growth.

## Validation
- `go test ./TreeDB/caching -run 'TestIteratorWrappersForwardUnsafeViews|TestIterator|TestSnapshotGetAppendPublishedAppendMissPreservesTombstone|TestGetMany_(UsesPublishedRootPointShardsAsAuthority|DuplicateHitsReuseSingleProbeWithoutResultAliasing|PublishedRootPointShardsPreservesEmptyValue|DuplicateMissesCollapseToSingleBackendKey)$'`
- `go test ./TreeDB/caching`
- `./bin/unified-bench -dbs treedb -profile fast -test full_scan,prefix_scan -keys 200000 -batchsize 4000 -valsize 128 -read-workers 12 -range-queries 2000 -range-span 100 -path-label native-fastpath -profile-dir /tmp/gomap_iter_unsafe_restack_xWNrU5 -progress=false -format markdown -allocsprofilerate 1`
- `./bin/benchprof -profiles-dir /tmp/gomap_iter_unsafe_restack_xWNrU5`
