### PR TITLE
Collections: batch indexed range document reads

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11457,17 +11457,32 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		// buffered primary documents come from one write-domain view. Releasing
 		// here would require copying the pending primary view up front, which is
 		// too much work for the common small-limit range probe.
-		defer func() {
-			if domainLocked {
-				domain.mu.RUnlock()
-			}
-		}()
 	}
-	snap := c.db.AcquireSnapshot()
+	var snap *backenddb.Snapshot
+	var bufferedTable memtable.Table
+	var bufferedIt iterator.UnsafeIterator
+	var persistedIt iterator.UnsafeIterator
+	defer func() {
+		if domainLocked {
+			domain.mu.RUnlock()
+		}
+		if persistedIt != nil {
+			_ = persistedIt.Close()
+		}
+		if bufferedIt != nil {
+			_ = bufferedIt.Close()
+		}
+		if bufferedTable != nil {
+			resetCollectionRunTable(bufferedTable)
+		}
+		if snap != nil {
+			_ = snap.Close()
+		}
+	}()
+	snap = c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, false, backenddb.ErrClosed
 	}
-	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshotWithWriteDomainLocked(snap)
 	if err != nil {
 		return nil, false, err
@@ -11490,7 +11505,6 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	if err != nil {
 		return nil, false, err
 	}
-	var bufferedTable memtable.Table
 	if exactPrefixScan {
 		// Exact document scans still need buffered tombstones for unique indexes.
 		// The unique reservation fast path only proves pending live values, so use
@@ -11504,19 +11518,11 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		return nil, false, err
 	}
 	if bufferedTable != nil {
-		defer resetCollectionRunTable(bufferedTable)
-	}
-	var bufferedIt iterator.UnsafeIterator
-	if bufferedTable != nil {
 		bufferedIt = bufferedTable.NewIterator(start, end)
-		defer func() { _ = bufferedIt.Close() }()
 	}
-	persistedIt, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
+	persistedIt, err = collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
 	if err != nil {
 		return nil, false, err
-	}
-	if persistedIt != nil {
-		defer func() { _ = persistedIt.Close() }()
 	}
 	capHint := defaultIndexRangeResultCap
 	if opts.Limit > 0 && opts.Limit < capHint {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11494,8 +11494,9 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	if exactPrefixScan {
 		// Exact document scans still need buffered tombstones for unique indexes.
 		// The unique reservation fast path only proves pending live values, so use
-		// the run-table path and cap it by the requested result limit.
-		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
+		// the uncapped run-table path; tombstones can sort after the live entries
+		// that satisfy opts.Limit and still need to hide persisted index rows.
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, 0)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}
@@ -11638,8 +11639,9 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	if exactPrefixScan {
 		// Exact scans still need buffered tombstones for unique indexes. The unique
 		// reservation fast path only proves pending live values, so use the
-		// run-table path and cap it by the requested result limit.
-		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
+		// uncapped run-table path; tombstones can sort after the live entries that
+		// satisfy opts.Limit and still need to hide persisted index rows.
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, 0)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11423,7 +11423,9 @@ func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) 
 // index falls inside opts, preserving index order. Persisted index and primary
 // reads share one snapshot/catalog; same-manager buffered documents are still
 // consulted before the persisted primary root so pending indexed writes remain
-// visible.
+// visible. Descending scans are not supported. Because this API holds a
+// write-domain read lock while pairing secondary IDs with buffered primary
+// documents, callers must provide a positive Limit.
 func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRangeOptions) ([]DocumentRecord, bool, error) {
 	if c == nil {
 		return nil, false, errCollectionNil
@@ -11436,6 +11438,9 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	if opts.Limit < 0 {
 		return nil, false, errors.New("collections: index range limit cannot be negative")
+	}
+	if opts.Limit == 0 {
+		return nil, false, errors.New("collections: document index range reads require a positive limit")
 	}
 	if opts.Desc {
 		return nil, false, errors.New("collections: descending index range scans are not supported")
@@ -11487,7 +11492,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
-		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, exactPrefix, 0)
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}
@@ -11628,7 +11633,7 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
-		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, exactPrefix, opts.Limit)
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11417,6 +11417,128 @@ func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) 
 	return out, truncated, nil
 }
 
