### PR TITLE
zipper: add many-leaf warm apply benchmark

### DIFF
--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -29,10 +30,13 @@ func (m *MockAllocator) Alloc(hint uint64) (uint64, error) {
 
 type recyclingMockAllocator struct {
 	p       *pager.Pager
+	mu      sync.Mutex
 	retired []uint64
 }
 
 func (m *recyclingMockAllocator) Alloc(hint uint64) (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	n := len(m.retired)
 	if n > 0 {
 		id := m.retired[n-1]
@@ -43,6 +47,8 @@ func (m *recyclingMockAllocator) Alloc(hint uint64) (uint64, error) {
 }
 
 func (m *recyclingMockAllocator) Recycle(ids []uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.retired = append(m.retired, ids...)
 }
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1333,6 +1333,73 @@ func BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf(b *testing.B) {
 	benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b, 4)
 }
 
+func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
+	dir := b.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer p.Close()
+
+	const (
+		keyCount = 8192
+		step     = 4
+		workers  = 4
+	)
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildInternalRootWithKeys(b, z, keyCount)
+
+	left := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = left.Close() }()
+	right := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = right.Close() }()
+	for i := 0; i < keyCount; i += step {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		left.Set(key, []byte("left"))
+		right.Set(key, []byte("right"))
+	}
+
+	prepared, err := z.PrepareReadOnly(rootID, left, ReadOnlyPrepareOptions{})
+	if err != nil {
+		b.Fatalf("PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(b, prepared)
+	summary := prepared.LeafSpanSummary()
+	workerSummary := prepared.LeafSpanWorkerRangeSummary(workers)
+	if summary.Spans < 2 || summary.Ops == 0 || workerSummary.Ranges < 2 {
+		b.Fatalf("prepare spans/ops/ranges=%d/%d/%d want many-leaf plan", summary.Spans, summary.Ops, workerSummary.Ranges)
+	}
+
+	var total adaptive.Metrics
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		delta := left
+		if i&1 == 1 {
+			delta = right
+		}
+		newRoot, _, metrics, err := z.Apply(rootID, delta)
+		if err != nil {
+			b.Fatalf("Apply: %v", err)
+		}
+		if newRoot == 0 || newRoot == rootID {
+			b.Fatalf("new root=%d old root=%d want changed non-zero root", newRoot, rootID)
+		}
+		rootID = newRoot
+		mergeMetrics(&total, &metrics)
+	}
+	b.ReportMetric(float64(summary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(summary.Ops), "ops/op")
+	b.ReportMetric(float64(workerSummary.Ranges), "worker_ranges/op")
+	b.ReportMetric(float64(workerSummary.MaxRangeOps), "max_worker_ops/op")
+	if b.N > 0 {
+		b.ReportMetric(float64(total.ZipperLeafMerges)/float64(b.N), "leaf_merges/op")
+		b.ReportMetric(float64(total.ZipperInternalMerges)/float64(b.N), "internal_merges/op")
+		b.ReportMetric(float64(total.IndexWriteBytes)/float64(b.N), "index_write_bytes/op")
+	}
+}
+
 func benchmarkZipperPrepareReadOnlyWarmSparseMultiLeaf(b *testing.B, step int) {
 	dir := b.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -27,6 +27,25 @@ func (m *MockAllocator) Alloc(hint uint64) (uint64, error) {
 	return m.p.Alloc(1)
 }
 
+type recyclingMockAllocator struct {
+	p       *pager.Pager
+	retired []uint64
+}
+
+func (m *recyclingMockAllocator) Alloc(hint uint64) (uint64, error) {
+	n := len(m.retired)
+	if n > 0 {
+		id := m.retired[n-1]
+		m.retired = m.retired[:n-1]
+		return id, nil
+	}
+	return m.p.Alloc(1)
+}
+
+func (m *recyclingMockAllocator) Recycle(ids []uint64) {
+	m.retired = append(m.retired, ids...)
+}
+
 type panicValueReader struct{}
 
 func (panicValueReader) Read(ptr page.ValuePtr) ([]byte, error) {
@@ -1346,7 +1365,7 @@ func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
 		step     = 4
 		workers  = 4
 	)
-	alloc := &MockAllocator{p: p}
+	alloc := &recyclingMockAllocator{p: p}
 	z := New(p, alloc)
 	rootID := buildInternalRootWithKeys(b, z, keyCount)
 
@@ -1372,6 +1391,7 @@ func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
 	}
 
 	var total adaptive.Metrics
+	var totalRetired int
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1379,7 +1399,7 @@ func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
 		if i&1 == 1 {
 			delta = right
 		}
-		newRoot, _, metrics, err := z.Apply(rootID, delta)
+		newRoot, retired, metrics, err := z.Apply(rootID, delta)
 		if err != nil {
 			b.Fatalf("Apply: %v", err)
 		}
@@ -1387,6 +1407,8 @@ func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
 			b.Fatalf("new root=%d old root=%d want changed non-zero root", newRoot, rootID)
 		}
 		rootID = newRoot
