### PR TITLE
Mongo gateway bench: add range-read measurement modes

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2162,7 +2162,9 @@ func validateSetFieldName(key string) error {
 	return nil
 }
 
-func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
+// EncodePrimaryKey encodes a MongoDB _id value into the canonical TreeDB
+// collection primary key used by the Mongo gateway.
+func EncodePrimaryKey(value bson.RawValue) ([]byte, error) {
 	if value.IsZero() {
 		return nil, errors.New("Mongo document _id is required")
 	}
@@ -2176,6 +2178,10 @@ func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
 	key = append(key, primaryKeyPrefixBSONValue, byte(value.Type))
 	key = append(key, value.Value...)
 	return key, nil
+}
+
+func encodePrimaryKey(value bson.RawValue) ([]byte, error) {
+	return EncodePrimaryKey(value)
 }
 
 func validateSupportedDocument(doc bson.Raw) error {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -77,6 +77,20 @@ func (c *Client) InsertManyRawBSON(ctx context.Context, database, collection str
 	return c.roundTripInsert(ctx, msg, len(docs))
 }
 
+func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw, error) {
+	if c == nil || c.conn == nil {
+		return nil, errors.New("mongo gateway fast client is closed")
+	}
+	if len(command) == 0 {
+		return nil, errors.New("FindRawBSON requires a command document")
+	}
+	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
+	if err != nil {
+		return nil, err
+	}
+	return c.roundTripFind(ctx, msg)
+}
+
 func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (int, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -108,6 +122,39 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 		return 0, err
 	}
 	return parseInsertResponse(header, body, wantN)
