### PR TITLE
Mongo gateway: fast path indexed range reads

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1947,6 +1947,9 @@ func validateStoredBSONFrame(doc []byte) error {
 		return fmt.Errorf("stored BSON document too short: %d", len(doc))
 	}
 	size := int(int32(binary.LittleEndian.Uint32(doc[:4])))
+	if size < 5 {
+		return fmt.Errorf("stored BSON document length=%d below minimum", size)
+	}
 	if size != len(doc) {
 		return fmt.Errorf("stored BSON document length=%d available=%d", size, len(doc))
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
 const (
@@ -135,10 +137,6 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	results, err := s.executeFind(col, plan)
-	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
-	}
 	batchSize, batchSizeSet, err := optionalInt32FieldWithPresence(command, "batchSize")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
@@ -148,16 +146,40 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
+	results, err := s.executeFind(col, plan)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	if singleBatch {
 		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if !results.projection.present {
+			consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
+			if err != nil {
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+			return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs[:consumed])
 		}
 		firstBatch, _, err := documentsBatchWithLimit(results.docs, results.projection, normalizedBatchSize, s.maxFindBatchBytes())
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
 		return marshalCursorResponseWithID(ns, 0, "firstBatch", firstBatch)
+	}
+	if !results.projection.present {
+		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if consumed >= len(results.docs) {
+			return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs)
+		}
 	}
 	cursorID, firstBatch, err := s.openCursor(ns, results.docs, results.projection, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)
 	if err != nil {
@@ -1258,6 +1280,65 @@ func marshalCursorResponseWithID(ns string, cursorID int64, batchKey string, bat
 	})
 }
 
