### PR TITLE
zipper: validate read-only leaf span plans

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1135,19 +1135,19 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 			return fmt.Errorf("zipper: read-only leaf span %d has empty last op key", i)
 		}
 		if bytes.Compare(span.FirstOpKey, span.LastOpKey) > 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is after last op key %q", i, span.FirstOpKey, span.LastOpKey)
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is after last op key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LastOpKey))
 		}
 		if prevLastOp != nil && bytes.Compare(prevLastOp, span.FirstOpKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is not after previous last op key %q", i, span.FirstOpKey, prevLastOp)
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is not after previous last op key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(prevLastOp))
 		}
 		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d low key %q is not before high key %q", i, span.LowKey, span.HighKey)
+			return fmt.Errorf("zipper: read-only leaf span %d low key %s is not before high key %s", i, readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(span.HighKey))
 		}
 		if span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is before low key %q", i, span.FirstOpKey, span.LowKey)
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is before low key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LowKey))
 		}
 		if span.HighKey != nil && bytes.Compare(span.LastOpKey, span.HighKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d last op key %q is not before high key %q", i, span.LastOpKey, span.HighKey)
+			return fmt.Errorf("zipper: read-only leaf span %d last op key %s is not before high key %s", i, readOnlyPrepareKeyForError(span.LastOpKey), readOnlyPrepareKeyForError(span.HighKey))
 		}
 		totalOps += span.OpCount
 		prevLastOp = span.LastOpKey
@@ -1156,6 +1156,17 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		return fmt.Errorf("zipper: read-only leaf spans cover %d ops, want %d", totalOps, r.Ops)
 	}
 	return nil
+}
+
+func readOnlyPrepareKeyForError(key []byte) string {
+	const maxPrefix = 8
+	if key == nil {
+		return "nil"
+	}
+	if len(key) <= maxPrefix {
+		return fmt.Sprintf("len=%d hex=%x", len(key), key)
+	}
+	return fmt.Sprintf("len=%d hex_prefix=%x", len(key), key[:maxPrefix])
 }
 
 func (r *ReadOnlyPrepareResult) cloneKey(src []byte) []byte {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1126,28 +1126,28 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 	var prevLastOp []byte
 	for i, span := range r.LeafSpans {
 		if span.OpCount <= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d has non-positive op count %d", i, span.OpCount)
+			return readOnlyPrepareSpanError(i, "has non-positive op count %d", span.OpCount)
 		}
 		if len(span.FirstOpKey) == 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d has empty first op key", i)
+			return readOnlyPrepareSpanError(i, "has empty first op key")
 		}
 		if len(span.LastOpKey) == 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d has empty last op key", i)
+			return readOnlyPrepareSpanError(i, "has empty last op key")
 		}
 		if bytes.Compare(span.FirstOpKey, span.LastOpKey) > 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is after last op key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LastOpKey))
+			return readOnlyPrepareSpanError(i, "first op key %s is after last op key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LastOpKey))
 		}
 		if prevLastOp != nil && bytes.Compare(prevLastOp, span.FirstOpKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is not after previous last op key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(prevLastOp))
+			return readOnlyPrepareSpanError(i, "first op key %s is not after previous last op key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(prevLastOp))
 		}
 		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d low key %s is not before high key %s", i, readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(span.HighKey))
+			return readOnlyPrepareSpanError(i, "low key %s is not before high key %s", readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(span.HighKey))
 		}
 		if span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d first op key %s is before low key %s", i, readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LowKey))
+			return readOnlyPrepareSpanError(i, "first op key %s is before low key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LowKey))
 		}
 		if span.HighKey != nil && bytes.Compare(span.LastOpKey, span.HighKey) >= 0 {
-			return fmt.Errorf("zipper: read-only leaf span %d last op key %s is not before high key %s", i, readOnlyPrepareKeyForError(span.LastOpKey), readOnlyPrepareKeyForError(span.HighKey))
+			return readOnlyPrepareSpanError(i, "last op key %s is not before high key %s", readOnlyPrepareKeyForError(span.LastOpKey), readOnlyPrepareKeyForError(span.HighKey))
 		}
 		totalOps += span.OpCount
 		prevLastOp = span.LastOpKey