+// FindDocumentsByIndexRange returns primary documents whose named secondary
+// index falls inside opts, preserving index order. Persisted index and primary
+// reads share one snapshot/catalog; same-manager buffered documents are still
+// consulted before the persisted primary root so pending indexed writes remain
+// visible.
+func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRangeOptions) ([]DocumentRecord, bool, error) {
+	if c == nil {
+		return nil, false, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, false, errCollectionDBNil
+	}
+	if err := ValidateIndexName(indexName); err != nil {
+		return nil, false, err
+	}
+	if opts.Limit < 0 {
+		return nil, false, errors.New("collections: index range limit cannot be negative")
+	}
+	if opts.Desc {
+		return nil, false, errors.New("collections: descending index range scans are not supported")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, false, err
+	}
+	domain := c.writeDomain
+	domainLocked := false
+	if domain != nil {
+		domain.mu.RLock()
+		domainLocked = true
+		defer func() {
+			if domainLocked {
+				domain.mu.RUnlock()
+			}
+		}()
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshotWithWriteDomainLocked(snap)
+	if err != nil {
+		return nil, false, err
+	}
+	if catalog == nil {
+		return nil, false, errCollectionNotFound
+	}
+	idx, ok := findIndex(catalog.meta.Indexes, indexName)
+	if !ok {
+		return nil, false, nil
+	}
+	start, end, empty, err := indexRangeScanBounds(idx.ValueType, opts)
+	if err != nil {
+		return nil, true, err
+	}
+	if empty {
+		return make([]DocumentRecord, 0), false, nil
+	}
+	exactPrefix, exactPrefixScan, err := exactIndexRangePrefix(idx.ValueType, opts)
+	if err != nil {
+		return nil, true, err
+	}
+	var bufferedTable memtable.Table
+	if exactPrefixScan {
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, exactPrefix, opts.Limit)
+	} else {
+		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if domainLocked {
+		domain.mu.RUnlock()
+		domainLocked = false
+	}
+	if bufferedTable != nil {
+		defer resetCollectionRunTable(bufferedTable)
+	}
+	var bufferedIt iterator.UnsafeIterator
+	if bufferedTable != nil {
+		bufferedIt = bufferedTable.NewIterator(start, end)
+		defer func() { _ = bufferedIt.Close() }()
+	}
+	persistedIt, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
+	if err != nil {
+		return nil, true, err
+	}
+	if persistedIt != nil {
+		defer func() { _ = persistedIt.Close() }()
+	}
+	capHint := 16
+	if opts.Limit > 0 && opts.Limit < capHint {
+		capHint = opts.Limit
+	}
+	out := make([]DocumentRecord, 0, capHint)
+	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	var scratch []byte
+	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
+		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
+		if !buffered {
+			var err error
+			value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
+			if err != nil {
+				return false, err
+			}
+		}
+		if !found {
+			return true, nil
+		}
+		scratch = value
+		out = append(out, DocumentRecord{
+			ID:       bytes.Clone(id),
+			Document: bytes.Clone(value),
+		})
+		return true, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return out, truncated, nil
+}
+
 func (c *Collection) ScanIndexRange(indexName string, opts IndexRangeOptions, fn func(id []byte) (bool, error)) (bool, error) {
 	if fn == nil {
 		return false, errors.New("collections: nil index range callback")

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11371,6 +11371,8 @@ type IndexRangeOptions struct {
 	Desc  bool
 }
 
+const defaultIndexRangeResultCap = 16
+
 // FindByIndexValue returns document IDs whose named secondary index equals
 // value. Query values must match the index value type. If indexName does not
 // exist, it returns nil, nil.
@@ -11393,7 +11395,7 @@ func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) 
 	if opts.Limit < 0 {
 		return nil, false, errors.New("collections: index range limit cannot be negative")
 	}
-	capHint := 16
+	capHint := defaultIndexRangeResultCap
 	if opts.Limit > 0 && opts.Limit < capHint {
 		capHint = opts.Limit
 	}
@@ -11470,7 +11472,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	idx, ok := findIndex(catalog.meta.Indexes, indexName)
 	if !ok {
-		return nil, false, nil
+		return make([]DocumentRecord, 0), false, nil
 	}
 	start, end, empty, err := indexRangeScanBounds(idx.ValueType, opts)
 	if err != nil {
@@ -11490,7 +11492,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}
 	if err != nil {
-		return nil, true, err
+		return nil, false, err
 	}
 	if bufferedTable != nil {
 		defer resetCollectionRunTable(bufferedTable)
@@ -11502,12 +11504,12 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	persistedIt, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
 	if err != nil {
-		return nil, true, err
+		return nil, false, err
 	}
 	if persistedIt != nil {
 		defer func() { _ = persistedIt.Close() }()
 	}
-	capHint := 16
+	capHint := defaultIndexRangeResultCap
 	if opts.Limit > 0 && opts.Limit < capHint {
 		capHint = opts.Limit
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11488,10 +11488,6 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	if err != nil {
 		return nil, true, err
 	}
-	if domainLocked {
-		domain.mu.RUnlock()
-		domainLocked = false
-	}
 	if bufferedTable != nil {
 		defer resetCollectionRunTable(bufferedTable)
 	}
@@ -11515,7 +11511,11 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
 	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
-		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
+		var value []byte
+		var buffered, found bool
+		if domainLocked {
+			value, buffered, found = c.getBufferedDocumentIntoLocked(domain, id, scratch[:0])
+		}
 		if !buffered {
 			var err error
 			value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
@@ -11528,7 +11528,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		}
 		scratch = value
 		out = append(out, DocumentRecord{
-			ID:       bytes.Clone(id),
+			ID:       id,
 			Document: bytes.Clone(value),
 		})
 		return true, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11474,14 +11474,14 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	start, end, empty, err := indexRangeScanBounds(idx.ValueType, opts)
 	if err != nil {
-		return nil, true, err
+		return nil, false, err
 	}
 	if empty {
 		return make([]DocumentRecord, 0), false, nil
 	}
 	exactPrefix, exactPrefixScan, err := exactIndexRangePrefix(idx.ValueType, opts)
 	if err != nil {
-		return nil, true, err
+		return nil, false, err
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
@@ -11514,7 +11514,8 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
-	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
+	documentTruncated := false
+	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, 0, func(id []byte) (bool, error) {
 		var value []byte
 		var buffered, found bool
 		if domainLocked {
@@ -11530,6 +11531,10 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		if !found {
 			return true, nil
 		}
+		if opts.Limit > 0 && len(out) >= opts.Limit {
+			documentTruncated = true
+			return false, nil
+		}
 		scratch = value
 		out = append(out, DocumentRecord{
 			ID:       id,
@@ -11539,6 +11544,9 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	})
 	if err != nil {
 		return nil, false, err
+	}
+	if documentTruncated {
+		return out, true, nil
 	}
 	return out, truncated, nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11446,6 +11446,10 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	if domain != nil {
 		domain.mu.RLock()
 		domainLocked = true
+		// Keep the read lock through the scan so buffered secondary IDs and
+		// buffered primary documents come from one write-domain view. Releasing
+		// here would require copying the pending primary view up front, which is
+		// too much work for the common small-limit range probe.
 		defer func() {
 			if domainLocked {
 				domain.mu.RUnlock()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11477,7 +11477,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	idx, ok := findIndex(catalog.meta.Indexes, indexName)
 	if !ok {
-		return make([]DocumentRecord, 0), false, nil
+		return nil, false, nil
 	}
 	start, end, empty, err := indexRangeScanBounds(idx.ValueType, opts)
 	if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11492,6 +11492,9 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
+		// Exact document scans still need buffered tombstones for unique indexes.
+		// The unique reservation fast path only proves pending live values, so use
+		// the run-table path and cap it by the requested result limit.
 		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
@@ -11633,6 +11636,9 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
+		// Exact scans still need buffered tombstones for unique indexes. The unique
+		// reservation fast path only proves pending live values, so use the
+		// run-table path and cap it by the requested result limit.
 		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, false, exactPrefix, opts.Limit)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11485,7 +11485,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
-		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, exactPrefix, opts.Limit)
+		bufferedTable, err = bufferedIndexPrefixTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, exactPrefix, 0)
 	} else {
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11732,6 +11732,13 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	if truncated || len(records) != 0 {
 		t.Fatalf("empty records len=%d truncated=%v want 0,false", len(records), truncated)
 	}
+
+	if _, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "not-an-int", Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+	}); err == nil || truncated {
+		t.Fatalf("bad bound err=%v truncated=%v want error,false", err, truncated)
+	}
 }
 
 func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11678,6 +11678,62 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 	}
 }
 
+func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":-10,"name":"low"}`),
+			[]byte(`{"score":0,"name":"zero"}`),
+			[]byte(`{"score":2,"name":"two"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	records, truncated, err := col.FindDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("find documents range: %v", err)
+	}
+	if !truncated || len(records) != 1 {
+		t.Fatalf("records len=%d truncated=%v want 1,true", len(records), truncated)
+	}
+	if !bytes.Equal(records[0].ID, []byte("u2")) || !bytes.Contains(records[0].Document, []byte(`"name":"zero"`)) {
+		t.Fatalf("record=%q/%s want u2 zero", records[0].ID, records[0].Document)
+	}
+
+	records, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(100), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+	})
+	if err != nil {
+		t.Fatalf("find empty documents range: %v", err)
+	}
+	if truncated || len(records) != 0 {
+		t.Fatalf("empty records len=%d truncated=%v want 0,false", len(records), truncated)
+	}
+}
+
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11935,6 +11935,81 @@ func TestCollectionFindDocumentsByIndexRangeUniqueExactBufferedTombstone(t *test
 	requireJSONFieldValue(t, records[0].Document, "email", "grace@example.com")
 }
 
+func TestCollectionFindDocumentsByIndexRangeExactBufferedTombstoneAfterLimit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"ada@example.com","name":"stale"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted row: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted row: %v", err)
+	}
+
+	email, err := encodeIndexScalar(IndexValueString, "ada@example.com")
+	if err != nil {
+		t.Fatalf("encode email: %v", err)
+	}
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u0"), []byte(`{"email":"ada@example.com","name":"live"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	emailTable := newCollectionRunTable(2)
+	if _, err := setCollectionSecondaryIndexEntry(emailTable, email, []byte("u0")); err != nil {
+		t.Fatalf("set live email index entry: %v", err)
+	}
+	if _, err := deleteCollectionSecondaryIndexEntry(emailTable, email, []byte("u2")); err != nil {
+		t.Fatalf("delete stale email index entry: %v", err)
+	}
+	emailTable.Freeze()
+	defer resetCollectionRunTable(emailTable)
+
+	domain := col.writeDomain
+	domain.mu.Lock()
+	domain.count = 1
+	domain.meta = col.Meta()
+	domain.rootRuns = map[string][]memtable.Table{
+		collectionPrimaryRootName("users"):            {primaryTable},
+		collectionSecondaryRootName("users", "email"): {emailTable},
+	}
+	domain.rootRunCount = 2
+	domain.mu.Unlock()
+
+	records, truncated, err := col.FindDocumentsByIndexRange("email", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "ada@example.com", Inclusive: true},
+		Upper: IndexRangeBound{Value: "ada@example.com", Inclusive: true},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("find exact email range: %v", err)
+	}
+	if truncated || len(records) != 1 || !bytes.Equal(records[0].ID, []byte("u0")) {
+		t.Fatalf("records=%+v truncated=%v want u0 false", records, truncated)
+	}
+	requireJSONFieldValue(t, records[0].Document, "name", "live")
+}
+
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11752,6 +11752,7 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	records, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(100), Inclusive: true},
 		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 10,
 	})
 	if err != nil {
 		t.Fatalf("find empty documents range: %v", err)
@@ -11763,8 +11764,15 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	if _, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: "not-an-int", Inclusive: true},
 		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 1,
 	}); err == nil || truncated {
 		t.Fatalf("bad bound err=%v truncated=%v want error,false", err, truncated)
+	}
+	if _, _, err := col.FindDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+	}); err == nil || !strings.Contains(err.Error(), "positive limit") {
+		t.Fatalf("unlimited document range err=%v want positive limit", err)
 	}
 }
 
