### PR TITLE
collections: reuse freeze-sort run table scratch

### DIFF
--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -23,14 +23,20 @@ type freezeSortRunEntry struct {
 }
 
 type freezeSortRunTable struct {
-	mu          sync.RWMutex
-	entries     []freezeSortRunEntry
-	latest      map[string]int
-	latestDirty bool
-	frozen      bool
-	released    bool
-	sizeBytes   int64
-	nextSeq     uint64
+	mu              sync.RWMutex
+	entries         []freezeSortRunEntry
+	latest          map[string]int
+	latestDirty     bool
+	frozen          bool
+	released        bool
+	sizeBytes       int64
+	nextSeq         uint64
+	ownerGeneration uint64
+}
+
+type freezeSortRunTableHandle struct {
+	table           *freezeSortRunTable
+	ownerGeneration uint64
 }
 
 const (
@@ -58,12 +64,147 @@ func newFreezeSortRunTable() memtable.Table {
 		freezeSortRunTablePool.entryCapacity -= cap(t.entries)
 		freezeSortRunTablePool.mu.Unlock()
 		t.mu.Lock()
+		t.ownerGeneration++
 		t.released = false
+		ownerGeneration := t.ownerGeneration
 		t.mu.Unlock()
-		return t
+		return freezeSortRunTableHandle{table: t, ownerGeneration: ownerGeneration}
 	}
 	freezeSortRunTablePool.mu.Unlock()
-	return &freezeSortRunTable{}
+	return freezeSortRunTableHandle{table: &freezeSortRunTable{ownerGeneration: 1}, ownerGeneration: 1}
+}
+
+func (h freezeSortRunTableHandle) StableUnsafeIteratorSlices() bool { return true }
+
+func (h freezeSortRunTableHandle) Set(key, value []byte) {
+	h.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+}
+
+func (h freezeSortRunTableHandle) SetSteal(key, value []byte) {
+	h.SetEntrySteal(key, value, page.ValuePtr{}, node.FlagInline)
+}
+
+func (h freezeSortRunTableHandle) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	h.SetEntrySteal(bytes.Clone(key), bytes.Clone(value), ptr, flags)
+}
+
+func (h freezeSortRunTableHandle) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
+	keyCopy := bytes.Clone(key)
+	valueCopy := bytes.Clone(value)
+	if cb != nil {
+		if err := cb(keyCopy, valueCopy); err != nil {
+			return err
+		}
+	}
+	h.SetEntrySteal(keyCopy, valueCopy, page.ValuePtr{}, node.FlagInline)
+	return nil
+}
+
+func (h freezeSortRunTableHandle) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	if h.table == nil {
+		return
+	}
+	h.table.setEntryStealOwned(h.ownerGeneration, key, value, ptr, flags)
+}
+
+func (h freezeSortRunTableHandle) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
+	if h.table == nil {
+		return nil
+	}
+	return h.table.applyStealEntryFuncOwned(h.ownerGeneration, count, emit)
+}
+
+func (h freezeSortRunTableHandle) Delete(key []byte) {
+	h.SetEntry(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (h freezeSortRunTableHandle) DeleteWithCallback(key []byte, cb func(k, v []byte) error) error {
+	keyCopy := bytes.Clone(key)
+	if cb != nil {
+		if err := cb(keyCopy, nil); err != nil {
+			return err
+		}
+	}
+	h.SetEntrySteal(keyCopy, nil, page.ValuePtr{}, node.FlagTombstone)
+	return nil
+}
+
+func (h freezeSortRunTableHandle) DeleteSteal(key []byte) {
+	h.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (h freezeSortRunTableHandle) SetInlineNilKeyParts(first, second []byte) {
+	key := make([]byte, len(first)+len(second))
+	n := copy(key, first)
+	copy(key[n:], second)
+	h.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagInline)
+}
+
+func (h freezeSortRunTableHandle) DeleteKeyParts(first, second []byte) {
+	key := make([]byte, len(first)+len(second))
+	n := copy(key, first)
+	copy(key[n:], second)
+	h.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (h freezeSortRunTableHandle) Get(key []byte) ([]byte, bool, bool) {
+	if h.table == nil {
+		return nil, false, false
+	}
+	return h.table.getOwned(h.ownerGeneration, key)
+}
+
+func (h freezeSortRunTableHandle) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	if h.table == nil {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	return h.table.getEntryOwned(h.ownerGeneration, key)
+}
+
+func (h freezeSortRunTableHandle) Size() int64 {
+	if h.table == nil {
+		return 0
+	}
+	return h.table.sizeOwned(h.ownerGeneration)
+}
+
+func (h freezeSortRunTableHandle) Len() int {
+	if h.table == nil {
+		return 0
+	}
+	return h.table.lenOwned(h.ownerGeneration)
+}
+
+func (h freezeSortRunTableHandle) Freeze() {
+	if h.table != nil {
+		h.table.freezeOwned(h.ownerGeneration)
+	}
+}
+
+func (h freezeSortRunTableHandle) Reset() {
+	if h.table != nil {
+		h.table.resetOwned(h.ownerGeneration)
+	}
+}
+
+func (h freezeSortRunTableHandle) Release() {
+	if h.table != nil {
+		h.table.releaseOwned(h.ownerGeneration)
+	}
+}
+
+func (h freezeSortRunTableHandle) NewIterator(start, end []byte) iterator.UnsafeIterator {
+	if h.table == nil {
+		return &freezeSortRunIterator{idx: -1}
+	}
+	return h.table.newIteratorOwned(h.ownerGeneration, start, end, false)
+}
+
+func (h freezeSortRunTableHandle) NewReverseIterator(start, end []byte) iterator.UnsafeIterator {
+	if h.table == nil {
+		return &freezeSortRunIterator{reverse: true, idx: -1}
+	}
+	return h.table.newIteratorOwned(h.ownerGeneration, start, end, true)
 }
 
 func (*freezeSortRunTable) StableUnsafeIteratorSlices() bool { return true }
@@ -93,6 +234,10 @@ func (t *freezeSortRunTable) PutWithCallback(key, value []byte, cb func(k, v []b
 }
 
 func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	t.setEntryStealOwned(0, key, value, ptr, flags)
+}
+
+func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, value []byte, ptr page.ValuePtr, flags byte) {
 	if t == nil || len(key) == 0 {
 		return
 	}
@@ -101,7 +246,7 @@ func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr,
 		ptr = page.ValuePtr{}
 	}
 	t.mu.Lock()
-	t.mustNotReleasedLocked()
+	t.mustOwnedLocked(ownerGeneration)
 	idx := len(t.entries)
 	t.entries = append(t.entries, freezeSortRunEntry{
 		key:   key,
@@ -119,6 +264,10 @@ func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr,
 }
 
 func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
+	return t.applyStealEntryFuncOwned(0, count, emit)
+}
+
+func (t *freezeSortRunTable) applyStealEntryFuncOwned(ownerGeneration uint64, count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
 	if count <= 0 {
 		return nil
 	}
@@ -130,7 +279,7 @@ func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (ke
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mustNotReleasedLocked()
+	t.mustOwnedLocked(ownerGeneration)
 	t.entries = slices.Grow(t.entries, count)
 	for i := 0; i < count; i++ {
 		key, value, ptr, flags, err := emit(i)
@@ -195,7 +344,11 @@ func (t *freezeSortRunTable) DeleteKeyParts(first, second []byte) {
 }
 
 func (t *freezeSortRunTable) Get(key []byte) ([]byte, bool, bool) {
-	value, _, flags, found := t.GetEntry(key)
+	return t.getOwned(0, key)
+}
+
+func (t *freezeSortRunTable) getOwned(ownerGeneration uint64, key []byte) ([]byte, bool, bool) {
+	value, _, flags, found := t.getEntryOwned(ownerGeneration, key)
 	if !found {
 		return nil, false, false
 	}
@@ -203,10 +356,15 @@ func (t *freezeSortRunTable) Get(key []byte) ([]byte, bool, bool) {
 }
 
 func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	return t.getEntryOwned(0, key)
+}
+
+func (t *freezeSortRunTable) getEntryOwned(ownerGeneration uint64, key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	if t == nil || len(key) == 0 {
 		return nil, page.ValuePtr{}, 0, false
 	}
 	t.mu.RLock()
+	t.mustOwnedLocked(ownerGeneration)
 	if t.frozen {
 		entry, found := t.getFrozenEntryLocked(key)
 		t.mu.RUnlock()
@@ -219,6 +377,7 @@ func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, 
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.mustOwnedLocked(ownerGeneration)
 	if t.frozen {
 		entry, found := t.getFrozenEntryLocked(key)
 		if !found {
@@ -249,30 +408,44 @@ func (t *freezeSortRunTable) getFrozenEntryLocked(key []byte) (freezeSortRunEntr
 }
 
 func (t *freezeSortRunTable) Size() int64 {
+	return t.sizeOwned(0)
+}
+
+func (t *freezeSortRunTable) sizeOwned(ownerGeneration uint64) int64 {
 	if t == nil {
 		return 0
 	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+	t.mustOwnedLocked(ownerGeneration)
 	return t.sizeBytes
 }
 
 func (t *freezeSortRunTable) Len() int {
+	return t.lenOwned(0)
+}
+
+func (t *freezeSortRunTable) lenOwned(ownerGeneration uint64) int {
 	if t == nil {
 		return 0
 	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+	t.mustOwnedLocked(ownerGeneration)
 	return len(t.entries)
 }
 
 func (t *freezeSortRunTable) Freeze() {
+	t.freezeOwned(0)
+}
+
+func (t *freezeSortRunTable) freezeOwned(ownerGeneration uint64) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mustNotReleasedLocked()
+	t.mustOwnedLocked(ownerGeneration)
 	if t.frozen {
 		return
 	}
@@ -283,20 +456,32 @@ func (t *freezeSortRunTable) Freeze() {
 }
 
 func (t *freezeSortRunTable) Reset() {
+	t.resetOwned(0)
+}
+
+func (t *freezeSortRunTable) resetOwned(ownerGeneration uint64) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
-	t.mustNotReleasedLocked()
+	t.mustOwnedLocked(ownerGeneration)
 	t.resetLocked(false)
 	t.mu.Unlock()
 }
 
 func (t *freezeSortRunTable) Release() {
+	t.releaseOwned(0)
+}
+
+func (t *freezeSortRunTable) releaseOwned(ownerGeneration uint64) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
+	if ownerGeneration != 0 && ownerGeneration != t.ownerGeneration {
+		t.mu.Unlock()
+		return
+	}
 	if t.released {
 		t.mu.Unlock()
 		return
@@ -338,24 +523,33 @@ func (t *freezeSortRunTable) resetLocked(dropOversizedEntries bool) {
 }
 
 func (t *freezeSortRunTable) mustNotReleasedLocked() {
-	if t.released {
+	t.mustOwnedLocked(0)
+}
+
+func (t *freezeSortRunTable) mustOwnedLocked(ownerGeneration uint64) {
+	if t.released || (ownerGeneration != 0 && ownerGeneration != t.ownerGeneration) {
 		panic("collections: freeze-sort run table used after Release")
 	}
 }
 
 func (t *freezeSortRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {
-	return t.newIterator(start, end, false)
+	return t.newIteratorOwned(0, start, end, false)
 }
 
 func (t *freezeSortRunTable) NewReverseIterator(start, end []byte) iterator.UnsafeIterator {
-	return t.newIterator(start, end, true)
+	return t.newIteratorOwned(0, start, end, true)
 }
 
 func (t *freezeSortRunTable) newIterator(start, end []byte, reverse bool) iterator.UnsafeIterator {
+	return t.newIteratorOwned(0, start, end, reverse)
+}
+
+func (t *freezeSortRunTable) newIteratorOwned(ownerGeneration uint64, start, end []byte, reverse bool) iterator.UnsafeIterator {
 	if t == nil {
 		return &freezeSortRunIterator{reverse: reverse, idx: -1}
 	}
 	t.mu.RLock()
+	t.mustOwnedLocked(ownerGeneration)
 	if t.frozen {
 		entries := t.entries
 		it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse, table: t}
@@ -364,6 +558,7 @@ func (t *freezeSortRunTable) newIterator(start, end []byte, reverse bool) iterat
 	}
 	t.mu.RUnlock()
 	t.mu.Lock()
+	t.mustOwnedLocked(ownerGeneration)
 	entries := t.sortedLatestCopyLocked()
 	t.mu.Unlock()
 	it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse}

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -57,7 +57,9 @@ func newFreezeSortRunTable() memtable.Table {
 		freezeSortRunTablePool.tables = freezeSortRunTablePool.tables[:n-1]
 		freezeSortRunTablePool.entryCapacity -= cap(t.entries)
 		freezeSortRunTablePool.mu.Unlock()
+		t.mu.Lock()
 		t.released = false
+		t.mu.Unlock()
 		return t
 	}
 	freezeSortRunTablePool.mu.Unlock()

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -246,6 +246,7 @@ func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, val
 		ptr = page.ValuePtr{}
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.mustOwnedLocked(ownerGeneration)
 	idx := len(t.entries)
 	t.entries = append(t.entries, freezeSortRunEntry{
@@ -260,7 +261,6 @@ func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, val
 	if t.latest != nil && !t.latestDirty {
 		t.latest[unsafe.String(&key[0], len(key))] = idx
 	}
-	t.mu.Unlock()
 }
 
 func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
@@ -364,7 +364,10 @@ func (t *freezeSortRunTable) getEntryOwned(ownerGeneration uint64, key []byte) (
 		return nil, page.ValuePtr{}, 0, false
 	}
 	t.mu.RLock()
-	t.mustOwnedLocked(ownerGeneration)
+	if !t.ownedLocked(ownerGeneration) {
+		t.mu.RUnlock()
+		panicFreezeSortRunTableNotOwned()
+	}
 	if t.frozen {
 		entry, found := t.getFrozenEntryLocked(key)
 		t.mu.RUnlock()
@@ -464,9 +467,9 @@ func (t *freezeSortRunTable) resetOwned(ownerGeneration uint64) {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.mustOwnedLocked(ownerGeneration)
 	t.resetLocked(false)
-	t.mu.Unlock()
 }
 
 func (t *freezeSortRunTable) Release() {
@@ -527,9 +530,17 @@ func (t *freezeSortRunTable) mustNotReleasedLocked() {
 }
 
 func (t *freezeSortRunTable) mustOwnedLocked(ownerGeneration uint64) {
-	if t.released || (ownerGeneration != 0 && ownerGeneration != t.ownerGeneration) {
-		panic("collections: freeze-sort run table used after Release")
+	if !t.ownedLocked(ownerGeneration) {
+		panicFreezeSortRunTableNotOwned()
 	}
+}
+
+func (t *freezeSortRunTable) ownedLocked(ownerGeneration uint64) bool {
+	return !t.released && (ownerGeneration == 0 || ownerGeneration == t.ownerGeneration)
+}
+
+func panicFreezeSortRunTableNotOwned() {
+	panic("collections: freeze-sort run table used after Release or after reuse by a new owner")
 }
 
 func (t *freezeSortRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -549,7 +560,10 @@ func (t *freezeSortRunTable) newIteratorOwned(ownerGeneration uint64, start, end
 		return &freezeSortRunIterator{reverse: reverse, idx: -1}
 	}
 	t.mu.RLock()
-	t.mustOwnedLocked(ownerGeneration)
+	if !t.ownedLocked(ownerGeneration) {
+		t.mu.RUnlock()
+		panicFreezeSortRunTableNotOwned()
+	}
 	if t.frozen {
 		entries := t.entries
 		it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse, table: t}
@@ -558,9 +572,9 @@ func (t *freezeSortRunTable) newIteratorOwned(ownerGeneration uint64, start, end
 	}
 	t.mu.RUnlock()
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.mustOwnedLocked(ownerGeneration)
 	entries := t.sortedLatestCopyLocked()
-	t.mu.Unlock()
 	it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse}
 	it.seekInitial()
 	return it

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"slices"
 	"sort"
 	"sync"
 	"unsafe"
@@ -27,14 +28,39 @@ type freezeSortRunTable struct {
 	latest      map[string]int
 	latestDirty bool
 	frozen      bool
+	released    bool
 	sizeBytes   int64
 	nextSeq     uint64
+}
+
+const (
+	freezeSortRunTableMaxPooledEntryCapacity      = 512 << 10
+	freezeSortRunTableMaxPooledTotalEntryCapacity = 1 << 20
+	freezeSortRunTableMaxPooledTables             = 32
+)
+
+var freezeSortRunTablePool struct {
+	mu            sync.Mutex
+	tables        []*freezeSortRunTable
+	entryCapacity int
 }
 
 // freezeSortRunTable is a collection-write-domain run table optimized for
 // root-local accumulation: writes append cheaply while mutable, and rotation to
 // an immutable flush unit pays the sort/coalesce cost once.
 func newFreezeSortRunTable() memtable.Table {
+	freezeSortRunTablePool.mu.Lock()
+	n := len(freezeSortRunTablePool.tables)
+	if n > 0 {
+		t := freezeSortRunTablePool.tables[n-1]
+		freezeSortRunTablePool.tables[n-1] = nil
+		freezeSortRunTablePool.tables = freezeSortRunTablePool.tables[:n-1]
+		freezeSortRunTablePool.entryCapacity -= cap(t.entries)
+		freezeSortRunTablePool.mu.Unlock()
+		t.released = false
+		return t
+	}
+	freezeSortRunTablePool.mu.Unlock()
 	return &freezeSortRunTable{}
 }
 
@@ -101,6 +127,7 @@ func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (ke
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.entries = slices.Grow(t.entries, count)
 	for i := 0; i < count; i++ {
 		key, value, ptr, flags, err := emit(i)
 		if err != nil {
@@ -255,14 +282,53 @@ func (t *freezeSortRunTable) Reset() {
 		return
 	}
 	t.mu.Lock()
-	clear(t.entries)
-	t.entries = t.entries[:0]
+	t.resetLocked(false)
+	t.mu.Unlock()
+}
+
+func (t *freezeSortRunTable) Release() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.released {
+		t.mu.Unlock()
+		return
+	}
+	t.resetLocked(true)
+	t.released = true
+	entryCapacity := cap(t.entries)
+	t.mu.Unlock()
+
+	if entryCapacity == 0 || entryCapacity > freezeSortRunTableMaxPooledEntryCapacity {
+		return
+	}
+	freezeSortRunTablePool.mu.Lock()
+	if len(freezeSortRunTablePool.tables) >= freezeSortRunTableMaxPooledTables ||
+		freezeSortRunTablePool.entryCapacity+entryCapacity > freezeSortRunTableMaxPooledTotalEntryCapacity {
+		freezeSortRunTablePool.mu.Unlock()
+		t.mu.Lock()
+		t.entries = nil
+		t.mu.Unlock()
+		return
+	}
+	freezeSortRunTablePool.tables = append(freezeSortRunTablePool.tables, t)
+	freezeSortRunTablePool.entryCapacity += entryCapacity
+	freezeSortRunTablePool.mu.Unlock()
+}
+
+func (t *freezeSortRunTable) resetLocked(dropOversizedEntries bool) {
+	if dropOversizedEntries && cap(t.entries) > freezeSortRunTableMaxPooledEntryCapacity {
+		t.entries = nil
+	} else {
+		clear(t.entries)
+		t.entries = t.entries[:0]
+	}
 	t.latest = nil
 	t.latestDirty = false
 	t.frozen = false
 	t.sizeBytes = 0
 	t.nextSeq = 0
-	t.mu.Unlock()
 }
 
 func (t *freezeSortRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -101,7 +101,7 @@ func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr,
 		ptr = page.ValuePtr{}
 	}
 	t.mu.Lock()
-	t.mustMutableLocked()
+	t.mustNotReleasedLocked()
 	idx := len(t.entries)
 	t.entries = append(t.entries, freezeSortRunEntry{
 		key:   key,
@@ -130,7 +130,7 @@ func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (ke
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mustMutableLocked()
+	t.mustNotReleasedLocked()
 	t.entries = slices.Grow(t.entries, count)
 	for i := 0; i < count; i++ {
 		key, value, ptr, flags, err := emit(i)
@@ -272,7 +272,7 @@ func (t *freezeSortRunTable) Freeze() {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mustMutableLocked()
+	t.mustNotReleasedLocked()
 	if t.frozen {
 		return
 	}
@@ -287,7 +287,7 @@ func (t *freezeSortRunTable) Reset() {
 		return
 	}
 	t.mu.Lock()
-	t.mustMutableLocked()
+	t.mustNotReleasedLocked()
 	t.resetLocked(false)
 	t.mu.Unlock()
 }
@@ -337,7 +337,7 @@ func (t *freezeSortRunTable) resetLocked(dropOversizedEntries bool) {
 	t.nextSeq = 0
 }
 
-func (t *freezeSortRunTable) mustMutableLocked() {
+func (t *freezeSortRunTable) mustNotReleasedLocked() {
 	if t.released {
 		panic("collections: freeze-sort run table used after Release")
 	}

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -34,9 +34,9 @@ type freezeSortRunTable struct {
 }
 
 const (
-	freezeSortRunTableMaxPooledEntryCapacity      = 512 << 10
-	freezeSortRunTableMaxPooledTotalEntryCapacity = 1 << 20
-	freezeSortRunTableMaxPooledTables             = 32
+	freezeSortRunTableMaxPooledEntries      = 512 << 10
+	freezeSortRunTableMaxPooledTotalEntries = 1 << 20
+	freezeSortRunTableMaxPooledTables       = 32
 )
 
 var freezeSortRunTablePool struct {
@@ -99,6 +99,7 @@ func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr,
 		ptr = page.ValuePtr{}
 	}
 	t.mu.Lock()
+	t.mustMutableLocked()
 	idx := len(t.entries)
 	t.entries = append(t.entries, freezeSortRunEntry{
 		key:   key,
@@ -127,6 +128,7 @@ func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (ke
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.mustMutableLocked()
 	t.entries = slices.Grow(t.entries, count)
 	for i := 0; i < count; i++ {
 		key, value, ptr, flags, err := emit(i)
@@ -268,6 +270,7 @@ func (t *freezeSortRunTable) Freeze() {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.mustMutableLocked()
 	if t.frozen {
 		return
 	}
@@ -282,6 +285,7 @@ func (t *freezeSortRunTable) Reset() {
 		return
 	}
 	t.mu.Lock()
+	t.mustMutableLocked()
 	t.resetLocked(false)
 	t.mu.Unlock()
 }
@@ -300,12 +304,12 @@ func (t *freezeSortRunTable) Release() {
 	entryCapacity := cap(t.entries)
 	t.mu.Unlock()
 
-	if entryCapacity == 0 || entryCapacity > freezeSortRunTableMaxPooledEntryCapacity {
+	if entryCapacity == 0 || entryCapacity > freezeSortRunTableMaxPooledEntries {
 		return
 	}
 	freezeSortRunTablePool.mu.Lock()
 	if len(freezeSortRunTablePool.tables) >= freezeSortRunTableMaxPooledTables ||
-		freezeSortRunTablePool.entryCapacity+entryCapacity > freezeSortRunTableMaxPooledTotalEntryCapacity {
+		freezeSortRunTablePool.entryCapacity+entryCapacity > freezeSortRunTableMaxPooledTotalEntries {
 		freezeSortRunTablePool.mu.Unlock()
 		t.mu.Lock()
 		t.entries = nil
@@ -318,7 +322,7 @@ func (t *freezeSortRunTable) Release() {
 }
 
 func (t *freezeSortRunTable) resetLocked(dropOversizedEntries bool) {
-	if dropOversizedEntries && cap(t.entries) > freezeSortRunTableMaxPooledEntryCapacity {
+	if dropOversizedEntries && cap(t.entries) > freezeSortRunTableMaxPooledEntries {
 		t.entries = nil
 	} else {
 		clear(t.entries)
@@ -329,6 +333,12 @@ func (t *freezeSortRunTable) resetLocked(dropOversizedEntries bool) {
 	t.frozen = false
 	t.sizeBytes = 0
 	t.nextSeq = 0
+}
+
+func (t *freezeSortRunTable) mustMutableLocked() {
+	if t.released {
+		panic("collections: freeze-sort run table used after Release")
+	}
 }
 
 func (t *freezeSortRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -157,14 +157,6 @@ func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 	if pooledTables != 1 {
 		t.Fatalf("pooled tables after double release=%d want 1", pooledTables)
 	}
-	table.Reset()
-	table.Release()
-	freezeSortRunTablePool.mu.Lock()
-	pooledTables = len(freezeSortRunTablePool.tables)
-	freezeSortRunTablePool.mu.Unlock()
-	if pooledTables != 1 {
-		t.Fatalf("pooled tables after reset/release=%d want 1", pooledTables)
-	}
 
 	reused := newFreezeSortRunTable().(*freezeSortRunTable)
 	if reused != table {
@@ -186,13 +178,35 @@ func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 	reused.SetEntrySteal([]byte("z"), []byte("new"), page.ValuePtr{}, node.FlagInline)
 	reused.Freeze()
 	requireFreezeSortRunIterator(t, reused.NewIterator(nil, nil), []string{"z"})
+
+	reused.Reset()
+	reused.Release()
+	freezeSortRunTablePool.mu.Lock()
+	pooledTables = len(freezeSortRunTablePool.tables)
+	freezeSortRunTablePool.mu.Unlock()
+	if pooledTables != 1 {
+		t.Fatalf("pooled tables after reacquire/reset/release=%d want 1", pooledTables)
+	}
+}
+
+func TestFreezeSortRunTablePanicsOnMutationAfterRelease(t *testing.T) {
+	resetFreezeSortRunTablePoolForTest(t)
+
+	table := newFreezeSortRunTable().(*freezeSortRunTable)
+	table.Set([]byte("a"), []byte("value-a"))
+	table.Release()
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("Reset after Release did not panic")
+		}
+	}()
+	table.Reset()
 }
 
 func resetFreezeSortRunTablePoolForTest(t *testing.T) {
 	t.Helper()
 	reset := func() {
 		freezeSortRunTablePool.mu.Lock()
-		clear(freezeSortRunTablePool.tables)
 		freezeSortRunTablePool.tables = nil
 		freezeSortRunTablePool.entryCapacity = 0
 		freezeSortRunTablePool.mu.Unlock()

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -136,6 +136,71 @@ func TestFreezeSortRunTableApplyStealEntryFunc(t *testing.T) {
 	}
 }
 
+func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
+	resetFreezeSortRunTablePoolForTest(t)
+
+	table := newFreezeSortRunTable().(*freezeSortRunTable)
+	for i := 0; i < 16; i++ {
+		table.SetEntrySteal([]byte{byte('a' + i)}, []byte("old"), page.ValuePtr{}, node.FlagInline)
+	}
+	table.Freeze()
+	if table.Len() != 16 {
+		t.Fatalf("table Len=%d want 16 before release", table.Len())
+	}
+	capBefore := cap(table.entries)
+
+	table.Release()
+	table.Release()
+	freezeSortRunTablePool.mu.Lock()
+	pooledTables := len(freezeSortRunTablePool.tables)
+	freezeSortRunTablePool.mu.Unlock()
+	if pooledTables != 1 {
+		t.Fatalf("pooled tables after double release=%d want 1", pooledTables)
+	}
+	table.Reset()
+	table.Release()
+	freezeSortRunTablePool.mu.Lock()
+	pooledTables = len(freezeSortRunTablePool.tables)
+	freezeSortRunTablePool.mu.Unlock()
+	if pooledTables != 1 {
+		t.Fatalf("pooled tables after reset/release=%d want 1", pooledTables)
+	}
+
+	reused := newFreezeSortRunTable().(*freezeSortRunTable)
+	if reused != table {
+		t.Fatal("freeze-sort table was not reused from pool")
+	}
+	if reused.Len() != 0 {
+		t.Fatalf("reused table Len=%d want 0", reused.Len())
+	}
+	if reused.Size() != 0 {
+		t.Fatalf("reused table Size=%d want 0", reused.Size())
+	}
+	if reused.frozen {
+		t.Fatal("reused table is still frozen")
+	}
+	if cap(reused.entries) != capBefore {
+		t.Fatalf("reused entry capacity=%d want %d", cap(reused.entries), capBefore)
+	}
+
+	reused.SetEntrySteal([]byte("z"), []byte("new"), page.ValuePtr{}, node.FlagInline)
+	reused.Freeze()
+	requireFreezeSortRunIterator(t, reused.NewIterator(nil, nil), []string{"z"})
+}
+
+func resetFreezeSortRunTablePoolForTest(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		freezeSortRunTablePool.mu.Lock()
+		clear(freezeSortRunTablePool.tables)
+		freezeSortRunTablePool.tables = nil
+		freezeSortRunTablePool.entryCapacity = 0
+		freezeSortRunTablePool.mu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
 func requireFreezeSortRunIterator(t *testing.T, it interface {
 	Valid() bool
 	Next()

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -139,18 +139,19 @@ func TestFreezeSortRunTableApplyStealEntryFunc(t *testing.T) {
 func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 	resetFreezeSortRunTablePoolForTest(t)
 
-	table := newFreezeSortRunTable().(*freezeSortRunTable)
+	handle := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	table := handle.table
 	for i := 0; i < 16; i++ {
-		table.SetEntrySteal([]byte{byte('a' + i)}, []byte("old"), page.ValuePtr{}, node.FlagInline)
+		handle.SetEntrySteal([]byte{byte('a' + i)}, []byte("old"), page.ValuePtr{}, node.FlagInline)
 	}
-	table.Freeze()
-	if table.Len() != 16 {
-		t.Fatalf("table Len=%d want 16 before release", table.Len())
+	handle.Freeze()
+	if handle.Len() != 16 {
+		t.Fatalf("table Len=%d want 16 before release", handle.Len())
 	}
 	capBefore := cap(table.entries)
 
-	table.Release()
-	table.Release()
+	handle.Release()
+	handle.Release()
 	freezeSortRunTablePool.mu.Lock()
 	pooledTables := len(freezeSortRunTablePool.tables)
 	freezeSortRunTablePool.mu.Unlock()
@@ -158,15 +159,16 @@ func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 		t.Fatalf("pooled tables after double release=%d want 1", pooledTables)
 	}
 
-	reused := newFreezeSortRunTable().(*freezeSortRunTable)
+	reusedHandle := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	reused := reusedHandle.table
 	if reused != table {
 		t.Fatal("freeze-sort table was not reused from pool")
 	}
-	if reused.Len() != 0 {
-		t.Fatalf("reused table Len=%d want 0", reused.Len())
+	if reusedHandle.Len() != 0 {
+		t.Fatalf("reused table Len=%d want 0", reusedHandle.Len())
 	}
-	if reused.Size() != 0 {
-		t.Fatalf("reused table Size=%d want 0", reused.Size())
+	if reusedHandle.Size() != 0 {
+		t.Fatalf("reused table Size=%d want 0", reusedHandle.Size())
 	}
 	if reused.frozen {
 		t.Fatal("reused table is still frozen")
@@ -175,12 +177,12 @@ func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 		t.Fatalf("reused entry capacity=%d want %d", cap(reused.entries), capBefore)
 	}
 
-	reused.SetEntrySteal([]byte("z"), []byte("new"), page.ValuePtr{}, node.FlagInline)
-	reused.Freeze()
-	requireFreezeSortRunIterator(t, reused.NewIterator(nil, nil), []string{"z"})
+	reusedHandle.SetEntrySteal([]byte("z"), []byte("new"), page.ValuePtr{}, node.FlagInline)
+	reusedHandle.Freeze()
+	requireFreezeSortRunIterator(t, reusedHandle.NewIterator(nil, nil), []string{"z"})
 
-	reused.Reset()
-	reused.Release()
+	reusedHandle.Reset()
+	reusedHandle.Release()
 	freezeSortRunTablePool.mu.Lock()
 	pooledTables = len(freezeSortRunTablePool.tables)
 	freezeSortRunTablePool.mu.Unlock()
@@ -189,10 +191,51 @@ func TestFreezeSortRunTableReleaseReusesClearedEntryScratch(t *testing.T) {
 	}
 }
 
+func TestFreezeSortRunTableStaleReleaseDoesNotAffectReusedOwner(t *testing.T) {
+	resetFreezeSortRunTablePoolForTest(t)
+
+	stale := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	stale.Set([]byte("a"), []byte("old"))
+	stale.Release()
+
+	current := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	if current.table != stale.table {
+		t.Fatal("freeze-sort table was not reused from pool")
+	}
+	current.Set([]byte("b"), []byte("new-b"))
+	stale.Release()
+	current.Set([]byte("c"), []byte("new-c"))
+	if got := current.Len(); got != 2 {
+		t.Fatalf("current Len=%d want 2 after stale release no-op", got)
+	}
+	current.Freeze()
+	requireFreezeSortRunIterator(t, current.NewIterator(nil, nil), []string{"b", "c"})
+	current.Release()
+}
+
+func TestFreezeSortRunTablePanicsOnStaleMutationAfterReuse(t *testing.T) {
+	resetFreezeSortRunTablePoolForTest(t)
+
+	stale := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	stale.Set([]byte("a"), []byte("old"))
+	stale.Release()
+	current := newFreezeSortRunTable().(freezeSortRunTableHandle)
+	if current.table != stale.table {
+		t.Fatal("freeze-sort table was not reused from pool")
+	}
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("stale mutation after reuse did not panic")
+		}
+	}()
+	stale.Set([]byte("z"), []byte("stale"))
+}
+
 func TestFreezeSortRunTablePanicsOnMutationAfterRelease(t *testing.T) {
 	resetFreezeSortRunTablePoolForTest(t)
 
-	table := newFreezeSortRunTable().(*freezeSortRunTable)
+	table := newFreezeSortRunTable().(freezeSortRunTableHandle)
 	table.Set([]byte("a"), []byte("value-a"))
 	table.Release()
 	defer func() {


### PR DESCRIPTION
## Summary

This PR reduces update-buffer freeze/sort allocation by reusing `freezeSortRunTable` scratch after flushed run tables are released.

Changes:
- add a bounded freeze-sort table pool used by `newFreezeSortRunTable`
- implement `Release()` so existing `resetCollectionRunTable` cleanup returns frozen tables to the pool
- pre-grow `ApplyStealEntryFunc` bulk appends to avoid repeated first-fill growth
- add coverage that released tables are cleared before reuse and are not double-pooled

The pool is deliberately bounded by both table count and retained entry capacity, and oversized entry slices are dropped instead of retained.

## Perf evidence

Canary command:

```sh
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=1 go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchmem \
  -benchtime=5000000x \
  -count=1 \
  -p=1 \
  -timeout=20m \
  -memprofile /tmp/mem.pprof
```

Parent `0318a6af47`:
- `8646 ns/op`, `4293 B/op`, `16 allocs/op`
- `update_buffer_freeze_ns/doc=587.2`
- alloc profile: `(*freezeSortRunTable).ApplyStealEntryFunc` allocated `6.53 GB` over 5M updates, the top allocation site

This PR `64afbb2c88`:
- `8447 ns/op`, `2847 B/op`, `16 allocs/op`
- `update_buffer_freeze_ns/doc=617.1`
- alloc profile: `ApplyStealEntryFunc` no longer appears as the multi-GB hotspot; residual freeze-sort growth is `slices.Grow` at `327.77 MB`

Interpretation: this is an allocation/GC-pressure improvement, not a proven freeze-stage latency improvement. Follow-up profiling shows the remaining freeze time is sort/coalesce CPU, primarily `sort.Slice` over the accumulated root tables.

Rejected local experiments:
- `slices.SortFunc` over `freezeSortRunEntry`: worse, `update_buffer_freeze_ns/doc=790.0`
- typed `sort.Sort` wrapper: effectively neutral/noisy, `update_buffer_freeze_ns/doc=594.7`
- common-prefix comparator: worse, `update_buffer_freeze_ns/doc=749.6`

## Validation

```sh
go test ./TreeDB/collections -run 'TestFreezeSortRunTable'
go test ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```
