### PR TITLE
Collections: borrow range scan ids for document reads

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11851,12 +11851,12 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 				persistedIt.Next()
 				continue
 			}
+			if maxResults > 0 && emitted >= maxResults {
+				return true, nil
+			}
 			id, err := indexKeyDocumentID(valueType, persistedKey)
 			if err != nil {
 				return false, err
-			}
-			if maxResults > 0 && emitted >= maxResults {
-				return true, nil
 			}
 			if cloneID {
 				id = bytes.Clone(id)
@@ -11870,18 +11870,23 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 		}
 		return false, collectionIndexIteratorError(persistedIt)
 	}
-	seen := make(map[string]struct{})
+	var seen map[string]struct{}
+	if dedupeIDs {
+		seen = make(map[string]struct{})
+	}
 	emitted := 0
 	emit := func(key []byte) (bool, bool, error) {
 		id, err := indexKeyDocumentID(valueType, key)
 		if err != nil {
 			return false, false, err
 		}
-		idKey := string(id)
-		if _, ok := seen[idKey]; ok {
-			return true, false, nil
+		if dedupeIDs {
+			idKey := string(id)
+			if _, ok := seen[idKey]; ok {
+				return true, false, nil
+			}
+			seen[idKey] = struct{}{}
 		}
-		seen[idKey] = struct{}{}
 		if maxResults > 0 && emitted >= maxResults {
 			return false, true, nil
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11849,17 +11849,20 @@ func encodedDoubleComponentIsNaN(encoded []byte) bool {
 	return len(encoded) == 1 && encoded[0] == 0x00
 }
 
-func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
+func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentID bool, fn func([]byte) (bool, error)) (bool, error) {
 	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
 		CloneDocumentID:  true,
-		DedupeDocumentID: dedupeDocumentIDs,
+		DedupeDocumentID: dedupeDocumentID,
 	}, fn)
 }
 
-func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
+// scanMergedCollectionIndexIDsBorrowed calls fn with document IDs that may alias
+// iterator key memory. fn must not retain or mutate id after returning; clone it
+// first if the ID needs to outlive the callback.
+func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentID bool, fn func([]byte) (bool, error)) (bool, error) {
 	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
 		CloneDocumentID:  false,
-		DedupeDocumentID: dedupeDocumentIDs,
+		DedupeDocumentID: dedupeDocumentID,
 	}, fn)
 }
 
@@ -11884,7 +11887,7 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 				continue
 			}
 			if maxResults > 0 && emitted >= maxResults {
-				return true, nil
+				return true, collectionIndexIteratorError(persistedIt)
 			}
 			id, err := indexKeyDocumentID(valueType, persistedKey)
 			if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11514,7 +11514,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