@@ -1156,6 +1156,11 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		return fmt.Errorf("zipper: read-only leaf spans cover %d ops, want %d", totalOps, r.Ops)
 	}
 	return nil
+}
+
+func readOnlyPrepareSpanError(spanIdx int, format string, args ...any) error {
+	args = append([]any{spanIdx}, args...)
+	return fmt.Errorf("zipper: read-only leaf span %d "+format, args...)
 }
 
 func readOnlyPrepareKeyForError(key []byte) string {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1102,6 +1102,62 @@ func (r ReadOnlyPrepareResult) ReuseOptions() ReadOnlyPrepareOptions {
 	}
 }
 
+// ValidateLeafSpans checks the deterministic planning invariants for r's
+// read-only leaf-span view. It is intended for tests and future prepared-output
+// callers that want to assert a plan before using it; PrepareReadOnly itself
+// does not call this helper on the hot path.
+func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
+	if r.Ops < 0 {
+		return fmt.Errorf("zipper: read-only prepare has negative op count %d", r.Ops)
+	}
+	if r.Ops == 0 {
+		if len(r.LeafSpans) != 0 {
+			return fmt.Errorf("zipper: read-only prepare has %d spans for zero ops", len(r.LeafSpans))
+		}
+		return nil
+	}
+	if len(r.LeafSpans) == 0 {
+		return fmt.Errorf("zipper: read-only prepare has %d ops but no leaf spans", r.Ops)
+	}
+	if r.ColdBuild && len(r.LeafSpans) != 1 {
+		return fmt.Errorf("zipper: cold read-only prepare has %d leaf spans, want 1", len(r.LeafSpans))
+	}
+	totalOps := 0
+	var prevLastOp []byte
+	for i, span := range r.LeafSpans {
+		if span.OpCount <= 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d has non-positive op count %d", i, span.OpCount)
+		}
+		if len(span.FirstOpKey) == 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d has empty first op key", i)
+		}
+		if len(span.LastOpKey) == 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d has empty last op key", i)
+		}
+		if bytes.Compare(span.FirstOpKey, span.LastOpKey) > 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is after last op key %q", i, span.FirstOpKey, span.LastOpKey)
+		}
+		if prevLastOp != nil && bytes.Compare(prevLastOp, span.FirstOpKey) >= 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is not after previous last op key %q", i, span.FirstOpKey, prevLastOp)
+		}
+		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d low key %q is not before high key %q", i, span.LowKey, span.HighKey)
+		}
+		if span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d first op key %q is before low key %q", i, span.FirstOpKey, span.LowKey)
+		}
+		if span.HighKey != nil && bytes.Compare(span.LastOpKey, span.HighKey) >= 0 {
+			return fmt.Errorf("zipper: read-only leaf span %d last op key %q is not before high key %q", i, span.LastOpKey, span.HighKey)
+		}
+		totalOps += span.OpCount
+		prevLastOp = span.LastOpKey
+	}
+	if totalOps != r.Ops {
+		return fmt.Errorf("zipper: read-only leaf spans cover %d ops, want %d", totalOps, r.Ops)
+	}
+	return nil
+}
+
 func (r *ReadOnlyPrepareResult) cloneKey(src []byte) []byte {
 	if src == nil {
 		return nil

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1124,6 +1124,7 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 	}
 	totalOps := 0
 	var prevLastOp []byte
+	var prevHigh []byte
 	for i, span := range r.LeafSpans {
 		if span.OpCount <= 0 {
 			return readOnlyPrepareSpanError(i, "has non-positive op count %d", span.OpCount)
@@ -1143,6 +1144,15 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
 			return readOnlyPrepareSpanError(i, "low key %s is not before high key %s", readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(span.HighKey))
 		}
+		if i > 0 && span.LowKey == nil {
+			return readOnlyPrepareSpanError(i, "has open low key after earlier span")
+		}
+		if i > 0 && prevHigh == nil {
+			return readOnlyPrepareSpanError(i, "follows previous span with open high key")
+		}
+		if i > 0 && bytes.Compare(span.LowKey, prevHigh) < 0 {
+			return readOnlyPrepareSpanError(i, "low key %s is before previous high key %s", readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(prevHigh))
+		}
 		if span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
 			return readOnlyPrepareSpanError(i, "first op key %s is before low key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LowKey))
 		}
@@ -1151,6 +1161,7 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		}
 		totalOps += span.OpCount
 		prevLastOp = span.LastOpKey
+		prevHigh = span.HighKey
 	}
 	if totalOps != r.Ops {
 		return fmt.Errorf("zipper: read-only leaf spans cover %d ops, want %d", totalOps, r.Ops)

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -260,6 +260,13 @@ func buildMultiLevelInternalRoot(tb testing.TB, z *Zipper) (uint64, int) {
 	return 0, 0
 }
 
+func requireValidReadOnlyPrepare(tb testing.TB, prepared ReadOnlyPrepareResult) {
+	tb.Helper()
+	if err := prepared.ValidateLeafSpans(); err != nil {
+		tb.Fatalf("ValidateLeafSpans: %v", err)
+	}
+}
+
 func TestZipperPrepareReadOnlyColdBuildDoesNotLoadOrWrite(t *testing.T) {
 	b := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
 	defer func() { _ = b.Close() }()
@@ -271,6 +278,7 @@ func TestZipperPrepareReadOnlyColdBuildDoesNotLoadOrWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if !prepared.ColdBuild {
 		t.Fatal("ColdBuild=false want true")
 	}
@@ -314,6 +322,7 @@ func TestZipperPrepareReadOnlyEmptyBatchDoesNotTraverse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("page count changed during empty read-only prepare: got %d want %d", got, beforePages)
 	}
@@ -355,6 +364,7 @@ func TestZipperPrepareReadOnlyExistingLeafRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans {
 		t.Fatalf("prepare cold/maintenance/exact=%v/%v/%v want false/false/true", prepared.ColdBuild, prepared.Maintenance, prepared.ExactLeafSpans)
 	}
@@ -392,6 +402,7 @@ func TestZipperPrepareReadOnlyDiscoversLeafSpansWithoutWrites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("page count changed during read-only prepare: got %d want %d", got, beforePages)
 	}
