### PR TITLE
mongo bench: trust stored BSON in direct reads

### DIFF
--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1873,11 +1873,9 @@ func directStoredDocumentToBSON(collection *collections.Collection, materializer
 		return nil, errors.New("direct TreeDB benchmark requires a document materializer")
 	}
 	if materializer.DocumentFormat() == collections.DocumentFormatBSON {
-		raw := bson.Raw(stored)
-		if err := raw.Validate(); err != nil {
-			return nil, err
-		}
-		return raw, nil
+		// Match the gateway hot read path: stored BSON was validated on write,
+		// so direct read timing should not include repeated full validation.
+		return bson.Raw(stored), nil
 	}
 	materialized, err := materializer.StoredDocumentJSON(stored)
 	if err != nil {


### PR DESCRIPTION
## Summary

Updates the direct TreeDB Mongo-gateway benchmark path to trust stored BSON bytes instead of validating them on every read.

This matches the production gateway hot path, where stored BSON is validated when accepted or built and `storedDocumentToBSON` returns the stored bytes directly for BSON document collections.

## Why

After #1416 removes the owned document clone from direct indexed range reads, the direct profile still showed benchmark-side `bson.Raw.Validate` as a visible cost. That validation is not part of the gateway read path and made the direct/native baseline look slower than the server path it is meant to isolate.

## Validation

```bash
go test -count=1 ./cmd/mongo_gateway_bench
```

Result: passed.

## Benchmark

Config: TreeDB target, direct client mode, BSON collection storage, settled reads, `20k` docs, `age_1` indexed range `limit: 10`, `50k` range reads, maintenance disabled, prebuilt load docs.

| Branch | ops/sec | ns/op |
|---|---:|---:|
| #1415 borrowed id scan | 107,954 | 9,263 |
| #1416 borrowed document scan | 120,588 | 8,293 |
| this PR trust stored BSON | 131,393 | 7,611 |

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_direct_trust_bson_20260506_230649`

This is a measurement cleanup for the direct/native benchmark layer. It should not be presented as a production gateway throughput improvement by itself.
