### PR TITLE
zipper: cap internal merge worker fan-out

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -151,6 +151,7 @@ const (
 	mergeInternalMinParallelOps              = 1024
 	mergeInternalMaintenanceMinParallelOps   = 4096
 	mergeInternalOuterLeafLogMinParallelOps  = 4096
+	mergeInternalMaxParallelWorkers          = 4
 	mergeInternalHighPressureMinChildren     = 16
 	mergeInternalHighPressureMinOps          = 16 * 1024
 	mergeInternalCriticalPressureMinChildren = 32
@@ -2524,6 +2525,9 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		maxParallel := gomaxprocs
 		if activeChildren > 0 && maxParallel > activeChildren {
 			maxParallel = activeChildren
+		}
+		if maxParallel > mergeInternalMaxParallelWorkers {
+			maxParallel = mergeInternalMaxParallelWorkers
 		}
 		if maxParallel < 1 {
 			maxParallel = 1

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -722,7 +722,7 @@ func TestZipperApplyWithOptionsDefaultSkipsReadOnlyPrepare(t *testing.T) {
 }
 
 func TestZipperApplyWarmSparseManyLeafPreservesValues(t *testing.T) {
-	prevGOMAXPROCS := runtime.GOMAXPROCS(4)
+	prevGOMAXPROCS := runtime.GOMAXPROCS(8)
 	defer runtime.GOMAXPROCS(prevGOMAXPROCS)
 
 	dir := t.TempDir()
@@ -766,8 +766,8 @@ func TestZipperApplyWarmSparseManyLeafPreservesValues(t *testing.T) {
 	if got := metrics.ZipperInternalParallelChildren; got < 2 {
 		t.Fatalf("ZipperInternalParallelChildren=%d want multiple active children", got)
 	}
-	if got := metrics.ZipperInternalParallelWorkers; got < 2 {
-		t.Fatalf("ZipperInternalParallelWorkers=%d want multiple workers", got)
+	if got := metrics.ZipperInternalParallelWorkers; got != mergeInternalMaxParallelWorkers {
+		t.Fatalf("ZipperInternalParallelWorkers=%d want capped workers %d", got, mergeInternalMaxParallelWorkers)
 	}
 	if got := metrics.ZipperInternalParallelOps; got == 0 {
 		t.Fatalf("ZipperInternalParallelOps=%d want routed parallel ops", got)


### PR DESCRIPTION
## Summary
- cap internal parallel merge fan-out at 4 workers after the existing child/op/pressure gates admit the parallel path
- keep active-child and pressure thresholds unchanged
- pin the cap in the sparse many-leaf apply test using the internal parallel metrics from #1373

## Why
#1373 showed the sparse many-leaf apply uses 8 workers for one internal parallel merge over 185 active children / 1249 routed ops. Local A/B shows 4 workers is faster on this shape with no allocation movement.

## Validation
- `go test ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `go test ./TreeDB/zipper -count=1`\n- `go test ./TreeDB/db -run 'TestPublishOrderedRootDelta|TestMergeOrderedRootPublishMetricsIncludesLeafLogAttribution' -count=1`\n- `go test ./TreeDB/zipper ./TreeDB/db -count=1`\n- `go test -race ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `PASS COUNT=3 scripts/treedb_raw_smoke_gate.sh --out /private/tmp/gomap_1374_raw_gate_1777997195 --count 3`\n\n## Benchmarks\nZipper cap vs #1373, `BenchmarkZipperApplyWarmSparseManyLeaf-8`:\n- `sec/op`: `296.6us ±2% -> 290.3us ±1%`, `-2.14%`, `p=0.028`\n- `B/op`: neutral, `9.370Ki -> 9.353Ki`, `p=0.328`\n- `allocs/op`: neutral, `21 -> 21`, `p=0.631`\n- `internal_parallel_workers/op`: `8 -> 4`, `p=0.000`\n\nRaw DB root apply cap vs #1373:\n- `BenchmarkPublishSystemRootIterator_WarmSparseDelta-8`: neutral, `232.3us -> 231.2us`, `p=0.161`\n- `BenchmarkPublishSystemRootIterator_WarmDenseDelta-8`: slight improvement, `344.8us -> 342.4us`, `-0.69%`, `p=0.007`\n- `B/op` and `allocs/op`: neutral\n\nBenchmark artifacts:\n- `/tmp/gomap_pr6p_worker_cap_1777997007/`\n- `/tmp/gomap_pr6p_worker_cap_db_1777997019/`\n- `/private/tmp/gomap_1374_raw_gate_1777997195`