### PR TITLE
db: track prepared leaf-log output inventory

### DIFF
--- a/TreeDB/db/alloc_tracker.go
+++ b/TreeDB/db/alloc_tracker.go
@@ -4,14 +4,16 @@ import (
 	"sync"
 
 	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 // allocTracker wraps the freelist allocator and remembers allocated pages so
 // they can be returned if a write attempt is abandoned.
 type allocTracker struct {
-	alloc *freelist.Allocator
-	mu    sync.Mutex
-	pages []uint64
+	alloc       *freelist.Allocator
+	mu          sync.Mutex
+	pages       []uint64
+	leafLogPtrs []page.LeafLogPtr
 
 	preparedOutputID    preparedOutputID
 	preparedOutputState preparedOutputState
@@ -65,10 +67,22 @@ func (t *allocTracker) PreparedOutputSnapshot() preparedOutputSnapshot {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return preparedOutputSnapshot{
-		ID:    t.preparedOutputID,
-		State: t.preparedOutputState,
-		Pages: append([]uint64(nil), t.pages...),
+		ID:          t.preparedOutputID,
+		State:       t.preparedOutputState,
+		Pages:       append([]uint64(nil), t.pages...),
+		LeafLogPtrs: append([]page.LeafLogPtr(nil), t.leafLogPtrs...),
 	}
+}
+
+func (t *allocTracker) notePreparedLeafLogPtr(ptr page.LeafLogPtr) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.preparedOutputID != 0 && t.preparedOutputState == preparedOutputStatePrepared {
+		t.leafLogPtrs = append(t.leafLogPtrs, ptr)
+	}
+	t.mu.Unlock()
 }
 
 func (t *allocTracker) MarkInstalled() {
@@ -97,7 +111,9 @@ func (t *allocTracker) FreeAll() error {
 	}
 	pages := append([]uint64(nil), t.pages...)
 	t.pages = nil
-	if t.preparedOutputID != 0 && len(pages) > 0 {
+	hadSideOutput := len(pages) > 0 || len(t.leafLogPtrs) > 0
+	t.leafLogPtrs = nil
+	if t.preparedOutputID != 0 && hadSideOutput {
 		t.preparedOutputState = preparedOutputStateAbandoned
 	}
 	t.mu.Unlock()

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -43,6 +43,29 @@ type leafPageLogWithRecordLengthHints struct {
 	inner LeafPageLog
 }
 
+type preparedOutputLeafPageAppender interface {
+	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
+}
+
+type preparedOutputLeafPageLog struct {
+	inner   preparedOutputLeafPageAppender
+	tracker *allocTracker
+}
+
+func (l preparedOutputLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if l.inner == nil {
+		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
+	}
+	ptr, err := l.inner.AppendLeafPage(leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	if l.tracker != nil {
+		l.tracker.notePreparedLeafLogPtr(ptr)
+	}
+	return ptr, nil
+}
+
 func (l *leafPageLogWithRecordLengthHints) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if l == nil || l.inner == nil {
 		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1448,8 +1448,23 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []OrderedRootDeltaBatchPublishInput, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator, includeOutputSnapshot bool) ([]orderedRootDeltaBatchGroupApplyResult, bool) {
 	results := make([]orderedRootDeltaBatchGroupApplyResult, len(ordered))
 	var outputID preparedOutputID
+	var outputTracker *allocTracker
 	if tracker, ok := alloc.(*allocTracker); ok {
+		outputTracker = tracker
 		outputID = tracker.PreparedOutputID()
+	}
+	captureOutputSnapshot := func() {
+		if !includeOutputSnapshot || outputTracker == nil {
+			return
+		}
+		output := outputTracker.PreparedOutputSnapshot()
+		for resultIdx := range results {
+			if !results[resultIdx].attempted || results[resultIdx].err != nil {
+				continue
+			}
+			results[resultIdx].output = &output
+			results[resultIdx].outputID = output.ID
+		}
 	}
 	applyOne := func(orderedIdx int) orderedRootDeltaBatchGroupApplyResult {
 		result := orderedRootDeltaBatchGroupApplyResult{
@@ -1467,15 +1482,6 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		result.pendingRetiredPages = pendingRetiredPages
 		result.metrics = metrics
 		result.err = err
-		if includeOutputSnapshot {
-			tracker, _ := alloc.(*allocTracker)
-			if tracker == nil {
-				return result
-			}
-			output := tracker.PreparedOutputSnapshot()
-			result.output = &output
-			result.outputID = output.ID
-		}
 		return result
 	}
 
@@ -1483,9 +1489,11 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		for orderedIdx := range ordered {
 			results[orderedIdx] = applyOne(orderedIdx)
 			if results[orderedIdx].err != nil {
+				captureOutputSnapshot()
 				return results, false
 			}
 		}
+		captureOutputSnapshot()
 		return results, false
 	}
 
@@ -1511,15 +1519,18 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 	for orderedIdx := range ordered {
 		if ordered[orderedIdx].ParallelApply && ordered[orderedIdx].Delta != nil && !ordered[orderedIdx].Delta.IsEmpty() {
 			if results[orderedIdx].err != nil {
+				captureOutputSnapshot()
 				return results, false
 			}
 			continue
 		}
 		results[orderedIdx] = applyOne(orderedIdx)
 		if results[orderedIdx].err != nil {
+			captureOutputSnapshot()
 			return results, false
 		}
 	}
+	captureOutputSnapshot()
 	return results, parallelRoots >= orderedRootDeltaBatchGroupParallelApplyMinRoots
 }
 

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -64,6 +64,7 @@ type orderedRootDeltaBatchGroupApplyResult struct {
 	idx                 int
 	rootID              uint64
 	outputID            preparedOutputID
+	output              *preparedOutputSnapshot
 	pendingRetiredPages []uint64
 	metrics             adaptive.Metrics
 	err                 error
@@ -674,6 +675,11 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 		err = errors.New("ordered root value-log leaf storage requires a leaf page log")
 		return
 	}
+	if opts.outerLeavesInValueLog {
+		if tracker := preparedOutputTrackerFromAlloc(alloc, coldBuildAlloc); tracker != nil {
+			opts.leafPageLog = preparedOutputLeafPageLog{inner: opts.leafPageLog, tracker: tracker}
+		}
+	}
 	if delta.IsEmpty() {
 		return baseRoot, nil, metrics, nil
 	}
@@ -702,6 +708,16 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 		return 0, nil, metrics, err
 	}
 	return applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta)
+}
+
+func preparedOutputTrackerFromAlloc(alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator) *allocTracker {
+	if tracker, ok := alloc.(*allocTracker); ok && tracker != nil && tracker.PreparedOutputID() != 0 {
+		return tracker
+	}
+	if tracker, ok := coldBuildAlloc.(*allocTracker); ok && tracker != nil && tracker.PreparedOutputID() != 0 {
+		return tracker
+	}
+	return nil
 }
 
 func applyOrderedRootDeltaWithOptions(rootZipper *zipper.Zipper, baseRoot uint64, delta *batch.Batch) (uint64, []uint64, adaptive.Metrics, error) {
@@ -1431,14 +1447,18 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 	return parallelActive >= orderedRootDeltaBatchGroupParallelApplyMinRoots
 }
 
-func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []OrderedRootDeltaBatchPublishInput, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator) ([]orderedRootDeltaBatchGroupApplyResult, bool) {
+func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []OrderedRootDeltaBatchPublishInput, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator, includeOutputSnapshot bool) ([]orderedRootDeltaBatchGroupApplyResult, bool) {
 	results := make([]orderedRootDeltaBatchGroupApplyResult, len(ordered))
 	var outputID preparedOutputID
 	if tracker, ok := alloc.(*allocTracker); ok {
 		outputID = tracker.PreparedOutputID()
 	}
 	applyOne := func(orderedIdx int) orderedRootDeltaBatchGroupApplyResult {
-		result := orderedRootDeltaBatchGroupApplyResult{idx: orderedIdx, outputID: outputID, attempted: true}
+		result := orderedRootDeltaBatchGroupApplyResult{
+			idx:       orderedIdx,
+			outputID:  outputID,
+			attempted: true,
+		}
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[orderedIdx].StoragePolicy)
 		if err != nil {
 			result.err = err
@@ -1449,6 +1469,15 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		result.pendingRetiredPages = pendingRetiredPages
 		result.metrics = metrics
 		result.err = err
+		if includeOutputSnapshot {
+			tracker, _ := alloc.(*allocTracker)
+			if tracker == nil {
+				return result
+			}
+			output := tracker.PreparedOutputSnapshot()
+			result.output = &output
+			result.outputID = output.ID
+		}
 		return result
 	}
 
@@ -1521,7 +1550,11 @@ func recordOrderedRootDeltaBatchGroupApplyResults(
 			rootIDs[orderedIdx] = result.rootID
 		}
 		if preparedGroup != nil {
-			preparedGroup.markPrepared(orderedIdx, result.rootID, result.outputID)
+			if result.output != nil {
+				preparedGroup.markPreparedOutput(orderedIdx, result.rootID, *result.output)
+			} else {
+				preparedGroup.markPrepared(orderedIdx, result.rootID, result.outputID)
+			}
 		}
 		if rootsObserved != nil {
 			(*rootsObserved)++
@@ -1649,7 +1682,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 	var nonSystemPendingRetiredPages []uint64
 	var nonSystemMetrics adaptive.Metrics
 	phaseStart = time.Now()
-	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idx, ordered, rootTracker, rootTracker)
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idx, ordered, rootTracker, rootTracker, includePreparedChecksum)
 	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if parallelRootApply {
 		phaseStats.rootApplyParallelGroups++
@@ -1694,7 +1727,11 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 			err = applyErr
 			return 0, nil, false, err
 		}
