### PR TITLE
TreeDB collections: shallow checkpoint semantic records

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4239,23 +4239,25 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		return bufferedIndexedCheckpoint{}
 	}
 	return bufferedIndexedCheckpoint{
-		loaded:                 domain.loaded,
-		meta:                   domain.meta,
-		catalog:                domain.catalog,
-		baseCommitSeq:          domain.baseCommitSeq,
-		baseSystemRoot:         domain.baseSystemRoot,
-		primaryRoot:            domain.primaryRoot,
-		count:                  domain.count,
-		bufferedBytes:          domain.bufferedBytes,
-		mutableCount:           domain.mutableCount,
-		mutableBytes:           domain.mutableBytes,
-		writeGeneration:        domain.writeGeneration,
-		rootRuns:               cloneTableRunMap(domain.rootRuns),
-		rootMutableRuns:        cloneMutableRunMap(domain.rootMutableRuns),
-		rootPolicies:           cloneRootPolicyMap(domain.rootPolicies),
-		rootBaseIDs:            cloneUint64Map(domain.rootBaseIDs),
-		rootValueArenas:        cloneArenaRefs(domain.rootValueArenas),
-		indexedSemanticRecords: cloneIndexedSemanticRecords(domain.indexedSemanticRecords),
+		loaded:          domain.loaded,
+		meta:            domain.meta,
+		catalog:         domain.catalog,
+		baseCommitSeq:   domain.baseCommitSeq,
+		baseSystemRoot:  domain.baseSystemRoot,
+		primaryRoot:     domain.primaryRoot,
+		count:           domain.count,
+		bufferedBytes:   domain.bufferedBytes,
+		mutableCount:    domain.mutableCount,
+		mutableBytes:    domain.mutableBytes,
+		writeGeneration: domain.writeGeneration,
+		rootRuns:        cloneTableRunMap(domain.rootRuns),
+		rootMutableRuns: cloneMutableRunMap(domain.rootMutableRuns),
+		rootPolicies:    cloneRootPolicyMap(domain.rootPolicies),
+		rootBaseIDs:     cloneUint64Map(domain.rootBaseIDs),
+		rootValueArenas: cloneArenaRefs(domain.rootValueArenas),
+		// Semantic records are immutable after staging. Rollback only needs to
+		// restore the previous mutable slice view, not deep-clone every record.
+		indexedSemanticRecords: domain.indexedSemanticRecords,
 		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
 		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
 		primaryRunIndexActive:  domain.primaryRunIndex != nil,
@@ -4291,6 +4293,9 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.rootValueArenas = checkpoint.rootValueArenas
+	if len(domain.indexedSemanticRecords) > len(checkpoint.indexedSemanticRecords) {
+		clear(domain.indexedSemanticRecords[len(checkpoint.indexedSemanticRecords):])
+	}
 	domain.indexedSemanticRecords = checkpoint.indexedSemanticRecords
 	domain.rootRunCount = checkpoint.rootRunCount
 	domain.rootDeltaStats = checkpoint.rootDeltaStats


### PR DESCRIPTION
## Summary

- Avoid deep-cloning immutable indexed semantic records when taking a buffered indexed-domain checkpoint.
- Rollback now restores the prior semantic-record slice view and clears any appended tail so rolled-back records do not stay retained.
- Keeps checkpoint/rollback semantics unchanged while removing a hot allocation source from PR3b semantic staging.

## Validation

- `go test ./TreeDB/collections -run 'TestPR3bSemantic|TestIndexedSemantic|TestCollection.*SkipsSecondaryRoot|Test.*Rollback|Test.*AutoFlush|TestCollectionIndexedFlush' -count=1`
- Direct update allocation profile: `/tmp/gomap_pr1381_shallow_checkpoint_direct_5k_500k_allocs.pprof`
- Direct update benchmark output: `/tmp/gomap_pr1381_shallow_checkpoint_direct_5k_500k_bench.txt`
- Repetition output: `/tmp/gomap_pr1381_shallow_checkpoint_direct_5k_50k_count3.txt`

Benchmark evidence from the 5k docs / 500k direct indexed repeated-ID update canary:

```text
#1380 clean branch:        ~4014 ns/op, 3888 B/op, 15 allocs/op
shallow checkpoint branch:  3881 ns/op, 3691 B/op, 10 allocs/op
```

The stable improvement is allocation count: the checkpoint clone path drops out of the hot allocation profile. After this change, `checkpointBufferedIndexedDomain` is no longer a material allocator in the saved profile; remaining hot spots are `freezeSortRunTable.ApplyStealEntryFunc`, `appendIndexedSemanticRecordsLocked`, `getUpdateBatchPlanScratch`, and semantic value-set materialization.
