### PR TITLE
mongo bench: add TreeDB direct collection client mode

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2162,7 +2162,9 @@ func validateSetFieldName(key string) error {
 	return nil
 }
 
-func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
+// EncodePrimaryKey encodes a MongoDB _id value into the canonical TreeDB
+// collection primary key used by the Mongo gateway.
+func EncodePrimaryKey(value bson.RawValue) ([]byte, error) {
 	if value.IsZero() {
 		return nil, errors.New("Mongo document _id is required")
 	}
@@ -2176,6 +2178,10 @@ func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
 	key = append(key, primaryKeyPrefixBSONValue, byte(value.Type))
 	key = append(key, value.Value...)
 	return key, nil
+}
+
+func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
+	return EncodePrimaryKey(value)
 }
 
 func validateSupportedDocument(doc bson.Raw) error {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1415,7 +1415,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 		b.WriteString(loadModeBarChart(fmt.Sprintf("Load throughput by client mode, %d indexes", idx), cats, tree, mongo))
 	}
 	b.WriteString("</div>")
-	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the BSON collection API directly. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
+	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the collection API directly in the selected TreeDB document format. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
 	var body [][]string
 	for _, row := range rows {
 		body = append(body, []string{strconv.Itoa(row.Indexes), row.Target, row.Config, fmtOps(row.OpsPerSec), fmtBytes(float64(row.PhysicalBytes)), row.RawJSON})

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1758,7 +1758,7 @@ func loadModeChartRows(rows []loadModeRow, idx int) ([]string, []float64, []floa
 }
 
 func isTreeDBOnlyLoadMode(mode string) bool {
-	return mode == "BSON direct" || mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
+	return loadModeKind(mode) != ""
 }
 
 func loadModeDisplayLabel(mode string) string {
@@ -1791,7 +1791,30 @@ func loadModeOrder(mode string) string {
 	if idx, ok := order[mode]; ok {
 		return fmt.Sprintf("%02d_%s", idx, mode)
 	}
+	switch loadModeKind(mode) {
+	case "direct":
+		return "04_" + mode
+	case "raw_wire_tcp":
+		return "05_" + mode
+	case "raw_wire":
+		return "06_" + mode
+	}
 	return "99_" + mode
+}
+
+func loadModeKind(mode string) string {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	normalized = strings.TrimPrefix(normalized, "bson ")
+	switch {
+	case normalized == "direct" || strings.HasSuffix(normalized, "_direct"):
+		return "direct"
+	case normalized == "raw_wire_tcp" || strings.HasSuffix(normalized, "_raw_wire_tcp"):
+		return "raw_wire_tcp"
+	case normalized == "raw_wire" || strings.HasSuffix(normalized, "_raw_wire"):
+		return "raw_wire"
+	default:
+		return ""
+	}
 }
 
 func indexCountLabel(indexes int) string {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1405,7 +1405,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 	b.WriteString("<section id=\"mongo-load\"><h2>Load-Only Client-Mode Matrix</h2>")
 	b.WriteString("<p class=\"subtle\">Insert-only matrix. This section uses raw JSON directly so every MongoDB and TreeDB client mode has its own throughput and physical-disk row.</p>")
 	b.WriteString("<p class=\"subtle\">Use this section for pure ingest client-path comparisons. It is intentionally separate from the full-sweep load chart, which inherits the broader read/range/update sweep setup.</p>")
-	b.WriteString("<p class=\"subtle\">Driver, driver-command, driver-command-raw, and driver-unack modes are comparable Mongo-compatible client paths and render as paired TreeDB/MongoDB bars. Client modes marked with <strong>*</strong> are TreeDB-only raw-wire ceiling probes explained below.</p>")
+	b.WriteString("<p class=\"subtle\">Driver, driver-command, driver-command-raw, and driver-unack modes are comparable Mongo-compatible client paths and render as paired TreeDB/MongoDB bars. Client modes marked with <strong>*</strong> are TreeDB-only ceiling probes explained below.</p>")
 	b.WriteString("<div class=\"chart-grid\">")
 	for _, idx := range sortedLoadModeIndexes(rows) {
 		cats, tree, mongo := loadModeChartRows(rows, idx)
@@ -1415,7 +1415,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 		b.WriteString(loadModeBarChart(fmt.Sprintf("Load throughput by client mode, %d indexes", idx), cats, tree, mongo))
 	}
 	b.WriteString("</div>")
-	b.WriteString("<p class=\"subtle\"><strong>* Raw-wire modes:</strong> <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ingest ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
+	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the BSON collection API directly. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
 	var body [][]string
 	for _, row := range rows {
 		body = append(body, []string{strconv.Itoa(row.Indexes), row.Target, row.Config, fmtOps(row.OpsPerSec), fmtBytes(float64(row.PhysicalBytes)), row.RawJSON})
@@ -1757,12 +1757,12 @@ func loadModeChartRows(rows []loadModeRow, idx int) ([]string, []float64, []floa
 	return labels, tree, mongo
 }
 
-func isRawWireLoadMode(mode string) bool {
-	return mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
+func isTreeDBOnlyLoadMode(mode string) bool {
+	return mode == "BSON direct" || mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
 }
 
 func loadModeDisplayLabel(mode string) string {
-	if isRawWireLoadMode(mode) {
+	if isTreeDBOnlyLoadMode(mode) {
 		return mode + " *"
 	}
 	return mode
@@ -1784,8 +1784,9 @@ func loadModeOrder(mode string) string {
 		"BSON driver_command":     1,
 		"BSON driver_command_raw": 2,
 		"BSON driver_unack":       3,
-		"BSON raw_wire_tcp":       4,
-		"BSON raw_wire":           5,
+		"BSON direct":             4,
+		"BSON raw_wire_tcp":       5,
+		"BSON raw_wire":           6,
 	}
 	if idx, ok := order[mode]; ok {
 		return fmt.Sprintf("%02d_%s", idx, mode)
@@ -2021,14 +2022,14 @@ func loadModeBarChart(title string, categories []string, tree, mongo []float64) 
 	b.WriteString(fmt.Sprintf("<line x1=\"%.1f\" y1=\"%.1f\" x2=\"%.1f\" y2=\"%.1f\" stroke=\"#748399\" stroke-width=\"2\"/>", left, top, left, axisY))
 	for i, cat := range categories {
 		groupX := left + float64(i)*groupW
-		rawMode := isRawWireLoadMode(cat)
-		if rawMode {
+		treeDBOnlyMode := isTreeDBOnlyLoadMode(cat)
+		if treeDBOnlyMode {
 			if i < len(tree) && tree[i] > 0 {
 				v := tree[i]
 				barH := (v / maxV) * plotH
 				x := groupX + (groupW-soloBarW)/2
 				yy := axisY - barH
-				b.WriteString(fmt.Sprintf("<rect x=\"%.1f\" y=\"%.1f\" width=\"%.1f\" height=\"%.1f\" rx=\"2\" fill=\"#2867c7\"><title>%s TreeDB-only raw-wire ceiling: %s docs/sec</title></rect>", x, yy, soloBarW, barH, esc(cat), esc(formatChartValue(v, "docs/sec"))))
+				b.WriteString(fmt.Sprintf("<rect x=\"%.1f\" y=\"%.1f\" width=\"%.1f\" height=\"%.1f\" rx=\"2\" fill=\"#2867c7\"><title>%s TreeDB-only ceiling: %s docs/sec</title></rect>", x, yy, soloBarW, barH, esc(cat), esc(formatChartValue(v, "docs/sec"))))
 				if soloBarW >= 10 {
 					b.WriteString(fmt.Sprintf("<text x=\"%.1f\" y=\"%.1f\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"700\" fill=\"#344256\">%s</text>", x+soloBarW/2, math.Max(top+10, yy-5), esc(formatChartValue(v, "docs/sec"))))
 				}

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -71,10 +71,12 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	writeFile(t, filepath.Join(root, "mongo_gateway_reader_writer_scaling_1m", "indexes_4", "summary.tsv"), summary4)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
 		"treedb\ttreedb_bson_driver\t100\t0\traw/treedb.json\t5000000000\n"+
+		"treedb\ttreedb_bson_direct\t100\t0\traw/treedb_direct.json\t2800\n"+
 		"treedb\ttreedb_bson_raw_wire_tcp\t100\t0\traw/treedb_raw_wire_tcp.json\t3000\n"+
 		"treedb\ttreedb_bson_raw_wire\t100\t0\traw/treedb_raw_wire.json\t2500\n"+
 		"mongo\tmongo_driver\t100\t0\traw/mongo.json\t5000\n")
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1000}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","phases":[{"name":"load_insert_many","ops_per_sec":1700}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire_tcp.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1500}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1800}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "mongo.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":500}]}`)
@@ -110,10 +112,12 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"TreeDB JSON",
 		"SQLite native VACUUM: 20",
 		"Client modes marked with <strong>*</strong>",
+		"BSON Direct</text><text",
 		"BSON Raw</text><text",
 		"Wire TCP *</text>",
 		"Wire *</text>",
-		"* Raw-wire modes:",
+		"* TreeDB-only modes:",
+		"calls the BSON collection API directly",
 		"bypassing the MongoDB Go driver",
 		"same raw command/gateway path in process",
 		"one centered TreeDB bar",
@@ -124,6 +128,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	}
 	for _, unwanted := range []string{
 		"TreeDB Raw Wire Ceiling Modes",
+		"BSON direct MongoDB",
 		"BSON raw_wire_tcp MongoDB",
 		"BSON raw_wire MongoDB",
 	} {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -117,7 +117,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"Wire TCP *</text>",
 		"Wire *</text>",
 		"* TreeDB-only modes:",
-		"calls the BSON collection API directly",
+		"calls the collection API directly",
 		"bypassing the MongoDB Go driver",
 		"same raw command/gateway path in process",
 		"one centered TreeDB bar",

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -72,11 +72,13 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
 		"treedb\ttreedb_bson_driver\t100\t0\traw/treedb.json\t5000000000\n"+
 		"treedb\ttreedb_bson_direct\t100\t0\traw/treedb_direct.json\t2800\n"+
+		"treedb\ttreedb_json_direct\t100\t0\traw/treedb_json_direct.json\t2900\n"+
 		"treedb\ttreedb_bson_raw_wire_tcp\t100\t0\traw/treedb_raw_wire_tcp.json\t3000\n"+
 		"treedb\ttreedb_bson_raw_wire\t100\t0\traw/treedb_raw_wire.json\t2500\n"+
 		"mongo\tmongo_driver\t100\t0\traw/mongo.json\t5000\n")
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1000}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","phases":[{"name":"load_insert_many","ops_per_sec":1700}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_json_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","treedb_document_format":"json","phases":[{"name":"load_insert_many","ops_per_sec":1750}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire_tcp.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1500}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1800}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "mongo.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":500}]}`)
@@ -113,6 +115,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"SQLite native VACUUM: 20",
 		"Client modes marked with <strong>*</strong>",
 		"BSON Direct</text><text",
+		"BSON JSON</text><text",
 		"BSON Raw</text><text",
 		"Wire TCP *</text>",
 		"Wire *</text>",
@@ -129,6 +132,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	for _, unwanted := range []string{
 		"TreeDB Raw Wire Ceiling Modes",
 		"BSON direct MongoDB",
+		"BSON json_direct MongoDB",
 		"BSON raw_wire_tcp MongoDB",
 		"BSON raw_wire MongoDB",
 	} {
@@ -197,6 +201,31 @@ func TestCollectionChartsIncludeAdditionalFormats(t *testing.T) {
 func TestLoadModeLabelNormalizesSingleMongoConfig(t *testing.T) {
 	if got, want := loadModeLabel(loadModeRow{Target: "mongo", Config: "mongo"}), "BSON driver"; got != want {
 		t.Fatalf("label = %q, want %q", got, want)
+	}
+}
+
+func TestTreeDBOnlyLoadModeIncludesNonBSONDirectFormats(t *testing.T) {
+	for _, mode := range []string{
+		"BSON direct",
+		"BSON json_direct",
+		"BSON template_v1_direct",
+		"BSON raw_wire_tcp",
+		"BSON json_raw_wire_tcp",
+		"BSON raw_wire",
+		"BSON json_raw_wire",
+	} {
+		if !isTreeDBOnlyLoadMode(mode) {
+			t.Fatalf("%q should be TreeDB-only", mode)
+		}
+	}
+	for _, mode := range []string{
+		"BSON driver",
+		"BSON driver_command_raw",
+		"BSON json_driver",
+	} {
+		if isTreeDBOnlyLoadMode(mode) {
+			t.Fatalf("%q should not be TreeDB-only", mode)
+		}
 	}
 }
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -61,20 +61,21 @@ sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
 cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
-read/update phases on the driver. `-client-mode direct` is a BSON-only,
-TreeDB-only path that calls `collections.Collection` directly for the same
-phase names, bypassing the MongoDB Go driver, loopback sockets, and Mongo
-gateway command/response handling. Use direct mode to answer whether a slow
-Mongo API phase is already slow in the collection engine; use raw-wire mode to
-estimate the gateway/server ceiling without the driver's per-document marshal
-and `_id` discovery overhead; use driver mode for user-visible Mongo
-compatibility throughput.
+read/update phases on the driver. `-client-mode direct` is a TreeDB-only path
+that calls `collections.Collection` directly for the same phase names, using the
+selected `-treedb-document-format` (`json`, `template-v1`, or `bson`) while
+bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
+command/response handling. Use direct mode to answer whether a slow Mongo API
+phase is already slow in the collection engine and selected storage format; use
+raw-wire mode to estimate the gateway/server ceiling without the driver's
+per-document marshal and `_id` discovery overhead; use driver mode for
+user-visible Mongo compatibility throughput.
 
 When `-prebuild-documents` is enabled, the harness builds both structured BSON
 documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
 does not include fixture BSON marshaling. Direct mode also reuses prebuilt raw
-BSON documents for direct collection inserts.
+BSON-derived stored documents for direct collection inserts.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert
@@ -345,10 +346,11 @@ The initial workload phases are:
   on `client_mode`: `InsertMany` for `driver`, `RunCommand({insert,
   documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
   command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
-  visibility wait for `driver-unack`, direct BSON `Collection.InsertBatch` for
-  `direct`, and raw OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`.
-  When `-insert-producers` is greater than 1, this phase reports aggregate
-  wall-clock throughput and per-producer call latency in `producer_results`.
+  visibility wait for `driver-unack`, direct `Collection.InsertBatch` in the
+  selected storage format for `direct`, and raw OP_MSG document sequences for
+  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
+  phase reports aggregate wall-clock throughput and per-producer call latency in
+  `producer_results`.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field; emitted only when the
   email secondary index is part of the cell.

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -63,8 +63,8 @@ cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
 read/update phases on the driver. `-client-mode direct` is a TreeDB-only path
 that calls `collections.Collection` directly for the same phase names, using the
-selected `-treedb-document-format` (`json`, `template-v1`, or `bson`) while
-bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
+selected `-treedb-document-format` (`json`, `template-v1`/`collections-v1`, or
+`bson`) while bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
 command/response handling. Use direct mode to answer whether a slow Mongo API
 phase is already slow in the collection engine and selected storage format; use
 raw-wire mode to estimate the gateway/server ceiling without the driver's
@@ -116,7 +116,7 @@ vacuum. The final vacuum closes the benchmark gateway before rewriting
 `-treedb-maintenance checkpoint` to reproduce the older checkpoint-only disk
 metric, or `none` to skip final TreeDB disk reporting.
 
-`-treedb-document-format` accepts `json`, `template-v1`, and `bson`. BSON mode
+`-treedb-document-format` accepts `json`, `template-v1`/`collections-v1`, and `bson`. BSON mode
 stores Mongo wire documents as native BSON collection records, avoiding the
 canonical Extended JSON bridge used by the JSON/template-v1 gateway paths.
 Use `-treedb-buffered-indexed-write-max-documents`,

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -61,15 +61,20 @@ sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
 cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
-read/update phases on the driver. Use raw-wire mode to estimate the
-gateway/server ceiling without the driver's per-document marshal and `_id`
-discovery overhead; use driver mode for user-visible Mongo compatibility
-throughput.
+read/update phases on the driver. `-client-mode direct` is a BSON-only,
+TreeDB-only path that calls `collections.Collection` directly for the same
+phase names, bypassing the MongoDB Go driver, loopback sockets, and Mongo
+gateway command/response handling. Use direct mode to answer whether a slow
+Mongo API phase is already slow in the collection engine; use raw-wire mode to
+estimate the gateway/server ceiling without the driver's per-document marshal
+and `_id` discovery overhead; use driver mode for user-visible Mongo
+compatibility throughput.
 
 When `-prebuild-documents` is enabled, the harness builds both structured BSON
 documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
-does not include fixture BSON marshaling.
+does not include fixture BSON marshaling. Direct mode also reuses prebuilt raw
+BSON documents for direct collection inserts.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert
@@ -191,7 +196,7 @@ beside the normal MongoDB Go driver `InsertMany` path:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
 scripts/mongo_gateway_compare.sh
 ```
 
@@ -263,7 +268,7 @@ Useful overrides:
 
 - `DOCS_LIST="1000 10000 100000"`
 - `INDEXES_LIST="0 1 2"`
-- `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire"`
+- `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire"`
 - `MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
@@ -340,10 +345,10 @@ The initial workload phases are:
   on `client_mode`: `InsertMany` for `driver`, `RunCommand({insert,
   documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
   command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
-  visibility wait for `driver-unack`, and raw OP_MSG document sequences for
-  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
-  phase reports aggregate wall-clock throughput and per-producer call latency in
-  `producer_results`.
+  visibility wait for `driver-unack`, direct BSON `Collection.InsertBatch` for
+  `direct`, and raw OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`.
+  When `-insert-producers` is greater than 1, this phase reports aggregate
+  wall-clock throughput and per-producer call latency in `producer_results`.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field; emitted only when the
   email secondary index is part of the cell.

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2040,6 +2040,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 }
 
 func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, updatedCityValues []string) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			if err := ctx.Err(); err != nil {
@@ -2047,7 +2052,7 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 			}
 			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
 			key, id := keys.at(documentOrdinal)
-			if err := runDirectTreeDBUpdateOperation(collection, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+			if err := runDirectTreeDBUpdateOperation(collection, materializer, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
 				return err
 			}
 		}
@@ -2087,16 +2092,84 @@ func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, colle
 
 func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, phaseName string, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
-		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
-			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
-			key, id := keys.at(documentOrdinal)
-			return runDirectTreeDBUpdateOperation(collection, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample)
-		})
+		return runDirectTreeDBConcurrentUpdateOperations(ctx, cfg, collection, keys, updatedCityValues, sample)
 	})
+}
+
+func runDirectTreeDBConcurrentUpdateOperations(
+	ctx context.Context,
+	cfg config,
+	collection *collections.Collection,
+	keys directBenchmarkKeySet,
+	updatedCityValues []string,
+	sample func(time.Duration),
+) error {
+	workers := cfg.ConcurrentWriters
+	operations := cfg.ConcurrentWrites
+	if workers <= 0 || operations <= 0 {
+		return nil
+	}
+	if workers > operations {
+		workers = operations
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	var errOnce sync.Once
+	var firstErr error
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			materializer, err := directNewStoredDocumentMaterializer(collection)
+			if err != nil {
+				recordErr(err)
+				return
+			}
+			defer func() {
+				if err := materializer.Close(); err != nil {
+					recordErr(err)
+				}
+			}()
+			for {
+				if err := runCtx.Err(); err != nil {
+					return
+				}
+				op := int(next.Add(1) - 1)
+				if op >= operations {
+					return
+				}
+				documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
+				key, id := keys.at(documentOrdinal)
+				if err := runDirectTreeDBUpdateOperation(collection, materializer, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample); err != nil {
+					recordErr(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
 }
 
 func runDirectTreeDBUpdateOperation(
 	collection *collections.Collection,
+	materializer *collections.StoredDocumentJSONMaterializer,
 	cfg config,
 	key []byte,
 	id string,
@@ -2117,11 +2190,6 @@ func runDirectTreeDBUpdateOperation(
 	if err != nil {
 		return err
 	}
-	materializer, err := directNewStoredDocumentMaterializer(collection)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = materializer.Close() }()
 	begin := time.Now()
 	matched, _, err := collection.Update(key, func(stored []byte) ([]byte, bool, error) {
 		current, err := directStoredDocumentToBSON(collection, materializer, stored)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -470,7 +470,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
 	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
-	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1, or bson")
+	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1/collections-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexStateRootStorage, "treedb-index-state-root-storage", treeDBIndexStateRootStorage, "TreeDB collection index-state root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
@@ -652,7 +652,7 @@ func parseTreeDBProfile(raw string) (treedb.Profile, error) {
 
 func parseTreeDBDocumentFormat(raw string) (collections.DocumentFormat, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", string(collections.DocumentFormatTemplateV1):
+	case "", string(collections.DocumentFormatTemplateV1), "collections-v1":
 		return collections.DocumentFormatTemplateV1, nil
 	case string(collections.DocumentFormatJSON):
 		return collections.DocumentFormatJSON, nil

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -609,9 +609,6 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBDocumentFormat = documentFormat
-	if cfg.ClientMode == clientModeDirect && cfg.TreeDBDocumentFormat != collections.DocumentFormatBSON {
-		return config{}, fmt.Errorf("client-mode %q currently requires -treedb-document-format bson", cfg.ClientMode)
-	}
 	dataRootStorage, err := parseTreeDBRootStoragePolicy(treeDBDataRootStorage)
 	if err != nil {
 		return config{}, fmt.Errorf("treedb-data-root-storage: %w", err)
@@ -1478,17 +1475,17 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	var prebuiltIDs [][]byte
-	var prebuiltRaw []bson.Raw
+	var prebuiltDocuments [][]byte
 	if cfg.PrebuildDocuments {
 		prebuiltIDs = make([][]byte, cfg.Documents)
-		prebuiltRaw = make([]bson.Raw, cfg.Documents)
-		for i := range prebuiltRaw {
-			prebuiltIDs[i] = []byte(benchmarkID(i))
-			raw, err := bson.Marshal(benchmarkDocument(i))
+		prebuiltDocuments = make([][]byte, cfg.Documents)
+		for i := range prebuiltDocuments {
+			id, document, err := directTreeDBBenchmarkDocument(i, cfg.TreeDBDocumentFormat)
 			if err != nil {
 				return nil, fmt.Errorf("prebuild direct document %d: %w", i, err)
 			}
-			prebuiltRaw[i] = bson.Raw(raw)
+			prebuiltIDs[i] = id
+			prebuiltDocuments[i] = document
 		}
 	}
 
@@ -1504,7 +1501,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
-		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltRaw)
+		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltDocuments)
 	})
 	if err != nil {
 		return nil, err
@@ -1664,53 +1661,229 @@ func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
 	return indexes
 }
 
-func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) (phaseResult, error) {
+const directPrimaryKeyPrefixBSONValue byte = 1
+
+func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]byte, []byte, error) {
+	raw, err := bson.Marshal(benchmarkDocument(i))
+	if err != nil {
+		return nil, nil, err
+	}
+	return directPrepareTreeDBDocument(bson.Raw(raw), format)
+}
+
+func directPrepareTreeDBDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, []byte, error) {
+	id := raw.Lookup("_id")
+	key, err := directEncodePrimaryKey(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	stored, err := directEncodeStoredDocument(raw, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, stored, nil
+}
+
+func directEncodeStoredDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, error) {
+	switch format {
+	case collections.DocumentFormatBSON:
+		if err := raw.Validate(); err != nil {
+			return nil, err
+		}
+		return bytes.Clone(raw), nil
+	case collections.DocumentFormatDefault, collections.DocumentFormatJSON:
+		return bson.MarshalExtJSON(raw, true, false)
+	case collections.DocumentFormatTemplateV1:
+		stored, err := bson.MarshalExtJSON(raw, true, false)
+		if err != nil {
+			return nil, err
+		}
+		return collections.EncodeTemplateV1DocumentJSON(stored)
+	default:
+		return nil, fmt.Errorf("direct TreeDB benchmark unsupported document format %q", format)
+	}
+}
+
+func directBenchmarkDocumentKey(i int) ([]byte, string, error) {
+	id := benchmarkID(i)
+	typ, value, err := bson.MarshalValue(id)
+	if err != nil {
+		return nil, "", err
+	}
+	key, err := directEncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	if err != nil {
+		return nil, "", err
+	}
+	return key, id, nil
+}
+
+func directEncodePrimaryKey(value bson.RawValue) ([]byte, error) {
+	if value.IsZero() {
+		return nil, errors.New("direct TreeDB benchmark document _id is required")
+	}
+	if value.Type == bson.TypeArray {
+		return nil, errors.New("direct TreeDB benchmark document _id cannot be an array")
+	}
+	if err := value.Validate(); err != nil {
+		return nil, err
+	}
+	key := make([]byte, 0, 2+len(value.Value))
+	key = append(key, directPrimaryKeyPrefixBSONValue, byte(value.Type))
+	key = append(key, value.Value...)
+	return key, nil
+}
+
+func directNewStoredDocumentMaterializer(collection *collections.Collection) (*collections.StoredDocumentJSONMaterializer, error) {
+	if collection == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a collection")
+	}
+	return collection.NewStoredDocumentJSONMaterializer()
+}
+
+type directTreeDBMaterializerPool struct {
+	collection    *collections.Collection
+	pool          sync.Pool
+	mu            sync.Mutex
+	materializers []*collections.StoredDocumentJSONMaterializer
+}
+
+func newDirectTreeDBMaterializerPool(collection *collections.Collection) *directTreeDBMaterializerPool {
+	return &directTreeDBMaterializerPool{collection: collection}
+}
+
+func (p *directTreeDBMaterializerPool) get() (*collections.StoredDocumentJSONMaterializer, error) {
+	if p == nil {
+		return nil, errors.New("direct TreeDB benchmark materializer pool is nil")
+	}
+	if v := p.pool.Get(); v != nil {
+		return v.(*collections.StoredDocumentJSONMaterializer), nil
+	}
+	materializer, err := directNewStoredDocumentMaterializer(p.collection)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	p.materializers = append(p.materializers, materializer)
+	p.mu.Unlock()
+	return materializer, nil
+}
+
+func (p *directTreeDBMaterializerPool) put(materializer *collections.StoredDocumentJSONMaterializer) {
+	if p == nil || materializer == nil {
+		return
+	}
+	p.pool.Put(materializer)
+}
+
+func (p *directTreeDBMaterializerPool) close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	materializers := p.materializers
+	p.materializers = nil
+	p.mu.Unlock()
+	var err error
+	for _, materializer := range materializers {
+		err = errors.Join(err, materializer.Close())
+	}
+	return err
+}
+
+func directStoredDocumentToBSON(collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (bson.Raw, error) {
+	if materializer == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a document materializer")
+	}
+	if materializer.DocumentFormat() == collections.DocumentFormatBSON {
+		raw := bson.Raw(stored)
+		if err := raw.Validate(); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	}
+	materialized, err := materializer.StoredDocumentJSON(stored)
+	if err != nil {
+		// A reused template-v1 resolver can lag a concurrently fetched document.
+		// Retry once with a fresh snapshot before surfacing the original error.
+		if collection != nil {
+			if fresh, freshErr := collection.StoredDocumentJSON(stored); freshErr == nil {
+				materialized = fresh
+				err = nil
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var raw bson.Raw
+	if err := bson.UnmarshalExtJSON(materialized, true, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) (phaseResult, error) {
 	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		_ = producer
 		if err := batchCtx.Err(); err != nil {
 			return err
 		}
-		ids, docs, err := directTreeDBLoadBatch(start, end, prebuiltIDs, prebuiltRaw)
+		ids, docs, err := directTreeDBLoadBatch(start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
 		if err != nil {
 			return err
 		}
-		_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		if cfg.TreeDBDocumentFormat == collections.DocumentFormatBSON {
+			_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		} else {
+			_, err = collection.InsertBatch(ids, docs)
+		}
 		return err
 	})
 }
 
-func directTreeDBLoadBatch(start, end int, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) ([][]byte, [][]byte, error) {
+func directTreeDBLoadBatch(start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
 	ids := make([][]byte, end-start)
 	docs := make([][]byte, end-start)
 	for i := start; i < end; i++ {
 		out := i - start
-		if prebuiltIDs != nil {
+		if prebuiltIDs != nil && prebuiltDocuments != nil {
 			ids[out] = prebuiltIDs[i]
-		} else {
-			ids[out] = []byte(benchmarkID(i))
-		}
-		if prebuiltRaw != nil {
-			docs[out] = prebuiltRaw[i]
+			docs[out] = prebuiltDocuments[i]
 			continue
+		} else {
+			id, document, err := directTreeDBBenchmarkDocument(i, format)
+			if err != nil {
+				return nil, nil, err
+			}
+			ids[out] = id
+			docs[out] = document
 		}
-		raw, err := bson.Marshal(benchmarkDocument(i))
-		if err != nil {
-			return nil, nil, err
-		}
-		docs[out] = raw
 	}
 	return ids, docs, nil
 }
 
 func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			id := benchmarkID(i % cfg.Documents)
+			key, id, err := directBenchmarkDocumentKey(i % cfg.Documents)
+			if err != nil {
+				return err
+			}
 			begin := time.Now()
-			raw, err := collection.Get([]byte(id))
+			stored, err := collection.Get(key)
+			if err != nil {
+				sample(time.Since(begin))
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1724,6 +1897,11 @@ func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *col
 }
 
 func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			if err := ctx.Err(); err != nil {
@@ -1732,9 +1910,13 @@ func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *
 			email := benchmarkEmail((i * 17) % cfg.Documents)
 			begin := time.Now()
 			ids, truncated, err := collection.FindByIndexValueLimit("email_1", email, 1)
-			var raw []byte
+			var raw bson.Raw
 			if err == nil && len(ids) > 0 {
-				raw, err = collection.Get(ids[0])
+				var stored []byte
+				stored, err = collection.Get(ids[0])
+				if err == nil {
+					raw, err = directStoredDocumentToBSON(collection, materializer, stored)
+				}
 			}
 			sample(time.Since(begin))
 			if err != nil {
@@ -1753,6 +1935,11 @@ func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *
 
 func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
 	name := rangePhaseName(cfg)
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase(name, cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			if err := ctx.Err(); err != nil {
@@ -1760,7 +1947,7 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 			}
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
-			err := runDirectTreeDBRangeQuery(cfg, collection, minAge)
+			err := runDirectTreeDBRangeQuery(cfg, collection, materializer, minAge)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1770,7 +1957,7 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 	})
 }
 
-func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, minAge int64) error {
+func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
 		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
@@ -1781,7 +1968,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 			return err
 		}
 		for _, id := range ids {
-			raw, err := collection.Get(id)
+			stored, err := collection.Get(id)
+			if err != nil {
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			if err != nil {
 				return err
 			}
@@ -1793,7 +1984,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 	}
 	matches := 0
 	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {
-		age, ok := directBSONInt64Field(record.Document, "age")
+		raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)
+		if err != nil {
+			return false, err
+		}
+		age, ok := directBSONInt64Field(raw, "age")
 		if !ok {
 			return false, errors.New("direct range scan document missing int64 age")
 		}
@@ -1824,11 +2019,26 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 }
 
 func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	materializers := newDirectTreeDBMaterializerPool(collection)
+	defer func() { _ = materializers.close() }()
 	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
-			id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			key, id, err := directBenchmarkDocumentKey(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			if err != nil {
+				return err
+			}
+			materializer, err := materializers.get()
+			if err != nil {
+				return err
+			}
+			defer materializers.put(materializer)
 			begin := time.Now()
-			raw, err := collection.Get([]byte(id))
+			stored, err := collection.Get(key)
+			if err != nil {
+				sample(time.Since(begin))
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1859,7 +2069,10 @@ func runDirectTreeDBUpdateOperation(
 	updatedCityValues []string,
 	sample func(time.Duration),
 ) error {
-	id := benchmarkID(documentOrdinal)
+	key, id, err := directBenchmarkDocumentKey(documentOrdinal)
+	if err != nil {
+		return err
+	}
 	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
 		Operation:          operation,
 		DocumentOrdinal:    documentOrdinal,
@@ -1871,9 +2084,18 @@ func runDirectTreeDBUpdateOperation(
 	if err != nil {
 		return err
 	}
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = materializer.Close() }()
 	begin := time.Now()
-	matched, _, err := collection.Update([]byte(id), func(stored []byte) ([]byte, bool, error) {
-		updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(stored), bson.Raw(updateRaw))
+	matched, _, err := collection.Update(key, func(stored []byte) ([]byte, bool, error) {
+		current, err := directStoredDocumentToBSON(collection, materializer, stored)
+		if err != nil {
+			return nil, false, err
+		}
+		updated, changed, err := applyDirectBSONSetUpdate(current, bson.Raw(updateRaw))
 		if err != nil {
 			return nil, false, err
 		}
@@ -1883,7 +2105,14 @@ func runDirectTreeDBUpdateOperation(
 		if !changed {
 			return nil, false, nil
 		}
-		return []byte(updated), true, nil
+		updatedKey, encoded, err := directPrepareTreeDBDocument(updated, cfg.TreeDBDocumentFormat)
+		if err != nil {
+			return nil, false, err
+		}
+		if !bytes.Equal(updatedKey, key) {
+			return nil, false, fmt.Errorf("direct update changed primary key for %s", id)
+		}
+		return encoded, true, nil
 	})
 	sample(time.Since(begin))
 	if err != nil {
@@ -1901,9 +2130,12 @@ func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *col
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			id := benchmarkID(cfg.Documents - 1 - i)
+			key, _, err := directBenchmarkDocumentKey(cfg.Documents - 1 - i)
+			if err != nil {
+				return err
+			}
 			begin := time.Now()
-			err := collection.Delete([]byte(id))
+			err = collection.Delete(key)
 			sample(time.Since(begin))
 			if err != nil {
 				return err

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1473,6 +1473,10 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, target); err != nil {
 		return nil, err
 	}
+	directKeys, err := buildDirectBenchmarkKeySet(cfg.Documents)
+	if err != nil {
+		return nil, err
+	}
 
 	var prebuiltIDs [][]byte
 	var prebuiltDocuments [][]byte
@@ -1512,7 +1516,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	idPhase, err := runTreeDBProfiledPhase(target, profiler, "id_find_one", func() (phaseResult, error) {
-		return runDirectTreeDBIDFindPhase(ctx, cfg, collection)
+		return runDirectTreeDBIDFindPhase(ctx, cfg, collection, directKeys)
 	})
 	if err != nil {
 		return nil, err
@@ -1538,7 +1542,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	result.Phases = append(result.Phases, rangePhase)
 
 	updatePhase, err := runTreeDBProfiledPhase(target, profiler, "id_update_set", func() (phaseResult, error) {
-		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, updatedCityValuesForUpdate())
+		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, directKeys, updatedCityValuesForUpdate())
 	})
 	if err != nil {
 		return nil, err
@@ -1548,7 +1552,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	for _, concurrentReaders := range concurrentReaderCounts(cfg) {
 		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", concurrentReaders)
 		concurrentReadPhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
-			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, concurrentReaders, phaseName)
+			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, directKeys, concurrentReaders, phaseName)
 		})
 		if err != nil {
 			return nil, err
@@ -1559,7 +1563,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
 		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
 		concurrentWritePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
-			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, phaseName, updatedCityValuesForUpdate())
+			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, directKeys, phaseName, updatedCityValuesForUpdate())
 		})
 		if err != nil {
 			return nil, err
@@ -1569,7 +1573,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 
 	if cfg.Deletes > 0 {
 		deletePhase, err := runTreeDBProfiledPhase(target, profiler, "id_delete_one", func() (phaseResult, error) {
-			return runDirectTreeDBDeletePhase(ctx, cfg, collection)
+			return runDirectTreeDBDeletePhase(ctx, cfg, collection, directKeys)
 		})
 		if err != nil {
 			return nil, err
@@ -1661,8 +1665,6 @@ func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
 	return indexes
 }
 
-const directPrimaryKeyPrefixBSONValue byte = 1
-
 func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]byte, []byte, error) {
 	raw, err := bson.Marshal(benchmarkDocument(i))
 	if err != nil {
@@ -1673,7 +1675,7 @@ func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]
 
 func directPrepareTreeDBDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, []byte, error) {
 	id := raw.Lookup("_id")
-	key, err := directEncodePrimaryKey(id)
+	key, err := mongogateway.EncodePrimaryKey(id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1710,27 +1712,43 @@ func directBenchmarkDocumentKey(i int) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	key, err := directEncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	key, err := mongogateway.EncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
 	if err != nil {
 		return nil, "", err
 	}
 	return key, id, nil
 }
 
-func directEncodePrimaryKey(value bson.RawValue) ([]byte, error) {
-	if value.IsZero() {
-		return nil, errors.New("direct TreeDB benchmark document _id is required")
+type directBenchmarkKeySet struct {
+	keys [][]byte
+	ids  []string
+}
+
+func buildDirectBenchmarkKeySet(documents int) (directBenchmarkKeySet, error) {
+	out := directBenchmarkKeySet{
+		keys: make([][]byte, documents),
+		ids:  make([]string, documents),
 	}
-	if value.Type == bson.TypeArray {
-		return nil, errors.New("direct TreeDB benchmark document _id cannot be an array")
+	for i := 0; i < documents; i++ {
+		key, id, err := directBenchmarkDocumentKey(i)
+		if err != nil {
+			return directBenchmarkKeySet{}, err
+		}
+		out.keys[i] = key
+		out.ids[i] = id
 	}
-	if err := value.Validate(); err != nil {
-		return nil, err
+	return out, nil
+}
+
+func (s directBenchmarkKeySet) at(ordinal int) ([]byte, string) {
+	if len(s.keys) == 0 {
+		return nil, ""
 	}
-	key := make([]byte, 0, 2+len(value.Value))
-	key = append(key, directPrimaryKeyPrefixBSONValue, byte(value.Type))
-	key = append(key, value.Value...)
-	return key, nil
+	ordinal %= len(s.keys)
+	if ordinal < 0 {
+		ordinal += len(s.keys)
+	}
+	return s.keys[ordinal], s.ids[ordinal]
 }
 
 func directNewStoredDocumentMaterializer(collection *collections.Collection) (*collections.StoredDocumentJSONMaterializer, error) {
@@ -1823,12 +1841,17 @@ func directStoredDocumentToBSON(collection *collections.Collection, materializer
 }
 
 func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) (phaseResult, error) {
+	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
+	scratch := make([]directTreeDBLoadScratch, producers)
+	for i := range scratch {
+		scratch[i].ids = make([][]byte, 0, cfg.BatchSize)
+		scratch[i].docs = make([][]byte, 0, cfg.BatchSize)
+	}
 	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
-		_ = producer
 		if err := batchCtx.Err(); err != nil {
 			return err
 		}
-		ids, docs, err := directTreeDBLoadBatch(start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
+		ids, docs, err := directTreeDBLoadBatch(producerScratch(scratch, producer), start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
 		if err != nil {
 			return err
 		}
@@ -1841,28 +1864,44 @@ func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *colle
 	})
 }
 
-func directTreeDBLoadBatch(start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
-	ids := make([][]byte, end-start)
-	docs := make([][]byte, end-start)
+type directTreeDBLoadScratch struct {
+	ids  [][]byte
+	docs [][]byte
+}
+
+func producerScratch(scratch []directTreeDBLoadScratch, producer int) *directTreeDBLoadScratch {
+	if producer < 0 || producer >= len(scratch) {
+		return &directTreeDBLoadScratch{}
+	}
+	return &scratch[producer]
+}
+
+func directTreeDBLoadBatch(scratch *directTreeDBLoadScratch, start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
+	if scratch == nil {
+		scratch = &directTreeDBLoadScratch{}
+	}
+	ids := scratch.ids[:0]
+	docs := scratch.docs[:0]
 	for i := start; i < end; i++ {
-		out := i - start
 		if prebuiltIDs != nil && prebuiltDocuments != nil {
-			ids[out] = prebuiltIDs[i]
-			docs[out] = prebuiltDocuments[i]
+			ids = append(ids, prebuiltIDs[i])
+			docs = append(docs, prebuiltDocuments[i])
 			continue
 		} else {
 			id, document, err := directTreeDBBenchmarkDocument(i, format)
 			if err != nil {
 				return nil, nil, err
 			}
-			ids[out] = id
-			docs[out] = document
+			ids = append(ids, id)
+			docs = append(docs, document)
 		}
 	}
+	scratch.ids = ids
+	scratch.docs = docs
 	return ids, docs, nil
 }
 
-func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet) (phaseResult, error) {
 	materializer, err := directNewStoredDocumentMaterializer(collection)
 	if err != nil {
 		return phaseResult{}, err
@@ -1873,10 +1912,7 @@ func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *col
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			key, id, err := directBenchmarkDocumentKey(i % cfg.Documents)
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(i % cfg.Documents)
 			begin := time.Now()
 			stored, err := collection.Get(key)
 			if err != nil {
@@ -2003,14 +2039,15 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 	return err
 }
 
-func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, updatedCityValues []string) (phaseResult, error) {
+func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
 			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
-			if err := runDirectTreeDBUpdateOperation(collection, cfg, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+			key, id := keys.at(documentOrdinal)
+			if err := runDirectTreeDBUpdateOperation(collection, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
 				return err
 			}
 		}
@@ -2018,15 +2055,12 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 	})
 }
 
-func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, readers int, phaseName string) (phaseResult, error) {
 	materializers := newDirectTreeDBMaterializerPool(collection)
 	defer func() { _ = materializers.close() }()
 	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
-			key, id, err := directBenchmarkDocumentKey(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
 			materializer, err := materializers.get()
 			if err != nil {
 				return err
@@ -2051,11 +2085,12 @@ func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, colle
 	})
 }
 
-func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, phaseName string, updatedCityValues []string) (phaseResult, error) {
+func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, phaseName string, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
 			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
-			return runDirectTreeDBUpdateOperation(collection, cfg, op, documentOrdinal, true, updatedCityValues, sample)
+			key, id := keys.at(documentOrdinal)
+			return runDirectTreeDBUpdateOperation(collection, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample)
 		})
 	})
 }
@@ -2063,16 +2098,14 @@ func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, colle
 func runDirectTreeDBUpdateOperation(
 	collection *collections.Collection,
 	cfg config,
+	key []byte,
+	id string,
 	operation int,
 	documentOrdinal int,
 	concurrent bool,
 	updatedCityValues []string,
 	sample func(time.Duration),
 ) error {
-	key, id, err := directBenchmarkDocumentKey(documentOrdinal)
-	if err != nil {
-		return err
-	}
 	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
 		Operation:          operation,
 		DocumentOrdinal:    documentOrdinal,
@@ -2124,21 +2157,21 @@ func runDirectTreeDBUpdateOperation(
 	return nil
 }
 
-func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet) (phaseResult, error) {
 	return measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Deletes; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			key, _, err := directBenchmarkDocumentKey(cfg.Documents - 1 - i)
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(cfg.Documents - 1 - i)
 			begin := time.Now()
-			err = collection.Delete(key)
+			deleted, err := collection.DeleteDocument(key)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
+			}
+			if !deleted {
+				return fmt.Errorf("direct delete missed document %s", id)
 			}
 		}
 		return nil
@@ -2397,7 +2430,7 @@ func treedbCreateIndexDocs(secondaryIndexes int, rangeIndex bool) bson.A {
 }
 
 func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config, target *benchTarget) error {
-	if result == nil || cfg.Target != "treedb" || target == nil || target.collections == nil || cfg.SecondaryIndexes == 0 {
+	if result == nil || cfg.Target != "treedb" || target == nil || target.collections == nil || !cfgHasAnySecondaryIndex(cfg) {
 		return nil
 	}
 	col, err := target.collections.OpenCollection(cfg.Database + "." + cfg.Collection)
@@ -2411,6 +2444,10 @@ func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config,
 	result.TreeDBBufferedIndexedAsyncFlush = meta.Options.BufferedIndexedAsyncFlush
 	result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits
 	return nil
+}
+
+func cfgHasAnySecondaryIndex(cfg config) bool {
+	return cfg.SecondaryIndexes > 0 || cfg.RangeIndex
 }
 
 func runLoadPhase(ctx context.Context, cfg config, target *benchTarget, coll *mongo.Collection, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -350,6 +350,7 @@ const (
 	clientModeDriverCommand    = "driver-command"
 	clientModeDriverCommandRaw = "driver-command-raw"
 	clientModeDriverUnack      = "driver-unack"
+	clientModeDirect           = "direct"
 	clientModeRawWire          = "raw-wire"
 	clientModeRawWireTCP       = "raw-wire-tcp"
 )
@@ -467,7 +468,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes >= 2 so the city index exists")
 	fs.BoolVar(&cfg.RangeIndex, "range-index", false, "create an age_1 secondary index for the age range-read phase")
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
-	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, raw-wire, or raw-wire-tcp; raw-wire modes are TreeDB-only and bypass the MongoDB Go driver for the insert load phase")
+	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
@@ -514,6 +515,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	cfg.ClientMode = clientMode
 	if cfg.Target != "treedb" && isRawWireClientMode(cfg.ClientMode) {
+		return config{}, fmt.Errorf("client-mode %q is only supported with -target treedb", cfg.ClientMode)
+	}
+	if cfg.Target != "treedb" && cfg.ClientMode == clientModeDirect {
 		return config{}, fmt.Errorf("client-mode %q is only supported with -target treedb", cfg.ClientMode)
 	}
 	if cfg.Documents <= 0 {
@@ -605,6 +609,9 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBDocumentFormat = documentFormat
+	if cfg.ClientMode == clientModeDirect && cfg.TreeDBDocumentFormat != collections.DocumentFormatBSON {
+		return config{}, fmt.Errorf("client-mode %q currently requires -treedb-document-format bson", cfg.ClientMode)
+	}
 	dataRootStorage, err := parseTreeDBRootStoragePolicy(treeDBDataRootStorage)
 	if err != nil {
 		return config{}, fmt.Errorf("treedb-data-root-storage: %w", err)
@@ -695,6 +702,8 @@ func parseClientMode(raw string) (string, error) {
 		return clientModeDriverCommandRaw, nil
 	case clientModeDriverUnack:
 		return clientModeDriverUnack, nil
+	case clientModeDirect:
+		return clientModeDirect, nil
 	case clientModeRawWire:
 		return clientModeRawWire, nil
 	case clientModeRawWireTCP:
@@ -751,12 +760,60 @@ func isRawWireClientMode(mode string) bool {
 func openTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	switch cfg.Target {
 	case "treedb":
+		if cfg.ClientMode == clientModeDirect {
+			return openTreeDBDirectTarget(ctx, cfg)
+		}
 		return openTreeDBTarget(ctx, cfg)
 	case "mongo":
 		return openMongoTarget(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("unknown target %q", cfg.Target)
 	}
+}
+
+func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, error) {
+	_ = ctx
+	dir := cfg.TreeDBDir
+	removeDir := false
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "mongo-gateway-direct-bench-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = tmp
+		removeDir = !cfg.KeepTreeDBDir
+	} else {
+		if err := resetTreeDBDir(dir); err != nil {
+			return nil, err
+		}
+	}
+
+	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	db, backendCleanup, err := open(opts)
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	manager := collections.NewCollectionManager(db)
+	cleanup := func(cleanupCtx context.Context) error {
+		_ = cleanupCtx
+		return errors.Join(manager.FlushAll(), backendCleanup())
+	}
+	return &benchTarget{
+		db:              db,
+		collections:     manager,
+		treedbDir:       dir,
+		removeTreeDBDir: removeDir,
+		cleanup:         cleanup,
+	}, nil
 }
 
 func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
@@ -1083,6 +1140,9 @@ func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server
 }
 
 func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeDirect {
+		return runDirectTreeDBBenchmark(ctx, cfg, target, profiler)
+	}
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
@@ -1371,6 +1431,584 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.MongoPoolStatsFinal = target.poolStats.Snapshot()
 	}
 	return result, nil
+}
+
+func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
+	result := &benchmarkResult{
+		Target:                                 cfg.Target,
+		Database:                               cfg.Database,
+		Collection:                             cfg.Collection,
+		Documents:                              cfg.Documents,
+		BatchSize:                              cfg.BatchSize,
+		InsertProducers:                        cfg.InsertProducers,
+		MongoMaxPoolSize:                       cfg.MongoMaxPoolSize,
+		MongoMinPoolSize:                       cfg.MongoMinPoolSize,
+		MongoMaxConnecting:                     cfg.MongoMaxConnecting,
+		SecondaryIndexes:                       cfg.SecondaryIndexes,
+		ClientMode:                             cfg.ClientMode,
+		ConcurrentReaders:                      cfg.ConcurrentReaders,
+		ConcurrentReaderSweep:                  append([]int(nil), cfg.ConcurrentReaderSweep...),
+		ConcurrentReads:                        cfg.ConcurrentReads,
+		ConcurrentWriters:                      cfg.ConcurrentWriters,
+		ConcurrentWrites:                       cfg.ConcurrentWrites,
+		UpdateIndexedField:                     cfg.UpdateIndexedField,
+		RangeIndex:                             cfg.RangeIndex,
+		PrebuildDocuments:                      cfg.PrebuildDocuments,
+		TreeDBProfile:                          string(cfg.TreeDBProfile),
+		TreeDBDocumentFormat:                   string(cfg.TreeDBDocumentFormat),
+		TreeDBDataRootStorage:                  string(cfg.TreeDBDataRootStorage),
+		TreeDBIndexStateRootStorage:            string(cfg.TreeDBIndexStateRootStorage),
+		TreeDBIndexRootStorage:                 string(cfg.TreeDBIndexRootStorage),
+		TreeDBBufferedIndexedWriteMaxDocuments: cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		TreeDBBufferedIndexedWriteMaxBytes:     cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		TreeDBBufferedIndexedWriteMaxRootRuns:  cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		TreeDBBufferedIndexedAsyncFlush:        cfg.TreeDBBufferedIndexedAsyncFlush,
+		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+		TreeDBMaintenanceMode:                         cfg.TreeDBMaintenance,
+	}
+	if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
+		result.TreeDBDir = target.treedbDir
+	}
+	collection, err := createDirectTreeDBCollection(cfg, target)
+	if err != nil {
+		return nil, err
+	}
+	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, target); err != nil {
+		return nil, err
+	}
+
+	var prebuiltIDs [][]byte
+	var prebuiltRaw []bson.Raw
+	if cfg.PrebuildDocuments {
+		prebuiltIDs = make([][]byte, cfg.Documents)
+		prebuiltRaw = make([]bson.Raw, cfg.Documents)
+		for i := range prebuiltRaw {
+			prebuiltIDs[i] = []byte(benchmarkID(i))
+			raw, err := bson.Marshal(benchmarkDocument(i))
+			if err != nil {
+				return nil, fmt.Errorf("prebuild direct document %d: %w", i, err)
+			}
+			prebuiltRaw[i] = bson.Raw(raw)
+		}
+	}
+
+	var updatedCityValues []string
+	updatedCityValuesForUpdate := func() []string {
+		if !cfg.UpdateIndexedField {
+			return nil
+		}
+		if updatedCityValues == nil {
+			updatedCityValues = buildBenchmarkUpdatedCityValues()
+		}
+		return updatedCityValues
+	}
+
+	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
+		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltRaw)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, loadPhase)
+	if err := collectAfterLoadStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+
+	idPhase, err := runTreeDBProfiledPhase(target, profiler, "id_find_one", func() (phaseResult, error) {
+		return runDirectTreeDBIDFindPhase(ctx, cfg, collection)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, idPhase)
+
+	if runEmailFindPhase(cfg) {
+		emailPhase, err := runTreeDBProfiledPhase(target, profiler, "email_find_one", func() (phaseResult, error) {
+			return runDirectTreeDBEmailFindPhase(ctx, cfg, collection)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, emailPhase)
+	}
+
+	rangePhase, err := runTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), func() (phaseResult, error) {
+		return runDirectTreeDBRangePhase(ctx, cfg, collection)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, rangePhase)
+
+	updatePhase, err := runTreeDBProfiledPhase(target, profiler, "id_update_set", func() (phaseResult, error) {
+		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, updatedCityValuesForUpdate())
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, updatePhase)
+
+	for _, concurrentReaders := range concurrentReaderCounts(cfg) {
+		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", concurrentReaders)
+		concurrentReadPhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
+			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, concurrentReaders, phaseName)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentReadPhase)
+	}
+
+	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
+		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
+		concurrentWritePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
+			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, phaseName, updatedCityValuesForUpdate())
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentWritePhase)
+	}
+
+	if cfg.Deletes > 0 {
+		deletePhase, err := runTreeDBProfiledPhase(target, profiler, "id_delete_one", func() (phaseResult, error) {
+			return runDirectTreeDBDeletePhase(ctx, cfg, collection)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, deletePhase)
+	}
+
+	if err := collectFinalStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func directTreeDBCollectionName(cfg config) string {
+	return cfg.Database + "." + cfg.Collection
+}
+
+func directTreeDBCollectionOptions(cfg config) collections.CollectionOptions {
+	return collections.CollectionOptions{
+		DocumentFormat:                          cfg.TreeDBDocumentFormat,
+		DataRootStoragePolicy:                   cfg.TreeDBDataRootStorage,
+		IndexStateStoragePolicy:                 cfg.TreeDBIndexStateRootStorage,
+		BufferedIndexedWriteMaxDocuments:        cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:            cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRootRuns:         cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		BufferedIndexedAsyncFlush:               cfg.TreeDBBufferedIndexedAsyncFlush,
+		BufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+	}
+}
+
+func createDirectTreeDBCollection(cfg config, target *benchTarget) (*collections.Collection, error) {
+	if target == nil || target.collections == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a collection manager")
+	}
+	name := directTreeDBCollectionName(cfg)
+	if _, err := target.collections.CreateCollection(&collections.CollectionMeta{
+		Name:    name,
+		Options: directTreeDBCollectionOptions(cfg),
+	}); err != nil {
+		return nil, err
+	}
+	collection, err := target.collections.OpenCollection(name)
+	if err != nil {
+		return nil, err
+	}
+	for _, index := range directTreeDBIndexDefinitions(cfg) {
+		if _, err := collection.CreateIndex(index); err != nil {
+			return nil, err
+		}
+	}
+	return collection, nil
+}
+
+func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
+	indexes := make([]collections.IndexDefinition, 0, cfg.SecondaryIndexes+1)
+	if cfg.SecondaryIndexes >= 1 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.SecondaryIndexes >= 2 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.SecondaryIndexes >= 3 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "active_1",
+			Field:         "active",
+			ValueType:     collections.IndexValueBool,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.RangeIndex {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "age_1",
+			Field:         "age",
+			ValueType:     collections.IndexValueInt64,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	return indexes
+}
+
+func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) (phaseResult, error) {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
+		_ = producer
+		if err := batchCtx.Err(); err != nil {
+			return err
+		}
+		ids, docs, err := directTreeDBLoadBatch(start, end, prebuiltIDs, prebuiltRaw)
+		if err != nil {
+			return err
+		}
+		_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		return err
+	})
+}
+
+func directTreeDBLoadBatch(start, end int, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, end-start)
+	docs := make([][]byte, end-start)
+	for i := start; i < end; i++ {
+		out := i - start
+		if prebuiltIDs != nil {
+			ids[out] = prebuiltIDs[i]
+		} else {
+			ids[out] = []byte(benchmarkID(i))
+		}
+		if prebuiltRaw != nil {
+			docs[out] = prebuiltRaw[i]
+			continue
+		}
+		raw, err := bson.Marshal(benchmarkDocument(i))
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[out] = raw
+	}
+	return ids, docs, nil
+}
+
+func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			id := benchmarkID(i % cfg.Documents)
+			begin := time.Now()
+			raw, err := collection.Get([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if got, ok := bson.Raw(raw).Lookup("_id").StringValueOK(); !ok || got != id {
+				return fmt.Errorf("direct id lookup returned _id=%v ok=%t want %s", got, ok, id)
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			email := benchmarkEmail((i * 17) % cfg.Documents)
+			begin := time.Now()
+			ids, truncated, err := collection.FindByIndexValueLimit("email_1", email, 1)
+			var raw []byte
+			if err == nil && len(ids) > 0 {
+				raw, err = collection.Get(ids[0])
+			}
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if truncated || len(ids) != 1 {
+				return fmt.Errorf("direct email lookup ids=%d truncated=%t want one id", len(ids), truncated)
+			}
+			if got, ok := bson.Raw(raw).Lookup("email").StringValueOK(); !ok || got != email {
+				return fmt.Errorf("direct email lookup returned email=%v ok=%t want %s", got, ok, email)
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	name := rangePhaseName(cfg)
+	return measurePhase(name, cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			minAge := int64(20 + (i % 40))
+			begin := time.Now()
+			err := runDirectTreeDBRangeQuery(cfg, collection, minAge)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, minAge int64) error {
+	if cfg.RangeIndex {
+		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
+			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
+			Upper: collections.IndexRangeBound{Unbounded: true},
+			Limit: 10,
+		})
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			raw, err := collection.Get(id)
+			if err != nil {
+				return err
+			}
+			if age, ok := directBSONInt64Field(raw, "age"); !ok || age < minAge {
+				return fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
+			}
+		}
+		return nil
+	}
+	matches := 0
+	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {
+		age, ok := directBSONInt64Field(record.Document, "age")
+		if !ok {
+			return false, errors.New("direct range scan document missing int64 age")
+		}
+		if age >= minAge {
+			matches++
+			if matches >= 10 {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	return err
+}
+
+func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, updatedCityValues []string) (phaseResult, error) {
+	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Updates; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
+			if err := runDirectTreeDBUpdateOperation(collection, cfg, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
+			id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			begin := time.Now()
+			raw, err := collection.Get([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if got, ok := bson.Raw(raw).Lookup("_id").StringValueOK(); !ok || got != id {
+				return fmt.Errorf("direct concurrent id lookup returned _id=%v ok=%t want %s", got, ok, id)
+			}
+			return nil
+		})
+	})
+}
+
+func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, phaseName string, updatedCityValues []string) (phaseResult, error) {
+	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
+			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
+			return runDirectTreeDBUpdateOperation(collection, cfg, op, documentOrdinal, true, updatedCityValues, sample)
+		})
+	})
+}
+
+func runDirectTreeDBUpdateOperation(
+	collection *collections.Collection,
+	cfg config,
+	operation int,
+	documentOrdinal int,
+	concurrent bool,
+	updatedCityValues []string,
+	sample func(time.Duration),
+) error {
+	id := benchmarkID(documentOrdinal)
+	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
+		Operation:          operation,
+		DocumentOrdinal:    documentOrdinal,
+		DocumentCount:      cfg.Documents,
+		ConcurrentPhase:    concurrent,
+		UpdateIndexedField: cfg.UpdateIndexedField,
+		UpdatedCityValues:  updatedCityValues,
+	}))
+	if err != nil {
+		return err
+	}
+	begin := time.Now()
+	matched, _, err := collection.Update([]byte(id), func(stored []byte) ([]byte, bool, error) {
+		updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(stored), bson.Raw(updateRaw))
+		if err != nil {
+			return nil, false, err
+		}
+		if got, ok := updated.Lookup("_id").StringValueOK(); !ok || got != id {
+			return nil, false, fmt.Errorf("direct update changed _id to %v ok=%t want %s", got, ok, id)
+		}
+		if !changed {
+			return nil, false, nil
+		}
+		return []byte(updated), true, nil
+	})
+	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return fmt.Errorf("direct update missed document %s", id)
+	}
+	return nil
+}
+
+func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Deletes; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			id := benchmarkID(cfg.Documents - 1 - i)
+			begin := time.Now()
+			err := collection.Delete([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func directBSONInt64Field(raw []byte, key string) (int64, bool) {
+	value := bson.Raw(raw).Lookup(key)
+	if value.Type == bson.TypeInt64 {
+		return value.Int64OK()
+	}
+	if value.Type == bson.TypeInt32 {
+		v, ok := value.Int32OK()
+		return int64(v), ok
+	}
+	return 0, false
+}
+
+func applyDirectBSONSetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, error) {
+	updateElements, err := update.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(updateElements) != 1 {
+		return nil, false, errors.New("direct TreeDB update currently supports exactly one $set operator")
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil {
+		return nil, false, err
+	}
+	if operator != "$set" {
+		return nil, false, errors.New("direct TreeDB update currently supports $set only")
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, false, errors.New("direct TreeDB $set value must be a document")
+	}
+	sets, setOrder, err := parseDirectBSONSetDocument(setDoc)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(sets) == 0 {
+		return doc, false, nil
+	}
+
+	elements, err := doc.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(bson.D, 0, len(elements)+len(sets))
+	used := make(map[string]struct{}, len(sets))
+	changed := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, false, err
+		}
+		value := elem.Value()
+		if replacement, ok := sets[key]; ok {
+			if !replacement.Equal(value) {
+				changed = true
+			}
+			value = replacement
+			used[key] = struct{}{}
+		}
+		out = append(out, bson.E{Key: key, Value: value})
+	}
+	for _, key := range setOrder {
+		if _, ok := used[key]; ok {
+			continue
+		}
+		out = append(out, bson.E{Key: key, Value: sets[key]})
+		changed = true
+	}
+	raw, err := bson.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return bson.Raw(raw), changed, nil
+}
+
+func parseDirectBSONSetDocument(setDoc bson.Raw) (map[string]bson.RawValue, []string, error) {
+	elements, err := setDoc.Elements()
+	if err != nil {
+		return nil, nil, err
+	}
+	sets := make(map[string]bson.RawValue, len(elements))
+	order := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, nil, err
+		}
+		if key == "_id" {
+			return nil, nil, errors.New("direct TreeDB update cannot modify _id")
+		}
+		if _, exists := sets[key]; !exists {
+			order = append(order, key)
+		}
+		sets[key] = elem.Value()
+	}
+	return sets, order, nil
 }
 
 func measureProfiledPhase(profiler *profileRecorder, name string, operations int, run func(func(time.Duration)) error) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -19,6 +19,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
 )
@@ -2024,6 +2025,24 @@ func TestRangePhaseNameDistinguishesScanAndIndexedRuns(t *testing.T) {
 	}
 }
 
+func TestDirectBenchmarkDocumentKeyUsesGatewayEncoding(t *testing.T) {
+	key, id, err := directBenchmarkDocumentKey(7)
+	if err != nil {
+		t.Fatalf("directBenchmarkDocumentKey: %v", err)
+	}
+	typ, value, err := bson.MarshalValue(id)
+	if err != nil {
+		t.Fatalf("MarshalValue: %v", err)
+	}
+	want, err := mongogateway.EncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	if err != nil {
+		t.Fatalf("EncodePrimaryKey: %v", err)
+	}
+	if !bytes.Equal(key, want) {
+		t.Fatalf("direct key=%x want gateway key=%x", key, want)
+	}
+}
+
 func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	result := &benchmarkResult{
 		Target:                                 "treedb",
@@ -2110,7 +2129,8 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 		Target:           "treedb",
 		Database:         "bench",
 		Collection:       "docs",
-		SecondaryIndexes: 1,
+		SecondaryIndexes: 0,
+		RangeIndex:       true,
 	}
 	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, &benchTarget{collections: manager}); err != nil {
 		t.Fatalf("record effective options: %v", err)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -650,7 +650,7 @@ func TestParseConfigValidation(t *testing.T) {
 	if directCfg.ClientMode != clientModeDirect {
 		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
 	}
-	for _, format := range []string{"json", "template-v1", "bson"} {
+	for _, format := range []string{"json", "template-v1", "collections-v1", "bson"} {
 		if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", format}); err != nil {
 			t.Fatalf("parse direct %s config: %v", format, err)
 		}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -643,6 +643,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if unackCfg.ClientMode != clientModeDriverUnack {
 		t.Fatalf("ClientMode=%q want %q", unackCfg.ClientMode, clientModeDriverUnack)
 	}
+	directCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "bson"})
+	if err != nil {
+		t.Fatalf("parse direct config: %v", err)
+	}
+	if directCfg.ClientMode != clientModeDirect {
+		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
+	}
 	oneIndexCfg, err := parseConfig([]string{"-secondary-indexes", "1"})
 	if err != nil {
 		t.Fatalf("parse secondary-indexes=1 config: %v", err)
@@ -665,6 +672,12 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "raw-wire-tcp"}); err == nil {
 		t.Fatal("raw-wire-tcp client-mode accepted for mongo target")
+	}
+	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
+		t.Fatal("direct client-mode accepted for mongo target")
+	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "json"}); err == nil {
+		t.Fatal("direct client-mode accepted for non-BSON TreeDB document format")
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)
@@ -1228,11 +1241,87 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("client mode smoke benchmark skipped in short mode")
 	}
-	for _, mode := range []string{clientModeDriver, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeRawWire, clientModeRawWireTCP} {
+	for _, mode := range []string{clientModeDriver, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP} {
 		t.Run(mode, func(t *testing.T) {
 			opsPerSecond := runTreeDBClientModeSmoke(t, mode)
 			t.Logf("%s load_insert_many ops/sec=%.1f", mode, opsPerSecond)
 		})
+	}
+}
+
+func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("direct benchmark smoke skipped in short mode")
+	}
+	cfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-client-mode", "direct",
+		"-treedb-document-format", "bson",
+		"-documents", "96",
+		"-batch-size", "24",
+		"-insert-producers", "2",
+		"-reads", "12",
+		"-range-reads", "6",
+		"-updates", "6",
+		"-deletes", "2",
+		"-secondary-indexes", "2",
+		"-range-index",
+		"-concurrent-reader-sweep", "1,2",
+		"-concurrent-reads", "12",
+		"-concurrent-writers", "2",
+		"-concurrent-writes", "8",
+		"-update-indexed-field",
+		"-prebuild-documents",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+		"-timeout", "0",
+		"-format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parse direct smoke config: %v", err)
+	}
+	target, err := openTarget(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open direct target: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := closeBenchTarget(cleanupCtx, target); err != nil {
+			t.Errorf("cleanup direct target: %v", err)
+		}
+	}()
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
+	if err != nil {
+		t.Fatalf("run direct benchmark: %v", err)
+	}
+	if result.ClientMode != clientModeDirect {
+		t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
+	}
+	phases := make(map[string]phaseResult, len(result.Phases))
+	for _, phase := range result.Phases {
+		phases[phase.Name] = phase
+	}
+	for _, name := range []string{
+		"load_insert_many",
+		"id_find_one",
+		"email_find_one",
+		"age_range_indexed_limit_10",
+		"id_update_set",
+		"concurrent_id_find_one_r1",
+		"concurrent_id_find_one_r2",
+		"concurrent_id_update_set_w2",
+		"id_delete_one",
+	} {
+		phase, ok := phases[name]
+		if !ok {
+			t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
+		}
+		if phase.OpsPerSecond <= 0 {
+			t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
+		}
+		if phase.SampledNsPerOp <= 0 {
+			t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
+		}
 	}
 }
 
@@ -1764,6 +1853,58 @@ func TestBenchmarkSetUpdateCanExerciseIndexedField(t *testing.T) {
 		if first, revisited := benchmarkUpdatedCity(op, documentOrdinal, documents), benchmarkUpdatedCity(op+documents, documentOrdinal, documents); first == revisited {
 			t.Fatalf("benchmarkUpdatedCity repeated value %q when revisiting document %d at op+documents for op=%d documents=%d", first, documentOrdinal, op, documents)
 		}
+	}
+}
+
+func TestApplyDirectBSONSetUpdate(t *testing.T) {
+	docRaw, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: "user-000001"},
+		{Key: "name", Value: "Ada"},
+		{Key: "age", Value: int64(37)},
+	})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+		{Key: "name", Value: "Grace"},
+		{Key: "city", Value: "honolulu"},
+	}}})
+	if err != nil {
+		t.Fatalf("marshal update: %v", err)
+	}
+	updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(docRaw), bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed=false want true")
+	}
+	if got, ok := updated.Lookup("_id").StringValueOK(); !ok || got != "user-000001" {
+		t.Fatalf("_id=%q ok=%t want user-000001", got, ok)
+	}
+	if got, ok := updated.Lookup("name").StringValueOK(); !ok || got != "Grace" {
+		t.Fatalf("name=%q ok=%t want Grace", got, ok)
+	}
+	if got, ok := updated.Lookup("city").StringValueOK(); !ok || got != "honolulu" {
+		t.Fatalf("city=%q ok=%t want honolulu", got, ok)
+	}
+	updatedAgain, changed, err := applyDirectBSONSetUpdate(updated, bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("apply unchanged update: %v", err)
+	}
+	if changed {
+		t.Fatal("changed=true want false for idempotent $set")
+	}
+	if !bytes.Equal(updated, updatedAgain) {
+		t.Fatalf("unchanged update bytes changed:\nfirst=%v\nagain=%v", updated, updatedAgain)
+	}
+
+	idUpdateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{{Key: "_id", Value: "other"}}}})
+	if err != nil {
+		t.Fatalf("marshal _id update: %v", err)
+	}
+	if _, _, err := applyDirectBSONSetUpdate(updated, bson.Raw(idUpdateRaw)); err == nil {
+		t.Fatal("_id update accepted")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -650,6 +650,11 @@ func TestParseConfigValidation(t *testing.T) {
 	if directCfg.ClientMode != clientModeDirect {
 		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
 	}
+	for _, format := range []string{"json", "template-v1", "bson"} {
+		if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", format}); err != nil {
+			t.Fatalf("parse direct %s config: %v", format, err)
+		}
+	}
 	oneIndexCfg, err := parseConfig([]string{"-secondary-indexes", "1"})
 	if err != nil {
 		t.Fatalf("parse secondary-indexes=1 config: %v", err)
@@ -675,9 +680,6 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
 		t.Fatal("direct client-mode accepted for mongo target")
-	}
-	if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "json"}); err == nil {
-		t.Fatal("direct client-mode accepted for non-BSON TreeDB document format")
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)
@@ -1253,75 +1255,86 @@ func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("direct benchmark smoke skipped in short mode")
 	}
-	cfg, err := parseConfig([]string{
-		"-target", "treedb",
-		"-client-mode", "direct",
-		"-treedb-document-format", "bson",
-		"-documents", "96",
-		"-batch-size", "24",
-		"-insert-producers", "2",
-		"-reads", "12",
-		"-range-reads", "6",
-		"-updates", "6",
-		"-deletes", "2",
-		"-secondary-indexes", "2",
-		"-range-index",
-		"-concurrent-reader-sweep", "1,2",
-		"-concurrent-reads", "12",
-		"-concurrent-writers", "2",
-		"-concurrent-writes", "8",
-		"-update-indexed-field",
-		"-prebuild-documents",
-		"-treedb-maintenance", treeDBMaintenanceNone,
-		"-timeout", "0",
-		"-format", "json",
-	})
-	if err != nil {
-		t.Fatalf("parse direct smoke config: %v", err)
-	}
-	target, err := openTarget(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("open direct target: %v", err)
-	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := closeBenchTarget(cleanupCtx, target); err != nil {
-			t.Errorf("cleanup direct target: %v", err)
-		}
-	}()
-	result, err := runBenchmark(context.Background(), cfg, target, nil)
-	if err != nil {
-		t.Fatalf("run direct benchmark: %v", err)
-	}
-	if result.ClientMode != clientModeDirect {
-		t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
-	}
-	phases := make(map[string]phaseResult, len(result.Phases))
-	for _, phase := range result.Phases {
-		phases[phase.Name] = phase
-	}
-	for _, name := range []string{
-		"load_insert_many",
-		"id_find_one",
-		"email_find_one",
-		"age_range_indexed_limit_10",
-		"id_update_set",
-		"concurrent_id_find_one_r1",
-		"concurrent_id_find_one_r2",
-		"concurrent_id_update_set_w2",
-		"id_delete_one",
+	for _, format := range []collections.DocumentFormat{
+		collections.DocumentFormatJSON,
+		collections.DocumentFormatTemplateV1,
+		collections.DocumentFormatBSON,
 	} {
-		phase, ok := phases[name]
-		if !ok {
-			t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
-		}
-		if phase.OpsPerSecond <= 0 {
-			t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
-		}
-		if phase.SampledNsPerOp <= 0 {
-			t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
-		}
+		t.Run(string(format), func(t *testing.T) {
+			cfg, err := parseConfig([]string{
+				"-target", "treedb",
+				"-client-mode", "direct",
+				"-treedb-document-format", string(format),
+				"-documents", "96",
+				"-batch-size", "24",
+				"-insert-producers", "2",
+				"-reads", "12",
+				"-range-reads", "6",
+				"-updates", "6",
+				"-deletes", "2",
+				"-secondary-indexes", "2",
+				"-range-index",
+				"-concurrent-reader-sweep", "1,2",
+				"-concurrent-reads", "12",
+				"-concurrent-writers", "2",
+				"-concurrent-writes", "8",
+				"-update-indexed-field",
+				"-prebuild-documents",
+				"-treedb-maintenance", treeDBMaintenanceNone,
+				"-timeout", "0",
+				"-format", "json",
+			})
+			if err != nil {
+				t.Fatalf("parse direct smoke config: %v", err)
+			}
+			target, err := openTarget(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("open direct target: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := closeBenchTarget(cleanupCtx, target); err != nil {
+					t.Errorf("cleanup direct target: %v", err)
+				}
+			}()
+			result, err := runBenchmark(context.Background(), cfg, target, nil)
+			if err != nil {
+				t.Fatalf("run direct benchmark: %v", err)
+			}
+			if result.ClientMode != clientModeDirect {
+				t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
+			}
+			if result.TreeDBDocumentFormat != string(format) {
+				t.Fatalf("document format=%q want %q", result.TreeDBDocumentFormat, format)
+			}
+			phases := make(map[string]phaseResult, len(result.Phases))
+			for _, phase := range result.Phases {
+				phases[phase.Name] = phase
+			}
+			for _, name := range []string{
+				"load_insert_many",
+				"id_find_one",
+				"email_find_one",
+				"age_range_indexed_limit_10",
+				"id_update_set",
+				"concurrent_id_find_one_r1",
+				"concurrent_id_find_one_r2",
+				"concurrent_id_update_set_w2",
+				"id_delete_one",
+			} {
+				phase, ok := phases[name]
+				if !ok {
+					t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
+				}
+				if phase.OpsPerSecond <= 0 {
+					t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
+				}
+				if phase.SampledNsPerOp <= 0 {
+					t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -285,16 +285,17 @@ Interpret client modes as separate questions:
 - `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
 - `driver-unack`: official driver unacknowledged insert enqueue path plus
   post-load visibility wait.
-- `direct`: TreeDB-only BSON collection API path. It emits the same phase names
-  as the Mongo gateway benchmark while bypassing the MongoDB driver, sockets,
-  and Mongo gateway command handling.
+- `direct`: TreeDB-only collection API path in the selected TreeDB document
+  format. It emits the same phase names as the Mongo gateway benchmark while
+  bypassing the MongoDB driver, sockets, and Mongo gateway command handling.
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
 the fastest current acknowledged official-driver load path. Use `direct` to
-separate collection-engine bottlenecks from Mongo compatibility overhead. Use
-raw-wire modes only to estimate TreeDB gateway/server ceiling.
+separate collection-engine and storage-format bottlenecks from Mongo
+compatibility overhead. Use raw-wire modes only to estimate TreeDB
+gateway/server ceiling.
 
 ## Reader and Writer Scaling
 

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -249,7 +249,7 @@ Use a client-mode matrix when measuring driver overhead and gateway ceiling:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
 MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
 BATCH_SIZE=5000 \
 INSERT_PRODUCERS=8 \
@@ -285,12 +285,16 @@ Interpret client modes as separate questions:
 - `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
 - `driver-unack`: official driver unacknowledged insert enqueue path plus
   post-load visibility wait.
+- `direct`: TreeDB-only BSON collection API path. It emits the same phase names
+  as the Mongo gateway benchmark while bypassing the MongoDB driver, sockets,
+  and Mongo gateway command handling.
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
-the fastest current acknowledged official-driver load path. Use raw-wire modes
-only to estimate TreeDB gateway/server ceiling.
+the fastest current acknowledged official-driver load path. Use `direct` to
+separate collection-engine bottlenecks from Mongo compatibility overhead. Use
+raw-wire modes only to estimate TreeDB gateway/server ceiling.
 
 ## Reader and Writer Scaling
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -105,9 +105,9 @@ Options:
   --treedb-document-formats LIST
                         Space-separated TreeDB formats. Example: "json template-v1 bson".
   --treedb-client-mode MODE
-                        Single TreeDB client mode: driver, driver-command, driver-command-raw, driver-unack, raw-wire-tcp, or raw-wire.
+                        Single TreeDB client mode: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, or raw-wire.
   --treedb-client-modes LIST
-                        Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire".
+                        Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
   --treedb-maintenance MODE
                         TreeDB final maintenance: full, checkpoint, or none.
   --title TITLE         Markdown report title.


### PR DESCRIPTION
## Summary

Adds a TreeDB-only `-client-mode direct` to `cmd/mongo_gateway_bench`. Direct mode emits the same phase names as the Mongo gateway benchmark, but bypasses the MongoDB Go driver, loopback sockets, and Mongo gateway command/response handling by calling `collections.Collection` directly.

Direct mode now supports all benchmarked TreeDB document formats via `-treedb-document-format`: `json`, `template-v1`/`collections-v1`, and `bson`. It stores BSON-derived benchmark documents in the selected collection storage format and uses the same canonical BSON `_id` primary-key encoding as the gateway path.

This gives us a direct answer for each Mongo benchmark surface: is the phase slow in the collection engine/storage format itself, or mostly above the collection layer?

Also updates the benchmark docs, canonical runbook, and deep report load-mode chart so `direct` renders as a TreeDB-only ceiling probe alongside raw-wire modes.

## Validation

```sh
go test -count=1 ./cmd/mongo_gateway_bench ./cmd/benchmark_run_report ./cmd/mongo_gateway_compare_report
```

All-format direct smoke artifacts:

```text
/tmp/treedb_direct_formats_pr1397_20260506_141930
```

Config highlights: `wal_on_fast`, `client-mode direct`, 10k docs, batch 1k, 8 insert producers, prebuilt documents, 2 secondary indexes plus `age_1`, maintenance none. Rows below report aggregate wall throughput and aggregate ns/op as `1e9 / ops_per_sec`.

| Format | Phase | Ops/s | ns/op |
| --- | --- | ---: | ---: |
| BSON | `load_insert_many` | 664,632 | 1,505 |
| BSON | `id_find_one` | 847,317 | 1,180 |
| BSON | `email_find_one` | 322,804 | 3,098 |
| BSON | `age_range_indexed_limit_10` | 89,910 | 11,122 |
| BSON | `id_update_set` | 56,868 | 17,584 |
| BSON | `concurrent_id_find_one_r16` | 1,930,993 | 518 |
| BSON | `concurrent_id_update_set_w8` | 71,646 | 13,957 |
| BSON | `id_delete_one` | 5,682 | 175,965 |
| JSON | `load_insert_many` | 611,265 | 1,636 |
| JSON | `id_find_one` | 157,237 | 6,360 |
| JSON | `email_find_one` | 112,920 | 8,856 |
| JSON | `age_range_indexed_limit_10` | 16,141 | 61,952 |
| JSON | `id_update_set` | 26,472 | 37,775 |
| JSON | `concurrent_id_find_one_r16` | 652,413 | 1,533 |
| JSON | `concurrent_id_update_set_w8` | 35,570 | 28,113 |
| JSON | `id_delete_one` | 4,478 | 223,264 |
| TemplateV1 | `load_insert_many` | 333,558 | 2,998 |
| TemplateV1 | `id_find_one` | 106,925 | 9,352 |
| TemplateV1 | `email_find_one` | 86,188 | 11,603 |
| TemplateV1 | `age_range_indexed_limit_10` | 11,198 | 89,300 |
| TemplateV1 | `id_update_set` | 18,809 | 53,166 |
| TemplateV1 | `concurrent_id_find_one_r16` | 439,755 | 2,274 |
| TemplateV1 | `concurrent_id_update_set_w8` | 23,801 | 42,014 |
| TemplateV1 | `id_delete_one` | 6,361 | 157,201 |

## Read on the Results

The new format sweep makes the direct family useful for two questions: Mongo compatibility overhead and TreeDB storage-format overhead. BSON direct reads and indexed reads are much faster than JSON/template-v1 in this direct harness because JSON/template-v1 must materialize stored documents back through Extended JSON/BSON for Mongo-phase validation. That cost is deliberately included because these are Mongo parity phases.

Indexed insert remains a real TreeDB storage/root-publish target. BSON direct load is 664,632 ops/s / 1,505 ns/op in this all-format smoke; JSON is close at 611,265 ops/s / 1,636 ns/op; template-v1 is lower at 333,558 ops/s / 2,998 ns/op.

Delete remains slow even in direct mode, especially once indexed root work is involved. That continues to justify focused delete/root-apply profiling after the current insert allocation work.

## Suggested Next Optimizations

1. For Mongo read throughput, profile and optimize the gateway read response path first: raw BSON response construction, cursor/single-batch reply encoding, and avoid driver-visible decode churn where possible. Direct BSON collection reads are already sub-microsecond to low-microsecond.
2. For JSON/template-v1 Mongo parity reads, separate pure collection read cost from materialization-to-BSON cost with a follow-up direct-storage-only variant or submetric.
3. For indexed insert, keep pursuing TreeDB storage-path work: value-log compression/training allocation, root-delta materialization, and indexed flush/root-apply costs.
4. For delete, add focused delete benchmarks/profiles. Direct delete is slow without Mongo overhead, so the bottleneck is below the gateway layer.