-		preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
+		if includePreparedChecksum {
+			preparedGroup.markPreparedOutput(systemPreparedIdx, rootID, systemTracker.PreparedOutputSnapshot())
+		} else {
+			preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
+		}
 		phaseStats.systemApplyMetrics.add(systemMetrics)
 
 		lockStart := time.Now()
@@ -1859,7 +1896,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	var pendingRetiredPages []uint64
 	var merged adaptive.Metrics
 	phaseStart = time.Now()
-	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, rootTracker, rootTracker)
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, rootTracker, rootTracker, includePreparedChecksum)
 	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if parallelRootApply {
 		phaseStats.rootApplyParallelGroups++
@@ -1898,7 +1935,11 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	if err != nil {
 		return 0, nil, err
 	}
-	preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
+	if includePreparedChecksum {
+		preparedGroup.markPreparedOutput(systemPreparedIdx, rootID, systemTracker.PreparedOutputSnapshot())
+	} else {
+		preparedGroup.markPrepared(systemPreparedIdx, rootID, systemTracker.PreparedOutputID())
+	}
 	newSystemRoot = rootID
 	pendingRetiredPages = append(pendingRetiredPages, systemPendingRetiredPages...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1539,7 +1539,7 @@ func TestApplyOrderedRootDeltaBatchGroupRoots_MixedOptInStartsParallelBeforeSeri
 		{BaseRoot: 0, Delta: deltaA, ParallelApply: true},
 		{BaseRoot: baseRootB, Delta: deltaB},
 		{BaseRoot: 0, Delta: deltaC, ParallelApply: true},
-	}, serialAlloc, coldAlloc)
+	}, serialAlloc, coldAlloc, false)
 	if !parallel {
 		t.Fatal("expected mixed group to use parallel apply")
 	}

