### PR TITLE
zipper: summarize read-only leaf span plans

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1074,7 +1074,8 @@ type ReadOnlyLeafSpan struct {
 
 // ReadOnlyLeafSpanSummary is a compact, allocation-free summary of a read-only
 // leaf-span plan. It is intended for callers and benchmarks that need to
-// report span distribution without walking or retaining the span slice.
+// report span distribution without requiring each caller to walk or retain the
+// span slice.
 type ReadOnlyLeafSpanSummary struct {
 	Ops            int
 	Spans          int
@@ -1082,6 +1083,7 @@ type ReadOnlyLeafSpanSummary struct {
 	ColdBuild      bool
 	Maintenance    bool
 
+	// MinSpanOps and MaxSpanOps are zero when Spans is zero.
 	MinSpanOps    int
 	MaxSpanOps    int
 	SingleOpSpans int

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1072,6 +1072,23 @@ type ReadOnlyLeafSpan struct {
 	OpCount    int
 }
 
+// ReadOnlyLeafSpanSummary is a compact, allocation-free summary of a read-only
+// leaf-span plan. It is intended for callers and benchmarks that need to
+// report span distribution without walking or retaining the span slice.
+type ReadOnlyLeafSpanSummary struct {
+	Ops            int
+	Spans          int
+	ExactLeafSpans bool
+	ColdBuild      bool
+	Maintenance    bool
+
+	MinSpanOps    int
+	MaxSpanOps    int
+	SingleOpSpans int
+	OpenLowSpans  int
+	OpenHighSpans int
+}
+
 // ReadOnlyPrepareResult is the read-only portion of a root apply attempt. It is
 // safe to discard on root mismatch because it has not allocated or persisted
 // output pages.
@@ -1091,6 +1108,35 @@ type ReadOnlyPrepareResult struct {
 	Metrics   adaptive.Metrics
 
 	keyArena []byte
+}
+
+// LeafSpanSummary returns an allocation-free aggregate view of r's leaf spans.
+func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
+	summary := ReadOnlyLeafSpanSummary{
+		Ops:            r.Ops,
+		Spans:          len(r.LeafSpans),
+		ExactLeafSpans: r.ExactLeafSpans,
+		ColdBuild:      r.ColdBuild,
+		Maintenance:    r.Maintenance,
+	}
+	for i, span := range r.LeafSpans {
+		if i == 0 || span.OpCount < summary.MinSpanOps {
+			summary.MinSpanOps = span.OpCount
+		}
+		if i == 0 || span.OpCount > summary.MaxSpanOps {
+			summary.MaxSpanOps = span.OpCount
+		}
+		if span.OpCount == 1 {
+			summary.SingleOpSpans++
+		}
+		if span.LowKey == nil {
+			summary.OpenLowSpans++
+		}
+		if span.HighKey == nil {
+			summary.OpenHighSpans++
+		}
+	}
+	return summary
 }
 
 // ReuseOptions returns buffers from r for a later read-only preparation pass.

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1121,7 +1121,8 @@ func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
 		ColdBuild:      r.ColdBuild,
 		Maintenance:    r.Maintenance,
 	}
-	for i, span := range r.LeafSpans {
+	for i := range r.LeafSpans {
+		span := &r.LeafSpans[i]
 		if i == 0 || span.OpCount < summary.MinSpanOps {
 			summary.MinSpanOps = span.OpCount
 		}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -775,6 +775,19 @@ func TestReadOnlyPrepareResultLeafSpanSummary(t *testing.T) {
 	}
 }
 
+func TestReadOnlyPrepareResultLeafSpanSummaryEmptyPlan(t *testing.T) {
+	summary := (ReadOnlyPrepareResult{ExactLeafSpans: true}).LeafSpanSummary()
+	if summary.Ops != 0 || summary.Spans != 0 || !summary.ExactLeafSpans {
+		t.Fatalf("empty summary ops/spans/exact=%d/%d/%v want 0/0/true", summary.Ops, summary.Spans, summary.ExactLeafSpans)
+	}
+	if summary.MinSpanOps != 0 || summary.MaxSpanOps != 0 || summary.SingleOpSpans != 0 {
+		t.Fatalf("empty summary op distribution min/max/single=%d/%d/%d want 0/0/0", summary.MinSpanOps, summary.MaxSpanOps, summary.SingleOpSpans)
+	}
+	if summary.OpenLowSpans != 0 || summary.OpenHighSpans != 0 {
+		t.Fatalf("empty summary open bounds low/high=%d/%d want 0/0", summary.OpenLowSpans, summary.OpenHighSpans)
+	}
+}
+
 func TestZipperPrepareReadOnlyLeafSpanSummaryMatchesPlan(t *testing.T) {
 	dir := t.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
@@ -804,11 +817,29 @@ func TestZipperPrepareReadOnlyLeafSpanSummaryMatchesPlan(t *testing.T) {
 	if summary.Ops != prepared.Ops || summary.Spans != len(prepared.LeafSpans) {
 		t.Fatalf("summary ops/spans=%d/%d want %d/%d", summary.Ops, summary.Spans, prepared.Ops, len(prepared.LeafSpans))
 	}
-	if summary.MaxSpanOps < summary.MinSpanOps || summary.MinSpanOps <= 0 {
-		t.Fatalf("invalid summary span distribution: %+v", summary)
+	wantMin, wantMax, wantSingle, wantOpenLow, wantOpenHigh := 0, 0, 0, 0, 0
+	for i, span := range prepared.LeafSpans {
+		if i == 0 || span.OpCount < wantMin {
+			wantMin = span.OpCount
+		}
+		if i == 0 || span.OpCount > wantMax {
+			wantMax = span.OpCount
+		}
+		if span.OpCount == 1 {
+			wantSingle++
+		}
+		if span.LowKey == nil {
+			wantOpenLow++
+		}
+		if span.HighKey == nil {
+			wantOpenHigh++
+		}
 	}
-	if summary.OpenLowSpans == 0 || summary.OpenHighSpans == 0 {
-		t.Fatalf("summary open bounds low/high=%d/%d want both nonzero", summary.OpenLowSpans, summary.OpenHighSpans)
+	if summary.MinSpanOps != wantMin || summary.MaxSpanOps != wantMax || summary.SingleOpSpans != wantSingle {
+		t.Fatalf("summary op distribution min/max/single=%d/%d/%d want %d/%d/%d", summary.MinSpanOps, summary.MaxSpanOps, summary.SingleOpSpans, wantMin, wantMax, wantSingle)
+	}
+	if summary.OpenLowSpans != wantOpenLow || summary.OpenHighSpans != wantOpenHigh {
+		t.Fatalf("summary open bounds low/high=%d/%d want %d/%d", summary.OpenLowSpans, summary.OpenHighSpans, wantOpenLow, wantOpenHigh)
 	}
 }
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -730,6 +730,85 @@ func TestReadOnlyPrepareResultValidateLeafSpansAcceptsOpenBounds(t *testing.T) {
 	requireValidReadOnlyPrepare(t, prepared)
 }
 
+func TestReadOnlyPrepareResultLeafSpanSummary(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{
+		Ops:            6,
+		ExactLeafSpans: true,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1, HighKey: []byte("d")},
+			{LowKey: []byte("d"), HighKey: []byte("m"), FirstOpKey: []byte("e"), LastOpKey: []byte("h"), OpCount: 2},
+			{LowKey: []byte("m"), FirstOpKey: []byte("q"), LastOpKey: []byte("z"), OpCount: 3},
+		},
+	}
+
+	summary := prepared.LeafSpanSummary()
+	if summary.Ops != 6 || summary.Spans != 3 || !summary.ExactLeafSpans {
+		t.Fatalf("summary ops/spans/exact=%d/%d/%v want 6/3/true", summary.Ops, summary.Spans, summary.ExactLeafSpans)
+	}
+	if summary.MinSpanOps != 1 || summary.MaxSpanOps != 3 || summary.SingleOpSpans != 1 {
+		t.Fatalf("summary op distribution min/max/single=%d/%d/%d want 1/3/1", summary.MinSpanOps, summary.MaxSpanOps, summary.SingleOpSpans)
+	}
+	if summary.OpenLowSpans != 1 || summary.OpenHighSpans != 1 {
+		t.Fatalf("summary open bounds low/high=%d/%d want 1/1", summary.OpenLowSpans, summary.OpenHighSpans)
+	}
+}
+
+func TestZipperPrepareReadOnlyLeafSpanSummaryMatchesPlan(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildOuterLeafInternalRoot(t, z)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	delta.Set([]byte("key-001"), []byte("new-001"))
+	delta.Set([]byte("key-067"), []byte("new-067"))
+	delta.Set([]byte("key-133"), []byte("new-133"))
+	delta.Set([]byte("key-199"), []byte("new-199"))
+
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, prepared)
+
+	summary := prepared.LeafSpanSummary()
+	if summary.Ops != prepared.Ops || summary.Spans != len(prepared.LeafSpans) {
+		t.Fatalf("summary ops/spans=%d/%d want %d/%d", summary.Ops, summary.Spans, prepared.Ops, len(prepared.LeafSpans))
+	}
+	if summary.MaxSpanOps < summary.MinSpanOps || summary.MinSpanOps <= 0 {
+		t.Fatalf("invalid summary span distribution: %+v", summary)
+	}
+	if summary.OpenLowSpans == 0 || summary.OpenHighSpans == 0 {
+		t.Fatalf("summary open bounds low/high=%d/%d want both nonzero", summary.OpenLowSpans, summary.OpenHighSpans)
+	}
+}
+
+var readOnlyLeafSpanSummaryBenchmarkSink ReadOnlyLeafSpanSummary
+
+func BenchmarkReadOnlyPrepareResultLeafSpanSummary(b *testing.B) {
+	prepared := ReadOnlyPrepareResult{
+		Ops:            4,
+		ExactLeafSpans: true,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1, HighKey: []byte("d")},
+			{LowKey: []byte("d"), HighKey: []byte("m"), FirstOpKey: []byte("e"), LastOpKey: []byte("h"), OpCount: 2},
+			{LowKey: []byte("m"), FirstOpKey: []byte("q"), LastOpKey: []byte("z"), OpCount: 1},
+		},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		readOnlyLeafSpanSummaryBenchmarkSink = prepared.LeafSpanSummary()
+	}
+}
+
 func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {
 	dir := b.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -887,6 +887,7 @@ func BenchmarkReadOnlyPrepareResultLeafSpanSummary(b *testing.B) {
 	}
 
 	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		readOnlyLeafSpanSummaryBenchmarkSink = prepared.LeafSpanSummary()
 	}


