### PR TITLE
TreeDB collections: reuse semantic document IDs in direct buffered updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9223,15 +9223,23 @@ func applyDirectBufferedRootEntries(table memtable.Table, entries []directBuffer
 	})
 }
 
-func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRuntime, updates []preparedBatchUpdate) []indexedSemanticRecord {
+func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRuntime, updates []preparedBatchUpdate, primaryEntries []directBufferedRootEntry) []indexedSemanticRecord {
 	if len(updates) == 0 {
 		return nil
 	}
 	records := make([]indexedSemanticRecord, 0, len(updates))
-	for _, update := range updates {
+	for i, update := range updates {
+		var documentID []byte
+		if i < len(primaryEntries) && len(primaryEntries[i].key) > 0 {
+			// Direct primary entries are built from the same changed slice and carry
+			// an owned, staged document ID clone, so the semantic sidecar can share it.
+			documentID = primaryEntries[i].key
+		} else {
+			documentID = bytes.Clone(update.documentID)
+		}
 		record := indexedSemanticRecord{
 			kind:       indexedSemanticRecordUpdate,
-			documentID: bytes.Clone(update.documentID),
+			documentID: documentID,
 		}
 		if update.indexStateChanged && len(runtimes) > 0 {
 			for runtimeIdx, runtime := range runtimes {
@@ -10425,7 +10433,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		stats = updateCollectionUpdateStatsCounts(stats, results, len(rootNames))
 		var semanticRecords []indexedSemanticRecord
 		if c.writeDomain != nil && canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites {
-			semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+			semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed, primaryEntries)
 		}
 		*plan = updateBatchPlan{
 			results:                     results,
@@ -10629,7 +10637,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
 	var semanticRecords []indexedSemanticRecord
 	if c.writeDomain != nil && canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites {
-		semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+		semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed, nil)
 	}
 	*plan = updateBatchPlan{
 		results:                     results,


### PR DESCRIPTION
## Summary

This is a small allocation follow-up stacked on #1379.

The direct buffered update path already builds a cloned primary root key for each modified document. Semantic update records were cloning the same document ID again. This reuses the direct primary entry key for the semantic sidecar when the direct plan is available, while keeping the existing clone fallback for non-direct plans.

## Scope

- No semantic behavior change.
- No publish path change.
- No root-delta planning change.
- Direct buffered plans only avoid the redundant document ID clone.

## Validation

```bash
go test ./TreeDB/collections -count=1
go test -race ./TreeDB/collections \
  -run 'TestIndexedSemanticValueSetDiffFastPathsMatchMultiValueSemantics|TestPR3bSemantic|TestCollection.*SkipsSecondaryRoot' \
  -count=1
```

Exact direct 5k docs / 50k indexed repeated-ID update canary:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=5000 \
MONGO_GATEWAY_PROFILE_BENCH_CONCURRENT_WRITERS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=5000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=0 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate$' \
  -benchtime=50000x \
  -benchmem \
  -count=3
```

Local result summary:

| Branch | ns/op avg | B/op avg | allocs/op |
| --- | ---: | ---: | ---: |
| #1379 baseline | ~4020 | ~4658 | 11 |
| this PR | ~3953 | ~4548 | 10 |

This does not solve the broader allocation gap versus main, but it removes one redundant per-update allocation in the PR3b direct buffered path.