--- a/TreeDB/db/prepared_output.go
+++ b/TreeDB/db/prepared_output.go
@@ -1,6 +1,9 @@
 package db
 
-import "github.com/snissn/gomap/TreeDB/freelist"
+import (
+	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/page"
+)
 
 type preparedOutputID uint64
 
@@ -14,9 +17,10 @@ const (
 )
 
 type preparedOutputSnapshot struct {
-	ID    preparedOutputID
-	State preparedOutputState
-	Pages []uint64
+	ID          preparedOutputID
+	State       preparedOutputState
+	Pages       []uint64
+	LeafLogPtrs []page.LeafLogPtr
 }
 
 func (db *DB) nextPreparedOutputID() preparedOutputID {

--- a/TreeDB/db/prepared_output_test.go
+++ b/TreeDB/db/prepared_output_test.go
@@ -1,6 +1,32 @@
 package db
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type preparedOutputTestLeafLog struct {
+	ptrs []page.LeafLogPtr
+}
+
+func (l *preparedOutputTestLeafLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	ptr := page.LeafLogPtr{
+		FileID:           uint32(len(l.ptrs) + 1),
+		Offset:           uint64(len(l.ptrs)+1) * 100,
+		RecordLengthHint: uint32(len(leafPage)),
+	}
+	l.ptrs = append(l.ptrs, ptr)
+	return ptr, nil
+}
+
+func (l *preparedOutputTestLeafLog) Flush() error {
+	return nil
+}
+
+func (l *preparedOutputTestLeafLog) Sync() error {
+	return nil
+}
 
 func TestPreparedOutputAllocTrackerAbandonsOwnedPagesOnFree(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir()})
