### PR TITLE
mongo bench: add official driver raw find range mode

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11556,14 +11556,46 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 		defer func() { _ = persistedIt.Close() }()
 	}
 	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	var primaryReader backenddb.SnapshotRootReader
+	primaryReaderOK := false
+	primaryRootMissing := false
+	if len(catalog.overlayRootIDs(primaryRootName)) == 0 {
+		primaryRootID := catalog.rootID(primaryRootName)
+		if primaryRootID == 0 {
+			primaryRootMissing = true
+		} else {
+			primaryReader, err = snap.ReaderAtRoot(primaryRootID)
+			if errors.Is(err, tree.ErrKeyNotFound) {
+				primaryRootMissing = true
+			} else if err != nil {
+				return false, true, err
+			} else {
+				primaryReaderOK = true
+			}
+		}
+	}
 	var scratch []byte
 	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
 		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
 		if !buffered {
-			var err error
-			value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
-			if err != nil {
-				return false, err
+			if primaryReaderOK {
+				var err error
+				value, err = primaryReader.GetAppend(id, scratch[:0])
+				if errors.Is(err, tree.ErrKeyNotFound) {
+					found = false
+				} else if err != nil {
+					return false, err
+				} else {
+					found = true
+				}
+			} else if primaryRootMissing {
+				found = false
+			} else {
+				var err error
+				value, found, err = collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, id, scratch[:0])
+				if err != nil {
+					return false, err
+				}
 			}
 		}
 		if !found {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2157,7 +2157,9 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: m.writeDomainForCollection(catalog.meta.Name),
-		meta:        copyCollectionMeta(catalog.meta),
+		// Collection catalogs are immutable once loaded; public Meta returns a
+		// defensive copy, so handles can keep the catalog meta value directly.
+		meta: catalog.meta,
 	}
 	if collection.writeDomain == nil {
 		return nil, backenddb.ErrClosed
@@ -2192,7 +2194,9 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: domain,
-		meta:        copyCollectionMeta(catalog.meta),
+		// Collection catalogs are immutable once loaded; public Meta returns a
+		// defensive copy, so handles can keep the catalog meta value directly.
+		meta: catalog.meta,
 	}
 	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
 	return collection, true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11570,9 +11570,7 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 			primaryRootMissing = true
 		} else {
 			primaryReader, err = snap.ReaderAtRoot(primaryRootID)
-			if errors.Is(err, tree.ErrKeyNotFound) {
-				primaryRootMissing = true
-			} else if err != nil {
+			if err != nil {
 				return false, true, err
 			} else {
 				primaryReaderOK = true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11536,6 +11536,11 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 	if err != nil {
 		return false, true, err
 	}
+	// Match the buffered-primary visibility decision to the same domain snapshot
+	// used to materialize buffered secondary index entries above. Settled scans
+	// skip per-result domain probes; concurrent later writes are not mixed into
+	// an already-started persisted index scan.
+	bufferedDocumentsVisible := domain != nil && domain.count > 0
 	if domainLocked {
 		domain.mu.RUnlock()
 		domainLocked = false
@@ -11576,7 +11581,12 @@ func (c *Collection) scanDocumentsByIndexRange(indexName string, opts IndexRange
 	}
 	var scratch []byte
 	truncated, err := scanMergedCollectionIndexIDsBorrowed(bufferedIt, persistedIt, idx.ValueType, opts.Limit, func(id []byte) (bool, error) {
-		value, buffered, found := c.getBufferedDocumentInto(id, scratch[:0])
+		var value []byte
+		buffered := false
+		found := false
+		if bufferedDocumentsVisible {
+			value, buffered, found = c.getBufferedDocumentInto(id, scratch[:0])
+		}
 		if !buffered {
 			if primaryReaderOK {
 				var err error

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -91,6 +91,41 @@ func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
 	}
 }
 
+func TestCollectionMetaReturnsDefensiveIndexCopyAcrossHandles(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left collection: %v", err)
+	}
+	right, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right collection: %v", err)
+	}
+
+	meta := left.Meta()
+	meta.Indexes[0].Name = "mutated"
+	if got := left.Meta().Indexes[0].Name; got != "email" {
+		t.Fatalf("left Meta leaked mutation: got index %q want email", got)
+	}
+	if got := right.Meta().Indexes[0].Name; got != "email" {
+		t.Fatalf("right Meta leaked mutation: got index %q want email", got)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1630,7 +1630,13 @@ func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, single
 }
 
 func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int, maxMessageLength int) ([]byte, error) {
+	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
+		maxMessageLength = int(server.maxMessageLength())
+	}
 	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
+	if need > maxMessageLength {
+		return dst, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, need, maxMessageLength)
+	}
 	dst = ensureWireAppendCapacity(dst, need)
 	msg := dst
 	base := len(msg)
@@ -1659,9 +1665,6 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	messageLength := len(msg) - base
 	if int64(messageLength) > maxWireMessageLengthInt32Limit {
 		return msg[:base], fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
-	}
-	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
-		maxMessageLength = int(server.maxMessageLength())
 	}
 	if messageLength > maxMessageLength {
 		return msg[:base], fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -165,13 +165,14 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 	if err != nil {
 		return nil, err
 	}
+	base := len(dst)
 	msg, err := payload.marshalMsgInto(dst, requestID, responseTo)
 	if err != nil && payload.indexedRange != nil {
 		doc, docErr := commandError(commandCodeBadValue, "BadValue", err.Error())
 		if docErr != nil {
 			return nil, docErr
 		}
-		return wire.AppendMsgMessage(dst[:0], requestID, responseTo, 0, doc)
+		return wire.AppendMsgMessage(dst[:base], requestID, responseTo, 0, doc)
 	}
 	return msg, err
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -114,20 +114,30 @@ type rawCursorDocumentsResponse struct {
 	batch    []wire.Document
 }
 
+type findResponsePayloadKind uint8
+
+const (
+	findResponsePayloadDocument findResponsePayloadKind = iota
+	findResponsePayloadRaw
+	findResponsePayloadIndexedRange
+)
+
 type findResponsePayload struct {
+	kind         findResponsePayloadKind
 	document     wire.Document
-	raw          *rawCursorDocumentsResponse
-	indexedRange *indexedRangeCursorResponse
+	raw          rawCursorDocumentsResponse
+	indexedRange indexedRangeCursorResponse
 }
 
 func (p findResponsePayload) marshalDocument() (wire.Document, error) {
-	if p.raw != nil {
+	switch p.kind {
+	case findResponsePayloadRaw:
 		return marshalCursorDocumentsResponseWithID(p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
-	}
-	if p.indexedRange != nil {
+	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalDocument()
+	default:
+		return p.document, nil
 	}
-	return p.document, nil
 }
 
 func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, error) {
@@ -135,13 +145,14 @@ func (p findResponsePayload) marshalMsg(requestID, responseTo int32) ([]byte, er
 }
 
 func (p findResponsePayload) marshalMsgInto(dst []byte, requestID, responseTo int32) ([]byte, error) {
-	if p.raw != nil {
+	switch p.kind {
+	case findResponsePayloadRaw:
 		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
-	}
-	if p.indexedRange != nil {
+	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalMsgInto(dst, requestID, responseTo)
+	default:
+		return wire.AppendMsgMessage(dst, requestID, responseTo, 0, p.document)
 	}
-	return wire.AppendMsgMessage(dst, requestID, responseTo, 0, p.document)
 }
 
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
@@ -150,7 +161,7 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 		return nil, err
 	}
 	doc, err := payload.marshalDocument()
-	if err != nil && payload.indexedRange != nil {
+	if err != nil && payload.kind == findResponsePayloadIndexedRange {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	return doc, err
@@ -167,7 +178,7 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 	}
 	base := len(dst)
 	msg, err := payload.marshalMsgInto(dst, requestID, responseTo)
-	if err != nil && payload.indexedRange != nil {
+	if err != nil && payload.kind == findResponsePayloadIndexedRange {
 		doc, docErr := commandError(commandCodeBadValue, "BadValue", err.Error())
 		if docErr != nil {
 			return nil, docErr
@@ -240,21 +251,27 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 				return findResponsePayload{document: doc}, err
 			}
 			if empty || limit == 0 {
-				return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"}}, nil
+				return findResponsePayload{
+					kind: findResponsePayloadRaw,
+					raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"},
+				}, nil
 			}
 			if normalizedBatchSize >= limit {
 				opts.Limit = limit
-				return findResponsePayload{indexedRange: &indexedRangeCursorResponse{
-					col:           col,
-					server:        s,
-					ns:            ns,
-					indexName:     idx.Name,
-					opts:          opts,
-					batchKey:      "firstBatch",
-					maxBatchBytes: s.maxFindBatchBytes(),
-					cursorOwner:   cursorOwner,
-					singleBatch:   singleBatch,
-				}}, nil
+				return findResponsePayload{
+					kind: findResponsePayloadIndexedRange,
+					indexedRange: indexedRangeCursorResponse{
+						col:           col,
+						server:        s,
+						ns:            ns,
+						indexName:     idx.Name,
+						opts:          opts,
+						batchKey:      "firstBatch",
+						maxBatchBytes: s.maxFindBatchBytes(),
+						cursorOwner:   cursorOwner,
+						singleBatch:   singleBatch,
+					},
+				}, nil
 			}
 		}
 	}
@@ -275,7 +292,10 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 				return findResponsePayload{document: doc}, err
 			}
-			return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs[:consumed]}}, nil
+			return findResponsePayload{
+				kind: findResponsePayloadRaw,
+				raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs[:consumed]},
+			}, nil
 		}
 		firstBatch, _, err := documentsBatchWithLimit(results.docs, results.projection, normalizedBatchSize, s.maxFindBatchBytes())
 		if err != nil {
@@ -297,7 +317,10 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 			return findResponsePayload{document: doc}, err
 		}
 		if consumed >= len(results.docs) {
-			return findResponsePayload{raw: &rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs}}, nil
+			return findResponsePayload{
+				kind: findResponsePayloadRaw,
+				raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: results.docs},
+			}, nil
 		}
 	}
 	cursorID, firstBatch, err := s.openCursor(ns, results.docs, results.projection, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -137,7 +137,7 @@ func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalDocument()
 	default:
-		return p.document, nil
+		return p.documentPayload()
 	}
 }
 
@@ -156,6 +156,9 @@ func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, 
 	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalMsgIntoWithMaxLength(dst, requestID, responseTo, maxMessageLength)
 	default:
+		if _, err := p.documentPayload(); err != nil {
+			return dst, err
+		}
 		if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
 			maxMessageLength = wire.DefaultMaxMessageLength
 		}
@@ -170,6 +173,17 @@ func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, 
 		}
 		return msg, nil
 	}
+}
+
+func (p findResponsePayload) documentPayload() (wire.Document, error) {
+	if p.document == nil {
+		return nil, errors.New("mongo gateway: find response payload missing document")
+	}
+	if p.raw.ns != "" || p.raw.batchKey != "" || p.raw.batch != nil ||
+		p.indexedRange.col != nil || p.indexedRange.server != nil || p.indexedRange.ns != "" || p.indexedRange.indexName != "" {
+		return nil, errors.New("mongo gateway: find response payload kind mismatch")
+	}
+	return p.document, nil
 }
 
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -165,7 +165,7 @@ func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, 
 		base := len(dst)
 		msg, err := wire.AppendMsgMessage(dst, requestID, responseTo, 0, p.document)
 		if err != nil {
-			return msg, err
+			return dst[:base], err
 		}
 		messageLength := len(msg) - base
 		if messageLength > maxMessageLength {
@@ -179,12 +179,19 @@ func (p findResponsePayload) documentPayload() (wire.Document, error) {
 	if p.document == nil {
 		return nil, errors.New("mongo gateway: find response payload missing document")
 	}
-	if p.raw.ns != "" || p.raw.batchKey != "" || p.raw.batch != nil ||
-		p.indexedRange.col != nil || p.indexedRange.server != nil || p.indexedRange.ns != "" || p.indexedRange.indexName != "" {
-		return nil, fmt.Errorf("mongo gateway: find response payload kind mismatch: kind=%d raw.ns=%q raw.batchKey=%q raw.batch=%t indexedRange.ns=%q indexedRange.indexName=%q indexedRange.col=%t indexedRange.server=%t",
-			p.kind, p.raw.ns, p.raw.batchKey, p.raw.batch != nil, p.indexedRange.ns, p.indexedRange.indexName, p.indexedRange.col != nil, p.indexedRange.server != nil)
+	if p.raw.ns != "" || p.raw.cursorID != 0 || p.raw.batchKey != "" || p.raw.batch != nil ||
+		p.indexedRange.col != nil || p.indexedRange.server != nil || p.indexedRange.ns != "" ||
+		p.indexedRange.indexName != "" || p.indexedRange.batchKey != "" || p.indexedRange.maxBatchBytes != 0 ||
+		p.indexedRange.cursorOwner != 0 || p.indexedRange.singleBatch || !zeroIndexRangeOptions(p.indexedRange.opts) {
+		return nil, fmt.Errorf("mongo gateway: find response payload kind mismatch: kind=%d raw.ns=%q raw.cursorID=%d raw.batchKey=%q raw.batch=%t indexedRange.ns=%q indexedRange.indexName=%q indexedRange.batchKey=%q indexedRange.maxBatchBytes=%d indexedRange.cursorOwner=%d indexedRange.singleBatch=%t indexedRange.optsSet=%t indexedRange.col=%t indexedRange.server=%t",
+			p.kind, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch != nil, p.indexedRange.ns, p.indexedRange.indexName, p.indexedRange.batchKey, p.indexedRange.maxBatchBytes, p.indexedRange.cursorOwner, p.indexedRange.singleBatch, !zeroIndexRangeOptions(p.indexedRange.opts), p.indexedRange.col != nil, p.indexedRange.server != nil)
 	}
 	return p.document, nil
+}
+
+func zeroIndexRangeOptions(opts collections.IndexRangeOptions) bool {
+	return opts.Limit == 0 && !opts.Desc && opts.Lower.Value == nil && !opts.Lower.Inclusive && !opts.Lower.Unbounded &&
+		opts.Upper.Value == nil && !opts.Upper.Inclusive && !opts.Upper.Unbounded
 }
 
 func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1507,7 +1507,13 @@ func marshalCursorDocumentsMsgResponseWithIDInto(dst []byte, requestID, response
 	for i, doc := range batch {
 		batchBytes += findBatchDocumentBytes(doc, i)
 	}
-	need := 16 + 5 + len(ns) + batchBytes + 96
+	need := cursorDocumentsMsgResponseLength(ns, batchKey, batchBytes)
+	if int64(need) > maxWireMessageLengthInt32Limit {
+		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, need)
+	}
+	if need > maxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, need, maxMessageLength)
+	}
 	dst = ensureWireAppendCapacity(dst, need)
 	msg := dst
 	base := len(msg)
@@ -1633,9 +1639,15 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
 		maxMessageLength = int(server.maxMessageLength())
 	}
+	if maxBatchLimit := maxMessageLength - findBatchResponseReserveBytes; maxBatchLimit < maxBatchBytes {
+		if maxBatchLimit < 0 {
+			maxBatchLimit = 0
+		}
+		maxBatchBytes = maxBatchLimit
+	}
 	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
 	if need > maxMessageLength {
-		return dst, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, need, maxMessageLength)
+		need = maxMessageLength
 	}
 	dst = ensureWireAppendCapacity(dst, need)
 	msg := dst
@@ -1671,6 +1683,14 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	}
 	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
 	return msg, nil
