### PR TITLE
[codex] document native wire protocol plan

### DIFF
--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -19,7 +19,7 @@ When behavior or format changes, update this spec and the test matrix in `TreeDB
 
 When native-wire protocol IDs, command schemas, feature gates, or deterministic
 entry formats change, update the native-wire spec, implementation guidelines,
-roadmap, schema registry or drift tests, golden vectors, and verification matrix
+roadmap, schema registry or drift tests, golden fixtures, and verification matrix
 in the same change.
 
 ## Scope

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -17,6 +17,11 @@ TreeDB is pre-alpha.
 
 When behavior or format changes, update this spec and the test matrix in `TreeDB/docs/spec/verification.md` in the same change.
 
+When native-wire protocol IDs, command schemas, feature gates, or deterministic
+entry formats change, update the native-wire spec, implementation guidelines,
+roadmap, schema registry or drift tests, golden vectors, and verification matrix
+in the same change.
+
 ## Scope
 
 This spec covers the public `treedb` engine and its backend/index implementation:
@@ -99,6 +104,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     framing, command payloads, explicit ack/consistency policies, and the
     boundary between wire requests and future deterministic Raft command
     entries.
+- `TreeDB/docs/spec/native-wire-implementation-guidelines.md`
+  - implementation playbook for keeping codecs, schema IDs, validation,
+    conformance tests, benchmarks, and future Raft entry handling aligned with
+    the native wire protocol.
 - `TreeDB/docs/spec/native-query-raft-roadmap.md`
   - draft query feature roadmap and distributed/Raft sequencing policy for the
     native protocol.

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -94,6 +94,14 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/collections-native-fastpath-baseline-2026-04-25.md`
   - refreshed pre-`R0` baseline note for issue `#768`, including exact
     main/oracle SHAs, artifact dirs, commands, and benchmark baselines.
+- `TreeDB/docs/spec/native-wire-protocol.md`
+  - draft native binary network protocol for TreeDB collections, including
+    framing, command payloads, explicit ack/consistency policies, and the
+    boundary between wire requests and future deterministic Raft command
+    entries.
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+  - draft query feature roadmap and distributed/Raft sequencing policy for the
+    native protocol.
 
 ## Relationship to Existing Docs
 

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -431,13 +431,14 @@ affect routing, snapshots, or catch-up behavior.
 
 ### Protocol TODO
 
-- Assign command IDs and section IDs.
-- Define scalar binary encodings.
-- Define result-set and presence-bitmap encodings.
-- Define cursor resource limits.
+- Keep command IDs and section IDs synchronized between
+  `native-wire-protocol.md`, the schema registry, and drift tests.
+- Keep scalar, byte-vector, result-set, presence-bitmap, and cursor-limit
+  encodings covered by fixtures and conformance tests.
 - Define error-code mapping from current collection errors.
 - Define authentication placeholder fields.
-- Define benchmark mode labels.
+- Keep benchmark mode labels synchronized with the benchmark harness and report
+  renderers.
 
 ### Query TODO
 

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -1,0 +1,440 @@
+# Native Query and Raft Roadmap
+
+Status: draft proposal, non-normative.
+
+This document defines the proposed query feature roadmap for the TreeDB native
+protocol and explains when Raft/distributed execution should enter the stack.
+It assumes the native wire protocol described in
+`TreeDB/docs/spec/native-wire-protocol.md`.
+
+## 1. Recommendation
+
+Raft should be early in the architecture, but not first in implementation.
+
+TreeDB should first define and test:
+
+1. native wire framing,
+2. versioned command schemas,
+3. deterministic command-entry encoding,
+4. single-node native server behavior for the core collection surface.
+
+After that, Raft should be added for the small deterministic write surface before
+the system grows rich distributed query features such as fanout aggregation or
+server-side WASM callbacks.
+
+Raft should not wait until the full query roadmap is complete. Rich queries
+should be designed with distributed execution in mind, but the first distributed
+system should replicate boring, deterministic metadata and mutation commands.
+
+## 2. Design Principles
+
+1. The wire protocol is not the Raft log.
+2. Every replicated write command must have deterministic command-entry bytes.
+3. Reads are not Raft-log entries unless they mutate state.
+4. Query features should be organized by distributed complexity.
+5. Aggregations should expose partial-result formats before cross-node fanout is
+   implemented.
+6. Server-side callbacks must be bounded, deterministic where required, and
+   feature-gated.
+7. Cursor resources must be cancellable and budgeted from v1.
+
+## 3. Implementation Order
+
+### R0. Protocol Spec and Codecs
+
+Define:
+
+- frame header,
+- body sections,
+- command IDs,
+- command versions,
+- error model,
+- byte-vector encoding,
+- typed scalar encoding,
+- ack and consistency policies,
+- deterministic command-entry envelope.
+
+Acceptance:
+
+- codec package with golden byte fixtures,
+- fuzz tests for frame/section decoding,
+- unknown-section compatibility tests,
+- max-frame and malformed-frame tests.
+
+### R1. Single-Node Native Server MVP
+
+Implement the native server for:
+
+- `hello`,
+- `create_collection`,
+- `create_index`,
+- `insert_batch`,
+- `delete_batch`,
+- `get_many`,
+- `index_lookup`,
+- `index_range`,
+- `open_scan`,
+- `cursor_next`,
+- `cursor_close`,
+- `flush_collection`,
+- `checkpoint`,
+- `stats`.
+
+Acceptance:
+
+- parity tests against direct `TreeDB/collections` calls,
+- native-wire TCP and in-process benchmark modes,
+- clear benchmark separation from Mongo raw-wire modes,
+- cursor cancellation and resource-limit tests.
+
+### R2. Deterministic Command Entry v1
+
+Implement a canonical command-entry encoder for mutating commands:
+
+- collection metadata changes,
+- index metadata changes,
+- insert/replace/delete batches,
+- flush/checkpoint only if a cluster policy decides they are replicated
+  commands rather than local maintenance barriers.
+
+Acceptance:
+
+- deterministic encoding tests,
+- cross-process/cross-map-order stability tests,
+- idempotency-key tests,
+- rejection tests for non-deterministic sections.
+
+### R3. Raft MVP for Writes
+
+Add Raft around the deterministic write set only.
+
+Replicate:
+
+- collection create/drop metadata,
+- index create/drop metadata,
+- insert/replace/delete batches,
+- deterministic schema/catalog guards,
+- idempotency records.
+
+Do not replicate:
+
+- ordinary reads,
+- local cursor state,
+- tracing/deadlines,
+- physical maintenance commands unless the cluster policy explicitly requires
+  them.
+
+Acceptance:
+
+- leader writes commit and apply on followers,
+- duplicate client requests are deduplicated by `client_id + sequence` or a
+  stable idempotency key,
+- failed leadership changes do not double-apply mutations,
+- restart tests preserve Raft log, stable metadata, and applied collection state.
+
+### R4. Read Consistency Modes
+
+Implement explicit read policies:
+
+```text
+local_stale
+leader_read
+linearizable
+lease_read
+```
+
+`local_stale` may read from any node and may be behind the leader.
+
+`leader_read` routes to the current leader but does not necessarily perform a
+fresh read-index barrier.
+
+`linearizable` performs the consensus read barrier required by the selected Raft
+implementation before reading.
+
+`lease_read` is allowed only if leader leases are implemented and the server can
+prove the lease is valid.
+
+Acceptance:
+
+- response metadata reports the actual consistency mode used,
+- stale follower reads are explicitly labeled,
+- linearizable reads fail or redirect when the node cannot prove leadership or
+  freshness.
+
+### R5. Local Advanced Queries
+
+Implement richer single-node reads only after the core read/write and cursor
+model is stable:
+
+- projection,
+- server-side predicate filters over bounded candidate sets,
+- count-only index queries,
+- local `count`, `min`, `max`, `sum`, `avg`,
+- local group-by over indexed scalar fields,
+- local top-k over bounded/indexed ranges,
+- `explain` and query stats.
+
+Acceptance:
+
+- all advanced queries have resource limits,
+- all query plans can be explained,
+- aggregation responses can be encoded as partial results.
+
+### R6. Distributed Query Execution
+
+Add distributed query execution after Raft write replication and read consistency
+policies are working.
+
+Initial distributed query features:
+
+- scatter/gather get-many by partition routing,
+- scatter/gather index lookup,
+- fanout range scan with coordinator-side merge,
+- partial aggregation merge,
+- distributed cursor cancellation,
+- shard-level and coordinator-level memory/time budgets.
+
+Acceptance:
+
+- coordinator reports shard participation and partial failures,
+- global limits and ordering are correct,
+- canceled distributed cursors release shard resources,
+- partial aggregation merge is deterministic.
+
+### R7. Server-Side WASM or Callback Execution
+
+WASM should be last or feature-gated behind explicit experimental flags.
+
+Read-only callbacks may come first:
+
+- bounded map/filter over scan batches,
+- no host state mutation,
+- deterministic imports only,
+- fuel, time, memory, and result-size limits,
+- module hash in request metadata.
+
+Write-producing callbacks require a stricter policy:
+
+- callback execution must expand to deterministic mutation batches before Raft
+  commit, or
+- the Raft log must record a deterministic invocation plus module hash and all
+  deterministic inputs needed to replay exactly.
+
+The safer default is to log the expanded mutation batch, not arbitrary callback
+execution, until determinism and audit tooling are mature.
+
+## 4. Query Feature Tiers
+
+### Tier 0: Core Collection Surface
+
+These features are required before Raft:
+
+- collection metadata commands,
+- index metadata commands,
+- insert/replace/delete batches,
+- primary get/get-many,
+- secondary equality lookup,
+- secondary range lookup,
+- bounded primary scans,
+- cursor pagination,
+- cancellation,
+- flush/checkpoint barriers,
+- stats.
+
+These map directly onto current collection and ordered-root concepts.
+
+### Tier 1: Local Query Quality
+
+These features may be implemented before or after Raft, but they should not
+delay Raft MVP:
+
+- projection,
+- count-only queries,
+- bounded filters,
+- explain plans,
+- response-side query stats,
+- server-side limits for documents, bytes, time, and intermediate rows.
+
+Projection and count-only queries are high-value because they reduce network
+bytes without introducing hard distributed semantics.
+
+### Tier 2: Local Aggregations
+
+Local aggregation should use partial-result encodings from the start.
+
+Initial aggregations:
+
+- `count`,
+- `min`,
+- `max`,
+- `sum`,
+- `avg` as `sum + count`,
+- group by one indexed scalar,
+- top-k over an indexed range.
+
+Aggregation requests MUST include explicit limits for:
+
+- scanned candidates,
+- groups,
+- output bytes,
+- execution time.
+
+### Tier 3: Distributed Queries
+
+Distributed queries require a partition/shard policy. The roadmap should not
+pretend global queries are simple until that policy exists.
+
+Open design areas:
+
+- collection partitioning by primary key hash or range,
+- secondary-index partitioning,
+- coordinator selection,
+- shard-local cursor ownership,
+- global ordering,
+- partial failure semantics,
+- retry and resume tokens,
+- query admission control.
+
+Distributed aggregation should be implemented as:
+
+```text
+shard query -> typed partial result -> coordinator merge -> final response
+```
+
+The partial result format should be deterministic and independent of the wire
+transport frame.
+
+### Tier 4: Server-Side WASM and Callbacks
+
+Server-side callbacks are powerful but easy to make unsafe or non-deterministic.
+
+Required policy before enabling:
+
+- module hash and optional module registry,
+- deterministic import set,
+- no wall-clock, random, network, filesystem, or process-global access,
+- fuel limit,
+- memory limit,
+- result-size limit,
+- explicit read-only vs write-producing mode,
+- stable error and timeout behavior,
+- observability for callback CPU/memory/result bytes.
+
+For distributed mode:
+
+- read-only callbacks can run shard-local and return partial outputs,
+- write-producing callbacks must produce deterministic mutation batches before
+  consensus or be replayable byte-for-byte from the Raft log.
+
+## 5. Raft Policy Boundaries
+
+### 5.1 Writes
+
+The leader validates client mutation commands and appends deterministic command
+entries to Raft. Followers apply committed command entries to their local TreeDB
+state machine.
+
+The command entry should include:
+
+- command ID and version,
+- collection or metadata target,
+- mutation input bytes,
+- expected catalog/schema guard when applicable,
+- idempotency key,
+- deterministic command flags.
+
+The command entry should not include:
+
+- request ID,
+- stream ID,
+- connection-local collection handle,
+- tracing,
+- deadline,
+- negotiated compression,
+- response page size,
+- client socket metadata.
+
+### 5.2 Reads
+
+Reads are governed by consistency policy, not by command-entry replication.
+
+The server may satisfy `local_stale` reads from a follower. Stronger reads must
+be routed or proved according to the cluster policy.
+
+Read responses in cluster mode SHOULD include:
+
+- serving node ID,
+- leader ID if known,
+- applied log index,
+- consistency mode requested,
+- consistency mode actually used.
+
+### 5.3 Metadata
+
+Collection and index metadata changes are replicated writes. They should use the
+same deterministic command-entry path as document mutations.
+
+Open question: whether global metadata is one Raft group or whether each
+collection/shard has its own group plus a separate metadata group. The first
+Raft MVP SHOULD use the simplest model that can prove correctness.
+
+### 5.4 Maintenance
+
+Local physical maintenance, such as value-log rewrite, GC, leaf-generation pack,
+or index vacuum, should not become user-visible replicated commands by default.
+
+Cluster-visible maintenance policy is needed only when physical layout choices
+affect routing, snapshots, or catch-up behavior.
+
+## 6. TODO List
+
+### Protocol TODO
+
+- Assign command IDs and section IDs.
+- Define scalar binary encodings.
+- Define result-set and presence-bitmap encodings.
+- Define cursor resource limits.
+- Define error-code mapping from current collection errors.
+- Define authentication placeholder fields.
+- Define benchmark mode labels.
+
+### Query TODO
+
+- Specify projection syntax.
+- Specify bounded predicate filter syntax.
+- Specify count-only query response.
+- Specify local aggregation request/response.
+- Specify partial aggregation encoding.
+- Specify explain-plan format.
+- Specify query stats fields.
+
+### Raft TODO
+
+- Choose Raft library or implementation boundary.
+- Define `CommandEntryV1` bytes.
+- Define idempotency record storage.
+- Define stable store and log store mappings.
+- Define snapshot/export/restore format.
+- Define read-index or equivalent linearizable-read mechanism.
+- Define initial cluster metadata model.
+
+### WASM TODO
+
+- Decide whether WASM is needed before distributed query MVP.
+- Define deterministic host imports.
+- Define module hash and registry policy.
+- Define fuel/memory/result limits.
+- Define whether write callbacks log invocation or expanded mutations.
+
+## 7. Open Questions
+
+1. Should raw ordered-KV commands be part of the first native protocol, or should
+   v1 stay collection-only?
+2. Should Raft be single group for the first MVP, or should the protocol reserve
+   collection/shard group IDs immediately?
+3. Should `flush` and `checkpoint` be client-visible in cluster mode, or treated
+   as local maintenance/admin commands only?
+4. Should distributed query partial failures return partial results, fail the
+   entire query, or be policy-selectable?
+5. Should read-only WASM be allowed before distributed queries, or should it wait
+   until shard-local resource accounting exists?

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -5,7 +5,8 @@ Status: draft proposal, non-normative.
 This document defines the proposed query feature roadmap for the TreeDB native
 protocol and explains when Raft/distributed execution should enter the stack.
 It assumes the native wire protocol described in