@@ -123,5 +149,84 @@ func TestPreparedOutputAllocTrackerEmptyFreeLeavesPreparedState(t *testing.T) {
 	}
 	if len(after.Pages) != 0 {
 		t.Fatalf("empty tracker pages=%v want none", after.Pages)
+	}
+}
+
+func TestPreparedOutputLeafPageLogTracksPointers(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	log := preparedOutputLeafPageLog{
+		inner:   &preparedOutputTestLeafLog{},
+		tracker: tracker,
+	}
+	first, err := log.AppendLeafPage(make([]byte, page.PageSize))
+	if err != nil {
+		t.Fatalf("append first leaf page: %v", err)
+	}
+	second, err := log.AppendLeafPage(make([]byte, page.PageSize))
+	if err != nil {
+		t.Fatalf("append second leaf page: %v", err)
+	}
+
+	before := tracker.PreparedOutputSnapshot()
+	if before.State != preparedOutputStatePrepared {
+		t.Fatalf("state=%v want prepared", before.State)
+	}
+	if len(before.LeafLogPtrs) != 2 || before.LeafLogPtrs[0] != first || before.LeafLogPtrs[1] != second {
+		t.Fatalf("leaf log ptrs=%v want [%v %v]", before.LeafLogPtrs, first, second)
+	}
+
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free prepared leaf-log output: %v", err)
+	}
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStateAbandoned {
+		t.Fatalf("state=%v want abandoned", after.State)
+	}
+	if len(after.LeafLogPtrs) != 0 {
+		t.Fatalf("abandoned tracker retained leaf-log ptrs: %v", after.LeafLogPtrs)
+	}
+}
+
+func TestPreparedOutputLeafPageLogInstalledRetainsPointers(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		t.Fatal("missing index")
+	}
+	tracker := db.newPreparedOutputAllocTracker(idx.allocator)
+	log := preparedOutputLeafPageLog{
+		inner:   &preparedOutputTestLeafLog{},
+		tracker: tracker,
+	}
+	ptr, err := log.AppendLeafPage(make([]byte, page.PageSize))
+	if err != nil {
+		t.Fatalf("append leaf page: %v", err)
+	}
+
+	tracker.MarkInstalled()
+	if err := tracker.FreeAll(); err != nil {
+		t.Fatalf("free installed prepared leaf-log output: %v", err)
+	}
+	after := tracker.PreparedOutputSnapshot()
+	if after.State != preparedOutputStateInstalled {
+		t.Fatalf("state=%v want installed", after.State)
+	}
+	if len(after.LeafLogPtrs) != 1 || after.LeafLogPtrs[0] != ptr {
+		t.Fatalf("installed tracker leaf-log ptrs=%v want [%v]", after.LeafLogPtrs, ptr)
 	}
 }

