### PR TITLE
db: reuse ordered read-only prepare buffers

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -172,7 +172,7 @@ type OrderedRootDeltaBatchPublishInput struct {
 	// ReadOnlyPrepareResult, when non-nil, is both the reuse source and output
 	// destination for this root's optional preparation metadata. It must be
 	// owned by this input within the group; sharing one result pointer across
-	// group inputs is rejected.
+	// group inputs is rejected. It is ignored unless PrepareReadOnly is true.
 	ReadOnlyPrepareResult *zipper.ReadOnlyPrepareResult
 }
 
@@ -1557,6 +1557,8 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 }
 
 func validateOrderedRootReadOnlyPrepareResultOwnership(ordered []OrderedRootDeltaBatchPublishInput) error {
+	// Keep this validation allocation-free. Ordered root groups are expected to
+	// be small, and the read-only prepare reuse path is allocation-sensitive.
 	for idx := range ordered {
 		result := ordered[idx].ReadOnlyPrepareResult
 		if !ordered[idx].PrepareReadOnly || result == nil {
@@ -1575,6 +1577,9 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 	results := make([]orderedRootDeltaBatchGroupApplyResult, len(ordered))
 	if err := validateOrderedRootReadOnlyPrepareResultOwnership(ordered); err != nil {
 		if len(results) > 0 {
+			// recordOrderedRootDeltaBatchGroupApplyResults uses attempted to find
+			// terminal per-input errors. No root apply metrics are recorded for
+			// errored results.
 			results[0] = orderedRootDeltaBatchGroupApplyResult{idx: 0, err: err, attempted: true}
 		}
 		return results, false

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -52,18 +52,18 @@ type orderedRootPublishStats struct {
 }
 
 type orderedRootPublishOptions struct {
-	maxWarmDeltaOps               int
-	leafPrefixCompression         bool
-	leafColumnar                  bool
-	packedValuePtr                bool
-	internalBaseDelta             bool
-	outerLeavesInValueLog         bool
-	leafPageLog                   bulk.LeafPageAppender
-	applyOptions                  zipper.ApplyOptions
-	readOnlyPrepareSummary        *zipper.ReadOnlyLeafSpanSummary
-	readOnlyPrepareExternalResult *zipper.ReadOnlyPrepareResult
-	readOnlyPrepareNs             *uint64
-	readOnlyPrepareAttempted      *bool
+	maxWarmDeltaOps             int
+	leafPrefixCompression       bool
+	leafColumnar                bool
+	packedValuePtr              bool
+	internalBaseDelta           bool
+	outerLeavesInValueLog       bool
+	leafPageLog                 bulk.LeafPageAppender
+	applyOptions                zipper.ApplyOptions
+	readOnlyPrepareSummary      *zipper.ReadOnlyLeafSpanSummary
+	readOnlyPrepareCallerResult *zipper.ReadOnlyPrepareResult
+	readOnlyPrepareNs           *uint64
+	readOnlyPrepareAttempted    *bool
 }
 
 type orderedRootDeltaBatchGroupApplyResult struct {
@@ -169,14 +169,10 @@ type OrderedRootDeltaBatchPublishInput struct {
 	// root apply and records planning stats. It is observability/planning only;
 	// it does not change publish output or enable parallel leaf execution.
 	PrepareReadOnly bool
-	// ReadOnlyPrepareOptions supplies optional reusable buffers for
-	// PrepareReadOnly. The zero value is valid. Callers that keep the matching
-	// ReadOnlyPrepareResult can pass result.ReuseOptions() on later publishes to
-	// reduce allocation churn.
-	ReadOnlyPrepareOptions zipper.ReadOnlyPrepareOptions
-	// ReadOnlyPrepareResult, when non-nil, receives the optional preparation
-	// metadata for this root. Do not share one result pointer across inputs that
-	// may be applied concurrently.
+	// ReadOnlyPrepareResult, when non-nil, is both the reuse source and output
+	// destination for this root's optional preparation metadata. It must be
+	// owned by this input within the group; sharing one result pointer across
+	// group inputs is rejected.
 	ReadOnlyPrepareResult *zipper.ReadOnlyPrepareResult
 }
 
@@ -702,8 +698,8 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		summary := readOnlyPrepare.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
 	}
-	if opts.readOnlyPrepareExternalResult != nil {
-		*opts.readOnlyPrepareExternalResult = readOnlyPrepare
+	if opts.readOnlyPrepareCallerResult != nil {
+		*opts.readOnlyPrepareCallerResult = readOnlyPrepare
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
@@ -816,8 +812,8 @@ func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, d
 		summary := prepared.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
 	}
-	if opts.readOnlyPrepareExternalResult != nil {
-		*opts.readOnlyPrepareExternalResult = prepared
+	if opts.readOnlyPrepareCallerResult != nil {
+		*opts.readOnlyPrepareCallerResult = prepared
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = prepareNs
@@ -1560,8 +1556,29 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 	return parallelActive >= orderedRootDeltaBatchGroupParallelApplyMinRoots
 }
 
+func validateOrderedRootReadOnlyPrepareResultOwnership(ordered []OrderedRootDeltaBatchPublishInput) error {
+	for idx := range ordered {
+		result := ordered[idx].ReadOnlyPrepareResult
+		if !ordered[idx].PrepareReadOnly || result == nil {
+			continue
+		}
+		for otherIdx := idx + 1; otherIdx < len(ordered); otherIdx++ {
+			if ordered[otherIdx].PrepareReadOnly && ordered[otherIdx].ReadOnlyPrepareResult == result {
+				return errors.New("ordered root read-only prepare result reused by multiple inputs")
+			}
+		}
+	}
+	return nil
+}
+
 func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []OrderedRootDeltaBatchPublishInput, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator, includeOutputSnapshot bool) ([]orderedRootDeltaBatchGroupApplyResult, bool) {
 	results := make([]orderedRootDeltaBatchGroupApplyResult, len(ordered))
+	if err := validateOrderedRootReadOnlyPrepareResultOwnership(ordered); err != nil {
+		if len(results) > 0 {
+			results[0] = orderedRootDeltaBatchGroupApplyResult{idx: 0, err: err, attempted: true}
+		}
+		return results, false
+	}
 	var outputID preparedOutputID
 	var outputTracker *allocTracker
 	if tracker, ok := alloc.(*allocTracker); ok {
@@ -1594,9 +1611,11 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		}
 		if ordered[orderedIdx].PrepareReadOnly {
 			opts.applyOptions.PrepareReadOnly = true
-			opts.applyOptions.ReadOnlyPrepare = ordered[orderedIdx].ReadOnlyPrepareOptions
+			if resultOut := ordered[orderedIdx].ReadOnlyPrepareResult; resultOut != nil {
+				opts.applyOptions.ReadOnlyPrepare = resultOut.ReuseOptions()
+			}
 			opts.readOnlyPrepareSummary = &result.readOnlyPrepareSummary
-			opts.readOnlyPrepareExternalResult = ordered[orderedIdx].ReadOnlyPrepareResult
+			opts.readOnlyPrepareCallerResult = ordered[orderedIdx].ReadOnlyPrepareResult
 			opts.readOnlyPrepareNs = &result.readOnlyPrepareNs
 			opts.readOnlyPrepareAttempted = &result.readOnlyPrepareAttempted
 		}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -52,17 +52,18 @@ type orderedRootPublishStats struct {
 }
 
 type orderedRootPublishOptions struct {
-	maxWarmDeltaOps          int
-	leafPrefixCompression    bool
-	leafColumnar             bool
-	packedValuePtr           bool
-	internalBaseDelta        bool
-	outerLeavesInValueLog    bool
-	leafPageLog              bulk.LeafPageAppender
-	applyOptions             zipper.ApplyOptions
-	readOnlyPrepareResult    *zipper.ReadOnlyPrepareResult
-	readOnlyPrepareNs        *uint64
-	readOnlyPrepareAttempted *bool
+	maxWarmDeltaOps               int
+	leafPrefixCompression         bool
+	leafColumnar                  bool
+	packedValuePtr                bool
+	internalBaseDelta             bool
+	outerLeavesInValueLog         bool
+	leafPageLog                   bulk.LeafPageAppender
+	applyOptions                  zipper.ApplyOptions
+	readOnlyPrepareResult         *zipper.ReadOnlyPrepareResult
+	readOnlyPrepareExternalResult *zipper.ReadOnlyPrepareResult
+	readOnlyPrepareNs             *uint64
+	readOnlyPrepareAttempted      *bool
 }
 
 type orderedRootDeltaBatchGroupApplyResult struct {
@@ -168,6 +169,15 @@ type OrderedRootDeltaBatchPublishInput struct {
 	// root apply and records planning stats. It is observability/planning only;
 	// it does not change publish output or enable parallel leaf execution.
 	PrepareReadOnly bool
+	// ReadOnlyPrepareOptions supplies optional reusable buffers for
+	// PrepareReadOnly. The zero value is valid. Callers that keep the matching
+	// ReadOnlyPrepareResult can pass result.ReuseOptions() on later publishes to
+	// reduce allocation churn.
+	ReadOnlyPrepareOptions zipper.ReadOnlyPrepareOptions
+	// ReadOnlyPrepareResult, when non-nil, receives the optional preparation
+	// metadata for this root. Do not share one result pointer across inputs that
+	// may be applied concurrently.
+	ReadOnlyPrepareResult *zipper.ReadOnlyPrepareResult
 }
 
 func closeUnconsumedOrderedRootPublishIterators(ordered []OrderedRootPublishInput, consumed []bool) {
@@ -691,6 +701,9 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	if opts.readOnlyPrepareResult != nil {
 		*opts.readOnlyPrepareResult = readOnlyPrepare
 	}
+	if opts.readOnlyPrepareExternalResult != nil {
+		*opts.readOnlyPrepareExternalResult = readOnlyPrepare
+	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
 	}
@@ -769,6 +782,9 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, opts.applyOptions)
 	if opts.readOnlyPrepareResult != nil {
 		*opts.readOnlyPrepareResult = readOnlyPrepare
+	}
+	if opts.readOnlyPrepareExternalResult != nil {
+		*opts.readOnlyPrepareExternalResult = readOnlyPrepare
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
@@ -1545,7 +1561,9 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		}
 		if ordered[orderedIdx].PrepareReadOnly {
 			opts.applyOptions.PrepareReadOnly = true
+			opts.applyOptions.ReadOnlyPrepare = ordered[orderedIdx].ReadOnlyPrepareOptions
 			opts.readOnlyPrepareResult = &result.readOnlyPrepare
+			opts.readOnlyPrepareExternalResult = ordered[orderedIdx].ReadOnlyPrepareResult
 			opts.readOnlyPrepareNs = &result.readOnlyPrepareNs
 			opts.readOnlyPrepareAttempted = &result.readOnlyPrepareAttempted
 		}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -60,7 +60,7 @@ type orderedRootPublishOptions struct {
 	outerLeavesInValueLog    bool
 	leafPageLog              bulk.LeafPageAppender
 	applyOptions             zipper.ApplyOptions
-	readOnlyPrepareResult    *zipper.ReadOnlyPrepareResult
+	readOnlyPrepareSummary   *zipper.ReadOnlyLeafSpanSummary
 	readOnlyPrepareNs        *uint64
 	readOnlyPrepareAttempted *bool
 }
@@ -74,7 +74,7 @@ type orderedRootDeltaBatchGroupApplyResult struct {
 	outputLeafLogPtrs        uint64
 	pendingRetiredPages      []uint64
 	metrics                  adaptive.Metrics
-	readOnlyPrepare          zipper.ReadOnlyPrepareResult
+	readOnlyPrepareSummary   zipper.ReadOnlyLeafSpanSummary
 	readOnlyPrepareNs        uint64
 	readOnlyPrepareAttempted bool
 	err                      error
@@ -688,8 +688,9 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		return 0, nil, metrics, err
 	}
 	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, opts.applyOptions)
-	if opts.readOnlyPrepareResult != nil {
-		*opts.readOnlyPrepareResult = readOnlyPrepare
+	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareSummary != nil {
+		summary := readOnlyPrepare.LeafSpanSummary()
+		*opts.readOnlyPrepareSummary = summary
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
@@ -737,9 +738,19 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 		}
 	}
 	if delta.IsEmpty() {
+		if opts.applyOptions.PrepareReadOnly {
+			if err = db.runOrderedRootReadOnlyPrepare(idx, baseRoot, delta, opts, alloc); err != nil {
+				return 0, nil, metrics, err
+			}
+		}
 		return baseRoot, nil, metrics, nil
 	}
 	if baseRoot == 0 {
+		if opts.applyOptions.PrepareReadOnly {
+			if err = db.runOrderedRootReadOnlyPrepare(idx, baseRoot, delta, opts, alloc); err != nil {
+				return 0, nil, metrics, err
+			}
+		}
 		iter := newOrderedRootDeltaBatchIterator(delta, includeDeletedOnColdBuild)
 		defer func() { _ = iter.Close() }()
 		if coldBuildAlloc == nil {
@@ -763,17 +774,39 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 	if err != nil {
 		return 0, nil, metrics, err
 	}
-	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareAttempted != nil {
+	if opts.applyOptions.PrepareReadOnly {
+		if err = runOrderedRootReadOnlyPrepare(rootZipper, baseRoot, delta, opts); err != nil {
+			return 0, nil, metrics, err
+		}
+		opts.applyOptions.PrepareReadOnly = false
+	}
+	newRoot, retired, metrics, _, _, err = applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, opts.applyOptions)
+	return newRoot, retired, metrics, err
+}
+
+func (db *DB) runOrderedRootReadOnlyPrepare(idx *indexGen, baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions, alloc zipper.PageAllocator) error {
+	rootZipper, err := db.orderedRootZipperForOptionsWithAllocator(idx, opts, alloc)
+	if err != nil {
+		return err
+	}
+	return runOrderedRootReadOnlyPrepare(rootZipper, baseRoot, delta, opts)
+}
+
+func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions) error {
+	if opts.readOnlyPrepareAttempted != nil {
 		*opts.readOnlyPrepareAttempted = true
 	}
-	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, opts.applyOptions)
-	if opts.readOnlyPrepareResult != nil {
-		*opts.readOnlyPrepareResult = readOnlyPrepare
+	prepareStart := time.Now()
+	prepared, err := rootZipper.PrepareReadOnly(baseRoot, delta, opts.applyOptions.ReadOnlyPrepare)
+	prepareNs := elapsedDurationNs(prepareStart)
+	if opts.readOnlyPrepareSummary != nil {
+		summary := prepared.LeafSpanSummary()
+		*opts.readOnlyPrepareSummary = summary
 	}
 	if opts.readOnlyPrepareNs != nil {
-		*opts.readOnlyPrepareNs = readOnlyPrepareNs
+		*opts.readOnlyPrepareNs = prepareNs
 	}
-	return newRoot, retired, metrics, err
+	return err
 }
 
 func preparedOutputTrackerFromAlloc(alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator) preparedLeafLogOutputRecorder {
@@ -1545,7 +1578,7 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		}
 		if ordered[orderedIdx].PrepareReadOnly {
 			opts.applyOptions.PrepareReadOnly = true
-			opts.readOnlyPrepareResult = &result.readOnlyPrepare
+			opts.readOnlyPrepareSummary = &result.readOnlyPrepareSummary
 			opts.readOnlyPrepareNs = &result.readOnlyPrepareNs
 			opts.readOnlyPrepareAttempted = &result.readOnlyPrepareAttempted
 		}
@@ -1685,7 +1718,7 @@ func recordOrderedRootDeltaBatchGroupApplyResults(
 			phaseStats.rootApplyMetrics.add(result.metrics)
 			phaseStats.rootApplyCalls++
 			if result.readOnlyPrepareAttempted {
-				summary := result.readOnlyPrepare.LeafSpanSummary()
+				summary := result.readOnlyPrepareSummary
 				phaseStats.rootApplyReadOnlyPrepareNs += result.readOnlyPrepareNs
 				phaseStats.rootApplyReadOnlyPrepareCalls++
 				phaseStats.rootApplyReadOnlyPrepareOps += uint64(summary.Ops)

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -52,17 +52,18 @@ type orderedRootPublishStats struct {
 }
 
 type orderedRootPublishOptions struct {
-	maxWarmDeltaOps          int
-	leafPrefixCompression    bool
-	leafColumnar             bool
-	packedValuePtr           bool
-	internalBaseDelta        bool
-	outerLeavesInValueLog    bool
-	leafPageLog              bulk.LeafPageAppender
-	applyOptions             zipper.ApplyOptions
-	readOnlyPrepareSummary   *zipper.ReadOnlyLeafSpanSummary
-	readOnlyPrepareNs        *uint64
-	readOnlyPrepareAttempted *bool
+	maxWarmDeltaOps               int
+	leafPrefixCompression         bool
+	leafColumnar                  bool
+	packedValuePtr                bool
+	internalBaseDelta             bool
+	outerLeavesInValueLog         bool
+	leafPageLog                   bulk.LeafPageAppender
+	applyOptions                  zipper.ApplyOptions
+	readOnlyPrepareSummary        *zipper.ReadOnlyLeafSpanSummary
+	readOnlyPrepareExternalResult *zipper.ReadOnlyPrepareResult
+	readOnlyPrepareNs             *uint64
+	readOnlyPrepareAttempted      *bool
 }
 
 type orderedRootDeltaBatchGroupApplyResult struct {
@@ -168,6 +169,15 @@ type OrderedRootDeltaBatchPublishInput struct {
 	// root apply and records planning stats. It is observability/planning only;
 	// it does not change publish output or enable parallel leaf execution.
 	PrepareReadOnly bool
+	// ReadOnlyPrepareOptions supplies optional reusable buffers for
+	// PrepareReadOnly. The zero value is valid. Callers that keep the matching
+	// ReadOnlyPrepareResult can pass result.ReuseOptions() on later publishes to
+	// reduce allocation churn.
+	ReadOnlyPrepareOptions zipper.ReadOnlyPrepareOptions
+	// ReadOnlyPrepareResult, when non-nil, receives the optional preparation
+	// metadata for this root. Do not share one result pointer across inputs that
+	// may be applied concurrently.
+	ReadOnlyPrepareResult *zipper.ReadOnlyPrepareResult
 }
 
 func closeUnconsumedOrderedRootPublishIterators(ordered []OrderedRootPublishInput, consumed []bool) {
@@ -692,6 +702,9 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		summary := readOnlyPrepare.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
 	}
+	if opts.readOnlyPrepareExternalResult != nil {
+		*opts.readOnlyPrepareExternalResult = readOnlyPrepare
+	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
 	}
@@ -802,6 +815,9 @@ func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, d
 	if opts.readOnlyPrepareSummary != nil {
 		summary := prepared.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
+	}
+	if opts.readOnlyPrepareExternalResult != nil {
+		*opts.readOnlyPrepareExternalResult = prepared
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = prepareNs
@@ -1578,7 +1594,9 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 		}
 		if ordered[orderedIdx].PrepareReadOnly {
 			opts.applyOptions.PrepareReadOnly = true
+			opts.applyOptions.ReadOnlyPrepare = ordered[orderedIdx].ReadOnlyPrepareOptions
 			opts.readOnlyPrepareSummary = &result.readOnlyPrepareSummary
+			opts.readOnlyPrepareExternalResult = ordered[orderedIdx].ReadOnlyPrepareResult
 			opts.readOnlyPrepareNs = &result.readOnlyPrepareNs
 			opts.readOnlyPrepareAttempted = &result.readOnlyPrepareAttempted
 		}

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 type closeCountingUnsafeIterator struct {
@@ -891,6 +892,72 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptionalReadOnl
 	}
 	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_cold_build_plans_total"]; got != "0" {
 		t.Fatalf("readonly prepare cold build plans=%q want 0", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepareResultReuse(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/m", "vm",
+		"root/z", "vz",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+
+	first := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := first.Set([]byte("root/b"), []byte("vb")); err != nil {
+		t.Fatalf("set first delta: %v", err)
+	}
+	defer func() { _ = first.Close() }()
+
+	second := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := second.Set([]byte("root/y"), []byte("vy")); err != nil {
+		t.Fatalf("set second delta: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	var prepared zipper.ReadOnlyPrepareResult
+	publish := func(delta *batch.Batch, opts zipper.ReadOnlyPrepareOptions) uint64 {
+		t.Helper()
+		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+			BaseRoot:               baseRoot,
+			Delta:                  delta,
+			PrepareReadOnly:        true,
+			ReadOnlyPrepareOptions: opts,
+			ReadOnlyPrepareResult:  &prepared,
+		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		})
+		if err != nil {
+			t.Fatalf("publish ordered root delta batch group: %v", err)
+		}
+		if prepared.RootID != baseRoot {
+			t.Fatalf("prepared root=%d want base root %d", prepared.RootID, baseRoot)
+		}
+		if prepared.Ops != 1 || len(prepared.LeafSpans) == 0 {
+			t.Fatalf("prepared ops/spans=%d/%d want 1/>0", prepared.Ops, len(prepared.LeafSpans))
+		}
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+		}
+		return rootIDs[0]
+	}
+
+	baseRoot = publish(first, zipper.ReadOnlyPrepareOptions{})
+	reuse := prepared.ReuseOptions()
+	baseRoot = publish(second, reuse)
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "2" {
+		t.Fatalf("readonly prepare calls=%q want 2", got)
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1018,14 +1019,13 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepare
 	defer func() { _ = second.Close() }()
 
 	var prepared zipper.ReadOnlyPrepareResult
-	publish := func(delta *batch.Batch, opts zipper.ReadOnlyPrepareOptions) uint64 {
+	publish := func(delta *batch.Batch) uint64 {
 		t.Helper()
 		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
-			BaseRoot:               baseRoot,
-			Delta:                  delta,
-			PrepareReadOnly:        true,
-			ReadOnlyPrepareOptions: opts,
-			ReadOnlyPrepareResult:  &prepared,
+			BaseRoot:              baseRoot,
+			Delta:                 delta,
+			PrepareReadOnly:       true,
+			ReadOnlyPrepareResult: &prepared,
 		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
 		})
@@ -1044,13 +1044,74 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepare
 		return rootIDs[0]
 	}
 
-	baseRoot = publish(first, zipper.ReadOnlyPrepareOptions{})
-	reuse := prepared.ReuseOptions()
-	baseRoot = publish(second, reuse)
+	baseRoot = publish(first)
+	firstSpanCap := cap(prepared.LeafSpans)
+	if firstSpanCap == 0 {
+		t.Fatal("prepared leaf span capacity is zero after first publish")
+	}
+	firstSpan := &prepared.LeafSpans[0]
+	baseRoot = publish(second)
+	if cap(prepared.LeafSpans) < firstSpanCap {
+		t.Fatalf("prepared leaf span capacity shrank from %d to %d", firstSpanCap, cap(prepared.LeafSpans))
+	}
+	if &prepared.LeafSpans[0] != firstSpan {
+		t.Fatal("prepared leaf span backing array was not reused")
+	}
 
 	stats := db.Stats()
 	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "2" {
 		t.Fatalf("readonly prepare calls=%q want 2", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepareResultRejectsSharedResult(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRootA, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/a", "va").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root A: %v", err)
+	}
+	baseRootB, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/b", "vb").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root B: %v", err)
+	}
+	deltaA := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := deltaA.Set([]byte("root/a"), []byte("next-a")); err != nil {
+		t.Fatalf("set delta A: %v", err)
+	}
+	defer func() { _ = deltaA.Close() }()
+	deltaB := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := deltaB.Set([]byte("root/b"), []byte("next-b")); err != nil {
+		t.Fatalf("set delta B: %v", err)
+	}
+	defer func() { _ = deltaB.Close() }()
+
+	var shared zipper.ReadOnlyPrepareResult
+	_, _, err = db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{
+			BaseRoot:              baseRootA,
+			Delta:                 deltaA,
+			PrepareReadOnly:       true,
+			ParallelApply:         true,
+			ReadOnlyPrepareResult: &shared,
+		},
+		{
+			BaseRoot:              baseRootB,
+			Delta:                 deltaB,
+			PrepareReadOnly:       true,
+			ParallelApply:         true,
+			ReadOnlyPrepareResult: &shared,
+		},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "read-only prepare result reused") {
+		t.Fatalf("error=%v want shared read-only prepare result rejection", err)
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -894,6 +894,100 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptionalReadOnl
 	}
 }
 
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_DefaultReadOnlyPrepareStatsZero(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/a", "va").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := delta.Set([]byte("root/b"), []byte("vb")); err != nil {
+		t.Fatalf("set delta: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	_, _, err = db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot: baseRoot,
+		Delta:    delta,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish ordered root delta batch group: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "0" {
+		t.Fatalf("readonly prepare calls=%q want 0", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_ops_total"]; got != "0" {
+		t.Fatalf("readonly prepare ops=%q want 0", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPreparePlanKindStats(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cold := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := cold.Set([]byte("root/a"), []byte("va")); err != nil {
+		t.Fatalf("set cold delta: %v", err)
+	}
+	defer func() { _ = cold.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:        0,
+		Delta:           cold,
+		PrepareReadOnly: true,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish cold ordered root delta batch group: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("cold rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	maintenance := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := maintenance.Delete([]byte("root/a")); err != nil {
+		t.Fatalf("delete maintenance delta: %v", err)
+	}
+	defer func() { _ = maintenance.Close() }()
+
+	_, _, err = db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:        rootIDs[0],
+		Delta:           maintenance,
+		PrepareReadOnly: true,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish maintenance ordered root delta batch group: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "2" {
+		t.Fatalf("readonly prepare calls=%q want 2", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_cold_build_plans_total"]; got != "1" {
+		t.Fatalf("readonly prepare cold build plans=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_maintenance_plans_total"]; got != "1" {
+		t.Fatalf("readonly prepare maintenance plans=%q want 1", got)
+	}
+}
+
 func requireUintStat(tb testing.TB, stats map[string]string, key string) uint64 {
 	tb.Helper()
 	raw, ok := stats[key]

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 type closeCountingUnsafeIterator struct {
@@ -975,7 +976,6 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepare
 	if err != nil {
 		t.Fatalf("publish maintenance ordered root delta batch group: %v", err)
 	}
-
 	stats := db.Stats()
 	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "2" {
 		t.Fatalf("readonly prepare calls=%q want 2", got)
@@ -985,6 +985,72 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepare
 	}
 	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_maintenance_plans_total"]; got != "1" {
 		t.Fatalf("readonly prepare maintenance plans=%q want 1", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepareResultReuse(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/m", "vm",
+		"root/z", "vz",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+
+	first := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := first.Set([]byte("root/b"), []byte("vb")); err != nil {
+		t.Fatalf("set first delta: %v", err)
+	}
+	defer func() { _ = first.Close() }()
+
+	second := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := second.Set([]byte("root/y"), []byte("vy")); err != nil {
+		t.Fatalf("set second delta: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	var prepared zipper.ReadOnlyPrepareResult
+	publish := func(delta *batch.Batch, opts zipper.ReadOnlyPrepareOptions) uint64 {
+		t.Helper()
+		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+			BaseRoot:               baseRoot,
+			Delta:                  delta,
+			PrepareReadOnly:        true,
+			ReadOnlyPrepareOptions: opts,
+			ReadOnlyPrepareResult:  &prepared,
+		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		})
+		if err != nil {
+			t.Fatalf("publish ordered root delta batch group: %v", err)
+		}
+		if prepared.RootID != baseRoot {
+			t.Fatalf("prepared root=%d want base root %d", prepared.RootID, baseRoot)
+		}
+		if prepared.Ops != 1 || len(prepared.LeafSpans) == 0 {
+			t.Fatalf("prepared ops/spans=%d/%d want 1/>0", prepared.Ops, len(prepared.LeafSpans))
+		}
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+		}
+		return rootIDs[0]
+	}
+
+	baseRoot = publish(first, zipper.ReadOnlyPrepareOptions{})
+	reuse := prepared.ReuseOptions()
+	baseRoot = publish(second, reuse)
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"]; got != "2" {
+		t.Fatalf("readonly prepare calls=%q want 2", got)
 	}
 }
 

--- a/TreeDB/db/prepared_root_apply_test.go
+++ b/TreeDB/db/prepared_root_apply_test.go
@@ -183,7 +183,7 @@ func TestRecordOrderedRootDeltaBatchGroupApplyResultsCountsZeroReadOnlyPrepare(t
 			idx:                      0,
 			attempted:                true,
 			readOnlyPrepareAttempted: true,
-			readOnlyPrepare: zipper.ReadOnlyPrepareResult{
+			readOnlyPrepareSummary: zipper.ReadOnlyLeafSpanSummary{
 				ExactLeafSpans: true,
 			},
 		}},

--- a/TreeDB/db/system_root_publish_bench_test.go
+++ b/TreeDB/db/system_root_publish_bench_test.go
@@ -171,18 +171,23 @@ func BenchmarkPublishSystemRootIterator_WarmDenseDelta(b *testing.B) {
 }
 
 func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot(b *testing.B) {
-	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, false, false)
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, orderedRootBatchGroupWarmBenchOptions{})
 }
 
 func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRootReadOnlyPrepare(b *testing.B) {
-	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, true, false)
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, orderedRootBatchGroupWarmBenchOptions{prepareReadOnly: true})
 }
 
 func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRootReadOnlyPrepareReuse(b *testing.B) {
-	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, true, true)
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, orderedRootBatchGroupWarmBenchOptions{prepareReadOnly: true, reusePrepare: true})
 }
 
-func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b *testing.B, prepareReadOnly, reusePrepare bool) {
+type orderedRootBatchGroupWarmBenchOptions struct {
+	prepareReadOnly bool
+	reusePrepare    bool
+}
+
+func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b *testing.B, benchOpts orderedRootBatchGroupWarmBenchOptions) {
 	dir := b.TempDir()
 	db, err := Open(Options{Dir: dir})
 	if err != nil {
@@ -207,7 +212,7 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 
 	ordered := []OrderedRootDeltaBatchPublishInput{{
 		StoragePolicy:   OrderedRootStorageDefault,
-		PrepareReadOnly: prepareReadOnly,
+		PrepareReadOnly: benchOpts.prepareReadOnly,
 	}}
 	var prepared zipper.ReadOnlyPrepareResult
 	systemKey := []byte("sys/collections/users/primary")
@@ -215,7 +220,7 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 	publish := func(delta *batch.Batch) {
 		ordered[0].BaseRoot = baseRoot
 		ordered[0].Delta = delta
-		if prepareReadOnly && reusePrepare {
+		if benchOpts.prepareReadOnly && benchOpts.reusePrepare {
 			ordered[0].ReadOnlyPrepareResult = &prepared
 		}
 		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -231,7 +236,7 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 		}
 		baseRoot = rootIDs[0]
 	}
-	if prepareReadOnly && reusePrepare {
+	if benchOpts.prepareReadOnly && benchOpts.reusePrepare {
 		publish(left)
 	}
 	b.ReportAllocs()

--- a/TreeDB/db/system_root_publish_bench_test.go
+++ b/TreeDB/db/system_root_publish_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 type benchSingleKVIterator struct {
@@ -170,14 +171,18 @@ func BenchmarkPublishSystemRootIterator_WarmDenseDelta(b *testing.B) {
 }
 
 func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot(b *testing.B) {
-	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, false)
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, false, false)
 }
 
 func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRootReadOnlyPrepare(b *testing.B) {
-	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, true)
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, true, false)
 }
 
-func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b *testing.B, prepareReadOnly bool) {
+func BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRootReadOnlyPrepareReuse(b *testing.B) {
+	benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b, true, true)
+}
+
+func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleRoot(b *testing.B, prepareReadOnly, reusePrepare bool) {
 	dir := b.TempDir()
 	db, err := Open(Options{Dir: dir})
 	if err != nil {
@@ -204,6 +209,7 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 		StoragePolicy:   OrderedRootStorageDefault,
 		PrepareReadOnly: prepareReadOnly,
 	}}
+	var prepared zipper.ReadOnlyPrepareResult
 	systemKey := []byte("sys/collections/users/primary")
 	var systemValueBuf [20]byte
 	b.ReportAllocs()
@@ -215,6 +221,10 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 		}
 		ordered[0].BaseRoot = baseRoot
 		ordered[0].Delta = delta
+		if prepareReadOnly && reusePrepare {
+			ordered[0].ReadOnlyPrepareOptions = prepared.ReuseOptions()
+			ordered[0].ReadOnlyPrepareResult = &prepared
+		}
 		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			value := strconv.AppendUint(systemValueBuf[:0], rootIDs[0], 10)
 			return &benchSingleKVIterator{

--- a/TreeDB/db/system_root_publish_bench_test.go
+++ b/TreeDB/db/system_root_publish_bench_test.go
@@ -212,17 +212,10 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 	var prepared zipper.ReadOnlyPrepareResult
 	systemKey := []byte("sys/collections/users/primary")
 	var systemValueBuf [20]byte
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		delta := left
-		if i&1 == 1 {
-			delta = right
-		}
+	publish := func(delta *batch.Batch) {
 		ordered[0].BaseRoot = baseRoot
 		ordered[0].Delta = delta
 		if prepareReadOnly && reusePrepare {
-			ordered[0].ReadOnlyPrepareOptions = prepared.ReuseOptions()
 			ordered[0].ReadOnlyPrepareResult = &prepared
 		}
 		_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -237,5 +230,17 @@ func benchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderWarmSingleR
 			b.Fatalf("publish batch group: %v", err)
 		}
 		baseRoot = rootIDs[0]
+	}
+	if prepareReadOnly && reusePrepare {
+		publish(left)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		delta := left
+		if i&1 == 1 {
+			delta = right
+		}
+		publish(delta)
 	}
 }


### PR DESCRIPTION
## Summary

- add optional `ReadOnlyPrepareOptions` / `ReadOnlyPrepareResult` plumbing to `OrderedRootDeltaBatchPublishInput`
- let opt-in ordered-root callers feed `ReadOnlyPrepareResult.ReuseOptions()` back into later publishes
- add a DB benchmark variant proving read-only prepare reuse returns the ordered-root publish path to baseline allocation count

## Validation

```text
PASS go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_(OptionalReadOnlyPrepareStats|ReadOnlyPrepareResultReuse)|TestRecordOrderedRootDeltaBatchGroupApplyResultsCountsZeroReadOnlyPrepare' -count=1
PASS go test ./TreeDB/zipper ./TreeDB/db -count=1
PASS go test ./TreeDB/db -run '^$' -bench 'BenchmarkPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot' -benchmem -count=3 -benchtime=1s
PASS git diff --check
PASS COUNT=1 scripts/treedb_raw_smoke_gate.sh --out /private/tmp/gomap_raw_smoke_pr6f_readonly_reuse --count 1
```

Benchmark allocation result:

```text
WarmSingleRoot                         40 allocs/op
WarmSingleRootReadOnlyPrepare          43 allocs/op
WarmSingleRootReadOnlyPrepareReuse     40 allocs/op
```

Raw smoke artifacts: `/private/tmp/gomap_raw_smoke_pr6f_readonly_reuse`.