+func marshalCursorDocumentsResponseWithID(ns string, cursorID int64, batchKey string, batch []wire.Document) (wire.Document, error) {
+	batchBytes := findBatchOverheadBytes
+	for i, doc := range batch {
+		batchBytes += findBatchDocumentBytes(doc, i)
+	}
+	cursorIdx, cursorDoc := bsoncore.AppendDocumentStart(make([]byte, 0, len(ns)+batchBytes+64))
+	cursorDoc = bsoncore.AppendInt64Element(cursorDoc, "id", cursorID)
+	cursorDoc = bsoncore.AppendStringElement(cursorDoc, "ns", ns)
+	batchIdx, cursorDoc := bsoncore.AppendArrayElementStart(cursorDoc, batchKey)
+	for i, doc := range batch {
+		cursorDoc = bsoncore.AppendDocumentElement(cursorDoc, bsonArrayIndexKey(i), doc)
+	}
+	var err error
+	cursorDoc, err = bsoncore.AppendArrayEnd(cursorDoc, batchIdx)
+	if err != nil {
+		return nil, err
+	}
+	cursorDoc, err = bsoncore.AppendDocumentEnd(cursorDoc, cursorIdx)
+	if err != nil {
+		return nil, err
+	}
+
+	docIdx, doc := bsoncore.AppendDocumentStart(make([]byte, 0, len(cursorDoc)+32))
+	doc = bsoncore.AppendDocumentElement(doc, "cursor", cursorDoc)
+	doc = bsoncore.AppendDoubleElement(doc, "ok", 1.0)
+	doc, err = bsoncore.AppendDocumentEnd(doc, docIdx)
+	if err != nil {
+		return nil, err
+	}
+	return wire.Document(doc), nil
+}
+
+func bsonArrayIndexKey(index int) string {
+	switch index {
+	case 0:
+		return "0"
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	case 3:
+		return "3"
+	case 4:
+		return "4"
+	case 5:
+		return "5"
+	case 6:
+		return "6"
+	case 7:
+		return "7"
+	case 8:
+		return "8"
+	case 9:
+		return "9"
+	default:
+		return strconv.Itoa(index)
+	}
+}
+
 func (s *Server) openCursor(ns string, docs []wire.Document, projection compiledProjection, batchSize int, explicitBatchSize bool, defaultBatchSize int, owner int64) (int64, bson.A, error) {
 	if s.isClosed() {
 		return 0, nil, errServerClosed
@@ -1481,6 +1562,29 @@ func documentsBatchWithLimit(docs []wire.Document, projection compiledProjection
 		consumed++
 	}
 	return out, consumed, nil
+}
+
+func rawDocumentsBatchLimit(docs []wire.Document, maxDocs int, maxBytes int) (int, error) {
+	if maxDocs < 0 || maxDocs > len(docs) {
+		maxDocs = len(docs)
+	}
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	batchBytes := 0
+	consumed := 0
+	for consumed < maxDocs {
+		docBytes := findBatchDocumentBytes(docs[consumed], consumed)
+		if findBatchOverheadBytes+docBytes > maxBytes {
+			return 0, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, maxBytes)
+		}
+		if consumed > 0 && findBatchOverheadBytes+batchBytes+docBytes > maxBytes {
+			break
+		}
+		batchBytes += docBytes
+		consumed++
+	}
+	return consumed, nil
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
@@ -1806,11 +1910,10 @@ func storedDocumentMaterializerForCollection(col *collections.Collection) (*coll
 func storedDocumentToBSON(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (wire.Document, error) {
 	if materializer != nil {
 		if materializer.DocumentFormat() == collections.DocumentFormatBSON {
-			raw := bson.Raw(stored)
-			if err := raw.Validate(); err != nil {
-				return nil, err
-			}
-			return wire.Document(raw), nil
+			// Stored BSON bytes are validated when the gateway accepts or builds
+			// the document. Avoid repeating full BSON validation on every hot
+			// read response.
+			return wire.Document(stored), nil
 		}
 		materialized, err := materializer.StoredDocumentJSON(stored)
 		if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2,6 +2,7 @@ package mongogateway
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -1911,8 +1912,11 @@ func storedDocumentToBSON(col *collections.Collection, materializer *collections
 	if materializer != nil {
 		if materializer.DocumentFormat() == collections.DocumentFormatBSON {
 			// Stored BSON bytes are validated when the gateway accepts or builds
-			// the document. Avoid repeating full BSON validation on every hot
-			// read response.
+			// the document. Keep a cheap frame check but avoid repeating full BSON
+			// validation on every hot read response.
+			if err := validateStoredBSONFrame(stored); err != nil {
+				return nil, err
+			}
 			return wire.Document(stored), nil
 		}
 		materialized, err := materializer.StoredDocumentJSON(stored)
@@ -1936,6 +1940,20 @@ func storedDocumentToBSON(col *collections.Collection, materializer *collections
 		return nil, err
 	}
 	return wire.Document(raw), nil
+}
+
+func validateStoredBSONFrame(doc []byte) error {
+	if len(doc) < 5 {
+		return fmt.Errorf("stored BSON document too short: %d", len(doc))
+	}
+	size := int(int32(binary.LittleEndian.Uint32(doc[:4])))
+	if size != len(doc) {
+		return fmt.Errorf("stored BSON document length=%d available=%d", size, len(doc))
+	}
+	if doc[len(doc)-1] != 0 {
+		return errors.New("stored BSON document missing terminator")
+	}
+	return nil
 }
 
 func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, bool, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -174,12 +174,14 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
-		consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		if consumed >= len(results.docs) {
-			return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs)
+		if normalizedBatchSize >= len(results.docs) {
+			consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
+			if err != nil {
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+			if consumed >= len(results.docs) {
+				return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs)
+			}
 		}
 	}
 	cursorID, firstBatch, err := s.openCursor(ns, results.docs, results.projection, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)
@@ -1313,31 +1315,19 @@ func marshalCursorDocumentsResponseWithID(ns string, cursorID int64, batchKey st
 	return wire.Document(doc), nil
 }
 
-func bsonArrayIndexKey(index int) string {
-	switch index {
-	case 0:
-		return "0"
-	case 1:
-		return "1"
-	case 2:
-		return "2"
-	case 3:
-		return "3"
-	case 4:
-		return "4"
-	case 5:
-		return "5"
-	case 6:
-		return "6"
-	case 7:
-		return "7"
-	case 8:
-		return "8"
-	case 9:
-		return "9"
-	default:
-		return strconv.Itoa(index)
+var bsonArrayIndexKeyCache = func() [128]string {
+	var keys [128]string
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
 	}
+	return keys
+}()
+
+func bsonArrayIndexKey(index int) string {
+	if index >= 0 && index < len(bsonArrayIndexKeyCache) {
+		return bsonArrayIndexKeyCache[index]
+	}
+	return strconv.Itoa(index)
 }
 
 func (s *Server) openCursor(ns string, docs []wire.Document, projection compiledProjection, batchSize int, explicitBatchSize bool, defaultBatchSize int, owner int64) (int64, bson.A, error) {
@@ -1947,6 +1937,9 @@ func validateStoredBSONFrame(doc []byte) error {
 		return fmt.Errorf("stored BSON document too short: %d", len(doc))
 	}
 	size := int(int32(binary.LittleEndian.Uint32(doc[:4])))
+	if size < 0 {
+		return fmt.Errorf("stored BSON document has negative length header: %d", size)
+	}
 	if size < 5 {
 		return fmt.Errorf("stored BSON document length=%d below minimum", size)
 	}

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -98,6 +98,12 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (findRe
 		}
 		return findResultSet{docs: docs, projection: plan.projection}, nil
 	}
+	if docs, ok, err := s.findPureIndexedRangeLimitDocuments(col, materializer, plan); ok || err != nil {
+		if err != nil {
+			return findResultSet{}, err
+		}
+		return findResultSet{docs: docs, projection: plan.projection}, nil
+	}
 	docs, err := s.findCandidateDocuments(col, materializer, plan)
 	if err != nil {
 		return findResultSet{}, err
@@ -150,7 +156,19 @@ func findBatchDocumentBytes(doc wire.Document, index int) int {
 }
 
 func bsonArrayElementOverhead(index int) int {
-	return 1 + len(strconv.Itoa(index)) + 1
+	return 1 + bsonArrayIndexDigitCount(index) + 1
+}
+
+func bsonArrayIndexDigitCount(index int) int {
+	if index < 10 {
+		return 1
+	}
+	digits := 1
+	for index >= 10 {
+		index /= 10
+		digits++
+	}
+	return digits
 }
 
 func validateFindCommandOptions(command wire.Document, filter wire.Document) error {
@@ -177,6 +195,44 @@ func (s *Server) maxFindBatchBytes() int {
 		return 0
 	}
 	return max
+}
+
+func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, bool, error) {
+	idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	if empty || limit == 0 {
+		return nil, true, nil
+	}
+	docs, err := documentsForIndexedRange(col, materializer, idx, opts, limit, limit)
+	return docs, true, err
+}
+
+func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, maxDocuments int) (collections.IndexDefinition, collections.IndexRangeOptions, int, bool, bool, error) {
+	if plan.limit <= 0 || plan.skip != 0 || plan.sort.field != "" || len(plan.predicates) != 1 {
+		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
+	}
+	limit := int(plan.limit)
+	if maxDocuments > 0 && limit > maxDocuments {
+		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
+	}
+	pred := plan.predicates[0]
+	if !isRangePredicate(pred.op) {
+		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
+	}
+	for _, idx := range meta.Indexes {
+		if idx.Field != pred.field {
+			continue
+		}
+		opts, ok, empty, err := indexRangeOptionsForPredicates(plan.predicates, idx)
+		if err != nil || !ok {
+			return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, ok, false, err
+		}
+		opts.Limit = limit
+		return idx, opts, limit, true, empty, nil
+	}
+	return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
 }
 
 func (s *Server) findCandidateDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -209,7 +209,7 @@ func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection,
 		return nil, true, nil
 	}
 	candidateLimit := candidateLimitWithOverflowSlot(s.maxFindScanDocuments())
-	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, limit)
+	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, limit, false)
 	return docs, true, err
 }
 
@@ -819,7 +819,7 @@ func documentsForIndexedFieldPredicates(col *collections.Collection, materialize
 	if limit, ok := indexedRangeCandidateLimit(plan, idx, maxDocuments); ok {
 		candidateLimit = limit
 	}
-	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, maxDocuments)
+	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, maxDocuments, true)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1046,7 +1046,7 @@ func compareFloat64IndexValues(left, right float64) int {
 	}
 }
 
