### PR TITLE
collections: opt into read-only prepare telemetry

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -623,6 +623,14 @@ type CollectionOptions struct {
 	// Maintenance can later compact overlay roots into base roots; reads merge
 	// overlay roots over base roots while they are pending.
 	BufferedIndexedOverlayRoots bool `json:"buffered_indexed_overlay_roots,omitempty"`
+	// BufferedIndexedReadOnlyPrepare asks indexed write-domain flush publish to
+	// run the DB read-only leaf-span preparation pass. This is
+	// observability/planning only and does not change publish output.
+	BufferedIndexedReadOnlyPrepare bool `json:"buffered_indexed_read_only_prepare,omitempty"`
+	// BufferedIndexedReadOnlyPrepareWorkerCount records deterministic leaf-span
+	// worker-range summaries for this target worker count when read-only prepare
+	// is enabled. Zero disables worker-range summaries.
+	BufferedIndexedReadOnlyPrepareWorkerCount int `json:"buffered_indexed_read_only_prepare_worker_count,omitempty"`
 	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
 	// units queued for the background publisher. Zero uses the native default
 	// when async flush is enabled on an indexed schema.
@@ -5531,7 +5539,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.batch.rootOverlayFilters = rootOverlayFilters
-		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.mergedUnit.rootPolicies, work.batch.rootOverlays)
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.mergedUnit.rootPolicies, work.batch.rootOverlays, work.meta.Options.BufferedIndexedReadOnlyPrepare, work.meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount)
 		if err != nil {
 			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
@@ -5575,7 +5583,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	work.batch.rootBaseIDs = view.rootBaseIDs
 	work.batch.rootCount = len(view.rootNames)
 	work.batch.effectiveRecords = view.effectiveRecords
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies)
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies, work.meta.Options.BufferedIndexedReadOnlyPrepare, work.meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount)
 	if err != nil {
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
@@ -5615,15 +5623,17 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	return publishErr
 }
 
-func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64, prepareReadOnly bool, readOnlyPrepareWorkerCount int) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
 	specs := make([]bufferedRootDeltaBatchSpec, len(rootNames))
 	for i, rootName := range rootNames {
 		specs[i] = bufferedRootDeltaBatchSpec{
-			rootName:                  rootName,
-			baseRoot:                  overlayDeltaBaseRoot(rootOverlays[rootName]),
-			storagePolicy:             rootPolicies[rootName],
-			includeDeletedOnColdBuild: true,
-			parallelApply:             true,
+			rootName:                   rootName,
+			baseRoot:                   overlayDeltaBaseRoot(rootOverlays[rootName]),
+			storagePolicy:              rootPolicies[rootName],
+			includeDeletedOnColdBuild:  true,
+			parallelApply:              true,
+			prepareReadOnly:            prepareReadOnly,
+			readOnlyPrepareWorkerCount: readOnlyPrepareWorkerCount,
 		}
 	}
 	return buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs, rootRuns)
@@ -5636,7 +5646,7 @@ func overlayDeltaBaseRoot(overlays []uint64) uint64 {
 	return 0
 }
 
