### PR TITLE
[codex] nativewire R1a server kernel

### DIFF
--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -89,6 +89,9 @@ func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte
 	if err != nil {
 		return iwire.Header{}, nil, err
 	}
+	if err := iwire.ValidateHeaderVersion(header, iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0}); err != nil {
+		return header, response, err
+	}
 	if header.RequestID != requestID {
 		return header, response, protocolError(iwire.ErrMalformedFrame, "response request_id %d want %d", header.RequestID, requestID)
 	}

--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -82,12 +82,14 @@ func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte
 		_ = c.conn.SetDeadline(deadline)
 		defer func() { _ = c.conn.SetDeadline(noDeadline) }()
 	}
+	stopCancel := c.closeOnContextCancel(ctx)
+	defer stopCancel()
 	if err := writeFrame(c.conn, iwire.Header{Type: typ, RequestID: requestID}, body); err != nil {
-		return iwire.Header{}, nil, err
+		return iwire.Header{}, nil, errorOrContext(ctx, err)
 	}
 	header, response, err := readFrame(c.conn, c.limits)
 	if err != nil {
-		return iwire.Header{}, nil, err
+		return iwire.Header{}, nil, errorOrContext(ctx, err)
 	}
 	if err := iwire.ValidateHeaderVersion(header, iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0}); err != nil {
 		return header, response, err
@@ -102,6 +104,28 @@ func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte
 		return header, response, protocolError(iwire.ErrMalformedFrame, "response frame type %d want %d", header.Type, want)
 	}
 	return header, response, nil