+}
+
+func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := c.conn.SetDeadline(deadline); err != nil {
+			return nil, err
+		}
+	}
+	stopCancelWatch := c.watchContextCancelLocked(ctx)
+	defer func() {
+		stopCancelWatch()
+		_ = c.conn.SetDeadline(time.Time{})
+	}()
+	if err := writeFull(c.conn, msg); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+	header, body, err := wire.ReadMessage(c.conn, c.maxMessageLen)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+	return parseFindResponse(header, body)
 }
 
 func (c *Client) watchContextCancelLocked(ctx context.Context) func() {
@@ -151,6 +198,41 @@ func parseInsertResponse(header wire.Header, body []byte, wantN int) (int, error
 		return 0, fmt.Errorf("insert response n=%d want %d", n, wantN)
 	}
 	return n, nil
+}
+
+func parseFindResponse(header wire.Header, body []byte) ([]bson.Raw, error) {
+	if header.OpCode != wire.OpMsg {
+		return nil, fmt.Errorf("find response opcode=%d want %d", header.OpCode, wire.OpMsg)
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		return nil, err
+	}
+	raw := bson.Raw(msg.Body)
+	if !rawOK(raw) {
+		return nil, fmt.Errorf("find failed: %s", commandErrorMessage(raw))
+	}
+	cursor, ok := raw.Lookup("cursor").DocumentOK()
+	if !ok {
+		return nil, errors.New("find response missing cursor")
+	}
+	batch, ok := cursor.Lookup("firstBatch").ArrayOK()
+	if !ok {
+		return nil, errors.New("find response missing cursor.firstBatch")
+	}
+	values, err := batch.Values()
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]bson.Raw, 0, len(values))
+	for _, value := range values {
+		doc, ok := value.DocumentOK()
+		if !ok {
+			return nil, errors.New("find firstBatch entry is not a document")
+		}
+		docs = append(docs, bson.Raw(doc))
+	}
+	return docs, nil
 }
 
 func rawOK(raw bson.Raw) bool {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -77,12 +77,18 @@ func (c *Client) InsertManyRawBSON(ctx context.Context, database, collection str
 	return c.roundTripInsert(ctx, msg, len(docs))
 }
 
+// FindRawBSON sends a find command and returns the cursor.firstBatch documents
+// from the response. Non-find commands are rejected because this helper only
+// understands find-style cursor replies.
 func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw, error) {
 	if c == nil || c.conn == nil {
 		return nil, errors.New("mongo gateway fast client is closed")
 	}
 	if len(command) == 0 {
 		return nil, errors.New("FindRawBSON requires a command document")
+	}
+	if _, ok := command.Lookup("find").StringValueOK(); !ok {
+		return nil, errors.New("FindRawBSON requires a find command document")
 	}
 	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
 	if err != nil {

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -77,6 +77,22 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	if n != len(rawDocs) {
 		t.Fatalf("inserted=%d want %d", n, len(rawDocs))
 	}
+	findCommand := mustBSON(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "name", Value: "grace"}}},
+		{Key: "limit", Value: 1},
+		{Key: "$db", Value: "app"},
+	})
+	found, err := client.FindRawBSON(insertCtx, findCommand)
+	if err != nil {
+		t.Fatalf("FindRawBSON: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("FindRawBSON docs=%d want 1", len(found))
+	}
+	if got, ok := found[0].Lookup("name").StringValueOK(); !ok || got != "grace" {
+		t.Fatalf("FindRawBSON name=%q ok=%t want grace", got, ok)
+	}
 
 	driverClient, err := mongo.Connect(options.Client().
 		ApplyURI("mongodb://" + ln.Addr().String()).

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1415,7 +1415,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 		b.WriteString(loadModeBarChart(fmt.Sprintf("Load throughput by client mode, %d indexes", idx), cats, tree, mongo))
 	}
 	b.WriteString("</div>")
-	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the BSON collection API directly. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
+	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the collection API directly in the selected TreeDB document format. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
 	var body [][]string
 	for _, row := range rows {
 		body = append(body, []string{strconv.Itoa(row.Indexes), row.Target, row.Config, fmtOps(row.OpsPerSec), fmtBytes(float64(row.PhysicalBytes)), row.RawJSON})

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1758,7 +1758,7 @@ func loadModeChartRows(rows []loadModeRow, idx int) ([]string, []float64, []floa
 }
 
 func isTreeDBOnlyLoadMode(mode string) bool {
-	return mode == "BSON direct" || mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
+	return loadModeKind(mode) != ""
 }
 
 func loadModeDisplayLabel(mode string) string {
@@ -1791,7 +1791,30 @@ func loadModeOrder(mode string) string {
 	if idx, ok := order[mode]; ok {
 		return fmt.Sprintf("%02d_%s", idx, mode)
 	}
+	switch loadModeKind(mode) {
+	case "direct":
+		return "04_" + mode
+	case "raw_wire_tcp":
+		return "05_" + mode
+	case "raw_wire":
+		return "06_" + mode
+	}
 	return "99_" + mode
+}
+
+func loadModeKind(mode string) string {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	normalized = strings.TrimPrefix(normalized, "bson ")
+	switch {
+	case normalized == "direct" || strings.HasSuffix(normalized, "_direct"):
+		return "direct"
+	case normalized == "raw_wire_tcp" || strings.HasSuffix(normalized, "_raw_wire_tcp"):
+		return "raw_wire_tcp"
+	case normalized == "raw_wire" || strings.HasSuffix(normalized, "_raw_wire"):
+		return "raw_wire"
+	default:
+		return ""
+	}
 }
 
 func indexCountLabel(indexes int) string {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1405,7 +1405,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 	b.WriteString("<section id=\"mongo-load\"><h2>Load-Only Client-Mode Matrix</h2>")
 	b.WriteString("<p class=\"subtle\">Insert-only matrix. This section uses raw JSON directly so every MongoDB and TreeDB client mode has its own throughput and physical-disk row.</p>")
 	b.WriteString("<p class=\"subtle\">Use this section for pure ingest client-path comparisons. It is intentionally separate from the full-sweep load chart, which inherits the broader read/range/update sweep setup.</p>")
-	b.WriteString("<p class=\"subtle\">Driver, driver-command, driver-command-raw, and driver-unack modes are comparable Mongo-compatible client paths and render as paired TreeDB/MongoDB bars. Client modes marked with <strong>*</strong> are TreeDB-only raw-wire ceiling probes explained below.</p>")
+	b.WriteString("<p class=\"subtle\">Driver, driver-command, driver-command-raw, and driver-unack modes are comparable Mongo-compatible client paths and render as paired TreeDB/MongoDB bars. Client modes marked with <strong>*</strong> are TreeDB-only ceiling probes explained below.</p>")
 	b.WriteString("<div class=\"chart-grid\">")
 	for _, idx := range sortedLoadModeIndexes(rows) {
 		cats, tree, mongo := loadModeChartRows(rows, idx)
@@ -1415,7 +1415,7 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 		b.WriteString(loadModeBarChart(fmt.Sprintf("Load throughput by client mode, %d indexes", idx), cats, tree, mongo))
 	}
 	b.WriteString("</div>")
-	b.WriteString("<p class=\"subtle\"><strong>* Raw-wire modes:</strong> <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ingest ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
+	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the BSON collection API directly. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
 	var body [][]string
 	for _, row := range rows {
 		body = append(body, []string{strconv.Itoa(row.Indexes), row.Target, row.Config, fmtOps(row.OpsPerSec), fmtBytes(float64(row.PhysicalBytes)), row.RawJSON})
@@ -1757,12 +1757,12 @@ func loadModeChartRows(rows []loadModeRow, idx int) ([]string, []float64, []floa
 	return labels, tree, mongo
 }
 
-func isRawWireLoadMode(mode string) bool {
-	return mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
+func isTreeDBOnlyLoadMode(mode string) bool {
+	return mode == "BSON direct" || mode == "BSON raw_wire_tcp" || mode == "BSON raw_wire"
 }
 
 func loadModeDisplayLabel(mode string) string {
-	if isRawWireLoadMode(mode) {
+	if isTreeDBOnlyLoadMode(mode) {
 		return mode + " *"
 	}
 	return mode
@@ -1784,8 +1784,9 @@ func loadModeOrder(mode string) string {
 		"BSON driver_command":     1,
 		"BSON driver_command_raw": 2,
 		"BSON driver_unack":       3,
-		"BSON raw_wire_tcp":       4,
-		"BSON raw_wire":           5,
+		"BSON direct":             4,
+		"BSON raw_wire_tcp":       5,
+		"BSON raw_wire":           6,
 	}
 	if idx, ok := order[mode]; ok {
 		return fmt.Sprintf("%02d_%s", idx, mode)
@@ -2021,14 +2022,14 @@ func loadModeBarChart(title string, categories []string, tree, mongo []float64) 
 	b.WriteString(fmt.Sprintf("<line x1=\"%.1f\" y1=\"%.1f\" x2=\"%.1f\" y2=\"%.1f\" stroke=\"#748399\" stroke-width=\"2\"/>", left, top, left, axisY))
 	for i, cat := range categories {
 		groupX := left + float64(i)*groupW
-		rawMode := isRawWireLoadMode(cat)
-		if rawMode {
+		treeDBOnlyMode := isTreeDBOnlyLoadMode(cat)
+		if treeDBOnlyMode {
 			if i < len(tree) && tree[i] > 0 {
 				v := tree[i]
 				barH := (v / maxV) * plotH
 				x := groupX + (groupW-soloBarW)/2
 				yy := axisY - barH
-				b.WriteString(fmt.Sprintf("<rect x=\"%.1f\" y=\"%.1f\" width=\"%.1f\" height=\"%.1f\" rx=\"2\" fill=\"#2867c7\"><title>%s TreeDB-only raw-wire ceiling: %s docs/sec</title></rect>", x, yy, soloBarW, barH, esc(cat), esc(formatChartValue(v, "docs/sec"))))
+				b.WriteString(fmt.Sprintf("<rect x=\"%.1f\" y=\"%.1f\" width=\"%.1f\" height=\"%.1f\" rx=\"2\" fill=\"#2867c7\"><title>%s TreeDB-only ceiling: %s docs/sec</title></rect>", x, yy, soloBarW, barH, esc(cat), esc(formatChartValue(v, "docs/sec"))))
 				if soloBarW >= 10 {
 					b.WriteString(fmt.Sprintf("<text x=\"%.1f\" y=\"%.1f\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"700\" fill=\"#344256\">%s</text>", x+soloBarW/2, math.Max(top+10, yy-5), esc(formatChartValue(v, "docs/sec"))))
 				}

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -71,10 +71,12 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	writeFile(t, filepath.Join(root, "mongo_gateway_reader_writer_scaling_1m", "indexes_4", "summary.tsv"), summary4)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
 		"treedb\ttreedb_bson_driver\t100\t0\traw/treedb.json\t5000000000\n"+
+		"treedb\ttreedb_bson_direct\t100\t0\traw/treedb_direct.json\t2800\n"+
 		"treedb\ttreedb_bson_raw_wire_tcp\t100\t0\traw/treedb_raw_wire_tcp.json\t3000\n"+
 		"treedb\ttreedb_bson_raw_wire\t100\t0\traw/treedb_raw_wire.json\t2500\n"+
 		"mongo\tmongo_driver\t100\t0\traw/mongo.json\t5000\n")
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1000}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","phases":[{"name":"load_insert_many","ops_per_sec":1700}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire_tcp.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1500}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1800}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "mongo.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":500}]}`)
@@ -110,10 +112,12 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"TreeDB JSON",
 		"SQLite native VACUUM: 20",
 		"Client modes marked with <strong>*</strong>",
+		"BSON Direct</text><text",
 		"BSON Raw</text><text",
 		"Wire TCP *</text>",
 		"Wire *</text>",
-		"* Raw-wire modes:",
+		"* TreeDB-only modes:",
+		"calls the BSON collection API directly",
 		"bypassing the MongoDB Go driver",
 		"same raw command/gateway path in process",
 		"one centered TreeDB bar",
@@ -124,6 +128,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	}
 	for _, unwanted := range []string{
 		"TreeDB Raw Wire Ceiling Modes",
+		"BSON direct MongoDB",
 		"BSON raw_wire_tcp MongoDB",
 		"BSON raw_wire MongoDB",
 	} {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -117,7 +117,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"Wire TCP *</text>",
 		"Wire *</text>",
 		"* TreeDB-only modes:",
-		"calls the BSON collection API directly",
+		"calls the collection API directly",
 		"bypassing the MongoDB Go driver",
 		"same raw command/gateway path in process",
 		"one centered TreeDB bar",

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -72,11 +72,13 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
 		"treedb\ttreedb_bson_driver\t100\t0\traw/treedb.json\t5000000000\n"+
 		"treedb\ttreedb_bson_direct\t100\t0\traw/treedb_direct.json\t2800\n"+
+		"treedb\ttreedb_json_direct\t100\t0\traw/treedb_json_direct.json\t2900\n"+
 		"treedb\ttreedb_bson_raw_wire_tcp\t100\t0\traw/treedb_raw_wire_tcp.json\t3000\n"+
 		"treedb\ttreedb_bson_raw_wire\t100\t0\traw/treedb_raw_wire.json\t2500\n"+
 		"mongo\tmongo_driver\t100\t0\traw/mongo.json\t5000\n")
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1000}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","phases":[{"name":"load_insert_many","ops_per_sec":1700}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_json_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","treedb_document_format":"json","phases":[{"name":"load_insert_many","ops_per_sec":1750}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire_tcp.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1500}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1800}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "mongo.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":500}]}`)
@@ -113,6 +115,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"SQLite native VACUUM: 20",
 		"Client modes marked with <strong>*</strong>",
 		"BSON Direct</text><text",
+		"BSON JSON</text><text",
 		"BSON Raw</text><text",
 		"Wire TCP *</text>",
 		"Wire *</text>",
@@ -129,6 +132,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	for _, unwanted := range []string{
 		"TreeDB Raw Wire Ceiling Modes",
 		"BSON direct MongoDB",
+		"BSON json_direct MongoDB",
 		"BSON raw_wire_tcp MongoDB",
 		"BSON raw_wire MongoDB",
 	} {
@@ -197,6 +201,31 @@ func TestCollectionChartsIncludeAdditionalFormats(t *testing.T) {
 func TestLoadModeLabelNormalizesSingleMongoConfig(t *testing.T) {
 	if got, want := loadModeLabel(loadModeRow{Target: "mongo", Config: "mongo"}), "BSON driver"; got != want {
 		t.Fatalf("label = %q, want %q", got, want)
+	}
+}
+
+func TestTreeDBOnlyLoadModeIncludesNonBSONDirectFormats(t *testing.T) {
+	for _, mode := range []string{
+		"BSON direct",
+		"BSON json_direct",
+		"BSON template_v1_direct",
+		"BSON raw_wire_tcp",
+		"BSON json_raw_wire_tcp",
+		"BSON raw_wire",
+		"BSON json_raw_wire",
+	} {
+		if !isTreeDBOnlyLoadMode(mode) {
+			t.Fatalf("%q should be TreeDB-only", mode)
+		}
+	}
+	for _, mode := range []string{
+		"BSON driver",
+		"BSON driver_command_raw",
+		"BSON json_driver",
+	} {
+		if isTreeDBOnlyLoadMode(mode) {
+			t.Fatalf("%q should not be TreeDB-only", mode)
+		}
 	}
 }
 

--- a/cmd/collection_workload_bench/README.md
+++ b/cmd/collection_workload_bench/README.md
@@ -1,0 +1,76 @@
+# Native Collection Workload Bench
+
+`collection_workload_bench` measures TreeDB collection operations without the
+MongoDB compatibility stack. It is intended to answer whether an operation is
+slow before Mongo gateway, wire protocol, cursor, driver, and BSON `_id`
+primary-key encoding overhead.
+
+The harness uses native `collections.Collection` calls:
+
+- `InsertBatch`
+- `GetInto`
+- `FindByIndexValueLimit`
+- `FindByIndexRange`
+- `Update`
+- `Delete`
+
+Document IDs are external native `[]byte` keys such as `doc-000000000001`.
+Stored documents still include a normal `id` payload field, but the primary key
+is not derived from Mongo `_id` encoding.
+
+## Storage Formats
+
+Use `-formats` to run one or more collection storage formats:
+
+```bash
+go run ./cmd/collection_workload_bench \
+  -formats json,template-v1,bson \
+  -indexes 0,1,2 \
+  -read-states buffered,flushed,checkpointed \
+  -documents 16000 \
+  -batch-size 16000
+```
+
+`collections-v1` is accepted as an alias for `template-v1`.
+
+## Index Shapes
+
+The index count is deliberately native and small:
+
+- `indexes_0`: primary root only
+- `indexes_1`: unique `email` index
+- `indexes_2`: `email` plus non-unique `age`
+- `indexes_3`: `email`, `age`, and non-unique `city`
+
+`email_find_one` is skipped for `indexes_0`. `age_range_indexed_limit_10` is
+skipped until `indexes_2`. `age_range_scan_limit_10` always runs and measures a
+native primary-key scan floor using deterministic IDs and `GetInto`.
+
+## Read State
+
+Each matrix row creates a fresh TreeDB directory, loads the fixture, then applies
+one read state:
+
+- `buffered`: read before an explicit collection flush
+- `flushed`: run `CollectionManager.FlushAll()` before reads
+- `checkpointed`: run `FlushAll()` and `DB.Checkpoint()` before reads
+
+This separates memtable/overlay reads from settled backend reads.
+
+## Output
+
+Text output includes both latency and throughput for every non-skipped phase:
+
+```text
+id_find_one        1200.0 ns/op    833333 ops/sec
+```
+
+JSON output is available with `-format json` and includes selected TreeDB stats
+deltas for each phase.
+
+## Profiling
+
+For now, capture pprof around this command with normal Go tooling, or use the
+existing `unified-bench -profile-dir` flow for end-to-end report artifacts. If
+this command grows a built-in `-profile-dir`, keep the artifact names compatible
+with `cmd/benchprof`.

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -494,7 +494,7 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 		return rowResult{}, err
 	}
 
-	readPhases, err := runReadPhases(target, cfg, indexes)
+	readPhases, err := runReadPhases(target, cfg, indexes, state)
 	if err != nil {
 		return rowResult{}, err
 	}
@@ -534,7 +534,7 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 	return row, nil
 }
 
-func runReadPhases(target *benchTarget, cfg config, indexes int) ([]phaseResult, error) {
+func runReadPhases(target *benchTarget, cfg config, indexes int, state readState) ([]phaseResult, error) {
 	var phases []phaseResult
 	appendPhase := func(phase phaseResult, err error) error {
 		if err != nil {
@@ -596,18 +596,22 @@ func runReadPhases(target *benchTarget, cfg config, indexes int) ([]phaseResult,
 		} else {
 			phases = append(phases, skippedPhase("age_range_indexed_limit_10", "age index is absent until indexes_2"))
 		}
-		phase, err := timedPhase(target, "age_range_scan_limit_10", func() (int64, int64, error) {
-			return runAgeScanRangeReads(target, cfg.RangeReads, 1)
-		})
-		if err := appendPhase(phase, err); err != nil {
-			return nil, err
-		}
-		for _, readers := range cfg.ReaderSweep {
-			phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_scan_limit_10_r%d", readers), func() (int64, int64, error) {
-				return runAgeScanRangeReads(target, cfg.RangeReads, readers)
+		if state == readStateBuffered {
+			phases = append(phases, skippedPhase("age_range_scan_limit_10", "primary scan API flushes buffered writes before scanning"))
+		} else {
+			phase, err := timedPhase(target, "age_range_scan_limit_10", func() (int64, int64, error) {
+				return runAgeScanRangeReads(target, cfg.RangeReads, 1)
 			})
 			if err := appendPhase(phase, err); err != nil {
 				return nil, err
+			}
+			for _, readers := range cfg.ReaderSweep {
+				phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_scan_limit_10_r%d", readers), func() (int64, int64, error) {
+					return runAgeScanRangeReads(target, cfg.RangeReads, readers)
+				})
+				if err := appendPhase(phase, err); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -405,7 +405,7 @@ func run(cfg config) (result, error) {
 		Notes: []string{
 			"Native collection benchmark: no Mongo driver, gateway, wire protocol, cursor materialization, or BSON _id primary-key encoding.",
 			"Index-count shapes are native: 0=primary only, 1=email, 2=email+age, 3=email+age+city.",
-			"age_range_scan_limit_10 uses deterministic native IDs and primary GetInto calls as the unindexed scan floor.",
+			"age_range_scan_limit_10 uses the collection primary scan API and filters materialized document age values.",
 		},
 	}
 	for _, format := range cfg.Formats {
@@ -983,32 +983,80 @@ func runAgeIndexedRangeReads(target *benchTarget, total, workers int) (int64, in
 
 func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
 	docs := len(target.fixture.ids)
-	buffers := make([][]byte, workerBufferCount(workers))
+	materializers := make([]*collections.StoredDocumentJSONMaterializer, workerBufferCount(workers))
+	defer func() {
+		for _, materializer := range materializers {
+			_ = materializer.Close()
+		}
+	}()
 	return runParallel(total, workers, func(op int, worker int) error {
-		start := benchmarkDocumentOrdinal(op, 43, docs)
 		minAge := rangeReadMinAge(op)
 		foundCount := 0
-		buf := buffers[worker]
-		for scanned := 0; scanned < docs && foundCount < 10; scanned++ {
-			ordinal := (start + scanned) % docs
-			value, found, err := target.col.GetInto(target.fixture.ids[ordinal], buf[:0])
+		materializer := materializers[worker]
+		_, err := target.col.ScanDocumentsFunc(docs, func(record collections.DocumentRecord) (bool, error) {
+			if materializer == nil && target.fixture.format == collections.DocumentFormatTemplateV1 {
+				var err error
+				materializer, err = target.col.NewStoredDocumentJSONMaterializer()
+				if err != nil {
+					return false, err
+				}
+				materializers[worker] = materializer
+			}
+			age, err := storedDocumentAge(target, materializer, record.Document)
 			if err != nil {
-				return err
+				return false, err
 			}
-			if !found {
-				continue
-			}
-			buf = value
-			if target.fixture.ages[ordinal] >= minAge {
+			if age >= minAge {
 				foundCount++
 			}
+			return foundCount < 10, nil
+		})
+		if err != nil {
+			return err
 		}
-		buffers[worker] = buf
 		if foundCount == 0 {
 			return fmt.Errorf("age scan found no documents")
 		}
 		return nil
 	})
+}
+
+func storedDocumentAge(target *benchTarget, materializer *collections.StoredDocumentJSONMaterializer, document []byte) (int64, error) {
+	if target == nil || target.fixture == nil {
+		return 0, errors.New("missing benchmark fixture")
+	}
+	switch target.fixture.format {
+	case collections.DocumentFormatBSON:
+		value := bson.Raw(document).Lookup("age")
+		if age, ok := value.Int64OK(); ok {
+			return age, nil
+		}
+		if age, ok := value.Int32OK(); ok {
+			return int64(age), nil
+		}
+		return 0, errors.New("BSON document missing numeric age")
+	case collections.DocumentFormatJSON:
+		return jsonDocumentAge(document)
+	default:
+		if materializer == nil {
+			return 0, errors.New("missing document materializer")
+		}
+		jsonDoc, err := materializer.StoredDocumentJSON(document)
+		if err != nil {
+			return 0, err
+		}
+		return jsonDocumentAge(jsonDoc)
+	}
+}
+
+func jsonDocumentAge(document []byte) (int64, error) {
+	var decoded struct {
+		Age int64 `json:"age"`
+	}
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		return 0, err
+	}
+	return decoded.Age, nil
 }
 
 func workerBufferCount(workers int) int {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -895,8 +895,24 @@ func benchmarkDocumentOrdinal(operation int, stride uint64, documentCount int) i
 	return int((uint64(operation) * stride) % uint64(documentCount))
 }
 
-func rangeReadMinAge(operation int) int64 {
-	return int64(20 + (operation % 40))
+func rangeReadMinAge(operation int, documentCount int) int64 {
+	if documentCount <= 0 {
+		return 20
+	}
+	ageSpan := documentCount
+	if ageSpan > 67 {
+		ageSpan = 67
+	}
+	maxAge := int64(18 + ageSpan - 1)
+	base := int64(20)
+	if maxAge < base {
+		return maxAge
+	}
+	span := maxAge - base + 1
+	if span > 40 {
+		span = 40
+	}
+	return base + int64(operation%int(span))
 }
 
 func loadFixture(target *benchTarget, batchSize int) (int64, int64, error) {
@@ -980,7 +996,7 @@ func runEmailReads(target *benchTarget, total, workers int) (int64, int64, error
 func runAgeIndexedRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
 	buffers := make([][]byte, workerBufferCount(workers))
 	return runParallel(total, workers, func(op int, worker int) error {
-		minAge := rangeReadMinAge(op)
+		minAge := rangeReadMinAge(op, len(target.fixture.ids))
 		ids, _, err := target.col.FindByIndexRange("age", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
 			Upper: collections.IndexRangeBound{Unbounded: true},
@@ -1017,7 +1033,7 @@ func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64
 		}
 	}()
 	return runParallel(total, workers, func(op int, worker int) error {
-		minAge := rangeReadMinAge(op)
+		minAge := rangeReadMinAge(op, len(target.fixture.ids))
 		foundCount := 0
 		materializer := materializers[worker]
 		_, err := target.col.ScanDocumentsFunc(docs, func(record collections.DocumentRecord) (bool, error) {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -30,6 +30,9 @@ const (
 	defaultRangeReads     = 10000
 	defaultUpdates        = 10000
 	defaultDeletes        = 1000
+
+	treedbBenchDirMarkerName = ".collection-workload-bench"
+	treedbBenchDirMarkerBody = "created by cmd/collection_workload_bench\n"
 )
 
 type config struct {
@@ -585,6 +588,12 @@ func openTarget(cfg config, format collections.DocumentFormat, indexes int) (*be
 		}
 		dir = tmp
 		removeDir = !cfg.KeepTreeDBDir
+		if err := writeTreeDBBenchDirMarker(dir); err != nil {
+			if removeDir {
+				_ = os.RemoveAll(dir)
+			}
+			return nil, err
+		}
 	} else if err := resetTreeDBDir(dir); err != nil {
 		return nil, err
 	}
@@ -676,10 +685,55 @@ func resetTreeDBDir(dir string) error {
 	if abs == string(os.PathSeparator) || filepath.Dir(abs) == string(os.PathSeparator) {
 		return fmt.Errorf("unsafe treedb-dir %q", dir)
 	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.MkdirAll(abs, 0o700); err != nil {
+			return err
+		}
+		return writeTreeDBBenchDirMarker(abs)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("treedb-dir %q is not a directory", dir)
+	}
+	if err := requireResettableTreeDBBenchDir(abs); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(abs); err != nil {
 		return err
 	}
-	return os.MkdirAll(abs, 0o700)
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return err
+	}
+	return writeTreeDBBenchDirMarker(abs)
+}
+
+func requireResettableTreeDBBenchDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if hasTreeDBBenchDirMarker(dir) {
+		return nil
+	}
+	return fmt.Errorf("refusing to delete non-empty treedb-dir %q without %s marker", dir, treedbBenchDirMarkerName)
+}
+
+func hasTreeDBBenchDirMarker(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, treedbBenchDirMarkerName))
+	if err != nil {
+		return false
+	}
+	return string(data) == treedbBenchDirMarkerBody
+}
+
+func writeTreeDBBenchDirMarker(dir string) error {
+	return os.WriteFile(filepath.Join(dir, treedbBenchDirMarkerName), []byte(treedbBenchDirMarkerBody), 0o600)
 }
 
 func indexDefinitions(count int, storage collections.RootStoragePolicy) []collections.IndexDefinition {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -263,17 +263,24 @@ func parseFormats(raw string) ([]collections.DocumentFormat, error) {
 		return nil, errors.New("formats cannot be empty")
 	}
 	out := make([]collections.DocumentFormat, 0, len(parts))
+	seen := make(map[collections.DocumentFormat]struct{}, len(parts))
 	for _, part := range parts {
+		var format collections.DocumentFormat
 		switch strings.ToLower(part) {
 		case "json":
-			out = append(out, collections.DocumentFormatJSON)
+			format = collections.DocumentFormatJSON
 		case "", "template-v1", "collections-v1":
-			out = append(out, collections.DocumentFormatTemplateV1)
+			format = collections.DocumentFormatTemplateV1
 		case "bson":
-			out = append(out, collections.DocumentFormatBSON)
+			format = collections.DocumentFormatBSON
 		default:
 			return nil, fmt.Errorf("unknown format %q", part)
 		}
+		if _, ok := seen[format]; ok {
+			return nil, fmt.Errorf("formats contains duplicate value %q", format)
+		}
+		seen[format] = struct{}{}
+		out = append(out, format)
 	}
 	return out, nil
 }
@@ -288,6 +295,9 @@ func parseIndexCounts(raw string) ([]int, error) {
 			return nil, fmt.Errorf("indexes=%d unsupported by native workload harness; max is 3", n)
 		}
 	}
+	if err := rejectDuplicateInts(out, "indexes"); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
@@ -297,17 +307,24 @@ func parseReadStates(raw string) ([]readState, error) {
 		return nil, errors.New("read-states cannot be empty")
 	}
 	out := make([]readState, 0, len(parts))
+	seen := make(map[readState]struct{}, len(parts))
 	for _, part := range parts {
+		var state readState
 		switch strings.ToLower(part) {
 		case string(readStateBuffered):
-			out = append(out, readStateBuffered)
+			state = readStateBuffered
 		case string(readStateFlushed):
-			out = append(out, readStateFlushed)
+			state = readStateFlushed
 		case string(readStateCheckpointed):
-			out = append(out, readStateCheckpointed)
+			state = readStateCheckpointed
 		default:
 			return nil, fmt.Errorf("unknown read-state %q", part)
 		}
+		if _, ok := seen[state]; ok {
+			return nil, fmt.Errorf("read-states contains duplicate value %q", state)
+		}
+		seen[state] = struct{}{}
+		out = append(out, state)
 	}
 	return out, nil
 }
@@ -317,17 +334,23 @@ func parsePositiveInts(raw, label string) ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	seen := make(map[int]struct{}, len(out))
 	for _, n := range out {
 		if n <= 0 {
 			return nil, fmt.Errorf("%s values must be positive", label)
 		}
+	}
+	return out, rejectDuplicateInts(out, label)
+}
+
+func rejectDuplicateInts(values []int, label string) error {
+	seen := make(map[int]struct{}, len(values))
+	for _, n := range values {
 		if _, ok := seen[n]; ok {
-			return nil, fmt.Errorf("%s contains duplicate value %d", label, n)
+			return fmt.Errorf("%s contains duplicate value %d", label, n)
 		}
 		seen[n] = struct{}{}
 	}
-	return out, nil
+	return nil
 }
 
 func parsePositiveOrZeroInts(raw, label string) ([]int, error) {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -451,10 +451,18 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 		return rowResult{}, err
 	}
 
-	row.Phases = append(row.Phases, runReadPhases(target, cfg, indexes)...)
+	readPhases, err := runReadPhases(target, cfg, indexes)
+	if err != nil {
+		return rowResult{}, err
+	}
+	row.Phases = append(row.Phases, readPhases...)
 	if cfg.Updates > 0 {
+		updateWorkload, err := prepareUpdateSet(target, cfg.Updates)
+		if err != nil {
+			return rowResult{}, err
+		}
 		phase, err := timedPhase(target, "id_update_set", func() (int64, int64, error) {
-			return runUpdateSet(target, cfg.Updates, 1)
+			return runUpdateSet(target, updateWorkload, 1)
 		})
 		if err != nil {
 			return rowResult{}, err
@@ -462,7 +470,7 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 		row.Phases = append(row.Phases, phase)
 		for _, writers := range cfg.ReaderSweep {
 			phase, err := timedPhase(target, fmt.Sprintf("concurrent_id_update_set_w%d", writers), func() (int64, int64, error) {
-				return runUpdateSet(target, cfg.Updates, writers)
+				return runUpdateSet(target, updateWorkload, writers)
 			})
 			if err != nil {
 				return rowResult{}, err
@@ -471,7 +479,7 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 		}
 	}
 	if cfg.Deletes > 0 {
-		phase, err := timedPhase(target, "id_delete", func() (int64, int64, error) {
+		phase, err := timedPhase(target, "id_delete_one", func() (int64, int64, error) {
 			return runDeletes(target, cfg.Deletes)
 		})
 		if err != nil {
@@ -483,36 +491,44 @@ func runRow(cfg config, format collections.DocumentFormat, indexes int, state re
 	return row, nil
 }
 
-func runReadPhases(target *benchTarget, cfg config, indexes int) []phaseResult {
+func runReadPhases(target *benchTarget, cfg config, indexes int) ([]phaseResult, error) {
 	var phases []phaseResult
-	appendPhase := func(phase phaseResult, err error) {
+	appendPhase := func(phase phaseResult, err error) error {
 		if err != nil {
-			phases = append(phases, phaseResult{Name: phase.Name, Skipped: true, SkipReason: err.Error()})
-			return
+			return fmt.Errorf("%s: %w", phase.Name, err)
 		}
 		phases = append(phases, phase)
+		return nil
 	}
 	if cfg.Reads > 0 {
 		phase, err := timedPhase(target, "id_find_one", func() (int64, int64, error) {
 			return runIDReads(target, cfg.Reads, 1)
 		})
-		appendPhase(phase, err)
+		if err := appendPhase(phase, err); err != nil {
+			return nil, err
+		}
 		for _, readers := range cfg.ReaderSweep {
 			phase, err := timedPhase(target, fmt.Sprintf("concurrent_id_find_one_r%d", readers), func() (int64, int64, error) {
 				return runIDReads(target, cfg.Reads, readers)
 			})
-			appendPhase(phase, err)
+			if err := appendPhase(phase, err); err != nil {
+				return nil, err
+			}
 		}
 		if indexes >= 1 {
 			phase, err = timedPhase(target, "email_find_one", func() (int64, int64, error) {
 				return runEmailReads(target, cfg.Reads, 1)
 			})
-			appendPhase(phase, err)
+			if err := appendPhase(phase, err); err != nil {
+				return nil, err
+			}
 			for _, readers := range cfg.ReaderSweep {
 				phase, err := timedPhase(target, fmt.Sprintf("concurrent_email_find_one_r%d", readers), func() (int64, int64, error) {
 					return runEmailReads(target, cfg.Reads, readers)
 				})
-				appendPhase(phase, err)
+				if err := appendPhase(phase, err); err != nil {
+					return nil, err
+				}
 			}
 		} else {
 			phases = append(phases, skippedPhase("email_find_one", "email index is absent for indexes_0"))
@@ -523,12 +539,16 @@ func runReadPhases(target *benchTarget, cfg config, indexes int) []phaseResult {
 			phase, err := timedPhase(target, "age_range_indexed_limit_10", func() (int64, int64, error) {
 				return runAgeIndexedRangeReads(target, cfg.RangeReads, 1)
 			})
-			appendPhase(phase, err)
+			if err := appendPhase(phase, err); err != nil {
+				return nil, err
+			}
 			for _, readers := range cfg.ReaderSweep {
 				phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_indexed_limit_10_r%d", readers), func() (int64, int64, error) {
 					return runAgeIndexedRangeReads(target, cfg.RangeReads, readers)
 				})
-				appendPhase(phase, err)
+				if err := appendPhase(phase, err); err != nil {
+					return nil, err
+				}
 			}
 		} else {
 			phases = append(phases, skippedPhase("age_range_indexed_limit_10", "age index is absent until indexes_2"))
@@ -536,15 +556,19 @@ func runReadPhases(target *benchTarget, cfg config, indexes int) []phaseResult {
 		phase, err := timedPhase(target, "age_range_scan_limit_10", func() (int64, int64, error) {
 			return runAgeScanRangeReads(target, cfg.RangeReads, 1)
 		})
-		appendPhase(phase, err)
+		if err := appendPhase(phase, err); err != nil {
+			return nil, err
+		}
 		for _, readers := range cfg.ReaderSweep {
 			phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_scan_limit_10_r%d", readers), func() (int64, int64, error) {
 				return runAgeScanRangeReads(target, cfg.RangeReads, readers)
 			})
-			appendPhase(phase, err)
+			if err := appendPhase(phase, err); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return phases
+	return phases, nil
 }
 
 func skippedPhase(name, reason string) phaseResult {
@@ -854,7 +878,8 @@ func runEmailReads(target *benchTarget, total, workers int) (int64, int64, error
 func runAgeIndexedRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
 	buffers := make([][]byte, workerBufferCount(workers))
 	return runParallel(total, workers, func(op int, worker int) error {
-		age := int64(18 + (op % 67))
+		ordinal := benchmarkDocumentOrdinal(op, 19, len(target.fixture.ids))
+		age := target.fixture.ages[ordinal]
 		ids, _, err := target.col.FindByIndexRange("age", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: age, Inclusive: true},
 			Upper: collections.IndexRangeBound{Value: age, Inclusive: true},
@@ -886,8 +911,8 @@ func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64
 	docs := len(target.fixture.ids)
 	buffers := make([][]byte, workerBufferCount(workers))
 	return runParallel(total, workers, func(op int, worker int) error {
-		wantAge := int64(18 + (op % 67))
 		start := benchmarkDocumentOrdinal(op, 43, docs)
+		wantAge := target.fixture.ages[start]
 		foundCount := 0
 		buf := buffers[worker]
 		for scanned := 0; scanned < docs && foundCount < 10; scanned++ {
@@ -919,21 +944,33 @@ func workerBufferCount(workers int) int {
 	return workers
 }
 
-func runUpdateSet(target *benchTarget, total, workers int) (int64, int64, error) {
-	replacements := make([][]byte, total)
-	ordinals := make([]int, total)
+type updateSetWorkload struct {
+	ordinals     []int
+	replacements [][]byte
+}
+
+func prepareUpdateSet(target *benchTarget, total int) (updateSetWorkload, error) {
+	workload := updateSetWorkload{
+		ordinals:     make([]int, total),
+		replacements: make([][]byte, total),
+	}
 	for i := 0; i < total; i++ {
 		ordinal := benchmarkDocumentOrdinal(i, 37, len(target.fixture.ids))
-		ordinals[i] = ordinal
+		workload.ordinals[i] = ordinal
 		doc, err := target.fixture.encodeDocument(ordinal, true, i)
 		if err != nil {
-			return 0, 0, err
+			return updateSetWorkload{}, err
 		}
-		replacements[i] = doc
+		workload.replacements[i] = doc
 	}
+	return workload, nil
+}
+
+func runUpdateSet(target *benchTarget, workload updateSetWorkload, workers int) (int64, int64, error) {
+	total := len(workload.replacements)
 	return runParallel(total, workers, func(op int, worker int) error {
-		id := target.fixture.ids[ordinals[op]]
-		replacement := replacements[op]
+		id := target.fixture.ids[workload.ordinals[op]]
+		replacement := workload.replacements[op]
 		_, _, err := target.col.Update(id, func(current []byte) ([]byte, bool, error) {
 			if current == nil {
 				return nil, false, fmt.Errorf("update id %q missing", id)
@@ -958,14 +995,18 @@ func runParallel(total, workers int, fn func(op int, worker int) error) (int64, 
 		return 0, 0, nil
 	}
 	if workers <= 1 {
+		var completed int64
 		for i := 0; i < total; i++ {
 			if err := fn(i, 0); err != nil {
-				return int64(i), int64(i), err
+				return completed, completed, err
 			}
+			completed++
 		}
 		return int64(total), int64(total), nil
 	}
 	var next atomic.Int64
+	var completed atomic.Int64
+	var stopped atomic.Bool
 	errCh := make(chan error, workers)
 	var wg sync.WaitGroup
 	for worker := 0; worker < workers; worker++ {
@@ -974,24 +1015,30 @@ func runParallel(total, workers int, fn func(op int, worker int) error) (int64, 
 		go func() {
 			defer wg.Done()
 			for {
+				if stopped.Load() {
+					return
+				}
 				op := int(next.Add(1) - 1)
 				if op >= total {
 					return
 				}
 				if err := fn(op, worker); err != nil {
+					stopped.Store(true)
 					select {
 					case errCh <- err:
 					default:
 					}
 					return
 				}
+				completed.Add(1)
 			}
 		}()
 	}
 	wg.Wait()
 	select {
 	case err := <-errCh:
-		return next.Load(), next.Load(), err
+		n := completed.Load()
+		return n, n, err
 	default:
 		return int64(total), int64(total), nil
 	}

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -1,0 +1,1143 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/cmd/internal/treedbstats"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	defaultCollectionName = "users"
+	defaultDocuments      = 16000
+	defaultBatchSize      = 16000
+	defaultReads          = 50000
+	defaultRangeReads     = 10000
+	defaultUpdates        = 10000
+	defaultDeletes        = 1000
+)
+
+type config struct {
+	TreeDBDir             string
+	KeepTreeDBDir         bool
+	Documents             int
+	BatchSize             int
+	Formats               []collections.DocumentFormat
+	IndexCounts           []int
+	ReadStates            []readState
+	Reads                 int
+	RangeReads            int
+	Updates               int
+	Deletes               int
+	ReaderSweep           []int
+	OutputFormat          string
+	TreeDBProfile         treedb.Profile
+	DataRootStorage       collections.RootStoragePolicy
+	IndexStateRootStorage collections.RootStoragePolicy
+	IndexRootStorage      collections.RootStoragePolicy
+}
+
+type readState string
+
+const (
+	readStateBuffered     readState = "buffered"
+	readStateFlushed      readState = "flushed"
+	readStateCheckpointed readState = "checkpointed"
+)
+
+type result struct {
+	BenchmarkFamily       string           `json:"benchmark_family"`
+	TreeDBProfile         string           `json:"treedb_profile"`
+	Documents             int              `json:"documents"`
+	BatchSize             int              `json:"batch_size"`
+	Reads                 int              `json:"reads"`
+	RangeReads            int              `json:"range_reads"`
+	Updates               int              `json:"updates"`
+	Deletes               int              `json:"deletes"`
+	ReaderSweep           []int            `json:"reader_sweep"`
+	Rows                  []rowResult      `json:"rows"`
+	StartedAt             string           `json:"started_at"`
+	FinishedAt            string           `json:"finished_at"`
+	DurationMS            float64          `json:"duration_ms"`
+	TreeDBDataRootStorage string           `json:"treedb_data_root_storage,omitempty"`
+	TreeDBIndexStorage    string           `json:"treedb_index_root_storage,omitempty"`
+	TreeDBIndexStateRoot  string           `json:"treedb_index_state_root_storage,omitempty"`
+	Notes                 []string         `json:"notes,omitempty"`
+	Errors                []benchmarkError `json:"errors,omitempty"`
+}
+
+type benchmarkError struct {
+	Format    string `json:"format"`
+	Indexes   int    `json:"indexes"`
+	ReadState string `json:"read_state"`
+	Error     string `json:"error"`
+}
+
+type rowResult struct {
+	Format          string                 `json:"format"`
+	Indexes         int                    `json:"indexes"`
+	ReadState       string                 `json:"read_state"`
+	IndexNames      []string               `json:"index_names"`
+	Load            phaseResult            `json:"load_insert_many"`
+	StateTransition phaseResult            `json:"state_transition"`
+	Phases          []phaseResult          `json:"phases"`
+	FinalStats      map[string]string      `json:"final_treedb_stats,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type phaseResult struct {
+	Name             string             `json:"name"`
+	Operations       int64              `json:"operations"`
+	DriverCalls      int64              `json:"driver_calls,omitempty"`
+	NSPerOp          float64            `json:"ns_per_op"`
+	OpsPerSec        float64            `json:"ops_per_sec"`
+	DurationMS       float64            `json:"duration_ms"`
+	Skipped          bool               `json:"skipped,omitempty"`
+	SkipReason       string             `json:"skip_reason,omitempty"`
+	TreeDBStatsDelta map[string]string  `json:"treedb_stats_delta,omitempty"`
+	TreeDBMetrics    map[string]float64 `json:"treedb_metrics,omitempty"`
+}
+
+type benchTarget struct {
+	dir       string
+	removeDir bool
+	db        *backenddb.DB
+	manager   *collections.CollectionManager
+	col       *collections.Collection
+	cleanup   func() error
+	fixture   *fixture
+	meta      collections.CollectionMeta
+}
+
+type fixture struct {
+	ids     [][]byte
+	idText  []string
+	emails  []string
+	cities  []string
+	ages    []int64
+	docs    [][]byte
+	format  collections.DocumentFormat
+	indexes int
+	encoder collections.TemplateV1Encoder
+}
+
+type phaseFunc func() (int64, int64, error)
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	res, err := run(cfg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := writeResult(os.Stdout, cfg.OutputFormat, res); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{
+		Documents:             defaultDocuments,
+		BatchSize:             defaultBatchSize,
+		Reads:                 defaultReads,
+		RangeReads:            defaultRangeReads,
+		Updates:               defaultUpdates,
+		Deletes:               defaultDeletes,
+		OutputFormat:          "text",
+		TreeDBProfile:         treedb.ProfileBench,
+		Formats:               []collections.DocumentFormat{collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1, collections.DocumentFormatBSON},
+		IndexCounts:           []int{0, 1, 2},
+		ReadStates:            []readState{readStateBuffered, readStateFlushed, readStateCheckpointed},
+		ReaderSweep:           []int{1, 2, 4, 8, 16, 32},
+		DataRootStorage:       collections.RootStorageDefault,
+		IndexStateRootStorage: collections.RootStorageDefault,
+		IndexRootStorage:      collections.RootStorageDefault,
+	}
+	var formats, indexes, readStates, readerSweep string
+	fs := flag.NewFlagSet("collection_workload_bench", flag.ContinueOnError)
+	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory; empty uses a temporary directory per matrix row")
+	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep temporary TreeDB directories after the run")
+	fs.IntVar(&cfg.Documents, "documents", cfg.Documents, "documents loaded before each row")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch during load")
+	fs.StringVar(&formats, "formats", "json,template-v1,bson", "comma-separated storage formats: json, template-v1|collections-v1, bson")
+	fs.StringVar(&indexes, "indexes", "0,1,2", "comma-separated native index-count shapes: 0, 1=email, 2=email+age, 3=email+age+city")
+	fs.StringVar(&readStates, "read-states", "buffered,flushed,checkpointed", "comma-separated read states: buffered, flushed, checkpointed")
+	fs.IntVar(&cfg.Reads, "reads", cfg.Reads, "per-phase point-read/query operations")
+	fs.IntVar(&cfg.RangeReads, "range-reads", cfg.RangeReads, "per-phase range query operations")
+	fs.IntVar(&cfg.Updates, "updates", cfg.Updates, "native update operations")
+	fs.IntVar(&cfg.Deletes, "deletes", cfg.Deletes, "native delete operations")
+	fs.StringVar(&readerSweep, "reader-sweep", "1,2,4,8,16,32", "comma-separated reader/writer fanout values")
+	profile := string(cfg.TreeDBProfile)
+	fs.StringVar(&profile, "treedb-profile", profile, "TreeDB profile: bench, fast, wal_on_fast, durable")
+	dataRootStorage := string(cfg.DataRootStorage)
+	indexStateRootStorage := string(cfg.IndexStateRootStorage)
+	indexRootStorage := string(cfg.IndexRootStorage)
+	fs.StringVar(&dataRootStorage, "treedb-data-root-storage", dataRootStorage, "collection data root storage: default, fast, compressed")
+	fs.StringVar(&indexStateRootStorage, "treedb-index-state-root-storage", indexStateRootStorage, "collection index-state root storage: default, fast, compressed")
+	fs.StringVar(&indexRootStorage, "treedb-index-root-storage", indexRootStorage, "secondary index root storage: default, fast, compressed")
+	fs.StringVar(&cfg.OutputFormat, "format", cfg.OutputFormat, "output format: text or json")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	var err error
+	cfg.Formats, err = parseFormats(formats)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.IndexCounts, err = parseIndexCounts(indexes)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.ReadStates, err = parseReadStates(readStates)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.ReaderSweep, err = parsePositiveInts(readerSweep, "reader-sweep")
+	if err != nil {
+		return config{}, err
+	}
+	cfg.TreeDBProfile, err = parseProfile(profile)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.DataRootStorage, err = parseRootStorage(dataRootStorage)
+	if err != nil {
+		return config{}, fmt.Errorf("treedb-data-root-storage: %w", err)
+	}
+	cfg.IndexStateRootStorage, err = parseRootStorage(indexStateRootStorage)
+	if err != nil {
+		return config{}, fmt.Errorf("treedb-index-state-root-storage: %w", err)
+	}
+	cfg.IndexRootStorage, err = parseRootStorage(indexRootStorage)
+	if err != nil {
+		return config{}, fmt.Errorf("treedb-index-root-storage: %w", err)
+	}
+	if cfg.Documents <= 0 {
+		return config{}, errors.New("documents must be positive")
+	}
+	if cfg.BatchSize <= 0 {
+		return config{}, errors.New("batch-size must be positive")
+	}
+	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 {
+		return config{}, errors.New("reads, range-reads, updates, and deletes must be non-negative")
+	}
+	if cfg.Deletes > cfg.Documents {
+		return config{}, errors.New("deletes cannot exceed documents")
+	}
+	if cfg.OutputFormat != "text" && cfg.OutputFormat != "json" {
+		return config{}, fmt.Errorf("unknown format %q", cfg.OutputFormat)
+	}
+	return cfg, nil
+}
+
+func parseFormats(raw string) ([]collections.DocumentFormat, error) {
+	parts := splitCSV(raw)
+	if len(parts) == 0 {
+		return nil, errors.New("formats cannot be empty")
+	}
+	out := make([]collections.DocumentFormat, 0, len(parts))
+	for _, part := range parts {
+		switch strings.ToLower(part) {
+		case "json":
+			out = append(out, collections.DocumentFormatJSON)
+		case "", "template-v1", "collections-v1":
+			out = append(out, collections.DocumentFormatTemplateV1)
+		case "bson":
+			out = append(out, collections.DocumentFormatBSON)
+		default:
+			return nil, fmt.Errorf("unknown format %q", part)
+		}
+	}
+	return out, nil
+}
+
+func parseIndexCounts(raw string) ([]int, error) {
+	out, err := parsePositiveOrZeroInts(raw, "indexes")
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range out {
+		if n > 3 {
+			return nil, fmt.Errorf("indexes=%d unsupported by native workload harness; max is 3", n)
+		}
+	}
+	return out, nil
+}
+
+func parseReadStates(raw string) ([]readState, error) {
+	parts := splitCSV(raw)
+	if len(parts) == 0 {
+		return nil, errors.New("read-states cannot be empty")
+	}
+	out := make([]readState, 0, len(parts))
+	for _, part := range parts {
+		switch strings.ToLower(part) {
+		case string(readStateBuffered):
+			out = append(out, readStateBuffered)
+		case string(readStateFlushed):
+			out = append(out, readStateFlushed)
+		case string(readStateCheckpointed):
+			out = append(out, readStateCheckpointed)
+		default:
+			return nil, fmt.Errorf("unknown read-state %q", part)
+		}
+	}
+	return out, nil
+}
+
+func parsePositiveInts(raw, label string) ([]int, error) {
+	out, err := parsePositiveOrZeroInts(raw, label)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range out {
+		if n <= 0 {
+			return nil, fmt.Errorf("%s values must be positive", label)
+		}
+	}
+	return out, nil
+}
+
+func parsePositiveOrZeroInts(raw, label string) ([]int, error) {
+	parts := splitCSV(raw)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("%s cannot be empty", label)
+	}
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return nil, fmt.Errorf("%s contains invalid non-negative integer %q", label, part)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(treedb.ProfileBench), "":
+		return treedb.ProfileBench, nil
+	case string(treedb.ProfileFast):
+		return treedb.ProfileFast, nil
+	case string(treedb.ProfileWALOnFast):
+		return treedb.ProfileWALOnFast, nil
+	case string(treedb.ProfileDurable):
+		return treedb.ProfileDurable, nil
+	default:
+		return "", fmt.Errorf("unknown treedb-profile %q", raw)
+	}
+}
+
+func parseRootStorage(raw string) (collections.RootStoragePolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "default":
+		return collections.RootStorageDefault, nil
+	case string(collections.RootStorageFast):
+		return collections.RootStorageFast, nil
+	case string(collections.RootStorageCompressed):
+		return collections.RootStorageCompressed, nil
+	default:
+		return "", fmt.Errorf("unknown root storage policy %q", raw)
+	}
+}
+
+func splitCSV(raw string) []string {
+	fields := strings.Split(raw, ",")
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func run(cfg config) (result, error) {
+	started := time.Now()
+	res := result{
+		BenchmarkFamily:       "native_collections",
+		TreeDBProfile:         string(cfg.TreeDBProfile),
+		Documents:             cfg.Documents,
+		BatchSize:             cfg.BatchSize,
+		Reads:                 cfg.Reads,
+		RangeReads:            cfg.RangeReads,
+		Updates:               cfg.Updates,
+		Deletes:               cfg.Deletes,
+		ReaderSweep:           append([]int(nil), cfg.ReaderSweep...),
+		StartedAt:             started.Format(time.RFC3339Nano),
+		TreeDBDataRootStorage: string(cfg.DataRootStorage),
+		TreeDBIndexStorage:    string(cfg.IndexRootStorage),
+		TreeDBIndexStateRoot:  string(cfg.IndexStateRootStorage),
+		Notes: []string{
+			"Native collection benchmark: no Mongo driver, gateway, wire protocol, cursor materialization, or BSON _id primary-key encoding.",
+			"Index-count shapes are native: 0=primary only, 1=email, 2=email+age, 3=email+age+city.",
+			"age_range_scan_limit_10 uses deterministic native IDs and primary GetInto calls as the unindexed scan floor.",
+		},
+	}
+	for _, format := range cfg.Formats {
+		for _, indexes := range cfg.IndexCounts {
+			for _, state := range cfg.ReadStates {
+				row, err := runRow(cfg, format, indexes, state)
+				if err != nil {
+					res.Errors = append(res.Errors, benchmarkError{
+						Format:    string(format),
+						Indexes:   indexes,
+						ReadState: string(state),
+						Error:     err.Error(),
+					})
+					return res, err
+				}
+				res.Rows = append(res.Rows, row)
+			}
+		}
+	}
+	res.FinishedAt = time.Now().Format(time.RFC3339Nano)
+	res.DurationMS = float64(time.Since(started).Nanoseconds()) / 1e6
+	return res, nil
+}
+
+func runRow(cfg config, format collections.DocumentFormat, indexes int, state readState) (rowResult, error) {
+	target, err := openTarget(cfg, format, indexes)
+	if err != nil {
+		return rowResult{}, err
+	}
+	defer func() { _ = target.close() }()
+
+	row := rowResult{
+		Format:     string(format),
+		Indexes:    indexes,
+		ReadState:  string(state),
+		IndexNames: indexNames(indexes),
+		Metadata: map[string]interface{}{
+			"native_document_ids":  true,
+			"mongo_gateway":        false,
+			"mongo_wire":           false,
+			"mongo_driver":         false,
+			"bson_id_key_encoding": false,
+		},
+	}
+	row.Load, err = timedPhase(target, "load_insert_many", func() (int64, int64, error) {
+		return loadFixture(target, cfg.BatchSize)
+	})
+	if err != nil {
+		return rowResult{}, err
+	}
+	row.StateTransition, err = timedPhase(target, "read_state_"+string(state), func() (int64, int64, error) {
+		return applyReadState(target, state)
+	})
+	if err != nil {
+		return rowResult{}, err
+	}
+
+	row.Phases = append(row.Phases, runReadPhases(target, cfg, indexes)...)
+	if cfg.Updates > 0 {
+		phase, err := timedPhase(target, "id_update_set", func() (int64, int64, error) {
+			return runUpdateSet(target, cfg.Updates, 1)
+		})
+		if err != nil {
+			return rowResult{}, err
+		}
+		row.Phases = append(row.Phases, phase)
+		for _, writers := range cfg.ReaderSweep {
+			phase, err := timedPhase(target, fmt.Sprintf("concurrent_id_update_set_w%d", writers), func() (int64, int64, error) {
+				return runUpdateSet(target, cfg.Updates, writers)
+			})
+			if err != nil {
+				return rowResult{}, err
+			}
+			row.Phases = append(row.Phases, phase)
+		}
+	}
+	if cfg.Deletes > 0 {
+		phase, err := timedPhase(target, "id_delete", func() (int64, int64, error) {
+			return runDeletes(target, cfg.Deletes)
+		})
+		if err != nil {
+			return rowResult{}, err
+		}
+		row.Phases = append(row.Phases, phase)
+	}
+	row.FinalStats = collectStats(target)
+	return row, nil
+}
+
+func runReadPhases(target *benchTarget, cfg config, indexes int) []phaseResult {
+	var phases []phaseResult
+	appendPhase := func(phase phaseResult, err error) {
+		if err != nil {
+			phases = append(phases, phaseResult{Name: phase.Name, Skipped: true, SkipReason: err.Error()})
+			return
+		}
+		phases = append(phases, phase)
+	}
+	if cfg.Reads > 0 {
+		phase, err := timedPhase(target, "id_find_one", func() (int64, int64, error) {
+			return runIDReads(target, cfg.Reads, 1)
+		})
+		appendPhase(phase, err)
+		for _, readers := range cfg.ReaderSweep {
+			phase, err := timedPhase(target, fmt.Sprintf("concurrent_id_find_one_r%d", readers), func() (int64, int64, error) {
+				return runIDReads(target, cfg.Reads, readers)
+			})
+			appendPhase(phase, err)
+		}
+		if indexes >= 1 {
+			phase, err = timedPhase(target, "email_find_one", func() (int64, int64, error) {
+				return runEmailReads(target, cfg.Reads, 1)
+			})
+			appendPhase(phase, err)
+			for _, readers := range cfg.ReaderSweep {
+				phase, err := timedPhase(target, fmt.Sprintf("concurrent_email_find_one_r%d", readers), func() (int64, int64, error) {
+					return runEmailReads(target, cfg.Reads, readers)
+				})
+				appendPhase(phase, err)
+			}
+		} else {
+			phases = append(phases, skippedPhase("email_find_one", "email index is absent for indexes_0"))
+		}
+	}
+	if cfg.RangeReads > 0 {
+		if indexes >= 2 {
+			phase, err := timedPhase(target, "age_range_indexed_limit_10", func() (int64, int64, error) {
+				return runAgeIndexedRangeReads(target, cfg.RangeReads, 1)
+			})
+			appendPhase(phase, err)
+			for _, readers := range cfg.ReaderSweep {
+				phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_indexed_limit_10_r%d", readers), func() (int64, int64, error) {
+					return runAgeIndexedRangeReads(target, cfg.RangeReads, readers)
+				})
+				appendPhase(phase, err)
+			}
+		} else {
+			phases = append(phases, skippedPhase("age_range_indexed_limit_10", "age index is absent until indexes_2"))
+		}
+		phase, err := timedPhase(target, "age_range_scan_limit_10", func() (int64, int64, error) {
+			return runAgeScanRangeReads(target, cfg.RangeReads, 1)
+		})
+		appendPhase(phase, err)
+		for _, readers := range cfg.ReaderSweep {
+			phase, err := timedPhase(target, fmt.Sprintf("concurrent_age_range_scan_limit_10_r%d", readers), func() (int64, int64, error) {
+				return runAgeScanRangeReads(target, cfg.RangeReads, readers)
+			})
+			appendPhase(phase, err)
+		}
+	}
+	return phases
+}
+
+func skippedPhase(name, reason string) phaseResult {
+	return phaseResult{Name: name, Skipped: true, SkipReason: reason}
+}
+
+func openTarget(cfg config, format collections.DocumentFormat, indexes int) (*benchTarget, error) {
+	dir := cfg.TreeDBDir
+	removeDir := false
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "collection-workload-bench-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = tmp
+		removeDir = !cfg.KeepTreeDBDir
+	} else if err := resetTreeDBDir(dir); err != nil {
+		return nil, err
+	}
+	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	db, cleanup, err := open(opts)
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	manager := collections.NewCollectionManager(db)
+	meta := collections.CollectionMeta{
+		Name: defaultCollectionName,
+		Options: collections.CollectionOptions{
+			DocumentFormat:          format,
+			DataRootStoragePolicy:   cfg.DataRootStorage,
+			IndexStateStoragePolicy: cfg.IndexStateRootStorage,
+		},
+		Indexes: indexDefinitions(indexes, cfg.IndexRootStorage),
+	}
+	if _, err := manager.CreateCollection(&meta); err != nil {
+		_ = cleanup()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	col, err := manager.OpenCollection(defaultCollectionName)
+	if err != nil {
+		_ = cleanup()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	fixture, err := buildFixture(cfg.Documents, format, indexes)
+	if err != nil {
+		_ = cleanup()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	return &benchTarget{
+		dir:       dir,
+		removeDir: removeDir,
+		db:        db,
+		manager:   manager,
+		col:       col,
+		cleanup:   cleanup,
+		fixture:   fixture,
+		meta:      meta,
+	}, nil
+}
+
+func (t *benchTarget) close() error {
+	if t == nil {
+		return nil
+	}
+	var err error
+	if t.cleanup != nil {
+		err = t.cleanup()
+		t.cleanup = nil
+	}
+	if t.removeDir {
+		if rmErr := os.RemoveAll(t.dir); err == nil {
+			err = rmErr
+		}
+	}
+	return err
+}
+
+func resetTreeDBDir(dir string) error {
+	clean := filepath.Clean(strings.TrimSpace(dir))
+	if clean == "" || clean == "." || clean == ".." {
+		return fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return err
+	}
+	if abs == string(os.PathSeparator) || filepath.Dir(abs) == string(os.PathSeparator) {
+		return fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	if err := os.RemoveAll(abs); err != nil {
+		return err
+	}
+	return os.MkdirAll(abs, 0o700)
+}
+
+func indexDefinitions(count int, storage collections.RootStoragePolicy) []collections.IndexDefinition {
+	defs := make([]collections.IndexDefinition, 0, count)
+	if count >= 1 {
+		defs = append(defs, collections.IndexDefinition{Name: "email", Field: "email", ValueType: collections.IndexValueString, Unique: true, StoragePolicy: storage})
+	}
+	if count >= 2 {
+		defs = append(defs, collections.IndexDefinition{Name: "age", Field: "age", ValueType: collections.IndexValueInt64, StoragePolicy: storage})
+	}
+	if count >= 3 {
+		defs = append(defs, collections.IndexDefinition{Name: "city", Field: "city", ValueType: collections.IndexValueString, StoragePolicy: storage})
+	}
+	return defs
+}
+
+func indexNames(count int) []string {
+	defs := indexDefinitions(count, collections.RootStorageDefault)
+	out := make([]string, 0, len(defs))
+	for _, def := range defs {
+		out = append(out, def.Name)
+	}
+	return out
+}
+
+func buildFixture(documents int, format collections.DocumentFormat, indexes int) (*fixture, error) {
+	f := &fixture{
+		ids:     make([][]byte, documents),
+		idText:  make([]string, documents),
+		emails:  make([]string, documents),
+		cities:  make([]string, documents),
+		ages:    make([]int64, documents),
+		docs:    make([][]byte, documents),
+		format:  format,
+		indexes: indexes,
+	}
+	for i := 0; i < documents; i++ {
+		idText := nativeDocumentIDText(i)
+		f.idText[i] = idText
+		f.ids[i] = []byte(idText)
+		f.emails[i] = nativeEmail(i)
+		f.cities[i] = nativeCity(i)
+		f.ages[i] = nativeAge(i)
+		doc, err := f.encodeDocument(i, false, 0)
+		if err != nil {
+			return nil, err
+		}
+		f.docs[i] = doc
+	}
+	return f, nil
+}
+
+func (f *fixture) encodeDocument(i int, updated bool, updateSeq int) ([]byte, error) {
+	id := f.idText[i]
+	email := f.emails[i]
+	city := f.cities[i]
+	age := f.ages[i]
+	active := i%2 == 0
+	score := float64(i%1000) / 10.0
+	rank := int32(i % 1000)
+	switch f.format {
+	case collections.DocumentFormatJSON:
+		return []byte(fmt.Sprintf(
+			`{"id":%q,"email":%q,"city":%q,"age":%d,"active":%t,"score":%.1f,"tag0":%q,"tag1":%q,"rank":%d,"bio":%q,"updated":%t,"update_seq":%d}`,
+			id, email, city, age, active, score, city, fmt.Sprintf("bucket-%02d", i%32), rank, nativeBio(), updated, updateSeq,
+		)), nil
+	case collections.DocumentFormatTemplateV1:
+		return f.encoder.EncodeDocument(
+			[]string{"id", "email", "city", "age", "active", "score", "tag0", "tag1", "rank", "bio", "updated", "update_seq"},
+			[]any{id, email, city, age, active, score, city, fmt.Sprintf("bucket-%02d", i%32), int64(rank), nativeBio(), updated, int64(updateSeq)},
+		)
+	case collections.DocumentFormatBSON:
+		return bson.Marshal(bson.D{
+			{Key: "id", Value: id},
+			{Key: "email", Value: email},
+			{Key: "city", Value: city},
+			{Key: "age", Value: age},
+			{Key: "active", Value: active},
+			{Key: "score", Value: score},
+			{Key: "tag0", Value: city},
+			{Key: "tag1", Value: fmt.Sprintf("bucket-%02d", i%32)},
+			{Key: "rank", Value: rank},
+			{Key: "bio", Value: nativeBio()},
+			{Key: "updated", Value: updated},
+			{Key: "update_seq", Value: int64(updateSeq)},
+		})
+	default:
+		return nil, fmt.Errorf("unsupported document format %q", f.format)
+	}
+}
+
+func nativeDocumentIDText(i int) string {
+	return fmt.Sprintf("doc-%012d", i)
+}
+
+func nativeEmail(i int) string {
+	return fmt.Sprintf("user%012d@example.test", i)
+}
+
+func nativeCity(i int) string {
+	return nativeCities[i%len(nativeCities)]
+}
+
+func nativeAge(i int) int64 {
+	return int64(18 + (i % 67))
+}
+
+func nativeBio() string {
+	return "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+
+var nativeCities = [...]string{"hnl", "sfo", "nyc", "lon", "sin", "ber", "tyo", "syd"}
+
+func benchmarkDocumentOrdinal(operation int, stride uint64, documentCount int) int {
+	return int((uint64(operation) * stride) % uint64(documentCount))
+}
+
+func loadFixture(target *benchTarget, batchSize int) (int64, int64, error) {
+	docs := target.fixture.docs
+	ids := target.fixture.ids
+	for start := 0; start < len(docs); start += batchSize {
+		end := start + batchSize
+		if end > len(docs) {
+			end = len(docs)
+		}
+		if _, err := target.col.InsertBatch(ids[start:end], docs[start:end]); err != nil {
+			return 0, 0, err
+		}
+	}
+	return int64(len(docs)), int64((len(docs) + batchSize - 1) / batchSize), nil
+}
+
+func applyReadState(target *benchTarget, state readState) (int64, int64, error) {
+	switch state {
+	case readStateBuffered:
+		return 1, 1, nil
+	case readStateFlushed:
+		if err := target.manager.FlushAll(); err != nil {
+			return 0, 0, err
+		}
+		return 1, 1, nil
+	case readStateCheckpointed:
+		if err := target.manager.FlushAll(); err != nil {
+			return 0, 0, err
+		}
+		if err := target.db.Checkpoint(); err != nil {
+			return 0, 0, err
+		}
+		return 1, 1, nil
+	default:
+		return 0, 0, fmt.Errorf("unknown read-state %q", state)
+	}
+}
+
+func runIDReads(target *benchTarget, total, workers int) (int64, int64, error) {
+	buffers := make([][]byte, workerBufferCount(workers))
+	return runParallel(total, workers, func(op int, worker int) error {
+		id := target.fixture.ids[benchmarkDocumentOrdinal(op, 17, len(target.fixture.ids))]
+		buf := buffers[worker]
+		value, found, err := target.col.GetInto(id, buf[:0])
+		buffers[worker] = value
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("missing id %q", id)
+		}
+		return nil
+	})
+}
+
+func runEmailReads(target *benchTarget, total, workers int) (int64, int64, error) {
+	buffers := make([][]byte, workerBufferCount(workers))
+	return runParallel(total, workers, func(op int, worker int) error {
+		ordinal := benchmarkDocumentOrdinal(op, 31, len(target.fixture.ids))
+		ids, _, err := target.col.FindByIndexValueLimit("email", target.fixture.emails[ordinal], 1)
+		if err != nil {
+			return err
+		}
+		if len(ids) != 1 {
+			return fmt.Errorf("email lookup returned %d ids", len(ids))
+		}
+		buf := buffers[worker]
+		value, found, err := target.col.GetInto(ids[0], buf[:0])
+		buffers[worker] = value
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("email lookup id %q missing", ids[0])
+		}
+		return nil
+	})
+}
+
+func runAgeIndexedRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
+	buffers := make([][]byte, workerBufferCount(workers))
+	return runParallel(total, workers, func(op int, worker int) error {
+		age := int64(18 + (op % 67))
+		ids, _, err := target.col.FindByIndexRange("age", collections.IndexRangeOptions{
+			Lower: collections.IndexRangeBound{Value: age, Inclusive: true},
+			Upper: collections.IndexRangeBound{Value: age, Inclusive: true},
+			Limit: 10,
+		})
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return fmt.Errorf("age indexed range returned no ids")
+		}
+		buf := buffers[worker]
+		for _, id := range ids {
+			value, found, err := target.col.GetInto(id, buf[:0])
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("range lookup id %q missing", id)
+			}
+			buf = value
+		}
+		buffers[worker] = buf
+		return nil
+	})
+}
+
+func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
+	docs := len(target.fixture.ids)
+	buffers := make([][]byte, workerBufferCount(workers))
+	return runParallel(total, workers, func(op int, worker int) error {
+		wantAge := int64(18 + (op % 67))
+		start := benchmarkDocumentOrdinal(op, 43, docs)
+		foundCount := 0
+		buf := buffers[worker]
+		for scanned := 0; scanned < docs && foundCount < 10; scanned++ {
+			ordinal := (start + scanned) % docs
+			value, found, err := target.col.GetInto(target.fixture.ids[ordinal], buf[:0])
+			if err != nil {
+				return err
+			}
+			if !found {
+				continue
+			}
+			buf = value
+			if target.fixture.ages[ordinal] == wantAge {
+				foundCount++
+			}
+		}
+		buffers[worker] = buf
+		if foundCount == 0 {
+			return fmt.Errorf("age scan found no documents")
+		}
+		return nil
+	})
+}
+
+func workerBufferCount(workers int) int {
+	if workers <= 1 {
+		return 1
+	}
+	return workers
+}
+
+func runUpdateSet(target *benchTarget, total, workers int) (int64, int64, error) {
+	replacements := make([][]byte, total)
+	ordinals := make([]int, total)
+	for i := 0; i < total; i++ {
+		ordinal := benchmarkDocumentOrdinal(i, 37, len(target.fixture.ids))
+		ordinals[i] = ordinal
+		doc, err := target.fixture.encodeDocument(ordinal, true, i)
+		if err != nil {
+			return 0, 0, err
+		}
+		replacements[i] = doc
+	}
+	return runParallel(total, workers, func(op int, worker int) error {
+		id := target.fixture.ids[ordinals[op]]
+		replacement := replacements[op]
+		_, _, err := target.col.Update(id, func(current []byte) ([]byte, bool, error) {
+			if current == nil {
+				return nil, false, fmt.Errorf("update id %q missing", id)
+			}
+			return replacement, true, nil
+		})
+		return err
+	})
+}
+
+func runDeletes(target *benchTarget, total int) (int64, int64, error) {
+	for i := 0; i < total; i++ {
+		if err := target.col.Delete(target.fixture.ids[i]); err != nil {
+			return int64(i), int64(i), err
+		}
+	}
+	return int64(total), int64(total), nil
+}
+
+func runParallel(total, workers int, fn func(op int, worker int) error) (int64, int64, error) {
+	if total <= 0 {
+		return 0, 0, nil
+	}
+	if workers <= 1 {
+		for i := 0; i < total; i++ {
+			if err := fn(i, 0); err != nil {
+				return int64(i), int64(i), err
+			}
+		}
+		return int64(total), int64(total), nil
+	}
+	var next atomic.Int64
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				op := int(next.Add(1) - 1)
+				if op >= total {
+					return
+				}
+				if err := fn(op, worker); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		return next.Load(), next.Load(), err
+	default:
+		return int64(total), int64(total), nil
+	}
+}
+
+func timedPhase(target *benchTarget, name string, fn phaseFunc) (phaseResult, error) {
+	before := collectStats(target)
+	start := time.Now()
+	ops, calls, err := fn()
+	elapsed := time.Since(start)
+	after := collectStats(target)
+	phase := phaseResult{
+		Name:        name,
+		Operations:  ops,
+		DriverCalls: calls,
+		DurationMS:  float64(elapsed.Nanoseconds()) / 1e6,
+	}
+	if ops > 0 {
+		phase.NSPerOp = float64(elapsed.Nanoseconds()) / float64(ops)
+		phase.OpsPerSec = float64(ops) / elapsed.Seconds()
+	}
+	attachStats(&phase, before, after)
+	return phase, err
+}
+
+func collectStats(target *benchTarget) map[string]string {
+	if target == nil {
+		return nil
+	}
+	stats := make(map[string]string)
+	if target.db != nil {
+		for key, value := range target.db.Stats() {
+			stats[key] = value
+		}
+	}
+	if target.manager != nil {
+		for key, value := range target.manager.Stats() {
+			stats[key] = value
+		}
+	}
+	return treedbstats.Selected(stats)
+}
+
+func attachStats(phase *phaseResult, before, after map[string]string) {
+	delta, numeric := statsDelta(before, after)
+	if len(delta) > 0 {
+		phase.TreeDBStatsDelta = delta
+	}
+	if phase.Operations > 0 && len(numeric) > 0 {
+		metrics := make(map[string]float64)
+		for key, value := range numeric {
+			if strings.HasSuffix(key, "_ns_total") {
+				metrics[strings.TrimSuffix(key, "_total")+"/op"] = value / float64(phase.Operations)
+			}
+		}
+		if len(metrics) > 0 {
+			phase.TreeDBMetrics = metrics
+		}
+	}
+}
+
+func statsDelta(before, after map[string]string) (map[string]string, map[string]float64) {
+	if len(after) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string)
+	numeric := make(map[string]float64)
+	for key, afterValue := range after {
+		beforeNumber := 0.0
+		beforeHadNumber := false
+		if beforeValue, ok := before[key]; ok {
+			if parsed, err := strconv.ParseFloat(beforeValue, 64); err == nil {
+				beforeNumber = parsed
+				beforeHadNumber = true
+			}
+		}
+		parsedAfter, err := strconv.ParseFloat(afterValue, 64)
+		if err != nil {
+			continue
+		}
+		if !beforeHadNumber {
+			beforeNumber = 0
+		}
+		delta := parsedAfter - beforeNumber
+		if delta == 0 {
+			continue
+		}
+		out[key] = strconv.FormatFloat(delta, 'f', -1, 64)
+		numeric[key] = delta
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, numeric
+}
+
+func writeResult(w io.Writer, format string, res result) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	case "text":
+		return writeTextResult(w, res)
+	default:
+		return fmt.Errorf("unknown output format %q", format)
+	}
+}
+
+func writeTextResult(w io.Writer, res result) error {
+	fmt.Fprintf(w, "Native collection workload benchmark\n")
+	fmt.Fprintf(w, "profile=%s documents=%d batch_size=%d reads=%d range_reads=%d updates=%d deletes=%d\n\n",
+		res.TreeDBProfile, res.Documents, res.BatchSize, res.Reads, res.RangeReads, res.Updates, res.Deletes)
+	for _, row := range res.Rows {
+		fmt.Fprintf(w, "%s indexes_%d read_state=%s indexes=%s\n", row.Format, row.Indexes, row.ReadState, strings.Join(row.IndexNames, ","))
+		writePhaseText(w, row.Load)
+		writePhaseText(w, row.StateTransition)
+		for _, phase := range row.Phases {
+			writePhaseText(w, phase)
+		}
+		fmt.Fprintln(w)
+	}
+	if len(res.Errors) > 0 {
+		fmt.Fprintln(w, "errors:")
+		for _, err := range res.Errors {
+			fmt.Fprintf(w, "  %s indexes_%d %s: %s\n", err.Format, err.Indexes, err.ReadState, err.Error)
+		}
+	}
+	return nil
+}
+
+func writePhaseText(w io.Writer, phase phaseResult) {
+	if phase.Skipped {
+		fmt.Fprintf(w, "  %-44s skipped (%s)\n", phase.Name, phase.SkipReason)
+		return
+	}
+	fmt.Fprintf(w, "  %-44s %12.1f ns/op %12.0f ops/sec ops=%d duration=%.2fms\n",
+		phase.Name, phase.NSPerOp, phase.OpsPerSec, phase.Operations, phase.DurationMS)
+}
+
+func sortedPhaseNames(row rowResult) []string {
+	names := make([]string, 0, len(row.Phases)+2)
+	names = append(names, row.Load.Name, row.StateTransition.Name)
+	for _, phase := range row.Phases {
+		names = append(names, phase.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -147,15 +147,19 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+	if err := runAndWrite(os.Stdout, cfg); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func runAndWrite(w io.Writer, cfg config) error {
 	res, err := run(cfg)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	writeErr := writeResult(w, cfg.OutputFormat, res)
+	if err != nil || writeErr != nil {
+		return errors.Join(err, writeErr)
 	}
-	if err := writeResult(os.Stdout, cfg.OutputFormat, res); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	return nil
 }
 
 func parseConfig(args []string) (config, error) {
@@ -313,10 +317,15 @@ func parsePositiveInts(raw, label string) ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
+	seen := make(map[int]struct{}, len(out))
 	for _, n := range out {
 		if n <= 0 {
 			return nil, fmt.Errorf("%s values must be positive", label)
 		}
+		if _, ok := seen[n]; ok {
+			return nil, fmt.Errorf("%s contains duplicate value %d", label, n)
+		}
+		seen[n] = struct{}{}
 	}
 	return out, nil
 }
@@ -410,15 +419,23 @@ func run(cfg config) (result, error) {
 						ReadState: string(state),
 						Error:     err.Error(),
 					})
+					finishResult(&res, started)
 					return res, err
 				}
 				res.Rows = append(res.Rows, row)
 			}
 		}
 	}