-`TreeDB/docs/spec/native-wire-protocol.md`.
+`TreeDB/docs/spec/native-wire-protocol.md` and the implementation discipline in
+`TreeDB/docs/spec/native-wire-implementation-guidelines.md`.
 
 ## 1. Recommendation
 
@@ -40,7 +41,7 @@ system should replicate boring, deterministic metadata and mutation commands.
 
 ## 3. Implementation Order
 
-### R0. Protocol Spec and Codecs
+### R0. Protocol Spec, Registry, and Codecs
 
 Define:
 
@@ -48,18 +49,32 @@ Define:
 - body sections,
 - command IDs,
 - command versions,
+- schema registry and drift-test policy,
 - error model,
 - byte-vector encoding,
 - typed scalar encoding,
 - ack and consistency policies,
 - deterministic command-entry envelope.
 
+Suggested slices:
+
+- R0a: protocol constants, schema registry, and golden byte fixtures,
+- R0b: frame/section codec, fuzzing, and malformed-frame tests,
+- R0c: deterministic-entry encoder for the mutation allowlist.
+
 Acceptance:
 
+- versioned schema registry for frame, section, command, feature, policy, and
+  error-code allocations,
+- generated Go constants or drift tests proving constants match the registry,
 - codec package with golden byte fixtures,
-- fuzz tests for frame/section decoding,
-- unknown-section compatibility tests,
-- max-frame and malformed-frame tests.
+- schema-validator tests for required, optional, repeated, ordered, and
+  deterministic sections,
+- feature-negotiation rejection tests,
+- unknown-section and unknown-flag compatibility tests,
+- fuzz tests for frame, section, byte-vector, and command decoding,
+- deterministic-entry canonicalization and rejection tests,
+- max-frame, malformed-frame, and bounded-allocation tests.
 
 ### R1. Single-Node Native Server MVP
 
@@ -80,6 +95,16 @@ Implement the native server for:
 - `checkpoint`,
 - `stats`.
 
+Suggested slices:
+
+- R1a: server lifecycle, `hello`/`hello_ok`, `ping`/`pong`, `goaway`, and
+  `stats`,
+- R1b: collection metadata commands and connection-local handles,
+- R1c: read commands and pull-cursor lifecycle,
+- R1d: mutation commands with ack-policy handling,
+- R1e: TCP, Unix socket, and in-process benchmark transports over the same
+  dispatch path.
+
 Acceptance:
 
 - parity tests against direct `TreeDB/collections` calls,
@@ -99,10 +124,15 @@ Implement a canonical command-entry encoder for mutating commands:
 
 Acceptance:
 
+- golden canonical-entry byte fixtures for every replicated command version,
 - deterministic encoding tests,
 - cross-process/cross-map-order stability tests,
 - idempotency-key tests,
-- rejection tests for non-deterministic sections.
+- same logical mutation encoded from shuffled sections, different request IDs,
+  deadlines, compression choices, and trace metadata produces the same canonical
+  entry digest,
+- rejection tests for non-deterministic sections, duplicate singleton sections,
+  unsupported command versions, local handles, and missing guards.
 
 ### R3. Raft MVP for Writes
 
@@ -129,8 +159,19 @@ Acceptance:
 - leader writes commit and apply on followers,
 - duplicate client requests are deduplicated by `client_id + sequence` or a
   stable idempotency key,
+- duplicate idempotency identity with the same digest returns the original
+  outcome,
+- duplicate idempotency identity with a different digest fails deterministically,
+- catalog guard races commit in one log order and replay to the same success or
+  guard-failure results on every replica,
 - failed leadership changes do not double-apply mutations,
-- restart tests preserve Raft log, stable metadata, and applied collection state.
+- restart tests preserve Raft log, stable metadata, and applied collection state,
+- the same committed entry sequence applied to fresh DBs in separate processes
+  produces the same logical state digest,
+- snapshot restore plus log-tail replay produces the same logical state digest
+  as full log replay,
+- mixed-version clusters refuse to advertise or append command versions that any
+  voting replica cannot decode and apply.
 
 ### R4. Read Consistency Modes
 

