### PR TITLE
mongo gateway: reduce raw-wire range overhead

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -515,10 +515,9 @@ type DocumentRecord struct {
 	Document []byte
 }
 
-// borrowedDocumentRecord is one primary collection record borrowed during an
-// internal callback scan. ID and Document are valid only until the callback
-// returns.
-type borrowedDocumentRecord struct {
+// BorrowedDocumentRecord is one primary collection record borrowed during a
+// callback scan. ID and Document are valid only until the callback returns.
+type BorrowedDocumentRecord struct {
 	ID       []byte
 	Document []byte
 }
@@ -11436,7 +11435,7 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 		capHint = opts.Limit
 	}
 	var out []DocumentRecord
-	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record borrowedDocumentRecord) (bool, error) {
+	truncated, found, err := c.scanDocumentsByIndexRange(indexName, opts, func(record BorrowedDocumentRecord) (bool, error) {
 		if out == nil {
 			out = make([]DocumentRecord, 0, capHint)
 		}
@@ -11458,7 +11457,21 @@ func (c *Collection) FindDocumentsByIndexRange(indexName string, opts IndexRange
 	return out, truncated, nil
 }
 
-func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(borrowedDocumentRecord) (bool, error)) (bool, bool, error) {
+// ScanBorrowedDocumentsByIndexRange calls fn with primary documents whose named
+// secondary index falls inside opts, preserving index order. This is a
+// performance-oriented internal integration API for the Mongo gateway: record
+// slices are borrowed, and fn runs while the collection write-domain read lock
+// may be held. The callback must not retain slices, call back into Collection,
+// or perform blocking work. General callers should use FindDocumentsByIndexRange.
+func (c *Collection) ScanBorrowedDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, error) {
+	if fn == nil {
+		return false, errors.New("collections: nil borrowed index document range callback")
+	}
+	truncated, _, err := c.scanDocumentsByIndexRange(indexName, opts, fn)
+	return truncated, err
+}
+
+func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRangeOptions, fn func(BorrowedDocumentRecord) (bool, error)) (bool, bool, error) {
 	if c == nil {
 		return false, false, errCollectionNil
 	}
@@ -11563,7 +11576,7 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 			return true, nil
 		}
 		scratch = value
-		return fn(borrowedDocumentRecord{
+		return fn(BorrowedDocumentRecord{
 			ID:       id,
 			Document: value,
 		})

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -255,7 +255,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 				return findResponsePayload{document: doc}, err
 			}
-			if empty || limit == 0 {
+			if empty {
 				return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"}}, nil
 			}
 			if normalizedBatchSize >= limit {
@@ -1605,28 +1605,28 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	builder := newRawCursorDocumentBuilder(msg, ns, batchKey, maxBatchBytes)
 	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, builder, singleBatch)
 	if err != nil {
-		return nil, err
+		return msg[:base], err
 	}
 	msg, err = builder.finish()
 	if err != nil {
-		return nil, err
+		return msg[:base], err
 	}
 	if len(retainedDocs) > 0 {
 		cursorID, err := server.openRetainedCursor(ns, retainedDocs, compiledProjection{}, cursorOwner)
 		if err != nil {
-			return nil, err
+			return msg[:base], err
 		}
 		builder.setCursorID(cursorID)
 	}
 	messageLength := len(msg) - base
 	if int64(messageLength) > maxWireMessageLengthInt32Limit {
-		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
+		return msg[:base], fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
 	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
 		maxMessageLength = int(server.maxMessageLength())
 	}
 	if messageLength > maxMessageLength {
-		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
+		return msg[:base], fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
 	}
 	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
 	return msg, nil
@@ -1947,7 +1947,7 @@ func (s *Server) addCursorLocked(cursorID int64, cursor *serverCursor) {
 	if s.cursors == nil {
 		s.cursors = make(map[int64]*serverCursor)
 	}
-	if s.cursors[cursorID] == nil {
+	if _, ok := s.cursors[cursorID]; !ok {
 		s.cursorCount.Add(1)
 	}
 	s.cursors[cursorID] = cursor

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1531,16 +1531,16 @@ func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, single
 	if err != nil {
 		return nil, err
 	}
+	doc, err := builder.finish()
+	if err != nil {
+		return nil, err
+	}
 	if len(retainedDocs) > 0 {
 		cursorID, err := server.openRetainedCursor(ns, retainedDocs, compiledProjection{}, cursorOwner)
 		if err != nil {
 			return nil, err
 		}
 		builder.setCursorID(cursorID)
-	}
-	doc, err := builder.finish()
-	if err != nil {
-		return nil, err
 	}
 	return wire.Document(doc), nil
 }
@@ -1565,16 +1565,16 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	if err != nil {
 		return nil, err
 	}
+	msg, err = builder.finish()
+	if err != nil {
+		return nil, err
+	}
 	if len(retainedDocs) > 0 {
 		cursorID, err := server.openRetainedCursor(ns, retainedDocs, compiledProjection{}, cursorOwner)
 		if err != nil {
 			return nil, err
 		}
 		builder.setCursorID(cursorID)
-	}
-	msg, err = builder.finish()
-	if err != nil {
-		return nil, err
 	}
 	messageLength := len(msg) - base
 	if int64(messageLength) > maxWireMessageLengthInt32Limit {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1572,8 +1572,9 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	if int64(messageLength) > maxWireMessageLengthInt32 {
 		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
-	if messageLength > wire.DefaultMaxMessageLength {
-		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
+	maxMessageLength := int(server.maxMessageLength())
+	if messageLength > maxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
 	}
 	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
 	return msg, nil

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -127,10 +127,14 @@ func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 }
 
 func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, error) {
+	return p.marshalMsgInto(nil, requestID, responseTo)
+}
+
+func (p findResponsePayload) marshalMsgInto(dst []byte, requestID, responseTo int32) ([]byte, error) {
 	if p.raw != nil {
-		return marshalCursorDocumentsMsgResponseWithID(requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
 	}
-	return wire.AppendMsgMessage(nil, requestID, responseTo, 0, p.document)
+	return wire.AppendMsgMessage(dst, requestID, responseTo, 0, p.document)
 }
 
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
@@ -142,11 +146,15 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 }
 
 func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
+	return s.findMsgResponseInto(nil, command, requestID, responseTo, cursorOwner)
+}
+
+func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
 	payload, err := s.findResponsePayload(command, cursorOwner)
 	if err != nil {
 		return nil, err
 	}
-	return payload.marshalMsg(requestID, responseTo)
+	return payload.marshalMsgInto(dst, requestID, responseTo)
 }
 
 func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {
@@ -1373,11 +1381,21 @@ func marshalCursorDocumentsResponseWithID(ns string, cursorID int64, batchKey st
 }
 
 func marshalCursorDocumentsMsgResponseWithID(requestID, responseTo int32, ns string, cursorID int64, batchKey string, batch []wire.Document) ([]byte, error) {
+	return marshalCursorDocumentsMsgResponseWithIDInto(nil, requestID, responseTo, ns, cursorID, batchKey, batch)
+}
+
+func marshalCursorDocumentsMsgResponseWithIDInto(dst []byte, requestID, responseTo int32, ns string, cursorID int64, batchKey string, batch []wire.Document) ([]byte, error) {
 	batchBytes := findBatchOverheadBytes
 	for i, doc := range batch {
 		batchBytes += findBatchDocumentBytes(doc, i)
 	}
-	msg := make([]byte, 0, 16+5+len(ns)+batchBytes+96)
+	need := 16 + 5 + len(ns) + batchBytes + 96
+	if cap(dst)-len(dst) < need {
+		grown := make([]byte, len(dst), len(dst)+need)
+		copy(grown, dst)
+		dst = grown
+	}
+	msg := dst
 	base := len(msg)
 	msg = appendWireInt32(msg, 0)
 	msg = appendWireInt32(msg, requestID)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1535,7 +1535,7 @@ func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
 	}
 	materializer, materializerErr := storedDocumentMaterializerForCollection(r.col)
 	if materializerErr != nil {
-		return nil, err
+		return nil, materializerErr
 	}
 	defer func() { _ = materializer.Close() }()
 	return marshalIndexedRangeCursorDocument(r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
@@ -1554,7 +1554,7 @@ func (r *indexedRangeCursorResponse) marshalMsgIntoWithMaxLength(dst []byte, req
 	}
 	materializer, materializerErr := storedDocumentMaterializerForCollection(r.col)
 	if materializerErr != nil {
-		return nil, err
+		return nil, materializerErr
 	}
 	defer func() { _ = materializer.Close() }()
 	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes, maxMessageLength)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1520,9 +1520,21 @@ type indexedRangeCursorResponse struct {
 	singleBatch   bool
 }
 
+var errBorrowedRangeMaterialization = errors.New("mongo gateway: borrowed range materialization")
+
 func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
 	materializer, err := storedDocumentMaterializerForCollection(r.col)
 	if err != nil {
+		return nil, err
+	}
+	doc, err := marshalIndexedRangeCursorDocument(r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	retry := shouldRetryBorrowedRangeMaterialization(materializer, err)
+	_ = materializer.Close()
+	if !retry {
+		return doc, err
+	}
+	materializer, materializerErr := storedDocumentMaterializerForCollection(r.col)
+	if materializerErr != nil {
 		return nil, err
 	}
 	defer func() { _ = materializer.Close() }()
@@ -1534,8 +1546,25 @@ func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, respo
 	if err != nil {
 		return nil, err
 	}
+	msg, err := marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	retry := shouldRetryBorrowedRangeMaterialization(materializer, err)
+	_ = materializer.Close()
+	if !retry {
+		return msg, err
+	}
+	materializer, materializerErr := storedDocumentMaterializerForCollection(r.col)
+	if materializerErr != nil {
+		return nil, err
+	}
 	defer func() { _ = materializer.Close() }()
 	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+}
+
+func shouldRetryBorrowedRangeMaterialization(materializer *collections.StoredDocumentJSONMaterializer, err error) bool {
+	return err != nil &&
+		errors.Is(err, errBorrowedRangeMaterialization) &&
+		materializer != nil &&
+		materializer.DocumentFormat() == collections.DocumentFormatTemplateV1
 }
 
 func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) (wire.Document, error) {
@@ -1610,7 +1639,7 @@ func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *co
 		}
 		doc, err := borrowedStoredDocumentToBSON(materializer, record.Document)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("%w: %w", errBorrowedRangeMaterialization, err)
 		}
 		if retainOnly {
 			retainedDocs = append(retainedDocs, append(wire.Document(nil), doc...))

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -245,11 +245,14 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 				opts.Limit = limit
 				return findResponsePayload{indexedRange: &indexedRangeCursorResponse{
 					col:           col,
+					server:        s,
 					ns:            ns,
 					indexName:     idx.Name,
 					opts:          opts,
 					batchKey:      "firstBatch",
 					maxBatchBytes: s.maxFindBatchBytes(),
+					cursorOwner:   cursorOwner,
+					singleBatch:   singleBatch,
 				}}, nil
 			}
 		}
@@ -1482,11 +1485,14 @@ func marshalCursorDocumentsMsgResponseWithIDInto(dst []byte, requestID, response
 
 type indexedRangeCursorResponse struct {
 	col           *collections.Collection
+	server        *Server
 	ns            string
 	indexName     string
 	opts          collections.IndexRangeOptions
 	batchKey      string
 	maxBatchBytes int
+	cursorOwner   int64
+	singleBatch   bool
 }
 
 func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
@@ -1495,7 +1501,7 @@ func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
 		return nil, err
 	}
 	defer func() { _ = materializer.Close() }()
-	return marshalIndexedRangeCursorDocument(r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	return marshalIndexedRangeCursorDocument(r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
 }
 
 func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, responseTo int32) ([]byte, error) {
@@ -1504,23 +1510,21 @@ func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, respo
 		return nil, err
 	}
 	defer func() { _ = materializer.Close() }()
-	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
 }
 
-func marshalIndexedRangeCursorDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) (wire.Document, error) {
+func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) (wire.Document, error) {
 	builder := newRawCursorDocumentBuilder(make([]byte, 0, rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)), ns, batchKey, maxBatchBytes)
-	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
-		if len(record.Document) == 0 {
-			return true, nil
-		}
-		doc, err := storedDocumentToBSON(col, materializer, record.Document)
-		if err != nil {
-			return false, err
-		}
-		return builder.appendDocument(doc)
-	})
+	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, builder, singleBatch)
 	if err != nil {
 		return nil, err
+	}
+	if len(retainedDocs) > 0 {
+		cursorID, err := server.openRetainedCursor(ns, retainedDocs, compiledProjection{}, cursorOwner)
+		if err != nil {
+			return nil, err
+		}
+		builder.setCursorID(cursorID)
 	}
 	doc, err := builder.finish()
 	if err != nil {
@@ -1529,7 +1533,7 @@ func marshalIndexedRangeCursorDocument(col *collections.Collection, materializer
 	return wire.Document(doc), nil
 }
 
-func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) ([]byte, error) {
+func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) ([]byte, error) {
 	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
 	if cap(dst)-len(dst) < need {
 		grown := make([]byte, len(dst), len(dst)+need)
@@ -1545,18 +1549,16 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, c
 	msg = appendWireInt32(msg, 0)
 	msg = append(msg, wire.MsgSectionBody)
 	builder := newRawCursorDocumentBuilder(msg, ns, batchKey, maxBatchBytes)
-	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
-		if len(record.Document) == 0 {
-			return true, nil
-		}
-		doc, err := storedDocumentToBSON(col, materializer, record.Document)
-		if err != nil {
-			return false, err
-		}
-		return builder.appendDocument(doc)
-	})
+	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, builder, singleBatch)
 	if err != nil {
 		return nil, err
+	}
+	if len(retainedDocs) > 0 {
+		cursorID, err := server.openRetainedCursor(ns, retainedDocs, compiledProjection{}, cursorOwner)
+		if err != nil {
+			return nil, err
+		}
+		builder.setCursorID(cursorID)
 	}
 	msg, err = builder.finish()
 	if err != nil {
@@ -1570,10 +1572,37 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, c
 	return msg, nil
 }
 
