### PR TITLE
db: pool temporary read-only prepare results

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -728,10 +728,17 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		pooledResult = acquireOrderedRootReadOnlyPrepareResult()
 		applyOptions.ReadOnlyPrepare = pooledResult.ReuseOptions()
 	}
+	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareAttempted != nil {
+		*opts.readOnlyPrepareAttempted = true
+	}
 	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, applyOptions)
 	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareSummary != nil {
 		summary := readOnlyPrepare.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
+	}
+	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareWorkerSummary != nil {
+		summary := readOnlyPrepare.LeafSpanWorkerRangeSummary(opts.readOnlyPrepareWorkerCount)
+		*opts.readOnlyPrepareWorkerSummary = summary
 	}
 	if opts.readOnlyPrepareCallerResult != nil {
 		*opts.readOnlyPrepareCallerResult = readOnlyPrepare

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -41,6 +41,12 @@ const orderedRootOptimisticSystemDeltaRebaseMaxAttempts = 4
 
 const orderedRootDeltaBatchGroupParallelApplyMinRoots = 2
 
+var orderedRootReadOnlyPrepareResultPool = sync.Pool{
+	New: func() any {
+		return new(zipper.ReadOnlyPrepareResult)
+	},
+}
+
 type orderedRootPublishStats struct {
 	warmAttempts                          uint64
 	warmNativeApplyAttempts               uint64
@@ -812,9 +818,22 @@ func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, d
 	if opts.readOnlyPrepareAttempted != nil {
 		*opts.readOnlyPrepareAttempted = true
 	}
+	prepareOptions := opts.applyOptions.ReadOnlyPrepare
+	var pooledResult *zipper.ReadOnlyPrepareResult
+	if opts.readOnlyPrepareCallerResult == nil {
+		pooledResult, _ = orderedRootReadOnlyPrepareResultPool.Get().(*zipper.ReadOnlyPrepareResult)
+		if pooledResult == nil {
+			pooledResult = new(zipper.ReadOnlyPrepareResult)
+		}
+		prepareOptions = pooledResult.ReuseOptions()
+	}
 	prepareStart := time.Now()
-	prepared, err := rootZipper.PrepareReadOnly(baseRoot, delta, opts.applyOptions.ReadOnlyPrepare)
+	prepared, err := rootZipper.PrepareReadOnly(baseRoot, delta, prepareOptions)
 	prepareNs := elapsedDurationNs(prepareStart)
+	if pooledResult != nil {
+		*pooledResult = prepared
+		defer orderedRootReadOnlyPrepareResultPool.Put(pooledResult)
+	}
 	if opts.readOnlyPrepareSummary != nil {
 		summary := prepared.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -41,8 +41,6 @@ const orderedRootOptimisticSystemDeltaRebaseMaxAttempts = 4
 
 const orderedRootDeltaBatchGroupParallelApplyMinRoots = 2
 
-const orderedRootReadOnlyPrepareResultPoolMaxLeafSpanCap = 4096
-
 var orderedRootReadOnlyPrepareResultPool = sync.Pool{
 	New: func() any {
 		return new(zipper.ReadOnlyPrepareResult)
@@ -61,9 +59,7 @@ func releaseOrderedRootReadOnlyPrepareResult(result *zipper.ReadOnlyPrepareResul
 	if result == nil {
 		return
 	}
-	if cap(result.LeafSpans) > orderedRootReadOnlyPrepareResultPoolMaxLeafSpanCap {
-		*result = zipper.ReadOnlyPrepareResult{}
-	}
+	result.ResetForReuse()
 	orderedRootReadOnlyPrepareResultPool.Put(result)
 }
 

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -47,6 +47,21 @@ var orderedRootReadOnlyPrepareResultPool = sync.Pool{
 	},
 }
 
+func acquireOrderedRootReadOnlyPrepareResult() *zipper.ReadOnlyPrepareResult {
+	result, _ := orderedRootReadOnlyPrepareResultPool.Get().(*zipper.ReadOnlyPrepareResult)
+	if result == nil {
+		return new(zipper.ReadOnlyPrepareResult)
+	}
+	return result
+}
+
+func releaseOrderedRootReadOnlyPrepareResult(result *zipper.ReadOnlyPrepareResult) {
+	if result == nil {
+		return
+	}
+	orderedRootReadOnlyPrepareResultPool.Put(result)
+}
+
 type orderedRootPublishStats struct {
 	warmAttempts                          uint64
 	warmNativeApplyAttempts               uint64
@@ -706,7 +721,13 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	if err != nil {
 		return 0, nil, metrics, err
 	}
-	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, opts.applyOptions)
+	applyOptions := opts.applyOptions
+	var pooledResult *zipper.ReadOnlyPrepareResult
+	if applyOptions.PrepareReadOnly && opts.readOnlyPrepareCallerResult == nil {
+		pooledResult = acquireOrderedRootReadOnlyPrepareResult()
+		applyOptions.ReadOnlyPrepare = pooledResult.ReuseOptions()
+	}
+	newRoot, retired, metrics, readOnlyPrepare, readOnlyPrepareNs, err := applyOrderedRootDeltaWithOptions(rootZipper, baseRoot, delta, applyOptions)
 	if opts.applyOptions.PrepareReadOnly && opts.readOnlyPrepareSummary != nil {
 		summary := readOnlyPrepare.LeafSpanSummary()
 		*opts.readOnlyPrepareSummary = summary
@@ -716,6 +737,10 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	}
 	if opts.readOnlyPrepareNs != nil {
 		*opts.readOnlyPrepareNs = readOnlyPrepareNs
+	}
+	if pooledResult != nil {
+		*pooledResult = readOnlyPrepare
+		releaseOrderedRootReadOnlyPrepareResult(pooledResult)
 	}
 	return newRoot, retired, metrics, err
 }
@@ -821,10 +846,7 @@ func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, d
 	prepareOptions := opts.applyOptions.ReadOnlyPrepare
 	var pooledResult *zipper.ReadOnlyPrepareResult
 	if opts.readOnlyPrepareCallerResult == nil {
-		pooledResult, _ = orderedRootReadOnlyPrepareResultPool.Get().(*zipper.ReadOnlyPrepareResult)
-		if pooledResult == nil {
-			pooledResult = new(zipper.ReadOnlyPrepareResult)
-		}
+		pooledResult = acquireOrderedRootReadOnlyPrepareResult()
 		prepareOptions = pooledResult.ReuseOptions()
 	}
 	prepareStart := time.Now()
@@ -832,7 +854,7 @@ func runOrderedRootReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, d
 	prepareNs := elapsedDurationNs(prepareStart)
 	if pooledResult != nil {
 		*pooledResult = prepared
-		defer orderedRootReadOnlyPrepareResultPool.Put(pooledResult)
+		defer releaseOrderedRootReadOnlyPrepareResult(pooledResult)
 	}
 	if opts.readOnlyPrepareSummary != nil {
 		summary := prepared.LeafSpanSummary()

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -41,6 +41,8 @@ const orderedRootOptimisticSystemDeltaRebaseMaxAttempts = 4
 
 const orderedRootDeltaBatchGroupParallelApplyMinRoots = 2
 
+const orderedRootReadOnlyPrepareResultPoolMaxLeafSpanCap = 4096
+
 var orderedRootReadOnlyPrepareResultPool = sync.Pool{
 	New: func() any {
 		return new(zipper.ReadOnlyPrepareResult)
@@ -58,6 +60,9 @@ func acquireOrderedRootReadOnlyPrepareResult() *zipper.ReadOnlyPrepareResult {
 func releaseOrderedRootReadOnlyPrepareResult(result *zipper.ReadOnlyPrepareResult) {
 	if result == nil {
 		return
+	}
+	if cap(result.LeafSpans) > orderedRootReadOnlyPrepareResultPoolMaxLeafSpanCap {
+		*result = zipper.ReadOnlyPrepareResult{}
 	}
 	orderedRootReadOnlyPrepareResultPool.Put(result)
 }

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -901,6 +901,60 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptionalReadOnl
 	}
 }
 
+func TestPublishOrderedRootDeltaIteratorOptionalReadOnlyPrepareSummary(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/m", "vm",
+		"root/z", "vz",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+
+	opts, err := db.orderedRootPublishOptionsForPolicy(OrderedRootStorageDefault)
+	if err != nil {
+		t.Fatalf("ordered root publish options: %v", err)
+	}
+	var summary zipper.ReadOnlyLeafSpanSummary
+	var workerSummary zipper.ReadOnlyLeafSpanWorkerRangeSummary
+	var attempted bool
+	opts.applyOptions.PrepareReadOnly = true
+	opts.readOnlyPrepareSummary = &summary
+	opts.readOnlyPrepareWorkerSummary = &workerSummary
+	opts.readOnlyPrepareWorkerCount = 4
+	opts.readOnlyPrepareAttempted = &attempted
+
+	newRoot, retired, _, err := db.publishOrderedRootDeltaIterator(baseRoot, mustFrozenSystemMemtable(t,
+		"root/b", "vb",
+		"root/y", "vy",
+	).NewIterator(nil, nil), opts)
+	if err != nil {
+		t.Fatalf("publish ordered root delta iterator: %v", err)
+	}
+	if newRoot == 0 || newRoot == baseRoot {
+		t.Fatalf("new root=%d base=%d want changed non-zero root", newRoot, baseRoot)
+	}
+	if len(retired) == 0 {
+		t.Fatal("retired pages empty; warm iterator apply should retire old root pages")
+	}
+	if summary.Ops != 2 || summary.Spans == 0 || !summary.ExactLeafSpans {
+		t.Fatalf("read-only prepare summary=%+v want ops=2 spans>0 exact", summary)
+	}
+	if workerSummary.TargetWorkers != 4 || workerSummary.Ranges == 0 || workerSummary.Ops != summary.Ops {
+		t.Fatalf("worker summary=%+v want target=4 ranges>0 ops=%d", workerSummary, summary.Ops)
+	}
+	if !attempted {
+		t.Fatal("read-only prepare attempt was not recorded")
+	}
+}
+
 func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ReadOnlyPrepareWorkerRangeStats(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1148,6 +1148,11 @@ type ReadOnlyPrepareResult struct {
 	keyArena []byte
 }
 
+const (
+	readOnlyPrepareResultReuseLeafSpanKeepCap = 4096
+	readOnlyPrepareResultReuseKeyArenaKeepCap = 1 << 20
+)
+
 // LeafSpanSummary returns an allocation-free aggregate view of r's leaf spans.
 func (r ReadOnlyPrepareResult) LeafSpanSummary() ReadOnlyLeafSpanSummary {
 	summary := ReadOnlyLeafSpanSummary{
@@ -1274,6 +1279,25 @@ func (r ReadOnlyPrepareResult) ReuseOptions() ReadOnlyPrepareOptions {
 	return ReadOnlyPrepareOptions{
 		leafSpans: r.LeafSpans[:0],
 		keyArena:  r.keyArena[:0],
+	}
+}
+
+// ResetForReuse clears result metadata while retaining bounded reusable
+// leaf-span and key-arena buffers for a later ReuseOptions call. Oversized
+// buffers are dropped so temporary prepare pools do not retain one-off large
+// batch state indefinitely.
+func (r *ReadOnlyPrepareResult) ResetForReuse() {
+	if r == nil {
+		return
+	}
+	leafSpans := r.LeafSpans
+	keyArena := r.keyArena
+	*r = ReadOnlyPrepareResult{}
+	if cap(leafSpans) <= readOnlyPrepareResultReuseLeafSpanKeepCap {
+		r.LeafSpans = leafSpans[:0]
+	}
+	if cap(keyArena) <= readOnlyPrepareResultReuseKeyArenaKeepCap {
+		r.keyArena = keyArena[:0]
 	}
 }
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -738,6 +738,50 @@ func TestZipperApplyWithOptionsReusesReadOnlyPrepareBuffers(t *testing.T) {
 	}
 }
 
+func TestReadOnlyPrepareResultResetForReuseKeepsBoundedBuffers(t *testing.T) {
+	result := ReadOnlyPrepareResult{
+		RootID:         123,
+		Ops:            2,
+		ExactLeafSpans: true,
+		LeafSpans:      make([]ReadOnlyLeafSpan, 2, 8),
+		keyArena:       make([]byte, 4, 16),
+	}
+	leafBase := &result.LeafSpans[:cap(result.LeafSpans)][0]
+	keyBase := &result.keyArena[:cap(result.keyArena)][0]
+
+	result.ResetForReuse()
+	if result.RootID != 0 || result.Ops != 0 || result.ExactLeafSpans {
+		t.Fatalf("metadata not reset: %+v", result)
+	}
+	if len(result.LeafSpans) != 0 || cap(result.LeafSpans) != 8 {
+		t.Fatalf("leaf spans len/cap=%d/%d want 0/8", len(result.LeafSpans), cap(result.LeafSpans))
+	}
+	if &result.LeafSpans[:cap(result.LeafSpans)][0] != leafBase {
+		t.Fatal("leaf span buffer was not retained")
+	}
+	if len(result.keyArena) != 0 || cap(result.keyArena) != 16 {
+		t.Fatalf("key arena len/cap=%d/%d want 0/16", len(result.keyArena), cap(result.keyArena))
+	}
+	if &result.keyArena[:cap(result.keyArena)][0] != keyBase {
+		t.Fatal("key arena buffer was not retained")
+	}
+}
+
+func TestReadOnlyPrepareResultResetForReuseDropsOversizedBuffers(t *testing.T) {
+	result := ReadOnlyPrepareResult{
+		LeafSpans: make([]ReadOnlyLeafSpan, 1, readOnlyPrepareResultReuseLeafSpanKeepCap+1),
+		keyArena:  make([]byte, 1, readOnlyPrepareResultReuseKeyArenaKeepCap+1),
+	}
+
+	result.ResetForReuse()
+	if cap(result.LeafSpans) != 0 {
+		t.Fatalf("leaf span cap=%d want dropped", cap(result.LeafSpans))
+	}
+	if cap(result.keyArena) != 0 {
+		t.Fatalf("key arena cap=%d want dropped", cap(result.keyArena))
+	}
+}
+
 func TestReadOnlyPrepareResultValidateLeafSpansRejectsInvalidPlans(t *testing.T) {
 	validSpan := ReadOnlyLeafSpan{
 		LowKey:     []byte("a"),


### PR DESCRIPTION
## Summary

- pools temporary `zipper.ReadOnlyPrepareResult` values for ordered-root read-only prepare when the caller did not provide a reusable result
- covers both ordered-root delta batch publish and ordered-root delta iterator publish paths
- keeps caller-owned `ReadOnlyPrepareResult` behavior unchanged for collection/root publish inputs that already attach reuse buffers
- reduces anonymous read-only prepare allocation overhead while preserving summary/stat output
- trims pooled read-only prepare buffers through `ReadOnlyPrepareResult.ResetForReuse` so one-off large span/key-arena state is not retained indefinitely

## Correctness Notes

The pooled result is only used when `readOnlyPrepareCallerResult == nil`. If a caller supplies `ReadOnlyPrepareResult`, that pointer remains the reuse source and output owner exactly as before. Pooled results are returned only after summary, worker-summary, duration, and error handling consume the prepared metadata.

## Validation

```bash
go test ./TreeDB/zipper -run 'ReadOnlyPrepareResultResetForReuse|ApplyWithOptionsReusesReadOnlyPrepareBuffers' -count=1
go test ./TreeDB/db -run 'ReadOnlyPrepare|PreparedRootApply|PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder' -count=1
go test ./TreeDB/db -count=1
go test ./TreeDB/collections -run 'ReadOnlyPrepare|BuildBufferedRootDeltaBatchPublishInputsReusesReadOnlyPrepareResults' -count=1
go test ./TreeDB/zipper ./TreeDB/db -count=1
git diff --check
```

## Benchmark / Allocation Evidence

Baseline artifact from #1368: `/tmp/gomap_pr1368_focus_20260505_040446/db_readonly_prepare_bench.txt`
PR artifacts:

- `/tmp/gomap_pr6n_pool_20260505_040701/db_readonly_prepare_pool_bench.txt`
- `/tmp/gomap_pr6n_pool2_20260505_041107/db_readonly_prepare_pool_bench.txt`
- `/tmp/gomap_pr6n_pool3_20260505_041733/db_readonly_prepare_pool_bench.txt`

Command:

```bash
go test ./TreeDB/db -run '^$' \
  -bench 'PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_WarmSingleRoot(ReadOnlyPrepare|ReadOnlyPrepareReuse|ReadOnlyPrepareWorkerStats)?$' \
  -benchmem -benchtime=100x -count=5
```

Initial `benchstat` summary vs #1368 local baseline:

```text
WarmSingleRootReadOnlyPrepare:            43.00 -> 40.00 allocs/op
WarmSingleRootReadOnlyPrepareWorkerStats: 43.00 -> 40.00 allocs/op
geomean allocs/op:                        41.47 -> 40.00 (-3.55%)

WarmSingleRootReadOnlyPrepare B/op:       5.683Ki -> 5.535Ki
WorkerStats B/op:                         5.683Ki -> 5.535Ki (-2.59%)
geomean B/op:                             5.567Ki -> 5.494Ki (-1.31%)
```

After extending the same pool helper to the iterator path, a repeated focused run still showed anonymous read-only prepare variants at 40 allocs/op. Timing is noisy in these short local runs; the intended win is allocation pressure, not a claimed wall-time improvement.