-func documentsForIndexedRange(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, idx collections.IndexDefinition, opts collections.IndexRangeOptions, candidateLimit, maxDocuments int) ([]wire.Document, error) {
+func documentsForIndexedRange(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, idx collections.IndexDefinition, opts collections.IndexRangeOptions, candidateLimit, maxDocuments int, allowOverflow bool) ([]wire.Document, error) {
 	if candidateLimit <= 0 {
 		candidateLimit = candidateLimitWithOverflowSlot(maxDocuments)
 	}
@@ -1069,7 +1069,10 @@ func documentsForIndexedRange(col *collections.Collection, materializer *collect
 			return nil, err
 		}
 		out = append(out, doc)
-		if len(out) > maxDocuments {
+		if maxDocuments > 0 && len(out) >= maxDocuments {
+			if allowOverflow && len(out) == maxDocuments {
+				continue
+			}
 			return out, nil
 		}
 	}

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -160,6 +160,9 @@ func bsonArrayElementOverhead(index int) int {
 }
 
 func bsonArrayIndexDigitCount(index int) int {
+	if index < 0 {
+		return len(strconv.Itoa(index))
+	}
 	if index < 10 {
 		return 1
 	}

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -226,8 +226,11 @@ func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, m
 			continue
 		}
 		opts, ok, empty, err := indexRangeOptionsForPredicates(plan.predicates, idx)
-		if err != nil || !ok {
-			return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, ok, false, err
+		if err != nil {
+			return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, err
+		}
+		if !ok {
+			continue
 		}
 		opts.Limit = limit
 		return idx, opts, limit, true, empty, nil

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -208,12 +208,16 @@ func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection,
 	if empty || limit == 0 {
 		return nil, true, nil
 	}
-	docs, err := documentsForIndexedRange(col, materializer, idx, opts, limit, limit)
+	candidateLimit := candidateLimitWithOverflowSlot(s.maxFindScanDocuments())
+	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, limit)
 	return docs, true, err
 }
 
 func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, maxDocuments int) (collections.IndexDefinition, collections.IndexRangeOptions, int, bool, bool, error) {
 	if plan.limit <= 0 || plan.skip != 0 || plan.sort.field != "" || len(plan.predicates) != 1 {
+		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
+	}
+	if int64(plan.limit) > int64(maxInt) {
 		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
 	}
 	limit := int(plan.limit)

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -208,7 +208,7 @@ func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection,
 	if empty || limit == 0 {
 		return nil, true, nil
 	}
-	candidateLimit := candidateLimitWithOverflowSlot(s.maxFindScanDocuments())
+	candidateLimit := candidateLimitWithOverflowSlot(limit)
 	docs, err := documentsForIndexedRange(col, materializer, idx, opts, candidateLimit, limit, false)
 	return docs, true, err
 }
