### PR TITLE
Mongo gateway: reduce range read response copies

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -129,7 +129,7 @@ func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 
 func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, error) {
 	if p.raw != nil {
-		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, wire.DefaultMaxMessageLength)
 	}
 	return wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
 }
@@ -146,6 +146,9 @@ func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo in
 	payload, err := s.findResponsePayload(command, cursorOwner)
 	if err != nil {
 		return nil, err
+	}
+	if payload.raw != nil {
+		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, payload.raw.ns, payload.raw.cursorID, payload.raw.batchKey, payload.raw.batch, int(s.maxMessageLength()))
 	}
 	return payload.marshalMsg(requestID, responseTo)
 }
@@ -1373,7 +1376,10 @@ func marshalCursorDocumentsResponseWithID(ns string, cursorID int64, batchKey st
 	return wire.Document(doc), nil
 }
 
-func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns string, cursorID int64, batchKey string, batch []wire.Document) ([]byte, error) {
+func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns string, cursorID int64, batchKey string, batch []wire.Document, maxMessageLength int) ([]byte, error) {
+	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
+		maxMessageLength = wire.DefaultMaxMessageLength
+	}
 	batchBytes := findBatchOverheadBytes
 	for i, doc := range batch {
 		batchBytes += findBatchDocumentBytes(doc, i)
@@ -1412,8 +1418,8 @@ func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns str
 	if int64(messageLength) > maxWireMessageLengthInt32Limit {
 		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
-	if messageLength > wire.DefaultMaxMessageLength {
-		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
+	if messageLength > maxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
 	}
 	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
 	return msg, nil

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -128,8 +128,12 @@ func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 }
 
 func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, error) {
+	return p.marshalMsgWithMaxLength(requestID, responseTo, wire.DefaultMaxMessageLength)
+}
+
+func (p findResponsePayload) marshalMsgWithMaxLength(requestID, responseTo int32, maxMessageLength int) ([]byte, error) {
 	if p.raw != nil {
-		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, wire.DefaultMaxMessageLength)
+		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, maxMessageLength)
 	}
 	return wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
 }
@@ -150,7 +154,7 @@ func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo in
 	if payload.raw != nil {
 		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, payload.raw.ns, payload.raw.cursorID, payload.raw.batchKey, payload.raw.batch, int(s.maxMessageLength()))
 	}
-	return payload.marshalMsg(requestID, responseTo)
+	return payload.marshalMsgWithMaxLength(requestID, responseTo, int(s.maxMessageLength()))
 }
 
 func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2,6 +2,7 @@ package mongogateway
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -106,86 +107,147 @@ func prepareInsertDocuments(documents []wire.Document, format collections.Docume
 	return ids, stored, nil
 }
 
