### PR TITLE
Bump snissn/compress for BuildDict allocation fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/nutsdb/nutsdb v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.22
-	github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e
+	github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tidwall/btree v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e h1:l7jLklDDpTMHvsUEmzIudcHa3AF+c8eKNmsiyL4k5lw=
-github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
+github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a h1:hmddFRpKvJH6mpHoHCE/b/QqttiDIlmxNzb4ZzrU6lQ=
+github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
Updates github.com/snissn/compress to include the zstd BuildDict allocation fix from snissn/compress#3.

Local insert compression profiling shows the unused explicit-level BuildDict encoder allocation is removed while insert shape and disk metrics remain stable.

Validation:
- go test ./TreeDB/internal/compression ./TreeDB/collections
- focused TreeDB insert compression benchmark, count=10, benchtime=50000x, indexes 0/1/2

Key local result versus previous main baseline:
- zstd.BuildDict flat alloc: ~2.99GB -> ~4MB
- total alloc_space: ~11.52GB -> ~8.57GB
- sec/op geomean: -4.29%
- B/op geomean: -15.19%
- disk_bytes/doc, roots/batch, and secondary_entries/doc unchanged

Artifacts:
- /tmp/treedb_insert_compression_bumped_compress
- /tmp/treedb_insert_compression_bumped_compress/benchstat_vs_baseline.txt
- /tmp/treedb_insert_compression_bumped_compress/auto/builddict_list.txt