@@ -11813,6 +11821,7 @@ func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T
 	records, truncated, err := col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
 		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+		Limit: 10,
 	})
 	if err != nil {
 		t.Fatalf("find documents range: %v", err)
@@ -11828,6 +11837,96 @@ func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T
 		t.Fatalf("second record id=%q want u2", records[1].ID)
 	}
 	requireJSONFieldValue(t, records[1].Document, "name", "fresh-primary")
+}
+
+func TestCollectionFindDocumentsByIndexRangeUniqueExactBufferedTombstone(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","name":"ada"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted row: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted row: %v", err)
+	}
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"email":"grace@example.com","name":"ada"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	oldEmail, err := encodeIndexScalar(IndexValueString, "ada@example.com")
+	if err != nil {
+		t.Fatalf("encode old email: %v", err)
+	}
+	newEmail, err := encodeIndexScalar(IndexValueString, "grace@example.com")
+	if err != nil {
+		t.Fatalf("encode new email: %v", err)
+	}
+	emailTable := newCollectionRunTable(2)
+	if _, err := deleteCollectionSecondaryIndexEntry(emailTable, oldEmail, []byte("u1")); err != nil {
+		t.Fatalf("delete old email index entry: %v", err)
+	}
+	if _, err := setCollectionSecondaryIndexEntry(emailTable, newEmail, []byte("u1")); err != nil {
+		t.Fatalf("set new email index entry: %v", err)
+	}
+	emailTable.Freeze()
+	defer resetCollectionRunTable(emailTable)
+
+	domain := col.writeDomain
+	domain.mu.Lock()
+	domain.count = 1
+	domain.meta = col.Meta()
+	domain.rootRuns = map[string][]memtable.Table{
+		collectionPrimaryRootName("users"):            {primaryTable},
+		collectionSecondaryRootName("users", "email"): {emailTable},
+	}
+	domain.rootRunCount = 2
+	domain.mu.Unlock()
+
+	records, truncated, err := col.FindDocumentsByIndexRange("email", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "ada@example.com", Inclusive: true},
+		Upper: IndexRangeBound{Value: "ada@example.com", Inclusive: true},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("find old email exact range: %v", err)
+	}
+	if truncated || len(records) != 0 {
+		t.Fatalf("old email records=%+v truncated=%v want none false", records, truncated)
+	}
+
+	records, truncated, err = col.FindDocumentsByIndexRange("email", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "grace@example.com", Inclusive: true},
+		Upper: IndexRangeBound{Value: "grace@example.com", Inclusive: true},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("find new email exact range: %v", err)
+	}
+	if truncated || len(records) != 1 || !bytes.Equal(records[0].ID, []byte("u1")) {
+		t.Fatalf("new email records=%+v truncated=%v want u1 false", records, truncated)
+	}
+	requireJSONFieldValue(t, records[0].Document, "email", "grace@example.com")
 }
 
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11680,8 +11680,10 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 
 func requireJSONFieldValue(t *testing.T, document []byte, field string, want any) {
 	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
 	var decoded map[string]any
-	if err := json.Unmarshal(document, &decoded); err != nil {
+	if err := decoder.Decode(&decoded); err != nil {
 		t.Fatalf("decode document %s: %v", document, err)
 	}
 	got, ok := decoded[field]
@@ -11695,8 +11697,12 @@ func requireJSONFieldValue(t *testing.T, document []byte, field string, want any
 			t.Fatalf("document %s field %q=%v want %q", document, field, got, want)
 		}
 	case int64:
-		gotFloat, ok := got.(float64)
-		if !ok || int64(gotFloat) != want || gotFloat != float64(want) {
+		gotNumber, ok := got.(json.Number)
+		if !ok {
+			t.Fatalf("document %s field %q=%v want JSON number %d", document, field, got, want)
+		}
+		gotInt, err := gotNumber.Int64()
+		if err != nil || gotInt != want {
 			t.Fatalf("document %s field %q=%v want %d", document, field, got, want)
 		}
 	default:

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11678,6 +11678,32 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 	}
 }
 
+func requireJSONFieldValue(t *testing.T, document []byte, field string, want any) {
+	t.Helper()
+	var decoded map[string]any
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		t.Fatalf("decode document %s: %v", document, err)
+	}
+	got, ok := decoded[field]
+	if !ok {
+		t.Fatalf("document %s missing field %q", document, field)
+	}
+	switch want := want.(type) {
+	case string:
+		gotString, ok := got.(string)
+		if !ok || gotString != want {
+			t.Fatalf("document %s field %q=%v want %q", document, field, got, want)
+		}
+	case int64:
+		gotFloat, ok := got.(float64)
+		if !ok || int64(gotFloat) != want || gotFloat != float64(want) {
+			t.Fatalf("document %s field %q=%v want %d", document, field, got, want)
+		}
+	default:
+		t.Fatalf("unsupported expected JSON field type %T", want)
+	}
+}
+
 func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -11718,9 +11744,10 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	if !truncated || len(records) != 1 {
 		t.Fatalf("records len=%d truncated=%v want 1,true", len(records), truncated)
 	}