@@ -446,6 +457,7 @@ func TestZipperPrepareReadOnlyReuseOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, first)
 	if len(first.LeafSpans) == 0 {
 		t.Fatal("first prepare returned no spans")
 	}
@@ -459,6 +471,7 @@ func TestZipperPrepareReadOnlyReuseOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, second)
 	if len(second.LeafSpans) != 1 {
 		t.Fatalf("second spans=%d want 1", len(second.LeafSpans))
 	}
@@ -490,6 +503,7 @@ func TestZipperPrepareReadOnlyMarksDeleteMaintenanceSpansNonExact(t *testing.T) 
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("page count changed during read-only prepare: got %d want %d", got, beforePages)
 	}
@@ -532,6 +546,7 @@ func TestZipperPrepareReadOnlyInternalBaseDeltaKeyBoundsAreStable(t *testing.T) 
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("page count changed during read-only prepare: got %d want %d", got, beforePages)
 	}
@@ -581,6 +596,7 @@ func TestZipperPrepareReadOnlyNestedInternalBoundsInheritParentRange(t *testing.
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
+	requireValidReadOnlyPrepare(t, prepared)
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("page count changed during read-only prepare: got %d want %d", got, beforePages)
 	}
@@ -604,6 +620,114 @@ func TestZipperPrepareReadOnlyNestedInternalBoundsInheritParentRange(t *testing.
 			t.Fatalf("span high bound %q is not after first op %q; span=%+v", span.HighKey, span.FirstOpKey, span)
 		}
 	}