--- a/TreeDB/db/prepared_root_apply.go
+++ b/TreeDB/db/prepared_root_apply.go
@@ -43,6 +43,7 @@ type preparedRootApply struct {
 	baseRootID   uint64
 	preparedRoot uint64
 	outputID     preparedOutputID
+	output       preparedOutputSnapshot
 	prepared     bool
 	storage      OrderedRootStoragePolicy
 	plan         preparedRootDeltaPlanSummary
@@ -172,12 +173,17 @@ func (group *preparedRootApplyGroup) setSystemRoot(baseRootID uint64, delta *bat
 }
 
 func (group *preparedRootApplyGroup) markPrepared(idx int, rootID uint64, outputID preparedOutputID) {
+	group.markPreparedOutput(idx, rootID, preparedOutputSnapshot{ID: outputID})
+}
+
+func (group *preparedRootApplyGroup) markPreparedOutput(idx int, rootID uint64, output preparedOutputSnapshot) {
 	apply := group.applyAt(idx)
 	if apply == nil {
 		return
 	}
 	apply.preparedRoot = rootID
-	apply.outputID = outputID
+	apply.outputID = output.ID
+	apply.output = clonePreparedOutputSnapshot(output)
 	apply.prepared = true
 	apply.state = preparedRootApplyStatePrepared
 }
@@ -203,6 +209,7 @@ func (group *preparedRootApplyGroup) markInstalled() {
 	for i := 0; i < group.applyCount; i++ {
 		if apply := group.applyAt(i); apply != nil && apply.prepared && apply.state != preparedRootApplyStateAbandoned {
 			apply.state = preparedRootApplyStateInstalled
+			apply.output.State = preparedOutputStateInstalled
 		}
 	}
 }
@@ -216,6 +223,7 @@ func (group *preparedRootApplyGroup) markAbandoned() {
 		apply := group.applyAt(i)
 		if apply != nil && apply.prepared && apply.state != preparedRootApplyStateInstalled {
 			apply.state = preparedRootApplyStateAbandoned
+			apply.output.State = preparedOutputStateAbandoned
 		}
 	}
 }
@@ -293,9 +301,19 @@ func clonePreparedRootApplyGroup(src preparedRootApplyGroup) preparedRootApplyGr
 		apply := *srcApply
 		apply.plan.firstKey = append([]byte(nil), apply.plan.firstKey...)
 		apply.plan.lastKey = append([]byte(nil), apply.plan.lastKey...)
+		apply.output = clonePreparedOutputSnapshot(apply.output)
 		dst.appendApply(apply)
 	}
 	return dst
