### PR TITLE
Collections: add borrowed indexed range document scan

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11454,7 +11454,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		return nil, false, err
 	}
 	if !indexFound {
-		return make([]DocumentRecord, 0), false, nil
+		return nil, false, nil
 	}
 	if out == nil {
 		out = make([]DocumentRecord, 0)
@@ -11606,8 +11606,11 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 			ID:       id,
 			Document: value,
 		})
-		if err != nil || !cont {
-			return cont, err
+		if err != nil {
+			return false, err
+		}
+		if !cont {
+			return false, nil
 		}
 		documentCount++
 		return true, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -517,7 +517,7 @@ type DocumentRecord struct {
 
 // borrowedDocumentRecord is one primary collection record borrowed during an
 // internal callback scan. ID and Document are valid only until the callback
-// returns.
+// returns and must not be retained or modified.
 type borrowedDocumentRecord struct {
 	ID       []byte
 	Document []byte

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -515,10 +515,10 @@ type DocumentRecord struct {
 	Document []byte
 }
 
-// BorrowedDocumentRecord is one primary collection record borrowed during a
-// callback scan. ID and Document are valid only until the callback returns.
-// Callers must clone any slice they need to retain.
-type BorrowedDocumentRecord struct {
+// borrowedDocumentRecord is one primary collection record borrowed during an
+// internal callback scan. ID and Document are valid only until the callback
+// returns.
+type borrowedDocumentRecord struct {
 	ID       []byte
 	Document []byte
 }
@@ -11436,7 +11436,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		capHint = opts.Limit
 	}
 	var out []DocumentRecord
-	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record BorrowedDocumentRecord) (bool, error) {
+	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record borrowedDocumentRecord) (bool, error) {
 		if out == nil {
 			out = make([]DocumentRecord, 0, capHint)
 		}
@@ -11458,19 +11458,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	return out, truncated, nil
 }
 
-// ScanDocumentsByIndexRange calls fn with primary documents whose named
-// secondary index falls inside opts, preserving index order. The record slices
-// are borrowed and valid only until fn returns. The returned boolean is true
-// when additional index matches were present beyond opts.Limit.
-func (c *Collection) ScanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, error) {
-	if fn == nil {
-		return false, errors.New("collections: nil index document range callback")
-	}
-	truncated, _, err := c.scanDocumentsByIndexRange(indexName, opts, fn)
-	return truncated, err
-}
-
-func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, bool, error) {
+func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(borrowedDocumentRecord) (bool, error)) (bool, bool, error) {
 	if c == nil {
 		return false, false, errCollectionNil
 	}
@@ -11574,7 +11562,7 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 			return true, nil
 		}
 		scratch = value