--- a/TreeDB/docs/spec/native-wire-implementation-guidelines.md
+++ b/TreeDB/docs/spec/native-wire-implementation-guidelines.md
@@ -1,0 +1,246 @@
+# Native Wire Protocol Implementation Guidelines
+
+Status: draft playbook, non-normative.
+
+This document is the implementation operating guide for:
+
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+
+The wire protocol spec defines the bytes and semantics. This playbook defines
+how implementation work should keep code, tests, benchmarks, and future Raft
+behavior aligned with that spec.
+
+## 1. Purpose
+
+The native protocol should not become a pile of hand-decoded commands whose
+behavior is only discoverable from server dispatch code. The implementation
+should make protocol rules explicit, testable, and hard to bypass.
+
+The first implementation goal is not public compatibility. TreeDB is pre-alpha.
+The goal is internal discipline: every command, section, error, feature bit, and
+canonical Raft entry rule should have one obvious place in code and one obvious
+set of tests.
+
+## 2. Source of Truth
+
+Until a machine-readable schema exists, the Markdown spec is the human source of
+truth and the Go schema registry is the executable source of truth. A future
+registry file, for example `TreeDB/docs/spec/native-wire-v1.registry.json`, can
+become the shared source for generated constants and documentation tables once
+manual duplication becomes risky.
+
+Every PR that changes the wire protocol MUST update all affected artifacts in
+the same change:
+
+- `native-wire-protocol.md`,
+- `native-query-raft-roadmap.md` when sequencing or distributed policy changes,
+- the command/section schema registry,
+- golden byte fixtures,
+- negative conformance tests,
+- benchmark labels or report parsing when new benchmark modes are added.
+
+Command IDs, section IDs, error codes, feature bits, and protocol versions MUST
+not be invented inline in server handlers. They should be declared in one schema
+package with names that match the spec. Go constants used by the codec, server,
+tests, and benchmarks should either be generated from the registry or checked
+against it by a drift test.
+
+When the schema grows enough that manual duplication becomes risky, generate
+either constants or documentation tables from the registry. Do not introduce a
+generator until it removes real drift risk.
+
+## 3. Package Boundaries
+
+The exact package names can change, but the implementation should preserve these
+boundaries:
+
+- **Frame codec:** encodes and decodes fixed headers, frame types, frame flags,
+  section envelopes, byte vectors, compression framing, checksums, and resource
+  limits. It should not depend on collections or Raft packages.
+- **Schema registry:** describes supported commands, versions, sections,
+  multiplicity, deterministic status, required feature bits, and validation
+  rules.
+- **Command normalization:** converts validated wire sections into typed request
+  structs. It resolves defaults and rejects ambiguous encodings before execution.
+- **Server dispatch:** handles connection state, handshake, authentication,
+  request routing, cursor lifecycle, cancellation, response metadata, and error
+  mapping.
+- **Collection adapter:** maps normalized commands onto `TreeDB/collections`
+  behavior and owns parity tests against direct collection calls.
+- **Deterministic entry codec:** encodes and decodes canonical Raft command-entry
+  bytes. It must not depend on connection state, negotiated compression, request
+  IDs, cursor state, deadlines, or tracing.
+- **Conformance fixtures:** stores golden wire frames, canonical entries, and
+  rejection cases that can be reused by future clients or compatibility tests.
+
+Do not let the server dispatch path be the only validator. The codec and schema
+layers should reject malformed or unsupported input before collection execution.
+
+## 4. Decode and Validation Pipeline
+
+Each request should pass through the same staged pipeline:
+
+1. validate frame header, frame size, negotiated version, and frame flags;
+2. decode sections with maximum count and maximum byte limits;
+3. enforce unknown critical section and unknown required flag rules;
+4. look up `command_id + command_version` in the negotiated schema;
+5. enforce required sections, singleton multiplicity, and repeated-section
+   ordering rules;
+6. decode command-specific fields into typed structs;
+7. apply explicit defaults from the command schema;
+8. reject duplicate IDs, stale catalog guards, unsupported document formats, and
+   unsupported ack or consistency policies;
+9. execute the command or, in distributed mode, pass it through the append-time
+   determinism gate before execution.
+
+Decoders should reject before allocating large buffers whenever possible.
+Length fields, section counts, byte-vector counts, and cursor limits should be
+checked against negotiated or configured maximums at the boundary.
+
+## 5. Schema Registry Rules
+
+Each command schema should record:
+
+- command name, ID, and version,
+- minimum protocol version,
+- required feature bits,
+- required and optional sections,
+- allowed section multiplicity,
+- whether repeated section order is meaningful,
+- deterministic sections and deterministic command flags,
+- optional-field default rules,
+- request and response section layouts,
+- whether the command is local-only, read-only, or replicated,
+- allowed ack and consistency policies,
+- error mappings for expected collection failures.
+
+Adding a command version is preferred over changing existing semantics. Once a
+command version can appear in a deterministic command entry, its deterministic
+meaning is immutable for that Raft log lineage.
+
+Each command should also have an implementation-status row recording:
+
+- whether it is in the v1 target surface,
+- first implementation phase,
+- implementation state,
+- whether it can produce a deterministic entry,
+- whether a benchmark is required.
+
+The command list in `native-wire-protocol.md` is the v1 target surface. The
+roadmap decides which subset is implemented in each phase.
+
+## 6. Conformance Tests
+
+R0 implementation should land conformance tests before or with codecs. Store
+native-wire fixtures under package `testdata`, for example
+`TreeDB/internal/nativewire/testdata/v1/`.
+
+Required positive fixtures:
+
+- `hello` and `hello_ok`,
+- a minimal request/response,
+- `insert_batch` with byte-vector document IDs and documents,
+- `get_many` with a presence bitmap,
+- an error frame,
+- `open_scan` plus `cursor_next`,
+- a canonical deterministic entry for every replicated command version.
+
+Each fixture should include:
+
+- fixture name and schema version,
+- negotiated feature set,
+- hex-encoded frame bytes,
+- expected decoded summary,
+- expected error code for rejection fixtures,
+- expected deterministic-entry bytes for mutating command fixtures.
+
+Required rejection fixtures:
+
+- bad magic,
+- invalid `header_len`,
+- frame larger than the negotiated maximum,
+- unnegotiated protocol version,
+- unknown required frame flag,
+- unknown critical section,
+- unknown required section flag,
+- duplicate singleton section,
+- missing required section,
+- byte-vector length overflow, truncation, and extra bytes,
+- non-minimal canonical varint in deterministic entries,
+- local handle inside a deterministic entry,
+- missing idempotency identity or catalog guard for distributed mutation.
+
+Changing an existing golden fixture is a protocol change. Prefer adding a new
+fixture or a new command version unless the old fixture intentionally documents
+a pre-alpha break.
+
+Fuzz tests should target frame and section decoding, byte vectors, compression
+boundaries, and command normalization. Fuzzers must use memory and frame-size
+caps so malformed input cannot turn into unbounded allocation.
+
+## 7. Determinism Tests
+
+Before Raft, add deterministic-entry tests that prove:
+
+- the same logical mutation encoded with different request IDs, deadlines, trace
+  metadata, compression choices, and section order produces the same canonical
+  entry digest;
+- shuffled Go map iteration and cross-process execution produce the same bytes;
+- unsupported command versions and non-deterministic sections are rejected before
+  append;
+- replaying the same canonical entry sequence into fresh databases produces the
+  same logical catalog, document, index, and idempotency state;
+- snapshot restore plus log-tail replay produces the same logical state digest
+  as full log replay.
+
+The logical state digest should be independent of local file layout, value-log
+offsets, flush timing, or maintenance decisions.
+
+## 8. Performance Practices
+
+The hot path should stay binary and vectorized:
+
+- parse byte vectors into offset tables or borrowed slices,
+- avoid reflection and generic map decoding in request parsing,
+- avoid per-document allocation where a batch view is enough,
+- keep JSON/OpenRPC/admin description layers out of the data-plane codec,
+- profile decode, validation, dispatch, and collection execution separately,
+- track per-frame overhead in benchmark reports.
+
+Benchmarks should keep native-wire results separate from direct collection calls,
+Mongo driver paths, and Mongo raw-wire paths.
+
+## 9. Observability
+
+The first server should expose enough counters to debug protocol behavior:
+
+- frames and bytes in/out,
+- decode failures by error code,
+- command counts and latency by command ID/version,
+- rejected unsupported versions/features,
+- cursor opens, closes, cancellations, timeouts, and limit hits,
+- in-flight requests and cursors,
+- requested and actual ack/consistency policies,
+- response metadata for serving node, leader node, and applied log index when
+  cluster mode exists.
+
+Trace context is transport metadata. It must not influence deterministic command
+entry bytes.
+
+## 10. PR Checklist
+
+Every protocol implementation PR should answer:
+
+1. Which spec sections changed or were implemented?
+2. Which command/section schema entries changed?
+3. Which golden fixtures were added or updated?
+4. Which rejection tests prove unsupported input fails at the right layer?
+5. Which parity tests compare native-wire behavior to direct collection calls?
+6. Which deterministic-entry tests are needed now or deferred with a clear
+   reason?
+7. Which benchmark labels, profile captures, or report parsers changed?
+8. Did the roadmap need an update because implementation reality changed?
+
+Do not merge a new replicated command version without a canonical fixture,
+append-time rejection tests, and a replay determinism test.

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -96,6 +96,19 @@ future authenticated transport wrapper. The frame format does not require HTTP.
 All fixed-width integers are little-endian. Variable-length integers use unsigned
 base-128 varints.
 