+}
+
+func TestReadOnlyPrepareResultValidateLeafSpansRejectsInvalidPlans(t *testing.T) {
+	validSpan := ReadOnlyLeafSpan{
+		LowKey:     []byte("a"),
+		HighKey:    []byte("z"),
+		FirstOpKey: []byte("b"),
+		LastOpKey:  []byte("c"),
+		OpCount:    2,
+	}
+	tests := []struct {
+		name string
+		in   ReadOnlyPrepareResult
+	}{
+		{
+			name: "zero ops with span",
+			in: ReadOnlyPrepareResult{
+				Ops:       0,
+				LeafSpans: []ReadOnlyLeafSpan{validSpan},
+			},
+		},
+		{
+			name: "missing spans",
+			in:   ReadOnlyPrepareResult{Ops: 1},
+		},
+		{
+			name: "cold build multiple spans",
+			in: ReadOnlyPrepareResult{
+				Ops:       2,
+				ColdBuild: true,
+				LeafSpans: []ReadOnlyLeafSpan{
+					{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1},
+					{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1},
+				},
+			},
+		},
+		{
+			name: "empty op key",
+			in: ReadOnlyPrepareResult{
+				Ops:       1,
+				LeafSpans: []ReadOnlyLeafSpan{{LastOpKey: []byte("b"), OpCount: 1}},
+			},
+		},
+		{
+			name: "reversed op keys",
+			in: ReadOnlyPrepareResult{
+				Ops:       1,
+				LeafSpans: []ReadOnlyLeafSpan{{FirstOpKey: []byte("c"), LastOpKey: []byte("b"), OpCount: 1}},
+			},
+		},
+		{
+			name: "overlapping op key ranges",
+			in: ReadOnlyPrepareResult{
+				Ops: 2,
+				LeafSpans: []ReadOnlyLeafSpan{
+					{FirstOpKey: []byte("b"), LastOpKey: []byte("d"), OpCount: 1},
+					{FirstOpKey: []byte("d"), LastOpKey: []byte("e"), OpCount: 1},
+				},
+			},
+		},
+		{
+			name: "bad bounds",
+			in: ReadOnlyPrepareResult{
+				Ops:       1,
+				LeafSpans: []ReadOnlyLeafSpan{{LowKey: []byte("z"), HighKey: []byte("a"), FirstOpKey: []byte("m"), LastOpKey: []byte("m"), OpCount: 1}},
+			},
+		},
+		{
+			name: "op before low bound",
+			in: ReadOnlyPrepareResult{
+				Ops:       1,
+				LeafSpans: []ReadOnlyLeafSpan{{LowKey: []byte("c"), FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1}},
+			},
+		},
+		{
+			name: "op at high bound",
+			in: ReadOnlyPrepareResult{
+				Ops:       1,
+				LeafSpans: []ReadOnlyLeafSpan{{HighKey: []byte("b"), FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1}},
+			},
+		},
+		{
+			name: "op count mismatch",
+			in: ReadOnlyPrepareResult{
+				Ops:       3,
+				LeafSpans: []ReadOnlyLeafSpan{validSpan},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.in.ValidateLeafSpans(); err == nil {
+				t.Fatal("ValidateLeafSpans returned nil, want error")
+			}
+		})
+	}
+}
+
+func TestReadOnlyPrepareResultValidateLeafSpansAcceptsOpenBounds(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{
+		Ops:            3,
+		ExactLeafSpans: true,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{HighKey: []byte("m"), FirstOpKey: []byte("a"), LastOpKey: []byte("b"), OpCount: 2},
+			{LowKey: []byte("m"), FirstOpKey: []byte("m"), LastOpKey: []byte("m"), OpCount: 1},
+		},
+	}
+	requireValidReadOnlyPrepare(t, prepared)
 }
 
 func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -688,6 +688,36 @@ func TestReadOnlyPrepareResultValidateLeafSpansRejectsInvalidPlans(t *testing.T)
 			},
 		},
 		{
+			name: "second span open low bound",
+			in: ReadOnlyPrepareResult{
+				Ops: 2,
+				LeafSpans: []ReadOnlyLeafSpan{
+					{HighKey: []byte("m"), FirstOpKey: []byte("a"), LastOpKey: []byte("b"), OpCount: 1},
+					{FirstOpKey: []byte("n"), LastOpKey: []byte("n"), OpCount: 1},
+				},
+			},
+		},
+		{
+			name: "non-final open high bound",
+			in: ReadOnlyPrepareResult{
+				Ops: 2,
+				LeafSpans: []ReadOnlyLeafSpan{
+					{FirstOpKey: []byte("a"), LastOpKey: []byte("b"), OpCount: 1},
+					{LowKey: []byte("m"), FirstOpKey: []byte("n"), LastOpKey: []byte("n"), OpCount: 1},
+				},
+			},
+		},
+		{
+			name: "overlapping bounds",
+			in: ReadOnlyPrepareResult{
+				Ops: 2,
+				LeafSpans: []ReadOnlyLeafSpan{
+					{HighKey: []byte("m"), FirstOpKey: []byte("a"), LastOpKey: []byte("b"), OpCount: 1},
+					{LowKey: []byte("c"), FirstOpKey: []byte("d"), LastOpKey: []byte("d"), OpCount: 1},
+				},
+			},
+		},
+		{
 			name: "op before low bound",
 			in: ReadOnlyPrepareResult{
 				Ops:       1,

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -718,6 +718,28 @@ func TestReadOnlyPrepareResultValidateLeafSpansRejectsInvalidPlans(t *testing.T)
 	}
 }
 
