### PR TITLE
TreeDB collections: pack semantic index deltas per batch

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9233,6 +9233,21 @@ func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRu
 		return nil
 	}
 	records := make([]indexedSemanticRecord, 0, len(updates))
+	totalIndexDeltas := 0
+	if len(runtimes) > 0 {
+		for _, update := range updates {
+			if !update.indexStateChanged {
+				continue
+			}
+			for runtimeIdx := range runtimes {
+				if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+					totalIndexDeltas++
+				}
+			}
+		}
+	}
+	indexDeltas := make([]indexedSemanticIndexDelta, totalIndexDeltas)
+	indexDeltaPos := 0
 	for i, update := range updates {
 		var documentID []byte
 		if i < len(primaryEntries) && len(primaryEntries[i].key) > 0 {
@@ -9247,6 +9262,7 @@ func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRu
 			documentID: documentID,
 		}
 		if update.indexStateChanged && len(runtimes) > 0 {
+			indexDeltaStart := indexDeltaPos
 			for runtimeIdx, runtime := range runtimes {
 				if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 					continue
@@ -9254,14 +9270,18 @@ func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRu
 				if runtime.def.unique {
 					record.fallback = indexedSemanticFallbackRawOnly
 				}
-				record.indexDeltas = append(record.indexDeltas, indexedSemanticIndexDelta{
+				indexDeltas[indexDeltaPos] = indexedSemanticIndexDelta{
 					indexName:  runtime.def.name,
 					rootName:   runtimeSecondaryRootName(collectionName, runtime),
 					runtimeIdx: runtimeIdx,
 					unique:     runtime.def.unique,
 					oldValues:  cloneIndexedSemanticValueSet(update.oldState.valuesAt(runtimeIdx)),
 					newValues:  cloneIndexedSemanticValueSet(update.newState.valuesAt(runtimeIdx)),
-				})
+				}
+				indexDeltaPos++
+			}
+			if indexDeltaPos > indexDeltaStart {
+				record.indexDeltas = indexDeltas[indexDeltaStart:indexDeltaPos:indexDeltaPos]
 			}
 		}
 		records = append(records, record)


### PR DESCRIPTION
## Summary

- Pack semantic index-delta records for each update batch into one contiguous slice.
- Each semantic record keeps a tight subslice of that batch-local delta arena.
- Avoids allocating a separate `[]indexedSemanticIndexDelta` backing array for every changed document.

## Validation

- `go test ./TreeDB/collections -run 'TestPR3bSemantic|TestIndexedSemantic|TestCollection.*SkipsSecondaryRoot|Test.*Rollback|Test.*AutoFlush|TestCollectionIndexedFlush' -count=1`
- `go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate$' -benchtime=500000x -benchmem -count=1`
- `go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate$' -benchtime=50000x -benchmem -count=3`

Benchmark evidence on the 5k docs / 500k direct indexed repeated-ID update canary, relative to #1382:

```text
#1382 shallow checkpoint: 3881 ns/op, 3691 B/op, 10 allocs/op
this branch:              3843-3860 ns/op, 3716-3736 B/op, 9 allocs/op
```

The profile still shows `appendIndexedSemanticRecordsLocked` as the larger remaining semantic-record allocation source. This PR only removes the per-record delta backing arrays; it does not change publish semantics or effective coalescing behavior.