+}
+
+func cursorDocumentsMsgResponseLength(ns, batchKey string, batchBytes int) int {
+	const (
+		messageHeaderAndMsgBodyBytes = wire.HeaderLen + 5
+		responseDocumentFixedBytes   = 53
+	)
+	return messageHeaderAndMsgBodyBytes + responseDocumentFixedBytes + len(ns) + len(batchKey) + batchBytes
 }
 
 func collectIndexedRangeCursorDocs(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, indexName string, opts collections.IndexRangeOptions, builder *rawCursorDocumentBuilder, singleBatch bool) ([]wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1464,11 +1464,7 @@ func marshalCursorDocumentsMsgResponseWithIDInto(dst []byte, requestID, response
 		batchBytes += findBatchDocumentBytes(doc, i)
 	}
 	need := 16 + 5 + len(ns) + batchBytes + 96
-	if cap(dst)-len(dst) < need {
-		grown := make([]byte, len(dst), len(dst)+need)
-		copy(grown, dst)
-		dst = grown
-	}
+	dst = ensureWireAppendCapacity(dst, need)
 	msg := dst
 	base := len(msg)
 	msg = appendWireInt32(msg, 0)
@@ -1559,11 +1555,7 @@ func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, single
 
 func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) ([]byte, error) {
 	need := wire.HeaderLen + 5 + rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)
-	if cap(dst)-len(dst) < need {
-		grown := make([]byte, len(dst), len(dst)+need)
-		copy(grown, dst)
-		dst = grown
-	}
+	dst = ensureWireAppendCapacity(dst, need)
 	msg := dst
 	base := len(msg)
 	msg = appendWireInt32(msg, 0)
@@ -1708,6 +1700,23 @@ func appendWireInt32(dst []byte, v int32) []byte {
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], uint32(v))
 	return append(dst, buf[:]...)
+}
+
+func ensureWireAppendCapacity(dst []byte, need int) []byte {
+	if need <= 0 || cap(dst)-len(dst) >= need {
+		return dst
+	}
+	minCap := len(dst) + need
+	newCap := cap(dst) * 2
+	if newCap < minCap {
+		newCap = minCap
+	}
+	if minCap <= maxRetainedWireWriteBuffer && newCap > maxRetainedWireWriteBuffer {
+		newCap = maxRetainedWireWriteBuffer
+	}
+	grown := make([]byte, len(dst), newCap)
+	copy(grown, dst)
+	return grown
 }
 
 func bsonArrayIndexKey(index int) string {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -181,7 +181,8 @@ func (p findResponsePayload) documentPayload() (wire.Document, error) {
 	}
 	if p.raw.ns != "" || p.raw.batchKey != "" || p.raw.batch != nil ||
 		p.indexedRange.col != nil || p.indexedRange.server != nil || p.indexedRange.ns != "" || p.indexedRange.indexName != "" {
-		return nil, errors.New("mongo gateway: find response payload kind mismatch")
+		return nil, fmt.Errorf("mongo gateway: find response payload kind mismatch: kind=%d raw.ns=%q raw.batchKey=%q raw.batch=%t indexedRange.ns=%q indexedRange.indexName=%q indexedRange.col=%t indexedRange.server=%t",
+			p.kind, p.raw.ns, p.raw.batchKey, p.raw.batch != nil, p.indexedRange.ns, p.indexedRange.indexName, p.indexedRange.col != nil, p.indexedRange.server != nil)
 	}
 	return p.document, nil
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1516,7 +1516,7 @@ func (r *indexedRangeCursorResponse) marshalMsgInto(dst []byte, requestID, respo
 
 func marshalIndexedRangeCursorDocument(server *Server, cursorOwner int64, singleBatch bool, col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, ns, indexName string, opts collections.IndexRangeOptions, batchKey string, maxBatchBytes int) (wire.Document, error) {
 	builder := newRawCursorDocumentBuilder(make([]byte, 0, rawCursorResponseCapacityHint(ns, opts.Limit, maxBatchBytes)), ns, batchKey, maxBatchBytes)
-	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, builder, singleBatch)
+	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, &builder, singleBatch)
 	if err != nil {
 		return nil, err
 	}
@@ -1550,7 +1550,7 @@ func marshalIndexedRangeCursorMsgInto(dst []byte, requestID, responseTo int32, s
 	msg = appendWireInt32(msg, 0)
 	msg = append(msg, wire.MsgSectionBody)
 	builder := newRawCursorDocumentBuilder(msg, ns, batchKey, maxBatchBytes)
-	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, builder, singleBatch)
+	retainedDocs, err := collectIndexedRangeCursorDocs(col, materializer, indexName, opts, &builder, singleBatch)
 	if err != nil {
 		return nil, err
 	}
@@ -1610,14 +1610,14 @@ type rawCursorDocumentBuilder struct {
 	maxBatchBytes int
 }
 
-func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes int) *rawCursorDocumentBuilder {
+func newRawCursorDocumentBuilder(dst []byte, ns, batchKey string, maxBatchBytes int) rawCursorDocumentBuilder {
 	docIdx, dst := bsoncore.AppendDocumentStart(dst)
 	cursorIdx, dst := bsoncore.AppendDocumentElementStart(dst, "cursor")
 	cursorIDIdx := len(dst) + 1 + len("id") + 1
 	dst = bsoncore.AppendInt64Element(dst, "id", 0)
 	dst = bsoncore.AppendStringElement(dst, "ns", ns)
 	batchIdx, dst := bsoncore.AppendArrayElementStart(dst, batchKey)
-	return &rawCursorDocumentBuilder{
+	return rawCursorDocumentBuilder{
 		buf:           dst,
 		docIdx:        docIdx,
 		cursorIdx:     cursorIdx,

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -2,6 +2,7 @@ package mongogateway
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -435,7 +436,7 @@ func bufferedMessageCommandName(op wire.OpCode, body []byte) (string, bool) {
 					return "", false
 				}
 				size := int(int32(binary.LittleEndian.Uint32(rem[:4])))
-				if size < 4 || size > len(rem) {
+				if size <= 4 || size > len(rem) || bytes.IndexByte(rem[4:size], 0) < 0 {
 					return "", false
 				}
 				rem = rem[size:]
@@ -546,6 +547,9 @@ func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwn
 	retainRequestBody := name != "insert"
 
 	if name == "find" {
+		// The find path builds a raw OP_MSG response directly, so reject OP_MSG
+		// features it does not preserve. Other commands go through
+		// commandResponse with parsed document sequences.
 		if msg.Flags&wire.MsgFlagMoreToCome != 0 {
 			return nil, retainRequestBody, fmt.Errorf("%w: find with moreToCome flag", wire.ErrUnsupported)
 		}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -216,6 +216,14 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			var appended bool
 			writeBuf, appended, err = s.appendBufferedMessageWithOwner(rw.reader, owner, writeBuf)
 			if err != nil {
+				if len(writeBuf) > 0 {
+					if flushErr := writeFull(rw, writeBuf); flushErr != nil {
+						if ctx.Err() != nil && (errors.Is(flushErr, net.ErrClosed) || errors.Is(flushErr, io.ErrClosedPipe)) {
+							return ctx.Err()
+						}
+						return flushErr
+					}
+				}
 				return err
 			}
 			if !appended {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -409,7 +409,12 @@ func bufferedMessageCanRetainRequestBody(h wire.Header, body []byte) bool {
 	if !ok {
 		return false
 	}
-	return name != "insert"
+	switch name {
+	case "find", "getMore", "hello", "isMaster", "ismaster", "killCursors", "listCollections", "listIndexes", "ping":
+		return true
+	default:
+		return false
+	}
 }
 
 func bufferedMessageCommandName(op wire.OpCode, body []byte) (string, bool) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -242,6 +242,29 @@ func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
 	return err
 }
 
+// ServeBuffers holds reusable per-connection buffers for callers that dispatch
+// individual wire messages without using ServeConn.
+//
+// ServeBuffers is not safe for concurrent use. Use one instance per logical
+// connection/worker.
+type ServeBuffers struct {
+	readBuf  []byte
+	writeBuf []byte
+}
+
+// ServeOneWithOwnerBuffered serves one MongoDB wire message with caller-owned
+// reusable buffers. It is intended for in-process dispatchers and benchmarks
+// that need the same buffer reuse behavior as ServeConn.
+func (s *Server) ServeOneWithOwnerBuffered(rw io.ReadWriter, cursorOwner int64, buffers *ServeBuffers) error {
+	if buffers == nil {
+		return s.ServeOneWithOwner(rw, cursorOwner)
+	}
+	readBuf, writeBuf, err := s.serveOneWithOwner(rw, cursorOwner, buffers.readBuf, buffers.writeBuf)
+	buffers.readBuf = readBuf
+	buffers.writeBuf = writeBuf
+	return err
+}
+
 func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
 	if s.isClosed() {
 		return readBuf, writeBuf, errServerClosed

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -340,12 +340,7 @@ func (s *Server) appendOneWithOwner(rw io.Reader, cursorOwner int64, readBuf, wr
 	if response == nil {
 		return readBuf, writeBuf, nil
 	}
-	if cap(response) <= maxRetainedWireWriteBuffer {
-		writeBuf = response
-	} else {
-		writeBuf = response
-	}
-	return readBuf, writeBuf, nil
+	return readBuf, response, nil
 }
 
 func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwner int64, writeBuf []byte) ([]byte, bool, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -358,6 +358,9 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 	if err != nil {
 		return writeBuf, false, err
 	}
+	if h.MessageLength < wire.HeaderLen {
+		return writeBuf, false, fmt.Errorf("%w: message length %d below header length", wire.ErrMalformed, h.MessageLength)
+	}
 	if h.MessageLength > s.maxMessageLength() {
 		return writeBuf, false, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, h.MessageLength, s.maxMessageLength())
 	}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -225,6 +225,9 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 						return flushErr
 					}
 				}
+				if ctxErr := serveConnContextError(ctx, err); ctxErr != nil {
+					return ctxErr
+				}
 				return err
 			}
 			if !appended {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -3,6 +3,7 @@ package mongogateway
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -378,7 +379,11 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 		}
 		return writeBuf, false, err
 	}
-	response, err := s.handleMessageInto(writeBuf, h, message[wire.HeaderLen:messageLength], cursorOwner)
+	body := message[wire.HeaderLen:messageLength]
+	if !bufferedMessageCanRetainRequestBody(h, body) {
+		body = append([]byte(nil), body...)
+	}
+	response, _, err := s.handleMessageInto(writeBuf, h, body, cursorOwner)
 	if err != nil {
 		return writeBuf, false, err
 	}
@@ -394,6 +399,86 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	response, _, err := s.handleMessageInto(nil, h, body, cursorOwner)
 	return response, err
+}
+
+func bufferedMessageCanRetainRequestBody(h wire.Header, body []byte) bool {
+	name, ok := bufferedMessageCommandName(h.OpCode, body)
+	if !ok {
+		return false
+	}
+	return name != "insert"
+}
+
+func bufferedMessageCommandName(op wire.OpCode, body []byte) (string, bool) {
+	switch op {
+	case wire.OpMsg:
+		if len(body) < 5 {
+			return "", false
+		}
+		rem := body[4:]
+		for len(rem) > 0 {
+			kind := rem[0]
+			rem = rem[1:]
+			switch kind {
+			case wire.MsgSectionBody:
+				return bsonDocumentCommandName(rem)
+			case wire.MsgSectionDocumentSequence:
+				if len(rem) < 4 {
+					return "", false
+				}
+				size := int(int32(binary.LittleEndian.Uint32(rem[:4])))
+				if size < 4 || size > len(rem) {
+					return "", false
+				}
+				rem = rem[size:]
+			default:
+				return "", false
+			}
+		}
+		return "", false
+	case wire.OpQuery:
+		if len(body) < 4 {
+			return "", false
+		}
+		rem := body[4:]
+		i := 0
+		for i < len(rem) && rem[i] != 0 {
+			i++
+		}
+		if i == len(rem) {
+			return "", false
+		}
+		rem = rem[i+1:]
+		if len(rem) < 8 {
+			return "", false
+		}
+		return bsonDocumentCommandName(rem[8:])
+	default:
+		return "", false
+	}
+}
+
+func bsonDocumentCommandName(doc []byte) (string, bool) {
+	if len(doc) < 5 {
+		return "", false
+	}
+	size := int(int32(binary.LittleEndian.Uint32(doc[:4])))
+	if size < 5 || size > len(doc) || doc[size-1] != 0 {
+		return "", false
+	}
+	if size == 5 || doc[4] == 0 {
+		return "", false
+	}
+	key := doc[5:size]
+	for i, b := range key {
+		if b == 0 {
+			if i == 0 {
+				return "", false
+			}
+			return string(key[:i]), true
+		}
+	}
+	return "", false
 }
 
 func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -385,7 +385,7 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 	}
 	body := message[wire.HeaderLen:messageLength]
 	if !bufferedMessageCanRetainRequestBody(h, body) {
-		body = append([]byte(nil), body...)
+		return writeBuf, false, nil
 	}
 	response, _, err := s.handleMessageInto(writeBuf, h, body, cursorOwner)
 	if err != nil {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -207,8 +207,8 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
-				return ctx.Err()
+			if ctxErr := serveConnContextError(ctx, err); ctxErr != nil {
+				return ctxErr
 			}
 			return err
 		}
@@ -218,8 +218,8 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			if err != nil {
 				if len(writeBuf) > 0 {
 					if flushErr := writeFull(rw, writeBuf); flushErr != nil {
-						if ctx.Err() != nil && (errors.Is(flushErr, net.ErrClosed) || errors.Is(flushErr, io.ErrClosedPipe)) {
-							return ctx.Err()
+						if ctxErr := serveConnContextError(ctx, flushErr); ctxErr != nil {
+							return ctxErr
 						}
 						return flushErr
 					}
@@ -234,8 +234,8 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			continue
 		}
 		if err := writeFull(rw, writeBuf); err != nil {
-			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
-				return ctx.Err()
+			if ctxErr := serveConnContextError(ctx, err); ctxErr != nil {
+				return ctxErr
 			}
 			return err
 		}
@@ -531,6 +531,24 @@ func writeFull(w io.Writer, p []byte) error {
 			return io.ErrShortWrite
 		}
 		p = p[n:]
+	}
+	return nil
+}
+
+func serveConnContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		return nil
+	}
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+		return ctxErr
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return ctxErr
 	}
 	return nil
 }

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -32,6 +32,7 @@ const (
 	maxRetainedWireReadBuffer      = 1 << 20
 	maxRetainedWireWriteBuffer     = 1 << 20
 	defaultWireReadBufferSize      = 32 * 1024
+	maxCoalescedWireResponses      = 64
 )
 
 var errServerClosed = errors.New("mongo gateway server is closed")
@@ -201,7 +202,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 
 		var err error
-		readBuf, writeBuf, err = s.serveOneWithOwner(rw, owner, readBuf, writeBuf)
+		readBuf, writeBuf, err = s.appendOneWithOwner(rw, owner, readBuf, writeBuf[:0])
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -210,6 +211,30 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 				return ctx.Err()
 			}
 			return err
+		}
+		for coalesced := 1; coalesced < maxCoalescedWireResponses && len(writeBuf) < maxRetainedWireWriteBuffer; coalesced++ {
+			var appended bool
+			writeBuf, appended, err = s.appendBufferedMessageWithOwner(rw.reader, owner, writeBuf)
+			if err != nil {
+				return err
+			}
+			if !appended {
+				break
+			}
+		}
+		if len(writeBuf) == 0 {
+			continue
+		}
+		if err := writeFull(rw, writeBuf); err != nil {
+			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
+				return ctx.Err()
+			}
+			return err
+		}
+		if cap(writeBuf) <= maxRetainedWireWriteBuffer {
+			writeBuf = writeBuf[:0]
+		} else {
+			writeBuf = nil
 		}
 	}
 }
@@ -266,6 +291,25 @@ func (s *Server) ServeOneWithOwnerBuffered(rw io.ReadWriter, cursorOwner int64, 
 }
 
 func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