+Primitive payload encodings:
+
+- `uvarint`: unsigned base-128, least-significant 7-bit group first, high bit set
+  on every non-final byte. Senders MUST use the shortest encoding; receivers
+  MUST reject encodings that overflow `uint64` or exceed 10 bytes.
+- `varint`: signed `int64` encoded by zig-zag mapping to `uvarint`
+  (`n >= 0 => n*2`, `n < 0 => (-n*2)-1`).
+- `bool`: one byte, `0=false`, `1=true`; all other values are malformed.
+- `string`: `uvarint` byte length followed by UTF-8 bytes. Command-specific
+  validators may impose a narrower grammar, such as collection or index names.
+- `bytes`: `uvarint` byte length followed by exactly that many opaque bytes,
+  except where a containing structure already supplies an explicit length.
+
 ```text
 offset  size  field
 0       4     magic = "TDB1"
@@ -252,9 +265,11 @@ instead of allocating one object per element.
 
 Byte vectors do not encode nulls. Optional or missing results MUST use a
 separate presence bitmap or status vector whose item count exactly matches the
-byte-vector count required by the command. Decoders MUST reject length
-overflows, truncated payloads, extra bytes, and byte vectors whose declared
-lengths do not sum to the remaining payload size.
+byte-vector count required by the command. After a decoder reads `count` and
+then exactly `count` length varints, the remaining bytes in that same
+byte-vector payload are `payload_bytes`. Decoders MUST reject length overflows,
+truncated payloads, extra bytes, and any byte vector where `sum(lengths) !=
+len(payload_bytes)`.
 
 ### 5.6 Response Metadata
 

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -170,17 +170,21 @@ Clients MUST match responses by `request_id`.
 
 `stream_id` identifies a logical stream or cursor. Non-streaming requests and
 initial cursor-open requests use `stream_id=0`. For v1 cursors,
-`cursor_next`/`cursor_close` requests name the server-assigned cursor ID in
-`stream_id`, and responses MAY echo it. Negotiated push-streaming extensions MAY
-use the same `request_id` with a non-zero `stream_id`.
+`cursor_next`/`cursor_close` requests MUST carry the server-assigned cursor ID
+in a `cursor_ref` section. Clients SHOULD also set `stream_id` to the same
+cursor ID for transport observability; servers MUST reject a request where a
+non-zero `stream_id` disagrees with `cursor_ref`. Responses MAY echo the cursor
+ID in `stream_id`. Negotiated push-streaming extensions MAY use the same
+`request_id` with a non-zero `stream_id`.
 
 v1 cursor delivery is pull-based. `open_scan` returns a server-assigned cursor
 ID in `cursor_meta.stream_id` and MAY return an initial batch. Each
-`cursor_next` or `cursor_close` is a new request with a new `request_id` and the
-cursor ID in `stream_id`. The server returns at most one batch per
-`cursor_next`. EOF, `cursor_close`, idle timeout, cancel, or any terminal cursor
-error releases the cursor. The `data` frame type is reserved for a separately
-negotiated push-streaming extension and MUST NOT be used for v1 cursors.
+`cursor_next` or `cursor_close` is a new request with a new `request_id`, a
+`cursor_ref` body section, and normally the cursor ID in `stream_id`. The server
+returns at most one batch per `cursor_next`. EOF, `cursor_close`, idle timeout,
+cancel, or any terminal cursor error releases the cursor. The `data` frame type
+is reserved for a separately negotiated push-streaming extension and MUST NOT be
+used for v1 cursors.
 
 A `cancel` frame targets the `request_id` in its header. `stream_id=0` cancels
 the whole request; non-zero `stream_id` cancels that cursor or stream. Cancel is
@@ -587,8 +591,10 @@ has_more
 server_cursor_deadline optional
 ```
 
-`cursor_next` requests MUST include a maximum item count, maximum response bytes,
-or both. Servers MAY return fewer results than requested. A response with
+`cursor_next` requests MUST include `cursor_ref` and `cursor_limits` sections.
+The `cursor_limits` section MUST include a maximum item count, maximum response
+bytes, or both. `cursor_close` requests MUST include `cursor_ref`. Servers MAY
+return fewer results than requested. A response with
 `has_more=false` is terminal and releases the cursor. A `cursor_not_found` error
 is terminal for the named cursor but not for the connection.
 

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -68,6 +68,11 @@ Raft entries. Layer 2 MAY contain optional client/server convenience sections
 that are also excluded from deterministic entries unless explicitly marked as
 deterministic command input.
 
+Protocol compatibility is based on explicit version and feature negotiation, not
+best-effort decoding of unknown required fields. Unknown required frame flags,
+section flags, command IDs, command versions, or critical sections MUST fail
+fast with a structured error. Unknown advisory fields MAY be ignored.
+
 ## 5. Transport
 
 The primary transports are:
@@ -101,8 +106,21 @@ The initial fixed header length is 40 bytes. `header_len` allows future fixed
 header extensions. Receivers MUST reject frames whose `header_len` is smaller
 than 40 or larger than their configured maximum fixed-header length.
 
+The frame body begins at byte offset `header_len`. v1 senders MUST set
+`header_len=40` unless a fixed-header extension has been negotiated. Receivers
+that accept `header_len > 40` MUST skip bytes `[40, header_len)` before reading
+the body. Unknown fixed-header extensions are invalid unless explicitly
+negotiated.
+
 `body_len` is the number of bytes following the header. Receivers MUST enforce a
 negotiated maximum frame size.
+
+`frame_flags` use the low 16 bits for required semantics and the high 16 bits
+for advisory semantics. A receiver MUST reject a frame with an unknown required
+flag bit. A receiver MAY ignore unknown advisory flag bits. Frame flags are
+transport metadata and MUST NOT be copied into deterministic command entries
+unless a command schema explicitly promotes the same logical meaning into a
+deterministic command flag.
 
 ### 5.2 Frame Types
 
@@ -125,9 +143,35 @@ Initial frame types:
 pipelined requests out of order unless the command explicitly requires ordering.
 Clients MUST match responses by `request_id`.
 
-`stream_id` identifies a logical stream or cursor. Non-streaming requests use
-`stream_id=0`. Streaming result frames use the same `request_id` and a non-zero
-`stream_id` assigned by the server.
+`stream_id` identifies a logical stream or cursor. Non-streaming requests and
+initial cursor-open requests use `stream_id=0`. For v1 cursors,
+`cursor_next`/`cursor_close` requests name the server-assigned cursor ID in
+`stream_id`, and responses MAY echo it. Negotiated push-streaming extensions MAY
+use the same `request_id` with a non-zero `stream_id`.
+
+v1 cursor delivery is pull-based. `open_scan` returns a server-assigned cursor
+ID in `cursor_meta.stream_id` and MAY return an initial batch. Each
+`cursor_next` or `cursor_close` is a new request with a new `request_id` and the
+cursor ID in `stream_id`. The server returns at most one batch per
+`cursor_next`. EOF, `cursor_close`, idle timeout, cancel, or any terminal cursor
+error releases the cursor. The `data` frame type is reserved for a separately
+negotiated push-streaming extension and MUST NOT be used for v1 cursors.
+
+A `cancel` frame targets the `request_id` in its header. `stream_id=0` cancels
+the whole request; non-zero `stream_id` cancels that cursor or stream. Cancel is
+best-effort: clients MUST tolerate a successful response racing with cancel.
+After observing cancel, servers SHOULD stop work promptly, release cursor state,
+and return `canceled` if no terminal response has already been sent.
+
+v1 read backpressure is expressed by `cursor_next` maximum item count,
+`cursor_next` maximum response bytes, negotiated maximum frame size, and
+negotiated maximum in-flight requests and cursors. Servers MUST NOT send
+unbounded unsolicited frames.
+
+`goaway` indicates that the peer will accept no new requests on the connection.
+Its body MUST include `last_accepted_request_id` and an optional error code.
+Clients MAY retry requests with IDs greater than `last_accepted_request_id`
+when the command and idempotency policy allow retry.
 
 ### 5.3 Body Sections
 
@@ -141,10 +185,19 @@ section_bytes  bytes[section_len]
 ```
 
 `section_flags & 1` marks a section as critical. Unknown critical sections MUST
-fail the frame. Unknown non-critical sections MUST be ignored.
+fail the frame. Unknown non-critical sections MUST be ignored. Unknown
+`section_flags` bits are required semantics and MUST fail the frame unless the
+command schema or negotiated feature explicitly defines them.
 
 Sections SHOULD be ordered by increasing `section_id`, but receivers MUST NOT
 depend on order unless a command schema says a repeated section is ordered.
+Deterministic command-entry encoders MUST sort deterministic sections by
+`section_id` and MUST reject duplicate non-repeatable deterministic sections.
+
+Each command schema MUST list required sections, optional sections, allowed
+multiplicity, ordering significance, and whether each section is deterministic
+command input. Duplicate singleton sections and missing required sections MUST
+be rejected as `invalid_command`.
 
 ### 5.4 Common Sections
 
@@ -161,6 +214,8 @@ Initial common section IDs:
 8  idempotency_key
 9  checksum
 10 compression
+11 response_meta
+12 cursor_meta
 ```
 
 Command-specific sections start at `100`.
@@ -170,15 +225,42 @@ Command-specific sections start at `100`.
 Batch-oriented fields use byte-vector encoding:
 
 ```text
-count uvarint
-repeat count:
-  length uvarint
-bytes concatenated_payloads
+count          uvarint
+lengths[count] uvarint
+payload_bytes  bytes[sum(lengths)]
 ```
 
 This avoids per-item maps and keeps IDs, documents, keys, and values compact.
 Implementations SHOULD parse byte vectors into offset tables or borrowed slices
 instead of allocating one object per element.