-		return fn(BorrowedDocumentRecord{
+		return fn(borrowedDocumentRecord{
 			ID:       id,
 			Document: value,
 		})

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -515,6 +515,14 @@ type DocumentRecord struct {
 	Document []byte
 }
 
+// BorrowedDocumentRecord is one primary collection record borrowed during a
+// callback scan. ID and Document are valid only until the callback returns.
+// Callers must clone any slice they need to retain.
+type BorrowedDocumentRecord struct {
+	ID       []byte
+	Document []byte
+}
+
 type RootStoragePolicy string
 
 const (
@@ -11423,23 +11431,63 @@ func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) 
 // consulted before the persisted primary root so pending indexed writes remain
 // visible.
 func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRangeOptions) ([]DocumentRecord, bool, error) {
+	capHint := 16
+	if opts.Limit > 0 && opts.Limit < capHint {
+		capHint = opts.Limit
+	}
+	var out []DocumentRecord
+	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record BorrowedDocumentRecord) (bool, error) {
+		if out == nil {
+			out = make([]DocumentRecord, 0, capHint)
+		}
+		out = append(out, DocumentRecord{
+			ID:       bytes.Clone(record.ID),
+			Document: bytes.Clone(record.Document),
+		})
+		return true, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+	if out == nil {
+		out = make([]DocumentRecord, 0)
+	}
+	return out, truncated, nil
+}
+
+// ScanDocumentsByIndexRange calls fn with primary documents whose named
+// secondary index falls inside opts, preserving index order. The record slices
+// are borrowed and valid only until fn returns. The returned boolean is true
+// when additional index matches were present beyond opts.Limit.
+func (c *Collection) ScanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, error) {
+	if fn == nil {
+		return false, errors.New("collections: nil index document range callback")
+	}
+	truncated, _, err := c.scanDocumentsByIndexRange(indexName, opts, fn)
+	return truncated, err
+}
+
+func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, bool, error) {
 	if c == nil {
-		return nil, false, errCollectionNil
+		return false, false, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, false, errCollectionDBNil
+		return false, false, errCollectionDBNil
 	}
 	if err := ValidateIndexName(indexName); err != nil {
-		return nil, false, err
+		return false, false, err
 	}
 	if opts.Limit < 0 {
-		return nil, false, errors.New("collections: index range limit cannot be negative")
+		return false, false, errors.New("collections: index range limit cannot be negative")
 	}
 	if opts.Desc {
-		return nil, false, errors.New("collections: descending index range scans are not supported")
+		return false, false, errors.New("collections: descending index range scans are not supported")
 	}
 	if err := c.flushBufferedNoIndex(); err != nil {
-		return nil, false, err
+		return false, false, err
 	}
 	domain := c.writeDomain
 	domainLocked := false
@@ -11454,30 +11502,30 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return nil, false, backenddb.ErrClosed
+		return false, false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshotWithWriteDomainLocked(snap)
 	if err != nil {
-		return nil, false, err
+		return false, false, err
 	}
 	if catalog == nil {
-		return nil, false, errCollectionNotFound
+		return false, false, errCollectionNotFound
 	}
 	idx, ok := findIndex(catalog.meta.Indexes, indexName)
 	if !ok {
-		return nil, false, nil
+		return false, false, nil
 	}
 	start, end, empty, err := indexRangeScanBounds(idx.ValueType, opts)
 	if err != nil {
-		return nil, true, err
+		return false, true, err
 	}
 	if empty {
-		return make([]DocumentRecord, 0), false, nil
+		return false, true, nil
 	}
 	exactPrefix, exactPrefixScan, err := exactIndexRangePrefix(idx.ValueType, opts)
 	if err != nil {
-		return nil, true, err
+		return false, true, err
 	}
 	var bufferedTable memtable.Table
 	if exactPrefixScan {
@@ -11486,7 +11534,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		bufferedTable, err = bufferedIndexRangeTableLocked(domain, catalog.meta.Name, indexName, start, end)
 	}
 	if err != nil {
-		return nil, true, err
+		return false, true, err
 	}
 	if domainLocked {
 		domain.mu.RUnlock()
@@ -11502,16 +11550,11 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	persistedIt, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
 	if err != nil {
-		return nil, true, err
+		return false, true, err
 	}
 	if persistedIt != nil {
 		defer func() { _ = persistedIt.Close() }()
 	}
-	capHint := 16
-	if opts.Limit > 0 && opts.Limit < capHint {
-		capHint = opts.Limit
-	}
-	out := make([]DocumentRecord, 0, capHint)
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
 	var scratch []byte
 	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
@@ -11527,16 +11570,15 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 			return true, nil
 		}
 		scratch = value
-		out = append(out, DocumentRecord{
-			ID:       bytes.Clone(id),
-			Document: bytes.Clone(value),
+		return fn(BorrowedDocumentRecord{
+			ID:       id,
+			Document: value,
 		})
-		return true, nil
 	})
 	if err != nil {
-		return nil, false, err
+		return false, true, err
 	}
-	return out, truncated, nil
+	return truncated, true, nil
 }
 
 func (c *Collection) ScanIndexRange(indexName string, opts IndexRangeOptions, fn func(id []byte) (bool, error)) (bool, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11440,7 +11440,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		capHint = opts.Limit
 	}
 	var out []DocumentRecord