+type rawCursorDocumentsResponse struct {
+	ns       string
+	cursorID int64
+	batchKey string
+	batch    []wire.Document
+}
+
+type findResponsePayload struct {
+	document wire.Document
+	raw      *rawCursorDocumentsResponse
+}
+
+func (p findResponsePayload) marshalDocument() (wire.Document, error) {
+	if p.raw != nil {
+		return marshalCursorDocumentsResponseWithID(p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+	}
+	return p.document, nil
+}
+
+func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, error) {
+	if p.raw != nil {
+		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+	}
+	return wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
+}
+
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
+	payload, err := s.findResponsePayload(command, cursorOwner)
+	if err != nil {
+		return nil, err
+	}
+	return payload.marshalDocument()
+}
+
+func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
+	payload, err := s.findResponsePayload(command, cursorOwner)
+	if err != nil {
+		return nil, err
+	}
+	return payload.marshalMsg(requestID, responseTo)
+}
+
+func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		doc, err := commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return findResponsePayload{document: doc}, err
 	}
 	collection, err := commandString(command, "find")
 	if err != nil {
-		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		doc, err := commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	db, err := commandString(command, "$db")
 	if err != nil {
-		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		doc, err := commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	name, err := gatewayCollectionName(db, collection)
 	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	filter, err := commandOptionalDocument(command, "filter")
 	if err != nil {
-		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		doc, err := commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	plan, err := parseFindPlan(command, filter)
 	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	col, err := s.Collections.OpenCollection(name)
 	if errors.Is(err, collections.ErrCollectionNotFound) {
-		return marshalCursorResponse(db, collection, bson.A{})
+		doc, err := marshalCursorResponse(db, collection, bson.A{})
+		return findResponsePayload{document: doc}, err
 	}
 	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	batchSize, batchSizeSet, err := optionalInt32FieldWithPresence(command, "batchSize")
 	if err != nil {
-		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		doc, err := commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	singleBatch, err := optionalBoolField(command, "singleBatch")
 	if err != nil {
-		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		doc, err := commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	ns := db + "." + collection
 	results, err := s.executeFind(col, plan)
 	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
 	if singleBatch {
 		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
 		}
 		if !results.projection.present {
 			consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
 			if err != nil {
-				return commandError(commandCodeBadValue, "BadValue", err.Error())
+				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+				return findResponsePayload{document: doc}, err
 			}
-			return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs[:consumed])
+			return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs[:consumed]}}, nil
 		}
 		firstBatch, _, err := documentsBatchWithLimit(results.docs, results.projection, normalizedBatchSize, s.maxFindBatchBytes())
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
 		}
-		return marshalCursorResponseWithID(ns, 0, "firstBatch", firstBatch)
+		doc, err := marshalCursorResponseWithID(ns, 0, "firstBatch", firstBatch)
+		return findResponsePayload{document: doc}, err
 	}
 	if !results.projection.present {
 		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
 		}
 		consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
 		}
 		if consumed >= len(results.docs) {
-			return marshalCursorDocumentsResponseWithID(ns, 0, "firstBatch", results.docs)
+			return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs}}, nil
 		}
 	}
 	cursorID, firstBatch, err := s.openCursor(ns, results.docs, results.projection, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)
 	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
 	}