-	if !bytes.Equal(records[0].ID, []byte("u2")) || !bytes.Contains(records[0].Document, []byte(`"name":"zero"`)) {
-		t.Fatalf("record=%q/%s want u2 zero", records[0].ID, records[0].Document)
+	if !bytes.Equal(records[0].ID, []byte("u2")) {
+		t.Fatalf("record id=%q want u2", records[0].ID)
 	}
+	requireJSONFieldValue(t, records[0].Document, "name", "zero")
 
 	records, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(100), Inclusive: true},
@@ -11793,12 +11820,14 @@ func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T
 	if truncated || len(records) != 2 {
 		t.Fatalf("records len=%d truncated=%v want 2,false", len(records), truncated)
 	}
-	if !bytes.Equal(records[0].ID, []byte("u1")) || !bytes.Contains(records[0].Document, []byte(`"score":7`)) {
-		t.Fatalf("first record=%q/%s want buffered indexed score update", records[0].ID, records[0].Document)
+	if !bytes.Equal(records[0].ID, []byte("u1")) {
+		t.Fatalf("first record id=%q want u1", records[0].ID)
 	}
-	if !bytes.Equal(records[1].ID, []byte("u2")) || !bytes.Contains(records[1].Document, []byte(`"name":"fresh-primary"`)) {
-		t.Fatalf("second record=%q/%s want buffered primary update", records[1].ID, records[1].Document)
+	requireJSONFieldValue(t, records[0].Document, "score", int64(7))
+	if !bytes.Equal(records[1].ID, []byte("u2")) {
+		t.Fatalf("second record id=%q want u2", records[1].ID)
 	}
+	requireJSONFieldValue(t, records[1].Document, "name", "fresh-primary")
 }
 
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11734,6 +11734,66 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	}
 }
 