-func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, prepareReadOnly bool, readOnlyPrepareWorkerCount int) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
 	specs := make([]bufferedRootDeltaBatchSpec, 0, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := rootBaseIDs[rootName]
@@ -5644,21 +5654,25 @@ func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[s
 			return nil, func() {}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		specs = append(specs, bufferedRootDeltaBatchSpec{
-			rootName:      rootName,
-			baseRoot:      baseRoot,
-			storagePolicy: rootPolicies[rootName],
-			parallelApply: true,
+			rootName:                   rootName,
+			baseRoot:                   baseRoot,
+			storagePolicy:              rootPolicies[rootName],
+			parallelApply:              true,
+			prepareReadOnly:            prepareReadOnly,
+			readOnlyPrepareWorkerCount: readOnlyPrepareWorkerCount,
 		})
 	}
 	return buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs, rootRuns)
 }
 
 type bufferedRootDeltaBatchSpec struct {
-	rootName                  string
-	baseRoot                  uint64
-	storagePolicy             backenddb.OrderedRootStoragePolicy
-	includeDeletedOnColdBuild bool
-	parallelApply             bool
+	rootName                   string
+	baseRoot                   uint64
+	storagePolicy              backenddb.OrderedRootStoragePolicy
+	includeDeletedOnColdBuild  bool
+	parallelApply              bool
+	prepareReadOnly            bool
+	readOnlyPrepareWorkerCount int
 }
 
 func buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs []bufferedRootDeltaBatchSpec, rootRuns map[string][]memtable.Table) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -5739,11 +5753,13 @@ func buildBufferedRootDeltaBatchPublishInput(spec bufferedRootDeltaBatchSpec, ro
 		return err
 	}
 	*ordered = backenddb.OrderedRootDeltaBatchPublishInput{
-		BaseRoot:                  spec.baseRoot,
-		Delta:                     delta,
-		StoragePolicy:             spec.storagePolicy,
-		IncludeDeletedOnColdBuild: spec.includeDeletedOnColdBuild,
-		ParallelApply:             spec.parallelApply,
+		BaseRoot:                   spec.baseRoot,
+		Delta:                      delta,
+		StoragePolicy:              spec.storagePolicy,
+		IncludeDeletedOnColdBuild:  spec.includeDeletedOnColdBuild,
+		ParallelApply:              spec.parallelApply,
+		PrepareReadOnly:            spec.prepareReadOnly,
+		ReadOnlyPrepareWorkerCount: spec.readOnlyPrepareWorkerCount,
 	}
 	return nil
 }
@@ -6421,7 +6437,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays, meta.Options.BufferedIndexedReadOnlyPrepare, meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount)
 		if err != nil {
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
@@ -6456,7 +6472,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 			return err
 		}
 		defer resetIndexedSemanticPublishView(view)
-		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies)
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies, meta.Options.BufferedIndexedReadOnlyPrepare, meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount)
 		if err != nil {
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
@@ -13653,6 +13669,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits < 0 {
 		return CollectionMeta{}, errors.New("collections: buffered indexed async flush max queued units cannot be negative")
 	}
+	if meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed read-only prepare worker count cannot be negative")
+	}
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return CollectionMeta{}, err
@@ -13695,9 +13714,13 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedAsyncFlush = false
 		meta.Options.BufferedIndexedOverlayRoots = false
+		meta.Options.BufferedIndexedReadOnlyPrepare = false
+		meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount = 0
 		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