+
+Byte vectors do not encode nulls. Optional or missing results MUST use a
+separate presence bitmap or status vector whose item count exactly matches the
+byte-vector count required by the command. Decoders MUST reject length
+overflows, truncated payloads, extra bytes, and byte vectors whose declared
+lengths do not sum to the remaining payload size.
+
+### 5.6 Response Metadata
+
+Successful responses SHOULD include `response_meta` when the command touches
+durability, consistency, catalog state, or cluster routing. Response metadata is
+not deterministic command input.
+
+Initial response metadata fields:
+
+```text
+actual_ack_policy        uvarint optional
+actual_consistency       uvarint optional
+commit_seq              uvarint optional
+catalog_version         uvarint optional
+applied_log_index       uvarint optional
+serving_node_id         bytes optional
+leader_node_id          bytes optional
+```
+
+Single-node implementations may omit cluster fields. Cluster implementations
+SHOULD report `applied_log_index` and serving/leader node identity for reads
+whose freshness matters.
 
 ## 6. Handshake
 
@@ -208,6 +290,13 @@ Feature negotiation MUST be explicit. A client MUST NOT assume support for a
 command, document format, compression codec, query operator, or consistency mode
 that the server did not advertise.
 
+A connection has exactly one selected transport protocol version. `hello` and
+`hello_ok` for this specification use header version 1.0. After `hello_ok`, all
+frames on the connection MUST carry the selected version. Receivers MUST reject
+ordinary frames with a different major version and MUST reject an unnegotiated
+minor version. Major versions are incompatible. Minor versions are additive only
+when explicitly negotiated.
+
 ## 7. Command Header
 
 Every `request` frame has a `command_header` section:
@@ -221,6 +310,19 @@ command_flags    uvarint
 Command versions are per-command schema versions. A server MAY support multiple
 versions of the same command during pre-alpha development, but the selected
 schema MUST be explicit in every request.
+
+Once a `command_id + command_version` is admitted to a deterministic command
+entry, its deterministic semantics are immutable for that Raft log lineage.
+Section IDs MUST NOT be reused with different meanings. Semantic changes,
+canonical encoding changes, or changed default behavior require a new
+`command_version` or `entry_version`. Mixed-version clusters MUST only advertise
+command versions that every voting replica can decode and apply
+deterministically.
+
+`command_flags` are command payload metadata, not transport metadata. Flags that
+affect mutation semantics MUST be part of deterministic command-entry encoding.
+Flags that only affect response shaping, tracing, or pagination MUST NOT be
+replicated.
 
 ## 8. Document Formats
 
@@ -250,12 +352,63 @@ matches the collection root model: template records, primary documents,
 index-state, and secondary-index postings are one logical collection mutation
 group.
 
-## 9. Initial Command Set
+Deterministic entries replicate logical mutation input: collection identity,
+document IDs, stored document bytes, template records when required, command
+flags, and catalog guards. Secondary-index postings, index-state deltas, backend
+root IDs, value-log offsets, flush artifacts, and other node-local derived
+storage state MUST be regenerated by the state machine and MUST NOT be
+replicated unless a future command version explicitly freezes that
+representation.
+
+## 9. Collection References and Metadata
+
+`collection_ref` supports two forms:
+
+```text
+1 collection_name
+2 connection_local_handle
+```
+
+Collection names are stable command input. Connection-local handles are a
+transport optimization returned by `open_collection`; they are never valid
+outside the connection that received them and MUST NOT appear in deterministic
+command entries.
+
+Collection metadata commands SHOULD use the same logical fields as the current
+`CollectionMeta` and `IndexDefinition` model:
+
+```text
+collection_name
+document_format
+allow_array_values_in_index
+data_root_storage_policy
+index_state_storage_policy
+buffered_indexed_write_policy
+index_name
+index_field
+index_value_type
+index_unique
+index_multi_key
+index_storage_policy
+```
+
+Metadata mutation responses SHOULD include the resulting catalog version or
+equivalent schema guard. Later mutation requests MAY use
+`expected_catalog_version` to fail fast when a client planned against stale
+metadata.
+
+For distributed mode, collection and index mutation entries MUST include a
+deterministic catalog guard: either `expected_catalog_version` or an equivalent
+catalog epoch plus stable collection/index IDs resolved from committed metadata.
+Connection-local handles and unguarded client names MUST be resolved before
+append and MUST NOT be stored in the deterministic entry.
+
+## 10. Initial Command Set
 
 The v1 implementation SHOULD start with the smallest surface that can replace
 the current Mongo raw-wire benchmark path for native clients.
 
-### 9.1 Control Commands
+### 10.1 Control Commands
 
 ```text
 10 create_collection
@@ -273,7 +426,7 @@ an optimization only. The deterministic command entry MUST use stable collection
 names or stable collection IDs from committed metadata, not connection-local
 handles.
 
-### 9.2 Mutation Commands
+### 10.2 Mutation Commands
 
 ```text
 30 insert_batch
@@ -283,6 +436,11 @@ handles.
 34 flush_all
 35 checkpoint
 ```
+
+`insert_batch`, `replace_batch`, and `delete_batch` are logical mutation
+commands. `flush_collection`, `flush_all`, and `checkpoint` are local durability
+barriers in v1 and MUST NOT be replicated as Raft state-machine commands unless
+a future distributed barrier command gives them explicit consensus semantics.
 
 `insert_batch` sections:
 
@@ -318,7 +476,31 @@ handles.
 Duplicate IDs in one mutation batch MUST be rejected unless a future command
 schema explicitly defines ordered same-ID semantics.
 
-### 9.3 Read Commands
+In distributed mode, mutation entries MUST carry either `idempotency_key` or
+`client_id + client_sequence`. The identity is scoped to the cluster/database
+and is part of state-machine deduplication state. Reuse of the same identity
+with the same canonical command digest MUST return the prior outcome. Reuse with
+a different digest MUST fail with `idempotency_conflict`. Transport `request_id`
+MUST NOT participate in this identity.
+
+Mutation responses SHOULD include:
+
+```text
+matched_count optional
+modified_count optional
+inserted_count optional
+deleted_count optional
+result_ids optional byte_vector
+per_item_status optional status_vector
+response_meta optional
+```
+
+`per_item_status` is required when a command can partially classify items while
+still returning an overall command error or partial-success result in a later
+schema. The initial v1 mutation commands SHOULD remain all-or-nothing unless a
+command version explicitly defines partial success.
+
+### 10.3 Read Commands
 
 ```text
 50 get_many
@@ -343,7 +525,38 @@ encoded as typed scalar sections, not as JSON filter objects.
 `open_scan` creates a cursor over a primary or secondary ordered range. Cursors
 MUST have server-side byte, document-count, and idle-time limits.
 
-## 10. Typed Scalars
+Read responses SHOULD use:
+
+```text
+presence_bitmap optional
+document_ids optional byte_vector
+documents optional byte_vector
+values optional byte_vector
+truncated optional bool
+cursor_meta optional
+response_meta optional
+```
+
+For `get_many`, result order MUST match request key order. For index and scan
+commands, result order MUST match the ordered root or index order selected by
+the command.
+
+`cursor_meta` SHOULD include:
+
+```text
+stream_id
+batch_items
+batch_bytes
+has_more
+server_cursor_deadline optional
+```
+
+`cursor_next` requests MUST include a maximum item count, maximum response bytes,
+or both. Servers MAY return fewer results than requested. A response with
+`has_more=false` is terminal and releases the cursor. A `cursor_not_found` error
+is terminal for the named cursor but not for the connection.
+
+## 11. Typed Scalars
 
 Index and query scalar codes:
 
@@ -361,9 +574,10 @@ wire scalar encoding is logical. The internal secondary-index key encoding
 remains an implementation detail unless a future server-to-server command
 explicitly freezes it.
 
-## 11. Durability and Consistency Policies
+## 12. Durability and Consistency Policies
 
-The `ack_policy` section controls when a mutation response is sent:
+The `ack_policy` section requests the minimum acknowledgement boundary for a
+mutation:
 
 ```text
 1 visible
@@ -385,6 +599,15 @@ available under the server's configured TreeDB durability mode.
 committed by consensus and applied according to the cluster's state-machine
 policy.
 
+If `ack_policy` is absent, the server uses its advertised default. The initial
+single-node native server SHOULD default to `visible` to match current
+collection API behavior, but clients that need a durability boundary SHOULD ask
+for `flushed` or `synced` explicitly.
+
+A server MUST either satisfy the requested minimum policy or fail the request.
+It MUST NOT silently downgrade `synced` to a relaxed or checkpoint-only
+guarantee. Successful responses SHOULD report `actual_ack_policy`.
+
 Read `consistency_policy` values:
 
 ```text
@@ -398,7 +621,7 @@ Single-node servers MAY treat `leader_read`, `linearizable`, and `lease_read` as
 equivalent when no cluster is configured, but they MUST report the actual mode in
 the response.
 
-## 12. Error Model
+## 13. Error Model
 
 Errors use stable numeric codes plus machine-readable fields:
 
@@ -429,13 +652,27 @@ Initial error classes:
 15 canceled
 16 resource_exhausted
 17 internal
+18 durability_unavailable
+19 consistency_unavailable
+20 cursor_not_found
+21 catalog_changed
+22 idempotency_conflict
 ```
 
 Errors that map to current collection duplicate-key conditions SHOULD preserve a
 stable duplicate-key class so clients can handle inserts and unique-index
 conflicts uniformly.
 
-## 13. Deterministic Command Entry v1
+Error frames MUST carry the target `request_id` when the error is
+request-scoped and the target `stream_id` when stream-scoped. A request-scoped
+error is terminal for that request. A stream-scoped error is terminal for that
+stream or cursor.
+
+`malformed_frame`, invalid header length, frame-size violations, and unsupported
+post-handshake versions are connection-fatal. The server MAY send `goaway` or an
+`error` frame before closing when safe.
+
+## 14. Deterministic Command Entry v1
 
 Future Raft log entries SHOULD use a deterministic command-entry envelope:
 
@@ -448,6 +685,30 @@ client_id optional
 client_sequence optional
 deterministic_sections
 ```