+func TestReadOnlyPrepareResultValidateLeafSpansFormatsKeysSafely(t *testing.T) {
+	longKey := []byte("0123456789abcdef")
+	prepared := ReadOnlyPrepareResult{
+		Ops: 1,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: longKey, LastOpKey: []byte("0"), OpCount: 1},
+		},
+	}
+
+	err := prepared.ValidateLeafSpans()
+	if err == nil {
+		t.Fatal("ValidateLeafSpans returned nil, want key-order error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, string(longKey)) {
+		t.Fatalf("error leaked full raw key %q: %s", longKey, msg)
+	}
+	if !strings.Contains(msg, "len=16") || !strings.Contains(msg, "hex_prefix=3031323334353637") {
+		t.Fatalf("error missing safe key summary: %s", msg)
+	}
+}
+
 func TestReadOnlyPrepareResultValidateLeafSpansAcceptsOpenBounds(t *testing.T) {
 	prepared := ReadOnlyPrepareResult{
 		Ops:            3,


### PR DESCRIPTION
## Summary

Adds a behavior-preserving PR6a foundation for #1242 leaf-span planning:

- adds `ReadOnlyPrepareResult.ValidateLeafSpans()` for deterministic read-only span-plan invariants;
- validates zero-op, cold-build, ordering, bounds, overlap, and op-count coverage rules;
- wires existing `PrepareReadOnly` tests through the validator;
- adds negative validator tests and an open-bound positive test.

This does not change `PrepareReadOnly` execution, root publish behavior, prepared output ownership, DB ordered-root APIs, or leaf-span execution. The validator is an explicit helper for tests/future callers and is not invoked on the hot path.

## #1242 scope

This starts the PR6a direction from the issue: deterministic leaf-span planner contracts before any parallel execution. It intentionally avoids:

- parallel leaf-span execution;
- root rebase;
- prepared output install behavior changes;
- DB publish behavior changes;
- collection-only zipper logic.

## Validation

- PASS `go test ./TreeDB/zipper -run 'TestZipperPrepareReadOnly|TestReadOnlyPrepareResultValidateLeafSpans' -count=1`
- PASS `go test ./TreeDB/zipper -count=1`
- PASS `go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkZipperPrepareReadOnlyWarmSparse' -benchmem -count=3 -benchtime=1s`
  - 257.2 / 256.9 / 256.8 ns/op
  - 0 B/op
  - 0 allocs/op