+	readBuf, writeBuf, err := s.appendOneWithOwner(rw, cursorOwner, readBuf, writeBuf[:0])
+	if err != nil {
+		return readBuf, writeBuf, err
+	}
+	if len(writeBuf) == 0 {
+		return readBuf, writeBuf, nil
+	}
+	if err := writeFull(rw, writeBuf); err != nil {
+		return readBuf, writeBuf, err
+	}
+	if cap(writeBuf) <= maxRetainedWireWriteBuffer {
+		writeBuf = writeBuf[:0]
+	} else {
+		writeBuf = nil
+	}
+	return readBuf, writeBuf, nil
+}
+
+func (s *Server) appendOneWithOwner(rw io.Reader, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
 	if s.isClosed() {
 		return readBuf, writeBuf, errServerClosed
 	}
@@ -288,15 +332,51 @@ func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf,
 	if response == nil {
 		return readBuf, writeBuf, nil
 	}
-	if err := writeFull(rw, response); err != nil {
-		return readBuf, writeBuf, err
-	}
 	if cap(response) <= maxRetainedWireWriteBuffer {
-		writeBuf = response[:0]
+		writeBuf = response
 	} else {
-		writeBuf = nil
+		writeBuf = response
 	}
 	return readBuf, writeBuf, nil
+}
+
+func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwner int64, writeBuf []byte) ([]byte, bool, error) {
+	if s.isClosed() {
+		return writeBuf, false, errServerClosed
+	}
+	if reader == nil || reader.Buffered() < wire.HeaderLen {
+		return writeBuf, false, nil
+	}
+	headerBytes, err := reader.Peek(wire.HeaderLen)
+	if err != nil {
+		return writeBuf, false, nil
+	}
+	h, err := wire.ParseHeader(headerBytes)
+	if err != nil {
+		return writeBuf, false, err
+	}
+	if h.MessageLength > s.maxMessageLength() {
+		return writeBuf, false, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, h.MessageLength, s.maxMessageLength())
+	}
+	messageLength := int(h.MessageLength)
+	if reader.Buffered() < messageLength {
+		return writeBuf, false, nil
+	}
+	message, err := reader.Peek(messageLength)
+	if err != nil {
+		return writeBuf, false, nil
+	}
+	response, err := s.handleMessageInto(writeBuf, h, message[wire.HeaderLen:messageLength], cursorOwner)
+	if err != nil {
+		return writeBuf, false, err
+	}
+	if _, err := reader.Discard(messageLength); err != nil {
+		return writeBuf, false, err
+	}
+	if response != nil {
+		writeBuf = response
+	}
+	return writeBuf, true, nil
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -40,6 +40,12 @@ type partialReadWriter struct {
 	maxWrite int
 }
 
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return true }
+
 func (rw *partialReadWriter) Read(p []byte) (int, error) {
 	return rw.r.Read(p)
 }
@@ -4598,6 +4604,17 @@ func TestServeConnCancellationInterruptsRead(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("ServeConn did not return after context cancellation")
+	}
+}
+
+func TestServeConnContextErrorMapsCanceledTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := serveConnContextError(ctx, timeoutNetError{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("serveConnContextError canceled timeout=%v want context.Canceled", err)
+	}
+	if err := serveConnContextError(context.Background(), timeoutNetError{}); err != nil {
+		t.Fatalf("serveConnContextError active context=%v want nil", err)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -4277,6 +4277,67 @@ func TestServeConnBufferedMessageCoalescingAppendsResponses(t *testing.T) {
 	}
 }
 
+func TestServeConnFlushesBufferedResponseBeforeCoalescedError(t *testing.T) {
+	firstCommand := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	firstReq, err := wire.AppendMsgMessage(nil, 501, 0, 0, firstCommand)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage first: %v", err)
+	}
+	badReq, err := wire.AppendMessage(nil, 502, 0, wire.OpCompressed, nil)
+	if err != nil {
+		t.Fatalf("AppendMessage bad: %v", err)
+	}
+	requests := append(firstReq, badReq...)
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	if err := clientConn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- NewServer().ServeConn(context.Background(), serverConn)
+	}()
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- writeFull(clientConn, requests)
+	}()
+
+	header, body, err := wire.ReadMessage(clientConn, 0)
+	if err != nil {
+		t.Fatalf("read flushed response: %v", err)
+	}
+	if header.OpCode != wire.OpMsg || header.ResponseTo != 501 {
+		t.Fatalf("response header=%+v", header)
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		t.Fatalf("ParseMsg: %v", err)
+	}
+	assertOK(t, msg.Body)
+
+	select {
+	case err := <-writeErrCh:
+		if err != nil {
+			t.Fatalf("write requests: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request write did not finish")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, wire.ErrUnsupported) {
+			t.Fatalf("ServeConn err=%v want ErrUnsupported", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ServeConn did not return after coalesced error")
+	}
+}
+
 func TestServeConnCancellationInterruptsRead(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -4499,6 +4499,26 @@ func TestServeConnBufferedMessageCoalescingAppendsResponses(t *testing.T) {
 	}
 }
 
+func TestServeConnBufferedMessageRejectsShortMessageLength(t *testing.T) {
+	req := wire.AppendHeader(nil, wire.Header{
+		MessageLength: wire.HeaderLen - 1,
+		RequestID:     401,
+		OpCode:        wire.OpMsg,
+	})
+	reader := bufio.NewReaderSize(bytes.NewReader(req), len(req))
+	if _, err := reader.Peek(len(req)); err != nil {
+		t.Fatalf("prime buffered reader: %v", err)
+	}
+
+	_, appended, err := NewServer().appendBufferedMessageWithOwner(reader, 1, nil)
+	if !errors.Is(err, wire.ErrMalformed) {
+		t.Fatalf("append buffered message err=%v want ErrMalformed", err)
+	}
+	if appended {
+		t.Fatal("malformed buffered message was appended")
+	}
+}
+
 func TestServeConnFlushesBufferedResponseBeforeCoalescedError(t *testing.T) {
 	firstCommand := mustDocument(t, bson.D{
 		{Key: "ping", Value: int32(1)},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -176,6 +176,33 @@ func TestServerDoesNotRetainReadBufferAfterBSONInsert(t *testing.T) {
 	assertOK(t, readMsgResponse(t, rw.w.Bytes(), 22002))
 }
 
+func TestBufferedMessageCanRetainRequestBody(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		doc  bson.D
+		want bool
+	}{
+		{name: "ping", doc: bson.D{{Key: "ping", Value: int32(1)}, {Key: "$db", Value: "admin"}}, want: true},
+		{name: "find", doc: bson.D{{Key: "find", Value: "users"}, {Key: "$db", Value: "app"}}, want: true},
+		{name: "insert", doc: bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}}, {Key: "$db", Value: "app"}}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			commandDoc := mustDocument(t, tc.doc)
+			req, err := wire.AppendMsgMessage(nil, 22003, 0, 0, commandDoc)
+			if err != nil {
+				t.Fatalf("AppendMsgMessage: %v", err)
+			}
+			header, err := wire.ParseHeader(req[:wire.HeaderLen])
+			if err != nil {
+				t.Fatalf("ParseHeader: %v", err)
+			}
+			if got := bufferedMessageCanRetainRequestBody(header, req[wire.HeaderLen:]); got != tc.want {
+				t.Fatalf("retain=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestServerRejectsFindWithMoreToCome(t *testing.T) {
 	commandDoc := mustDocument(t, bson.D{
 		{Key: "find", Value: "users"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1,6 +1,7 @@
 package mongogateway
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -4200,6 +4201,79 @@ func TestServerRejectsCompressedMessages(t *testing.T) {
 	}
 	if rw.w.Len() != 0 {
 		t.Fatalf("unexpected response bytes=%d", rw.w.Len())
+	}
+}
+
+func TestServeConnBufferedMessageCoalescingAppendsResponses(t *testing.T) {
+	firstCommand := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	firstReq, err := wire.AppendMsgMessage(nil, 401, 0, 0, firstCommand)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage first: %v", err)
+	}
+	secondCommand := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	secondReq, err := wire.AppendMsgMessage(nil, 402, 0, 0, secondCommand)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage second: %v", err)
+	}
+	requests := append(firstReq, secondReq...)
+	reader := bufio.NewReaderSize(bytes.NewReader(requests), len(requests))
+	if _, err := reader.Peek(len(requests)); err != nil {
+		t.Fatalf("prime buffered reader: %v", err)
+	}
+
+	server := NewServer()
+	var writeBuf []byte
+	writeBuf, appended, err := server.appendBufferedMessageWithOwner(reader, 1, writeBuf)
+	if err != nil {
+		t.Fatalf("append first buffered message: %v", err)
+	}
+	if !appended {
+		t.Fatal("first buffered message was not appended")
+	}
+	writeBuf, appended, err = server.appendBufferedMessageWithOwner(reader, 1, writeBuf)
+	if err != nil {
+		t.Fatalf("append second buffered message: %v", err)
+	}
+	if !appended {
+		t.Fatal("second buffered message was not appended")
+	}
+	if reader.Buffered() != 0 {
+		t.Fatalf("reader buffered bytes=%d want 0", reader.Buffered())
+	}
+
+	responseReader := bytes.NewReader(writeBuf)
+	firstHeader, firstBody, err := wire.ReadMessage(responseReader, 0)
+	if err != nil {
+		t.Fatalf("read first response: %v", err)
+	}
+	if firstHeader.OpCode != wire.OpMsg || firstHeader.ResponseTo != 401 {
+		t.Fatalf("first response header=%+v", firstHeader)
+	}
+	firstMsg, err := wire.ParseMsg(firstBody)
+	if err != nil {
+		t.Fatalf("parse first response: %v", err)
+	}
+	assertOK(t, firstMsg.Body)
+	secondHeader, secondBody, err := wire.ReadMessage(responseReader, 0)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	if secondHeader.OpCode != wire.OpMsg || secondHeader.ResponseTo != 402 {
+		t.Fatalf("second response header=%+v", secondHeader)
+	}
+	secondMsg, err := wire.ParseMsg(secondBody)
+	if err != nil {
+		t.Fatalf("parse second response: %v", err)
+	}
+	assertOK(t, secondMsg.Body)
+	if responseReader.Len() != 0 {
+		t.Fatalf("trailing response bytes=%d", responseReader.Len())
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -184,6 +184,7 @@ func TestBufferedMessageCanRetainRequestBody(t *testing.T) {
 	}{
 		{name: "ping", doc: bson.D{{Key: "ping", Value: int32(1)}, {Key: "$db", Value: "admin"}}, want: true},
 		{name: "find", doc: bson.D{{Key: "find", Value: "users"}, {Key: "$db", Value: "app"}}, want: true},
+		{name: "update", doc: bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{}}, {Key: "$db", Value: "app"}}, want: false},
 		{name: "insert", doc: bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}}, {Key: "$db", Value: "app"}}, want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -3369,6 +3369,65 @@ func TestServerFindIndexedRangeStreamingFirstBatchOverflowOpensCursor(t *testing
 	}
 }
 
+func TestMarshalIndexedRangeCursorMsgDoesNotRejectCapacityHint(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 2525, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "name", Value: "age_1"},
+			{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
+			{Key: "treedbValueType", Value: "int64"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 2526, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "a"}, {Key: "age", Value: int64(37)}, {Key: "payload", Value: strings.Repeat("x", 64)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush collection: %v", err)
+	}
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		t.Fatalf("open materializer: %v", err)
+	}
+	defer func() { _ = materializer.Close() }()
+
+	opts := collections.IndexRangeOptions{
+		Lower: collections.IndexRangeBound{Value: int64(37), Inclusive: true},
+		Upper: collections.IndexRangeBound{Unbounded: true},
+		Limit: 10_000,
+	}
+	msg, err := marshalIndexedRangeCursorMsgInto(nil, 1, 2526, server, 1, false, col, materializer, "app.users", "age_1", opts, "firstBatch", server.maxFindBatchBytes(), 64*1024)
+	if err != nil {
+		t.Fatalf("marshal indexed range cursor msg: %v", err)
+	}
+	firstBatch := cursorFirstBatch(t, readMsgResponse(t, msg, 2526))
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("_id").StringValueOK(); !ok || got != "a" {
+		t.Fatalf("firstBatch _id=%q ok=%v want a", got, ok)
+	}
+}
+
 func TestServerGetMoreDropsCursorOnOversizedNextDocument(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -67,8 +67,11 @@ sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
 cost from Mongo Go driver cost. `-client-mode raw-wire-tcp-pipeline` uses the
 same raw TCP load path and pipelines age range `find` requests on one connection
-up to `-raw-wire-tcp-pipeline-depth`, which isolates single-connection
-request/response latency from server execution. Raw-wire modes use raw OP_MSG
+up to `-raw-wire-tcp-pipeline-depth` (default `128`), which isolates
+single-connection request/response latency from server execution. The gateway
+coalesces already-buffered pipelined responses before writing, so deeper
+pipelines can keep the socket full across server write cycles without changing
+the server's per-write coalescing cap. Raw-wire modes use raw OP_MSG
 document sequences for the insert load phase and raw OP_MSG `find` requests for
 the age range-read phase while keeping setup and non-range phases on the driver.
 `-client-mode direct` is a TreeDB-only path

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -65,9 +65,12 @@ become visible before reporting wall ops/sec. `-client-mode raw-wire` is
 TreeDB-only and calls the in-process gateway directly with raw OP_MSG document
 sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
-cost from Mongo Go driver cost. Raw-wire modes use raw OP_MSG document
-sequences for the insert load phase and raw OP_MSG `find` requests for the age
-range-read phase while keeping setup and non-range phases on the driver.
+cost from Mongo Go driver cost. `-client-mode raw-wire-tcp-pipeline` uses the
+same raw TCP load path and pipelines age range `find` requests on one connection
+up to `-raw-wire-tcp-pipeline-depth`, which isolates single-connection
+request/response latency from server execution. Raw-wire modes use raw OP_MSG
+document sequences for the insert load phase and raw OP_MSG `find` requests for
+the age range-read phase while keeping setup and non-range phases on the driver.
 `-client-mode direct` is a TreeDB-only path
 that calls `collections.Collection` directly for the same phase names, using the
 selected `-treedb-document-format` (`json`, `template-v1`/`collections-v1`, or
@@ -91,8 +94,9 @@ batches so small runs do not open unused clients. Official-driver modes share on
 `-mongo-max-pool-size`, `-mongo-min-pool-size`, and `-mongo-max-connecting`
 control the driver pool used by those producers. When `-mongo-max-pool-size` is
 left unset, validation treats the driver default max pool size as 100 for
-`-mongo-min-pool-size` checks. `raw-wire-tcp` opens one fastclient connection per
-effective producer, and `raw-wire` uses one in-process wire owner per effective
+`-mongo-min-pool-size` checks. `raw-wire-tcp` and
+`raw-wire-tcp-pipeline` open one fastclient connection per effective producer
+for the load phase, and `raw-wire` uses one in-process wire owner per effective
 producer. JSON output includes `effective_producers` and `producer_results` for
 the load phase plus `mongo_pool_stats_after_load` and `mongo_pool_stats_final`
 when the official driver pool is involved.
@@ -204,7 +208,7 @@ beside the normal MongoDB Go driver `InsertMany` path:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire-tcp-pipeline raw-wire" \
 scripts/mongo_gateway_compare.sh
 ```
 
@@ -276,7 +280,7 @@ Useful overrides:
 
 - `DOCS_LIST="1000 10000 100000"`
 - `INDEXES_LIST="0 1 2"`
-- `TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire"`
+- `TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire-tcp-pipeline raw-wire"`
 - `MONGO_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
@@ -359,7 +363,8 @@ The initial workload phases are:
   prebuilt raw BSON command for `driver-command-raw`, unacknowledged `InsertMany`
   plus a post-load visibility wait for `driver-unack`, direct
   `Collection.InsertBatch` in the selected storage format for `direct`, and raw
-  OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`. When
+  OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`/
+  `raw-wire-tcp-pipeline`. When
   `-insert-producers` is greater than 1, this
   phase reports aggregate wall-clock throughput and per-producer call latency in
   `producer_results`.
@@ -623,8 +628,10 @@ Use the official-driver row for user-visible Mongo compatibility throughput,
 `driver-find-raw` to remove range-read `bson.M` decode while keeping
 official-driver `Find`/cursor behavior, the driver-command rows to quantify the
 driver's CRUD-helper overhead, the raw-wire rows to estimate the gateway/server
-ceiling, and the direct collection row to estimate the storage-engine ceiling
-for the same document shape. For acknowledged high-throughput ingest through the
+ceiling, `raw-wire-tcp-pipeline` to measure how much single-connection TCP
+latency can be hidden by request pipelining, and the direct collection row to
+estimate the storage-engine ceiling for the same document shape. For
+acknowledged high-throughput ingest through the
 public MongoDB Go driver,
 `driver-command-raw` is the fastest current path because it keeps the official
 driver transport while bypassing `InsertMany`'s explicit-`_id` discovery and

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -45,8 +45,12 @@ checkout, the temp directory itself, a home directory, or an immediate child of
 a home directory are rejected.
 
 The default `-client-mode driver` uses the official MongoDB Go driver
-`Collection.InsertMany` path for the load phase and all later phases.
-`-client-mode driver-command` still uses the official driver but sends the load
+`Collection.InsertMany` path for the load phase and app-style decoded read
+phases. `-client-mode driver-find-raw` still uses official-driver
+`Collection.Find` for range reads, but iterates `cursor.Current` as raw BSON
+instead of decoding documents into `bson.M`; use it to isolate official-driver
+find/cursor overhead from application decode overhead. `-client-mode
+driver-command` still uses the official driver but sends the load
 phase as a raw `insert` command through `Database.RunCommand`, avoiding the
 driver's `InsertMany` `_id` discovery and `InsertedIDs` bookkeeping. It is useful
 for isolating driver CRUD-helper overhead and works against both TreeDB and
@@ -200,7 +204,7 @@ beside the normal MongoDB Go driver `InsertMany` path:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
 scripts/mongo_gateway_compare.sh
 ```
 
@@ -209,8 +213,8 @@ mode:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
-MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
+TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack" \
+MONGO_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack" \
 scripts/mongo_gateway_compare.sh
 ```
 
@@ -272,8 +276,8 @@ Useful overrides:
 
 - `DOCS_LIST="1000 10000 100000"`
 - `INDEXES_LIST="0 1 2"`
-- `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire"`
-- `MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack"`
+- `TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire"`
+- `MONGO_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
 - `RANGE_INDEX=true` or `--range-index` to create `age_1` and report
@@ -350,12 +354,13 @@ done
 The initial workload phases are:
 
 - `load_insert_many`: batched document inserts. The exact client call depends
-  on `client_mode`: `InsertMany` for `driver`, `RunCommand({insert,
-  documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
-  command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
-  visibility wait for `driver-unack`, direct `Collection.InsertBatch` in the
-  selected storage format for `direct`, and raw OP_MSG document sequences for
-  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
+  on `client_mode`: `InsertMany` for `driver` and `driver-find-raw`,
+  `RunCommand({insert, documents})` for `driver-command`, `RunCommand` with a
+  prebuilt raw BSON command for `driver-command-raw`, unacknowledged `InsertMany`
+  plus a post-load visibility wait for `driver-unack`, direct
+  `Collection.InsertBatch` in the selected storage format for `direct`, and raw
+  OP_MSG document sequences for `raw-wire`/`raw-wire-tcp`. When
+  `-insert-producers` is greater than 1, this
   phase reports aggregate wall-clock throughput and per-producer call latency in
   `producer_results`.
 - `id_find_one`: point lookup by `_id`.
@@ -614,11 +619,13 @@ The benchmark-only helpers accept these optional environment variables:
 `MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS` for
 focused indexed async-flush experiments.
 
-Use the official-driver row for user-visible Mongo compatibility throughput, the
-driver-command rows to quantify the driver's CRUD-helper overhead, the raw-wire
-rows to estimate the gateway/server ceiling, and the direct collection row to
-estimate the storage-engine ceiling for the same document shape. For
-acknowledged high-throughput ingest through the public MongoDB Go driver,
+Use the official-driver row for user-visible Mongo compatibility throughput,
+`driver-find-raw` to remove range-read `bson.M` decode while keeping
+official-driver `Find`/cursor behavior, the driver-command rows to quantify the
+driver's CRUD-helper overhead, the raw-wire rows to estimate the gateway/server
+ceiling, and the direct collection row to estimate the storage-engine ceiling
+for the same document shape. For acknowledged high-throughput ingest through the
+public MongoDB Go driver,
 `driver-command-raw` is the fastest current path because it keeps the official
 driver transport while bypassing `InsertMany`'s explicit-`_id` discovery and
 `InsertedIDs` bookkeeping.

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2966,10 +2966,14 @@ func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *ben
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	commandDoc, err := rawWireFindAgeRangeCommand(cfg.Database, cfg.Collection, minAge)
+	if scratch == nil {
+		scratch = &rawWireInProcessScratch{}
+	}
+	commandDoc, err := appendRawWireFindAgeRangeCommand(scratch.commandBuf[:0], cfg.Database, cfg.Collection, minAge)
 	if err != nil {
 		return err
 	}
+	scratch.commandBuf = commandDoc
 	begin := time.Now()
 	batch, err := serveRawWireFind(target.server, requestID.Add(1), cursorOwner, commandDoc, scratch)
 	sample(time.Since(begin))
@@ -2988,9 +2992,12 @@ func runTreeDBRawWireTCPRangePhase(ctx context.Context, cfg config, target *benc
 		return phaseResult{}, err
 	}
 	defer func() { _ = client.Close() }()
+	var commandBuf []byte
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runTreeDBRawWireTCPRangeOperation(ctx, cfg, client, rangeReadMinAge(i), sample); err != nil {
+			var err error
+			commandBuf, err = runTreeDBRawWireTCPRangeOperation(ctx, cfg, client, rangeReadMinAge(i), sample, commandBuf)
+			if err != nil {
 				return err
 			}
 		}
@@ -2998,17 +3005,17 @@ func runTreeDBRawWireTCPRangePhase(ctx context.Context, cfg config, target *benc
 	})
 }
 
-func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *fastclient.Client, minAge int64, sample func(time.Duration)) error {
-	commandDoc, err := rawWireFindAgeRangeCommand(cfg.Database, cfg.Collection, minAge)
+func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *fastclient.Client, minAge int64, sample func(time.Duration), commandBuf []byte) ([]byte, error) {
+	commandDoc, err := appendRawWireFindAgeRangeCommand(commandBuf[:0], cfg.Database, cfg.Collection, minAge)
 	if err != nil {
-		return err
+		return commandBuf, err
 	}
 	begin := time.Now()
 	err = client.FindRawBSONBorrowed(ctx, commandDoc, func(batch []bson.Raw) error {
 		return validateRawAgeBatch(batch, minAge)
 	})
 	sample(time.Since(begin))
-	return err
+	return commandDoc, err
 }
 
 func runTreeDBRawWireTCPPipelineRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
@@ -3083,6 +3090,7 @@ type rawWireTCPPipelineClient struct {
 	nextID      atomic.Int32
 	writeBuf    []byte
 	readBuf     []byte
+	commandBuf  []byte
 	responseBuf []bson.Raw
 }
 
@@ -3114,10 +3122,11 @@ func (c *rawWireTCPPipelineClient) AppendFind(database, collection string, minAg
 	if c == nil || c.conn == nil {
 		return 0, errors.New("raw-wire TCP pipeline client is closed")
 	}
-	commandDoc, err := rawWireFindAgeRangeCommand(database, collection, minAge)
+	commandDoc, err := appendRawWireFindAgeRangeCommand(c.commandBuf[:0], database, collection, minAge)
 	if err != nil {
 		return 0, err
 	}
+	c.commandBuf = commandDoc
 	requestID := c.nextID.Add(1)
 	msg, err := wire.AppendMsgMessage(c.writeBuf, requestID, 0, 0, commandDoc)
 	if err != nil {
@@ -3181,6 +3190,7 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 			return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
 		}
 		clients := make([]*fastclient.Client, readers)
+		commandBufs := make([][]byte, readers)
 		for i := range clients {
 			client, err := fastclient.Connect(ctx, target.mongoAddr)
 			if err != nil {
@@ -3200,7 +3210,9 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		}()
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
-				return runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op), sample)
+				var err error
+				commandBufs[worker], err = runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op), sample, commandBufs[worker])
+				return err
 			})
 		})
 	}