+
+Deterministic entries MUST use one canonical encoding:
+
+- little-endian fixed-width integers,
+- minimal unsigned base-128 varints for variable integers,
+- sections sorted by `section_id`,
+- command-defined ordering for repeated sections,
+- no duplicate non-repeatable sections,
+- exact bytes for document IDs, document payloads, template records, and scalar
+  query values,
+- no map iteration order.
+
+Unknown, ignored, transport-only, or non-critical convenience sections MUST NOT
+be copied into the deterministic entry. Optional fields MUST either be omitted
+or encoded with explicit defaults according to the command schema; both forms
+MUST NOT be accepted for the same `command_version`.
+
+The deterministic Raft command set is an allowlist. Logical metadata mutations
+and logical collection mutations MAY be replicated. Reads, cursors, explain,
+stats, open/close handles, `ack_policy`, `consistency_policy`, deadlines,
+cancellation, checksums, compression framing, flush, checkpoint, and other local
+durability or response-shaping controls MUST NOT be replicated as command
+identity. If a distributed barrier is needed, define it as a separate
+deterministic no-op or barrier command with explicit semantics.
 
 The following MUST NOT be included in deterministic command entries:
 
@@ -467,10 +728,20 @@ The following SHOULD be included when present:
 - idempotency key or `client_id + client_sequence`,
 - deterministic command flags.
 
+In distributed mode, mutating entries MUST include the idempotency identity and
+catalog guard rules described above. Clients may omit those sections for a
+single-node pre-alpha server only when the advertised command schema permits it.
+
+Commands that are read-only, cursor-only, or response-shaping only SHOULD NOT be
+encoded as Raft entries. Write-producing future features, such as server-side
+callbacks, MUST either log their fully expanded deterministic mutation batch or
+define a deterministic replay envelope with module hash and all deterministic
+inputs needed to reproduce the same writes.
+
 Raft implementations MAY store deterministic entries directly or wrap them in a
 larger consensus-layer entry that also carries term/index metadata.
 
-## 14. Benchmark Requirements
+## 15. Benchmark Requirements
 
 The first implementation MUST add native client modes beside the existing Mongo
 gateway client modes:
@@ -496,14 +767,13 @@ Native-wire benchmarks SHOULD include:
 - per-frame byte overhead,
 - server decode/dispatch overhead.
 
-## 15. Open Questions
+## 16. Open Questions
 
 1. Whether v1 should support raw ordered-KV commands alongside collection
    commands, or keep raw-KV access as a later capability.
 2. Whether connection-local collection handles are worth the complexity in v1.
 3. Which compression codecs should be allowed on the wire initially.
-4. Whether `synced` should be rejected or downgraded under relaxed durability
-   modes, or accepted with a response field describing the weaker actual
-   guarantee.
-5. How authentication and authorization should map onto collections, indexes,
+4. How authentication and authorization should map onto collections, indexes,
    and future cluster routing.
+5. Whether `visible` should remain the standalone default once native clients
+   move beyond benchmark and compatibility work.

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -198,9 +198,11 @@ negotiated maximum in-flight requests and cursors. Servers MUST NOT send
 unbounded unsolicited frames.
 
 `goaway` indicates that the peer will accept no new requests on the connection.
-Its body MUST include `last_accepted_request_id` and an optional error code.
-Clients MAY retry requests with IDs greater than `last_accepted_request_id`
-when the command and idempotency policy allow retry.
+Its body is a `response_meta` section encoded as a string map. The map MUST
+include `last_accepted_request_id` encoded as an unsigned decimal string and MAY
+include `error_code` encoded as an unsigned decimal string plus an optional
+human-readable `message`. Clients MAY retry requests with IDs greater than
+`last_accepted_request_id` when the command and idempotency policy allow retry.
 
 Each request moves through frame decode, schema validation, admission, dispatch,
 engine execution, response encode, and terminal cleanup. A request MUST emit at
@@ -257,6 +259,37 @@ Initial common section IDs:
 ```
 
 Command-specific sections start at `100`.
+
+Initial command-specific section IDs used by v1 commands and responses:
+
+```text
+100 collection_ref
+101 document_format
+102 document_ids              byte_vector
+103 documents                 byte_vector
+104 template_records optional byte_vector
+105 expected_catalog_version
+106 replacement_mode
+107 collection_meta
+108 index_definition
+109 index_name
+110 collection_handle
+111 index_value
+112 index_lower_bound
+113 index_upper_bound
+114 cursor_ref                uvarint cursor_id
+115 cursor_limits             uvarint max_items, uvarint max_bytes
+116 presence_bitmap           bitset, least-significant bit first
+117 truncated                 bool
+118 status_vector             byte_vector of per-item status records, reserved
+```
+
+`cursor_limits` encodes both fields. A zero `max_items` or `max_bytes` means
+"no client-specified limit" for that dimension; servers still enforce
+negotiated and configured limits. `presence_bitmap` has exactly
+`ceil(result_count/8)` bytes, where bit `i` says whether result `i` is present.
+`status_vector` is reserved for a future command version that defines partial
+success records; v1 all-or-nothing commands MUST NOT emit it.
 
 ### 5.5 Byte Vectors
 
@@ -665,14 +698,20 @@ the response.
 
 ## 13. Error Model
 
-Errors use stable numeric codes plus machine-readable fields:
+The v1 `error` section uses stable numeric codes plus a retry hint and a
+human-readable message:
 
 ```text
