### PR TITLE
zipper: partition read-only leaf spans for workers

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1193,9 +1193,6 @@ func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpan
 }
 
 func readOnlyPrepareCeilDiv64(n, d int64) int64 {
-	if d <= 0 {
-		return 0
-	}
 	return (n + d - 1) / d
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1089,6 +1089,15 @@ type ReadOnlyLeafSpanSummary struct {
 	OpenHighSpans int
 }
 
+// ReadOnlyLeafSpanWorkerRange assigns a contiguous range of read-only leaf
+// spans to one future worker. The range is a planning primitive only; it does
+// not imply parallel execution or prepared output ownership.
+type ReadOnlyLeafSpanWorkerRange struct {
+	FirstSpan int
+	SpanCount int
+	Ops       int
+}
+
 // ReadOnlyPrepareResult is the read-only portion of a root apply attempt. It is
 // safe to discard on root mismatch because it has not allocated or persisted
 // output pages.
@@ -1137,6 +1146,56 @@ func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
 		}
 	}
 	return summary
+}
+
+// AppendLeafSpanWorkerRanges appends deterministic contiguous span partitions
+// to dst. It creates at most workers ranges and never creates empty ranges. The
+// returned ranges preserve span order and are suitable for future parallel
+// preparation steps that still need serial output append and assembly order.
+func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpanWorkerRange, workers int) []ReadOnlyLeafSpanWorkerRange {
+	if workers <= 0 || len(r.LeafSpans) == 0 {
+		return dst
+	}
+	if workers > len(r.LeafSpans) {
+		workers = len(r.LeafSpans)
+	}
+	totalOps := 0
+	for _, span := range r.LeafSpans {
+		totalOps += span.OpCount
+	}
+
+	spanIdx := 0
+	cumulativeOps := 0
+	for rangeIdx := 0; rangeIdx < workers && spanIdx < len(r.LeafSpans); rangeIdx++ {
+		firstSpan := spanIdx
+		rangeOps := 0
+		remainingRanges := workers - rangeIdx - 1
+		lastAllowedSpan := len(r.LeafSpans) - remainingRanges
+		targetCumulativeOps := readOnlyPrepareCeilDiv(totalOps*(rangeIdx+1), workers)
+
+		for spanIdx < lastAllowedSpan {
+			spanOps := r.LeafSpans[spanIdx].OpCount
+			rangeOps += spanOps
+			cumulativeOps += spanOps
+			spanIdx++
+			if remainingRanges > 0 && cumulativeOps >= targetCumulativeOps {
+				break
+			}
+		}
+		dst = append(dst, ReadOnlyLeafSpanWorkerRange{
+			FirstSpan: firstSpan,
+			SpanCount: spanIdx - firstSpan,
+			Ops:       rangeOps,
+		})
+	}
+	return dst
+}
+
+func readOnlyPrepareCeilDiv(n, d int) int {
+	if d <= 0 {
+		return 0
+	}
+	return (n + d - 1) / d
 }
 
 // ReuseOptions returns buffers from r for a later read-only preparation pass.

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1155,9 +1155,10 @@ func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
 // to dst. It creates at most workers ranges and never creates empty ranges. The
 // returned ranges preserve span order and are suitable for future parallel
 // preparation steps that still need serial output append and assembly order.
