### PR TITLE
Fix collection large document value-log storage

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9275,6 +9275,11 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if outerLeafPageLogSetter != nil {
 		outerLeafPageLogSetter.SetLeafPageLog(newCachingLeafPageLog(db, &db.leafLog))
 	}
+	if setter, ok := backend.(interface {
+		SetValueLogAppender(backenddb.ValueLogAppender)
+	}); ok && len(db.lanes) > 0 {
+		setter.SetValueLogAppender(newCachingValueLogAppender(db, &db.lanes[0]))
+	}
 	if opts.DisableWAL {
 		// Stage the adaptive gate on the fastest cached profile first. WAL-on
 		// modes keep the legacy zipper fan-out policy until benchmark data shows

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -1,0 +1,90 @@
+package caching
+
+import (
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type cachingValueLogAppender struct {
+	db   *DB
+	lane *lane
+}
+
+var _ backenddb.ValueLogAppender = (*cachingValueLogAppender)(nil)
+
+func newCachingValueLogAppender(db *DB, l *lane) backenddb.ValueLogAppender {
+	return &cachingValueLogAppender{db: db, lane: l}
+}
+
+func (a *cachingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	if a == nil || a.db == nil || a.lane == nil {
+		return nil, errWALUnavailable
+	}
+	if len(values) == 0 {
+		return nil, nil
+	}
+	startRID, err := a.db.ReserveValueLogRIDs(len(values))
+	if err != nil {
+		return nil, err
+	}
+	records := make([]valuelog.Record, len(values))
+	for i := range values {
+		records[i] = valuelog.Record{
+			RID:   startRID + uint64(i),
+			Value: values[i],
+		}
+	}
+	ptrs, err := a.db.appendValueLogForRecords(a.lane, records, journalDurabilityNone)
+	if err != nil {
+		return nil, err
+	}
+	if len(ptrs) != len(values) {
+		putValueLogPtrs(ptrs)
+		return nil, fmt.Errorf("cachingdb: value-log appender returned %d ptrs for %d values", len(ptrs), len(values))
+	}
+	out := append([]page.ValuePtr(nil), ptrs...)
+	putValueLogPtrs(ptrs)
+	return out, nil
+}
+
+func (a *cachingValueLogAppender) Flush() error {
+	if a == nil || a.db == nil || a.lane == nil {
+		return errWALUnavailable
+	}
+	return a.db.flushValueLogLane(a.lane)
+}
+
+func (a *cachingValueLogAppender) Sync() error {
+	if a == nil || a.db == nil || a.lane == nil {
+		return errWALUnavailable
+	}
+	if err := a.db.flushValueLogLane(a.lane); err != nil {
+		return err
+	}
+	if a.db.relaxedSync {
+		return nil
+	}
+	return a.db.syncValueLogLane(a.lane)
+}
+
+func (a *cachingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	if a == nil || a.db == nil || a.lane == nil {
+		return "", 0, false
+	}
+	l := a.lane
+	l.vlogMu.Lock()
+	path := l.vlogPath
+	seq := l.vlogSeq
+	l.vlogMu.Unlock()
+	if path == "" || seq <= 0 {
+		return "", 0, false
+	}
+	fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(seq))
+	if err != nil {
+		return "", 0, false
+	}
+	return path, fileID, true
+}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3491,14 +3491,55 @@ func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, plan *insertBatchPlan) 
 	return obsolete, nil
 }
 
+func collectionDataRootNameSet(meta CollectionMeta) map[string]struct{} {
+	return map[string]struct{}{
+		collectionPrimaryRootName(meta.Name):  {},
+		collectionTemplateRootName(meta.Name): {},
+	}
+}
+
+func pointerizeCollectionDataRootDeltaTables(db *backenddb.DB, meta CollectionMeta, rootNames []string, tables []memtable.Table) ([]memtable.Table, func(), error) {
+	if db == nil || !db.HasValueLogAppender() || len(rootNames) == 0 || len(tables) == 0 {
+		return tables, func() {}, nil
+	}
+	if len(rootNames) != len(tables) {
+		return nil, nil, fmt.Errorf("collections: invalid delta table lengths roots=%d tables=%d", len(rootNames), len(tables))
+	}
+	dataRoots := collectionDataRootNameSet(meta)
+	var out []memtable.Table
+	var pointerizedTables []memtable.Table
+	cleanup := func() {
+		resetCollectionTables(pointerizedTables)
+	}
+	for i, rootName := range rootNames {
+		if _, ok := dataRoots[rootName]; !ok {
+			continue
+		}
+		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, tables[i])
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+		if !pointerized {
+			continue
+		}
+		if out == nil {
+			out = append([]memtable.Table(nil), tables...)
+		}
+		out[i] = pointerizedTable
+		pointerizedTables = append(pointerizedTables, pointerizedTable)
+	}
+	if out == nil {
+		return tables, func() {}, nil
+	}
+	return out, cleanup, nil
+}
+
 func pointerizeCollectionDataRootRunMapValues(db *backenddb.DB, meta CollectionMeta, rootRuns map[string][]memtable.Table) (map[string][]memtable.Table, func(), error) {
 	if db == nil || !db.HasValueLogAppender() || len(rootRuns) == 0 {
 		return rootRuns, func() {}, nil
 	}
-	dataRoots := map[string]struct{}{
-		collectionPrimaryRootName(meta.Name):  {},
-		collectionTemplateRootName(meta.Name): {},
-	}
+	dataRoots := collectionDataRootNameSet(meta)
 	var out map[string][]memtable.Table
 	var clonedSlices map[string]bool
 	var pointerizedTables []memtable.Table
@@ -9624,7 +9665,12 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 
-	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, plan.rootNames, plan.deltaTables, plan.baseRootIDs, plan.policies)
+	publishTables, cleanupPointerized, err := pointerizeCollectionDataRootDeltaTables(c.db, plan.meta, plan.rootNames, plan.deltaTables)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupPointerized()
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, plan.rootNames, publishTables, plan.baseRootIDs, plan.policies)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -568,8 +568,12 @@ const (
 )
 
 type CollectionOptions struct {
-	AllowArrayValuesInIndex bool              `json:"allow_array_values_in_index,omitempty"`
-	DocumentFormat          DocumentFormat    `json:"document_format,omitempty"`
+	AllowArrayValuesInIndex bool           `json:"allow_array_values_in_index,omitempty"`
+	DocumentFormat          DocumentFormat `json:"document_format,omitempty"`
+	// DataRootStoragePolicy selects the requested collection data-root layout.
+	// Cached TreeDB backends with a persistent value-log appender promote
+	// default/fast data roots to value-log leaf roots at runtime so large
+	// documents can be stored through stable value pointers.
 	DataRootStoragePolicy   RootStoragePolicy `json:"data_root_storage_policy,omitempty"`
 	IndexStateStoragePolicy RootStoragePolicy `json:"index_state_storage_policy,omitempty"`
 	// DisableIndexedWriteMemtables opts an indexed collection out of the native
@@ -3384,12 +3388,16 @@ func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 }
 
 type collectionPointerizedRunEntry struct {
-	key          []byte
-	value        []byte
-	ptr          page.ValuePtr
-	flags        byte
-	pointerIndex int
+	key   []byte
+	value []byte
+	ptr   page.ValuePtr
+	flags byte
 }