-code        uvarint
-retryable   bool
-message     string
-detail_kv   repeated string/string or typed values
+code       uvarint
+retryable  bool
+message    string
 ```
+
+The `string` encoding is the base protocol string encoding from section 3.
+Machine-readable request or stream metadata MAY be carried in a sibling
+`response_meta` string map. Typed error detail values are not frozen in v1; a
+future command or negotiated feature must define a separate critical detail
+section before typed details are emitted.
 
 Initial error classes:
 

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -7,6 +7,13 @@ shape for TreeDB collections and raw ordered-key operations. It is intended to
 guide implementation, benchmark work, and the future Raft/distributed database
 surface. It does not describe current shipped server behavior.
 
+Normative keywords are conformance requirements for code that advertises
+native-wire v1. Until a phase lands, unmatched requirements are design
+constraints. Any PR that changes frame layout, command IDs, section IDs,
+deterministic encoding, benchmark labels, or observability keys MUST update this
+document, the roadmap, relevant codec/golden tests, and benchmark documentation
+in the same change.
+
 ## 1. Decision
 
 TreeDB SHOULD use a native binary protocol for its production data plane.
@@ -172,6 +179,15 @@ unbounded unsolicited frames.
 Its body MUST include `last_accepted_request_id` and an optional error code.
 Clients MAY retry requests with IDs greater than `last_accepted_request_id`
 when the command and idempotency policy allow retry.
+
+Each request moves through frame decode, schema validation, admission, dispatch,
+engine execution, response encode, and terminal cleanup. A request MUST emit at
+most one terminal response or error. Cursor-open commands create server-owned
+cursor state only after admission succeeds. EOF, `cursor_close`, cancel, idle
+timeout, connection close, or terminal cursor error MUST release that state.
+Mutation dispatch MUST resolve connection-local handles and catalog guards before
+execution. Distributed mode MUST canonicalize and admit deterministic command
+bytes before applying the mutation.
 
 ### 5.3 Body Sections
 
@@ -741,7 +757,101 @@ inputs needed to reproduce the same writes.
 Raft implementations MAY store deterministic entries directly or wrap them in a
 larger consensus-layer entry that also carries term/index metadata.
 
-## 15. Benchmark Requirements
+## 15. Implementation Conformance
+
+Implementation guidance is expanded in
+`TreeDB/docs/spec/native-wire-implementation-guidelines.md`. The rules below are
+part of the protocol contract for code that advertises native-wire v1.
+
+### 15.1 Append-Time Determinism Gate
+
+In distributed mode, the leader MUST pass every mutating request through an
+append-time determinism gate before Raft append:
+
+1. decode the wire request using the negotiated command schema,
+2. reject unsupported command versions, unknown required sections, duplicate
+   singleton sections, and non-deterministic sections,
+3. resolve connection-local handles and client names to committed stable catalog
+   identities,
+4. verify that the command is in the deterministic command allowlist,
+5. require an idempotency identity and catalog guard,
+6. encode the command with the canonical command-entry encoder,
+7. compute the canonical command digest over the exact entry bytes,
+8. append only those canonical bytes to Raft.
+
+Followers MUST apply committed command-entry bytes directly. They MUST NOT
+reconstruct entries from wire frames, negotiated connection features, local
+defaults, map iteration order, timestamps, handles, or transport metadata.
+
+### 15.2 Canonical Encoder Registry
+
+Each replicated `command_id + command_version` MUST have exactly one canonical
+encoder and decoder. Generic section copying is not sufficient for Raft entry
+construction.
+
+The command schema MUST define deterministic sections, field order inside each
+section, optional-field defaults, repeated-section ordering, scalar encoding,
+and rejection rules. A command version MUST NOT accept both omitted and
+explicit-default encodings for the same logical value.
+
+Canonical encoders MUST reject inputs that cannot be represented with one stable
+byte form. Any future replicated scalar that admits multiple encodings, such as
+floating NaN values, MUST either define a canonical representation or be
+rejected.
+
+### 15.3 Catalog Guards and Stable IDs
+
+Catalog guards are evaluated by the state machine at apply time. Leader-side
+validation is only a preflight optimization. A committed command whose guard
+does not match the applied catalog state MUST produce the same deterministic
+failure on every replica and MUST still update idempotency state for that
+command identity.
+
+Create/drop collection and create/drop index commands MUST encode deterministic
+existence guards, stable names, and any stable IDs assigned by committed catalog
+state. Replicas MUST NOT allocate catalog IDs from local randomness, wall-clock
+time, process-local counters outside the log, or map iteration order.
+
+### 15.4 State-Machine Boundary
+
+Raft entries replicate logical state-machine input only. Applying an entry may
+derive secondary-index postings, index-state deltas, value-log writes, backend
+roots, flush artifacts, and physical file layout locally. Those derived
+artifacts MUST NOT influence later logical command results except through
+committed logical state.
+
+The apply path MUST NOT depend on wall-clock time, process-global randomness,
+goroutine scheduling, map iteration order, local value-log offsets, local flush
+timing, or local maintenance decisions. Snapshots MUST include logical catalog
+state, collection contents, index definitions, and idempotency records; they
+need not preserve byte-identical local storage layout.
+
+### 15.5 Local-Only Commands
+
+`open_collection`, `close_collection`, cursors, reads, `explain`, `stats`,
+`flush_collection`, `flush_all`, `checkpoint`, value-log GC, value-log rewrite,
+and physical maintenance commands are local-only in v1.
+
+Cluster servers MUST NOT satisfy `ack_policy=raft_committed` by appending these
+commands to Raft. They MUST either execute them as local operations with
+response metadata naming the serving node, reject them as `invalid_command`, or
+define a future deterministic distributed barrier command with explicit
+consensus semantics.
+
+### 15.6 Mixed-Version Cluster Admission
+
+In cluster mode, `hello_ok` MUST distinguish locally implemented command
+versions from cluster-admitted command versions. A leader MUST only admit
+deterministic entries whose `entry_version`, `command_id`, `command_version`,
+and required feature bits can be decoded and applied by every current voting
+replica for the Raft group.
+
+Rolling upgrades MUST keep new deterministic command versions disabled until the
+membership and feature floor prove that all voting replicas can replay them. A
+node that cannot decode an already committed entry version MUST refuse to join
+as a voting replica for that log lineage.
+
+## 16. Benchmark and Observability Requirements
 
 The first implementation MUST add native client modes beside the existing Mongo
 gateway client modes:
@@ -765,9 +875,24 @@ Native-wire benchmarks SHOULD include:
 - cursor scan throughput,
 - allocation profile,
 - per-frame byte overhead,
-- server decode/dispatch overhead.
+- server encode/decode/dispatch overhead,
+- frames and bytes in/out,
+- request count and item count,
+- cursor count,
+- error and cancellation totals.
 
-## 16. Open Questions
+Native-wire benchmark PRs MUST update `cmd/unified_bench` labels and tests before
+publishing native-wire results. Native-wire TCP and in-process results MUST NOT
+be reported under `native-fastpath`.
+
+The native server SHOULD expose stable `treedb.native_wire.*` stats through the
+same stats path consumed by `unified-bench` and `benchprof`. Minimum counters are
+connections opened/closed, frames in/out, bytes in/out, malformed frames,
+requests started/completed/failed/canceled/timed out, in-flight requests, open
+cursors, cursor closes/timeouts, per-command request/error counts, and
+encode/decode/dispatch nanoseconds.
+
+## 17. Open Questions
 
 1. Whether v1 should support raw ordered-KV commands alongside collection
    commands, or keep raw-KV access as a later capability.

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -108,6 +108,11 @@ Primitive payload encodings:
   validators may impose a narrower grammar, such as collection or index names.
 - `bytes`: `uvarint` byte length followed by exactly that many opaque bytes,
   except where a containing structure already supplies an explicit length.
+- Optional fields are represented by section or field presence, not by an
+  implicit null encoding. A section schema that contains optional scalar fields
+  MUST define an explicit presence mechanism, such as a field-count prefix,
+  fixed presence bitmap, or command-specific sentinel, and MUST define the
+  default value used when the field is absent.
 
 ```text
 offset  size  field

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -1,0 +1,509 @@
+# TreeDB Native Wire Protocol v1
+
+Status: draft proposal, non-normative.
+
+TreeDB is pre-alpha. This document defines the target native network protocol
+shape for TreeDB collections and raw ordered-key operations. It is intended to
+guide implementation, benchmark work, and the future Raft/distributed database
+surface. It does not describe current shipped server behavior.
+
+## 1. Decision
+
+TreeDB SHOULD use a native binary protocol for its production data plane.
+
+OpenRPC, OpenAPI, Swagger, and JSON-RPC style descriptions are intentionally
+not the canonical TreeDB network protocol. They can be useful for generated
+admin clients or human-readable documentation, but their JSON object model,
+field-name repetition, generic map decoding, HTTP request shape, and awkward
+streaming/backpressure semantics are the wrong default costs for the TreeDB hot
+path.
+
+The native protocol MUST be designed so the same logical command schema can also
+produce future deterministic Raft command entries. Transport fields, tracing,
+deadlines, negotiated compression choices, and socket-level request identifiers
+MUST NOT be part of the replicated command identity.
+
+## 2. Goals
+
+1. Provide a fast collection-native network protocol.
+2. Keep command payloads vectorized for insert/get/query batches.
+3. Avoid JSON/BSON command envelopes on the hot path.
+4. Preserve TreeDB's existing collection document formats:
+   - JSON document bytes,
+   - native BSON document bytes,
+   - template-v1 stored documents and template records.
+5. Make durability and consistency semantics explicit per request.
+6. Leave room for streaming reads, backpressure, cancellation, compression,
+   authentication, and future cluster routing.
+7. Define a clean boundary between client wire frames and future Raft log
+   entries.
+
+## 3. Non-Goals
+
+The v1 protocol does not initially require:
+
+1. MongoDB compatibility.
+2. Redis/RESP compatibility.
+3. OpenRPC or JSON-RPC compatibility.
+4. Arbitrary SQL execution.
+5. Cross-node distributed query execution.
+6. Server-side WASM execution.
+7. A stable public compatibility promise before TreeDB exits pre-alpha.
+
+MongoDB and Redis compatibility layers MAY continue to exist as adapters, but
+they MUST NOT define the native TreeDB protocol or future Raft log format.
+
+## 4. Layering
+
+The protocol has three layers:
+
+1. **Transport frame:** connection-local framing, request IDs, stream IDs,
+   frame type, and frame flags.
+2. **Command payload:** versioned command IDs and typed sections.
+3. **Deterministic command entry:** a canonical subset of the command payload
+   suitable for future Raft replication.
+
+Only layer 3 is eligible for Raft log storage. Layer 1 MUST be excluded from
+Raft entries. Layer 2 MAY contain optional client/server convenience sections
+that are also excluded from deterministic entries unless explicitly marked as
+deterministic command input.
+
+## 5. Transport
+
+The primary transports are:
+
+- TCP,
+- Unix domain sockets,
+- in-process benchmark transport.
+
+TLS and authentication are negotiated above the raw connection or through a
+future authenticated transport wrapper. The frame format does not require HTTP.
+
+### 5.1 Fixed Frame Header
+
+All fixed-width integers are little-endian. Variable-length integers use unsigned
+base-128 varints.
+
+```text
+offset  size  field
+0       4     magic = "TDB1"
+4       2     header_len
+6       2     version_major
+8       2     version_minor
+10      2     frame_type
+12      4     frame_flags
+16      8     stream_id
+24      8     request_id
+32      8     body_len
+```
+
+The initial fixed header length is 40 bytes. `header_len` allows future fixed
+header extensions. Receivers MUST reject frames whose `header_len` is smaller
+than 40 or larger than their configured maximum fixed-header length.
+
+`body_len` is the number of bytes following the header. Receivers MUST enforce a
+negotiated maximum frame size.
+
+### 5.2 Frame Types
+
+Initial frame types:
+
+```text
+1  hello
+2  hello_ok
+3  request
+4  response
+5  data
+6  error
+7  cancel
+8  ping
+9  pong
+10 goaway
+```
+
+`request_id` identifies one client request on a connection. Servers MAY process
+pipelined requests out of order unless the command explicitly requires ordering.
+Clients MUST match responses by `request_id`.
+
+`stream_id` identifies a logical stream or cursor. Non-streaming requests use
+`stream_id=0`. Streaming result frames use the same `request_id` and a non-zero
+`stream_id` assigned by the server.
+
+### 5.3 Body Sections
+
+Frame bodies are a sequence of typed sections:
+
+```text
+section_id     uvarint
+section_flags  uvarint
+section_len    uvarint
+section_bytes  bytes[section_len]
+```
+
+`section_flags & 1` marks a section as critical. Unknown critical sections MUST
+fail the frame. Unknown non-critical sections MUST be ignored.
+
+Sections SHOULD be ordered by increasing `section_id`, but receivers MUST NOT
+depend on order unless a command schema says a repeated section is ordered.
+
+### 5.4 Common Sections
+
+Initial common section IDs:
+
+```text
+1  command_header
+2  error
+3  capability_set
+4  deadline
+5  trace_context
+6  ack_policy
+7  consistency_policy
+8  idempotency_key
+9  checksum
+10 compression
+```
+
+Command-specific sections start at `100`.
+
+### 5.5 Byte Vectors
+
+Batch-oriented fields use byte-vector encoding:
+
+```text
+count uvarint
+repeat count:
+  length uvarint
+bytes concatenated_payloads
+```
+
+This avoids per-item maps and keeps IDs, documents, keys, and values compact.
+Implementations SHOULD parse byte vectors into offset tables or borrowed slices
+instead of allocating one object per element.
+
+## 6. Handshake
+
+The client MUST send `hello` before ordinary requests. The server replies with
+`hello_ok` or `error`.
+
+`hello` advertises:
+
+- client protocol versions,
+- maximum frame size,
+- supported compression codecs,
+- supported document formats,
+- desired authentication mode,
+- optional client name and driver version.
+
+`hello_ok` returns:
+
+- selected protocol version,
+- server maximum frame size,
+- selected compression policy,
+- supported command IDs,
+- supported document formats,
+- durability/consistency modes,
+- server feature bits.
+
+Feature negotiation MUST be explicit. A client MUST NOT assume support for a
+command, document format, compression codec, query operator, or consistency mode
+that the server did not advertise.
+
+## 7. Command Header
+
+Every `request` frame has a `command_header` section:
+
+```text
+command_id       uvarint
+command_version  uvarint
+command_flags    uvarint
+```
+
+Command versions are per-command schema versions. A server MAY support multiple
+versions of the same command during pre-alpha development, but the selected
+schema MUST be explicit in every request.
+
+## 8. Document Formats
+
+Document format codes:
+
+```text
+0 default
+1 json
+2 bson
+3 template_v1
+```
+
+The native protocol carries stored document bytes without wrapping them in a
+JSON command object.
+
+For BSON collections, the server SHOULD validate BSON once while decoding the
+request and then call the trusted BSON insertion path.
+
+For template-v1 collections, the protocol MUST support both:
+
+- current self-contained `TD1I` per-document insert envelopes,
+- a batch-level template-record section that lets clients send each template
+  record once per batch.
+
+The batch-level template section is preferred for native clients because it
+matches the collection root model: template records, primary documents,
+index-state, and secondary-index postings are one logical collection mutation
+group.
+
+## 9. Initial Command Set
+
+The v1 implementation SHOULD start with the smallest surface that can replace
+the current Mongo raw-wire benchmark path for native clients.
+
+### 9.1 Control Commands
+
+```text
+10 create_collection
+11 list_collections
+12 create_index
+13 list_indexes
+14 drop_index
+15 open_collection
+16 close_collection
+17 drop_collection
+```
+
+`open_collection` MAY return a connection-local collection handle. Handles are
+an optimization only. The deterministic command entry MUST use stable collection
+names or stable collection IDs from committed metadata, not connection-local
+handles.
+
+### 9.2 Mutation Commands
+
+```text
+30 insert_batch
+31 replace_batch
+32 delete_batch
+33 flush_collection
+34 flush_all
+35 checkpoint
+```
+
+`insert_batch` sections:
+
+```text
+100 collection_ref
+101 document_format
+102 document_ids byte_vector
+103 documents byte_vector
+104 template_records optional byte_vector
+105 expected_catalog_version optional
+```
+
+`replace_batch` sections:
+
+```text
+100 collection_ref
+101 document_format
+102 document_ids byte_vector
+103 documents byte_vector
+104 template_records optional byte_vector
+105 expected_catalog_version optional
+106 replacement_mode
+```
+
+`delete_batch` sections:
+
+```text
+100 collection_ref
+102 document_ids byte_vector
+105 expected_catalog_version optional
+```
+
+Duplicate IDs in one mutation batch MUST be rejected unless a future command
+schema explicitly defines ordered same-ID semantics.
+
+### 9.3 Read Commands
+
+```text
+50 get_many
+51 index_lookup
+52 index_range
+53 open_scan
+54 cursor_next
+55 cursor_close
+56 explain
+57 stats
+```
+
+`get_many` returns results in request order. Missing documents are represented
+with an explicit presence bitmap or result-status vector; missing values MUST
+not be confused with present empty documents.
+
+`index_lookup` is equality lookup over one typed secondary index value.
+
+`index_range` is a bounded range over one typed secondary index. Bounds are
+encoded as typed scalar sections, not as JSON filter objects.
+
+`open_scan` creates a cursor over a primary or secondary ordered range. Cursors
+MUST have server-side byte, document-count, and idle-time limits.
+
+## 10. Typed Scalars
+
+Index and query scalar codes:
+
+```text
+1 string
+2 bool
+3 int64
+4 double
+5 bytes
+6 null
+```
+
+Index query commands MUST use the index definition's declared value type. The
+wire scalar encoding is logical. The internal secondary-index key encoding
+remains an implementation detail unless a future server-to-server command
+explicitly freezes it.
+
+## 11. Durability and Consistency Policies
+
+The `ack_policy` section controls when a mutation response is sent:
+
+```text
+1 visible
+2 flushed
+3 synced
+4 raft_committed
+```
+
+`visible` means the mutation is visible to reads through the serving process or
+owning write domain. It is not necessarily crash-durable.
+
+`flushed` means collection write-domain state has been published to backend
+roots for that collection or all touched roots.
+
+`synced` means the operation reached the strongest local durability boundary
+available under the server's configured TreeDB durability mode.
+
+`raft_committed` is reserved for distributed mode. It means the command has been
+committed by consensus and applied according to the cluster's state-machine
+policy.
+
+Read `consistency_policy` values:
+
+```text
+1 local_stale
+2 leader_read
+3 linearizable
+4 lease_read
+```
+
+Single-node servers MAY treat `leader_read`, `linearizable`, and `lease_read` as
+equivalent when no cluster is configured, but they MUST report the actual mode in
+the response.
+
+## 12. Error Model
+
+Errors use stable numeric codes plus machine-readable fields:
+
+```text
+code        uvarint
+retryable   bool
+message     string
+detail_kv   repeated string/string or typed values
+```
+
+Initial error classes:
+
+```text
+1 malformed_frame
+2 unsupported_version
+3 unsupported_feature
+4 auth_required
+5 permission_denied
+6 invalid_command
+7 collection_not_found
+8 index_not_found
+9 duplicate_document_id
+10 document_exists
+11 unique_index_conflict
+12 catalog_version_mismatch
+13 read_only
+14 timeout
+15 canceled
+16 resource_exhausted
+17 internal
+```
+
+Errors that map to current collection duplicate-key conditions SHOULD preserve a
+stable duplicate-key class so clients can handle inserts and unique-index
+conflicts uniformly.
+
+## 13. Deterministic Command Entry v1
+
+Future Raft log entries SHOULD use a deterministic command-entry envelope:
+
+```text
+entry_magic = "TDC1"
+entry_version
+command_id
+command_version
+client_id optional
+client_sequence optional
+deterministic_sections
+```
+
+The following MUST NOT be included in deterministic command entries:
+
+- connection-local request IDs,
+- stream IDs,
+- transport deadlines,
+- trace context,
+- negotiated compression choices,
+- non-deterministic server timestamps,
+- response-shaping hints that do not change state.
+
+The following SHOULD be included when present:
+
+- collection metadata mutation input,
+- collection mutation IDs and document bytes,
+- expected catalog version or equivalent conflict guard,
+- idempotency key or `client_id + client_sequence`,
+- deterministic command flags.
+
+Raft implementations MAY store deterministic entries directly or wrap them in a
+larger consensus-layer entry that also carries term/index metadata.
+
+## 14. Benchmark Requirements
+
+The first implementation MUST add native client modes beside the existing Mongo
+gateway client modes:
+
+```text
+native-wire-tcp
+native-wire-inproc
+```
+
+Benchmark reports MUST label native-wire results separately from:
+
+- direct in-process collection calls,
+- Mongo driver paths,
+- Mongo raw-wire paths.
+
+Native-wire benchmarks SHOULD include:
+
+- insert load throughput,
+- get/get-many throughput,
+- equality/range index lookup throughput,
+- cursor scan throughput,
+- allocation profile,
+- per-frame byte overhead,
+- server decode/dispatch overhead.
+
+## 15. Open Questions
+
+1. Whether v1 should support raw ordered-KV commands alongside collection
+   commands, or keep raw-KV access as a later capability.
+2. Whether connection-local collection handles are worth the complexity in v1.
+3. Which compression codecs should be allowed on the wire initially.
+4. Whether `synced` should be rejected or downgraded under relaxed durability
+   modes, or accepted with a response field describing the weaker actual
+   guarantee.
+5. How authentication and authorization should map onto collections, indexes,
+   and future cluster routing.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -204,3 +204,20 @@ Coverage:
 - `TreeDB/collections/overhead_bench_test.go`:
   - `BenchmarkCollectionOverheadPlanIndexedTemplateV1`
   - `BenchmarkCollectionOverheadIndexStateTemplateV1Extraction`