+}
+
+func (c *Client) closeOnContextCancel(ctx context.Context) func() {
+	if c == nil || c.conn == nil || ctx == nil || ctx.Done() == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = c.conn.Close()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
+
+func errorOrContext(ctx context.Context, err error) error {
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func decodeWireError(body []byte, limits iwire.Limits) error {

--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -89,14 +89,14 @@ func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte
 	if err != nil {
 		return iwire.Header{}, nil, err
 	}
+	if header.RequestID != requestID {
+		return header, response, protocolError(iwire.ErrMalformedFrame, "response request_id %d want %d", header.RequestID, requestID)
+	}
 	if header.Type == iwire.FrameError {
 		return header, response, decodeWireError(response, c.limits)
 	}
 	if header.Type != want {
 		return header, response, protocolError(iwire.ErrMalformedFrame, "response frame type %d want %d", header.Type, want)
-	}
-	if header.RequestID != requestID {
-		return header, response, protocolError(iwire.ErrMalformedFrame, "response request_id %d want %d", header.RequestID, requestID)
 	}
 	return header, response, nil
 }

--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -12,6 +12,7 @@ import (
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 )
 
+// Client sends native-wire requests over a single connection.
 type Client struct {
 	conn    net.Conn
 	limits  iwire.Limits
@@ -19,10 +20,12 @@ type Client struct {
 	mu      sync.Mutex
 }
 
+// NewClient returns a native-wire client that owns conn until Close.
 func NewClient(conn net.Conn) *Client {
 	return &Client{conn: conn, limits: iwire.DefaultLimits()}
 }
 
+// Close closes the underlying client connection.
 func (c *Client) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
@@ -30,21 +33,25 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
+// Hello performs the native-wire hello handshake.
 func (c *Client) Hello(ctx context.Context) error {
 	_, _, err := c.roundTrip(ctx, iwire.FrameHello, nil, iwire.FrameHelloOK)
 	return err
 }
 
+// Ping sends a ping frame and waits for a pong response.
 func (c *Client) Ping(ctx context.Context) error {
 	_, _, err := c.roundTrip(ctx, iwire.FramePing, nil, iwire.FramePong)
 	return err
 }
 
+// Goaway asks the server to close the connection gracefully.
 func (c *Client) Goaway(ctx context.Context) error {
 	_, _, err := c.roundTrip(ctx, iwire.FrameGoaway, nil, iwire.FrameGoaway)
 	return err
 }
 
+// Stats fetches the server stats map over the native-wire stats command.
 func (c *Client) Stats(ctx context.Context) (map[string]string, error) {
 	body, err := appendCommandRequestBody(nil, iwire.CommandStats)
 	if err != nil {
@@ -83,20 +90,23 @@ func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte
 	requestID := c.nextReq.Add(1)
 	if deadline, ok := ctxDeadline(ctx); ok {
 		_ = c.conn.SetDeadline(deadline)
-		defer func() { _ = c.conn.SetDeadline(noDeadline) }()
 	}
 	stopCancel := c.interruptDeadlineOnContextCancel(ctx)
-	defer stopCancel()
+	defer func() {
+		stopCancel()
+		_ = c.conn.SetDeadline(noDeadline)
+	}()
+	onWire := true
 	if err := writeFrame(c.conn, iwire.Header{
 		Version:   iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0},
 		Type:      typ,
 		RequestID: requestID,
 	}, body); err != nil {
-		return iwire.Header{}, nil, errorOrContext(ctx, err)
+		return iwire.Header{}, nil, c.errorOrCanceledOnWire(ctx, onWire, err)
 	}
 	header, response, err := readFrame(c.conn, c.limits)
 	if err != nil {
-		return iwire.Header{}, nil, errorOrContext(ctx, err)
+		return iwire.Header{}, nil, c.errorOrCanceledOnWire(ctx, onWire, err)
 	}
 	if err := iwire.ValidateHeaderVersion(header, iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0}); err != nil {
 		return header, response, err
@@ -117,19 +127,17 @@ func (c *Client) interruptDeadlineOnContextCancel(ctx context.Context) func() {
 	if c == nil || c.conn == nil || ctx == nil || ctx.Done() == nil {
 		return func() {}
 	}
-	done := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = c.conn.SetDeadline(time.Now())
-		case <-done:
-		}
-	}()
-	return func() { close(done) }
+	stop := context.AfterFunc(ctx, func() {
+		_ = c.conn.SetDeadline(time.Now())
+	})
+	return func() { _ = stop() }
 }
 
-func errorOrContext(ctx context.Context, err error) error {
+func (c *Client) errorOrCanceledOnWire(ctx context.Context, onWire bool, err error) error {
 	if ctx != nil && ctx.Err() != nil {
+		if onWire && c != nil && c.conn != nil {
+			_ = c.conn.Close()
+		}
 		return ctx.Err()
 	}
 	return err

--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -1,0 +1,139 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+type Client struct {
+	conn    net.Conn
+	limits  iwire.Limits
+	nextReq atomic.Uint64
+	mu      sync.Mutex
+}
+
+func NewClient(conn net.Conn) *Client {
+	return &Client{conn: conn, limits: iwire.DefaultLimits()}
+}
+
+func (c *Client) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+func (c *Client) Hello(ctx context.Context) error {
+	_, _, err := c.roundTrip(ctx, iwire.FrameHello, nil, iwire.FrameHelloOK)
+	return err
+}
+
+func (c *Client) Ping(ctx context.Context) error {
+	_, _, err := c.roundTrip(ctx, iwire.FramePing, nil, iwire.FramePong)
+	return err
+}
+
+func (c *Client) Goaway(ctx context.Context) error {
+	_, _, err := c.roundTrip(ctx, iwire.FrameGoaway, nil, iwire.FrameGoaway)
+	return err
+}
+
+func (c *Client) Stats(ctx context.Context) (map[string]string, error) {
+	body, err := appendCommandRequestBody(nil, iwire.CommandStats)
+	if err != nil {
+		return nil, err
+	}
+	_, response, err := c.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+	if err != nil {
+		return nil, err
+	}
+	sections, err := iwire.DecodeSections(response, c.limits)
+	if err != nil {
+		return nil, err
+	}
+	payload, ok, err := singletonSection(sections, iwire.SectionResponseMeta)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, protocolError(iwire.ErrMalformedFrame, "stats response missing response_meta")
+	}
+	return decodeStringMap(payload)
+}
+
+func (c *Client) roundTrip(ctx context.Context, typ iwire.FrameType, body []byte, want iwire.FrameType) (iwire.Header, []byte, error) {
+	if c == nil || c.conn == nil {
+		return iwire.Header{}, nil, io.ErrClosedPipe
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return iwire.Header{}, nil, ctx.Err()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	requestID := c.nextReq.Add(1)
+	if deadline, ok := ctxDeadline(ctx); ok {
+		_ = c.conn.SetDeadline(deadline)
+		defer func() { _ = c.conn.SetDeadline(noDeadline) }()
+	}
+	if err := writeFrame(c.conn, iwire.Header{Type: typ, RequestID: requestID}, body); err != nil {
+		return iwire.Header{}, nil, err
+	}
+	header, response, err := readFrame(c.conn, c.limits)
+	if err != nil {
+		return iwire.Header{}, nil, err
+	}
+	if header.Type == iwire.FrameError {
+		return header, response, decodeWireError(response, c.limits)
+	}
+	if header.Type != want {
+		return header, response, protocolError(iwire.ErrMalformedFrame, "response frame type %d want %d", header.Type, want)
+	}
+	if header.RequestID != requestID {
+		return header, response, protocolError(iwire.ErrMalformedFrame, "response request_id %d want %d", header.RequestID, requestID)
+	}
+	return header, response, nil
+}
+
+func decodeWireError(body []byte, limits iwire.Limits) error {
+	sections, err := iwire.DecodeSections(body, limits)
+	if err != nil {
+		return err
+	}
+	payload, ok, err := singletonSection(sections, iwire.SectionError)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return protocolError(iwire.ErrMalformedFrame, "error frame missing error section")
+	}
+	code, retryable, message, err := decodeErrorPayload(payload)
+	if err != nil {
+		return err
+	}
+	return &WireError{Code: code, Retryable: retryable, Message: message}
+}
+
+func ctxDeadline(ctx context.Context) (time.Time, bool) {
+	if ctx == nil {
+		return time.Time{}, false
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return time.Time{}, false
+	}
+	return deadline, true
+}
+
+var noDeadline time.Time
+
+func isRemoteError(err error, code iwire.ErrorCode) bool {
+	var wireErr *WireError
+	return errors.As(err, &wireErr) && wireErr.Code == code
+}

--- a/TreeDB/nativewire/codec.go
+++ b/TreeDB/nativewire/codec.go
@@ -34,17 +34,27 @@ func readFrame(r io.Reader, limits iwire.Limits) (iwire.Header, []byte, error) {
 
 func writeFrame(w io.Writer, header iwire.Header, body []byte) error {
 	header.BodyLen = uint64(len(body))
-	frame, err := iwire.AppendHeader(nil, header)
+	var headerBuf [iwire.FrameHeaderLenV1]byte
+	frameHeader, err := iwire.AppendHeader(headerBuf[:0], header)
 	if err != nil {
 		return err
 	}
-	frame = append(frame, body...)
-	for len(frame) > 0 {
-		n, err := w.Write(frame)
+	if err := writeAll(w, frameHeader); err != nil {
+		return err
+	}
+	return writeAll(w, body)
+}
+
+func writeAll(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
 		if err != nil {
 			return err
 		}
-		frame = frame[n:]
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
 	}
 	return nil
 }

--- a/TreeDB/nativewire/codec.go
+++ b/TreeDB/nativewire/codec.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/bits"
 	"sort"
-	"strconv"
 
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 )
@@ -93,9 +93,9 @@ func readString(src []byte, off *int) (string, error) {
 	if off == nil || *off > len(src) {
 		return "", protocolError(iwire.ErrMalformedFrame, "invalid string offset")
 	}
-	n, read := binary.Uvarint(src[*off:])
-	if read <= 0 {
-		return "", protocolError(iwire.ErrMalformedFrame, "invalid string length")
+	n, read, err := readUvarint(src[*off:])
+	if err != nil {
+		return "", err
 	}
 	*off += read
 	if n > uint64(len(src)-*off) {
@@ -151,10 +151,24 @@ func decodeStringMap(src []byte) (map[string]string, error) {
 
 func readUvarint(src []byte) (uint64, int, error) {
 	value, n := binary.Uvarint(src)
-	if n <= 0 {
+	switch {
+	case n > 0:
+		if n != uvarintLen(value) {
+			return 0, 0, protocolError(iwire.ErrMalformedFrame, "non-minimal uvarint")
+		}
+		return value, n, nil
+	case n == 0:
 		return 0, 0, protocolError(iwire.ErrMalformedFrame, "invalid uvarint")
+	default:
+		return 0, 0, protocolError(iwire.ErrMalformedFrame, "uvarint overflow")
 	}
-	return value, n, nil
+}
+
+func uvarintLen(v uint64) int {
+	if v == 0 {
+		return 1
+	}
+	return (bits.Len64(v) + 6) / 7
 }
 
 func appendErrorPayload(dst []byte, code iwire.ErrorCode, retryable bool, message string) []byte {
@@ -175,7 +189,15 @@ func decodeErrorPayload(src []byte) (iwire.ErrorCode, bool, string, error) {
 	if off >= len(src) {
 		return 0, false, "", protocolError(iwire.ErrMalformedFrame, "missing error retryable flag")
 	}
-	retryable := src[off] != 0
+	var retryable bool
+	switch src[off] {
+	case 0:
+		retryable = false
+	case 1:
+		retryable = true
+	default:
+		return 0, false, "", protocolError(iwire.ErrMalformedFrame, "invalid error retryable flag %d", src[off])
+	}
 	off++
 	message, err := readString(src, &off)
 	if err != nil {
@@ -211,10 +233,6 @@ func singletonSection(sections []iwire.Section, id iwire.SectionID) ([]byte, boo
 		found = true
 	}
 	return out, found, nil
-}
-
-func statsString(key string, value uint64) (string, string) {
-	return key, strconv.FormatUint(value, 10)
 }
 
 func protocolError(code iwire.ErrorCode, format string, args ...any) error {

--- a/TreeDB/nativewire/codec.go
+++ b/TreeDB/nativewire/codec.go
@@ -1,0 +1,203 @@
+package nativewire
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+func readFrame(r io.Reader, limits iwire.Limits) (iwire.Header, []byte, error) {
+	var headerBuf [iwire.FrameHeaderLenV1]byte
+	if _, err := io.ReadFull(r, headerBuf[:]); err != nil {
+		return iwire.Header{}, nil, err
+	}
+	header, err := iwire.DecodeHeader(headerBuf[:], limits)
+	if err != nil {
+		return iwire.Header{}, nil, err
+	}
+	if header.BodyLen == 0 {
+		return header, nil, nil
+	}
+	if header.BodyLen > uint64(maxInt) {
+		return iwire.Header{}, nil, protocolError(iwire.ErrResourceExhausted, "frame body exceeds int capacity")
+	}
+	body := make([]byte, int(header.BodyLen))
+	if _, err := io.ReadFull(r, body); err != nil {
+		return iwire.Header{}, nil, err
+	}
+	return header, body, nil
+}
+
+func writeFrame(w io.Writer, header iwire.Header, body []byte) error {
+	header.BodyLen = uint64(len(body))
+	frame, err := iwire.AppendHeader(nil, header)
+	if err != nil {
+		return err
+	}
+	frame = append(frame, body...)
+	for len(frame) > 0 {
+		n, err := w.Write(frame)
+		if err != nil {
+			return err
+		}
+		frame = frame[n:]
+	}
+	return nil
+}
+
+func appendCommandRequestBody(dst []byte, commandID iwire.CommandID, sections ...iwire.Section) ([]byte, error) {
+	body, err := iwire.AppendSection(dst, iwire.Section{
+		ID:    iwire.SectionCommandHeader,
+		Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: commandID, Version: 1}),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, section := range sections {
+		body, err = iwire.AppendSection(body, section)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return body, nil
+}
+
+func appendString(dst []byte, s string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(s)))
+	return append(dst, s...)
+}
+
+func readString(src []byte, off *int) (string, error) {
+	if off == nil || *off > len(src) {
+		return "", protocolError(iwire.ErrMalformedFrame, "invalid string offset")
+	}
+	n, read := binary.Uvarint(src[*off:])
+	if read <= 0 {
+		return "", protocolError(iwire.ErrMalformedFrame, "invalid string length")
+	}
+	*off += read
+	if n > uint64(len(src)-*off) {
+		return "", protocolError(iwire.ErrMalformedFrame, "string length exceeds remaining payload")
+	}
+	out := string(src[*off : *off+int(n)])
+	*off += int(n)
+	return out, nil
+}
+
+func appendStringMap(dst []byte, values map[string]string) []byte {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	dst = binary.AppendUvarint(dst, uint64(len(keys)))
+	for _, key := range keys {
+		dst = appendString(dst, key)
+		dst = appendString(dst, values[key])
+	}
+	return dst
+}
+
+func decodeStringMap(src []byte) (map[string]string, error) {
+	count, off, err := readUvarint(src)
+	if err != nil {
+		return nil, err
+	}
+	if count > uint64(maxInt) {
+		return nil, protocolError(iwire.ErrResourceExhausted, "string map count exceeds int capacity")
+	}
+	out := make(map[string]string, int(count))
+	for i := uint64(0); i < count; i++ {
+		key, err := readString(src, &off)
+		if err != nil {
+			return nil, err
+		}
+		value, err := readString(src, &off)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	if off != len(src) {
+		return nil, protocolError(iwire.ErrMalformedFrame, "string map has %d trailing bytes", len(src)-off)
+	}
+	return out, nil
+}
+
+func readUvarint(src []byte) (uint64, int, error) {
+	value, n := binary.Uvarint(src)
+	if n <= 0 {
+		return 0, 0, protocolError(iwire.ErrMalformedFrame, "invalid uvarint")
+	}
+	return value, n, nil
+}
+
+func appendErrorPayload(dst []byte, code iwire.ErrorCode, retryable bool, message string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(code))
+	if retryable {
+		dst = append(dst, 1)
+	} else {
+		dst = append(dst, 0)
+	}
+	return appendString(dst, message)
+}
+
+func decodeErrorPayload(src []byte) (iwire.ErrorCode, bool, string, error) {
+	code, off, err := readUvarint(src)
+	if err != nil {
+		return 0, false, "", err
+	}
+	if off >= len(src) {
+		return 0, false, "", protocolError(iwire.ErrMalformedFrame, "missing error retryable flag")
+	}
+	retryable := src[off] != 0
+	off++
+	message, err := readString(src, &off)
+	if err != nil {
+		return 0, false, "", err
+	}
+	if off != len(src) {
+		return 0, false, "", protocolError(iwire.ErrMalformedFrame, "error payload has %d trailing bytes", len(src)-off)
+	}
+	return iwire.ErrorCode(code), retryable, message, nil
+}
+
+func sectionsByID(sections []iwire.Section, id iwire.SectionID) []iwire.Section {
+	var out []iwire.Section
+	for _, section := range sections {
+		if section.ID == id {
+			out = append(out, section)
+		}
+	}
+	return out
+}
+
+func singletonSection(sections []iwire.Section, id iwire.SectionID) ([]byte, bool, error) {
+	var out []byte
+	found := false
+	for _, section := range sections {
+		if section.ID != id {
+			continue
+		}
+		if found {
+			return nil, false, protocolError(iwire.ErrInvalidCommand, "duplicate section %d", id)
+		}
+		out = section.Bytes
+		found = true
+	}
+	return out, found, nil
+}
+
+func statsString(key string, value uint64) (string, string) {
+	return key, strconv.FormatUint(value, 10)
+}
+
+func protocolError(code iwire.ErrorCode, format string, args ...any) error {
+	return &iwire.ProtocolError{Code: code, Reason: fmt.Sprintf(format, args...)}
+}
+
+const maxInt = int(^uint(0) >> 1)

--- a/TreeDB/nativewire/doc.go
+++ b/TreeDB/nativewire/doc.go
@@ -1,0 +1,2 @@
+// Package nativewire implements TreeDB's native client/server wire transport.
+package nativewire

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -1,0 +1,82 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+var ErrServerClosed = errors.New("nativewire: server is closed")
+
+type WireError struct {
+	Code      iwire.ErrorCode
+	Retryable bool
+	Message   string
+}
+
+func (e *WireError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message == "" {
+		return fmt.Sprintf("nativewire: remote error code %d", e.Code)
+	}
+	return fmt.Sprintf("nativewire: remote error code %d: %s", e.Code, e.Message)
+}
+
+func errorCodeFor(err error) iwire.ErrorCode {
+	if err == nil {
+		return 0
+	}
+	if code, ok := iwire.ErrorCodeOf(err); ok {
+		return code
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return iwire.ErrCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return iwire.ErrTimeout
+	case errors.Is(err, collections.ErrCollectionNotFound):
+		return iwire.ErrCollectionNotFound
+	case errors.Is(err, collections.ErrIndexNotFound):
+		return iwire.ErrIndexNotFound
+	case errors.Is(err, collections.ErrDuplicateDocumentID):
+		return iwire.ErrDuplicateDocumentID
+	case errors.Is(err, collections.ErrDocumentExists):
+		return iwire.ErrDocumentExists
+	case errors.Is(err, collections.ErrUniqueIndexConflict):
+		return iwire.ErrUniqueIndexConflict
+	case errors.Is(err, backenddb.ErrClosed), errors.Is(err, ErrServerClosed), errors.Is(err, net.ErrClosed), errors.Is(err, io.ErrClosedPipe):
+		return iwire.ErrCanceled
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "duplicate document id"):
+		return iwire.ErrDuplicateDocumentID
+	case strings.Contains(msg, "document already exists"):
+		return iwire.ErrDocumentExists
+	case strings.Contains(msg, "unique index conflict"):
+		return iwire.ErrUniqueIndexConflict
+	case strings.Contains(msg, "collection not found"):
+		return iwire.ErrCollectionNotFound
+	case strings.Contains(msg, "index not found"):
+		return iwire.ErrIndexNotFound
+	}
+	return iwire.ErrInternal
+}
+
+func retryableError(code iwire.ErrorCode) bool {
+	switch code {
+	case iwire.ErrTimeout, iwire.ErrCanceled, iwire.ErrResourceExhausted, iwire.ErrDurabilityUnavailable, iwire.ErrConsistencyUnavailable:
+		return true
+	default:
+		return false
+	}
+}

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -13,8 +13,10 @@ import (
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 )
 
+// ErrServerClosed reports that the server is closed or refusing connections.
 var ErrServerClosed = errors.New("nativewire: server is closed")
 
+// WireError is an error response decoded from a remote native-wire peer.
 type WireError struct {
 	Code      iwire.ErrorCode
 	Retryable bool

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -57,19 +56,6 @@ func errorCodeFor(err error) iwire.ErrorCode {
 		return iwire.ErrUniqueIndexConflict
 	case errors.Is(err, backenddb.ErrClosed), errors.Is(err, ErrServerClosed), errors.Is(err, net.ErrClosed), errors.Is(err, io.ErrClosedPipe):
 		return iwire.ErrCanceled
-	}
-	msg := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(msg, "duplicate document id"):
-		return iwire.ErrDuplicateDocumentID
-	case strings.Contains(msg, "document already exists"):
-		return iwire.ErrDocumentExists
-	case strings.Contains(msg, "unique index conflict"):
-		return iwire.ErrUniqueIndexConflict
-	case strings.Contains(msg, "collection not found"):
-		return iwire.ErrCollectionNotFound
-	case strings.Contains(msg, "index not found"):
-		return iwire.ErrIndexNotFound
 	}
 	return iwire.ErrInternal
 }

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -172,7 +172,13 @@ func (s *Server) handleFrame(ctx context.Context, w io.Writer, state *connState,
 	s.counters.inc("frames.in_total")
 	s.counters.add("bytes.in_total", uint64(iwire.FrameHeaderLenV1)+uint64(len(body)))
 	if err := iwire.ValidateHeaderVersion(header, iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0}); err != nil {
-		return s.writeError(w, header, err)
+		if writeErr := s.writeError(w, header, err); writeErr != nil {
+			return writeErr
+		}
+		if state != nil && state.hello {
+			return errGoaway
+		}
+		return nil
 	}
 	switch header.Type {
 	case iwire.FrameHello:

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -1,0 +1,319 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+const (
+	defaultMaxInFlight = 1024
+)
+
+type ServerOptions struct {
+	Limits           iwire.Limits
+	MaxInFlight      int
+	DefaultAckPolicy iwire.AckPolicy
+	Collections      *collections.CollectionManager
+	Backend          *backenddb.DB
+}
+
+type Server struct {
+	limits           iwire.Limits
+	maxInFlight      int
+	defaultAckPolicy iwire.AckPolicy
+	registry         *iwire.Registry
+	collections      *collections.CollectionManager
+	backend          *backenddb.DB
+
+	closed atomic.Bool
+	connMu sync.Mutex
+	conns  map[net.Conn]struct{}
+
+	inFlight atomic.Int64
+	nextConn atomic.Int64
+	counters counters
+}
+
+type connState struct {
+	id uint64
+}
+
+func NewServer(opts ServerOptions) *Server {
+	limits := opts.Limits
+	if limits.MaxFrameSize == 0 {
+		limits = iwire.DefaultLimits()
+	}
+	maxInFlight := opts.MaxInFlight
+	if maxInFlight <= 0 {
+		maxInFlight = defaultMaxInFlight
+	}
+	defaultAck := opts.DefaultAckPolicy
+	if defaultAck == 0 {
+		defaultAck = iwire.AckVisible
+	}
+	return &Server{
+		limits:           limits,
+		maxInFlight:      maxInFlight,
+		defaultAckPolicy: defaultAck,
+		registry:         iwire.MustV1Registry(),
+		collections:      opts.Collections,
+		backend:          opts.Backend,
+	}
+}
+
+func (s *Server) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closed.Store(true)
+	s.connMu.Lock()
+	conns := make([]net.Conn, 0, len(s.conns))
+	for conn := range s.conns {
+		conns = append(conns, conn)
+	}
+	s.conns = nil
+	s.connMu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	return nil
+}
+
+func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
+	if s == nil || conn == nil {
+		return ErrServerClosed
+	}
+	if !s.registerConn(conn) {
+		_ = conn.Close()
+		return ErrServerClosed
+	}
+	defer s.unregisterConn(conn)
+	defer conn.Close()
+
+	state := &connState{id: uint64(s.nextConn.Add(1))}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	for {
+		if s.closed.Load() {
+			return ErrServerClosed
+		}
+		header, body, err := readFrame(conn, s.limits)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
+				return ctx.Err()
+			}
+			s.counters.inc("malformed_frames_total")
+			return err
+		}
+		if err := s.handleFrame(ctx, conn, state, header, body); err != nil {
+			if errors.Is(err, errGoaway) {
+				return nil
+			}
+			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
+				return ctx.Err()
+			}
+			return err
+		}
+	}
+}
+
+var errGoaway = errors.New("nativewire: goaway")
+
+func (s *Server) registerConn(conn net.Conn) bool {
+	if s == nil || conn == nil || s.closed.Load() {
+		return false
+	}
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	if s.closed.Load() {
+		return false
+	}
+	if s.conns == nil {
+		s.conns = make(map[net.Conn]struct{})
+	}
+	s.conns[conn] = struct{}{}
+	s.counters.inc("connections.opened_total")
+	return true
+}
+
+func (s *Server) unregisterConn(conn net.Conn) {
+	if s == nil || conn == nil {
+		return
+	}
+	s.connMu.Lock()
+	delete(s.conns, conn)
+	s.connMu.Unlock()
+	s.counters.inc("connections.closed_total")
+}
+
+func (s *Server) handleFrame(ctx context.Context, w io.Writer, state *connState, header iwire.Header, body []byte) error {
+	s.counters.inc("frames.in_total")
+	s.counters.add("bytes.in_total", uint64(iwire.FrameHeaderLenV1)+uint64(len(body)))
+	if err := iwire.ValidateHeaderVersion(header, iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0}); err != nil {
+		return s.writeError(w, header, err)
+	}
+	switch header.Type {
+	case iwire.FrameHello:
+		return s.writeHelloOK(w, header, state)
+	case iwire.FramePing:
+		return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FramePong, StreamID: header.StreamID, RequestID: header.RequestID}, nil)
+	case iwire.FrameGoaway:
+		if err := s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameGoaway, StreamID: header.StreamID, RequestID: header.RequestID}, nil); err != nil {
+			return err
+		}
+		return errGoaway
+	case iwire.FrameCancel:
+		s.counters.inc("requests.canceled_total")
+		return nil
+	case iwire.FrameRequest:
+		return s.handleRequest(ctx, w, header, body)
+	default:
+		return s.writeError(w, header, protocolError(iwire.ErrInvalidCommand, "unexpected frame type %d", header.Type))
+	}
+}
+
+func (s *Server) handleRequest(ctx context.Context, w io.Writer, header iwire.Header, body []byte) error {
+	if ctx.Err() != nil {
+		return s.writeError(w, header, ctx.Err())
+	}
+	if s.inFlight.Add(1) > int64(s.maxInFlight) {
+		s.inFlight.Add(-1)
+		return s.writeError(w, header, protocolError(iwire.ErrResourceExhausted, "too many in-flight requests"))
+	}
+	defer s.inFlight.Add(-1)
+
+	s.counters.inc("requests.started_total")
+	start := time.Now()
+	sections, err := iwire.DecodeSections(body, s.limits)
+	if err != nil {
+		s.counters.inc("requests.failed_total")
+		return s.writeError(w, header, err)
+	}
+	cmd, err := s.registry.ValidateRequestSections(sections)
+	if err != nil {
+		s.counters.inc("requests.failed_total")
+		return s.writeError(w, header, err)
+	}
+	s.counters.inc("commands." + cmd.Schema.Name + ".requests_total")
+	var responseSections []iwire.Section
+	switch cmd.Header.ID {
+	case iwire.CommandStats:
+		responseSections = []iwire.Section{{ID: iwire.SectionResponseMeta, Bytes: appendStringMap(nil, s.Stats())}}
+	default:
+		err = protocolError(iwire.ErrUnsupportedFeature, "command %s is not implemented", cmd.Schema.Name)
+	}
+	s.counters.add("dispatch_nanos_total", uint64(time.Since(start).Nanoseconds()))
+	if err != nil {
+		s.counters.inc("requests.failed_total")
+		s.counters.inc("commands." + cmd.Schema.Name + ".errors_total")
+		return s.writeError(w, header, err)
+	}
+	body = body[:0]
+	for _, section := range responseSections {
+		body, err = iwire.AppendSection(body, section)
+		if err != nil {
+			return err
+		}
+	}
+	s.counters.inc("requests.completed_total")
+	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameResponse, StreamID: header.StreamID, RequestID: header.RequestID}, body)
+}
+
+func (s *Server) writeHelloOK(w io.Writer, header iwire.Header, state *connState) error {
+	caps := map[string]string{
+		"protocol":           "treedb-native-wire",
+		"protocol_major":     strconv.Itoa(int(iwire.ProtocolMajorV1)),
+		"protocol_minor":     strconv.Itoa(int(iwire.ProtocolMinorV0)),
+		"connection_id":      strconv.FormatUint(state.id, 10),
+		"default_ack_policy": strconv.FormatUint(uint64(s.defaultAckPolicy), 10),
+	}
+	body, err := iwire.AppendSection(nil, iwire.Section{ID: iwire.SectionCapabilitySet, Bytes: appendStringMap(nil, caps)})
+	if err != nil {
+		return err
+	}
+	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameHelloOK, StreamID: header.StreamID, RequestID: header.RequestID}, body)
+}
+
+func (s *Server) writeError(w io.Writer, request iwire.Header, err error) error {
+	code := errorCodeFor(err)
+	if code == 0 {
+		code = iwire.ErrInternal
+	}
+	message := err.Error()
+	body, sectionErr := iwire.AppendSection(nil, iwire.Section{
+		ID:    iwire.SectionError,
+		Bytes: appendErrorPayload(nil, code, retryableError(code), message),
+	})
+	if sectionErr != nil {
+		return sectionErr
+	}
+	s.counters.inc("errors.total")
+	s.counters.inc("errors.code." + strconv.FormatUint(uint64(code), 10))
+	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameError, StreamID: request.StreamID, RequestID: request.RequestID}, body)
+}
+
+func (s *Server) writeSimpleFrame(w io.Writer, header iwire.Header, body []byte) error {
+	if err := writeFrame(w, header, body); err != nil {
+		return err
+	}
+	s.counters.inc("frames.out_total")
+	s.counters.add("bytes.out_total", uint64(iwire.FrameHeaderLenV1)+uint64(len(body)))
+	return nil
+}
+
+func (s *Server) Stats() map[string]string {
+	out := make(map[string]string)
+	for _, key := range []string{
+		"connections.opened_total",
+		"connections.closed_total",
+		"frames.in_total",
+		"frames.out_total",
+		"bytes.in_total",
+		"bytes.out_total",
+		"malformed_frames_total",
+		"requests.started_total",
+		"requests.completed_total",
+		"requests.failed_total",
+		"requests.canceled_total",
+		"errors.total",
+		"dispatch_nanos_total",
+	} {
+		out[nativeStatsPrefix+key] = "0"
+	}
+	for key, value := range s.counters.snapshot() {
+		out[nativeStatsPrefix+key] = strconv.FormatUint(value, 10)
+	}
+	out[nativeStatsPrefix+"requests.in_flight"] = strconv.FormatInt(s.inFlight.Load(), 10)
+	if s.collections != nil {
+		for key, value := range s.collections.Stats() {
+			out[key] = value
+		}
+	}
+	if s.backend != nil {
+		for key, value := range s.backend.Stats() {
+			out[key] = value
+		}
+	}
+	return out
+}

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -19,6 +19,7 @@ const (
 	defaultMaxInFlight = 1024
 )
 
