### PR TITLE
node: reuse internal fence builder scratch

### DIFF
--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -100,6 +100,7 @@ const (
 	leafColumnarEntriesPoolMaxCap  = 1024
 	internalBaseEntriesPoolInitCap = 256
 	internalBaseEntriesPoolMaxCap  = 1024
+	internalFenceScratchMaxCap     = page.PageSize
 )
 
 var leafColumnarV2EntriesPool = sync.Pool{
@@ -279,6 +280,8 @@ func NewBuilderWithOptions(data []byte, pType page.PageType, opts BuilderOptions
 
 // ResetWithOptions reinitializes an existing builder instance for reuse.
 func (b *Builder) ResetWithOptions(data []byte, pType page.PageType, opts BuilderOptions) {
+	internalFenceLow := keepInternalFenceScratch(b.internalFenceLow)
+	internalFenceHigh := keepInternalFenceScratch(b.internalFenceHigh)
 	b.ReleaseScratch()
 
 	leafPrefix := opts.LeafPrefixCompression
@@ -295,6 +298,8 @@ func (b *Builder) ResetWithOptions(data []byte, pType page.PageType, opts Builde
 		leafColumnarV2:        leafColumnarV2,
 		leafPackedValuePtr:    opts.PackedValuePtr,
 		internalBaseDelta:     opts.InternalBaseDelta,
+		internalFenceLow:      internalFenceLow,
+		internalFenceHigh:     internalFenceHigh,
 	}
 	if pType == page.PageTypeLeaf && opts.LeafColumnar {
 		if leafPrefix {
@@ -335,8 +340,15 @@ func (b *Builder) ResetWithOptions(data []byte, pType page.PageType, opts Builde
 	}
 }
 
+func keepInternalFenceScratch(buf []byte) []byte {
+	if cap(buf) > internalFenceScratchMaxCap {
+		return nil
+	}
+	return buf[:0]
+}
+
 // ReleaseScratch returns pooled scratch resources held by the builder and
-// drops references so the builder can be reused safely.
+// drops large references so the builder can be reused safely.
 func (b *Builder) ReleaseScratch() {
 	if b == nil {
 		return
@@ -346,8 +358,8 @@ func (b *Builder) ReleaseScratch() {
 	b.releaseInternalBaseDeltaScratch()
 	b.data = nil
 	b.leafPrevKey = nil
-	b.internalFenceLow = nil
-	b.internalFenceHigh = nil
+	b.internalFenceLow = keepInternalFenceScratch(b.internalFenceLow)
+	b.internalFenceHigh = keepInternalFenceScratch(b.internalFenceHigh)
 }
 
 // SetPageID sets the page ID (can be done at finish too).
@@ -372,12 +384,12 @@ func (b *Builder) SetInternalFenceBounds(low, high []byte) {
 	}
 	b.internalFenceBounds = true
 	if len(low) == 0 {
-		b.internalFenceLow = nil
+		b.internalFenceLow = b.internalFenceLow[:0]
 	} else {
 		b.internalFenceLow = append(b.internalFenceLow[:0], low...)
 	}
 	if len(high) == 0 {
-		b.internalFenceHigh = nil
+		b.internalFenceHigh = b.internalFenceHigh[:0]
 	} else {
 		b.internalFenceHigh = append(b.internalFenceHigh[:0], high...)
 	}

--- a/TreeDB/node/builder_test.go
+++ b/TreeDB/node/builder_test.go
@@ -1,0 +1,51 @@
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestBuilderReusesInternalFenceScratch(t *testing.T) {
+	data := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(data, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+
+	low := bytes.Repeat([]byte("l"), 32)
+	high := bytes.Repeat([]byte("h"), 32)
+	b.SetInternalFenceBounds(low, high)
+	lowCap := cap(b.internalFenceLow)
+	highCap := cap(b.internalFenceHigh)
+	if lowCap < len(low) || highCap < len(high) {
+		t.Fatalf("initial fence caps low/high=%d/%d want at least %d/%d", lowCap, highCap, len(low), len(high))
+	}
+
+	b.ReleaseScratch()
+	if len(b.internalFenceLow) != 0 || len(b.internalFenceHigh) != 0 {
+		t.Fatalf("released fence lengths low/high=%d/%d want 0/0", len(b.internalFenceLow), len(b.internalFenceHigh))
+	}
+	if cap(b.internalFenceLow) != lowCap || cap(b.internalFenceHigh) != highCap {
+		t.Fatalf("released fence caps low/high=%d/%d want %d/%d", cap(b.internalFenceLow), cap(b.internalFenceHigh), lowCap, highCap)
+	}
+
+	b.ResetWithOptions(data, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetInternalFenceBounds(low[:8], high[:8])
+	if cap(b.internalFenceLow) != lowCap || cap(b.internalFenceHigh) != highCap {
+		t.Fatalf("reused fence caps low/high=%d/%d want %d/%d", cap(b.internalFenceLow), cap(b.internalFenceHigh), lowCap, highCap)
+	}
+	if !bytes.Equal(b.internalFenceLow, low[:8]) || !bytes.Equal(b.internalFenceHigh, high[:8]) {
+		t.Fatalf("reused fence values low/high=%q/%q", b.internalFenceLow, b.internalFenceHigh)
+	}
+}
+
+func TestBuilderDropsOversizedInternalFenceScratch(t *testing.T) {
+	data := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(data, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+
+	oversized := bytes.Repeat([]byte("x"), internalFenceScratchMaxCap+1)
+	b.SetInternalFenceBounds(oversized, oversized)
+	b.ReleaseScratch()
+	if cap(b.internalFenceLow) != 0 || cap(b.internalFenceHigh) != 0 {
+		t.Fatalf("oversized fence caps low/high=%d/%d want 0/0", cap(b.internalFenceLow), cap(b.internalFenceHigh))
+	}
+}


### PR DESCRIPTION
## Summary
- retain bounded internal fence-bound buffers on pooled node builders
- reuse those buffers across builder reset/release instead of reallocating for every internal rewrite
- add tests for bounded reuse and oversized-buffer drop behavior

## Why
The sparse many-leaf apply benchmark still showed per-apply allocations from `SetInternalFenceBounds` after the retired-page pre-grow slice. Internal builders are already pooled; this keeps the small copied fence bounds as bounded scratch while still dropping page/data and large references.

## Validation
- `go test ./TreeDB/node -run 'TestBuilder(ReusesInternalFenceScratch|DropsOversizedInternalFenceScratch)' -count=1`\n- `go test ./TreeDB/node ./TreeDB/zipper -run 'Test.*Internal|TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `go test ./TreeDB/node ./TreeDB/zipper -count=1`\n- `go test ./TreeDB/db -run 'TestPublishOrderedRootDelta|TestMergeOrderedRootPublishMetricsIncludesLeafLogAttribution' -count=1`\n- `go test ./TreeDB/node ./TreeDB/zipper ./TreeDB/db -count=1`\n- `go test -race ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1`\n- `PASS COUNT=3 scripts/treedb_raw_smoke_gate.sh --out /private/tmp/gomap_1376_raw_gate_1777998430 --count 3`\n\n## Benchmarks\nAgainst #1375, `BenchmarkZipperApplyWarmSparseManyLeaf-8`:\n- `sec/op`: neutral, `290.3us ±3% -> 291.6us ±12%`, `p=0.393`\n- `B/op`: `4.900Ki ±1% -> 4.889Ki ±1%`, `-0.23%`, `p=0.019`\n- `allocs/op`: `13 -> 11`, `-15.38%`, `p=0.000`\n\nRaw DB root apply against #1375:\n- `BenchmarkPublishSystemRootIterator_WarmSparseDelta-8`: neutral, `230.2us -> 230.4us`, `p=0.481`\n- `BenchmarkPublishSystemRootIterator_WarmDenseDelta-8`: neutral, `345.4us -> 342.3us`, `p=0.218`\n- DB-level `B/op` and `allocs/op`: neutral\n\nBenchmark artifacts:\n- `/tmp/gomap_pr6r_builder_fence_reuse_1777998109/`\n- `/tmp/gomap_pr6r_builder_fence_reuse_db_1777998145/`\n- `/private/tmp/gomap_1376_raw_gate_1777998430`