-	return marshalCursorResponseWithID(ns, cursorID, "firstBatch", firstBatch)
+	doc, err := marshalCursorResponseWithID(ns, cursorID, "firstBatch", firstBatch)
+	return findResponsePayload{document: doc}, err
 }
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
@@ -1285,31 +1347,78 @@ func marshalCursorDocumentsResponseWithID(ns string, cursorID int64, batchKey st
 	for i, doc := range batch {
 		batchBytes += findBatchDocumentBytes(doc, i)
 	}
-	cursorIdx, cursorDoc := bsoncore.AppendDocumentStart(make([]byte, 0, len(ns)+batchBytes+64))
-	cursorDoc = bsoncore.AppendInt64Element(cursorDoc, "id", cursorID)
-	cursorDoc = bsoncore.AppendStringElement(cursorDoc, "ns", ns)
-	batchIdx, cursorDoc := bsoncore.AppendArrayElementStart(cursorDoc, batchKey)
-	for i, doc := range batch {
-		cursorDoc = bsoncore.AppendDocumentElement(cursorDoc, bsonArrayIndexKey(i), doc)
+	docIdx, doc := bsoncore.AppendDocumentStart(make([]byte, 0, len(ns)+batchBytes+96))
+	cursorIdx, doc := bsoncore.AppendDocumentElementStart(doc, "cursor")
+	doc = bsoncore.AppendInt64Element(doc, "id", cursorID)
+	doc = bsoncore.AppendStringElement(doc, "ns", ns)
+	batchIdx, doc := bsoncore.AppendArrayElementStart(doc, batchKey)
+	for i, batchDoc := range batch {
+		doc = bsoncore.AppendDocumentElement(doc, bsonArrayIndexKey(i), batchDoc)
 	}
 	var err error
-	cursorDoc, err = bsoncore.AppendArrayEnd(cursorDoc, batchIdx)
+	doc, err = bsoncore.AppendArrayEnd(doc, batchIdx)
 	if err != nil {
 		return nil, err
 	}
-	cursorDoc, err = bsoncore.AppendDocumentEnd(cursorDoc, cursorIdx)
+	doc, err = bsoncore.AppendDocumentEnd(doc, cursorIdx)
 	if err != nil {
 		return nil, err
 	}
-
-	docIdx, doc := bsoncore.AppendDocumentStart(make([]byte, 0, len(cursorDoc)+32))
-	doc = bsoncore.AppendDocumentElement(doc, "cursor", cursorDoc)
 	doc = bsoncore.AppendDoubleElement(doc, "ok", 1.0)
 	doc, err = bsoncore.AppendDocumentEnd(doc, docIdx)
 	if err != nil {
 		return nil, err
 	}
 	return wire.Document(doc), nil
+}
+
+func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns string, cursorID int64, batchKey string, batch []wire.Document) ([]byte, error) {
+	batchBytes := findBatchOverheadBytes
+	for i, doc := range batch {
+		batchBytes += findBatchDocumentBytes(doc, i)
+	}
+	msg := make([]byte, 0, 16+5+len(ns)+batchBytes+96)
+	base := len(msg)
+	msg = appendWireInt32(msg, 0)
+	msg = appendWireInt32(msg, requestID)
+	msg = appendWireInt32(msg, responseTo)
+	msg = appendWireInt32(msg, int32(wire.OpMsg))
+	msg = appendWireInt32(msg, 0)
+	msg = append(msg, wire.MsgSectionBody)
+	docIdx, msg := bsoncore.AppendDocumentStart(msg)
+	cursorIdx, msg := bsoncore.AppendDocumentElementStart(msg, "cursor")
+	msg = bsoncore.AppendInt64Element(msg, "id", cursorID)
+	msg = bsoncore.AppendStringElement(msg, "ns", ns)
+	batchIdx, msg := bsoncore.AppendArrayElementStart(msg, batchKey)
+	for i, batchDoc := range batch {
+		msg = bsoncore.AppendDocumentElement(msg, bsonArrayIndexKey(i), batchDoc)
+	}
+	var err error
+	msg, err = bsoncore.AppendArrayEnd(msg, batchIdx)
+	if err != nil {
+		return nil, err
+	}
+	msg, err = bsoncore.AppendDocumentEnd(msg, cursorIdx)
+	if err != nil {
+		return nil, err
+	}
+	msg = bsoncore.AppendDoubleElement(msg, "ok", 1.0)
+	msg, err = bsoncore.AppendDocumentEnd(msg, docIdx)
+	if err != nil {
+		return nil, err
+	}
+	messageLength := len(msg) - base
+	if messageLength > wire.DefaultMaxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
+	}
+	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
+	return msg, nil
+}
+
+func appendWireInt32(dst []byte, v int32) []byte {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(v))
+	return append(dst, buf[:]...)
 }
 
 func bsonArrayIndexKey(index int) string {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -135,7 +135,17 @@ func (p findResponsePayload) marshalMsgWithMaxLength(requestID, responseTo int32
 	if p.raw != nil {
 		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, maxMessageLength)
 	}
-	return wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
+	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
+		maxMessageLength = wire.DefaultMaxMessageLength
+	}
+	msg, err := wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
+	if err != nil {
+		return nil, err
+	}
+	if len(msg) > maxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, len(msg), maxMessageLength)
+	}
+	return msg, nil
 }
 
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
@@ -150,9 +160,6 @@ func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo in
 	payload, err := s.findResponsePayload(command, cursorOwner)
 	if err != nil {
 		return nil, err
-	}
-	if payload.raw != nil {
-		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, payload.raw.ns, payload.raw.cursorID, payload.raw.batchKey, payload.raw.batch, int(s.maxMessageLength()))
 	}
 	return payload.marshalMsgWithMaxLength(requestID, responseTo, int(s.maxMessageLength()))
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -23,6 +23,7 @@ const (
 	commandCodeIndexNotFound     int32 = 27
 	commandCodeCursorNotFound    int32 = 43
 	commandCodeDuplicateKey      int32 = 11000
+	maxWireMessageLengthInt32          = int64(1<<31 - 1)
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -1408,6 +1409,9 @@ func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns str
 		return nil, err
 	}
 	messageLength := len(msg) - base
