### PR TITLE
collections: inline lone update combine path

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -62,6 +62,7 @@ const (
 	defaultCollectionUpdateCombineMaxBatch              = 256
 	defaultCollectionUpdateCombineDrainYields           = 1
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
+	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
 	collectionPprofComponentKey                         = "gomap_component"
 	collectionPprofOperationKey                         = "gomap_operation"
 	collectionPprofIndexedAsyncFlush                    = "collections_indexed_async_flush"
@@ -464,6 +465,7 @@ type CollectionManagerStats struct {
 	UpdateCombineBatchedRequests    uint64
 	UpdateCombineFallbackRequests   uint64
 	UpdateCombineQueueDepthMax      uint64
+	UpdateCombineInlineRequests     uint64
 	UpdateCombineEnqueue            time.Duration
 	UpdateCombineWait               time.Duration
 	UpdateCombineDrain              time.Duration
@@ -841,6 +843,12 @@ type collectionWriteDomain struct {
 	updateCombineBatchedRequests       atomic.Uint64
 	updateCombineFallbackRequests      atomic.Uint64
 	updateCombineQueueDepthMax         atomic.Uint64
+	updateCombineInlineRequests        atomic.Uint64
+	updateInlineInFlight               atomic.Uint64
+	updateCombineLastRequestUnixNano   atomic.Uint64
+	updateInlineDocumentID             [collectionUpdateCombineInlineDocumentIDMax]byte
+	updateInlineDocumentIDHeap         []byte
+	updateInlineItems                  [1]UpdateBatchItem
 	updateCombineEnqueueNs             atomic.Uint64
 	updateCombineWaitNs                atomic.Uint64
 	updateCombineDrainNs               atomic.Uint64
@@ -1122,6 +1130,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
 	out["treedb.collections.write_domain.update_combine.fallback_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineFallbackRequests)
 	out["treedb.collections.write_domain.update_combine.queue_depth_max"] = fmt.Sprintf("%d", stats.UpdateCombineQueueDepthMax)
+	out["treedb.collections.write_domain.update_combine.inline_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineInlineRequests)
 	out["treedb.collections.write_domain.update_combine.enqueue_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineEnqueue.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineWait.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.drain_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineDrain.Nanoseconds())
@@ -1355,6 +1364,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if other.UpdateCombineQueueDepthMax > s.UpdateCombineQueueDepthMax {
 		s.UpdateCombineQueueDepthMax = other.UpdateCombineQueueDepthMax
 	}
+	s.UpdateCombineInlineRequests += other.UpdateCombineInlineRequests
 	s.UpdateCombineEnqueue += other.UpdateCombineEnqueue
 	s.UpdateCombineWait += other.UpdateCombineWait
 	s.UpdateCombineDrain += other.UpdateCombineDrain
@@ -1484,6 +1494,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
 	stats.UpdateCombineFallbackRequests = domain.updateCombineFallbackRequests.Load()
 	stats.UpdateCombineQueueDepthMax = domain.updateCombineQueueDepthMax.Load()
+	stats.UpdateCombineInlineRequests = domain.updateCombineInlineRequests.Load()
 	stats.UpdateCombineEnqueue = durationFromAtomicNs(domain.updateCombineEnqueueNs.Load())
 	stats.UpdateCombineWait = durationFromAtomicNs(domain.updateCombineWaitNs.Load())
 	stats.UpdateCombineDrain = durationFromAtomicNs(domain.updateCombineDrainNs.Load())
@@ -1974,9 +1985,17 @@ func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int)
 		return
 	}
 	domain.updateCombineRequests.Add(1)
+	domain.updateCombineLastRequestUnixNano.Store(uint64(time.Now().UnixNano()))
 	if queueDepth > 0 {
 		atomicMaxUint64(&domain.updateCombineQueueDepthMax, uint64(queueDepth))
 	}
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineInline() {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineInlineRequests.Add(1)
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineEnqueue(d time.Duration) {
@@ -6794,6 +6813,13 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
 	}
+	if combiner, domain := c.updateFastPathWithoutCreatingCombiner(); combiner != nil {
+		return combiner.update(c, documentID, update)
+	} else if domain != nil {
+		defer domain.finishInlineUpdateWithoutCombiner()
+		domain.observeUpdateCombineInline()
+		return c.updateSingleInlineWithoutCombiner(domain, documentID, update)
+	}
 	if combiner := c.updateCombiner(); combiner != nil {
 		return combiner.update(c, documentID, update)
 	}
@@ -6983,6 +7009,114 @@ type collectionUpdateCombineResult struct {
 
 type collectionUpdateCombineWaiter struct {
 	ch chan collectionUpdateCombineResult
+}
+
+func (c *Collection) updateFastPathWithoutCreatingCombiner() (*collectionUpdateCombiner, *collectionWriteDomain) {
+	if c == nil || c.db == nil || c.db.IsClosing() || c.writeDomain == nil {
+		return nil, nil
+	}
+	domain := c.writeDomain
+	if domain.closingWrites.Load() {
+		return nil, nil
+	}
+	domain.updateCombineMu.Lock()
+	defer domain.updateCombineMu.Unlock()
+	if domain.updateCombineDone || domain.updateDraining != nil {
+		return nil, nil
+	}
+	combiner := domain.updateCombiner
+	if combiner != nil {
+		if combiner.isStopped() {
+			if domain.updateCombiner == combiner {
+				domain.updateCombiner = nil
+			}
+		} else if combiner.running.Load() || len(combiner.requests) > 0 {
+			return combiner, nil
+		}
+	}
+	if !domain.updateInlineQuietAfterCombinerActivity() {
+		return nil, nil
+	}
+	if domain.updateInlineInFlight.CompareAndSwap(0, 1) {
+		return nil, domain
+	}
+	return nil, nil
+}
+
+func (domain *collectionWriteDomain) updateInlineQuietAfterCombinerActivity() bool {
+	if domain == nil {
+		return false
+	}
+	last := domain.updateCombineLastRequestUnixNano.Load()
+	if last == 0 {
+		return true
+	}
+	return time.Now().UnixNano()-int64(last) >= int64(collectionUpdateCombineInlineQuietPeriod)
+}
+
+func (domain *collectionWriteDomain) finishInlineUpdateWithoutCombiner() {
+	if domain == nil {
+		return
+	}
+	domain.updateInlineInFlight.Store(0)
+}
+
+func (c *Collection) updateSingleInlineWithoutCombiner(domain *collectionWriteDomain, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (matched bool, modified bool, err error) {
+	items := domain.prepareInlineUpdateItems(documentID, update)
+	defer domain.clearInlineUpdateItems()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			matched = false
+			modified = false
+			err = collectionUpdatePanicError("inline", recovered)
+		}
+	}()
+	results, batched, err := c.updateBatchOwnedItems(items, updateBatchModeNoSecondaryUniqueIndexChanges)
+	if !batched && err == nil {
+		return c.updateDirect(items[0].DocumentID, items[0].Update)
+	}
+	if err != nil {
+		var itemErr *UpdateBatchItemError
+		if errors.As(err, &itemErr) && itemErr.Index == 0 && itemErr.Err != nil {
+			return false, false, itemErr.Err
+		}
+		return false, false, err
+	}
+	if len(results) != 1 {
+		return false, false, fmt.Errorf("collections: inline update result count %d for single update", len(results))
+	}
+	return results[0].Matched, results[0].Modified, nil
+}
+
+func (domain *collectionWriteDomain) prepareInlineUpdateItems(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) []UpdateBatchItem {
+	if domain == nil {
+		return []UpdateBatchItem{{DocumentID: documentID, Update: update}}
+	}
+	var ownedDocumentID []byte
+	if len(documentID) <= len(domain.updateInlineDocumentID) {
+		copy(domain.updateInlineDocumentID[:], documentID)
+		ownedDocumentID = domain.updateInlineDocumentID[:len(documentID):len(documentID)]
+	} else {
+		if cap(domain.updateInlineDocumentIDHeap) < len(documentID) {
+			domain.updateInlineDocumentIDHeap = make([]byte, len(documentID))
+		} else {
+			domain.updateInlineDocumentIDHeap = domain.updateInlineDocumentIDHeap[:len(documentID)]
+		}
+		copy(domain.updateInlineDocumentIDHeap, documentID)
+		ownedDocumentID = domain.updateInlineDocumentIDHeap[:len(documentID):len(documentID)]
+	}
+	domain.updateInlineItems[0] = UpdateBatchItem{
+		DocumentID: ownedDocumentID,
+		Update:     update,
+	}
+	return domain.updateInlineItems[:]
+}
+
+func (domain *collectionWriteDomain) clearInlineUpdateItems() {
+	if domain == nil {
+		return
+	}
+	domain.updateInlineItems[0] = UpdateBatchItem{}
 }
 
 func (c *Collection) updateCombiner() *collectionUpdateCombiner {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -964,6 +964,7 @@ func TestCollectionUpdateIndexStateBreakdownStatsSnapshotAndAdd(t *testing.T) {
 
 func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
 	domain := &collectionWriteDomain{}
+	domain.observeUpdateCombineInline()
 	domain.observeUpdateCombineEnqueue(3 * time.Nanosecond)
 	domain.observeUpdateCombineWait(5 * time.Nanosecond)
 	domain.observeUpdateCombineDrain(7 * time.Nanosecond)
@@ -972,6 +973,15 @@ func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
 	var merged CollectionManagerStats
 	merged.add(snapshot)
 	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
+	if snapshot.UpdateCombineInlineRequests != 1 {
+		t.Fatalf("snapshot inline requests=%d want 1", snapshot.UpdateCombineInlineRequests)
+	}
+	if merged.UpdateCombineInlineRequests != 1 {
+		t.Fatalf("merged inline requests=%d want 1", merged.UpdateCombineInlineRequests)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_combine.inline_requests_total"], "1"; got != want {
+		t.Fatalf("exported inline requests=%q want %q", got, want)
+	}
 	cases := []struct {
 		name string
 		key  string
@@ -1555,22 +1565,17 @@ func TestCollectionManagerResetUpdateCombinersForProfiling(t *testing.T) {
 	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
 		t.Fatalf("insert batch: %v", err)
 	}
-	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
-		return []byte(`{"name":"ada","n":1}`), true, nil
-	}); err != nil {
-		t.Fatalf("first update: %v", err)
-	}
 	domain := col.writeDomain
 	if domain == nil {
 		t.Fatal("collection write domain is nil")
 	}
-	domain.updateCombineMu.Lock()
-	first := domain.updateCombiner
-	draining := domain.updateDraining
-	domain.updateCombineMu.Unlock()
+	first := col.updateCombiner()
 	if first == nil {
 		t.Fatal("first update combiner is nil")
 	}
+	domain.updateCombineMu.Lock()
+	draining := domain.updateDraining
+	domain.updateCombineMu.Unlock()
 	if draining != nil {
 		t.Fatal("unexpected draining combiner before reset")
 	}
@@ -1584,14 +1589,7 @@ func TestCollectionManagerResetUpdateCombinersForProfiling(t *testing.T) {
 		t.Fatalf("combiner after reset=%p draining=%p want nil/nil", afterReset, afterResetDraining)
 	}
 
-	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
-		return []byte(`{"name":"ada","n":2}`), true, nil
-	}); err != nil {
-		t.Fatalf("second update after reset: %v", err)
-	}
-	domain.updateCombineMu.Lock()
-	second := domain.updateCombiner
-	domain.updateCombineMu.Unlock()
+	second := col.updateCombiner()
 	if second == nil {
 		t.Fatal("second update combiner is nil")
 	}
@@ -7975,6 +7973,198 @@ func TestCollectionUpdateCombinerDocumentIDLongStorageClonesCallerBytes(t *testi
 	id[0] = 'y'
 	if got := req.documentIDBytes(); got[0] != 'x' {
 		t.Fatalf("long document id changed after caller mutation: first byte %q", got[0])
+	}
+}
+
+func TestCollectionUpdateBypassesIdleCombinerWhenNoBatchPressure(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"city":"hnl","score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	idle := col.updateCombiner()
+	if idle == nil {
+		t.Fatal("expected idle combiner")
+	}
+
+	before := mgr.StatsSnapshot()
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"city":"sea","score":1}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched=%v modified=%v want true,true", matched, modified)
+	}
+	after := mgr.StatsSnapshot()
+	if got := after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests; got != 1 {
+		t.Fatalf("inline requests delta=%d want 1", got)
+	}
+	if got := after.UpdateCombineRequests - before.UpdateCombineRequests; got != 0 {
+		t.Fatalf("combine requests delta=%d want 0", got)
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find updated city: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"))
+}
+
+func TestCollectionUpdateUsesCombinerWhenInlineUpdateInFlight(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl","score":0}`),
+			[]byte(`{"city":"hnl","score":0}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	before := mgr.StatsSnapshot()
+	enteredFirstUpdate := make(chan struct{})
+	releaseFirstUpdate := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseFirstUpdate) })
+
+	firstDone := make(chan error, 1)
+	go func() {
+		matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+			enterOnce.Do(func() { close(enteredFirstUpdate) })
+			<-releaseFirstUpdate
+			return []byte(`{"city":"bos","score":1}`), true, nil
+		})
+		if err == nil && (!matched || !modified) {
+			err = fmt.Errorf("first update matched=%v modified=%v", matched, modified)
+		}
+		firstDone <- err
+	}()
+
+	select {
+	case <-enteredFirstUpdate:
+	case <-time.After(collectionTestTimeout(t, time.Second)):
+		t.Fatal("first update callback did not start")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		matched, modified, err := col.Update([]byte("u2"), func([]byte) ([]byte, bool, error) {
+			return []byte(`{"city":"sea","score":1}`), true, nil
+		})
+		if err == nil && (!matched || !modified) {
+			err = fmt.Errorf("second update matched=%v modified=%v", matched, modified)
+		}
+		secondDone <- err
+	}()
+
+	deadline := time.After(collectionTestTimeout(t, time.Second))
+	for {
+		stats := mgr.StatsSnapshot()
+		if stats.UpdateCombineRequests-before.UpdateCombineRequests > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("second update did not enqueue through combiner")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	releaseOnce.Do(func() { close(releaseFirstUpdate) })
+	for name, done := range map[string]chan error{
+		"first":  firstDone,
+		"second": secondDone,
+	} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s update: %v", name, err)
+			}
+		case <-time.After(collectionTestTimeout(t, time.Second)):
+			t.Fatalf("%s update did not complete", name)
+		}
+	}
+
+	after := mgr.StatsSnapshot()
+	if got := after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests; got != 1 {
+		t.Fatalf("inline requests delta=%d want 1", got)
+	}
+	if got := after.UpdateCombineRequests - before.UpdateCombineRequests; got == 0 {
+		t.Fatal("combine requests delta=0 want positive")
+	}
+	if got := after.UpdateCombineQueueDepthMax; got == 0 {
+		t.Fatal("combine queue depth max=0 want positive")
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find updated city: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u2"))
+
+	col.writeDomain.updateCombineLastRequestUnixNano.Store(uint64(time.Now().Add(time.Hour).UnixNano()))
+	combineBeforeCooldownCheck := after.UpdateCombineRequests
+	inlineBeforeCooldownCheck := after.UpdateCombineInlineRequests
+	matched, modified, err := col.Update([]byte("u2"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"city":"iad","score":2}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("cooldown update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("cooldown update matched=%v modified=%v want true,true", matched, modified)
+	}
+	afterCooldownCheck := mgr.StatsSnapshot()
+	if got := afterCooldownCheck.UpdateCombineInlineRequests - inlineBeforeCooldownCheck; got != 0 {
+		t.Fatalf("cooldown inline requests delta=%d want 0", got)
+	}
+	if got := afterCooldownCheck.UpdateCombineRequests - combineBeforeCooldownCheck; got == 0 {
+		t.Fatal("cooldown combine requests delta=0 want positive")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1121,6 +1121,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatches:             after.UpdateCombineBatches - before.UpdateCombineBatches,
 		UpdateCombineBatchedRequests:     after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:    after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
+		UpdateCombineInlineRequests:      after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests,
 		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
 		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
 		UpdateCombineDrain:               after.UpdateCombineDrain - before.UpdateCombineDrain,
@@ -1213,6 +1214,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineBatchedRequests:     8,
 		UpdateCombineFallbackRequests:    1,
 		UpdateCombineQueueDepthMax:       12,
+		UpdateCombineInlineRequests:      4,
 		UpdateCombineEnqueue:             100 * time.Nanosecond,
 		UpdateCombineWait:                200 * time.Nanosecond,
 		UpdateCombineDrain:               300 * time.Nanosecond,
@@ -1270,6 +1272,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineBatchedRequests:     14,
 		UpdateCombineFallbackRequests:    2,
 		UpdateCombineQueueDepthMax:       31,
+		UpdateCombineInlineRequests:      15,
 		UpdateCombineEnqueue:             700 * time.Nanosecond,
 		UpdateCombineWait:                1400 * time.Nanosecond,
 		UpdateCombineDrain:               2100 * time.Nanosecond,
@@ -1336,6 +1339,9 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineQueueDepthMax != 31 {
 		t.Fatalf("UpdateCombineQueueDepthMax=%d want 31", got.UpdateCombineQueueDepthMax)
+	}
+	if got.UpdateCombineInlineRequests != 11 {
+		t.Fatalf("UpdateCombineInlineRequests=%d want 11", got.UpdateCombineInlineRequests)
 	}
 	if got.UpdateCombineEnqueue != 600*time.Nanosecond || got.UpdateCombineWait != 1200*time.Nanosecond || got.UpdateCombineDrain != 1800*time.Nanosecond || got.UpdateCombineRun != 2400*time.Nanosecond {
 		t.Fatalf("update combine timing delta enqueue/wait/drain/run=%s/%s/%s/%s want 600ns/1200ns/1800ns/2400ns",
@@ -1545,6 +1551,7 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		UpdateCombineBatchedRequests:  600,
 		UpdateCombineFallbackRequests: 6,
 		UpdateCombineQueueDepthMax:    31,
+		UpdateCombineInlineRequests:   300,
 		UpdateCombineEnqueue:          600 * time.Nanosecond,
 		UpdateCombineWait:             1200 * time.Nanosecond,
 		UpdateCombineDrain:            1800 * time.Nanosecond,
@@ -1563,6 +1570,8 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		"update_combine_fallback_requests":     6,
 		"update_combine_fallback_requests/doc": 0.01,
 		"update_combine_queue_depth_max":       31,
+		"update_combine_inline_requests":       300,
+		"update_combine_inline_requests/doc":   0.5,
 		"update_combine_enqueue_ns/doc":        1,
 		"update_combine_wait_ns/doc":           2,
 		"update_combine_drain_ns/doc":          3,
@@ -1736,6 +1745,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.UpdateCombineQueueDepthMax > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
+	}
+	if stats.UpdateCombineInlineRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineInlineRequests), "update_combine_inline_requests")
+		b.ReportMetric(float64(stats.UpdateCombineInlineRequests)/float64(docs), "update_combine_inline_requests/doc")
 	}
 	reportDuration := func(name string, d time.Duration) {
 		if d > 0 {


### PR DESCRIPTION
## Summary

This is a follow-on to #1426. It keeps the UpdateBatch-backed update path, but skips creating/crossing the update combiner when there is no useful batching pressure.

The new path:

- runs a single-item `updateBatchOwnedItems(..., updateBatchModeNoSecondaryUniqueIndexChanges)` inline when no combiner is running or queued
- allows only one inline update per write domain at a time
- falls back to the existing combiner when another inline update is in flight
- keeps using the combiner briefly after recent combiner activity, so concurrent writer workloads keep batching instead of fragmenting into inline work
- reports `update_combine_inline_requests` in collection-manager stats and mongo gateway benchmark output

This is deliberately not the earlier unsafe direct-write bypass. Indexed buffered-write semantics stay on the same batch/staging path that the combiner uses.

## Validation

Unit/package tests:

```sh
go test -count=1 ./TreeDB/collections ./cmd/mongo_gateway_bench
```

Race coverage for the new routing tests:

```sh
go test -race ./TreeDB/collections -run 'TestCollectionUpdate(BypassesIdleCombinerWhenNoBatchPressure|UsesCombinerWhenInlineUpdateInFlight)$'
```

Benchmark commands, comparing base `codex/update-profile-instrumentation` to this branch:

```sh
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=1 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' -benchmem -benchtime=500000x -count=5 -p=1 -timeout=20m
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' -benchmem -benchtime=500000x -count=5 -p=1 -timeout=20m
```

1 writer:

```text
DirectCollectionConcurrentUpdateBSONIndexes3CityUpdate-8  11.245µs/op -> 7.739µs/op  -31.18% (p=0.008 n=5)
B/op:      4.199Ki -> 4.199Ki
allocs/op: 16      -> 16
base:      update_combine_requests/doc=1.000, update_combine_wait_ns/doc=10.58k, update_combine_run_ns/doc=9.857k
branch:    update_combine_inline_requests/doc=1.000
```

8 writers:

```text
DirectCollectionConcurrentUpdateBSONIndexes3CityUpdate-8  7.476µs/op -> 7.414µs/op  ~ (p=0.841 n=5)
B/op:      3.001Ki -> 3.003Ki
allocs/op: 4       -> 4
items/batch:             7.064 -> 7.251
update_combine_requests/doc: 1.000 -> 1.000
update_combine_wait_ns/doc: 57.09k -> 57.12k
update_combine_run_ns/doc:   6.574k -> 6.486k
branch inline_requests/doc: 50.00µ, i.e. only startup/admission edges inline
```

Interpretation: the lone-writer canary removes the combiner handoff cost without increasing allocation count. The 8-writer canary remains statistically flat and keeps essentially all requests on the combiner, preserving the batching win under pressure.
