### PR TITLE
memtable: reuse append-only entry buffers across close

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7454,6 +7454,35 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool) {
 	view.retiredMems = nil
 }
 
+func (db *DB) releaseClosingEmptyMemtables() {
+	if db == nil {
+		return
+	}
+	view := db.memtables.Swap(nil)
+	if view == nil {
+		return
+	}
+	if !view.refs.CompareAndSwap(1, 0) {
+		return
+	}
+	for _, mt := range view.mutables {
+		db.releaseClosingEmptyMemtable(mt)
+	}
+	db.recycleMemtables(view.retiredMems)
+	view.retiredMems = nil
+}
+
+func (db *DB) releaseClosingEmptyMemtable(mt memtable.Table) {
+	if db == nil || mt == nil || mt.Len() != 0 {
+		return
+	}
+	db.releaseBatchArenaLeasesForMemtable(mt)
+	db.releaseAppendOnlyDirectArenaLeaseForMemtable(mt)
+	if releaser, ok := mt.(interface{ Release() }); ok {
+		releaser.Release()
+	}
+}
+
 func cachedBatchWriteNeedsBatchArenaRetention(mt memtable.Table) bool {
 	// This helper is only used for the cached batch write path, where
 	// cachedBatchWriteUsesSteal governs whether a memtable receives borrowed
@@ -19271,6 +19300,7 @@ func (db *DB) Close() error {
 	db.writeMu.Unlock()
 	db.flushMu.Unlock()
 	db.wg.Wait()
+	db.releaseClosingEmptyMemtables()
 	// Drain any in-flight dict-profile publish callbacks before teardown.
 	// New callbacks will observe closing=true and return without touching stores.
 	db.valueLogDictApplyMu.Lock()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7471,12 +7471,26 @@ func (db *DB) releaseClosingEmptyMemtables() {
 		if view.refs.Load() > 0 {
 			view.closingEmptyMems = append(view.closingEmptyMems, view.mutables...)
 			db.releasePublishedMemtableView(view)
+		} else {
+			db.releaseClosingMemtableViewContents(view)
 		}
+		return
+	}
+	db.releaseClosingMemtableViewContents(view)
+}
+
+func (db *DB) releaseClosingMemtableViewContents(view *memtableView) {
+	if db == nil || view == nil {
 		return
 	}
 	for _, mt := range view.mutables {
 		db.releaseClosingEmptyMemtable(mt)
 	}
+	view.mutables = nil
+	for _, mt := range view.closingEmptyMems {
+		db.releaseClosingEmptyMemtable(mt)
+	}
+	view.closingEmptyMems = nil
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7243,6 +7243,7 @@ type memtableView struct {
 	retiredMems              []memtable.Table
 	deferredRetiredMemtables atomic.Int64
 	deferredRetiredBytes     atomic.Int64
+	closingEmptyMems         []memtable.Table
 }
 
 // appendOnlyEstimatedBytesPerEntryDefault tunes initial append-only memtable
@@ -7450,6 +7451,10 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool) {
 	db.noteMemtableViewDeferredExit(view)
 	view.deferredRetiredMemtables.Store(0)
 	view.deferredRetiredBytes.Store(0)
+	for _, mt := range view.closingEmptyMems {
+		db.releaseClosingEmptyMemtable(mt)
+	}
+	view.closingEmptyMems = nil
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
 }
@@ -7463,6 +7468,10 @@ func (db *DB) releaseClosingEmptyMemtables() {
 		return
 	}
 	if !view.refs.CompareAndSwap(1, 0) {
+		if view.refs.Load() > 0 {
+			view.closingEmptyMems = append(view.closingEmptyMems, view.mutables...)
+			db.releasePublishedMemtableView(view)
+		}
 		return
 	}
 	for _, mt := range view.mutables {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6340,15 +6340,22 @@ type DB struct {
 	appendOnlyDirectArenaLeaseMu     sync.Mutex
 	appendOnlyDirectArenaLeasesByMem map[memtable.Table]*appendOnlyDirectArenaLease
 	pendingRetiredMems               []memtable.Table
-	memtableViewTelemetry            memtableViewLifecycleTelemetry
-	retainedArenaTrimLastUnixNano    atomic.Int64
-	queueRanges                      []keyRange
-	queueWALPaths                    [][]string
-	queueValueLogPaths               [][]string
-	backendRange                     keyRange
-	backendRangeKnown                bool
-	backendRangeInit                 sync.Once
-	backendRangeErr                  error
+	// closingEmptyMemsMu guards closingEmptyByView. The map holds per-view
+	// lists of mutable memtables that should be released once the last reader
+	// drops the view, registered by releaseClosingEmptyMemtables at DB close.
+	// Keeping this in DB-owned state (rather than inside memtableView) ensures
+	// memtableView itself is never mutated after being published.
+	closingEmptyMemsMu            sync.Mutex
+	closingEmptyByView            map[*memtableView][]memtable.Table
+	memtableViewTelemetry         memtableViewLifecycleTelemetry
+	retainedArenaTrimLastUnixNano atomic.Int64
+	queueRanges                   []keyRange
+	queueWALPaths                 [][]string
+	queueValueLogPaths            [][]string
+	backendRange                  keyRange
+	backendRangeKnown             bool
+	backendRangeInit              sync.Once
+	backendRangeErr               error
 
 	// Durability
 	lanes         []lane
@@ -7243,7 +7250,6 @@ type memtableView struct {
 	retiredMems              []memtable.Table
 	deferredRetiredMemtables atomic.Int64
 	deferredRetiredBytes     atomic.Int64
-	closingEmptyMems         []memtable.Table
 }
 
 // appendOnlyEstimatedBytesPerEntryDefault tunes initial append-only memtable
@@ -7451,10 +7457,13 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool) {
 	db.noteMemtableViewDeferredExit(view)
 	view.deferredRetiredMemtables.Store(0)
 	view.deferredRetiredBytes.Store(0)
-	for _, mt := range view.closingEmptyMems {
+	db.closingEmptyMemsMu.Lock()
+	closingMems := db.closingEmptyByView[view]
+	delete(db.closingEmptyByView, view)
+	db.closingEmptyMemsMu.Unlock()
+	for _, mt := range closingMems {
 		db.releaseClosingEmptyMemtable(mt)
 	}
-	view.closingEmptyMems = nil
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
 }
@@ -7469,7 +7478,12 @@ func (db *DB) releaseClosingEmptyMemtables() {
 	}
 	if !view.refs.CompareAndSwap(1, 0) {
 		if view.refs.Load() > 0 {
-			view.closingEmptyMems = append(view.closingEmptyMems, view.mutables...)
+			db.closingEmptyMemsMu.Lock()
+			if db.closingEmptyByView == nil {
+				db.closingEmptyByView = make(map[*memtableView][]memtable.Table)
+			}
+			db.closingEmptyByView[view] = append(db.closingEmptyByView[view], view.mutables...)
+			db.closingEmptyMemsMu.Unlock()
 			db.releasePublishedMemtableView(view)
 		} else {
 			db.releaseClosingMemtableViewContents(view)
@@ -7487,10 +7501,6 @@ func (db *DB) releaseClosingMemtableViewContents(view *memtableView) {
 		db.releaseClosingEmptyMemtable(mt)
 	}
 	view.mutables = nil
-	for _, mt := range view.closingEmptyMems {
-		db.releaseClosingEmptyMemtable(mt)
-	}
-	view.closingEmptyMems = nil
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
 }

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
+type releaseTrackingMemtable struct {
+	*memtable.AppendOnly
+	released bool
+}
+
+func (m *releaseTrackingMemtable) Release() {
+	m.released = true
+	m.AppendOnly.Release()
+}
+
 func TestRetainMemtableViewSelfHealsZeroRefPublishedView(t *testing.T) {
 	db := &DB{}
 	view := &memtableView{}
@@ -105,6 +115,62 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 	}
 	if leased != retired {
 		t.Fatalf("leased memtable=%p want retired=%p", leased, retired)
+	}
+}
+
+func TestReleaseClosingEmptyMemtablesDefersCleanupForRetainedView(t *testing.T) {
+	db := &DB{}
+	mutable := &releaseTrackingMemtable{AppendOnly: memtable.NewAppendOnlyWithCapacity(0)}
+	retired := memtable.NewAppendOnlyWithCapacity(0)
+	retired.Set([]byte("retired"), []byte("value"))
+	retired.Freeze()
+
+	view := &memtableView{
+		mutables:    []memtable.Table{mutable},
+		retiredMems: []memtable.Table{retired},
+	}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	held := db.retainMemtableView()
+	if held != view {
+		t.Fatalf("retainMemtableView returned %p want %p", held, view)
+	}
+	if refs := view.refs.Load(); refs != 2 {
+		t.Fatalf("view refs after retain=%d want=2", refs)
+	}
+
+	db.releaseClosingEmptyMemtables()
+
+	if got := db.memtables.Load(); got != nil {
+		t.Fatalf("published view after close cleanup=%p want nil", got)
+	}
+	if refs := view.refs.Load(); refs != 1 {
+		t.Fatalf("view refs after closing cleanup=%d want=1", refs)
+	}
+	if mutable.released {
+		t.Fatalf("mutable released before retained reader dropped view")
+	}
+	if got := len(view.retiredMems); got != 1 {
+		t.Fatalf("retired memtables after closing cleanup=%d want=1", got)
+	}
+
+	db.releaseMemtableView(held)
+
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after final release=%d want=0", refs)
+	}
+	if !mutable.released {
+		t.Fatalf("mutable was not released after final view release")
+	}
+	if got := retired.Len(); got != 0 {
+		t.Fatalf("retired memtable len after final release=%d want=0", got)
+	}
+	if got := len(view.retiredMems); got != 0 {
+		t.Fatalf("retired memtables not cleared len=%d", got)
+	}
+	if got := len(view.closingEmptyMems); got != 0 {
+		t.Fatalf("closing empty memtables not cleared len=%d", got)
 	}
 }
 

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -154,6 +154,13 @@ func TestReleaseClosingEmptyMemtablesDefersCleanupForRetainedView(t *testing.T) 
 	if got := len(view.retiredMems); got != 1 {
 		t.Fatalf("retired memtables after closing cleanup=%d want=1", got)
 	}
+	// Closing-empty mems should be registered in the DB map (not on the view).
+	db.closingEmptyMemsMu.Lock()
+	pendingCount := len(db.closingEmptyByView[view])
+	db.closingEmptyMemsMu.Unlock()
+	if pendingCount != 1 {
+		t.Fatalf("pending closing-empty mems in DB map=%d want=1", pendingCount)
+	}
 
 	db.releaseMemtableView(held)
 
@@ -169,8 +176,11 @@ func TestReleaseClosingEmptyMemtablesDefersCleanupForRetainedView(t *testing.T) 
 	if got := len(view.retiredMems); got != 0 {
 		t.Fatalf("retired memtables not cleared len=%d", got)
 	}
-	if got := len(view.closingEmptyMems); got != 0 {
-		t.Fatalf("closing empty memtables not cleared len=%d", got)
+	db.closingEmptyMemsMu.Lock()
+	remainingCount := len(db.closingEmptyByView[view])
+	db.closingEmptyMemsMu.Unlock()
+	if remainingCount != 0 {
+		t.Fatalf("DB closing-empty map not cleared after final release: len=%d", remainingCount)
 	}
 }
 

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -174,6 +174,41 @@ func TestReleaseClosingEmptyMemtablesDefersCleanupForRetainedView(t *testing.T) 
 	}
 }
 
