### PR TITLE
[codex] Compare benchmark run roots in HTML report

### DIFF
--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -17,9 +17,12 @@ import (
 )
 
 type config struct {
-	RunRoot string
-	OutPath string
-	Title   string
+	RunRoot        string
+	CompareRunRoot string
+	OutPath        string
+	Title          string
+	CurrentLabel   string
+	BaselineLabel  string
 }
 
 type rawEngineRun struct {
@@ -154,7 +157,26 @@ type reportData struct {
 	MongoFullSweep        []mongoSummaryRow
 	MongoLoadModes        []loadModeRow
 	MongoScaling          map[int][]mongoSummaryRow
+	Comparison            *runComparison
 	Warnings              []string
+}
+
+type runComparison struct {
+	BaselineRoot       string
+	CurrentRoot        string
+	BaselineLabel      string
+	CurrentLabel       string
+	BaselineGit        []gitIdentity
+	MongoFullSweepRows []comparisonRow
+	MongoLoadModeRows  []comparisonRow
+	MongoScalingRows   []comparisonRow
+	CollectionRows     []comparisonRow
+	RawEngineRows      []comparisonRow
+}
+
+type comparisonRow struct {
+	Cells   []string
+	Classes map[int]string
 }
 
 func main() {
@@ -185,31 +207,32 @@ func run(args []string) error {
 }
 
 func parseConfig(args []string) (config, error) {
-	cfg := config{Title: "TreeDB Benchmark Run Report"}
+	cfg := config{Title: "TreeDB Benchmark Run Report", CurrentLabel: "current", BaselineLabel: "baseline"}
 	fs := flag.NewFlagSet("benchmark_run_report", flag.ContinueOnError)
 	fs.StringVar(&cfg.RunRoot, "run-root", "", "Root directory containing canonical benchmark run artifacts")
+	fs.StringVar(&cfg.CompareRunRoot, "compare-run-root", "", "Optional baseline run root to compare against -run-root")
+	fs.StringVar(&cfg.CompareRunRoot, "baseline-run-root", "", "Alias for -compare-run-root")
 	fs.StringVar(&cfg.OutPath, "out", "", "HTML report output path; defaults to <run-root>/deep_report.html")
 	fs.StringVar(&cfg.Title, "title", cfg.Title, "Report title")
+	fs.StringVar(&cfg.CurrentLabel, "current-label", cfg.CurrentLabel, "Label for -run-root when rendering comparison deltas")
+	fs.StringVar(&cfg.BaselineLabel, "baseline-label", cfg.BaselineLabel, "Label for -compare-run-root when rendering comparison deltas")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
 	if cfg.RunRoot == "" {
 		return config{}, errors.New("-run-root is required")
 	}
-	abs, err := filepath.Abs(cfg.RunRoot)
+	runRoot, err := validateRunRoot("-run-root", cfg.RunRoot)
 	if err != nil {
 		return config{}, err
 	}
-	cfg.RunRoot = abs
-	info, err := os.Stat(cfg.RunRoot)
-	if err != nil {
-		return config{}, fmt.Errorf("-run-root %q: %w", cfg.RunRoot, err)
-	}
-	if !info.IsDir() {
-		return config{}, fmt.Errorf("-run-root %q is not a directory", cfg.RunRoot)
-	}
-	if _, err := os.ReadDir(cfg.RunRoot); err != nil {
-		return config{}, fmt.Errorf("-run-root %q is not readable: %w", cfg.RunRoot, err)
+	cfg.RunRoot = runRoot
+	if cfg.CompareRunRoot != "" {
+		compareRoot, err := validateRunRoot("-compare-run-root", cfg.CompareRunRoot)
+		if err != nil {
+			return config{}, err
+		}
+		cfg.CompareRunRoot = compareRoot
 	}
 	if cfg.OutPath == "" {
 		cfg.OutPath = filepath.Join(cfg.RunRoot, "deep_report.html")
@@ -217,7 +240,44 @@ func parseConfig(args []string) (config, error) {
 	return cfg, nil
 }
 
+func validateRunRoot(flagName, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", flagName, abs, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s %q is not a directory", flagName, abs)
+	}
+	if _, err := os.ReadDir(abs); err != nil {
+		return "", fmt.Errorf("%s %q is not readable: %w", flagName, abs, err)
+	}
+	return abs, nil
+}
+
 func loadReportData(cfg config) (reportData, error) {
+	data, err := loadSingleReportData(cfg)
+	if err != nil {
+		return reportData{}, err
+	}
+	if cfg.CompareRunRoot != "" {
+		baselineCfg := cfg
+		baselineCfg.RunRoot = cfg.CompareRunRoot
+		baselineCfg.CompareRunRoot = ""
+		baselineCfg.OutPath = ""
+		baseline, err := loadSingleReportData(baselineCfg)
+		if err != nil {
+			return reportData{}, err
+		}
+		data.Comparison = buildRunComparison(data, baseline)
+	}
+	return data, nil
+}
+
+func loadSingleReportData(cfg config) (reportData, error) {
 	data := reportData{
 		Config:       cfg,
 		GeneratedAt:  time.Now().UTC(),
@@ -830,6 +890,7 @@ func renderHTML(data reportData) string {
 		}
 		b.WriteString("</ul></section>\n")
 	}
+	renderRunComparison(&b, data.Comparison)
 	renderMongoFullSweep(&b, data.MongoFullSweep)
 	renderMongoLoadModes(&b, data.MongoLoadModes)
 	renderMongoScaling(&b, data.MongoScaling)
@@ -847,6 +908,9 @@ func reportNav(data reportData) string {
 	var items []navItem
 	if len(data.MongoFullSweep) > 0 {
 		items = append(items, navItem{Href: "#mongo-full", Label: "Mongo full sweep"})
+	}
+	if comparisonHasRows(data.Comparison) {
+		items = append(items, navItem{Href: "#compare", Label: "Compare runs"})
 	}
 	if len(data.MongoLoadModes) > 0 {
 		items = append(items, navItem{Href: "#mongo-load", Label: "Load modes"})
@@ -909,12 +973,334 @@ tr:hover td { background:#fafcff; }
 details { margin:12px 0; }
 summary { cursor:pointer; color:var(--blue); font-weight:700; }
 .warn { border-color:#e6c36a; background:#fff8e1; }
+.compare-card { border:1px solid var(--line); border-radius:8px; padding:12px; background:#fbfdff; }
+.compare-card strong { display:block; margin-bottom:4px; }
+.delta-good { color:#116329; font-weight:700; }
+.delta-bad { color:#a61b1b; font-weight:700; }
+.delta-flat { color:#475569; font-weight:700; }
 .legend { display:flex; gap:12px; flex-wrap:wrap; font-size:12px; color:var(--muted); justify-content:flex-end; text-align:right; }
 .chart-head .legend { max-width:72%; }
 .swatch { display:inline-block; width:10px; height:10px; border-radius:2px; margin-right:5px; vertical-align:-1px; }
 @media (max-width: 980px) { :root { --page-gutter:10px; } section { width:calc(100% - 20px); } .chart-grid { grid-template-columns:1fr; } header { position:static; } }
 </style>
 `
+}
+
+func buildRunComparison(current, baseline reportData) *runComparison {
+	comparison := &runComparison{
+		BaselineRoot:       baseline.Config.RunRoot,
+		CurrentRoot:        current.Config.RunRoot,
+		BaselineLabel:      current.Config.BaselineLabel,
+		CurrentLabel:       current.Config.CurrentLabel,
+		BaselineGit:        baseline.Git,
+		MongoFullSweepRows: compareMongoRows(current.MongoFullSweep, baseline.MongoFullSweep, false),
+		MongoLoadModeRows:  compareMongoLoadModes(current.MongoLoadModes, baseline.MongoLoadModes),
+		MongoScalingRows:   compareMongoRows(flattenMongoScaling(current.MongoScaling), flattenMongoScaling(baseline.MongoScaling), true),
+		CollectionRows:     compareCollections(current.Collections, baseline.Collections),
+		RawEngineRows:      compareRawEngine(current.RawEngine, baseline.RawEngine),
+	}
+	if !comparisonHasRows(comparison) {
+		return nil
+	}
+	return comparison
+}
+
+func comparisonHasRows(comparison *runComparison) bool {
+	return comparison != nil && (len(comparison.MongoFullSweepRows) > 0 ||
+		len(comparison.MongoLoadModeRows) > 0 ||
+		len(comparison.MongoScalingRows) > 0 ||
+		len(comparison.CollectionRows) > 0 ||
+		len(comparison.RawEngineRows) > 0)
+}
+
+func renderRunComparison(b *strings.Builder, comparison *runComparison) {
+	if !comparisonHasRows(comparison) {
+		return
+	}
+	b.WriteString("<section id=\"compare\"><h2>Run Comparison</h2>")
+	b.WriteString("<p class=\"subtle\">Comparing <code>" + esc(comparison.CurrentRoot) + "</code> against baseline <code>" + esc(comparison.BaselineRoot) + "</code>. Throughput deltas use higher-is-better coloring; bytes/doc deltas use lower-is-better coloring.</p>")
+	if len(comparison.BaselineGit) > 0 {
+		b.WriteString("<p class=\"subtle\">Baseline git identity:")
+		for _, item := range comparison.BaselineGit {
+			b.WriteString(" <code>" + esc(item.Label) + "=" + esc(item.Hash) + "</code>")
+		}
+		b.WriteString("</p>")
+	}
+	b.WriteString("<div class=\"grid\">")
+	renderComparisonCard(b, "Mongo full sweep", comparison.MongoFullSweepRows)
+	renderComparisonCard(b, "Load modes", comparison.MongoLoadModeRows)
+	renderComparisonCard(b, "Scaling", comparison.MongoScalingRows)
+	renderComparisonCard(b, "Collections", comparison.CollectionRows)
+	renderComparisonCard(b, "Raw engine", comparison.RawEngineRows)
+	b.WriteString("</div>")
+	if len(comparison.MongoFullSweepRows) > 0 {
+		b.WriteString("<details open><summary>Mongo full-sweep deltas</summary>")
+		writeComparisonTable(b, []string{"docs", "indexes", "TreeDB config", "Mongo config", "phase", comparison.BaselineLabel + " TreeDB ops/s", comparison.CurrentLabel + " TreeDB ops/s", "TreeDB delta", comparison.BaselineLabel + " ratio", comparison.CurrentLabel + " ratio", comparison.CurrentLabel + " TreeDB physical", comparison.CurrentLabel + " Mongo physical"}, comparison.MongoFullSweepRows, numericColumns(0, 1, 5, 6, 7, 8, 9, 10, 11))
+		b.WriteString("</details>")
+	}
+	if len(comparison.MongoLoadModeRows) > 0 {
+		b.WriteString("<details><summary>Load-mode deltas</summary>")
+		writeComparisonTable(b, []string{"indexes", "target", "config", comparison.BaselineLabel + " docs/s", comparison.CurrentLabel + " docs/s", "delta", comparison.BaselineLabel + " physical", comparison.CurrentLabel + " physical"}, comparison.MongoLoadModeRows, numericColumns(0, 3, 4, 5, 6, 7))
+		b.WriteString("</details>")
+	}
+	if len(comparison.MongoScalingRows) > 0 {
+		b.WriteString("<details open><summary>Dedicated scaling deltas</summary>")
+		writeComparisonTable(b, []string{"docs", "indexes", "TreeDB config", "Mongo config", "phase", comparison.BaselineLabel + " TreeDB ops/s", comparison.CurrentLabel + " TreeDB ops/s", "TreeDB delta", comparison.BaselineLabel + " ratio", comparison.CurrentLabel + " ratio", comparison.CurrentLabel + " TreeDB physical", comparison.CurrentLabel + " Mongo physical"}, comparison.MongoScalingRows, numericColumns(0, 1, 5, 6, 7, 8, 9, 10, 11))
+		b.WriteString("</details>")
+	}
+	if len(comparison.CollectionRows) > 0 {
+		b.WriteString("<details><summary>Collection deltas</summary>")
+		writeComparisonTable(b, []string{"indexes", "engine", "format", "phase", "maintenance", comparison.BaselineLabel + " docs/s", comparison.CurrentLabel + " docs/s", "docs delta", comparison.BaselineLabel + " B/doc", comparison.CurrentLabel + " B/doc", "B/doc delta"}, comparison.CollectionRows, numericColumns(0, 5, 6, 7, 8, 9, 10))
+		b.WriteString("</details>")
+	}
+	if len(comparison.RawEngineRows) > 0 {
+		b.WriteString("<details><summary>Raw engine deltas</summary>")
+		writeComparisonTable(b, []string{"profile", "checkpoint mode", "test", comparison.BaselineLabel + " ops/s", comparison.CurrentLabel + " ops/s", "delta"}, comparison.RawEngineRows, numericColumns(3, 4, 5))
+		b.WriteString("</details>")
+	}
+	b.WriteString("</section>\n")
+}
+
+func renderComparisonCard(b *strings.Builder, title string, rows []comparisonRow) {
+	if len(rows) == 0 {
+		return
+	}
+	good, flat, bad := comparisonDeltaCounts(rows)
+	total := good + flat + bad
+	b.WriteString("<div class=\"compare-card\"><strong>" + esc(title) + "</strong>")
+	b.WriteString("<span class=\"delta-good\">" + strconv.Itoa(good) + " better</span>")
+	b.WriteString(" / <span class=\"delta-flat\">" + strconv.Itoa(flat) + " flat</span>")
+	b.WriteString(" / <span class=\"delta-bad\">" + strconv.Itoa(bad) + " worse</span>")
+	b.WriteString("<p class=\"subtle\">" + strconv.Itoa(total) + " matched deltas across " + strconv.Itoa(len(rows)) + " rows</p></div>")
+}
+
+func comparisonDeltaCounts(rows []comparisonRow) (good, flat, bad int) {
+	for _, row := range rows {
+		for _, className := range row.Classes {
+			switch className {
+			case "delta-good":
+				good++
+			case "delta-bad":
+				bad++
+			case "delta-flat":
+				flat++
+			}
+		}
+	}
+	return good, flat, bad
+}
+
+func compareRawEngine(current, baseline []rawEngineRun) []comparisonRow {
+	base := make(map[string]rawEngineRun, len(baseline))
+	for _, run := range baseline {
+		base[rawRunKey(run)] = run
+	}
+	var rows []comparisonRow
+	for _, cur := range current {
+		prev, ok := base[rawRunKey(cur)]
+		if !ok {
+			continue
+		}
+		tests := make([]string, 0, len(cur.Results))
+		for test := range cur.Results {
+			if _, ok := prev.Results[test]; ok {
+				tests = append(tests, test)
+			}
+		}
+		sort.Slice(tests, func(i, j int) bool {
+			return rawTestOrder(tests[i]) < rawTestOrder(tests[j])
+		})
+		for _, test := range tests {
+			old, now := prev.Results[test], cur.Results[test]
+			rows = append(rows, comparisonRow{
+				Cells: []string{cur.Profile, cur.Checkpoint, test, fmtOps(old), fmtOps(now), fmtDelta(old, now)},
+				Classes: map[int]string{
+					5: deltaClass(old, now, true),
+				},
+			})
+		}
+	}
+	return rows
+}
+
+func rawRunKey(run rawEngineRun) string {
+	return run.Profile + "\x00" + run.Checkpoint
+}
+
+type mongoCompareKey struct {
+	Documents        int
+	SecondaryIndexes int
+	RangeIndex       bool
+	RangeMode        string
+	TreeDBConfig     string
+	MongoConfig      string
+	Phase            string
+}
+
+func compareMongoRows(current, baseline []mongoSummaryRow, anyScope bool) []comparisonRow {
+	base := make(map[mongoCompareKey]mongoSummaryRow, len(baseline))
+	for _, row := range baseline {
+		base[mongoComparisonKey(row, anyScope)] = row
+	}
+	var rows []comparisonRow
+	for _, cur := range current {
+		prev, ok := base[mongoComparisonKey(cur, anyScope)]
+		if !ok {
+			continue
+		}
+		rows = append(rows, comparisonRow{
+			Cells: []string{
+				strconv.Itoa(cur.Documents),
+				strconv.Itoa(cur.SecondaryIndexes),
+				cur.TreeDBConfig,
+				emptyDash(cur.MongoConfig),
+				cur.Phase,
+				fmtOps(prev.TreeDBOpsSec),
+				fmtOps(cur.TreeDBOpsSec),
+				fmtDelta(prev.TreeDBOpsSec, cur.TreeDBOpsSec),
+				fmtRatio(prev.TreeDBToMongoRatio),
+				fmtRatio(cur.TreeDBToMongoRatio),
+				fmtBytes(cur.TreeDBPhysicalBytes),
+				fmtBytes(cur.MongoPhysicalBytes),
+			},
+			Classes: map[int]string{
+				7: deltaClass(prev.TreeDBOpsSec, cur.TreeDBOpsSec, true),
+			},
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return strings.Join(rows[i].Cells[:5], "\x00") < strings.Join(rows[j].Cells[:5], "\x00")
+	})
+	return rows
+}
+
+func mongoComparisonKey(row mongoSummaryRow, anyScope bool) mongoCompareKey {
+	key := mongoCompareKey{
+		Documents:        row.Documents,
+		SecondaryIndexes: row.SecondaryIndexes,
+		RangeIndex:       row.RangeIndex,
+		RangeMode:        row.RangeMode,
+		TreeDBConfig:     row.TreeDBConfig,
+		MongoConfig:      row.MongoConfig,
+		Phase:            row.Phase,
+	}
+	if anyScope {
+		key.RangeIndex = false
+		key.RangeMode = ""
+	}
+	return key
+}
+
+func flattenMongoScaling(byIndex map[int][]mongoSummaryRow) []mongoSummaryRow {
+	var rows []mongoSummaryRow
+	indexes := make([]int, 0, len(byIndex))
+	for idx := range byIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Ints(indexes)
+	for _, idx := range indexes {
+		rows = append(rows, byIndex[idx]...)
+	}
+	return rows
+}
+
+func compareMongoLoadModes(current, baseline []loadModeRow) []comparisonRow {
+	base := make(map[string]loadModeRow, len(baseline))
+	for _, row := range baseline {
+		base[loadModeCompareKey(row)] = row
+	}
+	var rows []comparisonRow
+	for _, cur := range current {
+		prev, ok := base[loadModeCompareKey(cur)]
+		if !ok {
+			continue
+		}
+		rows = append(rows, comparisonRow{
+			Cells: []string{
+				strconv.Itoa(cur.Indexes),
+				cur.Target,
+				cur.Config,
+				fmtOps(prev.OpsPerSec),
+				fmtOps(cur.OpsPerSec),
+				fmtDelta(prev.OpsPerSec, cur.OpsPerSec),
+				fmtBytes(float64(prev.PhysicalBytes)),
+				fmtBytes(float64(cur.PhysicalBytes)),
+			},
+			Classes: map[int]string{
+				5: deltaClass(prev.OpsPerSec, cur.OpsPerSec, true),
+			},
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return strings.Join(rows[i].Cells[:3], "\x00") < strings.Join(rows[j].Cells[:3], "\x00")
+	})
+	return rows
+}
+
+func loadModeCompareKey(row loadModeRow) string {
+	return strconv.Itoa(row.Indexes) + "\x00" + row.Target + "\x00" + row.Config
+}
+
+type collectionCompareKey struct {
+	ConfigName      string
+	Engine          string
+	Format          string
+	IndexCount      int
+	Phase           string
+	MaintenanceMode string
+	MeasurementKind string
+}
+
+func compareCollections(current, baseline []collectionRow) []comparisonRow {
+	base := make(map[collectionCompareKey]collectionRow, len(baseline))
+	for _, row := range baseline {
+		base[collectionComparisonKey(row)] = row
+	}
+	var rows []comparisonRow
+	for _, cur := range current {
+		prev, ok := base[collectionComparisonKey(cur)]
+		if !ok {
+			continue
+		}
+		if prev.DocsPerSec == 0 && cur.DocsPerSec == 0 && prev.BytesPerDoc == 0 && cur.BytesPerDoc == 0 {
+			continue
+		}
+		row := comparisonRow{
+			Cells: []string{
+				strconv.Itoa(cur.IndexCount),
+				cur.Engine,
+				cur.Format,
+				cur.Phase,
+				emptyDash(cur.MaintenanceMode),
+				fmtOps(prev.DocsPerSec),
+				fmtOps(cur.DocsPerSec),
+				fmtDelta(prev.DocsPerSec, cur.DocsPerSec),
+				fmtFloat(prev.BytesPerDoc, 1),
+				fmtFloat(cur.BytesPerDoc, 1),
+				fmtDelta(prev.BytesPerDoc, cur.BytesPerDoc),
+			},
+			Classes: make(map[int]string),
+		}
+		row.Classes[7] = deltaClass(prev.DocsPerSec, cur.DocsPerSec, true)
+		row.Classes[10] = deltaClass(prev.BytesPerDoc, cur.BytesPerDoc, false)
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return strings.Join(rows[i].Cells[:5], "\x00") < strings.Join(rows[j].Cells[:5], "\x00")
+	})
+	return rows
+}
+
+func collectionComparisonKey(row collectionRow) collectionCompareKey {
+	return collectionCompareKey{
+		ConfigName:      row.ConfigName,
+		Engine:          row.Engine,
+		Format:          row.Format,
+		IndexCount:      row.IndexCount,
+		Phase:           row.Phase,
+		MaintenanceMode: row.MaintenanceMode,
+		MeasurementKind: row.MeasurementKind,
+	}
 }
 
 func renderRawEngine(b *strings.Builder, rows []rawEngineRun) {
@@ -2179,6 +2565,41 @@ func writeTable(b *strings.Builder, headers []string, rows [][]string, numeric m
 	b.WriteString("</tbody></table></div>")
 }
 
+func writeComparisonTable(b *strings.Builder, headers []string, rows []comparisonRow, numeric map[int]bool) {
+	b.WriteString("<div class=\"table-wrap\"><table><thead><tr>")
+	for i, h := range headers {
+		cls := ""
+		if numeric[i] {
+			cls = " class=\"num\""
+		}
+		b.WriteString("<th" + cls + ">" + esc(h) + "</th>")
+	}
+	b.WriteString("</tr></thead><tbody>")
+	for _, row := range rows {
+		b.WriteString("<tr>")
+		for i := range headers {
+			value := "-"
+			if i < len(row.Cells) {
+				value = row.Cells[i]
+			}
+			classes := []string{}
+			if numeric[i] {
+				classes = append(classes, "num")
+			}
+			if cls := row.Classes[i]; cls != "" {
+				classes = append(classes, cls)
+			}
+			classAttr := ""
+			if len(classes) > 0 {
+				classAttr = " class=\"" + esc(strings.Join(classes, " ")) + "\""
+			}
+			b.WriteString("<td" + classAttr + ">" + esc(value) + "</td>")
+		}
+		b.WriteString("</tr>")
+	}
+	b.WriteString("</tbody></table></div>")
+}
+
 func numericColumns(indexes ...int) map[int]bool {
 	out := make(map[int]bool)
 	if len(indexes) == 2 && indexes[0] <= indexes[1] {
@@ -2212,6 +2633,40 @@ func fmtRatio(v float64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%.2fx", v)
+}
+
+func fmtDelta(old, current float64) string {
+	pct, ok := deltaPercent(old, current)
+	if !ok {
+		return "-"
+	}
+	return fmt.Sprintf("%+.1f%%", pct)
+}
+
+func deltaClass(old, current float64, higherIsBetter bool) string {
+	pct, ok := deltaPercent(old, current)
+	if !ok {
+		return ""
+	}
+	const threshold = 2.0
+	if math.Abs(pct) < threshold {
+		return "delta-flat"
+	}
+	improved := pct > 0
+	if !higherIsBetter {
+		improved = pct < 0
+	}
+	if improved {
+		return "delta-good"
+	}
+	return "delta-bad"
+}
+
+func deltaPercent(old, current float64) (float64, bool) {
+	if old == 0 || current == 0 {
+		return 0, false
+	}
+	return (current/old - 1) * 100, true
 }
 
 func fmtBytes(v float64) string {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -177,6 +177,12 @@ type runComparison struct {
 type comparisonRow struct {
 	Cells   []string
 	Classes map[int]string
+	Deltas  []comparisonDelta
+}
+
+type comparisonDelta struct {
+	Percent float64
+	Class   string
 }
 
 func main() {
@@ -1027,6 +1033,7 @@ func renderRunComparison(b *strings.Builder, comparison *runComparison) {
 		b.WriteString("</p>")
 	}
 	b.WriteString("<div class=\"grid\">")
+	renderOverallComparisonCard(b, comparison)
 	renderComparisonCard(b, "Mongo full sweep", comparison.MongoFullSweepRows)
 	renderComparisonCard(b, "Load modes", comparison.MongoLoadModeRows)
 	renderComparisonCard(b, "Scaling", comparison.MongoScalingRows)
@@ -1034,7 +1041,7 @@ func renderRunComparison(b *strings.Builder, comparison *runComparison) {
 	renderComparisonCard(b, "Raw engine", comparison.RawEngineRows)
 	b.WriteString("</div>")
 	if len(comparison.MongoFullSweepRows) > 0 {
-		b.WriteString("<details open><summary>Mongo full-sweep deltas</summary>")
+		b.WriteString("<details><summary>Mongo full-sweep deltas</summary>")
 		writeComparisonTable(b, []string{"docs", "indexes", "TreeDB config", "Mongo config", "phase", comparison.BaselineLabel + " TreeDB ops/s", comparison.CurrentLabel + " TreeDB ops/s", "TreeDB delta", comparison.BaselineLabel + " ratio", comparison.CurrentLabel + " ratio", comparison.CurrentLabel + " TreeDB physical", comparison.CurrentLabel + " Mongo physical"}, comparison.MongoFullSweepRows, numericColumns(0, 1, 5, 6, 7, 8, 9, 10, 11))
 		b.WriteString("</details>")
 	}
@@ -1044,7 +1051,7 @@ func renderRunComparison(b *strings.Builder, comparison *runComparison) {
 		b.WriteString("</details>")
 	}
 	if len(comparison.MongoScalingRows) > 0 {
-		b.WriteString("<details open><summary>Dedicated scaling deltas</summary>")
+		b.WriteString("<details><summary>Dedicated scaling deltas</summary>")
 		writeComparisonTable(b, []string{"docs", "indexes", "TreeDB config", "Mongo config", "phase", comparison.BaselineLabel + " TreeDB ops/s", comparison.CurrentLabel + " TreeDB ops/s", "TreeDB delta", comparison.BaselineLabel + " ratio", comparison.CurrentLabel + " ratio", comparison.CurrentLabel + " TreeDB physical", comparison.CurrentLabel + " Mongo physical"}, comparison.MongoScalingRows, numericColumns(0, 1, 5, 6, 7, 8, 9, 10, 11))
 		b.WriteString("</details>")
 	}
@@ -1061,33 +1068,96 @@ func renderRunComparison(b *strings.Builder, comparison *runComparison) {
 	b.WriteString("</section>\n")
 }
 
+func renderOverallComparisonCard(b *strings.Builder, comparison *runComparison) {
+	rows := allComparisonRows(comparison)
+	if len(rows) == 0 {
+		return
+	}
+	renderComparisonCard(b, "Overall", rows)
+}
+
+func allComparisonRows(comparison *runComparison) []comparisonRow {
+	if comparison == nil {
+		return nil
+	}
+	var rows []comparisonRow
+	rows = append(rows, comparison.MongoFullSweepRows...)
+	rows = append(rows, comparison.MongoLoadModeRows...)
+	rows = append(rows, comparison.MongoScalingRows...)
+	rows = append(rows, comparison.CollectionRows...)
+	rows = append(rows, comparison.RawEngineRows...)
+	return rows
+}
+
 func renderComparisonCard(b *strings.Builder, title string, rows []comparisonRow) {
 	if len(rows) == 0 {
 		return
 	}
-	good, flat, bad := comparisonDeltaCounts(rows)
-	total := good + flat + bad
+	stats := comparisonDeltaStats(rows)
 	b.WriteString("<div class=\"compare-card\"><strong>" + esc(title) + "</strong>")
-	b.WriteString("<span class=\"delta-good\">" + strconv.Itoa(good) + " better</span>")
-	b.WriteString(" / <span class=\"delta-flat\">" + strconv.Itoa(flat) + " flat</span>")
-	b.WriteString(" / <span class=\"delta-bad\">" + strconv.Itoa(bad) + " worse</span>")
-	b.WriteString("<p class=\"subtle\">" + strconv.Itoa(total) + " matched deltas across " + strconv.Itoa(len(rows)) + " rows</p></div>")
+	b.WriteString("<span class=\"delta-good\">" + strconv.Itoa(stats.Good) + " better</span>")
+	b.WriteString(" / <span class=\"delta-flat\">" + strconv.Itoa(stats.Flat) + " flat</span>")
+	b.WriteString(" / <span class=\"delta-bad\">" + strconv.Itoa(stats.Bad) + " worse</span>")
+	b.WriteString("<p class=\"subtle\">" + strconv.Itoa(len(rows)) + " matched rows, " + strconv.Itoa(stats.Total()) + " measured deltas</p>")
+	if stats.Good > 0 || stats.Bad > 0 {
+		b.WriteString("<p class=\"subtle\">")
+		if stats.Good > 0 {
+			b.WriteString("<span class=\"delta-good\">avg better " + esc(fmtSignedPercent(stats.AvgGood())) + "</span>")
+		}
+		if stats.Good > 0 && stats.Bad > 0 {
+			b.WriteString(" / ")
+		}
+		if stats.Bad > 0 {
+			b.WriteString("<span class=\"delta-bad\">avg worse " + esc(fmtSignedPercent(stats.AvgBad())) + "</span>")
+		}
+		b.WriteString("</p>")
+	}
+	b.WriteString("</div>")
 }
 
-func comparisonDeltaCounts(rows []comparisonRow) (good, flat, bad int) {
+type comparisonDeltaSummary struct {
+	Good    int
+	Flat    int
+	Bad     int
+	GoodSum float64
+	BadSum  float64
+}
+
+func (s comparisonDeltaSummary) Total() int {
+	return s.Good + s.Flat + s.Bad
+}
+
+func (s comparisonDeltaSummary) AvgGood() float64 {
+	if s.Good == 0 {
+		return 0
+	}
+	return s.GoodSum / float64(s.Good)
+}
+
+func (s comparisonDeltaSummary) AvgBad() float64 {
+	if s.Bad == 0 {
+		return 0
+	}
+	return s.BadSum / float64(s.Bad)
+}
+
+func comparisonDeltaStats(rows []comparisonRow) comparisonDeltaSummary {
+	var stats comparisonDeltaSummary
 	for _, row := range rows {
-		for _, className := range row.Classes {
-			switch className {
+		for _, delta := range row.Deltas {
+			switch delta.Class {
 			case "delta-good":
-				good++
+				stats.Good++
+				stats.GoodSum += delta.Percent
 			case "delta-bad":
-				bad++
+				stats.Bad++
+				stats.BadSum += delta.Percent
 			case "delta-flat":
-				flat++
+				stats.Flat++
 			}
 		}
 	}
-	return good, flat, bad
+	return stats
 }
 
 func compareRawEngine(current, baseline []rawEngineRun) []comparisonRow {
@@ -1112,12 +1182,12 @@ func compareRawEngine(current, baseline []rawEngineRun) []comparisonRow {
 		})
 		for _, test := range tests {
 			old, now := prev.Results[test], cur.Results[test]
-			rows = append(rows, comparisonRow{
-				Cells: []string{cur.Profile, cur.Checkpoint, test, fmtOps(old), fmtOps(now), fmtDelta(old, now)},
-				Classes: map[int]string{
-					5: deltaClass(old, now, true),
-				},
-			})
+			row := comparisonRow{
+				Cells:   []string{cur.Profile, cur.Checkpoint, test, fmtOps(old), fmtOps(now), fmtDelta(old, now)},
+				Classes: map[int]string{},
+			}
+			addComparisonDelta(&row, 5, old, now, true)
+			rows = append(rows, row)
 		}
 	}
 	return rows
@@ -1148,7 +1218,7 @@ func compareMongoRows(current, baseline []mongoSummaryRow, anyScope bool) []comp
 		if !ok {
 			continue
 		}
-		rows = append(rows, comparisonRow{
+		row := comparisonRow{
 			Cells: []string{
 				strconv.Itoa(cur.Documents),
 				strconv.Itoa(cur.SecondaryIndexes),
@@ -1163,10 +1233,10 @@ func compareMongoRows(current, baseline []mongoSummaryRow, anyScope bool) []comp
 				fmtBytes(cur.TreeDBPhysicalBytes),
 				fmtBytes(cur.MongoPhysicalBytes),
 			},
-			Classes: map[int]string{
-				7: deltaClass(prev.TreeDBOpsSec, cur.TreeDBOpsSec, true),
-			},
-		})
+			Classes: map[int]string{},
+		}
+		addComparisonDelta(&row, 7, prev.TreeDBOpsSec, cur.TreeDBOpsSec, true)
+		rows = append(rows, row)
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		return strings.Join(rows[i].Cells[:5], "\x00") < strings.Join(rows[j].Cells[:5], "\x00")
@@ -1215,7 +1285,7 @@ func compareMongoLoadModes(current, baseline []loadModeRow) []comparisonRow {
 		if !ok {
 			continue
 		}
-		rows = append(rows, comparisonRow{
+		row := comparisonRow{
 			Cells: []string{
 				strconv.Itoa(cur.Indexes),
 				cur.Target,
@@ -1226,10 +1296,10 @@ func compareMongoLoadModes(current, baseline []loadModeRow) []comparisonRow {
 				fmtBytes(float64(prev.PhysicalBytes)),
 				fmtBytes(float64(cur.PhysicalBytes)),
 			},
-			Classes: map[int]string{
-				5: deltaClass(prev.OpsPerSec, cur.OpsPerSec, true),
-			},
-		})
+			Classes: map[int]string{},
+		}
+		addComparisonDelta(&row, 5, prev.OpsPerSec, cur.OpsPerSec, true)
+		rows = append(rows, row)
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		return strings.Join(rows[i].Cells[:3], "\x00") < strings.Join(rows[j].Cells[:3], "\x00")
@@ -1281,8 +1351,8 @@ func compareCollections(current, baseline []collectionRow) []comparisonRow {
 			},
 			Classes: make(map[int]string),
 		}
-		row.Classes[7] = deltaClass(prev.DocsPerSec, cur.DocsPerSec, true)
-		row.Classes[10] = deltaClass(prev.BytesPerDoc, cur.BytesPerDoc, false)
+		addComparisonDelta(&row, 7, prev.DocsPerSec, cur.DocsPerSec, true)
+		addComparisonDelta(&row, 10, prev.BytesPerDoc, cur.BytesPerDoc, false)
 		rows = append(rows, row)
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -2640,14 +2710,31 @@ func fmtDelta(old, current float64) string {
 	if !ok {
 		return "-"
 	}
+	return fmtSignedPercent(pct)
+}
+
+func fmtSignedPercent(pct float64) string {
 	return fmt.Sprintf("%+.1f%%", pct)
 }
 
-func deltaClass(old, current float64, higherIsBetter bool) string {
+func addComparisonDelta(row *comparisonRow, column int, old, current float64, higherIsBetter bool) {
+	delta, ok := newComparisonDelta(old, current, higherIsBetter)
+	if !ok {
+		return
+	}
+	row.Classes[column] = delta.Class
+	row.Deltas = append(row.Deltas, delta)
+}
+
+func newComparisonDelta(old, current float64, higherIsBetter bool) (comparisonDelta, bool) {
 	pct, ok := deltaPercent(old, current)
 	if !ok {
-		return ""
+		return comparisonDelta{}, false
 	}
+	return comparisonDelta{Percent: pct, Class: deltaClassForPercent(pct, higherIsBetter)}, true
+}
+
+func deltaClassForPercent(pct float64, higherIsBetter bool) string {
 	const threshold = 2.0
 	if math.Abs(pct) < threshold {
 		return "delta-flat"

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -133,6 +133,64 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	}
 }
 
+func TestDeepReportComparesRunRoots(t *testing.T) {
+	baseline := t.TempDir()
+	current := t.TempDir()
+	writeComparableRun(t, baseline, comparableRunValues{
+		Head:            "base123",
+		RawOps:          1000,
+		MongoLoadOps:    1000,
+		MongoReaderOps:  2000,
+		LoadModeOps:     1500,
+		CollectionDocs:  10000,
+		CollectionBytes: 10,
+	})
+	writeComparableRun(t, current, comparableRunValues{
+		Head:            "cur456",
+		RawOps:          1100,
+		MongoLoadOps:    1100,
+		MongoReaderOps:  2200,
+		LoadModeOps:     1800,
+		CollectionDocs:  12000,
+		CollectionBytes: 8,
+	})
+
+	out := filepath.Join(current, "deep_report.html")
+	if err := run([]string{
+		"-run-root", current,
+		"-compare-run-root", baseline,
+		"-out", out,
+		"-title", "compare report",
+		"-current-label", "candidate",
+		"-baseline-label", "control",
+	}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	html := readFile(t, out)
+	for _, want := range []string{
+		"compare report",
+		"href=\"#compare\"",
+		"Run Comparison",
+		"Baseline git identity:",
+		"HEAD=base123",
+		"Mongo full-sweep deltas",
+		"Load-mode deltas",
+		"Dedicated scaling deltas",
+		"Collection deltas",
+		"Raw engine deltas",
+		"control TreeDB ops/s",
+		"candidate TreeDB ops/s",
+		"+10.0%",
+		"+20.0%",
+		"-20.0%",
+		"delta-good",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("comparison report missing %q\n%s", want, html)
+		}
+	}
+}
+
 func TestRenderHTMLNavOmitsMissingSections(t *testing.T) {
 	html := renderHTML(reportData{
 		Config: config{Title: "partial", RunRoot: t.TempDir()},
@@ -430,6 +488,11 @@ func TestParseConfigRejectsInvalidRunRoot(t *testing.T) {
 	if _, err := parseConfig([]string{"-run-root", file}); err == nil {
 		t.Fatal("parseConfig accepted a file as run root")
 	}
+
+	valid := t.TempDir()
+	if _, err := parseConfig([]string{"-run-root", valid, "-compare-run-root", missing}); err == nil {
+		t.Fatal("parseConfig accepted a missing compare run root")
+	}
 }
 
 const mongoSummaryHeader = "documents\tsecondary_indexes\trange_index\trange_mode\ttreedb_config\tmongo_config\tphase\ttreedb_ops_sec\ttreedb_sampled_ops_sec\ttreedb_sampled_ns_per_op\tmongo_ops_sec\tmongo_sampled_ops_sec\tmongo_sampled_ns_per_op\ttreedb_to_mongo_ops_ratio\ttreedb_to_mongo_sampled_ops_ratio\ttreedb_p50_us\tmongo_p50_us\ttreedb_p95_us\tmongo_p95_us\ttreedb_p99_us\tmongo_p99_us\ttreedb_disk_snapshot\ttreedb_disk_bytes\ttreedb_physical_bytes\tmongo_dbstats_data_size_bytes\tmongo_dbstats_total_size_bytes\tmongo_physical_bytes\ttreedb_to_mongo_dbstats_total_ratio\ttreedb_to_mongo_physical_ratio\n"
@@ -438,6 +501,42 @@ func mongoSummaryFixture(indexes int) string {
 	return mongoSummaryHeader +
 		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t1000\t1000\t1000\t500\t500\t2000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", indexes) +
 		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tconcurrent_id_find_one_r1\t2000\t2000\t500\t1000\t1000\t1000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", indexes)
+}
+
+type comparableRunValues struct {
+	Head            string
+	RawOps          float64
+	MongoLoadOps    float64
+	MongoReaderOps  float64
+	LoadModeOps     float64
+	CollectionDocs  float64
+	CollectionBytes float64
+}
+
+func writeComparableRun(t *testing.T, root string, values comparableRunValues) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "HEAD.txt"), "HEAD="+values.Head+"\n")
+	writeFile(t, filepath.Join(root, "raw_engine_full_matrix", "wal_on_fast_checkpoint_between_tests", "benchprof_results.json"), fmt.Sprintf(`{
+  "runs": [{
+    "profile": "wal_on_fast",
+    "results": {
+      "sequential_write": {"TreeDB": %.0f}
+    }
+  }]
+}`, values.RawOps))
+	writeFile(t, filepath.Join(root, "collections_sqlite_canonical_1m", "indexes_0", "benchmark_results.json"), fmt.Sprintf(`{
+  "results": [
+    {"config_name":"treedb_bson_collection_0_indexes","engine":"treedb_fast","format":"bson","shape":"collection","index_count":0,"document_count":100,"phase":"post_insert","maintenance_mode":"none","total_bytes":800,"bytes_per_doc":%.1f,"docs_per_sec":%.0f,"measurement_kind":"go_benchmark"}
+  ]
+}`, values.CollectionBytes, values.CollectionDocs))
+	summary := mongoSummaryHeader +
+		fmt.Sprintf("100\t0\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t%.0f\t%.0f\t1000\t500\t500\t2000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", values.MongoLoadOps, values.MongoLoadOps) +
+		fmt.Sprintf("100\t0\tfalse\t\ttreedb_bson\tmongo\tconcurrent_id_find_one_r1\t%.0f\t%.0f\t500\t1000\t1000\t1000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", values.MongoReaderOps, values.MongoReaderOps)
+	writeFile(t, filepath.Join(root, "mongo_gateway_full_sweep_1m_expanded", "summary.tsv"), summary)
+	writeFile(t, filepath.Join(root, "mongo_gateway_reader_writer_scaling_1m", "indexes_0", "summary.tsv"), summary)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver\t100\t0\traw/treedb.json\t2000\n")
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb.json"), fmt.Sprintf(`{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":%.0f}]}`, values.LoadModeOps))
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -139,6 +139,7 @@ func TestDeepReportComparesRunRoots(t *testing.T) {
 	writeComparableRun(t, baseline, comparableRunValues{
 		Head:            "base123",
 		RawOps:          1000,
+		RawReadOps:      1000,
 		MongoLoadOps:    1000,
 		MongoReaderOps:  2000,
 		LoadModeOps:     1500,
@@ -148,6 +149,7 @@ func TestDeepReportComparesRunRoots(t *testing.T) {
 	writeComparableRun(t, current, comparableRunValues{
 		Head:            "cur456",
 		RawOps:          1100,
+		RawReadOps:      900,
 		MongoLoadOps:    1100,
 		MongoReaderOps:  2200,
 		LoadModeOps:     1800,
@@ -171,6 +173,7 @@ func TestDeepReportComparesRunRoots(t *testing.T) {
 		"compare report",
 		"href=\"#compare\"",
 		"Run Comparison",
+		"Overall",
 		"Baseline git identity:",
 		"HEAD=base123",
 		"Mongo full-sweep deltas",
@@ -182,11 +185,28 @@ func TestDeepReportComparesRunRoots(t *testing.T) {
 		"candidate TreeDB ops/s",
 		"+10.0%",
 		"+20.0%",
+		"-10.0%",
 		"-20.0%",
 		"delta-good",
+		"delta-bad",
+		"matched rows",
+		"measured deltas",
+		"avg better",
+		"avg worse",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("comparison report missing %q\n%s", want, html)
+		}
+	}
+	for _, collapsed := range []string{
+		"<details open><summary>Mongo full-sweep deltas",
+		"<details open><summary>Load-mode deltas",
+		"<details open><summary>Dedicated scaling deltas",
+		"<details open><summary>Collection deltas",
+		"<details open><summary>Raw engine deltas",
+	} {
+		if strings.Contains(html, collapsed) {
+			t.Fatalf("comparison report should hide %q by default\n%s", collapsed, html)
 		}
 	}
 }
@@ -506,6 +526,7 @@ func mongoSummaryFixture(indexes int) string {
 type comparableRunValues struct {
 	Head            string
 	RawOps          float64
+	RawReadOps      float64
 	MongoLoadOps    float64
 	MongoReaderOps  float64
 	LoadModeOps     float64
@@ -520,10 +541,11 @@ func writeComparableRun(t *testing.T, root string, values comparableRunValues) {
   "runs": [{
     "profile": "wal_on_fast",
     "results": {
-      "sequential_write": {"TreeDB": %.0f}
+      "sequential_write": {"TreeDB": %.0f},
+      "random_read": {"TreeDB": %.0f}
     }
   }]
-}`, values.RawOps))
+}`, values.RawOps, values.RawReadOps))
 	writeFile(t, filepath.Join(root, "collections_sqlite_canonical_1m", "indexes_0", "benchmark_results.json"), fmt.Sprintf(`{
   "results": [
     {"config_name":"treedb_bson_collection_0_indexes","engine":"treedb_fast","format":"bson","shape":"collection","index_count":0,"document_count":100,"phase":"post_insert","maintenance_mode":"none","total_bytes":800,"bytes_per_doc":%.1f,"docs_per_sec":%.0f,"measurement_kind":"go_benchmark"}

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -195,6 +195,32 @@ For TreeDB runs, `benchprof_results.json` also preserves selected TreeDB stats
 under `runs[].treedb_stats`, including ordered-root/root-apply and cache
 counters used by raw-engine review gates.
 
+## Full Run HTML Reports
+
+`benchmark_run_report` assembles the canonical raw-engine, collection/SQLite,
+Mongo gateway, load-mode, and scaling artifacts from a run root into one HTML
+report:
+
+```bash
+go run ./cmd/benchmark_run_report \
+  -run-root /tmp/gomap_candidate_run \
+  -out /tmp/gomap_candidate_run/deep_report.html
+```
+
+To compare two complete run roots, pass the older or control run as
+`-compare-run-root`. The report adds a Run Comparison section with matched-row
+deltas for raw engine throughput, Mongo full sweep, Mongo load modes, dedicated
+reader/writer scaling, and collection disk/throughput rows:
+
+```bash
+go run ./cmd/benchmark_run_report \
+  -run-root /tmp/gomap_candidate_run \
+  -compare-run-root /tmp/gomap_control_run \
+  -current-label candidate \
+  -baseline-label control \
+  -out /tmp/gomap_candidate_run/deep_report.html
+```
+
 ## Notes
 
 TreeDB is a cached engine (memtable + background flush). If you run long write-heavy phases and then measure `random_read`/scans immediately, the results can be dominated by background flush work (“flush debt”).


### PR DESCRIPTION
## Summary
- add `-compare-run-root` / `-baseline-run-root` support to `benchmark_run_report`
- render a Run Comparison section with matched deltas for Mongo full sweep, load modes, dedicated scaling, collections, and raw engine rows
- keep comparison detail tables collapsed by default and add per-sweep plus overall aggregate cards with better/flat/worse counts and avg better/avg worse percentages
- document the compare workflow in the unified benchmark README

## Validation
- `GOWORK=off go test -count=1 ./cmd/benchmark_run_report`
- `GOWORK=off go test -count=1 ./cmd/benchmark_run_report ./cmd/collection_canonical_bench ./cmd/collection_bench_matrix`
- generated real-run comparison report: `/tmp/gomap_readopts_1376_full_bench_20260505_164008/deep_report_native_compare.html`