+
+const (
+	collectionPointerizeBatchMaxValues = 1024
+	collectionPointerizeBatchMaxBytes  = 4 << 20
+)
 
 func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) (memtable.Table, bool, error) {
 	if db == nil || table == nil || !db.HasValueLogAppender() {
@@ -3417,49 +3425,78 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 	}
 
 	entries := make([]collectionPointerizedRunEntry, 0, table.Len())
-	values := make([][]byte, 0)
+	batchValues := make([][]byte, 0, collectionPointerizeBatchMaxValues)
+	batchEntryIndexes := make([]int, 0, collectionPointerizeBatchMaxValues)
+	batchBytes := 0
+	pointerized := false
+	flushBatch := func() error {
+		if len(batchValues) == 0 {
+			return nil
+		}
+		ptrs, err := db.AppendValueLogValues(batchValues)
+		if err != nil {
+			return err
+		}
+		if len(ptrs) != len(batchValues) {
+			return fmt.Errorf("collections: value-log appender returned %d ptrs for %d values", len(ptrs), len(batchValues))
+		}
+		for i, ptr := range ptrs {
+			entryIndex := batchEntryIndexes[i]
+			entries[entryIndex].value = nil
+			entries[entryIndex].ptr = ptr
+			entries[entryIndex].flags = (entries[entryIndex].flags &^ node.FlagTombstone) | node.FlagPointer
+		}
+		for i := range batchValues {
+			batchValues[i] = nil
+		}
+		batchValues = batchValues[:0]
+		batchEntryIndexes = batchEntryIndexes[:0]
+		batchBytes = 0
+		pointerized = true
+		return nil
+	}
 	it := table.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
 		value, ptr, flags := it.UnsafeEntry()
 		entry := collectionPointerizedRunEntry{
-			key:          bytes.Clone(it.UnsafeKey()),
-			ptr:          ptr,
-			flags:        flags,
-			pointerIndex: -1,
+			key:   bytes.Clone(it.UnsafeKey()),
+			ptr:   ptr,
+			flags: flags,
 		}
 		if flags&node.FlagTombstone == 0 &&
 			flags&node.FlagPointer == 0 &&
 			len(value) > db.InlineThresholdForKey(entry.key) {
-			entry.pointerIndex = len(values)
-			values = append(values, bytes.Clone(value))
+			entries = append(entries, entry)
+			valueCopy := bytes.Clone(value)
+			batchValues = append(batchValues, valueCopy)
+			batchEntryIndexes = append(batchEntryIndexes, len(entries)-1)
+			batchBytes += len(valueCopy)
+			if len(batchValues) >= collectionPointerizeBatchMaxValues || batchBytes >= collectionPointerizeBatchMaxBytes {
+				if err := flushBatch(); err != nil {
+					return table, false, err
+				}
+			}
 		} else if value != nil {
 			entry.value = bytes.Clone(value)
+			entries = append(entries, entry)
+		} else {
+			entries = append(entries, entry)
 		}
-		entries = append(entries, entry)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
 		return table, false, err
 	}