-	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record BorrowedDocumentRecord) (bool, error) {
+	truncated, indexFound, err := c.scanDocumentsByIndexRange(indexName, opts, func(record BorrowedDocumentRecord) (bool, error) {
 		if out == nil {
 			out = make([]DocumentRecord, 0, capHint)
 		}
@@ -11453,7 +11453,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	if err != nil {
 		return nil, false, err
 	}
-	if !found {
+	if !indexFound {
 		return make([]DocumentRecord, 0), false, nil
 	}
 	if out == nil {
@@ -11467,8 +11467,9 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 // performance-oriented internal integration API for the Mongo gateway: record
 // slices are borrowed, and fn runs while the collection write-domain read lock
 // may be held. The callback must not retain or modify slices, call back into
-// Collection, or perform blocking work. General callers should use
-// FindDocumentsByIndexRange.
+// Collection, or perform blocking work. Missing indexes are treated as empty
+// scans. Descending scans are not supported, and opts.Limit must be positive.
+// General callers should use FindDocumentsByIndexRange.
 func (c *Collection) ScanBorrowedDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, error) {
 	if fn == nil {
 		return false, errors.New("collections: nil borrowed index document range callback")
@@ -11477,7 +11478,7 @@ func (c *Collection) ScanBorrowedDocumentsByIndexRange(indexName string, opts In
 	return truncated, err
 }
 
-func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (truncated bool, found bool, err error) {
+func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (truncated bool, indexFound bool, err error) {
 	if c == nil {
 		return false, false, errCollectionNil
 	}
@@ -11491,7 +11492,7 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 		return false, false, errors.New("collections: index range limit cannot be negative")
 	}
 	if opts.Limit == 0 {
-		return nil, false, errors.New("collections: document index range reads require a positive limit")
+		return false, false, errors.New("collections: document index range reads require a positive limit")
 	}
 	if opts.Desc {
 		return false, false, errors.New("collections: descending index range scans are not supported")

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -516,8 +516,8 @@ type DocumentRecord struct {
 }
 
 // BorrowedDocumentRecord is one primary collection record borrowed during a
-// callback scan. ID and Document are valid only until the callback returns and
-// must not be retained or modified.
+// callback scan. This is an unsafe performance type: ID and Document are valid
+// only until the callback returns and must not be retained or modified.
 type BorrowedDocumentRecord struct {
 	ID       []byte
 	Document []byte
@@ -11463,13 +11463,13 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 }
 
 // ScanBorrowedDocumentsByIndexRange calls fn with primary documents whose named
-// secondary index falls inside opts, preserving index order. This is a
-// performance-oriented internal integration API for the Mongo gateway: record
-// slices are borrowed, and fn runs while the collection write-domain read lock
-// may be held. The callback must not retain or modify slices, call back into
-// Collection, or perform blocking work. Missing indexes are treated as empty
-// scans. Descending scans are not supported, and opts.Limit must be positive.
-// General callers should use FindDocumentsByIndexRange.
+// secondary index falls inside opts, preserving index order. This is a borrowed
+// performance API for gateway integrations: record slices are valid only during
+// the callback, and fn may run while the collection write-domain read lock is
+// held. The callback must not retain or modify slices, call back into Collection,
+// or perform blocking work. Missing indexes are treated as empty scans.
+// Descending scans are not supported, and opts.Limit must be positive. General
+// callers should use FindDocumentsByIndexRange.
 func (c *Collection) ScanBorrowedDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, error) {
 	if fn == nil {
 		return false, errors.New("collections: nil borrowed index document range callback")

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11793,6 +11793,76 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 	}
 }
 
+func TestCollectionScanBorrowedDocumentsByIndexRangeContracts(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"score":1,"name":"one"}`),
+			[]byte(`{"score":2,"name":"two"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush rows: %v", err)
+	}
+	opts := IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 2,
+	}
+	if _, err := col.ScanBorrowedDocumentsByIndexRange("score", opts, nil); err == nil || !strings.Contains(err.Error(), "nil borrowed") {
+		t.Fatalf("nil borrowed callback err=%v want nil-callback error", err)
+	}
+	called := false
+	truncated, err := col.ScanBorrowedDocumentsByIndexRange("missing", opts, func(BorrowedDocumentRecord) (bool, error) {
+		called = true
+		return true, nil
+	})
+	if err != nil || truncated || called {
+		t.Fatalf("missing index truncated=%v called=%v err=%v want false,false,nil", truncated, called, err)
+	}
+	if _, err := col.ScanBorrowedDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+	}, func(BorrowedDocumentRecord) (bool, error) { return true, nil }); err == nil || !strings.Contains(err.Error(), "positive limit") {
+		t.Fatalf("zero limit borrowed err=%v want positive limit", err)
+	}
+	if _, err := col.ScanBorrowedDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(1), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 1,
+		Desc:  true,
+	}, func(BorrowedDocumentRecord) (bool, error) { return true, nil }); err == nil || !strings.Contains(err.Error(), "descending") {
+		t.Fatalf("descending borrowed err=%v want descending error", err)
+	}
+	var ids [][]byte
+	truncated, err = col.ScanBorrowedDocumentsByIndexRange("score", opts, func(record BorrowedDocumentRecord) (bool, error) {
+		ids = append(ids, bytes.Clone(record.ID))
+		return false, nil
+	})
+	if err != nil || truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("early stop ids=%q truncated=%v err=%v want u1,false,nil", ids, truncated, err)
+	}
+}
+
 func TestCollectionFindDocumentsByIndexRangeUsesBufferedPrimaryView(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11722,31 +11722,6 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 		t.Fatalf("record=%q/%s want u2 zero", records[0].ID, records[0].Document)
 	}
 
