### PR TITLE
Add TreeDB insert compression profile harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,32 @@ Focus on pointer durability and GC correctness:
   - update parsers in `cmd/benchprof/main.go`
   - update tests in `cmd/benchprof/main_test.go` and `cmd/unified_bench/profile_artifact_dir_test.go`
   - update `cmd/unified_bench/README.md` and `cmd/benchprof/README.md`
+
+### Focused collection insert compression profile
+
+Use this when investigating TreeDB collection `InsertBatch` throughput and
+value-log compression allocation costs:
+
+```sh
+RUN_DIR=/tmp/treedb_insert_compression_profile_$(date +%Y%m%d_%H%M%S) \
+  scripts/treedb_insert_compression_profile.sh
+```
+
+The harness runs the short-lived `BenchmarkCollectionShapeInsertBatch` insert
+shape for template-v1 collections on the native fast path. It captures the
+default value-log compression path under `auto/`, optionally captures a
+compression-off ceiling under `off/`, and writes `benchstat_auto_vs_off.txt`
+when `benchstat` is installed.
+
+Primary artifacts:
+
+- `auto/collections_report.md`
+- `auto/collections_cpu.pprof`, `auto/collections_cpu_top.txt`
+- `auto/collections_mem.pprof`, `auto/collections_mem_top.txt`
+- `benchstat_auto_vs_off.txt`
+
+Useful overrides:
+
+- `COUNT=1 BENCHTIME=1000x RUN_COMPRESSION_OFF=false` for a smoke run.
+- `INDEXES_REGEX='0|1|2|3'` to include all current shape insert index counts.
+- `RUN_TIMED_CPU=true` to also run the timed CPU-only insert profile.