-	if len(values) == 0 {
-		return table, false, nil
-	}
-	ptrs, err := db.AppendValueLogValues(values)
-	if err != nil {
+	if err := flushBatch(); err != nil {
 		return table, false, err
 	}
-	if len(ptrs) != len(values) {
-		return table, false, fmt.Errorf("collections: value-log appender returned %d ptrs for %d values", len(ptrs), len(values))
+	if !pointerized {
+		return table, false, nil
 	}
 	out := newCollectionRunTable(len(entries))
 	for i := range entries {
 		entry := entries[i]
-		if entry.pointerIndex >= 0 {
-			entry.value = nil
-			entry.ptr = ptrs[entry.pointerIndex]
-			entry.flags = (entry.flags &^ node.FlagTombstone) | node.FlagPointer
-		}
 		out.SetEntrySteal(entry.key, entry.value, entry.ptr, entry.flags)
 	}
 	out.Freeze()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -165,12 +165,30 @@ func backendRootStoragePolicy(policy RootStoragePolicy) (backenddb.OrderedRootSt
 	}
 }
 
+func backendCollectionDataRootStoragePolicy(db *backenddb.DB, policy RootStoragePolicy) (backenddb.OrderedRootStoragePolicy, error) {
+	base, err := backendRootStoragePolicy(policy)
+	if err != nil {
+		return base, err
+	}
+	if base == backenddb.OrderedRootStoragePagerLeaves && db != nil && db.HasValueLogAppender() {
+		return backenddb.OrderedRootStorageValueLogLeaves, nil
+	}
+	if policy == RootStorageDefault && db != nil && db.HasValueLogAppender() {
+		return backenddb.OrderedRootStorageValueLogLeaves, nil
+	}
+	return base, nil
+}
+
 func collectionPlannerOptions(meta CollectionMeta) (collectionOptions, error) {
+	return collectionPlannerOptionsForDB(nil, meta)
+}
+
+func collectionPlannerOptionsForDB(db *backenddb.DB, meta CollectionMeta) (collectionOptions, error) {
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return collectionOptions{}, err
 	}
-	dataPolicy, err := backendRootStoragePolicy(meta.Options.DataRootStoragePolicy)
+	dataPolicy, err := backendCollectionDataRootStoragePolicy(db, meta.Options.DataRootStoragePolicy)
 	if err != nil {
 		return collectionOptions{}, err
 	}
@@ -2322,7 +2340,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 
 	baseMeta := catalog.meta
 	c.meta = baseMeta
-	baseOptions, err := collectionPlannerOptions(baseMeta)
+	baseOptions, err := collectionPlannerOptionsForDB(c.db, baseMeta)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -2611,7 +2629,7 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 		if len(overlays) == 0 {
 			continue
 		}
-		policy, err := collectionRootStoragePolicy(catalog.meta, rootName)
+		policy, err := collectionRootStoragePolicyForDB(c.db, catalog.meta, rootName)
 		if err != nil {
 			cleanupIters()
 			return stats, err
@@ -2719,7 +2737,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		options, err := collectionPlannerOptions(catalog.meta)
+		options, err := collectionPlannerOptionsForDB(c.db, catalog.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
@@ -2729,7 +2747,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(domain.catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		options, err := collectionPlannerOptions(domain.meta)
+		options, err := collectionPlannerOptionsForDB(c.db, domain.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
@@ -2749,7 +2767,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		}
 		c.rememberCatalog(snap, catalog)
 		_ = snap.Close()
-		options, err := collectionPlannerOptions(catalog.meta)
+		options, err := collectionPlannerOptionsForDB(c.db, catalog.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
@@ -2775,7 +2793,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	c.rememberCatalog(snap, catalog)
 	_ = snap.Close()
 
-	options, err := collectionPlannerOptions(catalog.meta)
+	options, err := collectionPlannerOptionsForDB(c.db, catalog.meta)
 	if err != nil {
 		return nil, collectionOptions{}, false, err
 	}
@@ -2849,7 +2867,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
-	options, err := collectionPlannerOptions(catalog.meta)
+	options, err := collectionPlannerOptionsForDB(c.db, catalog.meta)
 	if err != nil {
 		return nil, err
 	}
@@ -2974,7 +2992,14 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
-	iter := table.NewIterator(nil, nil)
+	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	if err != nil {
+		return err
+	}
+	if pointerized {
+		defer resetCollectionRunTable(publishTable)
+	}
+	iter := publishTable.NewIterator(nil, nil)
 
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
 		BaseRoot:      baseRoot,
@@ -3356,6 +3381,166 @@ func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 	}
 	table.Freeze()
 	return table, nil
+}
+
+type collectionPointerizedRunEntry struct {
+	key          []byte
+	value        []byte
+	ptr          page.ValuePtr
+	flags        byte
+	pointerIndex int
+}
+
+func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) (memtable.Table, bool, error) {
+	if db == nil || table == nil || !db.HasValueLogAppender() {
+		return table, false, nil
+	}
+	needsPointer := false
+	probe := table.NewIterator(nil, nil)
+	for probe.Valid() {
+		value, _, flags := probe.UnsafeEntry()
+		if flags&node.FlagTombstone == 0 &&
+			flags&node.FlagPointer == 0 &&
+			len(value) > db.InlineThresholdForKey(probe.UnsafeKey()) {
+			needsPointer = true
+			break
+		}
+		probe.Next()
+	}
+	probeErr := probe.Error()
+	_ = probe.Close()
+	if probeErr != nil {
+		return table, false, probeErr
+	}
+	if !needsPointer {
+		return table, false, nil
+	}
+
+	entries := make([]collectionPointerizedRunEntry, 0, table.Len())
+	values := make([][]byte, 0)
+	it := table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		value, ptr, flags := it.UnsafeEntry()
+		entry := collectionPointerizedRunEntry{
+			key:          bytes.Clone(it.UnsafeKey()),
+			ptr:          ptr,
+			flags:        flags,
+			pointerIndex: -1,
+		}
+		if flags&node.FlagTombstone == 0 &&
+			flags&node.FlagPointer == 0 &&
+			len(value) > db.InlineThresholdForKey(entry.key) {
+			entry.pointerIndex = len(values)
+			values = append(values, bytes.Clone(value))
+		} else if value != nil {
+			entry.value = bytes.Clone(value)
+		}
+		entries = append(entries, entry)
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return table, false, err
+	}
+	if len(values) == 0 {
+		return table, false, nil
+	}
+	ptrs, err := db.AppendValueLogValues(values)
+	if err != nil {
+		return table, false, err
+	}
+	if len(ptrs) != len(values) {
+		return table, false, fmt.Errorf("collections: value-log appender returned %d ptrs for %d values", len(ptrs), len(values))
+	}
+	out := newCollectionRunTable(len(entries))
+	for i := range entries {
+		entry := entries[i]
+		if entry.pointerIndex >= 0 {
+			entry.value = nil
+			entry.ptr = ptrs[entry.pointerIndex]
+			entry.flags = (entry.flags &^ node.FlagTombstone) | node.FlagPointer
+		}
+		out.SetEntrySteal(entry.key, entry.value, entry.ptr, entry.flags)
+	}
+	out.Freeze()
+	return out, true, nil
+}
+
+func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, plan *insertBatchPlan) ([]memtable.Table, error) {
+	if plan == nil || db == nil || !db.HasValueLogAppender() {
+		return nil, nil
+	}
+	var obsolete []memtable.Table
+	for i := range plan.runs {
+		switch plan.runs[i].kind {
+		case collectionRootPrimary, collectionRootTemplate:
+		default:
+			continue
+		}
+		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, plan.runs[i].table)
+		if err != nil {
+			resetCollectionTables(obsolete)
+			return nil, err
+		}
+		if !pointerized {
+			continue
+		}
+		obsolete = append(obsolete, plan.runs[i].table)
+		plan.runs[i].table = pointerizedTable
+	}
+	return obsolete, nil
+}
+
+func pointerizeCollectionDataRootRunMapValues(db *backenddb.DB, meta CollectionMeta, rootRuns map[string][]memtable.Table) (map[string][]memtable.Table, func(), error) {
+	if db == nil || !db.HasValueLogAppender() || len(rootRuns) == 0 {
+		return rootRuns, func() {}, nil
+	}
+	dataRoots := map[string]struct{}{
+		collectionPrimaryRootName(meta.Name):  {},
+		collectionTemplateRootName(meta.Name): {},
+	}
+	var out map[string][]memtable.Table
+	var clonedSlices map[string]bool
+	var pointerizedTables []memtable.Table
+	cleanup := func() {
+		resetCollectionTables(pointerizedTables)
+	}
+	ensureOut := func() {
+		if out != nil {
+			return
+		}
+		out = make(map[string][]memtable.Table, len(rootRuns))
+		for name, runs := range rootRuns {
+			out[name] = runs
+		}
+		clonedSlices = make(map[string]bool, 2)
+	}
+	for rootName, runs := range rootRuns {
+		if _, ok := dataRoots[rootName]; !ok {
+			continue
+		}
+		for i, run := range runs {
+			pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, run)
+			if err != nil {
+				cleanup()
+				return nil, nil, err
+			}
+			if !pointerized {
+				continue
+			}
+			ensureOut()
+			if !clonedSlices[rootName] {
+				out[rootName] = append([]memtable.Table(nil), runs...)
+				clonedSlices[rootName] = true
+			}
+			out[rootName][i] = pointerizedTable
+			pointerizedTables = append(pointerizedTables, pointerizedTable)
+		}
+	}
+	if out == nil {
+		return rootRuns, func() {}, nil
+	}
+	return out, cleanup, nil
 }
 
 func mutableRootRunLocked(domain *collectionWriteDomain, rootName string) (memtable.Table, bool) {
@@ -5065,6 +5250,11 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			work.pin = nil
 		}
 	}()
