### PR TITLE
zipper: pre-grow parallel retired page output

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -588,6 +588,25 @@ func putChildWorkSlice(children []childWork) {
 	childWorkPool.Put(children[:0])
 }
 
+func appendChildRetiredPages(dst *[]uint64, children []childWork, total int) {
+	if dst == nil {
+		return
+	}
+	if total == 0 {
+		return
+	}
+	retired := *dst
+	if cap(retired)-len(retired) < total {
+		grown := make([]uint64, len(retired), len(retired)+total)
+		copy(grown, retired)
+		retired = grown
+	}
+	for i := range children {
+		retired = append(retired, children[i].retired...)
+	}
+	*dst = retired
+}
+
 func getInternalEntrySlice(capacity int) []internalEntry {
 	if capacity < 0 {
 		capacity = 0
@@ -2571,15 +2590,15 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		if firstErr != nil {
 			return page.ChildRef{}, nil, firstErr
 		}
+		totalRetired := 0
 		for i := range children {
 			if len(children[i].ops) == 0 {
 				continue
 			}
 			mergeMetrics(metrics, &children[i].childStat)
-			if retired != nil && len(children[i].retired) > 0 {
-				*retired = append(*retired, children[i].retired...)
-			}
+			totalRetired += len(children[i].retired)
 		}
+		appendChildRetiredPages(retired, children, totalRetired)
 	} else {
 		for i := range children {
 			if len(children[i].ops) > 0 {


### PR DESCRIPTION
## Summary
- pre-size the returned retired-page slice once after parallel internal child work finishes
- keep child-local retired collection unchanged while avoiding repeated growth when merging child results
- leave serial and maintenance paths unchanged

## Why
The parallel internal merge path returns hundreds of retired page IDs on the sparse many-leaf apply shape. Appending each child's retired pages into the output slice caused repeated growth allocations. This keeps the same output and reduces allocation pressure in the parallel branch.

## Validation
- `go test ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `go test ./TreeDB/zipper -count=1`\n- `go test ./TreeDB/db -run 'TestPublishOrderedRootDelta|TestMergeOrderedRootPublishMetricsIncludesLeafLogAttribution' -count=1`\n- `go test ./TreeDB/zipper ./TreeDB/db -count=1`\n- `go test -race ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `PASS COUNT=3 scripts/treedb_raw_smoke_gate.sh --out /private/tmp/gomap_1375_raw_gate_1777997862 --count 3`\n\n## Benchmarks\nAgainst #1374, `BenchmarkZipperApplyWarmSparseManyLeaf-8`:\n- `sec/op`: neutral, `290.7us ±1% -> 290.7us ±0%`, `p=0.631`\n- `B/op`: `8.471Ki ±0% -> 4.901Ki ±1%`, `-42.14%`, `p=0.000`\n- `allocs/op`: `19 -> 13`, `-31.58%`, `p=0.000`\n- root-apply shape counters unchanged (`internal_parallel_workers/op=4`, `pending_retired_pages/op=307`)\n\nRaw DB root apply against #1374:\n- `BenchmarkPublishSystemRootIterator_WarmSparseDelta-8`: neutral, `230.5us -> 230.4us`, `p=0.754`\n- `BenchmarkPublishSystemRootIterator_WarmDenseDelta-8`: neutral, `343.0us -> 345.0us`, `p=0.105`\n- DB-level `B/op` and `allocs/op`: neutral\n\nBenchmark artifacts:\n- `/tmp/gomap_pr6q_pregrow_retired_final_1777997805/`\n- `/tmp/gomap_pr6q_pregrow_retired_db_final_1777997825/`\n- `/private/tmp/gomap_1375_raw_gate_1777997862`