@@ -239,7 +239,6 @@ func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, m
 		if !ok {
 			continue
 		}
-		opts.Limit = limit
 		return idx, opts, limit, true, empty, nil
 	}
 	return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2487,6 +2487,25 @@ func TestRawDocumentsBatchLimit(t *testing.T) {
 	}
 }
 
+func TestValidateStoredBSONFrame(t *testing.T) {
+	valid := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}})
+	if err := validateStoredBSONFrame(valid); err != nil {
+		t.Fatalf("valid frame: %v", err)
+	}
+	for name, doc := range map[string][]byte{
+		"too_short":            {1, 0, 0, 0},
+		"declared_too_small":   {4, 0, 0, 0, 0},
+		"length_mismatch":      {6, 0, 0, 0, 0},
+		"missing_terminator":   {5, 0, 0, 0, 1},
+		"negative_length":      {0xff, 0xff, 0xff, 0xff, 0},
+		"zero_declared_length": {0, 0, 0, 0, 0},
+	} {
+		if err := validateStoredBSONFrame(doc); err == nil {
+			t.Fatalf("%s accepted invalid frame %v", name, doc)
+		}
+	}
+}
+
 func TestServeOneCleansUpOneShotCursors(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2449,6 +2449,44 @@ func TestServerFindSingleBatchClosesCursor(t *testing.T) {
 	}
 }
 