@@ -3302,21 +3314,38 @@ func rawDriverFindAgeRangeCommand(collection string, minAge int64) (bson.Raw, er
 }
 
 func rawWireFindAgeRangeCommand(database, collection string, minAge int64) (wire.Document, error) {
-	raw, err := rawFindAgeRangeCommand(database, collection, minAge)
-	return wire.Document(raw), err
+	return appendRawWireFindAgeRangeCommand(nil, database, collection, minAge)
 }
 
 func rawFindAgeRangeCommand(database, collection string, minAge int64) (bson.Raw, error) {
-	agePredicate := bsoncore.BuildDocument(nil, bsoncore.AppendInt64Element(nil, "$gte", minAge))
-	filter := bsoncore.BuildDocument(nil, bsoncore.AppendDocumentElement(nil, "age", agePredicate))
-	idx, doc := bsoncore.AppendDocumentStart(nil)
+	return appendRawFindAgeRangeCommand(nil, database, collection, minAge)
+}
+
+func appendRawWireFindAgeRangeCommand(dst []byte, database, collection string, minAge int64) (wire.Document, error) {
+	raw, err := appendRawFindAgeRangeCommand(dst, database, collection, minAge)
+	return wire.Document(raw), err
+}
+
+func appendRawFindAgeRangeCommand(dst []byte, database, collection string, minAge int64) (bson.Raw, error) {
+	idx, doc := bsoncore.AppendDocumentStart(dst[:0])
 	doc = bsoncore.AppendStringElement(doc, "find", collection)
-	doc = bsoncore.AppendDocumentElement(doc, "filter", filter)
+	filterIdx, doc := bsoncore.AppendDocumentElementStart(doc, "filter")
+	ageIdx, doc := bsoncore.AppendDocumentElementStart(doc, "age")
+	doc = bsoncore.AppendInt64Element(doc, "$gte", minAge)
+	var err error
+	doc, err = bsoncore.AppendDocumentEnd(doc, ageIdx)
+	if err != nil {
+		return nil, err
+	}
+	doc, err = bsoncore.AppendDocumentEnd(doc, filterIdx)
+	if err != nil {
+		return nil, err
+	}
 	doc = bsoncore.AppendInt32Element(doc, "limit", 10)
 	if database != "" {
 		doc = bsoncore.AppendStringElement(doc, "$db", database)
 	}
-	doc, err := bsoncore.AppendDocumentEnd(doc, idx)
+	doc, err = bsoncore.AppendDocumentEnd(doc, idx)
 	if err != nil {
 		return nil, err
 	}
@@ -3324,6 +3353,7 @@ func rawFindAgeRangeCommand(database, collection string, minAge int64) (bson.Raw
 }
 
 type rawWireInProcessScratch struct {
+	commandBuf  []byte
 	requestBuf  []byte
 	serveBufs   mongogateway.ServeBuffers
 	rw          inMemoryReadWriter

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -445,7 +445,7 @@ func parseConfig(args []string) (config, error) {
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		TreeDBReadState:             treeDBReadStateSettled,
 		ClientMode:                  clientModeDriver,
-		RawWireTCPPipelineDepth:     8,
+		RawWireTCPPipelineDepth:     128,
 		InsertProducers:             1,
 		ProfileBlockRate:            1,
 		ProfileMutexFraction:        5,

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -358,6 +358,7 @@ const (
 	treeDBReadStateUnsettled = "unsettled"
 
 	clientModeDriver           = "driver"
+	clientModeDriverFindRaw    = "driver-find-raw"
 	clientModeDriverCommand    = "driver-command"
 	clientModeDriverCommandRaw = "driver-command-raw"
 	clientModeDriverUnack      = "driver-unack"
@@ -484,7 +485,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes >= 2 so the city index exists")
 	fs.BoolVar(&cfg.RangeIndex, "range-index", false, "create an age_1 secondary index for the age range-read phase")
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
-	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
+	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1/collections-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
@@ -741,6 +742,8 @@ func parseClientMode(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "", clientModeDriver:
 		return clientModeDriver, nil
+	case clientModeDriverFindRaw:
+		return clientModeDriverFindRaw, nil
 	case clientModeDriverCommand:
 		return clientModeDriverCommand, nil
 	case clientModeDriverCommandRaw:
@@ -2804,6 +2807,9 @@ func runRangePhase(ctx context.Context, cfg config, target *benchTarget, profile
 	if cfg.ClientMode == clientModeDriverCommandRaw {
 		return runDriverCommandRawRangePhase(ctx, cfg, target, profiler)
 	}
+	if cfg.ClientMode == clientModeDriverFindRaw {
+		return runDriverFindRawRangePhase(ctx, cfg, target, profiler, coll)
+	}
 	return runDriverDecodedRangePhase(ctx, cfg, target, profiler, coll)
 }
 
@@ -2839,6 +2845,54 @@ func runDriverDecodedRangeOperation(ctx context.Context, coll *mongo.Collection,
 			return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
 		}
 	}
+	return nil
+}
+
+func runDriverFindRawRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
+	if coll == nil {
+		return phaseResult{}, errors.New("driver-find-raw range phase requires a Mongo driver collection")
+	}
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			if err := runDriverFindRawRangeOperation(ctx, coll, rangeReadMinAge(i), sample); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func runDriverFindRawRangeOperation(ctx context.Context, coll *mongo.Collection, minAge int64, sample func(time.Duration)) error {
+	begin := time.Now()
+	cursor, err := coll.Find(ctx,
+		bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
+		options.Find().SetLimit(10))
+	if err != nil {
+		sample(time.Since(begin))
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = cursor.Close(ctx)
+		}
+	}()
+	for cursor.Next(ctx) {
+		if err := validateRawAgeDocument(cursor.Current, minAge); err != nil {
+			sample(time.Since(begin))
+			return err
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		sample(time.Since(begin))
+		return err
+	}
+	if err := cursor.Close(ctx); err != nil {
+		sample(time.Since(begin))
+		return err
+	}
+	closed = true
+	sample(time.Since(begin))
 	return nil
 }
 
@@ -2988,6 +3042,13 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 			})
 		})
 	}
+	if cfg.ClientMode == clientModeDriverFindRaw {
+		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+			return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
+				return runDriverFindRawRangeOperation(ctx, coll, rangeReadMinAge(op), sample)
+			})
+		})
+	}
 	return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, cfg.ConcurrentRangeReads, func(op int) error {
 			return runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(op), sample)
