### PR TITLE
zipper: return optional read-only prepare from apply

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1030,10 +1030,18 @@ func validateLoadedLeafLogNodeFrom(source string, data []byte) (node.Node, error
 	return n, nil
 }
 
-// ApplyOptions configures a root apply attempt. The first version is
-// intentionally empty so callers can move to the result-shaped API before
-// prepared-output options exist.
-type ApplyOptions struct{}
+// ApplyOptions configures a root apply attempt.
+type ApplyOptions struct {
+	// PrepareReadOnly asks ApplyWithOptions to run the read-only preparation
+	// pass before applying the delta. This is opt-in because it traverses the
+	// existing root in addition to the apply pass. It does not change apply
+	// output, root installation, or prepared-output ownership.
+	PrepareReadOnly bool
+
+	// ReadOnlyPrepare reuses buffers for the optional read-only preparation
+	// pass. It is ignored unless PrepareReadOnly is true.
+	ReadOnlyPrepare ReadOnlyPrepareOptions
+}
 
 // ApplyResult is the complete in-memory result of a root apply attempt. The
 // retired page list is pending until the caller's install guard succeeds and
@@ -1042,6 +1050,10 @@ type ApplyResult struct {
 	RootID              uint64
 	PendingRetiredPages []uint64
 	Metrics             adaptive.Metrics
+
+	// ReadOnlyPrepare is populated only when ApplyOptions.PrepareReadOnly is
+	// true. It is planning metadata only; it owns no pager or leaf-log output.
+	ReadOnlyPrepare ReadOnlyPrepareResult
 }
 
 // ReadOnlyPrepareOptions configures a read-only root preparation pass. The zero
