### PR TITLE
db: track prepared output allocation ownership

### DIFF
--- a/TreeDB/db/alloc_tracker.go
+++ b/TreeDB/db/alloc_tracker.go
@@ -76,12 +76,16 @@ func (t *allocTracker) MarkInstalled() {
 		return
 	}
 	t.mu.Lock()
-	if t.preparedOutputID != 0 {
+	if t.preparedOutputID != 0 && t.preparedOutputState == preparedOutputStatePrepared {
 		t.preparedOutputState = preparedOutputStateInstalled
 	}
 	t.mu.Unlock()
 }
 
+// FreeAll releases tracked pages for abandoned write attempts. Prepared output
+// trackers that have been marked installed intentionally retain their pages;
+// those pages are now reachable through the installed root and must not be
+// returned to the allocator by this cleanup path.
 func (t *allocTracker) FreeAll() error {
 	if t == nil {
 		return nil
@@ -93,7 +97,7 @@ func (t *allocTracker) FreeAll() error {
 	}
 	pages := append([]uint64(nil), t.pages...)
 	t.pages = nil
-	if t.preparedOutputID != 0 {
+	if t.preparedOutputID != 0 && len(pages) > 0 {
 		t.preparedOutputState = preparedOutputStateAbandoned
 	}
 	t.mu.Unlock()

--- a/TreeDB/db/alloc_tracker.go
+++ b/TreeDB/db/alloc_tracker.go
@@ -12,10 +12,21 @@ type allocTracker struct {
 	alloc *freelist.Allocator
 	mu    sync.Mutex
 	pages []uint64
+
+	preparedOutputID    preparedOutputID
+	preparedOutputState preparedOutputState
 }
 
 func newAllocTracker(alloc *freelist.Allocator) *allocTracker {
 	return &allocTracker{alloc: alloc}
+}
+
+func newPreparedOutputAllocTracker(alloc *freelist.Allocator, id preparedOutputID) *allocTracker {
+	return &allocTracker{
+		alloc:               alloc,
+		preparedOutputID:    id,
+		preparedOutputState: preparedOutputStatePrepared,
+	}
 }
 
 func (t *allocTracker) Alloc(hint uint64) (uint64, error) {
@@ -38,13 +49,53 @@ func (t *allocTracker) Pages() []uint64 {
 	return append([]uint64(nil), t.pages...)
 }
 
+func (t *allocTracker) PreparedOutputID() preparedOutputID {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.preparedOutputID
+}
+
+func (t *allocTracker) PreparedOutputSnapshot() preparedOutputSnapshot {
+	if t == nil {
+		return preparedOutputSnapshot{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return preparedOutputSnapshot{
+		ID:    t.preparedOutputID,
+		State: t.preparedOutputState,
+		Pages: append([]uint64(nil), t.pages...),
+	}
+}
+
+func (t *allocTracker) MarkInstalled() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.preparedOutputID != 0 {
+		t.preparedOutputState = preparedOutputStateInstalled
+	}
+	t.mu.Unlock()
+}
+
 func (t *allocTracker) FreeAll() error {
 	if t == nil {
 		return nil
 	}
 	t.mu.Lock()
+	if t.preparedOutputState == preparedOutputStateInstalled {
+		t.mu.Unlock()
+		return nil
+	}
 	pages := append([]uint64(nil), t.pages...)
 	t.pages = nil
+	if t.preparedOutputID != 0 {
+		t.preparedOutputState = preparedOutputStateAbandoned
+	}
 	t.mu.Unlock()
 	var firstErr error
 	for _, id := range pages {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -233,6 +233,7 @@ type DB struct {
 	orderedRootDeltaGroupPreparedRootPointerValues atomic.Uint64
 	orderedRootDeltaGroupPreparedRootInstalled     atomic.Uint64
 	orderedRootDeltaGroupPreparedRootAbandoned     atomic.Uint64
+	preparedOutputNextID                           atomic.Uint64
 
 	publishInstallGuardNs                   atomic.Uint64
 	publishInstallGuardCalls                atomic.Uint64

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -63,6 +63,7 @@ type orderedRootPublishOptions struct {
 type orderedRootDeltaBatchGroupApplyResult struct {
 	idx                 int
 	rootID              uint64
+	outputID            preparedOutputID
 	pendingRetiredPages []uint64
 	metrics             adaptive.Metrics
 	err                 error
@@ -1441,8 +1442,12 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 
 func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []OrderedRootDeltaBatchPublishInput, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator) ([]orderedRootDeltaBatchGroupApplyResult, bool) {
 	results := make([]orderedRootDeltaBatchGroupApplyResult, len(ordered))
+	var outputID preparedOutputID
+	if tracker, ok := alloc.(*allocTracker); ok {
+		outputID = tracker.PreparedOutputID()
+	}
 	applyOne := func(orderedIdx int) orderedRootDeltaBatchGroupApplyResult {
-		result := orderedRootDeltaBatchGroupApplyResult{idx: orderedIdx, attempted: true}
+		result := orderedRootDeltaBatchGroupApplyResult{idx: orderedIdx, outputID: outputID, attempted: true}
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[orderedIdx].StoragePolicy)
 		if err != nil {
 			result.err = err
@@ -1525,7 +1530,7 @@ func recordOrderedRootDeltaBatchGroupApplyResults(
 			rootIDs[orderedIdx] = result.rootID
 		}
 		if preparedGroup != nil {
-			preparedGroup.markPrepared(orderedIdx, result.rootID)
+			preparedGroup.markPrepared(orderedIdx, result.rootID, result.outputID)
 		}
 		if rootsObserved != nil {
 			(*rootsObserved)++
@@ -1629,7 +1634,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		}
 	}()
 
-	rootTracker := newAllocTracker(idx.allocator)
+	rootTracker := db.newPreparedOutputAllocTracker(idx.allocator)
 	var systemTracker *allocTracker
 	commitStarted := false
 	freeTrackedPages := func() {
@@ -1671,7 +1676,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 	var committedRootPages []uint64
 	var committedSystemPages []uint64
 	for attempt := 0; ; attempt++ {
-		systemTracker = newAllocTracker(idx.allocator)
+		systemTracker = db.newPreparedOutputAllocTracker(idx.allocator)
 		phaseStart := time.Now()
 		iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
 		phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
@@ -1698,7 +1703,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 			err = applyErr
 			return 0, nil, false, err
 		}
-		preparedGroup.markPrepared(systemPreparedIdx, rootID)
+		preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
 		phaseStats.systemApplyMetrics.add(systemMetrics)
 
 		lockStart := time.Now()
@@ -1766,6 +1771,8 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 			observePublish(wait, hold, err)
 			return 0, nil, false, err
 		}
+		rootTracker.MarkInstalled()
+		systemTracker.MarkInstalled()
 		db.invalidateLeafGenerationSubtreeStats(append(committedRootPages, committedSystemPages...))
 		db.finalizeCommitPostWork(post)
 		db.writeMu.RUnlock()
@@ -1846,8 +1853,8 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		}
 	}()
 
-	rootTracker := newAllocTracker(idxGen.allocator)
-	systemTracker := newAllocTracker(idxGen.allocator)
+	rootTracker := db.newPreparedOutputAllocTracker(idxGen.allocator)
+	systemTracker := db.newPreparedOutputAllocTracker(idxGen.allocator)
 	commitFinished := false
 	defer func() {
 		if err != nil && !commitFinished {
@@ -1900,7 +1907,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	if err != nil {
 		return 0, nil, err
 	}
-	preparedGroup.markPrepared(systemPreparedIdx, rootID)
+	preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
 	newSystemRoot = rootID
 	pendingRetiredPages = append(pendingRetiredPages, systemPendingRetiredPages...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -1930,6 +1937,8 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		return 0, nil, err
 	}
 	commitFinished = true
+	rootTracker.MarkInstalled()
+	systemTracker.MarkInstalled()
 	db.invalidateLeafGenerationSubtreeStats(append(committedRootPages, committedSystemPages...))
 	observePreparedGroup(preparedRootApplyStateInstalled)
 	return newSystemRoot, rootIDs, nil

--- a/TreeDB/db/prepared_output.go
+++ b/TreeDB/db/prepared_output.go
@@ -1,0 +1,31 @@
+package db
+
+import "github.com/snissn/gomap/TreeDB/freelist"
+
+type preparedOutputID uint64
+
+type preparedOutputState uint8
+
+const (
+	preparedOutputStateNone preparedOutputState = iota
+	preparedOutputStatePrepared
+	preparedOutputStateInstalled
+	preparedOutputStateAbandoned
+)
+
+type preparedOutputSnapshot struct {
+	ID    preparedOutputID
+	State preparedOutputState
+	Pages []uint64
+}
+
+func (db *DB) nextPreparedOutputID() preparedOutputID {
+	if db == nil {
+		return 0
+	}
+	return preparedOutputID(db.preparedOutputNextID.Add(1))
+}
+
+func (db *DB) newPreparedOutputAllocTracker(alloc *freelist.Allocator) *allocTracker {
+	return newPreparedOutputAllocTracker(alloc, db.nextPreparedOutputID())
+}

--- a/TreeDB/db/prepared_output_test.go
+++ b/TreeDB/db/prepared_output_test.go
@@ -71,3 +71,57 @@ func TestPreparedOutputAllocTrackerInstallPreventsAbandonFree(t *testing.T) {
 		t.Fatalf("installed tracker pages=%v want [%d]", after.Pages, pageID)
 	}
 }
+
+func TestPreparedOutputAllocTrackerAbandonDoesNotBecomeInstalled(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	if _, err := tracker.Alloc(0); err != nil {
+		t.Fatalf("alloc prepared page: %v", err)
+	}
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free prepared pages: %v", err)
+	}
+
+	tracker.MarkInstalled()
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStateAbandoned {
+		t.Fatalf("state=%v want abandoned", after.State)
+	}
+	if len(after.Pages) != 0 {
+		t.Fatalf("abandoned tracker retained pages: %v", after.Pages)
+	}
+}
+
+func TestPreparedOutputAllocTrackerEmptyFreeLeavesPreparedState(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free empty prepared output: %v", err)
+	}
+
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStatePrepared {
+		t.Fatalf("state=%v want prepared", after.State)
+	}
+	if len(after.Pages) != 0 {
+		t.Fatalf("empty tracker pages=%v want none", after.Pages)
+	}
+}

--- a/TreeDB/db/prepared_output_test.go
+++ b/TreeDB/db/prepared_output_test.go
@@ -1,0 +1,73 @@
+package db
+
+import "testing"
+
+func TestPreparedOutputAllocTrackerAbandonsOwnedPagesOnFree(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	if got := tracker.PreparedOutputID(); got == 0 {
+		t.Fatal("prepared output ID is zero")
+	}
+
+	pageID, err := tracker.Alloc(0)
+	if err != nil {
+		t.Fatalf("alloc prepared page: %v", err)
+	}
+	before := tracker.PreparedOutputSnapshot()
+	if before.State != preparedOutputStatePrepared {
+		t.Fatalf("state=%v want prepared", before.State)
+	}
+	if len(before.Pages) != 1 || before.Pages[0] != pageID {
+		t.Fatalf("pages=%v want [%d]", before.Pages, pageID)
+	}
+
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free prepared pages: %v", err)
+	}
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStateAbandoned {
+		t.Fatalf("state=%v want abandoned", after.State)
+	}
+	if len(after.Pages) != 0 {
+		t.Fatalf("abandoned tracker retained pages: %v", after.Pages)
+	}
+}
+
+func TestPreparedOutputAllocTrackerInstallPreventsAbandonFree(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	pageID, err := tracker.Alloc(0)
+	if err != nil {
+		t.Fatalf("alloc prepared page: %v", err)
+	}
+
+	tracker.MarkInstalled()
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free installed prepared output: %v", err)
+	}
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStateInstalled {
+		t.Fatalf("state=%v want installed", after.State)
+	}
+	if len(after.Pages) != 1 || after.Pages[0] != pageID {
+		t.Fatalf("installed tracker pages=%v want [%d]", after.Pages, pageID)
+	}
+}

--- a/TreeDB/db/prepared_root_apply.go
+++ b/TreeDB/db/prepared_root_apply.go
@@ -42,6 +42,7 @@ type preparedRootApply struct {
 	identity     preparedRootIdentity
 	baseRootID   uint64
 	preparedRoot uint64
+	outputID     preparedOutputID
 	prepared     bool
 	storage      OrderedRootStoragePolicy
 	plan         preparedRootDeltaPlanSummary
@@ -166,12 +167,13 @@ func (group *preparedRootApplyGroup) setSystemRoot(baseRootID uint64, delta *bat
 	})
 }
 
-func (group *preparedRootApplyGroup) markPrepared(idx int, rootID uint64) {
+func (group *preparedRootApplyGroup) markPrepared(idx int, rootID uint64, outputID preparedOutputID) {
 	apply := group.applyAt(idx)
 	if apply == nil {
 		return
 	}
 	apply.preparedRoot = rootID
+	apply.outputID = outputID
 	apply.prepared = true
 	apply.state = preparedRootApplyStatePrepared
 }

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -194,9 +194,9 @@ func TestPreparedRootSetSystemRootSupersedesLatestActiveSystemApply(t *testing.T
 		state:            preparedRootApplyStatePlanned,
 	}
 	firstIdx := group.setSystemRoot(10, first, false)
-	group.markPrepared(firstIdx, 100)
+	group.markPrepared(firstIdx, 100, 1)
 	secondIdx := group.setSystemRoot(20, second, false)
-	group.markPrepared(secondIdx, 200)
+	group.markPrepared(secondIdx, 200, 2)
 	thirdIdx := group.setSystemRoot(30, third, false)
 
 	if firstIdx == secondIdx || secondIdx == thirdIdx || firstIdx == thirdIdx {

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -101,7 +101,7 @@ func TestPreparedRootApplyStatsCountsPreparedZeroRoot(t *testing.T) {
 		},
 		state: preparedRootApplyStatePlanned,
 	})
-	group.markPrepared(0, 0)
+	group.markPrepared(0, 0, 1)
 	group.markInstalled()
 
 	var stats preparedRootApplyStats
@@ -266,6 +266,9 @@ func TestOrderedRootDeltaBatchGroupPreparedRootMetadataRecordsInstall(t *testing
 	if data.preparedRoot != rootIDs[0] {
 		t.Fatalf("data prepared root=%d want %d", data.preparedRoot, rootIDs[0])
 	}
+	if data.outputID == 0 {
+		t.Fatal("data prepared output ID is zero")
+	}
 	if data.storage != OrderedRootStoragePagerLeaves {
 		t.Fatalf("data storage=%d want pager leaves", data.storage)
 	}
@@ -288,6 +291,12 @@ func TestOrderedRootDeltaBatchGroupPreparedRootMetadataRecordsInstall(t *testing
 	}
 	if system.preparedRoot != newSystemRoot {
 		t.Fatalf("system prepared root=%d want %d", system.preparedRoot, newSystemRoot)
+	}
+	if system.outputID == 0 {
+		t.Fatal("system prepared output ID is zero")
+	}
+	if system.outputID == data.outputID {
+		t.Fatalf("system/data prepared output IDs both %d, want distinct owners", system.outputID)
 	}
 	if system.state != preparedRootApplyStateInstalled {
 		t.Fatalf("system state=%v want installed", system.state)


### PR DESCRIPTION
## Summary

Adds the first PR5a prepared-output ownership slice for pager-backed ordered-root applies:

- introduces `preparedOutputID` and prepared output states;
- attaches owner IDs/state to allocation trackers used by ordered-root group data and system root preparation;
- records prepared output IDs in `preparedRootApply` metadata;
- marks prepared output installed after successful final commit and abandoned when tracked pages are freed before commit;
- keeps leaf-log/value-log prepared output, persistent pre-install output, and group install behavior out of scope.

## Validation

- `go test ./TreeDB/db -run 'Test(PreparedOutput|PreparedRoot|PublishOrderedRoot|OrderedRootDelta|InstallGuard)' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/db -run '^$' -bench 'BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot$' -benchmem -count=3 -benchtime=1s`
- benchmark: 39626 / 39558 / 39469 ns/op, ~4.35 KB/op, 39 allocs/op
- `git diff --check`

## Notes

This is intentionally a scaffold PR: it establishes owner identity and abandon/install state for pager-backed prepared pages while existing publish still writes persistent output inside the current apply path. Leaf-log prepared output inventory and orphan reclamation remain follow-up work.