### PR TITLE
zipper: pool child work buffers by pointer

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -469,12 +469,20 @@ type childWork struct {
 	childStat adaptive.Metrics
 }
 
+type childWorkBuffer struct {
+	items []childWork
+}
+
 const (
 	maxChildWorkCap            = 1 << 14
 	maxChildWorkRetiredKeepCap = 8
 )
 
-var childWorkPool sync.Pool
+var childWorkPool = sync.Pool{
+	New: func() any {
+		return &childWorkBuffer{}
+	},
+}
 
 const maxInternalEntryCap = 1 << 15
 
@@ -558,24 +566,33 @@ func (b *maintenanceBudget) take(n int64) bool {
 	}
 }
 
-func getChildWorkSlice(capacity int) []childWork {
+func getChildWorkBuffer(capacity int) *childWorkBuffer {
 	if capacity < 0 {
 		capacity = 0
 	}
+	buf, _ := childWorkPool.Get().(*childWorkBuffer)
+	if buf == nil {
+		buf = &childWorkBuffer{}
+	}
 	if capacity > maxChildWorkCap {
-		return make([]childWork, 0, capacity)
+		buf.items = make([]childWork, 0, capacity)
+		return buf
 	}
-	if v := childWorkPool.Get(); v != nil {
-		s := v.([]childWork)
-		if cap(s) >= capacity {
-			return s[:0]
-		}
+	if cap(buf.items) >= capacity {
+		buf.items = buf.items[:0]
+		return buf
 	}
-	return make([]childWork, 0, capacity)
+	buf.items = make([]childWork, 0, capacity)
+	return buf
 }
 
-func putChildWorkSlice(children []childWork) {
+func putChildWorkBuffer(buf *childWorkBuffer) {
+	if buf == nil {
+		return
+	}
+	children := buf.items
 	if cap(children) > maxChildWorkCap {
+		buf.items = nil
 		return
 	}
 	for i := range children {
@@ -585,7 +602,8 @@ func putChildWorkSlice(children []childWork) {
 			children[i].retired = retired[:0]
 		}
 	}
-	childWorkPool.Put(children[:0])
+	buf.items = children[:0]
+	childWorkPool.Put(buf)
 }
 
 func appendChildRetiredPages(dst *[]uint64, children []childWork, total int) {
@@ -2461,9 +2479,11 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		return page.PageChildRef(builder.PageID()), splits, nil
 	}
 
-	children := getChildWorkSlice(int(count))
+	childBuf := getChildWorkBuffer(int(count))
+	children := childBuf.items
 	defer func() {
-		putChildWorkSlice(children)
+		childBuf.items = children
+		putChildWorkBuffer(childBuf)
 	}()
 
 	for i := uint16(0); i < count; i++ {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -570,13 +570,12 @@ func getChildWorkBuffer(capacity int) *childWorkBuffer {
 	if capacity < 0 {
 		capacity = 0
 	}
+	if capacity > maxChildWorkCap {
+		return &childWorkBuffer{items: make([]childWork, 0, capacity)}
+	}
 	buf, _ := childWorkPool.Get().(*childWorkBuffer)
 	if buf == nil {
 		buf = &childWorkBuffer{}
-	}
-	if capacity > maxChildWorkCap {
-		buf.items = make([]childWork, 0, capacity)
-		return buf
 	}
 	if cap(buf.items) >= capacity {
 		buf.items = buf.items[:0]


### PR DESCRIPTION
## Summary

- pool `childWork` buffers through a pointer holder instead of storing slice values in `sync.Pool`
- keep the existing child-work retired-page scratch retention behavior unchanged
- remove one allocation from sparse parallel internal apply without changing merge policy or output ownership

## Validation

Tests:

```text
go test ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1
go test ./TreeDB/db -run 'TestPublishOrderedRootDelta|TestMergeOrderedRootPublishMetricsIncludesLeafLogAttribution' -count=1
go test ./TreeDB/zipper ./TreeDB/db -count=1
go test -race ./TreeDB/zipper -run 'TestZipperApplyWarmSparseManyLeafPreservesValues|TestInternalMergeParallelThresholds' -count=1
git diff --check
./scripts/check_read_snapshot_guardrail.sh
```

Benchmark, compared against #1376 (`codex/1242-pr6r-builder-fence-reuse`):

```text
BenchmarkZipperApplyWarmSparseManyLeaf-8
sec/op      292.0us +/- 1% -> 291.4us +/- 1%   ~ (p=0.443 n=12)
B/op        4.865Ki +/- 1% -> 4.854Ki +/- 1%   ~ (p=0.876 n=12)
allocs/op   11.00 +/- 0%  -> 10.00 +/- 0%    -9.09% (p=0.000 n=12)
```

Artifacts: `/tmp/gomap_1377_childwork_bench_1777999418`; review-fix rerun `/tmp/gomap_1377_childwork_reviewfix_1777999815`.