+		totalRetired += len(retired)
+		alloc.Recycle(retired)
 		mergeMetrics(&total, &metrics)
 	}
 	b.ReportMetric(float64(summary.Spans), "leaf_spans/op")
@@ -1397,6 +1419,7 @@ func BenchmarkZipperApplyWarmSparseManyLeaf(b *testing.B) {
 		b.ReportMetric(float64(total.ZipperLeafMerges)/float64(b.N), "leaf_merges/op")
 		b.ReportMetric(float64(total.ZipperInternalMerges)/float64(b.N), "internal_merges/op")
 		b.ReportMetric(float64(total.IndexWriteBytes)/float64(b.N), "index_write_bytes/op")
+		b.ReportMetric(float64(totalRetired)/float64(b.N), "pending_retired_pages/op")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a warm many-leaf zipper apply benchmark for the #1242 PR6b line.
- Keep this slice benchmark-only: no root apply behavior, read-only prepare behavior, publish semantics, or storage format changes.
- Use the same 8192-key / every-4th-key mutation shape as the many-leaf read-only prepare baseline from #1370.
- Report leaf-span planning shape plus actual apply work: leaf merges, internal merges, and index bytes written per operation.

This is stacked on #1370 and gives the upcoming PR6b behavior slice a direct apply-side baseline.

## Local validation

```text
PASS go test ./TreeDB/zipper -run '^$' -bench 'Zipper(PrepareReadOnlyWarmSparseManyLeaf|ApplyWarmSparseManyLeaf)$' -benchmem -benchtime=50x -count=3
PASS go test ./TreeDB/zipper -count=1
```

Observed on Apple M3:

```text
BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf-8  50   65102 ns/op   304 leaf_spans/op  2048 ops/op  4 worker_ranges/op  0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf-8  50   70298 ns/op   304 leaf_spans/op  2048 ops/op  4 worker_ranges/op  0 allocs/op
BenchmarkZipperPrepareReadOnlyWarmSparseManyLeaf-8  50   95632 ns/op   304 leaf_spans/op  2048 ops/op  4 worker_ranges/op  0 allocs/op

BenchmarkZipperApplyWarmSparseManyLeaf-8            50 2267878 ns/op  304 leaf_merges/op  3 internal_merges/op  1257472 index_write_bytes/op  52 allocs/op
BenchmarkZipperApplyWarmSparseManyLeaf-8            50 2278492 ns/op  304 leaf_merges/op  3 internal_merges/op  1257472 index_write_bytes/op  52 allocs/op
BenchmarkZipperApplyWarmSparseManyLeaf-8            50 2526228 ns/op  304 leaf_merges/op  3 internal_merges/op  1257472 index_write_bytes/op  52 allocs/op
```