--- a/cmd/collection_bench_matrix/README.md
+++ b/cmd/collection_bench_matrix/README.md
@@ -39,6 +39,20 @@ Useful focused variants:
 ./bin/collection-bench-matrix -out-dir "$OUT" -formats json -storage-cells mainline
 ```
 
+For a narrower insert-throughput profile aimed at value-log compression
+allocation costs, use the committed shell harness:
+
+```sh
+RUN_DIR=/tmp/treedb_insert_compression_profile_$(date +%Y%m%d_%H%M%S) \
+  scripts/treedb_insert_compression_profile.sh
+```
+
+It runs the short-lived `BenchmarkCollectionShapeInsertBatch` template-v1 insert
+shape, captures CPU/allocation profiles for the default compression path, and
+optionally compares against `TREEDB_VLOG_COMPRESSION=off` with `benchstat`.
+Use `COUNT=1 BENCHTIME=1000x RUN_COMPRESSION_OFF=false` for a fast harness
+smoke test.
+
 Primary outputs:
 
 - `README.md`: run metadata and cell inventory.

--- a/scripts/treedb_insert_compression_profile.sh
+++ b/scripts/treedb_insert_compression_profile.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/treedb_insert_compression_profile_$(date +%Y%m%d_%H%M%S)}"
+COUNT="${COUNT:-10}"
+BENCHTIME="${BENCHTIME:-50000x}"
+INDEXES_REGEX="${INDEXES_REGEX:-0|1|2}"
+BENCH_REGEX="${BENCH_REGEX:-^BenchmarkCollectionShapeInsertBatch$/^indexes_(${INDEXES_REGEX})$}"
+BATCH_SIZE="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-50000}"
+DOCUMENT_FORMAT="${TREEDB_COLLECTION_DOCUMENT_FORMAT:-template-v1}"
+BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-production_fast}"
+PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
+RUN_COMPRESSION_OFF="${RUN_COMPRESSION_OFF:-true}"
+RUN_TIMED_CPU="${RUN_TIMED_CPU:-false}"
+TIMED_BENCHTIME="${TIMED_BENCHTIME:-1000000x}"
+TIMED_BENCH_REGEX="${TIMED_BENCH_REGEX:-^BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes$}"
+
+mkdir -p "$RUN_DIR"
+
+is_true() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		1|true|yes|y|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+extract_bench_text() {
+	local raw_json=$1
+	local dest=$2
+	python3 - "$raw_json" "$dest" <<'PY'
+import json
+import sys
+
+src, dest = sys.argv[1], sys.argv[2]
+with open(src, "r", encoding="utf-8") as inp, open(dest, "w", encoding="utf-8") as out:
+    for line in inp:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if item.get("Action") == "output":
+            out.write(item.get("Output", ""))
+PY
+}
+
+run_collection_report() {
+	local name=$1
+	local compression=$2
+	local bench_regex=$3
+	local benchtime=$4
+	local count=$5
+	local timed_cpu=$6
+	local dir="$RUN_DIR/$name"
+
+	mkdir -p "$dir"
+	echo "running $name insert compression profile into: $dir"
+	(
+		export OUT_DIR="$dir"
+		export TREEDB_VLOG_COMPRESSION="$compression"
+		export TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL"
+		export TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE"
+		export TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE"
+		export TREEDB_COLLECTION_DOCUMENT_FORMAT="$DOCUMENT_FORMAT"
+		export BENCH_REGEX="$bench_regex"
+		export BENCHTIME="$benchtime"
+		export COUNT="$count"
+		if is_true "$timed_cpu"; then
+			export TREEDB_COLLECTION_TIMED_CPU_PROFILE=true
+		else
+			unset TREEDB_COLLECTION_TIMED_CPU_PROFILE
+		fi
+		scripts/bench_collections_report.sh
+	) 2>&1 | tee "$dir/run.log"
+
+	if [[ -s "$dir/collections_bench.json" ]]; then
+		extract_bench_text "$dir/collections_bench.json" "$dir/bench.txt"
+	fi
+}
+
+cat >"$RUN_DIR/README.md" <<EOF
+# TreeDB Insert Compression Profile
+
+- worktree: \`$ROOT\`
+- branch: \`$(git rev-parse --abbrev-ref HEAD)\`
+- commit: \`$(git rev-parse --short HEAD)\`
+- benchmark regex: \`$BENCH_REGEX\`
+- benchmark count: \`$COUNT\`
+- benchtime: \`$BENCHTIME\`
+- benchmark engine: \`$BENCH_ENGINE\`
+- document format: \`$DOCUMENT_FORMAT\`
+- collection batch size: \`$BATCH_SIZE\`
+- execution path: \`$PATH_LABEL\`
+- compression-off comparison: \`$RUN_COMPRESSION_OFF\`
+- timed CPU run: \`$RUN_TIMED_CPU\`
+
+This harness captures the short-lived collection insert shape that exposes value-log
+compression setup and encoder-history allocation costs. The \`auto\` run is the
+default TreeDB value-log compression path. The optional \`off\` run is a ceiling
+comparison only: it removes value-log compression work but usually grows
+\`disk_bytes/doc\`.
+
+Primary artifacts:
+
+- \`auto/collections_report.md\`
+- \`auto/collections_cpu_top.txt\`
+- \`auto/collections_mem_top.txt\`
+- \`auto/collections_cpu.pprof\`
+- \`auto/collections_mem.pprof\`
+- \`benchstat_auto_vs_off.txt\` when compression-off is enabled and \`benchstat\` is available
+
+The allocation profile covers the whole Go test process, which is intentional
+for this short-lived benchmark because dictionary training and zstd encoder
+setup happen around the benchmarked collection lifetime.
+EOF
+
+run_collection_report "auto" "auto" "$BENCH_REGEX" "$BENCHTIME" "$COUNT" "false"
+
+if is_true "$RUN_COMPRESSION_OFF"; then
+	run_collection_report "off" "off" "$BENCH_REGEX" "$BENCHTIME" "$COUNT" "false"
+	if command -v benchstat >/dev/null 2>&1; then
+		benchstat "$RUN_DIR/auto/bench.txt" "$RUN_DIR/off/bench.txt" | tee "$RUN_DIR/benchstat_auto_vs_off.txt"
+	else
+		echo "benchstat not found; skipping auto/off benchstat comparison" | tee "$RUN_DIR/benchstat_auto_vs_off.txt"
+	fi
+fi
+
+if is_true "$RUN_TIMED_CPU"; then
+	run_collection_report "timed_cpu_auto" "auto" "$TIMED_BENCH_REGEX" "$TIMED_BENCHTIME" "1" "true"
+fi
+
+echo "insert compression profile bundle: $RUN_DIR"
+echo "bundle index: $RUN_DIR/README.md"
+echo "auto report: $RUN_DIR/auto/collections_report.md"
+if is_true "$RUN_COMPRESSION_OFF"; then
+	echo "auto/off benchstat: $RUN_DIR/benchstat_auto_vs_off.txt"
+fi


### PR DESCRIPTION
## Summary

- add `scripts/treedb_insert_compression_profile.sh` for focused TreeDB collection insert compression profiling
- capture default value-log compression profiles under `auto/` and optional `TREEDB_VLOG_COMPRESSION=off` ceiling data under `off/`
- extract benchmark text and write `benchstat_auto_vs_off.txt` when `benchstat` is available
- document the harness in `AGENTS.md` and the collection benchmark matrix README

## Local verification

- `bash -n scripts/treedb_insert_compression_profile.sh`
- `COUNT=1 BENCHTIME=1000x RUN_COMPRESSION_OFF=false scripts/treedb_insert_compression_profile.sh`
- default wrapper run produced auto/off reports and `benchstat_auto_vs_off.txt`

CI and AI review are intentionally left for a later pass.