-	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
+	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
 		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
 		if !buffered {
 			var err error
@@ -11825,8 +11825,46 @@ func encodedDoubleComponentIsNaN(encoded []byte) bool {
 }
 
 func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, fn func([]byte) (bool, error)) (bool, error) {
+	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, true, fn)
+}
+
+func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, fn func([]byte) (bool, error)) (bool, error) {
+	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, false, fn)
+}
+
+func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, cloneID bool, fn func([]byte) (bool, error)) (bool, error) {
 	if maxResults < 0 {
 		return false, errors.New("collections: max index results cannot be negative")
+	}
+	if bufferedIt == nil {
+		emitted := 0
+		for {
+			persistedKey, persistedOK := collectionIndexIteratorKey(persistedIt)
+			if !persistedOK {
+				break
+			}
+			if persistedIt.IsDeleted() {
+				persistedIt.Next()
+				continue
+			}
+			id, err := indexKeyDocumentID(valueType, persistedKey)
+			if err != nil {
+				return false, err
+			}
+			if maxResults > 0 && emitted >= maxResults {
+				return true, nil
+			}
+			if cloneID {
+				id = bytes.Clone(id)
+			}
+			cont, err := fn(id)
+			if err != nil || !cont {
+				return false, err
+			}
+			emitted++
+			persistedIt.Next()
+		}
+		return false, collectionIndexIteratorError(persistedIt)
 	}
 	seen := make(map[string]struct{})
 	emitted := 0
@@ -11843,7 +11881,10 @@ func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterato
 		if maxResults > 0 && emitted >= maxResults {
 			return false, true, nil
 		}
-		cont, err := fn(bytes.Clone(id))
+		if cloneID {
+			id = bytes.Clone(id)
+		}
+		cont, err := fn(id)
 		if err != nil {
 			return false, false, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11514,7 +11514,8 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
-	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, idx.MultiKey, func(id []byte) (bool, error) {
+	dedupeIDs := idx.MultiKey || catalog.meta.Options.AllowArrayValuesInIndex
+	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, dedupeIDs, func(id []byte) (bool, error) {
 		var value []byte
 		var buffered, found bool
 		if domainLocked {
@@ -11645,7 +11646,8 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	if persistedIt != nil {
 		defer func() { _ = persistedIt.Close() }()
 	}
-	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, idx.MultiKey, fn)
+	dedupeIDs := idx.MultiKey || catalog.meta.Options.AllowArrayValuesInIndex
+	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, dedupeIDs, fn)
 	return truncated, true, err
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11528,7 +11528,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		}
 		scratch = value
 		out = append(out, DocumentRecord{
-			ID:       id,
+			ID:       bytes.Clone(id),
 			Document: bytes.Clone(value),
 		})
 		return true, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11863,20 +11863,20 @@ func encodedDoubleComponentIsNaN(encoded []byte) bool {
 	return len(encoded) == 1 && encoded[0] == 0x00
 }
 
-func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentID bool, fn func([]byte) (bool, error)) (bool, error) {
+func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
 	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
 		CloneDocumentID:  true,
-		DedupeDocumentID: dedupeDocumentID,
+		DedupeDocumentID: dedupeDocumentIDs,
 	}, fn)
 }
 
 // scanMergedCollectionIndexIDsBorrowed calls fn with document IDs that may alias
 // iterator key memory. fn must not retain or mutate id after returning; clone it
 // first if the ID needs to outlive the callback.
-func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentID bool, fn func([]byte) (bool, error)) (bool, error) {
+func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
 	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
 		CloneDocumentID:  false,
-		DedupeDocumentID: dedupeDocumentID,
+		DedupeDocumentID: dedupeDocumentIDs,
 	}, fn)
 }
 
@@ -11921,7 +11921,11 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 	}
 	var seen map[string]struct{}
 	if opts.DedupeDocumentID {
-		seen = make(map[string]struct{})
+		if maxResults > 0 {
+			seen = make(map[string]struct{}, maxResults)
+		} else {
+			seen = make(map[string]struct{})
+		}
 	}
 	emitted := 0
 	emit := func(key []byte) (bool, bool, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11516,7 +11516,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
-	dedupeDocumentIDs := idx.MultiKey || catalog.meta.Options.AllowArrayValuesInIndex
+	dedupeDocumentIDs := shouldDedupeIndexDocumentIDs(idx, catalog.meta.Options)
 	documentTruncated := false
 	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, 0, dedupeDocumentIDs, func(id []byte) (bool, error) {
 		var value []byte
@@ -11656,9 +11656,13 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	if persistedIt != nil {
 		defer func() { _ = persistedIt.Close() }()
 	}
-	dedupeDocumentIDs := idx.MultiKey || catalog.meta.Options.AllowArrayValuesInIndex
+	dedupeDocumentIDs := shouldDedupeIndexDocumentIDs(idx, catalog.meta.Options)
 	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, dedupeDocumentIDs, fn)
 	return truncated, true, err
+}
+
+func shouldDedupeIndexDocumentIDs(idx IndexDefinition, opts CollectionOptions) bool {
+	return idx.MultiKey || opts.AllowArrayValuesInIndex
 }
 
 func exactIndexRangePrefix(valueType IndexValueType, opts IndexRangeOptions) ([]byte, bool, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11839,18 +11839,29 @@ func encodedDoubleComponentIsNaN(encoded []byte) bool {
 }
 
 func scanMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
-	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, true, dedupeDocumentIDs, fn)
+	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
+		CloneDocumentID:  true,
+		DedupeDocumentID: dedupeDocumentIDs,
+	}, fn)
 }
 
 func scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
