### PR TITLE
Collections: reuse primary root reader for range documents

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11513,14 +11513,38 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	var primaryReader backenddb.SnapshotRootReader
+	primaryReaderOK := false
+	if len(catalog.overlayRootIDs(primaryRootName)) == 0 {
+		rootID := catalog.rootID(primaryRootName)
+		if rootID != 0 {
+			primaryReader, err = snap.ReaderAtRoot(rootID)
+			if err != nil {
+				return nil, false, err
+			}
+			primaryReaderOK = true
+		}
+	}
 	var scratch []byte
 	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
 		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
 		if !buffered {
-			var err error
-			value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
-			if err != nil {
-				return false, err
+			if primaryReaderOK {
+				nextScratch, err := primaryReader.GetAppend(id, scratch[:0])
+				if errors.Is(err, tree.ErrKeyNotFound) {
+					found = false
+				} else if err != nil {
+					return false, err
+				} else {
+					value = nextScratch
+					found = true
+				}
+			} else {
+				var err error
+				value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
+				if err != nil {
+					return false, err
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
## Summary

Small follow-up on #1412. `FindDocumentsByIndexRange` now binds a `SnapshotRootReader` for the persisted primary root when the primary root has no catalog overlays, then reuses that root reader while materializing the indexed range batch.

This avoids re-resolving the primary root for every returned id in the common settled collection shape. Overlay and buffered-document cases still fall back to the existing catalog-aware lookup path.

## Local validation

```text
go test -count=1 ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```

## Direct indexed range-read smoke

Compared against #1412 head with settled reads, `age_1` index, `documents=20000`, `range_reads=20000`, all non-range phases disabled.

| Format | #1412 ops/sec | PR ops/sec | #1412 ns/op | PR ns/op | Notes |
|---|---:|---:|---:|---:|---|
| JSON | 16,954 | 16,945 | 58,926 | 58,952 | flat |
| TemplateV1 | 11,928 | 11,923 | 83,786 | 83,822 | flat |
| BSON | 101,909 | 103,501 | 9,765 | 9,616 | +1.6% |

Interpretation: this is a small direct BSON cleanup, not a broad direct-read win. JSON/template direct range reads remain dominated by materialization/validation work after #1412.

Artifacts:

```text
/tmp/mongo_range_pr3_rr_json.json
/tmp/mongo_range_pr4_rr_json.json
/tmp/mongo_range_pr3_rr_template-v1.json
/tmp/mongo_range_pr4_rr_template-v1.json
/tmp/mongo_range_pr3_rr_bson.json
/tmp/mongo_range_pr4_rr_bson.json
```