+	publishRootRuns, cleanupPointerizedRuns, err := pointerizeCollectionDataRootRunMapValues(c.db, work.meta, work.flushUnit.rootRuns)
+	if err != nil {
+		return c.completePreparedIndexedFlush(work, 0, nil, err, 0, 0, 0)
+	}
+	defer cleanupPointerizedRuns()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
 		materializeStart := time.Now()
 		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
@@ -5073,7 +5263,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
-		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, publishRootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
 			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
@@ -5096,7 +5286,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	materializeStart := time.Now()
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, publishRootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
@@ -5510,6 +5700,11 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		baseRootIDs[rootName] = baseRoot
 		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
+	publishRootRuns, cleanupPointerizedRuns, err := pointerizeCollectionDataRootRunMapValues(c.db, meta, flushUnit.rootRuns)
+	if err != nil {
+		return err
+	}
+	defer cleanupPointerizedRuns()
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	var rootOverlayFilters map[string]collectionRootOverlayFilter
@@ -5520,7 +5715,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, publishRootRuns, flushUnit.rootPolicies, rootOverlays)
 		if err != nil {
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
@@ -5538,7 +5733,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		}
 	} else {
 		materializeStart := time.Now()
-		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, publishRootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
@@ -5871,7 +6066,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		_ = snap.Close()
 		return c.insertOneViaBatch(id, document)
 	}
-	plannerOptions, err := collectionPlannerOptions(c.meta)
+	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -5900,11 +6095,22 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 	defer func() { _ = snap.Close() }()
 
 	resultID := bytes.Clone(id)
-	iter := &systemTargetIterator{entries: []systemTargetEntry{{
-		key:   resultID,
-		value: bytes.Clone(document),
-	}}}
-	defer func() { _ = iter.Close() }()
+	table := newCollectionRunTable(1)
+	setCollectionRunValue(table, resultID, bytes.Clone(document))
+	table.Freeze()
+	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	if err != nil {
+		resetCollectionRunTable(table)
+		return nil, err
+	}
+	if pointerized {
+		defer resetCollectionRunTable(publishTable)
+	}
+	iter := publishTable.NewIterator(nil, nil)
+	defer func() {
+		_ = iter.Close()
+		resetCollectionRunTable(table)
+	}()
 
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
 		BaseRoot:      baseRoot,
@@ -6023,7 +6229,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	}
 	meta := catalog.meta
 	c.meta = meta
-	plannerOptions, err := collectionPlannerOptions(meta)
+	plannerOptions, err := collectionPlannerOptionsForDB(c.db, meta)
 	if err != nil {
 		closePlanningSnapshot()
 		return nil, err
@@ -6060,7 +6266,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		}
 		meta = catalog.meta
 		c.meta = meta
-		plannerOptions, err = collectionPlannerOptions(meta)
+		plannerOptions, err = collectionPlannerOptionsForDB(c.db, meta)
 		if err != nil {
 			closePlanningSnapshot()
 			return nil, err
@@ -6158,6 +6364,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = pin.Close() }()
+	obsoletePointerizedTables, err := pointerizeInsertBatchPlanDataRuns(c.db, plan)
+	if err != nil {
+		return nil, err
+	}
+	defer resetCollectionTables(obsoletePointerizedTables)
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
@@ -6441,7 +6652,14 @@ func (c *Collection) insertBatchNoIndex(
 	}
 	table.Freeze()
 	stats.PrimaryRunBuild = time.Since(phaseStart)
-	iter := table.NewIterator(nil, nil)
+	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	if err != nil {
+		return nil, err
+	}
+	if pointerized {
+		defer resetCollectionRunTable(publishTable)
+	}
+	iter := publishTable.NewIterator(nil, nil)
 	defer func() {
 		_ = iter.Close()
 		resetCollectionRunTable(table)
@@ -6529,7 +6747,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 		return false, err
 	}
 	c.meta = catalog.meta