-	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, false, dedupeDocumentIDs, fn)
+	return scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt, valueType, maxResults, scanMergedCollectionIndexIDOptions{
+		CloneDocumentID:  false,
+		DedupeDocumentID: dedupeDocumentIDs,
+	}, fn)
 }
 
-func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, cloneID bool, dedupeDocumentIDs bool, fn func([]byte) (bool, error)) (bool, error) {
+type scanMergedCollectionIndexIDOptions struct {
+	CloneDocumentID  bool
+	DedupeDocumentID bool
+}
+
+func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.UnsafeIterator, valueType IndexValueType, maxResults int, opts scanMergedCollectionIndexIDOptions, fn func([]byte) (bool, error)) (bool, error) {
 	if maxResults < 0 {
 		return false, errors.New("collections: max index results cannot be negative")
 	}
-	if bufferedIt == nil && !dedupeDocumentIDs {
+	if bufferedIt == nil && !opts.DedupeDocumentID {
 		emitted := 0
 		for {
 			persistedKey, persistedOK := collectionIndexIteratorKey(persistedIt)
@@ -11868,7 +11879,7 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 			if err != nil {
 				return false, err
 			}
-			if cloneID {
+			if opts.CloneDocumentID {
 				id = bytes.Clone(id)
 			}
 			cont, err := fn(id)
@@ -11881,7 +11892,7 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 		return false, collectionIndexIteratorError(persistedIt)
 	}
 	var seen map[string]struct{}
-	if dedupeDocumentIDs {
+	if opts.DedupeDocumentID {
 		seen = make(map[string]struct{})
 	}
 	emitted := 0
@@ -11890,7 +11901,7 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 		if err != nil {
 			return false, false, err
 		}
-		if dedupeDocumentIDs {
+		if opts.DedupeDocumentID {
 			idKey := string(id)
 			if _, ok := seen[idKey]; ok {
 				return true, false, nil
@@ -11900,7 +11911,7 @@ func scanMergedCollectionIndexIDsWithOptions(bufferedIt, persistedIt iterator.Un
 		if maxResults > 0 && emitted >= maxResults {
 			return false, true, nil
 		}
-		if cloneID {
+		if opts.CloneDocumentID {
 			id = bytes.Clone(id)
 		}
 		cont, err := fn(id)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11839,6 +11839,54 @@ func TestCollectionFindByIndexRangeDedupesPersistedOnlyMultiKeyRange(t *testing.
 	}
 }
 
+func TestCollectionFindByIndexRangeDedupesAllowedArrayScalarIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			AllowArrayValuesInIndex: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "tag", Field: "tags", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("d1"), []byte("d2")},
+		[][]byte{
+			[]byte(`{"tags":["a","b"]}`),
+			[]byte(`{"tags":["c"]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexRange("tag", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "a", Inclusive: true},
+		Upper: IndexRangeBound{Value: "d", Inclusive: false},
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("find range: %v", err)
+	}
+	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("d1")) || !bytes.Equal(ids[1], []byte("d2")) {
+		t.Fatalf("ids=%q truncated=%v want d1,d2 false", ids, truncated)
+	}
+}
+
 func TestCollectionFindByIndexRangePersistedOnlyFastPathLimitAndClones(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11966,6 +11966,9 @@ func TestCollectionFindByIndexRangePersistedOnlyFastPathLimitAndClones(t *testin
 		t.Fatalf("ids=%q truncated=%v want u1,u2 true", ids, truncated)
 	}
 	ids[0][0] = 'x'
+	if !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("ids[1]=%q changed after mutating ids[0]", ids[1])
+	}
 	again, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
 		Upper: IndexRangeBound{Unbounded: true},

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11846,11 +11846,11 @@ func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T
 }
 
 func TestCollectionFindByIndexRangeDedupesPersistedOnlyMultiKeyRange(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer func() { _ = d.Close() }()
 
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
@@ -11877,7 +11877,19 @@ func TestCollectionFindByIndexRangeDedupesPersistedOnlyMultiKeyRange(t *testing.
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush: %v", err)
 	}
-	ids, truncated, err := col.FindByIndexRange("tag", IndexRangeOptions{
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, truncated, err := reopenedCol.FindByIndexRange("tag", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: "a", Inclusive: true},
 		Upper: IndexRangeBound{Value: "d", Inclusive: false},
 		Limit: 2,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11839,6 +11839,62 @@ func TestCollectionFindByIndexRangeDedupesPersistedOnlyMultiKeyRange(t *testing.
 	}
 }
 
+func TestCollectionFindByIndexRangePersistedOnlyFastPathLimitAndClones(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":1}`),
+			[]byte(`{"score":2}`),
+			[]byte(`{"score":3}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("find range: %v", err)
+	}
+	if !truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("ids=%q truncated=%v want u1,u2 true", ids, truncated)
+	}
+	ids[0][0] = 'x'
+	again, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("find range again: %v", err)
+	}
+	if !truncated || len(again) != 1 || !bytes.Equal(again[0], []byte("u1")) {
+		t.Fatalf("again ids=%q truncated=%v want u1 true", again, truncated)
+	}
+}
+
 func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

Stacked on #1414. This trims the native indexed range document scan path:

- keep existing public `ScanIndexRange`/`FindByIndexRange` owned-id behavior;
- let `FindDocumentsByIndexRange` use an internal borrowed-id scan so the id is not cloned once by the scan and then cloned again into the returned `DocumentRecord`;
- skip the dedupe map/string allocation entirely when there is no buffered index iterator, which is the settled persisted-read case used by the range benchmarks.

The returned `DocumentRecord` values from `FindDocumentsByIndexRange` remain owned just as before.

## Validation

```bash
go test -count=1 ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench
```

## Range-read benchmark

Workload: TreeDB target, BSON collection storage, settled reads, 20k loaded docs, age indexed range query with `limit=10`, 50k single-flight range operations, `-treedb-maintenance none`.

Artifacts:

- #1414 baseline: `/Users/michaelseiler/dev/snissn/benchdata/mongo_4levels_opt3_20260506_224606`
- current PR: `/Users/michaelseiler/dev/snissn/benchdata/mongo_4levels_opt4_20260506_225235`

| Mode | #1414 ops/s | #1414 ns/op | Current ops/s | Current ns/op | Delta |
|---|---:|---:|---:|---:|---:|
| driver-command-raw | 22,330 | 44,783 | 22,432 | 44,578 | +0.5% |
| raw-wire-tcp | 24,721 | 40,451 | 24,826 | 40,281 | +0.4% |
| raw-wire | 77,790 | 12,855 | 81,962 | 12,201 | +5.4% |
| direct | 101,310 | 9,871 | 107,954 | 9,263 | +6.6% |

This mostly helps the lower two layers where native range scan work is visible. It barely moves driver/TCP single-flight, which is expected because those remain dominated by socket/request-response costs.

## Profile notes

Before this change, the direct range profile showed `scanMergedCollectionIndexIDs` cloning ids before the callback, then `FindDocumentsByIndexRange` cloning the same ids again for the returned owned records. After this change, the settled persisted-only path avoids the scan clone and avoids the dedupe map/string allocation.

The remaining large native allocation is the owned document clone in `FindDocumentsByIndexRange`. The next meaningful direct-path optimization is a borrowed document scan/cursor API for callers that consume documents during the scan and do not need an owned result slice.