+func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, indexName string, opts collections.IndexRangeOptions, builder *rawCursorDocumentBuilder, singleBatch bool) ([]wire.Document, error) {
+	var retainedDocs []wire.Document
+	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
+		if len(record.Document) == 0 {
+			return true, nil
+		}
+		doc, err := storedDocumentToBSON(col, materializer, record.Document)
+		if err != nil {
+			return false, err
+		}
+		appended, err := builder.appendDocument(doc)
+		if err != nil || appended {
+			return appended, err
+		}
+		if singleBatch {
+			return false, nil
+		}
+		retainedDocs = append(retainedDocs, append(wire.Document(nil), doc...))
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return retainedDocs, nil
+}
+
 type rawCursorDocumentBuilder struct {
 	buf           []byte
 	docIdx        int32
 	cursorIdx     int32
+	cursorIDIdx   int
 	batchIdx      int32
 	batchBytes    int
 	count         int
@@ -1583,6 +1612,7 @@ type rawCursorDocumentBuilder struct {
 func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes int) *rawCursorDocumentBuilder {
 	docIdx, dst := bsoncore.AppendDocumentStart(dst)
 	cursorIdx, dst := bsoncore.AppendDocumentElementStart(dst, "cursor")
+	cursorIDIdx := len(dst) + 1 + len("id") + 1
 	dst = bsoncore.AppendInt64Element(dst, "id", 0)
 	dst = bsoncore.AppendStringElement(dst, "ns", ns)
 	batchIdx, dst := bsoncore.AppendArrayElementStart(dst, batchKey)
@@ -1590,6 +1620,7 @@ func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes 
 		buf:           dst,
 		docIdx:        docIdx,
 		cursorIdx:     cursorIdx,
+		cursorIDIdx:   cursorIDIdx,
 		batchIdx:      batchIdx,
 		maxBatchBytes: maxBatchBytes,
 	}
@@ -1607,6 +1638,13 @@ func (b *rawCursorDocumentBuilder) appendDocument(doc wire.Document) (bool, erro
 	b.batchBytes += docBytes
 	b.count++
 	return true, nil
+}
+
+func (b *rawCursorDocumentBuilder) setCursorID(cursorID int64) {
+	if b.cursorIDIdx < 0 || b.cursorIDIdx+8 > len(b.buf) {
+		return
+	}
+	binary.LittleEndian.PutUint64(b.buf[b.cursorIDIdx:b.cursorIDIdx+8], uint64(cursorID))
 }
 
 func (b *rawCursorDocumentBuilder) finish() ([]byte, error) {
@@ -1691,9 +1729,20 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 		return 0, firstBatch, nil
 	}
 	retainedDocs := append([]wire.Document(nil), docs[consumed:]...)
-	retainedBytes := documentsBytes(retainedDocs)
+	cursorID, err := s.openRetainedCursor(ns, retainedDocs, projection, owner)
+	if err != nil {
+		return 0, nil, err
+	}
+	return cursorID, firstBatch, nil
+}
+
+func (s *Server) openRetainedCursor(ns string, docs []wire.Document, projection compiledProjection, owner int64) (int64, error) {
+	if len(docs) == 0 {
+		return 0, nil
+	}
+	retainedBytes := documentsBytes(docs)
 	if maxBytes := s.maxCursorRetainedBytes(); retainedBytes > maxBytes {
-		return 0, nil, fmt.Errorf("Mongo gateway cursor retained bytes exceeds limit: retainedBytes=%d maxBytes=%d", retainedBytes, maxBytes)
+		return 0, fmt.Errorf("Mongo gateway cursor retained bytes exceeds limit: retainedBytes=%d maxBytes=%d", retainedBytes, maxBytes)
 	}
 	cursorID := s.nextCursorID.Add(1)
 	if cursorID == 0 {
@@ -1703,17 +1752,17 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
 	if s.isClosed() {
-		return 0, nil, errServerClosed
+		return 0, errServerClosed
 	}
 	s.reapExpiredCursorsLocked(now)
 	if s.cursors == nil {
 		s.cursors = make(map[int64]*serverCursor)
 	}
 	if len(s.cursors) >= s.maxOpenCursors() {
-		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
+		return 0, errors.New("Mongo gateway cursor limit exceeded")
 	}
-	s.addCursorLocked(cursorID, &serverCursor{ns: ns, owner: owner, docs: retainedDocs, projection: projection, pos: 0, lastUsed: now})
-	return cursorID, firstBatch, nil
+	s.addCursorLocked(cursorID, &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, pos: 0, lastUsed: now})
+	return cursorID, nil
 }
 
 func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, explicitBatchSize bool, defaultBatchSize int) (int64, bson.A, bool, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1599,7 +1599,7 @@ func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *co
 		if len(record.Document) == 0 {
 			return true, nil
 		}
-		doc, err := storedDocumentToBSON(col, materializer, record.Document)
+		doc, err := borrowedStoredDocumentToBSON(materializer, record.Document)
 		if err != nil {
 			return false, err
 		}
@@ -1655,7 +1655,7 @@ func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes 
 func (b *rawCursorDocumentBuilder) appendDocument(doc wire.Document) (bool, error) {
 	docBytes := findBatchDocumentBytes(doc, b.count)
 	if findBatchOverheadBytes+docBytes > b.maxBatchBytes {
-		return false, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, b.maxBatchBytes)
+		return false, fmt.Errorf("mongo gateway cursor document exceeds max batch bytes: docBytes=%d maxBatchBytes=%d", docBytes, b.maxBatchBytes)
 	}
 	if b.count > 0 && findBatchOverheadBytes+b.batchBytes+docBytes > b.maxBatchBytes {
 		return false, nil
@@ -1977,7 +1977,7 @@ func documentsBatchWithLimit(docs []wire.Document, projection compiledProjection
 		}
 		docBytes := findBatchDocumentBytes(doc, len(out))
 		if findBatchOverheadBytes+docBytes > maxBytes {
-			return nil, 0, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, maxBytes)
+			return nil, 0, fmt.Errorf("mongo gateway cursor document exceeds max batch bytes: docBytes=%d maxBatchBytes=%d", docBytes, maxBytes)
 		}
 		if len(out) > 0 && findBatchOverheadBytes+batchBytes+docBytes > maxBytes {
 			break
@@ -2001,7 +2001,7 @@ func rawDocumentsBatchLimit(docs []wire.Document, maxDocs int, maxBytes int) (in
 	for consumed < maxDocs {
 		docBytes := findBatchDocumentBytes(docs[consumed], consumed)
 		if findBatchOverheadBytes+docBytes > maxBytes {
-			return 0, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, maxBytes)
+			return 0, fmt.Errorf("mongo gateway cursor document exceeds max batch bytes: docBytes=%d maxBatchBytes=%d", docBytes, maxBytes)
 		}
 		if consumed > 0 && findBatchOverheadBytes+batchBytes+docBytes > maxBytes {
 			break
@@ -2330,6 +2330,13 @@ func storedDocumentMaterializerForCollection(col *collections.Collection) (*coll
 	default:
 		return col.NewStoredDocumentJSONMaterializer()
 	}
+}
+
+func borrowedStoredDocumentToBSON(materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (wire.Document, error) {
+	// Borrowed scan callbacks already run under the collection's captured read
+	// state. Do not call back into Collection here; doing so can block behind a
+	// writer while the callback still holds the borrowed scan lock.
+	return storedDocumentToBSON(nil, materializer, stored)
 }
 
 func storedDocumentToBSON(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1503,7 +1503,7 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	if len(s.cursors) >= s.maxOpenCursors() {
 		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
 	}
-	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: retainedDocs, projection: projection, pos: 0, lastUsed: now}
+	s.addCursorLocked(cursorID, &serverCursor{ns: ns, owner: owner, docs: retainedDocs, projection: projection, pos: 0, lastUsed: now})
 	return cursorID, firstBatch, nil
 }
 
@@ -1540,7 +1540,7 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 			s.cursorMu.Lock()
 			current := s.cursors[cursorID]
 			if current == cursor && current.ns == ns && current.owner == owner && current.pos == startPos {
-				delete(s.cursors, cursorID)
+				s.deleteCursorLocked(cursorID)
 			}
 			s.cursorMu.Unlock()
 			return 0, nil, false, err
@@ -1559,7 +1559,7 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 		current.pos += consumed
 		current.lastUsed = time.Now()
 		if current.pos >= len(current.docs) {
-			delete(s.cursors, cursorID)
+			s.deleteCursorLocked(cursorID)
 			s.cursorMu.Unlock()
 			return 0, batch, true, nil
 		}
@@ -1576,7 +1576,7 @@ func (s *Server) killCursorsForOwner(owner int64) {
 	defer s.cursorMu.Unlock()
 	for cursorID, cursor := range s.cursors {
 		if cursor.owner == owner {
-			delete(s.cursors, cursorID)
+			s.deleteCursorLocked(cursorID)
 		}
 	}
 }
@@ -1593,7 +1593,7 @@ func (s *Server) killCursors(ns string, owner int64, cursorIDs []int64) ([]int64
 			notFound = append(notFound, cursorID)
 			continue
 		}
-		delete(s.cursors, cursorID)
+		s.deleteCursorLocked(cursorID)
 		killed = append(killed, cursorID)
 	}
 	return killed, notFound
@@ -1601,7 +1601,7 @@ func (s *Server) killCursors(ns string, owner int64, cursorIDs []int64) ([]int64
 
 func (s *Server) reapExpiredCursors() {
 	timeout := s.cursorIdleTimeout()
-	if timeout <= 0 {
+	if timeout <= 0 || s.cursorCount.Load() == 0 {
 		return
 	}
 	now := time.Now()
@@ -1622,9 +1622,34 @@ func (s *Server) reapExpiredCursorsLocked(now time.Time) {
 	cutoff := now.Add(-timeout)
 	for cursorID, cursor := range s.cursors {
 		if !cursor.lastUsed.IsZero() && !cursor.lastUsed.After(cutoff) {
-			delete(s.cursors, cursorID)
+			s.deleteCursorLocked(cursorID)
 		}
 	}
+}
+
+func (s *Server) addCursorLocked(cursorID int64, cursor *serverCursor) {
+	if cursor == nil {
+		return
+	}
+	if s.cursors == nil {
+		s.cursors = make(map[int64]*serverCursor)
+	}
+	if s.cursors[cursorID] == nil {
+		s.cursorCount.Add(1)
+	}
+	s.cursors[cursorID] = cursor
+}
+
+func (s *Server) deleteCursorLocked(cursorID int64) bool {
+	if s.cursors == nil {
+		return false
+	}
+	if _, ok := s.cursors[cursorID]; !ok {
+		return false
+	}
+	delete(s.cursors, cursorID)
+	s.cursorCount.Add(-1)
+	return true
 }
 
 func normalizeBatchSize(batchSize int, explicit bool, defaultBatchSize int) (int, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1569,7 +1569,7 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 		return nil, err
 	}
 	messageLength := len(msg) - base
-	if int64(messageLength) > maxWireMessageLengthInt32 {
+	if int64(messageLength) > maxWireMessageLengthInt32Limit {
 		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
 	maxMessageLength := int(server.maxMessageLength())
@@ -1582,6 +1582,7 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 
 func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, indexName string, opts collections.IndexRangeOptions, builder *rawCursorDocumentBuilder, singleBatch bool) ([]wire.Document, error) {
 	var retainedDocs []wire.Document
+	retainOnly := false
 	_, err := col.ScanBorrowedDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
 		if len(record.Document) == 0 {
 			return true, nil
@@ -1590,6 +1591,10 @@ func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *co
 		if err != nil {
 			return false, err
 		}
+		if retainOnly {
+			retainedDocs = append(retainedDocs, append(wire.Document(nil), doc...))
+			return true, nil
+		}
 		appended, err := builder.appendDocument(doc)
 		if err != nil || appended {
 			return appended, err
@@ -1597,6 +1602,7 @@ func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *co
 		if singleBatch {
 			return false, nil
 		}
+		retainOnly = true
 		retainedDocs = append(retainedDocs, append(wire.Document(nil), doc...))
 		return true, nil
 	})

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1569,6 +1569,9 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 		return nil, err
 	}
 	messageLength := len(msg) - base
+	if int64(messageLength) > maxWireMessageLengthInt32 {
+		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
+	}
 	if messageLength > wire.DefaultMaxMessageLength {
 		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1797,7 +1797,7 @@ func (s *Server) openRetainedCursor(ns string, docs []wire.Document, projection 
 	}
 	retainedBytes := documentsBytes(docs)
 	if maxBytes := s.maxCursorRetainedBytes(); retainedBytes > maxBytes {
-		return 0, fmt.Errorf("Mongo gateway cursor retained bytes exceeds limit: retainedBytes=%d maxBytes=%d", retainedBytes, maxBytes)
+		return 0, fmt.Errorf("mongo gateway cursor retained bytes exceeds limit: retainedBytes=%d maxBytes=%d", retainedBytes, maxBytes)
 	}
 	cursorID := s.nextCursorID.Add(1)
 	if cursorID == 0 {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -144,7 +144,7 @@ func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, 
 		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, maxMessageLength)
 	}
 	if p.indexedRange != nil {
-		return p.indexedRange.marshalMsgInto(dst, requestID, responseTo)
+		return p.indexedRange.marshalMsgIntoWithMaxLength(dst, requestID, responseTo, maxMessageLength)
 	}
 	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
 		maxMessageLength = wire.DefaultMaxMessageLength
@@ -188,7 +188,7 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 		if docErr != nil {
 			return nil, docErr
 		}
-		return wire.AppendMsgMessage(dst[:0], requestID, responseTo, 0, doc)
+		return wire.AppendMsgMessage(dst, requestID, responseTo, 0, doc)
 	}
 	return msg, err
 }
@@ -1541,12 +1541,12 @@ func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
 	return marshalIndexedRangeCursorDocument(r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
 }
 
-func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, responseTo int32) ([]byte, error) {
+func (r *indexedRangeCursorResponse) marshalMsgIntoWithMaxLength(dst []byte, requestID, responseTo int32, maxMessageLength int) ([]byte, error) {
 	materializer, err := storedDocumentMaterializerForCollection(r.col)
 	if err != nil {
 		return nil, err
 	}
-	msg, err := marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	msg, err := marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes, maxMessageLength)
 	retry := shouldRetryBorrowedRangeMaterialization(materializer, err)
 	_ = materializer.Close()
 	if !retry {
@@ -1557,7 +1557,7 @@ func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, respo
 		return nil, err
 	}
 	defer func() { _ = materializer.Close() }()
-	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.server, r.cursorOwner, r.singleBatch, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes, maxMessageLength)
 }
 
 func shouldRetryBorrowedRangeMaterialization(materializer *collections.StoredDocumentJSONMaterializer, err error) bool {
@@ -1587,7 +1587,7 @@ func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, single
 	return wire.Document(doc), nil
 }
 
-func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) ([]byte, error) {
+func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int, maxMessageLength int) ([]byte, error) {
 	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
 	if cap(dst)-len(dst) < need {
 		grown := make([]byte, len(dst), len(dst)+need)
@@ -1622,7 +1622,9 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	if int64(messageLength) > maxWireMessageLengthInt32Limit {
 		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
 	}
-	maxMessageLength := int(server.maxMessageLength())
+	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
+		maxMessageLength = int(server.maxMessageLength())
+	}
 	if messageLength > maxMessageLength {
 		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -115,13 +115,17 @@ type rawCursorDocumentsResponse struct {
 }
 
 type findResponsePayload struct {
-	document wire.Document
-	raw      *rawCursorDocumentsResponse
+	document     wire.Document
+	raw          *rawCursorDocumentsResponse
+	indexedRange *indexedRangeCursorResponse
 }
 
 func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 	if p.raw != nil {
 		return marshalCursorDocumentsResponseWithID(p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+	}
+	if p.indexedRange != nil {
+		return p.indexedRange.marshalDocument()
 	}
 	return p.document, nil
 }
@@ -134,6 +138,9 @@ func (p findResponsePayload) marshalMsgInto(dst []byte, requestID, responseTo in
 	if p.raw != nil {
 		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
 	}
+	if p.indexedRange != nil {
+		return p.indexedRange.marshalMsgInto(dst, requestID, responseTo)
+	}
 	return wire.AppendMsgMessage(dst, requestID, responseTo, 0, p.document)
 }
 
@@ -142,7 +149,11 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 	if err != nil {
 		return nil, err
 	}
-	return payload.marshalDocument()
+	doc, err := payload.marshalDocument()
+	if err != nil && payload.indexedRange != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	return doc, err
 }
 
 func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
@@ -154,7 +165,15 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 	if err != nil {
 		return nil, err
 	}
-	return payload.marshalMsgInto(dst, requestID, responseTo)
+	msg, err := payload.marshalMsgInto(dst, requestID, responseTo)
+	if err != nil && payload.indexedRange != nil {
+		doc, docErr := commandError(commandCodeBadValue, "BadValue", err.Error())
+		if docErr != nil {
+			return nil, docErr
+		}
+		return wire.AppendMsgMessage(dst[:0], requestID, responseTo, 0, doc)
+	}
+	return msg, err
 }
 
 func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {
@@ -207,6 +226,34 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return findResponsePayload{document: doc}, err
 	}
 	ns := db + "." + collection
+	if !plan.projection.present {
+		idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
+		if err != nil {
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
+		}
+		if ok {
+			normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
+			if err != nil {
+				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+				return findResponsePayload{document: doc}, err
+			}
+			if empty || limit == 0 {
+				return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"}}, nil
+			}
+			if normalizedBatchSize >= limit {
+				opts.Limit = limit
+				return findResponsePayload{indexedRange: &indexedRangeCursorResponse{
+					col:           col,
+					ns:            ns,
+					indexName:     idx.Name,
+					opts:          opts,
+					batchKey:      "firstBatch",
+					maxBatchBytes: s.maxFindBatchBytes(),
+				}}, nil
+			}
+		}
+	}
 	results, err := s.executeFind(col, plan)
 	if err != nil {
 		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -1431,6 +1478,168 @@ func marshalCursorDocumentsMsgResponseWithIDInto(dst []byte, requestID, response
 	}
 	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
 	return msg, nil
+}
+
+type indexedRangeCursorResponse struct {
+	col           *collections.Collection
+	ns            string
+	indexName     string
+	opts          collections.IndexRangeOptions
+	batchKey      string
+	maxBatchBytes int
+}
+
+func (r *indexedRangeCursorResponse) marshalDocument() (wire.Document, error) {
+	materializer, err := storedDocumentMaterializerForCollection(r.col)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = materializer.Close() }()
+	return marshalIndexedRangeCursorDocument(r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+}
+
+func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, responseTo int32) ([]byte, error) {
+	materializer, err := storedDocumentMaterializerForCollection(r.col)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = materializer.Close() }()
+	return marshalIndexedRangeCursorMsgInto(dst, requestID, responseTo, r.col, materializer, r.ns, r.indexName, r.opts, r.batchKey, r.maxBatchBytes)
+}
+
+func marshalIndexedRangeCursorDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) (wire.Document, error) {
+	builder := newRawCursorDocumentBuilder(make([]byte, 0, rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)), ns, batchKey, maxBatchBytes)
+	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
+		if len(record.Document) == 0 {
+			return true, nil
+		}
+		doc, err := storedDocumentToBSON(col, materializer, record.Document)
+		if err != nil {
+			return false, err
+		}
+		return builder.appendDocument(doc)
+	})
+	if err != nil {
+		return nil, err
+	}
+	doc, err := builder.finish()
+	if err != nil {
+		return nil, err
+	}
+	return wire.Document(doc), nil
+}
+
+func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) ([]byte, error) {
+	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
+	if cap(dst)-len(dst) < need {
+		grown := make([]byte, len(dst), len(dst)+need)
+		copy(grown, dst)
+		dst = grown
+	}
+	msg := dst
+	base := len(msg)
+	msg = appendWireInt32(msg, 0)
+	msg = appendWireInt32(msg, requestID)
+	msg = appendWireInt32(msg, responseTo)
+	msg = appendWireInt32(msg, int32(wire.OpMsg))
+	msg = appendWireInt32(msg, 0)
+	msg = append(msg, wire.MsgSectionBody)
+	builder := newRawCursorDocumentBuilder(msg, ns, batchKey, maxBatchBytes)
+	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
+		if len(record.Document) == 0 {
+			return true, nil
+		}
+		doc, err := storedDocumentToBSON(col, materializer, record.Document)
+		if err != nil {
+			return false, err
+		}
+		return builder.appendDocument(doc)
+	})
+	if err != nil {
+		return nil, err
+	}
+	msg, err = builder.finish()
+	if err != nil {
+		return nil, err
+	}
+	messageLength := len(msg) - base
+	if messageLength > wire.DefaultMaxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, wire.DefaultMaxMessageLength)
+	}
+	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
+	return msg, nil
+}
+
+type rawCursorDocumentBuilder struct {
+	buf           []byte
+	docIdx        int32
+	cursorIdx     int32
+	batchIdx      int32
+	batchBytes    int
+	count         int
+	maxBatchBytes int
+}
+
+func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes int) *rawCursorDocumentBuilder {
+	docIdx, dst := bsoncore.AppendDocumentStart(dst)
+	cursorIdx, dst := bsoncore.AppendDocumentElementStart(dst, "cursor")
+	dst = bsoncore.AppendInt64Element(dst, "id", 0)
+	dst = bsoncore.AppendStringElement(dst, "ns", ns)
+	batchIdx, dst := bsoncore.AppendArrayElementStart(dst, batchKey)
+	return &rawCursorDocumentBuilder{
+		buf:           dst,
+		docIdx:        docIdx,
+		cursorIdx:     cursorIdx,
+		batchIdx:      batchIdx,
+		maxBatchBytes: maxBatchBytes,
+	}
+}
+
+func (b *rawCursorDocumentBuilder) appendDocument(doc wire.Document) (bool, error) {
+	docBytes := findBatchDocumentBytes(doc, b.count)
+	if findBatchOverheadBytes+docBytes > b.maxBatchBytes {
+		return false, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, b.maxBatchBytes)
+	}
+	if b.count > 0 && findBatchOverheadBytes+b.batchBytes+docBytes > b.maxBatchBytes {
+		return false, nil
+	}
+	b.buf = bsoncore.AppendDocumentElement(b.buf, bsonArrayIndexKey(b.count), doc)
+	b.batchBytes += docBytes
+	b.count++
+	return true, nil
+}
+
+func (b *rawCursorDocumentBuilder) finish() ([]byte, error) {
+	var err error
+	b.buf, err = bsoncore.AppendArrayEnd(b.buf, b.batchIdx)
+	if err != nil {
+		return nil, err
+	}
+	b.buf, err = bsoncore.AppendDocumentEnd(b.buf, b.cursorIdx)
+	if err != nil {
+		return nil, err
+	}
+	b.buf = bsoncore.AppendDoubleElement(b.buf, "ok", 1.0)
+	b.buf, err = bsoncore.AppendDocumentEnd(b.buf, b.docIdx)
+	if err != nil {
+		return nil, err
+	}
+	return b.buf, nil
+}
+
+func rawCursorResponseCapacityHint(ns string, limit int, maxBatchBytes int) int {
+	const estimatedIndexedRangeDocumentBytes = 1024
+	need := len(ns) + 96 + findBatchOverheadBytes
+	if limit > 0 {
+		need += limit * estimatedIndexedRangeDocumentBytes
+	}
+	if maxBatchBytes > 0 && need > maxBatchBytes+len(ns)+96 {
+		need = maxBatchBytes + len(ns) + 96
+	}
+	if need > maxRetainedWireWriteBuffer {
+		return maxRetainedWireWriteBuffer
+	}
+	return need
 }
 
 func appendWireInt32(dst []byte, v int32) []byte {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1581,7 +1581,7 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 
 func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, indexName string, opts collections.IndexRangeOptions, builder *rawCursorDocumentBuilder, singleBatch bool) ([]wire.Document, error) {
 	var retainedDocs []wire.Document
-	_, err := col.ScanDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
+	_, err := col.ScanBorrowedDocumentsByIndexRange(indexName, opts, func(record collections.BorrowedDocumentRecord) (bool, error) {
 		if len(record.Document) == 0 {
 			return true, nil
 		}

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -162,6 +162,12 @@ func (c *Client) watchContextCancelLocked(ctx context.Context) func() {
 	if done == nil {
 		return func() {}
 	}
+	if _, ok := ctx.Deadline(); ok {
+		// The connection deadline already interrupts blocking reads/writes at
+		// timeout. Avoid a goroutine per request on benchmark hot paths that
+		// use a long-lived deadline context and do not cancel individual ops.
+		return func() {}
+	}
 	stop := make(chan struct{})
 	stopped := make(chan struct{})
 	go func() {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -111,8 +111,10 @@ func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw,
 }
 
 // FindRawBSONBorrowed is like FindRawBSON, but the returned BSON documents are
-// borrowed and valid only for the duration of fn. It is intended for benchmark
-// hot paths that validate a response without retaining it.
+// borrowed and valid only for the duration of fn. The callback runs while the
+// client mutex is held, so it must not call back into the same client and must
+// not retain the batch or any bson.Raw after returning. It is intended for
+// benchmark hot paths that validate a response without retaining it.
 func (c *Client) FindRawBSONBorrowed(ctx context.Context, command bson.Raw, fn func([]bson.Raw) error) error {
 	if fn == nil {
 		return errors.New("find raw bson borrowed requires a callback")

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -92,7 +92,31 @@ func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw,
 	if err != nil {
 		return nil, err
 	}
-	return c.roundTripFind(ctx, msg)
+	return c.roundTripFind(ctx, msg, false)
+}
+
+// FindRawBSONBorrowed is like FindRawBSON, but the returned BSON documents are
+// borrowed and valid only for the duration of fn. It is intended for benchmark
+// hot paths that validate a response without retaining it.
+func (c *Client) FindRawBSONBorrowed(ctx context.Context, command bson.Raw, fn func([]bson.Raw) error) error {
+	if fn == nil {
+		return errors.New("FindRawBSONBorrowed requires a callback")
+	}
+	if c == nil || c.conn == nil {
+		return errors.New("mongo gateway fast client is closed")
+	}
+	if len(command) == 0 {
+		return errors.New("FindRawBSONBorrowed requires a command document")
+	}
+	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
+	if err != nil {
+		return err
+	}
+	docs, err := c.roundTripFind(ctx, msg, true)
+	if err != nil {
+		return err
+	}
+	return fn(docs)
 }
 
 func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (int, error) {
@@ -118,7 +142,7 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 		}
 		return 0, err
 	}
-	header, body, err := c.readMessageLocked()
+	header, body, err := c.readMessageLocked(true)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return 0, ctxErr
@@ -128,7 +152,7 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 	return parseInsertResponse(header, body, wantN)
 }
 
-func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, error) {
+func (c *Client) roundTripFind(ctx context.Context, msg []byte, borrowed bool) ([]bson.Raw, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -151,7 +175,7 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 		}
 		return nil, err
 	}
-	header, body, err := c.readMessageLocked()
+	header, body, err := c.readMessageLocked(borrowed)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -161,14 +185,18 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 	return parseFindResponse(header, body)
 }
 
-func (c *Client) readMessageLocked() (wire.Header, []byte, error) {
-	header, body, err := wire.ReadMessageInto(c.conn, c.readBuf, c.maxMessageLen)
+func (c *Client) readMessageLocked(retain bool) (wire.Header, []byte, error) {
+	var dst []byte
+	if retain {
+		dst = c.readBuf
+	}
+	header, body, err := wire.ReadMessageInto(c.conn, dst, c.maxMessageLen)
 	if err != nil {
 		return wire.Header{}, nil, err
 	}
-	if cap(body) <= maxRetainedReadBuffer {
+	if retain && cap(body) <= maxRetainedReadBuffer {
 		c.readBuf = body
-	} else {
+	} else if retain {
 		c.readBuf = nil
 	}
 	return header, body, nil
@@ -179,25 +207,15 @@ func (c *Client) watchContextCancelLocked(ctx context.Context) func() {
 	if done == nil {
 		return func() {}
 	}
-	if _, ok := ctx.Deadline(); ok {
-		// The connection deadline already interrupts blocking reads/writes at
-		// timeout. Avoid a goroutine per request on benchmark hot paths that
-		// use a long-lived deadline context and do not cancel individual ops.
-		return func() {}
-	}
-	stop := make(chan struct{})
-	stopped := make(chan struct{})
-	go func() {
-		defer close(stopped)
-		select {
-		case <-done:
-			_ = c.conn.SetDeadline(time.Now())
-		case <-stop:
-		}
-	}()
+	fired := make(chan struct{})
+	stop := context.AfterFunc(ctx, func() {
+		defer close(fired)
+		_ = c.conn.SetDeadline(time.Now())
+	})
 	return func() {
-		close(stop)
-		<-stopped
+		if !stop() {
+			<-fired
+		}
 	}
 }
 

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -131,15 +131,11 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := c.conn.SetDeadline(deadline); err != nil {
-			return 0, err
-		}
-	}
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {
-		stopCancelWatch()
-		_ = c.conn.SetDeadline(time.Time{})
+		if stopCancelWatch() {
+			_ = c.conn.SetDeadline(time.Time{})
+		}
 	}()
 	if err := writeFull(c.conn, msg); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -164,15 +160,11 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := c.conn.SetDeadline(deadline); err != nil {
-			return nil, err
-		}
-	}
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {
-		stopCancelWatch()
-		_ = c.conn.SetDeadline(time.Time{})
+		if stopCancelWatch() {
+			_ = c.conn.SetDeadline(time.Time{})
+		}
 	}()
 	if err := writeFull(c.conn, msg); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -197,15 +189,11 @@ func (c *Client) roundTripFindBorrowed(ctx context.Context, msg []byte, fn func(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := c.conn.SetDeadline(deadline); err != nil {
-			return err
-		}
-	}
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {
-		stopCancelWatch()
-		_ = c.conn.SetDeadline(time.Time{})
+		if stopCancelWatch() {
+			_ = c.conn.SetDeadline(time.Time{})
+		}
 	}()
 	if err := writeFull(c.conn, msg); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -248,20 +236,22 @@ func (c *Client) readMessageLocked(retain bool) (wire.Header, []byte, error) {
 	return header, body, nil
 }
 
-func (c *Client) watchContextCancelLocked(ctx context.Context) func() {
+func (c *Client) watchContextCancelLocked(ctx context.Context) func() bool {
 	done := ctx.Done()
 	if done == nil {
-		return func() {}
+		return func() bool { return false }
 	}
 	fired := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
 		defer close(fired)
 		_ = c.conn.SetDeadline(time.Now())
 	})
-	return func() {
-		if !stop() {
-			<-fired
+	return func() bool {
+		if stop() {
+			return false
 		}
+		<-fired
+		return true
 	}
 }
 

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -92,7 +92,7 @@ func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw,
 	if err != nil {
 		return nil, err
 	}
-	return c.roundTripFind(ctx, msg, false)
+	return c.roundTripFind(ctx, msg)
 }
 
 // FindRawBSONBorrowed is like FindRawBSON, but the returned BSON documents are
@@ -112,11 +112,7 @@ func (c *Client) FindRawBSONBorrowed(ctx context.Context, command bson.Raw, fn f
 	if err != nil {
 		return err
 	}
-	docs, err := c.roundTripFind(ctx, msg, true)
-	if err != nil {
-		return err
-	}
-	return fn(docs)
+	return c.roundTripFindBorrowed(ctx, msg, fn)
 }
 
 func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (int, error) {
@@ -152,7 +148,7 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 	return parseInsertResponse(header, body, wantN)
 }
 
-func (c *Client) roundTripFind(ctx context.Context, msg []byte, borrowed bool) ([]bson.Raw, error) {
+func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -175,7 +171,7 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte, borrowed bool) (
 		}
 		return nil, err
 	}
-	header, body, err := c.readMessageLocked(borrowed)
+	header, body, err := c.readMessageLocked(false)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -183,6 +179,43 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte, borrowed bool) (
 		return nil, err
 	}
 	return parseFindResponse(header, body)
+}
+
+func (c *Client) roundTripFindBorrowed(ctx context.Context, msg []byte, fn func([]bson.Raw) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := c.conn.SetDeadline(deadline); err != nil {
+			return err
+		}
+	}
+	stopCancelWatch := c.watchContextCancelLocked(ctx)
+	defer func() {
+		stopCancelWatch()
+		_ = c.conn.SetDeadline(time.Time{})
+	}()
+	if err := writeFull(c.conn, msg); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	header, body, err := c.readMessageLocked(true)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	docs, err := parseFindResponse(header, body)
+	if err != nil {
+		return err
+	}
+	return fn(docs)
 }
 
 func (c *Client) readMessageLocked(retain bool) (wire.Header, []byte, error) {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -141,6 +141,9 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {
@@ -170,6 +173,9 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {
@@ -199,6 +205,9 @@ func (c *Client) roundTripFindBorrowed(ctx context.Context, msg []byte, fn func(
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	stopCancelWatch := c.watchContextCancelLocked(ctx)
 	defer func() {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -1,6 +1,7 @@
 package fastclient
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -18,13 +19,17 @@ import (
 
 type Client struct {
 	conn          net.Conn
+	rd            *bufio.Reader
 	maxMessageLen int32
 	nextRequestID atomic.Int32
 	readBuf       []byte
 	mu            sync.Mutex
 }
 
-const maxRetainedReadBuffer = 1 << 20
+const (
+	defaultReadBufferSize = 32 * 1024
+	maxRetainedReadBuffer = 1 << 20
+)
 
 func Connect(ctx context.Context, address string) (*Client, error) {
 	var dialer net.Dialer
@@ -36,7 +41,11 @@ func Connect(ctx context.Context, address string) (*Client, error) {
 }
 
 func New(conn net.Conn) *Client {
-	return &Client{conn: conn, maxMessageLen: wire.DefaultMaxMessageLength}
+	c := &Client{conn: conn, maxMessageLen: wire.DefaultMaxMessageLength}
+	if conn != nil {
+		c.rd = bufio.NewReaderSize(conn, defaultReadBufferSize)
+	}
+	return c
 }
 
 func (c *Client) Close() error {
@@ -223,7 +232,11 @@ func (c *Client) readMessageLocked(retain bool) (wire.Header, []byte, error) {
 	if retain {
 		dst = c.readBuf
 	}
-	header, body, err := wire.ReadMessageInto(c.conn, dst, c.maxMessageLen)
+	reader := io.Reader(c.conn)
+	if c.rd != nil {
+		reader = c.rd
+	}
+	header, body, err := wire.ReadMessageInto(reader, dst, c.maxMessageLen)
 	if err != nil {
 		return wire.Header{}, nil, err
 	}

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -95,7 +95,7 @@ func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw,
 		return nil, errors.New("mongo gateway fast client is closed")
 	}
 	if len(command) == 0 {
-		return nil, errors.New("FindRawBSON requires a command document")
+		return nil, errors.New("find raw bson requires a command document")
 	}
 	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
 	if err != nil {
@@ -109,13 +109,13 @@ func (c *Client) FindRawBSON(ctx context.Context, command bson.Raw) ([]bson.Raw,
 // hot paths that validate a response without retaining it.
 func (c *Client) FindRawBSONBorrowed(ctx context.Context, command bson.Raw, fn func([]bson.Raw) error) error {
 	if fn == nil {
-		return errors.New("FindRawBSONBorrowed requires a callback")
+		return errors.New("find raw bson borrowed requires a callback")
 	}
 	if c == nil || c.conn == nil {
 		return errors.New("mongo gateway fast client is closed")
 	}
 	if len(command) == 0 {
-		return errors.New("FindRawBSONBorrowed requires a command document")
+		return errors.New("find raw bson borrowed requires a command document")
 	}
 	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
 	if err != nil {
@@ -311,7 +311,7 @@ func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
 	}
 	rem = rem[:len(rem)-1]
 
-	docs := make([]bson.Raw, 0, 10)
+	docs := make([]bson.Raw, 0, rawArrayDocumentCapacityHint(len(rem)))
 	for len(rem) > 0 {
 		elem, next, ok := bsoncore.ReadElement(rem)
 		if !ok {
@@ -329,6 +329,22 @@ func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
 		rem = next
 	}
 	return docs, nil
+}
+
+func rawArrayDocumentCapacityHint(payloadBytes int) int {
+	if payloadBytes <= 0 {
+		return 0
+	}
+	const minElementOverhead = 8
+	const maxInitialCapacity = 1024
+	hint := payloadBytes / minElementOverhead
+	if hint < 1 {
+		return 1
+	}
+	if hint > maxInitialCapacity {
+		return maxInitialCapacity
+	}
+	return hint
 }
 
 func rawOK(raw bson.Raw) bool {

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
 type Client struct {
@@ -226,17 +227,36 @@ func parseFindResponse(header wire.Header, body []byte) ([]bson.Raw, error) {
 	if !ok {
 		return nil, errors.New("find response missing cursor.firstBatch")
 	}
-	values, err := batch.Values()
-	if err != nil {
-		return nil, err
+	return rawDocumentsFromArray(batch)
+}
+
+func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
+	length, rem, ok := bsoncore.ReadLength(bsoncore.Array(batch))
+	if !ok || length < 5 || int(length) > len(batch) {
+		return nil, errors.New("malformed find cursor.firstBatch")
 	}
-	docs := make([]bson.Raw, 0, len(values))
-	for _, value := range values {
+	rem = rem[:int(length)-4]
+	if len(rem) == 0 || rem[len(rem)-1] != 0x00 {
+		return nil, errors.New("malformed find cursor.firstBatch")
+	}
+	rem = rem[:len(rem)-1]
+
+	docs := make([]bson.Raw, 0, 10)
+	for len(rem) > 0 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return nil, errors.New("malformed find cursor.firstBatch")
+		}
+		value, err := elem.ValueErr()
+		if err != nil {
+			return nil, err
+		}
 		doc, ok := value.DocumentOK()
 		if !ok {
 			return nil, errors.New("find firstBatch entry is not a document")
 		}
 		docs = append(docs, bson.Raw(doc))
+		rem = next
 	}
 	return docs, nil
 }

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -125,6 +125,9 @@ func (c *Client) FindRawBSONBorrowed(ctx context.Context, command bson.Raw, fn f
 	if len(command) == 0 {
 		return errors.New("find raw bson borrowed requires a command document")
 	}
+	if _, ok := command.Lookup("find").StringValueOK(); !ok {
+		return errors.New("FindRawBSONBorrowed requires a find command document")
+	}
 	msg, err := wire.AppendMsgMessage(nil, c.nextRequestID.Add(1), 0, 0, wire.Document(command))
 	if err != nil {
 		return err

--- a/TreeDB/mongo_gateway/fastclient/client.go
+++ b/TreeDB/mongo_gateway/fastclient/client.go
@@ -20,8 +20,11 @@ type Client struct {
 	conn          net.Conn
 	maxMessageLen int32
 	nextRequestID atomic.Int32
+	readBuf       []byte
 	mu            sync.Mutex
 }
+
+const maxRetainedReadBuffer = 1 << 20
 
 func Connect(ctx context.Context, address string) (*Client, error) {
 	var dialer net.Dialer
@@ -115,7 +118,7 @@ func (c *Client) roundTripInsert(ctx context.Context, msg []byte, wantN int) (in
 		}
 		return 0, err
 	}
-	header, body, err := wire.ReadMessage(c.conn, c.maxMessageLen)
+	header, body, err := c.readMessageLocked()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return 0, ctxErr
@@ -148,7 +151,7 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 		}
 		return nil, err
 	}
-	header, body, err := wire.ReadMessage(c.conn, c.maxMessageLen)
+	header, body, err := c.readMessageLocked()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -156,6 +159,19 @@ func (c *Client) roundTripFind(ctx context.Context, msg []byte) ([]bson.Raw, err
 		return nil, err
 	}
 	return parseFindResponse(header, body)
+}
+
+func (c *Client) readMessageLocked() (wire.Header, []byte, error) {
+	header, body, err := wire.ReadMessageInto(c.conn, c.readBuf, c.maxMessageLen)
+	if err != nil {
+		return wire.Header{}, nil, err
+	}
+	if cap(body) <= maxRetainedReadBuffer {
+		c.readBuf = body
+	} else {
+		c.readBuf = nil
+	}
+	return header, body, nil
 }
 
 func (c *Client) watchContextCancelLocked(ctx context.Context) func() {

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	if err := client.FindRawBSONBorrowed(insertCtx, mustBSON(t, bson.D{{Key: "ping", Value: 1}, {Key: "$db", Value: "admin"}}), func([]bson.Raw) error {
 		t.Fatal("borrowed callback should not run for non-find command")
 		return nil
-	}); err == nil || err.Error() != "FindRawBSONBorrowed requires a find command document" {
+	}); err == nil || !strings.Contains(err.Error(), "requires a find command document") {
 		t.Fatalf("FindRawBSONBorrowed non-find err=%v want find-command error", err)
 	}
 	borrowedEntered := make(chan struct{})

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -265,6 +265,45 @@ func TestClientInsertManyRawBSONCanceledDeadlineContextInterruptsRead(t *testing
 	}
 }
 
+func TestClientInsertManyRawBSONDeadlineInterruptsRead(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	client := New(clientConn)
+	defer func() { _ = client.Close() }()
+
+	rawDocs := []bson.Raw{mustBSON(t, bson.D{{Key: "_id", Value: "u1"}})}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.InsertManyRawBSON(ctx, "app", "users", rawDocs)
+		errCh <- err
+	}()
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, err := wire.ReadMessage(serverConn, 0)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("server read request: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("InsertManyRawBSON err=%v want context.DeadlineExceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("InsertManyRawBSON did not return after deadline")
+	}
+}
+
 func mustBSON(t *testing.T, doc bson.D) bson.Raw {
 	t.Helper()
 	raw, err := bson.Marshal(doc)

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -93,6 +93,35 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	if got, ok := found[0].Lookup("name").StringValueOK(); !ok || got != "grace" {
 		t.Fatalf("FindRawBSON name=%q ok=%t want grace", got, ok)
 	}
+	adaCommand := mustBSON(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "name", Value: "ada"}}},
+		{Key: "limit", Value: 1},
+		{Key: "$db", Value: "app"},
+	})
+	adaFound, err := client.FindRawBSON(insertCtx, adaCommand)
+	if err != nil {
+		t.Fatalf("FindRawBSON ada: %v", err)
+	}
+	if len(adaFound) != 1 {
+		t.Fatalf("FindRawBSON ada docs=%d want 1", len(adaFound))
+	}
+	if got, ok := adaFound[0].Lookup("name").StringValueOK(); !ok || got != "ada" {
+		t.Fatalf("FindRawBSON ada name=%q ok=%t want ada", got, ok)
+	}
+	if got, ok := found[0].Lookup("name").StringValueOK(); !ok || got != "grace" {
+		t.Fatalf("first FindRawBSON result changed after second query: name=%q ok=%t want grace", got, ok)
+	}
+	var borrowedCount int
+	if err := client.FindRawBSONBorrowed(insertCtx, findCommand, func(docs []bson.Raw) error {
+		borrowedCount = len(docs)
+		return nil
+	}); err != nil {
+		t.Fatalf("FindRawBSONBorrowed: %v", err)
+	}
+	if borrowedCount != 1 {
+		t.Fatalf("FindRawBSONBorrowed docs=%d want 1", borrowedCount)
+	}
 
 	driverClient, err := mongo.Connect(options.Client().
 		ApplyURI("mongodb://" + ln.Addr().String()).
@@ -130,6 +159,46 @@ func TestClientInsertManyRawBSONCancellationWithoutDeadlineInterruptsRead(t *tes
 
 	rawDocs := []bson.Raw{mustBSON(t, bson.D{{Key: "_id", Value: "u1"}})}
 	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.InsertManyRawBSON(ctx, "app", "users", rawDocs)
+		errCh <- err
+	}()
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, err := wire.ReadMessage(serverConn, 0)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("server read request: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("InsertManyRawBSON err=%v want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("InsertManyRawBSON did not return after cancellation")
+	}
+}
+
+func TestClientInsertManyRawBSONCanceledDeadlineContextInterruptsRead(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	client := New(clientConn)
+	defer func() { _ = client.Close() }()
+
+	rawDocs := []bson.Raw{mustBSON(t, bson.D{{Key: "_id", Value: "u1"}})}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
 		_, err := client.InsertManyRawBSON(ctx, "app", "users", rawDocs)

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -129,22 +129,10 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "requires a find command document") {
 		t.Fatalf("FindRawBSONBorrowed non-find err=%v want find-command error", err)
 	}
-	borrowedEntered := make(chan struct{})
-	secondDone := make(chan error, 1)
-	go func() {
-		<-borrowedEntered
-		_, err := client.FindRawBSON(insertCtx, adaCommand)
-		secondDone <- err
-	}()
 	if err := client.FindRawBSONBorrowed(insertCtx, findCommand, func(docs []bson.Raw) error {
-		close(borrowedEntered)
-		select {
-		case err := <-secondDone:
-			if err != nil {
-				t.Fatalf("concurrent FindRawBSON: %v", err)
-			}
-			t.Fatal("concurrent FindRawBSON completed while borrowed callback was active")
-		case <-time.After(50 * time.Millisecond):
+		if client.mu.TryLock() {
+			client.mu.Unlock()
+			t.Fatal("FindRawBSONBorrowed callback ran without holding the client lock")
 		}
 		if len(docs) != 1 {
 			t.Fatalf("borrowed concurrent docs=%d want 1", len(docs))
@@ -155,14 +143,6 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("FindRawBSONBorrowed concurrent: %v", err)
-	}
-	select {
-	case err := <-secondDone:
-		if err != nil {
-			t.Fatalf("concurrent FindRawBSON after borrowed callback: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("concurrent FindRawBSON did not complete after borrowed callback")
 	}
 
 	driverClient, err := mongo.Connect(options.Client().

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -122,6 +122,41 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	if borrowedCount != 1 {
 		t.Fatalf("FindRawBSONBorrowed docs=%d want 1", borrowedCount)
 	}
+	borrowedEntered := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		<-borrowedEntered
+		_, err := client.FindRawBSON(insertCtx, adaCommand)
+		secondDone <- err
+	}()
+	if err := client.FindRawBSONBorrowed(insertCtx, findCommand, func(docs []bson.Raw) error {
+		close(borrowedEntered)
+		select {
+		case err := <-secondDone:
+			if err != nil {
+				t.Fatalf("concurrent FindRawBSON: %v", err)
+			}
+			t.Fatal("concurrent FindRawBSON completed while borrowed callback was active")
+		case <-time.After(50 * time.Millisecond):
+		}
+		if len(docs) != 1 {
+			t.Fatalf("borrowed concurrent docs=%d want 1", len(docs))
+		}
+		if got, ok := docs[0].Lookup("name").StringValueOK(); !ok || got != "grace" {
+			t.Fatalf("borrowed doc changed while callback active: name=%q ok=%t want grace", got, ok)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("FindRawBSONBorrowed concurrent: %v", err)
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("concurrent FindRawBSON after borrowed callback: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("concurrent FindRawBSON did not complete after borrowed callback")
+	}
 
 	driverClient, err := mongo.Connect(options.Client().
 		ApplyURI("mongodb://" + ln.Addr().String()).

--- a/TreeDB/mongo_gateway/fastclient/client_test.go
+++ b/TreeDB/mongo_gateway/fastclient/client_test.go
@@ -122,6 +122,12 @@ func TestClientInsertManyRawBSON(t *testing.T) {
 	if borrowedCount != 1 {
 		t.Fatalf("FindRawBSONBorrowed docs=%d want 1", borrowedCount)
 	}
+	if err := client.FindRawBSONBorrowed(insertCtx, mustBSON(t, bson.D{{Key: "ping", Value: 1}, {Key: "$db", Value: "admin"}}), func([]bson.Raw) error {
+		t.Fatal("borrowed callback should not run for non-find command")
+		return nil
+	}); err == nil || err.Error() != "FindRawBSONBorrowed requires a find command document" {
+		t.Fatalf("FindRawBSONBorrowed non-find err=%v want find-command error", err)
+	}
 	borrowedEntered := make(chan struct{})
 	secondDone := make(chan error, 1)
 	go func() {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -28,6 +28,7 @@ const (
 	defaultUpdateCoalescingBatch   = 256
 	maxUpdateCoalescingBatch       = 4096
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
+	maxRetainedWireReadBuffer      = 1 << 20
 )
 
 var errServerClosed = errors.New("mongo gateway server is closed")
@@ -181,6 +182,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 	}()
 
+	var readBuf []byte
 	for {
 		select {
 		case <-ctx.Done():
@@ -188,7 +190,9 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		default:
 		}
 
-		if err := s.ServeOneWithOwner(conn, owner); err != nil {
+		var err error
+		readBuf, err = s.serveOneWithOwner(conn, owner, readBuf)
+		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
@@ -211,24 +215,34 @@ func (s *Server) ServeOne(rw io.ReadWriter) error {
 }
 
 func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
+	_, err := s.serveOneWithOwner(rw, cursorOwner, nil)
+	return err
+}
+
+func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf []byte) ([]byte, error) {
 	if s.isClosed() {
-		return errServerClosed
+		return readBuf, errServerClosed
 	}
-	h, body, err := wire.ReadMessage(rw, s.maxMessageLength())
+	h, body, err := wire.ReadMessageInto(rw, readBuf, s.maxMessageLength())
 	if err != nil {
 		if s.isClosed() {
-			return errServerClosed
+			return readBuf, errServerClosed
 		}
-		return err
+		return readBuf, err
+	}
+	if cap(body) <= maxRetainedWireReadBuffer {
+		readBuf = body
+	} else {
+		readBuf = nil
 	}
 	response, err := s.handleMessage(h, body, cursorOwner)
 	if err != nil {
-		return err
+		return readBuf, err
 	}
 	if response == nil {
-		return nil
+		return readBuf, nil
 	}
-	return writeFull(rw, response)
+	return readBuf, writeFull(rw, response)
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -57,6 +57,7 @@ type Server struct {
 	nextResponseID   atomic.Int32
 	nextConnectionID atomic.Int64
 	nextCursorID     atomic.Int64
+	cursorCount      atomic.Int64
 	connMu           sync.Mutex
 	conns            map[net.Conn]struct{}
 	cursorMu         sync.Mutex
@@ -96,6 +97,7 @@ func (s *Server) Close() error {
 	s.closeUpdateCoalescers()
 	s.cursorMu.Lock()
 	s.cursors = nil
+	s.cursorCount.Store(0)
 	s.cursorMu.Unlock()
 	return nil
 }

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -1,6 +1,7 @@
 package mongogateway
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -30,6 +31,7 @@ const (
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
 	maxRetainedWireReadBuffer      = 1 << 20
 	maxRetainedWireWriteBuffer     = 1 << 20
+	defaultWireReadBufferSize      = 32 * 1024
 )
 
 var errServerClosed = errors.New("mongo gateway server is closed")
@@ -174,6 +176,10 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	defer conn.Close()
 	owner := s.nextConnectionID.Add(1)
 	defer s.killCursorsForOwner(owner)
+	rw := bufferedConnReadWriter{
+		reader: bufio.NewReaderSize(conn, defaultWireReadBufferSize),
+		writer: conn,
+	}
 
 	done := make(chan struct{})
 	defer close(done)
@@ -195,7 +201,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 
 		var err error
-		readBuf, writeBuf, err = s.serveOneWithOwner(conn, owner, readBuf, writeBuf)
+		readBuf, writeBuf, err = s.serveOneWithOwner(rw, owner, readBuf, writeBuf)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -206,6 +212,19 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			return err
 		}
 	}
+}
+
+type bufferedConnReadWriter struct {
+	reader *bufio.Reader
+	writer io.Writer
+}
+
+func (rw bufferedConnReadWriter) Read(p []byte) (int, error) {
+	return rw.reader.Read(p)
+}
+
+func (rw bufferedConnReadWriter) Write(p []byte) (int, error) {
+	return rw.writer.Write(p)
 }
 
 // ServeOne serves a single MongoDB wire message with a one-shot cursor owner.

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -29,6 +29,7 @@ const (
 	maxUpdateCoalescingBatch       = 4096
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
 	maxRetainedWireReadBuffer      = 1 << 20
+	maxRetainedWireWriteBuffer     = 1 << 20
 )
 
 var errServerClosed = errors.New("mongo gateway server is closed")
@@ -183,6 +184,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	}()
 
 	var readBuf []byte
+	var writeBuf []byte
 	for {
 		select {
 		case <-ctx.Done():
@@ -191,7 +193,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 
 		var err error
-		readBuf, err = s.serveOneWithOwner(conn, owner, readBuf)
+		readBuf, writeBuf, err = s.serveOneWithOwner(conn, owner, readBuf, writeBuf)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -215,46 +217,58 @@ func (s *Server) ServeOne(rw io.ReadWriter) error {
 }
 
 func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
-	_, err := s.serveOneWithOwner(rw, cursorOwner, nil)
+	_, _, err := s.serveOneWithOwner(rw, cursorOwner, nil, nil)
 	return err
 }
 
-func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf []byte) ([]byte, error) {
+func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
 	if s.isClosed() {
-		return readBuf, errServerClosed
+		return readBuf, writeBuf, errServerClosed
 	}
 	h, body, err := wire.ReadMessageInto(rw, readBuf, s.maxMessageLength())
 	if err != nil {
 		if s.isClosed() {
-			return readBuf, errServerClosed
+			return readBuf, writeBuf, errServerClosed
 		}
-		return readBuf, err
+		return readBuf, writeBuf, err
 	}
 	if cap(body) <= maxRetainedWireReadBuffer {
 		readBuf = body
 	} else {
 		readBuf = nil
 	}
-	response, err := s.handleMessage(h, body, cursorOwner)
+	response, err := s.handleMessageInto(writeBuf[:0], h, body, cursorOwner)
 	if err != nil {
-		return readBuf, err
+		return readBuf, writeBuf, err
 	}
 	if response == nil {
-		return readBuf, nil
+		return readBuf, writeBuf, nil
 	}
-	return readBuf, writeFull(rw, response)
+	if err := writeFull(rw, response); err != nil {
+		return readBuf, writeBuf, err
+	}
+	if cap(response) <= maxRetainedWireWriteBuffer {
+		writeBuf = response[:0]
+	} else {
+		writeBuf = nil
+	}
+	return readBuf, writeBuf, nil
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+	return s.handleMessageInto(nil, h, body, cursorOwner)
+}
+
+func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	if s.isClosed() {
 		return nil, errServerClosed
 	}
 	s.reapExpiredCursors()
 	switch h.OpCode {
 	case wire.OpQuery:
-		return s.handleQuery(h, body, cursorOwner)
+		return s.handleQueryInto(dst, h, body, cursorOwner)
 	case wire.OpMsg:
-		return s.handleMsg(h, body, cursorOwner)
+		return s.handleMsgInto(dst, h, body, cursorOwner)
 	case wire.OpCompressed:
 		return nil, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
 	default:
@@ -263,6 +277,10 @@ func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([
 }
 
 func (s *Server) handleQuery(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+	return s.handleQueryInto(nil, h, body, cursorOwner)
+}
+
+func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	q, err := wire.ParseQuery(body)
 	if err != nil {
 		return nil, err
@@ -276,10 +294,14 @@ func (s *Server) handleQuery(h wire.Header, body []byte, cursorOwner int64) ([]b
 	if err != nil {
 		return nil, err
 	}
-	return wire.AppendReplyMessage(nil, s.nextID(), h.RequestID, 0, 0, 0, response)
+	return wire.AppendReplyMessage(dst, s.nextID(), h.RequestID, 0, 0, 0, response)
 }
 
 func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+	return s.handleMsgInto(nil, h, body, cursorOwner)
+}
+
+func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
 		return nil, err
@@ -294,7 +316,7 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 		if msg.Flags&wire.MsgFlagMoreToCome == 0 {
 			responseID = s.nextID()
 		}
-		response, err := s.findMsgResponse(msg.Body, responseID, h.RequestID, cursorOwner)
+		response, err := s.findMsgResponseInto(dst, msg.Body, responseID, h.RequestID, cursorOwner)
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +333,7 @@ func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byt
 	if msg.Flags&wire.MsgFlagMoreToCome != 0 {
 		return nil, nil
 	}
-	return wire.AppendMsgMessage(nil, s.nextID(), h.RequestID, 0, response)
+	return wire.AppendMsgMessage(dst, s.nextID(), h.RequestID, 0, response)
 }
 
 func (s *Server) commandResponse(name string, command wire.Document, sequences []wire.DocumentSequence, cursorOwner int64) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -253,14 +253,14 @@ func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf,
 		}
 		return readBuf, writeBuf, err
 	}
-	if cap(body) <= maxRetainedWireReadBuffer {
+	response, retainRequestBody, err := s.handleMessageInto(writeBuf[:0], h, body, cursorOwner)
+	if err != nil {
+		return nil, writeBuf, err
+	}
+	if retainRequestBody && cap(body) <= maxRetainedWireReadBuffer {
 		readBuf = body
 	} else {
 		readBuf = nil
-	}
-	response, err := s.handleMessageInto(writeBuf[:0], h, body, cursorOwner)
-	if err != nil {
-		return readBuf, writeBuf, err
 	}
 	if response == nil {
 		return readBuf, writeBuf, nil
@@ -277,12 +277,13 @@ func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf,
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	return s.handleMessageInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleMessageInto(nil, h, body, cursorOwner)
+	return response, err
 }
 
-func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	if s.isClosed() {
-		return nil, errServerClosed
+		return nil, false, errServerClosed
 	}
 	s.reapExpiredCursors()
 	switch h.OpCode {
@@ -291,70 +292,75 @@ func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, curso
 	case wire.OpMsg:
 		return s.handleMsgInto(dst, h, body, cursorOwner)
 	case wire.OpCompressed:
-		return nil, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
+		return nil, false, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
 	default:
-		return nil, fmt.Errorf("%w: opcode %d", wire.ErrUnsupported, h.OpCode)
+		return nil, false, fmt.Errorf("%w: opcode %d", wire.ErrUnsupported, h.OpCode)
 	}
 }
 
 func (s *Server) handleQuery(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	return s.handleQueryInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleQueryInto(nil, h, body, cursorOwner)
+	return response, err
 }
 
-func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	q, err := wire.ParseQuery(body)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	name, err := wire.CommandNameFromValidatedDocument(q.Query)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	response, err := s.commandResponse(name, q.Query, nil, cursorOwner)
 	if err != nil {
-		return nil, err
+		return nil, name != "insert", err
 	}
-	return wire.AppendReplyMessage(dst, s.nextID(), h.RequestID, 0, 0, 0, response)
+	reply, err := wire.AppendReplyMessage(dst, s.nextID(), h.RequestID, 0, 0, 0, response)
+	return reply, name != "insert", err
 }
 
 func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	return s.handleMsgInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleMsgInto(nil, h, body, cursorOwner)
+	return response, err
 }
 
-func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	name, err := wire.CommandNameFromValidatedDocument(msg.Body)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
+	retainRequestBody := name != "insert"
 
 	if name == "find" {
 		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
-			return nil, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
+			return nil, retainRequestBody, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
 		}
 		if len(msg.Sequences) > 0 {
-			return nil, fmt.Errorf("%w: find with document sequences", wire.ErrUnsupported)
+			return nil, retainRequestBody, fmt.Errorf("%w: find with document sequences", wire.ErrUnsupported)
 		}
 		responseID := s.nextID()
 		response, err := s.findMsgResponseInto(dst, msg.Body, responseID, h.RequestID, cursorOwner)
 		if err != nil {
-			return nil, err
+			return nil, retainRequestBody, err
 		}
-		return response, nil
+		return response, retainRequestBody, nil
 	}
 
 	response, err := s.commandResponse(name, msg.Body, msg.Sequences, cursorOwner)
 	if err != nil {
-		return nil, err
+		return nil, retainRequestBody, err
 	}
 	if msg.Flags&wire.MsgFlagMoreToCome != 0 {
-		return nil, nil
+		return nil, retainRequestBody, nil
 	}
-	return wire.AppendMsgMessage(dst, s.nextID(), h.RequestID, 0, response)
+	msgResponse, err := wire.AppendMsgMessage(dst, s.nextID(), h.RequestID, 0, response)
+	return msgResponse, retainRequestBody, err
 }
 
 func (s *Server) commandResponse(name string, command wire.Document, sequences []wire.DocumentSequence, cursorOwner int64) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2760,9 +2760,7 @@ func TestServerBackgroundCursorReapIsThrottled(t *testing.T) {
 	server := NewServer()
 	server.CursorIdleTimeout = time.Nanosecond
 	server.cursorMu.Lock()
-	server.cursors = map[int64]*serverCursor{
-		1: {ns: "app.users", owner: 1, lastUsed: time.Now().Add(-time.Minute)},
-	}
+	server.addCursorLocked(1, &serverCursor{ns: "app.users", owner: 1, lastUsed: time.Now().Add(-time.Minute)})
 	server.lastCursorReap = time.Now()
 	server.cursorMu.Unlock()
 
@@ -2781,6 +2779,23 @@ func TestServerBackgroundCursorReapIsThrottled(t *testing.T) {
 	server.cursorMu.Unlock()
 	if stillPresent {
 		t.Fatal("cursor not reaped after throttle interval")
+	}
+}
+
+func TestServerBackgroundCursorReapSkipsEmptyCursorMap(t *testing.T) {
+	server := NewServer()
+	server.CursorIdleTimeout = time.Nanosecond
+	lastReap := time.Now().Add(-2 * defaultCursorReapInterval)
+	server.cursorMu.Lock()
+	server.lastCursorReap = lastReap
+	server.cursorMu.Unlock()
+
+	server.reapExpiredCursors()
+
+	server.cursorMu.Lock()
+	defer server.cursorMu.Unlock()
+	if !server.lastCursorReap.Equal(lastReap) {
+		t.Fatalf("lastCursorReap changed to %v want %v", server.lastCursorReap, lastReap)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2308,6 +2308,98 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	}
 }
 
+func TestServerPureIndexedRangeKeepsCursorWhenByteCapped(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 260, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
+				{Key: "name", Value: "age_1"}, {Key: "treedbValueType", Value: "int64"},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	docA := bson.D{{Key: "_id", Value: "a"}, {Key: "age", Value: int64(10)}, {Key: "payload", Value: strings.Repeat("a", 24)}}
+	docB := bson.D{{Key: "_id", Value: "b"}, {Key: "age", Value: int64(11)}, {Key: "payload", Value: strings.Repeat("b", 24)}}
+	docC := bson.D{{Key: "_id", Value: "c"}, {Key: "age", Value: int64(12)}, {Key: "payload", Value: strings.Repeat("c", 24)}}
+	assertOK(t, serveCommand(t, server, 261, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{docA, docB, docC}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	rawA, err := bson.Marshal(docA)
+	if err != nil {
+		t.Fatalf("marshal docA: %v", err)
+	}
+	oneDocBatchBytes := findBatchOverheadBytes + findBatchDocumentBytes(rawA, 0)
+	server.MaxMessageLength = int32(findBatchResponseReserveBytes + oneDocBatchBytes)
+	findResponse := serveCommand(t, server, 262, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(10)}}}}},
+		{Key: "limit", Value: int32(3)},
+		{Key: "batchSize", Value: int32(3)},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, findResponse)
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("_id").StringValueOK(); !ok || got != "a" {
+		t.Fatalf("firstBatch[0]._id=%q ok=%t want a", got, ok)
+	}
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id is 0 after byte-capped first batch, want retained cursor")
+	}
+
+	getMoreResponse := serveCommand(t, server, 263, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, getMoreResponse)
+	nextBatch := cursorNextBatch(t, getMoreResponse)
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	}
+	if got, ok := nextBatch[0].Lookup("_id").StringValueOK(); !ok || got != "b" {
+		t.Fatalf("nextBatch[0]._id=%q ok=%t want b", got, ok)
+	}
+	nextID := cursorIDFromResponse(t, getMoreResponse)
+	if nextID != cursorID {
+		t.Fatalf("cursor id after first getMore=%d want %d", nextID, cursorID)
+	}
+
+	finalResponse := serveCommand(t, server, 264, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, finalResponse)
+	finalBatch := cursorNextBatch(t, finalResponse)
+	if len(finalBatch) != 1 {
+		t.Fatalf("final nextBatch len=%d want 1", len(finalBatch))
+	}
+	if got, ok := finalBatch[0].Lookup("_id").StringValueOK(); !ok || got != "c" {
+		t.Fatalf("finalBatch[0]._id=%q ok=%t want c", got, ok)
+	}
+	if finalID := cursorIDFromResponse(t, finalResponse); finalID != 0 {
+		t.Fatalf("cursor id after final getMore=%d want 0", finalID)
+	}
+}
+
 func TestServerFindGetMoreAndKillCursors(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -115,6 +115,60 @@ func TestServerHandlesMsgPing(t *testing.T) {
 	assertOK(t, msg.Body)
 }
 
+func TestServerRetainsReadBufferForSafeCommands(t *testing.T) {
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 22001, 0, 0, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	server := NewServer()
+	readBuf, _, err := server.serveOneWithOwner(&readWriter{r: bytes.NewReader(req)}, 1, make([]byte, 0, len(req)), nil)
+	if err != nil {
+		t.Fatalf("serveOneWithOwner: %v", err)
+	}
+	if readBuf == nil {
+		t.Fatal("read buffer was not retained for ping")
+	}
+}
+
+func TestServerDoesNotRetainReadBufferAfterBSONInsert(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "payload", Value: strings.Repeat("x", 128)},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 22002, 0, 0, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+	readBuf, _, err := server.serveOneWithOwner(rw, 1, make([]byte, 0, len(req)), nil)
+	if err != nil {
+		t.Fatalf("serveOneWithOwner: %v", err)
+	}
+	if readBuf != nil {
+		t.Fatal("read buffer was retained after BSON insert")
+	}
+	assertOK(t, readMsgResponse(t, rw.w.Bytes(), 22002))
+}
+
 func TestServerRejectsFindWithMoreToCome(t *testing.T) {
 	commandDoc := mustDocument(t, bson.D{
 		{Key: "find", Value: "users"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2979,6 +2979,72 @@ func TestServerFindFirstBatchOverflowOpensCursor(t *testing.T) {
 	}
 }
 
+func TestServerFindIndexedRangeStreamingFirstBatchOverflowOpensCursor(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxMessageLength = 6 * 1024
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 2521, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "name", Value: "age_1"},
+			{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
+			{Key: "treedbValueType", Value: "int64"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	largeValue := strings.Repeat("x", 1400)
+	assertOK(t, serveCommand(t, server, 2522, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "a"}, {Key: "age", Value: int64(37)}, {Key: "payload", Value: largeValue}},
+			bson.D{{Key: "_id", Value: "b"}, {Key: "age", Value: int64(42)}, {Key: "payload", Value: largeValue}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 2523, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(37)}}}}},
+		{Key: "limit", Value: int32(2)},
+		{Key: "batchSize", Value: int32(2)},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("_id").StringValueOK(); !ok || got != "a" {
+		t.Fatalf("firstBatch _id=%q ok=%v want a", got, ok)
+	}
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+	getMoreResponse := serveCommand(t, server, 2524, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	nextBatch := cursorNextBatch(t, getMoreResponse)
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	}
+	if got, ok := nextBatch[0].Lookup("_id").StringValueOK(); !ok || got != "b" {
+		t.Fatalf("nextBatch _id=%q ok=%v want b", got, ok)
+	}
+	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != 0 {
+		t.Fatalf("cursor id after getMore=%d want 0", nextID)
+	}
+}
+
 func TestServerGetMoreDropsCursorOnOversizedNextDocument(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2152,6 +2152,28 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	}
 	server.MaxFindScanDocuments = oldMaxFindScanDocuments
 
+	limitedAgeRangeFind := serveCommand(t, server, 234041, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(37)}}}}},
+		{Key: "limit", Value: int32(2)},
+		{Key: "batchSize", Value: int32(2)},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, limitedAgeRangeFind)
+	firstBatch = cursorFirstBatch(t, limitedAgeRangeFind)
+	if len(firstBatch) != 2 {
+		t.Fatalf("limited indexed age range firstBatch len=%d want 2", len(firstBatch))
+	}
+	if cursorID := cursorIDFromResponse(t, limitedAgeRangeFind); cursorID != 0 {
+		t.Fatalf("limited indexed age range cursor id=%d want 0", cursorID)
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "ada" {
+		t.Fatalf("limited indexed age range first name=%q ok=%v want ada", got, ok)
+	}
+	if got, ok := firstBatch[1].Lookup("name").StringValueOK(); !ok || got != "grace" {
+		t.Fatalf("limited indexed age range second name=%q ok=%v want grace", got, ok)
+	}
+
 	wrongTypeIndexedFind := serveCommand(t, server, 2341, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "city", Value: int32(5)}}},

