### PR TITLE
zipper: enable sparse parallel internal apply

### DIFF
--- a/TreeDB/zipper/parallel_policy_test.go
+++ b/TreeDB/zipper/parallel_policy_test.go
@@ -11,8 +11,8 @@ func TestInternalMergeParallelThresholds_Default(t *testing.T) {
 
 func TestInternalMergeParallelThresholds_MaintenanceIgnoresPressure(t *testing.T) {
 	minChildren, minOps := internalMergeParallelThresholds(true, ParallelMergePressureCritical)
-	if minChildren != mergeInternalMinParallelChildren || minOps != mergeInternalMinParallelOps {
-		t.Fatalf("maintenance thresholds=(children=%d ops=%d) want (%d,%d)", minChildren, minOps, mergeInternalMinParallelChildren, mergeInternalMinParallelOps)
+	if minChildren != mergeInternalMinParallelChildren || minOps != mergeInternalMaintenanceMinParallelOps {
+		t.Fatalf("maintenance thresholds=(children=%d ops=%d) want (%d,%d)", minChildren, minOps, mergeInternalMinParallelChildren, mergeInternalMaintenanceMinParallelOps)
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -2426,7 +2426,9 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 	}
 
 	children := getChildWorkSlice(int(count))
-	defer putChildWorkSlice(children)
+	defer func() {
+		putChildWorkSlice(children)
+	}()
 
 	for i := uint16(0); i < count; i++ {
 		key, childRef, err := oldNode.GetInternalEntryRefView(i)

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -149,6 +149,8 @@ const (
 
 	mergeInternalMinParallelChildren         = 8
 	mergeInternalMinParallelOps              = 1024
+	mergeInternalMaintenanceMinParallelOps   = 4096
+	mergeInternalOuterLeafLogMinParallelOps  = 4096
 	mergeInternalHighPressureMinChildren     = 16
 	mergeInternalHighPressureMinOps          = 16 * 1024
 	mergeInternalCriticalPressureMinChildren = 32
@@ -758,7 +760,7 @@ func internalMergeParallelThresholds(maintenance bool, pressure ParallelMergePre
 	minChildren = mergeInternalMinParallelChildren
 	minOps = mergeInternalMinParallelOps
 	if maintenance {
-		return minChildren, minOps
+		return minChildren, mergeInternalMaintenanceMinParallelOps
 	}
 	switch pressure {
 	case ParallelMergePressureCritical:
@@ -2267,6 +2269,9 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			// extra recursive fan-out on the restore/fast path.
 			useParallel = shouldUseParallelInternalMerge(int(count), len(ops), gomaxprocs, maintenance, pressure)
 		}
+	}
+	if useParallel && z != nil && z.outerLeavesInValueLog && len(ops) < mergeInternalOuterLeafLogMinParallelOps {
+		useParallel = false
 	}
 
 	copyKeys := oldNode.InternalBaseDeltaEnabled()

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -148,7 +148,7 @@ const (
 	mergeNodeKeyScratchMaxCap = 1 << 20
 
 	mergeInternalMinParallelChildren         = 8
-	mergeInternalMinParallelOps              = 4096
+	mergeInternalMinParallelOps              = 1024
 	mergeInternalHighPressureMinChildren     = 16
 	mergeInternalHighPressureMinOps          = 16 * 1024
 	mergeInternalCriticalPressureMinChildren = 32
@@ -466,7 +466,10 @@ type childWork struct {
 	childStat adaptive.Metrics
 }
 
-const maxChildWorkCap = 1 << 14
+const (
+	maxChildWorkCap            = 1 << 14
+	maxChildWorkRetiredKeepCap = 8
+)
 
 var childWorkPool sync.Pool
 
@@ -573,7 +576,11 @@ func putChildWorkSlice(children []childWork) {
 		return
 	}
 	for i := range children {
+		retired := children[i].retired
 		children[i] = childWork{}
+		if cap(retired) <= maxChildWorkRetiredKeepCap {
+			children[i].retired = retired[:0]
+		}
 	}
 	childWorkPool.Put(children[:0])
 }
@@ -2425,11 +2432,17 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			key = []byte{}
 		}
 		keyCopy := cloneKey(key)
-		children = append(children, childWork{
+		children = children[:len(children)+1]
+		child := &children[len(children)-1]
+		retired := child.retired
+		*child = childWork{
 			key:   keyCopy,
 			low:   keyCopy,
 			child: childRef,
-		})
+		}
+		if cap(retired) <= maxChildWorkRetiredKeepCap {
+			child.retired = retired[:0]
+		}
 	}
 
 	for i := range children {
@@ -2463,7 +2476,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 	if useParallel {
 		const (
 			minParallelActiveChildren = 2
-			minParallelOpsPerChild    = 256
+			minParallelOpsPerChild    = 4
 		)
 		if activeChildren < minParallelActiveChildren || len(ops)/activeChildren < minParallelOpsPerChild {
 			useParallel = false
@@ -2511,17 +2524,15 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 				if len(children[i].ops) == 0 {
 					continue
 				}
-				var childMetrics adaptive.Metrics
-				childRet := children[i].retired[:0]
-				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, maintenance, budget, &childMetrics, children[i].low, children[i].high, &childRet, scratch)
+				children[i].childStat = adaptive.Metrics{}
+				children[i].retired = children[i].retired[:0]
+				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, maintenance, budget, &children[i].childStat, children[i].low, children[i].high, &children[i].retired, scratch)
 				if err != nil {
 					errOnce.Do(func() { firstErr = err })
 					continue
 				}
 				children[i].newChild = ncID
 				children[i].splits = cs
-				children[i].retired = childRet
-				children[i].childStat = childMetrics
 			}
 		}
 		for i := 0; i < maxParallel; i++ {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -720,6 +720,70 @@ func TestZipperApplyWithOptionsDefaultSkipsReadOnlyPrepare(t *testing.T) {
 	}
 }
 
+func TestZipperApplyWarmSparseManyLeafPreservesValues(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	const (
+		keyCount = 8192
+		step     = 4
+	)
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	rootID := buildInternalRootWithKeys(t, z, keyCount)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < keyCount; i += step {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		delta.Set(key, []byte("parallel"))
+	}
+
+	newRoot, retired, metrics, err := z.Apply(rootID, delta)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if newRoot == 0 || newRoot == rootID {
+		t.Fatalf("new root=%d old root=%d want changed non-zero root", newRoot, rootID)
+	}
+	if got := metrics.ZipperApplyOps; got != keyCount/step {
+		t.Fatalf("ZipperApplyOps=%d want %d", got, keyCount/step)
+	}
+	if got := metrics.ZipperLeafMerges; got < 2 {
+		t.Fatalf("ZipperLeafMerges=%d want multi-leaf apply", got)
+	}
+	if len(retired) == 0 {
+		t.Fatal("expected pending retired pages from warm apply")
+	}
+
+	tr := tree.New(p, panicValueReader{}, newRoot)
+	for _, i := range []int{0, 4, 2044, 4096, 8188} {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		got, err := tr.Get(key)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		if !bytes.Equal(got, []byte("parallel")) {
+			t.Fatalf("Get(%q)=%q want parallel", key, got)
+		}
+	}
+	originalValue := bytes.Repeat([]byte("v"), 128)
+	for _, i := range []int{1, 5, 2045, 4097, 8191} {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		got, err := tr.Get(key)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		if !bytes.Equal(got, originalValue) {
+			t.Fatalf("Get(%q)=%q want original value", key, got)
+		}
+	}
+}
+
 func TestZipperApplyWithOptionsReusesReadOnlyPrepareBuffers(t *testing.T) {
 	z, rootID := newTestZipperWithOuterLeafInternalRoot(t)
 


### PR DESCRIPTION
## Summary

- Enable the existing parallel internal merge path for sparse many-leaf applies by lowering the normal-pressure operation gate.
- Keep the change in the zipper apply layer only: no publish, root ownership, prepared-output, value-log, or collection visibility changes.
- Keep allocations bounded when the parallel path becomes active by storing per-child metrics and retired pages directly in `childWork`, and preserving small retired buffers through the child-work pool.

This PR is stacked on #1371 and uses its warm sparse many-leaf apply benchmark as the acceptance baseline.

## Local validation

```text
PASS go test ./TreeDB/zipper -count=1
PASS go test -race ./TreeDB/zipper -count=1
PASS go test ./TreeDB/zipper -run '^$' -bench 'Zipper(Apply|PrepareReadOnlyWarmSparse)' -benchmem -benchtime=100x -count=5
```

Focused benchstat against #1371 head on Apple M3:

```text
name                              old time/op   new time/op   delta
ZipperApplyWarmSparseManyLeaf-8    443.3us ±3%   301.2us ±4%  -32.04% (p=0.000 n=8)

name                              old alloc/op  new alloc/op  delta
ZipperApplyWarmSparseManyLeaf-8    8.143Ki ±0%   9.346Ki ±5%  +14.78% (p=0.000 n=8)

name                              old allocs/op new allocs/op delta
ZipperApplyWarmSparseManyLeaf-8     12.00 ±0%     20.00 ±5%  +66.67% (p=0.000 n=8)
```

Shape metrics stayed identical: `304 leaf_merges/op`, `3 internal_merges/op`, `2048 ops/op`, `307 pending_retired_pages/op`, and `1257472 index_write_bytes/op`.

The first naive version hit ~398-400 allocs/op. This version keeps the overhead to roughly eight extra allocs/op, mostly the worker goroutine path, while preserving the measured speedup.
