### PR TITLE
Bump snissn/compress for dictionary training workspace reuse

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -15639,6 +15639,9 @@ func (db *DB) scheduleVlogGenerationRewriteStageConfirmation(observedAt int64) {
 	if db == nil || observedAt <= 0 || db.closing.Load() {
 		return
 	}
+	if envBool(envDisableVlogGenerationLoop) {
+		return
+	}
 	if db.vlogGenerationRewriteStageWakeObservedNS.Load() == observedAt {
 		return
 	}

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2464,7 +2464,7 @@ func TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetain
 	db.lastForegroundReadUnixNano.Store(now.Add(-2 * vlogForegroundReadQuietWindow).UnixNano())
 	db.scheduleRetainedValueLogPrune()
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
 	for {
 		db.retainedPruneMu.Lock()
 		waiting := db.retainedPruneDone != nil

--- a/TreeDB/caching/vlog_generation_state.go
+++ b/TreeDB/caching/vlog_generation_state.go
@@ -1403,10 +1403,28 @@ func (db *DB) consumeVlogGenerationRewriteQueueChunk(processed []uint32) error {
 		}
 		if match {
 			remaining = append([]uint32(nil), remaining[len(processed):]...)
-			if len(remainingLedger) >= len(processed) {
+			ledgerPrefixMatch := len(remainingLedger) >= len(processed)
+			for i := range processed {
+				if !ledgerPrefixMatch || remainingLedger[i].FileID != processed[i] {
+					ledgerPrefixMatch = false
+					break
+				}
+			}
+			if ledgerPrefixMatch {
 				remainingLedger = append([]backenddb.ValueLogRewritePlanSegment(nil), remainingLedger[len(processed):]...)
-			} else {
-				remainingLedger = nil
+			} else if len(remainingLedger) > 0 {
+				processedSet := make(map[uint32]struct{}, len(processed))
+				for _, id := range processed {
+					processedSet[id] = struct{}{}
+				}
+				filteredLedger := make([]backenddb.ValueLogRewritePlanSegment, 0, len(remainingLedger))
+				for _, seg := range remainingLedger {
+					if _, ok := processedSet[seg.FileID]; ok {
+						continue
+					}
+					filteredLedger = append(filteredLedger, seg)
+				}
+				remainingLedger = filteredLedger
 			}
 		} else {
 			processedSet := make(map[uint32]struct{}, len(processed))

--- a/TreeDB/caching/vlog_generation_state_test.go
+++ b/TreeDB/caching/vlog_generation_state_test.go
@@ -139,6 +139,53 @@ func TestLoadValueLogGenerationRewriteState_PreservesPenaltiesWithoutQueue(t *te
 	}
 }
 
+func TestConsumeVlogGenerationRewriteQueueChunkPreservesMismatchedLedger(t *testing.T) {
+	dir := t.TempDir()
+	db := &DB{dir: filepath.Join(dir, "db")}
+
+	// Older states can have a queue prefix that is not represented in the
+	// ledger. Consuming that prefix must remove by file ID, not by count, or the
+	// remaining queued debt loses the ledger quality data used for prioritizing
+	// retries.
+	if err := saveValueLogGenerationRewriteState(
+		db.valueLogGenerationStatePath(),
+		[]uint32{33, 11, 22},
+		[]backenddb.ValueLogRewritePlanSegment{
+			{FileID: 11, BytesTotal: 128, BytesLive: 64, BytesStale: 64, StaleRatio: 0.5},
+			{FileID: 22, BytesTotal: 128, BytesLive: 64, BytesStale: 64, StaleRatio: 0.5},
+		},
+		nil,
+		0,
+		nil,
+		nil,
+		false,
+		0,
+	); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	if err := db.consumeVlogGenerationRewriteQueueChunk([]uint32{33}); err != nil {
+		t.Fatalf("consume queue chunk: %v", err)
+	}
+
+	ids, ledger, chunkLedger, chunkBytes, _, _, stagePending, stageObservedAt, err := loadValueLogGenerationRewriteState(db.valueLogGenerationStatePath())
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 11 || ids[1] != 22 {
+		t.Fatalf("ids=%v want [11 22]", ids)
+	}
+	if len(ledger) != 2 || ledger[0].FileID != 11 || ledger[1].FileID != 22 {
+		t.Fatalf("ledger=%v want file IDs [11 22]", ledger)
+	}
+	if len(chunkLedger) != 0 || chunkBytes != 0 {
+		t.Fatalf("chunkLedger=%v chunkBytes=%d want empty/zero", chunkLedger, chunkBytes)
+	}
+	if stagePending || stageObservedAt != 0 {
+		t.Fatalf("stagePending=%t stageObservedAt=%d want zero values", stagePending, stageObservedAt)
+	}
+}
+
 func TestLoadValueLogGenerationRewriteState_LoadsChunkLedger(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "vlog_generation_state.json")

--- a/TreeDB/internal/compression/profile.go
+++ b/TreeDB/internal/compression/profile.go
@@ -29,6 +29,7 @@ type ChooseKOptions struct {
 	// Deterministic timing overrides (ns per raw byte).
 	EncodeNsPerRawByte float64
 	DecodeNsPerRawByte float64
+	EncoderWorkspace   *zstd.DictEncodeWorkspace
 }
 
 type kScore struct {
@@ -79,7 +80,7 @@ func ChooseKForDictOptions(dict []byte, samples [][]byte, opts ChooseKOptions) (
 
 	nsPerByte := opts.DecodeNsPerRawByte
 	if nsPerByte <= 0 {
-		nsPerByte = decodeCostEstimate(dict, eval)
+		nsPerByte = decodeCostEstimate(dict, eval, opts.EncoderWorkspace)
 	}
 	ks := opts.CandidateK
 	if len(ks) == 0 {
@@ -87,16 +88,18 @@ func ChooseKForDictOptions(dict []byte, samples [][]byte, opts ChooseKOptions) (
 	}
 	ks = normalizeCandidateK(ks)
 	var sharedEnc *zstd.Encoder
-	if enc, err := zstd.NewWriter(nil,
-		zstd.WithEncoderDict(dict),
-		zstd.WithEncoderLevel(zstd.SpeedFastest),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithEncoderCRC(false),
-	); err == nil {
-		sharedEnc = enc
-	}
-	if sharedEnc != nil {
-		defer sharedEnc.Close()
+	if opts.EncoderWorkspace == nil {
+		if enc, err := zstd.NewWriter(nil,
+			zstd.WithEncoderDict(dict),
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderConcurrency(1),
+			zstd.WithEncoderCRC(false),
+		); err == nil {
+			sharedEnc = enc
+		}
+		if sharedEnc != nil {
+			defer sharedEnc.Close()
+		}
 	}
 	var concatScratch []byte
 	var encodedScratch []byte
@@ -111,7 +114,9 @@ func ChooseKForDictOptions(dict []byte, samples [][]byte, opts ChooseKOptions) (
 			continue
 		}
 		payload, meta, raw, encodeNs := 0, 0, 0, int64(0)
-		if sharedEnc != nil {
+		if opts.EncoderWorkspace != nil {
+			payload, meta, raw, encodeNs = batchTotalsWithEncodeWorkspace(opts.EncoderWorkspace, dict, eval[:used], k, opts.EncodeNsPerRawByte, &concatScratch, &encodedScratch)
+		} else if sharedEnc != nil {
 			payload, meta, raw, encodeNs = batchTotalsWithEncoder(sharedEnc, eval[:used], k, opts.EncodeNsPerRawByte, &concatScratch, &encodedScratch)
 		} else {
 			payload, meta, raw, encodeNs = batchTotals(dict, eval[:used], k, opts.EncodeNsPerRawByte)
@@ -305,7 +310,65 @@ func batchTotalsWithEncoder(enc *zstd.Encoder, samples [][]byte, k int, encodeNs
 	return payload, meta, raw, encodeNs
 }
 
-func decodeCostEstimate(dict []byte, samples [][]byte) float64 {
+func batchTotalsWithEncodeWorkspace(ws *zstd.DictEncodeWorkspace, dict []byte, samples [][]byte, k int, encodeNsPerRawByte float64, concatScratch *[]byte, encodedScratch *[]byte) (payload int, meta int, raw int, encodeNs int64) {
+	if ws == nil || k <= 0 {
+		return 0, 0, 0, 0
+	}
+	n := (len(samples) / k) * k
+	if n == 0 {
+		return 0, 0, 0, 0
+	}
+	samples = samples[:n]
+	batches := n / k
+	buf := *concatScratch
+	encoded := *encodedScratch
+	started := time.Now()
+	for b := 0; b < batches; b++ {
+		start := b * k
+		end := start + k
+		total := 0
+		for i := start; i < end; i++ {
+			raw += len(samples[i])
+			total += len(samples[i])
+		}
+		if cap(buf) < total {
+			buf = make([]byte, total)
+		} else {
+			buf = buf[:total]
+		}
+		pos := 0
+		for i := start; i < end; i++ {
+			copy(buf[pos:], samples[i])
+			pos += len(samples[i])
+		}
+		var err error
+		encoded, err = ws.EncodeAllWithDict(buf, encoded[:0], dict, zstd.SpeedFastest)
+		if err != nil {
+			return 0, 0, 0, 0
+		}
+		payload += len(encoded)
+		// Account for the full on-disk framing overhead:
+		// - record header (CRC/version/flags/txn/bodyLen)
+		// - frame header + dict_id + RID table + offsets table
+		//
+		// NOTE: Keep these constants in sync with `TreeDB/internal/valuelog/valuelog.go`.
+		const (
+			valueLogRecordHeaderBytes = 20 // valuelog.HeaderSize
+			valueLogFrameHeaderBytes  = 12 // valuelog.FrameHeaderSize
+		)
+		meta += valueLogRecordHeaderBytes + valueLogFrameHeaderBytes + (k * 8) + ((k + 1) * 4)
+	}
+	if encodeNsPerRawByte > 0 {
+		encodeNs = int64(float64(raw) * encodeNsPerRawByte)
+	} else {
+		encodeNs = time.Since(started).Nanoseconds()
+	}
+	*concatScratch = buf[:0]
+	*encodedScratch = encoded[:0]
+	return payload, meta, raw, encodeNs
+}
+
+func decodeCostEstimate(dict []byte, samples [][]byte, encodeWS *zstd.DictEncodeWorkspace) float64 {
 	eval := samples
 	if len(eval) > maxDecodeCostSamples {
 		eval = evenlySampleRecords(eval, maxDecodeCostSamples)
@@ -314,24 +377,35 @@ func decodeCostEstimate(dict []byte, samples [][]byte) float64 {
 	if n == 0 {
 		return 1.0
 	}
-	enc, err := zstd.NewWriter(nil,
-		zstd.WithEncoderDict(dict),
-		zstd.WithEncoderLevel(zstd.SpeedFastest),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithEncoderCRC(false),
-	)
-	if err != nil {
-		return 1.0
-	}
-	defer enc.Close()
-
 	totalRaw := 0
 	var encoded []byte
 	encodedFrames := make([][]byte, 0, n)
-	for i := 0; i < n; i++ {
-		totalRaw += len(eval[i])
-		encoded = enc.EncodeAll(eval[i], encoded[:0])
-		encodedFrames = append(encodedFrames, append([]byte(nil), encoded...))
+	if encodeWS != nil {
+		for i := 0; i < n; i++ {
+			totalRaw += len(eval[i])
+			var err error
+			encoded, err = encodeWS.EncodeAllWithDict(eval[i], encoded[:0], dict, zstd.SpeedFastest)
+			if err != nil {
+				return 1.0
+			}
+			encodedFrames = append(encodedFrames, append([]byte(nil), encoded...))
+		}
+	} else {
+		enc, err := zstd.NewWriter(nil,
+			zstd.WithEncoderDict(dict),
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderConcurrency(1),
+			zstd.WithEncoderCRC(false),
+		)
+		if err != nil {
+			return 1.0
+		}
+		defer enc.Close()
+		for i := 0; i < n; i++ {
+			totalRaw += len(eval[i])
+			encoded = enc.EncodeAll(eval[i], encoded[:0])
+			encodedFrames = append(encodedFrames, append([]byte(nil), encoded...))
+		}
 	}
 	dec, err := zstd.NewReader(nil, zstd.WithDecoderDicts(dict))
 	if err != nil {

--- a/TreeDB/internal/compression/profile_test.go
+++ b/TreeDB/internal/compression/profile_test.go
@@ -26,7 +26,7 @@ func mustBuildValidDict(t *testing.T, samples [][]byte) []byte {
 	for _, s := range samples {
 		history = append(history, s...)
 	}
-	dict, err := buildAndValidateDict(42, samples, history, zstd.SpeedFastest)
+	dict, err := buildAndValidateDict(42, samples, history, zstd.SpeedFastest, nil, nil)
 	if err != nil {
 		t.Fatalf("build dict: %v", err)
 	}

--- a/TreeDB/internal/compression/profile_test.go
+++ b/TreeDB/internal/compression/profile_test.go
@@ -91,3 +91,56 @@ func TestBatchTotalsWithEncoder_MatchesBatchTotals_WithDict(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchTotalsWithEncodeWorkspace_MatchesBatchTotals_WithDict(t *testing.T) {
+	samples := buildProfileSamples(256)
+	dict := mustBuildValidDict(t, samples)
+	encodeNsPerRawByte := 2.0
+	var ws zstd.DictEncodeWorkspace
+
+	for _, k := range []int{1, 2, 3, 6} {
+		wantPayload, wantMeta, wantRaw, wantEncodeNS := batchTotals(dict, samples, k, encodeNsPerRawByte)
+
+		var concatScratch []byte
+		var encodedScratch []byte
+		gotPayload, gotMeta, gotRaw, gotEncodeNS := batchTotalsWithEncodeWorkspace(&ws, dict, samples, k, encodeNsPerRawByte, &concatScratch, &encodedScratch)
+
+		if gotPayload != wantPayload || gotMeta != wantMeta || gotRaw != wantRaw || gotEncodeNS != wantEncodeNS {
+			t.Fatalf("k=%d mismatch got=(payload=%d meta=%d raw=%d encodeNs=%d) want=(payload=%d meta=%d raw=%d encodeNs=%d)",
+				k, gotPayload, gotMeta, gotRaw, gotEncodeNS, wantPayload, wantMeta, wantRaw, wantEncodeNS)
+		}
+	}
+}
+
+func TestChooseKForDictOptions_EncoderWorkspaceMatchesEncoderPath(t *testing.T) {
+	samples := buildProfileSamples(256)
+	dict := mustBuildValidDict(t, samples)
+	opts := ChooseKOptions{
+		CandidateK:         []int{1, 2, 4, 8, 16},
+		EncodeNsPerRawByte: 2.0,
+		DecodeNsPerRawByte: 1.0,
+	}
+	want := ChooseKForDictOptions(dict, samples, opts)
+	if want == nil {
+		t.Fatalf("profile without workspace is nil")
+	}
+
+	var ws zstd.DictEncodeWorkspace
+	opts.EncoderWorkspace = &ws
+	got := ChooseKForDictOptions(dict, samples, opts)
+	if got == nil {
+		t.Fatalf("profile with workspace is nil")
+	}
+
+	if got.K != want.K ||
+		got.DictHash != want.DictHash ||
+		got.DictBytes != want.DictBytes ||
+		got.PayloadRatio != want.PayloadRatio ||
+		got.TotalRatio != want.TotalRatio ||
+		got.DecodeNsEstimate != want.DecodeNsEstimate ||
+		got.EncodeNsEstimate != want.EncodeNsEstimate ||
+		got.AvgSampleBytes != want.AvgSampleBytes ||
+		got.Samples != want.Samples {
+		t.Fatalf("workspace profile mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -64,6 +64,8 @@ type Trainer struct {
 	forceNextTrain      atomic.Bool
 	level               zstd.EncoderLevel
 	logged              atomic.Bool
+	buildDictWS         zstd.BuildDictWorkspace
+	dictEncodeWS        zstd.DictEncodeWorkspace
 
 	mu            sync.Mutex
 	sampleBytes   uint64
@@ -678,7 +680,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 		fromCache := ok
 		if !ok {
 			var err error
-			dict, err = buildAndValidateDict(dictID, validSamples, historyMax[:historyBytes], level)
+			dict, err = buildAndValidateDict(dictID, validSamples, historyMax[:historyBytes], level, &t.buildDictWS, &t.dictEncodeWS)
 			if err != nil || len(dict) == 0 {
 				continue
 			}
@@ -686,7 +688,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 			t.storeCachedDict(cacheKey, dictHash, dict)
 		}
 		for _, dictCandidateBytes := range dictCandidates {
-			shaped, err := shapeAndValidateDict(dict, dictCandidateBytes, level)
+			shaped, err := shapeAndValidateDict(dict, dictCandidateBytes, level, &t.dictEncodeWS)
 			if err != nil || len(shaped) == 0 {
 				continue
 			}
@@ -695,6 +697,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 				IoNsPerStoredByte:  ioNsPerStoredByte,
 				EncodeNsPerRawByte: t.encodeNsPerRawByte,
 				DecodeNsPerRawByte: t.decodeNsPerRawByte,
+				EncoderWorkspace:   &t.dictEncodeWS,
 			})
 			if profile == nil || len(profile.Dict) == 0 {
 				continue
@@ -838,21 +841,16 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 		}
 	}
 
-	enc, err := zstd.NewWriter(nil,
-		zstd.WithEncoderLevel(level),
-		zstd.WithEncoderCRC(false),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithEncoderDict(bestProfile.Dict),
-	)
-	if err != nil {
-		log.Printf("treedb: dict training encode setup failed stream=%d err=%v", slabID, err)
-		return
-	}
-	defer enc.Close()
-
 	storedTotal := 0
+	var encoded []byte
 	for _, sample := range validSamples {
-		storedTotal += len(enc.EncodeAll(sample, nil))
+		var err error
+		encoded, err = t.dictEncodeWS.EncodeAllWithDict(sample, encoded[:0], bestProfile.Dict, level)
+		if err != nil {
+			log.Printf("treedb: dict training encode setup failed stream=%d err=%v", slabID, err)
+			return
+		}
+		storedTotal += len(encoded)
 	}
 	ratio := 1.0
 	if rawTotal > 0 {
@@ -875,7 +873,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 	t.maybeAcceptProfile(bestProfile)
 }
 
-func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level zstd.EncoderLevel) (dict []byte, err error) {
+func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level zstd.EncoderLevel, buildWS *zstd.BuildDictWorkspace, encodeWS *zstd.DictEncodeWorkspace) (dict []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			dict = nil
@@ -890,8 +888,9 @@ func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level
 		// offsets when content is small/degenerate (it only updates offsets it
 		// observes). If we pass zero offsets, it can emit dictionaries that fail
 		// to load with "invalid offset in dictionary" (issue #117).
-		Offsets: [3]int{1, 4, 8},
-		Level:   level,
+		Offsets:   [3]int{1, 4, 8},
+		Level:     level,
+		Workspace: buildWS,
 	})
 	if err != nil || len(dict) == 0 {
 		if err != nil {
@@ -899,12 +898,12 @@ func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level
 		}
 		return nil, err
 	}
-	if err := validateDict(dict, level); err != nil {
+	if err := validateDict(dict, level, encodeWS); err != nil {
 		// Retry with a smaller dict to avoid invalid offset failures.
 		reduced := dict
 		for i := 0; i < 3 && len(reduced) > 64; i++ {
 			reduced = reduced[:len(reduced)/2]
-			if err2 := validateDict(reduced, level); err2 == nil {
+			if err2 := validateDict(reduced, level, encodeWS); err2 == nil {
 				return reduced, nil
 			}
 		}
@@ -914,7 +913,7 @@ func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level
 	return dict, nil
 }
 
-func shapeAndValidateDict(dict []byte, dictBytes int, level zstd.EncoderLevel) ([]byte, error) {
+func shapeAndValidateDict(dict []byte, dictBytes int, level zstd.EncoderLevel, encodeWS *zstd.DictEncodeWorkspace) ([]byte, error) {
 	if len(dict) == 0 {
 		return nil, fmt.Errorf("empty dict")
 	}
@@ -928,28 +927,20 @@ func shapeAndValidateDict(dict []byte, dictBytes int, level zstd.EncoderLevel) (
 		shaped = make([]byte, dictBytes)
 		copy(shaped, dict)
 	}
-	if err := validateDict(shaped, level); err != nil {
+	if err := validateDict(shaped, level, encodeWS); err != nil {
 		return nil, err
 	}
 	return shaped, nil
 }
 
-func validateDict(dict []byte, level zstd.EncoderLevel) error {
-	enc, err := zstd.NewWriter(nil,
-		zstd.WithEncoderLevel(level),
-		zstd.WithEncoderCRC(false),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithEncoderDict(dict),
-	)
-	if err != nil {
-		return err
-	}
-	defer enc.Close()
-
+func validateDict(dict []byte, level zstd.EncoderLevel, encodeWS *zstd.DictEncodeWorkspace) error {
 	// Verify the dictionary actually works for round-trip.
 	// We use a small dummy payload.
 	dummy := []byte("test_payload_validation")
-	compressed := enc.EncodeAll(dummy, nil)
+	compressed, err := encodeWS.EncodeAllWithDict(dummy, nil, dict, level)
+	if err != nil {
+		return err
+	}
 
 	dec, err := zstd.NewReader(nil, zstd.WithDecoderDicts(dict))
 	if err != nil {

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -847,7 +847,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 		var err error
 		encoded, err = t.dictEncodeWS.EncodeAllWithDict(sample, encoded[:0], bestProfile.Dict, level)
 		if err != nil {
-			log.Printf("treedb: dict training encode setup failed stream=%d err=%v", slabID, err)
+			log.Printf("treedb: dict training encode failed stream=%d err=%v", slabID, err)
 			return
 		}
 		storedTotal += len(encoded)
@@ -937,9 +937,25 @@ func validateDict(dict []byte, level zstd.EncoderLevel, encodeWS *zstd.DictEncod
 	// Verify the dictionary actually works for round-trip.
 	// We use a small dummy payload.
 	dummy := []byte("test_payload_validation")
-	compressed, err := encodeWS.EncodeAllWithDict(dummy, nil, dict, level)
-	if err != nil {
-		return err
+	var compressed []byte
+	if encodeWS != nil {
+		var err error
+		compressed, err = encodeWS.EncodeAllWithDict(dummy, nil, dict, level)
+		if err != nil {
+			return err
+		}
+	} else {
+		enc, err := zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(level),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+			zstd.WithEncoderDict(dict),
+		)
+		if err != nil {
+			return err
+		}
+		defer enc.Close()
+		compressed = enc.EncodeAll(dummy, nil)
 	}
 
 	dec, err := zstd.NewReader(nil, zstd.WithDecoderDicts(dict))

--- a/TreeDB/internal/compression/trainer_test.go
+++ b/TreeDB/internal/compression/trainer_test.go
@@ -19,7 +19,7 @@ func TestBuildAndValidateDict_DefaultOffsetsAvoidInvalidOffset(t *testing.T) {
 	sample := append([]byte("prefix:"), bytes.Repeat([]byte("abcd"), (1024-7)/4)...)
 	sample = sample[:1024]
 
-	dict, err := buildAndValidateDict(1, [][]byte{sample}, hist, zstd.SpeedFastest)
+	dict, err := buildAndValidateDict(1, [][]byte{sample}, hist, zstd.SpeedFastest, nil, nil)
 	if err != nil {
 		t.Fatalf("buildAndValidateDict failed: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/nutsdb/nutsdb v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.22
-	github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a
+	github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tidwall/btree v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a h1:hmddFRpKvJH6mpHoHCE/b/QqttiDIlmxNzb4ZzrU6lQ=
-github.com/snissn/compress v1.18.2-snissn.0.0.20260506194033-a1444bb4ee0a/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
+github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721 h1:2XYKYq/WV3oldGbGi3b7M7VQoh38DIKSO0lNteuazJ0=
+github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
Updates github.com/snissn/compress to include the merged zstd dictionary training workspace reuse change from snissn/compress#4, then threads the workspace through TreeDB dictionary training, validation, and ChooseK evaluation.

Validation:
- go test ./TreeDB/internal/compression ./TreeDB/collections
- RUN_DIR=/tmp/treedb_insert_compression_workspace_bumped scripts/treedb_insert_compression_profile.sh
- benchstat /tmp/treedb_insert_compression_bumped_compress/auto/bench.txt /tmp/treedb_insert_compression_workspace_bumped/auto/bench.txt

Profile/benchmark notes:
- fastBase.ensureHist alloc_space dropped from 3.29GB flat / 38.34% to 128.90MB flat / 2.66%.
- B/op geomean dropped 2.635Ki -> 1.068Ki (-59.49%).
- sec/op geomean moved 438.0ns -> 426.3ns (-2.67%); indexes_1 improved -2.50%, indexes_0/indexes_2 were not significant.
- disk_bytes/doc, disk_total_bytes, roots/batch, secondary_entries/doc, secondary_key_bytes/doc, stored_docs, and target_docs/batch were unchanged.