--- a/TreeDB/mongo_gateway/wire/message.go
+++ b/TreeDB/mongo_gateway/wire/message.go
@@ -90,6 +90,10 @@ func AppendMessage(dst []byte, requestID, responseTo int32, opCode OpCode, body 
 }
 
 func ReadMessage(r io.Reader, maxMessageLength int32) (Header, []byte, error) {
+	return ReadMessageInto(r, nil, maxMessageLength)
+}
+
+func ReadMessageInto(r io.Reader, dst []byte, maxMessageLength int32) (Header, []byte, error) {
 	if maxMessageLength <= 0 {
 		maxMessageLength = DefaultMaxMessageLength
 	}
@@ -105,11 +109,15 @@ func ReadMessage(r io.Reader, maxMessageLength int32) (Header, []byte, error) {
 		return Header{}, nil, fmt.Errorf("%w: length=%d max=%d", ErrMessageTooLarge, h.MessageLength, maxMessageLength)
 	}
 	bodyLen := int(h.MessageLength) - HeaderLen
-	body := make([]byte, bodyLen)
-	if _, err := io.ReadFull(r, body); err != nil {
+	if cap(dst) < bodyLen {
+		dst = make([]byte, bodyLen)
+	} else {
+		dst = dst[:bodyLen]
+	}
+	if _, err := io.ReadFull(r, dst); err != nil {
 		return Header{}, nil, err
 	}
-	return h, body, nil
+	return h, dst, nil
 }
 
 func ValidateDocument(doc Document) error {

--- a/TreeDB/mongo_gateway/wire/message.go
+++ b/TreeDB/mongo_gateway/wire/message.go
@@ -93,6 +93,11 @@ func ReadMessage(r io.Reader, maxMessageLength int32) (Header, []byte, error) {
 	return ReadMessageInto(r, nil, maxMessageLength)
 }
 
+// ReadMessageInto reads one wire message and uses dst as reusable storage for
+// the returned body when dst has enough capacity. Callers that pass a reusable
+// dst must treat the returned body as borrowed: it may alias dst and remains
+// valid only until dst is reused or modified. Clone the body before retaining it
+// across subsequent reads.
 func ReadMessageInto(r io.Reader, dst []byte, maxMessageLength int32) (Header, []byte, error) {
 	if maxMessageLength <= 0 {
 		maxMessageLength = DefaultMaxMessageLength

--- a/TreeDB/mongo_gateway/wire/message_test.go
+++ b/TreeDB/mongo_gateway/wire/message_test.go
@@ -39,6 +39,29 @@ func TestReadMessageRoundTrip(t *testing.T) {
 	}
 }
 
+func TestReadMessageIntoReusesBodyBuffer(t *testing.T) {
+	body := []byte{1, 2, 3, 4}
+	wireBytes, err := AppendMessage(nil, 42, 7, OpMsg, body)
+	if err != nil {
+		t.Fatalf("AppendMessage: %v", err)
+	}
+
+	reuse := make([]byte, 0, 64)
+	h, gotBody, err := ReadMessageInto(bytes.NewReader(wireBytes), reuse, 0)
+	if err != nil {
+		t.Fatalf("ReadMessageInto: %v", err)
+	}
+	if h.MessageLength != int32(HeaderLen+len(body)) {
+		t.Fatalf("message length=%d want %d", h.MessageLength, HeaderLen+len(body))
+	}
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("body=%v want %v", gotBody, body)
+	}
+	if cap(gotBody) != cap(reuse) {
+		t.Fatalf("ReadMessageInto did not reuse buffer: cap=%d want %d", cap(gotBody), cap(reuse))
+	}
+}
+
 func TestReadMessageRejectsOversized(t *testing.T) {
 	wireBytes, err := AppendMessage(nil, 1, 0, OpMsg, []byte{1, 2, 3, 4})
 	if err != nil {

--- a/TreeDB/mongo_gateway/wire/message_test.go
+++ b/TreeDB/mongo_gateway/wire/message_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"unsafe"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -46,7 +47,8 @@ func TestReadMessageIntoReusesBodyBuffer(t *testing.T) {
 		t.Fatalf("AppendMessage: %v", err)
 	}
 
-	reuse := make([]byte, 0, 64)
+	reuse := make([]byte, 1, 64)
+	reuseStart := unsafe.SliceData(reuse)
 	h, gotBody, err := ReadMessageInto(bytes.NewReader(wireBytes), reuse, 0)
 	if err != nil {
 		t.Fatalf("ReadMessageInto: %v", err)
@@ -57,8 +59,11 @@ func TestReadMessageIntoReusesBodyBuffer(t *testing.T) {
 	if !bytes.Equal(gotBody, body) {
 		t.Fatalf("body=%v want %v", gotBody, body)
 	}
-	if cap(gotBody) != cap(reuse) {
-		t.Fatalf("ReadMessageInto did not reuse buffer: cap=%d want %d", cap(gotBody), cap(reuse))
+	if len(gotBody) == 0 {
+		t.Fatalf("empty body prevents reuse assertion")
+	}
+	if unsafe.SliceData(gotBody) != reuseStart {
+		t.Fatalf("ReadMessageInto did not reuse buffer")
 	}
 }
 

--- a/TreeDB/mongo_gateway/wire/message_test.go
+++ b/TreeDB/mongo_gateway/wire/message_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"testing"
-	"unsafe"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -48,7 +47,7 @@ func TestReadMessageIntoReusesBodyBuffer(t *testing.T) {
 	}
 
 	reuse := make([]byte, 1, 64)
-	reuseStart := unsafe.SliceData(reuse)
+	reuseStart := &reuse[:cap(reuse)][0]
 	h, gotBody, err := ReadMessageInto(bytes.NewReader(wireBytes), reuse, 0)
 	if err != nil {
 		t.Fatalf("ReadMessageInto: %v", err)
@@ -62,7 +61,7 @@ func TestReadMessageIntoReusesBodyBuffer(t *testing.T) {
 	if len(gotBody) == 0 {
 		t.Fatalf("empty body prevents reuse assertion")
 	}
-	if unsafe.SliceData(gotBody) != reuseStart {
+	if &gotBody[0] != reuseStart {
 		t.Fatalf("ReadMessageInto did not reuse buffer")
 	}
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2932,12 +2932,11 @@ func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *
 		return err
 	}
 	begin := time.Now()
-	batch, err := client.FindRawBSON(ctx, commandDoc)
+	err = client.FindRawBSONBorrowed(ctx, commandDoc, func(batch []bson.Raw) error {
+		return validateRawAgeBatch(batch, minAge)
+	})
 	sample(time.Since(begin))
-	if err != nil {
-		return err
-	}
-	return validateRawAgeBatch(batch, minAge)
+	return err
 }
 
 func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection, readers int) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3149,7 +3149,7 @@ func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
 	}
 	rem = rem[:len(rem)-1]
 
-	docs := make([]bson.Raw, 0, 10)
+	docs := make([]bson.Raw, 0, rawArrayDocumentCapacityHint(len(rem)))
 	for len(rem) > 0 {
 		elem, next, ok := bsoncore.ReadElement(rem)
 		if !ok {
@@ -3167,6 +3167,22 @@ func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
 		rem = next
 	}
 	return docs, nil
+}
+
+func rawArrayDocumentCapacityHint(payloadBytes int) int {
+	if payloadBytes <= 0 {
+		return 0
+	}
+	const minElementOverhead = 8
+	const maxInitialCapacity = 1024
+	hint := payloadBytes / minElementOverhead
+	if hint < 1 {
+		return 1
+	}
+	if hint > maxInitialCapacity {
+		return maxInitialCapacity
+	}
+	return hint
 }
 
 func rawCommandOK(raw bson.Raw) bool {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2948,10 +2948,15 @@ func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *
 		return err
 	}
 	begin := time.Now()
+	sampled := false
 	err = client.FindRawBSONBorrowed(ctx, commandDoc, func(batch []bson.Raw) error {
+		sample(time.Since(begin))
+		sampled = true
 		return validateRawAgeBatch(batch, minAge)
 	})
-	sample(time.Since(begin))
+	if !sampled {
+		sample(time.Since(begin))
+	}
 	return err
 }
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3061,17 +3061,36 @@ func parseFindFirstBatch(raw bson.Raw) ([]bson.Raw, error) {
 	if !ok {
 		return nil, errors.New("find response missing cursor.firstBatch")
 	}
-	values, err := batch.Values()
-	if err != nil {
-		return nil, err
+	return rawDocumentsFromArray(batch)
+}
+
+func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
+	length, rem, ok := bsoncore.ReadLength(bsoncore.Array(batch))
+	if !ok || length < 5 || int(length) > len(batch) {
+		return nil, errors.New("malformed find cursor.firstBatch")
 	}
-	docs := make([]bson.Raw, 0, len(values))
-	for _, value := range values {
+	rem = rem[:int(length)-4]
+	if len(rem) == 0 || rem[len(rem)-1] != 0x00 {
+		return nil, errors.New("malformed find cursor.firstBatch")
+	}
+	rem = rem[:len(rem)-1]
+
+	docs := make([]bson.Raw, 0, 10)
+	for len(rem) > 0 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return nil, errors.New("malformed find cursor.firstBatch")
+		}
+		value, err := elem.ValueErr()
+		if err != nil {
+			return nil, err
+		}
 		doc, ok := value.DocumentOK()
 		if !ok {
 			return nil, errors.New("find firstBatch entry is not a document")
 		}
 		docs = append(docs, bson.Raw(doc))
+		rem = next
 	}
 	return docs, nil
 }


### PR DESCRIPTION
## Summary

Reduces raw-wire range overhead across the fastclient and mongo gateway server path.

This PR now covers four related pieces:

- fastclient request/response overhead: reuse response buffers, keep borrowed BSON callbacks under the client lock, and preserve cancellation correctness for timed and untimed contexts.
- server connection overhead: reuse read buffers and response construction buffers in the gateway connection loop.
- indexed range response construction: build raw cursor responses directly and preserve cursors when byte caps truncate a first batch.
- benchmark safety: keep the raw BSON fast path scoped to borrowed/retained lifetimes with regression coverage.

## Why

The raw-wire TCP indexed range profile is dominated by socket syscalls, scheduler wakeups, and response construction. The single original fastclient cancellation-watch optimization was too narrow by itself; the useful win comes from reducing avoidable per-request work on both sides of the raw-wire path while preserving cursor and cancellation correctness.

## Validation

```bash
go test ./TreeDB/mongo_gateway ./TreeDB/mongo_gateway/fastclient ./cmd/mongo_gateway_bench
```

Review-fix validation also covered:

```bash
go test ./TreeDB/collections ./TreeDB/mongo_gateway ./TreeDB/mongo_gateway/fastclient ./cmd/mongo_gateway_bench ./cmd/collection_workload_bench
```

## Benchmark

Final stacked-head smoke after review fixes, TreeDB target, BSON collection storage, settled reads, indexed `age >= minAge limit 10`:

| Mode | ops/sec | ns/op | wall ops/sec |
|---|---:|---:|---:|
| raw-wire | 109,383 | 9,142 | 101,565 |
| raw-wire-tcp-pipeline depth 128 | 94,676 | 10,562 | 94,604 |

Artifact: `/tmp/mongo_range_stack_final_20260507_093649`

Skeptical read: the remaining raw-wire TCP gap is still mostly kernel read/write and scheduler wakeups. This PR reduces avoidable allocation/copy/client-lock overhead, but it does not eliminate request/response socket cost.