+func TestReleaseClosingEmptyMemtablesCleansZeroRefPublishedView(t *testing.T) {
+	db := &DB{}
+	mutable := &releaseTrackingMemtable{AppendOnly: memtable.NewAppendOnlyWithCapacity(0)}
+	retired := memtable.NewAppendOnlyWithCapacity(0)
+	retired.Set([]byte("retired"), []byte("value"))
+	retired.Freeze()
+
+	view := &memtableView{
+		mutables:    []memtable.Table{mutable},
+		retiredMems: []memtable.Table{retired},
+	}
+	db.memtables.Store(view)
+
+	db.releaseClosingEmptyMemtables()
+
+	if got := db.memtables.Load(); got != nil {
+		t.Fatalf("published view after close cleanup=%p want nil", got)
+	}
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after closing cleanup=%d want=0", refs)
+	}
+	if !mutable.released {
+		t.Fatalf("mutable was not released")
+	}
+	if got := retired.Len(); got != 0 {
+		t.Fatalf("retired memtable len after cleanup=%d want=0", got)
+	}
+	if got := len(view.mutables); got != 0 {
+		t.Fatalf("mutable memtables not cleared len=%d", got)
+	}
+	if got := len(view.retiredMems); got != 0 {
+		t.Fatalf("retired memtables not cleared len=%d", got)
+	}
+}
+
 func TestPutAppendOnlyMemLease_RespectsCap(t *testing.T) {
 	db := &DB{}
 	for i := 0; i < maxAppendOnlyMemLeases+8; i++ {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -710,14 +710,19 @@ type bufferedUniqueValueIndex struct {
 }
 
 type bufferedPrimaryRunIndex struct {
-	values     map[uint64]bufferedPrimaryRunRef
-	collisions map[uint64][]bufferedPrimaryRunRef
-	arenas     [][]byte
+	values        map[uint64]bufferedPrimaryRunRef
+	collisions    map[uint64][]bufferedPrimaryRunRef
+	arenas        [][]byte
+	directEntries bool
 }
 
 type bufferedPrimaryRunRef struct {
-	key   []byte
-	table memtable.Table
+	key        []byte
+	table      memtable.Table
+	value      []byte
+	ptr        page.ValuePtr
+	flags      byte
+	entryValid bool
 }
 
 type collectionWriteDomain struct {
@@ -4217,10 +4222,17 @@ func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtabl
 }
 
 func newBufferedPrimaryRunIndex(capacity int) *bufferedPrimaryRunIndex {
+	return newBufferedPrimaryRunIndexWithDirectEntries(capacity, false)
+}
+
+func newBufferedPrimaryRunIndexWithDirectEntries(capacity int, directEntries bool) *bufferedPrimaryRunIndex {
 	if capacity < 0 {
 		capacity = 0
 	}
-	return &bufferedPrimaryRunIndex{values: make(map[uint64]bufferedPrimaryRunRef, capacity)}
+	return &bufferedPrimaryRunIndex{
+		values:        make(map[uint64]bufferedPrimaryRunRef, capacity),
+		directEntries: directEntries,
+	}
 }
 
 func (index *bufferedPrimaryRunIndex) addRef(hash uint64, ref bufferedPrimaryRunRef) {
@@ -4250,20 +4262,28 @@ func (index *bufferedPrimaryRunIndex) addRef(hash uint64, ref bufferedPrimaryRun
 	collisions[hash] = append(bucket, ref)
 }
 
-func (index *bufferedPrimaryRunIndex) lookup(key []byte) (memtable.Table, bool) {
+func (index *bufferedPrimaryRunIndex) lookupRef(key []byte) (bufferedPrimaryRunRef, bool) {
 	if index == nil {
-		return nil, false
+		return bufferedPrimaryRunRef{}, false
 	}
 	hash := xxhash.Sum64(key)
 	if ref, ok := index.values[hash]; ok && bytes.Equal(ref.key, key) {
-		return ref.table, true
+		return ref, true
 	}
 	for _, ref := range index.collisions[hash] {
 		if bytes.Equal(ref.key, key) {
-			return ref.table, true
+			return ref, true
 		}
 	}
-	return nil, false
+	return bufferedPrimaryRunRef{}, false
+}
+
+func (index *bufferedPrimaryRunIndex) lookup(key []byte) (memtable.Table, bool) {
+	ref, ok := index.lookupRef(key)
+	if !ok {
+		return nil, false
+	}
+	return ref.table, true
 }
 
 func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrimary memtable.Table) error {
@@ -4279,7 +4299,15 @@ func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrim
 	if stableKeys {
 		for it.Valid() {
 			key := it.UnsafeKey()
-			index.addRef(xxhash.Sum64(key), bufferedPrimaryRunRef{key: key, table: batchPrimary})
+			ref := bufferedPrimaryRunRef{key: key, table: batchPrimary}
+			if index.directEntries {
+				value, ptr, flags := it.UnsafeEntry()
+				ref.value = value
+				ref.ptr = ptr
+				ref.flags = flags
+				ref.entryValid = true
+			}
+			index.addRef(xxhash.Sum64(key), ref)
 			it.Next()
 		}
 		return it.Error()
@@ -4347,7 +4375,7 @@ func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]mem
 	if len(tables) == 0 {
 		return nil, nil
 	}
-	index := newBufferedPrimaryRunIndex(bufferedRunLenHint(tables))
+	index := newBufferedPrimaryRunIndexWithDirectEntries(bufferedRunLenHint(tables), true)
 	for _, table := range tables {
 		if err := addBufferedPrimaryRunIndexEntries(index, table); err != nil {
 			return nil, err
@@ -8671,11 +8699,17 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 		return entries, buffer, nil
 	}
 	for i, item := range items {
-		table, ok := index.lookup(item.DocumentID)
-		if !ok || table == nil {
+		ref, ok := index.lookupRef(item.DocumentID)
+		if !ok {
 			continue
 		}
-		value, _, flags, found := table.GetEntry(item.DocumentID)
+		value, flags, found := ref.value, ref.flags, ref.entryValid
+		if !found {
+			if ref.table == nil {
+				continue
+			}
+			value, _, flags, found = ref.table.GetEntry(item.DocumentID)
+		}
 		if !found {
 			continue
 		}
@@ -11294,8 +11328,11 @@ func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain
 		var value []byte
 		var flags byte
 		found := false
-		if table, ok := domain.primaryRunIndex.lookup(documentID); ok {
-			value, _, flags, found = table.GetEntry(documentID)
+		if ref, ok := domain.primaryRunIndex.lookupRef(documentID); ok {
+			value, flags, found = ref.value, ref.flags, ref.entryValid
+			if !found && ref.table != nil {
+				value, _, flags, found = ref.table.GetEntry(documentID)
+			}
 		} else if domain.primaryRunIndex == nil {
 			value, _, flags, found = getBufferedRunEntry(pendingIndexedRootRunsLocked(domain, name), documentID)
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -720,7 +720,6 @@ type bufferedPrimaryRunRef struct {
 	key        []byte
 	table      memtable.Table
 	value      []byte
-	ptr        page.ValuePtr
 	flags      byte
 	entryValid bool
 }
@@ -4301,9 +4300,8 @@ func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrim
 			key := it.UnsafeKey()
 			ref := bufferedPrimaryRunRef{key: key, table: batchPrimary}
 			if index.directEntries {
-				value, ptr, flags := it.UnsafeEntry()
+				value, _, flags := it.UnsafeEntry()
 				ref.value = value
-				ref.ptr = ptr
 				ref.flags = flags
 				ref.entryValid = true
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -5960,7 +5960,7 @@ func TestBufferedPrimaryRunIndexFindsNewestTable(t *testing.T) {
 	defer resetCollectionRunTable(older)
 	defer resetCollectionRunTable(newer)
 
-	index := newBufferedPrimaryRunIndex(0)
+	index := newBufferedPrimaryRunIndexWithDirectEntries(0, true)
 	if err := addBufferedPrimaryRunIndexEntries(index, older); err != nil {
 		t.Fatalf("add older table: %v", err)
 	}
@@ -5977,6 +5977,13 @@ func TestBufferedPrimaryRunIndexFindsNewestTable(t *testing.T) {
 	value, _, flags, found := table.GetEntry([]byte("u1"))
 	if !found || flags&node.FlagTombstone != 0 || !bytes.Equal(value, []byte("newer")) {
 		t.Fatalf("lookup found=%v flags=%d value=%q want newer live value", found, flags, value)
+	}
+	ref, ok := index.lookupRef([]byte("u1"))
+	if !ok {
+		t.Fatal("lookupRef u1 missing")
+	}
+	if !ref.entryValid || ref.table != newer || ref.flags&node.FlagTombstone != 0 || !bytes.Equal(ref.value, []byte("newer")) {
+		t.Fatalf("lookupRef entryValid=%v table=%p flags=%d value=%q want newer direct entry", ref.entryValid, ref.table, ref.flags, ref.value)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -24,6 +24,9 @@ const (
 	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
+	appendOnlyEntryPoolMinShift             = 7
+	appendOnlyEntryPoolMaxShift             = 20
+	appendOnlyEntryPoolClassCount           = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyReusableKeyMaxCap             = 1 << 10
@@ -40,7 +43,7 @@ const (
 	appendOnlyAggressiveGrowCutoff          = appendOnlyResetDropThresholdEntries * 2
 )
 
-var appendOnlyEntryPool sync.Pool
+var appendOnlyEntryPools [appendOnlyEntryPoolClassCount]sync.Pool
 var appendOnlyIteratorPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
@@ -114,6 +117,38 @@ func appendOnlyMaxReuseEntries(length int) int {
 	return maxReuse
 }
 
+func appendOnlyEntryPoolClassForLength(length int) (int, int, bool) {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyEntryPoolMaxCap {
+		return 0, 0, false
+	}
+	capacity := appendOnlyMinInitialEntries
+	if length > appendOnlyMinInitialEntries {
+		capacity = 1 << bits.Len(uint(length-1))
+	}
+	if capacity > appendOnlyEntryPoolMaxCap {
+		return 0, 0, false
+	}
+	class := bits.Len(uint(capacity)) - 1 - appendOnlyEntryPoolMinShift
+	if class < 0 || class >= appendOnlyEntryPoolClassCount {
+		return 0, 0, false
+	}
+	return class, capacity, true
+}
+
+func appendOnlyEntryPoolClassForReusableCapacity(capacity int) (int, bool) {
+	if capacity < appendOnlyMinInitialEntries || capacity > appendOnlyEntryPoolMaxCap {
+		return 0, false
+	}
+	class, _, ok := appendOnlyEntryPoolClassForLength(capacity)
+	if !ok {
+		return 0, false
+	}
+	return class, true
+}
+
 func getAppendOnlyEntriesFromPool(length int, pool *sync.Pool) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
@@ -138,7 +173,21 @@ func getAppendOnlyEntriesFromPool(length int, pool *sync.Pool) []appendOnlyEntry
 }
 
 func getAppendOnlyEntries(length int) []appendOnlyEntry {
-	return getAppendOnlyEntriesFromPool(length, &appendOnlyEntryPool)
+	if length < 0 {
+		length = 0
+	}
+	class, _, ok := appendOnlyEntryPoolClassForLength(length)
+	if !ok {
+		return make([]appendOnlyEntry, length)
+	}
+	if v := appendOnlyEntryPools[class].Get(); v != nil {
+		if entries, ok := v.([]appendOnlyEntry); ok && cap(entries) >= length {
+			if cap(entries) <= appendOnlyMaxReuseEntries(length) {
+				return entries[:length]
+			}
+		}
+	}
+	return make([]appendOnlyEntry, length)
 }
 
 func putAppendOnlyEntries(entries []appendOnlyEntry) {
@@ -147,7 +196,11 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	}
 	full := entries[:cap(entries)]
 	clear(full)
-	appendOnlyEntryPool.Put(full[:0])
+	class, ok := appendOnlyEntryPoolClassForReusableCapacity(cap(entries))
+	if !ok {
+		return
+	}
+	appendOnlyEntryPools[class].Put(full[:0])
 }
 
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -20,27 +20,29 @@ const (
 	// appendOnlyEntry struct footprint. A lower estimate reduces growth/copy
 	// churn for pointer-heavy write paths.
 	appendOnlyEstimatedBytesPerEntryPointer = 24
-	appendOnlyMinInitialEntries             = 128
-	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
-	appendOnlyEntryPoolMaxCap               = 1 << 20
-	appendOnlyEntryPoolMinShift             = 7
-	appendOnlyEntryPoolMaxShift             = 20
-	appendOnlyEntryPoolClassCount           = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
-	appendOnlyIteratorPoolMaxCap            = 1 << 20
-	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
-	appendOnlyReusableKeyMaxCap             = 1 << 10
-	appendOnlyKeyArenaDefaultChunk          = 2 << 10
-	appendOnlyValueArenaMinShift            = 12
-	appendOnlyValueArenaMaxShift            = 20
-	appendOnlyValueArenaClassCount          = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
-	appendOnlyValueArenaDefaultChunk        = 32 << 10
-	appendOnlyValueArenaPoolMaxCap          = 1 << appendOnlyValueArenaMaxShift
-	appendOnlyValueArenaRetainMaxCap        = 4 << 20
-	appendOnlyValueArenaRetainChunks        = 128
-	appendOnlyReuseOversizeFactor           = 4
-	appendOnlyResetDropThresholdEntries     = 1 << 15
-	appendOnlyAggressiveGrowCutoff          = appendOnlyResetDropThresholdEntries * 2
+	// Pool size-class boundaries. Min/Max initial entries are derived from
+	// these shifts so the three constants can't drift out of sync.
+	appendOnlyEntryPoolMinShift         = 7
+	appendOnlyEntryPoolMaxShift         = 20
+	appendOnlyEntryPoolClassCount       = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
+	appendOnlyEntryPoolMaxCap           = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
+	appendOnlyMinInitialEntries         = 1 << appendOnlyEntryPoolMinShift // 128
+	appendOnlyMaxInitialEntries         = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
+	appendOnlyIteratorPoolMaxCap        = 1 << 20
+	appendOnlyIteratorPtrPoolMaxCap     = 1 << 20
+	appendOnlyReusableKeyMaxCap         = 1 << 10
+	appendOnlyKeyArenaDefaultChunk      = 2 << 10
+	appendOnlyValueArenaMinShift        = 12
+	appendOnlyValueArenaMaxShift        = 20
+	appendOnlyValueArenaClassCount      = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
+	appendOnlyValueArenaDefaultChunk    = 32 << 10
+	appendOnlyValueArenaPoolMaxCap      = 1 << appendOnlyValueArenaMaxShift
+	appendOnlyValueArenaRetainMaxCap    = 4 << 20
+	appendOnlyValueArenaRetainChunks    = 128
+	appendOnlyReuseOversizeFactor       = 4
+	appendOnlyResetDropThresholdEntries = 1 << 15
+	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
 )
 
 var appendOnlyEntryPools [appendOnlyEntryPoolClassCount]sync.Pool

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -26,6 +26,48 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyEntryPoolClassForLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		length   int
+		wantCap  int
+		wantPool bool
+	}{
+		{name: "negative", length: -1, wantCap: appendOnlyMinInitialEntries, wantPool: true},
+		{name: "zero", length: 0, wantCap: appendOnlyMinInitialEntries, wantPool: true},
+		{name: "minimum", length: appendOnlyMinInitialEntries, wantCap: appendOnlyMinInitialEntries, wantPool: true},
+		{name: "round-up", length: appendOnlyMinInitialEntries + 1, wantCap: appendOnlyMinInitialEntries * 2, wantPool: true},
+		{name: "bench-sized", length: 16000, wantCap: 1 << 14, wantPool: true},
+		{name: "maximum", length: appendOnlyEntryPoolMaxCap, wantCap: appendOnlyEntryPoolMaxCap, wantPool: true},
+		{name: "too-large", length: appendOnlyEntryPoolMaxCap + 1, wantPool: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, gotCap, gotPool := appendOnlyEntryPoolClassForLength(tc.length)
+			if gotPool != tc.wantPool {
+				t.Fatalf("pooled=%v want %v", gotPool, tc.wantPool)
+			}
+			if gotPool && gotCap != tc.wantCap {
+				t.Fatalf("cap=%d want %d", gotCap, tc.wantCap)
+			}
+		})
+	}
+}
+
+func TestAppendOnlyEntryPoolClassForReusableCapacity(t *testing.T) {
+	if _, ok := appendOnlyEntryPoolClassForReusableCapacity(appendOnlyMinInitialEntries - 1); ok {
+		t.Fatalf("sub-minimum capacity should not be pooled")
+	}
+	if _, ok := appendOnlyEntryPoolClassForReusableCapacity(16000); !ok {
+		t.Fatalf("bench-sized capacity should be pooled")
+	}
+	if _, ok := appendOnlyEntryPoolClassForReusableCapacity(appendOnlyEntryPoolMaxCap + 1); ok {
+		t.Fatalf("oversized capacity should not be pooled")
+	}
+}
+
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")


### PR DESCRIPTION
## Summary
- size-class append-only entry buffer pooling for production memtable allocation
- release empty final append-only mutable memtables on DB close so short-lived DBs can reuse their entry buffers
- add pool class coverage for append-only entry reuse decisions

## Benchmark / profile
Compared `/tmp/treedb_compression_smoke_latest_20260506_101515/template-v1/auto` to `/tmp/treedb_insert_memtable_entry_release_batch16000/auto` on `BenchmarkCollectionShapeInsertBatch` with TemplateV1 auto compression, indexes 0/1/2, count=10, batch=16000.

- total alloc-space: 5.315GB -> 4.466GB (-16.0%)
- `memtable.getAppendOnlyEntries*` flat alloc: 1.118GB -> 150.6MB (-86.5%)
- geomean sec/op: 529.3ns -> 514.5ns (-2.8%)
- disk bytes/doc, roots/batch, secondary entries/doc unchanged

Caveat: most of the allocation win is whole-process short-lived DB open/close cleanup. The timed insert path is mostly neutral, with a significant indexes_0 win and neutral/noisy indexed rows.

## Tests
- `go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/collections`
- `git diff --check`

Stacked on #1392 / `codex/bump-compress-dict-workspace` so this PR only shows the memtable cleanup.