### PR TITLE
TreeDB collections: fast-path semantic single-value diffs

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5965,17 +5965,19 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 			}
 			state := states[documentKey]
 			if state == nil {
+				// Unit semantic records are immutable during publish planning; keep
+				// transient references instead of cloning value sets again.
 				states[documentKey] = &indexedSemanticDocumentRootState{
 					documentID:  record.documentID,
-					baseValues:  cloneIndexedSemanticValueSet(delta.oldValues),
-					finalValues: cloneIndexedSemanticValueSet(delta.newValues),
+					baseValues:  delta.oldValues,
+					finalValues: delta.newValues,
 				}
 				continue
 			}
 			if !indexedSemanticValueSetsEqual(state.finalValues, delta.oldValues) {
 				return nil, 0, false, nil
 			}
-			state.finalValues = cloneIndexedSemanticValueSet(delta.newValues)
+			state.finalValues = delta.newValues
 		}
 	}
 	if len(rootStates) == 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6034,6 +6034,12 @@ func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
 	if len(left) != len(right) {
 		return false
 	}
+	switch len(left) {
+	case 0:
+		return true
+	case 1:
+		return bytes.Equal(left[0], right[0])
+	}
 	seen := make(map[string]int, len(left))
 	for _, value := range left {
 		seen[string(value)]++
@@ -6049,6 +6055,18 @@ func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
 }
 
 func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) {
+	if len(base) == 0 {
+		return nil, final
+	}
+	if len(final) == 0 {
+		return base, nil
+	}
+	if len(base) == 1 && len(final) == 1 {
+		if bytes.Equal(base[0], final[0]) {
+			return nil, nil
+		}
+		return base, final
+	}
 	baseCounts := make(map[string]int, len(base))
 	for _, value := range base {
 		baseCounts[string(value)]++

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6058,16 +6058,19 @@ func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
 
 func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) {
 	if len(base) == 0 {
-		return nil, final
+		if len(final) == 0 {
+			return nil, nil
+		}
+		return nil, cloneIndexedSemanticValueSetRefs(final)
 	}
 	if len(final) == 0 {
-		return base, nil
+		return cloneIndexedSemanticValueSetRefs(base), nil
 	}
 	if len(base) == 1 && len(final) == 1 {
 		if bytes.Equal(base[0], final[0]) {
 			return nil, nil
 		}
-		return base, final
+		return cloneIndexedSemanticValueSetRefs(base), cloneIndexedSemanticValueSetRefs(final)
 	}
 	baseCounts := make(map[string]int, len(base))
 	for _, value := range base {
@@ -6094,6 +6097,15 @@ func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) 
 		sets = append(sets, value)
 	}
 	return deletes, sets
+}
+
+func cloneIndexedSemanticValueSetRefs(values [][]byte) [][]byte {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(values))
+	copy(out, values)
+	return out
 }
 
 func collectionRootDeltaPlanStatsFromCollectionRootRuns(collectionName string, runs []collectionRootRun) (collectionRootDeltaPlanStats, error) {

--- a/TreeDB/collections/pr3b_semantic_indexed_test.go
+++ b/TreeDB/collections/pr3b_semantic_indexed_test.go
@@ -9,6 +9,39 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
+func TestIndexedSemanticValueSetDiffFastPathsMatchMultiValueSemantics(t *testing.T) {
+	empty := make([][]byte, 0)
+	deletes, sets := indexedSemanticValueSetDiff(nil, empty)
+	if deletes != nil || sets != nil {
+		t.Fatalf("nil/empty diff got deletes=%v sets=%v want nil/nil", deletes, sets)
+	}
+
+	base := [][]byte{[]byte("a")}
+	final := [][]byte{[]byte("b")}
+	deletes, sets = indexedSemanticValueSetDiff(base, final)
+	if got, want := string(deletes[0]), "a"; got != want {
+		t.Fatalf("delete value=%q want %q", got, want)
+	}
+	if got, want := string(sets[0]), "b"; got != want {
+		t.Fatalf("set value=%q want %q", got, want)
+	}
+
+	base[0] = []byte("base-replaced")
+	final[0] = []byte("final-replaced")
+	if got, want := string(deletes[0]), "a"; got != want {
+		t.Fatalf("delete alias changed after base replacement: got %q want %q", got, want)
+	}
+	if got, want := string(sets[0]), "b"; got != want {
+		t.Fatalf("set alias changed after final replacement: got %q want %q", got, want)
+	}
+
+	_, sets = indexedSemanticValueSetDiff(nil, final)
+	final[0] = []byte("second-replacement")
+	if got, want := string(sets[0]), "final-replaced"; got != want {
+		t.Fatalf("set-only alias changed after final replacement: got %q want %q", got, want)
+	}
+}
+
 func TestPR3bSemanticRawRecordsSurviveMutableQueuedActiveRequeued(t *testing.T) {
 	d, mgr, col := pr3bSemanticTestCollection(t)
 	defer func() { _ = d.Close() }()


### PR DESCRIPTION
## Summary

- Fast-path semantic value-set equality and diff for empty and single-value index states.
- Avoids map/string work in the common single-value secondary-index case.
- Avoids recloning semantic publish value sets while planning the effective publish view.
- Preserves the old diff helper result semantics for empty/nil and top-level slice aliasing.
- Leaves multi-value diff behavior unchanged.

## Validation

- `go test ./TreeDB/collections -run 'TestPR3bSemantic|TestCollectionUpdateBatchBSON.*SkipsSecondaryRoot|TestCollectionDirectUpdateBSON.*SkipsSecondaryRoot|TestCollectionUpdateBatchJSON.*SkipsSecondaryRoot|TestCollectionDirectUpdateJSON.*SkipsSecondaryRoot' -count=1`
- `go test ./TreeDB/collections -run 'TestIndexedSemanticValueSetDiffFastPathsMatchMultiValueSemantics|TestPR3bSemantic|TestCollection.*SkipsSecondaryRoot' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test -race ./TreeDB/collections -run 'TestPR3bSemantic|TestCollection.*SkipsSecondaryRoot' -count=1`

## Benchmark

Compared to PR1340 on direct collection indexed city updates:

| branch | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| PR1340 | 8,091 | 4,809 | 26.0 |
| this branch | 7,956 | 4,675 | 17.7 |

Compared to PR1340 on the 5k docs / 50k indexed repeated-ID update canary:

| branch | ops/s | sampled ns/op | final entries/doc | squashed/doc | materialize ms | publish ms | root apply ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| PR1340 | 50,106 | 75,316 | 0.30 | 2.70 | 14.10 | 3.97 | 3.83 |
| first commit | 51,253 | 73,686 | 0.30 | 2.70 | 12.64 | 3.99 | 3.84 |
| final sample avg | 50,320 | n/a | 0.30 | 2.70 | 9.14 | 3.99 | 3.88 |

Artifacts:

- `/tmp/gomap_pr1340_direct_update_city_benchmem.txt`
- `/tmp/gomap_pr1379_aliasfix_direct_update_city_benchmem.txt`
- `/tmp/gomap_pr1340_fastpath_indexed_repeat_5k_50k_1778001419.json`
- `/tmp/gomap_pr1379_noclone_indexed_repeat_5k_50k_1778001873.json`
- `/tmp/gomap_pr1379_noclone_repeat_samples_1778001893`