+	if int64(messageLength) > maxWireMessageLengthInt32 {
+		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
+	}
 	if messageLength > wire.DefaultMaxMessageLength {
 		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -17,13 +17,13 @@ import (
 )
 
 const (
-	commandCodeBadValue          int32 = 2
-	commandCodeFailedToParse     int32 = 9
-	commandCodeNamespaceNotFound int32 = 26
-	commandCodeIndexNotFound     int32 = 27
-	commandCodeCursorNotFound    int32 = 43
-	commandCodeDuplicateKey      int32 = 11000
-	maxWireMessageLengthInt32          = int64(1<<31 - 1)
+	commandCodeBadValue            int32 = 2
+	commandCodeFailedToParse       int32 = 9
+	commandCodeNamespaceNotFound   int32 = 26
+	commandCodeIndexNotFound       int32 = 27
+	commandCodeCursorNotFound      int32 = 43
+	commandCodeDuplicateKey        int32 = 11000
+	maxWireMessageLengthInt32Limit       = int64(1<<31 - 1)
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -1409,7 +1409,7 @@ func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns str
 		return nil, err
 	}
 	messageLength := len(msg) - base
-	if int64(messageLength) > maxWireMessageLengthInt32 {
+	if int64(messageLength) > maxWireMessageLengthInt32Limit {
 		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
 	if messageLength > wire.DefaultMaxMessageLength {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1420,9 +1420,10 @@ func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns str
 }
 
 func appendWireInt32(dst []byte, v int32) []byte {
-	var buf [4]byte
-	binary.LittleEndian.PutUint32(buf[:], uint32(v))
-	return append(dst, buf[:]...)
+	n := len(dst)
+	dst = append(dst, 0, 0, 0, 0)
+	binary.LittleEndian.PutUint32(dst[n:], uint32(v))
+	return dst
 }
 
 func bsonArrayIndexKey(index int) string {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -1041,20 +1041,16 @@ func documentsForIndexedRange(col *collections.Collection, materializer *collect
 		candidateLimit = candidateLimitWithOverflowSlot(maxDocuments)
 	}
 	opts.Limit = candidateLimit
-	ids, _, err := col.FindByIndexRange(idx.Name, opts)
+	records, _, err := col.FindDocumentsByIndexRange(idx.Name, opts)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]wire.Document, 0, len(ids))
-	for _, id := range ids {
-		stored, err := col.Get(id)
-		if err != nil {
-			return nil, err
-		}
-		if len(stored) == 0 {
+	out := make([]wire.Document, 0, len(records))
+	for _, record := range records {
+		if len(record.Document) == 0 {
 			continue
 		}
-		doc, err := storedDocumentToBSON(col, materializer, stored)
+		doc, err := storedDocumentToBSON(col, materializer, record.Document)
 		if err != nil {
 			return nil, err
 		}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -279,6 +279,9 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
 			return nil, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
 		}
+		if len(msg.Sequences) > 0 {
+			return nil, fmt.Errorf("%w: find with document sequences", wire.ErrUnsupported)
+		}
 		responseID := s.nextID()
 		response, err := s.findMsgResponse(msg.Body, responseID, h.RequestID, cursorOwner)
 		if err != nil {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -276,16 +276,13 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 	}
 
 	if name == "find" {
-		var responseID int32
-		if msg.Flags&wire.MsgFlagMoreToCome == 0 {
-			responseID = s.nextID()
+		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
+			return nil, nil
 		}
+		responseID := s.nextID()
 		response, err := s.findMsgResponse(msg.Body, responseID, h.RequestID, cursorOwner)
 		if err != nil {
 			return nil, err
-		}
-		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
-			return nil, nil
 		}
 		return response, nil
 	}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -275,6 +275,21 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 		return nil, err
 	}
 
+	if name == "find" {
+		var responseID int32
+		if msg.Flags&wire.MsgFlagMoreToCome == 0 {
+			responseID = s.nextID()
+		}
+		response, err := s.findMsgResponse(msg.Body, responseID, h.RequestID, cursorOwner)
+		if err != nil {
+			return nil, err
+		}
+		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
+			return nil, nil
+		}
+		return response, nil
+	}
+
 	response, err := s.commandResponse(name, msg.Body, msg.Sequences, cursorOwner)
 	if err != nil {
 		return nil, err

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -276,6 +276,9 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 	}
 
 	if name == "find" {
+		// The find path builds a raw OP_MSG response directly, so reject OP_MSG
+		// features it does not preserve. Other commands go through
+		// commandResponse with parsed document sequences.
 		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
 			return nil, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
 		}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -277,7 +277,7 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 
 	if name == "find" {
 		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
-			return nil, nil
+			return nil, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
 		}
 		responseID := s.nextID()
 		response, err := s.findMsgResponse(msg.Body, responseID, h.RequestID, cursorOwner)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2600,6 +2600,19 @@ func TestServerFindRawBSONOPMsgResponseHonorsMaxMessageLength(t *testing.T) {
 	}
 }
 