-	var borrowed []DocumentRecord
-	truncated, err = col.ScanDocumentsByIndexRange("score", IndexRangeOptions{
-		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
-		Upper: IndexRangeBound{Unbounded: true},
-		Limit: 2,
-	}, func(record BorrowedDocumentRecord) (bool, error) {
-		borrowed = append(borrowed, DocumentRecord{
-			ID:       bytes.Clone(record.ID),
-			Document: bytes.Clone(record.Document),
-		})
-		return true, nil
-	})
-	if err != nil {
-		t.Fatalf("scan borrowed documents range: %v", err)
-	}
-	if truncated || len(borrowed) != 2 {
-		t.Fatalf("borrowed len=%d truncated=%v want 2,false", len(borrowed), truncated)
-	}
-	if !bytes.Equal(borrowed[0].ID, []byte("u2")) || !bytes.Contains(borrowed[0].Document, []byte(`"name":"zero"`)) {
-		t.Fatalf("borrowed[0]=%q/%s want u2 zero", borrowed[0].ID, borrowed[0].Document)
-	}
-	if !bytes.Equal(borrowed[1].ID, []byte("u3")) || !bytes.Contains(borrowed[1].Document, []byte(`"name":"two"`)) {
-		t.Fatalf("borrowed[1]=%q/%s want u3 two", borrowed[1].ID, borrowed[1].Document)
-	}
-
 	records, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(100), Inclusive: true},
 		Upper: IndexRangeBound{Unbounded: true},

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11474,6 +11474,17 @@ func TestCollectionFindByMissingIndexReturnsNil(t *testing.T) {
 	if ids != nil || truncated {
 		t.Fatalf("missing index range ids=%q truncated=%v want nil/false", ids, truncated)
 	}
+	records, truncated, err := col.FindDocumentsByIndexRange("missing", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: "hnl", Inclusive: true},
+		Upper: IndexRangeBound{Value: "hnl", Inclusive: true},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("find documents missing index range: %v", err)
+	}
+	if records != nil || truncated {
+		t.Fatalf("missing index document range records=%v truncated=%v want nil/false", records, truncated)
+	}
 }
 
 func TestCollectionFindByIndexValueMatchesLargeJSONInteger(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11722,6 +11722,31 @@ func TestCollectionFindDocumentsByIndexRangeTypedInt64(t *testing.T) {
 		t.Fatalf("record=%q/%s want u2 zero", records[0].ID, records[0].Document)
 	}
 
+	var borrowed []DocumentRecord
+	truncated, err = col.ScanDocumentsByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
+		Upper: IndexRangeBound{Unbounded: true},
+		Limit: 2,
+	}, func(record BorrowedDocumentRecord) (bool, error) {
+		borrowed = append(borrowed, DocumentRecord{
+			ID:       bytes.Clone(record.ID),
+			Document: bytes.Clone(record.Document),
+		})
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("scan borrowed documents range: %v", err)
+	}
+	if truncated || len(borrowed) != 2 {
+		t.Fatalf("borrowed len=%d truncated=%v want 2,false", len(borrowed), truncated)
+	}
+	if !bytes.Equal(borrowed[0].ID, []byte("u2")) || !bytes.Contains(borrowed[0].Document, []byte(`"name":"zero"`)) {
+		t.Fatalf("borrowed[0]=%q/%s want u2 zero", borrowed[0].ID, borrowed[0].Document)
+	}
+	if !bytes.Equal(borrowed[1].ID, []byte("u3")) || !bytes.Contains(borrowed[1].Document, []byte(`"name":"two"`)) {
+		t.Fatalf("borrowed[1]=%q/%s want u3 two", borrowed[1].ID, borrowed[1].Document)
+	}
+
 	records, truncated, err = col.FindDocumentsByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(100), Inclusive: true},
 		Upper: IndexRangeBound{Unbounded: true},

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2088,21 +2088,24 @@ func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collec
 
 func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