-	plannerOptions, err := collectionPlannerOptions(c.meta)
+	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
 		return false, err
@@ -7565,7 +7783,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		return false, false, err
 	}
 	c.meta = catalog.meta
-	plannerOptions, err := collectionPlannerOptions(c.meta)
+	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
@@ -7741,7 +7959,17 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	primaryTable := newCollectionRunTable(1)
 	setCollectionRunValue(primaryTable, bytes.Clone(documentID), document)
 	primaryTable.Freeze()
-	deltaTables = append(deltaTables, primaryTable)
+	if pointerizedPrimaryTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, primaryTable); err != nil {
+		_ = snap.Close()
+		resetCollectionTables(append(deltaTables, primaryTable))
+		return false, false, err
+	} else if pointerized {
+		deltaTables = append(deltaTables, pointerizedPrimaryTable)
+		resetCollectionRunTable(primaryTable)
+		primaryTable = nil
+	} else {
+		deltaTables = append(deltaTables, primaryTable)
+	}
 	stats.PrimaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 	if indexStateChanged {
@@ -8831,7 +9059,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		(!collectionMetaHasSecondaryUniqueIndex(meta) ||
 			mode == updateBatchModeNoSecondaryUniqueIndexes ||
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges)
-	plannerOptions, err := collectionPlannerOptions(meta)
+	plannerOptions, err := collectionPlannerOptionsForDB(c.db, meta)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -10244,7 +10472,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	if domain.count != 0 {
 		return
 	}
-	options, err := collectionPlannerOptions(catalog.meta)
+	options, err := collectionPlannerOptionsForDB(c.db, catalog.meta)
 	if err != nil {
 		domain.loaded = false
 		return
@@ -11208,7 +11436,7 @@ func (c *Collection) NewStoredDocumentJSONMaterializer() (*StoredDocumentJSONMat
 		if catalog == nil {
 			return nil, errCollectionNotFound
 		}
-		plannerOptions, err := collectionPlannerOptions(c.meta)
+		plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 		if err != nil {
 			return nil, err
 		}
@@ -12428,9 +12656,13 @@ func (c *collectionCatalog) anyOverlayRootMayContainKey(rootName string, key []b
 }
 
 func collectionRootStoragePolicy(meta CollectionMeta, rootName string) (backenddb.OrderedRootStoragePolicy, error) {
+	return collectionRootStoragePolicyForDB(nil, meta, rootName)
+}
+
+func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, rootName string) (backenddb.OrderedRootStoragePolicy, error) {
 	switch rootName {
 	case collectionPrimaryRootName(meta.Name), collectionTemplateRootName(meta.Name):
-		return backendRootStoragePolicy(meta.Options.DataRootStoragePolicy)
+		return backendCollectionDataRootStoragePolicy(db, meta.Options.DataRootStoragePolicy)
 	case collectionIndexStateRootName(meta.Name):
 		return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -593,6 +593,71 @@ func TestCollectionFastJSONBufferedIndexedLargeDocumentsUseValueLogPointers(t *t
 	requireCollectionPrimaryEntryPointer(t, d, "bluesky", ids[documents-1])
 }
 
+func TestCollectionFastJSONUpdateBatchLargeDocumentsUseValueLogPointers(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	closeDB := collectionMaintenanceCloseOnce(cleanup)
+	t.Cleanup(func() { _ = closeDB() })
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bluesky",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatJSON,
+			DataRootStoragePolicy: RootStorageFast,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bluesky")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const documents = 32
+	ids := make([][]byte, documents)
+	initialDocs := make([][]byte, documents)
+	updatedDocs := make([][]byte, documents)
+	items := make([]UpdateBatchItem, documents)
+	for i := 0; i < documents; i++ {
+		id := []byte(fmt.Sprintf("at://did:example:%06d", i))
+		updated := collectionLargeJSONDocumentForTest(i, 8<<10)
+		ids[i] = id
+		initialDocs[i] = []byte(fmt.Sprintf(`{"id":%d,"commit":{"collection":"app.bsky.feed.post"}}`, i))
+		updatedDocs[i] = updated
+		items[i] = UpdateBatchItem{
+			DocumentID: id,
+			Update: func([]byte) ([]byte, bool, error) {
+				return bytes.Clone(updated), true, nil
+			},
+		}
+	}
+	if _, err := col.InsertBatch(ids, initialDocs); err != nil {
+		t.Fatalf("insert initial JSON batch: %v", err)
+	}
+	results, err := col.UpdateBatch(items)
+	if err != nil {
+		t.Fatalf("UpdateBatch large JSON documents: %v", err)
+	}
+	if len(results) != documents {
+		t.Fatalf("UpdateBatch results=%d want %d", len(results), documents)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	got, err := col.Get(ids[documents-1])
+	if err != nil {
+		t.Fatalf("get updated large JSON doc: %v", err)
+	}
+	if !bytes.Equal(got, updatedDocs[documents-1]) {
+		t.Fatalf("updated large JSON doc mismatch: got %d bytes want %d", len(got), len(updatedDocs[documents-1]))
+	}
+	requireCollectionPrimaryEntryPointer(t, d, "bluesky", ids[documents-1])
+}
+
 func TestCollectionFastJSONMaintenanceVacuumUsesValueLogLeaves(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -463,6 +463,319 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 	requireCollectionMaintenanceTemplateReads(t, reopenedCol)
 }
 
+func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	closeDB := collectionMaintenanceCloseOnce(cleanup)
+	t.Cleanup(func() { _ = closeDB() })
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bluesky",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatJSON,
+			DataRootStoragePolicy: RootStorageFast,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bluesky")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const documents = 32
+	ids := make([][]byte, documents)
+	docs := make([][]byte, documents)
+	for i := 0; i < documents; i++ {
+		ids[i] = []byte(fmt.Sprintf("at://did:example:%06d", i))
+		docs[i] = collectionLargeJSONDocumentForTest(i, 8<<10)
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("insert large JSON batch: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	got, err := col.Get(ids[documents-1])
+	if err != nil {
+		t.Fatalf("get large JSON doc: %v", err)
+	}
+	if !bytes.Equal(got, docs[documents-1]) {
+		t.Fatalf("large JSON doc mismatch: got %d bytes want %d", len(got), len(docs[documents-1]))
+	}
+	requireCollectionPrimaryEntryPointer(t, d, "bluesky", ids[documents-1])
+
+	if err := closeDB(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	reopened, reopenedCleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopenedCleanup() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("bluesky")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedDoc, err := reopenedCol.Get(ids[0])
+	if err != nil {
+		t.Fatalf("get reopened large JSON doc: %v", err)
+	}
+	if !bytes.Equal(reopenedDoc, docs[0]) {
+		t.Fatalf("reopened large JSON doc mismatch: got %d bytes want %d", len(reopenedDoc), len(docs[0]))
+	}
+}
+
+func TestCollectionFastJSONBufferedIndexedLargeDocumentsUseValueLogPointers(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	closeDB := collectionMaintenanceCloseOnce(cleanup)
+	t.Cleanup(func() { _ = closeDB() })
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bluesky",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatJSON,
+			DataRootStoragePolicy: RootStorageFast,
+		},
+		Indexes: []IndexDefinition{{
+			Name:      "event",
+			Field:     "commit.collection",
+			ValueType: IndexValueString,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bluesky")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const documents = 32
+	ids := make([][]byte, documents)
+	docs := make([][]byte, documents)
+	for i := 0; i < documents; i++ {
+		ids[i] = []byte(fmt.Sprintf("at://did:example:%06d", i))
+		docs[i] = collectionLargeJSONDocumentForTest(i, 8<<10)
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("buffered indexed insert large JSON batch: %v", err)
+	}
+	eventIDs, err := col.FindByIndex("event", "app.bsky.feed.post")
+	if err != nil {
+		t.Fatalf("find event before flush: %v", err)
+	}
+	if len(eventIDs) != documents {
+		t.Fatalf("event ids before flush=%d want %d", len(eventIDs), documents)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered indexed writes: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	got, err := col.Get(ids[documents-1])
+	if err != nil {
+		t.Fatalf("get large JSON doc after flush: %v", err)
+	}
+	if !bytes.Equal(got, docs[documents-1]) {
+		t.Fatalf("large JSON doc mismatch after flush: got %d bytes want %d", len(got), len(docs[documents-1]))
+	}
+	requireCollectionPrimaryEntryPointer(t, d, "bluesky", ids[documents-1])
+}
+
+func TestCollectionFastJSONMaintenanceVacuumUsesValueLogLeaves(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bluesky",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatJSON,
+			DataRootStoragePolicy: RootStorageFast,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bluesky")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const (
+		documents = 20_000
+		batchSize = 1_000
+	)
+	for start := 0; start < documents; start += batchSize {
+		n := min(batchSize, documents-start)
+		ids := make([][]byte, n)
+		docs := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			row := start + i
+			ids[i] = []byte(fmt.Sprintf("did:example:%06d", row))
+			docs[i] = []byte(fmt.Sprintf(`{"event":"app.bsky.feed.post","seq":%d}`, row))
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			t.Fatalf("insert batch at %d: %v", start, err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint after load: %v", err)
+	}
+	requireCollectionPrimaryRootLeafLogChildren(t, d, "bluesky")
+
+	ctx := context.Background()
+	if _, err := col.CompactRootOverlays(ctx); err != nil {
+		t.Fatalf("compact root overlays: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint after overlay compaction: %v", err)
+	}
+	if _, err := d.ValueLogRewriteOnline(ctx, backenddb.ValueLogRewriteOnlineOptions{
+		BatchSize:      1024,
+		SyncEachBatch:  true,
+		LocalityPolicy: backenddb.ValueLogRewriteLocalityGrouped,
+	}); err != nil {
+		t.Fatalf("value-log rewrite: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint after value-log rewrite: %v", err)
+	}
+	if _, err := d.ValueLogGC(ctx, backenddb.ValueLogGCOptions{}); err != nil {
+		t.Fatalf("value-log GC: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint after value-log GC: %v", err)
+	}
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum index online: %v", err)
+	}
+
+	got, err := col.Get([]byte("did:example:019999"))
+	if err != nil {
+		t.Fatalf("get after vacuum: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"seq":19999`)) {
+		t.Fatalf("post-vacuum doc=%s want seq 19999", got)
+	}
+	requireCollectionPrimaryRootLeafLogChildren(t, d, "bluesky")
+}
+
+func collectionLargeJSONDocumentForTest(i, payloadBytes int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"id":%d,"commit":{"collection":"app.bsky.feed.post"},"payload":"%s"}`,
+		i,
+		strings.Repeat("x", payloadBytes),
+	))
+}
+
+func requireCollectionPrimaryEntryPointer(t *testing.T, d *backenddb.DB, collectionName string, id []byte) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		t.Fatalf("load collection catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection %q not found", collectionName)
+	}
+	rootID := catalog.rootID(collectionPrimaryRootName(collectionName))
+	entry, err := snap.GetEntryAtRoot(rootID, id)
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(%q): %v", id, err)
+	}
+	if entry.Flags&node.FlagPointer == 0 || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+		t.Fatalf("entry %q flags=%#x ptr=%+v, want value-log pointer", id, entry.Flags, entry.ValuePtr)
+	}
+}
+
+func requireCollectionPrimaryRootLeafLogChildren(t *testing.T, d *backenddb.DB, collectionName string) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load collection catalog: %v", err)
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		t.Fatalf("collection %q not found", collectionName)
+	}
+	rootID := catalog.rootID(collectionPrimaryRootName(collectionName))
+	_ = snap.Close()
+	if rootID == 0 {
+		t.Fatalf("collection %q primary root is empty", collectionName)
+	}
+	if !collectionRootHasLeafLogChild(t, d, rootID, make(map[uint64]bool)) {
+		t.Fatalf("collection %q primary root %d has no leaf-log children", collectionName, rootID)
+	}
+}
+
+func collectionRootHasLeafLogChild(t *testing.T, d *backenddb.DB, rootID uint64, seen map[uint64]bool) bool {
+	t.Helper()
+	if rootID == 0 || seen[rootID] {
+		return false
+	}
+	seen[rootID] = true
+	p := d.Pager()
+	if p == nil {
+		t.Fatal("missing pager")
+	}
+	data, err := p.Get(rootID)
+	if err != nil {
+		t.Fatalf("pager get root %d: %v", rootID, err)
+	}
+	n := node.NewNode(data)
+	switch n.Type() {
+	case page.PageTypeInternal:
+		for i := uint16(0); i < n.Count(); i++ {
+			_, childRef, err := n.GetInternalEntryRefView(i)
+			if err != nil {
+				t.Fatalf("internal child %d at root %d: %v", i, rootID, err)
+			}
+			if childRef.Kind == page.ChildRefLeafLog {
+				return true
+			}
+			if collectionRootHasLeafLogChild(t, d, childRef.Page, seen) {
+				return true
+			}
+		}
+		return false
+	case page.PageTypeLeaf:
+		return false
+	default:
+		t.Fatalf("unexpected page type %d at root %d", n.Type(), rootID)
+		return false
+	}
+}
+
 func TestCollectionManagerListCollections(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -487,7 +487,7 @@ func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
 		t.Fatalf("open collection: %v", err)
 	}
 
-	const documents = 32
+	const documents = collectionPointerizeBatchMaxValues + 7
 	ids := make([][]byte, documents)
 	docs := make([][]byte, documents)
 	for i := 0; i < documents; i++ {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -63,7 +63,7 @@ type DB struct {
 	snapshotViewRO                 atomic.Pointer[snapshotView]
 	snapshotAcquireRO              [snapshotAcquireShardCount]atomic.Int32
 	valueLogRefTracker             *valueLogRefTracker
-	valueLogAppender               ValueLogAppender
+	valueLogAppender               atomic.Pointer[valueLogAppenderHolder]
 	leafPageLog                    LeafPageLog
 	leafPageReadCache              *leafPageReadCache
 	leafGenerationManifest         *leafGenerationManifest
@@ -1859,6 +1859,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	if idx == nil {
 		return post, errors.New("missing index")
 	}
+	valueLogAppender := db.currentValueLogAppender()
 
 	// Ensure value-log-backed leaf pages are flushed before we publish an index
 	// commit that references them. Per-root storage policies can use the leaf
@@ -1874,13 +1875,13 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 			}
 		}
 	}
-	if db.valueLogAppender != nil {
+	if valueLogAppender != nil {
 		if sync {
-			if err := db.valueLogAppender.Sync(); err != nil {
+			if err := valueLogAppender.Sync(); err != nil {
 				return post, prePublishErr(err)
 			}
 		} else {
-			if err := db.valueLogAppender.Flush(); err != nil {
+			if err := valueLogAppender.Flush(); err != nil {
 				return post, prePublishErr(err)
 			}
 		}
@@ -1944,8 +1945,8 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 			return post, prePublishErr(err)
 		}
 		leafPageSegmentRegistered = registered
-		if db.valueLogAppender != nil {
-			path, fileID, ok := db.valueLogAppender.CurrentValueLogSegment()
+		if valueLogAppender != nil {
+			path, fileID, ok := valueLogAppender.CurrentValueLogSegment()
 			if ok && path != "" && fileID != 0 {
 				valueLogSegmentRegistrationAttempted = true
 				registered, err := db.ensureValueLogSegmentRegisteredAt(path, fileID)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -63,6 +63,7 @@ type DB struct {
 	snapshotViewRO                 atomic.Pointer[snapshotView]
 	snapshotAcquireRO              [snapshotAcquireShardCount]atomic.Int32
 	valueLogRefTracker             *valueLogRefTracker
+	valueLogAppender               ValueLogAppender
 	leafPageLog                    LeafPageLog
 	leafPageReadCache              *leafPageReadCache
 	leafGenerationManifest         *leafGenerationManifest
@@ -1873,6 +1874,17 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 			}
 		}
 	}
+	if db.valueLogAppender != nil {
+		if sync {
+			if err := db.valueLogAppender.Sync(); err != nil {
+				return post, prePublishErr(err)
+			}
+		} else {
+			if err := db.valueLogAppender.Flush(); err != nil {
+				return post, prePublishErr(err)
+			}
+		}
+	}
 	debugTiming := commitTimingEnabled()
 	var (
 		start    time.Time
@@ -1917,6 +1929,8 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 
 	leafPageSegmentRegistered := false
 	leafPageSegmentFileID := uint32(0)
+	valueLogSegmentRegistered := false
+	valueLogSegmentRegistrationAttempted := false
 	if db.testFailFinalizeCommit.Load() {
 		return post, prePublishErr(errTestFinalizeCommitFailpoint)
 	}
@@ -1930,6 +1944,17 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 			return post, prePublishErr(err)
 		}
 		leafPageSegmentRegistered = registered
+		if db.valueLogAppender != nil {
+			path, fileID, ok := db.valueLogAppender.CurrentValueLogSegment()
+			if ok && path != "" && fileID != 0 {
+				valueLogSegmentRegistrationAttempted = true
+				registered, err := db.ensureValueLogSegmentRegisteredAt(path, fileID)
+				if err != nil {
+					return post, prePublishErr(err)
+				}
+				valueLogSegmentRegistered = registered
+			}
+		}
 	}
 
 	// 3. Write Meta - No DB Lock
@@ -1972,7 +1997,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 				}
 			}
 		}
-		if forceValueLogRefresh && !leafPageSegmentRegistered {
+		if forceValueLogRefresh && (!leafPageSegmentRegistered || (valueLogSegmentRegistrationAttempted && !valueLogSegmentRegistered)) {
 			// If no registration path is available, force one refresh as a
 			// safety fallback before publishing the new state.
 			needRefresh = true

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -236,6 +236,25 @@ func (db *DB) ensureLeafPageLogSegmentRegisteredAt(path string, fileID uint32, c
 	return true, nil
 }
 
+func (db *DB) ensureValueLogSegmentRegisteredAt(path string, fileID uint32) (bool, error) {
+	if db == nil || db.valueLogManager == nil || path == "" || fileID == 0 {
+		return false, nil
+	}
+	if db.valueLogManager.HasSegment(fileID) {
+		if err := db.valueLogManager.PromoteCurrentWritable(fileID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err := db.RegisterValueLogSegment(path, fileID); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (db *DB) isLeafGenerationSegmentPath(path string) bool {
 	if db == nil || path == "" || db.leafGenerationManifest == nil {
 		return false

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -6,6 +6,8 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+var ErrValueLogAppenderUnavailable = errors.New("value-log appender unavailable")
+
 // ValueLogAppender appends user values to the persistent value log and returns
 // stable ValuePtr references that may be stored by native-root callers.
 type ValueLogAppender interface {
@@ -15,6 +17,10 @@ type ValueLogAppender interface {
 	CurrentValueLogSegment() (path string, fileID uint32, ok bool)
 }
 
+type valueLogAppenderHolder struct {
+	appender ValueLogAppender
+}
+
 // SetValueLogAppender installs the appender used by native-root APIs that need
 // to create persistent value-log pointers. Cached mode wires this to its normal
 // value-log writer.
@@ -22,21 +28,28 @@ func (db *DB) SetValueLogAppender(appender ValueLogAppender) {
 	if db == nil {
 		return
 	}
-	db.writeMu.Lock()
-	db.valueLogAppender = appender
-	db.writeMu.Unlock()
+	if appender == nil {
+		db.valueLogAppender.Store(nil)
+		return
+	}
+	db.valueLogAppender.Store(&valueLogAppenderHolder{appender: appender})
+}
+
+func (db *DB) currentValueLogAppender() ValueLogAppender {
+	if db == nil {
+		return nil
+	}
+	holder := db.valueLogAppender.Load()
+	if holder == nil {
+		return nil
+	}
+	return holder.appender
 }
 
 // HasValueLogAppender reports whether native-root callers can append user
 // values to the persistent value log.
 func (db *DB) HasValueLogAppender() bool {
-	if db == nil {
-		return false
-	}
-	db.writeMu.RLock()
-	ok := db.valueLogAppender != nil
-	db.writeMu.RUnlock()
-	return ok
+	return db.currentValueLogAppender() != nil
 }
 
 // AppendValueLogValues appends values through the configured persistent value
@@ -48,11 +61,9 @@ func (db *DB) AppendValueLogValues(values [][]byte) ([]page.ValuePtr, error) {
 	if db == nil {
 		return nil, ErrClosed
 	}
-	db.writeMu.RLock()
-	appender := db.valueLogAppender
-	db.writeMu.RUnlock()
+	appender := db.currentValueLogAppender()
 	if appender == nil {
-		return nil, errors.New("value-log appender unavailable")
+		return nil, ErrValueLogAppenderUnavailable
 	}
 	return appender.AppendValues(values)
 }

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// ValueLogAppender appends user values to the persistent value log and returns
+// stable ValuePtr references that may be stored by native-root callers.
+type ValueLogAppender interface {
+	AppendValues(values [][]byte) ([]page.ValuePtr, error)
+	Flush() error
+	Sync() error
+	CurrentValueLogSegment() (path string, fileID uint32, ok bool)
+}
+
+// SetValueLogAppender installs the appender used by native-root APIs that need
+// to create persistent value-log pointers. Cached mode wires this to its normal
+// value-log writer.
+func (db *DB) SetValueLogAppender(appender ValueLogAppender) {
+	if db == nil {
+		return
+	}
+	db.writeMu.Lock()
+	db.valueLogAppender = appender
+	db.writeMu.Unlock()
+}
+
+// HasValueLogAppender reports whether native-root callers can append user
+// values to the persistent value log.
+func (db *DB) HasValueLogAppender() bool {
+	if db == nil {
+		return false
+	}
+	db.writeMu.RLock()
+	ok := db.valueLogAppender != nil
+	db.writeMu.RUnlock()
+	return ok
+}
+
+// AppendValueLogValues appends values through the configured persistent value
+// log appender.
+func (db *DB) AppendValueLogValues(values [][]byte) ([]page.ValuePtr, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	if db == nil {
+		return nil, ErrClosed
+	}
+	db.writeMu.RLock()
+	appender := db.valueLogAppender
+	db.writeMu.RUnlock()
+	if appender == nil {
+		return nil, errors.New("value-log appender unavailable")
+	}
+	return appender.AppendValues(values)
+}

--- a/TreeDB/db/value_log_appender_test.go
+++ b/TreeDB/db/value_log_appender_test.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAppendValueLogValuesUnavailableReturnsSentinel(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, err = db.AppendValueLogValues([][]byte{[]byte("large value")})
+	if !errors.Is(err, ErrValueLogAppenderUnavailable) {
+		t.Fatalf("AppendValueLogValues err=%v want ErrValueLogAppenderUnavailable", err)
+	}
+}


### PR DESCRIPTION
Fixes #1429.

## Summary
- wire cached TreeDB value-log appends into the backend so collection primary/template roots can store oversized document values as persistent `ValuePtr`s
- promote fast/default collection data roots to value-log leaf storage when the cached value-log appender is available
- pointerize large collection run values at publish time, while keeping buffered indexed writes inline until flush so same-manager reads still work
- cover InsertBatch, buffered indexed InsertBatch, UpdateBatch, and post-load maintenance/vacuum regressions

## Tests
- `go test ./TreeDB/collections -run 'TestCollectionFastJSON(LargeDocumentsUseValueLogPointers|BufferedIndexedLargeDocumentsUseValueLogPointers|UpdateBatchLargeDocumentsUseValueLogPointers|MaintenanceVacuumUsesValueLogLeaves)|TestCollectionValueLogGC_RoundTripWithCompressedSecondaryIndexes' -count=1`\n- `go test ./TreeDB/db ./TreeDB/caching ./TreeDB/collections -count=1`\n- `go test ./TreeDB/... -count=1`