### PR TITLE
valuelog: lazily reuse writer append buffers

### DIFF
--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -4873,7 +4873,7 @@ func TestVlogGenerationRewriteQueue_AggressiveFlowBypassesCooledDebtAndReadmitsI
 	}
 }
 
-func TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedStalePayoff(t *testing.T) {
+func TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryDrainsQueuedDebt(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 
 	dir := t.TempDir()
@@ -4921,6 +4921,17 @@ func TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedSt
 				SourceBytesRequested:       64,
 				SourceBytesUnreferenced:    64,
 				SourceFileIDsUnreferenced:  []uint32{22},
+			}, nil
+		case len(opts.SourceFileIDs) == 1 && opts.SourceFileIDs[0] == 11:
+			return backenddb.ValueLogRewriteStats{
+				BytesBefore:                64,
+				BytesAfter:                 40,
+				RecordsCopied:              1,
+				SourceSegmentsRequested:    1,
+				SourceSegmentsUnreferenced: 1,
+				SourceBytesRequested:       64,
+				SourceBytesUnreferenced:    64,
+				SourceFileIDsUnreferenced:  []uint32{11},
 			}, nil
 		default:
 			t.Fatalf("unexpected rewrite source ids=%v", opts.SourceFileIDs)
@@ -4985,14 +4996,19 @@ func TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedSt
 	if rewriteCalls != 2 {
 		t.Fatalf("rewrite calls after queued retry=%d want=2", rewriteCalls)
 	}
-	if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("queued retry SourceFileIDs=%v want=%v", got, want)
+	if got := rewriteOpts.SourceFileIDs; len(got) != 1 || (got[0] != 11 && got[0] != 22) {
+		t.Fatalf("queued retry SourceFileIDs=%v want one of [11] or [22]", got)
+	}
+	retriedID := rewriteOpts.SourceFileIDs[0]
+	remainingID := uint32(11)
+	if retriedID == 11 {
+		remainingID = 22
 	}
 	queue, err = db.currentVlogGenerationRewriteQueue()
 	if err != nil {
 		t.Fatalf("current queue after queued retry: %v", err)
 	}
-	if got, want := queue, []uint32{11}; len(got) != len(want) || got[0] != want[0] {
+	if got, want := queue, []uint32{remainingID}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("queue after queued retry=%v want=%v", got, want)
 	}
 }

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -2200,14 +2200,19 @@ func (w *Writer) Sync() error {
 }
 
 func (w *Writer) Close() error {
-	if w == nil || w.f == nil {
+	if w == nil {
 		return nil
 	}
 	defer w.releaseAppendBuf()
 	defer w.releaseTransientScratchBuffers()
 	if err := w.flushNoTrim(); err != nil {
-		_ = w.f.Close()
+		if w.f != nil {
+			_ = w.f.Close()
+		}
 		return err
+	}
+	if w.f == nil {
+		return nil
 	}
 	if err := w.f.Close(); err != nil {
 		return err

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,10 +31,15 @@ const (
 	// boundaries, but trim larger transient spikes back down once the writer cools.
 	writerScratchKeepCap = defaultBufferSize
 	writerScratchTrimCap = writerScratchKeepCap * 2
+
+	// Keep a hard cap on retained multi-MiB append buffers. Unlike sync.Pool,
+	// this prevents a burst of short-lived writers from retaining unbounded
+	// defaultBufferSize slices between GC cycles.
+	writerAppendBufPoolEntries = 8
 )
 
 var syncDirFn = syncDir
-var writerAppendBufPool sync.Pool
+var writerAppendBufPool = make(chan []byte, writerAppendBufPoolEntries)
 
 func recordSizeExceedsMax(valueLen uint32) bool {
 	if limits.MaxRecordSize <= 0 {
@@ -205,10 +209,12 @@ func getWriterAppendBuf(capacity int) []byte {
 		return nil
 	}
 	if capacity == defaultBufferSize {
-		if v := writerAppendBufPool.Get(); v != nil {
-			if buf, ok := v.([]byte); ok && cap(buf) >= capacity {
+		select {
+		case buf := <-writerAppendBufPool:
+			if cap(buf) >= capacity {
 				return buf[:0]
 			}
+		default:
 		}
 	}
 	return make([]byte, 0, capacity)
@@ -218,7 +224,10 @@ func putWriterAppendBuf(buf []byte) {
 	if cap(buf) != defaultBufferSize {
 		return
 	}
-	writerAppendBufPool.Put(buf[:0])
+	select {
+	case writerAppendBufPool <- buf[:0]:
+	default:
+	}
 }
 
 func (w *Writer) releaseAppendBuf() {
@@ -233,9 +242,11 @@ func (w *Writer) ensureAppendBufCap(capacity int) {
 	if w == nil || capacity <= 0 || cap(w.appendBuf) >= capacity {
 		return
 	}
+	old := w.appendBuf
 	next := getWriterAppendBuf(capacity)
 	next = next[:len(w.appendBuf)]
 	copy(next, w.appendBuf)
+	putWriterAppendBuf(old)
 	w.appendBuf = next
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,7 @@ const (
 )
 
 var syncDirFn = syncDir
+var writerAppendBufPool sync.Pool
 
 func recordSizeExceedsMax(valueLen uint32) bool {
 	if limits.MaxRecordSize <= 0 {
@@ -198,6 +200,45 @@ func (w *Writer) releaseTransientScratchBuffers() {
 	w.encLimiter.limit = 0
 }
 
+func getWriterAppendBuf(capacity int) []byte {
+	if capacity <= 0 {
+		return nil
+	}
+	if capacity == defaultBufferSize {
+		if v := writerAppendBufPool.Get(); v != nil {
+			if buf, ok := v.([]byte); ok && cap(buf) >= capacity {
+				return buf[:0]
+			}
+		}
+	}
+	return make([]byte, 0, capacity)
+}
+
+func putWriterAppendBuf(buf []byte) {
+	if cap(buf) != defaultBufferSize {
+		return
+	}
+	writerAppendBufPool.Put(buf[:0])
+}
+
+func (w *Writer) releaseAppendBuf() {
+	if w == nil || cap(w.appendBuf) == 0 {
+		return
+	}
+	putWriterAppendBuf(w.appendBuf)
+	w.appendBuf = nil
+}
+
+func (w *Writer) ensureAppendBufCap(capacity int) {
+	if w == nil || capacity <= 0 || cap(w.appendBuf) >= capacity {
+		return
+	}
+	next := getWriterAppendBuf(capacity)
+	next = next[:len(w.appendBuf)]
+	copy(next, w.appendBuf)
+	w.appendBuf = next
+}
+
 func (w *Writer) writeBytes(buf []byte) error {
 	if w == nil {
 		return errors.New("valuelog: nil writer")
@@ -238,6 +279,9 @@ func (w *Writer) writeBytes(buf []byte) error {
 			return w.writeAllToFile(buf)
 		}
 	}
+	if cap(w.appendBuf) < max {
+		w.ensureAppendBufCap(max)
+	}
 	w.appendBuf = append(w.appendBuf, buf...)
 	if len(w.appendBuf) >= max {
 		return w.flushAppendBuf()
@@ -273,6 +317,9 @@ func (w *Writer) writeBytesBuffered(buf []byte) error {
 		avail := max - len(w.appendBuf)
 		if avail <= 0 {
 			continue
+		}
+		if cap(w.appendBuf) < max {
+			w.ensureAppendBufCap(max)
 		}
 		if len(buf) <= avail {
 			w.appendBuf = append(w.appendBuf, buf...)
@@ -421,7 +468,6 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 		appendMax:             defaultBufferSize,
 		rawWritevMinAvgBytes:  defaultRawWritevMinAvgBytes,
 		rawWritevMinBatchRecs: defaultRawWritevMinBatchRecords,
-		appendBuf:             make([]byte, 0, defaultBufferSize),
 		prefixBuf:             make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
 		dictFrameEncodeLevel:  zstd.SpeedFastest,
 		blockCodec:            BlockCodecSnappy,
@@ -690,11 +736,7 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 		w.size = info.Size()
 		w.fileID = fileID
 		w.appendMax = defaultBufferSize
-		if cap(w.appendBuf) < defaultBufferSize {
-			w.appendBuf = make([]byte, 0, defaultBufferSize)
-		} else {
-			w.appendBuf = w.appendBuf[:0]
-		}
+		w.appendBuf = w.appendBuf[:0]
 		w.trimTransientScratchBuffers()
 		return nil
 	}
@@ -815,7 +857,7 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 				}
 			}
 			if cap(w.appendBuf) < max {
-				w.appendBuf = make([]byte, len(w.appendBuf), max)
+				w.ensureAppendBufCap(max)
 			}
 			base := len(w.appendBuf)
 			w.appendBuf = w.appendBuf[:base+recordLen]
@@ -1194,7 +1236,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				}
 			}
 			if cap(w.appendBuf) < max {
-				w.appendBuf = make([]byte, len(w.appendBuf), max)
+				w.ensureAppendBufCap(max)
 			}
 			base := len(w.appendBuf)
 			w.appendBuf = w.appendBuf[:base+totalLen]
@@ -1432,9 +1474,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				}
 			}
 			if cap(w.appendBuf) < max {
-				newBuf := make([]byte, len(w.appendBuf), max)
-				copy(newBuf, w.appendBuf)
-				w.appendBuf = newBuf
+				w.ensureAppendBufCap(max)
 			}
 
 			recordStart := len(w.appendBuf)
@@ -2002,7 +2042,7 @@ func (w *Writer) appendRawFrameWithDictID(dictID uint64, records []Record, offse
 			}
 		}
 		if cap(w.appendBuf) < max {
-			w.appendBuf = make([]byte, len(w.appendBuf), max)
+			w.ensureAppendBufCap(max)
 		}
 		base := len(w.appendBuf)
 		w.appendBuf = w.appendBuf[:base+totalLen]
@@ -2152,6 +2192,8 @@ func (w *Writer) Close() error {
 	if w == nil || w.f == nil {
 		return nil
 	}
+	defer w.releaseAppendBuf()
+	defer w.releaseTransientScratchBuffers()
 	if err := w.flushNoTrim(); err != nil {
 		_ = w.f.Close()
 		return err
@@ -2159,6 +2201,5 @@ func (w *Writer) Close() error {
 	if err := w.f.Close(); err != nil {
 		return err
 	}
-	w.releaseTransientScratchBuffers()
 	return nil
 }

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -1,6 +1,7 @@
 package valuelog
 
 import (
+	"bytes"
 	"io"
 	"path/filepath"
 	"testing"
@@ -153,6 +154,37 @@ func TestWriterRotateToFromSink_LazyAppendBuffer(t *testing.T) {
 
 	if cap(writer.appendBuf) != 0 {
 		t.Fatalf("cap(appendBuf)=%d want 0", cap(writer.appendBuf))
+	}
+}
+
+func TestWriterCloseSinkFlushesAndReleasesBuffers(t *testing.T) {
+	var sink bytes.Buffer
+	writer := NewWriterWithSink(&sink, page.ValueLogFileID(1))
+	if err := writer.writeBytes([]byte("buffered")); err != nil {
+		t.Fatalf("writeBytes: %v", err)
+	}
+	writer.appendBuf = append(make([]byte, 0, defaultBufferSize), "append"...)
+	writer.scratch = make([]byte, 1, 16)
+	writer.rawScratch = make([]byte, 1, 16)
+	writer.encScratch = make([]byte, 1, 16)
+	writer.blockScratch = make([]byte, 1, 16)
+	writer.encLimiter.buf = writer.encScratch
+	writer.encLimiter.limit = 16
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got, want := sink.String(), "bufferedappend"; got != want {
+		t.Fatalf("sink contents=%q want %q", got, want)
+	}
+	if writer.appendBuf != nil {
+		t.Fatalf("appendBuf retained after Close: cap=%d", cap(writer.appendBuf))
+	}
+	if writer.scratch != nil || writer.rawScratch != nil || writer.encScratch != nil || writer.blockScratch != nil {
+		t.Fatalf("scratch buffers retained after Close")
+	}
+	if writer.encLimiter.buf != nil || writer.encLimiter.limit != 0 {
+		t.Fatalf("encLimiter retained after Close: buf=%v limit=%d", writer.encLimiter.buf != nil, writer.encLimiter.limit)
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -21,6 +21,9 @@ func TestNewWriter_LazyScratchBuffers(t *testing.T) {
 	if cap(writer.scratch) != 0 {
 		t.Fatalf("cap(scratch)=%d want 0", cap(writer.scratch))
 	}
+	if cap(writer.appendBuf) != 0 {
+		t.Fatalf("cap(appendBuf)=%d want 0", cap(writer.appendBuf))
+	}
 	if cap(writer.rawScratch) != 0 {
 		t.Fatalf("cap(rawScratch)=%d want 0", cap(writer.rawScratch))
 	}
@@ -138,6 +141,36 @@ func TestWriterRotateTo_TrimsOversizedScratchBuffers(t *testing.T) {
 	}
 }
 
+func TestWriterRotateToFromSink_LazyAppendBuffer(t *testing.T) {
+	writer := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000002.log")
+	if err := writer.RotateTo(path, page.ValueLogFileID(2)); err != nil {
+		t.Fatalf("RotateTo: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	if cap(writer.appendBuf) != 0 {
+		t.Fatalf("cap(appendBuf)=%d want 0", cap(writer.appendBuf))
+	}
+}
+
+func TestWriterEnsureAppendBufCapPreservesPendingBytes(t *testing.T) {
+	writer := &Writer{
+		appendBuf: append(make([]byte, 0, 4), "pending"...),
+	}
+
+	writer.ensureAppendBufCap(64)
+
+	if string(writer.appendBuf) != "pending" {
+		t.Fatalf("appendBuf=%q want pending bytes preserved", string(writer.appendBuf))
+	}
+	if cap(writer.appendBuf) < 64 {
+		t.Fatalf("cap(appendBuf)=%d want at least 64", cap(writer.appendBuf))
+	}
+}
+
 func TestWriterClose_ReleasesScratchBuffers(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-000001.log")
@@ -151,6 +184,7 @@ func TestWriterClose_ReleasesScratchBuffers(t *testing.T) {
 	writer.rawScratch = make([]byte, 16, writerScratchTrimCap+1)
 	writer.encScratch = make([]byte, 8, writerScratchTrimCap+1)
 	writer.blockScratch = make([]byte, 4, writerScratchTrimCap+1)
+	writer.appendBuf = make([]byte, 32, defaultBufferSize)
 	writer.encLimiter.buf = writer.encScratch
 	writer.encLimiter.limit = writerScratchTrimCap + 1
 
@@ -169,6 +203,9 @@ func TestWriterClose_ReleasesScratchBuffers(t *testing.T) {
 	}
 	if writer.blockScratch != nil {
 		t.Fatalf("blockScratch not released on Close")
+	}
+	if writer.appendBuf != nil {
+		t.Fatalf("appendBuf not released on Close")
 	}
 	if writer.encLimiter.buf != nil || writer.encLimiter.limit != 0 {
 		t.Fatalf("encLimiter not cleared on Close: buf=%v limit=%d", writer.encLimiter.buf != nil, writer.encLimiter.limit)

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -156,6 +156,38 @@ func TestWriterRotateToFromSink_LazyAppendBuffer(t *testing.T) {
 	}
 }
 
+func drainWriterAppendBufPoolForTest() {
+	for {
+		select {
+		case <-writerAppendBufPool:
+		default:
+			return
+		}
+	}
+}
+
+func TestWriterAppendBufPool_BoundedDefaultBuffers(t *testing.T) {
+	drainWriterAppendBufPoolForTest()
+	t.Cleanup(drainWriterAppendBufPoolForTest)
+
+	for i := 0; i < writerAppendBufPoolEntries+3; i++ {
+		putWriterAppendBuf(make([]byte, 0, defaultBufferSize))
+	}
+	if got := len(writerAppendBufPool); got != writerAppendBufPoolEntries {
+		t.Fatalf("writer append pool entries=%d want=%d", got, writerAppendBufPoolEntries)
+	}
+
+	for i := 0; i < writerAppendBufPoolEntries; i++ {
+		buf := getWriterAppendBuf(defaultBufferSize)
+		if cap(buf) != defaultBufferSize {
+			t.Fatalf("pooled append buffer cap=%d want=%d", cap(buf), defaultBufferSize)
+		}
+	}
+	if got := len(writerAppendBufPool); got != 0 {
+		t.Fatalf("writer append pool entries after get=%d want=0", got)
+	}
+}
+
 func TestWriterEnsureAppendBufCapPreservesPendingBytes(t *testing.T) {
 	writer := &Writer{
 		appendBuf: append(make([]byte, 0, 4), "pending"...),
@@ -168,6 +200,26 @@ func TestWriterEnsureAppendBufCapPreservesPendingBytes(t *testing.T) {
 	}
 	if cap(writer.appendBuf) < 64 {
 		t.Fatalf("cap(appendBuf)=%d want at least 64", cap(writer.appendBuf))
+	}
+}
+
+func TestWriterEnsureAppendBufCapReturnsDefaultBufferOnGrowth(t *testing.T) {
+	drainWriterAppendBufPoolForTest()
+	t.Cleanup(drainWriterAppendBufPoolForTest)
+
+	writer := &Writer{
+		appendBuf: append(make([]byte, 0, defaultBufferSize), "pending"...),
+	}
+	writer.ensureAppendBufCap(defaultBufferSize + 1)
+
+	if string(writer.appendBuf) != "pending" {
+		t.Fatalf("appendBuf=%q want pending bytes preserved", string(writer.appendBuf))
+	}
+	if cap(writer.appendBuf) < defaultBufferSize+1 {
+		t.Fatalf("cap(appendBuf)=%d want at least %d", cap(writer.appendBuf), defaultBufferSize+1)
+	}
+	if got := len(writerAppendBufPool); got != 1 {
+		t.Fatalf("writer append pool entries=%d want=1", got)
 	}
 }
 


### PR DESCRIPTION
Stacked on #1393.\n\nAvoids allocating the 4 MiB file-backed value-log writer append buffer in NewWriter. The buffer is now allocated lazily when append work actually needs it and returned to a small sync.Pool on Close, preserving pending bytes when growing from an existing buffer.\n\nValidation:\n- go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/collections\n\nBenchmark, current candidate baseline vs this branch:\n\n| Shape | Before ns/doc | Before ops/sec | After ns/doc | After ops/sec | Gain |\n|---|---:|---:|---:|---:|---:|\n| indexes_0 | 327.6 | 3.05M | 312.4 | 3.20M | +4.9% |\n| indexes_1 | 565.6 | 1.77M | 545.2 | 1.83M | +3.7% |\n| indexes_2 | 841.6 | 1.19M | 790.4 | 1.27M | +6.5% |\n| geomean | 538.3 | 1.86M | 512.6 | 1.95M | +5.0% |\n\nAllocation profile:\n- total alloc-space: 4319.64MB -> 3502.03MB\n- valuelog.NewWriter flat allocation: 1080.86MB -> effectively gone\n- remaining append buffer allocation is tied to actual append activity via getWriterAppendBuf