@@ -1318,12 +1330,20 @@ func (r *ReadOnlyPrepareResult) addLeafSpan(ref page.ChildRef, low, high []byte,
 // ApplyWithOptions applies the batch to the tree rooted at rootID and returns
 // a result object suitable for guarded install paths.
 func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptions) (ApplyResult, error) {
-	_ = opts
+	var prepared ReadOnlyPrepareResult
+	if opts.PrepareReadOnly {
+		var err error
+		prepared, err = z.PrepareReadOnly(rootID, b, opts.ReadOnlyPrepare)
+		if err != nil {
+			return ApplyResult{ReadOnlyPrepare: prepared}, err
+		}
+	}
 	newRoot, retired, metrics, err := z.Apply(rootID, b)
 	return ApplyResult{
 		RootID:              newRoot,
 		PendingRetiredPages: retired,
 		Metrics:             metrics,
+		ReadOnlyPrepare:     prepared,
 	}, err
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1327,8 +1327,11 @@ func (r *ReadOnlyPrepareResult) addLeafSpan(ref page.ChildRef, low, high []byte,
 	r.LeafSpans = append(r.LeafSpans, span)
 }
 
-// ApplyWithOptions applies the batch to the tree rooted at rootID and returns
-// a result object suitable for guarded install paths.
+// ApplyWithOptions applies the batch to the tree rooted at rootID and returns a
+// result object suitable for guarded install paths. When opts.PrepareReadOnly is
+// true, it first runs PrepareReadOnly and returns that planning metadata on the
+// result. If the read-only preparation fails, the returned result may contain
+// partial ReadOnlyPrepare metadata and no root output.
 func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptions) (ApplyResult, error) {
 	var prepared ReadOnlyPrepareResult
 	if opts.PrepareReadOnly {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -622,17 +622,23 @@ func TestZipperPrepareReadOnlyNestedInternalBoundsInheritParentRange(t *testing.
 	}
 }
 
-func TestZipperApplyWithOptionsReturnsReadOnlyPrepare(t *testing.T) {
-	dir := t.TempDir()
+func newTestZipperWithOuterLeafInternalRoot(tb testing.TB) (*Zipper, uint64) {
+	tb.Helper()
+	dir := tb.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	defer p.Close()
+	tb.Cleanup(func() { _ = p.Close() })
 
 	alloc := &MockAllocator{p: p}
 	z := New(p, alloc)
-	rootID := buildOuterLeafInternalRoot(t, z)
+	rootID := buildOuterLeafInternalRoot(tb, z)
+	return z, rootID
+}
+
+func TestZipperApplyWithOptionsReturnsReadOnlyPrepare(t *testing.T) {
+	z, rootID := newTestZipperWithOuterLeafInternalRoot(t)
 
 	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
 	defer func() { _ = delta.Close() }()
@@ -669,16 +675,7 @@ func TestZipperApplyWithOptionsReturnsReadOnlyPrepare(t *testing.T) {
 }
 
 func TestZipperApplyWithOptionsDefaultSkipsReadOnlyPrepare(t *testing.T) {
-	dir := t.TempDir()
-	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer p.Close()
-
-	alloc := &MockAllocator{p: p}
-	z := New(p, alloc)
-	rootID := buildOuterLeafInternalRoot(t, z)
+	z, rootID := newTestZipperWithOuterLeafInternalRoot(t)
 
 	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
 	defer func() { _ = delta.Close() }()
@@ -699,16 +696,7 @@ func TestZipperApplyWithOptionsDefaultSkipsReadOnlyPrepare(t *testing.T) {
 }
 
 func TestZipperApplyWithOptionsReusesReadOnlyPrepareBuffers(t *testing.T) {
-	dir := t.TempDir()
-	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer p.Close()
-
-	alloc := &MockAllocator{p: p}
-	z := New(p, alloc)
-	rootID := buildOuterLeafInternalRoot(t, z)
+	z, rootID := newTestZipperWithOuterLeafInternalRoot(t)
 
 	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
 	defer func() { _ = delta.Close() }()

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -622,6 +622,134 @@ func TestZipperPrepareReadOnlyNestedInternalBoundsInheritParentRange(t *testing.
 	}
 }
 
+func TestZipperApplyWithOptionsReturnsReadOnlyPrepare(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildOuterLeafInternalRoot(t, z)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	delta.Set([]byte("key-001"), []byte("new-001"))
+	delta.Set([]byte("key-067"), []byte("new-067"))
+	delta.Set([]byte("key-133"), []byte("new-133"))
+
+	result, err := z.ApplyWithOptions(rootID, delta, ApplyOptions{
+		PrepareReadOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("ApplyWithOptions: %v", err)
+	}
+	if result.RootID == 0 || result.RootID == rootID {
+		t.Fatalf("result root=%d want new non-zero root different from %d", result.RootID, rootID)
+	}
+	if len(result.PendingRetiredPages) == 0 {
+		t.Fatal("expected pending retired pages from warm apply")
+	}
+	prepared := result.ReadOnlyPrepare
+	requireValidReadOnlyPrepare(t, prepared)
+	if prepared.RootID != rootID {
+		t.Fatalf("prepared root=%d want %d", prepared.RootID, rootID)
+	}
+	if prepared.Ops != 3 {
+		t.Fatalf("prepared ops=%d want 3", prepared.Ops)
+	}
+	if len(prepared.LeafSpans) == 0 {
+		t.Fatal("expected read-only leaf spans")
+	}
+	if prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans {
+		t.Fatalf("prepared flags cold/maintenance/exact=%v/%v/%v want false/false/true", prepared.ColdBuild, prepared.Maintenance, prepared.ExactLeafSpans)
+	}
+}
+
+func TestZipperApplyWithOptionsDefaultSkipsReadOnlyPrepare(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildOuterLeafInternalRoot(t, z)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	delta.Set([]byte("key-001"), []byte("new-001"))
+
+	result, err := z.ApplyWithOptions(rootID, delta, ApplyOptions{})
+	if err != nil {
+		t.Fatalf("ApplyWithOptions: %v", err)
+	}
+	if result.RootID == 0 || result.RootID == rootID {
+		t.Fatalf("result root=%d want new non-zero root different from %d", result.RootID, rootID)
+	}
+	if result.ReadOnlyPrepare.RootID != 0 ||
+		result.ReadOnlyPrepare.Ops != 0 ||
+		len(result.ReadOnlyPrepare.LeafSpans) != 0 {
+		t.Fatalf("read-only prepare populated without opt-in: %+v", result.ReadOnlyPrepare)
+	}
+}
+
+func TestZipperApplyWithOptionsReusesReadOnlyPrepareBuffers(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildOuterLeafInternalRoot(t, z)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	delta.Set([]byte("key-001"), []byte("new-001"))
+	delta.Set([]byte("key-067"), []byte("new-067"))
+
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	if len(prepared.LeafSpans) == 0 {
+		t.Fatal("expected initial read-only leaf spans")
+	}
+	opts := ApplyOptions{
+		PrepareReadOnly: true,
+		ReadOnlyPrepare: prepared.ReuseOptions(),
+	}
+	if cap(opts.ReadOnlyPrepare.leafSpans) == 0 {
+		t.Fatal("expected reusable leaf-span capacity")
+	}
+	if cap(opts.ReadOnlyPrepare.keyArena) == 0 {
+		t.Fatal("expected reusable key arena capacity")
+	}
+	leafSpanBase := &opts.ReadOnlyPrepare.leafSpans[:cap(opts.ReadOnlyPrepare.leafSpans)][0]
+	keyArenaBase := &opts.ReadOnlyPrepare.keyArena[:cap(opts.ReadOnlyPrepare.keyArena)][0]
+
+	result, err := z.ApplyWithOptions(rootID, delta, opts)
+	if err != nil {
+		t.Fatalf("ApplyWithOptions: %v", err)
+	}
+	if len(result.ReadOnlyPrepare.LeafSpans) == 0 {
+		t.Fatal("expected reused read-only leaf spans")
+	}
+	if &result.ReadOnlyPrepare.LeafSpans[0] != leafSpanBase {
+		t.Fatal("read-only prepare leaf-span buffer was not reused")
+	}
+	if len(result.ReadOnlyPrepare.keyArena) == 0 || &result.ReadOnlyPrepare.keyArena[0] != keyArenaBase {
+		t.Fatal("read-only prepare key arena was not reused")
+	}
+}
+
 func TestReadOnlyPrepareResultValidateLeafSpansRejectsInvalidPlans(t *testing.T) {
 	validSpan := ReadOnlyLeafSpan{
 		LowKey:     []byte("a"),


### PR DESCRIPTION
## Summary

Adds an opt-in `ApplyOptions.PrepareReadOnly` path so `Zipper.ApplyWithOptions` can return the read-only leaf-span preparation result alongside the existing apply result.

This is a small #1242 follow-up after the read-only leaf-span planning/summary/worker-range PRs. It keeps the default apply path unchanged and only pays the extra read-only traversal when requested.

## Scope

- Extends `ApplyOptions` with `PrepareReadOnly` and reusable `ReadOnlyPrepareOptions` buffers.
- Extends `ApplyResult` with `ReadOnlyPrepare` planning metadata.
- Runs `PrepareReadOnly` before `Apply` only when explicitly requested.
- Preserves zero-value `ApplyOptions{}` behavior: no read-only prepare result is populated.
- Adds tests for opt-in metadata, default skip behavior, and buffer reuse.

## Non-goals

- No root output change.
- No prepared-output ownership or persistence change.
- No parallel apply execution.
- No install/finalize semantics change.

## Validation

```text
PASS go test ./TreeDB/zipper -count=1
PASS go test ./TreeDB/zipper ./TreeDB/db -count=1
PASS git diff --check
```

Allocation-sensitive benchmarks:

```text
PASS go test ./TreeDB/zipper -run '^$' -bench 'Benchmark(ReadOnlyPrepareResultLeafSpanSummary|ReadOnlyPrepareResultLeafSpanWorkerRanges|ZipperPrepareReadOnlyWarmSparse)' -benchmem -count=3 -benchtime=1s

BenchmarkReadOnlyPrepareResultLeafSpanSummary-8         13.83 ns/op   0 B/op   0 allocs/op
BenchmarkReadOnlyPrepareResultLeafSpanSummary-8         13.86 ns/op   0 B/op   0 allocs/op
BenchmarkReadOnlyPrepareResultLeafSpanSummary-8         13.86 ns/op   0 B/op   0 allocs/op
BenchmarkReadOnlyPrepareResultLeafSpanWorkerRanges-8    11.26 ns/op   0 B/op   0 allocs/op
BenchmarkReadOnlyPrepareResultLeafSpanWorkerRanges-8    11.28 ns/op   0 B/op   0 allocs/op
BenchmarkReadOnlyPrepareResultLeafSpanWorkerRanges-8    11.30 ns/op   0 B/op   0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparse-8              257.8 ns/op   0 B/op   0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparse-8              258.0 ns/op   0 B/op   0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparse-8              275.0 ns/op   0 B/op   0 allocs/op
```