+func TestMarshalCursorDocumentsResponseWithRawBatch(t *testing.T) {
+	rawDoc := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}})
+	response, err := marshalCursorDocumentsResponseWithID("app.users", 0, "firstBatch", []wire.Document{rawDoc})
+	if err != nil {
+		t.Fatalf("marshal raw cursor response: %v", err)
+	}
+	assertOK(t, response)
+	if cursorID := cursorIDFromResponse(t, response); cursorID != 0 {
+		t.Fatalf("cursor id=%d want 0", cursorID)
+	}
+	batch := cursorFirstBatch(t, response)
+	if len(batch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(batch))
+	}
+	if !bytes.Equal(batch[0], bson.Raw(rawDoc)) {
+		t.Fatalf("firstBatch[0]=%v want raw doc %v", batch[0], bson.Raw(rawDoc))
+	}
+}
+
+func TestRawDocumentsBatchLimit(t *testing.T) {
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u3"}}),
+	}
+	consumed, err := rawDocumentsBatchLimit(docs, 2, maxInt)
+	if err != nil {
+		t.Fatalf("raw batch limit: %v", err)
+	}
+	if consumed != 2 {
+		t.Fatalf("consumed=%d want 2", consumed)
+	}
+	tooSmall := findBatchOverheadBytes + findBatchDocumentBytes(docs[0], 0) - 1
+	if _, err := rawDocumentsBatchLimit(docs[:1], 1, tooSmall); err == nil {
+		t.Fatal("raw batch limit accepted oversized single document")
+	}
+}
+
 func TestServeOneCleansUpOneShotCursors(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3741,6 +3779,52 @@ func TestIndexedRangeCandidateLimitOnlyForPureSameFieldRange(t *testing.T) {
 	}
 	if got := candidateLimitWithOverflowSlot(100); got != 101 {
 		t.Fatalf("candidateLimitWithOverflowSlot(100)=%d want 101", got)
+	}
+}
+
+func TestPureIndexedRangeLimitPlanOnlyForSingleRangeNoSkip(t *testing.T) {
+	meta := collections.CollectionMeta{Indexes: []collections.IndexDefinition{
+		{Name: "age_1", Field: "age", ValueType: collections.IndexValueInt64},
+	}}
+	_, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(meta, findPlan{
+		predicates: []findPredicate{
+			{field: "age", op: findPredicateGTE, values: []bson.RawValue{mustRawValue(t, int64(40))}},
+		},
+		limit: 10,
+	}, 100)
+	if err != nil {
+		t.Fatalf("pure indexed range plan: %v", err)
+	}
+	if !ok || empty || limit != 10 || opts.Limit != 10 {
+		t.Fatalf("pure indexed range plan ok=%v empty=%v limit=%d opts.Limit=%d want true,false,10,10", ok, empty, limit, opts.Limit)
+	}
+
+	_, _, _, ok, _, err = pureIndexedRangeLimitPlan(meta, findPlan{
+		predicates: []findPredicate{
+			{field: "age", op: findPredicateGTE, values: []bson.RawValue{mustRawValue(t, int64(40))}},
+		},
+		skip:  1,
+		limit: 10,
+	}, 100)
+	if err != nil {
+		t.Fatalf("skipped pure indexed range plan: %v", err)
+	}
+	if ok {
+		t.Fatal("pure indexed range plan accepted skip")
+	}
+
+	_, _, _, ok, _, err = pureIndexedRangeLimitPlan(meta, findPlan{
+		predicates: []findPredicate{
+			{field: "age", op: findPredicateGTE, values: []bson.RawValue{mustRawValue(t, int64(40))}},
+			{field: "city", op: findPredicateEq, values: []bson.RawValue{mustRawValue(t, "hnl")}},
+		},
+		limit: 10,
+	}, 100)
+	if err != nil {
+		t.Fatalf("mixed pure indexed range plan: %v", err)
+	}
+	if ok {
+		t.Fatal("pure indexed range plan accepted mixed predicates")
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2152,6 +2152,27 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	}
 	server.MaxFindScanDocuments = oldMaxFindScanDocuments
 
+	limitedAgeRangeFind := serveCommand(t, server, 234041, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(36)}}}}},
+		{Key: "limit", Value: int32(2)},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, limitedAgeRangeFind)
+	firstBatch = cursorFirstBatch(t, limitedAgeRangeFind)
+	if len(firstBatch) != 2 {
+		t.Fatalf("limited indexed age range firstBatch len=%d want 2", len(firstBatch))
+	}
+	if cursorID := cursorIDFromResponse(t, limitedAgeRangeFind); cursorID != 0 {
+		t.Fatalf("limited indexed age range cursor id=%d want 0", cursorID)
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "katherine" {
+		t.Fatalf("limited indexed age range first name=%q ok=%v want katherine", got, ok)
+	}
+	if got, ok := firstBatch[1].Lookup("name").StringValueOK(); !ok || got != "ada" {
+		t.Fatalf("limited indexed age range second name=%q ok=%v want ada", got, ok)
+	}
+
 	wrongTypeIndexedFind := serveCommand(t, server, 2341, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "city", Value: int32(5)}}},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -3835,8 +3835,8 @@ func TestPureIndexedRangeLimitPlanOnlyForSingleRangeNoSkip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pure indexed range plan: %v", err)
 	}
