### PR TITLE
collections: add update profiling breakdowns

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -324,6 +324,8 @@ type CollectionUpdateStats struct {
 	Callback             time.Duration
 	PrepareDocuments     time.Duration
 	IndexStateExtraction time.Duration
+	OldIndexStateExtract time.Duration
+	NewIndexStateExtract time.Duration
 	UniqueIndexPreflight time.Duration
 	TemplateRunBuild     time.Duration
 	PrimaryRunBuild      time.Duration
@@ -340,14 +342,18 @@ type CollectionUpdateStats struct {
 	// relock contention after an async flush wait. It does not include async
 	// flush completion waits performed after releasing the mutex for
 	// backpressure.
-	BufferStageLockWait      time.Duration
-	BufferStageLockHold      time.Duration
-	BufferStageValidation    time.Duration
-	BufferStageRootScan      time.Duration
-	BufferStageDomainPrepare time.Duration
-	BufferStagePrimaryIdx    time.Duration
-	BufferStageUniqueIdx     time.Duration
-	BufferStageRootAppend    time.Duration
+	BufferStageLockWait        time.Duration
+	BufferStageLockHold        time.Duration
+	BufferStageValidation      time.Duration
+	BufferStageRootScan        time.Duration
+	BufferStageDomainPrepare   time.Duration
+	BufferStageFreeze          time.Duration
+	BufferStageRootTable       time.Duration
+	BufferStagePrimaryIdx      time.Duration
+	BufferStageUniqueIdx       time.Duration
+	BufferStagePrimaryAppend   time.Duration
+	BufferStageSecondaryAppend time.Duration
+	BufferStageRootAppend      time.Duration
 	// BufferStageFlush measures local threshold-flush schedule/publish work
 	// performed while staging an indexed buffered update batch. It excludes
 	// waits for an already-running async flush that leave no local schedule or
@@ -403,91 +409,101 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                        int
-	PendingDocuments               int
-	PendingBytes                   int64
-	PendingRootRuns                int
-	PendingIndexedFlushUnits       int
-	OverlayMutableDocuments        int
-	OverlayQueuedIndexedFlushUnits int
-	OverlayActiveIndexedFlushUnits int
-	OverlayVisibleDepth            int
-	IndexedAsyncFlushRunning       int
-	MutationLockCalls              uint64
-	MutationLockWait               time.Duration
-	MutationLockHold               time.Duration
-	IndexedStageBatches            uint64
-	IndexedStageDocs               uint64
-	IndexedStageBytes              uint64
-	IndexedStageRootRuns           uint64
-	IndexedAutoFlushes             uint64
-	IndexedAsyncFlushScheduled     uint64
-	IndexedAsyncFlushBackpressure  uint64
-	IndexedAsyncFlushWait          time.Duration
-	IndexedAsyncFlushErrors        uint64
-	IndexedFlushCalls              uint64
-	IndexedFlushErrors             uint64
-	IndexedFlushForcedDrains       uint64
-	IndexedFlushUnits              uint64
-	IndexedFlushDocs               uint64
-	IndexedFlushBytes              uint64
-	IndexedFlushRootRuns           uint64
-	IndexedFlushRoots              uint64
-	IndexedFlushDuration           time.Duration
-	IndexedFlushMaterialize        time.Duration
-	IndexedFlushPublish            time.Duration
-	RootDeltaPlanPrimaryRoots      uint64
-	RootDeltaPlanTemplateRoots     uint64
-	RootDeltaPlanIndexStateRoots   uint64
-	RootDeltaPlanSecondaryRoots    uint64
-	RootDeltaPlanEntries           uint64
-	RootDeltaPlanKeyBytes          uint64
-	RootDeltaPlanValueBytes        uint64
-	RootDeltaPlanTombstones        uint64
-	PrimaryOnlyUpdateCalls         uint64
-	PrimaryOnlyMatched             uint64
-	PrimaryOnlyModified            uint64
-	PrimaryOnlyBufferedCalls       uint64
-	PrimaryOnlyRootPublishes       uint64
-	PrimaryOnlyRootDeltaEntries    uint64
-	PrimaryOnlyRootDeltaKeyBytes   uint64
-	PrimaryOnlyRootDeltaValueBytes uint64
-	PrimaryOnlyCoalescedDocs       uint64
-	UpdateCombineRequests          uint64
-	UpdateCombineBatches           uint64
-	UpdateCombineBatchedRequests   uint64
-	UpdateCombineFallbackRequests  uint64
-	UpdateCombineQueueDepthMax     uint64
-	UpdateBatchCalls               uint64
-	UpdateBatchItems               uint64
-	UpdateBatchMatched             uint64
-	UpdateBatchModified            uint64
-	UpdateBatchRuns                uint64
-	UpdateBatchBufferedBatches     uint64
-	UpdateBatchCurrentRead         time.Duration
-	UpdateBatchCallback            time.Duration
-	UpdateBatchPrepareDocuments    time.Duration
-	UpdateBatchIndexStateExtract   time.Duration
-	UpdateBatchUniquePreflight     time.Duration
-	UpdateBatchTemplateRunBuild    time.Duration
-	UpdateBatchPrimaryRunBuild     time.Duration
-	UpdateBatchIndexStateRunBuild  time.Duration
-	UpdateBatchSecondaryRunBuild   time.Duration
-	UpdateBatchBufferStage         time.Duration
+	Domains                         int
+	PendingDocuments                int
+	PendingBytes                    int64
+	PendingRootRuns                 int
+	PendingIndexedFlushUnits        int
+	OverlayMutableDocuments         int
+	OverlayQueuedIndexedFlushUnits  int
+	OverlayActiveIndexedFlushUnits  int
+	OverlayVisibleDepth             int
+	IndexedAsyncFlushRunning        int
+	MutationLockCalls               uint64
+	MutationLockWait                time.Duration
+	MutationLockHold                time.Duration
+	IndexedStageBatches             uint64
+	IndexedStageDocs                uint64
+	IndexedStageBytes               uint64
+	IndexedStageRootRuns            uint64
+	IndexedAutoFlushes              uint64
+	IndexedAsyncFlushScheduled      uint64
+	IndexedAsyncFlushBackpressure   uint64
+	IndexedAsyncFlushWait           time.Duration
+	IndexedAsyncFlushErrors         uint64
+	IndexedFlushCalls               uint64
+	IndexedFlushErrors              uint64
+	IndexedFlushForcedDrains        uint64
+	IndexedFlushUnits               uint64
+	IndexedFlushDocs                uint64
+	IndexedFlushBytes               uint64
+	IndexedFlushRootRuns            uint64
+	IndexedFlushRoots               uint64
+	IndexedFlushDuration            time.Duration
+	IndexedFlushMaterialize         time.Duration
+	IndexedFlushPublish             time.Duration
+	RootDeltaPlanPrimaryRoots       uint64
+	RootDeltaPlanTemplateRoots      uint64
+	RootDeltaPlanIndexStateRoots    uint64
+	RootDeltaPlanSecondaryRoots     uint64
+	RootDeltaPlanEntries            uint64
+	RootDeltaPlanKeyBytes           uint64
+	RootDeltaPlanValueBytes         uint64
+	RootDeltaPlanTombstones         uint64
+	PrimaryOnlyUpdateCalls          uint64
+	PrimaryOnlyMatched              uint64
+	PrimaryOnlyModified             uint64
+	PrimaryOnlyBufferedCalls        uint64
+	PrimaryOnlyRootPublishes        uint64
+	PrimaryOnlyRootDeltaEntries     uint64
+	PrimaryOnlyRootDeltaKeyBytes    uint64
+	PrimaryOnlyRootDeltaValueBytes  uint64
+	PrimaryOnlyCoalescedDocs        uint64
+	UpdateCombineRequests           uint64
+	UpdateCombineBatches            uint64
+	UpdateCombineBatchedRequests    uint64
+	UpdateCombineFallbackRequests   uint64
+	UpdateCombineQueueDepthMax      uint64
+	UpdateCombineEnqueue            time.Duration
+	UpdateCombineWait               time.Duration
+	UpdateCombineDrain              time.Duration
+	UpdateCombineRun                time.Duration
+	UpdateBatchCalls                uint64
+	UpdateBatchItems                uint64
+	UpdateBatchMatched              uint64
+	UpdateBatchModified             uint64
+	UpdateBatchRuns                 uint64
+	UpdateBatchBufferedBatches      uint64
+	UpdateBatchCurrentRead          time.Duration
+	UpdateBatchCallback             time.Duration
+	UpdateBatchPrepareDocuments     time.Duration
+	UpdateBatchIndexStateExtract    time.Duration
+	UpdateBatchOldIndexStateExtract time.Duration
+	UpdateBatchNewIndexStateExtract time.Duration
+	UpdateBatchUniquePreflight      time.Duration
+	UpdateBatchTemplateRunBuild     time.Duration
+	UpdateBatchPrimaryRunBuild      time.Duration
+	UpdateBatchIndexStateRunBuild   time.Duration
+	UpdateBatchSecondaryRunBuild    time.Duration
+	UpdateBatchBufferStage          time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
 	// and overlaps the validation/root/index/root-append subphases; it is not
 	// additive with those child counters.
-	UpdateBatchBufferPrecheck      time.Duration
-	UpdateBatchBufferLockWait      time.Duration
-	UpdateBatchBufferLockHold      time.Duration
-	UpdateBatchBufferValidation    time.Duration
-	UpdateBatchBufferRootScan      time.Duration
-	UpdateBatchBufferDomainPrepare time.Duration
-	UpdateBatchBufferPrimaryIdx    time.Duration
-	UpdateBatchBufferUniqueIdx     time.Duration
-	UpdateBatchBufferRootAppend    time.Duration
+	UpdateBatchBufferPrecheck        time.Duration
+	UpdateBatchBufferLockWait        time.Duration
+	UpdateBatchBufferLockHold        time.Duration
+	UpdateBatchBufferValidation      time.Duration
+	UpdateBatchBufferRootScan        time.Duration
+	UpdateBatchBufferDomainPrepare   time.Duration
+	UpdateBatchBufferFreeze          time.Duration
+	UpdateBatchBufferRootTable       time.Duration
+	UpdateBatchBufferPrimaryIdx      time.Duration
+	UpdateBatchBufferUniqueIdx       time.Duration
+	UpdateBatchBufferPrimaryAppend   time.Duration
+	UpdateBatchBufferSecondaryAppend time.Duration
+	UpdateBatchBufferRootAppend      time.Duration
 	// UpdateBatchBufferFlush measures only threshold-flush work that was
 	// actually scheduled/executed while staging indexed buffered update batches.
 	UpdateBatchBufferFlush         time.Duration
@@ -776,99 +792,109 @@ type collectionWriteDomain struct {
 	rootRunCount     int
 	writeGeneration  uint64
 
-	mutationLockCalls                atomic.Uint64
-	mutationLockWaitTotalNs          atomic.Uint64
-	mutationLockHoldTotalNs          atomic.Uint64
-	indexedStageBatches              atomic.Uint64
-	indexedStageDocs                 atomic.Uint64
-	indexedStageBytes                atomic.Uint64
-	indexedStageRootRuns             atomic.Uint64
-	indexedAutoFlushes               atomic.Uint64
-	indexedAsyncFlushScheduled       atomic.Uint64
-	indexedAsyncFlushBackpressure    atomic.Uint64
-	indexedAsyncFlushWaitTotalNs     atomic.Uint64
-	indexedAsyncFlushErrors          atomic.Uint64
-	indexedFlushCalls                atomic.Uint64
-	indexedFlushErrors               atomic.Uint64
-	indexedFlushForcedDrains         atomic.Uint64
-	indexedFlushUnitsTotal           atomic.Uint64
-	indexedFlushRequeues             atomic.Uint64
-	indexedFlushRequeuedUnits        atomic.Uint64
-	indexedFlushLostOwnership        atomic.Uint64
-	indexedFlushRootBaseMismatches   atomic.Uint64
-	indexedFlushDocs                 atomic.Uint64
-	indexedFlushBytes                atomic.Uint64
-	indexedFlushRootRuns             atomic.Uint64
-	indexedFlushRoots                atomic.Uint64
-	indexedFlushDurationTotalNs      atomic.Uint64
-	indexedFlushMaterializeTotalNs   atomic.Uint64
-	indexedFlushPublishTotalNs       atomic.Uint64
-	rootDeltaPlanPrimaryRoots        atomic.Uint64
-	rootDeltaPlanTemplateRoots       atomic.Uint64
-	rootDeltaPlanIndexStateRoots     atomic.Uint64
-	rootDeltaPlanSecondaryRoots      atomic.Uint64
-	rootDeltaPlanEntries             atomic.Uint64
-	rootDeltaPlanKeyBytes            atomic.Uint64
-	rootDeltaPlanValueBytes          atomic.Uint64
-	rootDeltaPlanTombstones          atomic.Uint64
-	primaryOnlyUpdateCalls           atomic.Uint64
-	primaryOnlyMatched               atomic.Uint64
-	primaryOnlyModified              atomic.Uint64
-	primaryOnlyBufferedCalls         atomic.Uint64
-	primaryOnlyRootPublishes         atomic.Uint64
-	primaryOnlyRootDeltaEntries      atomic.Uint64
-	primaryOnlyRootDeltaKeyBytes     atomic.Uint64
-	primaryOnlyRootDeltaValueBytes   atomic.Uint64
-	primaryOnlyCoalescedDocs         atomic.Uint64
-	updateCombineRequests            atomic.Uint64
-	updateCombineBatches             atomic.Uint64
-	updateCombineBatchedRequests     atomic.Uint64
-	updateCombineFallbackRequests    atomic.Uint64
-	updateCombineQueueDepthMax       atomic.Uint64
-	updateBatchCalls                 atomic.Uint64
-	updateBatchItems                 atomic.Uint64
-	updateBatchMatched               atomic.Uint64
-	updateBatchModified              atomic.Uint64
-	updateBatchRuns                  atomic.Uint64
-	updateBatchBufferedBatches       atomic.Uint64
-	updateBatchCurrentReadNs         atomic.Uint64
-	updateBatchCallbackNs            atomic.Uint64
-	updateBatchPrepareNs             atomic.Uint64
-	updateBatchIndexStateNs          atomic.Uint64
-	updateBatchUniquePreflightNs     atomic.Uint64
-	updateBatchTemplateRunNs         atomic.Uint64
-	updateBatchPrimaryRunNs          atomic.Uint64
-	updateBatchIndexStateRunNs       atomic.Uint64
-	updateBatchSecondaryRunNs        atomic.Uint64
-	updateBatchBufferStageNs         atomic.Uint64
-	updateBatchBufferPrecheckNs      atomic.Uint64
-	updateBatchBufferLockWaitNs      atomic.Uint64
-	updateBatchBufferLockHoldNs      atomic.Uint64
-	updateBatchBufferValidationNs    atomic.Uint64
-	updateBatchBufferRootScanNs      atomic.Uint64
-	updateBatchBufferDomainPrepareNs atomic.Uint64
-	updateBatchBufferPrimaryIdxNs    atomic.Uint64
-	updateBatchBufferUniqueIdxNs     atomic.Uint64
-	updateBatchBufferRootAppendNs    atomic.Uint64
-	updateBatchBufferFlushNs         atomic.Uint64
-	updateBatchPublishNs             atomic.Uint64
-	updateBatchSecondaryDeletes      atomic.Uint64
-	updateBatchSecondarySets         atomic.Uint64
-	updateBatchSecondaryKeyBytes     atomic.Uint64
-	updateBatchIndexValueChanges     atomic.Uint64
-	updateBatchIndexValueUnchanged   atomic.Uint64
-	updateBatchMaskFallbacks         atomic.Uint64
-	updateBatchUniqueChecks          atomic.Uint64
-	updateBatchUniqueCheckSkips      atomic.Uint64
-	updateBatchDetailedStats         atomic.Bool
-	updateBatchIndexChanged          [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexUnchanged        [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexUniqueChecks     [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexUniqueSkips      [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexSecondaryRuns    [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexSecondaryDeletes [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexSecondarySets    [maxCollectionUpdateInlineIndexStats]atomic.Uint64
-	updateBatchIndexSecondaryBytes   [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	mutationLockCalls                  atomic.Uint64
+	mutationLockWaitTotalNs            atomic.Uint64
+	mutationLockHoldTotalNs            atomic.Uint64
+	indexedStageBatches                atomic.Uint64
+	indexedStageDocs                   atomic.Uint64
+	indexedStageBytes                  atomic.Uint64
+	indexedStageRootRuns               atomic.Uint64
+	indexedAutoFlushes                 atomic.Uint64
+	indexedAsyncFlushScheduled         atomic.Uint64
+	indexedAsyncFlushBackpressure      atomic.Uint64
+	indexedAsyncFlushWaitTotalNs       atomic.Uint64
+	indexedAsyncFlushErrors            atomic.Uint64
+	indexedFlushCalls                  atomic.Uint64
+	indexedFlushErrors                 atomic.Uint64
+	indexedFlushForcedDrains           atomic.Uint64
+	indexedFlushUnitsTotal             atomic.Uint64
+	indexedFlushRequeues               atomic.Uint64
+	indexedFlushRequeuedUnits          atomic.Uint64
+	indexedFlushLostOwnership          atomic.Uint64
+	indexedFlushRootBaseMismatches     atomic.Uint64
+	indexedFlushDocs                   atomic.Uint64
+	indexedFlushBytes                  atomic.Uint64
+	indexedFlushRootRuns               atomic.Uint64
+	indexedFlushRoots                  atomic.Uint64
+	indexedFlushDurationTotalNs        atomic.Uint64
+	indexedFlushMaterializeTotalNs     atomic.Uint64
+	indexedFlushPublishTotalNs         atomic.Uint64
+	rootDeltaPlanPrimaryRoots          atomic.Uint64
+	rootDeltaPlanTemplateRoots         atomic.Uint64
+	rootDeltaPlanIndexStateRoots       atomic.Uint64
+	rootDeltaPlanSecondaryRoots        atomic.Uint64
+	rootDeltaPlanEntries               atomic.Uint64
+	rootDeltaPlanKeyBytes              atomic.Uint64
+	rootDeltaPlanValueBytes            atomic.Uint64
+	rootDeltaPlanTombstones            atomic.Uint64
+	primaryOnlyUpdateCalls             atomic.Uint64
+	primaryOnlyMatched                 atomic.Uint64
+	primaryOnlyModified                atomic.Uint64
+	primaryOnlyBufferedCalls           atomic.Uint64
+	primaryOnlyRootPublishes           atomic.Uint64
+	primaryOnlyRootDeltaEntries        atomic.Uint64
+	primaryOnlyRootDeltaKeyBytes       atomic.Uint64
+	primaryOnlyRootDeltaValueBytes     atomic.Uint64
+	primaryOnlyCoalescedDocs           atomic.Uint64
+	updateCombineRequests              atomic.Uint64
+	updateCombineBatches               atomic.Uint64
+	updateCombineBatchedRequests       atomic.Uint64
+	updateCombineFallbackRequests      atomic.Uint64
+	updateCombineQueueDepthMax         atomic.Uint64
+	updateCombineEnqueueNs             atomic.Uint64
+	updateCombineWaitNs                atomic.Uint64
+	updateCombineDrainNs               atomic.Uint64
+	updateCombineRunNs                 atomic.Uint64
+	updateBatchCalls                   atomic.Uint64
+	updateBatchItems                   atomic.Uint64
+	updateBatchMatched                 atomic.Uint64
+	updateBatchModified                atomic.Uint64
+	updateBatchRuns                    atomic.Uint64
+	updateBatchBufferedBatches         atomic.Uint64
+	updateBatchCurrentReadNs           atomic.Uint64
+	updateBatchCallbackNs              atomic.Uint64
+	updateBatchPrepareNs               atomic.Uint64
+	updateBatchIndexStateNs            atomic.Uint64
+	updateBatchOldIndexStateNs         atomic.Uint64
+	updateBatchNewIndexStateNs         atomic.Uint64
+	updateBatchUniquePreflightNs       atomic.Uint64
+	updateBatchTemplateRunNs           atomic.Uint64
+	updateBatchPrimaryRunNs            atomic.Uint64
+	updateBatchIndexStateRunNs         atomic.Uint64
+	updateBatchSecondaryRunNs          atomic.Uint64
+	updateBatchBufferStageNs           atomic.Uint64
+	updateBatchBufferPrecheckNs        atomic.Uint64
+	updateBatchBufferLockWaitNs        atomic.Uint64
+	updateBatchBufferLockHoldNs        atomic.Uint64
+	updateBatchBufferValidationNs      atomic.Uint64
+	updateBatchBufferRootScanNs        atomic.Uint64
+	updateBatchBufferDomainPrepareNs   atomic.Uint64
+	updateBatchBufferFreezeNs          atomic.Uint64
+	updateBatchBufferRootTableNs       atomic.Uint64
+	updateBatchBufferPrimaryIdxNs      atomic.Uint64
+	updateBatchBufferUniqueIdxNs       atomic.Uint64
+	updateBatchBufferPrimaryAppendNs   atomic.Uint64
+	updateBatchBufferSecondaryAppendNs atomic.Uint64
+	updateBatchBufferRootAppendNs      atomic.Uint64
+	updateBatchBufferFlushNs           atomic.Uint64
+	updateBatchPublishNs               atomic.Uint64
+	updateBatchSecondaryDeletes        atomic.Uint64
+	updateBatchSecondarySets           atomic.Uint64
+	updateBatchSecondaryKeyBytes       atomic.Uint64
+	updateBatchIndexValueChanges       atomic.Uint64
+	updateBatchIndexValueUnchanged     atomic.Uint64
+	updateBatchMaskFallbacks           atomic.Uint64
+	updateBatchUniqueChecks            atomic.Uint64
+	updateBatchUniqueCheckSkips        atomic.Uint64
+	updateBatchDetailedStats           atomic.Bool
+	updateBatchIndexChanged            [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUnchanged          [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUniqueChecks       [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUniqueSkips        [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryRuns      [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryDeletes   [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondarySets      [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryBytes     [maxCollectionUpdateInlineIndexStats]atomic.Uint64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1096,6 +1122,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
 	out["treedb.collections.write_domain.update_combine.fallback_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineFallbackRequests)
 	out["treedb.collections.write_domain.update_combine.queue_depth_max"] = fmt.Sprintf("%d", stats.UpdateCombineQueueDepthMax)
+	out["treedb.collections.write_domain.update_combine.enqueue_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineEnqueue.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineWait.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.drain_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineDrain.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.run_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineRun.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.calls_total"] = fmt.Sprintf("%d", stats.UpdateBatchCalls)
 	out["treedb.collections.write_domain.update_batch.items_total"] = fmt.Sprintf("%d", stats.UpdateBatchItems)
 	out["treedb.collections.write_domain.update_batch.matched_total"] = fmt.Sprintf("%d", stats.UpdateBatchMatched)
@@ -1106,6 +1136,8 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.callback_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchCallback.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.prepare_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPrepareDocuments.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.index_state_extract_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexStateExtract.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.old_index_state_extract_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchOldIndexStateExtract.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.new_index_state_extract_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchNewIndexStateExtract.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.unique_preflight_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniquePreflight.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.template_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchTemplateRunBuild.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.primary_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPrimaryRunBuild.Nanoseconds())
@@ -1118,8 +1150,12 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferValidation.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootScan.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferDomainPrepare.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_freeze_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferFreeze.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_root_table_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootTable.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferPrimaryIdx.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferUniqueIdx.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_primary_append_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferPrimaryAppend.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_secondary_append_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferSecondaryAppend.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootAppend.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferFlush.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.publish_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPublish.Nanoseconds())
@@ -1234,6 +1270,27 @@ func (m *CollectionManager) ResetUpdateCombineQueueDepthMax() {
 	}
 }
 
+// ResetUpdateCombinersForProfiling stops current update combiners so subsequent
+// profiling operations recreate them inside the measured context. Call it after
+// benchmark warmup and before the measured phase; it does not flush collection
+// contents or change update semantics.
+func (m *CollectionManager) ResetUpdateCombinersForProfiling() {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.resetUpdateCombinerForProfiling()
+	}
+}
+
 func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if s == nil {
 		return
@@ -1298,6 +1355,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if other.UpdateCombineQueueDepthMax > s.UpdateCombineQueueDepthMax {
 		s.UpdateCombineQueueDepthMax = other.UpdateCombineQueueDepthMax
 	}
+	s.UpdateCombineEnqueue += other.UpdateCombineEnqueue
+	s.UpdateCombineWait += other.UpdateCombineWait
+	s.UpdateCombineDrain += other.UpdateCombineDrain
+	s.UpdateCombineRun += other.UpdateCombineRun
 	s.UpdateBatchCalls += other.UpdateBatchCalls
 	s.UpdateBatchItems += other.UpdateBatchItems
 	s.UpdateBatchMatched += other.UpdateBatchMatched
@@ -1308,6 +1369,8 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchCallback += other.UpdateBatchCallback
 	s.UpdateBatchPrepareDocuments += other.UpdateBatchPrepareDocuments
 	s.UpdateBatchIndexStateExtract += other.UpdateBatchIndexStateExtract
+	s.UpdateBatchOldIndexStateExtract += other.UpdateBatchOldIndexStateExtract
+	s.UpdateBatchNewIndexStateExtract += other.UpdateBatchNewIndexStateExtract
 	s.UpdateBatchUniquePreflight += other.UpdateBatchUniquePreflight
 	s.UpdateBatchTemplateRunBuild += other.UpdateBatchTemplateRunBuild
 	s.UpdateBatchPrimaryRunBuild += other.UpdateBatchPrimaryRunBuild
@@ -1320,8 +1383,12 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchBufferValidation += other.UpdateBatchBufferValidation
 	s.UpdateBatchBufferRootScan += other.UpdateBatchBufferRootScan
 	s.UpdateBatchBufferDomainPrepare += other.UpdateBatchBufferDomainPrepare
+	s.UpdateBatchBufferFreeze += other.UpdateBatchBufferFreeze
+	s.UpdateBatchBufferRootTable += other.UpdateBatchBufferRootTable
 	s.UpdateBatchBufferPrimaryIdx += other.UpdateBatchBufferPrimaryIdx
 	s.UpdateBatchBufferUniqueIdx += other.UpdateBatchBufferUniqueIdx
+	s.UpdateBatchBufferPrimaryAppend += other.UpdateBatchBufferPrimaryAppend
+	s.UpdateBatchBufferSecondaryAppend += other.UpdateBatchBufferSecondaryAppend
 	s.UpdateBatchBufferRootAppend += other.UpdateBatchBufferRootAppend
 	s.UpdateBatchBufferFlush += other.UpdateBatchBufferFlush
 	s.UpdateBatchPublish += other.UpdateBatchPublish
@@ -1417,6 +1484,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
 	stats.UpdateCombineFallbackRequests = domain.updateCombineFallbackRequests.Load()
 	stats.UpdateCombineQueueDepthMax = domain.updateCombineQueueDepthMax.Load()
+	stats.UpdateCombineEnqueue = durationFromAtomicNs(domain.updateCombineEnqueueNs.Load())
+	stats.UpdateCombineWait = durationFromAtomicNs(domain.updateCombineWaitNs.Load())
+	stats.UpdateCombineDrain = durationFromAtomicNs(domain.updateCombineDrainNs.Load())
+	stats.UpdateCombineRun = durationFromAtomicNs(domain.updateCombineRunNs.Load())
 	stats.UpdateBatchCalls = domain.updateBatchCalls.Load()
 	stats.UpdateBatchItems = domain.updateBatchItems.Load()
 	stats.UpdateBatchMatched = domain.updateBatchMatched.Load()
@@ -1427,6 +1498,8 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchCallback = durationFromAtomicNs(domain.updateBatchCallbackNs.Load())
 	stats.UpdateBatchPrepareDocuments = durationFromAtomicNs(domain.updateBatchPrepareNs.Load())
 	stats.UpdateBatchIndexStateExtract = durationFromAtomicNs(domain.updateBatchIndexStateNs.Load())
+	stats.UpdateBatchOldIndexStateExtract = durationFromAtomicNs(domain.updateBatchOldIndexStateNs.Load())
+	stats.UpdateBatchNewIndexStateExtract = durationFromAtomicNs(domain.updateBatchNewIndexStateNs.Load())
 	stats.UpdateBatchUniquePreflight = durationFromAtomicNs(domain.updateBatchUniquePreflightNs.Load())
 	stats.UpdateBatchTemplateRunBuild = durationFromAtomicNs(domain.updateBatchTemplateRunNs.Load())
 	stats.UpdateBatchPrimaryRunBuild = durationFromAtomicNs(domain.updateBatchPrimaryRunNs.Load())
@@ -1439,8 +1512,12 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchBufferValidation = durationFromAtomicNs(domain.updateBatchBufferValidationNs.Load())
 	stats.UpdateBatchBufferRootScan = durationFromAtomicNs(domain.updateBatchBufferRootScanNs.Load())
 	stats.UpdateBatchBufferDomainPrepare = durationFromAtomicNs(domain.updateBatchBufferDomainPrepareNs.Load())
+	stats.UpdateBatchBufferFreeze = durationFromAtomicNs(domain.updateBatchBufferFreezeNs.Load())
+	stats.UpdateBatchBufferRootTable = durationFromAtomicNs(domain.updateBatchBufferRootTableNs.Load())
 	stats.UpdateBatchBufferPrimaryIdx = durationFromAtomicNs(domain.updateBatchBufferPrimaryIdxNs.Load())
 	stats.UpdateBatchBufferUniqueIdx = durationFromAtomicNs(domain.updateBatchBufferUniqueIdxNs.Load())
+	stats.UpdateBatchBufferPrimaryAppend = durationFromAtomicNs(domain.updateBatchBufferPrimaryAppendNs.Load())
+	stats.UpdateBatchBufferSecondaryAppend = durationFromAtomicNs(domain.updateBatchBufferSecondaryAppendNs.Load())
 	stats.UpdateBatchBufferRootAppend = durationFromAtomicNs(domain.updateBatchBufferRootAppendNs.Load())
 	stats.UpdateBatchBufferFlush = durationFromAtomicNs(domain.updateBatchBufferFlushNs.Load())
 	stats.UpdateBatchPublish = durationFromAtomicNs(domain.updateBatchPublishNs.Load())
@@ -1543,6 +1620,8 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	domain.updateBatchCallbackNs.Add(durationToAtomicNs(stats.Callback))
 	domain.updateBatchPrepareNs.Add(durationToAtomicNs(stats.PrepareDocuments))
 	domain.updateBatchIndexStateNs.Add(durationToAtomicNs(stats.IndexStateExtraction))
+	domain.updateBatchOldIndexStateNs.Add(durationToAtomicNs(stats.OldIndexStateExtract))
+	domain.updateBatchNewIndexStateNs.Add(durationToAtomicNs(stats.NewIndexStateExtract))
 	domain.updateBatchUniquePreflightNs.Add(durationToAtomicNs(stats.UniqueIndexPreflight))
 	domain.updateBatchTemplateRunNs.Add(durationToAtomicNs(stats.TemplateRunBuild))
 	domain.updateBatchPrimaryRunNs.Add(durationToAtomicNs(stats.PrimaryRunBuild))
@@ -1556,8 +1635,12 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 		domain.updateBatchBufferValidationNs.Add(durationToAtomicNs(stats.BufferStageValidation))
 		domain.updateBatchBufferRootScanNs.Add(durationToAtomicNs(stats.BufferStageRootScan))
 		domain.updateBatchBufferDomainPrepareNs.Add(durationToAtomicNs(stats.BufferStageDomainPrepare))
+		domain.updateBatchBufferFreezeNs.Add(durationToAtomicNs(stats.BufferStageFreeze))
+		domain.updateBatchBufferRootTableNs.Add(durationToAtomicNs(stats.BufferStageRootTable))
 		domain.updateBatchBufferPrimaryIdxNs.Add(durationToAtomicNs(stats.BufferStagePrimaryIdx))
 		domain.updateBatchBufferUniqueIdxNs.Add(durationToAtomicNs(stats.BufferStageUniqueIdx))
+		domain.updateBatchBufferPrimaryAppendNs.Add(durationToAtomicNs(stats.BufferStagePrimaryAppend))
+		domain.updateBatchBufferSecondaryAppendNs.Add(durationToAtomicNs(stats.BufferStageSecondaryAppend))
 		domain.updateBatchBufferRootAppendNs.Add(durationToAtomicNs(stats.BufferStageRootAppend))
 		domain.updateBatchBufferFlushNs.Add(durationToAtomicNs(stats.BufferStageFlush))
 	}
@@ -1646,8 +1729,12 @@ func collectionUpdateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) b
 		stats.BufferStageValidation != 0 ||
 		stats.BufferStageRootScan != 0 ||
 		stats.BufferStageDomainPrepare != 0 ||
+		stats.BufferStageFreeze != 0 ||
+		stats.BufferStageRootTable != 0 ||
 		stats.BufferStagePrimaryIdx != 0 ||
 		stats.BufferStageUniqueIdx != 0 ||
+		stats.BufferStagePrimaryAppend != 0 ||
+		stats.BufferStageSecondaryAppend != 0 ||
 		stats.BufferStageRootAppend != 0 ||
 		stats.BufferStageFlush != 0
 }
@@ -1890,6 +1977,34 @@ func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int)
 	if queueDepth > 0 {
 		atomicMaxUint64(&domain.updateCombineQueueDepthMax, uint64(queueDepth))
 	}
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineEnqueue(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineEnqueueNs.Add(durationToAtomicNs(d))
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineWait(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineWaitNs.Add(durationToAtomicNs(d))
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineDrain(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineDrainNs.Add(durationToAtomicNs(d))
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineRun(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineRunNs.Add(durationToAtomicNs(d))
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineBatch(requests int, fallback bool) {
@@ -6935,6 +7050,34 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 	}
 }
 
+func (domain *collectionWriteDomain) resetUpdateCombinerForProfiling() {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineMu.Lock()
+	combiner := domain.updateCombiner
+	draining := domain.updateDraining
+	domain.updateCombiner = nil
+	if combiner != nil {
+		domain.updateDraining = combiner
+	}
+	domain.updateCombineMu.Unlock()
+	if combiner != nil {
+		combiner.stop()
+	}
+	if draining != nil && draining != combiner {
+		draining.waitDone()
+	}
+	domain.updateCombineMu.Lock()
+	if combiner != nil && domain.updateDraining == combiner {
+		domain.updateDraining = nil
+	}
+	if draining != nil && domain.updateDraining == draining {
+		domain.updateDraining = nil
+	}
+	domain.updateCombineMu.Unlock()
+}
+
 func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if combiner == nil || combiner.maxBatch <= 1 {
 		if err := c.ensureWriteDomainOpen(); err != nil {
@@ -6944,7 +7087,15 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	}
 	waiter := combiner.getWaiter()
 	req := newCollectionUpdateCombineRequest(c, documentID, update, waiter.ch)
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	var enqueueStart time.Time
+	if detailedStats {
+		enqueueStart = time.Now()
+	}
 	if !combiner.enqueue(req) {
+		if detailedStats {
+			combiner.domain.observeUpdateCombineEnqueue(time.Since(enqueueStart))
+		}
 		combiner.putWaiter(waiter)
 		// Combining is a best-effort throughput optimization. Saturated or stopped
 		// combiners fall back to the direct path so updates still make progress.
@@ -6956,7 +7107,17 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 		}
 		return c.updateDirect(documentID, update)
 	}
+	if detailedStats {
+		combiner.domain.observeUpdateCombineEnqueue(time.Since(enqueueStart))
+	}
+	var waitStart time.Time
+	if detailedStats {
+		waitStart = time.Now()
+	}
 	result, reusableWaiter := combiner.waitForUpdateResult(waiter.ch)
+	if detailedStats {
+		combiner.domain.observeUpdateCombineWait(time.Since(waitStart))
+	}
 	if reusableWaiter {
 		combiner.putWaiter(waiter)
 	}
@@ -7184,10 +7345,21 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	batch := combiner.batchScratch[:0]
 	batch = append(batch, first)
 	drainYields := 0
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	var drainStart time.Time
+	if detailedStats {
+		drainStart = time.Now()
+	}
+	finishDrain := func() {
+		if detailedStats {
+			combiner.domain.observeUpdateCombineDrain(time.Since(drainStart))
+		}
+	}
 	for len(batch) < batchCap {
 		select {
 		case req, ok := <-combiner.requests:
 			if !ok {
+				finishDrain()
 				combiner.runBatch(batch)
 				clear(batch)
 				combiner.batchScratch = batch[:0]
@@ -7204,12 +7376,14 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 				}
 				continue
 			}
+			finishDrain()
 			combiner.runBatch(batch)
 			clear(batch)
 			combiner.batchScratch = batch[:0]
 			return
 		}
 	}
+	finishDrain()
 	combiner.runBatch(batch)
 	clear(batch)
 	combiner.batchScratch = batch[:0]
@@ -7218,6 +7392,16 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
 	combiner.running.Store(true)
 	defer combiner.running.Store(false)
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	var runStart time.Time
+	if detailedStats {
+		runStart = time.Now()
+	}
+	defer func() {
+		if detailedStats {
+			combiner.domain.observeUpdateCombineRun(time.Since(runStart))
+		}
+	}()
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			if combiner.domain != nil {
@@ -8950,7 +9134,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		if len(runtimes) > 0 {
 			phaseStart = updateBatchStatsNow(detailedStats)
 			prepared.oldState, err = orderedIndexStateForDocumentWithArena(current.value, runtimes, plannerOptions, stateArena)
-			stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
+			phaseDuration := updateBatchStatsSince(detailedStats, phaseStart)
+			stats.IndexStateExtraction += phaseDuration
+			stats.OldIndexStateExtract += phaseDuration
 			if err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(i, err)
@@ -9035,7 +9221,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		if len(runtimes) > 0 {
 			phaseStart = updateBatchStatsNow(detailedStats)
 			changed[i].newState, err = orderedIndexStateForDocumentWithArena(changed[i].document, runtimes, plannerOptions, stateArena)
-			stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
+			phaseDuration := updateBatchStatsSince(detailedStats, phaseStart)
+			stats.IndexStateExtraction += phaseDuration
+			stats.NewIndexStateExtract += phaseDuration
 			if err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(changed[i].itemIndex, err)
@@ -9550,7 +9738,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 	}
 	if shouldAutoFlushAfterAdding {
+		freezeStart := updateBatchStatsNow(detailedStats)
 		freezeMutableIndexedRunMapsLocked(domain)
+		plan.stats.BufferStageFreeze += updateBatchStatsSince(detailedStats, freezeStart)
 	}
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta
@@ -9560,6 +9750,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 
 	phaseStart = updateBatchStatsNow(detailedStats)
+	rootTableStart := phaseStart
 	rootTables := make(map[string]memtable.Table, len(plan.rootNames))
 	actualRootRuns := 0
 	for i, rootName := range plan.rootNames {
@@ -9580,6 +9771,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			actualRootRuns = saturatingAddNonNegativeInt(actualRootRuns, 1)
 		}
 	}
+	plan.stats.BufferStageRootTable += updateBatchStatsSince(detailedStats, rootTableStart)
 	if len(direct.templateEntries) > 0 {
 		templateTable := rootTables[direct.templateRootName]
 		if templateTable == nil {
@@ -9594,6 +9786,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if domain.primaryRunIndex != nil {
 		primaryIndexKeys = make([][]byte, 0, len(direct.primaryEntries))
 	}
+	primaryAppendStart := updateBatchStatsNow(detailedStats)
 	if err := applyDirectBufferedRootEntries(primaryTable, direct.primaryEntries); err != nil {
 		return false, err
 	}
@@ -9602,27 +9795,32 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			primaryIndexKeys = append(primaryIndexKeys, entry.key)
 		}
 	}
+	plan.stats.BufferStagePrimaryAppend += updateBatchStatsSince(detailedStats, primaryAppendStart)
 	if primaryIndexKeys != nil {
 		addBufferedPrimaryRunIndexKeys(domain.primaryRunIndex, primaryIndexKeys, primaryTable)
 	}
-	for _, secondaryPlan := range direct.secondaryRootPlans {
-		table := rootTables[secondaryPlan.rootName]
-		if table == nil {
-			continue
-		}
-		if err := applyCollectionRunEntriesWithFlags(table, len(secondaryPlan.entries), func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
-			entry := secondaryPlan.entries[i]
-			if entry.tombstone {
-				return entry.key, nil, page.ValuePtr{}, node.FlagTombstone, nil
+	if len(direct.secondaryRootPlans) > 0 {
+		secondaryAppendStart := updateBatchStatsNow(detailedStats)
+		for _, secondaryPlan := range direct.secondaryRootPlans {
+			table := rootTables[secondaryPlan.rootName]
+			if table == nil {
+				continue
 			}
-			return entry.key, nil, page.ValuePtr{}, node.FlagInline, nil
-		}); err != nil {
-			if shouldAutoFlushAfterAdding {
-				rollbackBufferedIndexedDomain(domain, checkpoint)
-				c.meta = collectionMetaCheckpoint
+			if err := applyCollectionRunEntriesWithFlags(table, len(secondaryPlan.entries), func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+				entry := secondaryPlan.entries[i]
+				if entry.tombstone {
+					return entry.key, nil, page.ValuePtr{}, node.FlagTombstone, nil
+				}
+				return entry.key, nil, page.ValuePtr{}, node.FlagInline, nil
+			}); err != nil {
+				if shouldAutoFlushAfterAdding {
+					rollbackBufferedIndexedDomain(domain, checkpoint)
+					c.meta = collectionMetaCheckpoint
+				}
+				return false, err
 			}
-			return false, err
 		}
+		plan.stats.BufferStageSecondaryAppend += updateBatchStatsSince(detailedStats, secondaryAppendStart)
 	}
 	plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
 	retainDirectBufferedDocumentArenaLocked(domain, plan)
@@ -9787,7 +9985,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
+	freezeStart := updateBatchStatsNow(detailedStats)
 	freezeMutableIndexedRunMapsLocked(domain)
+	plan.stats.BufferStageFreeze += updateBatchStatsSince(detailedStats, freezeStart)
 	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
 	projectedStagedBytes := stagedBytes
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, projectedStagedBytes, stagedRootRuns)
@@ -9866,7 +10066,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
 		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 		plan.deltaTables[i] = nil
-		plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
+		appendDuration := updateBatchStatsSince(detailedStats, phaseStart)
+		if rootName == collectionPrimaryRootName(plan.meta.Name) {
+			plan.stats.BufferStagePrimaryAppend += appendDuration
+		} else {
+			plan.stats.BufferStageSecondaryAppend += appendDuration
+		}
+		plan.stats.BufferStageRootAppend += appendDuration
 	}
 	plan.deltaTables = nil
 	domain.loaded = true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -313,16 +313,25 @@ type CollectionSecondaryRunStats struct {
 
 // CollectionUpdateStats captures phase timings and counters from the most
 // recent successful Update/UpdateBatch-style call on a Collection handle.
+//
+// Some timings are nested rather than additive siblings. IndexStateExtraction
+// is the total time spent extracting old and new index state; OldIndexStateExtract
+// and NewIndexStateExtract are components of that total. BufferStageRootAppend
+// overlaps with BufferStagePrimaryAppend and BufferStageSecondaryAppend, and
+// BufferStageLockHold encloses other buffer-stage subphases while the write
+// domain mutex is held.
 type CollectionUpdateStats struct {
-	Items                int
-	Matched              int
-	Modified             int
-	Indexes              int
-	Runs                 int
-	BufferedBatches      int
-	CurrentRead          time.Duration
-	Callback             time.Duration
-	PrepareDocuments     time.Duration
+	Items            int
+	Matched          int
+	Modified         int
+	Indexes          int
+	Runs             int
+	BufferedBatches  int
+	CurrentRead      time.Duration
+	Callback         time.Duration
+	PrepareDocuments time.Duration
+	// IndexStateExtraction includes both OldIndexStateExtract and
+	// NewIndexStateExtract; do not add all three together.
 	IndexStateExtraction time.Duration
 	OldIndexStateExtract time.Duration
 	NewIndexStateExtract time.Duration
@@ -353,7 +362,9 @@ type CollectionUpdateStats struct {
 	BufferStageUniqueIdx       time.Duration
 	BufferStagePrimaryAppend   time.Duration
 	BufferStageSecondaryAppend time.Duration
-	BufferStageRootAppend      time.Duration
+	// BufferStageRootAppend is the total root-append time and overlaps with
+	// BufferStagePrimaryAppend and BufferStageSecondaryAppend.
+	BufferStageRootAppend time.Duration
 	// BufferStageFlush measures local threshold-flush schedule/publish work
 	// performed while staging an indexed buffered update batch. It excludes
 	// waits for an already-running async flush that leave no local schedule or
@@ -408,75 +419,83 @@ type CollectionUpdateIndexStats struct {
 // CollectionManagerStats captures aggregate write-domain counters for a
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
+//
+// The update-batch timing aggregates preserve the same nesting semantics as
+// CollectionUpdateStats: UpdateBatchIndexStateExtract includes old/new index
+// extraction, UpdateBatchBufferRootAppend overlaps with primary/secondary
+// append timings, and UpdateBatchBufferLockHold encloses other buffer-stage
+// work done while holding the write-domain mutex.
 type CollectionManagerStats struct {
-	Domains                         int
-	PendingDocuments                int
-	PendingBytes                    int64
-	PendingRootRuns                 int
-	PendingIndexedFlushUnits        int
-	OverlayMutableDocuments         int
-	OverlayQueuedIndexedFlushUnits  int
-	OverlayActiveIndexedFlushUnits  int
-	OverlayVisibleDepth             int
-	IndexedAsyncFlushRunning        int
-	MutationLockCalls               uint64
-	MutationLockWait                time.Duration
-	MutationLockHold                time.Duration
-	IndexedStageBatches             uint64
-	IndexedStageDocs                uint64
-	IndexedStageBytes               uint64
-	IndexedStageRootRuns            uint64
-	IndexedAutoFlushes              uint64
-	IndexedAsyncFlushScheduled      uint64
-	IndexedAsyncFlushBackpressure   uint64
-	IndexedAsyncFlushWait           time.Duration
-	IndexedAsyncFlushErrors         uint64
-	IndexedFlushCalls               uint64
-	IndexedFlushErrors              uint64
-	IndexedFlushForcedDrains        uint64
-	IndexedFlushUnits               uint64
-	IndexedFlushDocs                uint64
-	IndexedFlushBytes               uint64
-	IndexedFlushRootRuns            uint64
-	IndexedFlushRoots               uint64
-	IndexedFlushDuration            time.Duration
-	IndexedFlushMaterialize         time.Duration
-	IndexedFlushPublish             time.Duration
-	RootDeltaPlanPrimaryRoots       uint64
-	RootDeltaPlanTemplateRoots      uint64
-	RootDeltaPlanIndexStateRoots    uint64
-	RootDeltaPlanSecondaryRoots     uint64
-	RootDeltaPlanEntries            uint64
-	RootDeltaPlanKeyBytes           uint64
-	RootDeltaPlanValueBytes         uint64
-	RootDeltaPlanTombstones         uint64
-	PrimaryOnlyUpdateCalls          uint64
-	PrimaryOnlyMatched              uint64
-	PrimaryOnlyModified             uint64
-	PrimaryOnlyBufferedCalls        uint64
-	PrimaryOnlyRootPublishes        uint64
-	PrimaryOnlyRootDeltaEntries     uint64
-	PrimaryOnlyRootDeltaKeyBytes    uint64
-	PrimaryOnlyRootDeltaValueBytes  uint64
-	PrimaryOnlyCoalescedDocs        uint64
-	UpdateCombineRequests           uint64
-	UpdateCombineBatches            uint64
-	UpdateCombineBatchedRequests    uint64
-	UpdateCombineFallbackRequests   uint64
-	UpdateCombineQueueDepthMax      uint64
-	UpdateCombineEnqueue            time.Duration
-	UpdateCombineWait               time.Duration
-	UpdateCombineDrain              time.Duration
-	UpdateCombineRun                time.Duration
-	UpdateBatchCalls                uint64
-	UpdateBatchItems                uint64
-	UpdateBatchMatched              uint64
-	UpdateBatchModified             uint64
-	UpdateBatchRuns                 uint64
-	UpdateBatchBufferedBatches      uint64
-	UpdateBatchCurrentRead          time.Duration
-	UpdateBatchCallback             time.Duration
-	UpdateBatchPrepareDocuments     time.Duration
+	Domains                        int
+	PendingDocuments               int
+	PendingBytes                   int64
+	PendingRootRuns                int
+	PendingIndexedFlushUnits       int
+	OverlayMutableDocuments        int
+	OverlayQueuedIndexedFlushUnits int
+	OverlayActiveIndexedFlushUnits int
+	OverlayVisibleDepth            int
+	IndexedAsyncFlushRunning       int
+	MutationLockCalls              uint64
+	MutationLockWait               time.Duration
+	MutationLockHold               time.Duration
+	IndexedStageBatches            uint64
+	IndexedStageDocs               uint64
+	IndexedStageBytes              uint64
+	IndexedStageRootRuns           uint64
+	IndexedAutoFlushes             uint64
+	IndexedAsyncFlushScheduled     uint64
+	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushWait          time.Duration
+	IndexedAsyncFlushErrors        uint64
+	IndexedFlushCalls              uint64
+	IndexedFlushErrors             uint64
+	IndexedFlushForcedDrains       uint64
+	IndexedFlushUnits              uint64
+	IndexedFlushDocs               uint64
+	IndexedFlushBytes              uint64
+	IndexedFlushRootRuns           uint64
+	IndexedFlushRoots              uint64
+	IndexedFlushDuration           time.Duration
+	IndexedFlushMaterialize        time.Duration
+	IndexedFlushPublish            time.Duration
+	RootDeltaPlanPrimaryRoots      uint64
+	RootDeltaPlanTemplateRoots     uint64
+	RootDeltaPlanIndexStateRoots   uint64
+	RootDeltaPlanSecondaryRoots    uint64
+	RootDeltaPlanEntries           uint64
+	RootDeltaPlanKeyBytes          uint64
+	RootDeltaPlanValueBytes        uint64
+	RootDeltaPlanTombstones        uint64
+	PrimaryOnlyUpdateCalls         uint64
+	PrimaryOnlyMatched             uint64
+	PrimaryOnlyModified            uint64
+	PrimaryOnlyBufferedCalls       uint64
+	PrimaryOnlyRootPublishes       uint64
+	PrimaryOnlyRootDeltaEntries    uint64
+	PrimaryOnlyRootDeltaKeyBytes   uint64
+	PrimaryOnlyRootDeltaValueBytes uint64
+	PrimaryOnlyCoalescedDocs       uint64
+	UpdateCombineRequests          uint64
+	UpdateCombineBatches           uint64
+	UpdateCombineBatchedRequests   uint64
+	UpdateCombineFallbackRequests  uint64
+	UpdateCombineQueueDepthMax     uint64
+	UpdateCombineEnqueue           time.Duration
+	UpdateCombineWait              time.Duration
+	UpdateCombineDrain             time.Duration
+	UpdateCombineRun               time.Duration
+	UpdateBatchCalls               uint64
+	UpdateBatchItems               uint64
+	UpdateBatchMatched             uint64
+	UpdateBatchModified            uint64
+	UpdateBatchRuns                uint64
+	UpdateBatchBufferedBatches     uint64
+	UpdateBatchCurrentRead         time.Duration
+	UpdateBatchCallback            time.Duration
+	UpdateBatchPrepareDocuments    time.Duration
+	// UpdateBatchIndexStateExtract includes UpdateBatchOldIndexStateExtract
+	// and UpdateBatchNewIndexStateExtract; do not add all three together.
 	UpdateBatchIndexStateExtract    time.Duration
 	UpdateBatchOldIndexStateExtract time.Duration
 	UpdateBatchNewIndexStateExtract time.Duration
@@ -503,7 +522,9 @@ type CollectionManagerStats struct {
 	UpdateBatchBufferUniqueIdx       time.Duration
 	UpdateBatchBufferPrimaryAppend   time.Duration
 	UpdateBatchBufferSecondaryAppend time.Duration
-	UpdateBatchBufferRootAppend      time.Duration
+	// UpdateBatchBufferRootAppend is the total root-append time and overlaps
+	// with UpdateBatchBufferPrimaryAppend and UpdateBatchBufferSecondaryAppend.
+	UpdateBatchBufferRootAppend time.Duration
 	// UpdateBatchBufferFlush measures only threshold-flush work that was
 	// actually scheduled/executed while staging indexed buffered update batches.
 	UpdateBatchBufferFlush         time.Duration
@@ -1271,9 +1292,11 @@ func (m *CollectionManager) ResetUpdateCombineQueueDepthMax() {
 }
 
 // ResetUpdateCombinersForProfiling stops current update combiners so subsequent
-// profiling operations recreate them inside the measured context. Call it after
-// benchmark warmup and before the measured phase; it does not flush collection
-// contents or change update semantics.
+// profiling operations recreate them inside the measured context. It is
+// intended for benchmark/profiling harnesses; it may block while a combiner
+// drains in-flight updates. Call it after benchmark warmup and before the
+// measured phase; it does not flush collection contents or change update
+// semantics.
 func (m *CollectionManager) ResetUpdateCombinersForProfiling() {
 	if m == nil {
 		return
@@ -7031,34 +7054,35 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 }
 
 func (domain *collectionWriteDomain) stopUpdateCombiner() {
-	if domain == nil {
-		return
-	}
-	domain.closingWrites.Store(true)
-	domain.updateCombineMu.Lock()
-	combiner := domain.updateCombiner
-	draining := domain.updateDraining
-	domain.updateCombiner = nil
-	domain.updateDraining = nil
-	domain.updateCombineDone = true
-	domain.updateCombineMu.Unlock()
-	if combiner != nil {
-		combiner.stop()
-	}
-	if draining != nil && draining != combiner {
-		draining.waitDone()
-	}
+	domain.drainUpdateCombiner(updateCombinerDrainClose)
 }
 
 func (domain *collectionWriteDomain) resetUpdateCombinerForProfiling() {
+	domain.drainUpdateCombiner(updateCombinerDrainResetForProfiling)
+}
+
+type updateCombinerDrainMode uint8
+
+const (
+	updateCombinerDrainClose updateCombinerDrainMode = iota
+	updateCombinerDrainResetForProfiling
+)
+
+func (domain *collectionWriteDomain) drainUpdateCombiner(mode updateCombinerDrainMode) {
 	if domain == nil {
 		return
+	}
+	if mode == updateCombinerDrainClose {
+		domain.closingWrites.Store(true)
 	}
 	domain.updateCombineMu.Lock()
 	combiner := domain.updateCombiner
 	draining := domain.updateDraining
 	domain.updateCombiner = nil
-	if combiner != nil {
+	if mode == updateCombinerDrainClose {
+		domain.updateDraining = nil
+		domain.updateCombineDone = true
+	} else if combiner != nil {
 		domain.updateDraining = combiner
 	}
 	domain.updateCombineMu.Unlock()
@@ -7067,6 +7091,9 @@ func (domain *collectionWriteDomain) resetUpdateCombinerForProfiling() {
 	}
 	if draining != nil && draining != combiner {
 		draining.waitDone()
+	}
+	if mode != updateCombinerDrainResetForProfiling {
+		return
 	}
 	domain.updateCombineMu.Lock()
 	if combiner != nil && domain.updateDraining == combiner {
@@ -9949,6 +9976,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		return false, err
 	}
 	plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+	primaryRootName := collectionPrimaryRootName(plan.meta.Name)
 	var stagedBytes int64
 	stagedRootRuns := 0
 	phaseStart = updateBatchStatsNow(detailedStats)
@@ -10021,7 +10049,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		if _, ok := domain.rootBaseIDs[rootName]; !ok {
 			domain.rootBaseIDs[rootName] = baseRoot
 		}
-		if rootName == collectionPrimaryRootName(plan.meta.Name) && domain.primaryRunIndex != nil {
+		if rootName == primaryRootName && domain.primaryRunIndex != nil {
 			phaseStart = updateBatchStatsNow(detailedStats)
 			if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, table); err != nil {
 				plan.stats.BufferStagePrimaryIdx += updateBatchStatsSince(detailedStats, phaseStart)
@@ -10067,10 +10095,12 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 		plan.deltaTables[i] = nil
 		appendDuration := updateBatchStatsSince(detailedStats, phaseStart)
-		if rootName == collectionPrimaryRootName(plan.meta.Name) {
-			plan.stats.BufferStagePrimaryAppend += appendDuration
-		} else {
-			plan.stats.BufferStageSecondaryAppend += appendDuration
+		if appendDuration > 0 {
+			if rootName == primaryRootName {
+				plan.stats.BufferStagePrimaryAppend += appendDuration
+			} else {
+				plan.stats.BufferStageSecondaryAppend += appendDuration
+			}
 		}
 		plan.stats.BufferStageRootAppend += appendDuration
 	}
@@ -10081,7 +10111,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.baseCommitSeq = plan.baseCommitSeq
 	domain.baseSystemRoot = plan.baseSystemRoot
 	if plan.catalog != nil {
-		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+		domain.primaryRoot = plan.catalog.rootID(primaryRootName)
 	}
 	domain.count += modifiedCount
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -644,12 +644,16 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if stats.SecondaryKeyBytes == 0 {
 		t.Fatal("stats secondary key bytes=0 want positive")
 	}
-	if stats.CurrentRead != 0 || stats.Callback != 0 || stats.BufferStage != 0 ||
+	if stats.CurrentRead != 0 || stats.Callback != 0 ||
+		stats.OldIndexStateExtract != 0 || stats.NewIndexStateExtract != 0 ||
+		stats.BufferStage != 0 ||
 		stats.BufferStagePrecheck != 0 ||
 		stats.BufferStageLockWait != 0 || stats.BufferStageLockHold != 0 ||
 		stats.BufferStageValidation != 0 || stats.BufferStageRootScan != 0 ||
-		stats.BufferStageDomainPrepare != 0 ||
+		stats.BufferStageDomainPrepare != 0 || stats.BufferStageFreeze != 0 ||
+		stats.BufferStageRootTable != 0 ||
 		stats.BufferStagePrimaryIdx != 0 || stats.BufferStageUniqueIdx != 0 ||
+		stats.BufferStagePrimaryAppend != 0 || stats.BufferStageSecondaryAppend != 0 ||
 		stats.BufferStageRootAppend != 0 || stats.BufferStageFlush != 0 {
 		t.Fatalf("default update timings=%+v want zero unless detailed stats enabled", stats)
 	}
@@ -712,14 +716,20 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		}
 	}
 	for _, key := range []string{
+		"treedb.collections.write_domain.update_batch.old_index_state_extract_ns_total",
+		"treedb.collections.write_domain.update_batch.new_index_state_extract_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_precheck_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_lock_wait_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_freeze_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_root_table_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_primary_append_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_secondary_append_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total",
 	} {
@@ -883,8 +893,12 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 		{"validation", "treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageValidation = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferValidation }},
 		{"root_scan", "treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootScan = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootScan }},
 		{"domain_prepare", "treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageDomainPrepare = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferDomainPrepare }},
+		{"freeze", "treedb.collections.write_domain.update_batch.buffer_stage_freeze_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageFreeze = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferFreeze }},
+		{"root_table", "treedb.collections.write_domain.update_batch.buffer_stage_root_table_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootTable = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootTable }},
 		{"primary_index", "treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrimaryIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrimaryIdx }},
 		{"unique_index", "treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageUniqueIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferUniqueIdx }},
+		{"primary_append", "treedb.collections.write_domain.update_batch.buffer_stage_primary_append_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrimaryAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrimaryAppend }},
+		{"secondary_append", "treedb.collections.write_domain.update_batch.buffer_stage_secondary_append_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageSecondaryAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferSecondaryAppend }},
 		{"root_append", "treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootAppend }},
 		{"flush", "treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageFlush = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferFlush }},
 	}
@@ -908,6 +922,75 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 			t.Fatalf("merged %s=%s want %s", tc.name, got, want)
 		}
 		if got, want := exported[tc.key], fmt.Sprintf("%d", want.Nanoseconds()); got != want {
+			t.Fatalf("exported %s=%q want %q", tc.key, got, want)
+		}
+	}
+}
+
+func TestCollectionUpdateIndexStateBreakdownStatsSnapshotAndAdd(t *testing.T) {
+	updateStats := CollectionUpdateStats{
+		IndexStateExtraction: 11 * time.Nanosecond,
+		OldIndexStateExtract: 5 * time.Nanosecond,
+		NewIndexStateExtract: 6 * time.Nanosecond,
+	}
+	domain := &collectionWriteDomain{}
+	domain.observeUpdateBatchStats(updateStats)
+	snapshot := domain.statsSnapshot()
+	var merged CollectionManagerStats
+	merged.add(snapshot)
+	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
+	cases := []struct {
+		name string
+		key  string
+		want time.Duration
+		get  func(CollectionManagerStats) time.Duration
+	}{
+		{"total", "treedb.collections.write_domain.update_batch.index_state_extract_ns_total", 11 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchIndexStateExtract }},
+		{"old", "treedb.collections.write_domain.update_batch.old_index_state_extract_ns_total", 5 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchOldIndexStateExtract }},
+		{"new", "treedb.collections.write_domain.update_batch.new_index_state_extract_ns_total", 6 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchNewIndexStateExtract }},
+	}
+	for _, tc := range cases {
+		if got := tc.get(snapshot); got != tc.want {
+			t.Fatalf("snapshot %s=%s want %s", tc.name, got, tc.want)
+		}
+		if got := tc.get(merged); got != tc.want {
+			t.Fatalf("merged %s=%s want %s", tc.name, got, tc.want)
+		}
+		if got, want := exported[tc.key], fmt.Sprintf("%d", tc.want.Nanoseconds()); got != want {
+			t.Fatalf("exported %s=%q want %q", tc.key, got, want)
+		}
+	}
+}
+
+func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	domain.observeUpdateCombineEnqueue(3 * time.Nanosecond)
+	domain.observeUpdateCombineWait(5 * time.Nanosecond)
+	domain.observeUpdateCombineDrain(7 * time.Nanosecond)
+	domain.observeUpdateCombineRun(11 * time.Nanosecond)
+	snapshot := domain.statsSnapshot()
+	var merged CollectionManagerStats
+	merged.add(snapshot)
+	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
+	cases := []struct {
+		name string
+		key  string
+		want time.Duration
+		get  func(CollectionManagerStats) time.Duration
+	}{
+		{"enqueue", "treedb.collections.write_domain.update_combine.enqueue_ns_total", 3 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineEnqueue }},
+		{"wait", "treedb.collections.write_domain.update_combine.wait_ns_total", 5 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineWait }},
+		{"drain", "treedb.collections.write_domain.update_combine.drain_ns_total", 7 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineDrain }},
+		{"run", "treedb.collections.write_domain.update_combine.run_ns_total", 11 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineRun }},
+	}
+	for _, tc := range cases {
+		if got := tc.get(snapshot); got != tc.want {
+			t.Fatalf("snapshot %s=%s want %s", tc.name, got, tc.want)
+		}
+		if got := tc.get(merged); got != tc.want {
+			t.Fatalf("merged %s=%s want %s", tc.name, got, tc.want)
+		}
+		if got, want := exported[tc.key], fmt.Sprintf("%d", tc.want.Nanoseconds()); got != want {
 			t.Fatalf("exported %s=%q want %q", tc.key, got, want)
 		}
 	}
@@ -1451,6 +1534,69 @@ func TestCollectionManagerResetUpdateCombineQueueDepthMax(t *testing.T) {
 	domain.observeUpdateCombineRequest(5)
 	if got := mgr.StatsSnapshot().UpdateCombineQueueDepthMax; got != 5 {
 		t.Fatalf("queue depth max after new observation=%d want 5", got)
+	}
+}
+
+func TestCollectionManagerResetUpdateCombinersForProfiling(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","n":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	domain := col.writeDomain
+	if domain == nil {
+		t.Fatal("collection write domain is nil")
+	}
+	domain.updateCombineMu.Lock()
+	first := domain.updateCombiner
+	draining := domain.updateDraining
+	domain.updateCombineMu.Unlock()
+	if first == nil {
+		t.Fatal("first update combiner is nil")
+	}
+	if draining != nil {
+		t.Fatal("unexpected draining combiner before reset")
+	}
+
+	mgr.ResetUpdateCombinersForProfiling()
+	domain.updateCombineMu.Lock()
+	afterReset := domain.updateCombiner
+	afterResetDraining := domain.updateDraining
+	domain.updateCombineMu.Unlock()
+	if afterReset != nil || afterResetDraining != nil {
+		t.Fatalf("combiner after reset=%p draining=%p want nil/nil", afterReset, afterResetDraining)
+	}
+
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","n":2}`), true, nil
+	}); err != nil {
+		t.Fatalf("second update after reset: %v", err)
+	}
+	domain.updateCombineMu.Lock()
+	second := domain.updateCombiner
+	domain.updateCombineMu.Unlock()
+	if second == nil {
+		t.Fatal("second update combiner is nil")
+	}
+	if second == first {
+		t.Fatal("second update reused stopped combiner after profiling reset")
 	}
 }
 

--- a/TreeDB/collections/direct_buffered_update_bench_test.go
+++ b/TreeDB/collections/direct_buffered_update_bench_test.go
@@ -168,45 +168,52 @@ func benchmarkTemplateV1ReplaceWith(raw []byte) func([]byte) ([]byte, bool, erro
 
 func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) CollectionManagerStats {
 	return CollectionManagerStats{
-		IndexedStageBatches:            after.IndexedStageBatches - before.IndexedStageBatches,
-		IndexedStageDocs:               after.IndexedStageDocs - before.IndexedStageDocs,
-		IndexedStageBytes:              after.IndexedStageBytes - before.IndexedStageBytes,
-		IndexedStageRootRuns:           after.IndexedStageRootRuns - before.IndexedStageRootRuns,
-		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
-		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
-		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
-		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
-		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
-		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
-		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
-		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
-		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
-		UpdateBatchCalls:               after.UpdateBatchCalls - before.UpdateBatchCalls,
-		UpdateBatchItems:               after.UpdateBatchItems - before.UpdateBatchItems,
-		UpdateBatchMatched:             after.UpdateBatchMatched - before.UpdateBatchMatched,
-		UpdateBatchModified:            after.UpdateBatchModified - before.UpdateBatchModified,
-		UpdateBatchRuns:                after.UpdateBatchRuns - before.UpdateBatchRuns,
-		UpdateBatchBufferedBatches:     after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
-		UpdateBatchCurrentRead:         after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
-		UpdateBatchCallback:            after.UpdateBatchCallback - before.UpdateBatchCallback,
-		UpdateBatchPrepareDocuments:    after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
-		UpdateBatchIndexStateExtract:   after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
-		UpdateBatchUniquePreflight:     after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
-		UpdateBatchTemplateRunBuild:    after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
-		UpdateBatchPrimaryRunBuild:     after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
-		UpdateBatchSecondaryRunBuild:   after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
-		UpdateBatchBufferStage:         after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
-		UpdateBatchBufferLockWait:      after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
-		UpdateBatchBufferLockHold:      after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
-		UpdateBatchBufferRootAppend:    after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
-		UpdateBatchPublish:             after.UpdateBatchPublish - before.UpdateBatchPublish,
-		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
-		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
-		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
-		UpdateBatchIndexValueChanges:   after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
-		UpdateBatchIndexValueUnchanged: after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
-		UpdateBatchUniqueChecks:        after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
-		UpdateBatchUniqueCheckSkips:    after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
+		IndexedStageBatches:              after.IndexedStageBatches - before.IndexedStageBatches,
+		IndexedStageDocs:                 after.IndexedStageDocs - before.IndexedStageDocs,
+		IndexedStageBytes:                after.IndexedStageBytes - before.IndexedStageBytes,
+		IndexedStageRootRuns:             after.IndexedStageRootRuns - before.IndexedStageRootRuns,
+		IndexedFlushCalls:                after.IndexedFlushCalls - before.IndexedFlushCalls,
+		IndexedFlushErrors:               after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushDocs:                 after.IndexedFlushDocs - before.IndexedFlushDocs,
+		IndexedFlushBytes:                after.IndexedFlushBytes - before.IndexedFlushBytes,
+		IndexedFlushRootRuns:             after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
+		IndexedFlushRoots:                after.IndexedFlushRoots - before.IndexedFlushRoots,
+		IndexedFlushDuration:             after.IndexedFlushDuration - before.IndexedFlushDuration,
+		IndexedFlushMaterialize:          after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
+		IndexedFlushPublish:              after.IndexedFlushPublish - before.IndexedFlushPublish,
+		UpdateBatchCalls:                 after.UpdateBatchCalls - before.UpdateBatchCalls,
+		UpdateBatchItems:                 after.UpdateBatchItems - before.UpdateBatchItems,
+		UpdateBatchMatched:               after.UpdateBatchMatched - before.UpdateBatchMatched,
+		UpdateBatchModified:              after.UpdateBatchModified - before.UpdateBatchModified,
+		UpdateBatchRuns:                  after.UpdateBatchRuns - before.UpdateBatchRuns,
+		UpdateBatchBufferedBatches:       after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
+		UpdateBatchCurrentRead:           after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
+		UpdateBatchCallback:              after.UpdateBatchCallback - before.UpdateBatchCallback,
+		UpdateBatchPrepareDocuments:      after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
+		UpdateBatchIndexStateExtract:     after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
+		UpdateBatchOldIndexStateExtract:  after.UpdateBatchOldIndexStateExtract - before.UpdateBatchOldIndexStateExtract,
+		UpdateBatchNewIndexStateExtract:  after.UpdateBatchNewIndexStateExtract - before.UpdateBatchNewIndexStateExtract,
+		UpdateBatchUniquePreflight:       after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
+		UpdateBatchTemplateRunBuild:      after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
+		UpdateBatchPrimaryRunBuild:       after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
+		UpdateBatchSecondaryRunBuild:     after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
+		UpdateBatchBufferStage:           after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferLockWait:        after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
+		UpdateBatchBufferLockHold:        after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferDomainPrepare:   after.UpdateBatchBufferDomainPrepare - before.UpdateBatchBufferDomainPrepare,
+		UpdateBatchBufferFreeze:          after.UpdateBatchBufferFreeze - before.UpdateBatchBufferFreeze,
+		UpdateBatchBufferRootTable:       after.UpdateBatchBufferRootTable - before.UpdateBatchBufferRootTable,
+		UpdateBatchBufferPrimaryAppend:   after.UpdateBatchBufferPrimaryAppend - before.UpdateBatchBufferPrimaryAppend,
+		UpdateBatchBufferSecondaryAppend: after.UpdateBatchBufferSecondaryAppend - before.UpdateBatchBufferSecondaryAppend,
+		UpdateBatchBufferRootAppend:      after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchPublish:               after.UpdateBatchPublish - before.UpdateBatchPublish,
+		UpdateBatchSecondaryDeletes:      after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
+		UpdateBatchSecondarySets:         after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
+		UpdateBatchSecondaryKeyBytes:     after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateBatchIndexValueChanges:     after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
+		UpdateBatchIndexValueUnchanged:   after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
+		UpdateBatchUniqueChecks:          after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
+		UpdateBatchUniqueCheckSkips:      after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
 	}
 }
 
@@ -263,6 +270,8 @@ func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManag
 	reportDurationPerDoc(stats.UpdateBatchCallback, "update_callback_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchPrepareDocuments, "update_prepare_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchIndexStateExtract, "update_index_state_extract_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchOldIndexStateExtract, "update_old_index_state_extract_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchNewIndexStateExtract, "update_new_index_state_extract_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchUniquePreflight, "update_unique_preflight_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchTemplateRunBuild, "update_template_run_build_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchPrimaryRunBuild, "update_primary_run_build_ns/doc")
@@ -270,6 +279,11 @@ func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManag
 	reportDurationPerDoc(stats.UpdateBatchBufferStage, "update_buffer_stage_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferLockWait, "update_buffer_lock_wait_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferLockHold, "update_buffer_lock_hold_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferDomainPrepare, "update_buffer_domain_prepare_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferFreeze, "update_buffer_freeze_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferRootTable, "update_buffer_root_table_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferPrimaryAppend, "update_buffer_primary_append_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferSecondaryAppend, "update_buffer_secondary_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferRootAppend, "update_buffer_root_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchPublish, "update_publish_ns/doc")
 }

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -579,6 +579,8 @@ The benchmark shapes are intentionally different:
   collection-manager detailed update timing for its measured phase and reports
   update attribution metrics such as `update_current_read_ns/doc`,
   `update_callback_ns/doc`, `update_index_state_extract_ns/doc`,
+  `update_old_index_state_extract_ns/doc`,
+  `update_new_index_state_extract_ns/doc`,
   `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
   `update_index_value_changes/doc`, `update_index_value_unchanged/doc`,
   `update_unique_checks/doc`, `update_unique_check_skips/doc`,
@@ -592,12 +594,20 @@ The benchmark shapes are intentionally different:
   `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
   `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,
   `update_buffer_root_scan_ns/doc`, `update_buffer_domain_prepare_ns/doc`,
+  `update_buffer_freeze_ns/doc`, `update_buffer_root_table_ns/doc`,
   `update_buffer_primary_index_ns/doc`, `update_buffer_unique_index_ns/doc`,
+  `update_buffer_primary_append_ns/doc`,
+  `update_buffer_secondary_append_ns/doc`,
   `update_buffer_root_append_ns/doc`, `update_buffer_flush_ns/doc`,
-  `update_publish_ns/doc`, and `update_items/batch` from the collection
+  combiner timings such as `update_combine_enqueue_ns/doc`,
+  `update_combine_wait_ns/doc`, `update_combine_drain_ns/doc`, and
+  `update_combine_run_ns/doc`, `update_publish_ns/doc`, and
+  `update_items/batch` from the collection
   manager's measured-phase counters. `update_buffer_lock_hold_ns/doc` is the
   enclosing domain mutex hold time for buffered staging, not an additive sibling
-  of the other buffer-stage submetrics; `update_buffer_flush_ns/doc` reports
+  of the other buffer-stage submetrics; the narrower root-table, append, and
+  freeze submetrics are nested attribution inside the broader buffer-stage
+  timers. `update_buffer_flush_ns/doc` reports
   threshold-flush scheduling/publish time separately. The measured phase includes
   the final `FlushAll()` drain so background async publish work is charged to the
   same throughput row that scheduled it. The same row also reports backend

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -710,6 +710,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 
 	b.ReportAllocs()
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
 	backendStatsBefore := backend.Stats()
@@ -1075,74 +1076,84 @@ func reportProfileBenchOrderedRootPublishStats(b *testing.B, after, before map[s
 
 func deltaCollectionManagerUpdateStats(after, before collections.CollectionManagerStats) collections.CollectionManagerStats {
 	delta := collections.CollectionManagerStats{
-		UpdateBatchCalls:               after.UpdateBatchCalls - before.UpdateBatchCalls,
-		UpdateBatchItems:               after.UpdateBatchItems - before.UpdateBatchItems,
-		UpdateBatchMatched:             after.UpdateBatchMatched - before.UpdateBatchMatched,
-		UpdateBatchModified:            after.UpdateBatchModified - before.UpdateBatchModified,
-		UpdateBatchRuns:                after.UpdateBatchRuns - before.UpdateBatchRuns,
-		UpdateBatchBufferedBatches:     after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
-		UpdateBatchCurrentRead:         after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
-		UpdateBatchCallback:            after.UpdateBatchCallback - before.UpdateBatchCallback,
-		UpdateBatchPrepareDocuments:    after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
-		UpdateBatchIndexStateExtract:   after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
-		UpdateBatchUniquePreflight:     after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
-		UpdateBatchTemplateRunBuild:    after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
-		UpdateBatchPrimaryRunBuild:     after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
-		UpdateBatchIndexStateRunBuild:  after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
-		UpdateBatchSecondaryRunBuild:   after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
-		UpdateBatchBufferStage:         after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
-		UpdateBatchBufferPrecheck:      after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
-		UpdateBatchBufferLockWait:      after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
-		UpdateBatchBufferLockHold:      after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
-		UpdateBatchBufferValidation:    after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
-		UpdateBatchBufferRootScan:      after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
-		UpdateBatchBufferDomainPrepare: after.UpdateBatchBufferDomainPrepare - before.UpdateBatchBufferDomainPrepare,
-		UpdateBatchBufferPrimaryIdx:    after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
-		UpdateBatchBufferUniqueIdx:     after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
-		UpdateBatchBufferRootAppend:    after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
-		UpdateBatchBufferFlush:         after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
-		UpdateBatchPublish:             after.UpdateBatchPublish - before.UpdateBatchPublish,
-		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
-		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
-		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
-		UpdateBatchIndexValueChanges:   after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
-		UpdateBatchIndexValueUnchanged: after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
-		UpdateBatchMaskFallbacks:       after.UpdateBatchMaskFallbacks - before.UpdateBatchMaskFallbacks,
-		UpdateBatchUniqueChecks:        after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
-		UpdateBatchUniqueCheckSkips:    after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
-		UpdateCombineRequests:          after.UpdateCombineRequests - before.UpdateCombineRequests,
-		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
-		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
-		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
-		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
-		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
-		IndexedFlushForcedDrains:       after.IndexedFlushForcedDrains - before.IndexedFlushForcedDrains,
-		IndexedFlushUnits:              after.IndexedFlushUnits - before.IndexedFlushUnits,
-		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
-		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
-		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
-		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
-		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
-		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
-		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
-		IndexedAsyncFlushWait:          after.IndexedAsyncFlushWait - before.IndexedAsyncFlushWait,
-		RootDeltaPlanPrimaryRoots:      after.RootDeltaPlanPrimaryRoots - before.RootDeltaPlanPrimaryRoots,
-		RootDeltaPlanTemplateRoots:     after.RootDeltaPlanTemplateRoots - before.RootDeltaPlanTemplateRoots,
-		RootDeltaPlanIndexStateRoots:   after.RootDeltaPlanIndexStateRoots - before.RootDeltaPlanIndexStateRoots,
-		RootDeltaPlanSecondaryRoots:    after.RootDeltaPlanSecondaryRoots - before.RootDeltaPlanSecondaryRoots,
-		RootDeltaPlanEntries:           after.RootDeltaPlanEntries - before.RootDeltaPlanEntries,
-		RootDeltaPlanKeyBytes:          after.RootDeltaPlanKeyBytes - before.RootDeltaPlanKeyBytes,
-		RootDeltaPlanValueBytes:        after.RootDeltaPlanValueBytes - before.RootDeltaPlanValueBytes,
-		RootDeltaPlanTombstones:        after.RootDeltaPlanTombstones - before.RootDeltaPlanTombstones,
-		PrimaryOnlyUpdateCalls:         after.PrimaryOnlyUpdateCalls - before.PrimaryOnlyUpdateCalls,
-		PrimaryOnlyMatched:             after.PrimaryOnlyMatched - before.PrimaryOnlyMatched,
-		PrimaryOnlyModified:            after.PrimaryOnlyModified - before.PrimaryOnlyModified,
-		PrimaryOnlyBufferedCalls:       after.PrimaryOnlyBufferedCalls - before.PrimaryOnlyBufferedCalls,
-		PrimaryOnlyRootPublishes:       after.PrimaryOnlyRootPublishes - before.PrimaryOnlyRootPublishes,
-		PrimaryOnlyRootDeltaEntries:    after.PrimaryOnlyRootDeltaEntries - before.PrimaryOnlyRootDeltaEntries,
-		PrimaryOnlyRootDeltaKeyBytes:   after.PrimaryOnlyRootDeltaKeyBytes - before.PrimaryOnlyRootDeltaKeyBytes,
-		PrimaryOnlyRootDeltaValueBytes: after.PrimaryOnlyRootDeltaValueBytes - before.PrimaryOnlyRootDeltaValueBytes,
-		PrimaryOnlyCoalescedDocs:       after.PrimaryOnlyCoalescedDocs - before.PrimaryOnlyCoalescedDocs,
+		UpdateBatchCalls:                 after.UpdateBatchCalls - before.UpdateBatchCalls,
+		UpdateBatchItems:                 after.UpdateBatchItems - before.UpdateBatchItems,
+		UpdateBatchMatched:               after.UpdateBatchMatched - before.UpdateBatchMatched,
+		UpdateBatchModified:              after.UpdateBatchModified - before.UpdateBatchModified,
+		UpdateBatchRuns:                  after.UpdateBatchRuns - before.UpdateBatchRuns,
+		UpdateBatchBufferedBatches:       after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
+		UpdateBatchCurrentRead:           after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
+		UpdateBatchCallback:              after.UpdateBatchCallback - before.UpdateBatchCallback,
+		UpdateBatchPrepareDocuments:      after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
+		UpdateBatchIndexStateExtract:     after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
+		UpdateBatchOldIndexStateExtract:  after.UpdateBatchOldIndexStateExtract - before.UpdateBatchOldIndexStateExtract,
+		UpdateBatchNewIndexStateExtract:  after.UpdateBatchNewIndexStateExtract - before.UpdateBatchNewIndexStateExtract,
+		UpdateBatchUniquePreflight:       after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
+		UpdateBatchTemplateRunBuild:      after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
+		UpdateBatchPrimaryRunBuild:       after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
+		UpdateBatchIndexStateRunBuild:    after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
+		UpdateBatchSecondaryRunBuild:     after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
+		UpdateBatchBufferStage:           after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferPrecheck:        after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
+		UpdateBatchBufferLockWait:        after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
+		UpdateBatchBufferLockHold:        after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferValidation:      after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
+		UpdateBatchBufferRootScan:        after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
+		UpdateBatchBufferDomainPrepare:   after.UpdateBatchBufferDomainPrepare - before.UpdateBatchBufferDomainPrepare,
+		UpdateBatchBufferFreeze:          after.UpdateBatchBufferFreeze - before.UpdateBatchBufferFreeze,
+		UpdateBatchBufferRootTable:       after.UpdateBatchBufferRootTable - before.UpdateBatchBufferRootTable,
+		UpdateBatchBufferPrimaryIdx:      after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
+		UpdateBatchBufferUniqueIdx:       after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
+		UpdateBatchBufferPrimaryAppend:   after.UpdateBatchBufferPrimaryAppend - before.UpdateBatchBufferPrimaryAppend,
+		UpdateBatchBufferSecondaryAppend: after.UpdateBatchBufferSecondaryAppend - before.UpdateBatchBufferSecondaryAppend,
+		UpdateBatchBufferRootAppend:      after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchBufferFlush:           after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
+		UpdateBatchPublish:               after.UpdateBatchPublish - before.UpdateBatchPublish,
+		UpdateBatchSecondaryDeletes:      after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
+		UpdateBatchSecondarySets:         after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
+		UpdateBatchSecondaryKeyBytes:     after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateBatchIndexValueChanges:     after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
+		UpdateBatchIndexValueUnchanged:   after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
+		UpdateBatchMaskFallbacks:         after.UpdateBatchMaskFallbacks - before.UpdateBatchMaskFallbacks,
+		UpdateBatchUniqueChecks:          after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
+		UpdateBatchUniqueCheckSkips:      after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
+		UpdateCombineRequests:            after.UpdateCombineRequests - before.UpdateCombineRequests,
+		UpdateCombineBatches:             after.UpdateCombineBatches - before.UpdateCombineBatches,
+		UpdateCombineBatchedRequests:     after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
+		UpdateCombineFallbackRequests:    after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
+		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
+		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
+		UpdateCombineDrain:               after.UpdateCombineDrain - before.UpdateCombineDrain,
+		UpdateCombineRun:                 after.UpdateCombineRun - before.UpdateCombineRun,
+		IndexedFlushCalls:                after.IndexedFlushCalls - before.IndexedFlushCalls,
+		IndexedFlushErrors:               after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushForcedDrains:         after.IndexedFlushForcedDrains - before.IndexedFlushForcedDrains,
+		IndexedFlushUnits:                after.IndexedFlushUnits - before.IndexedFlushUnits,
+		IndexedFlushDocs:                 after.IndexedFlushDocs - before.IndexedFlushDocs,
+		IndexedFlushBytes:                after.IndexedFlushBytes - before.IndexedFlushBytes,
+		IndexedFlushRootRuns:             after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
+		IndexedFlushRoots:                after.IndexedFlushRoots - before.IndexedFlushRoots,
+		IndexedFlushDuration:             after.IndexedFlushDuration - before.IndexedFlushDuration,
+		IndexedFlushMaterialize:          after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
+		IndexedFlushPublish:              after.IndexedFlushPublish - before.IndexedFlushPublish,
+		IndexedAsyncFlushWait:            after.IndexedAsyncFlushWait - before.IndexedAsyncFlushWait,
+		RootDeltaPlanPrimaryRoots:        after.RootDeltaPlanPrimaryRoots - before.RootDeltaPlanPrimaryRoots,
+		RootDeltaPlanTemplateRoots:       after.RootDeltaPlanTemplateRoots - before.RootDeltaPlanTemplateRoots,
+		RootDeltaPlanIndexStateRoots:     after.RootDeltaPlanIndexStateRoots - before.RootDeltaPlanIndexStateRoots,
+		RootDeltaPlanSecondaryRoots:      after.RootDeltaPlanSecondaryRoots - before.RootDeltaPlanSecondaryRoots,
+		RootDeltaPlanEntries:             after.RootDeltaPlanEntries - before.RootDeltaPlanEntries,
+		RootDeltaPlanKeyBytes:            after.RootDeltaPlanKeyBytes - before.RootDeltaPlanKeyBytes,
+		RootDeltaPlanValueBytes:          after.RootDeltaPlanValueBytes - before.RootDeltaPlanValueBytes,
+		RootDeltaPlanTombstones:          after.RootDeltaPlanTombstones - before.RootDeltaPlanTombstones,
+		PrimaryOnlyUpdateCalls:           after.PrimaryOnlyUpdateCalls - before.PrimaryOnlyUpdateCalls,
+		PrimaryOnlyMatched:               after.PrimaryOnlyMatched - before.PrimaryOnlyMatched,
+		PrimaryOnlyModified:              after.PrimaryOnlyModified - before.PrimaryOnlyModified,
+		PrimaryOnlyBufferedCalls:         after.PrimaryOnlyBufferedCalls - before.PrimaryOnlyBufferedCalls,
+		PrimaryOnlyRootPublishes:         after.PrimaryOnlyRootPublishes - before.PrimaryOnlyRootPublishes,
+		PrimaryOnlyRootDeltaEntries:      after.PrimaryOnlyRootDeltaEntries - before.PrimaryOnlyRootDeltaEntries,
+		PrimaryOnlyRootDeltaKeyBytes:     after.PrimaryOnlyRootDeltaKeyBytes - before.PrimaryOnlyRootDeltaKeyBytes,
+		PrimaryOnlyRootDeltaValueBytes:   after.PrimaryOnlyRootDeltaValueBytes - before.PrimaryOnlyRootDeltaValueBytes,
+		PrimaryOnlyCoalescedDocs:         after.PrimaryOnlyCoalescedDocs - before.PrimaryOnlyCoalescedDocs,
 	}
 	delta.OverlayMutableDocuments = after.OverlayMutableDocuments
 	delta.OverlayQueuedIndexedFlushUnits = after.OverlayQueuedIndexedFlushUnits
@@ -1197,92 +1208,114 @@ func collectionManagerUpdateIndexStat(stats collections.CollectionManagerStats, 
 
 func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	before := collections.CollectionManagerStats{
-		UpdateCombineRequests:          10,
-		UpdateCombineBatches:           3,
-		UpdateCombineBatchedRequests:   8,
-		UpdateCombineFallbackRequests:  1,
-		UpdateCombineQueueDepthMax:     12,
-		UpdateBatchIndexValueChanges:   20,
-		UpdateBatchIndexValueUnchanged: 30,
-		UpdateBatchMaskFallbacks:       5,
-		UpdateBatchUniqueChecks:        4,
-		UpdateBatchUniqueCheckSkips:    10,
-		IndexedFlushCalls:              3,
-		IndexedFlushErrors:             1,
-		IndexedFlushForcedDrains:       2,
-		IndexedFlushUnits:              6,
-		IndexedFlushDocs:               300,
-		IndexedFlushBytes:              9000,
-		IndexedFlushRootRuns:           90,
-		IndexedFlushRoots:              9,
-		IndexedFlushDuration:           30 * time.Millisecond,
-		IndexedFlushMaterialize:        12 * time.Millisecond,
-		IndexedFlushPublish:            18 * time.Millisecond,
-		IndexedAsyncFlushWait:          2 * time.Millisecond,
-		RootDeltaPlanPrimaryRoots:      3,
-		RootDeltaPlanTemplateRoots:     2,
-		RootDeltaPlanIndexStateRoots:   1,
-		RootDeltaPlanSecondaryRoots:    6,
-		RootDeltaPlanEntries:           300,
-		RootDeltaPlanKeyBytes:          1200,
-		RootDeltaPlanValueBytes:        2400,
-		RootDeltaPlanTombstones:        30,
-		PrimaryOnlyUpdateCalls:         10,
-		PrimaryOnlyMatched:             9,
-		PrimaryOnlyModified:            8,
-		PrimaryOnlyBufferedCalls:       1,
-		PrimaryOnlyRootPublishes:       8,
-		PrimaryOnlyRootDeltaEntries:    8,
-		PrimaryOnlyRootDeltaKeyBytes:   16,
-		PrimaryOnlyRootDeltaValueBytes: 160,
-		PrimaryOnlyCoalescedDocs:       8,
-		UpdateBatchIndexStatsCount:     2,
+		UpdateCombineRequests:            10,
+		UpdateCombineBatches:             3,
+		UpdateCombineBatchedRequests:     8,
+		UpdateCombineFallbackRequests:    1,
+		UpdateCombineQueueDepthMax:       12,
+		UpdateCombineEnqueue:             100 * time.Nanosecond,
+		UpdateCombineWait:                200 * time.Nanosecond,
+		UpdateCombineDrain:               300 * time.Nanosecond,
+		UpdateCombineRun:                 400 * time.Nanosecond,
+		UpdateBatchIndexStateExtract:     70 * time.Nanosecond,
+		UpdateBatchOldIndexStateExtract:  30 * time.Nanosecond,
+		UpdateBatchNewIndexStateExtract:  40 * time.Nanosecond,
+		UpdateBatchBufferFreeze:          11 * time.Nanosecond,
+		UpdateBatchBufferRootTable:       13 * time.Nanosecond,
+		UpdateBatchBufferPrimaryAppend:   17 * time.Nanosecond,
+		UpdateBatchBufferSecondaryAppend: 19 * time.Nanosecond,
+		UpdateBatchIndexValueChanges:     20,
+		UpdateBatchIndexValueUnchanged:   30,
+		UpdateBatchMaskFallbacks:         5,
+		UpdateBatchUniqueChecks:          4,
+		UpdateBatchUniqueCheckSkips:      10,
+		IndexedFlushCalls:                3,
+		IndexedFlushErrors:               1,
+		IndexedFlushForcedDrains:         2,
+		IndexedFlushUnits:                6,
+		IndexedFlushDocs:                 300,
+		IndexedFlushBytes:                9000,
+		IndexedFlushRootRuns:             90,
+		IndexedFlushRoots:                9,
+		IndexedFlushDuration:             30 * time.Millisecond,
+		IndexedFlushMaterialize:          12 * time.Millisecond,
+		IndexedFlushPublish:              18 * time.Millisecond,
+		IndexedAsyncFlushWait:            2 * time.Millisecond,
+		RootDeltaPlanPrimaryRoots:        3,
+		RootDeltaPlanTemplateRoots:       2,
+		RootDeltaPlanIndexStateRoots:     1,
+		RootDeltaPlanSecondaryRoots:      6,
+		RootDeltaPlanEntries:             300,
+		RootDeltaPlanKeyBytes:            1200,
+		RootDeltaPlanValueBytes:          2400,
+		RootDeltaPlanTombstones:          30,
+		PrimaryOnlyUpdateCalls:           10,
+		PrimaryOnlyMatched:               9,
+		PrimaryOnlyModified:              8,
+		PrimaryOnlyBufferedCalls:         1,
+		PrimaryOnlyRootPublishes:         8,
+		PrimaryOnlyRootDeltaEntries:      8,
+		PrimaryOnlyRootDeltaKeyBytes:     16,
+		PrimaryOnlyRootDeltaValueBytes:   160,
+		PrimaryOnlyCoalescedDocs:         8,
+		UpdateBatchIndexStatsCount:       2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
 			{CollectionName: "users", IndexName: "city", IndexOrdinal: 1, Changed: 10, SecondaryRuns: 10, SecondaryDeletes: 10, SecondarySets: 10, SecondaryKeyBytes: 1000},
 		},
 	}
 	after := collections.CollectionManagerStats{
-		UpdateCombineRequests:          17,
-		UpdateCombineBatches:           5,
-		UpdateCombineBatchedRequests:   14,
-		UpdateCombineFallbackRequests:  2,
-		UpdateCombineQueueDepthMax:     31,
-		UpdateBatchIndexValueChanges:   27,
-		UpdateBatchIndexValueUnchanged: 43,
-		UpdateBatchMaskFallbacks:       12,
-		UpdateBatchUniqueChecks:        6,
-		UpdateBatchUniqueCheckSkips:    19,
-		IndexedFlushCalls:              8,
-		IndexedFlushErrors:             2,
-		IndexedFlushForcedDrains:       5,
-		IndexedFlushUnits:              16,
-		IndexedFlushDocs:               900,
-		IndexedFlushBytes:              27000,
-		IndexedFlushRootRuns:           270,
-		IndexedFlushRoots:              24,
-		IndexedFlushDuration:           90 * time.Millisecond,
-		IndexedFlushMaterialize:        30 * time.Millisecond,
-		IndexedFlushPublish:            60 * time.Millisecond,
-		IndexedAsyncFlushWait:          11 * time.Millisecond,
-		RootDeltaPlanPrimaryRoots:      8,
-		RootDeltaPlanTemplateRoots:     5,
-		RootDeltaPlanIndexStateRoots:   4,
-		RootDeltaPlanSecondaryRoots:    16,
-		RootDeltaPlanEntries:           900,
-		RootDeltaPlanKeyBytes:          3600,
-		RootDeltaPlanValueBytes:        7200,
-		RootDeltaPlanTombstones:        90,
-		PrimaryOnlyUpdateCalls:         17,
-		PrimaryOnlyMatched:             16,
-		PrimaryOnlyModified:            15,
-		PrimaryOnlyBufferedCalls:       3,
-		PrimaryOnlyRootPublishes:       15,
-		PrimaryOnlyRootDeltaEntries:    15,
-		PrimaryOnlyRootDeltaKeyBytes:   30,
-		PrimaryOnlyRootDeltaValueBytes: 300,
-		PrimaryOnlyCoalescedDocs:       15,
-		UpdateBatchIndexStatsCount:     2,
+		UpdateCombineRequests:            17,
+		UpdateCombineBatches:             5,
+		UpdateCombineBatchedRequests:     14,
+		UpdateCombineFallbackRequests:    2,
+		UpdateCombineQueueDepthMax:       31,
+		UpdateCombineEnqueue:             700 * time.Nanosecond,
+		UpdateCombineWait:                1400 * time.Nanosecond,
+		UpdateCombineDrain:               2100 * time.Nanosecond,
+		UpdateCombineRun:                 2800 * time.Nanosecond,
+		UpdateBatchIndexStateExtract:     700 * time.Nanosecond,
+		UpdateBatchOldIndexStateExtract:  300 * time.Nanosecond,
+		UpdateBatchNewIndexStateExtract:  400 * time.Nanosecond,
+		UpdateBatchBufferFreeze:          110 * time.Nanosecond,
+		UpdateBatchBufferRootTable:       130 * time.Nanosecond,
+		UpdateBatchBufferPrimaryAppend:   170 * time.Nanosecond,
+		UpdateBatchBufferSecondaryAppend: 190 * time.Nanosecond,
+		UpdateBatchIndexValueChanges:     27,
+		UpdateBatchIndexValueUnchanged:   43,
+		UpdateBatchMaskFallbacks:         12,
+		UpdateBatchUniqueChecks:          6,
+		UpdateBatchUniqueCheckSkips:      19,
+		IndexedFlushCalls:                8,
+		IndexedFlushErrors:               2,
+		IndexedFlushForcedDrains:         5,
+		IndexedFlushUnits:                16,
+		IndexedFlushDocs:                 900,
+		IndexedFlushBytes:                27000,
+		IndexedFlushRootRuns:             270,
+		IndexedFlushRoots:                24,
+		IndexedFlushDuration:             90 * time.Millisecond,
+		IndexedFlushMaterialize:          30 * time.Millisecond,
+		IndexedFlushPublish:              60 * time.Millisecond,
+		IndexedAsyncFlushWait:            11 * time.Millisecond,
+		RootDeltaPlanPrimaryRoots:        8,
+		RootDeltaPlanTemplateRoots:       5,
+		RootDeltaPlanIndexStateRoots:     4,
+		RootDeltaPlanSecondaryRoots:      16,
+		RootDeltaPlanEntries:             900,
+		RootDeltaPlanKeyBytes:            3600,
+		RootDeltaPlanValueBytes:          7200,
+		RootDeltaPlanTombstones:          90,
+		PrimaryOnlyUpdateCalls:           17,
+		PrimaryOnlyMatched:               16,
+		PrimaryOnlyModified:              15,
+		PrimaryOnlyBufferedCalls:         3,
+		PrimaryOnlyRootPublishes:         15,
+		PrimaryOnlyRootDeltaEntries:      15,
+		PrimaryOnlyRootDeltaKeyBytes:     30,
+		PrimaryOnlyRootDeltaValueBytes:   300,
+		PrimaryOnlyCoalescedDocs:         15,
+		UpdateBatchIndexStatsCount:       2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
 			{CollectionName: "users", IndexName: "city", IndexOrdinal: 1, Changed: 17, SecondaryRuns: 17, SecondaryDeletes: 17, SecondarySets: 17, SecondaryKeyBytes: 1700},
@@ -1303,6 +1336,29 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineQueueDepthMax != 31 {
 		t.Fatalf("UpdateCombineQueueDepthMax=%d want 31", got.UpdateCombineQueueDepthMax)
+	}
+	if got.UpdateCombineEnqueue != 600*time.Nanosecond || got.UpdateCombineWait != 1200*time.Nanosecond || got.UpdateCombineDrain != 1800*time.Nanosecond || got.UpdateCombineRun != 2400*time.Nanosecond {
+		t.Fatalf("update combine timing delta enqueue/wait/drain/run=%s/%s/%s/%s want 600ns/1200ns/1800ns/2400ns",
+			got.UpdateCombineEnqueue,
+			got.UpdateCombineWait,
+			got.UpdateCombineDrain,
+			got.UpdateCombineRun,
+		)
+	}
+	if got.UpdateBatchIndexStateExtract != 630*time.Nanosecond || got.UpdateBatchOldIndexStateExtract != 270*time.Nanosecond || got.UpdateBatchNewIndexStateExtract != 360*time.Nanosecond {
+		t.Fatalf("index state timing delta total/old/new=%s/%s/%s want 630ns/270ns/360ns",
+			got.UpdateBatchIndexStateExtract,
+			got.UpdateBatchOldIndexStateExtract,
+			got.UpdateBatchNewIndexStateExtract,
+		)
+	}
+	if got.UpdateBatchBufferFreeze != 99*time.Nanosecond || got.UpdateBatchBufferRootTable != 117*time.Nanosecond || got.UpdateBatchBufferPrimaryAppend != 153*time.Nanosecond || got.UpdateBatchBufferSecondaryAppend != 171*time.Nanosecond {
+		t.Fatalf("buffer detail timing delta freeze/root-table/primary/secondary=%s/%s/%s/%s want 99ns/117ns/153ns/171ns",
+			got.UpdateBatchBufferFreeze,
+			got.UpdateBatchBufferRootTable,
+			got.UpdateBatchBufferPrimaryAppend,
+			got.UpdateBatchBufferSecondaryAppend,
+		)
 	}
 	staleMax := deltaCollectionManagerUpdateStats(
 		collections.CollectionManagerStats{UpdateCombineQueueDepthMax: 31},
@@ -1489,6 +1545,10 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		UpdateCombineBatchedRequests:  600,
 		UpdateCombineFallbackRequests: 6,
 		UpdateCombineQueueDepthMax:    31,
+		UpdateCombineEnqueue:          600 * time.Nanosecond,
+		UpdateCombineWait:             1200 * time.Nanosecond,
+		UpdateCombineDrain:            1800 * time.Nanosecond,
+		UpdateCombineRun:              2400 * time.Nanosecond,
 	}
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
@@ -1503,6 +1563,10 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		"update_combine_fallback_requests":     6,
 		"update_combine_fallback_requests/doc": 0.01,
 		"update_combine_queue_depth_max":       31,
+		"update_combine_enqueue_ns/doc":        1,
+		"update_combine_wait_ns/doc":           2,
+		"update_combine_drain_ns/doc":          3,
+		"update_combine_run_ns/doc":            4,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1673,6 +1737,15 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	if stats.UpdateCombineQueueDepthMax > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
 	}
+	reportDuration := func(name string, d time.Duration) {
+		if d > 0 {
+			b.ReportMetric(float64(d.Nanoseconds())/float64(docs), name)
+		}
+	}
+	reportDuration("update_combine_enqueue_ns/doc", stats.UpdateCombineEnqueue)
+	reportDuration("update_combine_wait_ns/doc", stats.UpdateCombineWait)
+	reportDuration("update_combine_drain_ns/doc", stats.UpdateCombineDrain)
+	reportDuration("update_combine_run_ns/doc", stats.UpdateCombineRun)
 	if stats.UpdateBatchSecondaryDeletes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")
 	}
@@ -1729,15 +1802,12 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 			b.ReportMetric(float64(indexStats.SecondaryKeyBytes)/float64(docs), prefix+"secondary_key_bytes/doc")
 		}
 	}
-	reportDuration := func(name string, d time.Duration) {
-		if d > 0 {
-			b.ReportMetric(float64(d.Nanoseconds())/float64(docs), name)
-		}
-	}
 	reportDuration("update_current_read_ns/doc", stats.UpdateBatchCurrentRead)
 	reportDuration("update_callback_ns/doc", stats.UpdateBatchCallback)
 	reportDuration("update_prepare_ns/doc", stats.UpdateBatchPrepareDocuments)
 	reportDuration("update_index_state_extract_ns/doc", stats.UpdateBatchIndexStateExtract)
+	reportDuration("update_old_index_state_extract_ns/doc", stats.UpdateBatchOldIndexStateExtract)
+	reportDuration("update_new_index_state_extract_ns/doc", stats.UpdateBatchNewIndexStateExtract)
 	reportDuration("update_unique_preflight_ns/doc", stats.UpdateBatchUniquePreflight)
 	reportDuration("update_template_run_ns/doc", stats.UpdateBatchTemplateRunBuild)
 	reportDuration("update_primary_run_ns/doc", stats.UpdateBatchPrimaryRunBuild)
@@ -1750,8 +1820,12 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	reportDuration("update_buffer_validation_ns/doc", stats.UpdateBatchBufferValidation)
 	reportDuration("update_buffer_root_scan_ns/doc", stats.UpdateBatchBufferRootScan)
 	reportDuration("update_buffer_domain_prepare_ns/doc", stats.UpdateBatchBufferDomainPrepare)
+	reportDuration("update_buffer_freeze_ns/doc", stats.UpdateBatchBufferFreeze)
+	reportDuration("update_buffer_root_table_ns/doc", stats.UpdateBatchBufferRootTable)
 	reportDuration("update_buffer_primary_index_ns/doc", stats.UpdateBatchBufferPrimaryIdx)
 	reportDuration("update_buffer_unique_index_ns/doc", stats.UpdateBatchBufferUniqueIdx)
+	reportDuration("update_buffer_primary_append_ns/doc", stats.UpdateBatchBufferPrimaryAppend)
+	reportDuration("update_buffer_secondary_append_ns/doc", stats.UpdateBatchBufferSecondaryAppend)
 	reportDuration("update_buffer_root_append_ns/doc", stats.UpdateBatchBufferRootAppend)
 	reportDuration("update_buffer_flush_ns/doc", stats.UpdateBatchBufferFlush)
 	reportDuration("update_publish_ns/doc", stats.UpdateBatchPublish)


### PR DESCRIPTION
## Summary

Adds safe, durable update-path profiling instrumentation for the benchmark-driven Update work:

- splits update index-state extraction into old-document and new-document extraction timers
- splits buffered update staging into freeze, mutable root-table lookup/create, primary append, and secondary append timers
- records update-combiner enqueue, caller wait, drain, and run timings when detailed update stats are enabled
- adds `CollectionManager.ResetUpdateCombinersForProfiling()` so benchmarks can recreate combiner goroutines inside the measured pprof label context after warmup
- reports the new metrics from the mongo gateway direct collection update benchmark and the direct buffered collection benchmark

This intentionally does not add unsafe benchmark switches or change update semantics.

## Validation

- `go test ./TreeDB/collections ./cmd/mongo_gateway_bench`
- `go test ./TreeDB/collections -run '^TestCollectionManagerResetUpdateCombinersForProfiling$' -count=20`
- smoke benchmark/profile:
  - `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=2000 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=1 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' -benchmem -benchtime=100000x -count=1 -p=1 -cpuprofile /tmp/.../cpu.pprof`
  - result: `7420 ns/op`, `134773 docs/sec`, `3470 B/op`, `15 allocs/op`
  - emitted new metrics including `update_combine_run_ns/doc`, `update_combine_wait_ns/doc`, `update_buffer_freeze_ns/doc`, `update_buffer_root_table_ns/doc`, `update_buffer_primary_append_ns/doc`, `update_buffer_secondary_append_ns/doc`, `update_old_index_state_extract_ns/doc`, and `update_new_index_state_extract_ns/doc`
  - pprof labels captured `timed_update_and_flush` for about 65% of sampled CPU in the short smoke run
