### PR TITLE
treedb: avoid key update lock closure allocations

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -19428,7 +19428,7 @@ func (db *DB) Set(key, value []byte) error {
 	}
 	db.waitForCheckpoint()
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.set(key, value, false)
 }
 
@@ -19441,7 +19441,7 @@ func (db *DB) SetSync(key, value []byte) error {
 	}
 	db.waitForCheckpoint()
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.set(key, value, true)
 }
 
@@ -19469,7 +19469,7 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	for {
 		unlock := db.lockUpdateKey(key)
 		old, err := db.getForUpdate(key)
-		unlock()
+		unlock.Unlock()
 		if err != nil {
 			return err
 		}
@@ -19489,28 +19489,28 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 		unlock = db.lockUpdateKey(key)
 		latest, err := db.getForUpdate(key)
 		if err != nil {
-			unlock()
+			unlock.Unlock()
 			return err
 		}
 		if !sameUpdateValue(observed, latest) {
-			unlock()
+			unlock.Unlock()
 			continue
 		}
 
 		switch result.Op {
 		case backenddb.UpdateNoop:
-			unlock()
+			unlock.Unlock()
 			return nil
 		case backenddb.UpdateSet:
 			err = db.set(key, result.Value, syncWrite)
-			unlock()
+			unlock.Unlock()
 			return err
 		case backenddb.UpdateDelete:
 			err = db.delete(key, syncWrite)
-			unlock()
+			unlock.Unlock()
 			return err
 		default:
-			unlock()
+			unlock.Unlock()
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
@@ -19781,7 +19781,7 @@ func (db *DB) Delete(key []byte) error {
 	}
 	db.waitForCheckpoint()
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.delete(key, false)
 }
 
@@ -20395,13 +20395,13 @@ func (db *DB) DeleteSync(key []byte) error {
 	}
 	db.waitForCheckpoint()
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.delete(key, true)
 }
 