+// ServerOptions configures a native-wire server.
 type ServerOptions struct {
 	Limits           iwire.Limits
 	MaxInFlight      int
@@ -27,6 +28,7 @@ type ServerOptions struct {
 	Backend          *backenddb.DB
 }
 
+// Server serves native-wire control and command frames for TreeDB.
 type Server struct {
 	limits           iwire.Limits
 	maxInFlight      int
@@ -49,6 +51,7 @@ type connState struct {
 	hello bool
 }
 
+// NewServer creates a native-wire server with defaulted limits and policies.
 func NewServer(opts ServerOptions) *Server {
 	limits := opts.Limits
 	defaultLimits := iwire.DefaultLimits()
@@ -88,6 +91,7 @@ func NewServer(opts ServerOptions) *Server {
 	}
 }
 
+// Close closes all active server connections and rejects new ones.
 func (s *Server) Close() error {
 	if s == nil {
 		return nil
@@ -106,6 +110,7 @@ func (s *Server) Close() error {
 	return nil
 }
 
+// ServeConn serves native-wire frames on conn until shutdown, goaway, or error.
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	if s == nil || conn == nil {
 		return ErrServerClosed
@@ -337,6 +342,7 @@ func (s *Server) writeSimpleFrame(w io.Writer, header iwire.Header, body []byte)
 	return nil
 }
 
+// Stats returns the server's native-wire counters and backend stats.
 func (s *Server) Stats() map[string]string {
 	out := make(map[string]string)
 	for _, key := range []string{

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -203,10 +203,7 @@ func (s *Server) handleFrame(ctx context.Context, w io.Writer, state *connState,
 		if writeErr := s.writeError(w, header, err); writeErr != nil {
 			return writeErr
 		}
-		if state != nil && state.hello {
-			return errGoaway
-		}
-		return nil
+		return errGoaway
 	}
 	switch header.Type {
 	case iwire.FrameHello:
@@ -271,15 +268,15 @@ func (s *Server) handleRequest(ctx context.Context, w io.Writer, header iwire.He
 		s.counters.inc("commands." + cmd.Schema.Name + ".errors_total")
 		return s.writeError(w, header, err)
 	}
-	body = body[:0]
+	var responseBody []byte
 	for _, section := range responseSections {
-		body, err = iwire.AppendSection(body, section)
+		responseBody, err = iwire.AppendSection(responseBody, section)
 		if err != nil {
 			return err
 		}
 	}
 	s.counters.inc("requests.completed_total")
-	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameResponse, StreamID: header.StreamID, RequestID: header.RequestID}, body)
+	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameResponse, StreamID: header.StreamID, RequestID: header.RequestID}, responseBody)
 }
 
 func (s *Server) writeHelloOK(w io.Writer, header iwire.Header, state *connState) error {

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -179,7 +179,11 @@ func (s *Server) handleFrame(ctx context.Context, w io.Writer, state *connState,
 	case iwire.FramePing:
 		return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FramePong, StreamID: header.StreamID, RequestID: header.RequestID}, nil)
 	case iwire.FrameGoaway:
-		if err := s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameGoaway, StreamID: header.StreamID, RequestID: header.RequestID}, nil); err != nil {
+		body, err := appendGoawayBody(nil, header.RequestID)
+		if err != nil {
+			return err
+		}
+		if err := s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameGoaway, StreamID: header.StreamID, RequestID: header.RequestID}, body); err != nil {
 			return err
 		}
 		return errGoaway