@@ -3123,10 +3184,17 @@ func rawCommandErrorMessage(raw bson.Raw) string {
 
 func validateRawAgeBatch(batch []bson.Raw, minAge int64) error {
 	for _, doc := range batch {
-		age, ok := directBSONInt64Field(doc, "age")
-		if !ok || age < minAge {
-			return fmt.Errorf("raw range returned age=%v ok=%t below %d", age, ok, minAge)
+		if err := validateRawAgeDocument(doc, minAge); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func validateRawAgeDocument(doc bson.Raw, minAge int64) error {
+	age, ok := directBSONInt64Field(doc, "age")
+	if !ok || age < minAge {
+		return fmt.Errorf("raw range returned age=%v ok=%t below %d", age, ok, minAge)
 	}
 	return nil
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -39,7 +39,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
-const defaultMongoDriverMaxPoolSize = 100
+const (
+	defaultMongoDriverMaxPoolSize  = 100
+	defaultRawWireTCPPipelineDepth = 128
+	maxRawWireTCPPipelineDepth     = 4096
+)
 
 type config struct {
 	Target                                        string
@@ -446,7 +450,7 @@ func parseConfig(args []string) (config, error) {
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		TreeDBReadState:             treeDBReadStateSettled,
 		ClientMode:                  clientModeDriver,
-		RawWireTCPPipelineDepth:     128,
+		RawWireTCPPipelineDepth:     defaultRawWireTCPPipelineDepth,
 		InsertProducers:             1,
 		ProfileBlockRate:            1,
 		ProfileMutexFraction:        5,
@@ -569,6 +573,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.ClientMode == clientModeRawWireTCPPipeline && cfg.RawWireTCPPipelineDepth <= 0 {
 		return config{}, errors.New("raw-wire-tcp-pipeline-depth must be > 0")
+	}
+	if cfg.ClientMode == clientModeRawWireTCPPipeline && cfg.RawWireTCPPipelineDepth > maxRawWireTCPPipelineDepth {
+		return config{}, fmt.Errorf("raw-wire-tcp-pipeline-depth cannot exceed %d", maxRawWireTCPPipelineDepth)
 	}
 	concurrentRangeReaderSweepValues, err := parsePositiveIntList(concurrentRangeReaderSweep, "concurrent-range-reader-sweep")
 	if err != nil {
@@ -2926,13 +2933,14 @@ func runDriverDecodedRangeOperation(ctx context.Context, coll *mongo.Collection,
 		sample(time.Since(begin))
 		return err
 	}
-	sample(time.Since(begin))
 	for _, doc := range docs {
 		age, ok := int64Value(doc["age"])
 		if !ok || age < minAge {
+			sample(time.Since(begin))
 			return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
 		}
 	}
+	sample(time.Since(begin))
 	return nil
 }
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -56,6 +57,7 @@ type config struct {
 	MongoMaxConnecting                            int
 	Reads                                         int
 	RangeReads                                    int
+	RawWireTCPPipelineDepth                       int
 	ConcurrentRangeReaders                        int
 	ConcurrentRangeReaderSweep                    []int
 	ConcurrentRangeReads                          int
@@ -112,6 +114,7 @@ type benchmarkResult struct {
 	ConcurrentRangeReaders     int    `json:"concurrent_range_readers,omitempty"`
 	ConcurrentRangeReaderSweep []int  `json:"concurrent_range_reader_sweep,omitempty"`
 	ConcurrentRangeReads       int    `json:"concurrent_range_reads,omitempty"`
+	RawWireTCPPipelineDepth    int    `json:"raw_wire_tcp_pipeline_depth,omitempty"`
 	ConcurrentWriters          int    `json:"concurrent_writers,omitempty"`
 	ConcurrentWrites           int    `json:"concurrent_writes,omitempty"`
 
@@ -357,14 +360,15 @@ const (
 	treeDBReadStateSettled   = "settled"
 	treeDBReadStateUnsettled = "unsettled"
 
-	clientModeDriver           = "driver"
-	clientModeDriverFindRaw    = "driver-find-raw"
-	clientModeDriverCommand    = "driver-command"
-	clientModeDriverCommandRaw = "driver-command-raw"
-	clientModeDriverUnack      = "driver-unack"
-	clientModeDirect           = "direct"
-	clientModeRawWire          = "raw-wire"
-	clientModeRawWireTCP       = "raw-wire-tcp"
+	clientModeDriver             = "driver"
+	clientModeDriverFindRaw      = "driver-find-raw"
+	clientModeDriverCommand      = "driver-command"
+	clientModeDriverCommandRaw   = "driver-command-raw"
+	clientModeDriverUnack        = "driver-unack"
+	clientModeDirect             = "direct"
+	clientModeRawWire            = "raw-wire"
+	clientModeRawWireTCP         = "raw-wire-tcp"
+	clientModeRawWireTCPPipeline = "raw-wire-tcp-pipeline"
 )
 
 func main() {
@@ -441,6 +445,7 @@ func parseConfig(args []string) (config, error) {
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		TreeDBReadState:             treeDBReadStateSettled,
 		ClientMode:                  clientModeDriver,
+		RawWireTCPPipelineDepth:     8,
 		InsertProducers:             1,
 		ProfileBlockRate:            1,
 		ProfileMutexFraction:        5,
@@ -485,7 +490,8 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes >= 2 so the city index exists")
 	fs.BoolVar(&cfg.RangeIndex, "range-index", false, "create an age_1 secondary index for the age range-read phase")
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
-	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire, or raw-wire-tcp; direct and raw-wire modes are TreeDB-only")
+	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire, raw-wire-tcp, or raw-wire-tcp-pipeline; direct and raw-wire modes are TreeDB-only")
+	fs.IntVar(&cfg.RawWireTCPPipelineDepth, "raw-wire-tcp-pipeline-depth", cfg.RawWireTCPPipelineDepth, "number of raw-wire TCP find requests to pipeline on one connection when -client-mode raw-wire-tcp-pipeline")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1/collections-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
@@ -559,6 +565,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentRangeReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
+	}
+	if cfg.RawWireTCPPipelineDepth <= 0 {
+		return config{}, errors.New("raw-wire-tcp-pipeline-depth must be > 0")
 	}
 	concurrentRangeReaderSweepValues, err := parsePositiveIntList(concurrentRangeReaderSweep, "concurrent-range-reader-sweep")
 	if err != nil {
@@ -756,6 +765,8 @@ func parseClientMode(raw string) (string, error) {
 		return clientModeRawWire, nil
 	case clientModeRawWireTCP:
 		return clientModeRawWireTCP, nil
+	case clientModeRawWireTCPPipeline:
+		return clientModeRawWireTCPPipeline, nil
 	default:
 		return "", fmt.Errorf("unknown client-mode %q", raw)
 	}
@@ -812,7 +823,7 @@ func concurrentRangeReaderCounts(cfg config) []int {
 }
 
 func isRawWireClientMode(mode string) bool {
-	return mode == clientModeRawWire || mode == clientModeRawWireTCP
+	return mode == clientModeRawWire || mode == clientModeRawWireTCP || mode == clientModeRawWireTCPPipeline
 }
 
 func openTarget(ctx context.Context, cfg config) (*benchTarget, error) {
@@ -1226,6 +1237,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		UpdateIndexedField:         cfg.UpdateIndexedField,
 		RangeIndex:                 cfg.RangeIndex,
 		PrebuildDocuments:          cfg.PrebuildDocuments,
+	}
+	if cfg.ClientMode == clientModeRawWireTCPPipeline {
+		result.RawWireTCPPipelineDepth = cfg.RawWireTCPPipelineDepth
 	}
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
@@ -2616,7 +2630,7 @@ func runLoadPhase(ctx context.Context, cfg config, target *benchTarget, coll *mo
 	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWire {
 		return runTreeDBRawWireLoadPhase(ctx, cfg, target, prebuilt, prebuiltRaw)
 	}
-	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCP {
+	if cfg.Target == "treedb" && (cfg.ClientMode == clientModeRawWireTCP || cfg.ClientMode == clientModeRawWireTCPPipeline) {
 		return runTreeDBRawWireTCPLoadPhase(ctx, cfg, target, prebuilt, prebuiltRaw)
 	}
 	if cfg.ClientMode == clientModeDriverCommand {
@@ -2803,6 +2817,9 @@ func runRangePhase(ctx context.Context, cfg config, target *benchTarget, profile
 	}
 	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCP {
 		return runTreeDBRawWireTCPRangePhase(ctx, cfg, target, profiler)
+	}
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCPPipeline {
+		return runTreeDBRawWireTCPPipelineRangePhase(ctx, cfg, target, profiler)
 	}
 	if cfg.ClientMode == clientModeDriverCommandRaw {
 		return runDriverCommandRawRangePhase(ctx, cfg, target, profiler)
@@ -2994,6 +3011,157 @@ func runTreeDBRawWireTCPRangeOperation(ctx context.Context, cfg config, client *
 	return err
 }
 
+func runTreeDBRawWireTCPPipelineRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
+	if target == nil || target.mongoAddr == "" {
+		return phaseResult{}, errors.New("raw-wire-tcp-pipeline client mode requires a TreeDB gateway listener")
+	}
+	client, err := newRawWireTCPPipelineClient(ctx, target.mongoAddr)
+	if err != nil {
+		return phaseResult{}, err
+	}
+	defer func() { _ = client.Close() }()
+	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
+		minAges := make([]int64, cfg.RawWireTCPPipelineDepth)
+		responseTo := make([]int32, cfg.RawWireTCPPipelineDepth)
+		return runRawWireTCPPipelineRangeBatches(ctx, cfg, client, 0, cfg.RangeReads, minAges, responseTo, sample)
+	})
+}
+
+func runRawWireTCPPipelineRangeBatches(ctx context.Context, cfg config, client *rawWireTCPPipelineClient, start, count int, minAges []int64, responseTo []int32, sample func(time.Duration)) error {
+	if count <= 0 {
+		return nil
+	}
+	depth := cfg.RawWireTCPPipelineDepth
+	if depth <= 0 {
+		return errors.New("raw-wire-tcp-pipeline-depth must be > 0")
+	}
+	if len(minAges) < depth {
+		minAges = make([]int64, depth)
+	}
+	if len(responseTo) < depth {
+		responseTo = make([]int32, depth)
+	}
+	for offset := 0; offset < count; {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		batch := depth
+		if remaining := count - offset; remaining < batch {
+			batch = remaining
+		}
+		begin := time.Now()
+		for i := 0; i < batch; i++ {
+			minAge := rangeReadMinAge(start + offset + i)
+			id, err := client.AppendFind(cfg.Database, cfg.Collection, minAge)
+			if err != nil {
+				return err
+			}
+			minAges[i] = minAge
+			responseTo[i] = id
+		}
+		if err := client.Flush(); err != nil {
+			return err
+		}
+		for i := 0; i < batch; i++ {
+			if err := client.ReadFind(responseTo[i], minAges[i]); err != nil {
+				return err
+			}
+		}
+		elapsed := time.Since(begin)
+		perOp := elapsed / time.Duration(batch)
+		for i := 0; i < batch; i++ {
+			sample(perOp)
+		}
+		offset += batch
+	}
+	return nil
+}
+
+type rawWireTCPPipelineClient struct {
+	conn        net.Conn
+	rd          *bufio.Reader
+	nextID      atomic.Int32
+	writeBuf    []byte
+	readBuf     []byte
+	responseBuf []bson.Raw
+}
+
+const (
+	rawWireTCPReadBufferSize        = 32 * 1024
+	rawWireTCPMaxRetainedReadBuffer = 1 << 20
+)
+
+func newRawWireTCPPipelineClient(ctx context.Context, address string) (*rawWireTCPPipelineClient, error) {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	return &rawWireTCPPipelineClient{
+		conn: conn,
+		rd:   bufio.NewReaderSize(conn, rawWireTCPReadBufferSize),
+	}, nil
+}
+
+func (c *rawWireTCPPipelineClient) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+func (c *rawWireTCPPipelineClient) AppendFind(database, collection string, minAge int64) (int32, error) {
+	if c == nil || c.conn == nil {
+		return 0, errors.New("raw-wire TCP pipeline client is closed")
+	}
+	commandDoc, err := rawWireFindAgeRangeCommand(database, collection, minAge)
+	if err != nil {
+		return 0, err
+	}
+	requestID := c.nextID.Add(1)
+	msg, err := wire.AppendMsgMessage(c.writeBuf, requestID, 0, 0, commandDoc)
+	if err != nil {
+		return 0, err
+	}
+	c.writeBuf = msg
+	return requestID, nil
+}
+
+func (c *rawWireTCPPipelineClient) Flush() error {
+	if c == nil || c.conn == nil {
+		return errors.New("raw-wire TCP pipeline client is closed")
+	}
+	if len(c.writeBuf) == 0 {
+		return nil
+	}
+	if err := writeFull(c.conn, c.writeBuf); err != nil {
+		return err
+	}
+	c.writeBuf = c.writeBuf[:0]
+	return nil
+}
+
+func (c *rawWireTCPPipelineClient) ReadFind(responseTo int32, minAge int64) error {
+	header, body, err := wire.ReadMessageInto(c.rd, c.readBuf, wire.DefaultMaxMessageLength)
+	if err != nil {
+		return err
+	}
+	if cap(body) <= rawWireTCPMaxRetainedReadBuffer {
+		c.readBuf = body
+	} else {
+		c.readBuf = nil
+	}
+	if header.ResponseTo != responseTo {
+		return fmt.Errorf("raw-wire TCP pipeline responseTo=%d want %d", header.ResponseTo, responseTo)
+	}
+	batch, err := parseRawWireFindFirstBatchMessageInto(header, body, c.responseBuf)
+	if err != nil {
+		return err
+	}
+	c.responseBuf = batch
+	return validateRawAgeBatch(batch, minAge)
+}
+
 func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection, readers int) (phaseResult, error) {
 	phaseName := concurrentRangePhaseName(cfg, readers)
 	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWire {
@@ -3034,6 +3202,77 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
 				return runTreeDBRawWireTCPRangeOperation(ctx, cfg, clients[worker], rangeReadMinAge(op), sample)
 			})
+		})
+	}
+	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCPPipeline {
+		if target == nil || target.mongoAddr == "" {
+			return phaseResult{}, errors.New("raw-wire-tcp-pipeline client mode requires a TreeDB gateway listener")
+		}
+		clients := make([]*rawWireTCPPipelineClient, readers)
+		for i := range clients {
+			client, err := newRawWireTCPPipelineClient(ctx, target.mongoAddr)
+			if err != nil {
+				for _, existing := range clients {
+					if existing != nil {
+						_ = existing.Close()
+					}
+				}
+				return phaseResult{}, err
+			}
+			clients[i] = client
+		}
+		defer func() {
+			for _, client := range clients {
+				_ = client.Close()
+			}
+		}()
+		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
+			runCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			var next atomic.Int64
+			var wg sync.WaitGroup
+			var errOnce sync.Once
+			var firstErr error
+			recordErr := func(err error) {
+				if err == nil {
+					return
+				}
+				errOnce.Do(func() {
+					firstErr = err
+					cancel()
+				})
+			}
+			for worker := 0; worker < readers; worker++ {
+				wg.Add(1)
+				go func(worker int) {
+					defer wg.Done()
+					minAges := make([]int64, cfg.RawWireTCPPipelineDepth)
+					responseTo := make([]int32, cfg.RawWireTCPPipelineDepth)
+					for {
+						if err := runCtx.Err(); err != nil {
+							return
+						}
+						start := int(next.Add(int64(cfg.RawWireTCPPipelineDepth)) - int64(cfg.RawWireTCPPipelineDepth))
+						if start >= cfg.ConcurrentRangeReads {
+							return
+						}
+						count := cfg.RawWireTCPPipelineDepth
+						if remaining := cfg.ConcurrentRangeReads - start; remaining < count {
+							count = remaining
+						}
+						if err := runRawWireTCPPipelineRangeBatches(runCtx, cfg, clients[worker], start, count, minAges, responseTo, sample); err != nil {
+							recordErr(err)
+							return
+						}
+					}
+				}(worker)
+			}
+			wg.Wait()
+			if firstErr != nil {
+				return firstErr
+			}
+			return ctx.Err()
 		})
 	}
 	if cfg.ClientMode == clientModeDriverCommandRaw {
@@ -3127,10 +3366,13 @@ func parseRawWireFindFirstBatchInto(response []byte, dst []bson.Raw) ([]bson.Raw
 	if int(header.MessageLength) > len(response) {
 		return nil, fmt.Errorf("%w: response length=%d available=%d", wire.ErrMessageTooShort, header.MessageLength, len(response))
 	}
+	return parseRawWireFindFirstBatchMessageInto(header, response[wire.HeaderLen:int(header.MessageLength)], dst)
+}
+
+func parseRawWireFindFirstBatchMessageInto(header wire.Header, body []byte, dst []bson.Raw) ([]bson.Raw, error) {
 	if header.OpCode != wire.OpMsg {
 		return nil, fmt.Errorf("raw-wire find response opcode=%d want %d", header.OpCode, wire.OpMsg)
 	}
-	body := response[wire.HeaderLen:int(header.MessageLength)]
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
 		return nil, err

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2934,9 +2934,10 @@ func runTreeDBRawWireRangePhase(ctx context.Context, cfg config, target *benchTa
 		return phaseResult{}, errors.New("raw-wire client mode requires an in-process TreeDB gateway server")
 	}
 	var requestID atomic.Int32
+	var scratch rawWireInProcessScratch
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, 1, rangeReadMinAge(i), sample); err != nil {
+			if err := runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, 1, rangeReadMinAge(i), sample, &scratch); err != nil {
 				return err
 			}
 		}
@@ -2944,7 +2945,7 @@ func runTreeDBRawWireRangePhase(ctx context.Context, cfg config, target *benchTa
 	})
 }
 
-func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *benchTarget, requestID *atomic.Int32, cursorOwner int64, minAge int64, sample func(time.Duration)) error {
+func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *benchTarget, requestID *atomic.Int32, cursorOwner int64, minAge int64, sample func(time.Duration), scratch *rawWireInProcessScratch) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -2953,7 +2954,7 @@ func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *ben
 		return err
 	}
 	begin := time.Now()
-	batch, err := serveRawWireFind(target.server, requestID.Add(1), cursorOwner, commandDoc)
+	batch, err := serveRawWireFind(target.server, requestID.Add(1), cursorOwner, commandDoc, scratch)
 	sample(time.Since(begin))
 	if err != nil {
 		return err
@@ -3000,9 +3001,10 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 			return phaseResult{}, errors.New("raw-wire client mode requires an in-process TreeDB gateway server")
 		}
 		var requestID atomic.Int32
+		scratches := make([]rawWireInProcessScratch, readers)
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperationsByWorker(ctx, readers, cfg.ConcurrentRangeReads, func(worker, op int) error {
-				return runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, int64(worker+1), rangeReadMinAge(op), sample)
+				return runTreeDBRawWireRangeOperation(ctx, cfg, target, &requestID, int64(worker+1), rangeReadMinAge(op), sample, &scratches[worker])
 			})
 		})
 	}