+// No-op inputs return dst unchanged.
 func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpanWorkerRange, workers int) []ReadOnlyLeafSpanWorkerRange {
 	if workers <= 0 || len(r.LeafSpans) == 0 {
-		return dst[:0]
+		return dst
 	}
 	if workers > len(r.LeafSpans) {
 		workers = len(r.LeafSpans)

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1156,29 +1156,26 @@ func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
 // preparation steps that still need serial output append and assembly order.
 func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpanWorkerRange, workers int) []ReadOnlyLeafSpanWorkerRange {
 	if workers <= 0 || len(r.LeafSpans) == 0 {
-		return dst
+		return dst[:0]
 	}
 	if workers > len(r.LeafSpans) {
 		workers = len(r.LeafSpans)
 	}
-	totalOps := 0
-	for _, span := range r.LeafSpans {
-		totalOps += span.OpCount
-	}
+	totalOps := int64(r.Ops)
 
 	spanIdx := 0
-	cumulativeOps := 0
+	cumulativeOps := int64(0)
 	for rangeIdx := 0; rangeIdx < workers && spanIdx < len(r.LeafSpans); rangeIdx++ {
 		firstSpan := spanIdx
 		rangeOps := 0
 		remainingRanges := workers - rangeIdx - 1
 		lastAllowedSpan := len(r.LeafSpans) - remainingRanges
-		targetCumulativeOps := readOnlyPrepareCeilDiv(totalOps*(rangeIdx+1), workers)
+		targetCumulativeOps := readOnlyPrepareCeilDiv64(totalOps*int64(rangeIdx+1), int64(workers))
 
 		for spanIdx < lastAllowedSpan {
 			spanOps := r.LeafSpans[spanIdx].OpCount
 			rangeOps += spanOps
-			cumulativeOps += spanOps
+			cumulativeOps += int64(spanOps)
 			spanIdx++
 			if remainingRanges > 0 && cumulativeOps >= targetCumulativeOps {
 				break
@@ -1193,7 +1190,7 @@ func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpan
 	return dst
 }
 
-func readOnlyPrepareCeilDiv(n, d int) int {
+func readOnlyPrepareCeilDiv64(n, d int64) int64 {
 	if d <= 0 {
 		return 0
 	}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -790,6 +790,112 @@ func TestZipperPrepareReadOnlyLeafSpanSummaryMatchesPlan(t *testing.T) {
 	}
 }
 
+func TestReadOnlyPrepareResultAppendLeafSpanWorkerRanges(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{
+		Ops:            12,
+		ExactLeafSpans: true,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1},
+			{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1},
+			{FirstOpKey: []byte("c"), LastOpKey: []byte("j"), OpCount: 8},
+			{FirstOpKey: []byte("k"), LastOpKey: []byte("k"), OpCount: 1},
+			{FirstOpKey: []byte("z"), LastOpKey: []byte("z"), OpCount: 1},
+		},
+	}
+
+	ranges := prepared.AppendLeafSpanWorkerRanges(nil, 3)
+	requireLeafSpanWorkerRangesCoverPlan(t, prepared, ranges)
+	if len(ranges) != 3 {
+		t.Fatalf("ranges=%d want 3", len(ranges))
+	}
+	if ranges[0].FirstSpan != 0 || ranges[2].FirstSpan+ranges[2].SpanCount != len(prepared.LeafSpans) {
+		t.Fatalf("ranges do not preserve first/last span: %+v", ranges)
+	}
+}
+
+func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesCapsWorkersAtSpanCount(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{
+		Ops: 3,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1},
+			{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 2},
+		},
+	}
+
+	ranges := prepared.AppendLeafSpanWorkerRanges(nil, 8)
+	requireLeafSpanWorkerRangesCoverPlan(t, prepared, ranges)
+	if len(ranges) != len(prepared.LeafSpans) {
+		t.Fatalf("ranges=%d want span count %d", len(ranges), len(prepared.LeafSpans))
+	}
+	for i, r := range ranges {
+		if r.SpanCount != 1 {
+			t.Fatalf("range %d span count=%d want 1; ranges=%+v", i, r.SpanCount, ranges)
+		}
+	}
+}
+
+func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesUsesDestination(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{
+		Ops: 2,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1},
+			{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1},
+		},
+	}
+	dst := make([]ReadOnlyLeafSpanWorkerRange, 0, 2)
+	ranges := prepared.AppendLeafSpanWorkerRanges(dst, 2)
+	requireLeafSpanWorkerRangesCoverPlan(t, prepared, ranges)
+	if len(ranges) != 2 {
+		t.Fatalf("ranges=%d want 2", len(ranges))
+	}
+	if cap(ranges) != cap(dst) {
+		t.Fatalf("ranges cap=%d want reused cap=%d", cap(ranges), cap(dst))
+	}
+}
+
+func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesEmptyInputs(t *testing.T) {
+	prepared := ReadOnlyPrepareResult{}
+	dst := []ReadOnlyLeafSpanWorkerRange{{FirstSpan: 99, SpanCount: 1, Ops: 1}}
+	for _, workers := range []int{-1, 0, 1} {
+		ranges := prepared.AppendLeafSpanWorkerRanges(dst[:0], workers)
+		if len(ranges) != 0 {
+			t.Fatalf("workers=%d ranges=%+v want empty", workers, ranges)
+		}
+	}
+}
+
+func requireLeafSpanWorkerRangesCoverPlan(tb testing.TB, prepared ReadOnlyPrepareResult, ranges []ReadOnlyLeafSpanWorkerRange) {
+	tb.Helper()
+	spanIdx := 0
+	ops := 0
+	for i, r := range ranges {
+		if r.SpanCount <= 0 {
+			tb.Fatalf("range %d is empty: %+v", i, r)
+		}
+		if r.FirstSpan != spanIdx {
+			tb.Fatalf("range %d first span=%d want %d; ranges=%+v", i, r.FirstSpan, spanIdx, ranges)
+		}
+		if r.FirstSpan+r.SpanCount > len(prepared.LeafSpans) {
+			tb.Fatalf("range %d exceeds span count: %+v spans=%d", i, r, len(prepared.LeafSpans))
+		}
+		rangeOps := 0
+		for j := 0; j < r.SpanCount; j++ {
+			rangeOps += prepared.LeafSpans[r.FirstSpan+j].OpCount
+		}
+		if r.Ops != rangeOps {
+			tb.Fatalf("range %d ops=%d want %d; range=%+v", i, r.Ops, rangeOps, r)
+		}
+		ops += r.Ops
+		spanIdx += r.SpanCount
+	}
+	if spanIdx != len(prepared.LeafSpans) {
+		tb.Fatalf("ranges cover %d spans, want %d; ranges=%+v", spanIdx, len(prepared.LeafSpans), ranges)
+	}
+	if ops != prepared.Ops {
+		tb.Fatalf("ranges cover %d ops, want %d; ranges=%+v", ops, prepared.Ops, ranges)
+	}
+}
+
 var readOnlyLeafSpanSummaryBenchmarkSink ReadOnlyLeafSpanSummary
 
 func BenchmarkReadOnlyPrepareResultLeafSpanSummary(b *testing.B) {
@@ -807,6 +913,29 @@ func BenchmarkReadOnlyPrepareResultLeafSpanSummary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		readOnlyLeafSpanSummaryBenchmarkSink = prepared.LeafSpanSummary()
 	}