@@ -253,6 +257,15 @@ func (s *Server) writeHelloOK(w io.Writer, header iwire.Header, state *connState
 		return err
 	}
 	return s.writeSimpleFrame(w, iwire.Header{Type: iwire.FrameHelloOK, StreamID: header.StreamID, RequestID: header.RequestID}, body)
+}
+
+func appendGoawayBody(dst []byte, lastAcceptedRequestID uint64) ([]byte, error) {
+	return iwire.AppendSection(dst, iwire.Section{
+		ID: iwire.SectionResponseMeta,
+		Bytes: appendStringMap(nil, map[string]string{
+			"last_accepted_request_id": strconv.FormatUint(lastAcceptedRequestID, 10),
+		}),
+	})
 }
 
 func (s *Server) writeError(w io.Writer, request iwire.Header, err error) error {

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -45,7 +45,8 @@ type Server struct {
 }
 
 type connState struct {
-	id uint64
+	id    uint64
+	hello bool
 }
 
 func NewServer(opts ServerOptions) *Server {
@@ -191,6 +192,9 @@ func (s *Server) handleFrame(ctx context.Context, w io.Writer, state *connState,
 		s.counters.inc("requests.canceled_total")
 		return nil
 	case iwire.FrameRequest:
+		if state != nil && !state.hello {
+			return s.writeError(w, header, protocolError(iwire.ErrInvalidCommand, "hello required before request"))
+		}
 		return s.handleRequest(ctx, w, header, body)
 	default:
 		return s.writeError(w, header, protocolError(iwire.ErrInvalidCommand, "unexpected frame type %d", header.Type))
@@ -245,11 +249,16 @@ func (s *Server) handleRequest(ctx context.Context, w io.Writer, header iwire.He
 }
 
 func (s *Server) writeHelloOK(w io.Writer, header iwire.Header, state *connState) error {
+	var connectionID uint64
+	if state != nil {
+		state.hello = true
+		connectionID = state.id
+	}
 	caps := map[string]string{
 		"protocol":           "treedb-native-wire",
 		"protocol_major":     strconv.Itoa(int(iwire.ProtocolMajorV1)),
 		"protocol_minor":     strconv.Itoa(int(iwire.ProtocolMinorV0)),
-		"connection_id":      strconv.FormatUint(state.id, 10),
+		"connection_id":      strconv.FormatUint(connectionID, 10),
 		"default_ack_policy": strconv.FormatUint(uint64(s.defaultAckPolicy), 10),
 	}
 	body, err := iwire.AppendSection(nil, iwire.Section{ID: iwire.SectionCapabilitySet, Bytes: appendStringMap(nil, caps)})

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -113,13 +113,32 @@ func TestServerMalformedRequestReturnsWireError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
 	_, _, err := client.roundTrip(ctx, iwire.FrameRequest, []byte{0xff}, iwire.FrameResponse)
 	if !isRemoteError(err, iwire.ErrMalformedFrame) {
 		t.Fatalf("error=%v want malformed frame", err)
 	}
 }
 
-func TestClientDetectsUnexpectedResponseType(t *testing.T) {
+func TestServerRejectsRequestBeforeHello(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	client, _ := servePipe(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	body, err := appendCommandRequestBody(nil, iwire.CommandStats)
+	if err != nil {
+		t.Fatalf("append request: %v", err)
+	}
+	_, _, err = client.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+	if !isRemoteError(err, iwire.ErrInvalidCommand) {
+		t.Fatalf("error=%v want invalid command", err)
+	}
+}
+
+func TestClientDetectsResponseRequestIDMismatch(t *testing.T) {
 	left, right := net.Pipe()
 	defer left.Close()
 	defer right.Close()
@@ -138,6 +157,35 @@ func TestClientDetectsUnexpectedResponseType(t *testing.T) {
 	err := client.Ping(ctx)
 	if err == nil || !strings.Contains(err.Error(), "request_id") {
 		t.Fatalf("Ping error=%v want request_id mismatch", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("server goroutine: %v", err)
+	}
+}
+
+func TestClientRejectsUnsupportedResponseVersion(t *testing.T) {
+	left, right := net.Pipe()
+	defer left.Close()
+	defer right.Close()
+	client := NewClient(left)
+	errCh := make(chan error, 1)
+	go func() {
+		header, _, err := readFrame(right, iwire.DefaultLimits())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- writeFrame(right, iwire.Header{
+			Version:   iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0 + 1},
+			Type:      iwire.FramePong,
+			RequestID: header.RequestID,
+		}, nil)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := client.Ping(ctx)
+	if code, ok := iwire.ErrorCodeOf(err); !ok || code != iwire.ErrUnsupportedVersion {
+		t.Fatalf("Ping error=%v want unsupported version", err)
 	}
 	if err := <-errCh; err != nil {
 		t.Fatalf("server goroutine: %v", err)

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -3,6 +3,7 @@ package nativewire
 import (
 	"context"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -54,8 +55,27 @@ func TestServerControlHelloPingStatsGoaway(t *testing.T) {
 			t.Fatalf("stats missing %s in %#v", key, stats)
 		}
 	}
-	if err := client.Goaway(ctx); err != nil {
+	goawayHeader, goawayBody, err := client.roundTrip(ctx, iwire.FrameGoaway, nil, iwire.FrameGoaway)
+	if err != nil {
 		t.Fatalf("Goaway: %v", err)
+	}
+	sections, err := iwire.DecodeSections(goawayBody, iwire.DefaultLimits())
+	if err != nil {
+		t.Fatalf("decode goaway body: %v", err)
+	}
+	rawMeta, ok, err := singletonSection(sections, iwire.SectionResponseMeta)
+	if err != nil {
+		t.Fatalf("goaway response_meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("goaway missing response_meta")
+	}
+	meta, err := decodeStringMap(rawMeta)
+	if err != nil {
+		t.Fatalf("decode goaway response_meta: %v", err)
+	}
+	if got, want := meta["last_accepted_request_id"], strconv.FormatUint(goawayHeader.RequestID, 10); got != want {
+		t.Fatalf("last_accepted_request_id=%q want %q", got, want)
 	}
 	select {
 	case err := <-errCh:
@@ -112,6 +132,39 @@ func TestClientDetectsUnexpectedResponseType(t *testing.T) {
 			return
 		}
 		errCh <- writeFrame(right, iwire.Header{Type: iwire.FramePong, RequestID: header.RequestID + 1}, nil)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := client.Ping(ctx)
+	if err == nil || !strings.Contains(err.Error(), "request_id") {
+		t.Fatalf("Ping error=%v want request_id mismatch", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("server goroutine: %v", err)
+	}
+}
+
+func TestClientDetectsErrorResponseRequestIDMismatch(t *testing.T) {
+	left, right := net.Pipe()
+	defer left.Close()
+	defer right.Close()
+	client := NewClient(left)
+	errCh := make(chan error, 1)
+	go func() {
+		header, _, err := readFrame(right, iwire.DefaultLimits())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		body, err := iwire.AppendSection(nil, iwire.Section{
+			ID:    iwire.SectionError,
+			Bytes: appendErrorPayload(nil, iwire.ErrInvalidCommand, false, "wrong request"),
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- writeFrame(right, iwire.Header{Type: iwire.FrameError, RequestID: header.RequestID + 1}, body)
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -122,6 +122,56 @@ func TestServerMalformedRequestReturnsWireError(t *testing.T) {
 	}
 }
 
+func TestServerClosesPostHandshakeUnsupportedVersion(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	left, right := net.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ServeConn(context.Background(), right)
+	}()
+	t.Cleanup(func() {
+		_ = left.Close()
+		_ = right.Close()
+		_ = server.Close()
+	})
+
+	if err := writeFrame(left, iwire.Header{Type: iwire.FrameHello, RequestID: 1}, nil); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+	header, _, err := readFrame(left, iwire.DefaultLimits())
+	if err != nil {
+		t.Fatalf("read hello_ok: %v", err)
+	}
+	if header.Type != iwire.FrameHelloOK {
+		t.Fatalf("hello response type=%d want hello_ok", header.Type)
+	}
+	if err := writeFrame(left, iwire.Header{
+		Version:   iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0 + 1},
+		Type:      iwire.FramePing,
+		RequestID: 2,
+	}, nil); err != nil {
+		t.Fatalf("write bad-version ping: %v", err)
+	}
+	header, body, err := readFrame(left, iwire.DefaultLimits())
+	if err != nil {
+		t.Fatalf("read version error: %v", err)
+	}
+	if header.Type != iwire.FrameError {
+		t.Fatalf("bad-version response type=%d want error", header.Type)
+	}
+	if !isRemoteError(decodeWireError(body, iwire.DefaultLimits()), iwire.ErrUnsupportedVersion) {
+		t.Fatalf("bad-version body did not decode as unsupported version")
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ServeConn returned %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ServeConn did not close after post-handshake version error")
+	}
+}
+
 func TestServerRejectsRequestBeforeHello(t *testing.T) {
 	server := NewServer(ServerOptions{})
 	client, _ := servePipe(t, server)

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -155,6 +155,22 @@ func TestServerMalformedRequestReturnsWireError(t *testing.T) {
 	}
 }
 
+func TestPayloadDecodersRejectMalformedScalars(t *testing.T) {
+	if _, err := decodeStringMap([]byte{0x80, 0x00}); codeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("decodeStringMap non-minimal count err=%v code=%d", err, codeOf(err))
+	}
+
+	payload := appendErrorPayload(nil, iwire.ErrInvalidCommand, false, "bad")
+	payload[uvarintLen(uint64(iwire.ErrInvalidCommand))] = 2
+	if _, _, _, err := decodeErrorPayload(payload); codeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("decodeErrorPayload retryable err=%v code=%d", err, codeOf(err))
+	}
+
+	if _, _, _, err := decodeErrorPayload([]byte{0x80, 0x00, 0, 0}); codeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("decodeErrorPayload non-minimal code err=%v code=%d", err, codeOf(err))
+	}
+}
+
 func TestServerClosesPostHandshakeUnsupportedVersion(t *testing.T) {
 	server := NewServer(ServerOptions{})
 	left, right := net.Pipe()
@@ -281,12 +297,15 @@ func TestClientRoundTripHonorsCancellationWithoutDeadline(t *testing.T) {
 	defer right.Close()
 	client := NewClient(left)
 	started := make(chan struct{})
-	serverDone := make(chan struct{})
 	serverErr := make(chan error, 1)
 	go func() {
 		_, _, err := readFrame(right, iwire.DefaultLimits())
 		close(started)
-		<-serverDone
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		_, _, err = readFrame(right, iwire.DefaultLimits())
 		serverErr <- err
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -308,9 +327,13 @@ func TestClientRoundTripHonorsCancellationWithoutDeadline(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Ping did not return after cancel")
 	}
-	close(serverDone)
-	if err := <-serverErr; err != nil {
-		t.Fatalf("server read: %v", err)
+	select {
+	case err := <-serverErr:
+		if err == nil {
+			t.Fatal("server read after cancellation succeeded; client connection was reused")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not observe client close after cancel")
 	}
 }
 
@@ -345,4 +368,9 @@ func TestClientDetectsErrorResponseRequestIDMismatch(t *testing.T) {
 	if err := <-errCh; err != nil {
 		t.Fatalf("server goroutine: %v", err)
 	}
+}
+
+func codeOf(err error) iwire.ErrorCode {
+	code, _ := iwire.ErrorCodeOf(err)
+	return code
 }

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -2,6 +2,7 @@ package nativewire
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"strings"
@@ -239,6 +240,45 @@ func TestClientRejectsUnsupportedResponseVersion(t *testing.T) {
 	}
 	if err := <-errCh; err != nil {
 		t.Fatalf("server goroutine: %v", err)
+	}
+}
+
+func TestClientRoundTripHonorsCancellationWithoutDeadline(t *testing.T) {
+	left, right := net.Pipe()
+	defer left.Close()
+	defer right.Close()
+	client := NewClient(left)
+	started := make(chan struct{})
+	serverDone := make(chan struct{})
+	serverErr := make(chan error, 1)
+	go func() {
+		_, _, err := readFrame(right, iwire.DefaultLimits())
+		close(started)
+		<-serverDone
+		serverErr <- err
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.Ping(ctx)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive ping")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Ping err=%v want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Ping did not return after cancel")
+	}
+	close(serverDone)
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server read: %v", err)
 	}
 }
 

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -1,0 +1,125 @@
+package nativewire
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+func servePipe(t *testing.T, server *Server) (*Client, <-chan error) {
+	t.Helper()
+	left, right := net.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ServeConn(context.Background(), right)
+	}()
+	t.Cleanup(func() {
+		_ = left.Close()
+		_ = right.Close()
+		_ = server.Close()
+	})
+	return NewClient(left), errCh
+}
+
+func TestServerControlHelloPingStatsGoaway(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	client, errCh := servePipe(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	stats, err := client.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	for _, key := range []string{
+		"treedb.native_wire.connections.opened_total",
+		"treedb.native_wire.frames.in_total",
+		"treedb.native_wire.frames.out_total",
+		"treedb.native_wire.requests.started_total",
+		"treedb.native_wire.requests.completed_total",
+		"treedb.native_wire.commands.stats.requests_total",
+	} {
+		if _, ok := stats[key]; !ok {
+			t.Fatalf("stats missing %s in %#v", key, stats)
+		}
+	}
+	if err := client.Goaway(ctx); err != nil {
+		t.Fatalf("Goaway: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ServeConn returned %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ServeConn did not return after goaway")
+	}
+}
+
+func TestServerRequestUnsupportedCommandReturnsWireError(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	client, _ := servePipe(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	body, err := appendCommandRequestBody(nil, iwire.CommandOpenScan, iwire.Section{ID: iwire.SectionCollectionRef, Bytes: []byte("orders")})
+	if err != nil {
+		t.Fatalf("append request: %v", err)
+	}
+	_, _, err = client.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+	if !isRemoteError(err, iwire.ErrUnsupportedFeature) {
+		t.Fatalf("error=%v want unsupported feature", err)
+	}
+}
+
+func TestServerMalformedRequestReturnsWireError(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	client, _ := servePipe(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, _, err := client.roundTrip(ctx, iwire.FrameRequest, []byte{0xff}, iwire.FrameResponse)
+	if !isRemoteError(err, iwire.ErrMalformedFrame) {
+		t.Fatalf("error=%v want malformed frame", err)
+	}
+}
+
+func TestClientDetectsUnexpectedResponseType(t *testing.T) {
+	left, right := net.Pipe()
+	defer left.Close()
+	defer right.Close()
+	client := NewClient(left)
+	errCh := make(chan error, 1)
+	go func() {
+		header, _, err := readFrame(right, iwire.DefaultLimits())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- writeFrame(right, iwire.Header{Type: iwire.FramePong, RequestID: header.RequestID + 1}, nil)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := client.Ping(ctx)
+	if err == nil || !strings.Contains(err.Error(), "request_id") {
+		t.Fatalf("Ping error=%v want request_id mismatch", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("server goroutine: %v", err)
+	}
+}

--- a/TreeDB/nativewire/stats.go
+++ b/TreeDB/nativewire/stats.go
@@ -1,12 +1,10 @@
 package nativewire
 
-import (
-	"sort"
-	"sync"
-)
+import "sync"
 
 const nativeStatsPrefix = "treedb.native_wire."
 
+// Stats is a string-valued snapshot of native-wire and TreeDB counters.
 type Stats map[string]string
 
 type counters struct {
@@ -41,13 +39,4 @@ func (c *counters) snapshot() map[string]uint64 {
 	}
 	c.mu.Unlock()
 	return out
-}
-
-func sortedStatsKeys(stats map[string]string) []string {
-	keys := make([]string, 0, len(stats))
-	for key := range stats {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/TreeDB/nativewire/stats.go
+++ b/TreeDB/nativewire/stats.go
@@ -1,0 +1,53 @@
+package nativewire
+
+import (
+	"sort"
+	"sync"
+)
+
+const nativeStatsPrefix = "treedb.native_wire."
+
+type Stats map[string]string
+
+type counters struct {
+	mu     sync.Mutex
+	values map[string]uint64
+}
+
+func (c *counters) add(key string, delta uint64) {
+	if c == nil || key == "" || delta == 0 {
+		return
+	}
+	c.mu.Lock()
+	if c.values == nil {
+		c.values = make(map[string]uint64)
+	}
+	c.values[key] += delta
+	c.mu.Unlock()
+}
+
+func (c *counters) inc(key string) {
+	c.add(key, 1)
+}
+
+func (c *counters) snapshot() map[string]uint64 {
+	out := make(map[string]uint64)
+	if c == nil {
+		return out
+	}
+	c.mu.Lock()
+	for key, value := range c.values {
+		out[key] = value
+	}
+	c.mu.Unlock()
+	return out
+}
+
+func sortedStatsKeys(stats map[string]string) []string {
+	keys := make([]string, 0, len(stats))
+	for key := range stats {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
## Stack

R1a of the native-wire R1 stack. Base: `codex/nativewire-r0d-benchmarks`.

## Changes

- Adds the public `TreeDB/nativewire` package for server/client work over the internal codec/schema package.
- Implements the server frame loop, request admission, `hello`/`hello_ok`, `ping`/`pong`, `goaway`, `stats`, and structured error responses.
- Adds stable native-wire stats counters under `treedb.native_wire.*`.

## Validation

- `GOWORK=off go test ./TreeDB/internal/nativewire ./TreeDB/nativewire`