+func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"score":5,"name":"old-indexed"}`),
+			[]byte(`{"score":8,"name":"old-primary"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", int64(7))},
+		{DocumentID: []byte("u2"), Update: setJSONField("name", "fresh-primary")},
+	}); err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("batched=%v want buffered update batch", batched)
+	}
+
+	records, truncated, err := col.FindDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find documents range: %v", err)
+	}
+	if truncated || len(records) != 2 {
+		t.Fatalf("records len=%d truncated=%v want 2,false", len(records), truncated)
+	}
+	if !bytes.Equal(records[0].ID, []byte("u1")) || !bytes.Contains(records[0].Document, []byte(`"score":7`)) {
+		t.Fatalf("first record=%q/%s want buffered indexed score update", records[0].ID, records[0].Document)
+	}
+	if !bytes.Equal(records[1].ID, []byte("u2")) || !bytes.Contains(records[1].Document, []byte(`"name":"fresh-primary"`)) {
+		t.Fatalf("second record=%q/%s want buffered primary update", records[1].ID, records[1].Document)
+	}
+}
+
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2085,7 +2085,7 @@ func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collec
 
 func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
-		ids, _, err := collection.FindByIndexRange("age_1", collections.IndexRangeOptions{
+		records, _, err := collection.FindDocumentsByIndexRange("age_1", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
 			Upper: collections.IndexRangeBound{Unbounded: true},
 			Limit: 10,
@@ -2093,12 +2093,8 @@ func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, m
 		if err != nil {
 			return err
 		}
-		for _, id := range ids {
-			stored, err := collection.Get(id)
-			if err != nil {
-				return err
-			}
-			raw, err := directStoredDocumentToBSON(collection, materializer, stored)
+		for _, record := range records {
+			raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Adds a native collection helper for indexed range reads that returns primary documents directly:

- `Collection.FindDocumentsByIndexRange` scans the secondary index and fetches matching primary documents under one persisted snapshot/catalog;
- same-manager buffered documents remain visible by checking the collection write-domain before the persisted primary root;
- direct Mongo parity benchmarks now use the native helper for indexed range reads instead of `FindByIndexRange` plus one `Collection.Get` call per returned id.

This is stacked on #1405.

## Local validation

```text
GOWORK=off go test -count=1 ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```

## Direct range-read smoke

Compared against #1405 head with settled reads, `age_1` index, `documents=20000`, `range_reads=10000`, all non-range phases disabled.

| Format | #1405 ops/sec | PR ops/sec | #1405 ns/op | PR ns/op | Throughput delta |
|---|---:|---:|---:|---:|---:|
| JSON | 16,541 | 16,698 | 60,403 | 59,827 | +0.9% |
| TemplateV1 | 11,041 | 11,862 | 90,512 | 84,249 | +7.4% |
| BSON | 94,773 | 102,233 | 10,500 | 9,735 | +7.9% |

Artifacts:

```text
/tmp/mongo_range_pr2_direct_json.json
/tmp/mongo_range_pr3_direct_json.json
/tmp/mongo_range_pr2_direct_template-v1.json
/tmp/mongo_range_pr3_direct_template-v1.json
/tmp/mongo_range_pr2_direct_bson.json
/tmp/mongo_range_pr3_direct_bson.json
```
