### PR TITLE
caching: size GetMany copy arena by unique probes

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22862,7 +22862,7 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 	db.noteRootDomainGetManyNative(len(keys), len(unique))
 
 	results := make([]rootDomainProbeResult, len(unique))
-	arena := newGetManyValueCopyArena(len(keys))
+	arena := newGetManyValueCopyArena(len(unique))
 	start := 0
 	for start < len(unique) {
 		end := start + 1


### PR DESCRIPTION
## Summary

- Size the published-root `GetMany` copy arena from the number of unique probes instead of total requested keys.
- Keeps the allocation-count win from the arena-copy stack while avoiding duplicate-heavy over-allocation.
- Leaves distinct-key behavior unchanged except for the same existing arena path.

## Validation

- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/caching -run ^ -bench ^BenchmarkGetMany_PublishedRootPointShards -benchmem -benchtime=300ms -count=5 -p=1`

Benchmark evidence vs current `origin/main` (`d55deb8ae5`):

```text
duplicate64:       1.965 us/op -> 1.788 us/op, allocs 73 -> 9
duplicate256_hit: 6.806 us/op -> 5.895 us/op, allocs 265 -> 10, bytes roughly flat
duplicate256_miss:6.915 us/op -> 6.464 us/op, allocs 269 -> 20
distinct8:        roughly flat/slightly slower; this is a duplicate-heavy GetMany win
```