@@ -3082,34 +3084,65 @@ func rawFindAgeRangeCommand(database, collection string, minAge int64) (bson.Raw
 	return bson.Raw(doc), nil
 }
 
-func serveRawWireFind(server *mongogateway.Server, requestID int32, cursorOwner int64, commandDoc wire.Document) ([]bson.Raw, error) {
-	msg, err := wire.AppendMsgMessage(nil, requestID, 0, 0, commandDoc)
+type rawWireInProcessScratch struct {
+	requestBuf  []byte
+	serveBufs   mongogateway.ServeBuffers
+	rw          inMemoryReadWriter
+	responseBuf []bson.Raw
+}
+
+func serveRawWireFind(server *mongogateway.Server, requestID int32, cursorOwner int64, commandDoc wire.Document, scratch *rawWireInProcessScratch) ([]bson.Raw, error) {
+	if scratch == nil {
+		scratch = &rawWireInProcessScratch{}
+	}
+	msg, err := wire.AppendMsgMessage(scratch.requestBuf[:0], requestID, 0, 0, commandDoc)
 	if err != nil {
 		return nil, err
 	}
-	rw := inMemoryReadWriter{r: bytes.NewReader(msg)}
-	if err := server.ServeOneWithOwner(&rw, cursorOwner); err != nil {
+	scratch.requestBuf = msg
+	scratch.rw.Reset(msg)
+	if err := server.ServeOneWithOwnerBuffered(&scratch.rw, cursorOwner, &scratch.serveBufs); err != nil {
 		return nil, err
 	}
-	return parseRawWireFindFirstBatch(rw.w.Bytes())
+	batch, err := parseRawWireFindFirstBatchInto(scratch.rw.Bytes(), scratch.responseBuf)
+	if err != nil {
+		return nil, err
+	}
+	scratch.responseBuf = batch
+	return batch, nil
 }
 
 func parseRawWireFindFirstBatch(response []byte) ([]bson.Raw, error) {
-	header, body, err := wire.ReadMessage(bytes.NewReader(response), 0)
+	return parseRawWireFindFirstBatchInto(response, nil)
+}
+
+func parseRawWireFindFirstBatchInto(response []byte, dst []bson.Raw) ([]bson.Raw, error) {
+	if len(response) < wire.HeaderLen {
+		return nil, wire.ErrMessageTooShort
+	}
+	header, err := wire.ParseHeader(response[:wire.HeaderLen])
 	if err != nil {
 		return nil, err
+	}
+	if int(header.MessageLength) > len(response) {
+		return nil, fmt.Errorf("%w: response length=%d available=%d", wire.ErrMessageTooShort, header.MessageLength, len(response))
 	}
 	if header.OpCode != wire.OpMsg {
 		return nil, fmt.Errorf("raw-wire find response opcode=%d want %d", header.OpCode, wire.OpMsg)
 	}
+	body := response[wire.HeaderLen:int(header.MessageLength)]
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
 		return nil, err
 	}
-	return parseFindFirstBatch(bson.Raw(msg.Body))
+	return parseFindFirstBatchInto(bson.Raw(msg.Body), dst)
 }
 
 func parseFindFirstBatch(raw bson.Raw) ([]bson.Raw, error) {
+	return parseFindFirstBatchInto(raw, nil)
+}
+
+func parseFindFirstBatchInto(raw bson.Raw, dst []bson.Raw) ([]bson.Raw, error) {
 	if !rawCommandOK(raw) {
 		return nil, fmt.Errorf("find failed: %s", rawCommandErrorMessage(raw))
 	}
@@ -3121,10 +3154,14 @@ func parseFindFirstBatch(raw bson.Raw) ([]bson.Raw, error) {
 	if !ok {
 		return nil, errors.New("find response missing cursor.firstBatch")
 	}
-	return rawDocumentsFromArray(batch)
+	return rawDocumentsFromArrayInto(batch, dst)
 }
 
 func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
+	return rawDocumentsFromArrayInto(batch, nil)
+}
+
+func rawDocumentsFromArrayInto(batch bson.RawArray, dst []bson.Raw) ([]bson.Raw, error) {
 	length, rem, ok := bsoncore.ReadLength(bsoncore.Array(batch))
 	if !ok || length < 5 || int(length) > len(batch) {
 		return nil, errors.New("malformed find cursor.firstBatch")
@@ -3135,7 +3172,7 @@ func rawDocumentsFromArray(batch bson.RawArray) ([]bson.Raw, error) {
 	}
 	rem = rem[:len(rem)-1]
 
-	docs := make([]bson.Raw, 0, 10)
+	docs := dst[:0]
 	for len(rem) > 0 {
 		elem, next, ok := bsoncore.ReadElement(rem)
 		if !ok {
@@ -3314,11 +3351,12 @@ func serveRawWireInsert(server *mongogateway.Server, requestID int32, cursorOwne
 	if err != nil {
 		return err
 	}
-	rw := inMemoryReadWriter{r: bytes.NewReader(msg)}
+	var rw inMemoryReadWriter
+	rw.Reset(msg)
 	if err := server.ServeOneWithOwner(&rw, cursorOwner); err != nil {
 		return err
 	}
-	return assertRawWireInsertOK(rw.w.Bytes(), len(docs))
+	return assertRawWireInsertOK(rw.Bytes(), len(docs))
 }
 
 func serveRawWireTCPInsert(conn net.Conn, requestID int32, commandDoc wire.Document, docs []wire.Document) error {
@@ -3354,8 +3392,17 @@ func writeFull(w io.Writer, buf []byte) error {
 }
 
 type inMemoryReadWriter struct {
-	r *bytes.Reader
-	w bytes.Buffer
+	r bytes.Reader
+	w []byte
+}
+
+func (rw *inMemoryReadWriter) Reset(request []byte) {
+	rw.r.Reset(request)
+	rw.w = rw.w[:0]
+}
+
+func (rw *inMemoryReadWriter) Bytes() []byte {
+	return rw.w
 }
 
 func (rw *inMemoryReadWriter) Read(p []byte) (int, error) {
@@ -3363,7 +3410,8 @@ func (rw *inMemoryReadWriter) Read(p []byte) (int, error) {
 }
 
 func (rw *inMemoryReadWriter) Write(p []byte) (int, error) {
-	return rw.w.Write(p)
+	rw.w = append(rw.w, p...)
+	return len(p), nil
 }
 
 func assertRawWireInsertOK(response []byte, wantN int) error {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3099,6 +3099,54 @@ func runRawWireTCPPipelineRangeBatches(ctx context.Context, cfg config, client *
 	return nil
 }
 
+func runRawWireTCPPipelineRangeStridedBatches(ctx context.Context, cfg config, client *rawWireTCPPipelineClient, start, stride, total int, minAges []int64, responseTo []int32, sample func(time.Duration)) error {
+	if start < 0 || stride <= 0 || total <= 0 || start >= total {
+		return nil
+	}
+	depth := cfg.RawWireTCPPipelineDepth
+	if depth <= 0 {
+		return errors.New("raw-wire-tcp-pipeline-depth must be > 0")
+	}
+	if len(minAges) < depth {
+		minAges = make([]int64, depth)
+	}
+	if len(responseTo) < depth {
+		responseTo = make([]int32, depth)
+	}
+	for op := start; op < total; {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		begin := time.Now()
+		batch := 0
+		for batch < depth && op < total {
+			minAge := rangeReadMinAge(op)
+			id, err := client.AppendFind(cfg.Database, cfg.Collection, minAge)
+			if err != nil {
+				return err
+			}
+			minAges[batch] = minAge
+			responseTo[batch] = id
+			batch++
+			op += stride
+		}
+		if err := client.Flush(ctx); err != nil {
+			return err
+		}
+		for i := 0; i < batch; i++ {
+			if err := client.ReadFind(ctx, responseTo[i], minAges[i]); err != nil {
+				return err
+			}
+		}
+		elapsed := time.Since(begin)
+		perOp := elapsed / time.Duration(batch)
+		for i := 0; i < batch; i++ {
+			sample(perOp)
+		}
+	}
+	return nil
+}
+
 type rawWireTCPPipelineClient struct {
 	conn        net.Conn
 	rd          *bufio.Reader
@@ -3299,7 +3347,6 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 			stopCancelWatch := watchRawWireTCPPipelineClients(runCtx, clients...)
 			defer stopCancelWatch()
 
-			var next atomic.Int64
 			var wg sync.WaitGroup
 			var errOnce sync.Once
 			var firstErr error
@@ -3318,22 +3365,8 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 					defer wg.Done()
 					minAges := make([]int64, cfg.RawWireTCPPipelineDepth)
 					responseTo := make([]int32, cfg.RawWireTCPPipelineDepth)
-					for {
-						if err := runCtx.Err(); err != nil {
-							return
-						}
-						start := int(next.Add(int64(cfg.RawWireTCPPipelineDepth)) - int64(cfg.RawWireTCPPipelineDepth))
-						if start >= cfg.ConcurrentRangeReads {
-							return
-						}
-						count := cfg.RawWireTCPPipelineDepth
-						if remaining := cfg.ConcurrentRangeReads - start; remaining < count {
-							count = remaining
-						}
-						if err := runRawWireTCPPipelineRangeBatches(runCtx, cfg, clients[worker], start, count, minAges, responseTo, sample); err != nil {
-							recordErr(err)
-							return
-						}
+					if err := runRawWireTCPPipelineRangeStridedBatches(runCtx, cfg, clients[worker], worker, readers, cfg.ConcurrentRangeReads, minAges, responseTo, sample); err != nil {
+						recordErr(err)
 					}
 				}(worker)
 			}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2974,7 +2974,9 @@ func runDriverFindRawRangeOperation(ctx context.Context, coll *mongo.Collection,
 	closed := false
 	defer func() {
 		if !closed {
-			_ = cursor.Close(ctx)
+			closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_ = cursor.Close(closeCtx)
 		}
 	}()
 	seen := false

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -567,7 +567,7 @@ func parseConfig(args []string) (config, error) {
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentRangeReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
 	}
-	if cfg.RawWireTCPPipelineDepth <= 0 {
+	if cfg.ClientMode == clientModeRawWireTCPPipeline && cfg.RawWireTCPPipelineDepth <= 0 {
 		return config{}, errors.New("raw-wire-tcp-pipeline-depth must be > 0")
 	}
 	concurrentRangeReaderSweepValues, err := parsePositiveIntList(concurrentRangeReaderSweep, "concurrent-range-reader-sweep")
@@ -3230,6 +3230,9 @@ func (c *rawWireTCPPipelineClient) Flush(ctx context.Context) error {
 }
 
 func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int32, minAge int64) error {
+	if c == nil || c.conn == nil || c.rd == nil {
+		return errors.New("raw-wire TCP pipeline client is closed")
+	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -3495,6 +3498,9 @@ func parseRawWireFindFirstBatchInto(response []byte, dst []bson.Raw) ([]bson.Raw
 	header, err := wire.ParseHeader(response[:wire.HeaderLen])
 	if err != nil {
 		return nil, err
+	}
+	if header.MessageLength < wire.HeaderLen {
+		return nil, fmt.Errorf("%w: response length=%d below header length", wire.ErrMalformed, header.MessageLength)
 	}
 	if int(header.MessageLength) > len(response) {
 		return nil, fmt.Errorf("%w: response length=%d available=%d", wire.ErrMessageTooShort, header.MessageLength, len(response))

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3030,7 +3030,7 @@ func runTreeDBRawWireRangeOperation(ctx context.Context, cfg config, target *ben
 
 func runTreeDBRawWireTCPRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
 	if target == nil || target.mongoAddr == "" {
-		return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
+		return phaseResult{}, errors.New("raw-wire TCP client modes require a TreeDB gateway listener")
 	}
 	client, err := fastclient.Connect(ctx, target.mongoAddr)
 	if err != nil {
@@ -3192,6 +3192,8 @@ type rawWireTCPPipelineClient struct {
 	readBuf     []byte
 	commandBuf  []byte
 	responseBuf []bson.Raw
+	beforeFlush func()
+	beforeRead  func()
 }
 
 const (
@@ -3246,6 +3248,9 @@ func (c *rawWireTCPPipelineClient) Flush(ctx context.Context) error {
 	if len(c.writeBuf) == 0 {
 		return nil
 	}
+	if c.beforeFlush != nil {
+		c.beforeFlush()
+	}
 	if err := writeFull(c.conn, c.writeBuf); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
@@ -3262,6 +3267,9 @@ func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int3
 	}
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	if c.beforeRead != nil {
+		c.beforeRead()
 	}
 	header, body, err := wire.ReadMessageInto(c.rd, c.readBuf, wire.DefaultMaxMessageLength)
 	if err != nil {
@@ -3287,8 +3295,7 @@ func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int3
 }
 
 func watchRawWireTCPPipelineClients(ctx context.Context, clients ...*rawWireTCPPipelineClient) func() {
-	done := ctx.Done()
-	if done == nil {
+	if ctx.Done() == nil {
 		return func() {}
 	}
 	fired := make(chan struct{})
@@ -3330,7 +3337,7 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 	}
 	if cfg.Target == "treedb" && cfg.ClientMode == clientModeRawWireTCP {
 		if target == nil || target.mongoAddr == "" {
-			return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
+			return phaseResult{}, errors.New("raw-wire TCP client modes require a TreeDB gateway listener")
 		}
 		clients := make([]*fastclient.Client, readers)
 		commandBufs := make([][]byte, readers)
@@ -3689,7 +3696,7 @@ func runTreeDBRawWireLoadPhase(ctx context.Context, cfg config, target *benchTar
 
 func runTreeDBRawWireTCPLoadPhase(ctx context.Context, cfg config, target *benchTarget, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
 	if target == nil || target.mongoAddr == "" {
-		return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
+		return phaseResult{}, errors.New("raw-wire TCP client modes require a TreeDB gateway listener")
 	}
 	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
 	clients := make([]*fastclient.Client, producers)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3066,11 +3066,11 @@ func runRawWireTCPPipelineRangeBatches(ctx context.Context, cfg config, client *
 			minAges[i] = minAge
 			responseTo[i] = id
 		}
-		if err := client.Flush(); err != nil {
+		if err := client.Flush(ctx); err != nil {
 			return err
 		}
 		for i := 0; i < batch; i++ {
-			if err := client.ReadFind(responseTo[i], minAges[i]); err != nil {
+			if err := client.ReadFind(ctx, responseTo[i], minAges[i]); err != nil {
 				return err
 			}
 		}
@@ -3136,23 +3136,47 @@ func (c *rawWireTCPPipelineClient) AppendFind(database, collection string, minAg
 	return requestID, nil
 }
 
-func (c *rawWireTCPPipelineClient) Flush() error {
+func (c *rawWireTCPPipelineClient) Flush(ctx context.Context) error {
 	if c == nil || c.conn == nil {
 		return errors.New("raw-wire TCP pipeline client is closed")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if len(c.writeBuf) == 0 {
 		return nil
 	}
+	stopCancelWatch := c.watchContextCancel(ctx)
+	defer func() {
+		if stopCancelWatch() {
+			_ = c.conn.SetDeadline(time.Time{})
+		}
+	}()
 	if err := writeFull(c.conn, c.writeBuf); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return err
 	}
 	c.writeBuf = c.writeBuf[:0]
 	return nil
 }
 
-func (c *rawWireTCPPipelineClient) ReadFind(responseTo int32, minAge int64) error {
+func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int32, minAge int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	stopCancelWatch := c.watchContextCancel(ctx)
+	defer func() {
+		if stopCancelWatch() {
+			_ = c.conn.SetDeadline(time.Time{})
+		}
+	}()
 	header, body, err := wire.ReadMessageInto(c.rd, c.readBuf, wire.DefaultMaxMessageLength)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return err
 	}
 	if cap(body) <= rawWireTCPMaxRetainedReadBuffer {
@@ -3169,6 +3193,25 @@ func (c *rawWireTCPPipelineClient) ReadFind(responseTo int32, minAge int64) erro
 	}
 	c.responseBuf = batch
 	return validateRawAgeBatch(batch, minAge)
+}
+
+func (c *rawWireTCPPipelineClient) watchContextCancel(ctx context.Context) func() bool {
+	done := ctx.Done()
+	if done == nil {
+		return func() bool { return false }
+	}
+	fired := make(chan struct{})
+	stop := context.AfterFunc(ctx, func() {
+		defer close(fired)
+		_ = c.conn.SetDeadline(time.Now())
+	})
+	return func() bool {
+		if stop() {
+			return false
+		}
+		<-fired
+		return true
+	}
 }
 
 func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection, readers int) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3027,6 +3027,8 @@ func runTreeDBRawWireTCPPipelineRangePhase(ctx context.Context, cfg config, targ
 		return phaseResult{}, err
 	}
 	defer func() { _ = client.Close() }()
+	stopCancelWatch := watchRawWireTCPPipelineClients(ctx, client)
+	defer stopCancelWatch()
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		minAges := make([]int64, cfg.RawWireTCPPipelineDepth)
 		responseTo := make([]int32, cfg.RawWireTCPPipelineDepth)
@@ -3146,12 +3148,6 @@ func (c *rawWireTCPPipelineClient) Flush(ctx context.Context) error {
 	if len(c.writeBuf) == 0 {
 		return nil
 	}
-	stopCancelWatch := c.watchContextCancel(ctx)
-	defer func() {
-		if stopCancelWatch() {
-			_ = c.conn.SetDeadline(time.Time{})
-		}
-	}()
 	if err := writeFull(c.conn, c.writeBuf); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
@@ -3166,12 +3162,6 @@ func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int3
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	stopCancelWatch := c.watchContextCancel(ctx)
-	defer func() {
-		if stopCancelWatch() {
-			_ = c.conn.SetDeadline(time.Time{})
-		}
-	}()
 	header, body, err := wire.ReadMessageInto(c.rd, c.readBuf, wire.DefaultMaxMessageLength)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -3195,22 +3185,31 @@ func (c *rawWireTCPPipelineClient) ReadFind(ctx context.Context, responseTo int3
 	return validateRawAgeBatch(batch, minAge)
 }
 
-func (c *rawWireTCPPipelineClient) watchContextCancel(ctx context.Context) func() bool {
+func watchRawWireTCPPipelineClients(ctx context.Context, clients ...*rawWireTCPPipelineClient) func() {
 	done := ctx.Done()
 	if done == nil {
-		return func() bool { return false }
+		return func() {}
 	}
 	fired := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
 		defer close(fired)
-		_ = c.conn.SetDeadline(time.Now())
+		now := time.Now()
+		for _, client := range clients {
+			if client != nil && client.conn != nil {
+				_ = client.conn.SetDeadline(now)
+			}
+		}
 	})
-	return func() bool {
+	return func() {
 		if stop() {
-			return false
+			return
 		}
 		<-fired
-		return true
+		for _, client := range clients {
+			if client != nil && client.conn != nil {
+				_ = client.conn.SetDeadline(time.Time{})
+			}
+		}
 	}
 }
 
@@ -3284,6 +3283,8 @@ func runConcurrentRangePhase(ctx context.Context, cfg config, target *benchTarge
 		return measureTreeDBProfiledPhase(target, profiler, phaseName, cfg.ConcurrentRangeReads, func(sample func(time.Duration)) error {
 			runCtx, cancel := context.WithCancel(ctx)
 			defer cancel()
+			stopCancelWatch := watchRawWireTCPPipelineClients(runCtx, clients...)
+			defer stopCancelWatch()
 
 			var next atomic.Int64
 			var wg sync.WaitGroup

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -645,6 +645,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if commandCfg.ClientMode != clientModeDriverCommand {
 		t.Fatalf("ClientMode=%q want %q", commandCfg.ClientMode, clientModeDriverCommand)
 	}
+	findRawCfg, err := parseConfig([]string{"-target", "mongo", "-client-mode", "driver-find-raw"})
+	if err != nil {
+		t.Fatalf("parse driver-find-raw config: %v", err)
+	}
+	if findRawCfg.ClientMode != clientModeDriverFindRaw {
+		t.Fatalf("ClientMode=%q want %q", findRawCfg.ClientMode, clientModeDriverFindRaw)
+	}
 	commandRawCfg, err := parseConfig([]string{"-target", "mongo", "-client-mode", "driver-command-raw"})
 	if err != nil {
 		t.Fatalf("parse driver-command-raw config: %v", err)
@@ -1290,7 +1297,7 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("client mode smoke benchmark skipped in short mode")
 	}
-	for _, mode := range []string{clientModeDriver, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP} {
+	for _, mode := range []string{clientModeDriver, clientModeDriverFindRaw, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP} {
 		t.Run(mode, func(t *testing.T) {
 			opsPerSecond := runTreeDBClientModeSmoke(t, mode)
 			t.Logf("%s load_insert_many ops/sec=%.1f", mode, opsPerSecond)
@@ -1298,62 +1305,66 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	}
 }
 
-func TestTreeDBDriverCommandRawRangePhaseSmoke(t *testing.T) {
+func TestTreeDBDriverRawRangePhaseSmoke(t *testing.T) {
 	if testing.Short() {
-		t.Skip("driver-command-raw range smoke skipped in short mode")
+		t.Skip("driver raw range smoke skipped in short mode")
 	}
-	cfg, err := parseConfig([]string{
-		"-target", "treedb",
-		"-client-mode", clientModeDriverCommandRaw,
-		"-documents", "96",
-		"-batch-size", "24",
-		"-reads", "0",
-		"-range-reads", "8",
-		"-updates", "0",
-		"-secondary-indexes", "2",
-		"-range-index",
-		"-concurrent-range-reader-sweep", "1,2",
-		"-concurrent-range-reads", "8",
-		"-treedb-document-format", string(collections.DocumentFormatBSON),
-		"-treedb-maintenance", treeDBMaintenanceNone,
-		"-prebuild-documents",
-		"-timeout", "0",
-		"-format", "json",
-	})
-	if err != nil {
-		t.Fatalf("parse driver-command-raw range config: %v", err)
-	}
-	target, err := openTarget(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("open target: %v", err)
-	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := closeBenchTarget(cleanupCtx, target); err != nil {
-			t.Errorf("cleanup target: %v", err)
-		}
-	}()
-	result, err := runBenchmark(context.Background(), cfg, target, nil)
-	if err != nil {
-		t.Fatalf("run benchmark: %v", err)
-	}
-	phases := make(map[string]phaseResult, len(result.Phases))
-	for _, phase := range result.Phases {
-		phases[phase.Name] = phase
-	}
-	for _, name := range []string{
-		"age_range_indexed_limit_10",
-		"concurrent_age_range_indexed_limit_10_r1",
-		"concurrent_age_range_indexed_limit_10_r2",
-	} {
-		phase, ok := phases[name]
-		if !ok {
-			t.Fatalf("phase %q missing from result: %+v", name, result.Phases)
-		}
-		if phase.SampledNsPerOp <= 0 || phase.OpsPerSecond <= 0 {
-			t.Fatalf("phase %q metrics missing: %+v", name, phase)
-		}
+	for _, mode := range []string{clientModeDriverFindRaw, clientModeDriverCommandRaw} {
+		t.Run(mode, func(t *testing.T) {
+			cfg, err := parseConfig([]string{
+				"-target", "treedb",
+				"-client-mode", mode,
+				"-documents", "96",
+				"-batch-size", "24",
+				"-reads", "0",
+				"-range-reads", "8",
+				"-updates", "0",
+				"-secondary-indexes", "2",
+				"-range-index",
+				"-concurrent-range-reader-sweep", "1,2",
+				"-concurrent-range-reads", "8",
+				"-treedb-document-format", string(collections.DocumentFormatBSON),
+				"-treedb-maintenance", treeDBMaintenanceNone,
+				"-prebuild-documents",
+				"-timeout", "0",
+				"-format", "json",
+			})
+			if err != nil {
+				t.Fatalf("parse %s range config: %v", mode, err)
+			}
+			target, err := openTarget(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("open target: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := closeBenchTarget(cleanupCtx, target); err != nil {
+					t.Errorf("cleanup target: %v", err)
+				}
+			}()
+			result, err := runBenchmark(context.Background(), cfg, target, nil)
+			if err != nil {
+				t.Fatalf("run benchmark: %v", err)
+			}
+			phases := make(map[string]phaseResult, len(result.Phases))
+			for _, phase := range result.Phases {
+				phases[phase.Name] = phase
+			}
+			for _, name := range []string{
+				"age_range_indexed_limit_10",
+				"concurrent_age_range_indexed_limit_10_r1",
+				"concurrent_age_range_indexed_limit_10_r2",
+			} {
+				phase, ok := phases[name]
+				if !ok {
+					t.Fatalf("phase %q missing from result: %+v", name, result.Phases)
+				}
+				if phase.SampledNsPerOp <= 0 || phase.OpsPerSecond <= 0 {
+					t.Fatalf("phase %q metrics missing: %+v", name, phase)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -638,6 +638,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if rawWireTCPCfg.ClientMode != clientModeRawWireTCP {
 		t.Fatalf("ClientMode=%q want %q", rawWireTCPCfg.ClientMode, clientModeRawWireTCP)
 	}
+	defaultPipelineCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire-tcp-pipeline"})
+	if err != nil {
+		t.Fatalf("parse default raw-wire-tcp-pipeline config: %v", err)
+	}
+	if defaultPipelineCfg.RawWireTCPPipelineDepth != 128 {
+		t.Fatalf("default raw-wire-tcp-pipeline depth=%d want 128", defaultPipelineCfg.RawWireTCPPipelineDepth)
+	}
 	rawWireTCPPipelineCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", "16"})
 	if err != nil {
 		t.Fatalf("parse raw-wire-tcp-pipeline config: %v", err)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -723,8 +723,11 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
 		t.Fatal("direct client-mode accepted for mongo target")
 	}
-	if _, err := parseConfig([]string{"-raw-wire-tcp-pipeline-depth", "0"}); err == nil {
-		t.Fatal("raw-wire-tcp-pipeline-depth=0 accepted")
+	if _, err := parseConfig([]string{"-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", "0"}); err == nil {
+		t.Fatal("raw-wire-tcp-pipeline-depth=0 accepted for pipeline mode")
+	}
+	if _, err := parseConfig([]string{"-raw-wire-tcp-pipeline-depth", "0"}); err != nil {
+		t.Fatalf("raw-wire-tcp-pipeline-depth=0 should be ignored outside pipeline mode: %v", err)
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -860,9 +860,11 @@ func TestRawWireTCPPipelineClientReadFindHonorsContextCancel(t *testing.T) {
 	defer serverConn.Close()
 	defer clientConn.Close()
 
+	readStarted := make(chan struct{})
 	client := &rawWireTCPPipelineClient{
-		conn: clientConn,
-		rd:   bufio.NewReaderSize(clientConn, rawWireTCPReadBufferSize),
+		conn:       clientConn,
+		rd:         bufio.NewReaderSize(clientConn, rawWireTCPReadBufferSize),
+		beforeRead: func() { close(readStarted) },
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	stopCancelWatch := watchRawWireTCPPipelineClients(ctx, client)
@@ -872,7 +874,11 @@ func TestRawWireTCPPipelineClientReadFindHonorsContextCancel(t *testing.T) {
 		errCh <- client.ReadFind(ctx, 1, 0)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("ReadFind did not start read")
+	}
 	cancel()
 
 	select {
@@ -890,9 +896,11 @@ func TestRawWireTCPPipelineClientFlushHonorsContextCancel(t *testing.T) {
 	defer serverConn.Close()
 	defer clientConn.Close()
 
+	flushStarted := make(chan struct{})
 	client := &rawWireTCPPipelineClient{
-		conn:     clientConn,
-		writeBuf: bytes.Repeat([]byte("x"), 1024),
+		conn:        clientConn,
+		writeBuf:    bytes.Repeat([]byte("x"), 1024),
+		beforeFlush: func() { close(flushStarted) },
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	stopCancelWatch := watchRawWireTCPPipelineClients(ctx, client)
@@ -902,7 +910,11 @@ func TestRawWireTCPPipelineClientFlushHonorsContextCancel(t *testing.T) {
 		errCh <- client.Flush(ctx)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-flushStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Flush did not start write")
+	}
 	cancel()
 
 	select {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -638,6 +638,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if rawWireTCPCfg.ClientMode != clientModeRawWireTCP {
 		t.Fatalf("ClientMode=%q want %q", rawWireTCPCfg.ClientMode, clientModeRawWireTCP)
 	}
+	rawWireTCPPipelineCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", "16"})
+	if err != nil {
+		t.Fatalf("parse raw-wire-tcp-pipeline config: %v", err)
+	}
+	if rawWireTCPPipelineCfg.ClientMode != clientModeRawWireTCPPipeline || rawWireTCPPipelineCfg.RawWireTCPPipelineDepth != 16 {
+		t.Fatalf("raw-wire-tcp-pipeline config=%+v", rawWireTCPPipelineCfg)
+	}
 	commandCfg, err := parseConfig([]string{"-target", "mongo", "-client-mode", "driver-command"})
 	if err != nil {
 		t.Fatalf("parse driver-command config: %v", err)
@@ -701,8 +708,14 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "raw-wire-tcp"}); err == nil {
 		t.Fatal("raw-wire-tcp client-mode accepted for mongo target")
 	}
+	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "raw-wire-tcp-pipeline"}); err == nil {
+		t.Fatal("raw-wire-tcp-pipeline client-mode accepted for mongo target")
+	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-client-mode", "direct"}); err == nil {
 		t.Fatal("direct client-mode accepted for mongo target")
+	}
+	if _, err := parseConfig([]string{"-raw-wire-tcp-pipeline-depth", "0"}); err == nil {
+		t.Fatal("raw-wire-tcp-pipeline-depth=0 accepted")
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
 		t.Fatalf("timeout 0 should disable deadline: %v", err)
@@ -1297,7 +1310,7 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("client mode smoke benchmark skipped in short mode")
 	}
-	for _, mode := range []string{clientModeDriver, clientModeDriverFindRaw, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP} {
+	for _, mode := range []string{clientModeDriver, clientModeDriverFindRaw, clientModeDriverCommand, clientModeDriverCommandRaw, clientModeDriverUnack, clientModeDirect, clientModeRawWire, clientModeRawWireTCP, clientModeRawWireTCPPipeline} {
 		t.Run(mode, func(t *testing.T) {
 			opsPerSecond := runTreeDBClientModeSmoke(t, mode)
 			t.Logf("%s load_insert_many ops/sec=%.1f", mode, opsPerSecond)
@@ -1305,11 +1318,11 @@ func TestTreeDBClientModeSmoke(t *testing.T) {
 	}
 }
 
-func TestTreeDBDriverRawRangePhaseSmoke(t *testing.T) {
+func TestTreeDBRangeClientModeSmoke(t *testing.T) {
 	if testing.Short() {
-		t.Skip("driver raw range smoke skipped in short mode")
+		t.Skip("range client mode smoke skipped in short mode")
 	}
-	for _, mode := range []string{clientModeDriverFindRaw, clientModeDriverCommandRaw} {
+	for _, mode := range []string{clientModeDriverFindRaw, clientModeDriverCommandRaw, clientModeRawWireTCPPipeline} {
 		t.Run(mode, func(t *testing.T) {
 			cfg, err := parseConfig([]string{
 				"-target", "treedb",
@@ -1460,7 +1473,7 @@ func TestTreeDBDirectBenchmarkSmoke(t *testing.T) {
 }
 
 func TestTreeDBRawWireLoadPhaseHonorsCanceledContext(t *testing.T) {
-	for _, mode := range []string{clientModeRawWire, clientModeRawWireTCP} {
+	for _, mode := range []string{clientModeRawWire, clientModeRawWireTCP, clientModeRawWireTCPPipeline} {
 		t.Run(mode, func(t *testing.T) {
 			cfg, err := parseConfig([]string{
 				"-target", "treedb",

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -644,8 +645,8 @@ func TestParseConfigValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse default raw-wire-tcp-pipeline config: %v", err)
 	}
-	if defaultPipelineCfg.RawWireTCPPipelineDepth != 128 {
-		t.Fatalf("default raw-wire-tcp-pipeline depth=%d want 128", defaultPipelineCfg.RawWireTCPPipelineDepth)
+	if defaultPipelineCfg.RawWireTCPPipelineDepth != defaultRawWireTCPPipelineDepth {
+		t.Fatalf("default raw-wire-tcp-pipeline depth=%d want %d", defaultPipelineCfg.RawWireTCPPipelineDepth, defaultRawWireTCPPipelineDepth)
 	}
 	rawWireTCPPipelineCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", "16"})
 	if err != nil {
@@ -725,6 +726,9 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", "0"}); err == nil {
 		t.Fatal("raw-wire-tcp-pipeline-depth=0 accepted for pipeline mode")
+	}
+	if _, err := parseConfig([]string{"-client-mode", "raw-wire-tcp-pipeline", "-raw-wire-tcp-pipeline-depth", strconv.Itoa(maxRawWireTCPPipelineDepth + 1)}); err == nil {
+		t.Fatal("raw-wire-tcp-pipeline-depth above max accepted for pipeline mode")
 	}
 	if _, err := parseConfig([]string{"-raw-wire-tcp-pipeline-depth", "0"}); err != nil {
 		t.Fatalf("raw-wire-tcp-pipeline-depth=0 should be ignored outside pipeline mode: %v", err)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"math"
 	"math/bits"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -848,6 +850,62 @@ func mustTestBSON(t *testing.T, doc bson.D) bson.Raw {
 		t.Fatalf("marshal test BSON: %v", err)
 	}
 	return raw
+}
+
+func TestRawWireTCPPipelineClientReadFindHonorsContextCancel(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	client := &rawWireTCPPipelineClient{
+		conn: clientConn,
+		rd:   bufio.NewReaderSize(clientConn, rawWireTCPReadBufferSize),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.ReadFind(ctx, 1, 0)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ReadFind err=%v want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ReadFind did not return after context cancellation")
+	}
+}
+
+func TestRawWireTCPPipelineClientFlushHonorsContextCancel(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	client := &rawWireTCPPipelineClient{
+		conn:     clientConn,
+		writeBuf: bytes.Repeat([]byte("x"), 1024),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.Flush(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Flush err=%v want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Flush did not return after context cancellation")
+	}
 }
 
 func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -862,6 +862,8 @@ func TestRawWireTCPPipelineClientReadFindHonorsContextCancel(t *testing.T) {
 		rd:   bufio.NewReaderSize(clientConn, rawWireTCPReadBufferSize),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	stopCancelWatch := watchRawWireTCPPipelineClients(ctx, client)
+	defer stopCancelWatch()
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- client.ReadFind(ctx, 1, 0)
@@ -890,6 +892,8 @@ func TestRawWireTCPPipelineClientFlushHonorsContextCancel(t *testing.T) {
 		writeBuf: bytes.Repeat([]byte("x"), 1024),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	stopCancelWatch := watchRawWireTCPPipelineClients(ctx, client)
+	defer stopCancelWatch()
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- client.Flush(ctx)

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -249,7 +249,7 @@ Use a client-mode matrix when measuring driver overhead and gateway ceiling:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
+TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire-tcp-pipeline raw-wire" \
 MONGO_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack" \
 BATCH_SIZE=5000 \
 INSERT_PRODUCERS=8 \
@@ -291,6 +291,9 @@ Interpret client modes as separate questions:
   format. It emits the same phase names as the Mongo gateway benchmark while
   bypassing the MongoDB driver, sockets, and Mongo gateway command handling.
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
+- `raw-wire-tcp-pipeline`: TreeDB-only raw TCP load plus pipelined age range
+  `find` requests; use it to measure how much single-connection request/response
+  latency can be hidden without the official driver.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-find-raw` to

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -293,7 +293,9 @@ Interpret client modes as separate questions:
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire-tcp-pipeline`: TreeDB-only raw TCP load plus pipelined age range
   `find` requests; use it to measure how much single-connection request/response
-  latency can be hidden without the official driver.
+  latency can be hidden without the official driver. The default pipeline depth
+  is `128`, which keeps enough requests queued for the gateway's buffered
+  response coalescing to amortize write syscalls.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
 Use `driver` for user-visible Mongo compatibility. Use `driver-find-raw` to

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -249,8 +249,8 @@ Use a client-mode matrix when measuring driver overhead and gateway ceiling:
 
 ```sh
 TREEDB_DOCUMENT_FORMATS="bson" \
-TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
-MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
+TREEDB_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire" \
+MONGO_CLIENT_MODES="driver driver-find-raw driver-command driver-command-raw driver-unack" \
 BATCH_SIZE=5000 \
 INSERT_PRODUCERS=8 \
 MONGO_MAX_POOL_SIZE=128 \
@@ -281,6 +281,8 @@ new client-mode bundles remain readable side by side.
 Interpret client modes as separate questions:
 
 - `driver`: ordinary official MongoDB Go driver CRUD-helper path.
+- `driver-find-raw`: official driver `Collection.Find` range-read path using
+  `cursor.Current` raw BSON instead of decoding documents into `bson.M`.
 - `driver-command`: official driver `RunCommand` insert path.
 - `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
 - `driver-unack`: official driver unacknowledged insert enqueue path plus
@@ -291,11 +293,12 @@ Interpret client modes as separate questions:
 - `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
 - `raw-wire`: TreeDB-only in-process raw OP_MSG load.
 
-Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
-the fastest current acknowledged official-driver load path. Use `direct` to
-separate collection-engine and storage-format bottlenecks from Mongo
-compatibility overhead. Use raw-wire modes only to estimate TreeDB
-gateway/server ceiling.
+Use `driver` for user-visible Mongo compatibility. Use `driver-find-raw` to
+separate official-driver find/cursor overhead from application `bson.M` decode.
+Use `driver-command-raw` for the fastest current acknowledged official-driver
+load path. Use `direct` to separate collection-engine and storage-format
+bottlenecks from Mongo compatibility overhead. Use raw-wire modes only to
+estimate TreeDB gateway/server ceiling.
 
 ## Reader and Writer Scaling
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -108,11 +108,11 @@ Options:
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
   --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
   --mongo-client-mode MODE
-                        Single MongoDB client mode: driver, driver-command,
-                        driver-command-raw, or driver-unack.
+                        Single MongoDB client mode: driver, driver-find-raw,
+                        driver-command, driver-command-raw, or driver-unack.
   --mongo-client-modes LIST
                         Space-separated MongoDB client modes. Example:
-                        "driver driver-command driver-command-raw driver-unack".
+                        "driver driver-find-raw driver-command driver-command-raw driver-unack".
   --timeout DURATION    Per-run benchmark timeout. Default: 20m.
   --treedb-profile NAME TreeDB profile. Default: wal_on_fast.
   --treedb-document-format FORMAT
@@ -120,9 +120,9 @@ Options:
   --treedb-document-formats LIST
                         Space-separated TreeDB formats. Example: "json template-v1 bson".
   --treedb-client-mode MODE
-                        Single TreeDB client mode: driver, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, or raw-wire.
+                        Single TreeDB client mode: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, or raw-wire.
   --treedb-client-modes LIST
-                        Space-separated TreeDB client modes. Example: "driver driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
+                        Space-separated TreeDB client modes. Example: "driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
   --treedb-maintenance MODE
                         TreeDB final maintenance: full, checkpoint, or none.
   --treedb-read-state STATE
@@ -455,10 +455,10 @@ validate_mongo_client_modes() {
   local mode
   for mode in $1; do
     case "$mode" in
-      driver|driver-command|driver-command-raw|driver-unack)
+      driver|driver-find-raw|driver-command|driver-command-raw|driver-unack)
         ;;
       *)
-        echo "invalid MONGO_CLIENT_MODES value: $mode (want driver, driver-command, driver-command-raw, or driver-unack)" >&2
+        echo "invalid MONGO_CLIENT_MODES value: $mode (want driver, driver-find-raw, driver-command, driver-command-raw, or driver-unack)" >&2
         exit 2
         ;;
     esac

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -120,9 +120,9 @@ Options:
   --treedb-document-formats LIST
                         Space-separated TreeDB formats. Example: "json template-v1 bson".
   --treedb-client-mode MODE
-                        Single TreeDB client mode: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, or raw-wire.
+                        Single TreeDB client mode: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire-tcp, raw-wire-tcp-pipeline, or raw-wire.
   --treedb-client-modes LIST
-                        Space-separated TreeDB client modes. Example: "driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire".
+                        Space-separated TreeDB client modes. Example: "driver driver-find-raw driver-command driver-command-raw driver-unack direct raw-wire-tcp raw-wire-tcp-pipeline raw-wire".
   --treedb-maintenance MODE
                         TreeDB final maintenance: full, checkpoint, or none.
   --treedb-read-state STATE


### PR DESCRIPTION
Stacked on #1418.

## What

This PR measures and optimizes the Mongo indexed range-read stack across the four benchmark levels we have been using:

1. official Mongo driver path;
2. raw-wire TCP path;
3. raw-wire in-process gateway path;
4. direct collection path.

It started as a measurement PR for `driver-find-raw`, but the profile work found and fixed several gateway/benchmark hot-path issues as well.

## Functional / Benchmark Changes

- Adds `-client-mode driver-find-raw` to `cmd/mongo_gateway_bench` so the official Mongo Go driver still uses `Collection.Find` and cursor iteration, but validates `cursor.Current` raw BSON instead of decoding into `[]bson.M`.
- Adds raw-wire TCP pipelined range mode and fanout coverage so single-connection TCP/RTT costs can be separated from server execution.
- Adds direct and raw-wire benchmark parity/fanout paths for indexed range reads.
- Documents these modes in the benchmark README and canonical runbook.

## Gateway / Collection Optimizations

- Adds/uses the pure indexed range + limit fast path for Mongo `find({age: {$gte: x}}).limit(10)` style queries.
- Coalesces already-buffered pipelined Mongo wire responses in `ServeConn` while preserving earlier successful responses if a later buffered request errors.
- Reuses benchmark raw-wire command buffers and raw-wire TCP pipeline buffers.
- Removes per-response heap allocation in the raw cursor response builder.
- Inlines find response payload state instead of allocating wrapper structs for raw/indexed-range responses.
- Amortizes Mongo wire response-buffer growth under pipelined/coalesced replies.
- Makes raw-wire TCP pipeline cancellation unblock socket reads/writes without per-response context watcher overhead.
- Cleans up the direct indexed range reader path by removing an unreachable `ReaderAtRoot(...).ErrKeyNotFound` branch.

## Validation

```text
go test -count=1 ./TreeDB/mongo_gateway ./TreeDB/collections ./cmd/mongo_gateway_bench
go test -count=1 ./cmd/mongo_gateway_bench ./TreeDB/mongo_gateway ./TreeDB/mongo_gateway/fastclient ./TreeDB/mongo_gateway/wire
bash -n scripts/mongo_gateway_compare.sh
git diff --check
```

## Latest Single-Client Range Results

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_driver_find_raw_latest_20260507_005028`

Workload: settled BSON TreeDB, 20k docs, `age_1` range index, 50k `age_range_indexed_limit_10` operations.

| Mode | ops/sec | ns/op |
|---|---:|---:|
| driver | 12,045 | 83,025 |
| driver-find-raw | 23,406 | 42,725 |
| driver-command-raw | 24,531 | 40,764 |
| raw-wire-tcp | 30,834 | 32,431 |
| raw-wire | 91,633 | 10,913 |
| direct | 122,956 | 8,133 |

## Latest Raw-Wire TCP Pipeline Profile

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_wire_capacity_check_e617eed40c_20260507_033543`

| Metric | Value |
|---|---:|
| sampled ops/sec | 97,671 |
| sampled ns/op | 10,238 |
| total alloc-space | 204MB |
| `marshalIndexedRangeCursorMsgInto` cum alloc | 6.69MB |
| `ensureWireAppendCapacity` flat alloc | 1.19MB |

Previous profiled run before amortized response-buffer growth: `92,978 ops/sec`, `10,755 ns/op`, total alloc-space `252MB`, `marshalIndexedRangeCursorMsgInto` cum alloc `16.16MB`.

## Official-Driver Fanout Results

Artifact: `/Users/michaelseiler/dev/snissn/benchdata/mongo_driver_find_raw_fanout_20260507_005056`

| Mode | Peak readers | Peak ops/sec | Peak ns/op |
|---|---:|---:|---:|
| driver | 16 | 52,044 | 19,215 |
| driver-find-raw | 16 | 84,553 | 11,827 |
| driver-command-raw | 32 | 84,993 | 11,766 |

## Interpretation / Next Step

The decoded driver path is dominated by official-driver/app decode cost (`Cursor.All(&[]bson.M)`), while raw driver modes approach the raw-wire ceiling under fanout. The raw-wire TCP profile is mostly socket/syscall cost once pipelined. The remaining profile-backed gateway allocation is collection open/meta copy; collection caching is intentionally deferred for now per reviewer preference.

@codex review
@copilot review