-		_, err := collection.ScanDocumentsByIndexRange("age_1", collections.IndexRangeOptions{
+		records, _, err := collection.FindDocumentsByIndexRange("age_1", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
 			Upper: collections.IndexRangeBound{Unbounded: true},
 			Limit: 10,
-		}, func(record collections.BorrowedDocumentRecord) (bool, error) {
+		})
+		if err != nil {
+			return err
+		}
+		for _, record := range records {
 			raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)
 			if err != nil {
-				return false, err
+				return err
 			}
 			if age, ok := directBSONInt64Field(raw, "age"); !ok || age < minAge {
-				return false, fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
+				return fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
 			}
-			return true, nil
-		})
-		return err
+		}
+		return nil
 	}
 	matches := 0
 	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2085,24 +2085,21 @@ func runDirectTreeDBConcurrentRangePhase(ctx context.Context, cfg config, collec
 
 func runDirectTreeDBRangeQuery(cfg config, collection *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, minAge int64) error {
 	if cfg.RangeIndex {
-		records, _, err := collection.FindDocumentsByIndexRange("age_1", collections.IndexRangeOptions{
+		_, err := collection.ScanDocumentsByIndexRange("age_1", collections.IndexRangeOptions{
 			Lower: collections.IndexRangeBound{Value: minAge, Inclusive: true},
 			Upper: collections.IndexRangeBound{Unbounded: true},
 			Limit: 10,
-		})
-		if err != nil {
-			return err
-		}
-		for _, record := range records {
+		}, func(record collections.BorrowedDocumentRecord) (bool, error) {
 			raw, err := directStoredDocumentToBSON(collection, materializer, record.Document)
 			if err != nil {
-				return err
+				return false, err
 			}
 			if age, ok := directBSONInt64Field(raw, "age"); !ok || age < minAge {
-				return fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
+				return false, fmt.Errorf("direct indexed range returned age=%v ok=%t below %d", age, ok, minAge)
 			}
-		}
-		return nil
+			return true, nil
+		})
+		return err
 	}
 	matches := 0
 	_, err := collection.ScanDocumentsFunc(cfg.Documents, func(record collections.DocumentRecord) (bool, error) {


### PR DESCRIPTION
## Summary

Adds `Collection.ScanBorrowedDocumentsByIndexRange`, a callback API for indexed range reads that borrows the matched primary document slices for the duration of the callback.

The existing `FindDocumentsByIndexRange` API still returns owned `DocumentRecord` slices and preserves its clone/ownership contract by delegating through the borrowed scanner and cloning at the boundary.

The direct Mongo-gateway parity benchmark now uses the borrowed scan for indexed direct range reads, since it consumes each document immediately and does not need to retain an owned result slice.

## Why

On #1415, the remaining direct/native indexed range allocation was the owned document clone inside `FindDocumentsByIndexRange`. That clone is correct for the owned API, but it is unnecessary for immediate consumers such as the direct benchmark and future streaming response builders.

## Validation

Local tests:

```bash
go test -count=1 ./TreeDB/collections ./cmd/mongo_gateway_bench ./TreeDB/mongo_gateway
```

Result: passed.

## Benchmark

Config: TreeDB target, direct client mode, BSON collection storage, settled reads, `20k` docs, `age_1` indexed range `limit: 10`, `50k` range reads, maintenance disabled, prebuilt load docs.

| Branch | ops/sec | ns/op |
|---|---:|---:|
| #1414 parent | 101,310 | 9,871 |
| #1415 borrowed id scan | 107,954 | 9,263 |
| this PR borrowed document scan | 120,588 | 8,293 |

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_direct_borrowed_docs_20260506_230223`

Profiled validation run:

| Branch | ops/sec | ns/op |
|---|---:|---:|
| this PR profiled direct run | 116,759 | 8,565 |

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_direct_borrowed_docs_profile_20260506_230249`

The range-document clone site from `FindDocumentsByIndexRange` is no longer on the direct indexed range path. Remaining allocation profile entries are mostly setup/load costs captured by the broad harness profile, not isolated direct range inner-loop allocations.