### PR DESCRIPTION
## Summary

Adds an allocation-free `ReadOnlyPrepareResult.LeafSpanSummary()` helper for the read-only leaf-span planner introduced in the PR6a stack. The summary exposes plan distribution data without retaining or walking spans in external callers.

This is a small PR6 follow-up intended to support later PR6b reporting and benchmark comparisons before parallel leaf-span execution lands. It does not change `PrepareReadOnly`, `Apply`, ordered-root publish behavior, or hot-path validation.

## Details

- Adds `ReadOnlyLeafSpanSummary` with ops, span count, exact/cold/maintenance flags, span op distribution, and open-bound counts.
- Adds `LeafSpanSummary()` as a simple slice scan over an already-built read-only prepare result.
- Adds unit coverage for synthetic plans and real `PrepareReadOnly` output.
- Adds a focused benchmark for the summary helper.

## Validation

- PASS `go test ./TreeDB/zipper -count=1`
- PASS `go test ./TreeDB/zipper -run '^$' -bench 'Benchmark(ZipperPrepareReadOnlyWarmSparse|ReadOnlyPrepareResultLeafSpanSummary)' -benchmem -count=3 -benchtime=1s`\n  - `BenchmarkReadOnlyPrepareResultLeafSpanSummary`: `22.77 / 22.94 / 22.82 ns/op`, `0 B/op`, `0 allocs/op`\n  - `BenchmarkZipperPrepareReadOnlyWarmSparse`: `258.0 / 257.3 / 257.2 ns/op`, `0 B/op`, `0 allocs/op`\n\n## Scope\n\nNo parallel execution, no output writing, no DB ordered-root publish changes, and no validation call on the prepare hot path.