+}
+
+var readOnlyLeafSpanWorkerRangesBenchmarkSink []ReadOnlyLeafSpanWorkerRange
+
+func BenchmarkReadOnlyPrepareResultLeafSpanWorkerRanges(b *testing.B) {
+	prepared := ReadOnlyPrepareResult{
+		Ops:            12,
+		ExactLeafSpans: true,
+		LeafSpans: []ReadOnlyLeafSpan{
+			{FirstOpKey: []byte("a"), LastOpKey: []byte("a"), OpCount: 1},
+			{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1},
+			{FirstOpKey: []byte("c"), LastOpKey: []byte("j"), OpCount: 8},
+			{FirstOpKey: []byte("k"), LastOpKey: []byte("k"), OpCount: 1},
+			{FirstOpKey: []byte("z"), LastOpKey: []byte("z"), OpCount: 1},
+		},
+	}
+	ranges := make([]ReadOnlyLeafSpanWorkerRange, 0, 3)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ranges = prepared.AppendLeafSpanWorkerRanges(ranges[:0], 3)
+	}
+	readOnlyLeafSpanWorkerRangesBenchmarkSink = ranges
 }
 
 func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -941,8 +941,8 @@ func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesEmptyInputs(t *testing.T
 	dst := []ReadOnlyLeafSpanWorkerRange{{FirstSpan: 99, SpanCount: 1, Ops: 1}}
 	for _, workers := range []int{-1, 0, 1} {
 		ranges := prepared.AppendLeafSpanWorkerRanges(dst, workers)
-		if len(ranges) != 0 {
-			t.Fatalf("workers=%d ranges=%+v want empty", workers, ranges)
+		if len(ranges) != len(dst) || ranges[0] != dst[0] {
+			t.Fatalf("workers=%d ranges=%+v want dst unchanged", workers, ranges)
 		}
 	}
 }

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -910,7 +910,7 @@ func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesEmptyInputs(t *testing.T
 	prepared := ReadOnlyPrepareResult{}
 	dst := []ReadOnlyLeafSpanWorkerRange{{FirstSpan: 99, SpanCount: 1, Ops: 1}}
 	for _, workers := range []int{-1, 0, 1} {
-		ranges := prepared.AppendLeafSpanWorkerRanges(dst[:0], workers)
+		ranges := prepared.AppendLeafSpanWorkerRanges(dst, workers)
 		if len(ranges) != 0 {
 			t.Fatalf("workers=%d ranges=%+v want empty", workers, ranges)
 		}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -925,14 +925,25 @@ func TestReadOnlyPrepareResultAppendLeafSpanWorkerRangesUsesDestination(t *testi
 			{FirstOpKey: []byte("b"), LastOpKey: []byte("b"), OpCount: 1},
 		},
 	}
-	dst := make([]ReadOnlyLeafSpanWorkerRange, 0, 2)
+	dst := make([]ReadOnlyLeafSpanWorkerRange, 1, 3)
+	dstBase := &dst[:cap(dst)][0]
+	dst = dst[:0]
 	ranges := prepared.AppendLeafSpanWorkerRanges(dst, 2)
 	requireLeafSpanWorkerRangesCoverPlan(t, prepared, ranges)
 	if len(ranges) != 2 {
 		t.Fatalf("ranges=%d want 2", len(ranges))
 	}
-	if cap(ranges) != cap(dst) {
-		t.Fatalf("ranges cap=%d want reused cap=%d", cap(ranges), cap(dst))
+	if &ranges[0] != dstBase {
+		t.Fatalf("ranges backing array was not reused")
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		got := prepared.AppendLeafSpanWorkerRanges(dst, 2)
+		if len(got) != 2 {
+			t.Fatalf("ranges=%d want 2", len(got))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("AppendLeafSpanWorkerRanges allocations=%v want 0", allocs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds deterministic worker-range partitioning over an existing read-only leaf-span plan. This is a PR6 prep slice for future intra-root parallel apply: it gives later code a stable contiguous span-to-worker mapping while preserving serial output append and assembly order.

This PR does not execute work in parallel, allocate prepared output, or change `PrepareReadOnly`, `Apply`, or DB ordered-root publish behavior.

## Details

- Adds `ReadOnlyLeafSpanWorkerRange`.
- Adds `ReadOnlyPrepareResult.AppendLeafSpanWorkerRanges(dst, workers)`.
- Caps workers at span count and never emits empty ranges.
- Preserves span order with contiguous ranges.
- Supports caller-provided destination reuse to avoid allocations.

## Validation

- PASS `go test ./TreeDB/zipper -count=1`
- PASS `go test ./TreeDB/zipper -run '^$' -bench 'Benchmark(ZipperPrepareReadOnlyWarmSparse|ReadOnlyPrepareResultLeafSpanSummary|ReadOnlyPrepareResultLeafSpanWorkerRanges)' -benchmem -count=3 -benchtime=1s`\n  - `BenchmarkReadOnlyPrepareResultLeafSpanSummary`: `22.78 / 25.45 / 22.86 ns/op`, `0 B/op`, `0 allocs/op`\n  - `BenchmarkReadOnlyPrepareResultLeafSpanWorkerRanges`: `23.84 / 23.77 / 23.74 ns/op`, `0 B/op`, `0 allocs/op`\n  - `BenchmarkZipperPrepareReadOnlyWarmSparse`: `257.4 / 257.5 / 257.3 ns/op`, `0 B/op`, `0 allocs/op`\n\n## Scope\n\nNo parallel execution, no leaf-log or pager output writing, no DB ordered-root publish integration, and no validation call on the prepare hot path.