+func TestFindResponsePayloadOPMsgHonorsMaxMessageLength(t *testing.T) {
+	payload := findResponsePayload{
+		document: mustDocument(t, bson.D{{Key: "ok", Value: 1.0}, {Key: "payload", Value: strings.Repeat("x", 256)}}),
+	}
+	if _, err := payload.marshalMsgWithMaxLength(1, 250, wire.DefaultMaxMessageLength); err != nil {
+		t.Fatalf("marshal default max response: %v", err)
+	}
+	_, err := payload.marshalMsgWithMaxLength(1, 250, 128)
+	if !errors.Is(err, wire.ErrMessageTooLarge) {
+		t.Fatalf("marshal small max err=%v want ErrMessageTooLarge", err)
+	}
+}
+
 func TestRawDocumentsBatchLimit(t *testing.T) {
 	docs := []wire.Document{
 		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -115,6 +115,26 @@ func TestServerHandlesMsgPing(t *testing.T) {
 	assertOK(t, msg.Body)
 }
 
+func TestServerRejectsFindWithMoreToCome(t *testing.T) {
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 201, 0, wire.MsgFlagMoreToCome, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+
+	err = NewServer().ServeOne(rw)
+	if !errors.Is(err, wire.ErrUnsupported) {
+		t.Fatalf("ServeOne err=%v want ErrUnsupported", err)
+	}
+	if rw.w.Len() != 0 {
+		t.Fatalf("unexpected response bytes=%d", rw.w.Len())
+	}
+}
+
 func TestServerInsertAndFindByID(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -135,6 +135,29 @@ func TestServerRejectsFindWithMoreToCome(t *testing.T) {
 	}
 }
 
+func TestServerRejectsFindWithDocumentSequences(t *testing.T) {
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	req, err := wire.AppendMsgMessageWithSequences(nil, 202, 0, 0, commandDoc, []wire.DocumentSequence{{
+		Identifier: "ignored",
+		Documents:  []wire.Document{mustDocument(t, bson.D{{Key: "x", Value: 1}})},
+	}})
+	if err != nil {
+		t.Fatalf("AppendMsgMessageWithSequences: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+
+	err = NewServer().ServeOne(rw)
+	if !errors.Is(err, wire.ErrUnsupported) {
+		t.Fatalf("ServeOne err=%v want ErrUnsupported", err)
+	}
+	if rw.w.Len() != 0 {
+		t.Fatalf("unexpected response bytes=%d", rw.w.Len())
+	}
+}
+
 func TestServerInsertAndFindByID(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2485,6 +2508,74 @@ func TestMarshalCursorDocumentsResponseWithRawBatch(t *testing.T) {
 	}
 	if !bytes.Equal(batch[0], bson.Raw(rawDoc)) {
 		t.Fatalf("firstBatch[0]=%v want raw doc %v", batch[0], bson.Raw(rawDoc))
+	}
+}
+
+func TestServerFindRawBSONOPMsgResponse(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 249, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "age", Value: int64(41)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	findDoc := mustDocument(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(40)}}}}},
+		{Key: "limit", Value: int32(1)},
+		{Key: "singleBatch", Value: true},
+		{Key: "$db", Value: "app"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 250, 0, 0, findDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+	if err := server.ServeOne(rw); err != nil {
+		t.Fatalf("ServeOne: %v", err)
+	}
+	h, body, err := wire.ReadMessage(bytes.NewReader(rw.w.Bytes()), 0)
+	if err != nil {
+		t.Fatalf("ReadMessage response: %v", err)
+	}
+	if h.OpCode != wire.OpMsg || h.ResponseTo != 250 || h.MessageLength != int32(len(rw.w.Bytes())) {
+		t.Fatalf("response header=%+v len=%d", h, len(rw.w.Bytes()))
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		t.Fatalf("ParseMsg response: %v", err)
+	}
+	assertOK(t, msg.Body)
+	if cursorID := cursorIDFromResponse(t, msg.Body); cursorID != 0 {
+		t.Fatalf("cursor id=%d want 0", cursorID)
+	}
+	batch := cursorFirstBatch(t, msg.Body)
+	if len(batch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(batch))
+	}
+	if age, ok := batch[0].Lookup("age").Int64OK(); !ok || age != 41 {
+		t.Fatalf("firstBatch age=%d ok=%v want 41", age, ok)
+	}
+}
+
+func TestServerFindRawBSONOPMsgResponseHonorsMaxMessageLength(t *testing.T) {
+	rawDoc := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "payload", Value: strings.Repeat("x", 256)}})
+	if _, err := marshalCursorDocumentsMsgResponseWithID(1, 250, "app.users", 0, "firstBatch", []wire.Document{rawDoc}, wire.DefaultMaxMessageLength); err != nil {
+		t.Fatalf("marshal default max response: %v", err)
+	}
+	_, err := marshalCursorDocumentsMsgResponseWithID(1, 250, "app.users", 0, "firstBatch", []wire.Document{rawDoc}, 128)
+	if !errors.Is(err, wire.ErrMessageTooLarge) {
+		t.Fatalf("marshal small max err=%v want ErrMessageTooLarge", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on #1412. This trims the Mongo gateway indexed range-read response path:

- use `Collection.FindDocumentsByIndexRange` in the gateway indexed range materialization path instead of scanning ids and then issuing separate primary `Get` calls;
- build raw cursor BSON in one buffer for raw first-batch responses;
- for OP_MSG `find` responses with raw BSON documents, build the OP_MSG response directly instead of first building a command document and then copying it into the OP_MSG body.

This intentionally does **not** add a gateway collection lookup cache.

## Validation

```bash
go test -count=1 ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./TreeDB/collections
```

## Range-read benchmark

Workload: TreeDB target, BSON collection storage, settled reads, 20k loaded docs, age indexed range query with `limit=10`, 50k single-flight range operations, `-treedb-maintenance none`.

Artifacts:

- #1412 baseline: `/Users/michaelseiler/dev/snissn/benchdata/mongo_4levels_20260506_223314`
- current PR: `/Users/michaelseiler/dev/snissn/benchdata/mongo_4levels_opt3_20260506_224606`

| Mode | #1412 ops/s | #1412 ns/op | Current ops/s | Current ns/op | Delta |
|---|---:|---:|---:|---:|---:|
| driver-command-raw | 21,735 | 46,010 | 22,330 | 44,783 | +2.7% |
| raw-wire-tcp | 21,535 | 46,436 | 24,721 | 40,451 | +14.8% |
| raw-wire | 70,920 | 14,100 | 77,790 | 12,855 | +9.7% |
| direct | 105,103 | 9,514 | 101,310 | 9,871 | -3.6% |

The direct row should be treated as a noise/control row for this PR; the code path changed here is gateway-only.

## Fanout sweep

Workload: same setup, but `-concurrent-range-reads 80000 -concurrent-range-reader-sweep 1,2,4,8,16,32,64`.

Artifacts: `/Users/michaelseiler/dev/snissn/benchdata/mongo_range_concurrency_opt3_20260506_224710`

| Mode | R1 ops/s | R1 ns/op | Best readers | Best ops/s | Best ns/op |
|---|---:|---:|---:|---:|---:|
| driver-command-raw | 22,050 | 45,352 | 16 | 86,677 | 11,537 |
| raw-wire-tcp | 24,979 | 40,033 | 32 | 89,348 | 11,192 |
| raw-wire | 78,070 | 12,809 | 4 | 213,268 | 4,689 |
| direct | 101,251 | 9,876 | 4 | 255,384 | 3,916 |

## Profile notes

Before this PR, `marshalCursorDocumentsResponseWithID` and `wire.AppendMsgBodyWithSequences` were separate large allocation sites: the gateway built a cursor document, then copied it into OP_MSG. After the direct OP_MSG path, the OP_MSG wrapper copy is removed for raw `find` responses. The remaining major costs are not this response wrapper:

- direct/native scan plus primary document fetches/clones inside `FindDocumentsByIndexRange`;
- collection open/meta copy in `CollectionManager.OpenCollection`;
- request/response parsing in the raw-wire benchmark client;
- socket write/read syscalls for TCP and official-driver paths.

The driver-command-raw and raw-wire-tcp rows are now close in single-flight mode and both saturate around 87k-89k ops/s with fanout. That suggests the remaining slowest layer is mostly request/response/socket latency, not driver BSON map decode.