+	finishResult(&res, started)
+	return res, nil
+}
+
+func finishResult(res *result, started time.Time) {
+	if res == nil {
+		return
+	}
 	res.FinishedAt = time.Now().Format(time.RFC3339Nano)
 	res.DurationMS = float64(time.Since(started).Nanoseconds()) / 1e6
-	return res, nil
 }
 
 func runRow(cfg config, format collections.DocumentFormat, indexes int, state readState) (rowResult, error) {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -755,17 +755,13 @@ func resetTreeDBDir(dir string) error {
 }
 
 func requireResettableTreeDBBenchDir(dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
+	if _, err := os.ReadDir(dir); err != nil {
 		return err
-	}
-	if len(entries) == 0 {
-		return nil
 	}
 	if hasTreeDBBenchDirMarker(dir) {
 		return nil
 	}
-	return fmt.Errorf("refusing to delete non-empty treedb-dir %q without %s marker", dir, treedbBenchDirMarkerName)
+	return fmt.Errorf("refusing to delete treedb-dir %q without %s marker", dir, treedbBenchDirMarkerName)
 }
 
 func hasTreeDBBenchDirMarker(dir string) bool {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -868,6 +868,10 @@ func benchmarkDocumentOrdinal(operation int, stride uint64, documentCount int) i
 	return int((uint64(operation) * stride) % uint64(documentCount))
 }
 
+func rangeReadMinAge(operation int) int64 {
+	return int64(20 + (operation % 40))
+}
+
 func loadFixture(target *benchTarget, batchSize int) (int64, int64, error) {
 	docs := target.fixture.docs
 	ids := target.fixture.ids
@@ -949,11 +953,10 @@ func runEmailReads(target *benchTarget, total, workers int) (int64, int64, error
 func runAgeIndexedRangeReads(target *benchTarget, total, workers int) (int64, int64, error) {
 	buffers := make([][]byte, workerBufferCount(workers))
 	return runParallel(total, workers, func(op int, worker int) error {
-		ordinal := benchmarkDocumentOrdinal(op, 19, len(target.fixture.ids))
-		age := target.fixture.ages[ordinal]
+		minAge := rangeReadMinAge(op)
 		ids, _, err := target.col.FindByIndexRange("age", collections.IndexRangeOptions{
-			Lower: collections.IndexRangeBound{Value: age, Inclusive: true},
-			Upper: collections.IndexRangeBound{Value: age, Inclusive: true},
+			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
+			Upper: collections.IndexRangeBound{Unbounded: true},
 			Limit: 10,
 		})
 		if err != nil {
@@ -983,7 +986,7 @@ func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64
 	buffers := make([][]byte, workerBufferCount(workers))
 	return runParallel(total, workers, func(op int, worker int) error {
 		start := benchmarkDocumentOrdinal(op, 43, docs)
-		wantAge := target.fixture.ages[start]
+		minAge := rangeReadMinAge(op)
 		foundCount := 0
 		buf := buffers[worker]
 		for scanned := 0; scanned < docs && foundCount < 10; scanned++ {
@@ -996,7 +999,7 @@ func runAgeScanRangeReads(target *benchTarget, total, workers int) (int64, int64
 				continue
 			}
 			buf = value
-			if target.fixture.ages[ordinal] == wantAge {
+			if target.fixture.ages[ordinal] >= minAge {
 				foundCount++
 			}
 		}

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -111,7 +111,7 @@ func TestRunAndWriteEmitsPartialErrors(t *testing.T) {
 		t.Fatal("runAndWrite succeeded with unsafe treedb-dir")
 	}
 	got := out.String()
-	for _, want := range []string{"Native collection workload benchmark", "errors:", "refusing to delete non-empty treedb-dir"} {
+	for _, want := range []string{"Native collection workload benchmark", "errors:", "refusing to delete treedb-dir"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q\n%s", want, got)
 		}
@@ -160,11 +160,22 @@ func TestResetTreeDBDirRefusesNonEmptyUnmarkedDir(t *testing.T) {
 	if err == nil {
 		t.Fatal("resetTreeDBDir succeeded for non-empty unmarked directory")
 	}
-	if !strings.Contains(err.Error(), "refusing to delete non-empty treedb-dir") {
+	if !strings.Contains(err.Error(), "refusing to delete treedb-dir") {
 		t.Fatalf("error=%v want refusal", err)
 	}
 	if got, statErr := os.ReadFile(important); statErr != nil || string(got) != "keep" {
 		t.Fatalf("important file changed, got=%q err=%v", got, statErr)
+	}
+}
+
+func TestResetTreeDBDirRefusesEmptyUnmarkedDir(t *testing.T) {
+	dir := t.TempDir()
+	err := resetTreeDBDir(dir)
+	if err == nil {
+		t.Fatal("resetTreeDBDir succeeded for empty unmarked directory")
+	}
+	if !strings.Contains(err.Error(), "refusing to delete treedb-dir") {
+		t.Fatalf("error=%v want refusal", err)
 	}
 }
 

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -28,6 +29,14 @@ func TestParseFormatsAcceptsCollectionsV1Alias(t *testing.T) {
 		if formats[i] != want[i] {
 			t.Fatalf("formats[%d]=%q want %q", i, formats[i], want[i])
 		}
+	}
+}
+
+func TestParsePositiveIntsRejectsDuplicates(t *testing.T) {
+	if _, err := parsePositiveInts("1,2,2", "reader-sweep"); err == nil {
+		t.Fatal("parsePositiveInts accepted duplicate reader-sweep value")
+	} else if !strings.Contains(err.Error(), "duplicate value 2") {
+		t.Fatalf("error=%v want duplicate value", err)
 	}
 }
 
@@ -70,6 +79,42 @@ func TestRunSmallNativeCollectionMatrix(t *testing.T) {
 		requirePhase(t, row, "id_update_set", false)
 		requirePhase(t, row, "concurrent_id_update_set_w2", false)
 		requirePhase(t, row, "id_delete_one", false)
+	}
+}
+
+func TestRunAndWriteEmitsPartialErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "important.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write important file: %v", err)
+	}
+	cfg := config{
+		TreeDBDir:             dir,
+		Documents:             8,
+		BatchSize:             8,
+		Reads:                 1,
+		RangeReads:            1,
+		Updates:               0,
+		Deletes:               0,
+		Formats:               []collections.DocumentFormat{collections.DocumentFormatJSON},
+		IndexCounts:           []int{0},
+		ReadStates:            []readState{readStateBuffered},
+		ReaderSweep:           []int{1},
+		OutputFormat:          "text",
+		TreeDBProfile:         treedb.ProfileBench,
+		DataRootStorage:       collections.RootStorageDefault,
+		IndexStateRootStorage: collections.RootStorageDefault,
+		IndexRootStorage:      collections.RootStorageDefault,
+	}
+	var out bytes.Buffer
+	err := runAndWrite(&out, cfg)
+	if err == nil {
+		t.Fatal("runAndWrite succeeded with unsafe treedb-dir")
+	}
+	got := out.String()
+	for _, want := range []string{"Native collection workload benchmark", "errors:", "refusing to delete non-empty treedb-dir"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q\n%s", want, got)
+		}
 	}
 }
 

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -65,7 +65,7 @@ func TestRunSmallNativeCollectionMatrix(t *testing.T) {
 		requirePhase(t, row, "concurrent_age_range_indexed_limit_10_r2", false)
 		requirePhase(t, row, "id_update_set", false)
 		requirePhase(t, row, "concurrent_id_update_set_w2", false)
-		requirePhase(t, row, "id_delete", false)
+		requirePhase(t, row, "id_delete_one", false)
 	}
 }
 

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestParseFormatsAcceptsCollectionsV1Alias(t *testing.T) {
+	formats, err := parseFormats("json,collections-v1,bson")
+	if err != nil {
+		t.Fatalf("parseFormats: %v", err)
+	}
+	want := []collections.DocumentFormat{
+		collections.DocumentFormatJSON,
+		collections.DocumentFormatTemplateV1,
+		collections.DocumentFormatBSON,
+	}
+	if len(formats) != len(want) {
+		t.Fatalf("formats len=%d want %d", len(formats), len(want))
+	}
+	for i := range want {
+		if formats[i] != want[i] {
+			t.Fatalf("formats[%d]=%q want %q", i, formats[i], want[i])
+		}
+	}
+}
+
+func TestRunSmallNativeCollectionMatrix(t *testing.T) {
+	cfg := config{
+		Documents:             32,
+		BatchSize:             16,
+		Reads:                 8,
+		RangeReads:            4,
+		Updates:               4,
+		Deletes:               2,
+		Formats:               []collections.DocumentFormat{collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1, collections.DocumentFormatBSON},
+		IndexCounts:           []int{2},
+		ReadStates:            []readState{readStateBuffered},
+		ReaderSweep:           []int{1, 2},
+		OutputFormat:          "json",
+		TreeDBProfile:         treedb.ProfileBench,
+		DataRootStorage:       collections.RootStorageDefault,
+		IndexStateRootStorage: collections.RootStorageDefault,
+		IndexRootStorage:      collections.RootStorageDefault,
+	}
+	res, err := run(cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got, want := len(res.Rows), len(cfg.Formats); got != want {
+		t.Fatalf("rows=%d want %d", got, want)
+	}
+	for _, row := range res.Rows {
+		if row.Load.Operations != int64(cfg.Documents) {
+			t.Fatalf("%s load ops=%d want %d", row.Format, row.Load.Operations, cfg.Documents)
+		}
+		requirePhase(t, row, "id_find_one", false)
+		requirePhase(t, row, "email_find_one", false)
+		requirePhase(t, row, "age_range_indexed_limit_10", false)
+		requirePhase(t, row, "age_range_scan_limit_10", false)
+		requirePhase(t, row, "concurrent_id_find_one_r2", false)
+		requirePhase(t, row, "concurrent_email_find_one_r2", false)
+		requirePhase(t, row, "concurrent_age_range_indexed_limit_10_r2", false)
+		requirePhase(t, row, "id_update_set", false)
+		requirePhase(t, row, "concurrent_id_update_set_w2", false)
+		requirePhase(t, row, "id_delete", false)
+	}
+}
+
+func TestIndexesZeroSkipsSecondaryNativePhases(t *testing.T) {
+	cfg := config{
+		Documents:             16,
+		BatchSize:             16,
+		Reads:                 4,
+		RangeReads:            2,
+		Updates:               0,
+		Deletes:               0,
+		Formats:               []collections.DocumentFormat{collections.DocumentFormatJSON},
+		IndexCounts:           []int{0},
+		ReadStates:            []readState{readStateBuffered},
+		ReaderSweep:           []int{1},
+		OutputFormat:          "json",
+		TreeDBProfile:         treedb.ProfileBench,
+		DataRootStorage:       collections.RootStorageDefault,
+		IndexStateRootStorage: collections.RootStorageDefault,
+		IndexRootStorage:      collections.RootStorageDefault,
+	}
+	res, err := run(cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got, want := len(res.Rows), 1; got != want {
+		t.Fatalf("rows=%d want %d", got, want)
+	}
+	row := res.Rows[0]
+	requirePhase(t, row, "id_find_one", false)
+	requirePhase(t, row, "email_find_one", true)
+	requirePhase(t, row, "age_range_indexed_limit_10", true)
+	requirePhase(t, row, "age_range_scan_limit_10", false)
+}
+
+func requirePhase(t *testing.T, row rowResult, name string, skipped bool) {
+	t.Helper()
+	for _, phase := range row.Phases {
+		if phase.Name != name {
+			continue
+		}
+		if phase.Skipped != skipped {
+			t.Fatalf("%s/%s skipped=%v want %v", row.Format, name, phase.Skipped, skipped)
+		}
+		if !skipped {
+			if phase.Operations <= 0 {
+				t.Fatalf("%s/%s operations=%d want >0", row.Format, name, phase.Operations)
+			}
+			if phase.OpsPerSec <= 0 || phase.NSPerOp <= 0 {
+				t.Fatalf("%s/%s ops/sec=%f ns/op=%f want positive", row.Format, name, phase.OpsPerSec, phase.NSPerOp)
+			}
+		}
+		return
+	}
+	t.Fatalf("%s phase %q not found", row.Format, name)
+}

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -72,7 +72,7 @@ func TestRunSmallNativeCollectionMatrix(t *testing.T) {
 		requirePhase(t, row, "id_find_one", false)
 		requirePhase(t, row, "email_find_one", false)
 		requirePhase(t, row, "age_range_indexed_limit_10", false)
-		requirePhase(t, row, "age_range_scan_limit_10", false)
+		requirePhase(t, row, "age_range_scan_limit_10", true)
 		requirePhase(t, row, "concurrent_id_find_one_r2", false)
 		requirePhase(t, row, "concurrent_email_find_one_r2", false)
 		requirePhase(t, row, "concurrent_age_range_indexed_limit_10_r2", false)
@@ -147,7 +147,7 @@ func TestIndexesZeroSkipsSecondaryNativePhases(t *testing.T) {
 	requirePhase(t, row, "id_find_one", false)
 	requirePhase(t, row, "email_find_one", true)
 	requirePhase(t, row, "age_range_indexed_limit_10", true)
-	requirePhase(t, row, "age_range_scan_limit_10", false)
+	requirePhase(t, row, "age_range_scan_limit_10", true)
 }
 
 func TestResetTreeDBDirRefusesNonEmptyUnmarkedDir(t *testing.T) {

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -99,6 +103,44 @@ func TestIndexesZeroSkipsSecondaryNativePhases(t *testing.T) {
 	requirePhase(t, row, "email_find_one", true)
 	requirePhase(t, row, "age_range_indexed_limit_10", true)
 	requirePhase(t, row, "age_range_scan_limit_10", false)
+}
+
+func TestResetTreeDBDirRefusesNonEmptyUnmarkedDir(t *testing.T) {
+	dir := t.TempDir()
+	important := filepath.Join(dir, "important.txt")
+	if err := os.WriteFile(important, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write important file: %v", err)
+	}
+	err := resetTreeDBDir(dir)
+	if err == nil {
+		t.Fatal("resetTreeDBDir succeeded for non-empty unmarked directory")
+	}
+	if !strings.Contains(err.Error(), "refusing to delete non-empty treedb-dir") {
+		t.Fatalf("error=%v want refusal", err)
+	}
+	if got, statErr := os.ReadFile(important); statErr != nil || string(got) != "keep" {
+		t.Fatalf("important file changed, got=%q err=%v", got, statErr)
+	}
+}
+
+func TestResetTreeDBDirAllowsMarkedBenchmarkDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeTreeDBBenchDirMarker(dir); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	oldFile := filepath.Join(dir, "old.db")
+	if err := os.WriteFile(oldFile, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write old file: %v", err)
+	}
+	if err := resetTreeDBDir(dir); err != nil {
+		t.Fatalf("resetTreeDBDir: %v", err)
+	}
+	if _, err := os.Stat(oldFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old file still exists or unexpected stat err: %v", err)
+	}
+	if !hasTreeDBBenchDirMarker(dir) {
+		t.Fatal("benchmark marker missing after reset")
+	}
 }
 
 func requirePhase(t *testing.T, row rowResult, name string, skipped bool) {

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -61,20 +61,21 @@ sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
 cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
-read/update phases on the driver. `-client-mode direct` is a BSON-only,
-TreeDB-only path that calls `collections.Collection` directly for the same
-phase names, bypassing the MongoDB Go driver, loopback sockets, and Mongo
-gateway command/response handling. Use direct mode to answer whether a slow
-Mongo API phase is already slow in the collection engine; use raw-wire mode to
-estimate the gateway/server ceiling without the driver's per-document marshal
-and `_id` discovery overhead; use driver mode for user-visible Mongo
-compatibility throughput.
+read/update phases on the driver. `-client-mode direct` is a TreeDB-only path
+that calls `collections.Collection` directly for the same phase names, using the
+selected `-treedb-document-format` (`json`, `template-v1`, or `bson`) while
+bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
+command/response handling. Use direct mode to answer whether a slow Mongo API
+phase is already slow in the collection engine and selected storage format; use
+raw-wire mode to estimate the gateway/server ceiling without the driver's
+per-document marshal and `_id` discovery overhead; use driver mode for
+user-visible Mongo compatibility throughput.
 
 When `-prebuild-documents` is enabled, the harness builds both structured BSON
 documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
 does not include fixture BSON marshaling. Direct mode also reuses prebuilt raw
-BSON documents for direct collection inserts.
+BSON-derived stored documents for direct collection inserts.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert
@@ -345,10 +346,11 @@ The initial workload phases are:
   on `client_mode`: `InsertMany` for `driver`, `RunCommand({insert,
   documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
   command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
-  visibility wait for `driver-unack`, direct BSON `Collection.InsertBatch` for
-  `direct`, and raw OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`.
-  When `-insert-producers` is greater than 1, this phase reports aggregate
-  wall-clock throughput and per-producer call latency in `producer_results`.
+  visibility wait for `driver-unack`, direct `Collection.InsertBatch` in the
+  selected storage format for `direct`, and raw OP_MSG document sequences for
+  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
+  phase reports aggregate wall-clock throughput and per-producer call latency in
+  `producer_results`.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field; emitted only when the
   email secondary index is part of the cell.

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -52,16 +52,19 @@ driver's `InsertMany` `_id` discovery and `InsertedIDs` bookkeeping. It is usefu
 for isolating driver CRUD-helper overhead and works against both TreeDB and
 MongoDB targets. `-client-mode driver-command-raw` also uses `RunCommand`, but
 passes a prebuilt raw BSON insert command to reduce driver-side command encoding
-when `-prebuild-documents` is enabled. `-client-mode driver-unack` uses official-driver
+when `-prebuild-documents` is enabled; its age range-read phase also uses a raw
+`find` command and parses `cursor.firstBatch` as raw BSON instead of decoding
+documents into `bson.M`. `-client-mode driver-unack` uses official-driver
 `InsertMany` with unacknowledged write concern; its sampled load metric is
 client enqueue cost, while the phase waits for the final inserted `_id` to
 become visible before reporting wall ops/sec. `-client-mode raw-wire` is
 TreeDB-only and calls the in-process gateway directly with raw OP_MSG document
 sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
-cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
-document sequences for the insert load phase while keeping setup and later
-read/update phases on the driver. `-client-mode direct` is a TreeDB-only path
+cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG document
+sequences for the insert load phase and raw OP_MSG `find` requests for the age
+range-read phase while keeping setup and non-range phases on the driver.
+`-client-mode direct` is a TreeDB-only path
 that calls `collections.Collection` directly for the same phase names, using the
 selected `-treedb-document-format` (`json`, `template-v1`/`collections-v1`, or
 `bson`) while bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
@@ -279,6 +282,8 @@ Useful overrides:
   TreeDB cell and retain per-phase profiles under the bundle's `profiles/`
   directory.
 - `CONCURRENT_READERS=16`, `CONCURRENT_READS=50000`
+- `CONCURRENT_RANGE_READER_SWEEP="1,2,4,8,16"`,
+  `CONCURRENT_RANGE_READS=5000`
 - `CONCURRENT_WRITERS=8`, `CONCURRENT_WRITES=10000`
 - `BATCH_SIZE=1000`
 - `MONGO_IMAGE=mongo:8`
@@ -297,6 +302,8 @@ BATCH_SIZE=5000 scripts/mongo_gateway_compare.sh \
   --updates 5000 \
   --concurrent-reader-sweep "1,2,4,8,16" \
   --concurrent-reads 50000 \
+  --concurrent-range-reader-sweep "1,2,4,8,16" \
+  --concurrent-range-reads 5000 \
   --concurrent-writers 8 \
   --concurrent-writes 10000 \
   --timeout 120m
@@ -357,6 +364,12 @@ The initial workload phases are:
 - `age_range_scan_limit_10` / `age_range_indexed_limit_10`: bounded range query
   with `limit: 10`; operations count range queries, not returned documents. The
   indexed variant is emitted when `-range-index` creates `age_1`.
+- `concurrent_age_range_scan_limit_10_rN` /
+  `concurrent_age_range_indexed_limit_10_rN`: total age range queries split
+  across `N` goroutines. Use `-concurrent-range-reader-sweep 1,2,4,8,16` with
+  `-concurrent-range-reads` to emit multiple range-reader fanout phases from one
+  loaded database. The legacy `-concurrent-range-readers N` flag emits one
+  fanout phase and cannot be combined with `-concurrent-range-reader-sweep`.
 - `id_update_set`: `$set` update by `_id`.
 - `concurrent_id_find_one_rN`: total `_id` point reads split across `N`
   goroutines. Use `-concurrent-reader-sweep 1,2,4,8,16` with
@@ -617,6 +630,13 @@ adds `active_1`. The age range phase is a bounded scan unless `-range-index` is
 set; benchmark output names the phase `age_range_scan_limit_10` or
 `age_range_indexed_limit_10` so reports can separate fallback cost from indexed
 range-search cost.
+
+For TreeDB targets, `-treedb-read-state settled` (the default) calls
+`CollectionManager.FlushAll` after load and before read phases, so reads measure
+settled collection roots rather than mutable write-domain state. Use
+`-treedb-read-state unsettled` to leave post-load memtables/write-domain state in
+place for read phases when you want to compare settled and unsettled visibility
+costs.
 
 For TreeDB, prefer `treedb_disk_after_maintenance.total_bytes` when present, and
 use `treedb_disk_after_checkpoint.total_bytes` for checkpoint-only runs. The

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -63,8 +63,8 @@ cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
 read/update phases on the driver. `-client-mode direct` is a TreeDB-only path
 that calls `collections.Collection` directly for the same phase names, using the
-selected `-treedb-document-format` (`json`, `template-v1`, or `bson`) while
-bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
+selected `-treedb-document-format` (`json`, `template-v1`/`collections-v1`, or
+`bson`) while bypassing the MongoDB Go driver, loopback sockets, and Mongo gateway
 command/response handling. Use direct mode to answer whether a slow Mongo API
 phase is already slow in the collection engine and selected storage format; use
 raw-wire mode to estimate the gateway/server ceiling without the driver's
@@ -116,7 +116,7 @@ vacuum. The final vacuum closes the benchmark gateway before rewriting
 `-treedb-maintenance checkpoint` to reproduce the older checkpoint-only disk
 metric, or `none` to skip final TreeDB disk reporting.
 
-`-treedb-document-format` accepts `json`, `template-v1`, and `bson`. BSON mode
+`-treedb-document-format` accepts `json`, `template-v1`/`collections-v1`, and `bson`. BSON mode
 stores Mongo wire documents as native BSON collection records, avoiding the
 canonical Extended JSON bridge used by the JSON/template-v1 gateway paths.
 Use `-treedb-buffered-indexed-write-max-documents`,

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -61,15 +61,20 @@ sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
 cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase while keeping setup and later
-read/update phases on the driver. Use raw-wire mode to estimate the
-gateway/server ceiling without the driver's per-document marshal and `_id`
-discovery overhead; use driver mode for user-visible Mongo compatibility
-throughput.
+read/update phases on the driver. `-client-mode direct` is a BSON-only,
+TreeDB-only path that calls `collections.Collection` directly for the same
+phase names, bypassing the MongoDB Go driver, loopback sockets, and Mongo
+gateway command/response handling. Use direct mode to answer whether a slow
+Mongo API phase is already slow in the collection engine; use raw-wire mode to
+estimate the gateway/server ceiling without the driver's per-document marshal
+and `_id` discovery overhead; use driver mode for user-visible Mongo
+compatibility throughput.
 
 When `-prebuild-documents` is enabled, the harness builds both structured BSON
 documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
-does not include fixture BSON marshaling.
+does not include fixture BSON marshaling. Direct mode also reuses prebuilt raw
+BSON documents for direct collection inserts.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert
@@ -191,7 +196,7 @@ beside the normal MongoDB Go driver `InsertMany` path:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
 scripts/mongo_gateway_compare.sh
 ```
 
@@ -263,7 +268,7 @@ Useful overrides:
 
 - `DOCS_LIST="1000 10000 100000"`
 - `INDEXES_LIST="0 1 2"`
-- `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire"`
+- `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire"`
 - `MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
@@ -340,10 +345,10 @@ The initial workload phases are:
   on `client_mode`: `InsertMany` for `driver`, `RunCommand({insert,
   documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
   command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
-  visibility wait for `driver-unack`, and raw OP_MSG document sequences for
-  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
-  phase reports aggregate wall-clock throughput and per-producer call latency in
-  `producer_results`.
+  visibility wait for `driver-unack`, direct BSON `Collection.InsertBatch` for
+  `direct`, and raw OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`.
+  When `-insert-producers` is greater than 1, this phase reports aggregate
+  wall-clock throughput and per-producer call latency in `producer_results`.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field; emitted only when the
   email secondary index is part of the cell.

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2040,6 +2040,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 }
 
 func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, updatedCityValues []string) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			if err := ctx.Err(); err != nil {
@@ -2047,7 +2052,7 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 			}
 			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
 			key, id := keys.at(documentOrdinal)
-			if err := runDirectTreeDBUpdateOperation(collection, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+			if err := runDirectTreeDBUpdateOperation(collection, materializer, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
 				return err
 			}
 		}
@@ -2087,16 +2092,84 @@ func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, colle
 
 func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, phaseName string, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
-		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
-			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
-			key, id := keys.at(documentOrdinal)
-			return runDirectTreeDBUpdateOperation(collection, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample)
-		})
+		return runDirectTreeDBConcurrentUpdateOperations(ctx, cfg, collection, keys, updatedCityValues, sample)
 	})
+}
+
+func runDirectTreeDBConcurrentUpdateOperations(
+	ctx context.Context,
+	cfg config,
+	collection *collections.Collection,
+	keys directBenchmarkKeySet,
+	updatedCityValues []string,
+	sample func(time.Duration),
+) error {
+	workers := cfg.ConcurrentWriters
+	operations := cfg.ConcurrentWrites
+	if workers <= 0 || operations <= 0 {
+		return nil
+	}
+	if workers > operations {
+		workers = operations
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	var errOnce sync.Once
+	var firstErr error
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			materializer, err := directNewStoredDocumentMaterializer(collection)
+			if err != nil {
+				recordErr(err)
+				return
+			}
+			defer func() {
+				if err := materializer.Close(); err != nil {
+					recordErr(err)
+				}
+			}()
+			for {
+				if err := runCtx.Err(); err != nil {
+					return
+				}
+				op := int(next.Add(1) - 1)
+				if op >= operations {
+					return
+				}
+				documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
+				key, id := keys.at(documentOrdinal)
+				if err := runDirectTreeDBUpdateOperation(collection, materializer, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample); err != nil {
+					recordErr(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
 }
 
 func runDirectTreeDBUpdateOperation(
 	collection *collections.Collection,
+	materializer *collections.StoredDocumentJSONMaterializer,
 	cfg config,
 	key []byte,
 	id string,
@@ -2117,11 +2190,6 @@ func runDirectTreeDBUpdateOperation(
 	if err != nil {
 		return err
 	}
-	materializer, err := directNewStoredDocumentMaterializer(collection)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = materializer.Close() }()
 	begin := time.Now()
 	matched, _, err := collection.Update(key, func(stored []byte) ([]byte, bool, error) {
 		current, err := directStoredDocumentToBSON(collection, materializer, stored)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -470,7 +470,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
 	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
-	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1, or bson")
+	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1/collections-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexStateRootStorage, "treedb-index-state-root-storage", treeDBIndexStateRootStorage, "TreeDB collection index-state root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
@@ -652,7 +652,7 @@ func parseTreeDBProfile(raw string) (treedb.Profile, error) {
 
 func parseTreeDBDocumentFormat(raw string) (collections.DocumentFormat, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", string(collections.DocumentFormatTemplateV1):
+	case "", string(collections.DocumentFormatTemplateV1), "collections-v1":
 		return collections.DocumentFormatTemplateV1, nil
 	case string(collections.DocumentFormatJSON):
 		return collections.DocumentFormatJSON, nil

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -56,6 +56,9 @@ type config struct {
 	MongoMaxConnecting                            int
 	Reads                                         int
 	RangeReads                                    int
+	ConcurrentRangeReaders                        int
+	ConcurrentRangeReaderSweep                    []int
+	ConcurrentRangeReads                          int
 	Updates                                       int
 	Deletes                                       int
 	ConcurrentReaders                             int
@@ -78,6 +81,7 @@ type config struct {
 	TreeDBBufferedIndexedAsyncFlush               bool
 	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int
 	TreeDBMaintenance                             string
+	TreeDBReadState                               string
 	PrebuildDocuments                             bool
 	ProfileDir                                    string
 	ProfileBlockRate                              int
@@ -89,24 +93,27 @@ type config struct {
 }
 
 type benchmarkResult struct {
-	Target                string `json:"target"`
-	MongoURI              string `json:"mongo_uri,omitempty"`
-	TreeDBDir             string `json:"treedb_dir,omitempty"`
-	Database              string `json:"database"`
-	Collection            string `json:"collection"`
-	Documents             int    `json:"documents"`
-	BatchSize             int    `json:"batch_size"`
-	InsertProducers       int    `json:"insert_producers"`
-	MongoMaxPoolSize      int    `json:"mongo_max_pool_size,omitempty"`
-	MongoMinPoolSize      int    `json:"mongo_min_pool_size,omitempty"`
-	MongoMaxConnecting    int    `json:"mongo_max_connecting,omitempty"`
-	SecondaryIndexes      int    `json:"secondary_indexes"`
-	ClientMode            string `json:"client_mode"`
-	ConcurrentReaders     int    `json:"concurrent_readers,omitempty"`
-	ConcurrentReaderSweep []int  `json:"concurrent_reader_sweep,omitempty"`
-	ConcurrentReads       int    `json:"concurrent_reads,omitempty"`
-	ConcurrentWriters     int    `json:"concurrent_writers,omitempty"`
-	ConcurrentWrites      int    `json:"concurrent_writes,omitempty"`
+	Target                     string `json:"target"`
+	MongoURI                   string `json:"mongo_uri,omitempty"`
+	TreeDBDir                  string `json:"treedb_dir,omitempty"`
+	Database                   string `json:"database"`
+	Collection                 string `json:"collection"`
+	Documents                  int    `json:"documents"`
+	BatchSize                  int    `json:"batch_size"`
+	InsertProducers            int    `json:"insert_producers"`
+	MongoMaxPoolSize           int    `json:"mongo_max_pool_size,omitempty"`
+	MongoMinPoolSize           int    `json:"mongo_min_pool_size,omitempty"`
+	MongoMaxConnecting         int    `json:"mongo_max_connecting,omitempty"`
+	SecondaryIndexes           int    `json:"secondary_indexes"`
+	ClientMode                 string `json:"client_mode"`
+	ConcurrentReaders          int    `json:"concurrent_readers,omitempty"`
+	ConcurrentReaderSweep      []int  `json:"concurrent_reader_sweep,omitempty"`
+	ConcurrentReads            int    `json:"concurrent_reads,omitempty"`
+	ConcurrentRangeReaders     int    `json:"concurrent_range_readers,omitempty"`
+	ConcurrentRangeReaderSweep []int  `json:"concurrent_range_reader_sweep,omitempty"`
+	ConcurrentRangeReads       int    `json:"concurrent_range_reads,omitempty"`
+	ConcurrentWriters          int    `json:"concurrent_writers,omitempty"`
+	ConcurrentWrites           int    `json:"concurrent_writes,omitempty"`
 
 	// Always emit this knob in JSON so benchmark artifacts distinguish default
 	// false runs from older runs that predate indexed-field update coverage.
@@ -124,6 +131,7 @@ type benchmarkResult struct {
 	TreeDBBufferedIndexedAsyncFlush               bool                `json:"treedb_buffered_indexed_async_flush,omitempty"`
 	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int                 `json:"treedb_buffered_indexed_async_flush_max_queued_units,omitempty"`
 	TreeDBMaintenanceMode                         string              `json:"treedb_maintenance_mode,omitempty"`
+	TreeDBReadState                               string              `json:"treedb_read_state,omitempty"`
 	PrebuildDocuments                             bool                `json:"prebuild_documents,omitempty"`
 	Phases                                        []phaseResult       `json:"phases"`
 	TreeDBDiskAfterLoad                           *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
@@ -346,6 +354,9 @@ const (
 	treeDBMaintenanceCheckpoint = "checkpoint"
 	treeDBMaintenanceFull       = "full"
 
+	treeDBReadStateSettled   = "settled"
+	treeDBReadStateUnsettled = "unsettled"
+
 	clientModeDriver           = "driver"
 	clientModeDriverCommand    = "driver-command"
 	clientModeDriverCommandRaw = "driver-command-raw"
@@ -427,6 +438,7 @@ func parseConfig(args []string) (config, error) {
 		TreeDBIndexStateRootStorage: collections.RootStorageCompressed,
 		TreeDBIndexRootStorage:      collections.RootStorageCompressed,
 		TreeDBMaintenance:           treeDBMaintenanceFull,
+		TreeDBReadState:             treeDBReadStateSettled,
 		ClientMode:                  clientModeDriver,
 		InsertProducers:             1,
 		ProfileBlockRate:            1,
@@ -457,6 +469,10 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.MongoMaxConnecting, "mongo-max-connecting", 0, "MongoDB Go driver maxConnecting; 0 leaves the driver default")
 	fs.IntVar(&cfg.Reads, "reads", 1000, "point reads by _id and by email")
 	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
+	var concurrentRangeReaderSweep string
+	fs.IntVar(&cfg.ConcurrentRangeReaders, "concurrent-range-readers", 0, "reader goroutines for the concurrent age range-read phase; 0 disables the phase")
+	fs.StringVar(&concurrentRangeReaderSweep, "concurrent-range-reader-sweep", "", "comma- or space-separated reader counts for a concurrent age range-read throughput sweep; requires -concurrent-range-reads and cannot be combined with -concurrent-range-readers")
+	fs.IntVar(&cfg.ConcurrentRangeReads, "concurrent-range-reads", 0, "total age range-read operations for the concurrent range-read phase")
 	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
 	fs.IntVar(&cfg.Deletes, "deletes", 0, "deleteOne operations by _id")
 	var concurrentReaderSweep string
@@ -480,6 +496,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.TreeDBBufferedIndexedAsyncFlush, "treedb-buffered-indexed-async-flush", false, "TreeDB indexed collection threshold flushes publish in the background; explicit Flush/Close still drain before returning")
 	fs.IntVar(&cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, "treedb-buffered-indexed-async-flush-max-queued-units", 0, "TreeDB indexed collection background flush unit queue limit; 0 uses the collection default when async flush is enabled")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
+	fs.StringVar(&cfg.TreeDBReadState, "treedb-read-state", cfg.TreeDBReadState, "TreeDB state before read phases: settled forces collection FlushAll after load; unsettled leaves post-load memtables/write-domain state visible")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
 	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
 	fs.IntVar(&cfg.ProfileBlockRate, "profile-block-rate", cfg.ProfileBlockRate, "runtime block profile rate when -profile-dir is set; 0 disables block profiling")
@@ -539,16 +556,31 @@ func parseConfig(args []string) (config, error) {
 	if cfg.MongoMinPoolSize > mongoMaxPoolSize {
 		return config{}, fmt.Errorf("mongo-min-pool-size cannot exceed mongo-max-pool-size (%d when unset)", defaultMongoDriverMaxPoolSize)
 	}
-	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
+	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentRangeReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
 	}
+	concurrentRangeReaderSweepValues, err := parsePositiveIntList(concurrentRangeReaderSweep, "concurrent-range-reader-sweep")
+	if err != nil {
+		return config{}, err
+	}
+	cfg.ConcurrentRangeReaderSweep = concurrentRangeReaderSweepValues
 	concurrentReaderSweepValues, err := parsePositiveIntList(concurrentReaderSweep, "concurrent-reader-sweep")
 	if err != nil {
 		return config{}, err
 	}
 	cfg.ConcurrentReaderSweep = concurrentReaderSweepValues
-	if cfg.ConcurrentReaders < 0 || cfg.ConcurrentWriters < 0 {
+	if cfg.ConcurrentReaders < 0 || cfg.ConcurrentRangeReaders < 0 || cfg.ConcurrentWriters < 0 {
 		return config{}, errors.New("concurrency values cannot be negative")
+	}
+	if len(cfg.ConcurrentRangeReaderSweep) > 0 {
+		if cfg.ConcurrentRangeReaders != 0 {
+			return config{}, errors.New("concurrent-range-reader-sweep cannot be combined with concurrent-range-readers")
+		}
+		if cfg.ConcurrentRangeReads == 0 {
+			return config{}, errors.New("concurrent-range-reader-sweep requires concurrent-range-reads > 0")
+		}
+	} else if (cfg.ConcurrentRangeReaders == 0) != (cfg.ConcurrentRangeReads == 0) {
+		return config{}, errors.New("concurrent-range-readers and concurrent-range-reads must both be > 0 or both be 0")
 	}
 	if len(cfg.ConcurrentReaderSweep) > 0 {
 		if cfg.ConcurrentReaders != 0 {
@@ -578,6 +610,11 @@ func parseConfig(args []string) (config, error) {
 	if cfg.ProfileHeapGC && strings.TrimSpace(cfg.ProfileDir) == "" {
 		return config{}, errors.New("profile-heap-gc requires -profile-dir")
 	}
+	readState, err := parseTreeDBReadState(cfg.TreeDBReadState)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.TreeDBReadState = readState
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 3 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, 2, or 3")
 	}
@@ -689,6 +726,17 @@ func parseTreeDBMaintenance(raw string) (string, error) {
 	}
 }
 
+func parseTreeDBReadState(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", treeDBReadStateSettled, "flushed":
+		return treeDBReadStateSettled, nil
+	case treeDBReadStateUnsettled:
+		return treeDBReadStateUnsettled, nil
+	default:
+		return "", fmt.Errorf("unknown treedb-read-state %q", raw)
+	}
+}
+
 func parseClientMode(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "", clientModeDriver:
@@ -746,6 +794,16 @@ func concurrentReaderCounts(cfg config) []int {
 	}
 	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
 		return []int{cfg.ConcurrentReaders}
+	}
+	return nil
+}
+
+func concurrentRangeReaderCounts(cfg config) []int {
+	if len(cfg.ConcurrentRangeReaderSweep) > 0 {
+		return cfg.ConcurrentRangeReaderSweep
+	}
+	if cfg.ConcurrentRangeReaders > 0 && cfg.ConcurrentRangeReads > 0 {
+		return []int{cfg.ConcurrentRangeReaders}
 	}
 	return nil
 }
@@ -1143,25 +1201,28 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
-		Target:                cfg.Target,
-		Database:              cfg.Database,
-		Collection:            cfg.Collection,
-		Documents:             cfg.Documents,
-		BatchSize:             cfg.BatchSize,
-		InsertProducers:       cfg.InsertProducers,
-		MongoMaxPoolSize:      cfg.MongoMaxPoolSize,
-		MongoMinPoolSize:      cfg.MongoMinPoolSize,
-		MongoMaxConnecting:    cfg.MongoMaxConnecting,
-		SecondaryIndexes:      cfg.SecondaryIndexes,
-		ClientMode:            cfg.ClientMode,
-		ConcurrentReaders:     cfg.ConcurrentReaders,
-		ConcurrentReaderSweep: append([]int(nil), cfg.ConcurrentReaderSweep...),
-		ConcurrentReads:       cfg.ConcurrentReads,
-		ConcurrentWriters:     cfg.ConcurrentWriters,
-		ConcurrentWrites:      cfg.ConcurrentWrites,
-		UpdateIndexedField:    cfg.UpdateIndexedField,
-		RangeIndex:            cfg.RangeIndex,
-		PrebuildDocuments:     cfg.PrebuildDocuments,
+		Target:                     cfg.Target,
+		Database:                   cfg.Database,
+		Collection:                 cfg.Collection,
+		Documents:                  cfg.Documents,
+		BatchSize:                  cfg.BatchSize,
+		InsertProducers:            cfg.InsertProducers,
+		MongoMaxPoolSize:           cfg.MongoMaxPoolSize,
+		MongoMinPoolSize:           cfg.MongoMinPoolSize,
+		MongoMaxConnecting:         cfg.MongoMaxConnecting,
+		SecondaryIndexes:           cfg.SecondaryIndexes,
+		ClientMode:                 cfg.ClientMode,
+		ConcurrentReaders:          cfg.ConcurrentReaders,
+		ConcurrentReaderSweep:      append([]int(nil), cfg.ConcurrentReaderSweep...),
+		ConcurrentReads:            cfg.ConcurrentReads,
+		ConcurrentRangeReaders:     cfg.ConcurrentRangeReaders,
+		ConcurrentRangeReaderSweep: append([]int(nil), cfg.ConcurrentRangeReaderSweep...),
+		ConcurrentRangeReads:       cfg.ConcurrentRangeReads,
+		ConcurrentWriters:          cfg.ConcurrentWriters,
+		ConcurrentWrites:           cfg.ConcurrentWrites,
+		UpdateIndexedField:         cfg.UpdateIndexedField,
+		RangeIndex:                 cfg.RangeIndex,
+		PrebuildDocuments:          cfg.PrebuildDocuments,
 	}
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
@@ -1178,6 +1239,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBBufferedIndexedAsyncFlush = cfg.TreeDBBufferedIndexedAsyncFlush
 		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits
 		result.TreeDBMaintenanceMode = cfg.TreeDBMaintenance
+		result.TreeDBReadState = cfg.TreeDBReadState
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
 	}
@@ -1273,36 +1335,19 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.Phases = append(result.Phases, emailPhase)
 	}
 
-	rangePhase, err := measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
-		for i := 0; i < cfg.RangeReads; i++ {
-			minAge := int64(20 + (i % 40))
-			begin := time.Now()
-			cursor, err := coll.Find(ctx,
-				bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
-				options.Find().SetLimit(10))
-			if err != nil {
-				sample(time.Since(begin))
-				return err
-			}
-			var docs []bson.M
-			if err := cursor.All(ctx, &docs); err != nil {
-				sample(time.Since(begin))
-				return err
-			}
-			sample(time.Since(begin))
-			for _, doc := range docs {
-				age, ok := int64Value(doc["age"])
-				if !ok || age < minAge {
-					return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
-				}
-			}
-		}
-		return nil
-	})
+	rangePhase, err := runRangePhase(ctx, cfg, target, profiler, coll)
 	if err != nil {
 		return nil, err
 	}
 	result.Phases = append(result.Phases, rangePhase)
+
+	for _, concurrentReaders := range concurrentRangeReaderCounts(cfg) {
+		concurrentRangePhase, err := runConcurrentRangePhase(ctx, cfg, target, profiler, coll, concurrentReaders)
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentRangePhase)
+	}
 
 	var updateCityValues []string
 	if cfg.Updates > 0 {
@@ -1446,6 +1491,9 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 		ConcurrentReaders:                      cfg.ConcurrentReaders,
 		ConcurrentReaderSweep:                  append([]int(nil), cfg.ConcurrentReaderSweep...),
 		ConcurrentReads:                        cfg.ConcurrentReads,
+		ConcurrentRangeReaders:                 cfg.ConcurrentRangeReaders,
+		ConcurrentRangeReaderSweep:             append([]int(nil), cfg.ConcurrentRangeReaderSweep...),
+		ConcurrentRangeReads:                   cfg.ConcurrentRangeReads,
 		ConcurrentWriters:                      cfg.ConcurrentWriters,
 		ConcurrentWrites:                       cfg.ConcurrentWrites,
 		UpdateIndexedField:                     cfg.UpdateIndexedField,
@@ -1462,6 +1510,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 		TreeDBBufferedIndexedAsyncFlush:        cfg.TreeDBBufferedIndexedAsyncFlush,
 		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
 		TreeDBMaintenanceMode:                         cfg.TreeDBMaintenance,
+		TreeDBReadState:                               cfg.TreeDBReadState,
 	}
 	if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
 		result.TreeDBDir = target.treedbDir
@@ -1540,6 +1589,17 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 		return nil, err
 	}
 	result.Phases = append(result.Phases, rangePhase)
+
+	for _, concurrentReaders := range concurrentRangeReaderCounts(cfg) {
+		phaseName := concurrentRangePhaseName(cfg, concurrentReaders)
+		concurrentRangePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
+			return runDirectTreeDBConcurrentRangePhase(ctx, cfg, collection, concurrentReaders, phaseName)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentRangePhase)
+	}
 
 	updatePhase, err := runTreeDBProfiledPhase(target, profiler, "id_update_set", func() (phaseResult, error) {
 		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, directKeys, updatedCityValuesForUpdate())
@@ -1993,6 +2053,36 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 	})
 }
 
+func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	materializers := make([]*collections.StoredDocumentJSONMaterializer, readers)
+	for i := range materializers {
+		materializer, err := directNewStoredDocumentMaterializer(collection)
+		if err != nil {
+			for _, existing := range materializers {
+				if existing != nil {
+					_ = existing.Close()
+				}
+			}
+			return phaseResult{}, err
+		}
+		materializers[i] = materializer
+	}
+	defer func() {
+		for _, materializer := range materializers {
+			_ = materializer.Close()
+		}
+	}()
+	return measurePhase(phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+		return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
+			minAge := rangeReadMinAge(op)
+			begin := time.Now()
+			err := runDirectTreeDBRangeQuery(cfg, collection, materializers[worker], minAge)
+			sample(time.Since(begin))
+			return err
+		})
+	})
+}
+
 func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
 		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
@@ -2417,6 +2507,14 @@ func rangePhaseName(cfg config) string {
 	return "age_range_scan_limit_10"
 }
 
+func concurrentRangePhaseName(cfg config, readers int) string {
+	return fmt.Sprintf("concurrent_%s_r%d", rangePhaseName(cfg), readers)
+}
+
+func rangeReadMinAge(op int) int64 {
+	return int64(20 + (op % 40))
+}
+
 func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collection, secondaryIndexes int, rangeIndex bool, treedbTarget bool) error {
 	if treedbTarget {
 		indexDocs := treedbCreateIndexDocs(secondaryIndexes, rangeIndex)
@@ -2703,6 +2801,325 @@ func loadVisibilitySentinelIDs(documents, batchSize int) []string {
 	return ids
 }
 
+func runRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWire {
+		return runTreeDBRawWireRangePhase(ctx, cfg, target, profiler)
+	}
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCP {
+		return runTreeDBRawWireTCPRangePhase(ctx, cfg, target, profiler)
+	}
+	if cfg.ClientMode == clientModeDriverCommandRaw {
+		return runDriverCommandRawRangePhase(ctx, cfg, target, profiler)
+	}
+	return runDriverDecodedRangePhase(ctx, cfg, target, profiler, coll)
+}
+
+func runDriverDecodedRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(i), sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDriverDecodedRangeOperation(ctx context.Context, coll *mongo.Collection, minAge int64, sample func(time.Duration)) error {
+	begin := time.Now()
+	cursor, err := coll.Find(ctx,
+		bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
+		options.Find().SetLimit(10))
+	if err != nil {
+		sample(time.Since(begin))
+		return err
+	}
+	var docs []bson.M
+	if err := cursor.All(ctx, &docs); err != nil {
+		sample(time.Since(begin))
+		return err
+	}
+	sample(time.Since(begin))
+	for _, doc := range docs {
+		age, ok := int64Value(doc["age"])
+		if !ok || age < minAge {
+			return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
+		}
+	}
+	return nil
+}
+
+func runDriverCommandRawRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
+	if target == nil || target.client == nil {
+		return phaseResult{}, errors.New("driver-command-raw range phase requires a Mongo driver client")
+	}
+	db := target.client.Database(cfg.Database)
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(i), sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDriverCommandRawRangeOperation(ctx context.Context, cfg config, db *mongo.Database, minAge int64, sample func(time.Duration)) error {
+	commandDoc, err := rawDriverFindAgeRangeCommand(cfg.Collection, minAge)
+	if err != nil {
+		return err
+	}
+	begin := time.Now()
+	raw, err := db.RunCommand(ctx, commandDoc).Raw()
+	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	batch, err := parseFindFirstBatch(raw)
+	if err != nil {
+		return err
+	}
+	return validateRawAgeBatch(batch, minAge)
+}
+
+func runTreeDBRawWireRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
+	if target == nil || target.server == nil {
+		return phaseResult{}, errors.New("raw-wire client mode requires an in-process TreeDB gateway server")
+	}
+	var requestID atomic.Int32
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, 1, rangeReadMinAge(i), sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *benchTarget, requestID *atomic.Int32, cursorOwner int64, minAge int64, sample func(time.Duration)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	commandDoc, err := rawWireFindAgeRangeCommand(cfg.Database, cfg.Collection, minAge)
+	if err != nil {
+		return err
+	}
+	begin := time.Now()
+	batch, err := serveRawWireFind(target.server, requestID.Add(1), cursorOwner, commandDoc)
+	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	return validateRawAgeBatch(batch, minAge)
+}
+
+func runTreeDBRawWireTCPRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
+	if target == nil || target.mongoAddr == "" {
+		return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
+	}
+	client, err := fastclient.Connect(ctx, target.mongoAddr)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = client.Close() }()
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := runTreeDBRawWireTCPRangeOperation(ctx, cfg, client, rangeReadMinAge(i), sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *fastclient.Client, minAge int64, sample func(time.Duration)) error {
+	commandDoc, err := rawWireFindAgeRangeCommand(cfg.Database, cfg.Collection, minAge)
+	if err != nil {
+		return err
+	}
+	begin := time.Now()
+	batch, err := client.FindRawBSON(ctx, commandDoc)
+	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	return validateRawAgeBatch(batch, minAge)
+}
+
+func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection, readers int) (phaseResult, error) {
+	phaseName := concurrentRangePhaseName(cfg, readers)
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWire {
+		if target == nil || target.server == nil {
+			return phaseResult{}, errors.New("raw-wire client mode requires an in-process TreeDB gateway server")
+		}
+		var requestID atomic.Int32
+		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
+				return runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, int64(worker+1), rangeReadMinAge(op), sample)
+			})
+		})
+	}
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCP {
+		if target == nil || target.mongoAddr == "" {
+			return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
+		}
+		clients := make([]*fastclient.Client, readers)
+		for i := range clients {
+			client, err := fastclient.Connect(ctx, target.mongoAddr)
+			if err != nil {
+				for _, existing := range clients {
+					if existing != nil {
+						_ = existing.Close()
+					}
+				}
+				return phaseResult{}, err
+			}
+			clients[i] = client
+		}
+		defer func() {
+			for _, client := range clients {
+				_ = client.Close()
+			}
+		}()
+		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
+				return runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op), sample)
+			})
+		})
+	}
+	if cfg.ClientMode == clientModeDriverCommandRaw {
+		db := target.client.Database(cfg.Database)
+		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+			return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
+				return runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(op), sample)
+			})
+		})
+	}
+	return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
+			return runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(op), sample)
+		})
+	})
+}
+
+func rawDriverFindAgeRangeCommand(collection string, minAge int64) (bson.Raw, error) {
+	return rawFindAgeRangeCommand("", collection, minAge)
+}
+
+func rawWireFindAgeRangeCommand(database, collection string, minAge int64) (wire.Document, error) {
+	raw, err := rawFindAgeRangeCommand(database, collection, minAge)
+	return wire.Document(raw), err
+}
+
+func rawFindAgeRangeCommand(database, collection string, minAge int64) (bson.Raw, error) {
+	agePredicate := bsoncore.BuildDocument(nil, bsoncore.AppendInt64Element(nil, "$gte", minAge))
+	filter := bsoncore.BuildDocument(nil, bsoncore.AppendDocumentElement(nil, "age", agePredicate))
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendStringElement(doc, "find", collection)
+	doc = bsoncore.AppendDocumentElement(doc, "filter", filter)
+	doc = bsoncore.AppendInt32Element(doc, "limit", 10)
+	if database != "" {
+		doc = bsoncore.AppendStringElement(doc, "$db", database)
+	}
+	doc, err := bsoncore.AppendDocumentEnd(doc, idx)
+	if err != nil {
+		return nil, err
+	}
+	return bson.Raw(doc), nil
+}
+
+func serveRawWireFind(server *mongogateway.Server, requestID int32, cursorOwner int64, commandDoc wire.Document) ([]bson.Raw, error) {
+	msg, err := wire.AppendMsgMessage(nil, requestID, 0, 0, commandDoc)
+	if err != nil {
+		return nil, err
+	}
+	rw := inMemoryReadWriter{r: bytes.NewReader(msg)}
+	if err := server.ServeOneWithOwner(&rw, cursorOwner); err != nil {
+		return nil, err
+	}
+	return parseRawWireFindFirstBatch(rw.w.Bytes())
+}
+
+func parseRawWireFindFirstBatch(response []byte) ([]bson.Raw, error) {
+	header, body, err := wire.ReadMessage(bytes.NewReader(response), 0)
+	if err != nil {
+		return nil, err
+	}
+	if header.OpCode != wire.OpMsg {
+		return nil, fmt.Errorf("raw-wire find response opcode=%d want %d", header.OpCode, wire.OpMsg)
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		return nil, err
+	}
+	return parseFindFirstBatch(bson.Raw(msg.Body))
+}
+
+func parseFindFirstBatch(raw bson.Raw) ([]bson.Raw, error) {
+	if !rawCommandOK(raw) {
+		return nil, fmt.Errorf("find failed: %s", rawCommandErrorMessage(raw))
+	}
+	cursor, ok := raw.Lookup("cursor").DocumentOK()
+	if !ok {
+		return nil, errors.New("find response missing cursor")
+	}
+	batch, ok := cursor.Lookup("firstBatch").ArrayOK()
+	if !ok {
+		return nil, errors.New("find response missing cursor.firstBatch")
+	}
+	values, err := batch.Values()
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]bson.Raw, 0, len(values))
+	for _, value := range values {
+		doc, ok := value.DocumentOK()
+		if !ok {
+			return nil, errors.New("find firstBatch entry is not a document")
+		}
+		docs = append(docs, bson.Raw(doc))
+	}
+	return docs, nil
+}
+
+func rawCommandOK(raw bson.Raw) bool {
+	v := raw.Lookup("ok")
+	if ok, okType := v.DoubleOK(); okType {
+		return ok == 1.0
+	}
+	if ok, okType := v.Int32OK(); okType {
+		return ok == 1
+	}
+	if ok, okType := v.Int64OK(); okType {
+		return ok == 1
+	}
+	if ok, okType := v.BooleanOK(); okType {
+		return ok
+	}
+	return false
+}
+
+func rawCommandErrorMessage(raw bson.Raw) string {
+	if msg, ok := raw.Lookup("errmsg").StringValueOK(); ok && msg != "" {
+		return msg
+	}
+	if len(raw) == 0 {
+		return "missing ok field"
+	}
+	return string(raw)
+}
+
+func validateRawAgeBatch(batch []bson.Raw, minAge int64) error {
+	for _, doc := range batch {
+		age, ok := directBSONInt64Field(doc, "age")
+		if !ok || age < minAge {
+			return fmt.Errorf("raw range returned age=%v ok=%t below %d", age, ok, minAge)
+		}
+	}
+	return nil
+}
+
 func runTreeDBRawWireLoadPhase(ctx context.Context, cfg config, target *benchTarget, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
 	if target == nil || target.server == nil {
 		return phaseResult{}, errors.New("raw-wire client mode requires an in-process TreeDB gateway server")
@@ -2898,7 +3315,7 @@ func assertRawWireInsertMessageOK(header wire.Header, body []byte, wantN int) er
 
 func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget, result *benchmarkResult) error {
 	if cfg.Target == "treedb" {
-		if target.collections != nil {
+		if target.collections != nil && cfg.TreeDBReadState == treeDBReadStateSettled {
 			if err := target.collections.FlushAll(); err != nil {
 				return err
 			}
@@ -3793,6 +4210,12 @@ func measurePhase(name string, operations int, run func(sample func(time.Duratio
 }
 
 func runConcurrentOperations(ctx context.Context, workers, operations int, run func(op int) error) error {
+	return runConcurrentOperationsByWorker(ctx, workers, operations, func(_ int, op int) error {
+		return run(op)
+	})
+}
+
+func runConcurrentOperationsByWorker(ctx context.Context, workers, operations int, run func(worker, op int) error) error {
 	if workers <= 0 || operations <= 0 {
 		return nil
 	}
@@ -3818,7 +4241,7 @@ func runConcurrentOperations(ctx context.Context, workers, operations int, run f
 
 	for worker := 0; worker < workers; worker++ {
 		wg.Add(1)
-		go func() {
+		go func(worker int) {
 			defer wg.Done()
 			for {
 				if err := runCtx.Err(); err != nil {
@@ -3828,12 +4251,12 @@ func runConcurrentOperations(ctx context.Context, workers, operations int, run f
 				if op >= operations {
 					return
 				}
-				if err := run(op); err != nil {
+				if err := run(worker, op); err != nil {
 					recordErr(err)
 					return
 				}
 			}
-		}()
+		}(worker)
 	}
 	wg.Wait()
 	if firstErr != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2113,6 +2113,9 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 		}
 		return nil
 	}
+	if cfg.TreeDBReadState == treeDBReadStateUnsettled {
+		return errors.New("direct range scan uses ScanDocumentsFunc, which flushes unsettled buffered writes before scanning")
+	}
 	matches := 0
 	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {
 		raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -828,7 +828,9 @@ func openTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 }
 
 func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	dir := cfg.TreeDBDir
 	removeDir := false
 	if dir == "" {
@@ -850,6 +852,12 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 	open := treedb.OpenBackend
 	if opts.IndexOuterLeavesInValueLog {
 		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	if err := ctx.Err(); err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
 	}
 	db, backendCleanup, err := open(opts)
 	if err != nil {
@@ -2079,7 +2087,7 @@ func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collec
 	}()
 	return measurePhase(phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
-			minAge := rangeReadMinAge(op)
+			minAge := rangeReadMinAge(op, cfg.Documents)
 			begin := time.Now()
 			err := runDirectTreeDBRangeQuery(cfg, collection, materializers[worker], minAge)
 			sample(time.Since(begin))
@@ -2529,8 +2537,24 @@ func concurrentRangePhaseName(cfg config, readers int) string {
 	return fmt.Sprintf("concurrent_%s_r%d", rangePhaseName(cfg), readers)
 }
 
-func rangeReadMinAge(op int) int64 {
-	return int64(20 + (op % 40))
+func rangeReadMinAge(op int, documentCount int) int64 {
+	if documentCount <= 0 {
+		return 20
+	}
+	ageSpan := documentCount
+	if ageSpan > 67 {
+		ageSpan = 67
+	}
+	maxAge := int64(18 + ageSpan - 1)
+	base := int64(20)
+	if maxAge < base {
+		return maxAge
+	}
+	span := maxAge - base + 1
+	if span > 40 {
+		span = 40
+	}
+	return base + int64(op%int(span))
 }
 
 func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collection, secondaryIndexes int, rangeIndex bool, treedbTarget bool) error {
@@ -2835,7 +2859,7 @@ func runRangePhase(ctx context.Context, cfg config, target *benchTarget, profile
 func runDriverDecodedRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(i), sample); err != nil {
+			if err := runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
 				return err
 			}
 		}
@@ -2874,7 +2898,7 @@ func runDriverCommandRawRangePhase(ctx context.Context, cfg config, target *benc
 	db := target.client.Database(cfg.Database)
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(i), sample); err != nil {
+			if err := runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
 				return err
 			}
 		}
@@ -2907,7 +2931,7 @@ func runTreeDBRawWireRangePhase(ctx context.Context, cfg config, target *benchTa
 	var requestID atomic.Int32
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, 1, rangeReadMinAge(i), sample); err != nil {
+			if err := runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, 1, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
 				return err
 			}
 		}
@@ -2943,7 +2967,7 @@ func runTreeDBRawWireTCPRangePhase(ctx context.Context, cfg config, target *benc
 	defer func() { _ = client.Close() }()
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runTreeDBRawWireTCPRangeOperation(ctx, cfg, client, rangeReadMinAge(i), sample); err != nil {
+			if err := runTreeDBRawWireTCPRangeOperation(ctx, cfg, client, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
 				return err
 			}
 		}
@@ -2974,7 +2998,7 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		var requestID atomic.Int32
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
-				return runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, int64(worker+1), rangeReadMinAge(op), sample)
+				return runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, int64(worker+1), rangeReadMinAge(op, cfg.Documents), sample)
 			})
 		})
 	}
@@ -3002,7 +3026,7 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		}()
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
-				return runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op), sample)
+				return runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op, cfg.Documents), sample)
 			})
 		})
 	}
@@ -3013,13 +3037,13 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		db := target.client.Database(cfg.Database)
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
-				return runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(op), sample)
+				return runDriverCommandRawRangeOperation(ctx, cfg, db, rangeReadMinAge(op, cfg.Documents), sample)
 			})
 		})
 	}
 	return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
-			return runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(op), sample)
+			return runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(op, cfg.Documents), sample)
 		})
 	})
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3129,6 +3129,9 @@ func rawCommandErrorMessage(raw bson.Raw) string {
 }
 
 func validateRawAgeBatch(batch []bson.Raw, minAge int64) error {
+	if len(batch) == 0 {
+		return errors.New("raw range returned no documents")
+	}
 	for _, doc := range batch {
 		age, ok := directBSONInt64Field(doc, "age")
 		if !ok || age < minAge {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -214,15 +214,16 @@ type diskSnapshot struct {
 }
 
 type benchTarget struct {
-	client          *mongo.Client
-	db              *backenddb.DB
-	collections     *collections.CollectionManager
-	server          *mongogateway.Server
-	mongoAddr       string
-	treedbDir       string
-	removeTreeDBDir bool
-	poolStats       *mongoPoolStats
-	cleanup         func(context.Context) error
+	client               *mongo.Client
+	db                   *backenddb.DB
+	collections          *collections.CollectionManager
+	server               *mongogateway.Server
+	mongoAddr            string
+	treedbDir            string
+	removeTreeDBDir      bool
+	skipDrainAfterPhases bool
+	poolStats            *mongoPoolStats
+	cleanup              func(context.Context) error
 }
 
 type mongoPoolStats struct {
@@ -863,11 +864,12 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 		return errors.Join(manager.FlushAll(), backendCleanup())
 	}
 	return &benchTarget{
-		db:              db,
-		collections:     manager,
-		treedbDir:       dir,
-		removeTreeDBDir: removeDir,
-		cleanup:         cleanup,
+		db:                   db,
+		collections:          manager,
+		treedbDir:            dir,
+		removeTreeDBDir:      removeDir,
+		skipDrainAfterPhases: cfg.TreeDBReadState == treeDBReadStateUnsettled,
+		cleanup:              cleanup,
 	}, nil
 }
 
@@ -969,15 +971,16 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		return errors.Join(errs...)
 	}
 	return &benchTarget{
-		client:          client,
-		db:              db,
-		collections:     manager,
-		server:          server,
-		mongoAddr:       ln.Addr().String(),
-		treedbDir:       dir,
-		removeTreeDBDir: removeDir,
-		poolStats:       poolStats,
-		cleanup:         cleanup,
+		client:               client,
+		db:                   db,
+		collections:          manager,
+		server:               server,
+		mongoAddr:            ln.Addr().String(),
+		treedbDir:            dir,
+		removeTreeDBDir:      removeDir,
+		skipDrainAfterPhases: cfg.TreeDBReadState == treeDBReadStateUnsettled,
+		poolStats:            poolStats,
+		cleanup:              cleanup,
 	}, nil
 }
 
@@ -2454,7 +2457,11 @@ func runProfiledPhase(profiler *profileRecorder, name string, run func() (phaseR
 }
 
 func runTreeDBProfiledPhase(target *benchTarget, profiler *profileRecorder, name string, run func() (phaseResult, error)) (phaseResult, error) {
-	return runTreeDBProfiledPhaseWithDrain(target, profiler, name, true, run)
+	drainAfter := true
+	if target != nil && target.skipDrainAfterPhases {
+		drainAfter = false
+	}
+	return runTreeDBProfiledPhaseWithDrain(target, profiler, name, drainAfter, run)
 }
 
 func runTreeDBProfiledPhaseWithDrain(target *benchTarget, profiler *profileRecorder, name string, drainAfter bool, run func() (phaseResult, error)) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -616,6 +616,11 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBReadState = readState
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeDirect &&
+		cfg.TreeDBReadState == treeDBReadStateUnsettled && !cfg.RangeIndex &&
+		(cfg.RangeReads > 0 || cfg.ConcurrentRangeReads > 0) {
+		return config{}, errors.New("direct scan range reads require -treedb-read-state settled; use -range-index for unsettled direct range reads")
+	}
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 3 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, 2, or 3")
 	}
@@ -4456,12 +4461,12 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(result)
 	case "text":
-		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reader_sweep=%v concurrent_reads=%d concurrent_range_readers=%d concurrent_range_reader_sweep=%v concurrent_range_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
+		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reader_sweep=%v concurrent_reads=%d concurrent_range_readers=%d concurrent_range_reader_sweep=%v concurrent_range_reads=%d concurrent_writers=%d concurrent_writes=%d treedb_read_state=%s\n",
 			result.Target, result.ClientMode, result.Database, result.Collection, result.Documents, result.BatchSize,
 			result.InsertProducers, result.MongoMaxPoolSize, result.MongoMinPoolSize, result.MongoMaxConnecting, result.SecondaryIndexes,
 			result.ConcurrentReaders, result.ConcurrentReaderSweep, result.ConcurrentReads,
 			result.ConcurrentRangeReaders, result.ConcurrentRangeReaderSweep, result.ConcurrentRangeReads,
-			result.ConcurrentWriters, result.ConcurrentWrites)
+			result.ConcurrentWriters, result.ConcurrentWrites, result.TreeDBReadState)
 		fmt.Fprintf(out, "update_indexed_field=%t\n", result.UpdateIndexedField)
 		fmt.Fprintf(out, "range_index=%t\n", result.RangeIndex)
 		if result.TreeDBDir != "" {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -609,9 +609,6 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBDocumentFormat = documentFormat
-	if cfg.ClientMode == clientModeDirect && cfg.TreeDBDocumentFormat != collections.DocumentFormatBSON {
-		return config{}, fmt.Errorf("client-mode %q currently requires -treedb-document-format bson", cfg.ClientMode)
-	}
 	dataRootStorage, err := parseTreeDBRootStoragePolicy(treeDBDataRootStorage)
 	if err != nil {
 		return config{}, fmt.Errorf("treedb-data-root-storage: %w", err)
@@ -1478,17 +1475,17 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	var prebuiltIDs [][]byte
-	var prebuiltRaw []bson.Raw
+	var prebuiltDocuments [][]byte
 	if cfg.PrebuildDocuments {
 		prebuiltIDs = make([][]byte, cfg.Documents)
-		prebuiltRaw = make([]bson.Raw, cfg.Documents)
-		for i := range prebuiltRaw {
-			prebuiltIDs[i] = []byte(benchmarkID(i))
-			raw, err := bson.Marshal(benchmarkDocument(i))
+		prebuiltDocuments = make([][]byte, cfg.Documents)
+		for i := range prebuiltDocuments {
+			id, document, err := directTreeDBBenchmarkDocument(i, cfg.TreeDBDocumentFormat)
 			if err != nil {
 				return nil, fmt.Errorf("prebuild direct document %d: %w", i, err)
 			}
-			prebuiltRaw[i] = bson.Raw(raw)
+			prebuiltIDs[i] = id
+			prebuiltDocuments[i] = document
 		}
 	}
 
@@ -1504,7 +1501,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
-		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltRaw)
+		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltDocuments)
 	})
 	if err != nil {
 		return nil, err
@@ -1664,53 +1661,229 @@ func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
 	return indexes
 }
 
-func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) (phaseResult, error) {
+const directPrimaryKeyPrefixBSONValue byte = 1
+
+func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]byte, []byte, error) {
+	raw, err := bson.Marshal(benchmarkDocument(i))
+	if err != nil {
+		return nil, nil, err
+	}
+	return directPrepareTreeDBDocument(bson.Raw(raw), format)
+}
+
+func directPrepareTreeDBDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, []byte, error) {
+	id := raw.Lookup("_id")
+	key, err := directEncodePrimaryKey(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	stored, err := directEncodeStoredDocument(raw, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, stored, nil
+}
+
+func directEncodeStoredDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, error) {
+	switch format {
+	case collections.DocumentFormatBSON:
+		if err := raw.Validate(); err != nil {
+			return nil, err
+		}
+		return bytes.Clone(raw), nil
+	case collections.DocumentFormatDefault, collections.DocumentFormatJSON:
+		return bson.MarshalExtJSON(raw, true, false)
+	case collections.DocumentFormatTemplateV1:
+		stored, err := bson.MarshalExtJSON(raw, true, false)
+		if err != nil {
+			return nil, err
+		}
+		return collections.EncodeTemplateV1DocumentJSON(stored)
+	default:
+		return nil, fmt.Errorf("direct TreeDB benchmark unsupported document format %q", format)
+	}
+}
+
+func directBenchmarkDocumentKey(i int) ([]byte, string, error) {
+	id := benchmarkID(i)
+	typ, value, err := bson.MarshalValue(id)
+	if err != nil {
+		return nil, "", err
+	}
+	key, err := directEncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	if err != nil {
+		return nil, "", err
+	}
+	return key, id, nil
+}
+
+func directEncodePrimaryKey(value bson.RawValue) ([]byte, error) {
+	if value.IsZero() {
+		return nil, errors.New("direct TreeDB benchmark document _id is required")
+	}
+	if value.Type == bson.TypeArray {
+		return nil, errors.New("direct TreeDB benchmark document _id cannot be an array")
+	}
+	if err := value.Validate(); err != nil {
+		return nil, err
+	}
+	key := make([]byte, 0, 2+len(value.Value))
+	key = append(key, directPrimaryKeyPrefixBSONValue, byte(value.Type))
+	key = append(key, value.Value...)
+	return key, nil
+}
+
+func directNewStoredDocumentMaterializer(collection *collections.Collection) (*collections.StoredDocumentJSONMaterializer, error) {
+	if collection == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a collection")
+	}
+	return collection.NewStoredDocumentJSONMaterializer()
+}
+
+type directTreeDBMaterializerPool struct {
+	collection    *collections.Collection
+	pool          sync.Pool
+	mu            sync.Mutex
+	materializers []*collections.StoredDocumentJSONMaterializer
+}
+
+func newDirectTreeDBMaterializerPool(collection *collections.Collection) *directTreeDBMaterializerPool {
+	return &directTreeDBMaterializerPool{collection: collection}
+}
+
+func (p *directTreeDBMaterializerPool) get() (*collections.StoredDocumentJSONMaterializer, error) {
+	if p == nil {
+		return nil, errors.New("direct TreeDB benchmark materializer pool is nil")
+	}
+	if v := p.pool.Get(); v != nil {
+		return v.(*collections.StoredDocumentJSONMaterializer), nil
+	}
+	materializer, err := directNewStoredDocumentMaterializer(p.collection)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	p.materializers = append(p.materializers, materializer)
+	p.mu.Unlock()
+	return materializer, nil
+}
+
+func (p *directTreeDBMaterializerPool) put(materializer *collections.StoredDocumentJSONMaterializer) {
+	if p == nil || materializer == nil {
+		return
+	}
+	p.pool.Put(materializer)
+}
+
+func (p *directTreeDBMaterializerPool) close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	materializers := p.materializers
+	p.materializers = nil
+	p.mu.Unlock()
+	var err error
+	for _, materializer := range materializers {
+		err = errors.Join(err, materializer.Close())
+	}
+	return err
+}
+
+func directStoredDocumentToBSON(collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (bson.Raw, error) {
+	if materializer == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a document materializer")
+	}
+	if materializer.DocumentFormat() == collections.DocumentFormatBSON {
+		raw := bson.Raw(stored)
+		if err := raw.Validate(); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	}
+	materialized, err := materializer.StoredDocumentJSON(stored)
+	if err != nil {
+		// A reused template-v1 resolver can lag a concurrently fetched document.
+		// Retry once with a fresh snapshot before surfacing the original error.
+		if collection != nil {
+			if fresh, freshErr := collection.StoredDocumentJSON(stored); freshErr == nil {
+				materialized = fresh
+				err = nil
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var raw bson.Raw
+	if err := bson.UnmarshalExtJSON(materialized, true, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) (phaseResult, error) {
 	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		_ = producer
 		if err := batchCtx.Err(); err != nil {
 			return err
 		}
-		ids, docs, err := directTreeDBLoadBatch(start, end, prebuiltIDs, prebuiltRaw)
+		ids, docs, err := directTreeDBLoadBatch(start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
 		if err != nil {
 			return err
 		}
-		_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		if cfg.TreeDBDocumentFormat == collections.DocumentFormatBSON {
+			_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		} else {
+			_, err = collection.InsertBatch(ids, docs)
+		}
 		return err
 	})
 }
 
-func directTreeDBLoadBatch(start, end int, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) ([][]byte, [][]byte, error) {
+func directTreeDBLoadBatch(start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
 	ids := make([][]byte, end-start)
 	docs := make([][]byte, end-start)
 	for i := start; i < end; i++ {
 		out := i - start
-		if prebuiltIDs != nil {
+		if prebuiltIDs != nil && prebuiltDocuments != nil {
 			ids[out] = prebuiltIDs[i]
-		} else {
-			ids[out] = []byte(benchmarkID(i))
-		}
-		if prebuiltRaw != nil {
-			docs[out] = prebuiltRaw[i]
+			docs[out] = prebuiltDocuments[i]
 			continue
+		} else {
+			id, document, err := directTreeDBBenchmarkDocument(i, format)
+			if err != nil {
+				return nil, nil, err
+			}
+			ids[out] = id
+			docs[out] = document
 		}
-		raw, err := bson.Marshal(benchmarkDocument(i))
-		if err != nil {
-			return nil, nil, err
-		}
-		docs[out] = raw
 	}
 	return ids, docs, nil
 }
 
 func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			id := benchmarkID(i % cfg.Documents)
+			key, id, err := directBenchmarkDocumentKey(i % cfg.Documents)
+			if err != nil {
+				return err
+			}
 			begin := time.Now()
-			raw, err := collection.Get([]byte(id))
+			stored, err := collection.Get(key)
+			if err != nil {
+				sample(time.Since(begin))
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1724,6 +1897,11 @@ func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *col
 }
 
 func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			if err := ctx.Err(); err != nil {
@@ -1732,9 +1910,13 @@ func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *
 			email := benchmarkEmail((i * 17) % cfg.Documents)
 			begin := time.Now()
 			ids, truncated, err := collection.FindByIndexValueLimit("email_1", email, 1)
-			var raw []byte
+			var raw bson.Raw
 			if err == nil && len(ids) > 0 {
-				raw, err = collection.Get(ids[0])
+				var stored []byte
+				stored, err = collection.Get(ids[0])
+				if err == nil {
+					raw, err = directStoredDocumentToBSON(collection, materializer, stored)
+				}
 			}
 			sample(time.Since(begin))
 			if err != nil {
@@ -1753,6 +1935,11 @@ func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *
 
 func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
 	name := rangePhaseName(cfg)
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = materializer.Close() }()
 	return measurePhase(name, cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			if err := ctx.Err(); err != nil {
@@ -1760,7 +1947,7 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 			}
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
-			err := runDirectTreeDBRangeQuery(cfg, collection, minAge)
+			err := runDirectTreeDBRangeQuery(cfg, collection, materializer, minAge)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1770,7 +1957,7 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 	})
 }
 
-func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, minAge int64) error {
+func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
 		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
@@ -1781,7 +1968,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 			return err
 		}
 		for _, id := range ids {
-			raw, err := collection.Get(id)
+			stored, err := collection.Get(id)
+			if err != nil {
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			if err != nil {
 				return err
 			}
@@ -1793,7 +1984,11 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 	}
 	matches := 0
 	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {
-		age, ok := directBSONInt64Field(record.Document, "age")
+		raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)
+		if err != nil {
+			return false, err
+		}
+		age, ok := directBSONInt64Field(raw, "age")
 		if !ok {
 			return false, errors.New("direct range scan document missing int64 age")
 		}
@@ -1824,11 +2019,26 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 }
 
 func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	materializers := newDirectTreeDBMaterializerPool(collection)
+	defer func() { _ = materializers.close() }()
 	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
-			id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			key, id, err := directBenchmarkDocumentKey(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			if err != nil {
+				return err
+			}
+			materializer, err := materializers.get()
+			if err != nil {
+				return err
+			}
+			defer materializers.put(materializer)
 			begin := time.Now()
-			raw, err := collection.Get([]byte(id))
+			stored, err := collection.Get(key)
+			if err != nil {
+				sample(time.Since(begin))
+				return err
+			}
+			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
@@ -1859,7 +2069,10 @@ func runDirectTreeDBUpdateOperation(
 	updatedCityValues []string,
 	sample func(time.Duration),
 ) error {
-	id := benchmarkID(documentOrdinal)
+	key, id, err := directBenchmarkDocumentKey(documentOrdinal)
+	if err != nil {
+		return err
+	}
 	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
 		Operation:          operation,
 		DocumentOrdinal:    documentOrdinal,
@@ -1871,9 +2084,18 @@ func runDirectTreeDBUpdateOperation(
 	if err != nil {
 		return err
 	}
+	materializer, err := directNewStoredDocumentMaterializer(collection)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = materializer.Close() }()
 	begin := time.Now()
-	matched, _, err := collection.Update([]byte(id), func(stored []byte) ([]byte, bool, error) {
-		updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(stored), bson.Raw(updateRaw))
+	matched, _, err := collection.Update(key, func(stored []byte) ([]byte, bool, error) {
+		current, err := directStoredDocumentToBSON(collection, materializer, stored)
+		if err != nil {
+			return nil, false, err
+		}
+		updated, changed, err := applyDirectBSONSetUpdate(current, bson.Raw(updateRaw))
 		if err != nil {
 			return nil, false, err
 		}
@@ -1883,7 +2105,14 @@ func runDirectTreeDBUpdateOperation(
 		if !changed {
 			return nil, false, nil
 		}
-		return []byte(updated), true, nil
+		updatedKey, encoded, err := directPrepareTreeDBDocument(updated, cfg.TreeDBDocumentFormat)
+		if err != nil {
+			return nil, false, err
+		}
+		if !bytes.Equal(updatedKey, key) {
+			return nil, false, fmt.Errorf("direct update changed primary key for %s", id)
+		}
+		return encoded, true, nil
 	})
 	sample(time.Since(begin))
 	if err != nil {
@@ -1901,9 +2130,12 @@ func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *col
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			id := benchmarkID(cfg.Documents - 1 - i)
+			key, _, err := directBenchmarkDocumentKey(cfg.Documents - 1 - i)
+			if err != nil {
+				return err
+			}
 			begin := time.Now()
-			err := collection.Delete([]byte(id))
+			err = collection.Delete(key)
 			sample(time.Since(begin))
 			if err != nil {
 				return err

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1473,6 +1473,10 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, target); err != nil {
 		return nil, err
 	}
+	directKeys, err := buildDirectBenchmarkKeySet(cfg.Documents)
+	if err != nil {
+		return nil, err
+	}
 
 	var prebuiltIDs [][]byte
 	var prebuiltDocuments [][]byte
@@ -1512,7 +1516,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	}
 
 	idPhase, err := runTreeDBProfiledPhase(target, profiler, "id_find_one", func() (phaseResult, error) {
-		return runDirectTreeDBIDFindPhase(ctx, cfg, collection)
+		return runDirectTreeDBIDFindPhase(ctx, cfg, collection, directKeys)
 	})
 	if err != nil {
 		return nil, err
@@ -1538,7 +1542,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	result.Phases = append(result.Phases, rangePhase)
 
 	updatePhase, err := runTreeDBProfiledPhase(target, profiler, "id_update_set", func() (phaseResult, error) {
-		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, updatedCityValuesForUpdate())
+		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, directKeys, updatedCityValuesForUpdate())
 	})
 	if err != nil {
 		return nil, err
@@ -1548,7 +1552,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	for _, concurrentReaders := range concurrentReaderCounts(cfg) {
 		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", concurrentReaders)
 		concurrentReadPhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
-			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, concurrentReaders, phaseName)
+			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, directKeys, concurrentReaders, phaseName)
 		})
 		if err != nil {
 			return nil, err
@@ -1559,7 +1563,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
 		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
 		concurrentWritePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
-			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, phaseName, updatedCityValuesForUpdate())
+			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, directKeys, phaseName, updatedCityValuesForUpdate())
 		})
 		if err != nil {
 			return nil, err
@@ -1569,7 +1573,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 
 	if cfg.Deletes > 0 {
 		deletePhase, err := runTreeDBProfiledPhase(target, profiler, "id_delete_one", func() (phaseResult, error) {
-			return runDirectTreeDBDeletePhase(ctx, cfg, collection)
+			return runDirectTreeDBDeletePhase(ctx, cfg, collection, directKeys)
 		})
 		if err != nil {
 			return nil, err
@@ -1661,8 +1665,6 @@ func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
 	return indexes
 }
 
-const directPrimaryKeyPrefixBSONValue byte = 1
-
 func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]byte, []byte, error) {
 	raw, err := bson.Marshal(benchmarkDocument(i))
 	if err != nil {
@@ -1673,7 +1675,7 @@ func directTreeDBBenchmarkDocument(i int, format collections.DocumentFormat) ([]
 
 func directPrepareTreeDBDocument(raw bson.Raw, format collections.DocumentFormat) ([]byte, []byte, error) {
 	id := raw.Lookup("_id")
-	key, err := directEncodePrimaryKey(id)
+	key, err := mongogateway.EncodePrimaryKey(id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1710,27 +1712,43 @@ func directBenchmarkDocumentKey(i int) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	key, err := directEncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	key, err := mongogateway.EncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
 	if err != nil {
 		return nil, "", err
 	}
 	return key, id, nil
 }
 
-func directEncodePrimaryKey(value bson.RawValue) ([]byte, error) {
-	if value.IsZero() {
-		return nil, errors.New("direct TreeDB benchmark document _id is required")
+type directBenchmarkKeySet struct {
+	keys [][]byte
+	ids  []string
+}
+
+func buildDirectBenchmarkKeySet(documents int) (directBenchmarkKeySet, error) {
+	out := directBenchmarkKeySet{
+		keys: make([][]byte, documents),
+		ids:  make([]string, documents),
 	}
-	if value.Type == bson.TypeArray {
-		return nil, errors.New("direct TreeDB benchmark document _id cannot be an array")
+	for i := 0; i < documents; i++ {
+		key, id, err := directBenchmarkDocumentKey(i)
+		if err != nil {
+			return directBenchmarkKeySet{}, err
+		}
+		out.keys[i] = key
+		out.ids[i] = id
 	}
-	if err := value.Validate(); err != nil {
-		return nil, err
+	return out, nil
+}
+
+func (s directBenchmarkKeySet) at(ordinal int) ([]byte, string) {
+	if len(s.keys) == 0 {
+		return nil, ""
 	}
-	key := make([]byte, 0, 2+len(value.Value))
-	key = append(key, directPrimaryKeyPrefixBSONValue, byte(value.Type))
-	key = append(key, value.Value...)
-	return key, nil
+	ordinal %= len(s.keys)
+	if ordinal < 0 {
+		ordinal += len(s.keys)
+	}
+	return s.keys[ordinal], s.ids[ordinal]
 }
 
 func directNewStoredDocumentMaterializer(collection *collections.Collection) (*collections.StoredDocumentJSONMaterializer, error) {
@@ -1823,12 +1841,17 @@ func directStoredDocumentToBSON(collection *collections.Collection, materializer
 }
 
 func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) (phaseResult, error) {
+	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
+	scratch := make([]directTreeDBLoadScratch, producers)
+	for i := range scratch {
+		scratch[i].ids = make([][]byte, 0, cfg.BatchSize)
+		scratch[i].docs = make([][]byte, 0, cfg.BatchSize)
+	}
 	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
-		_ = producer
 		if err := batchCtx.Err(); err != nil {
 			return err
 		}
-		ids, docs, err := directTreeDBLoadBatch(start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
+		ids, docs, err := directTreeDBLoadBatch(producerScratch(scratch, producer), start, end, cfg.TreeDBDocumentFormat, prebuiltIDs, prebuiltDocuments)
 		if err != nil {
 			return err
 		}
@@ -1841,28 +1864,44 @@ func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *colle
 	})
 }
 
-func directTreeDBLoadBatch(start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
-	ids := make([][]byte, end-start)
-	docs := make([][]byte, end-start)
+type directTreeDBLoadScratch struct {
+	ids  [][]byte
+	docs [][]byte
+}
+
+func producerScratch(scratch []directTreeDBLoadScratch, producer int) *directTreeDBLoadScratch {
+	if producer < 0 || producer >= len(scratch) {
+		return &directTreeDBLoadScratch{}
+	}
+	return &scratch[producer]
+}
+
+func directTreeDBLoadBatch(scratch *directTreeDBLoadScratch, start, end int, format collections.DocumentFormat, prebuiltIDs [][]byte, prebuiltDocuments [][]byte) ([][]byte, [][]byte, error) {
+	if scratch == nil {
+		scratch = &directTreeDBLoadScratch{}
+	}
+	ids := scratch.ids[:0]
+	docs := scratch.docs[:0]
 	for i := start; i < end; i++ {
-		out := i - start
 		if prebuiltIDs != nil && prebuiltDocuments != nil {
-			ids[out] = prebuiltIDs[i]
-			docs[out] = prebuiltDocuments[i]
+			ids = append(ids, prebuiltIDs[i])
+			docs = append(docs, prebuiltDocuments[i])
 			continue
 		} else {
 			id, document, err := directTreeDBBenchmarkDocument(i, format)
 			if err != nil {
 				return nil, nil, err
 			}
-			ids[out] = id
-			docs[out] = document
+			ids = append(ids, id)
+			docs = append(docs, document)
 		}
 	}
+	scratch.ids = ids
+	scratch.docs = docs
 	return ids, docs, nil
 }
 
-func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet) (phaseResult, error) {
 	materializer, err := directNewStoredDocumentMaterializer(collection)
 	if err != nil {
 		return phaseResult{}, err
@@ -1873,10 +1912,7 @@ func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *col
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			key, id, err := directBenchmarkDocumentKey(i % cfg.Documents)
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(i % cfg.Documents)
 			begin := time.Now()
 			stored, err := collection.Get(key)
 			if err != nil {
@@ -2003,14 +2039,15 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 	return err
 }
 
-func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, updatedCityValues []string) (phaseResult, error) {
+func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
 			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
-			if err := runDirectTreeDBUpdateOperation(collection, cfg, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+			key, id := keys.at(documentOrdinal)
+			if err := runDirectTreeDBUpdateOperation(collection, cfg, key, id, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
 				return err
 			}
 		}
@@ -2018,15 +2055,12 @@ func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *col
 	})
 }
 
-func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, readers int, phaseName string) (phaseResult, error) {
 	materializers := newDirectTreeDBMaterializerPool(collection)
 	defer func() { _ = materializers.close() }()
 	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
-			key, id, err := directBenchmarkDocumentKey(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
 			materializer, err := materializers.get()
 			if err != nil {
 				return err
@@ -2051,11 +2085,12 @@ func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, colle
 	})
 }
 
-func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, phaseName string, updatedCityValues []string) (phaseResult, error) {
+func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, phaseName string, updatedCityValues []string) (phaseResult, error) {
 	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
 			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
-			return runDirectTreeDBUpdateOperation(collection, cfg, op, documentOrdinal, true, updatedCityValues, sample)
+			key, id := keys.at(documentOrdinal)
+			return runDirectTreeDBUpdateOperation(collection, cfg, key, id, op, documentOrdinal, true, updatedCityValues, sample)
 		})
 	})
 }
@@ -2063,16 +2098,14 @@ func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, colle
 func runDirectTreeDBUpdateOperation(
 	collection *collections.Collection,
 	cfg config,
+	key []byte,
+	id string,
 	operation int,
 	documentOrdinal int,
 	concurrent bool,
 	updatedCityValues []string,
 	sample func(time.Duration),
 ) error {
-	key, id, err := directBenchmarkDocumentKey(documentOrdinal)
-	if err != nil {
-		return err
-	}
 	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
 		Operation:          operation,
 		DocumentOrdinal:    documentOrdinal,
@@ -2124,21 +2157,21 @@ func runDirectTreeDBUpdateOperation(
 	return nil
 }
 
-func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet) (phaseResult, error) {
 	return measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Deletes; i++ {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			key, _, err := directBenchmarkDocumentKey(cfg.Documents - 1 - i)
-			if err != nil {
-				return err
-			}
+			key, id := keys.at(cfg.Documents - 1 - i)
 			begin := time.Now()
-			err = collection.Delete(key)
+			deleted, err := collection.DeleteDocument(key)
 			sample(time.Since(begin))
 			if err != nil {
 				return err
+			}
+			if !deleted {
+				return fmt.Errorf("direct delete missed document %s", id)
 			}
 		}
 		return nil
@@ -2397,7 +2430,7 @@ func treedbCreateIndexDocs(secondaryIndexes int, rangeIndex bool) bson.A {
 }
 
 func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config, target *benchTarget) error {
-	if result == nil || cfg.Target != "treedb" || target == nil || target.collections == nil || cfg.SecondaryIndexes == 0 {
+	if result == nil || cfg.Target != "treedb" || target == nil || target.collections == nil || !cfgHasAnySecondaryIndex(cfg) {
 		return nil
 	}
 	col, err := target.collections.OpenCollection(cfg.Database + "." + cfg.Collection)
@@ -2411,6 +2444,10 @@ func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config,
 	result.TreeDBBufferedIndexedAsyncFlush = meta.Options.BufferedIndexedAsyncFlush
 	result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits
 	return nil
+}
+
+func cfgHasAnySecondaryIndex(cfg config) bool {
+	return cfg.SecondaryIndexes > 0 || cfg.RangeIndex
 }
 
 func runLoadPhase(ctx context.Context, cfg config, target *benchTarget, coll *mongo.Collection, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2106,6 +2106,9 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 		if err != nil {
 			return err
 		}
+		if len(ids) == 0 {
+			return fmt.Errorf("direct indexed range returned no ids for minAge=%d", minAge)
+		}
 		for _, id := range ids {
 			stored, err := collection.Get(id)
 			if err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -350,6 +350,7 @@ const (
 	clientModeDriverCommand    = "driver-command"
 	clientModeDriverCommandRaw = "driver-command-raw"
 	clientModeDriverUnack      = "driver-unack"
+	clientModeDirect           = "direct"
 	clientModeRawWire          = "raw-wire"
 	clientModeRawWireTCP       = "raw-wire-tcp"
 )
@@ -467,7 +468,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes >= 2 so the city index exists")
 	fs.BoolVar(&cfg.RangeIndex, "range-index", false, "create an age_1 secondary index for the age range-read phase")
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
-	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, raw-wire, or raw-wire-tcp; raw-wire modes are TreeDB-only and bypass the MongoDB Go driver for the insert load phase")
+	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
@@ -514,6 +515,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	cfg.ClientMode = clientMode
 	if cfg.Target != "treedb" && isRawWireClientMode(cfg.ClientMode) {
+		return config{}, fmt.Errorf("client-mode %q is only supported with -target treedb", cfg.ClientMode)
+	}
+	if cfg.Target != "treedb" && cfg.ClientMode == clientModeDirect {
 		return config{}, fmt.Errorf("client-mode %q is only supported with -target treedb", cfg.ClientMode)
 	}
 	if cfg.Documents <= 0 {
@@ -605,6 +609,9 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBDocumentFormat = documentFormat
+	if cfg.ClientMode == clientModeDirect && cfg.TreeDBDocumentFormat != collections.DocumentFormatBSON {
+		return config{}, fmt.Errorf("client-mode %q currently requires -treedb-document-format bson", cfg.ClientMode)
+	}
 	dataRootStorage, err := parseTreeDBRootStoragePolicy(treeDBDataRootStorage)
 	if err != nil {
 		return config{}, fmt.Errorf("treedb-data-root-storage: %w", err)
@@ -695,6 +702,8 @@ func parseClientMode(raw string) (string, error) {
 		return clientModeDriverCommandRaw, nil
 	case clientModeDriverUnack:
 		return clientModeDriverUnack, nil
+	case clientModeDirect:
+		return clientModeDirect, nil
 	case clientModeRawWire:
 		return clientModeRawWire, nil
 	case clientModeRawWireTCP:
@@ -751,12 +760,60 @@ func isRawWireClientMode(mode string) bool {
 func openTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	switch cfg.Target {
 	case "treedb":
+		if cfg.ClientMode == clientModeDirect {
+			return openTreeDBDirectTarget(ctx, cfg)
+		}
 		return openTreeDBTarget(ctx, cfg)
 	case "mongo":
 		return openMongoTarget(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("unknown target %q", cfg.Target)
 	}
+}
+
+func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, error) {
+	_ = ctx
+	dir := cfg.TreeDBDir
+	removeDir := false
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "mongo-gateway-direct-bench-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = tmp
+		removeDir = !cfg.KeepTreeDBDir
+	} else {
+		if err := resetTreeDBDir(dir); err != nil {
+			return nil, err
+		}
+	}
+
+	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	db, backendCleanup, err := open(opts)
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	manager := collections.NewCollectionManager(db)
+	cleanup := func(cleanupCtx context.Context) error {
+		_ = cleanupCtx
+		return errors.Join(manager.FlushAll(), backendCleanup())
+	}
+	return &benchTarget{
+		db:              db,
+		collections:     manager,
+		treedbDir:       dir,
+		removeTreeDBDir: removeDir,
+		cleanup:         cleanup,
+	}, nil
 }
 
 func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
@@ -1083,6 +1140,9 @@ func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server
 }
 
 func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeDirect {
+		return runDirectTreeDBBenchmark(ctx, cfg, target, profiler)
+	}
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
@@ -1371,6 +1431,584 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.MongoPoolStatsFinal = target.poolStats.Snapshot()
 	}
 	return result, nil
+}
+
+func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
+	result := &benchmarkResult{
+		Target:                                 cfg.Target,
+		Database:                               cfg.Database,
+		Collection:                             cfg.Collection,
+		Documents:                              cfg.Documents,
+		BatchSize:                              cfg.BatchSize,
+		InsertProducers:                        cfg.InsertProducers,
+		MongoMaxPoolSize:                       cfg.MongoMaxPoolSize,
+		MongoMinPoolSize:                       cfg.MongoMinPoolSize,
+		MongoMaxConnecting:                     cfg.MongoMaxConnecting,
+		SecondaryIndexes:                       cfg.SecondaryIndexes,
+		ClientMode:                             cfg.ClientMode,
+		ConcurrentReaders:                      cfg.ConcurrentReaders,
+		ConcurrentReaderSweep:                  append([]int(nil), cfg.ConcurrentReaderSweep...),
+		ConcurrentReads:                        cfg.ConcurrentReads,
+		ConcurrentWriters:                      cfg.ConcurrentWriters,
+		ConcurrentWrites:                       cfg.ConcurrentWrites,
+		UpdateIndexedField:                     cfg.UpdateIndexedField,
+		RangeIndex:                             cfg.RangeIndex,
+		PrebuildDocuments:                      cfg.PrebuildDocuments,
+		TreeDBProfile:                          string(cfg.TreeDBProfile),
+		TreeDBDocumentFormat:                   string(cfg.TreeDBDocumentFormat),
+		TreeDBDataRootStorage:                  string(cfg.TreeDBDataRootStorage),
+		TreeDBIndexStateRootStorage:            string(cfg.TreeDBIndexStateRootStorage),
+		TreeDBIndexRootStorage:                 string(cfg.TreeDBIndexRootStorage),
+		TreeDBBufferedIndexedWriteMaxDocuments: cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		TreeDBBufferedIndexedWriteMaxBytes:     cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		TreeDBBufferedIndexedWriteMaxRootRuns:  cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		TreeDBBufferedIndexedAsyncFlush:        cfg.TreeDBBufferedIndexedAsyncFlush,
+		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+		TreeDBMaintenanceMode:                         cfg.TreeDBMaintenance,
+	}
+	if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
+		result.TreeDBDir = target.treedbDir
+	}
+	collection, err := createDirectTreeDBCollection(cfg, target)
+	if err != nil {
+		return nil, err
+	}
+	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, target); err != nil {
+		return nil, err
+	}
+
+	var prebuiltIDs [][]byte
+	var prebuiltRaw []bson.Raw
+	if cfg.PrebuildDocuments {
+		prebuiltIDs = make([][]byte, cfg.Documents)
+		prebuiltRaw = make([]bson.Raw, cfg.Documents)
+		for i := range prebuiltRaw {
+			prebuiltIDs[i] = []byte(benchmarkID(i))
+			raw, err := bson.Marshal(benchmarkDocument(i))
+			if err != nil {
+				return nil, fmt.Errorf("prebuild direct document %d: %w", i, err)
+			}
+			prebuiltRaw[i] = bson.Raw(raw)
+		}
+	}
+
+	var updatedCityValues []string
+	updatedCityValuesForUpdate := func() []string {
+		if !cfg.UpdateIndexedField {
+			return nil
+		}
+		if updatedCityValues == nil {
+			updatedCityValues = buildBenchmarkUpdatedCityValues()
+		}
+		return updatedCityValues
+	}
+
+	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
+		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltRaw)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, loadPhase)
+	if err := collectAfterLoadStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+
+	idPhase, err := runTreeDBProfiledPhase(target, profiler, "id_find_one", func() (phaseResult, error) {
+		return runDirectTreeDBIDFindPhase(ctx, cfg, collection)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, idPhase)
+
+	if runEmailFindPhase(cfg) {
+		emailPhase, err := runTreeDBProfiledPhase(target, profiler, "email_find_one", func() (phaseResult, error) {
+			return runDirectTreeDBEmailFindPhase(ctx, cfg, collection)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, emailPhase)
+	}
+
+	rangePhase, err := runTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), func() (phaseResult, error) {
+		return runDirectTreeDBRangePhase(ctx, cfg, collection)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, rangePhase)
+
+	updatePhase, err := runTreeDBProfiledPhase(target, profiler, "id_update_set", func() (phaseResult, error) {
+		return runDirectTreeDBUpdatePhase(ctx, cfg, collection, updatedCityValuesForUpdate())
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, updatePhase)
+
+	for _, concurrentReaders := range concurrentReaderCounts(cfg) {
+		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", concurrentReaders)
+		concurrentReadPhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
+			return runDirectTreeDBConcurrentIDFindPhase(ctx, cfg, collection, concurrentReaders, phaseName)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentReadPhase)
+	}
+
+	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
+		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
+		concurrentWritePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
+			return runDirectTreeDBConcurrentUpdatePhase(ctx, cfg, collection, phaseName, updatedCityValuesForUpdate())
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentWritePhase)
+	}
+
+	if cfg.Deletes > 0 {
+		deletePhase, err := runTreeDBProfiledPhase(target, profiler, "id_delete_one", func() (phaseResult, error) {
+			return runDirectTreeDBDeletePhase(ctx, cfg, collection)
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, deletePhase)
+	}
+
+	if err := collectFinalStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func directTreeDBCollectionName(cfg config) string {
+	return cfg.Database + "." + cfg.Collection
+}
+
+func directTreeDBCollectionOptions(cfg config) collections.CollectionOptions {
+	return collections.CollectionOptions{
+		DocumentFormat:                          cfg.TreeDBDocumentFormat,
+		DataRootStoragePolicy:                   cfg.TreeDBDataRootStorage,
+		IndexStateStoragePolicy:                 cfg.TreeDBIndexStateRootStorage,
+		BufferedIndexedWriteMaxDocuments:        cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:            cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRootRuns:         cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		BufferedIndexedAsyncFlush:               cfg.TreeDBBufferedIndexedAsyncFlush,
+		BufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+	}
+}
+
+func createDirectTreeDBCollection(cfg config, target *benchTarget) (*collections.Collection, error) {
+	if target == nil || target.collections == nil {
+		return nil, errors.New("direct TreeDB benchmark requires a collection manager")
+	}
+	name := directTreeDBCollectionName(cfg)
+	if _, err := target.collections.CreateCollection(&collections.CollectionMeta{
+		Name:    name,
+		Options: directTreeDBCollectionOptions(cfg),
+	}); err != nil {
+		return nil, err
+	}
+	collection, err := target.collections.OpenCollection(name)
+	if err != nil {
+		return nil, err
+	}
+	for _, index := range directTreeDBIndexDefinitions(cfg) {
+		if _, err := collection.CreateIndex(index); err != nil {
+			return nil, err
+		}
+	}
+	return collection, nil
+}
+
+func directTreeDBIndexDefinitions(cfg config) []collections.IndexDefinition {
+	indexes := make([]collections.IndexDefinition, 0, cfg.SecondaryIndexes+1)
+	if cfg.SecondaryIndexes >= 1 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.SecondaryIndexes >= 2 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.SecondaryIndexes >= 3 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "active_1",
+			Field:         "active",
+			ValueType:     collections.IndexValueBool,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	if cfg.RangeIndex {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:          "age_1",
+			Field:         "age",
+			ValueType:     collections.IndexValueInt64,
+			StoragePolicy: cfg.TreeDBIndexRootStorage,
+		})
+	}
+	return indexes
+}
+
+func runDirectTreeDBLoadPhase(ctx context.Context, cfg config, collection *collections.Collection, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) (phaseResult, error) {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
+		_ = producer
+		if err := batchCtx.Err(); err != nil {
+			return err
+		}
+		ids, docs, err := directTreeDBLoadBatch(start, end, prebuiltIDs, prebuiltRaw)
+		if err != nil {
+			return err
+		}
+		_, err = collection.InsertBatchValidatedBSON(ids, docs)
+		return err
+	})
+}
+
+func directTreeDBLoadBatch(start, end int, prebuiltIDs [][]byte, prebuiltRaw []bson.Raw) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, end-start)
+	docs := make([][]byte, end-start)
+	for i := start; i < end; i++ {
+		out := i - start
+		if prebuiltIDs != nil {
+			ids[out] = prebuiltIDs[i]
+		} else {
+			ids[out] = []byte(benchmarkID(i))
+		}
+		if prebuiltRaw != nil {
+			docs[out] = prebuiltRaw[i]
+			continue
+		}
+		raw, err := bson.Marshal(benchmarkDocument(i))
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[out] = raw
+	}
+	return ids, docs, nil
+}
+
+func runDirectTreeDBIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			id := benchmarkID(i % cfg.Documents)
+			begin := time.Now()
+			raw, err := collection.Get([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if got, ok := bson.Raw(raw).Lookup("_id").StringValueOK(); !ok || got != id {
+				return fmt.Errorf("direct id lookup returned _id=%v ok=%t want %s", got, ok, id)
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBEmailFindPhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			email := benchmarkEmail((i * 17) % cfg.Documents)
+			begin := time.Now()
+			ids, truncated, err := collection.FindByIndexValueLimit("email_1", email, 1)
+			var raw []byte
+			if err == nil && len(ids) > 0 {
+				raw, err = collection.Get(ids[0])
+			}
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if truncated || len(ids) != 1 {
+				return fmt.Errorf("direct email lookup ids=%d truncated=%t want one id", len(ids), truncated)
+			}
+			if got, ok := bson.Raw(raw).Lookup("email").StringValueOK(); !ok || got != email {
+				return fmt.Errorf("direct email lookup returned email=%v ok=%t want %s", got, ok, email)
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	name := rangePhaseName(cfg)
+	return measurePhase(name, cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			minAge := int64(20 + (i % 40))
+			begin := time.Now()
+			err := runDirectTreeDBRangeQuery(cfg, collection, minAge)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, minAge int64) error {
+	if cfg.RangeIndex {
+		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
+			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
+			Upper: collections.IndexRangeBound{Unbounded: true},
+			Limit: 10,
+		})
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			raw, err := collection.Get(id)
+			if err != nil {
+				return err
+			}
+			if age, ok := directBSONInt64Field(raw, "age"); !ok || age < minAge {
+				return fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
+			}
+		}
+		return nil
+	}
+	matches := 0
+	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {
+		age, ok := directBSONInt64Field(record.Document, "age")
+		if !ok {
+			return false, errors.New("direct range scan document missing int64 age")
+		}
+		if age >= minAge {
+			matches++
+			if matches >= 10 {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	return err
+}
+
+func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, updatedCityValues []string) (phaseResult, error) {
+	return measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Updates; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
+			if err := runDirectTreeDBUpdateOperation(collection, cfg, i, documentOrdinal, false, updatedCityValues, sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDirectTreeDBConcurrentIDFindPhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	return measurePhase(phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, readers, cfg.ConcurrentReads, func(op int) error {
+			id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
+			begin := time.Now()
+			raw, err := collection.Get([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if got, ok := bson.Raw(raw).Lookup("_id").StringValueOK(); !ok || got != id {
+				return fmt.Errorf("direct concurrent id lookup returned _id=%v ok=%t want %s", got, ok, id)
+			}
+			return nil
+		})
+	})
+}
+
+func runDirectTreeDBConcurrentUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, phaseName string, updatedCityValues []string) (phaseResult, error) {
+	return measurePhase(phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
+			documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
+			return runDirectTreeDBUpdateOperation(collection, cfg, op, documentOrdinal, true, updatedCityValues, sample)
+		})
+	})
+}
+
+func runDirectTreeDBUpdateOperation(
+	collection *collections.Collection,
+	cfg config,
+	operation int,
+	documentOrdinal int,
+	concurrent bool,
+	updatedCityValues []string,
+	sample func(time.Duration),
+) error {
+	id := benchmarkID(documentOrdinal)
+	updateRaw, err := bson.Marshal(benchmarkSetUpdate(benchmarkSetUpdateParams{
+		Operation:          operation,
+		DocumentOrdinal:    documentOrdinal,
+		DocumentCount:      cfg.Documents,
+		ConcurrentPhase:    concurrent,
+		UpdateIndexedField: cfg.UpdateIndexedField,
+		UpdatedCityValues:  updatedCityValues,
+	}))
+	if err != nil {
+		return err
+	}
+	begin := time.Now()
+	matched, _, err := collection.Update([]byte(id), func(stored []byte) ([]byte, bool, error) {
+		updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(stored), bson.Raw(updateRaw))
+		if err != nil {
+			return nil, false, err
+		}
+		if got, ok := updated.Lookup("_id").StringValueOK(); !ok || got != id {
+			return nil, false, fmt.Errorf("direct update changed _id to %v ok=%t want %s", got, ok, id)
+		}
+		if !changed {
+			return nil, false, nil
+		}
+		return []byte(updated), true, nil
+	})
+	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return fmt.Errorf("direct update missed document %s", id)
+	}
+	return nil
+}
+
+func runDirectTreeDBDeletePhase(ctx context.Context, cfg config, collection *collections.Collection) (phaseResult, error) {
+	return measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Deletes; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			id := benchmarkID(cfg.Documents - 1 - i)
+			begin := time.Now()
+			err := collection.Delete([]byte(id))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func directBSONInt64Field(raw []byte, key string) (int64, bool) {
+	value := bson.Raw(raw).Lookup(key)
+	if value.Type == bson.TypeInt64 {
+		return value.Int64OK()
+	}
+	if value.Type == bson.TypeInt32 {
+		v, ok := value.Int32OK()
+		return int64(v), ok
+	}
+	return 0, false
+}
+
+func applyDirectBSONSetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, error) {
+	updateElements, err := update.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(updateElements) != 1 {
+		return nil, false, errors.New("direct TreeDB update currently supports exactly one $set operator")
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil {
+		return nil, false, err
+	}
+	if operator != "$set" {
+		return nil, false, errors.New("direct TreeDB update currently supports $set only")
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, false, errors.New("direct TreeDB $set value must be a document")
+	}
+	sets, setOrder, err := parseDirectBSONSetDocument(setDoc)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(sets) == 0 {
+		return doc, false, nil
+	}
+
+	elements, err := doc.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(bson.D, 0, len(elements)+len(sets))
+	used := make(map[string]struct{}, len(sets))
+	changed := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, false, err
+		}
+		value := elem.Value()
+		if replacement, ok := sets[key]; ok {
+			if !replacement.Equal(value) {
+				changed = true
+			}
+			value = replacement
+			used[key] = struct{}{}
+		}
+		out = append(out, bson.E{Key: key, Value: value})
+	}
+	for _, key := range setOrder {
+		if _, ok := used[key]; ok {
+			continue
+		}
+		out = append(out, bson.E{Key: key, Value: sets[key]})
+		changed = true
+	}
+	raw, err := bson.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return bson.Raw(raw), changed, nil
+}
+
+func parseDirectBSONSetDocument(setDoc bson.Raw) (map[string]bson.RawValue, []string, error) {
+	elements, err := setDoc.Elements()
+	if err != nil {
+		return nil, nil, err
+	}
+	sets := make(map[string]bson.RawValue, len(elements))
+	order := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, nil, err
+		}
+		if key == "_id" {
+			return nil, nil, errors.New("direct TreeDB update cannot modify _id")
+		}
+		if _, exists := sets[key]; !exists {
+			order = append(order, key)
+		}
+		sets[key] = elem.Value()
+	}
+	return sets, order, nil
 }
 
 func measureProfiledPhase(profiler *profileRecorder, name string, operations int, run func(func(time.Duration)) error) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -860,7 +860,9 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 	}
 	manager := collections.NewCollectionManager(db)
 	cleanup := func(cleanupCtx context.Context) error {
-		_ = cleanupCtx
+		if err := cleanupCtx.Err(); err != nil {
+			return errors.Join(err, backendCleanup())
+		}
 		return errors.Join(manager.FlushAll(), backendCleanup())
 	}
 	return &benchTarget{
@@ -3002,6 +3004,9 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		})
 	}
 	if cfg.ClientMode == clientModeDriverCommandRaw {
+		if target == nil || target.client == nil {
+			return phaseResult{}, errors.New("driver-command-raw range phase requires a Mongo driver client")
+		}
 		db := target.client.Database(cfg.Database)
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
@@ -3120,7 +3125,7 @@ func rawCommandErrorMessage(raw bson.Raw) string {
 	if len(raw) == 0 {
 		return "missing ok field"
 	}
-	return string(raw)
+	return fmt.Sprintf("raw=%x", []byte(raw))
 }
 
 func validateRawAgeBatch(batch []bson.Raw, minAge int64) error {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1604,6 +1604,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	result.Phases = append(result.Phases, rangePhase)
 
 	for _, concurrentReaders := range concurrentRangeReaderCounts(cfg) {
+		concurrentReaders = effectiveConcurrentWorkers(concurrentReaders, cfg.ConcurrentRangeReads)
 		phaseName := concurrentRangePhaseName(cfg, concurrentReaders)
 		concurrentRangePhase, err := runTreeDBProfiledPhase(target, profiler, phaseName, func() (phaseResult, error) {
 			return runDirectTreeDBConcurrentRangePhase(ctx, cfg, collection, concurrentReaders, phaseName)
@@ -2067,6 +2068,7 @@ func runDirectTreeDBRangePhase(ctx context.Context, cfg config, collection *coll
 }
 
 func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collection *collections.Collection, readers int, phaseName string) (phaseResult, error) {
+	readers = effectiveConcurrentWorkers(readers, cfg.ConcurrentRangeReads)
 	materializers := make([]*collections.StoredDocumentJSONMaterializer, readers)
 	for i := range materializers {
 		materializer, err := directNewStoredDocumentMaterializer(collection)
@@ -2145,7 +2147,13 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 		}
 		return true, nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if matches == 0 {
+		return fmt.Errorf("direct range scan found no documents for minAge=%d", minAge)
+	}
+	return nil
 }
 
 func runDirectTreeDBUpdatePhase(ctx context.Context, cfg config, collection *collections.Collection, keys directBenchmarkKeySet, updatedCityValues []string) (phaseResult, error) {
@@ -2538,6 +2546,16 @@ func rangePhaseName(cfg config) string {
 
 func concurrentRangePhaseName(cfg config, readers int) string {
 	return fmt.Sprintf("concurrent_%s_r%d", rangePhaseName(cfg), readers)
+}
+
+func effectiveConcurrentWorkers(workers, operations int) int {
+	if workers <= 0 || operations <= 0 {
+		return 0
+	}
+	if workers > operations {
+		return operations
+	}
+	return workers
 }
 
 func rangeReadMinAge(op int, documentCount int) int64 {
@@ -2993,6 +3011,7 @@ func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *
 }
 
 func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection, readers int) (phaseResult, error) {
+	readers = effectiveConcurrentWorkers(readers, cfg.ConcurrentRangeReads)
 	phaseName := concurrentRangePhaseName(cfg, readers)
 	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWire {
 		if target == nil || target.server == nil {
@@ -4267,11 +4286,9 @@ func runConcurrentOperations(ctx context.Context, workers, operations int, run f
 }
 
 func runConcurrentOperationsByWorker(ctx context.Context, workers, operations int, run func(worker, op int) error) error {
-	if workers <= 0 || operations <= 0 {
+	workers = effectiveConcurrentWorkers(workers, operations)
+	if workers <= 0 {
 		return nil
-	}
-	if workers > operations {
-		workers = operations
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -4439,22 +4456,24 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(result)
 	case "text":
-		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reader_sweep=%v concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
+		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reader_sweep=%v concurrent_reads=%d concurrent_range_readers=%d concurrent_range_reader_sweep=%v concurrent_range_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
 			result.Target, result.ClientMode, result.Database, result.Collection, result.Documents, result.BatchSize,
 			result.InsertProducers, result.MongoMaxPoolSize, result.MongoMinPoolSize, result.MongoMaxConnecting, result.SecondaryIndexes,
-			result.ConcurrentReaders, result.ConcurrentReaderSweep, result.ConcurrentReads, result.ConcurrentWriters, result.ConcurrentWrites)
+			result.ConcurrentReaders, result.ConcurrentReaderSweep, result.ConcurrentReads,
+			result.ConcurrentRangeReaders, result.ConcurrentRangeReaderSweep, result.ConcurrentRangeReads,
+			result.ConcurrentWriters, result.ConcurrentWrites)
 		fmt.Fprintf(out, "update_indexed_field=%t\n", result.UpdateIndexedField)
 		fmt.Fprintf(out, "range_index=%t\n", result.RangeIndex)
 		if result.TreeDBDir != "" {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s\n",
+			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s read_state=%s\n",
 				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
 				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
 				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
-				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode)
+				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1277,7 +1277,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if target.poolStats != nil {
 		target.poolStats.Reset()
 	}
-	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
+	loadPhase, err := runTreeDBProfiledPhaseWithDrain(target, profiler, "load_insert_many", cfg.TreeDBReadState == treeDBReadStateSettled, func() (phaseResult, error) {
 		return runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
 	})
 	if err != nil {
@@ -1553,7 +1553,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 		return updatedCityValues
 	}
 
-	loadPhase, err := runTreeDBProfiledPhase(target, profiler, "load_insert_many", func() (phaseResult, error) {
+	loadPhase, err := runTreeDBProfiledPhaseWithDrain(target, profiler, "load_insert_many", cfg.TreeDBReadState == treeDBReadStateSettled, func() (phaseResult, error) {
 		return runDirectTreeDBLoadPhase(ctx, cfg, collection, prebuiltIDs, prebuiltDocuments)
 	})
 	if err != nil {
@@ -2454,17 +2454,23 @@ func runProfiledPhase(profiler *profileRecorder, name string, run func() (phaseR
 }
 
 func runTreeDBProfiledPhase(target *benchTarget, profiler *profileRecorder, name string, run func() (phaseResult, error)) (phaseResult, error) {
+	return runTreeDBProfiledPhaseWithDrain(target, profiler, name, true, run)
+}
+
+func runTreeDBProfiledPhaseWithDrain(target *benchTarget, profiler *profileRecorder, name string, drainAfter bool, run func() (phaseResult, error)) (phaseResult, error) {
 	before := collectLiveTreeDBStats(target)
 	result, err := runProfiledPhase(profiler, name, func() (phaseResult, error) {
 		result, err := run()
 		if err != nil {
 			return result, err
 		}
-		drainElapsed, err := drainTreeDBCollectionsForPhase(target)
-		if err != nil {
-			return result, err
+		if drainAfter {
+			drainElapsed, err := drainTreeDBCollectionsForPhase(target)
+			if err != nil {
+				return result, err
+			}
+			addPhaseDuration(&result, drainElapsed)
 		}
-		addPhaseDuration(&result, drainElapsed)
 		return result, nil
 	})
 	if err != nil {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -19,6 +19,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
 )
@@ -2024,6 +2025,24 @@ func TestRangePhaseNameDistinguishesScanAndIndexedRuns(t *testing.T) {
 	}
 }
 
+func TestDirectBenchmarkDocumentKeyUsesGatewayEncoding(t *testing.T) {
+	key, id, err := directBenchmarkDocumentKey(7)
+	if err != nil {
+		t.Fatalf("directBenchmarkDocumentKey: %v", err)
+	}
+	typ, value, err := bson.MarshalValue(id)
+	if err != nil {
+		t.Fatalf("MarshalValue: %v", err)
+	}
+	want, err := mongogateway.EncodePrimaryKey(bson.RawValue{Type: typ, Value: value})
+	if err != nil {
+		t.Fatalf("EncodePrimaryKey: %v", err)
+	}
+	if !bytes.Equal(key, want) {
+		t.Fatalf("direct key=%x want gateway key=%x", key, want)
+	}
+}
+
 func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	result := &benchmarkResult{
 		Target:                                 "treedb",
@@ -2110,7 +2129,8 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 		Target:           "treedb",
 		Database:         "bench",
 		Collection:       "docs",
-		SecondaryIndexes: 1,
+		SecondaryIndexes: 0,
+		RangeIndex:       true,
 	}
 	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, &benchTarget{collections: manager}); err != nil {
 		t.Fatalf("record effective options: %v", err)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -650,7 +650,7 @@ func TestParseConfigValidation(t *testing.T) {
 	if directCfg.ClientMode != clientModeDirect {
 		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
 	}
-	for _, format := range []string{"json", "template-v1", "bson"} {
+	for _, format := range []string{"json", "template-v1", "collections-v1", "bson"} {
 		if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", format}); err != nil {
 			t.Fatalf("parse direct %s config: %v", format, err)
 		}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -643,6 +643,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if unackCfg.ClientMode != clientModeDriverUnack {
 		t.Fatalf("ClientMode=%q want %q", unackCfg.ClientMode, clientModeDriverUnack)
 	}
+	directCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "bson"})
+	if err != nil {
+		t.Fatalf("parse direct config: %v", err)
+	}
+	if directCfg.ClientMode != clientModeDirect {
+		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
+	}
 	oneIndexCfg, err := parseConfig([]string{"-secondary-indexes", "1"})
 	if err != nil {
 		t.Fatalf("parse secondary-indexes=1 config: %v", err)
@@ -665,6 +672,12 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "raw-wire-tcp"}); err == nil {
 		t.Fatal("raw-wire-tcp client-mode accepted for mongo target")
+	}
+	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
+		t.Fatal("direct client-mode accepted for mongo target")
+	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "json"}); err == nil {
+		t.Fatal("direct client-mode accepted for non-BSON TreeDB document format")
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)
@@ -1228,11 +1241,87 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("client mode smoke benchmark skipped in short mode")
 	}
-	for _, mode := range []string{clientModeDriver, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeRawWire, clientModeRawWireTCP} {
+	for _, mode := range []string{clientModeDriver, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP} {
 		t.Run(mode, func(t *testing.T) {
 			opsPerSecond := runTreeDBClientModeSmoke(t, mode)
 			t.Logf("%s load_insert_many ops/sec=%.1f", mode, opsPerSecond)
 		})
+	}
+}
+
+func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("direct benchmark smoke skipped in short mode")
+	}
+	cfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-client-mode", "direct",
+		"-treedb-document-format", "bson",
+		"-documents", "96",
+		"-batch-size", "24",
+		"-insert-producers", "2",
+		"-reads", "12",
+		"-range-reads", "6",
+		"-updates", "6",
+		"-deletes", "2",
+		"-secondary-indexes", "2",
+		"-range-index",
+		"-concurrent-reader-sweep", "1,2",
+		"-concurrent-reads", "12",
+		"-concurrent-writers", "2",
+		"-concurrent-writes", "8",
+		"-update-indexed-field",
+		"-prebuild-documents",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+		"-timeout", "0",
+		"-format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parse direct smoke config: %v", err)
+	}
+	target, err := openTarget(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open direct target: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := closeBenchTarget(cleanupCtx, target); err != nil {
+			t.Errorf("cleanup direct target: %v", err)
+		}
+	}()
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
+	if err != nil {
+		t.Fatalf("run direct benchmark: %v", err)
+	}
+	if result.ClientMode != clientModeDirect {
+		t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
+	}
+	phases := make(map[string]phaseResult, len(result.Phases))
+	for _, phase := range result.Phases {
+		phases[phase.Name] = phase
+	}
+	for _, name := range []string{
+		"load_insert_many",
+		"id_find_one",
+		"email_find_one",
+		"age_range_indexed_limit_10",
+		"id_update_set",
+		"concurrent_id_find_one_r1",
+		"concurrent_id_find_one_r2",
+		"concurrent_id_update_set_w2",
+		"id_delete_one",
+	} {
+		phase, ok := phases[name]
+		if !ok {
+			t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
+		}
+		if phase.OpsPerSecond <= 0 {
+			t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
+		}
+		if phase.SampledNsPerOp <= 0 {
+			t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
+		}
 	}
 }
 
@@ -1764,6 +1853,58 @@ func TestBenchmarkSetUpdateCanExerciseIndexedField(t *testing.T) {
 		if first, revisited := benchmarkUpdatedCity(op, documentOrdinal, documents), benchmarkUpdatedCity(op+documents, documentOrdinal, documents); first == revisited {
 			t.Fatalf("benchmarkUpdatedCity repeated value %q when revisiting document %d at op+documents for op=%d documents=%d", first, documentOrdinal, op, documents)
 		}
+	}
+}
+
+func TestApplyDirectBSONSetUpdate(t *testing.T) {
+	docRaw, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: "user-000001"},
+		{Key: "name", Value: "Ada"},
+		{Key: "age", Value: int64(37)},
+	})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+		{Key: "name", Value: "Grace"},
+		{Key: "city", Value: "honolulu"},
+	}}})
+	if err != nil {
+		t.Fatalf("marshal update: %v", err)
+	}
+	updated, changed, err := applyDirectBSONSetUpdate(bson.Raw(docRaw), bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed=false want true")
+	}
+	if got, ok := updated.Lookup("_id").StringValueOK(); !ok || got != "user-000001" {
+		t.Fatalf("_id=%q ok=%t want user-000001", got, ok)
+	}
+	if got, ok := updated.Lookup("name").StringValueOK(); !ok || got != "Grace" {
+		t.Fatalf("name=%q ok=%t want Grace", got, ok)
+	}
+	if got, ok := updated.Lookup("city").StringValueOK(); !ok || got != "honolulu" {
+		t.Fatalf("city=%q ok=%t want honolulu", got, ok)
+	}
+	updatedAgain, changed, err := applyDirectBSONSetUpdate(updated, bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("apply unchanged update: %v", err)
+	}
+	if changed {
+		t.Fatal("changed=true want false for idempotent $set")
+	}
+	if !bytes.Equal(updated, updatedAgain) {
+		t.Fatalf("unchanged update bytes changed:\nfirst=%v\nagain=%v", updated, updatedAgain)
+	}
+
+	idUpdateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{{Key: "_id", Value: "other"}}}})
+	if err != nil {
+		t.Fatalf("marshal _id update: %v", err)
+	}
+	if _, _, err := applyDirectBSONSetUpdate(updated, bson.Raw(idUpdateRaw)); err == nil {
+		t.Fatal("_id update accepted")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -583,10 +583,13 @@ func TestParseConfigValidation(t *testing.T) {
 		"-format", "json",
 		"-concurrent-readers", "4",
 		"-concurrent-reads", "20",
+		"-concurrent-range-readers", "3",
+		"-concurrent-range-reads", "18",
 		"-concurrent-writers", "2",
 		"-concurrent-writes", "10",
 		"-update-indexed-field",
 		"-range-index",
+		"-treedb-read-state", "unsettled",
 	})
 	if err != nil {
 		t.Fatalf("parse valid config: %v", err)
@@ -595,8 +598,10 @@ func TestParseConfigValidation(t *testing.T) {
 		cfg.ClientMode != clientModeDriver ||
 		cfg.BatchSize != 5 || cfg.InsertProducers != 4 ||
 		cfg.MongoMaxPoolSize != 32 || cfg.MongoMinPoolSize != 8 || cfg.MongoMaxConnecting != 16 ||
-		cfg.ConcurrentReaders != 4 || cfg.ConcurrentReads != 20 || cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 ||
-		!cfg.UpdateIndexedField || !cfg.RangeIndex {
+		cfg.ConcurrentReaders != 4 || cfg.ConcurrentReads != 20 ||
+		cfg.ConcurrentRangeReaders != 3 || cfg.ConcurrentRangeReads != 18 ||
+		cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 ||
+		!cfg.UpdateIndexedField || !cfg.RangeIndex || cfg.TreeDBReadState != treeDBReadStateUnsettled {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 	sweepCfg, err := parseConfig([]string{
@@ -608,6 +613,16 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sweepCfg.ConcurrentReaderSweep, []int{1, 2, 4}) || sweepCfg.ConcurrentReads != 30 {
 		t.Fatalf("unexpected concurrent reader sweep config: %+v", sweepCfg)
+	}
+	rangeSweepCfg, err := parseConfig([]string{
+		"-concurrent-range-reader-sweep", "1,2 4",
+		"-concurrent-range-reads", "30",
+	})
+	if err != nil {
+		t.Fatalf("parse concurrent range reader sweep config: %v", err)
+	}
+	if !reflect.DeepEqual(rangeSweepCfg.ConcurrentRangeReaderSweep, []int{1, 2, 4}) || rangeSweepCfg.ConcurrentRangeReads != 30 {
+		t.Fatalf("unexpected concurrent range reader sweep config: %+v", rangeSweepCfg)
 	}
 	rawWireCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire"})
 	if err != nil {
@@ -708,6 +723,37 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-concurrent-reader-sweep", "1,1", "-concurrent-reads", "10"}); err == nil {
 		t.Fatal("duplicate concurrent-reader-sweep value accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-readers", "-1"}); err == nil {
+		t.Fatal("negative concurrent-range-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-readers", "1"}); err == nil {
+		t.Fatal("concurrent-range-readers without concurrent-range-reads accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-reads", "1"}); err == nil {
+		t.Fatal("concurrent-range-reads without concurrent-range-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-reader-sweep", "1,2"}); err == nil {
+		t.Fatal("concurrent-range-reader-sweep without concurrent-range-reads accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-reader-sweep", "1,2", "-concurrent-range-reads", "10", "-concurrent-range-readers", "2"}); err == nil {
+		t.Fatal("concurrent-range-reader-sweep combined with concurrent-range-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-reader-sweep", "1,0", "-concurrent-range-reads", "10"}); err == nil {
+		t.Fatal("invalid concurrent-range-reader-sweep accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-range-reader-sweep", "1,1", "-concurrent-range-reads", "10"}); err == nil {
+		t.Fatal("duplicate concurrent-range-reader-sweep value accepted")
+	}
+	if _, err := parseConfig([]string{"-treedb-read-state", "bad"}); err == nil {
+		t.Fatal("bad treedb-read-state accepted")
+	}
+	legacyFlushedCfg, err := parseConfig([]string{"-treedb-read-state", "flushed"})
+	if err != nil {
+		t.Fatalf("legacy flushed treedb-read-state rejected: %v", err)
+	}
+	if legacyFlushedCfg.TreeDBReadState != treeDBReadStateSettled {
+		t.Fatalf("legacy flushed read state normalized to %q want %q", legacyFlushedCfg.TreeDBReadState, treeDBReadStateSettled)
 	}
 	if _, err := parseConfig([]string{"-insert-producers", "0"}); err == nil {
 		t.Fatal("zero insert-producers accepted")
@@ -1252,6 +1298,65 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	}
 }
 
+func TestTreeDBDriverCommandRawRangePhaseSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("driver-command-raw range smoke skipped in short mode")
+	}
+	cfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-client-mode", clientModeDriverCommandRaw,
+		"-documents", "96",
+		"-batch-size", "24",
+		"-reads", "0",
+		"-range-reads", "8",
+		"-updates", "0",
+		"-secondary-indexes", "2",
+		"-range-index",
+		"-concurrent-range-reader-sweep", "1,2",
+		"-concurrent-range-reads", "8",
+		"-treedb-document-format", string(collections.DocumentFormatBSON),
+		"-treedb-maintenance", treeDBMaintenanceNone,
+		"-prebuild-documents",
+		"-timeout", "0",
+		"-format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parse driver-command-raw range config: %v", err)
+	}
+	target, err := openTarget(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := closeBenchTarget(cleanupCtx, target); err != nil {
+			t.Errorf("cleanup target: %v", err)
+		}
+	}()
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
+	if err != nil {
+		t.Fatalf("run benchmark: %v", err)
+	}
+	phases := make(map[string]phaseResult, len(result.Phases))
+	for _, phase := range result.Phases {
+		phases[phase.Name] = phase
+	}
+	for _, name := range []string{
+		"age_range_indexed_limit_10",
+		"concurrent_age_range_indexed_limit_10_r1",
+		"concurrent_age_range_indexed_limit_10_r2",
+	} {
+		phase, ok := phases[name]
+		if !ok {
+			t.Fatalf("phase %q missing from result: %+v", name, result.Phases)
+		}
+		if phase.SampledNsPerOp <= 0 || phase.OpsPerSecond <= 0 {
+			t.Fatalf("phase %q metrics missing: %+v", name, phase)
+		}
+	}
+}
+
 func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("direct benchmark smoke skipped in short mode")
@@ -1277,6 +1382,8 @@ func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 				"-range-index",
 				"-concurrent-reader-sweep", "1,2",
 				"-concurrent-reads", "12",
+				"-concurrent-range-reader-sweep", "1,2",
+				"-concurrent-range-reads", "10",
 				"-concurrent-writers", "2",
 				"-concurrent-writes", "8",
 				"-update-indexed-field",
@@ -1318,6 +1425,8 @@ func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 				"id_find_one",
 				"email_find_one",
 				"age_range_indexed_limit_10",
+				"concurrent_age_range_indexed_limit_10_r1",
+				"concurrent_age_range_indexed_limit_10_r2",
 				"id_update_set",
 				"concurrent_id_find_one_r1",
 				"concurrent_id_find_one_r2",
@@ -2022,6 +2131,9 @@ func TestRangePhaseNameDistinguishesScanAndIndexedRuns(t *testing.T) {
 	}
 	if got := rangePhaseName(config{RangeIndex: true}); got != "age_range_indexed_limit_10" {
 		t.Fatalf("indexed range phase name=%q want indexed", got)
+	}
+	if got := concurrentRangePhaseName(config{RangeIndex: true}, 16); got != "concurrent_age_range_indexed_limit_10_r16" {
+		t.Fatalf("concurrent indexed range phase name=%q", got)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -650,6 +650,11 @@ func TestParseConfigValidation(t *testing.T) {
 	if directCfg.ClientMode != clientModeDirect {
 		t.Fatalf("ClientMode=%q want %q", directCfg.ClientMode, clientModeDirect)
 	}
+	for _, format := range []string{"json", "template-v1", "bson"} {
+		if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", format}); err != nil {
+			t.Fatalf("parse direct %s config: %v", format, err)
+		}
+	}
 	oneIndexCfg, err := parseConfig([]string{"-secondary-indexes", "1"})
 	if err != nil {
 		t.Fatalf("parse secondary-indexes=1 config: %v", err)
@@ -675,9 +680,6 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
 		t.Fatal("direct client-mode accepted for mongo target")
-	}
-	if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-document-format", "json"}); err == nil {
-		t.Fatal("direct client-mode accepted for non-BSON TreeDB document format")
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)
@@ -1253,75 +1255,86 @@ func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("direct benchmark smoke skipped in short mode")
 	}
-	cfg, err := parseConfig([]string{
-		"-target", "treedb",
-		"-client-mode", "direct",
-		"-treedb-document-format", "bson",
-		"-documents", "96",
-		"-batch-size", "24",
-		"-insert-producers", "2",
-		"-reads", "12",
-		"-range-reads", "6",
-		"-updates", "6",
-		"-deletes", "2",
-		"-secondary-indexes", "2",
-		"-range-index",
-		"-concurrent-reader-sweep", "1,2",
-		"-concurrent-reads", "12",
-		"-concurrent-writers", "2",
-		"-concurrent-writes", "8",
-		"-update-indexed-field",
-		"-prebuild-documents",
-		"-treedb-maintenance", treeDBMaintenanceNone,
-		"-timeout", "0",
-		"-format", "json",
-	})
-	if err != nil {
-		t.Fatalf("parse direct smoke config: %v", err)
-	}
-	target, err := openTarget(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("open direct target: %v", err)
-	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := closeBenchTarget(cleanupCtx, target); err != nil {
-			t.Errorf("cleanup direct target: %v", err)
-		}
-	}()
-	result, err := runBenchmark(context.Background(), cfg, target, nil)
-	if err != nil {
-		t.Fatalf("run direct benchmark: %v", err)
-	}
-	if result.ClientMode != clientModeDirect {
-		t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
-	}
-	phases := make(map[string]phaseResult, len(result.Phases))
-	for _, phase := range result.Phases {
-		phases[phase.Name] = phase
-	}
-	for _, name := range []string{
-		"load_insert_many",
-		"id_find_one",
-		"email_find_one",
-		"age_range_indexed_limit_10",
-		"id_update_set",
-		"concurrent_id_find_one_r1",
-		"concurrent_id_find_one_r2",
-		"concurrent_id_update_set_w2",
-		"id_delete_one",
+	for _, format := range []collections.DocumentFormat{
+		collections.DocumentFormatJSON,
+		collections.DocumentFormatTemplateV1,
+		collections.DocumentFormatBSON,
 	} {
-		phase, ok := phases[name]
-		if !ok {
-			t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
-		}
-		if phase.OpsPerSecond <= 0 {
-			t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
-		}
-		if phase.SampledNsPerOp <= 0 {
-			t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
-		}
+		t.Run(string(format), func(t *testing.T) {
+			cfg, err := parseConfig([]string{
+				"-target", "treedb",
+				"-client-mode", "direct",
+				"-treedb-document-format", string(format),
+				"-documents", "96",
+				"-batch-size", "24",
+				"-insert-producers", "2",
+				"-reads", "12",
+				"-range-reads", "6",
+				"-updates", "6",
+				"-deletes", "2",
+				"-secondary-indexes", "2",
+				"-range-index",
+				"-concurrent-reader-sweep", "1,2",
+				"-concurrent-reads", "12",
+				"-concurrent-writers", "2",
+				"-concurrent-writes", "8",
+				"-update-indexed-field",
+				"-prebuild-documents",
+				"-treedb-maintenance", treeDBMaintenanceNone,
+				"-timeout", "0",
+				"-format", "json",
+			})
+			if err != nil {
+				t.Fatalf("parse direct smoke config: %v", err)
+			}
+			target, err := openTarget(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("open direct target: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := closeBenchTarget(cleanupCtx, target); err != nil {
+					t.Errorf("cleanup direct target: %v", err)
+				}
+			}()
+			result, err := runBenchmark(context.Background(), cfg, target, nil)
+			if err != nil {
+				t.Fatalf("run direct benchmark: %v", err)
+			}
+			if result.ClientMode != clientModeDirect {
+				t.Fatalf("client mode=%q want %q", result.ClientMode, clientModeDirect)
+			}
+			if result.TreeDBDocumentFormat != string(format) {
+				t.Fatalf("document format=%q want %q", result.TreeDBDocumentFormat, format)
+			}
+			phases := make(map[string]phaseResult, len(result.Phases))
+			for _, phase := range result.Phases {
+				phases[phase.Name] = phase
+			}
+			for _, name := range []string{
+				"load_insert_many",
+				"id_find_one",
+				"email_find_one",
+				"age_range_indexed_limit_10",
+				"id_update_set",
+				"concurrent_id_find_one_r1",
+				"concurrent_id_find_one_r2",
+				"concurrent_id_update_set_w2",
+				"id_delete_one",
+			} {
+				phase, ok := phases[name]
+				if !ok {
+					t.Fatalf("phase %q missing from direct result: %+v", name, result.Phases)
+				}
+				if phase.OpsPerSecond <= 0 {
+					t.Fatalf("phase %q ops/sec=%f", name, phase.OpsPerSecond)
+				}
+				if phase.SampledNsPerOp <= 0 {
+					t.Fatalf("phase %q sampled ns/op=%f", name, phase.SampledNsPerOp)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -748,6 +748,9 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-treedb-read-state", "bad"}); err == nil {
 		t.Fatal("bad treedb-read-state accepted")
 	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-client-mode", "direct", "-treedb-read-state", "unsettled", "-range-reads", "1"}); err == nil {
+		t.Fatal("direct unsettled scan range reads accepted")
+	}
 	legacyFlushedCfg, err := parseConfig([]string{"-treedb-read-state", "flushed"})
 	if err != nil {
 		t.Fatalf("legacy flushed treedb-read-state rejected: %v", err)
@@ -1848,6 +1851,7 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	if !bytes.Contains(out.Bytes(), []byte("concurrent_range_readers=4")) ||
 		!bytes.Contains(out.Bytes(), []byte("concurrent_range_reader_sweep=[1 4]")) ||
 		!bytes.Contains(out.Bytes(), []byte("concurrent_range_reads=8")) ||
+		!bytes.Contains(out.Bytes(), []byte("treedb_read_state=unsettled")) ||
 		!bytes.Contains(out.Bytes(), []byte("read_state=unsettled")) {
 		t.Fatalf("text output missing range/read-state metadata: %q", out.String())
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1808,13 +1808,18 @@ func TestMongoPoolStatsCapsCheckoutSamples(t *testing.T) {
 
 func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	result := &benchmarkResult{
-		Target:           "treedb",
-		Database:         "bench",
-		Collection:       "docs",
-		Documents:        1,
-		BatchSize:        1,
-		InsertProducers:  2,
-		SecondaryIndexes: 1,
+		Target:                     "treedb",
+		Database:                   "bench",
+		Collection:                 "docs",
+		Documents:                  1,
+		BatchSize:                  1,
+		InsertProducers:            2,
+		SecondaryIndexes:           1,
+		ConcurrentRangeReaders:     4,
+		ConcurrentRangeReaderSweep: []int{1, 4},
+		ConcurrentRangeReads:       8,
+		TreeDBProfile:              "wal-on-fast",
+		TreeDBReadState:            treeDBReadStateUnsettled,
 		Phases: []phaseResult{{
 			Name:           "load_insert_many",
 			Operations:     1,
@@ -1839,6 +1844,12 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("insert_producers=2")) || !bytes.Contains(out.Bytes(), []byte("producer=0")) {
 		t.Fatalf("text output missing producer metadata: %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("concurrent_range_readers=4")) ||
+		!bytes.Contains(out.Bytes(), []byte("concurrent_range_reader_sweep=[1 4]")) ||
+		!bytes.Contains(out.Bytes(), []byte("concurrent_range_reads=8")) ||
+		!bytes.Contains(out.Bytes(), []byte("read_state=unsettled")) {
+		t.Fatalf("text output missing range/read-state metadata: %q", out.String())
 	}
 }
 

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -44,6 +44,7 @@ type benchmarkResult struct {
 	RangeIndex                 bool              `json:"range_index"`
 	ClientMode                 string            `json:"client_mode,omitempty"`
 	ConcurrentReaderSweep      []int             `json:"concurrent_reader_sweep,omitempty"`
+	ConcurrentRangeReaderSweep []int             `json:"concurrent_range_reader_sweep,omitempty"`
 	TreeDBDocumentFormat       string            `json:"treedb_document_format,omitempty"`
 	Phases                     []phaseResult     `json:"phases"`
 	ProfileDir                 string            `json:"profile_dir,omitempty"`
@@ -649,6 +650,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	renderMongoRowsTable(&b, cells)
 	b.WriteString("\n")
 	renderConcurrentReadSweepTable(&b, cells)
+	renderConcurrentRangeReadSweepTable(&b, cells)
 	renderWriterSweepCounterTable(&b, cells)
 	renderOpsTable(&b, cells)
 	b.WriteString("\n")
@@ -672,6 +674,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- MongoDB physical bytes are the preferred local disk comparison when the matrix runner has an isolated data directory, such as Docker mode.\n")
 	b.WriteString("- Wall ops/sec values include the full benchmark phase loop. Sampled ops/sec values isolate the timed driver/gateway call inside each phase and are useful when prebuilt fixtures are enabled.\n")
 	b.WriteString("- `concurrent_id_find_one_rN` phases are an `_id` read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Read Sweep section when present.\n")
+	b.WriteString("- `concurrent_age_range_*_rN` phases are an age range-read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Range Read Sweep section when present.\n")
 	b.WriteString("- Range-query benchmark rows use explicit phase names: `age_range_indexed_limit_10` means `-range-index` created `age_1`; `age_range_scan_limit_10` means bounded scan fallback.\n")
 	b.WriteString("- Main comparison tables label the MongoDB config chosen as the baseline. In multi-mode matrices, all other MongoDB rows remain visible in the Mongo Matrix Rows section.\n")
 	return b.String()
@@ -990,6 +993,36 @@ func renderConcurrentReadSweepTable(b *strings.Builder, cells []cellComparison) 
 	b.WriteString("\n")
 }
 
+func renderConcurrentRangeReadSweepTable(b *strings.Builder, cells []cellComparison) {
+	rows := concurrentRangeReadSweepComparisons(cells)
+	if len(rows) == 0 {
+		return
+	}
+	b.WriteString("## Concurrent Range Read Sweep\n\n")
+	b.WriteString("These rows group `concurrent_age_range_*_rN` phases as one age range-read throughput sweep. Serial `age_range_*_limit_10` remains a separate single-in-flight latency phase.\n\n")
+	b.WriteString("| docs | indexes | range mode | TreeDB config | MongoDB baseline config | readers | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB p95 us | MongoDB p95 us |\n")
+	b.WriteString("| ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, cmp := range rows {
+		readers, _ := concurrentRangeReadReaders(cmp.Name)
+		fmt.Fprintf(b, "| %d | %d | %s | `%s` | %s | %d | %s | %s | %s | %s | %s | %s | %s |\n",
+			cmp.Cell.Documents,
+			cmp.Cell.SecondaryIndexes,
+			formatRangeMode(cmp.Name),
+			cmp.Cell.TreeDBConfig,
+			formatConfig(cmp.MongoConfig),
+			readers,
+			formatPhaseOps(cmp.HasTreeDB, cmp.TreeDBPhase.OpsPerSecond),
+			formatPhaseOps(cmp.HasTreeDB && cmp.TreeDBPhase.SampledOpsPerSecond > 0, cmp.TreeDBPhase.SampledOpsPerSecond),
+			formatPhaseOps(cmp.HasMongo, cmp.MongoPhase.OpsPerSecond),
+			formatPhaseOps(cmp.HasMongo && cmp.MongoPhase.SampledOpsPerSecond > 0, cmp.MongoPhase.SampledOpsPerSecond),
+			formatRatio(cmp.Ratio),
+			formatPhaseLatency(cmp.HasTreeDB, cmp.TreeDBPhase.LatencyMicros.P95),
+			formatPhaseLatency(cmp.HasMongo, cmp.MongoPhase.LatencyMicros.P95),
+		)
+	}
+	b.WriteString("\n")
+}
+
 func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
 	var out []phaseComparison
 	for _, cell := range cells {
@@ -1039,6 +1072,55 @@ func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
 	return out
 }
 
+func concurrentRangeReadSweepComparisons(cells []cellComparison) []phaseComparison {
+	var out []phaseComparison
+	for _, cell := range cells {
+		if !cellHasConcurrentRangeReadSweep(cell) {
+			continue
+		}
+		var mongoPhases []phaseResult
+		mongoPhaseMap := map[string]phaseResult{}
+		if cell.Mongo != nil {
+			mongoPhases = cell.Mongo.Result.Phases
+			mongoPhaseMap = cell.Mongo.PhaseMap
+		}
+		for _, name := range phaseNames(cell.TreeDB.Result.Phases, mongoPhases) {
+			if _, ok := concurrentRangeReadReaders(name); !ok {
+				continue
+			}
+			treePhase, hasTree := cell.TreeDB.PhaseMap[name]
+			mongoPhase, hasMongo := mongoPhaseMap[name]
+			out = append(out, phaseComparison{
+				Cell:        cell.Key,
+				Name:        name,
+				RangeIndex:  cell.TreeDB.Result.RangeIndex,
+				MongoConfig: recordConfig(cell.Mongo),
+				TreeDBPhase: treePhase,
+				MongoPhase:  mongoPhase,
+				HasTreeDB:   hasTree,
+				HasMongo:    hasMongo,
+				Ratio:       safeRatio(treePhase.OpsPerSecond, mongoPhase.OpsPerSecond),
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i], out[j]
+		if left.Cell.Documents != right.Cell.Documents {
+			return left.Cell.Documents < right.Cell.Documents
+		}
+		if left.Cell.SecondaryIndexes != right.Cell.SecondaryIndexes {
+			return left.Cell.SecondaryIndexes < right.Cell.SecondaryIndexes
+		}
+		if left.Cell.TreeDBConfig != right.Cell.TreeDBConfig {
+			return left.Cell.TreeDBConfig < right.Cell.TreeDBConfig
+		}
+		leftReaders, _ := concurrentRangeReadReaders(left.Name)
+		rightReaders, _ := concurrentRangeReadReaders(right.Name)
+		return leftReaders < rightReaders
+	})
+	return out
+}
+
 func cellHasConcurrentReadSweep(cell cellComparison) bool {
 	if len(cell.TreeDB.Result.ConcurrentReaderSweep) > 0 {
 		return true
@@ -1055,6 +1137,29 @@ func cellHasConcurrentReadSweep(cell cellComparison) bool {
 	if cell.Mongo != nil {
 		for _, phase := range cell.Mongo.Result.Phases {
 			if readerCount, ok := concurrentReadReaders(phase.Name); ok {
+				readers[readerCount] = struct{}{}
+			}
+		}
+	}
+	return len(readers) > 1
+}
+
+func cellHasConcurrentRangeReadSweep(cell cellComparison) bool {
+	if len(cell.TreeDB.Result.ConcurrentRangeReaderSweep) > 0 {
+		return true
+	}
+	if cell.Mongo != nil && len(cell.Mongo.Result.ConcurrentRangeReaderSweep) > 0 {
+		return true
+	}
+	readers := make(map[int]struct{})
+	for _, phase := range cell.TreeDB.Result.Phases {
+		if readerCount, ok := concurrentRangeReadReaders(phase.Name); ok {
+			readers[readerCount] = struct{}{}
+		}
+	}
+	if cell.Mongo != nil {
+		for _, phase := range cell.Mongo.Result.Phases {
+			if readerCount, ok := concurrentRangeReadReaders(phase.Name); ok {
 				readers[readerCount] = struct{}{}
 			}
 		}
@@ -1176,6 +1281,25 @@ func concurrentReadReaders(name string) (int, bool) {
 	return readers, true
 }
 
+func concurrentRangeReadReaders(name string) (int, bool) {
+	if !strings.HasPrefix(name, "concurrent_") || !strings.Contains(name, "_range_") {
+		return 0, false
+	}
+	idx := strings.LastIndex(name, "_r")
+	if idx < 0 {
+		return 0, false
+	}
+	prefix, count := name[:idx], name[idx+2:]
+	if !strings.Contains(prefix, "_limit_") {
+		return 0, false
+	}
+	readers, err := strconv.Atoi(count)
+	if err != nil || readers <= 0 {
+		return 0, false
+	}
+	return readers, true
+}
+
 func concurrentUpdateWriters(name string) (int, bool) {
 	const prefix = "concurrent_id_update_set_w"
 	if !strings.HasPrefix(name, prefix) {
@@ -1193,14 +1317,23 @@ func renderOpsTable(b *strings.Builder, cells []cellComparison) {
 	b.WriteString("| docs | indexes | range index | range mode | TreeDB config | MongoDB baseline config | phase | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB / MongoDB sampled | TreeDB p95 us | MongoDB p95 us |\n")
 	b.WriteString("| ---: | ---: | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
 	sweepCells := make(map[cellKey]bool, len(cells))
+	rangeSweepCells := make(map[cellKey]bool, len(cells))
 	for _, cell := range cells {
 		if cellHasConcurrentReadSweep(cell) {
 			sweepCells[cell.Key] = true
+		}
+		if cellHasConcurrentRangeReadSweep(cell) {
+			rangeSweepCells[cell.Key] = true
 		}
 	}
 	for _, cmp := range allPhaseComparisons(cells) {
 		if sweepCells[cmp.Cell] {
 			if _, ok := concurrentReadReaders(cmp.Name); ok {
+				continue
+			}
+		}
+		if rangeSweepCells[cmp.Cell] {
+			if _, ok := concurrentRangeReadReaders(cmp.Name); ok {
 				continue
 			}
 		}

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -1114,6 +1114,9 @@ func concurrentRangeReadSweepComparisons(cells []cellComparison) []phaseComparis
 		if left.Cell.TreeDBConfig != right.Cell.TreeDBConfig {
 			return left.Cell.TreeDBConfig < right.Cell.TreeDBConfig
 		}
+		if leftMode, rightMode := rangeMode(left.Name), rangeMode(right.Name); leftMode != rightMode {
+			return leftMode < rightMode
+		}
 		leftReaders, _ := concurrentRangeReadReaders(left.Name)
 		rightReaders, _ := concurrentRangeReadReaders(right.Name)
 		return leftReaders < rightReaders

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -255,6 +255,68 @@ func TestReportGroupsConcurrentReadSweepRows(t *testing.T) {
 	}
 }
 
+func TestReportGroupsConcurrentRangeReadSweepRows(t *testing.T) {
+	treedbPhases := []phaseResult{
+		{Name: "age_range_indexed_limit_10", OpsPerSecond: 700, SampledOpsPerSecond: 750, LatencyMicros: latencySummary{P95: 70}},
+		{Name: "concurrent_age_range_indexed_limit_10_r4", OpsPerSecond: 4000, SampledOpsPerSecond: 4200, LatencyMicros: latencySummary{P95: 10}},
+		{Name: "concurrent_age_range_indexed_limit_10_r1", OpsPerSecond: 1000, SampledOpsPerSecond: 1200, LatencyMicros: latencySummary{P95: 15}},
+	}
+	mongoPhases := []phaseResult{
+		{Name: "age_range_indexed_limit_10", OpsPerSecond: 600, SampledOpsPerSecond: 650, LatencyMicros: latencySummary{P95: 80}},
+		{Name: "concurrent_age_range_indexed_limit_10_r4", OpsPerSecond: 2000, SampledOpsPerSecond: 2200, LatencyMicros: latencySummary{P95: 20}},
+		{Name: "concurrent_age_range_indexed_limit_10_r1", OpsPerSecond: 500, SampledOpsPerSecond: 600, LatencyMicros: latencySummary{P95: 30}},
+	}
+	cells := []cellComparison{{
+		Key: cellKey{Documents: 100, SecondaryIndexes: 2, TreeDBConfig: "treedb_bson"},
+		TreeDB: &runRecord{
+			Row:      matrixRow{Target: "treedb", Config: "treedb_bson", Documents: 100, SecondaryIndexes: 2, RawJSON: "treedb.json"},
+			Result:   benchmarkResult{Target: "treedb", Documents: 100, SecondaryIndexes: 2, RangeIndex: true, ConcurrentRangeReaderSweep: []int{1, 4}, Phases: treedbPhases},
+			PhaseMap: phaseMap(treedbPhases),
+		},
+		Mongo: &runRecord{
+			Row:      matrixRow{Target: "mongo", Config: "mongo", Documents: 100, SecondaryIndexes: 2, RawJSON: "mongo.json"},
+			Result:   benchmarkResult{Target: "mongo", Documents: 100, SecondaryIndexes: 2, RangeIndex: true, ConcurrentRangeReaderSweep: []int{1, 4}, Phases: mongoPhases},
+			PhaseMap: phaseMap(mongoPhases),
+		},
+	}}
+
+	report := renderReport(config{Title: "test", MatrixPath: "matrix.tsv"}, cells, time.Unix(0, 0).UTC())
+	for _, want := range []string{
+		"## Concurrent Range Read Sweep",
+		"Serial `age_range_*_limit_10` remains a separate single-in-flight latency phase.",
+		"| 100 | 2 | `indexed` | `treedb_bson` | `mongo` | 1 | 1000 | 1200 | 500 | 600 | 2.00x | 15.0 | 30.0 |",
+		"| 100 | 2 | `indexed` | `treedb_bson` | `mongo` | 4 | 4000 | 4200 | 2000 | 2200 | 2.00x | 10.0 | 20.0 |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+	opsSection := strings.Split(strings.Split(report, "## Ops/Sec Summary")[1], "## Raw Inputs")[0]
+	if strings.Contains(opsSection, "`concurrent_age_range_indexed_limit_10_r1`") || strings.Contains(opsSection, "`concurrent_age_range_indexed_limit_10_r4`") {
+		t.Fatalf("range sweep phases should be grouped in the range sweep section, not repeated in ops summary:\n%s", opsSection)
+	}
+	if !strings.Contains(opsSection, "`age_range_indexed_limit_10`") {
+		t.Fatalf("serial range phase should remain in ops summary:\n%s", opsSection)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		readers int
+		ok      bool
+	}{
+		{name: "concurrent_age_range_indexed_limit_10_r8", readers: 8, ok: true},
+		{name: "concurrent_age_range_scan_limit_10_r2", readers: 2, ok: true},
+		{name: "concurrent_age_range_indexed_limit_10_r0", ok: false},
+		{name: "age_range_indexed_limit_10", ok: false},
+		{name: "concurrent_id_find_one_r8", ok: false},
+	} {
+		readers, ok := concurrentRangeReadReaders(tc.name)
+		if readers != tc.readers || ok != tc.ok {
+			t.Fatalf("concurrentRangeReadReaders(%q)=%d,%t want %d,%t", tc.name, readers, ok, tc.readers, tc.ok)
+		}
+	}
+}
+
 func TestReportDoesNotGroupLegacySingleConcurrentReadPhase(t *testing.T) {
 	phase := phaseResult{Name: "concurrent_id_find_one_r8", OpsPerSecond: 8000}
 	cells := []cellComparison{{

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -285,16 +285,17 @@ Interpret client modes as separate questions:
 - `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
 - `driver-unack`: official driver unacknowledged insert enqueue path plus
   post-load visibility wait.
-- `direct`: TreeDB-only BSON collection API path. It emits the same phase names
-  as the Mongo gateway benchmark while bypassing the MongoDB driver, sockets,
-  and Mongo gateway command handling.
+- `direct`: TreeDB-only collection API path in the selected TreeDB document
+  format. It emits the same phase names as the Mongo gateway benchmark while
+  bypassing the MongoDB driver, sockets, and Mongo gateway command handling.
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
 the fastest current acknowledged official-driver load path. Use `direct` to
-separate collection-engine bottlenecks from Mongo compatibility overhead. Use
-raw-wire modes only to estimate TreeDB gateway/server ceiling.
+separate collection-engine and storage-format bottlenecks from Mongo
+compatibility overhead. Use raw-wire modes only to estimate TreeDB
+gateway/server ceiling.
 
 ## Reader and Writer Scaling
 

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -249,7 +249,7 @@ Use a client-mode matrix when measuring driver overhead and gateway ceiling:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
 MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
 BATCH_SIZE=5000 \
 INSERT_PRODUCERS=8 \
@@ -285,12 +285,16 @@ Interpret client modes as separate questions:
 - `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
 - `driver-unack`: official driver unacknowledged insert enqueue path plus
   post-load visibility wait.
+- `direct`: TreeDB-only BSON collection API path. It emits the same phase names
+  as the Mongo gateway benchmark while bypassing the MongoDB driver, sockets,
+  and Mongo gateway command handling.
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
-the fastest current acknowledged official-driver load path. Use raw-wire modes
-only to estimate TreeDB gateway/server ceiling.
+the fastest current acknowledged official-driver load path. Use `direct` to
+separate collection-engine bottlenecks from Mongo compatibility overhead. Use
+raw-wire modes only to estimate TreeDB gateway/server ceiling.
 
 ## Reader and Writer Scaling
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -105,9 +105,9 @@ Options:
   --treedb-document-formats LIST
                         Space-separated TreeDB formats. Example: "json template-v1 bson".
   --treedb-client-mode MODE
-                        Single TreeDB client mode: driver, driver-command, driver-command-raw, driver-unack, raw-wire-tcp, or raw-wire.
+                        Single TreeDB client mode: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, or raw-wire.
   --treedb-client-modes LIST
-                        Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire".
+                        Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
   --treedb-maintenance MODE
                         TreeDB final maintenance: full, checkpoint, or none.
   --title TITLE         Markdown report title.

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -28,6 +28,10 @@ CONCURRENT_READERS="${CONCURRENT_READERS:-0}"
 CONCURRENT_READER_SWEEP="${CONCURRENT_READER_SWEEP:-}"
 CONCURRENT_READS="${CONCURRENT_READS:-}"
 CONCURRENT_READS_DIVISOR="${CONCURRENT_READS_DIVISOR:-10}"
+CONCURRENT_RANGE_READERS="${CONCURRENT_RANGE_READERS:-0}"
+CONCURRENT_RANGE_READER_SWEEP="${CONCURRENT_RANGE_READER_SWEEP:-}"
+CONCURRENT_RANGE_READS="${CONCURRENT_RANGE_READS:-}"
+CONCURRENT_RANGE_READS_DIVISOR="${CONCURRENT_RANGE_READS_DIVISOR:-10}"
 CONCURRENT_WRITERS="${CONCURRENT_WRITERS:-0}"
 CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
@@ -49,6 +53,7 @@ TREEDB_DATA_ROOT_STORAGE="${TREEDB_DATA_ROOT_STORAGE:-compressed}"
 TREEDB_INDEX_STATE_ROOT_STORAGE="${TREEDB_INDEX_STATE_ROOT_STORAGE:-compressed}"
 TREEDB_INDEX_ROOT_STORAGE="${TREEDB_INDEX_ROOT_STORAGE:-compressed}"
 TREEDB_MAINTENANCE="${TREEDB_MAINTENANCE:-full}"
+TREEDB_READ_STATE="${TREEDB_READ_STATE:-settled}"
 
 usage() {
   cat <<'EOF'
@@ -85,6 +90,16 @@ Options:
                         combined with --concurrent-readers.
   --concurrent-reads COUNT
                         Concurrent point reads per target/cell.
+  --concurrent-range-readers N
+                        Reader goroutines for the concurrent age range-read phase.
+  --concurrent-range-reader-sweep LIST
+                        Space- or comma-separated reader counts for concurrent
+                        age range-read throughput sweep phases. Uses
+                        --concurrent-range-reads when set, otherwise derives
+                        from documents / CONCURRENT_RANGE_READS_DIVISOR. Cannot
+                        be combined with --concurrent-range-readers.
+  --concurrent-range-reads COUNT
+                        Concurrent age range reads per target/cell.
   --concurrent-writers N
                         Writer goroutines for the concurrent update phase.
   --concurrent-writes COUNT
@@ -110,6 +125,8 @@ Options:
                         Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
   --treedb-maintenance MODE
                         TreeDB final maintenance: full, checkpoint, or none.
+  --treedb-read-state STATE
+                        TreeDB read state before read phases: settled or unsettled.
   --title TITLE         Markdown report title.
   --help                Show this help.
 
@@ -121,13 +138,15 @@ Environment overrides:
   RANGE_READS, UPDATES, DELETES, RANGE_READS_DIVISOR, UPDATES_DIVISOR,
   CONCURRENT_READERS, CONCURRENT_READS, CONCURRENT_READS_DIVISOR,
   CONCURRENT_READER_SWEEP,
+  CONCURRENT_RANGE_READERS, CONCURRENT_RANGE_READS, CONCURRENT_RANGE_READS_DIVISOR,
+  CONCURRENT_RANGE_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
   MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
   MONGO_CLIENT_MODE, MONGO_CLIENT_MODES,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
   TREEDB_CLIENT_MODE, TREEDB_CLIENT_MODES,
   TREEDB_DATA_ROOT_STORAGE, TREEDB_INDEX_STATE_ROOT_STORAGE, TREEDB_INDEX_ROOT_STORAGE,
-  TREEDB_MAINTENANCE, TITLE.
+  TREEDB_MAINTENANCE, TREEDB_READ_STATE, TITLE.
 EOF
 }
 
@@ -201,6 +220,18 @@ while [[ $# -gt 0 ]]; do
       CONCURRENT_READS="$2"
       shift 2
       ;;
+    --concurrent-range-readers)
+      CONCURRENT_RANGE_READERS="$2"
+      shift 2
+      ;;
+    --concurrent-range-reader-sweep)
+      CONCURRENT_RANGE_READER_SWEEP="$2"
+      shift 2
+      ;;
+    --concurrent-range-reads)
+      CONCURRENT_RANGE_READS="$2"
+      shift 2
+      ;;
     --concurrent-writers)
       CONCURRENT_WRITERS="$2"
       shift 2
@@ -258,6 +289,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --treedb-maintenance)
       TREEDB_MAINTENANCE="$2"
+      shift 2
+      ;;
+    --treedb-read-state)
+      TREEDB_READ_STATE="$2"
       shift 2
       ;;
     --title)
@@ -537,9 +572,11 @@ run_target() {
   local deletes=$9
   local concurrent_readers=${10}
   local concurrent_reads=${11}
-  local concurrent_writers=${12}
-  local concurrent_writes=${13}
-  shift 13
+  local concurrent_range_readers=${12}
+  local concurrent_range_reads=${13}
+  local concurrent_writers=${14}
+  local concurrent_writes=${15}
+  shift 15
 
   local prebuild_args=()
   if [[ "$PREBUILD_DOCUMENTS" == "true" ]]; then
@@ -567,6 +604,9 @@ run_target() {
     -concurrent-readers "$concurrent_readers" \
     -concurrent-reader-sweep "$CONCURRENT_READER_SWEEP" \
     -concurrent-reads "$concurrent_reads" \
+    -concurrent-range-readers "$concurrent_range_readers" \
+    -concurrent-range-reader-sweep "$CONCURRENT_RANGE_READER_SWEEP" \
+    -concurrent-range-reads "$concurrent_range_reads" \
     -concurrent-writers "$concurrent_writers" \
     -concurrent-writes "$concurrent_writes" \
     -secondary-indexes "$indexes" \
@@ -581,6 +621,13 @@ if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
   echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
   exit 2
 fi
+if [[ "$TREEDB_READ_STATE" == "flushed" ]]; then
+  TREEDB_READ_STATE=settled
+fi
+if [[ "$TREEDB_READ_STATE" != "settled" && "$TREEDB_READ_STATE" != "unsettled" ]]; then
+  echo "unknown TREEDB_READ_STATE=$TREEDB_READ_STATE (want settled or unsettled)" >&2
+  exit 2
+fi
 if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
@@ -589,7 +636,7 @@ if ! is_positive_int "$INSERT_PRODUCERS"; then
   echo "invalid INSERT_PRODUCERS=$INSERT_PRODUCERS (want positive integer)" >&2
   exit 2
 fi
-for value_name in DELETES CONCURRENT_READERS CONCURRENT_WRITERS MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
+for value_name in DELETES CONCURRENT_READERS CONCURRENT_RANGE_READERS CONCURRENT_WRITERS MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
   value=${!value_name}
   if ! is_nonnegative_int "$value"; then
     echo "invalid $value_name=$value (want non-negative integer)" >&2
@@ -674,6 +721,60 @@ elif [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_RE
   echo "CONCURRENT_READERS or CONCURRENT_READER_SWEEP must be set when CONCURRENT_READS is set" >&2
   exit 2
 fi
+raw_concurrent_range_reader_sweep=$CONCURRENT_RANGE_READER_SWEEP
+CONCURRENT_RANGE_READER_SWEEP=$(trim_spaces "$CONCURRENT_RANGE_READER_SWEEP")
+if [[ -n "$raw_concurrent_range_reader_sweep" && -z "$CONCURRENT_RANGE_READER_SWEEP" ]]; then
+  echo "CONCURRENT_RANGE_READER_SWEEP must contain at least one positive integer" >&2
+  exit 2
+fi
+if [[ -n "$CONCURRENT_RANGE_READER_SWEEP" && "$CONCURRENT_RANGE_READERS" -gt 0 ]]; then
+  echo "CONCURRENT_RANGE_READER_SWEEP cannot be combined with CONCURRENT_RANGE_READERS" >&2
+  exit 2
+fi
+if [[ -n "$CONCURRENT_RANGE_READER_SWEEP" ]]; then
+  seen_range_reader_counts=""
+  normalized_range_reader_sweep=""
+  validated_range_reader_counts=0
+  for reader_count in ${CONCURRENT_RANGE_READER_SWEEP//,/ }; do
+    if ! is_positive_decimal_string "$reader_count"; then
+      echo "invalid CONCURRENT_RANGE_READER_SWEEP value: $reader_count" >&2
+      exit 2
+    fi
+    normalized_reader_count=$reader_count
+    while [[ "$normalized_reader_count" == 0* && ${#normalized_reader_count} -gt 1 ]]; do
+      normalized_reader_count=${normalized_reader_count#0}
+    done
+    if [[ " $seen_range_reader_counts " == *" $normalized_reader_count "* ]]; then
+      echo "duplicate CONCURRENT_RANGE_READER_SWEEP value: $reader_count" >&2
+      exit 2
+    fi
+    seen_range_reader_counts="$seen_range_reader_counts $normalized_reader_count"
+    if [[ -z "$normalized_range_reader_sweep" ]]; then
+      normalized_range_reader_sweep=$normalized_reader_count
+    else
+      normalized_range_reader_sweep="$normalized_range_reader_sweep,$normalized_reader_count"
+    fi
+    validated_range_reader_counts=$((validated_range_reader_counts + 1))
+  done
+  if [[ "$validated_range_reader_counts" -eq 0 ]]; then
+    echo "CONCURRENT_RANGE_READER_SWEEP must contain at least one positive integer" >&2
+    exit 2
+  fi
+  if [[ -n "$CONCURRENT_RANGE_READS" && "$CONCURRENT_RANGE_READS" == "0" ]]; then
+    echo "CONCURRENT_RANGE_READER_SWEEP requires CONCURRENT_RANGE_READS > 0 when CONCURRENT_RANGE_READS is set" >&2
+    exit 2
+  fi
+  if [[ -n "$CONCURRENT_RANGE_READS" ]]; then
+    if ! is_nonnegative_int "$CONCURRENT_RANGE_READS"; then
+      echo "invalid CONCURRENT_RANGE_READS=$CONCURRENT_RANGE_READS (want non-negative integer)" >&2
+      exit 2
+    fi
+  fi
+  CONCURRENT_RANGE_READER_SWEEP=$normalized_range_reader_sweep
+elif [[ "$CONCURRENT_RANGE_READERS" -eq 0 && -n "$CONCURRENT_RANGE_READS" && "$CONCURRENT_RANGE_READS" != "0" ]]; then
+  echo "CONCURRENT_RANGE_READERS or CONCURRENT_RANGE_READER_SWEEP must be set when CONCURRENT_RANGE_READS is set" >&2
+  exit 2
+fi
 if [[ "$CONCURRENT_WRITERS" -eq 0 && -n "$CONCURRENT_WRITES" && "$CONCURRENT_WRITES" != "0" ]]; then
   echo "CONCURRENT_WRITERS must be > 0 when CONCURRENT_WRITES is set" >&2
   exit 2
@@ -696,6 +797,9 @@ fi
   echo "concurrent readers: $CONCURRENT_READERS"
   echo "concurrent reader sweep: ${CONCURRENT_READER_SWEEP:-none}"
   echo "concurrent reads: ${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers or reader sweep is set}"
+  echo "concurrent range readers: $CONCURRENT_RANGE_READERS"
+  echo "concurrent range reader sweep: ${CONCURRENT_RANGE_READER_SWEEP:-none}"
+  echo "concurrent range reads: ${CONCURRENT_RANGE_READS:-documents / $CONCURRENT_RANGE_READS_DIVISOR when range readers or range reader sweep is set}"
   echo "concurrent writers: $CONCURRENT_WRITERS"
   echo "concurrent writes: ${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}"
   echo "mongo mode: $MONGO_MODE"
@@ -705,6 +809,7 @@ fi
   echo "treedb client modes: $TREEDB_CLIENT_MODES"
   echo "treedb root storage: data=$TREEDB_DATA_ROOT_STORAGE index_state=$TREEDB_INDEX_STATE_ROOT_STORAGE index=$TREEDB_INDEX_ROOT_STORAGE"
   echo "treedb maintenance: $TREEDB_MAINTENANCE"
+  echo "treedb read state: $TREEDB_READ_STATE"
   if [[ "$MONGO_MODE" == "docker" ]]; then
     echo "mongo image: $MONGO_IMAGE"
   else
@@ -731,6 +836,14 @@ for docs in $DOCS_LIST; do
     concurrent_reads=$(derived_count "$docs" "$CONCURRENT_READS" "$CONCURRENT_READS_DIVISOR")
     if [[ "$concurrent_reads" -eq 0 ]]; then
       echo "concurrent reads must be > 0 when concurrent readers or reader sweep is set" >&2
+      exit 2
+    fi
+  fi
+  concurrent_range_reads=0
+  if [[ "$CONCURRENT_RANGE_READERS" -gt 0 || -n "$CONCURRENT_RANGE_READER_SWEEP" ]]; then
+    concurrent_range_reads=$(derived_count "$docs" "$CONCURRENT_RANGE_READS" "$CONCURRENT_RANGE_READS_DIVISOR")
+    if [[ "$concurrent_range_reads" -eq 0 ]]; then
+      echo "concurrent range reads must be > 0 when concurrent range readers or range reader sweep is set" >&2
       exit 2
     fi
   fi
@@ -773,7 +886,7 @@ for docs in $DOCS_LIST; do
         echo
         echo "==> $cell TreeDB ($tree_format, client=$tree_client_mode)"
         run_target treedb "$docs" "$indexes" "$tree_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
-          "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
+          "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
           -treedb-dir "$tree_data" \
           -keep-treedb-dir \
           -treedb-profile "$TREEDB_PROFILE" \
@@ -783,6 +896,7 @@ for docs in $DOCS_LIST; do
           -treedb-index-state-root-storage "$TREEDB_INDEX_STATE_ROOT_STORAGE" \
           -treedb-index-root-storage "$TREEDB_INDEX_ROOT_STORAGE" \
           -treedb-maintenance "$TREEDB_MAINTENANCE" \
+          -treedb-read-state "$TREEDB_READ_STATE" \
           "${tree_profile_args[@]}"
         tree_physical=$(du_bytes "$tree_data")
         printf "treedb\t%s\t%s\t%s\t%s\t%s\n" "$tree_config" "$docs" "$indexes" "$tree_raw_rel" "$tree_physical" >>"$MATRIX"
@@ -809,7 +923,7 @@ for docs in $DOCS_LIST; do
         fi
       fi
       run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
-        "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
+        "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
         -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
@@ -855,6 +969,9 @@ cat >"$README" <<EOF
 - concurrent readers: \`$CONCURRENT_READERS\`
 - concurrent reader sweep: \`${CONCURRENT_READER_SWEEP:-none}\`
 - concurrent reads: \`${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers or reader sweep is set}\`
+- concurrent range readers: \`$CONCURRENT_RANGE_READERS\`
+- concurrent range reader sweep: \`${CONCURRENT_RANGE_READER_SWEEP:-none}\`
+- concurrent range reads: \`${CONCURRENT_RANGE_READS:-documents / $CONCURRENT_RANGE_READS_DIVISOR when range readers or range reader sweep is set}\`
 - concurrent writers: \`$CONCURRENT_WRITERS\`
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}\`
 - MongoDB mode: \`$MONGO_MODE\`
@@ -866,6 +983,7 @@ cat >"$README" <<EOF
 - TreeDB client modes: \`$TREEDB_CLIENT_MODES\`
 - TreeDB root storage: \`data=$TREEDB_DATA_ROOT_STORAGE index_state=$TREEDB_INDEX_STATE_ROOT_STORAGE index=$TREEDB_INDEX_ROOT_STORAGE\`
 - TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
+- TreeDB read state: \`$TREEDB_READ_STATE\`
 
 Regenerate from the raw run index:
 


### PR DESCRIPTION
## Summary

Adds measurement-only coverage for the Mongo gateway indexed range-read stack:

- `driver-command-raw` now uses a raw `find` command for the age range phase and parses `cursor.firstBatch` as raw BSON instead of decoding into `bson.M`.
- `raw-wire` and `raw-wire-tcp` support age range-read phases through the fast raw client/in-process wire path.
- Adds concurrent range-reader phases: `concurrent_age_range_(scan|indexed)_limit_10_rN` via `-concurrent-range-readers` or `-concurrent-range-reader-sweep`.
- Adds `-treedb-read-state settled|unsettled` so TreeDB read phases can compare flushed/settled roots with post-load memtable/write-domain state. The old value `flushed` is accepted as an alias for `settled`.
- Updates the compare script/report renderer so concurrent range sweeps appear as a dedicated report section.

No gateway planner or response fast-path optimization is included in this PR.

## Validation

- `bash -n scripts/mongo_gateway_compare.sh`
- `GOWORK=off go test -count=1 ./cmd/mongo_gateway_bench ./TreeDB/mongo_gateway/fastclient ./cmd/mongo_gateway_compare_report`
- `git diff --check`

## Smoke Results

Artifact: `/tmp/mongo_range_measurement_smoke_20260506_201618`

TreeDB BSON, `driver-command-raw`, 1k docs, `age_1`, 100 single range reads, 200 concurrent range reads per fanout, compression off.

| read state | phase | ops/sec | ns/op |
|---|---|---:|---:|
| settled | age_range_indexed_limit_10 | 7,699 | 126,345 |
| settled | concurrent_age_range_indexed_limit_10_r1 | 10,317 | 93,769 |
| settled | concurrent_age_range_indexed_limit_10_r2 | 31,521 | 60,868 |
| settled | concurrent_age_range_indexed_limit_10_r4 | 43,611 | 86,570 |
| unsettled | age_range_indexed_limit_10 | 8,195 | 118,910 |
| unsettled | concurrent_age_range_indexed_limit_10_r1 | 10,885 | 89,235 |
| unsettled | concurrent_age_range_indexed_limit_10_r2 | 22,786 | 84,189 |
| unsettled | concurrent_age_range_indexed_limit_10_r4 | 47,597 | 79,609 |

Report-renderer smoke: `/tmp/mongo_range_measurement_report_smoke_20260506_201632` confirms the new `Concurrent Range Read Sweep` section.
