### PR TITLE
Fix value-log rewrite grouping and byte stats

### DIFF
--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -565,5 +565,10 @@ func fileSize(f *valuelog.File) int64 {
 	if f == nil {
 		return 0
 	}
+	if f.Path != "" {
+		if info, err := os.Stat(f.Path); err == nil {
+			return info.Size()
+		}
+	}
 	return f.SizeBestEffort()
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -38,6 +38,8 @@ const defaultValueLogRewriteSegmentBytes = 128 << 20
 
 const rewriteDictMinPayloadBytes = 32 << 10
 const rewriteDictBatchMaxK = 64
+const rewriteBlockBatchMaxK = valuelog.MaxFrameK
+const rewriteBlockBatchMaxRawBytes = 4 << 20
 const rewriteReadScratchMaxCap = 1 << 20 // 1MiB cap to avoid retaining oversized decode buffers
 const rewriteKeyArenaMaxCap = 1 << 20    // 1MiB cap to avoid retaining oversized key arenas
 
@@ -3052,7 +3054,7 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 		// Pointer mappings returned while grouped dict batches are still pending
 		// rely on batch-flush offset stability; flush here so record-count stats
 		// and subsequent tree builds observe committed batches.
-		if err := writer.flushPendingDictBatch(); err != nil {
+		if err := writer.flushPendingBatches(); err != nil {
 			return 0, err
 		}
 		stats.RecordsCopied = writer.records
@@ -3312,6 +3314,13 @@ type rewriteWriter struct {
 	createdIDs                []uint32
 	createdSegments           []rewriteCreatedSegment
 
+	pendingBlockStart   int64
+	pendingBlockRaw     int
+	pendingBlockArena   []byte
+	pendingBlockRecords []valuelog.Record
+	pendingBlockPtrs    []page.ValuePtr
+	pendingBlockDst     []page.ValuePtr
+
 	pendingDictID      uint64
 	pendingDict        []byte
 	pendingDictStart   int64
@@ -3366,6 +3375,25 @@ func (w *rewriteWriter) hasPendingDictBatch() bool {
 	return w != nil && len(w.pendingDictRecords) > 0
 }
 
+func (w *rewriteWriter) hasPendingBlockBatch() bool {
+	return w != nil && len(w.pendingBlockRecords) > 0
+}
+
+func (w *rewriteWriter) resetPendingBlockBatch() {
+	if w == nil {
+		return
+	}
+	w.pendingBlockStart = 0
+	w.pendingBlockRaw = 0
+	if cap(w.pendingBlockArena) > rewriteBlockBatchMaxRawBytes*2 {
+		w.pendingBlockArena = nil
+	} else {
+		w.pendingBlockArena = w.pendingBlockArena[:0]
+	}
+	w.pendingBlockRecords = w.pendingBlockRecords[:0]
+	w.pendingBlockPtrs = w.pendingBlockPtrs[:0]
+}
+
 func (w *rewriteWriter) resetPendingDictBatch() {
 	if w == nil {
 		return
@@ -3376,6 +3404,48 @@ func (w *rewriteWriter) resetPendingDictBatch() {
 	w.pendingDictRaw = 0
 	w.pendingDictRecords = w.pendingDictRecords[:0]
 	w.pendingDictPtrs = w.pendingDictPtrs[:0]
+}
+
+func (w *rewriteWriter) flushPendingBlockBatch() error {
+	if w == nil || !w.hasPendingBlockBatch() {
+		return nil
+	}
+	if w.w == nil {
+		return errors.New("vlog-rewrite: nil writer")
+	}
+	n := len(w.pendingBlockRecords)
+	if cap(w.pendingBlockDst) < n {
+		w.pendingBlockDst = make([]page.ValuePtr, n)
+	}
+	dst := w.pendingBlockDst[:n]
+	ptrs, _, err := w.w.AppendFrameWithStatsInto(0, nil, w.pendingBlockRecords, dst)
+	if err != nil {
+		return err
+	}
+	if len(ptrs) != n {
+		return fmt.Errorf("vlog-rewrite: block batch pointer count mismatch got=%d want=%d", len(ptrs), n)
+	}
+	if len(w.pendingBlockPtrs) == n {
+		for i := range ptrs {
+			if ptrs[i].FileID != w.pendingBlockPtrs[i].FileID ||
+				ptrs[i].Offset != w.pendingBlockPtrs[i].Offset ||
+				page.ValuePtrSubIndex(ptrs[i]) != page.ValuePtrSubIndex(w.pendingBlockPtrs[i]) {
+				return fmt.Errorf(
+					"vlog-rewrite: block batch pointer mismatch idx=%d got=(file=%d,off=%d,sub=%d) want=(file=%d,off=%d,sub=%d)",
+					i,
+					ptrs[i].FileID,
+					ptrs[i].Offset,
+					page.ValuePtrSubIndex(ptrs[i]),
+					w.pendingBlockPtrs[i].FileID,
+					w.pendingBlockPtrs[i].Offset,
+					page.ValuePtrSubIndex(w.pendingBlockPtrs[i]),
+				)
+			}
+		}
+	}
+	w.records += n
+	w.resetPendingBlockBatch()
+	return nil
 }
 
 func (w *rewriteWriter) maybeRotateForEstimate(estimate int64) error {
@@ -3436,6 +3506,16 @@ func (w *rewriteWriter) flushPendingDictBatch() error {
 	w.records += n
 	w.resetPendingDictBatch()
 	return nil
+}
+
+func (w *rewriteWriter) flushPendingBatches() error {
+	if w == nil {
+		return nil
+	}
+	if err := w.flushPendingBlockBatch(); err != nil {
+		return err
+	}
+	return w.flushPendingDictBatch()
 }
 
 func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
@@ -3696,8 +3776,8 @@ func (w *rewriteWriter) ensureWriter() error {
 }
 
 func (w *rewriteWriter) rotate() error {
-	if w.hasPendingDictBatch() {
-		if err := w.flushPendingDictBatch(); err != nil {
+	if w.hasPendingBlockBatch() || w.hasPendingDictBatch() {
+		if err := w.flushPendingBatches(); err != nil {
 			return err
 		}
 	}
@@ -3991,7 +4071,7 @@ func (w *rewriteWriter) appendRaw(raw []byte, length uint32) (page.ValuePtr, err
 	if err := w.ensureWriter(); err != nil {
 		return page.ValuePtr{}, err
 	}
-	if err := w.flushPendingDictBatch(); err != nil {
+	if err := w.flushPendingBatches(); err != nil {
 		return page.ValuePtr{}, err
 	}
 	if w.maxSize > 0 && w.w.Size()+int64(len(raw)) > w.maxSize {
@@ -4020,7 +4100,7 @@ func (w *rewriteWriter) appendSingleValueWithDictClass(class rewriteTemplateClas
 		return page.ValuePtr{}, err
 	}
 	dictID, dict, value = w.applyTemplateCompression(class, dictID, dict, value)
-	if err := w.flushPendingDictBatch(); err != nil {
+	if err := w.flushPendingBatches(); err != nil {
 		return page.ValuePtr{}, err
 	}
 	if err := w.maybeRotateForEstimate(rewriteDictFrameRecordLen(len(value), 1)); err != nil {
@@ -4038,12 +4118,80 @@ func (w *rewriteWriter) appendValueWithDict(dictID uint64, dict []byte, rid uint
 	return w.appendValueWithDictClass(rewriteTemplateClassPointerValue, dictID, dict, rid, value)
 }
 
+func (w *rewriteWriter) appendBlockValue(rid uint64, value []byte) (page.ValuePtr, error) {
+	if err := w.flushPendingDictBatch(); err != nil {
+		return page.ValuePtr{}, err
+	}
+	maxK := rewriteBlockBatchMaxK
+	if maxK < 1 {
+		maxK = 1
+	}
+	if maxK > valuelog.MaxFrameK {
+		maxK = valuelog.MaxFrameK
+	}
+	if w.hasPendingBlockBatch() &&
+		(len(w.pendingBlockRecords) >= maxK || w.pendingBlockRaw+len(value) > rewriteBlockBatchMaxRawBytes) {
+		if err := w.flushPendingBlockBatch(); err != nil {
+			return page.ValuePtr{}, err
+		}
+	}
+	if !w.hasPendingBlockBatch() {
+		if err := w.maybeRotateForEstimate(rewriteDictFrameRecordLen(len(value), 1)); err != nil {
+			return page.ValuePtr{}, err
+		}
+		w.pendingBlockStart = w.w.Size()
+		w.pendingBlockRaw = 0
+		w.pendingBlockRecords = w.pendingBlockRecords[:0]
+		w.pendingBlockPtrs = w.pendingBlockPtrs[:0]
+	}
+
+	projectedK := len(w.pendingBlockRecords) + 1
+	projectedRaw := w.pendingBlockRaw + len(value)
+	if w.maxSize > 0 &&
+		w.pendingBlockStart+rewriteDictFrameRecordLen(projectedRaw, projectedK) > w.maxSize &&
+		len(w.pendingBlockRecords) > 0 {
+		if err := w.flushPendingBlockBatch(); err != nil {
+			return page.ValuePtr{}, err
+		}
+		if err := w.maybeRotateForEstimate(rewriteDictFrameRecordLen(len(value), 1)); err != nil {
+			return page.ValuePtr{}, err
+		}
+		w.pendingBlockStart = w.w.Size()
+		w.pendingBlockRaw = 0
+	}
+
+	valueStart := len(w.pendingBlockArena)
+	w.pendingBlockArena = append(w.pendingBlockArena, value...)
+	ownedValue := w.pendingBlockArena[valueStart:]
+	w.pendingBlockRecords = append(w.pendingBlockRecords, valuelog.Record{
+		RID:   rid,
+		Value: ownedValue,
+	})
+	w.pendingBlockRaw += len(ownedValue)
+	subIndex := len(w.pendingBlockRecords) - 1
+	ptr := page.ValuePtr{
+		Offset: uint64(w.pendingBlockStart + 4),
+		Length: page.ValuePtrMarkGrouped(0, uint8(subIndex)),
+		FileID: w.w.FileID(),
+	}
+	w.pendingBlockPtrs = append(w.pendingBlockPtrs, ptr)
+	if len(w.pendingBlockRecords) >= maxK || w.pendingBlockRaw >= rewriteBlockBatchMaxRawBytes {
+		if err := w.flushPendingBlockBatch(); err != nil {
+			return page.ValuePtr{}, err
+		}
+	}
+	return ptr, nil
+}
+
 func (w *rewriteWriter) appendValueWithDictClass(class rewriteTemplateClass, dictID uint64, dict []byte, rid uint64, value []byte) (page.ValuePtr, error) {
 	if err := w.ensureWriter(); err != nil {
 		return page.ValuePtr{}, err
 	}
 	dictID, dict, value = w.applyTemplateCompression(class, dictID, dict, value)
 	if dictID == 0 || len(dict) == 0 {
+		if w.blockCompression {
+			return w.appendBlockValue(rid, value)
+		}
 		if err := w.flushPendingDictBatch(); err != nil {
 			return page.ValuePtr{}, err
 		}
@@ -4058,6 +4206,9 @@ func (w *rewriteWriter) appendValueWithDictClass(class rewriteTemplateClass, dic
 		return ptr, nil
 	}
 
+	if err := w.flushPendingBlockBatch(); err != nil {
+		return page.ValuePtr{}, err
+	}
 	// Flush when dict stream changes or when the pending batch has reached the
 	// target grouped-frame width.
 	if w.hasPendingDictBatch() && w.pendingDictID != dictID {
@@ -4133,7 +4284,7 @@ func (w *rewriteWriter) Sync() error {
 	if w == nil {
 		return nil
 	}
-	if err := w.flushPendingDictBatch(); err != nil {
+	if err := w.flushPendingBatches(); err != nil {
 		return err
 	}
 	if w.w == nil {
@@ -4155,7 +4306,7 @@ func (w *rewriteWriter) Flush() error {
 	if w == nil {
 		return nil
 	}
-	if err := w.flushPendingDictBatch(); err != nil {
+	if err := w.flushPendingBatches(); err != nil {
 		return err
 	}
 	if w.w == nil {
@@ -4178,7 +4329,7 @@ func (w *rewriteWriter) Close() error {
 		return nil
 	}
 	defer w.closeTemplateCompression()
-	if err := w.flushPendingDictBatch(); err != nil {
+	if err := w.flushPendingBatches(); err != nil {
 		return err
 	}
 	var err error
@@ -4193,7 +4344,7 @@ func (w *rewriteWriter) Close() error {
 
 func (w *rewriteWriter) createdFileIDs() ([]uint32, error) {
 	if w != nil {
-		if err := w.flushPendingDictBatch(); err != nil {
+		if err := w.flushPendingBatches(); err != nil {
 			return nil, err
 		}
 	}
@@ -4205,7 +4356,7 @@ func (w *rewriteWriter) createdFileIDs() ([]uint32, error) {
 
 func (w *rewriteWriter) createdSegmentsSnapshot() ([]rewriteCreatedSegment, error) {
 	if w != nil {
-		if err := w.flushPendingDictBatch(); err != nil {
+		if err := w.flushPendingBatches(); err != nil {
 			return nil, err
 		}
 	}
@@ -4575,25 +4726,7 @@ func (it *rewriteIterator) reencodeSingleRecord(ptr page.ValuePtr, frameHeader v
 		return newPtr, true, nil
 	}
 
-	// For large single-record block frames, reuse the segment's observed dict
-	// (when available) to increase post-rewrite dict coverage. This runs only in
-	// rewrite, not on the ingest hot path. Treat 4KiB outer-leaf payloads as
-	// eligible even though they are below the generic large-payload threshold.
 	if frameHeader.DictID != 0 || it.readValue == nil {
-		return page.ValuePtr{}, false, nil
-	}
-	if int(end-start) < page.PageSize {
-		return page.ValuePtr{}, false, nil
-	}
-	dictID, err := it.preferredDictID(ptr.FileID)
-	if err != nil {
-		return page.ValuePtr{}, false, err
-	}
-	if dictID == 0 {
-		return page.ValuePtr{}, false, nil
-	}
-	dict, ok := it.dictBytesForID(dictID)
-	if !ok || len(dict) == 0 {
 		return page.ValuePtr{}, false, nil
 	}
 	value, err := it.readValue(ptr)
@@ -4603,14 +4736,36 @@ func (it *rewriteIterator) reencodeSingleRecord(ptr page.ValuePtr, frameHeader v
 		}
 		return page.ValuePtr{}, false, err
 	}
-	if len(value) < rewriteDictMinPayloadBytes && !rewriteAllowDictForSmallPayload(value) {
-		return page.ValuePtr{}, false, nil
-	}
-	newPtr, err := it.writer.appendValueWithDict(dictID, dict, rids[0], value)
-	if err != nil {
-		if errors.Is(err, valuelog.ErrMissingDict) {
-			return page.ValuePtr{}, false, nil
+
+	// For large single-record block frames, reuse the segment's observed dict
+	// (when available) to increase post-rewrite dict coverage. This runs only in
+	// rewrite, not on the ingest hot path. Treat 4KiB outer-leaf payloads as
+	// eligible even though they are below the generic large-payload threshold.
+	if int(end-start) >= page.PageSize {
+		dictID, err := it.preferredDictID(ptr.FileID)
+		if err != nil {
+			return page.ValuePtr{}, false, err
 		}
+		if dictID != 0 {
+			if dict, ok := it.dictBytesForID(dictID); ok && len(dict) > 0 &&
+				(len(value) >= rewriteDictMinPayloadBytes || rewriteAllowDictForSmallPayload(value)) {
+				newPtr, err := it.writer.appendValueWithDict(dictID, dict, rids[0], value)
+				if err != nil {
+					if errors.Is(err, valuelog.ErrMissingDict) {
+						return page.ValuePtr{}, false, nil
+					}
+					return page.ValuePtr{}, false, err
+				}
+				return newPtr, true, nil
+			}
+		}
+	}
+
+	// Single-record block frames were often produced by the live write path when
+	// values arrived one at a time. Rewrite can see neighboring live records, so
+	// decode and regroup them instead of preserving weak k=1 frames.
+	newPtr, err := it.writer.appendValue(rids[0], value)
+	if err != nil {
 		return page.ValuePtr{}, false, err
 	}
 	return newPtr, true, nil

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2051,6 +2051,292 @@ func TestValueLogRewriteOnline_UsesBlockCompressionWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestValueLogRewriteOnline_GroupsSingleRecordJSONFrames(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			Compression: ValueLogCompressionBlock,
+			BlockCodec:  ValueLogBlockSnappy,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	})
+
+	const rows = 64
+	rawBytes := 0
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 1, rows, func(i int) []byte {
+		doc := []byte(fmt.Sprintf(
+			`{"did":"did:plc:%08d","time_us":1732206349%06d,"kind":"commit","commit":{"rev":"3lbhuvzds%04d","operation":"create","collection":"app.bsky.feed.post","rkey":"rkey%06d","record":{"$type":"app.bsky.feed.post","createdAt":"2024-11-21T16:%02d:%02d.095Z","langs":["en"],"text":"repeatable fixture text for value-log rewrite grouping number %06d"}}}`,
+			i%17, i, i%10000, i, i%60, (i*7)%60, i,
+		))
+		rawBytes += len(doc)
+		return doc
+	})
+	if len(ptrs) != rows {
+		t.Fatalf("expected %d pointers, got %d", rows, len(ptrs))
+	}
+
+	b := db.NewBatch().(*Batch)
+	for i, ptr := range ptrs {
+		key := []byte(fmt.Sprintf("k%04d", i))
+		if err := b.SetPointer(key, ptr); err != nil {
+			t.Fatalf("set pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	segmentsBefore, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("list segments before rewrite: %v", err)
+	}
+	before := make(map[string]struct{}, len(segmentsBefore))
+	for _, seg := range segmentsBefore {
+		before[seg.path] = struct{}{}
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		BatchSize:     rows,
+		SyncEachBatch: true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied != rows {
+		t.Fatalf("copied records=%d want %d; stats=%+v", stats.RecordsCopied, rows, stats)
+	}
+
+	segmentsAfter, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("list segments after rewrite: %v", err)
+	}
+	var newSeg string
+	for _, seg := range segmentsAfter {
+		if !seg.valueLog {
+			continue
+		}
+		if _, ok := before[seg.path]; ok {
+			continue
+		}
+		newSeg = seg.path
+		break
+	}
+	if newSeg == "" {
+		t.Fatalf("expected rewrite to create a new value-log segment")
+	}
+
+	f, err := os.Open(newSeg)
+	if err != nil {
+		t.Fatalf("open new segment: %v", err)
+	}
+	defer f.Close()
+	var header [valuelog.HeaderSize]byte
+	if _, err := io.ReadFull(f, header[:]); err != nil {
+		t.Fatalf("read record header: %v", err)
+	}
+	bodyLen := binary.LittleEndian.Uint32(header[16:20])
+	body := make([]byte, int(bodyLen))
+	if _, err := io.ReadFull(f, body); err != nil {
+		t.Fatalf("read frame body: %v", err)
+	}
+	frameHeader, _, offsets, _, err := valuelog.DecodeFrame(body)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	if frameHeader.DictID != 0 {
+		t.Fatalf("expected block frame, got dictID=%d", frameHeader.DictID)
+	}
+	if frameHeader.Flags&valuelog.FrameFlagCompressed == 0 {
+		t.Fatalf("expected rewritten frame to be compressed, header=%+v", frameHeader)
+	}
+	if frameHeader.K <= 1 {
+		t.Fatalf("expected rewrite to group JSON records, got k=%d", frameHeader.K)
+	}
+	if got, want := frameHeader.Reserved, uint8(valuelog.BlockCodecSnappy); got != want {
+		t.Fatalf("unexpected codec id %d, want %d", got, want)
+	}
+	storedPayload := int(bodyLen) - (valuelog.FrameHeaderSize + int(frameHeader.K)*8 + (int(frameHeader.K)+1)*4)
+	groupRaw := int(offsets[frameHeader.K])
+	if groupRaw <= 0 || groupRaw > rawBytes {
+		t.Fatalf("unexpected grouped raw bytes %d, total fixture raw=%d", groupRaw, rawBytes)
+	}
+	if storedPayload*100 >= groupRaw*80 {
+		t.Fatalf("expected grouped rewrite compression below 0.80 stored/raw, stored=%d raw=%d", storedPayload, groupRaw)
+	}
+}
+
+func TestValueLogRewriteOnline_ReportsActualBytesAfterSegmentGrowth(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			Compression: ValueLogCompressionBlock,
+			BlockCodec:  ValueLogBlockSnappy,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	})
+
+	const rows = 4
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 1, rows, func(i int) []byte {
+		return []byte(fmt.Sprintf(
+			`{"kind":"commit","commit":{"collection":"app.bsky.feed.post","rkey":"%06d"},"payload":"%s"}`,
+			i,
+			strings.Repeat("jsonbench-value-log-rewrite-fixture-", 32),
+		))
+	})
+	b := db.NewBatch().(*Batch)
+	for i, ptr := range ptrs {
+		if err := b.SetPointer([]byte(fmt.Sprintf("k%04d", i)), ptr); err != nil {
+			t.Fatalf("set pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		BatchSize:     1,
+		SyncEachBatch: true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+
+	postSet := db.valueLogManager.CurrentSetNoRefresh()
+	if postSet == nil {
+		t.Fatalf("missing post-rewrite value-log set")
+	}
+	defer func() { _ = db.valueLogManager.Release(postSet) }()
+
+	var actualBytes int64
+	var actualSegments int
+	for _, f := range db.valueOnlyValueLogFiles(postSet.Files) {
+		info, err := os.Stat(f.Path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", f.Path, err)
+		}
+		actualSegments++
+		actualBytes += info.Size()
+	}
+	if stats.SegmentsAfter != actualSegments || stats.BytesAfter != actualBytes {
+		t.Fatalf("rewrite stats after=(segments=%d bytes=%d) want actual=(segments=%d bytes=%d)",
+			stats.SegmentsAfter, stats.BytesAfter, actualSegments, actualBytes)
+	}
+}
+
+func TestValueLogRewriteOffline_GroupsSingleRecordCompressedJSONFrames(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			Compression: ValueLogCompressionBlock,
+			BlockCodec:  ValueLogBlockSnappy,
+		},
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	})
+
+	const rows = 64
+	ptrs := appendBlockCompressedPointersInNewSegment(t, dir, 0, 1, 1, rows, func(i int) []byte {
+		return []byte(fmt.Sprintf(
+			`{"did":"did:plc:%08d","kind":"commit","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"rkey%06d","record":{"$type":"app.bsky.feed.post","text":"%s"}}}`,
+			i%17,
+			i,
+			strings.Repeat("offline rewrite grouped compression fixture ", 12),
+		))
+	})
+	if len(ptrs) != rows {
+		t.Fatalf("expected %d pointers, got %d", rows, len(ptrs))
+	}
+
+	b := db.NewBatch().(*Batch)
+	for i, ptr := range ptrs {
+		if err := b.SetPointer([]byte(fmt.Sprintf("k%04d", i)), ptr); err != nil {
+			t.Fatalf("set pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	segmentsBefore, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("list segments before rewrite: %v", err)
+	}
+	before := make(map[string]struct{}, len(segmentsBefore))
+	for _, seg := range segmentsBefore {
+		before[seg.path] = struct{}{}
+	}
+
+	closeNoErr(t, db)
+	db = nil
+
+	stats, err := ValueLogRewriteOffline(opts)
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOffline: %v", err)
+	}
+	if stats.RecordsCopied != rows {
+		t.Fatalf("copied records=%d want %d; stats=%+v", stats.RecordsCopied, rows, stats)
+	}
+
+	segmentsAfter, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("list segments after rewrite: %v", err)
+	}
+	var newSeg string
+	for _, seg := range segmentsAfter {
+		if !seg.valueLog {
+			continue
+		}
+		if _, ok := before[seg.path]; ok {
+			continue
+		}
+		newSeg = seg.path
+		break
+	}
+	if newSeg == "" {
+		t.Fatalf("expected offline rewrite to create a new value-log segment")
+	}
+	frameHeader := readFirstFrameHeaderFromSegment(t, newSeg)
+	if frameHeader.DictID != 0 {
+		t.Fatalf("expected block frame, got dictID=%d", frameHeader.DictID)
+	}
+	if frameHeader.Flags&valuelog.FrameFlagCompressed == 0 {
+		t.Fatalf("expected rewritten frame to be compressed, header=%+v", frameHeader)
+	}
+	if frameHeader.K <= 1 {
+		t.Fatalf("expected offline rewrite to group compressed JSON records, got k=%d", frameHeader.K)
+	}
+}
+
 func TestValueLogRewriteOffline_ReencodesSingleUncompressedFramesWhenCompressionEnabled(t *testing.T) {
 	dir := t.TempDir()
 
@@ -2982,9 +3268,14 @@ func readFirstRewriteFrameHeader(t *testing.T, walDir string) valuelog.FrameHead
 		t.Fatalf("expected at least one value-log file in %s", walDir)
 	}
 	slices.Sort(paths)
-	f, err := os.Open(paths[0])
+	return readFirstFrameHeaderFromSegment(t, paths[0])
+}
+
+func readFirstFrameHeaderFromSegment(t *testing.T, path string) valuelog.FrameHeader {
+	t.Helper()
+	f, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("open %s: %v", filepath.Base(paths[0]), err)
+		t.Fatalf("open %s: %v", filepath.Base(path), err)
 	}
 	defer f.Close()
 	var header [valuelog.HeaderSize]byte
@@ -3001,6 +3292,36 @@ func readFirstRewriteFrameHeader(t *testing.T, walDir string) valuelog.FrameHead
 		t.Fatalf("DecodeFrame: %v", err)
 	}
 	return frameHeader
+}
+
+func appendBlockCompressedPointersInNewSegment(t *testing.T, dir string, lane, seq uint32, ridBase uint64, n int, valueAt func(i int) []byte) []page.ValuePtr {
+	t.Helper()
+	walDir := filepath.Join(dir, "value_vlog")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(lane, seq)
+	if err != nil {
+		t.Fatalf("encode file id lane=%d seq=%d: %v", lane, seq, err)
+	}
+	path := filepath.Join(walDir, fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	w.SetBlockCompression(valuelog.BlockCodecSnappy, true)
+	ptrs := make([]page.ValuePtr, 0, n)
+	for i := 0; i < n; i++ {
+		ptr, err := w.Append(0, nil, ridBase+uint64(i), valueAt(i))
+		if err != nil {
+			t.Fatalf("append rid=%d: %v", ridBase+uint64(i), err)
+		}
+		ptrs = append(ptrs, ptr)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return ptrs
 }
 
 func readFirstRewriteFrameHeaderForLane(t *testing.T, walDir string, lane uint32) valuelog.FrameHeader {


### PR DESCRIPTION
## Summary

Fixes the value-log rewrite regression documented in #1430 where rewrite could turn JSON-like pointer values into weak single-record Snappy frames and report misleading post-rewrite byte totals.

Changes:
- Batch dictID=0 rewrite values into grouped block-compressed frames, returning predicted grouped pointers and flushing at existing rewrite boundaries.
- Decode and regroup compressed k=1 source frames during iterator/offline rewrite instead of preserving weak single-record frames.
- Use actual file stat sizes for value-log rewrite/GC byte accounting so `BytesAfter`/GC totals match on-disk files after registered segments grow.
- Add regression tests for online grouping, offline grouping of compressed source frames, and actual byte reporting after segment growth.

## Evidence

Tests run locally:

```sh
go test ./TreeDB/db -count=1
go test ./TreeDB ./TreeDB/internal/valuelog -count=1
```

JSONBench raw TreeDB 1M confirmation against this branch:

```text
after_load_checkpoint:      234.37 MiB
after_value_log_rewrite:    235.61 MiB
after_leaf_generation_gc:   225.86 MiB
after_index_vacuum_offline: 245.86 MiB
value_vlog du:              212M
rewrite stats BytesAfter:   222,529,026 bytes
rewritten frames:           avg k ~= 128, payload ratio ~= 0.44
```

Before this fix, the same saved raw harness ended around 479 MiB total with value_vlog around 444 MiB and rewrite stats incorrectly reporting only 28.29 MB.

Fixes #1430.
