### PR TITLE
Move sealed indexed-run freeze outside write-domain lock

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1868,8 +1868,11 @@ func (domain *collectionWriteDomain) beginIndexedPrepareFreezeLocked() {
 }
 
 func (domain *collectionWriteDomain) finishIndexedPrepareFreezeLocked() {
-	if domain == nil || domain.indexedPrepareFreezes <= 0 {
+	if domain == nil {
 		return
+	}
+	if domain.indexedPrepareFreezes <= 0 {
+		panic("collections: indexed prepare freeze finish without matching begin")
 	}
 	domain.indexedPrepareFreezes--
 	if domain.indexedPrepareFreezes == 0 && domain.indexedPrepareCond != nil {
@@ -3645,11 +3648,11 @@ func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []m
 	freezeDuration = collectionObservedElapsedSince(freezeStart)
 	relockStart := time.Now()
 	domain.mu.Lock()
+	lockReleased = time.Since(unlockStart)
 	lockHeld = true
 	relockWait = time.Since(relockStart)
 	domain.finishIndexedPrepareFreezeLocked()
 	prepareFinished = true
-	lockReleased = time.Since(unlockStart)
 	return freezeDuration, lockReleased, relockWait
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3612,8 +3612,9 @@ func freezeIndexedRunTables(tables []memtable.Table) {
 	}
 }
 
-// freezeIndexedRunTablesOutsideLock releases domain.mu for expensive table-local
-// sort/coalesce work, then reacquires domain.mu before returning.
+// freezeIndexedRunTablesOutsideLock requires domain.mu to be held by the caller.
+// It releases domain.mu for expensive table-local sort/coalesce work, then
+// reacquires domain.mu before returning.
 func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []memtable.Table) (freezeDuration, lockReleased, relockWait time.Duration) {
 	if len(tables) == 0 {
 		return 0, 0, 0
@@ -10036,7 +10037,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
-			if domain.writeGeneration != checkpoint.writeGeneration+1 {
+			if domain.writeGeneration != checkpoint.writeGeneration {
 				rollbackOnError = false
 			}
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3625,15 +3625,30 @@ func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []m
 		return collectionObservedElapsedSince(freezeStart), 0, 0
 	}
 	domain.beginIndexedPrepareFreezeLocked()
+	prepareFinished := false
+	lockHeld := true
+	defer func() {
+		if prepareFinished {
+			return
+		}
+		if !lockHeld {
+			domain.mu.Lock()
+			lockHeld = true
+		}
+		domain.finishIndexedPrepareFreezeLocked()
+	}()
 	unlockStart := time.Now()
 	domain.mu.Unlock()
+	lockHeld = false
 	freezeStart := time.Now()
 	freezeIndexedRunTables(tables)
 	freezeDuration = collectionObservedElapsedSince(freezeStart)
 	relockStart := time.Now()
 	domain.mu.Lock()
+	lockHeld = true
 	relockWait = time.Since(relockStart)
 	domain.finishIndexedPrepareFreezeLocked()
+	prepareFinished = true
 	lockReleased = time.Since(unlockStart)
 	return freezeDuration, lockReleased, relockWait
 }
@@ -10030,6 +10045,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
+	rollbackGeneration := checkpoint.writeGeneration
 	freezePreAppendTables := func() {
 		if len(preAppendFreezeTables) == 0 {
 			return
@@ -10037,7 +10053,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
-			if domain.writeGeneration != checkpoint.writeGeneration {
+			if rollbackOnError && domain.writeGeneration != rollbackGeneration {
 				rollbackOnError = false
 			}
 		}
@@ -10137,6 +10153,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
 	domain.writeGeneration++
+	if rollbackOnError {
+		rollbackGeneration = domain.writeGeneration
+	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
 	c.meta = plan.meta
 	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
@@ -10152,7 +10171,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
-			rollbackOnError = false
+			if rollbackOnError && domain.writeGeneration != rollbackGeneration {
+				rollbackOnError = false
+			}
 		}
 		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
@@ -10307,9 +10328,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta
+	rollbackOnError := shouldAutoFlushAfterAdding
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
+	rollbackGeneration := checkpoint.writeGeneration
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]
@@ -10328,7 +10351,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, table); err != nil {
 				plan.stats.BufferStagePrimaryIdx += updateBatchStatsSince(detailedStats, phaseStart)
 				domain.primaryRunIndex = nil
-				if shouldAutoFlushAfterAdding {
+				if rollbackOnError {
 					rollbackBufferedIndexedDomain(domain, checkpoint)
 					c.meta = collectionMetaCheckpoint
 				}
@@ -10341,7 +10364,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			uniqueValueTable, uniquePrefixes, err := bufferedUniqueIndexValueRun(table, indexDef.ValueType)
 			if err != nil {
 				plan.stats.BufferStageUniqueIdx += updateBatchStatsSince(detailedStats, phaseStart)
-				if shouldAutoFlushAfterAdding {
+				if rollbackOnError {
 					rollbackBufferedIndexedDomain(domain, checkpoint)
 					c.meta = collectionMetaCheckpoint
 				}
@@ -10392,11 +10415,14 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.writeGeneration++
+	if rollbackOnError {
+		rollbackGeneration = domain.writeGeneration
+	}
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
 	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
 	if err != nil {
-		if shouldAutoFlushAfterAdding {
+		if rollbackOnError {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			c.meta = collectionMetaCheckpoint
 		}
@@ -10406,11 +10432,14 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
+			if rollbackOnError && domain.writeGeneration != rollbackGeneration {
+				rollbackOnError = false
+			}
 		}
 		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
 		if err != nil {
-			if shouldAutoFlushAfterAdding {
+			if rollbackOnError {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
 			}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3615,6 +3615,15 @@ func freezeIndexedRunTables(tables []memtable.Table) {
 	}
 }
 
+func freezeIndexedRunTablesObserved(tables []memtable.Table) time.Duration {
+	if len(tables) == 0 {
+		return 0
+	}
+	freezeStart := time.Now()
+	freezeIndexedRunTables(tables)
+	return collectionObservedElapsedSince(freezeStart)
+}
+
 // freezeIndexedRunTablesOutsideLock requires domain.mu to be held by the caller.
 // It releases domain.mu for expensive table-local sort/coalesce work, then
 // reacquires domain.mu before returning.
@@ -3623,9 +3632,7 @@ func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []m
 		return 0, 0, 0
 	}
 	if domain == nil {
-		freezeStart := time.Now()
-		freezeIndexedRunTables(tables)
-		return collectionObservedElapsedSince(freezeStart), 0, 0
+		return freezeIndexedRunTablesObserved(tables), 0, 0
 	}
 	domain.beginIndexedPrepareFreezeLocked()
 	prepareFinished := false

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3618,6 +3618,11 @@ func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []m
 	if len(tables) == 0 {
 		return 0, 0, 0
 	}
+	if domain == nil {
+		freezeStart := time.Now()
+		freezeIndexedRunTables(tables)
+		return collectionObservedElapsedSince(freezeStart), 0, 0
+	}
 	domain.beginIndexedPrepareFreezeLocked()
 	unlockStart := time.Now()
 	domain.mu.Unlock()
@@ -10024,6 +10029,22 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
+	freezePreAppendTables := func() {
+		if len(preAppendFreezeTables) == 0 {
+			return
+		}
+		freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
+		if lockReleased > 0 {
+			lockReleasedDuringHold += lockReleased
+			if domain.writeGeneration != checkpoint.writeGeneration+1 {
+				rollbackOnError = false
+			}
+		}
+		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
+		plan.stats.BufferStageFreeze += updateBatchStatsDuration(detailedStats, freezeDuration)
+		preAppendFreezeTables = nil
+	}
+	defer freezePreAppendTables()
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 
 	phaseStart = updateBatchStatsNow(detailedStats)
@@ -10126,17 +10147,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		return false, err
 	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
-		if len(preAppendFreezeTables) > 0 {
-			freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
-			if lockReleased > 0 {
-				lockReleasedDuringHold += lockReleased
-				if domain.writeGeneration != checkpoint.writeGeneration+1 {
-					rollbackOnError = false
-				}
-			}
-			plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
-			plan.stats.BufferStageFreeze += updateBatchStatsDuration(detailedStats, freezeDuration)
-		}
+		freezePreAppendTables()
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -760,6 +760,8 @@ type collectionWriteDomain struct {
 	indexedAsyncCond       *sync.Cond
 	indexedAsyncRun        bool
 	indexedAsyncErr        error
+	indexedPrepareCond     *sync.Cond
+	indexedPrepareFreezes  int
 	updateCombineMu        sync.Mutex
 	updateCombiner         *collectionUpdateCombiner
 	updateDraining         *collectionUpdateCombiner
@@ -1830,6 +1832,40 @@ func (domain *collectionWriteDomain) indexedAsyncFlushRunning() bool {
 	running := domain.indexedAsyncRun
 	domain.indexedAsyncMu.Unlock()
 	return running
+}
+
+func (domain *collectionWriteDomain) beginIndexedPrepareFreezeLocked() {
+	if domain == nil {
+		return
+	}
+	if domain.indexedPrepareCond == nil {
+		domain.indexedPrepareCond = sync.NewCond(&domain.mu)
+	}
+	domain.indexedPrepareFreezes++
+}
+
+func (domain *collectionWriteDomain) finishIndexedPrepareFreezeLocked() {
+	if domain == nil || domain.indexedPrepareFreezes <= 0 {
+		return
+	}
+	domain.indexedPrepareFreezes--
+	if domain.indexedPrepareFreezes == 0 && domain.indexedPrepareCond != nil {
+		domain.indexedPrepareCond.Broadcast()
+	}
+}
+
+func (domain *collectionWriteDomain) waitIndexedPrepareFreezeLocked() time.Duration {
+	if domain == nil || domain.indexedPrepareFreezes <= 0 {
+		return 0
+	}
+	if domain.indexedPrepareCond == nil {
+		domain.indexedPrepareCond = sync.NewCond(&domain.mu)
+	}
+	start := time.Now()
+	for domain.indexedPrepareFreezes > 0 {
+		domain.indexedPrepareCond.Wait()
+	}
+	return time.Since(start)
 }
 
 func (domain *collectionWriteDomain) clearIndexedAsyncFlushError() {
@@ -3400,6 +3436,9 @@ func shouldCompactBufferedIndexedMutableRuns(domain *collectionWriteDomain, opts
 	if domain == nil || domain.rootRunCount <= 0 {
 		return false
 	}
+	if domain.indexedPrepareFreezes > 0 {
+		return false
+	}
 	if opts.BufferedIndexedWriteMaxRootRuns <= 0 || opts.BufferedIndexedWriteMaxDocuments <= 0 {
 		return false
 	}
@@ -3526,6 +3565,48 @@ func freezeMutableIndexedRunMapsLocked(domain *collectionWriteDomain) {
 		}
 	}
 	domain.rootMutableRuns = nil
+}
+
+func detachMutableIndexedRunTablesLocked(domain *collectionWriteDomain) []memtable.Table {
+	if domain == nil || len(domain.rootMutableRuns) == 0 {
+		return nil
+	}
+	tables := make([]memtable.Table, 0, len(domain.rootMutableRuns))
+	for _, table := range domain.rootMutableRuns {
+		if table != nil {
+			tables = append(tables, table)
+		}
+	}
+	domain.rootMutableRuns = nil
+	return tables
+}
+
+func freezeIndexedRunTables(tables []memtable.Table) {
+	for _, table := range tables {
+		if table != nil {
+			table.Freeze()
+		}
+	}
+}
+
+// freezeIndexedRunTablesOutsideLock releases domain.mu for expensive table-local
+// sort/coalesce work, then reacquires domain.mu before returning.
+func freezeIndexedRunTablesOutsideLock(domain *collectionWriteDomain, tables []memtable.Table) (freezeDuration, lockReleased, relockWait time.Duration) {
+	if len(tables) == 0 {
+		return 0, 0, 0
+	}
+	domain.beginIndexedPrepareFreezeLocked()
+	unlockStart := time.Now()
+	domain.mu.Unlock()
+	freezeStart := time.Now()
+	freezeIndexedRunTables(tables)
+	freezeDuration = collectionObservedElapsedSince(freezeStart)
+	relockStart := time.Now()
+	domain.mu.Lock()
+	relockWait = time.Since(relockStart)
+	domain.finishIndexedPrepareFreezeLocked()
+	lockReleased = time.Since(unlockStart)
+	return freezeDuration, lockReleased, relockWait
 }
 
 func estimateAccumulatedRootRunsForNamesLocked(domain *collectionWriteDomain, rootNames []string) int {
@@ -3659,6 +3740,13 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 	if domain == nil {
 		return 0, 0, 0, nil
 	}
+	var prepareWait time.Duration
+	if domain.indexedPrepareFreezes > 0 {
+		prepareWait = domain.waitIndexedPrepareFreezeLocked()
+		if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+			return 0, prepareWait, 0, nil
+		}
+	}
 	domain.indexedAutoFlushes.Add(1)
 	if opts.BufferedIndexedAsyncFlush {
 		rotateIndexedMutableToFlushUnitLocked(domain)
@@ -3668,11 +3756,11 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				domain.observeIndexedFlushForcedDrain()
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
-				return collectionObservedElapsedSince(flushStart), 0, 0, err
+				return collectionObservedElapsedSince(flushStart), prepareWait, 0, err
 			}
 			domain.indexedAsyncFlushBackpressure.Add(1)
 			flushStart := time.Now()
-			var lockReleased time.Duration
+			lockReleased := prepareWait
 			var relockWait time.Duration
 			if domain.indexedAsyncFlushRunning() {
 				unlockStart := time.Now()
@@ -3707,13 +3795,13 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			domain.observeIndexedFlushForcedDrain()
 			err := c.flushBufferedIndexedLocked(domain)
-			return collectionObservedElapsedSince(flushStart), 0, 0, err
+			return collectionObservedElapsedSince(flushStart), prepareWait, 0, err
 		}
-		return collectionObservedElapsedSince(flushStart), 0, 0, nil
+		return collectionObservedElapsedSince(flushStart), prepareWait, 0, nil
 	}
 	flushStart := time.Now()
 	err := c.flushBufferedIndexedLocked(domain)
-	return collectionObservedElapsedSince(flushStart), 0, 0, err
+	return collectionObservedElapsedSince(flushStart), prepareWait, 0, err
 }
 
 func hasBufferedIndexedRootRuns(domain *collectionWriteDomain) bool {
@@ -5091,7 +5179,11 @@ func (c *Collection) prepareIndexedAsyncPublish() (*indexedFlushPublishWork, err
 }
 
 func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDomain) (*indexedFlushPublishWork, error) {
-	if c == nil || c.db == nil || domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+	if c == nil || c.db == nil || domain == nil {
+		return nil, nil
+	}
+	domain.waitIndexedPrepareFreezeLocked()
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil, nil
 	}
 	if len(domain.indexedFlushUnits) == 0 && len(domain.rootRuns) == 0 {
@@ -5566,7 +5658,11 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 }
 
 func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (err error) {
-	if domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+	if domain == nil {
+		return nil
+	}
+	domain.waitIndexedPrepareFreezeLocked()
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil
 	}
 	if len(domain.indexedPublishingUnits) > 0 {
@@ -9863,21 +9959,28 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, plan.rootNames)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
-	if !shouldAutoFlushAfterAdding && collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+	requiresPreAppendFreeze := false
+	if collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
 			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
+				requiresPreAppendFreeze = true
 				shouldAutoFlushAfterAdding = true
 				break
 			}
 		}
 	}
-	if shouldAutoFlushAfterAdding {
+	if shouldAutoFlushAfterAdding && requiresPreAppendFreeze {
 		freezeStart := updateBatchStatsNow(detailedStats)
 		freezeMutableIndexedRunMapsLocked(domain)
 		plan.stats.BufferStageFreeze += updateBatchStatsSince(detailedStats, freezeStart)
 	}
+	var preAppendFreezeTables []memtable.Table
+	if shouldAutoFlushAfterAdding && !requiresPreAppendFreeze {
+		preAppendFreezeTables = detachMutableIndexedRunTablesLocked(domain)
+	}
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta
+	rollbackOnError := shouldAutoFlushAfterAdding
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
@@ -9947,7 +10050,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 				}
 				return entry.key, nil, page.ValuePtr{}, node.FlagInline, nil
 			}); err != nil {
-				if shouldAutoFlushAfterAdding {
+				if rollbackOnError {
 					rollbackBufferedIndexedDomain(domain, checkpoint)
 					c.meta = collectionMetaCheckpoint
 				}
@@ -9976,21 +10079,33 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	c.meta = plan.meta
 	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
 	if err != nil {
-		if shouldAutoFlushAfterAdding {
+		if rollbackOnError {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			c.meta = collectionMetaCheckpoint
 		}
 		return false, err
 	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+		if len(preAppendFreezeTables) > 0 {
+			freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
+			if lockReleased > 0 {
+				lockReleasedDuringHold += lockReleased
+				if domain.writeGeneration != checkpoint.writeGeneration+1 {
+					rollbackOnError = false
+				}
+			}
+			plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
+			plan.stats.BufferStageFreeze += updateBatchStatsDuration(detailedStats, freezeDuration)
+		}
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
+			rollbackOnError = false
 		}
 		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
 		if err != nil {
-			if shouldAutoFlushAfterAdding {
+			if rollbackOnError {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6353,7 +6353,6 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 
 	done := make(chan time.Duration, 1)
 	waiterReady := make(chan struct{})
-	releaseWaiter := make(chan struct{})
 	go func() {
 		domain.mu.Lock()
 		if domain.indexedPrepareFreezes <= 0 {
@@ -6362,22 +6361,23 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 			return
 		}
 		close(waiterReady)
-		<-releaseWaiter
 		waited := domain.waitIndexedPrepareFreezeLocked()
 		domain.mu.Unlock()
 		done <- waited
 	}()
 
 	<-waiterReady
+	select {
+	case waited := <-done:
+		t.Fatalf("prepare freeze wait returned before finish: %s", waited)
+	default:
+	}
 
-	close(releaseWaiter)
 	domain.mu.Lock()
 	domain.finishIndexedPrepareFreezeLocked()
 	domain.mu.Unlock()
 
-	if waited := <-done; waited <= 0 {
-		t.Fatalf("prepare freeze wait duration=%s want positive", waited)
-	}
+	<-done
 }
 
 func TestIndexedPrepareFreezeFinishRequiresBegin(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6324,6 +6324,27 @@ func TestDetachMutableIndexedRunTablesKeepsRunsVisible(t *testing.T) {
 	resetCollectionTables(detached)
 }
 
+func TestFreezeIndexedRunTablesOutsideLockAllowsNilDomain(t *testing.T) {
+	table := newFreezeSortRunTable()
+	if err := applyCollectionRunEntriesWithFlags(table, 2, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+		if i == 0 {
+			return []byte("b"), []byte("value-b"), page.ValuePtr{}, node.FlagInline, nil
+		}
+		return []byte("a"), []byte("value-a"), page.ValuePtr{}, node.FlagInline, nil
+	}); err != nil {
+		t.Fatalf("append entries: %v", err)
+	}
+	freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(nil, []memtable.Table{table})
+	if freezeDuration <= 0 {
+		t.Fatalf("freeze duration=%s want positive", freezeDuration)
+	}
+	if lockReleased != 0 || relockWait != 0 {
+		t.Fatalf("lock released=%s relock wait=%s want 0/0", lockReleased, relockWait)
+	}
+	requireFreezeSortRunIterator(t, table.NewIterator(nil, nil), []string{"a", "b"})
+	resetCollectionRunTable(table)
+}
+
 func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 	domain := &collectionWriteDomain{}
 	domain.mu.Lock()
@@ -6331,17 +6352,26 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 	domain.mu.Unlock()
 
 	done := make(chan time.Duration, 1)
+	waiterReady := make(chan struct{})
 	go func() {
 		domain.mu.Lock()
+		if domain.indexedPrepareFreezes <= 0 {
+			domain.mu.Unlock()
+			done <- 0
+			return
+		}
+		close(waiterReady)
 		waited := domain.waitIndexedPrepareFreezeLocked()
 		domain.mu.Unlock()
 		done <- waited
 	}()
 
 	select {
-	case <-done:
-		t.Fatal("prepare freeze wait returned before finish")
-	case <-time.After(10 * time.Millisecond):
+	case <-waiterReady:
+	case waited := <-done:
+		t.Fatalf("prepare freeze wait returned before finish duration=%s", waited)
+	case <-time.After(time.Second):
+		t.Fatal("prepare freeze waiter did not start")
 	}
 
 	domain.mu.Lock()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6379,10 +6379,7 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 	domain.mu.Unlock()
 
 	select {
-	case waited := <-done:
-		if waited <= 0 {
-			t.Fatalf("prepare freeze wait duration=%s want positive", waited)
-		}
+	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("prepare freeze wait did not unblock after finish")
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6353,6 +6353,7 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 
 	done := make(chan time.Duration, 1)
 	waiterReady := make(chan struct{})
+	releaseWaiter := make(chan struct{})
 	go func() {
 		domain.mu.Lock()
 		if domain.indexedPrepareFreezes <= 0 {
@@ -6361,28 +6362,34 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 			return
 		}
 		close(waiterReady)
+		<-releaseWaiter
 		waited := domain.waitIndexedPrepareFreezeLocked()
 		domain.mu.Unlock()
 		done <- waited
 	}()
 
-	select {
-	case <-waiterReady:
-	case waited := <-done:
-		t.Fatalf("prepare freeze wait returned before finish duration=%s", waited)
-	case <-time.After(time.Second):
-		t.Fatal("prepare freeze waiter did not start")
-	}
+	<-waiterReady
 
+	close(releaseWaiter)
 	domain.mu.Lock()
 	domain.finishIndexedPrepareFreezeLocked()
 	domain.mu.Unlock()
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("prepare freeze wait did not unblock after finish")
+	if waited := <-done; waited <= 0 {
+		t.Fatalf("prepare freeze wait duration=%s want positive", waited)
 	}
+}
+
+func TestIndexedPrepareFreezeFinishRequiresBegin(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("finish without begin did not panic")
+		}
+	}()
+	domain.finishIndexedPrepareFreezeLocked()
 }
 
 func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6281,14 +6281,18 @@ func TestDetachMutableIndexedRunTablesKeepsRunsVisible(t *testing.T) {
 	primaryName := collectionPrimaryRootName("users")
 	secondaryName := collectionSecondaryRootName("users", "city")
 
+	domain.mu.Lock()
 	primary, created := mutableRootRunLocked(domain, primaryName)
 	if !created || primary == nil {
+		domain.mu.Unlock()
 		t.Fatal("primary mutable root run was not created")
 	}
 	city, created := mutableRootRunLocked(domain, secondaryName)
 	if !created || city == nil {
+		domain.mu.Unlock()
 		t.Fatal("city mutable root run was not created")
 	}
+	domain.mu.Unlock()
 	if err := applyCollectionRunEntriesWithFlags(primary, 2, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
 		if i == 0 {
 			return []byte("u2"), []byte("old-u2"), page.ValuePtr{}, node.FlagInline, nil
@@ -6303,19 +6307,25 @@ func TestDetachMutableIndexedRunTablesKeepsRunsVisible(t *testing.T) {
 		t.Fatalf("append city entries: %v", err)
 	}
 
+	domain.mu.Lock()
 	detached := detachMutableIndexedRunTablesLocked(domain)
 	if got := len(detached); got != 2 {
+		domain.mu.Unlock()
 		t.Fatalf("detached tables=%d want 2", got)
 	}
 	if domain.rootMutableRuns != nil {
+		domain.mu.Unlock()
 		t.Fatal("rootMutableRuns still has append targets after detach")
 	}
 	if got := pendingIndexedRootRunsLocked(domain, primaryName); len(got) != 1 || got[0] != primary {
+		domain.mu.Unlock()
 		t.Fatalf("pending primary runs=%v want original primary table", got)
 	}
 	if got := pendingIndexedRootRunsLocked(domain, secondaryName); len(got) != 1 || got[0] != city {
+		domain.mu.Unlock()
 		t.Fatalf("pending city runs=%v want original city table", got)
 	}
+	domain.mu.Unlock()
 
 	requireFreezeSortRunIterator(t, primary.NewIterator(nil, nil), []string{"u1", "u2"})
 	freezeIndexedRunTables(detached)
@@ -6334,12 +6344,9 @@ func TestFreezeIndexedRunTablesOutsideLockAllowsNilDomain(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("append entries: %v", err)
 	}
-	freezeDuration, lockReleased, relockWait := freezeIndexedRunTablesOutsideLock(nil, []memtable.Table{table})
+	freezeDuration := freezeIndexedRunTablesObserved([]memtable.Table{table})
 	if freezeDuration <= 0 {
 		t.Fatalf("freeze duration=%s want positive", freezeDuration)
-	}
-	if lockReleased != 0 || relockWait != 0 {
-		t.Fatalf("lock released=%s relock wait=%s want 0/0", lockReleased, relockWait)
 	}
 	requireFreezeSortRunIterator(t, table.NewIterator(nil, nil), []string{"a", "b"})
 	resetCollectionRunTable(table)
@@ -6356,6 +6363,7 @@ func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
 	go func() {
 		domain.mu.Lock()
 		if domain.indexedPrepareFreezes <= 0 {
+			close(waiterReady)
 			domain.mu.Unlock()
 			done <- 0
 			return

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6276,6 +6276,88 @@ func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 	}
 }
 
+func TestDetachMutableIndexedRunTablesKeepsRunsVisible(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	primaryName := collectionPrimaryRootName("users")
+	secondaryName := collectionSecondaryRootName("users", "city")
+
+	primary, created := mutableRootRunLocked(domain, primaryName)
+	if !created || primary == nil {
+		t.Fatal("primary mutable root run was not created")
+	}
+	city, created := mutableRootRunLocked(domain, secondaryName)
+	if !created || city == nil {
+		t.Fatal("city mutable root run was not created")
+	}
+	if err := applyCollectionRunEntriesWithFlags(primary, 2, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+		if i == 0 {
+			return []byte("u2"), []byte("old-u2"), page.ValuePtr{}, node.FlagInline, nil
+		}
+		return []byte("u1"), []byte("value-u1"), page.ValuePtr{}, node.FlagInline, nil
+	}); err != nil {
+		t.Fatalf("append primary entries: %v", err)
+	}
+	if err := applyCollectionRunEntriesWithFlags(city, 1, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+		return []byte("city\x00u1"), nil, page.ValuePtr{}, node.FlagInline, nil
+	}); err != nil {
+		t.Fatalf("append city entries: %v", err)
+	}
+
+	detached := detachMutableIndexedRunTablesLocked(domain)
+	if got := len(detached); got != 2 {
+		t.Fatalf("detached tables=%d want 2", got)
+	}
+	if domain.rootMutableRuns != nil {
+		t.Fatal("rootMutableRuns still has append targets after detach")
+	}
+	if got := pendingIndexedRootRunsLocked(domain, primaryName); len(got) != 1 || got[0] != primary {
+		t.Fatalf("pending primary runs=%v want original primary table", got)
+	}
+	if got := pendingIndexedRootRunsLocked(domain, secondaryName); len(got) != 1 || got[0] != city {
+		t.Fatalf("pending city runs=%v want original city table", got)
+	}
+
+	requireFreezeSortRunIterator(t, primary.NewIterator(nil, nil), []string{"u1", "u2"})
+	freezeIndexedRunTables(detached)
+	requireFreezeSortRunIterator(t, primary.NewIterator(nil, nil), []string{"u1", "u2"})
+
+	resetCollectionTables(detached)
+}
+
+func TestIndexedPrepareFreezeWaitsUntilFinished(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	domain.mu.Lock()
+	domain.beginIndexedPrepareFreezeLocked()
+	domain.mu.Unlock()
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		domain.mu.Lock()
+		waited := domain.waitIndexedPrepareFreezeLocked()
+		domain.mu.Unlock()
+		done <- waited
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("prepare freeze wait returned before finish")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	domain.mu.Lock()
+	domain.finishIndexedPrepareFreezeLocked()
+	domain.mu.Unlock()
+
+	select {
+	case waited := <-done:
+		if waited <= 0 {
+			t.Fatalf("prepare freeze wait duration=%s want positive", waited)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("prepare freeze wait did not unblock after finish")
+	}
+}
+
 func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	catalog := &collectionCatalog{
 		meta:  CollectionMeta{Name: "users"},


### PR DESCRIPTION
## Summary

Moves direct buffered-update threshold freezing of existing mutable indexed runs out from under `collectionWriteDomain.mu` for the non-unique direct update path. The old append targets are first sealed by detaching `rootMutableRuns` while leaving the tables visible through `rootRuns`; the current update then appends into fresh mutable tables. The sealed tables are frozen outside the domain mutex before flush consumes them.

This keeps append-then-sort as the run-table algorithm, but removes the old accumulated run sort/coalesce from the writer domain critical section. Unique-secondary mutation remains on the conservative in-lock pre-append freeze path.

## Correctness notes

- Sealed tables remain visible to buffered reads because they stay in `rootRuns`.
- Rollback checkpoints are taken after sealing, so the current update does not mutate tables captured by the checkpoint.
- A small prepare-freeze fence prevents flush/compaction from consuming or resetting sealed tables while another goroutine is freezing them outside `domain.mu`.

## Benchmark shape

The perf command below runs individual `Collection.Update` operations with one writer. It is not issuing external multi-document `UpdateBatch` calls. The internal metrics use `update_batch` names because single-document `Update` shares the same update planning/staging machinery; the benchmark output confirms `update_items/batch = 1.000` and `update_batches = 1000000`.

`MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000` affects setup/preload batching in this harness, not the timed update operation size.

## Tests

```sh
go test ./TreeDB/collections -run 'TestDetachMutableIndexedRunTablesKeepsRunsVisible|TestIndexedPrepareFreezeWaitsUntilFinished|TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns|TestCollectionUpdateBatchDirectBufferedBSONDoesNotReserveUnchangedUnique'
go test ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```

## Perf evidence

Command:

```sh
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=1 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchmem -benchtime=1000000x -count=5
```

Baseline: `64afbb2c88` (`codex/freeze-sort-scratch-reuse`)

- `ns/op`: mean `8033`, range `7842-8464`
- `update_buffer_stage_ns/doc`: mean `2949`
- `update_buffer_lock_hold_ns/doc`: mean `2800`, range `2685-3095`
- `update_buffer_domain_prepare_ns/doc`: mean `616`
- `update_buffer_freeze_ns/doc`: mean `556`
- `B/op`: mean `2829`, `allocs/op`: `16`

This PR after the prepare fence:

- `ns/op`: mean `8367` over the final 3-run check, range `7983-8614` (overall runtime remains noisy and publish-sensitive)
- `update_buffer_stage_ns/doc`: mean `3156`
- `update_buffer_lock_hold_ns/doc`: mean `2416`, range `2080-2594`
- `update_buffer_domain_prepare_ns/doc`: mean `61`
- `update_buffer_freeze_ns/doc`: mean `589`
- `B/op`: mean `2852`, `allocs/op`: `16`

Earlier 5-run sample before the prepare fence showed the same targeted direction more strongly (`update_buffer_lock_hold_ns/doc` mean `2089` vs baseline `2800`). The fence is intentionally conservative; the important result is structural: the old accumulated run freeze remains visible as freeze work, but is no longer part of `domain.mu` domain-prepare hold time.
