### PR TITLE
zipper: add multi-leaf read-only prepare benchmark

### DIFF
--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1325,11 +1325,11 @@ func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {
 	}
 }
 
-func BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B) {
+func BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeafReuse(b *testing.B) {
 	benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b, 257)
 }
 
-func BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf(b *testing.B) {
+func BenchmarkZipperPrepareReadOnlyWarmSparseManyLeafReuse(b *testing.B) {
 	benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b, 4)
 }
 
@@ -1371,6 +1371,7 @@ func benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B, step int) {
 	}
 
 	opts := first.ReuseOptions()
+	last := first
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1381,12 +1382,16 @@ func benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B, step int) {
 		if len(prepared.LeafSpans) != summary.Spans || prepared.Ops != summary.Ops {
 			b.Fatalf("prepared spans/ops=%d/%d want %d/%d", len(prepared.LeafSpans), prepared.Ops, summary.Spans, summary.Ops)
 		}
+		last = prepared
 		opts = prepared.ReuseOptions()
 	}
-	b.ReportMetric(float64(summary.Spans), "leaf_spans/op")
-	b.ReportMetric(float64(summary.Ops), "ops/op")
-	b.ReportMetric(float64(workerSummary.Ranges), "worker_ranges/op")
-	b.ReportMetric(float64(workerSummary.MaxRangeOps), "max_worker_ops/op")
+	b.StopTimer()
+	lastSummary := last.LeafSpanSummary()
+	lastWorkerSummary := last.LeafSpanWorkerRangeSummary(workers)
+	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(lastSummary.Ops), "ops/op")
+	b.ReportMetric(float64(lastWorkerSummary.Ranges), "worker_ranges/op")
+	b.ReportMetric(float64(lastWorkerSummary.MaxRangeOps), "max_worker_ops/op")
 }
 
 func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1326,6 +1326,14 @@ func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {
 }
 
 func BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B) {
+	benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b, 257)
+}
+
+func BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf(b *testing.B) {
+	benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b, 4)
+}
+
+func benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B, step int) {
 	dir := b.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
 	if err != nil {
@@ -1335,7 +1343,6 @@ func BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B) {
 
 	const (
 		keyCount = 8192
-		step     = 257
 		workers  = 4
 	)
 	alloc := &MockAllocator{p: p}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1325,6 +1325,63 @@ func BenchmarkZipperPrepareReadOnlyWarmSparse(b *testing.B) {
 	}
 }
 
+func BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B) {
+	dir := b.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer p.Close()
+
+	const (
+		keyCount = 8192
+		step     = 257
+		workers  = 4
+	)
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildInternalRootWithKeys(b, z, keyCount)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < keyCount; i += step {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		delta.Set(key, []byte("new"))
+	}
+
+	first, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		b.Fatalf("initial PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(b, first)
+	if first.Maintenance || !first.ExactLeafSpans {
+		b.Fatalf("initial prepare maintenance/exact=%v/%v want false/true", first.Maintenance, first.ExactLeafSpans)
+	}
+	summary := first.LeafSpanSummary()
+	workerSummary := first.LeafSpanWorkerRangeSummary(workers)
+	if summary.Spans < 2 || workerSummary.Ranges < 2 {
+		b.Fatalf("initial prepare spans/ranges=%d/%d want multi-leaf plan", summary.Spans, workerSummary.Ranges)
+	}
+
+	opts := first.ReuseOptions()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := z.PrepareReadOnly(rootID, delta, opts)
+		if err != nil {
+			b.Fatalf("PrepareReadOnly: %v", err)
+		}
+		if len(prepared.LeafSpans) != summary.Spans || prepared.Ops != summary.Ops {
+			b.Fatalf("prepared spans/ops=%d/%d want %d/%d", len(prepared.LeafSpans), prepared.Ops, summary.Spans, summary.Ops)
+		}
+		opts = prepared.ReuseOptions()
+	}
+	b.ReportMetric(float64(summary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(summary.Ops), "ops/op")
+	b.ReportMetric(float64(workerSummary.Ranges), "worker_ranges/op")
+	b.ReportMetric(float64(workerSummary.MaxRangeOps), "max_worker_ops/op")
+}
+
 func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {
 	dir := t.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)


### PR DESCRIPTION
## Summary

- Add multi-leaf and many-leaf read-only prepare reuse benchmarks for the #1242 PR6b line.
- Keep this slice behavior-preserving: no root apply, publish, read visibility, prepared output, or parallel execution changes.
- Report planning shape from the measured reuse path: leaf spans, ops, worker ranges, and max ops per worker range.

This PR is stacked on #1369 and is intended as the benchmark baseline for the next PR6b behavior slice: parallel leaf-span work with serial append and upper-tree assembly.

## Local validation

```text
PASS go test ./TreeDB/zipper -count=1
PASS go test ./TreeDB/zipper -run '^$' -bench 'ZipperPrepareReadOnlyWarmSparse(MultiLeaf|ManyLeaf)Reuse$' -benchmem -benchtime=100x -count=3
```

Observed on Apple M3:

```text
BenchmarkZipperPrepareReadOnlyWarmSparseMultiLeafReuse-8  9730-14549 ns/op  32 leaf_spans/op   32 ops/op    4 worker_ranges/op  0 B/op  0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparseManyLeafReuse-8  41441-51361 ns/op  304 leaf_spans/op  2048 ops/op  4 worker_ranges/op  0 B/op  0 allocs/op
```