-	if !ok || empty || limit != 10 || opts.Limit != 10 {
-		t.Fatalf("pure indexed range plan ok=%v empty=%v limit=%d opts.Limit=%d want true,false,10,10", ok, empty, limit, opts.Limit)
+	if !ok || empty || limit != 10 || opts.Limit != 0 {
+		t.Fatalf("pure indexed range plan ok=%v empty=%v limit=%d opts.Limit=%d want true,false,10,0", ok, empty, limit, opts.Limit)
 	}
 
 	_, _, _, ok, _, err = pureIndexedRangeLimitPlan(meta, findPlan{


### PR DESCRIPTION
## Summary

Fast-paths the Mongo gateway indexed range-read benchmark path after the measurement cleanup in #1404:

- bypasses the generic post-filter/sort/skip pipeline for a conservative pure indexed range + positive limit shape;
- builds unprojected cursor firstBatch responses directly from raw BSON documents instead of routing through generic `bson.D`/`bson.A` marshaling;
- skips repeated `bson.Raw.Validate()` on trusted stored-BSON read materialization;
- keeps collection lookup caching out of scope.

## Local validation

```text
GOWORK=off go test -count=1 ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./TreeDB/mongo_gateway/fastclient ./cmd/mongo_gateway_compare_report
git diff --check
```

## Range-read smoke

Compared against #1404 head `d2a32a2584` with settled TreeDB reads, BSON storage, `age_1` index, `documents=20000`, `range_reads=5000` for raw-wire modes and `3000` for official-driver raw-command mode, all non-range phases disabled.

| Surface | #1404 ops/sec | PR ops/sec | #1404 ns/op | PR ns/op | Throughput delta |
|---|---:|---:|---:|---:|---:|
| raw-wire in-process | 38,430 | 70,136 | 25,097 | 13,388 | +82.5% |
| raw-wire TCP | 18,725 | 25,090 | 52,212 | 38,734 | +34.0% |
| driver-command-raw | 16,529 | 22,993 | 58,287 | 41,470 | +39.1% |

Artifacts:

```text
/tmp/mongo_range_pr1_rawwire.json
/tmp/mongo_range_pr2_rawwire.json
/tmp/mongo_range_pr1_tcp.json
/tmp/mongo_range_pr2_tcp.json
/tmp/mongo_range_pr1_driverraw.json
/tmp/mongo_range_pr2_driverraw.json
```