+}
+
+func clonePreparedOutputSnapshot(src preparedOutputSnapshot) preparedOutputSnapshot {
+	return preparedOutputSnapshot{
+		ID:          src.ID,
+		State:       src.State,
+		Pages:       append([]uint64(nil), src.Pages...),
+		LeafLogPtrs: append([]page.LeafLogPtr(nil), src.LeafLogPtrs...),
+	}
 }
 
 func preparedRootDeltaPlanSummaryFromBatch(delta *batch.Batch, includeChecksum bool) preparedRootDeltaPlanSummary {

--- a/TreeDB/db/prepared_root_apply.go
+++ b/TreeDB/db/prepared_root_apply.go
@@ -141,6 +141,7 @@ func (group *preparedRootApplyGroup) setSystemRoot(baseRootID uint64, delta *bat
 			if apply.prepared {
 				if apply.state != preparedRootApplyStateInstalled {
 					apply.state = preparedRootApplyStateAbandoned
+					apply.output.State = preparedOutputStateAbandoned
 				}
 				break
 			}

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -194,9 +194,9 @@ func TestPreparedRootSetSystemRootSupersedesLatestActiveSystemApply(t *testing.T
 		state:            preparedRootApplyStatePlanned,
 	}
 	firstIdx := group.setSystemRoot(10, first, false)
-	group.markPrepared(firstIdx, 100, 1)
+	group.markPreparedOutput(firstIdx, 100, preparedOutputSnapshot{ID: 1, State: preparedOutputStatePrepared})
 	secondIdx := group.setSystemRoot(20, second, false)
-	group.markPrepared(secondIdx, 200, 2)
+	group.markPreparedOutput(secondIdx, 200, preparedOutputSnapshot{ID: 2, State: preparedOutputStatePrepared})
 	thirdIdx := group.setSystemRoot(30, third, false)
 
 	if firstIdx == secondIdx || secondIdx == thirdIdx || firstIdx == thirdIdx {
@@ -207,9 +207,13 @@ func TestPreparedRootSetSystemRootSupersedesLatestActiveSystemApply(t *testing.T
 	}
 	if firstApply := group.applyAt(firstIdx); firstApply == nil || firstApply.state != preparedRootApplyStateAbandoned {
 		t.Fatalf("first system apply=%+v want abandoned", firstApply)
+	} else if firstApply.output.State != preparedOutputStateAbandoned {
+		t.Fatalf("first system output state=%v want abandoned", firstApply.output.State)
 	}
 	if secondApply := group.applyAt(secondIdx); secondApply == nil || secondApply.state != preparedRootApplyStateAbandoned {
 		t.Fatalf("second system apply=%+v want abandoned", secondApply)
+	} else if secondApply.output.State != preparedOutputStateAbandoned {
+		t.Fatalf("second system output state=%v want abandoned", secondApply.output.State)
 	}
 	latest := group.applyAt(thirdIdx)
 	if latest == nil {

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -371,6 +371,71 @@ func TestOrderedRootDeltaBatchGroupPreparedRootMetadataRecordsInstall(t *testing
 	}
 }
 
+func TestOrderedRootDeltaBatchGroupPreparedRootMetadataTracksLeafLogOutput(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetLeafPageLog(&preparedOutputTestLeafLog{})
+
+	deltaTable := mustFrozenSystemMemtable(t, "root/a", "va", "root/b", "vb")
+	iter := deltaTable.NewIterator(nil, nil)
+	delta, err := OrderedRootDeltaBatchFromIterator(iter)
+	_ = iter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	var captured []preparedRootApplyGroup
+	db.testPreparedRootApplyHook = func(group preparedRootApplyGroup) {
+		captured = append(captured, group)
+	}
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:      0,
+		Delta:         delta,
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	db.testPreparedRootApplyHook = nil
+	if err != nil {
+		t.Fatalf("publish ordered root group: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("root IDs=%v want one nonzero root", rootIDs)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured groups=%d want 1", len(captured))
+	}
+
+	data := captured[0].applyAt(0)
+	if data == nil {
+		t.Fatal("missing data prepared root apply")
+	}
+	if data.outputID == 0 || data.output.ID != data.outputID {
+		t.Fatalf("output ID=%d snapshot ID=%d", data.outputID, data.output.ID)
+	}
+	if data.output.State != preparedOutputStateInstalled {
+		t.Fatalf("output state=%v want installed", data.output.State)
+	}
+	if len(data.output.LeafLogPtrs) == 0 {
+		t.Fatalf("data prepared output did not record leaf-log pointers: %+v", data.output)
+	}
+	if len(data.output.Pages) == 0 {
+		t.Fatalf("data prepared output did not record root/internal pages: %+v", data.output)
+	}
+
+	system := captured[0].applyAt(1)
+	if system == nil {
+		t.Fatal("missing system prepared root apply")
+	}
+	if len(system.output.LeafLogPtrs) != 0 {
+		t.Fatalf("system prepared output recorded leaf-log pointers: %+v", system.output.LeafLogPtrs)
+	}
+}
+
 func TestOrderedRootDeltaBatchGroupPreparedRootMetadataRecordsOptimisticBuilderError(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -440,6 +440,97 @@ func TestOrderedRootDeltaBatchGroupPreparedRootMetadataTracksLeafLogOutput(t *te
 	}
 }
 
+func TestOrderedRootDeltaBatchGroupPreparedRootMetadataCapturesFinalSharedOutput(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	leafLog := &preparedOutputTestLeafLog{}
+	db.SetLeafPageLog(leafLog)
+
+	deltaTableA := mustFrozenSystemMemtable(t, "root/a", "va")
+	iterA := deltaTableA.NewIterator(nil, nil)
+	deltaA, err := OrderedRootDeltaBatchFromIterator(iterA)
+	_ = iterA.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator A: %v", err)
+	}
+	defer func() { _ = deltaA.Close() }()
+
+	deltaTableB := mustFrozenSystemMemtable(t, "root/b", "vb")
+	iterB := deltaTableB.NewIterator(nil, nil)
+	deltaB, err := OrderedRootDeltaBatchFromIterator(iterB)
+	_ = iterB.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator B: %v", err)
+	}
+	defer func() { _ = deltaB.Close() }()
+
+	var captured []preparedRootApplyGroup
+	db.testPreparedRootApplyHook = func(group preparedRootApplyGroup) {
+		captured = append(captured, group)
+	}
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{
+			BaseRoot:      0,
+			Delta:         deltaA,
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		},
+		{
+			BaseRoot:      0,
+			Delta:         deltaB,
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+			return nil, errors.New("unexpected root IDs")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/primary",
+			strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/secondary",
+			strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	db.testPreparedRootApplyHook = nil
+	if err != nil {
+		t.Fatalf("publish ordered root group: %v", err)
+	}
+	if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+		t.Fatalf("root IDs=%v want two nonzero roots", rootIDs)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured groups=%d want 1", len(captured))
+	}
+	if len(leafLog.ptrs) == 0 {
+		t.Fatal("publish did not write leaf-log output")
+	}
+
+	for idx := 0; idx < 2; idx++ {
+		data := captured[0].applyAt(idx)
+		if data == nil {
+			t.Fatalf("missing data prepared root apply %d", idx)
+		}
+		if data.outputID == 0 || data.output.ID != data.outputID {
+			t.Fatalf("data %d output ID=%d snapshot ID=%d", idx, data.outputID, data.output.ID)
+		}
+		if data.output.State != preparedOutputStateInstalled {
+			t.Fatalf("data %d output state=%v want installed", idx, data.output.State)
+		}
+		if got, want := len(data.output.LeafLogPtrs), len(leafLog.ptrs); got != want {
+			t.Fatalf("data %d leaf-log ptrs=%d want final shared output %d", idx, got, want)
+		}
+	}
+	system := captured[0].applyAt(2)
+	if system == nil || system.identity.kind != preparedRootIdentitySystem {
+		t.Fatalf("missing system prepared root apply: %+v", system)
+	}
+	if len(system.output.LeafLogPtrs) != 0 {
+		t.Fatalf("system prepared output recorded leaf-log pointers: %+v", system.output.LeafLogPtrs)
+	}
+}
+
 func TestOrderedRootDeltaBatchGroupPreparedRootMetadataRecordsOptimisticBuilderError(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds the next prepared-output ownership slice: side-output inventory for leaf-log-backed root applies.

This keeps the PR behavior-preserving:
- no leaf-log/value-log reclamation behavior changes
- no root rebase
- no persistent prepared-output install API change
- no change to normal publish output

The new inventory records leaf-log pointers produced while a prepared output tracker owns an ordered-root apply attempt. Full output snapshots are only collected for the existing prepared-root test/debug hook path; the normal hot path continues to record output IDs only.

## Changes

- Extend `preparedOutputSnapshot` with `LeafLogPtrs`.
- Track leaf-log pointers in `allocTracker` while the output is still prepared.
- Wrap leaf-page appends during prepared ordered-root apply attempts so value-log-backed leaves are added to the owning prepared output inventory.
- Expose snapshot side-output inventory through prepared-root hook metadata when hooks request stable metadata.
- Preserve hot-path allocation behavior by avoiding snapshot copies unless the hook/debug path is active.
- Add tests for:
  - direct prepared leaf-log pointer tracking;
  - installed output retaining side-output inventory;
  - abandoned output clearing side-output inventory;
  - ordered-root prepared metadata exposing leaf-log pointers for `OrderedRootStorageValueLogLeaves`.

## Validation

- `go test ./TreeDB/db -run 'Test(PreparedOutput|PreparedRoot|OrderedRootDeltaBatchGroupPreparedRootMetadata|OrderedRootDeltaBatchGroupParallel)' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/db -run '^$' -bench 'BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot' -benchmem -count=3 -benchtime=1s`
- `git diff --check`

Benchmark result:
- `BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot`: 43505 / 40281 / 39584 ns/op, about 4.39-4.42 KB/op, 39 allocs/op.

## Notes

This intentionally only inventories leaf-log side output. It does not yet make leaf-log records reclaimable on abandoned prepared output; that needs a later value-log ownership/reclamation slice because the value log is persistent storage.