-func (db *DB) lockUpdateKey(key []byte) func() {
+func (db *DB) lockUpdateKey(key []byte) keyupdate.Unlocker {
 	if db == nil {
-		return func() {}
+		return keyupdate.Unlocker{}
 	}
 	return db.updateLocks.Lock(key)
 }

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -340,7 +340,7 @@ func (db *DB) Has(key []byte) (bool, error) {
 // Set sets the value for a key.
 func (db *DB) Set(key, value []byte) error {
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.setPoint(key, value, false)
 }
 
@@ -354,14 +354,14 @@ func (db *DB) setPoint(key, value []byte, sync bool) error {
 // SetSync sets the value and syncs to disk.
 func (db *DB) SetSync(key, value []byte) error {
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.setPoint(key, value, true)
 }
 
 // Delete removes a key.
 func (db *DB) Delete(key []byte) error {
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.deletePoint(key, false)
 }
 
@@ -375,7 +375,7 @@ func (db *DB) deletePoint(key []byte, sync bool) error {
 // DeleteSync removes a key and syncs.
 func (db *DB) DeleteSync(key []byte) error {
 	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	defer unlock.Unlock()
 	return db.deletePoint(key, true)
 }
 

--- a/TreeDB/db/bench_test.go
+++ b/TreeDB/db/bench_test.go
@@ -436,7 +436,7 @@ func BenchmarkLargeVal(b *testing.B) {
 			if closeErr := wb.Close(); err == nil {
 				err = closeErr
 			}
-			unlock()
+			unlock.Unlock()
 			if err != nil {
 				b.Errorf("SetPointer failed: %v", err)
 			}

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/keyupdate"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
@@ -82,7 +83,7 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 	for {
 		unlock := db.lockUpdateKey(key)
 		old, err := db.getForUpdate(key)
-		unlock()
+		unlock.Unlock()
 		if err != nil {
 			return err
 		}
@@ -102,36 +103,36 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 		unlock = db.lockUpdateKey(key)
 		latest, err := db.getForUpdate(key)
 		if err != nil {
-			unlock()
+			unlock.Unlock()
 			return err
 		}
 		if !sameUpdateValue(observed, latest) {
-			unlock()
+			unlock.Unlock()
 			continue
 		}
 
 		switch result.Op {
 		case UpdateNoop:
-			unlock()
+			unlock.Unlock()
 			return nil
 		case UpdateSet:
 			err = db.setPoint(key, result.Value, syncWrite)
-			unlock()
+			unlock.Unlock()
 			return err
 		case UpdateDelete:
 			err = db.deletePoint(key, syncWrite)
-			unlock()
+			unlock.Unlock()
 			return err
 		default:
-			unlock()
+			unlock.Unlock()
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
 }
 
-func (db *DB) lockUpdateKey(key []byte) func() {
+func (db *DB) lockUpdateKey(key []byte) keyupdate.Unlocker {
 	if db == nil {
-		return func() {}
+		return keyupdate.Unlocker{}
 	}
 	return db.updateLocks.Lock(key)
 }

--- a/TreeDB/internal/keyupdate/locks.go
+++ b/TreeDB/internal/keyupdate/locks.go
@@ -14,11 +14,24 @@ type Locks struct {
 	stripes [stripes]sync.Mutex
 }
 
-// Lock locks the stripe for key and returns its unlock function. Hash collisions
+// Unlocker releases a lock acquired by Locks.Lock.
+type Unlocker struct {
+	mu *sync.Mutex
+}
+
+// Unlock releases the lock acquired by Locks.Lock.
+func (u Unlocker) Unlock() {
+	if u.mu == nil {
+		return
+	}
+	u.mu.Unlock()
+}
+
+// Lock locks the stripe for key and returns its unlock handle. Hash collisions
 // only reduce concurrency; they do not affect correctness.
-func (l *Locks) Lock(key []byte) func() {
+func (l *Locks) Lock(key []byte) Unlocker {
 	idx := xxhash.Sum64(key) & (stripes - 1)
 	mu := &l.stripes[idx]
 	mu.Lock()
-	return mu.Unlock
+	return Unlocker{mu: mu}
 }

--- a/TreeDB/internal/keyupdate/locks_test.go
+++ b/TreeDB/internal/keyupdate/locks_test.go
@@ -1,0 +1,31 @@
+package keyupdate
+
+import "testing"
+
+func TestLocksLockDoesNotAllocate(t *testing.T) {
+	var locks Locks
+	key := []byte("alloc-key")
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		unlock := locks.Lock(key)
+		unlock.Unlock()
+	})
+	if allocs != 0 {
+		t.Fatalf("Lock allocations = %v, want 0", allocs)
+	}
+}
+
+func TestUnlockerZeroValueIsNoop(t *testing.T) {
+	var unlock Unlocker
+	unlock.Unlock()
+}
+
+func BenchmarkLocksLockUnlock(b *testing.B) {
+	var locks Locks
+	key := []byte("bench-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		unlock := locks.Lock(key)
+		unlock.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary

- replace the internal key-update lock API's per-call unlock closure with a tiny `Unlocker` handle
- update DB/caching callers to call `Unlock()` directly
- add a zero-allocation regression test and microbenchmark for `keyupdate.Locks.Lock`

## Performance evidence

Small `unified-bench` profile capture on 20k `random_write,random_read` TreeDB fast profile:

- before: sampled random-write allocation profile had `keyupdate.(*Locks).Lock` at `32,768` alloc objects out of `38,450` total
- after: `keyupdate.(*Locks).Lock` no longer appears; sampled random-write alloc objects dropped to `6,288` total
- after throughput in the same small harness: random write `2,706,055 ops/s`, random read `1,393,963 ops/s`

Microbenchmark after the change:

- `BenchmarkLocksLockUnlock`: `4.6-5.9 ns/op`, `0 B/op`, `0 allocs/op`

## Validation

- PASS `go test ./TreeDB/internal/keyupdate -count=1`
- PASS `go test ./TreeDB/internal/keyupdate -run '^$' -bench BenchmarkLocksLockUnlock -benchmem -count=5`\n- PASS `go test ./TreeDB/db ./TreeDB/caching -run '^TestNonExistent$' -count=1`\n- PASS `go test ./TreeDB/db ./TreeDB/caching -count=1`\n- PASS small profile run with `./bin/unified-bench -dbs treedb -profile fast -treedb-allow-unsafe -keys 20000 -valsize 128 -batchsize 1000 -test random_write,random_read -checkpoint-between-tests -profile-dir /tmp/gomap_keyupdate_profiles_HG1F7M -path-label native-fastpath -progress=false -format markdown -max-wall 3m`