+
+## 13. Native Wire Protocol
+
+Invariant:
+- Native-wire v1 code that advertises protocol support must enforce frame,
+  section, command-schema, feature-negotiation, and deterministic command-entry
+  rules from `TreeDB/docs/spec/native-wire-protocol.md`.
+- Protocol implementation work must keep schema IDs, codec constants, golden
+  vectors, fuzz targets, parity tests, deterministic-entry tests, benchmark
+  labels, and observability counters aligned with
+  `TreeDB/docs/spec/native-wire-implementation-guidelines.md`.
+
+Coverage:
+- No shipped native-wire server or codec exists yet. R0 implementation must add
+  the conformance fixtures, fuzz targets, and drift tests described in
+  `TreeDB/docs/spec/native-wire-implementation-guidelines.md` before claiming
+  native-wire v1 support.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -212,7 +212,7 @@ Invariant:
   section, command-schema, feature-negotiation, and deterministic command-entry
   rules from `TreeDB/docs/spec/native-wire-protocol.md`.
 - Protocol implementation work must keep schema IDs, codec constants, golden
-  vectors, fuzz targets, parity tests, deterministic-entry tests, benchmark
+  fixtures, fuzz targets, parity tests, deterministic-entry tests, benchmark
   labels, and observability counters aligned with
   `TreeDB/docs/spec/native-wire-implementation-guidelines.md`.
 


### PR DESCRIPTION
## Summary

- add a draft TreeDB native binary wire protocol v1 spec covering framing, TLV sections, command families, ack/consistency modes, errors, and deterministic command-entry boundaries for future Raft use
- add a draft native query and Raft roadmap that sequences protocol/codecs, single-node server work, deterministic command entries, Raft MVP writes, read consistency, distributed queries, and WASM/callback policy
- link both proposal docs from the canonical TreeDB spec README

## Validation

- `GOWORK=off go test ./TreeDB/docs`
- `bash scripts/docs_check.sh`
- `git diff --cached --check`