+		meta.Options.BufferedIndexedReadOnlyPrepare = false
+		meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount = 0
 	} else {
 		meta.Options.BufferedIndexedWrites = true
 		defaultMaxDocuments := DefaultIndexedWriteMemtableMaxDocuments
@@ -13715,6 +13738,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		}
 		if meta.Options.BufferedIndexedAsyncFlush && meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits == 0 {
 			meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
+		}
+		if !meta.Options.BufferedIndexedReadOnlyPrepare {
+			meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount = 0
 		}
 	}
 	return meta, nil

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1311,6 +1311,131 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedFlushReadOnlyPrepareDefaultOff(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	before := d.Stats()
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("flush all: %v", err)
+	}
+	after := d.Stats()
+	if got := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total"); got != 0 {
+		t.Fatalf("read-only prepare calls delta=%d want 0 by default", got)
+	}
+	if got := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_worker_ranges_total"); got != 0 {
+		t.Fatalf("read-only prepare worker ranges delta=%d want 0 by default", got)
+	}
+}
+
+func TestCollectionIndexedFlushReadOnlyPrepareOptInReportsDBStats(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedReadOnlyPrepare:            true,
+			BufferedIndexedReadOnlyPrepareWorkerCount: 4,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if !meta.Options.BufferedIndexedReadOnlyPrepare || meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount != 4 {
+		t.Fatalf("normalized read-only prepare options=%+v want enabled/4", meta.Options)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+			[]byte(`{"email":"katherine@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	before := d.Stats()
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("flush all: %v", err)
+	}
+	after := d.Stats()
+	calls := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_calls_total")
+	if calls == 0 {
+		t.Fatal("read-only prepare calls delta=0 want positive")
+	}
+	if got := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_ops_total"); got == 0 {
+		t.Fatal("read-only prepare ops delta=0 want positive")
+	}
+	if got := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_leaf_spans_total"); got == 0 {
+		t.Fatal("read-only prepare leaf spans delta=0 want positive")
+	}
+	targets := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_worker_targets_total")
+	if want := calls * 4; targets != want {
+		t.Fatalf("read-only prepare worker target delta=%d want calls*4=%d", targets, want)
+	}
+	if got := collectionDBUintStatDelta(t, before, after, "treedb.publish.ordered_root_delta_group.root_apply_readonly_prepare_worker_ranges_total"); got == 0 {
+		t.Fatal("read-only prepare worker ranges delta=0 want positive")
+	}
+}
+
+func collectionDBUintStatDelta(tb testing.TB, before, after map[string]string, key string) uint64 {
+	tb.Helper()
+	beforeValue := collectionDBUintStat(tb, before, key)
+	afterValue := collectionDBUintStat(tb, after, key)
+	if afterValue < beforeValue {
+		tb.Fatalf("stat %s decreased from %d to %d", key, beforeValue, afterValue)
+	}
+	return afterValue - beforeValue
+}
+
+func collectionDBUintStat(tb testing.TB, stats map[string]string, key string) uint64 {
+	tb.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		tb.Fatalf("stats missing %s", key)
+	}
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		tb.Fatalf("parse stat %s=%q: %v", key, raw, err)
+	}
+	return value
+}
+
 func TestCollectionRootDeltaPlanStatsCountsPointerValueBytes(t *testing.T) {
 	delta := batch.New(nil, 0)
 	defer func() { _ = delta.Close() }()
@@ -4465,7 +4590,7 @@ func TestBuildBufferedRootDeltaBatchPublishInputsParallelPreservesRootOrderAndTo
 		cityName:    backenddb.OrderedRootStoragePagerLeaves,
 	}
 
-	ordered, cleanup, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, rootRuns, rootBaseIDs, rootPolicies)
+	ordered, cleanup, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, rootRuns, rootBaseIDs, rootPolicies, false, 0)
 	if err != nil {
 		t.Fatalf("build buffered root deltas: %v", err)
 	}
@@ -4486,6 +4611,9 @@ func TestBuildBufferedRootDeltaBatchPublishInputsParallelPreservesRootOrderAndTo
 		}
 		if ordered[i].IncludeDeletedOnColdBuild {
 			t.Fatalf("ordered[%d] IncludeDeletedOnColdBuild=true want false", i)
+		}
+		if ordered[i].PrepareReadOnly || ordered[i].ReadOnlyPrepareWorkerCount != 0 {
+			t.Fatalf("ordered[%d] read-only prepare=%t/%d want false/0", i, ordered[i].PrepareReadOnly, ordered[i].ReadOnlyPrepareWorkerCount)
 		}
 	}
 
@@ -4538,7 +4666,7 @@ func TestBuildBufferedRootOverlayDeltaBatchPublishInputsPreservesColdTombstones(
 		cityName:    nil,
 	}
 
-	ordered, cleanup, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, rootRuns, rootPolicies, rootOverlays)
+	ordered, cleanup, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, rootRuns, rootPolicies, rootOverlays, false, 0)
 	if err != nil {
 		t.Fatalf("build overlay root deltas: %v", err)
 	}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -125,8 +125,8 @@ type benchmarkResult struct {
 	TreeDBBufferedIndexedWriteMaxRootRuns         int                 `json:"treedb_buffered_indexed_write_max_root_runs"`
 	TreeDBBufferedIndexedAsyncFlush               bool                `json:"treedb_buffered_indexed_async_flush,omitempty"`
 	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int                 `json:"treedb_buffered_indexed_async_flush_max_queued_units,omitempty"`
-	TreeDBBufferedIndexedReadOnlyPrepare          bool                `json:"treedb_buffered_indexed_read_only_prepare,omitempty"`
-	TreeDBBufferedIndexedReadOnlyPrepareWorkers   int                 `json:"treedb_buffered_indexed_read_only_prepare_workers,omitempty"`
+	TreeDBBufferedIndexedReadOnlyPrepare          bool                `json:"treedb_buffered_indexed_read_only_prepare"`
+	TreeDBBufferedIndexedReadOnlyPrepareWorkers   int                 `json:"treedb_buffered_indexed_read_only_prepare_workers"`
 	TreeDBMaintenanceMode                         string              `json:"treedb_maintenance_mode,omitempty"`
 	PrebuildDocuments                             bool                `json:"prebuild_documents,omitempty"`
 	Phases                                        []phaseResult       `json:"phases"`
@@ -603,7 +603,7 @@ func parseConfig(args []string) (config, error) {
 	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers < 0 {
 		return config{}, errors.New("treedb-buffered-indexed-read-only-prepare-workers must be >= 0")
 	}
-	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers > 0 && !cfg.TreeDBBufferedIndexedReadOnlyPrepare {
+	if seenFlags["treedb-buffered-indexed-read-only-prepare-workers"] && !cfg.TreeDBBufferedIndexedReadOnlyPrepare {
 		return config{}, errors.New("treedb-buffered-indexed-read-only-prepare-workers requires -treedb-buffered-indexed-read-only-prepare")
 	}
 	if cfg.Format != "text" && cfg.Format != "json" {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -77,6 +77,8 @@ type config struct {
 	TreeDBBufferedIndexedWriteMaxRootRuns         int
 	TreeDBBufferedIndexedAsyncFlush               bool
 	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int
+	TreeDBBufferedIndexedReadOnlyPrepare          bool
+	TreeDBBufferedIndexedReadOnlyPrepareWorkers   int
 	TreeDBMaintenance                             string
 	PrebuildDocuments                             bool
 	ProfileDir                                    string
@@ -123,6 +125,8 @@ type benchmarkResult struct {
 	TreeDBBufferedIndexedWriteMaxRootRuns         int                 `json:"treedb_buffered_indexed_write_max_root_runs"`
 	TreeDBBufferedIndexedAsyncFlush               bool                `json:"treedb_buffered_indexed_async_flush,omitempty"`
 	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int                 `json:"treedb_buffered_indexed_async_flush_max_queued_units,omitempty"`
+	TreeDBBufferedIndexedReadOnlyPrepare          bool                `json:"treedb_buffered_indexed_read_only_prepare,omitempty"`
+	TreeDBBufferedIndexedReadOnlyPrepareWorkers   int                 `json:"treedb_buffered_indexed_read_only_prepare_workers,omitempty"`
 	TreeDBMaintenanceMode                         string              `json:"treedb_maintenance_mode,omitempty"`
 	PrebuildDocuments                             bool                `json:"prebuild_documents,omitempty"`
 	Phases                                        []phaseResult       `json:"phases"`
@@ -480,6 +484,8 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "treedb-buffered-indexed-write-max-root-runs", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "TreeDB indexed collection write-domain root-run auto-flush threshold; explicit 0 disables this trigger; omitted with docs/bytes override keeps the compatibility default")
 	fs.BoolVar(&cfg.TreeDBBufferedIndexedAsyncFlush, "treedb-buffered-indexed-async-flush", false, "TreeDB indexed collection threshold flushes publish in the background; explicit Flush/Close still drain before returning")
 	fs.IntVar(&cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, "treedb-buffered-indexed-async-flush-max-queued-units", 0, "TreeDB indexed collection background flush unit queue limit; 0 uses the collection default when async flush is enabled")
+	fs.BoolVar(&cfg.TreeDBBufferedIndexedReadOnlyPrepare, "treedb-buffered-indexed-read-only-prepare", false, "TreeDB indexed collection flush publish runs read-only leaf-span preparation for observability; does not change publish output")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers, "treedb-buffered-indexed-read-only-prepare-workers", 0, "TreeDB indexed collection read-only prepare worker target for range summaries; requires -treedb-buffered-indexed-read-only-prepare")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
 	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
@@ -593,6 +599,12 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits < 0 {
 		return config{}, errors.New("treedb-buffered-indexed-async-flush-max-queued-units must be >= 0")
+	}
+	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers < 0 {
+		return config{}, errors.New("treedb-buffered-indexed-read-only-prepare-workers must be >= 0")
+	}
+	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers > 0 && !cfg.TreeDBBufferedIndexedReadOnlyPrepare {
+		return config{}, errors.New("treedb-buffered-indexed-read-only-prepare-workers requires -treedb-buffered-indexed-read-only-prepare")
 	}
 	if cfg.Format != "text" && cfg.Format != "json" {
 		return config{}, fmt.Errorf("unknown format %q", cfg.Format)
@@ -796,14 +808,16 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	server.Collections = manager
 	server.MaxFindScanDocuments = cfg.Documents
 	server.DefaultCollectionOptions = collections.CollectionOptions{
-		DocumentFormat:                          cfg.TreeDBDocumentFormat,
-		DataRootStoragePolicy:                   cfg.TreeDBDataRootStorage,
-		IndexStateStoragePolicy:                 cfg.TreeDBIndexStateRootStorage,
-		BufferedIndexedWriteMaxDocuments:        cfg.TreeDBBufferedIndexedWriteMaxDocuments,
-		BufferedIndexedWriteMaxBytes:            cfg.TreeDBBufferedIndexedWriteMaxBytes,
-		BufferedIndexedWriteMaxRootRuns:         cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
-		BufferedIndexedAsyncFlush:               cfg.TreeDBBufferedIndexedAsyncFlush,
-		BufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+		DocumentFormat:                            cfg.TreeDBDocumentFormat,
+		DataRootStoragePolicy:                     cfg.TreeDBDataRootStorage,
+		IndexStateStoragePolicy:                   cfg.TreeDBIndexStateRootStorage,
+		BufferedIndexedWriteMaxDocuments:          cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:              cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRootRuns:           cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		BufferedIndexedAsyncFlush:                 cfg.TreeDBBufferedIndexedAsyncFlush,
+		BufferedIndexedAsyncFlushMaxQueuedUnits:   cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+		BufferedIndexedReadOnlyPrepare:            cfg.TreeDBBufferedIndexedReadOnlyPrepare,
+		BufferedIndexedReadOnlyPrepareWorkerCount: cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers,
 	}
 	server.DefaultIndexStoragePolicy = cfg.TreeDBIndexRootStorage
 
@@ -1122,6 +1136,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBBufferedIndexedWriteMaxRootRuns = cfg.TreeDBBufferedIndexedWriteMaxRootRuns
 		result.TreeDBBufferedIndexedAsyncFlush = cfg.TreeDBBufferedIndexedAsyncFlush
 		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits
+		result.TreeDBBufferedIndexedReadOnlyPrepare = cfg.TreeDBBufferedIndexedReadOnlyPrepare
+		result.TreeDBBufferedIndexedReadOnlyPrepareWorkers = cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers
 		result.TreeDBMaintenanceMode = cfg.TreeDBMaintenance
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
@@ -1545,6 +1561,8 @@ func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config,
 	result.TreeDBBufferedIndexedWriteMaxRootRuns = meta.Options.BufferedIndexedWriteMaxRootRuns
 	result.TreeDBBufferedIndexedAsyncFlush = meta.Options.BufferedIndexedAsyncFlush
 	result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits
+	result.TreeDBBufferedIndexedReadOnlyPrepare = meta.Options.BufferedIndexedReadOnlyPrepare
+	result.TreeDBBufferedIndexedReadOnlyPrepareWorkers = meta.Options.BufferedIndexedReadOnlyPrepareWorkerCount
 	return nil
 }
 
@@ -3073,12 +3091,14 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s\n",
+			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d buffered_indexed_read_only_prepare=%t buffered_indexed_read_only_prepare_workers=%d maintenance=%s\n",
 				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
 				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
 				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
-				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode)
+				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+				result.TreeDBBufferedIndexedReadOnlyPrepare, result.TreeDBBufferedIndexedReadOnlyPrepareWorkers,
+				result.TreeDBMaintenanceMode)
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1072,6 +1072,11 @@ func TestParseConfigTreeDBBufferedIndexedReadOnlyPrepareWorkersRequirePrepare(t 
 	if err == nil || !strings.Contains(err.Error(), "requires -treedb-buffered-indexed-read-only-prepare") {
 		t.Fatalf("parse workers without prepare err=%v want requires prepare", err)
 	}
+
+	_, err = parseConfig([]string{"-treedb-buffered-indexed-read-only-prepare-workers", "0"})
+	if err == nil || !strings.Contains(err.Error(), "requires -treedb-buffered-indexed-read-only-prepare") {
+		t.Fatalf("parse explicit zero workers without prepare err=%v want requires prepare", err)
+	}
 }
 
 func TestParseConfigAcceptsTreeDBBSONDocumentFormat(t *testing.T) {
@@ -2145,6 +2150,31 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
 			decoded.TreeDBBufferedIndexedReadOnlyPrepare,
 			decoded.TreeDBBufferedIndexedReadOnlyPrepareWorkers)
+	}
+}
+
+func TestWriteResultIncludesTreeDBBufferedIndexedReadOnlyPrepareDefaultsJSON(t *testing.T) {
+	result := &benchmarkResult{
+		Target:     "treedb",
+		Database:   "bench",
+		Collection: "docs",
+		Documents:  1,
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal json result: %v", err)
+	}
+	for _, key := range []string{
+		"treedb_buffered_indexed_read_only_prepare",
+		"treedb_buffered_indexed_read_only_prepare_workers",
+	} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("json result omitted %s: %s", key, out.String())
+		}
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -991,6 +991,12 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 0 {
 		t.Fatalf("TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits=%d want 0", cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
 	}
+	if cfg.TreeDBBufferedIndexedReadOnlyPrepare {
+		t.Fatal("TreeDBBufferedIndexedReadOnlyPrepare=true want false by default")
+	}
+	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers != 0 {
+		t.Fatalf("TreeDBBufferedIndexedReadOnlyPrepareWorkers=%d want 0", cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers)
+	}
 	if cfg.InsertProducers != 1 {
 		t.Fatalf("InsertProducers=%d want 1", cfg.InsertProducers)
 	}
@@ -1032,6 +1038,8 @@ func TestParseConfigTreeDBBufferedIndexedWriteThresholds(t *testing.T) {
 		"-treedb-buffered-indexed-write-max-root-runs", "90",
 		"-treedb-buffered-indexed-async-flush",
 		"-treedb-buffered-indexed-async-flush-max-queued-units", "3",
+		"-treedb-buffered-indexed-read-only-prepare",
+		"-treedb-buffered-indexed-read-only-prepare-workers", "4",
 	})
 	if err != nil {
 		t.Fatalf("parse buffered indexed thresholds: %v", err)
@@ -1050,6 +1058,19 @@ func TestParseConfigTreeDBBufferedIndexedWriteThresholds(t *testing.T) {
 	}
 	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
 		t.Fatalf("TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits=%d want 3", cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
+	}
+	if !cfg.TreeDBBufferedIndexedReadOnlyPrepare {
+		t.Fatal("TreeDBBufferedIndexedReadOnlyPrepare=false want true")
+	}
+	if cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers != 4 {
+		t.Fatalf("TreeDBBufferedIndexedReadOnlyPrepareWorkers=%d want 4", cfg.TreeDBBufferedIndexedReadOnlyPrepareWorkers)
+	}
+}
+
+func TestParseConfigTreeDBBufferedIndexedReadOnlyPrepareWorkersRequirePrepare(t *testing.T) {
+	_, err := parseConfig([]string{"-treedb-buffered-indexed-read-only-prepare-workers", "4"})
+	if err == nil || !strings.Contains(err.Error(), "requires -treedb-buffered-indexed-read-only-prepare") {
+		t.Fatalf("parse workers without prepare err=%v want requires prepare", err)
 	}
 }
 
@@ -2078,6 +2099,8 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		TreeDBBufferedIndexedWriteMaxRootRuns:  90,
 		TreeDBBufferedIndexedAsyncFlush:        true,
 		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: 3,
+		TreeDBBufferedIndexedReadOnlyPrepare:          true,
+		TreeDBBufferedIndexedReadOnlyPrepareWorkers:   4,
 		TreeDBMaintenanceMode:                         "none",
 	}
 	var out bytes.Buffer
@@ -2091,6 +2114,8 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		"buffered_indexed_max_root_runs=90",
 		"buffered_indexed_async_flush=true",
 		"buffered_indexed_async_max_queued_units=3",
+		"buffered_indexed_read_only_prepare=true",
+		"buffered_indexed_read_only_prepare_workers=4",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %s: %q", want, text)
@@ -2109,13 +2134,17 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		decoded.TreeDBBufferedIndexedWriteMaxBytes != 5678 ||
 		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 ||
 		!decoded.TreeDBBufferedIndexedAsyncFlush ||
-		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
-		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d want 1234/5678/90/true/3",
+		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 ||
+		!decoded.TreeDBBufferedIndexedReadOnlyPrepare ||
+		decoded.TreeDBBufferedIndexedReadOnlyPrepareWorkers != 4 {
+		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d readonly=%t readonlyWorkers=%d want 1234/5678/90/true/3/true/4",
 			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
 			decoded.TreeDBBufferedIndexedWriteMaxBytes,
 			decoded.TreeDBBufferedIndexedWriteMaxRootRuns,
 			decoded.TreeDBBufferedIndexedAsyncFlush,
-			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
+			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+			decoded.TreeDBBufferedIndexedReadOnlyPrepare,
+			decoded.TreeDBBufferedIndexedReadOnlyPrepareWorkers)
 	}
 }
 
@@ -2129,11 +2158,13 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: "bench.docs",
 		Options: collections.CollectionOptions{
-			BufferedIndexedWriteMaxDocuments:        0,
-			BufferedIndexedWriteMaxBytes:            777,
-			BufferedIndexedWriteMaxRootRuns:         0,
-			BufferedIndexedAsyncFlush:               true,
-			BufferedIndexedAsyncFlushMaxQueuedUnits: 3,
+			BufferedIndexedWriteMaxDocuments:          0,
+			BufferedIndexedWriteMaxBytes:              777,
+			BufferedIndexedWriteMaxRootRuns:           0,
+			BufferedIndexedAsyncFlush:                 true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits:   3,
+			BufferedIndexedReadOnlyPrepare:            true,
+			BufferedIndexedReadOnlyPrepareWorkerCount: 4,
 		},
 		Indexes: []collections.IndexDefinition{{Name: "email_1", Field: "email", ValueType: collections.IndexValueString, Unique: true}},
 	}); err != nil {
@@ -2157,13 +2188,17 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 		result.TreeDBBufferedIndexedWriteMaxBytes != 777 ||
 		result.TreeDBBufferedIndexedWriteMaxRootRuns != 0 ||
 		!result.TreeDBBufferedIndexedAsyncFlush ||
-		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
-		t.Fatalf("effective thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d want %d/777/0/true/3",
+		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 ||
+		!result.TreeDBBufferedIndexedReadOnlyPrepare ||
+		result.TreeDBBufferedIndexedReadOnlyPrepareWorkers != 4 {
+		t.Fatalf("effective thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d readonly=%t readonlyWorkers=%d want %d/777/0/true/3/true/4",
 			result.TreeDBBufferedIndexedWriteMaxDocuments,
 			result.TreeDBBufferedIndexedWriteMaxBytes,
 			result.TreeDBBufferedIndexedWriteMaxRootRuns,
 			result.TreeDBBufferedIndexedAsyncFlush,
 			result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+			result.TreeDBBufferedIndexedReadOnlyPrepare,
+			result.TreeDBBufferedIndexedReadOnlyPrepareWorkers,
 			collections.DefaultIndexedWriteMemtableAsyncFlushMaxDocuments)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a default-off collection indexed flush option that lets benchmark runs opt into DB read-only leaf-span prepare telemetry during indexed write-domain publish.

This wires collection indexed flush materialization into the DB ordered-root fields added earlier in the stack:

- `BufferedIndexedReadOnlyPrepare`
- `BufferedIndexedReadOnlyPrepareWorkerCount`
- `OrderedRootDeltaBatchPublishInput.PrepareReadOnly`
- `OrderedRootDeltaBatchPublishInput.ReadOnlyPrepareWorkerCount`

The default path remains off, so ordinary collection publish behavior and allocations are unchanged.

## Benchmark / CLI support

`cmd/mongo_gateway_bench` now accepts:

- `-treedb-buffered-indexed-read-only-prepare`
- `-treedb-buffered-indexed-read-only-prepare-workers N`

The worker flag requires the prepare flag. Result JSON/text records the effective normalized options.

## Validation

Tests:

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedFlushReadOnlyPrepare|TestBuildBufferedRootDeltaBatchPublishInputs|TestBuildBufferedRootOverlayDeltaBatchPublishInputs|TestCollectionManagerStatsExposeIndexedWriteDomainMetrics' -count=1
go test ./cmd/mongo_gateway_bench -run 'TestParseConfigTreeDBCorrectnessDefaults|TestParseConfigTreeDBBufferedIndexedWriteThresholds|TestParseConfigTreeDBBufferedIndexedReadOnlyPrepareWorkersRequirePrepare|TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata' -count=1
go test ./TreeDB/db ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1
```

Default-off allocation comparison against the #1362 base branch:

```bash
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape/batch_80$' -benchmem -count=3 -benchtime=100x
```

- #1362 base: `24 allocs/op` in all 3 runs.
- this branch: `24 allocs/op` in all 3 runs.

Benchmark smoke evidence:

Default run keeps telemetry at zero:

```bash
go run ./cmd/mongo_gateway_bench -target treedb -documents 120 -batch-size 40 -reads 0 -range-reads 0 -updates 80 -secondary-indexes 2 -treedb-document-format bson -treedb-maintenance none -format json -timeout 2m
```

- final `root_apply_readonly_prepare_calls_total`: `0`
- final `root_apply_readonly_prepare_worker_targets_total`: `0`

Opt-in run emits collection-driven DB telemetry:

```bash
go run ./cmd/mongo_gateway_bench -target treedb -documents 120 -batch-size 40 -reads 0 -range-reads 0 -updates 80 -secondary-indexes 2 -treedb-document-format bson -treedb-buffered-indexed-read-only-prepare -treedb-buffered-indexed-read-only-prepare-workers 4 -treedb-maintenance none -format json -timeout 2m
```

- final `root_apply_readonly_prepare_calls_total`: `4`
- final worker targets: `16`
- final worker ranges: `7`
- update phase delta: calls `1`, targets `4`, ranges `4`
