### PR TITLE
Add full TreeDB storage compaction path

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -24,11 +24,12 @@ Use that folder for architecture, format, durability, recovery, lifecycle, and v
 ## Architecture
 
 ### Storage Layout
--   **Root dir:** `Options.Dir` is a root directory with two sub-databases: `maindb/` (main data) and `dictdb/` (dictionary store).
+-   **Root dir:** `Options.Dir` is a root directory with `maindb/` (main data) plus optional side stores such as `dictdb/` and `templatedb/`.
 -   **Pages:** 4KB fixed-size blocks in `maindb/index.db`.
 -   **Nodes:** Slotted pages supporting variable-length keys.
--   **Value log:** Append-only segments under `maindb/wal/` storing large values with CRC checksums.
--   **Journal/redo log:** Commit metadata stored alongside the value log under `maindb/wal/`.
+-   **Value log:** Persistent append-only segments under `maindb/value_vlog/` storing large values with CRC checksums.
+-   **Leaf log:** Optional persistent outer-leaf generations under `maindb/leaf_vlog/` when `IndexOuterLeavesInValueLog` is enabled.
+-   **Journal/redo log:** Commit metadata for crash recovery under `maindb/wal/`.
 
 ### Write Path ("The Zipper")
 Writes are batched and applied using a recursive "Zipper" merge algorithm. This creates a new version of the tree path (COW) without modifying existing on-disk pages, ensuring crash safety and snapshot isolation.
@@ -108,7 +109,7 @@ Profiles are intended to make intent explicit:
 
 Note: WAL-off is selected via `opts.Durability = treedb.DurabilityWALOffRelaxed`.
 The value log remains enabled in cached mode, so large values can still go
-through `wal/` even when WAL is off.
+through `value_vlog/` even when the redo journal is off.
 
 Details: `docs/TREEDB_WRITE_PATHS.md`.
 
@@ -134,7 +135,8 @@ existing placement rules.
 - CRC checksums detect accidental corruption, not malicious tampering; use filesystem encryption/HMAC if your threat model includes adversarial disk access.
 - `GetUnsafe` on a `Snapshot` and iterator `Key()`/`Value()` return short-lived views; use `Get`, `KeyCopy`, or `ValueCopy` for stable bytes.
 - TreeDB does not provide encryption-at-rest or secure deletion; deleted data may remain on disk until compacted. Use OS/disk encryption for confidentiality.
-- Value-log segments are persistent; reclaim disk via `DB.ValueLogGC` (deletes fully-unreferenced segments) and `treedb.ValueLogRewriteOffline` (offline rewrite/compaction).
+- For final disk footprint, use `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`. This is the best-practice path across `index.db`, `value_vlog`, `leaf_vlog`, and empty segment cleanup.
+- Low-level APIs such as `ValueLogGC`, `ValueLogRewriteOffline`, `LeafGenerationPack*`, and `VacuumIndex*` are maintenance building blocks. Do not manually chain them for benchmark storage numbers unless you are working on TreeDB internals.
 - Optional guardrail: `Options.ValueLog.MaxRetainedBytes` emits a warning when retained value-log bytes exceed the threshold.
 - Optional hard cap: `Options.ValueLog.MaxRetainedBytesHard` disables value-log pointers for new large values once retained bytes exceed the threshold.
 - TreeDB is pre-alpha; public APIs and on-disk format may change without backward-compatibility guarantees.
@@ -159,7 +161,8 @@ existing placement rules.
 - Optional piggyback compaction toggle: `DisablePiggybackCompaction`
 - Value-log retention guardrails: `ValueLog.MaxRetainedBytes`, `ValueLog.MaxRetainedBytesHard`
 - Value-log compression mode: `ValueLog.Compression` (`off|block|dict|auto`) and `ValueLog.BlockCodec` (`snappy|lz4`)
-- Index rebuild (in-place): `treedb.CompactIndex()` or `treedb.VacuumIndexOffline(opts)` (currently an alias for CompactIndex)
+- Full storage compaction: `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`
+- Index-only rebuild: `treedb.CompactIndex()` or `treedb.VacuumIndexOffline(opts)` when you explicitly want only `index.db` maintenance
 
 `ValueLog.Compression` defaults to `auto` when unset.
 

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -135,7 +135,7 @@ existing placement rules.
 - CRC checksums detect accidental corruption, not malicious tampering; use filesystem encryption/HMAC if your threat model includes adversarial disk access.
 - `GetUnsafe` on a `Snapshot` and iterator `Key()`/`Value()` return short-lived views; use `Get`, `KeyCopy`, or `ValueCopy` for stable bytes.
 - TreeDB does not provide encryption-at-rest or secure deletion; deleted data may remain on disk until compacted. Use OS/disk encryption for confidentiality.
-- For final disk footprint, use `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`. This is the best-practice path across `index.db`, `value_vlog`, `leaf_vlog`, and empty segment cleanup.
+- For final disk footprint, use `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`. This is the best-practice path across `index.db`, `value_vlog`, `leaf_vlog`, and empty segment cleanup; platforms without online index vacuum report that phase as skipped while still compacting the value-log domains.
 - Low-level APIs such as `ValueLogGC`, `ValueLogRewriteOffline`, `LeafGenerationPack*`, and `VacuumIndex*` are maintenance building blocks. Do not manually chain them for benchmark storage numbers unless you are working on TreeDB internals.
 - Optional guardrail: `Options.ValueLog.MaxRetainedBytes` emits a warning when retained value-log bytes exceed the threshold.
 - Optional hard cap: `Options.ValueLog.MaxRetainedBytesHard` disables value-log pointers for new large values once retained bytes exceed the threshold.

--- a/TreeDB/cached_backend_maintenance.go
+++ b/TreeDB/cached_backend_maintenance.go
@@ -1,0 +1,17 @@
+package treedb
+
+import "errors"
+
+func (db *DB) reconcileCachedBackendMaintenance(fnErr error) error {
+	if db == nil || db.cached == nil {
+		return fnErr
+	}
+	reconcileErr := db.cached.ReconcileAfterBackendMaintenance()
+	if fnErr != nil {
+		if reconcileErr != nil {
+			return errors.Join(fnErr, reconcileErr)
+		}
+		return fnErr
+	}
+	return reconcileErr
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5734,6 +5734,13 @@ func (db *DB) runWithBackendMaintenanceOptions(opts backendMaintenanceOptions, f
 	return reconcileErr
 }
 
+// ReconcileAfterBackendMaintenance refreshes cached-mode value-log readers and
+// advances split value-log writers past segments created directly by backend
+// maintenance.
+func (db *DB) ReconcileAfterBackendMaintenance() error {
+	return db.reconcileSplitValueLogWritersAfterBackendMaintenance()
+}
+
 func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 	if db == nil || db.closing.Load() {
 		return nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4311,6 +4311,13 @@ func (db *DB) valueLogProtectedPaths() []string {
 	return merged
 }
 
+// ValueLogProtectedPaths returns value-log segment paths that online backend
+// maintenance must protect while this cached DB is live. The set includes
+// retained pointer-lifecycle paths plus current/queued in-use writer paths.
+func (db *DB) ValueLogProtectedPaths() []string {
+	return db.valueLogProtectedPaths()
+}
+
 func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {
 	retained, inUse, merged := db.valueLogGCProtectedPathSets()
 	return backenddb.ValueLogGCOptions{

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3919,7 +3919,7 @@ func (db *DB) flushValueLogLaneWithSize(l *lane) (int64, error) {
 		w := l.vlog
 		if w == nil {
 			l.vlogMu.Unlock()
-			return -1, errWALUnavailable
+			return -1, nil
 		}
 		// Always take vlogMu first so flush acts as a write barrier for in-flight appends.
 		if !l.vlogDirty.Load() {
@@ -3985,7 +3985,7 @@ func (db *DB) syncValueLogLane(l *lane) error {
 		w := l.vlog
 		if w == nil {
 			l.vlogMu.Unlock()
-			return errWALUnavailable
+			return nil
 		}
 		start := time.Now()
 		err := w.Sync()
@@ -9171,36 +9171,11 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		outerLeafPageLogSetter = setter
 	}
 
-	// Open initial value-log segments (if enabled) and journal/commit log
-	// segments (if enabled). Journal and value log are decoupled.
-	if db.valueLogEnabled() {
-		for i := range db.lanes {
-			if err := db.rotateValueLogLocked(&db.lanes[i]); err != nil {
-				if db.valueLogReader != nil {
-					_ = db.valueLogReader.Close()
-					db.valueLogReader = nil
-				}
-				for j := 0; j <= i && j < len(db.lanes); j++ {
-					db.cleanupLaneWALWriters(&db.lanes[j])
-				}
-				db.cleanupLaneWALWriters(&db.leafLog)
-				return nil, err
-			}
-		}
-		if opts.IndexOuterLeavesInValueLog {
-			if err := db.rotateValueLogLocked(&db.leafLog); err != nil {
-				if db.valueLogReader != nil {
-					_ = db.valueLogReader.Close()
-					db.valueLogReader = nil
-				}
-				for i := range db.lanes {
-					db.cleanupLaneWALWriters(&db.lanes[i])
-				}
-				db.cleanupLaneWALWriters(&db.leafLog)
-				return nil, err
-			}
-		}
-	}
+	// Open journal/commit log segments eagerly, but leave value-log segment
+	// writers lazy. Opening every value-log lane here creates many zero-byte
+	// value_vlog files during read/write maintenance opens even when those lanes
+	// never receive values. Value-log appends allocate the current lane segment
+	// on first write instead.
 	if !db.disableJournal {
 		for i := range db.lanes {
 			if err := db.rotateWALLocked(&db.lanes[i]); err != nil {
@@ -12065,6 +12040,20 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	)
 
 	l.vlogMu.Lock()
+	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
+		l.vlogMu.Unlock()
+		for i := range requests {
+			ack := requests[i].ack
+			if ack == nil {
+				continue
+			}
+			ack.ptr = page.ValuePtr{}
+			ack.retainPath = ""
+			ack.err = err
+			ack.wg.Done()
+		}
+		return
+	}
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
@@ -13086,6 +13075,10 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 
 	l.vlogMu.Lock()
+	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
+		l.vlogMu.Unlock()
+		return nil, err
+	}
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
@@ -13670,6 +13663,10 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 
 	if allowQueue && db.shouldQueueValueLogOne(l, dictID, len(value), durability, finalWriteMode, wallStart) {
 		if dictID == 0 && !l.vlogQueueing.Load() && l.vlogMu.TryLock() {
+			if err := db.ensureValueLogWriterMuHeld(l); err != nil {
+				l.vlogMu.Unlock()
+				return page.ValuePtr{}, "", err
+			}
 			w := l.vlog
 			if w == nil {
 				l.vlogMu.Unlock()
@@ -13842,6 +13839,10 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	}
 
 	l.vlogMu.Lock()
+	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", err
+	}
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
@@ -21030,6 +21031,19 @@ func (db *DB) rotateValueLogLocked(l *lane) error {
 
 func (db *DB) rotateValueLogMuHeld(l *lane) error {
 	return db.rotateValueLogMuHeldToSeq(l, l.vlogSeq+1)
+}
+
+func (db *DB) ensureValueLogWriterMuHeld(l *lane) error {
+	if !db.splitValueLogEnabled() {
+		return nil
+	}
+	if l == nil {
+		return errWALUnavailable
+	}
+	if l.vlog != nil {
+		return nil
+	}
+	return db.rotateValueLogMuHeld(l)
 }
 
 func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2151,6 +2151,9 @@ func TestPruneRetainedValueLogs_SkipsLiveScanWhenAllRetainedPathsInUse(t *testin
 	}
 	defer cache.Close()
 
+	if err := cache.Set([]byte("seed"), bytes.Repeat([]byte("v"), 64)); err != nil {
+		t.Fatalf("seed value-log writer: %v", err)
+	}
 	retained := cache.currentValueLogPath(&cache.lanes[0])
 	if retained == "" {
 		t.Fatalf("expected current value-log path")

--- a/TreeDB/caching/vlog_generation_gc_protection_test.go
+++ b/TreeDB/caching/vlog_generation_gc_protection_test.go
@@ -278,7 +278,11 @@ func TestVlogGenerationGC_ProtectedPathsSnapshotDoesNotDeleteNewerSegments(t *te
 	defer db.Close()
 
 	// Establish a stable backend boundary and create the initial (protected)
-	// value-log segment.
+	// value-log segment. Cached value-log writers are lazy, so write an actual
+	// pointer-backed value before taking the protected-path snapshot.
+	if err := db.Set([]byte("protected-seed"), bytes.Repeat([]byte("p"), 8<<10)); err != nil {
+		t.Fatalf("Set protected seed: %v", err)
+	}
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("Checkpoint: %v", err)
 	}

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -1240,8 +1240,8 @@ func TestCachedGenerationalMaintenance_DirectPointersManualGC_WALOn(t *testing.T
 	if err != nil {
 		t.Fatalf("manual ValueLogGC: %v", err)
 	}
-	if stats.SegmentsDeleted == 0 && stats.SegmentsEligible == 0 {
-		t.Fatalf("expected manual gc to observe reclaimable segments in large seed phase, got %+v", stats)
+	if stats.SegmentsTotal == 0 || stats.BytesTotal == 0 {
+		t.Fatalf("expected manual gc to observe value-log segments in large seed phase, got %+v", stats)
 	}
 
 	after, err := tryCollectBackendLiveFileCounts(t, backend)

--- a/TreeDB/cmd/treemap/leaf_generation.go
+++ b/TreeDB/cmd/treemap/leaf_generation.go
@@ -107,6 +107,7 @@ func runLeafGenerationPack(dir string, args []string) {
 	if !*rw {
 		fatalf("leafgen-pack requires -rw")
 	}
+	warnAdvancedMaintenance("leafgen-pack", "leaf_vlog-only pack")
 	generationIDs, err := parseUint64CSV(*generationIDsCSV)
 	if err != nil {
 		fatalf("invalid -generation-ids: %v", err)
@@ -192,6 +193,7 @@ func runLeafGenerationGC(dir string, args []string) {
 	if !*rw {
 		fatalf("leafgen-gc requires -rw")
 	}
+	warnAdvancedMaintenance("leafgen-gc", "leaf_vlog-only GC")
 
 	db := openTreeDB(dir, true)
 	defer closeTreeDB(db)

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -512,14 +512,11 @@ func runCompact(dir string, args []string) {
 		fatalf("compact -scope must be all or index")
 	}
 
-	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dir, ReadOnly: false})
-	if err != nil {
-		fatalf("Failed to open DB: %v", err)
-	}
-	defer func() { _ = cleanup() }()
+	db := openTreeDB(dir, true)
+	defer closeTreeDB(db)
 
-	stats, err := backend.CompactStorage(context.Background(), treedbdb.CompactStorageOptions{
-		Mode:                           parseCompactStorageModeFlag("compact", *mode),
+	stats, err := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+		Mode:                           treedb.CompactStorageMode(parseCompactStorageModeFlag("compact", *mode)),
 		SyncEachPhase:                  *syncEachPhase,
 		ValueLogRewriteBatchSize:       *batchSize,
 		ValueLogRewriteMaxSegmentBytes: *maxSegmentBytes,
@@ -590,7 +587,7 @@ func printCompactStorageStats(stats treedb.CompactStorageStats, jsonOut bool) {
 		stats.RemainingDebt.ValueLogGCBytes,
 		stats.RemainingDebt.LeafPackGenerations,
 		stats.RemainingDebt.LeafPackBytes,
-		stats.RemainingDebt.LeafGCSegments,
+		stats.RemainingDebt.LeafGCGenerations,
 		stats.RemainingDebt.LeafGCBytes,
 		stats.RemainingDebt.ZeroByteValueLogFiles,
 	)

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -519,7 +519,7 @@ func runCompact(dir string, args []string) {
 	defer func() { _ = cleanup() }()
 
 	stats, err := backend.CompactStorage(context.Background(), treedbdb.CompactStorageOptions{
-		Mode:                           treedbdb.CompactStorageMode(strings.TrimSpace(*mode)),
+		Mode:                           parseCompactStorageModeFlag("compact", *mode),
 		SyncEachPhase:                  *syncEachPhase,
 		ValueLogRewriteBatchSize:       *batchSize,
 		ValueLogRewriteMaxSegmentBytes: *maxSegmentBytes,
@@ -542,12 +542,24 @@ func runCompactPlan(dir string, args []string) {
 	defer closeTreeDB(db)
 
 	stats, err := db.CompactStoragePlan(context.Background(), treedb.CompactStorageOptions{
-		Mode: treedb.CompactStorageMode(strings.TrimSpace(*mode)),
+		Mode: treedb.CompactStorageMode(parseCompactStorageModeFlag("compact-plan", *mode)),
 	})
 	if err != nil {
 		fatalf("CompactStoragePlan error: %v", err)
 	}
 	printCompactStorageStats(stats, *jsonOut)
+}
+
+func parseCompactStorageModeFlag(command, raw string) treedbdb.CompactStorageMode {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "full":
+		return treedbdb.CompactStorageFull
+	case "quick":
+		return treedbdb.CompactStorageQuick
+	default:
+		fatalf("%s -mode must be full or quick", command)
+		return treedbdb.CompactStorageFull
+	}
 }
 
 func printCompactStorageStats(stats treedb.CompactStorageStats, jsonOut bool) {

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -41,7 +41,7 @@ Commands:
   compact-plan    Preview full storage compaction debt without mutating storage
   compact         Run full storage compaction (requires -rw; use -scope=index for legacy index-only compaction)
   vacuum          Rebuild index.db via swap (shrinks file; requires -rw)
-  vlog-audit      Advanced: audit value-log filesystem, GC, and rewrite-plan state
+  vlog-audit      Advanced: audit value-log filesystem, GC, and rewrite-plan state (read-only by default)
   vlog-gc         Advanced: delete unreferenced value-log segments only (requires -rw)
   vlog-rewrite    Advanced: rewrite value-log segments only (requires -rw)
   leafgen-plan    Advanced: print explicit leaf-generation pack plan

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -38,14 +38,15 @@ Commands:
   verify          Full scan verification (counts items)
   checkpoint       Force a durable checkpoint (requires -rw)
   checkpoint-bench Write workload then checkpoint (requires -rw)
-  compact         Compact/rebuild the index.db in-place (requires -rw)
+  compact-plan    Preview full storage compaction debt without mutating storage
+  compact         Run full storage compaction (requires -rw; use -scope=index for legacy index-only compaction)
   vacuum          Rebuild index.db via swap (shrinks file; requires -rw)
-  vlog-audit      Audit value-log filesystem, GC, and rewrite-plan state (requires -rw)
-  vlog-gc         Delete unreferenced value-log segments (requires -rw)
-  vlog-rewrite    Rewrite value-log segments and shrink via swap (requires -rw)
-  leafgen-plan    Print explicit leaf-generation pack plan
-  leafgen-pack    Pack sealed leaf generations by id (requires -rw)
-  leafgen-gc      Delete fully unreachable sealed leaf generations (requires -rw)
+  vlog-audit      Advanced: audit value-log filesystem, GC, and rewrite-plan state
+  vlog-gc         Advanced: delete unreferenced value-log segments only (requires -rw)
+  vlog-rewrite    Advanced: rewrite value-log segments only (requires -rw)
+  leafgen-plan    Advanced: print explicit leaf-generation pack plan
+  leafgen-pack    Advanced: pack sealed leaf generations only (requires -rw)
+  leafgen-gc      Advanced: delete unreachable sealed leaf generations only (requires -rw)
   get             Get a single key
   keys            List keys in a range/prefix
   scan            Scan keys and values in a range/prefix (requires -allow-values)
@@ -94,6 +95,8 @@ func main() {
 		runCheckpoint(dir, args)
 	case "checkpoint-bench":
 		runCheckpointBench(dir, args)
+	case "compact-plan":
+		runCompactPlan(dir, args)
 	case "compact":
 		runCompact(dir, args)
 	case "vacuum":
@@ -482,19 +485,131 @@ func runVerify(dir string, args []string) {
 func runCompact(dir string, args []string) {
 	fs := flag.NewFlagSet("compact", flag.ExitOnError)
 	rw := fs.Bool("rw", false, "Open read-write (required; may replay WAL or repair files)")
+	jsonOut := fs.Bool("json", false, "Emit JSON report")
+	scope := fs.String("scope", "all", "Compaction scope: all|index")
+	mode := fs.String("mode", "full", "Compaction mode: full|quick")
+	syncEachPhase := fs.Bool("sync-each-phase", false, "Force fsync boundaries for rewrite/pack batches")
+	batchSize := fs.Int("rewrite-batch-size", 0, "Value-log rewrite pointer-swap batch size (0=default)")
+	maxSegmentBytes := fs.Int64("rewrite-max-segment-bytes", 0, "Maximum value-log segment bytes during rewrite (0=default)")
+	leafPackPasses := fs.Int("leaf-pack-max-passes", 0, "Maximum leaf-generation pack passes (0=default)")
 	_ = fs.Parse(args)
 
 	if !*rw {
 		fatalf("compact requires -rw")
 	}
 
-	db := openTreeDB(dir, true)
+	if strings.EqualFold(strings.TrimSpace(*scope), "index") {
+		db := openTreeDB(dir, true)
+		defer closeTreeDB(db)
+
+		if err := db.CompactIndex(); err != nil {
+			fatalf("CompactIndex error: %v", err)
+		}
+		fmt.Println("Index compaction complete.")
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(*scope), "all") && strings.TrimSpace(*scope) != "" {
+		fatalf("compact -scope must be all or index")
+	}
+
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dir, ReadOnly: false})
+	if err != nil {
+		fatalf("Failed to open DB: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	stats, err := backend.CompactStorage(context.Background(), treedbdb.CompactStorageOptions{
+		Mode:                           treedbdb.CompactStorageMode(strings.TrimSpace(*mode)),
+		SyncEachPhase:                  *syncEachPhase,
+		ValueLogRewriteBatchSize:       *batchSize,
+		ValueLogRewriteMaxSegmentBytes: *maxSegmentBytes,
+		LeafPackMaxPasses:              *leafPackPasses,
+	})
+	if err != nil {
+		fatalf("CompactStorage error: %v", err)
+	}
+	printCompactStorageStats(stats, *jsonOut)
+}
+
+func runCompactPlan(dir string, args []string) {
+	fs := flag.NewFlagSet("compact-plan", flag.ExitOnError)
+	jsonOut := fs.Bool("json", false, "Emit JSON report")
+	mode := fs.String("mode", "full", "Compaction mode: full|quick")
+	_ = fs.Parse(args)
+
+	opts := treedb.Options{Dir: dir, ReadOnly: true}
+	db := openTreeDBWithOptions(opts)
 	defer closeTreeDB(db)
 
-	if err := db.CompactIndex(); err != nil {
-		fatalf("CompactIndex error: %v", err)
+	stats, err := db.CompactStoragePlan(context.Background(), treedb.CompactStorageOptions{
+		Mode: treedb.CompactStorageMode(strings.TrimSpace(*mode)),
+	})
+	if err != nil {
+		fatalf("CompactStoragePlan error: %v", err)
 	}
-	fmt.Println("Index compaction complete.")
+	printCompactStorageStats(stats, *jsonOut)
+}
+
+func printCompactStorageStats(stats treedb.CompactStorageStats, jsonOut bool) {
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(stats); err != nil {
+			fatalf("encode compact stats: %v", err)
+		}
+		return
+	}
+	mode := "applied"
+	if stats.DryRun {
+		mode = "plan"
+	}
+	beforeTotal := compactStorageUsageBytes(stats.Before, "total")
+	afterTotal := compactStorageUsageBytes(stats.After, "total")
+	fmt.Printf("compact-storage (%s): fully_compacted=%t before_bytes=%d after_bytes=%d\n",
+		mode,
+		stats.FullyCompacted,
+		beforeTotal,
+		afterTotal,
+	)
+	fmt.Printf("remaining-debt: value_rewrite_segments=%d value_rewrite_bytes=%d value_gc_segments=%d value_gc_bytes=%d leaf_pack_generations=%d leaf_pack_bytes=%d leaf_gc_generations=%d leaf_gc_bytes=%d zero_byte_value_log_files=%d\n",
+		stats.RemainingDebt.ValueLogRewriteSegments,
+		stats.RemainingDebt.ValueLogRewriteBytes,
+		stats.RemainingDebt.ValueLogGCSegments,
+		stats.RemainingDebt.ValueLogGCBytes,
+		stats.RemainingDebt.LeafPackGenerations,
+		stats.RemainingDebt.LeafPackBytes,
+		stats.RemainingDebt.LeafGCSegments,
+		stats.RemainingDebt.LeafGCBytes,
+		stats.RemainingDebt.ZeroByteValueLogFiles,
+	)
+	for _, usage := range stats.After {
+		if usage.Name == "total" {
+			continue
+		}
+		fmt.Printf("storage-domain: name=%s bytes=%d files=%d zero_byte_files=%d path=%s\n",
+			usage.Name,
+			usage.Bytes,
+			usage.Files,
+			usage.ZeroByteFiles,
+			usage.Path,
+		)
+	}
+	if stats.ZeroByteValueLogFilesDeleted > 0 {
+		fmt.Printf("cleanup: zero_byte_value_log_files_deleted=%d\n", stats.ZeroByteValueLogFilesDeleted)
+	}
+}
+
+func compactStorageUsageBytes(usages []treedb.CompactStorageUsage, name string) int64 {
+	for _, usage := range usages {
+		if usage.Name == name {
+			return usage.Bytes
+		}
+	}
+	return 0
+}
+
+func warnAdvancedMaintenance(command, scope string) {
+	fmt.Fprintf(os.Stderr, "warning: %s is an advanced %s operation and does not fully compact TreeDB storage; for final disk footprint use `treemap compact <db-dir> -rw`.\n", command, scope)
 }
 
 func runVacuum(dir string, args []string) {
@@ -522,6 +637,7 @@ func runVlogGC(dir string, args []string) {
 	if !*rw {
 		fatalf("vlog-gc requires -rw")
 	}
+	warnAdvancedMaintenance("vlog-gc", "value_vlog-only GC")
 
 	// Use backend DB directly for GC to avoid cached-layer lane initialization,
 	// which can pre-create empty value-log segments and pollute GC stats.
@@ -677,6 +793,7 @@ func runVlogRewrite(dir string, args []string) {
 	if !*rw {
 		fatalf("vlog-rewrite requires -rw")
 	}
+	warnAdvancedMaintenance("vlog-rewrite", "value_vlog-only rewrite")
 	templateMode, err := parseTemplateModeFlag(*templateModeFlag)
 	if err != nil {
 		fatalf("%v", err)
@@ -1230,10 +1347,15 @@ func registerSignalCloser(fn func()) {
 func openTreeDB(dir string, rw bool) *treedb.DB {
 	rootDir := resolveTreeDBRootDir(dir)
 	opts := treedb.Options{Dir: rootDir}
-	applyPersistedFormatConfig(dir, &opts)
 	if !rw {
 		opts.ReadOnly = true
 	}
+	return openTreeDBWithOptions(opts)
+}
+
+func openTreeDBWithOptions(opts treedb.Options) *treedb.DB {
+	opts.Dir = resolveTreeDBRootDir(opts.Dir)
+	applyPersistedFormatConfig(opts.Dir, &opts)
 	db, err := treedb.Open(opts)
 	if err != nil {
 		fatalf("Failed to open DB: %v", err)

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -594,6 +594,25 @@ func printCompactStorageStats(stats treedb.CompactStorageStats, jsonOut bool) {
 		stats.RemainingDebt.LeafGCBytes,
 		stats.RemainingDebt.ZeroByteValueLogFiles,
 	)
+	if !stats.FullyCompacted {
+		if stats.DryRun {
+			fmt.Fprintln(os.Stderr, "warning: compact storage plan found remaining debt; inspect remaining-debt")
+		} else {
+			fmt.Fprintln(os.Stderr, "warning: compact storage finished with remaining debt; inspect remaining-debt")
+		}
+	}
+	for _, usage := range stats.Before {
+		if usage.Name == "total" {
+			continue
+		}
+		fmt.Printf("storage-domain-before: name=%s bytes=%d files=%d zero_byte_files=%d path=%s\n",
+			usage.Name,
+			usage.Bytes,
+			usage.Files,
+			usage.ZeroByteFiles,
+			usage.Path,
+		)
+	}
 	for _, usage := range stats.After {
 		if usage.Name == "total" {
 			continue

--- a/TreeDB/cmd/treemap/main_test.go
+++ b/TreeDB/cmd/treemap/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -174,6 +175,77 @@ func TestCompactCommandsExposeFullStoragePath(t *testing.T) {
 		!strings.Contains(compactOut, "storage-domain: name=value_vlog") {
 		t.Fatalf("compact output missing full-storage report:\n%s", compactOut)
 	}
+}
+
+func TestCompactCommandReplaysCachedWALBeforeCompaction(t *testing.T) {
+	dir := t.TempDir()
+	runCompactPendingWALWriter(t, dir)
+
+	_ = captureStdout(t, func() {
+		runCompact(dir, []string{"-rw"})
+	})
+
+	db, err := treedb.Open(treedb.Options{Dir: dir, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("open read-only after compact: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	got, err := db.Get([]byte("pending-after-crash"))
+	if err != nil {
+		t.Fatalf("get replayed key: %v", err)
+	}
+	if want := bytes.Repeat([]byte("p"), 8192); !bytes.Equal(got, want) {
+		t.Fatalf("replayed value mismatch: got=%dB want=%dB", len(got), len(want))
+	}
+}
+
+func runCompactPendingWALWriter(t *testing.T, dir string) {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestHelperTreemapCompactPendingWALWriter$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"TREEMAP_COMPACT_WAL_HELPER=1",
+		"TREEMAP_COMPACT_WAL_DIR="+dir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compact pending WAL helper failed: %v\n%s", err, out)
+	}
+}
+
+func TestHelperTreemapCompactPendingWALWriter(t *testing.T) {
+	if os.Getenv("TREEMAP_COMPACT_WAL_HELPER") != "1" {
+		t.Skip("helper")
+	}
+	dir := os.Getenv("TREEMAP_COMPACT_WAL_DIR")
+	if dir == "" {
+		t.Fatalf("missing TREEMAP_COMPACT_WAL_DIR")
+	}
+
+	opts := treedb.OptionsFor(treedb.ProfileWALOnFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.FlushThreshold = 1 << 30
+	opts.JournalLanes = 1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.ForcePointers = true
+	opts.ValueLog.PointerThreshold = 1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.SetSync([]byte("pending-after-crash"), bytes.Repeat([]byte("p"), 8192)); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+
+	// Simulate a process crash with cached WAL present and no clean close/checkpoint.
+	os.Exit(0)
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/TreeDB/cmd/treemap/main_test.go
+++ b/TreeDB/cmd/treemap/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -120,6 +122,84 @@ func TestImportJSONLInvalidBase64(t *testing.T) {
 	if _, err := importJSONL(db, f, "auto", 0); err == nil {
 		t.Fatalf("expected invalid base64 import to fail")
 	}
+}
+
+func TestCompactCommandsExposeFullStoragePath(t *testing.T) {
+	if !strings.Contains(usageText, "compact-plan    Preview full storage compaction debt") {
+		t.Fatalf("usageText missing compact-plan full-storage wording: %q", usageText)
+	}
+	if !strings.Contains(usageText, "compact         Run full storage compaction") {
+		t.Fatalf("usageText missing compact full-storage wording: %q", usageText)
+	}
+	if !strings.Contains(usageText, "vlog-gc         Advanced:") || !strings.Contains(usageText, "leafgen-gc      Advanced:") {
+		t.Fatalf("usageText does not mark low-level maintenance advanced: %q", usageText)
+	}
+
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.SetSync([]byte("k"), bytes.Repeat([]byte("v"), 256)); err != nil {
+		_ = db.Close()
+		t.Fatalf("set: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	planOut := captureStdout(t, func() {
+		runCompactPlan(dir, nil)
+	})
+	if !strings.Contains(planOut, "compact-storage (plan):") ||
+		!strings.Contains(planOut, "remaining-debt:") ||
+		!strings.Contains(planOut, "storage-domain-before: name=value_vlog") ||
+		!strings.Contains(planOut, "storage-domain: name=value_vlog") {
+		t.Fatalf("compact-plan output missing full-storage report:\n%s", planOut)
+	}
+
+	compactOut := captureStdout(t, func() {
+		runCompact(dir, []string{"-rw"})
+	})
+	if !strings.Contains(compactOut, "compact-storage (applied):") ||
+		!strings.Contains(compactOut, "remaining-debt:") ||
+		!strings.Contains(compactOut, "storage-domain-before: name=value_vlog") ||
+		!strings.Contains(compactOut, "storage-domain: name=value_vlog") {
+		t.Fatalf("compact output missing full-storage report:\n%s", compactOut)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stdout pipe reader: %v", err)
+	}
+	return buf.String()
 }
 
 func writeDB(t *testing.T, dir string, entries []kv) {

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -108,7 +108,7 @@ const recordFlagGroupedAudit byte = 1 << 0
 
 func runVlogAudit(dir string, args []string) {
 	fs := flag.NewFlagSet("vlog-audit", flag.ExitOnError)
-	rw := fs.Bool("rw", false, "Open read-write (required; may replay WAL or repair files)")
+	rw := fs.Bool("rw", false, "Open read-write to allow recovery before auditing")
 	asJSON := fs.Bool("json", false, "Emit machine-readable JSON")
 	frameStats := fs.Bool("frame-stats", false, "Scan value-log records and report frame-mode + record-length stats")
 	frameTopLengths := fs.Int("frame-top-lengths", 12, "Number of top record lengths (by retained bytes) to report with -frame-stats")
@@ -120,11 +120,7 @@ func runVlogAudit(dir string, args []string) {
 	maxTrackedRIDs := fs.Int("rid-scan-max-tracked", 0, "Maximum distinct RIDs to track in-memory during RID scan (0=unbounded exact mode; may use high memory)")
 	_ = fs.Parse(args)
 
-	if !*rw {
-		fatalf("vlog-audit requires -rw")
-	}
-
-	report, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{
+	report, err := collectValueLogAudit(dir, !*rw, treedbdb.ValueLogRewriteOnlineOptions{
 		MaxSourceSegments:    *maxSegments,
 		MaxSourceBytes:       *maxBytes,
 		MinSegmentStaleRatio: *minStaleRatio,
@@ -278,7 +274,7 @@ func runVlogAudit(dir string, args []string) {
 	}
 }
 
-func collectValueLogAudit(dir string, rewriteOpts treedbdb.ValueLogRewriteOnlineOptions, ridOpts valueLogRIDAuditOptions, frameOpts valueLogFrameScanAuditOptions) (report valueLogAuditReport, err error) {
+func collectValueLogAudit(dir string, readOnly bool, rewriteOpts treedbdb.ValueLogRewriteOnlineOptions, ridOpts valueLogRIDAuditOptions, frameOpts valueLogFrameScanAuditOptions) (report valueLogAuditReport, err error) {
 	report = valueLogAuditReport{Dir: dir}
 	mainDir, err := resolveTreemapMainDir(dir)
 	if err != nil {
@@ -307,7 +303,7 @@ func collectValueLogAudit(dir string, rewriteOpts treedbdb.ValueLogRewriteOnline
 		}
 	}
 
-	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: rootDir, ReadOnly: true})
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: rootDir, ReadOnly: readOnly})
 	if err != nil {
 		return report, err
 	}

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -307,7 +307,7 @@ func collectValueLogAudit(dir string, rewriteOpts treedbdb.ValueLogRewriteOnline
 		}
 	}
 
-	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: rootDir, ReadOnly: false})
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: rootDir, ReadOnly: true})
 	if err != nil {
 		return report, err
 	}

--- a/TreeDB/cmd/treemap/vlog_audit_test.go
+++ b/TreeDB/cmd/treemap/vlog_audit_test.go
@@ -22,7 +22,7 @@ func TestCollectValueLogAudit_WiresDictLookupFromRoot(t *testing.T) {
 	dir := t.TempDir()
 	buildDictCompressedDBForAudit(t, dir)
 
-	report, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
+	report, err := collectValueLogAudit(dir, true, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
 	if err != nil {
 		t.Fatalf("collectValueLogAudit(root): %v", err)
 	}
@@ -50,7 +50,7 @@ func TestCollectValueLogAudit_AcceptsMainDBDir(t *testing.T) {
 	dir := t.TempDir()
 	buildDictCompressedDBForAudit(t, dir)
 
-	report, err := collectValueLogAudit(filepath.Join(dir, "maindb"), treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
+	report, err := collectValueLogAudit(filepath.Join(dir, "maindb"), true, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
 	if err != nil {
 		t.Fatalf("collectValueLogAudit(maindb): %v", err)
 	}
@@ -77,7 +77,7 @@ func TestCollectValueLogAuditDoesNotCreateEmptyValueLogLaneFiles(t *testing.T) {
 	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
 	beforeFiles, beforeZero := countValueLogFilesForTest(t, valueLogDir)
 
-	if _, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{}); err != nil {
+	if _, err := collectValueLogAudit(dir, true, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{}); err != nil {
 		t.Fatalf("collectValueLogAudit: %v", err)
 	}
 
@@ -108,7 +108,7 @@ func TestCollectValueLogAudit_IncludesLeafLogSegments(t *testing.T) {
 		t.Fatalf("Close(leaf log): %v", err)
 	}
 
-	report, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
+	report, err := collectValueLogAudit(dir, true, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
 	if err != nil {
 		t.Fatalf("collectValueLogAudit(with leaf_vlog): %v", err)
 	}
@@ -258,7 +258,7 @@ func TestCollectValueLogAudit_FrameScanIncludesModeAndLengthBreakdown(t *testing
 	dir := t.TempDir()
 	buildDictCompressedDBForAudit(t, dir)
 
-	report, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{
+	report, err := collectValueLogAudit(dir, true, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{
 		Enabled:    true,
 		TopLengths: 8,
 	})

--- a/TreeDB/cmd/treemap/vlog_audit_test.go
+++ b/TreeDB/cmd/treemap/vlog_audit_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,6 +68,22 @@ func TestCollectValueLogAudit_AcceptsMainDBDir(t *testing.T) {
 	}
 	if got := report.Stats["cosmos.db.type"]; got != "treedb" {
 		t.Fatalf("unexpected stats db type from maindb path: %q", got)
+	}
+}
+
+func TestCollectValueLogAuditDoesNotCreateEmptyValueLogLaneFiles(t *testing.T) {
+	dir := t.TempDir()
+	buildDictCompressedDBForAudit(t, dir)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	beforeFiles, beforeZero := countValueLogFilesForTest(t, valueLogDir)
+
+	if _, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{}); err != nil {
+		t.Fatalf("collectValueLogAudit: %v", err)
+	}
+
+	afterFiles, afterZero := countValueLogFilesForTest(t, valueLogDir)
+	if afterFiles != beforeFiles || afterZero != beforeZero {
+		t.Fatalf("value-log file counts changed after audit: before files=%d zero=%d after files=%d zero=%d", beforeFiles, beforeZero, afterFiles, afterZero)
 	}
 }
 
@@ -471,4 +488,30 @@ func buildDictCompressedDBForAudit(t *testing.T, dir string) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+}
+
+func countValueLogFilesForTest(t *testing.T, dir string) (files int, zero int) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "value-") || (!strings.HasSuffix(name, ".log") && !strings.HasSuffix(name, ".log.gz")) {
+			continue
+		}
+		files++
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatalf("Info(%s): %v", name, err)
+		}
+		if info.Size() == 0 {
+			zero++
+		}
+	}
+	return files, zero
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1742,7 +1742,7 @@ func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
 	}
 	domain.indexedAsyncMu.Unlock()
 	if !waitStart.IsZero() {
-		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(time.Since(waitStart)))
+		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(collectionObservedElapsedSince(waitStart)))
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
@@ -3663,6 +3664,112 @@ func TestCollectionCompactRootOverlaysFoldsIntoBaseRoots(t *testing.T) {
 	}
 	if len(reopenedIDs) != 1 || !bytes.Equal(reopenedIDs[0], []byte("u1")) {
 		t.Fatalf("reopened city ids=%q want [u1]", reopenedIDs)
+	}
+}
+
+func TestCollectionCompactStorageFoldsRootsAndCleansStorage(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.DisableSideStores = true
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	doc := []byte(`{"city":"hnl","payload":"` + strings.Repeat("x", 512) + `"}`)
+	if _, err := col.Insert([]byte("u1"), doc); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, _, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"city":"sea","payload":"` + strings.Repeat("y", 512) + `"}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+
+	valueLogDir := backenddb.ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l42-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value-log file: %v", err)
+	}
+
+	stats, err := col.CompactStorage(context.Background(), CompactStorageOptions{
+		LeafPackMinExpectedReclaimBytes: 1,
+		LeafPackMinReclaimPerCopyPPM:    1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if rootStats, ok := stats.RootOverlays["users"]; !ok || rootStats.OverlayRoots == 0 {
+		t.Fatalf("root overlay compaction stats=%+v", stats.RootOverlays)
+	}
+	if !stats.Storage.FullyCompacted {
+		t.Fatalf("storage FullyCompacted=false debt=%+v", stats.Storage.RemainingDebt)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("empty value-log file remains or stat failed: %v", err)
+	}
+
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after compact storage: %v", err)
+	}
+	want := []byte(`{"city":"sea","payload":"` + strings.Repeat("y", 512) + `"}`)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("doc after compact storage=%q want %q", got, want)
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find by index after compact storage: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("ids after compact storage=%q want [u1]", ids)
+	}
+
+	again, err := col.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		LeafPackMinExpectedReclaimBytes: 1,
+		LeafPackMinReclaimPerCopyPPM:    1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan after: %v", err)
+	}
+	if !again.Storage.FullyCompacted {
+		t.Fatalf("post-compact plan FullyCompacted=false debt=%+v", again.Storage.RemainingDebt)
 	}
 }
 

--- a/TreeDB/collections/compact_storage.go
+++ b/TreeDB/collections/compact_storage.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"context"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// CompactStorageOptions controls collection-aware storage compaction.
+type CompactStorageOptions = backenddb.CompactStorageOptions
+
+// CompactStorageStats summarizes collection root-overlay compaction plus the
+// underlying TreeDB storage compaction report.
+type CompactStorageStats struct {
+	RootOverlays map[string]CollectionRootOverlayCompactionStats `json:"root_overlays,omitempty"`
+	Storage      backenddb.CompactStorageStats                   `json:"storage"`
+}
+
+// CompactStorage folds this collection's root overlays and then runs the
+// recommended full TreeDB storage compaction sequence.
+func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	var stats CompactStorageStats
+	if c == nil {
+		return stats, errCollectionNil
+	}
+	if c.db == nil {
+		return stats, errCollectionDBNil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rootStats, err := c.CompactRootOverlays(ctx)
+	if err != nil {
+		return stats, err
+	}
+	stats.RootOverlays = map[string]CollectionRootOverlayCompactionStats{
+		c.meta.Name: rootStats,
+	}
+	storage, err := c.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
+	if err != nil {
+		return stats, err
+	}
+	stats.Storage = storage
+	return stats, nil
+}
+
+// CompactStorage folds root overlays for all known collections and then runs
+// the recommended full TreeDB storage compaction sequence.
+func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	var stats CompactStorageStats
+	if m == nil {
+		return stats, errCollectionManagerNil
+	}
+	if m.db == nil {
+		return stats, errCollectionDBNil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metas, err := m.ListCollections()
+	if err != nil {
+		return stats, err
+	}
+	stats.RootOverlays = make(map[string]CollectionRootOverlayCompactionStats, len(metas))
+	for _, meta := range metas {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		collection, err := m.OpenCollection(meta.Name)
+		if err != nil {
+			return stats, err
+		}
+		rootStats, err := collection.CompactRootOverlays(ctx)
+		if err != nil {
+			return stats, err
+		}
+		stats.RootOverlays[meta.Name] = rootStats
+	}
+	storage, err := m.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
+	if err != nil {
+		return stats, err
+	}
+	stats.Storage = storage
+	return stats, nil
+}

--- a/TreeDB/collections/compact_storage.go
+++ b/TreeDB/collections/compact_storage.go
@@ -16,6 +16,13 @@ type CompactStorageStats struct {
 	Storage      backenddb.CompactStorageStats                   `json:"storage"`
 }
 
+// CompactStoragePlan reports collection-aware storage compaction debt without
+// folding root overlays or mutating storage.
+func (c *Collection) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	opts.DryRun = true
+	return c.CompactStorage(ctx, opts)
+}
+
 // CompactStorage folds this collection's root overlays and then runs the
 // recommended full TreeDB storage compaction sequence.
 func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
@@ -28,6 +35,11 @@ func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOpti
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if opts.DryRun {
+		storage, err := c.db.CompactStoragePlan(ctx, backenddb.CompactStorageOptions(opts))
+		stats.Storage = storage
+		return stats, err
 	}
 	rootStats, err := c.CompactRootOverlays(ctx)
 	if err != nil {
@@ -44,6 +56,13 @@ func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOpti
 	return stats, nil
 }
 
+// CompactStoragePlan reports collection-manager storage compaction debt without
+// folding root overlays or mutating storage.
+func (m *CollectionManager) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	opts.DryRun = true
+	return m.CompactStorage(ctx, opts)
+}
+
 // CompactStorage folds root overlays for all known collections and then runs
 // the recommended full TreeDB storage compaction sequence.
 func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
@@ -56,6 +75,11 @@ func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStor
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if opts.DryRun {
+		storage, err := m.db.CompactStoragePlan(ctx, backenddb.CompactStorageOptions(opts))
+		stats.Storage = storage
+		return stats, err
 	}
 	metas, err := m.ListCollections()
 	if err != nil {

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -44,6 +44,7 @@ func (db *DB) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions
 	if db.backend == nil {
 		return out, ErrClosed
 	}
+	db.applyCachedCompactStorageOptions(&opts, false)
 	return db.backend.CompactStoragePlan(ctx, treedbdb.CompactStorageOptions(opts))
 }
 
@@ -63,14 +64,8 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	success := false
 	defer func() { finishMaintenance(success) }()
 
-	if db.cached != nil {
-		if err := db.Checkpoint(); err != nil {
-			return out, err
-		}
-		if opts.ReserveRIDs == nil {
-			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
-		}
-		opts.DisableZeroByteValueLogCleanup = true
+	if err := db.applyCachedCompactStorageOptions(&opts, true); err != nil {
+		return out, err
 	}
 	stats, err := db.backend.CompactStorage(ctx, treedbdb.CompactStorageOptions(opts))
 	if err != nil {
@@ -78,4 +73,29 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	success = true
 	return CompactStorageStats(stats), nil
+}
+
+func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, checkpoint bool) error {
+	if db == nil || db.cached == nil || opts == nil {
+		return nil
+	}
+	if checkpoint {
+		if err := db.Checkpoint(); err != nil {
+			return err
+		}
+	}
+	if len(opts.ValueLogProtectedPaths) == 0 {
+		opts.ValueLogProtectedPaths = db.cached.ValueLogRetainedPaths()
+	}
+	if len(opts.ValueLogProtectedPaths) == 0 {
+		// Cached-mode callers may have concurrent writers even when there are no
+		// retained paths yet; pass a non-empty slice to activate the backend
+		// rewrite/GC active-segment protection.
+		opts.ValueLogProtectedPaths = []string{""}
+	}
+	if opts.ReserveRIDs == nil {
+		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+	}
+	opts.DisableZeroByteValueLogCleanup = true
+	return nil
 }

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -84,18 +84,42 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 			return err
 		}
 	}
-	if len(opts.ValueLogProtectedPaths) == 0 {
-		opts.ValueLogProtectedPaths = db.cached.ValueLogProtectedPaths()
+	explicitProtectedPaths := append([]string(nil), opts.ValueLogProtectedPaths...)
+	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
+	opts.ValueLogProtectedPathsFunc = func() []string {
+		var out []string
+		if userProtectedPathsFunc != nil {
+			out = appendCompactStorageProtectedPaths(out, userProtectedPathsFunc())
+		}
+		out = appendCompactStorageProtectedPaths(out, db.cached.ValueLogProtectedPaths())
+		if len(out) == 0 && len(explicitProtectedPaths) == 0 {
+			// Cached-mode callers may have concurrent writers even when there
+			// are no protected paths yet; pass a non-empty slice to activate
+			// the backend rewrite/GC active-segment protection.
+			out = append(out, "")
+		}
+		return out
 	}
-	if len(opts.ValueLogProtectedPaths) == 0 {
-		// Cached-mode callers may have concurrent writers even when there are no
-		// protected paths yet; pass a non-empty slice to activate the backend
-		// rewrite/GC active-segment protection.
-		opts.ValueLogProtectedPaths = []string{""}
-	}
+	opts.ValueLogProtectedPaths = explicitProtectedPaths
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
 	opts.DisableZeroByteValueLogCleanup = true
 	return nil
+}
+
+func appendCompactStorageProtectedPaths(dst []string, src []string) []string {
+	for _, path := range src {
+		seen := false
+		for _, existing := range dst {
+			if existing == path {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			dst = append(dst, path)
+		}
+	}
+	return dst
 }

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -70,7 +70,7 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return out, err
 	}
 	stats, err := db.backend.CompactStorage(ctx, treedbdb.CompactStorageOptions(opts))
-	if err != nil {
+	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
 	success = true

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -44,7 +44,9 @@ func (db *DB) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions
 	if db.backend == nil {
 		return out, ErrClosed
 	}
-	db.applyCachedCompactStorageOptions(&opts, false)
+	if err := db.applyCachedCompactStorageOptions(&opts, false); err != nil {
+		return out, err
+	}
 	return db.backend.CompactStoragePlan(ctx, treedbdb.CompactStorageOptions(opts))
 }
 

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -106,7 +106,12 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
-	opts.DisableZeroByteValueLogCleanup = true
+	if checkpoint {
+		// Applied cached compaction can race live writer file creation. Plan
+		// mode is read-only and should still report unprotected empty files as
+		// cleanup debt.
+		opts.DisableZeroByteValueLogCleanup = true
+	}
 	return nil
 }
 

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -106,12 +106,6 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
-	if checkpoint {
-		// Applied cached compaction can race live writer file creation. Plan
-		// mode is read-only and should still report unprotected empty files as
-		// cleanup debt.
-		opts.DisableZeroByteValueLogCleanup = true
-	}
 	return nil
 }
 

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -1,0 +1,81 @@
+package treedb
+
+import (
+	"context"
+
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// CompactStorageMode selects how aggressively CompactStorage should reclaim
+// storage. Empty/default currently maps to full storage compaction.
+type CompactStorageMode = treedbdb.CompactStorageMode
+
+const (
+	CompactStorageDefault = treedbdb.CompactStorageDefault
+	CompactStorageFull    = treedbdb.CompactStorageFull
+	CompactStorageQuick   = treedbdb.CompactStorageQuick
+)
+
+// CompactStorageOptions controls full storage compaction across TreeDB storage
+// domains. Prefer this high-level API over manually sequencing value-log
+// rewrite, value-log GC, leaf-generation pack/GC, and index vacuum.
+type CompactStorageOptions = treedbdb.CompactStorageOptions
+
+// CompactStorageUsage summarizes file usage for a storage domain.
+type CompactStorageUsage = treedbdb.CompactStorageUsage
+
+// CompactStorageDebt summarizes remaining work after planning or compaction.
+type CompactStorageDebt = treedbdb.CompactStorageDebt
+
+// CompactStoragePhaseStats records one phase in a full compaction run.
+type CompactStoragePhaseStats = treedbdb.CompactStoragePhaseStats
+
+// CompactStorageStats is the single high-level report for TreeDB storage
+// compaction and planning.
+type CompactStorageStats = treedbdb.CompactStorageStats
+
+// CompactStoragePlan reports full storage compaction debt without mutating the
+// database. It is safe for read-only opens.
+func (db *DB) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	var out CompactStorageStats
+	if err := db.ensureOpen(); err != nil {
+		return out, err
+	}
+	if db.backend == nil {
+		return out, ErrClosed
+	}
+	return db.backend.CompactStoragePlan(ctx, treedbdb.CompactStorageOptions(opts))
+}
+
+// CompactStorage runs the recommended full storage compaction sequence:
+// value-log rewrite, value-log GC, leaf-generation pack, leaf-generation GC,
+// index vacuum, final GC settle passes, empty value-log file cleanup, and a
+// final audit.
+func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	var out CompactStorageStats
+	if err := db.ensureOpen(); err != nil {
+		return out, err
+	}
+	if db.backend == nil {
+		return out, ErrClosed
+	}
+	_, finishMaintenance := db.beginFullScanMaintenance("compact-storage")
+	success := false
+	defer func() { finishMaintenance(success) }()
+
+	if db.cached != nil {
+		if err := db.Checkpoint(); err != nil {
+			return out, err
+		}
+		if opts.ReserveRIDs == nil {
+			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+		}
+		opts.DisableZeroByteValueLogCleanup = true
+	}
+	stats, err := db.backend.CompactStorage(ctx, treedbdb.CompactStorageOptions(opts))
+	if err != nil {
+		return out, err
+	}
+	success = true
+	return CompactStorageStats(stats), nil
+}

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -85,11 +85,11 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		}
 	}
 	if len(opts.ValueLogProtectedPaths) == 0 {
-		opts.ValueLogProtectedPaths = db.cached.ValueLogRetainedPaths()
+		opts.ValueLogProtectedPaths = db.cached.ValueLogProtectedPaths()
 	}
 	if len(opts.ValueLogProtectedPaths) == 0 {
 		// Cached-mode callers may have concurrent writers even when there are no
-		// retained paths yet; pass a non-empty slice to activate the backend
+		// protected paths yet; pass a non-empty slice to activate the backend
 		// rewrite/GC active-segment protection.
 		opts.ValueLogProtectedPaths = []string{""}
 	}

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -1,0 +1,88 @@
+package treedb
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestCompactStorageCachedAdvancesWritersPastBackendSegments(t *testing.T) {
+	dir := t.TempDir()
+	opts := OptionsFor(ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
+	opts.JournalLanes = 1
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	valueLogDir := backenddb.ValueLogDirPath(dir)
+	seededPath := filepath.Join(valueLogDir, "value-l0-000001.log")
+	writeTestValueLogSegment(t, seededPath, 0, 1, []byte("backend-created-segment"))
+	seededSize := testFileSize(t, seededPath)
+
+	if _, err := db.CompactStorage(context.Background(), CompactStorageOptions{
+		ValueLogProtectedPaths: []string{seededPath},
+	}); err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+
+	if err := db.SetSync([]byte("after-compact"), bytes.Repeat([]byte("v"), 512)); err != nil {
+		t.Fatalf("SetSync after CompactStorage: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint after CompactStorage write: %v", err)
+	}
+
+	if got := testFileSize(t, seededPath); got != seededSize {
+		t.Fatalf("backend-created segment was reused: size=%d want %d", got, seededSize)
+	}
+	nextPath := filepath.Join(valueLogDir, "value-l0-000002.log")
+	if got := testFileSize(t, nextPath); got == 0 {
+		t.Fatalf("next cached value-log segment was not written: %s", nextPath)
+	}
+}
+
+func writeTestValueLogSegment(t *testing.T, path string, lane, seq uint32, value []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir value-log dir: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(lane, seq)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if _, err := w.Append(0, nil, 1, value); err != nil {
+		_ = w.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+}
+
+func testFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -173,6 +173,49 @@ func TestCompactStorageCachedPlanReportsZeroByteValueLogDebt(t *testing.T) {
 	}
 }
 
+func TestCompactStorageCachedDeletesZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	valueLogDir := backenddb.ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l42-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := stats.ZeroByteValueLogFilesDeleted; got != 1 {
+		t.Fatalf("deleted zero-byte files=%d want 1", got)
+	}
+	if got := stats.RemainingDebt.ZeroByteValueLogFiles; got != 0 {
+		t.Fatalf("remaining zero-byte debt=%d want 0", got)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("empty value-log file still exists or stat failed: %v", err)
+	}
+}
+
 func TestCachedValueLogWritersAreLazy(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileFast, dir)

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -3,9 +3,12 @@ package treedb_test
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
@@ -127,5 +130,45 @@ func TestCompactStorageCachedRefreshesProtectedPathsAcrossPhases(t *testing.T) {
 	}
 	if calls < 3 {
 		t.Fatalf("protected path callback calls=%d want at least 3", calls)
+	}
+}
+
+func TestCompactStorageCachedPlanReportsZeroByteValueLogDebt(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	valueLogDir := backenddb.ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l42-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	stats, err := db.CompactStoragePlan(context.Background(), treedb.CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := stats.RemainingDebt.ZeroByteValueLogFiles; got != 1 {
+		t.Fatalf("zero-byte debt=%d want 1", got)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("plan mutated empty value-log file: %v", err)
 	}
 }

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -1,6 +1,7 @@
 package treedb_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -91,5 +92,40 @@ func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 	}
 	if closeErr != nil {
 		t.Fatalf("close reopened: %v", closeErr)
+	}
+}
+
+func TestCompactStorageCachedRefreshesProtectedPathsAcrossPhases(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.SetSync([]byte("k"), bytes.Repeat([]byte("v"), 256)); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	calls := 0
+	if _, err := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+		ValueLogProtectedPathsFunc: func() []string {
+			calls++
+			return []string{"user-protected-path"}
+		},
+	}); err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("protected path callback calls=%d want at least 3", calls)
 	}
 }

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -1,0 +1,69 @@
+package treedb_test
+
+import (
+	"context"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
+	opts.ValueLog.Generational.LeafSegmentTargetBytes = 64 << 10
+	opts.ValueLog.Generational.HotSegmentTargetBytes = 64 << 10
+	opts.ValueLog.Generational.WarmSegmentTargetBytes = 64 << 10
+	opts.ValueLog.Generational.ColdSegmentTargetBytes = 64 << 10
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	db.SetMaintenancePhase(treedb.MaintenancePhaseRestore)
+	writeLeafGenerationChurnWorkload(t, db, 20000, 5000, 4, 96)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("OpenBackend: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	compactOpts := treedb.CompactStorageOptions{
+		LeafPackMinExpectedReclaimBytes: 1,
+		LeafPackMinReclaimPerCopyPPM:    1,
+	}
+	before, err := backend.CompactStoragePlan(context.Background(), compactOpts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan before: %v", err)
+	}
+	if before.RemainingDebt.LeafPackGenerations == 0 || before.RemainingDebt.LeafPackBytes == 0 {
+		t.Fatalf("expected leaf-pack debt before compaction, debt=%+v", before.RemainingDebt)
+	}
+
+	stats, err := backend.CompactStorage(context.Background(), compactOpts)
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+	if len(stats.LeafGenerationPacks) == 0 || !stats.LeafGenerationPacks[0].Ran {
+		t.Fatalf("expected at least one leaf-generation pack run, packs=%+v", stats.LeafGenerationPacks)
+	}
+
+	again, err := backend.CompactStoragePlan(context.Background(), compactOpts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan after: %v", err)
+	}
+	if again.RemainingDebt.LeafPackGenerations != 0 || again.RemainingDebt.LeafPackBytes != 0 {
+		t.Fatalf("leaf-pack debt remains after compaction, debt=%+v", again.RemainingDebt)
+	}
+}

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -172,3 +172,99 @@ func TestCompactStorageCachedPlanReportsZeroByteValueLogDebt(t *testing.T) {
 		t.Fatalf("plan mutated empty value-log file: %v", err)
 	}
 }
+
+func TestCachedValueLogWritersAreLazy(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if total, zero, _ := countValueLogSegmentFiles(t, dir); total != 0 || zero != 0 {
+		_ = db.Close()
+		t.Fatalf("fresh read/write open created value-log files: total=%d zero=%d", total, zero)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close fresh open: %v", err)
+	}
+	if total, zero, _ := countValueLogSegmentFiles(t, dir); total != 0 || zero != 0 {
+		t.Fatalf("fresh close left value-log files: total=%d zero=%d", total, zero)
+	}
+
+	db, err = treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen for write: %v", err)
+	}
+	if err := db.SetSync([]byte("large"), bytes.Repeat([]byte("v"), 256)); err != nil {
+		_ = db.Close()
+		t.Fatalf("set large value: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close after write: %v", err)
+	}
+	total, zero, nonzero := countValueLogSegmentFiles(t, dir)
+	if nonzero == 0 {
+		t.Fatalf("expected one written value-log segment, total=%d zero=%d nonzero=%d", total, zero, nonzero)
+	}
+	if zero != 0 {
+		t.Fatalf("write created inactive zero-byte value-log files: total=%d zero=%d nonzero=%d", total, zero, nonzero)
+	}
+	if total > 4 {
+		t.Fatalf("write created unexpected value-log fan-out: total=%d zero=%d nonzero=%d", total, zero, nonzero)
+	}
+
+	db, err = treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("maintenance-style reopen: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close maintenance-style reopen: %v", err)
+	}
+	afterTotal, afterZero, afterNonzero := countValueLogSegmentFiles(t, dir)
+	if afterTotal != total || afterZero != 0 || afterNonzero != nonzero {
+		t.Fatalf("read/write reopen changed value-log files: before total=%d nonzero=%d after total=%d zero=%d nonzero=%d",
+			total, nonzero, afterTotal, afterZero, afterNonzero)
+	}
+}
+
+func countValueLogSegmentFiles(t *testing.T, rootDir string) (total, zero, nonzero int) {
+	t.Helper()
+	valueLogDir := filepath.Join(rootDir, "maindb", "value_vlog")
+	entries, err := os.ReadDir(valueLogDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, 0
+		}
+		t.Fatalf("read value_vlog dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		matched, err := filepath.Match("value-l*.log", entry.Name())
+		if err != nil {
+			t.Fatalf("match value-log name: %v", err)
+		}
+		if !matched {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatalf("stat value-log segment: %v", err)
+		}
+		total++
+		if info.Size() == 0 {
+			zero++
+		} else {
+			nonzero++
+		}
+	}
+	return total, zero, nonzero
+}

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -14,6 +14,7 @@ func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 	opts.BackgroundCheckpointIdleDuration = -1
 	opts.BackgroundIndexVacuumInterval = -1
 	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
 	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
 	opts.ValueLog.Generational.LeafSegmentTargetBytes = 64 << 10
 	opts.ValueLog.Generational.HotSegmentTargetBytes = 64 << 10
@@ -30,11 +31,16 @@ func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dir})
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dir, DisableSideStores: true})
 	if err != nil {
 		t.Fatalf("OpenBackend: %v", err)
 	}
-	defer func() { _ = cleanup() }()
+	cleanupDone := false
+	defer func() {
+		if !cleanupDone {
+			_ = cleanup()
+		}
+	}()
 
 	compactOpts := treedb.CompactStorageOptions{
 		LeafPackMinExpectedReclaimBytes: 1,
@@ -66,4 +72,8 @@ func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 	if again.RemainingDebt.LeafPackGenerations != 0 || again.RemainingDebt.LeafPackBytes != 0 {
 		t.Fatalf("leaf-pack debt remains after compaction, debt=%+v", again.RemainingDebt)
 	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	cleanupDone = true
 }

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -76,4 +76,20 @@ func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 		t.Fatalf("cleanup: %v", err)
 	}
 	cleanupDone = true
+
+	reopened, err := treedb.Open(treedb.Options{Dir: dir, DisableSideStores: true})
+	if err != nil {
+		t.Fatalf("reopen after CompactStorage: %v", err)
+	}
+	value, err := reopened.Get([]byte("k00000000"))
+	closeErr := reopened.Close()
+	if err != nil {
+		t.Fatalf("get after CompactStorage reopen: %v", err)
+	}
+	if len(value) == 0 {
+		t.Fatal("empty value after CompactStorage reopen")
+	}
+	if closeErr != nil {
+		t.Fatalf("close reopened: %v", closeErr)
+	}
 }

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -329,9 +329,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 	stats.ValueLogRewritePlan = finalAudit.ValueLogRewritePlan
-	stats.ValueLogGC = finalAudit.ValueLogGC
 	stats.LeafGenerationPlan = finalAudit.LeafGenerationPlan
-	stats.LeafGenerationGC = finalAudit.LeafGenerationGC
 	stats.RemainingDebt = finalDebt
 	stats.FullyCompacted = finalDebt.Empty()
 	return stats, nil

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -189,7 +189,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 
-	cleanupLeafLog, err := db.installCompactStorageLeafPageLog(opts)
+	compactLeafLog, cleanupLeafLog, err := db.installCompactStorageLeafPageLog(opts)
 	if err != nil {
 		return stats, err
 	}
@@ -253,6 +253,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 				stats.Phases[len(stats.Phases)-1].SkipReason = pack.SkipReason
 			}
 			break
+		}
+		if err := db.refreshCompactStorageLeafPageLog(compactLeafLog); err != nil {
+			return stats, err
 		}
 		if err := db.runCompactStoragePhase(&stats, fmt.Sprintf("checkpoint-after-%s", phaseName), func() error {
 			return db.Checkpoint()
@@ -767,13 +770,13 @@ func compactStorageValueLogFileID(name string) (uint32, bool) {
 	return fileID, true
 }
 
-func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (func(), error) {
+func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (*rewriteWriter, func(), error) {
 	if db == nil || !db.indexOuterLeavesInValueLog || db.leafPageLog != nil {
-		return func() {}, nil
+		return nil, func() {}, nil
 	}
 	segments, err := listValueLogSegments(db.dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	leafStartSeq := maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
 	writer := newRewriteWriter(ValueLogDirPath(db.dir), 0, 0, 0)
@@ -783,7 +786,7 @@ func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (func
 		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
 			_ = writer.Close()
-			return nil, fmt.Errorf("scan rewrite rid start in %s: %w", db.dir, err)
+			return nil, nil, fmt.Errorf("scan rewrite rid start in %s: %w", db.dir, err)
 		}
 	}
 	writer.ridAlloc = newRewriteRIDAllocator(nextRID, opts.ReserveRIDs)
@@ -795,7 +798,7 @@ func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (func
 			leafDictID, leafDictBytes, leafDictUseRawPages, err := prepareRewriteLeafDict(db, state, db.valueLogDictCurrentForClass, db.valueLogDictLeafPayloadMode, db.valueLogDictLookup, db.valueLogDictPut, db.valueLogDictSetCurrentForClass, db.valueLogDictSetLeafPayloadMode, compression.TrainConfig{})
 			if err != nil {
 				_ = writer.Close()
-				return nil, err
+				return nil, nil, err
 			}
 			if leafDictID != 0 && len(leafDictBytes) > 0 {
 				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
@@ -803,8 +806,20 @@ func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (func
 		}
 	}
 	db.SetLeafPageLog(writer)
-	return func() {
+	return writer, func() {
 		db.SetLeafPageLog(nil)
 		_ = writer.Close()
 	}, nil
+}
+
+func (db *DB) refreshCompactStorageLeafPageLog(writer *rewriteWriter) error {
+	if db == nil || writer == nil || writer.leafDir == "" {
+		return nil
+	}
+	segments, err := listValueLogSegments(db.dir)
+	if err != nil {
+		return err
+	}
+	leafSeq := maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
+	return writer.resetLeafLogSeqAtLeast(leafSeq)
 }

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -310,7 +310,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		})
 	} else {
 		if err := db.runCompactStoragePhase(&stats, "prune-empty-value-log-files", func() error {
-			deleted, err := db.pruneZeroByteValueLogFiles()
+			deleted, err := db.pruneZeroByteValueLogFiles(compactStorageValueLogProtectedPaths(opts))
 			stats.ZeroByteValueLogFilesDeleted = deleted
 			return err
 		}); err != nil {
@@ -497,7 +497,11 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		return debt, err
 	}
 	if !opts.DisableZeroByteValueLogCleanup {
-		debt.ZeroByteValueLogFiles = zeroByteValueLogFilesFromUsage(usage)
+		zeroBytes, err := zeroByteValueLogFilesFromUsage(usage, protectedPaths)
+		if err != nil {
+			return debt, err
+		}
+		debt.ZeroByteValueLogFiles = zeroBytes
 	}
 	return debt, nil
 }
@@ -585,13 +589,13 @@ func compactStoragePathUsage(name, path string) (CompactStorageUsage, error) {
 	return usage, err
 }
 
-func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage) int {
+func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage, protectedPaths []string) (int, error) {
 	for _, domain := range usage {
 		if domain.Name == "value_vlog" {
-			return domain.ZeroByteFiles
+			return zeroByteValueLogSegmentFiles(domain.Path, protectedPaths)
 		}
 	}
-	return 0
+	return 0, nil
 }
 
 func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
@@ -624,7 +628,7 @@ func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 	return out
 }
 
-func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
+func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 	layout := resolveStorageLayout(db.dir)
 	entries, err := os.ReadDir(layout.valueVLogDir)
 	if err != nil {
@@ -633,16 +637,20 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 		}
 		return 0, err
 	}
+	protected := compactStorageProtectedPathSet(protectedPaths)
 	deleted := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
-		if !strings.HasPrefix(name, "value-l") || !strings.HasSuffix(name, ".log") {
+		if !compactStorageIsValueLogSegmentName(name) {
 			continue
 		}
 		path := filepath.Join(layout.valueVLogDir, name)
+		if _, ok := protected[filepath.Clean(path)]; ok {
+			continue
+		}
 		info, err := entry.Info()
 		if err != nil {
 			return deleted, err
@@ -685,6 +693,54 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 		}
 	}
 	return deleted, nil
+}
+
+func zeroByteValueLogSegmentFiles(dir string, protectedPaths []string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	protected := compactStorageProtectedPathSet(protectedPaths)
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !compactStorageIsValueLogSegmentName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if _, ok := protected[filepath.Clean(path)]; ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return 0, err
+		}
+		if info.Size() == 0 {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func compactStorageProtectedPathSet(paths []string) map[string]struct{} {
+	protected := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		protected[filepath.Clean(path)] = struct{}{}
+	}
+	return protected
+}
+
+func compactStorageIsValueLogSegmentName(name string) bool {
+	if !strings.HasPrefix(name, "value-l") || !strings.HasSuffix(name, ".log") {
+		return false
+	}
+	_, ok := compactStorageValueLogFileID(name)
+	return ok
 }
 
 func compactStorageValueLogFileID(name string) (uint32, bool) {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -82,7 +82,7 @@ type CompactStorageDebt struct {
 	ValueLogGCBytes         int64 `json:"value_log_gc_bytes"`
 	LeafPackGenerations     int   `json:"leaf_pack_generations"`
 	LeafPackBytes           int64 `json:"leaf_pack_bytes"`
-	LeafGCSegments          int   `json:"leaf_gc_generations"`
+	LeafGCGenerations       int   `json:"leaf_gc_generations"`
 	LeafGCBytes             int64 `json:"leaf_gc_bytes"`
 	ZeroByteValueLogFiles   int   `json:"zero_byte_value_log_files"`
 }
@@ -95,7 +95,7 @@ func (d CompactStorageDebt) Empty() bool {
 		d.ValueLogGCBytes == 0 &&
 		d.LeafPackGenerations == 0 &&
 		d.LeafPackBytes == 0 &&
-		d.LeafGCSegments == 0 &&
+		d.LeafGCGenerations == 0 &&
 		d.LeafGCBytes == 0 &&
 		d.ZeroByteValueLogFiles == 0
 }
@@ -352,7 +352,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if err != nil {
 			return err
 		}
-		if debt.ValueLogGCSegments == 0 && debt.LeafGCSegments == 0 {
+		if debt.ValueLogGCSegments == 0 && debt.LeafGCGenerations == 0 {
 			return nil
 		}
 		if debt.ValueLogGCSegments > 0 {
@@ -370,7 +370,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 				return err
 			}
 		}
-		if debt.LeafGCSegments > 0 {
+		if debt.LeafGCGenerations > 0 {
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, lockMaintenance)
@@ -495,7 +495,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		return debt, err
 	}
 	stats.LeafGenerationGC = leafGC
-	debt.LeafGCSegments = leafGC.GenerationsEligible
+	debt.LeafGCGenerations = leafGC.GenerationsEligible
 	debt.LeafGCBytes = leafGC.BytesEligible
 
 	usage, err := compactStorageUsage(db.dir)

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -665,24 +665,30 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 			continue
 		}
 		if db.valueLogManager != nil {
-			if fileID, ok := compactStorageValueLogFileID(name); ok && db.valueLogManager.HasSegment(fileID) {
-				if err := db.valueLogManager.MarkZombie(fileID); err != nil {
+			if fileID, ok := compactStorageValueLogFileID(name); ok {
+				tracked, _, err := db.valueLogManager.MarkZombieIfTracked(fileID)
+				if err != nil {
 					return deleted, err
 				}
-				if err := db.publishValueLogSetNoRefresh(); err != nil {
-					return deleted, err
-				}
-				if _, err := db.valueLogManager.RemoveSegmentIfUnpinned(fileID); err != nil {
-					return deleted, err
-				}
-				if _, err := os.Stat(path); err != nil {
-					if os.IsNotExist(err) {
+				if tracked {
+					if err := db.publishValueLogSetNoRefresh(); err != nil {
+						return deleted, err
+					}
+					if removed, err := db.valueLogManager.RemoveSegmentIfUnpinned(fileID); err != nil {
+						return deleted, err
+					} else if removed {
 						deleted++
 						continue
 					}
-					return deleted, err
+					if _, err := os.Stat(path); err != nil {
+						if os.IsNotExist(err) {
+							deleted++
+							continue
+						}
+						return deleted, err
+					}
+					continue
 				}
-				continue
 			}
 		}
 		if err := os.Remove(path); err != nil {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -196,14 +196,13 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	defer cleanupLeafLog()
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageValueLogProtectedPaths(opts)
-		rewrite, err := db.ValueLogRewriteOnline(ctx, ValueLogRewriteOnlineOptions{
-			BatchSize:       opts.ValueLogRewriteBatchSize,
-			SyncEachBatch:   opts.SyncEachPhase,
-			MaxSegmentBytes: opts.ValueLogRewriteMaxSegmentBytes,
-			LocalityPolicy:  ValueLogRewriteLocalityGrouped,
-			ReserveRIDs:     opts.ReserveRIDs,
-			ProtectedPaths:  protectedPaths,
-		})
+		rewriteOpts := compactStorageRewritePlanOptions(protectedPaths)
+		rewriteOpts.BatchSize = opts.ValueLogRewriteBatchSize
+		rewriteOpts.SyncEachBatch = opts.SyncEachPhase
+		rewriteOpts.MaxSegmentBytes = opts.ValueLogRewriteMaxSegmentBytes
+		rewriteOpts.LocalityPolicy = ValueLogRewriteLocalityGrouped
+		rewriteOpts.ReserveRIDs = opts.ReserveRIDs
+		rewrite, err := db.ValueLogRewriteOnline(ctx, rewriteOpts)
 		stats.ValueLogRewrite = rewrite
 		return err
 	}); err != nil {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -38,6 +38,7 @@ type CompactStorageOptions struct {
 	// Value-log rewrite knobs.
 	ValueLogRewriteBatchSize       int
 	ValueLogRewriteMaxSegmentBytes int64
+	ValueLogProtectedPaths         []string
 
 	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
 	// single compaction request finite while still draining ordinary debt.
@@ -180,7 +181,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 
-	cleanupLeafLog, err := db.installCompactStorageLeafPageLog()
+	cleanupLeafLog, err := db.installCompactStorageLeafPageLog(opts)
 	if err != nil {
 		return stats, err
 	}
@@ -192,6 +193,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 			MaxSegmentBytes: opts.ValueLogRewriteMaxSegmentBytes,
 			LocalityPolicy:  ValueLogRewriteLocalityGrouped,
 			ReserveRIDs:     opts.ReserveRIDs,
+			ProtectedPaths:  opts.ValueLogProtectedPaths,
 		})
 		stats.ValueLogRewrite = rewrite
 		return err
@@ -205,7 +207,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "value-log-gc", func() error {
-		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{})
+		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: opts.ValueLogProtectedPaths})
 		stats.ValueLogGC = gc
 		return err
 	}); err != nil {
@@ -341,7 +343,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.ValueLogGCSegments > 0 {
 			phaseName := fmt.Sprintf("settle-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{})
+				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: opts.ValueLogProtectedPaths})
 				stats.ValueLogGC = gc
 				return err
 			}); err != nil {
@@ -393,18 +395,36 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 	if opts.LeafPackMaxGenerationsPerPass < 0 {
 		opts.LeafPackMaxGenerationsPerPass = 0
 	}
+	if opts.LeafPackMaxGenerationsPerPass == 0 {
+		if opts.Mode == CompactStorageQuick {
+			opts.LeafPackMaxGenerationsPerPass = 8
+		} else {
+			opts.LeafPackMaxGenerationsPerPass = 64
+		}
+	}
+	if opts.LeafPackMaxBytesToCopyPerPass < 0 {
+		opts.LeafPackMaxBytesToCopyPerPass = 0
+	}
+	if opts.LeafPackMaxBytesToCopyPerPass == 0 {
+		if opts.Mode == CompactStorageQuick {
+			opts.LeafPackMaxBytesToCopyPerPass = 256 << 20
+		} else {
+			opts.LeafPackMaxBytesToCopyPerPass = 1 << 30
+		}
+	}
 	return opts
 }
 
-func compactStorageRewritePlanOptions() ValueLogRewriteOnlineOptions {
+func compactStorageRewritePlanOptions(opts CompactStorageOptions) ValueLogRewriteOnlineOptions {
 	return ValueLogRewriteOnlineOptions{
 		MinSegmentStaleBytes: 1,
+		ProtectedPaths:       opts.ValueLogProtectedPaths,
 	}
 }
 
 func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
-	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions())
+	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(opts))
 	if err != nil {
 		return debt, err
 	}
@@ -415,7 +435,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.ValueLogRewriteBytes = rewritePlan.SelectedBytesTotal
 	}
 
-	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true})
+	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true, ProtectedPaths: opts.ValueLogProtectedPaths})
 	if err != nil {
 		return debt, err
 	}
@@ -449,7 +469,9 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	if err != nil {
 		return debt, err
 	}
-	debt.ZeroByteValueLogFiles = zeroByteValueLogFilesFromUsage(usage)
+	if !opts.DisableZeroByteValueLogCleanup {
+		debt.ZeroByteValueLogFiles = zeroByteValueLogFilesFromUsage(usage)
+	}
 	return debt, nil
 }
 
@@ -580,8 +602,11 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 				continue
 			}
 		}
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return deleted, err
+		if err := os.Remove(path); err != nil {
+			if !os.IsNotExist(err) {
+				return deleted, err
+			}
+			continue
 		}
 		deleted++
 	}
@@ -608,7 +633,7 @@ func compactStorageValueLogFileID(name string) (uint32, bool) {
 	return fileID, true
 }
 
-func (db *DB) installCompactStorageLeafPageLog() (func(), error) {
+func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (func(), error) {
 	if db == nil || !db.indexOuterLeavesInValueLog || db.leafPageLog != nil {
 		return func() {}, nil
 	}
@@ -619,6 +644,15 @@ func (db *DB) installCompactStorageLeafPageLog() (func(), error) {
 	leafStartSeq := maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
 	writer := newRewriteWriter(ValueLogDirPath(db.dir), 0, 0, 0)
 	writer.ConfigureLeafLog(LeafLogDirPath(db.dir), rewriteLeafLogLaneID, leafStartSeq)
+	nextRID := uint64(0)
+	if opts.ReserveRIDs == nil {
+		nextRID, err = rewriteRIDStartScanner(segments)
+		if err != nil {
+			_ = writer.Close()
+			return nil, fmt.Errorf("scan rewrite rid start in %s: %w", db.dir, err)
+		}
+	}
+	writer.ridAlloc = newRewriteRIDAllocator(nextRID, opts.ReserveRIDs)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -180,6 +180,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}); err != nil {
 		return stats, err
 	}
+	if err := db.prepareCompactStorageRIDAllocator(&opts); err != nil {
+		return stats, err
+	}
 
 	cleanupLeafLog, err := db.installCompactStorageLeafPageLog(opts)
 	if err != nil {
@@ -371,6 +374,23 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 			}
 		}
 	}
+	return nil
+}
+
+func (db *DB) prepareCompactStorageRIDAllocator(opts *CompactStorageOptions) error {
+	if db == nil || opts == nil || opts.ReserveRIDs != nil || !db.indexOuterLeavesInValueLog {
+		return nil
+	}
+	segments, err := rewriteWALSegmentsLister(db.dir)
+	if err != nil {
+		return fmt.Errorf("list value-log segments for compact storage rid selection in %s: %w", db.dir, err)
+	}
+	nextRID, err := rewriteRIDStartScanner(segments)
+	if err != nil {
+		return fmt.Errorf("scan compact storage rid start in %s: %w", db.dir, err)
+	}
+	allocator := newRewriteRIDAllocator(nextRID, nil)
+	opts.ReserveRIDs = allocator.Reserve
 	return nil
 }
 

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -39,6 +39,11 @@ type CompactStorageOptions struct {
 	ValueLogRewriteBatchSize       int
 	ValueLogRewriteMaxSegmentBytes int64
 	ValueLogProtectedPaths         []string
+	// ValueLogProtectedPathsFunc refreshes online protected paths before each
+	// value-log rewrite/GC audit or applied phase. Live cached-mode callers use
+	// this so foreground writer rotations that happen during a multi-phase
+	// compaction cannot leave newly queued value-log segments unprotected.
+	ValueLogProtectedPathsFunc func() []string
 
 	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
 	// single compaction request finite while still draining ordinary debt.
@@ -190,13 +195,14 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	defer cleanupLeafLog()
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
+		protectedPaths := compactStorageValueLogProtectedPaths(opts)
 		rewrite, err := db.ValueLogRewriteOnline(ctx, ValueLogRewriteOnlineOptions{
 			BatchSize:       opts.ValueLogRewriteBatchSize,
 			SyncEachBatch:   opts.SyncEachPhase,
 			MaxSegmentBytes: opts.ValueLogRewriteMaxSegmentBytes,
 			LocalityPolicy:  ValueLogRewriteLocalityGrouped,
 			ReserveRIDs:     opts.ReserveRIDs,
-			ProtectedPaths:  opts.ValueLogProtectedPaths,
+			ProtectedPaths:  protectedPaths,
 		})
 		stats.ValueLogRewrite = rewrite
 		return err
@@ -210,7 +216,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "value-log-gc", func() error {
-		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: opts.ValueLogProtectedPaths})
+		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)})
 		stats.ValueLogGC = gc
 		return err
 	}); err != nil {
@@ -346,7 +352,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.ValueLogGCSegments > 0 {
 			phaseName := fmt.Sprintf("settle-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: opts.ValueLogProtectedPaths})
+				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)})
 				stats.ValueLogGC = gc
 				return err
 			}); err != nil {
@@ -435,16 +441,17 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 	return opts
 }
 
-func compactStorageRewritePlanOptions(opts CompactStorageOptions) ValueLogRewriteOnlineOptions {
+func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOnlineOptions {
 	return ValueLogRewriteOnlineOptions{
 		MinSegmentStaleBytes: 1,
-		ProtectedPaths:       opts.ValueLogProtectedPaths,
+		ProtectedPaths:       protectedPaths,
 	}
 }
 
 func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
-	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(opts))
+	protectedPaths := compactStorageValueLogProtectedPaths(opts)
+	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(protectedPaths))
 	if err != nil {
 		return debt, err
 	}
@@ -455,7 +462,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.ValueLogRewriteBytes = rewritePlan.SelectedBytesTotal
 	}
 
-	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true, ProtectedPaths: opts.ValueLogProtectedPaths})
+	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true, ProtectedPaths: protectedPaths})
 	if err != nil {
 		return debt, err
 	}
@@ -587,6 +594,36 @@ func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage) int {
 	return 0
 }
 
+func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
+	if opts.ValueLogProtectedPathsFunc == nil {
+		return opts.ValueLogProtectedPaths
+	}
+	dynamic := opts.ValueLogProtectedPathsFunc()
+	if len(opts.ValueLogProtectedPaths) == 0 {
+		return dynamic
+	}
+	if len(dynamic) == 0 {
+		return opts.ValueLogProtectedPaths
+	}
+	seen := make(map[string]struct{}, len(opts.ValueLogProtectedPaths)+len(dynamic))
+	out := make([]string, 0, len(opts.ValueLogProtectedPaths)+len(dynamic))
+	for _, path := range opts.ValueLogProtectedPaths {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	for _, path := range dynamic {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	return out
+}
+
 func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 	layout := resolveStorageLayout(db.dir)
 	entries, err := os.ReadDir(layout.valueVLogDir)
@@ -615,10 +652,22 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 		}
 		if db.valueLogManager != nil {
 			if fileID, ok := compactStorageValueLogFileID(name); ok && db.valueLogManager.HasSegment(fileID) {
-				if err := db.valueLogManager.RemoveSegment(fileID); err != nil {
+				if err := db.valueLogManager.MarkZombie(fileID); err != nil {
 					return deleted, err
 				}
-				deleted++
+				if err := db.publishValueLogSetNoRefresh(); err != nil {
+					return deleted, err
+				}
+				if _, err := db.valueLogManager.RemoveSegmentIfUnpinned(fileID); err != nil {
+					return deleted, err
+				}
+				if _, err := os.Stat(path); err != nil {
+					if os.IsNotExist(err) {
+						deleted++
+						continue
+					}
+					return deleted, err
+				}
 				continue
 			}
 		}

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
 // CompactStorageMode selects how aggressively CompactStorage should reclaim
@@ -262,12 +264,24 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 
+	indexVacuumSkipped := false
 	if err := db.runCompactStoragePhase(&stats, "index-vacuum", func() error {
-		return db.VacuumIndexOnline(ctx)
+		indexVacuumSkipped = false
+		err := db.VacuumIndexOnline(ctx)
+		if errors.Is(err, ErrVacuumUnsupported) {
+			indexVacuumSkipped = true
+			return nil
+		}
+		return err
 	}); err != nil {
 		return stats, err
 	}
-	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-index-vacuum", func() error {
+	if indexVacuumSkipped {
+		if len(stats.Phases) > 0 {
+			stats.Phases[len(stats.Phases)-1].Skipped = true
+			stats.Phases[len(stats.Phases)-1].SkipReason = ErrVacuumUnsupported.Error()
+		}
+	} else if err := db.runCompactStoragePhase(&stats, "checkpoint-after-index-vacuum", func() error {
 		return db.Checkpoint()
 	}); err != nil {
 		return stats, err
@@ -557,6 +571,15 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 		if info.Size() != 0 {
 			continue
 		}
+		if db.valueLogManager != nil {
+			if fileID, ok := compactStorageValueLogFileID(name); ok && db.valueLogManager.HasSegment(fileID) {
+				if err := db.valueLogManager.RemoveSegment(fileID); err != nil {
+					return deleted, err
+				}
+				deleted++
+				continue
+			}
+		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return deleted, err
 		}
@@ -568,6 +591,21 @@ func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
 		}
 	}
 	return deleted, nil
+}
+
+func compactStorageValueLogFileID(name string) (uint32, bool) {
+	lane, seq, valueLog, ok := parseLogSeq(name)
+	if !ok || !valueLog || lane < 0 {
+		return 0, false
+	}
+	if uint64(lane) > uint64(^uint32(0)) || seq > uint64(^uint32(0)) {
+		return 0, false
+	}
+	fileID, err := valuelog.EncodeFileID(uint32(lane), uint32(seq))
+	if err != nil {
+		return 0, false
+	}
+	return fileID, true
 }
 
 func (db *DB) installCompactStorageLeafPageLog() (func(), error) {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -60,8 +60,8 @@ type CompactStorageOptions struct {
 	ReserveRIDs func(count int) (start uint64, err error)
 
 	// DisableZeroByteValueLogCleanup leaves zero-byte value_vlog segment files in
-	// place. Live cached-mode wrappers use this because their current writer
-	// files may be open even when empty.
+	// place. This is intended for specialty diagnostics that need to inspect
+	// empty segment files after compaction.
 	DisableZeroByteValueLogCleanup bool
 }
 
@@ -162,6 +162,12 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if db.readOnly && !opts.DryRun {
 		return stats, ErrReadOnly
 	}
+	maintenanceLocked := false
+	if !opts.DryRun {
+		db.maintenanceMu.Lock()
+		maintenanceLocked = true
+		defer db.maintenanceMu.Unlock()
+	}
 
 	before, err := compactStorageUsage(db.dir)
 	if err != nil {
@@ -169,7 +175,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	stats.Before = before
 
-	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats)
+	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats, !maintenanceLocked)
 	if err != nil {
 		return stats, err
 	}
@@ -202,7 +208,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		rewriteOpts.MaxSegmentBytes = opts.ValueLogRewriteMaxSegmentBytes
 		rewriteOpts.LocalityPolicy = ValueLogRewriteLocalityGrouped
 		rewriteOpts.ReserveRIDs = opts.ReserveRIDs
-		rewrite, err := db.ValueLogRewriteOnline(ctx, rewriteOpts)
+		rewrite, err := db.valueLogRewriteOnline(ctx, rewriteOpts, !maintenanceLocked)
 		stats.ValueLogRewrite = rewrite
 		return err
 	}); err != nil {
@@ -215,7 +221,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "value-log-gc", func() error {
-		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)})
+		gc, err := db.valueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)}, !maintenanceLocked)
 		stats.ValueLogGC = gc
 		return err
 	}); err != nil {
@@ -232,7 +238,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		phaseName := fmt.Sprintf("leaf-generation-pack-%d", pass+1)
 		if err := db.runCompactStoragePhase(&stats, phaseName, func() error {
 			var err error
-			pack, err = db.LeafGenerationPackRunOnce(ctx, LeafGenerationPackFromPlanOptions{
+			pack, err = db.leafGenerationPackRunOnce(ctx, LeafGenerationPackFromPlanOptions{
 				Sync:                       opts.SyncEachPhase,
 				MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
 				MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
@@ -241,7 +247,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 				MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
 				ReserveRIDs:                opts.ReserveRIDs,
 				LeafFrameK:                 opts.LeafPackLeafFrameK,
-			})
+			}, !maintenanceLocked)
 			return err
 		}); err != nil {
 			return stats, err
@@ -265,7 +271,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "leaf-generation-gc", func() error {
-		gc, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{})
+		gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, !maintenanceLocked)
 		stats.LeafGenerationGC = gc
 		return err
 	}); err != nil {
@@ -280,7 +286,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	indexVacuumSkipped := false
 	if err := db.runCompactStoragePhase(&stats, "index-vacuum", func() error {
 		indexVacuumSkipped = false
-		err := db.VacuumIndexOnline(ctx)
+		err := db.vacuumIndexOnline(ctx, !maintenanceLocked)
 		if errors.Is(err, ErrVacuumUnsupported) {
 			indexVacuumSkipped = true
 			return nil
@@ -300,7 +306,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 
-	if err := db.settleCompactStorageGC(ctx, opts, &stats); err != nil {
+	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked); err != nil {
 		return stats, err
 	}
 
@@ -327,7 +333,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	stats.After = after
 
 	var finalAudit CompactStorageStats
-	finalDebt, err := db.populateCompactStorageAudit(ctx, opts, &finalAudit)
+	finalDebt, err := db.populateCompactStorageAudit(ctx, opts, &finalAudit, !maintenanceLocked)
 	if err != nil {
 		return stats, err
 	}
@@ -338,11 +344,11 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	return stats, nil
 }
 
-func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) error {
+func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool) error {
 	const maxSettlePasses = 4
 	for pass := 0; pass < maxSettlePasses; pass++ {
 		var audit CompactStorageStats
-		debt, err := db.populateCompactStorageAudit(ctx, opts, &audit)
+		debt, err := db.populateCompactStorageAudit(ctx, opts, &audit, lockMaintenance)
 		if err != nil {
 			return err
 		}
@@ -352,7 +358,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.ValueLogGCSegments > 0 {
 			phaseName := fmt.Sprintf("settle-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)})
+				gc, err := db.valueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)}, lockMaintenance)
 				stats.ValueLogGC = gc
 				return err
 			}); err != nil {
@@ -367,7 +373,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.LeafGCSegments > 0 {
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				gc, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{})
+				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, lockMaintenance)
 				stats.LeafGenerationGC = gc
 				return err
 			}); err != nil {
@@ -448,7 +454,7 @@ func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOn
 	}
 }
 
-func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) (CompactStorageDebt, error) {
+func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
 	protectedPaths := compactStorageValueLogProtectedPaths(opts)
 	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(protectedPaths))
@@ -462,7 +468,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.ValueLogRewriteBytes = rewritePlan.SelectedBytesTotal
 	}
 
-	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true, ProtectedPaths: protectedPaths})
+	valueGC, err := db.valueLogGC(ctx, ValueLogGCOptions{DryRun: true, ProtectedPaths: protectedPaths}, lockMaintenance)
 	if err != nil {
 		return debt, err
 	}
@@ -484,7 +490,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.LeafPackBytes = leafPlan.ExpectedReclaimBytes
 	}
 
-	leafGC, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{DryRun: true})
+	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{DryRun: true}, lockMaintenance)
 	if err != nil {
 		return debt, err
 	}
@@ -528,7 +534,7 @@ func compactStorageUsage(dir string) ([]CompactStorageUsage, error) {
 		name string
 		path string
 	}{
-		{name: "index", path: filepath.Join(dir, "index.db")},
+		{name: "index", path: filepath.Join(dir, indexFileName)},
 		{name: "wal", path: layout.walDir},
 		{name: "value_vlog", path: layout.valueVLogDir},
 		{name: "leaf_vlog", path: layout.leafVLogDir},

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1,0 +1,604 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+)
+
+// CompactStorageMode selects how aggressively CompactStorage should reclaim
+// storage. Empty/default currently maps to full storage compaction.
+type CompactStorageMode string
+
+const (
+	CompactStorageDefault CompactStorageMode = ""
+	CompactStorageFull    CompactStorageMode = "full"
+	CompactStorageQuick   CompactStorageMode = "quick"
+)
+
+// CompactStorageOptions controls full storage compaction across TreeDB storage
+// domains. Prefer this high-level API over manually sequencing value-log
+// rewrite, value-log GC, leaf-generation pack/GC, and index vacuum.
+type CompactStorageOptions struct {
+	Mode CompactStorageMode
+
+	// DryRun reports the current compaction plan without mutating storage.
+	DryRun bool
+
+	// SyncEachPhase asks rewrite/pack phases to fsync each durable batch.
+	SyncEachPhase bool
+
+	// Value-log rewrite knobs.
+	ValueLogRewriteBatchSize       int
+	ValueLogRewriteMaxSegmentBytes int64
+
+	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
+	// single compaction request finite while still draining ordinary debt.
+	LeafPackMaxPasses                  int
+	LeafPackMaxGenerationsPerPass      int
+	LeafPackMaxBytesToCopyPerPass      int64
+	LeafPackMinExpectedReclaimBytes    int64
+	LeafPackMinExpectedReclaimRatioPPM int
+	LeafPackMinReclaimPerCopyPPM       int
+	LeafPackLeafFrameK                 int
+
+	// ReserveRIDs lets cached-mode callers share the live RID allocator with
+	// foreground writers.
+	ReserveRIDs func(count int) (start uint64, err error)
+
+	// DisableZeroByteValueLogCleanup leaves zero-byte value_vlog segment files in
+	// place. Live cached-mode wrappers use this because their current writer
+	// files may be open even when empty.
+	DisableZeroByteValueLogCleanup bool
+}
+
+// CompactStorageUsage summarizes file usage for a storage domain.
+type CompactStorageUsage struct {
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	Bytes         int64  `json:"bytes"`
+	Files         int    `json:"files"`
+	ZeroByteFiles int    `json:"zero_byte_files"`
+}
+
+// CompactStorageDebt summarizes remaining work after planning or compaction.
+type CompactStorageDebt struct {
+	ValueLogRewriteSegments int   `json:"value_log_rewrite_segments"`
+	ValueLogRewriteBytes    int64 `json:"value_log_rewrite_bytes"`
+	ValueLogGCSegments      int   `json:"value_log_gc_segments"`
+	ValueLogGCBytes         int64 `json:"value_log_gc_bytes"`
+	LeafPackGenerations     int   `json:"leaf_pack_generations"`
+	LeafPackBytes           int64 `json:"leaf_pack_bytes"`
+	LeafGCSegments          int   `json:"leaf_gc_generations"`
+	LeafGCBytes             int64 `json:"leaf_gc_bytes"`
+	ZeroByteValueLogFiles   int   `json:"zero_byte_value_log_files"`
+}
+
+// Empty reports whether the storage audit found no meaningful compaction debt.
+func (d CompactStorageDebt) Empty() bool {
+	return d.ValueLogRewriteSegments == 0 &&
+		d.ValueLogRewriteBytes == 0 &&
+		d.ValueLogGCSegments == 0 &&
+		d.ValueLogGCBytes == 0 &&
+		d.LeafPackGenerations == 0 &&
+		d.LeafPackBytes == 0 &&
+		d.LeafGCSegments == 0 &&
+		d.LeafGCBytes == 0 &&
+		d.ZeroByteValueLogFiles == 0
+}
+
+// CompactStoragePhaseStats records one phase in a full compaction run.
+type CompactStoragePhaseStats struct {
+	Name          string `json:"name"`
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkipReason    string `json:"skip_reason,omitempty"`
+	WallTimeNanos int64  `json:"wall_time_nanos"`
+}
+
+// CompactStorageStats is the single high-level report for TreeDB storage
+// compaction and planning.
+type CompactStorageStats struct {
+	Mode   CompactStorageMode `json:"mode"`
+	DryRun bool               `json:"dry_run"`
+
+	Before []CompactStorageUsage `json:"before"`
+	After  []CompactStorageUsage `json:"after"`
+
+	Phases []CompactStoragePhaseStats `json:"phases,omitempty"`
+
+	ValueLogRewritePlan ValueLogRewritePlan              `json:"value_log_rewrite_plan"`
+	ValueLogRewrite     ValueLogRewriteStats             `json:"value_log_rewrite,omitempty"`
+	ValueLogGC          ValueLogGCStats                  `json:"value_log_gc"`
+	LeafGenerationPlan  LeafGenerationPlan               `json:"leaf_generation_plan"`
+	LeafGenerationPacks []LeafGenerationPackRunOnceStats `json:"leaf_generation_packs,omitempty"`
+	LeafGenerationGC    LeafGenerationGCStats            `json:"leaf_generation_gc"`
+
+	ZeroByteValueLogFilesDeleted int `json:"zero_byte_value_log_files_deleted,omitempty"`
+
+	RemainingDebt  CompactStorageDebt `json:"remaining_debt"`
+	FullyCompacted bool               `json:"fully_compacted"`
+}
+
+// CompactStoragePlan reports full storage compaction debt without mutating the
+// database. It is safe for read-only opens.
+func (db *DB) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	opts.DryRun = true
+	return db.compactStorage(ctx, opts)
+}
+
+// CompactStorage runs the recommended full storage compaction sequence:
+// value-log rewrite, value-log GC, leaf-generation pack, leaf-generation GC,
+// index vacuum, final GC settle passes, empty value-log file cleanup, and a
+// final audit.
+func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	opts.DryRun = false
+	return db.compactStorage(ctx, opts)
+}
+
+func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
+	var stats CompactStorageStats
+	if db == nil {
+		return stats, fmt.Errorf("missing db")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts = normalizeCompactStorageOptions(opts)
+	stats.Mode = opts.Mode
+	stats.DryRun = opts.DryRun
+	if db.readOnly && !opts.DryRun {
+		return stats, ErrReadOnly
+	}
+
+	before, err := compactStorageUsage(db.dir)
+	if err != nil {
+		return stats, err
+	}
+	stats.Before = before
+
+	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats)
+	if err != nil {
+		return stats, err
+	}
+	stats.RemainingDebt = initialDebt
+	if opts.DryRun {
+		stats.After = before
+		stats.FullyCompacted = initialDebt.Empty()
+		return stats, nil
+	}
+
+	if err := db.runCompactStoragePhase(&stats, "checkpoint", func() error {
+		return db.Checkpoint()
+	}); err != nil {
+		return stats, err
+	}
+
+	cleanupLeafLog, err := db.installCompactStorageLeafPageLog()
+	if err != nil {
+		return stats, err
+	}
+	defer cleanupLeafLog()
+	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
+		rewrite, err := db.ValueLogRewriteOnline(ctx, ValueLogRewriteOnlineOptions{
+			BatchSize:       opts.ValueLogRewriteBatchSize,
+			SyncEachBatch:   opts.SyncEachPhase,
+			MaxSegmentBytes: opts.ValueLogRewriteMaxSegmentBytes,
+			LocalityPolicy:  ValueLogRewriteLocalityGrouped,
+			ReserveRIDs:     opts.ReserveRIDs,
+		})
+		stats.ValueLogRewrite = rewrite
+		return err
+	}); err != nil {
+		return stats, err
+	}
+	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-value-log-rewrite", func() error {
+		return db.Checkpoint()
+	}); err != nil {
+		return stats, err
+	}
+
+	if err := db.runCompactStoragePhase(&stats, "value-log-gc", func() error {
+		gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{})
+		stats.ValueLogGC = gc
+		return err
+	}); err != nil {
+		return stats, err
+	}
+	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-value-log-gc", func() error {
+		return db.Checkpoint()
+	}); err != nil {
+		return stats, err
+	}
+
+	for pass := 0; pass < opts.LeafPackMaxPasses; pass++ {
+		var pack LeafGenerationPackRunOnceStats
+		phaseName := fmt.Sprintf("leaf-generation-pack-%d", pass+1)
+		if err := db.runCompactStoragePhase(&stats, phaseName, func() error {
+			var err error
+			pack, err = db.LeafGenerationPackRunOnce(ctx, LeafGenerationPackFromPlanOptions{
+				Sync:                       opts.SyncEachPhase,
+				MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
+				MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
+				MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
+				MaxGenerations:             opts.LeafPackMaxGenerationsPerPass,
+				MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
+				ReserveRIDs:                opts.ReserveRIDs,
+				LeafFrameK:                 opts.LeafPackLeafFrameK,
+			})
+			return err
+		}); err != nil {
+			return stats, err
+		}
+		stats.LeafGenerationPacks = append(stats.LeafGenerationPacks, pack)
+		if !pack.Ran {
+			if len(stats.Phases) > 0 {
+				stats.Phases[len(stats.Phases)-1].Skipped = true
+				stats.Phases[len(stats.Phases)-1].SkipReason = pack.SkipReason
+			}
+			break
+		}
+		if err := db.runCompactStoragePhase(&stats, fmt.Sprintf("checkpoint-after-%s", phaseName), func() error {
+			return db.Checkpoint()
+		}); err != nil {
+			return stats, err
+		}
+	}
+
+	if err := db.runCompactStoragePhase(&stats, "leaf-generation-gc", func() error {
+		gc, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{})
+		stats.LeafGenerationGC = gc
+		return err
+	}); err != nil {
+		return stats, err
+	}
+	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-leaf-generation-gc", func() error {
+		return db.Checkpoint()
+	}); err != nil {
+		return stats, err
+	}
+
+	if err := db.runCompactStoragePhase(&stats, "index-vacuum", func() error {
+		return db.VacuumIndexOnline(ctx)
+	}); err != nil {
+		return stats, err
+	}
+	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-index-vacuum", func() error {
+		return db.Checkpoint()
+	}); err != nil {
+		return stats, err
+	}
+
+	if err := db.settleCompactStorageGC(ctx, opts, &stats); err != nil {
+		return stats, err
+	}
+
+	if opts.DisableZeroByteValueLogCleanup {
+		stats.Phases = append(stats.Phases, CompactStoragePhaseStats{
+			Name:       "prune-empty-value-log-files",
+			Skipped:    true,
+			SkipReason: "disabled",
+		})
+	} else {
+		if err := db.runCompactStoragePhase(&stats, "prune-empty-value-log-files", func() error {
+			deleted, err := db.pruneZeroByteValueLogFiles()
+			stats.ZeroByteValueLogFilesDeleted = deleted
+			return err
+		}); err != nil {
+			return stats, err
+		}
+	}
+
+	after, err := compactStorageUsage(db.dir)
+	if err != nil {
+		return stats, err
+	}
+	stats.After = after
+
+	var finalAudit CompactStorageStats
+	finalDebt, err := db.populateCompactStorageAudit(ctx, opts, &finalAudit)
+	if err != nil {
+		return stats, err
+	}
+	stats.ValueLogRewritePlan = finalAudit.ValueLogRewritePlan
+	stats.ValueLogGC = finalAudit.ValueLogGC
+	stats.LeafGenerationPlan = finalAudit.LeafGenerationPlan
+	stats.LeafGenerationGC = finalAudit.LeafGenerationGC
+	stats.RemainingDebt = finalDebt
+	stats.FullyCompacted = finalDebt.Empty()
+	return stats, nil
+}
+
+func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) error {
+	const maxSettlePasses = 4
+	for pass := 0; pass < maxSettlePasses; pass++ {
+		var audit CompactStorageStats
+		debt, err := db.populateCompactStorageAudit(ctx, opts, &audit)
+		if err != nil {
+			return err
+		}
+		if debt.ValueLogGCSegments == 0 && debt.LeafGCSegments == 0 {
+			return nil
+		}
+		if debt.ValueLogGCSegments > 0 {
+			phaseName := fmt.Sprintf("settle-value-log-gc-%d", pass+1)
+			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
+				gc, err := db.ValueLogGC(ctx, ValueLogGCOptions{})
+				stats.ValueLogGC = gc
+				return err
+			}); err != nil {
+				return err
+			}
+			if err := db.runCompactStoragePhase(stats, fmt.Sprintf("checkpoint-after-%s", phaseName), func() error {
+				return db.Checkpoint()
+			}); err != nil {
+				return err
+			}
+		}
+		if debt.LeafGCSegments > 0 {
+			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
+			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
+				gc, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{})
+				stats.LeafGenerationGC = gc
+				return err
+			}); err != nil {
+				return err
+			}
+			if err := db.runCompactStoragePhase(stats, fmt.Sprintf("checkpoint-after-%s", phaseName), func() error {
+				return db.Checkpoint()
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOptions {
+	switch opts.Mode {
+	case CompactStorageDefault:
+		opts.Mode = CompactStorageFull
+	case CompactStorageFull, CompactStorageQuick:
+	default:
+		opts.Mode = CompactStorageFull
+	}
+	if opts.ValueLogRewriteBatchSize < 0 {
+		opts.ValueLogRewriteBatchSize = 0
+	}
+	if opts.LeafPackMaxPasses <= 0 {
+		if opts.Mode == CompactStorageQuick {
+			opts.LeafPackMaxPasses = 1
+		} else {
+			opts.LeafPackMaxPasses = 32
+		}
+	}
+	if opts.LeafPackMaxGenerationsPerPass < 0 {
+		opts.LeafPackMaxGenerationsPerPass = 0
+	}
+	return opts
+}
+
+func compactStorageRewritePlanOptions() ValueLogRewriteOnlineOptions {
+	return ValueLogRewriteOnlineOptions{
+		MinSegmentStaleBytes: 1,
+	}
+}
+
+func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats) (CompactStorageDebt, error) {
+	var debt CompactStorageDebt
+	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions())
+	if err != nil {
+		return debt, err
+	}
+	stats.ValueLogRewritePlan = rewritePlan
+	debt.ValueLogRewriteSegments = rewritePlan.SegmentsSelected
+	debt.ValueLogRewriteBytes = rewritePlan.SelectedBytesStale
+	if debt.ValueLogRewriteBytes == 0 {
+		debt.ValueLogRewriteBytes = rewritePlan.SelectedBytesTotal
+	}
+
+	valueGC, err := db.ValueLogGC(ctx, ValueLogGCOptions{DryRun: true})
+	if err != nil {
+		return debt, err
+	}
+	stats.ValueLogGC = valueGC
+	debt.ValueLogGCSegments = valueGC.SegmentsEligible
+	debt.ValueLogGCBytes = valueGC.BytesEligible
+
+	leafPlan, err := db.LeafGenerationPlan(ctx, LeafGenerationPlanOptions{
+		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
+		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
+	})
+	if err != nil {
+		return debt, err
+	}
+	stats.LeafGenerationPlan = leafPlan
+	if leafPlan.Admission == leafGenerationPlanAdmissionEligible {
+		debt.LeafPackGenerations = len(leafPlan.Candidates)
+		debt.LeafPackBytes = leafPlan.ExpectedReclaimBytes
+	}
+
+	leafGC, err := db.LeafGenerationGC(ctx, LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		return debt, err
+	}
+	stats.LeafGenerationGC = leafGC
+	debt.LeafGCSegments = leafGC.GenerationsEligible
+	debt.LeafGCBytes = leafGC.BytesEligible
+
+	usage, err := compactStorageUsage(db.dir)
+	if err != nil {
+		return debt, err
+	}
+	debt.ZeroByteValueLogFiles = zeroByteValueLogFilesFromUsage(usage)
+	return debt, nil
+}
+
+func (db *DB) runCompactStoragePhase(stats *CompactStorageStats, name string, fn func() error) error {
+	started := time.Now()
+	err := fn()
+	stats.Phases = append(stats.Phases, CompactStoragePhaseStats{
+		Name:          name,
+		WallTimeNanos: time.Since(started).Nanoseconds(),
+	})
+	if err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	if db != nil && db.compactStorageAfterPhase != nil {
+		db.compactStorageAfterPhase(name)
+	}
+	return nil
+}
+
+func compactStorageUsage(dir string) ([]CompactStorageUsage, error) {
+	layout := resolveStorageLayout(dir)
+	domains := []struct {
+		name string
+		path string
+	}{
+		{name: "index", path: filepath.Join(dir, "index.db")},
+		{name: "wal", path: layout.walDir},
+		{name: "value_vlog", path: layout.valueVLogDir},
+		{name: "leaf_vlog", path: layout.leafVLogDir},
+	}
+	out := make([]CompactStorageUsage, 0, len(domains)+1)
+	var total CompactStorageUsage
+	total.Name = "total"
+	total.Path = dir
+	for _, domain := range domains {
+		usage, err := compactStoragePathUsage(domain.name, domain.path)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, usage)
+		total.Bytes += usage.Bytes
+		total.Files += usage.Files
+		total.ZeroByteFiles += usage.ZeroByteFiles
+	}
+	out = append(out, total)
+	return out, nil
+}
+
+func compactStoragePathUsage(name, path string) (CompactStorageUsage, error) {
+	usage := CompactStorageUsage{Name: name, Path: path}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return usage, nil
+		}
+		return usage, err
+	}
+	if !info.IsDir() {
+		usage.Files = 1
+		usage.Bytes = info.Size()
+		if info.Size() == 0 {
+			usage.ZeroByteFiles = 1
+		}
+		return usage, nil
+	}
+	err = filepath.WalkDir(path, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		usage.Files++
+		usage.Bytes += info.Size()
+		if info.Size() == 0 {
+			usage.ZeroByteFiles++
+		}
+		return nil
+	})
+	return usage, err
+}
+
+func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage) int {
+	for _, domain := range usage {
+		if domain.Name == "value_vlog" {
+			return domain.ZeroByteFiles
+		}
+	}
+	return 0
+}
+
+func (db *DB) pruneZeroByteValueLogFiles() (int, error) {
+	layout := resolveStorageLayout(db.dir)
+	entries, err := os.ReadDir(layout.valueVLogDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	deleted := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "value-l") || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		path := filepath.Join(layout.valueVLogDir, name)
+		info, err := entry.Info()
+		if err != nil {
+			return deleted, err
+		}
+		if info.Size() != 0 {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return deleted, err
+		}
+		deleted++
+	}
+	if deleted > 0 && db.valueLogManager != nil {
+		if err := db.valueLogManager.Refresh(); err != nil {
+			return deleted, err
+		}
+	}
+	return deleted, nil
+}
+
+func (db *DB) installCompactStorageLeafPageLog() (func(), error) {
+	if db == nil || !db.indexOuterLeavesInValueLog || db.leafPageLog != nil {
+		return func() {}, nil
+	}
+	segments, err := listValueLogSegments(db.dir)
+	if err != nil {
+		return nil, err
+	}
+	leafStartSeq := maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
+	writer := newRewriteWriter(ValueLogDirPath(db.dir), 0, 0, 0)
+	writer.ConfigureLeafLog(LeafLogDirPath(db.dir), rewriteLeafLogLaneID, leafStartSeq)
+	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
+	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
+	if writer.blockCompression {
+		if state := db.State(); state != nil {
+			leafDictID, leafDictBytes, leafDictUseRawPages, err := prepareRewriteLeafDict(db, state, db.valueLogDictCurrentForClass, db.valueLogDictLeafPayloadMode, db.valueLogDictLookup, db.valueLogDictPut, db.valueLogDictSetCurrentForClass, db.valueLogDictSetLeafPayloadMode, compression.TrainConfig{})
+			if err != nil {
+				_ = writer.Close()
+				return nil, err
+			}
+			if leafDictID != 0 && len(leafDictBytes) > 0 {
+				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			}
+		}
+	}
+	db.SetLeafPageLog(writer)
+	return func() {
+		db.SetLeafPageLog(nil)
+		_ = writer.Close()
+	}, nil
+}

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -600,10 +600,16 @@ func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage, protectedPaths 
 
 func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 	if opts.ValueLogProtectedPathsFunc == nil {
+		if len(opts.ValueLogProtectedPaths) == 0 {
+			return []string{""}
+		}
 		return opts.ValueLogProtectedPaths
 	}
 	dynamic := opts.ValueLogProtectedPathsFunc()
 	if len(opts.ValueLogProtectedPaths) == 0 {
+		if len(dynamic) == 0 {
+			return []string{""}
+		}
 		return dynamic
 	}
 	if len(dynamic) == 0 {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -1,0 +1,176 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestCompactStorageDeletesZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir: dir,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l42-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	reopened, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	plan, err := reopened.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.RemainingDebt.ZeroByteValueLogFiles; got != 1 {
+		t.Fatalf("zero-byte debt=%d want 1", got)
+	}
+
+	stats, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("empty value-log file still exists or stat failed: %v", err)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+}
+
+func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l7-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	readonly, err := Open(Options{Dir: dir, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("read-only open: %v", err)
+	}
+	stats, err := readonly.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	closeErr := readonly.Close()
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("close readonly: %v", closeErr)
+	}
+	if got := stats.RemainingDebt.ZeroByteValueLogFiles; got != 1 {
+		t.Fatalf("zero-byte debt=%d want 1", got)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("read-only plan mutated empty value-log file: %v", err)
+	}
+}
+
+func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) {
+	d, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "k", 64, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	pinned := d.AcquireSnapshot()
+	if pinned == nil {
+		t.Fatal("expected pinned snapshot")
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, d, "k", 64, 'b')
+
+	closedPinned := false
+	d.compactStorageAfterPhase = func(name string) {
+		if name != "leaf-generation-gc" || closedPinned {
+			return
+		}
+		closedPinned = true
+		if err := pinned.Close(); err != nil {
+			t.Fatalf("close pinned snapshot: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		d.compactStorageAfterPhase = nil
+		if !closedPinned {
+			_ = pinned.Close()
+		}
+	})
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !closedPinned {
+		t.Fatal("phase hook did not close pinned snapshot")
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+	if !compactStoragePhaseSeen(stats.Phases, "settle-leaf-generation-gc-1") {
+		t.Fatalf("settle leaf GC phase missing: %+v", stats.Phases)
+	}
+	if err := waitForPathRemoval(path1, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", path1, err)
+	}
+	manifest := loadLeafGenerationManifestOrFatal(t, dir)
+	for _, gen := range manifest.Generations {
+		if gen.GenerationID == 0 {
+			t.Fatalf("invalid generation in manifest: %+v", gen)
+		}
+		if gen.State == leafGenerationStateRetiring || gen.State == leafGenerationStateDeleted {
+			t.Fatalf("generation %d state=%q after compact storage; manifest=%+v", gen.GenerationID, gen.State, manifest.Generations)
+		}
+		for _, fileID := range gen.FileIDs {
+			if fileID == rawFileID1 {
+				t.Fatalf("dead generation file %d still present in manifest: %+v", rawFileID1, manifest.Generations)
+			}
+		}
+	}
+}
+
+func compactStoragePhaseSeen(phases []CompactStoragePhaseStats, name string) bool {
+	for _, phase := range phases {
+		if phase.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -568,7 +568,7 @@ func TestCompactStorageRIDAllocatorIsSharedAcrossOfflineWriters(t *testing.T) {
 		t.Fatalf("rid start scans=%d want 1", scanCalls)
 	}
 
-	cleanup, err := d.installCompactStorageLeafPageLog(opts)
+	_, cleanup, err := d.installCompactStorageLeafPageLog(opts)
 	if err != nil {
 		t.Fatalf("installCompactStorageLeafPageLog: %v", err)
 	}
@@ -586,6 +586,58 @@ func TestCompactStorageRIDAllocatorIsSharedAcrossOfflineWriters(t *testing.T) {
 	}
 	if start != 501 {
 		t.Fatalf("ReserveRIDs start=%d want 501 after leaf writer consumed rid 500", start)
+	}
+}
+
+func TestCompactStorageRefreshesInstalledLeafWriterAfterPack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(ValueLogDirPath(dir), 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	if err := os.MkdirAll(LeafLogDirPath(dir), 0755); err != nil {
+		t.Fatalf("mkdir leaf_vlog: %v", err)
+	}
+
+	d := &DB{
+		dir:                        dir,
+		indexOuterLeavesInValueLog: true,
+		valueLogCompression:        ValueLogCompressionOff,
+	}
+	opts := CompactStorageOptions{ReserveRIDs: newRewriteRIDAllocator(1, nil).Reserve}
+	installed, cleanup, err := d.installCompactStorageLeafPageLog(opts)
+	if err != nil {
+		t.Fatalf("installCompactStorageLeafPageLog: %v", err)
+	}
+	defer cleanup()
+	if installed == nil {
+		t.Fatal("expected installed compact leaf writer")
+	}
+
+	packWriter := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 0)
+	packWriter.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	if _, err := packWriter.AppendLeafPage(bytes.Repeat([]byte("p"), page.PageSize)); err != nil {
+		_ = packWriter.Close()
+		t.Fatalf("pack writer AppendLeafPage: %v", err)
+	}
+	if err := packWriter.Close(); err != nil {
+		t.Fatalf("close pack writer: %v", err)
+	}
+
+	if err := d.refreshCompactStorageLeafPageLog(installed); err != nil {
+		t.Fatalf("refreshCompactStorageLeafPageLog: %v", err)
+	}
+	if _, err := installed.AppendLeafPage(bytes.Repeat([]byte("v"), page.PageSize)); err != nil {
+		t.Fatalf("installed AppendLeafPage: %v", err)
+	}
+	gotPath, _, ok := installed.CurrentValueLogSegment()
+	if !ok {
+		t.Fatal("installed writer did not report current leaf segment")
+	}
+	if got := filepath.Base(gotPath); got != "value-l255-000002.log" {
+		t.Fatalf("installed writer segment=%s, want value-l255-000002.log", got)
+	}
+	if _, err := os.Stat(filepath.Join(LeafLogDirPath(dir), "value-l255-000001.log")); err != nil {
+		t.Fatalf("expected packed leaf segment to remain: %v", err)
 	}
 }
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -206,6 +206,13 @@ func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
+func TestCompactStorageDefaultProtectedPathsActivatesActiveProtection(t *testing.T) {
+	paths := compactStorageValueLogProtectedPaths(CompactStorageOptions{})
+	if len(paths) != 1 || paths[0] != "" {
+		t.Fatalf("default protected paths=%q want sentinel", paths)
+	}
+}
+
 func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -155,6 +155,57 @@ func TestCompactStorageDeletesManagerPinnedZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
+func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l9-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	reopened, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	opts := CompactStorageOptions{ValueLogProtectedPaths: []string{emptyPath}}
+	plan, err := reopened.CompactStoragePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.RemainingDebt.ZeroByteValueLogFiles; got != 0 {
+		t.Fatalf("protected zero-byte debt=%d want 0", got)
+	}
+	stats, err := reopened.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("protected empty value-log file was removed: %v", err)
+	}
+	if stats.ZeroByteValueLogFilesDeleted != 0 {
+		t.Fatalf("deleted protected zero-byte files=%d want 0", stats.ZeroByteValueLogFilesDeleted)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+}
+
 func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -55,6 +56,99 @@ func TestCompactStorageDeletesZeroByteValueLogFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
 		t.Fatalf("empty value-log file still exists or stat failed: %v", err)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageDeletesManagerPinnedZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	livePath := filepath.Join(valueLogDir, "value-l0-000001.log")
+	liveID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("live file id: %v", err)
+	}
+	liveWriter, err := valuelog.NewWriter(livePath, liveID)
+	if err != nil {
+		t.Fatalf("live writer: %v", err)
+	}
+	livePtr, err := liveWriter.Append(0, nil, 1, bytes.Repeat([]byte("v"), 256))
+	if err != nil {
+		_ = liveWriter.Close()
+		t.Fatalf("append live value: %v", err)
+	}
+	if err := liveWriter.Close(); err != nil {
+		t.Fatalf("close live writer: %v", err)
+	}
+	batch := d.NewBatch()
+	ptrBatch, ok := batch.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch %T", batch)
+	}
+	if err := ptrBatch.SetPointer([]byte("k"), livePtr); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write: %v", err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+	state := reopened.State()
+	if state == nil || state.ValueLogSet == nil {
+		t.Fatal("expected state value-log set")
+	}
+	if _, ok := state.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("expected empty segment %d to be pinned by state value-log set", fileID)
+	}
+
+	stats, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("manager-pinned empty value-log file still exists or stat failed: %v", err)
 	}
 	if !stats.FullyCompacted {
 		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -102,6 +102,48 @@ func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing
 	}
 }
 
+func TestCompactStoragePlanIgnoresZeroByteValueLogFilesWhenCleanupDisabled(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	emptyPath := filepath.Join(valueLogDir, "value-l8-000001.log")
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	reopened, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	stats, err := reopened.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		DisableZeroByteValueLogCleanup: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := stats.RemainingDebt.ZeroByteValueLogFiles; got != 0 {
+		t.Fatalf("zero-byte debt=%d want 0 when cleanup is disabled", got)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("plan mutated empty value-log file: %v", err)
+	}
+}
+
 func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) {
 	d, leafLog, dir := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -141,6 +142,60 @@ func TestCompactStoragePlanIgnoresZeroByteValueLogFilesWhenCleanupDisabled(t *te
 	}
 	if _, err := os.Stat(emptyPath); err != nil {
 		t.Fatalf("plan mutated empty value-log file: %v", err)
+	}
+}
+
+func TestCompactStorageRIDAllocatorIsSharedAcrossOfflineWriters(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(ValueLogDirPath(dir), 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	if err := os.MkdirAll(LeafLogDirPath(dir), 0o755); err != nil {
+		t.Fatalf("mkdir leaf_vlog: %v", err)
+	}
+
+	origScanner := rewriteRIDStartScanner
+	scanCalls := 0
+	rewriteRIDStartScanner = func([]logSegment) (uint64, error) {
+		scanCalls++
+		return 500, nil
+	}
+	t.Cleanup(func() { rewriteRIDStartScanner = origScanner })
+
+	d := &DB{
+		dir:                        dir,
+		indexOuterLeavesInValueLog: true,
+		valueLogCompression:        ValueLogCompressionOff,
+	}
+	opts := CompactStorageOptions{}
+	if err := d.prepareCompactStorageRIDAllocator(&opts); err != nil {
+		t.Fatalf("prepareCompactStorageRIDAllocator: %v", err)
+	}
+	if opts.ReserveRIDs == nil {
+		t.Fatal("expected shared ReserveRIDs callback")
+	}
+	if scanCalls != 1 {
+		t.Fatalf("rid start scans=%d want 1", scanCalls)
+	}
+
+	cleanup, err := d.installCompactStorageLeafPageLog(opts)
+	if err != nil {
+		t.Fatalf("installCompactStorageLeafPageLog: %v", err)
+	}
+	defer cleanup()
+	if d.leafPageLog == nil {
+		t.Fatal("expected installed leaf page log")
+	}
+	if _, err := d.leafPageLog.AppendLeafPage(bytes.Repeat([]byte("l"), page.PageSize)); err != nil {
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+
+	start, err := opts.ReserveRIDs(2)
+	if err != nil {
+		t.Fatalf("ReserveRIDs: %v", err)
+	}
+	if start != 501 {
+		t.Fatalf("ReserveRIDs start=%d want 501 after leaf writer consumed rid 500", start)
 	}
 }
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -691,6 +691,38 @@ func TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments(t *testin
 	}
 }
 
+func TestCompactStorageHoldsMaintenanceLockAcrossPhases(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	phaseChecks := 0
+	d.compactStorageAfterPhase = func(name string) {
+		phaseChecks++
+		if d.maintenanceMu.TryLock() {
+			d.maintenanceMu.Unlock()
+			t.Fatalf("maintenance lock was not held after compact phase %q", name)
+		}
+	}
+	t.Cleanup(func() {
+		d.compactStorageAfterPhase = nil
+	})
+
+	if _, err := d.CompactStorage(context.Background(), CompactStorageOptions{}); err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if phaseChecks == 0 {
+		t.Fatal("expected compact storage phase hook to run")
+	}
+}
+
 func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) {
 	d, leafLog, dir := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -155,6 +155,77 @@ func TestCompactStorageDeletesManagerPinnedZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
+func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.SetSync([]byte("live"), []byte("v")); err != nil {
+		_ = d.Close()
+		t.Fatalf("set live: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+	pinned := reopened.AcquireSnapshot()
+	if pinned == nil {
+		t.Fatal("expected pinned snapshot")
+	}
+	pinnedClosed := false
+	defer func() {
+		if !pinnedClosed {
+			_ = pinned.Close()
+		}
+	}()
+
+	if _, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{}); err != nil {
+		t.Fatalf("CompactStorage first: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("pinned zombie empty value-log file removed on first prune: %v", err)
+	}
+	if reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected segment %d to be zombie after first prune", fileID)
+	}
+
+	if _, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{}); err != nil {
+		t.Fatalf("CompactStorage second: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		t.Fatalf("pinned zombie empty value-log file removed on second prune: %v", err)
+	}
+
+	if err := pinned.Close(); err != nil {
+		t.Fatalf("close pinned snapshot: %v", err)
+	}
+	pinnedClosed = true
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pinned zombie file to delete after release, stat err=%v", err)
+	}
+}
+
 func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -641,6 +641,56 @@ func TestCompactStorageRefreshesInstalledLeafWriterAfterPack(t *testing.T) {
 	}
 }
 
+func TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir:                        dir,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 0)
+	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	d.SetLeafPageLog(leafLog)
+	defer func() { _ = leafLog.Close() }()
+
+	if _, err := leafLog.AppendLeafPage(bytes.Repeat([]byte("v"), page.PageSize)); err != nil {
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	createdSegments, err := leafLog.createdSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("createdSegmentsSnapshot: %v", err)
+	}
+	if len(createdSegments) != 1 {
+		t.Fatalf("created segments=%d want 1", len(createdSegments))
+	}
+	if d.valueLogManager.HasSegment(createdSegments[0].fileID) {
+		t.Fatalf("segment %d was registered before publish helper", createdSegments[0].fileID)
+	}
+
+	registered, err := d.registerLeafPageLogSegmentsForPublish(7)
+	if err != nil {
+		t.Fatalf("registerLeafPageLogSegmentsForPublish: %v", err)
+	}
+	if !registered {
+		t.Fatal("current leaf segment was not registered")
+	}
+	if !d.valueLogManager.HasSegment(createdSegments[0].fileID) {
+		t.Fatalf("segment %d was not registered", createdSegments[0].fileID)
+	}
+	set := d.valueLogManager.CurrentSetNoRefresh()
+	defer func() { _ = d.valueLogManager.Release(set) }()
+	if set == nil {
+		t.Fatal("missing value-log set")
+	}
+	if _, ok := set.Files[createdSegments[0].fileID]; !ok {
+		t.Fatalf("published value-log set missing segment %d", createdSegments[0].fileID)
+	}
+}
+
 func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) {
 	d, leafLog, dir := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -226,6 +226,85 @@ func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
+func TestCompactStoragePlanMatchesAppliedRewriteScopeForLiveOnlySegments(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	livePath := filepath.Join(valueLogDir, "value-l0-000001.log")
+	liveID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("live file id: %v", err)
+	}
+	liveWriter, err := valuelog.NewWriter(livePath, liveID)
+	if err != nil {
+		t.Fatalf("live writer: %v", err)
+	}
+	livePtr, err := liveWriter.Append(0, nil, 1, bytes.Repeat([]byte("v"), 256))
+	if err != nil {
+		_ = liveWriter.Close()
+		t.Fatalf("append live value: %v", err)
+	}
+	if err := liveWriter.Close(); err != nil {
+		t.Fatalf("close live writer: %v", err)
+	}
+
+	batch := d.NewBatch()
+	ptrBatch, ok := batch.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch %T", batch)
+	}
+	if err := ptrBatch.SetPointer([]byte("k"), livePtr); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write: %v", err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+	if err := d.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	plan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.RemainingDebt.ValueLogRewriteSegments; got != 0 {
+		t.Fatalf("plan rewrite segments=%d want 0, rewrite plan=%+v debt=%+v", got, plan.ValueLogRewritePlan, plan.RemainingDebt)
+	}
+	if plan.ValueLogRewritePlan.SegmentsTotal == 0 {
+		t.Fatalf("expected rewrite plan to see live value-log segment, rewrite plan=%+v", plan.ValueLogRewritePlan)
+	}
+	if !plan.FullyCompacted {
+		t.Fatalf("plan FullyCompacted=false for live-only segment, rewrite plan=%+v debt=%+v", plan.ValueLogRewritePlan, plan.RemainingDebt)
+	}
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := stats.ValueLogRewrite.SourceSegmentsRequested; got != 0 {
+		t.Fatalf("applied rewrite source segments=%d want 0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueRecordsCopied; got != 0 {
+		t.Fatalf("applied rewrite copied value records=%d want 0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("applied FullyCompacted=false for live-only segment, rewrite plan=%+v debt=%+v", stats.ValueLogRewritePlan, stats.RemainingDebt)
+	}
+}
+
 func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -305,6 +305,94 @@ func TestCompactStoragePlanMatchesAppliedRewriteScopeForLiveOnlySegments(t *test
 	}
 }
 
+func TestCompactStorageReportsAppliedValueLogGCStats(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+
+	path1 := filepath.Join(valueLogDir, "value-l0-000001.log")
+	id1, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("file id 1: %v", err)
+	}
+	w1, err := valuelog.NewWriter(path1, id1)
+	if err != nil {
+		t.Fatalf("writer 1: %v", err)
+	}
+	ptr1, err := w1.Append(0, nil, 1, bytes.Repeat([]byte("stale-value|"), 64))
+	if err != nil {
+		_ = w1.Close()
+		t.Fatalf("append 1: %v", err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatalf("close writer 1: %v", err)
+	}
+
+	path2 := filepath.Join(valueLogDir, "value-l0-000002.log")
+	id2, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("file id 2: %v", err)
+	}
+	w2, err := valuelog.NewWriter(path2, id2)
+	if err != nil {
+		t.Fatalf("writer 2: %v", err)
+	}
+	ptr2, err := w2.Append(0, nil, 2, bytes.Repeat([]byte("live-value|"), 64))
+	if err != nil {
+		_ = w2.Close()
+		t.Fatalf("append 2: %v", err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatalf("close writer 2: %v", err)
+	}
+
+	b := db.NewBatch()
+	ptrBatch, ok := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch")
+	}
+	if err := ptrBatch.SetPointer([]byte("stale"), ptr1); err != nil {
+		t.Fatalf("set stale: %v", err)
+	}
+	if err := ptrBatch.SetPointer([]byte("live"), ptr2); err != nil {
+		t.Fatalf("set live: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+	if err := db.Delete([]byte("stale")); err != nil {
+		t.Fatalf("delete stale: %v", err)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if stats.ValueLogGC.SegmentsDeleted == 0 {
+		t.Fatalf("applied ValueLogGC stats were not preserved: %+v", stats.ValueLogGC)
+	}
+	if stats.ValueLogGC.BytesDeleted == 0 {
+		t.Fatalf("applied ValueLogGC bytes deleted were not preserved: %+v", stats.ValueLogGC)
+	}
+	if stats.RemainingDebt.ValueLogGCSegments != 0 || stats.RemainingDebt.ValueLogGCBytes != 0 {
+		t.Fatalf("remaining GC debt=%+v, want none", stats.RemainingDebt)
+	}
+}
+
 func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -75,6 +75,9 @@ type DB struct {
 	adaptive                       *adaptive.Controller
 	pruner                         pruneWorker
 	leafGenerationPins             leafGenerationPinTracker
+	// Test hook used to release synthetic snapshot pins at exact compaction
+	// phase boundaries.
+	compactStorageAfterPhase func(string)
 
 	// idx is the current index generation (pager + MVCC lifecycle state).
 	idx atomic.Pointer[indexGen]

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -32,7 +32,7 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
 	}
-	if db.readOnly {
+	if db.readOnly && !opts.DryRun {
 		return stats, ErrReadOnly
 	}
 	if !db.indexOuterLeavesInValueLog {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -28,6 +28,10 @@ type LeafGenerationGCStats struct {
 }
 
 func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions) (LeafGenerationGCStats, error) {
+	return db.leafGenerationGC(ctx, opts, true)
+}
+
+func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions, lockMaintenance bool) (LeafGenerationGCStats, error) {
 	var stats LeafGenerationGCStats
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
@@ -42,8 +46,10 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		ctx = context.Background()
 	}
 
-	db.maintenanceMu.Lock()
-	defer db.maintenanceMu.Unlock()
+	if lockMaintenance {
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
 	db.writeMu.Lock()
 	defer db.writeMu.Unlock()
 

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -91,7 +91,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats)
 }
 
-func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan) (stats LeafGenerationPackStats, err error) {
+func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, lockMaintenance bool) (stats LeafGenerationPackStats, err error) {
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
 	}
@@ -111,8 +111,10 @@ func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGeneratio
 	stats.GenerationsRequested = len(opts.GenerationIDs)
 	opts = normalizeLeafGenerationPackOptions(opts)
 
-	db.maintenanceMu.Lock()
-	defer db.maintenanceMu.Unlock()
+	if lockMaintenance {
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
 	stats.SourceGenerationIDs = append(stats.SourceGenerationIDs, selectedPlan.CandidateGenerationIDs...)
 	stats.SourceBytesTotal = selectedPlan.CandidateBytesTotal
 	stats.SourceBytesLive = selectedPlan.CandidateBytesLive

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -59,5 +59,5 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 	if err != nil {
 		return LeafGenerationPackStats{}, err
 	}
-	return db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
+	return db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection), true)
 }

--- a/TreeDB/db/leaf_generation_pack_run_once.go
+++ b/TreeDB/db/leaf_generation_pack_run_once.go
@@ -18,6 +18,10 @@ type LeafGenerationPackRunOnceStats struct {
 // LeafGenerationPackRunOnce computes the current plan, applies bounded
 // selection, and either runs one pack pass or reports why it skipped.
 func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGenerationPackFromPlanOptions) (LeafGenerationPackRunOnceStats, error) {
+	return db.leafGenerationPackRunOnce(ctx, opts, true)
+}
+
+func (db *DB) leafGenerationPackRunOnce(ctx context.Context, opts LeafGenerationPackFromPlanOptions, lockMaintenance bool) (LeafGenerationPackRunOnceStats, error) {
 	var stats LeafGenerationPackRunOnceStats
 	plan, err := db.LeafGenerationPlan(ctx, leafGenerationPackFromPlanPlanOptions(opts))
 	if err != nil {
@@ -40,7 +44,7 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		return stats, nil
 	}
 	stats.Selection = selection
-	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
+	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection), lockMaintenance)
 	if err != nil {
 		return stats, err
 	}

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -142,6 +142,22 @@ func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) 
 	return provider.CurrentValueLogSegment()
 }
 
+func leafPageLogCreatedSegments(log LeafPageLog) ([]rewriteCreatedSegment, error) {
+	if log == nil {
+		return nil, nil
+	}
+	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
+		return leafPageLogCreatedSegments(wrapped.inner)
+	}
+	provider, ok := log.(interface {
+		createdSegmentsSnapshot() ([]rewriteCreatedSegment, error)
+	})
+	if !ok {
+		return nil, nil
+	}
+	return provider.createdSegmentsSnapshot()
+}
+
 func wrapLeafPageLogWithRecordLengthHints(db *DB, log LeafPageLog) LeafPageLog {
 	if db == nil || log == nil || !db.indexOuterLeavesInValueLog {
 		return log
@@ -202,6 +218,29 @@ func (db *DB) ensureLeafPageLogSegmentRegistered(commitSeq uint64) (bool, error)
 	path, fileID, ok := db.currentLeafPageLogSegment()
 	if !ok || path == "" || fileID == 0 {
 		return false, nil
+	}
+	return db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
+}
+
+func (db *DB) registerLeafPageLogSegmentsForPublish(commitSeq uint64) (bool, error) {
+	if db == nil || db.valueLogManager == nil || db.leafPageLog == nil {
+		return true, nil
+	}
+	createdSegments, err := leafPageLogCreatedSegments(db.leafPageLog)
+	if err != nil {
+		return false, err
+	}
+	for _, seg := range createdSegments {
+		if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
+			return false, err
+		}
+		if db.isLeafGenerationSegmentPath(seg.path) && commitSeq > 0 {
+			db.queueLeafGenerationWritableFileIDAtCommit(seg.fileID, commitSeq)
+		}
+	}
+	path, fileID, ok := db.currentLeafPageLogSegment()
+	if !ok || path == "" || fileID == 0 {
+		return true, nil
 	}
 	return db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
 }

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -120,6 +120,10 @@ func (r *vacuumRecorder) Drain() map[string]batch.Entry {
 // generation until readers drain; disk space is reclaimed once the old mmap is
 // closed.
 func (db *DB) VacuumIndexOnline(ctx context.Context) error {
+	return db.vacuumIndexOnline(ctx, true)
+}
+
+func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -129,8 +133,10 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	if runtime.GOOS == "windows" {
 		return ErrVacuumUnsupported
 	}
-	db.maintenanceMu.Lock()
-	defer db.maintenanceMu.Unlock()
+	if lockMaintenance {
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
 
 	if !db.vacuumInProgress.CompareAndSwap(false, true) {
 		return ErrVacuumInProgress

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -435,6 +435,16 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 				return err
 			}
 		}
+		leafPageLogSegmentsRegistered := true
+		if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
+			var err error
+			leafPageLogSegmentsRegistered, err = db.registerLeafPageLogSegmentsForPublish(nextMeta.CommitSeq)
+			if err != nil {
+				db.writeMu.Unlock()
+				cleanupNewPager()
+				return err
+			}
+		}
 
 		// Write redundant Meta pages (0/1) to the new file and sync it.
 		if err := writeMetaToPager(newPager, MetaPage0ID, nextMeta); err != nil {
@@ -504,11 +514,21 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 		db.idx.Store(newGen)
 		db.meta = nextMeta
 		db.metaPageID = MetaPage0ID
+		valueLogSet := db.valueLogManager.CurrentSetNoRefresh()
+		if !leafPageLogSegmentsRegistered {
+			if err := db.valueLogManager.Refresh(); err != nil {
+				db.mu.Unlock()
+				db.writeMu.Unlock()
+				cleanupNewPager()
+				return err
+			}
+			valueLogSet = db.valueLogManager.CurrentSetNoRefresh()
+		}
 		newState := &DBState{
 			CommitSeq:                  nextMeta.CommitSeq,
 			RootPageID:                 nextMeta.UserRootPageID,
 			SystemRootPageID:           nextMeta.SystemRootPageID,
-			ValueLogSet:                db.valueLogManager.CurrentSetNoRefresh(),
+			ValueLogSet:                valueLogSet,
 			LeafGenerations:            oldState.LeafGenerations,
 			LeafGenerationStateVersion: oldState.LeafGenerationStateVersion,
 		}

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -522,6 +522,10 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 		db.metaPageID = MetaPage0ID
 		valueLogSet := db.valueLogManager.CurrentSetNoRefresh()
 		if !leafPageLogSegmentsRegistered {
+			if valueLogSet != nil {
+				_ = db.valueLogManager.Release(valueLogSet)
+				valueLogSet = nil
+			}
 			if err := db.valueLogManager.Refresh(); err != nil {
 				db.mu.Unlock()
 				db.writeMu.Unlock()

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -139,7 +139,9 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		if set != nil {
 			_ = vm.Release(set)
 		}
-		db.persistValueLogRefTrackerBestEffort()
+		if !opts.DryRun && !db.readOnly {
+			db.persistValueLogRefTrackerBestEffort()
+		}
 		return stats, nil
 	}
 	valueSet := &valuelog.Set{Files: files}
@@ -378,9 +380,6 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 	if opts.DryRun {
 		if set != nil {
 			_ = vm.Release(set)
-		}
-		if !db.readOnly {
-			db.persistValueLogRefTrackerBestEffort()
 		}
 		return stats, nil
 	}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -94,6 +94,10 @@ type ValueLogGCStats struct {
 //   - not the currently-active segment per lane,
 //   - and not pinned by active snapshots.
 func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogGCStats, error) {
+	return db.valueLogGC(ctx, opts, true)
+}
+
+func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMaintenance bool) (ValueLogGCStats, error) {
 	var stats ValueLogGCStats
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
@@ -101,8 +105,10 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 	if db.readOnly && !opts.DryRun {
 		return stats, ErrReadOnly
 	}
-	db.maintenanceMu.Lock()
-	defer db.maintenanceMu.Unlock()
+	if lockMaintenance {
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -434,7 +434,9 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		}
 	}
 
-	db.persistValueLogRefTrackerBestEffort()
+	if !opts.DryRun && !db.readOnly {
+		db.persistValueLogRefTrackerBestEffort()
+	}
 	return stats, nil
 }
 

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -98,7 +98,7 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
 	}
-	if db.readOnly {
+	if db.readOnly && !opts.DryRun {
 		return stats, ErrReadOnly
 	}
 	db.maintenanceMu.Lock()
@@ -379,7 +379,9 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		if set != nil {
 			_ = vm.Release(set)
 		}
-		db.persistValueLogRefTrackerBestEffort()
+		if !db.readOnly {
+			db.persistValueLogRefTrackerBestEffort()
+		}
 		return stats, nil
 	}
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3270,6 +3270,7 @@ type rewriteWriter struct {
 	leafLane uint32
 	leafSeq  uint32
 	nextRID  uint64
+	ridAlloc *rewriteRIDAllocator
 	// currentPath/currentFileID cache the active writer segment identity so
 	// CurrentValueLogSegment can avoid per-call path/fileID recomputation.
 	currentPath       string
@@ -3522,13 +3523,9 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	if w == nil {
 		return page.LeafLogPtr{}, errors.New("vlog-rewrite: nil writer")
 	}
-	if w.nextRID == 0 {
-		w.nextRID = 1
-	}
-	rid := w.nextRID
-	w.nextRID++
-	if w.nextRID == 0 {
-		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
+	rid, err := w.nextRecordRID()
+	if err != nil {
+		return page.LeafLogPtr{}, err
 	}
 	return w.appendLeafPageWithRID(rid, leafPage)
 }
@@ -3540,18 +3537,42 @@ func (w *rewriteWriter) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, 
 	if len(leafPages) == 0 {
 		return nil, nil
 	}
+	startRID, err := w.reserveRecordRIDs(len(leafPages))
+	if err != nil {
+		return nil, err
+	}
+	return w.appendLeafPagesWithRIDStart(startRID, leafPages)
+}
+
+func (w *rewriteWriter) nextRecordRID() (uint64, error) {
+	if w == nil {
+		return 0, errors.New("vlog-rewrite: nil writer")
+	}
+	if w.ridAlloc != nil {
+		return w.ridAlloc.Next()
+	}
+	return w.reserveRecordRIDs(1)
+}
+
+func (w *rewriteWriter) reserveRecordRIDs(count int) (uint64, error) {
+	if w == nil {
+		return 0, errors.New("vlog-rewrite: nil writer")
+	}
+	if w.ridAlloc != nil {
+		return w.ridAlloc.Reserve(count)
+	}
 	if w.nextRID == 0 {
 		w.nextRID = 1
 	}
 	startRID := w.nextRID
-	if uint64(len(leafPages)) > ^uint64(0)-startRID {
-		return nil, fmt.Errorf("value-log rid space exhausted")
+	if uint64(count) > ^uint64(0)-startRID {
+		return 0, fmt.Errorf("value-log rid space exhausted")
 	}
-	w.nextRID += uint64(len(leafPages))
+	w.nextRID += uint64(count)
 	if w.nextRID == 0 {
-		return nil, fmt.Errorf("value-log rid space exhausted")
+		return 0, fmt.Errorf("value-log rid space exhausted")
 	}
-	return w.appendLeafPagesWithRIDStart(startRID, leafPages)
+	return startRID, nil
 }
 
 func (w *rewriteWriter) LastLeafPageRecordLength() uint32 {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3558,6 +3558,12 @@ func (w *rewriteWriter) reserveRecordRIDs(count int) (uint64, error) {
 	if w == nil {
 		return 0, errors.New("vlog-rewrite: nil writer")
 	}
+	if count < 0 {
+		return 0, fmt.Errorf("value-log rid reserve count must be non-negative")
+	}
+	if count == 0 {
+		return 0, nil
+	}
 	if w.ridAlloc != nil {
 		return w.ridAlloc.Reserve(count)
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1519,6 +1519,10 @@ func selectRewriteSourceSegmentsWithStats(opts ValueLogRewriteOnlineOptions, fil
 // ValueLogRewriteOnline rewrites pointer-backed values in bounded commit
 // batches, then atomically swaps keys to rewritten pointers.
 func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnlineOptions) (stats ValueLogRewriteStats, err error) {
+	return db.valueLogRewriteOnline(ctx, opts, true)
+}
+
+func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnlineOptions, lockMaintenance bool) (stats ValueLogRewriteStats, err error) {
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
 	}
@@ -1528,8 +1532,10 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if db.valueLogManager == nil {
 		return stats, fmt.Errorf("value log manager unavailable")
 	}
-	db.maintenanceMu.Lock()
-	defer db.maintenanceMu.Unlock()
+	if lockMaintenance {
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3353,6 +3353,22 @@ func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) 
 	w.leafSeq = startSeq
 }
 
+func (w *rewriteWriter) resetLeafLogSeqAtLeast(seq uint32) error {
+	if w == nil || w.leafDir == "" || seq <= w.leafSeq {
+		return nil
+	}
+	if w.leafW != nil {
+		if err := w.leafW.Close(); err != nil {
+			return err
+		}
+		w.leafW = nil
+	}
+	w.leafSeq = seq
+	w.leafCurrentPath = ""
+	w.leafCurrentFileID = 0
+	return nil
+}
+
 func (w *rewriteWriter) noteCreatedSegment(path string, fileID uint32) {
 	if w == nil || path == "" || fileID == 0 {
 		return

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -9,10 +9,10 @@ TreeDB is pre-alpha; format compatibility between versions is not guaranteed.
 A TreeDB deployment uses:
 
 - `index.db` (paged B+Tree index and metadata),
-- value-log segments (`value-l*.log`),
+- commit-log segments under `wal/commit-l*.log`,
+- value-log segments under `value_vlog/value-l*.log`,
 - optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
   when `IndexOuterLeavesInValueLog` is enabled,
-- commit-log segments (`commit-l*.log`),
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
 ## 2. Index Page Basics
@@ -404,8 +404,34 @@ Validation rules:
 
 Current canonical names:
 
-- commit log: `commit-l<lane>-<seq>.log`
-- value log: `value-l<lane>-<seq>.log`
+- commit log: `wal/commit-l<lane>-<seq>.log`
+- value log: `value_vlog/value-l<lane>-<seq>.log`
 - split leaf log: `leaf_vlog/value-l<lane>-<seq>.log`
 
 Recovery parser also accepts legacy names (`commit-`, `value-`, `wal-`, `vlog-`) for backward compatibility during pre-alpha evolution.
+
+## 10. Storage Compaction Lifecycle
+
+`DB.CompactStorage` is the canonical online storage compaction entry point. It
+does not introduce a new on-disk format; it coordinates the existing storage
+objects above into one lifecycle:
+
+1. establish a durable checkpoint boundary,
+2. rewrite live value-log records into new `value_vlog` segments,
+3. run reachability-based value-log GC,
+4. pack live split outer-leaf pages into new `leaf_vlog` generations,
+5. run leaf-generation GC,
+6. vacuum/rewrite `index.db`,
+7. run settle GC passes,
+8. delete untracked zero-byte `value_vlog` segment files,
+9. audit the remaining storage debt.
+
+Applied compaction is serialized with other backend maintenance for the full
+multi-phase sequence. Planning mode reports debt without mutating storage and is
+safe for read-only opens.
+
+In cached mode, public maintenance wrappers checkpoint first, protect cached
+value-log paths, reserve rewrite RIDs from the live cached allocator, and
+reconcile cached split value-log writers after backend maintenance so later
+writes advance past backend-created `value_vlog`/`leaf_vlog` segments instead of
+reusing segment file names.

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -72,17 +72,33 @@ Checkpoint and retention pruning:
 - drop only paths no longer live/retained,
 - refresh manager segment set after changes.
 
-## 6. Rewrite/Compaction (`ValueLogRewriteOffline`)
+Backend maintenance that creates new value-log or split leaf-log segments must
+reconcile cached-mode split writers after the backend operation. Reconciliation
+refreshes the value-log reader and advances each cached writer lane past the
+maximum observed on-disk segment sequence, preventing later cached writes from
+reusing segment filenames created by compaction, rewrite, leaf packing, or index
+vacuum.
+
+## 6. Rewrite/Compaction
+
+### 6.1 Online rewrite (`DB.ValueLogRewriteOnline`)
+
+Online rewrite copies live pointer-backed values into fresh value-log segments
+and updates keys in bounded commit batches. Cached-mode callers must checkpoint
+first, protect cached value-log paths, and allocate rewrite RIDs from the shared
+cached allocator.
+
+### 6.2 Offline rewrite (`ValueLogRewriteOffline`)
 
 Offline rewrite rewrites live pointer records into fresh segments and swaps index.
 
-### 6.1 Preconditions
+#### Preconditions
 
 - exclusive DB lock,
 - clean commit log (no pending `commit-*.log`),
 - readable existing value-log segments.
 
-### 6.2 Procedure
+#### Procedure
 
 1. Open DB read-only under exclusive lock.
 2. Build new value-log segments by iterating current trees and copying referenced records.
@@ -92,11 +108,33 @@ Offline rewrite rewrites live pointer records into fresh segments and swaps inde
 6. Remove obsolete value-log segments.
 7. Report before/after size and segment counts.
 
-### 6.3 Safety properties
+#### Safety properties
 
 - Only referenced records are copied.
 - Pointer map deduplicates source record copies when needed.
 - Old segments are removed only after index swap succeeds.
+
+### 6.3 Full storage compaction (`DB.CompactStorage`)
+
+`DB.CompactStorage` is the preferred online operator path for reclaiming TreeDB
+storage. It composes:
+
+1. checkpoint,
+2. value-log rewrite,
+3. value-log GC,
+4. split leaf-generation pack,
+5. split leaf-generation GC,
+6. index vacuum,
+7. settle GC passes,
+8. zero-byte value-log cleanup,
+9. final debt audit.
+
+Applied full storage compaction holds backend maintenance serialization for the
+whole sequence. Plan mode computes the same debt model without mutating storage.
+
+Value-log deletion in this lifecycle remains reachability-based. Zero-byte
+cleanup is limited to untracked `value_vlog` segment files and must honor
+cached-mode protected paths.
 
 ## 7. Read Integrity Options
 
@@ -110,7 +148,10 @@ Template and dictionary lookup failures for encoded/compressed records are treat
 ## 8. Operational Guidance
 
 - Use `ValueLogGC` regularly to reclaim fully unreachable segments.
-- Use `ValueLogRewriteOffline` for deeper space reclaim/locality rewrite.
+- Prefer `DB.CompactStorage` for explicit online "make this DB compact"
+  maintenance across value logs, split leaf logs, and `index.db`.
+- Use `ValueLogRewriteOffline` only when an exclusive offline rewrite is
+  intentionally required.
 - Monitor retained bytes and optional guardrails:
   - `ValueLog.MaxRetainedBytes` (warning threshold),
   - `ValueLog.MaxRetainedBytesHard` (pointer admission cap).

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -89,11 +89,21 @@ Coverage:
 
 Invariant:
 - Index rewrite/vacuum paths preserve data and handle pinned snapshots safely.
+- Full storage compaction preserves value visibility, removes reachable debt only
+  through the documented lifecycle, serializes backend maintenance phases, and
+  keeps cached-mode value-log writers from reusing backend-created segments.
 
 Coverage:
 - `TreeDB/db/compact_index_test.go`
 - `TreeDB/db/compact_index_sequential_alloc_test.go`
 - `TreeDB/db/vacuum_online_swap_test.go`
+- `TreeDB/db/compact_storage_test.go`
+  - `TestCompactStorageHoldsMaintenanceLockAcrossPhases`
+- `TreeDB/compact_storage_test.go`
+  - `TestCompactStorageFullPacksLeafGenerationDebtOffline`
+  - `TestCompactStorageCachedDeletesZeroByteValueLogFiles`
+- `TreeDB/compact_storage_cached_internal_test.go`
+  - `TestCompactStorageCachedAdvancesWritersPastBackendSegments`
 
 ## 8. Required Checks for Format/Behavior Changes
 

--- a/TreeDB/internal/valuelog/errors.go
+++ b/TreeDB/internal/valuelog/errors.go
@@ -7,6 +7,10 @@ import (
 
 var ErrFileNotFound = errors.New("valuelog: file not found")
 
+// ErrFilePinned reports that a value-log segment is still pinned by a live
+// snapshot and cannot be removed yet.
+var ErrFilePinned = errors.New("valuelog: file pinned")
+
 type fileNotFoundError struct {
 	id         uint32
 	inSnapshot bool
@@ -24,4 +28,23 @@ func (e *fileNotFoundError) Error() string {
 
 func (e *fileNotFoundError) Is(target error) bool {
 	return target == ErrFileNotFound
+}
+
+type filePinnedError struct {
+	id uint32
+	op string
+}
+
+func (e *filePinnedError) Error() string {
+	if e == nil {
+		return ErrFilePinned.Error()
+	}
+	if e.op == "" {
+		return fmt.Sprintf("valuelog file %d still pinned", e.id)
+	}
+	return fmt.Sprintf("cannot %s valuelog file %d: still pinned", e.op, e.id)
+}
+
+func (e *filePinnedError) Is(target error) bool {
+	return target == ErrFilePinned
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -2109,6 +2109,9 @@ func (m *Manager) RemoveSegment(id uint32) error {
 // pins it. It returns false with no error when the segment is absent or still
 // pinned.
 func (m *Manager) RemoveSegmentIfUnpinned(id uint32) (bool, error) {
+	if m == nil {
+		return false, nil
+	}
 	m.mu.Lock()
 	f, ok := m.files[id]
 	if !ok {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1747,7 +1747,7 @@ func (m *Manager) EvictSegment(id uint32) error {
 	}
 	if f.RefCount.Load() != 0 {
 		m.mu.Unlock()
-		return fmt.Errorf("cannot evict valuelog file %d: still pinned", id)
+		return &filePinnedError{id: id, op: "evict"}
 	}
 	delete(m.files, id)
 	m.mu.Unlock()
@@ -2080,13 +2080,34 @@ func (m *Manager) RemoveSegment(id uint32) error {
 	}
 	if f.RefCount.Load() != 0 {
 		m.mu.Unlock()
-		return fmt.Errorf("cannot remove valuelog file %d: still pinned", id)
+		return &filePinnedError{id: id, op: "remove"}
 	}
 	delete(m.files, id)
 	m.mu.Unlock()
 
 	_ = f.Close()
 	return removeSegmentFileWithRetry(f.Path)
+}
+
+// RemoveSegmentIfUnpinned removes a tracked segment only when no live snapshot
+// pins it. It returns false with no error when the segment is absent or still
+// pinned.
+func (m *Manager) RemoveSegmentIfUnpinned(id uint32) (bool, error) {
+	m.mu.Lock()
+	f, ok := m.files[id]
+	if !ok {
+		m.mu.Unlock()
+		return false, nil
+	}
+	if f.RefCount.Load() != 0 {
+		m.mu.Unlock()
+		return false, nil
+	}
+	delete(m.files, id)
+	m.mu.Unlock()
+
+	_ = f.Close()
+	return true, removeSegmentFileWithRetry(f.Path)
 }
 
 // RemoveSegmentForce removes a segment without refcount checks.

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1736,6 +1736,23 @@ func (m *Manager) MarkZombie(id uint32) error {
 	return nil
 }
 
+// MarkZombieIfTracked marks id zombie when the manager still tracks it,
+// including files that were already marked zombie by a previous cleanup pass.
+func (m *Manager) MarkZombieIfTracked(id uint32) (tracked bool, newlyMarked bool, err error) {
+	if m == nil {
+		return false, false, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f, ok := m.files[id]
+	if !ok {
+		return false, false, nil
+	}
+	wasZombie := f.IsZombie.Load()
+	f.IsZombie.Store(true)
+	return true, !wasZombie, nil
+}
+
 // EvictSegment closes and forgets a segment without deleting it from disk.
 // This is useful when another component owns lifecycle/deletion.
 func (m *Manager) EvictSegment(id uint32) error {
@@ -2085,8 +2102,7 @@ func (m *Manager) RemoveSegment(id uint32) error {
 	delete(m.files, id)
 	m.mu.Unlock()
 
-	_ = f.Close()
-	return removeSegmentFileWithRetry(f.Path)
+	return closeAndRemoveSegmentFile(f)
 }
 
 // RemoveSegmentIfUnpinned removes a tracked segment only when no live snapshot
@@ -2106,8 +2122,7 @@ func (m *Manager) RemoveSegmentIfUnpinned(id uint32) (bool, error) {
 	delete(m.files, id)
 	m.mu.Unlock()
 
-	_ = f.Close()
-	return true, removeSegmentFileWithRetry(f.Path)
+	return true, closeAndRemoveSegmentFile(f)
 }
 
 // RemoveSegmentForce removes a segment without refcount checks.
@@ -2122,11 +2137,17 @@ func (m *Manager) RemoveSegmentForce(id uint32) error {
 	delete(m.files, id)
 	m.mu.Unlock()
 
-	_ = f.Close()
-	return removeSegmentFileWithRetry(f.Path)
+	return closeAndRemoveSegmentFile(f)
 }
 
 var removeSegmentPath = os.Remove
+
+func closeAndRemoveSegmentFile(f *File) error {
+	if f == nil {
+		return nil
+	}
+	return errors.Join(f.Close(), removeSegmentFileWithRetry(f.Path))
+}
 
 func removeSegmentFileOnce(path string) error {
 	err := removeSegmentPath(path)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -50,6 +50,17 @@ func withMappedLeafSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
 	})
 }
 
+func TestManagerRemoveSegmentIfUnpinnedNil(t *testing.T) {
+	var mgr *Manager
+	removed, err := mgr.RemoveSegmentIfUnpinned(1)
+	if err != nil {
+		t.Fatalf("RemoveSegmentIfUnpinned nil manager err=%v", err)
+	}
+	if removed {
+		t.Fatal("RemoveSegmentIfUnpinned nil manager removed=true")
+	}
+}
+
 func waitForRemapIdle(t *testing.T, files ...*File) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/TreeDB/leaf_generation_pack.go
+++ b/TreeDB/leaf_generation_pack.go
@@ -36,7 +36,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 		}
 	}
 	stats, err := db.backend.LeafGenerationPack(ctx, treedbdb.LeafGenerationPackOptions(opts))
-	if err != nil {
+	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
 	success = true

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -36,7 +36,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		}
 	}
 	stats, err := db.backend.LeafGenerationPackFromPlan(ctx, treedbdb.LeafGenerationPackFromPlanOptions(opts))
-	if err != nil {
+	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
 	success = true

--- a/TreeDB/open_backend.go
+++ b/TreeDB/open_backend.go
@@ -16,13 +16,13 @@ func OpenBackend(opts Options) (*db.DB, func() error, error) {
 	}
 	opts.DisableSideStores = layout.disableSideStores
 
-	// Apply persisted index encoding knobs so direct backend opens agree with the
-	// on-disk index format.
+	// Apply persisted storage/runtime knobs so direct maintenance opens agree
+	// with the on-disk format and compression policy used by the DB.
 	if !opts.IgnoreFormatConfig {
 		if cfg, ok, err := db.LoadFormatConfig(layout.mainDir); err != nil {
 			return nil, nil, err
 		} else if ok {
-			cfg.ApplyIndexFormatToOptions(&opts)
+			cfg.ApplyToOptions(&opts)
 		}
 	}
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1722,7 +1722,8 @@ func (db *DB) CompactIndex() error {
 			return err
 		}
 	}
-	return db.backend.CompactIndex()
+	err := db.backend.CompactIndex()
+	return db.reconcileCachedBackendMaintenance(err)
 }
 
 // VacuumIndexOnline rebuilds the user index into a new file and swaps it in with
@@ -1749,7 +1750,7 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 		}
 	}
 
-	if err := db.backend.VacuumIndexOnline(ctx); err != nil {
+	if err := db.reconcileCachedBackendMaintenance(db.backend.VacuumIndexOnline(ctx)); err != nil {
 		return err
 	}
 	success = true

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -420,8 +420,8 @@ func TestReopenVerify_ValueLogGC_LeafPagesInValueLog_ReopenParity(t *testing.T) 
 		_ = db.Close()
 		t.Fatalf("ValueLogGC: %v", err)
 	}
-	if stats.SegmentsEligible == 0 {
-		t.Fatalf("expected GC to find eligible segments, stats=%+v", stats)
+	if stats.SegmentsDeleted != 0 {
+		t.Fatalf("value-log GC deleted segments in leaf-only split-log workload, stats=%+v", stats)
 	}
 
 	if err := db.Close(); err != nil {

--- a/TreeDB/vlog_gc.go
+++ b/TreeDB/vlog_gc.go
@@ -87,8 +87,8 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 				return out, err
 			}
 		case ValueLogGCModeOnline:
-			backendOpts.ProtectedPaths = db.cached.ValueLogRetainedPaths()
-			// Fail closed when online mode has no retained-path protection data.
+			backendOpts.ProtectedPaths = db.cached.ValueLogProtectedPaths()
+			// Fail closed when online mode has no protected-path data.
 			if !backendOpts.DryRun && len(backendOpts.ProtectedPaths) == 0 {
 				backendOpts.DryRun = true
 				out.FailClosedToDryRun = true

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -80,7 +80,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 		if len(backendOpts.ProtectedPaths) == 0 {
 			// Cached-mode callers may have concurrent writers even when there are
-			// no retained paths yet; pass a non-empty slice to activate the
+			// no protected paths yet; pass a non-empty slice to activate the
 			// backend rewrite's active-segment protection.
 			backendOpts.ProtectedPaths = []string{""}
 		}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -89,7 +89,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 	}
 	stats, err := db.backend.ValueLogRewriteOnline(ctx, backendOpts)
-	if err != nil {
+	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return ValueLogRewriteStats{}, err
 	}
 	success = true

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -76,7 +76,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			return ValueLogRewriteStats{}, err
 		}
 		if len(backendOpts.ProtectedPaths) == 0 {
-			backendOpts.ProtectedPaths = db.cached.ValueLogRetainedPaths()
+			backendOpts.ProtectedPaths = db.cached.ValueLogProtectedPaths()
 		}
 		if len(backendOpts.ProtectedPaths) == 0 {
 			// Cached-mode callers may have concurrent writers even when there are

--- a/docs/TREEDB_CONCEPTS.md
+++ b/docs/TREEDB_CONCEPTS.md
@@ -34,7 +34,9 @@ See: `docs/API_STABILITY.md`.
 At a conceptual level, the backend engine stores:
 
 - A memory-mapped index file (`Dir/maindb/index.db`) containing B+Tree pages and metadata.
-- A value log under `Dir/maindb/wal/` used to store larger values efficiently.
+- A persistent value log under `Dir/maindb/value_vlog/` used to store larger values efficiently.
+- An optional persistent outer-leaf log under `Dir/maindb/leaf_vlog/` when leaf pages are stored outside `index.db`.
+- A redo journal under `Dir/maindb/wal/` for crash recovery.
 - A dictionary store under `Dir/dictdb/` used to persist compression dictionaries (when enabled).
 
 Writes are “commit-like”: a batch updates pages + value-log pointers and then updates the active meta page.
@@ -45,9 +47,29 @@ Writes are “commit-like”: a batch updates pages + value-log pointers and the
   - B+Tree pages (internal + leaf nodes)
   - freelist / lifecycle metadata
   - redundant meta (“superblock”) pages used for recovery
-- `Dir/maindb/wal/`: journal + value-log segments (internal naming may change).
+- `Dir/maindb/wal/`: redo journal segments.
+- `Dir/maindb/value_vlog/`: persistent value-log segments for large values.
+- `Dir/maindb/leaf_vlog/`: persistent outer-leaf generations when enabled.
 - `Dir/maindb/LOCK`: the cross-process exclusive-open lock file.
 - `Dir/dictdb/`: dictionary store DB used by value-log compression.
+
+For final disk footprint, use the high-level compaction path:
+
+```go
+stats, err := db.CompactStorage(ctx, treedb.CompactStorageOptions{
+    Mode: treedb.CompactStorageFull,
+})
+```
+
+or:
+
+```sh
+treemap compact <db-dir> -rw
+```
+
+`vlog-gc`, `vlog-rewrite`, `leafgen-pack`, `leafgen-gc`, and index `vacuum`
+are domain-specific internals. They are useful for diagnostics, but they are
+not the recommended user-facing way to obtain a fully compacted storage number.
 
 ### Inline vs value-log values
 

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -152,6 +152,32 @@ Use when you want:
 
 Not recommended for production.
 
+## Measuring Final Storage
+
+Profiles choose write-path and maintenance policy; they do not by themselves
+produce a fully compacted on-disk footprint. If you are reporting final disk
+usage for a benchmark or handoff, run the high-level storage compaction path
+after loading and before measuring:
+
+```sh
+treemap compact <db-dir> -rw
+treemap compact-plan <db-dir>
+```
+
+or in Go:
+
+```go
+stats, err := db.CompactStorage(ctx, treedb.CompactStorageOptions{
+	Mode: treedb.CompactStorageFull,
+})
+```
+
+This is the recommended path for `ProfileFast`, `ProfileWALOnFast`, and
+`ProfileBench` databases. It coordinates `value_vlog` rewrite/GC, `leaf_vlog`
+generation pack/GC, index vacuum, and zero-byte value-log cleanup. Do not
+manually chain `vlog-gc`, `vlog-rewrite`, `leafgen-pack`, `leafgen-gc`, and
+index vacuum unless you are debugging TreeDB internals.
+
 ## Important Notes
 
 ### Profiles do not prevent overrides

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -333,8 +333,10 @@ stats, err := db.CompactStorage(ctx, treedb.CompactStorageOptions{
 
 This is the user-facing contract. It coordinates value-log rewrite, value-log
 GC, leaf-generation packing, leaf-generation GC, index vacuum, and zero-byte
-`value_vlog` cleanup. The lower-level operations below are advanced internals
-for debugging and maintenance schedulers.
+`value_vlog` cleanup. If online index vacuum is unsupported on the current
+platform, that phase is explicitly reported as skipped and the other storage
+domains are still compacted. The lower-level operations below are advanced
+internals for debugging and maintenance schedulers.
 
 ### GC: delete fully-unreferenced segments
 

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -18,9 +18,9 @@ Operator-facing behavior is covered by:
 ## TL;DR
 
 - `Options.Dir` is a *root* directory containing:
-  - `Dir/maindb/`: main database (index + journal + value log)
+  - `Dir/maindb/`: main database (`index.db`, `wal`, `value_vlog`, and optional `leaf_vlog`)
   - `Dir/dictdb/`: dictionary store (for value-log compression)
-- Large values can be stored out-of-line in `Dir/maindb/wal/` and referenced by `page.ValuePtr` pointers stored in the B+Tree.
+- Large values can be stored out-of-line in `Dir/maindb/value_vlog/` and referenced by `page.ValuePtr` pointers stored in the B+Tree.
 - The value log is **persistent storage**: pointers are valid long-term; segments are deleted only when unreachable (GC) or after rewrite/compaction.
 
 ## Directory layout
@@ -30,9 +30,9 @@ TreeDB creates/manages two sub-databases under the root directory:
 ### Main DB (`Dir/maindb/`)
 
 - `Dir/maindb/index.db`: memory-mapped pager file containing B+Tree pages + metadata.
-- `Dir/maindb/wal/`: journal (redo) + value-log segments.
-  - journal segments: `commit-l<lane>-<seq>.log`
-  - value-log segments: `value-l<lane>-<seq>.log`
+- `Dir/maindb/wal/`: redo journal segments named `commit-l<lane>-<seq>.log`.
+- `Dir/maindb/value_vlog/`: persistent large-value segments named `value-l<lane>-<seq>.log`.
+- `Dir/maindb/leaf_vlog/`: optional persistent outer-leaf generation segments named `value-l<lane>-<seq>.log`.
 - `Dir/maindb/LOCK`: cross-process exclusive-open lock for the main DB.
 
 ### Dictionary store (`Dir/dictdb/`)
@@ -315,6 +315,27 @@ The value log is **not** an ephemeral write-ahead log:
 - pointers stored in the index are expected to remain valid across restarts,
 - old segments are not truncated “because they’re old”.
 
+### Recommended full compaction
+
+For a fully compacted storage footprint, use:
+
+```sh
+treemap compact <db-dir> -rw
+```
+
+or:
+
+```go
+stats, err := db.CompactStorage(ctx, treedb.CompactStorageOptions{
+    Mode: treedb.CompactStorageFull,
+})
+```
+
+This is the user-facing contract. It coordinates value-log rewrite, value-log
+GC, leaf-generation packing, leaf-generation GC, index vacuum, and zero-byte
+`value_vlog` cleanup. The lower-level operations below are advanced internals
+for debugging and maintenance schedulers.
+
 ### GC: delete fully-unreferenced segments
 
 TreeDB can delete value-log segments that are completely unreachable:
@@ -333,7 +354,7 @@ Behavior:
 In cached mode, `ValueLogGC` checkpoints first to ensure memtables/journal state
 is reflected in the backend before pointer scanning.
 
-### Rewrite: compact partially-dead segments (offline)
+### Rewrite: compact partially-dead value segments
 
 GC only removes segments that are *fully* unreferenced. To reclaim space from
 segments that contain a mix of live and dead records, TreeDB provides an offline

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -13,7 +13,7 @@ This doc describes the knobs exposed via `treedb.Options` and the cached write-b
 - Cached-mode auto checkpointing:
   - `BackgroundCheckpointInterval`: defaults to 30s
   - `BackgroundCheckpointIdleDuration`: defaults to 2s
-  - `MaxWALBytes`: defaults to 2 GiB (legacy name; journal/value-log bytes)
+  - `MaxWALBytes`: defaults to 2 GiB (legacy name; journal and side-log bytes)
 
 ## Options
 
@@ -22,7 +22,9 @@ This doc describes the knobs exposed via `treedb.Options` and the cached write-b
 DB directory containing:
 
 - `index.db` (B+Tree index)
-- `wal/` directory (journal + value-log segments)
+- `wal/` directory (redo journal segments)
+- `value_vlog/` directory (persistent large-value segments)
+- optional `leaf_vlog/` directory (outer leaf generations)
 - `LOCK` file (exclusive open)
 
 ### `Options.ChunkSize`
@@ -158,8 +160,8 @@ Mitigations:
 TreeDB cached mode uses a journal for crash recovery, but (like many engines) the default
 `Set`/`Batch.Write` path does not force an `fsync` per operation.
 
-To keep `wal/` (journal + value log) from growing without bound in long-running workloads, TreeDB enables a
-periodic cached-mode checkpoint by default:
+To keep the redo journal and side logs bounded in long-running workloads,
+TreeDB enables a periodic cached-mode checkpoint by default:
 
 - `Options.BackgroundCheckpointInterval` (default 30s): periodic checkpoint cadence
 - `Options.BackgroundCheckpointIdleDuration` (default 2s): opportunistic checkpoint after write-idle
@@ -360,26 +362,45 @@ fragmentation under churn:
 Use `db.FragmentationReport()` to observe index span ratio and fill percentiles,
 and let background index vacuum handle high-fragmentation recovery.
 
-### Offline index vacuum (index.db)
+### Full storage compaction
 
-TreeDB’s `index.db` grows in chunks and does not shrink in-place. Reclaiming
-index disk space requires rewriting the index into a fresh file and swapping it
-in.
+For final disk footprint, use the high-level compaction path:
 
-TreeDB provides an **offline** rewrite operation (DB closed) that rebuilds
-`index.db` into a fresh file and swaps it in using a crash-safe protocol:
+```go
+stats, err := db.CompactStorage(ctx, treedb.CompactStorageOptions{
+    Mode: treedb.CompactStorageFull,
+})
+```
 
-- Call: `treedb.VacuumIndexOffline(treedb.Options{Dir: ..., ChunkSize: ...})`
-- Requires the database to be **closed** (it acquires the exclusive `LOCK` under `Dir/maindb/LOCK`)
-- Crash safety: `treedb.Open` will automatically recover from a partial swap
-  (e.g. if the process crashed mid-vacuum).
+or:
 
-### Value-log maintenance (GC / rewrite)
+```sh
+treemap compact <db-dir> -rw
+```
 
-TreeDB’s value log is persistent storage. Disk space is reclaimed via:
+This plans and executes the best-practice sequence across storage domains:
 
-- **GC**: `db.ValueLogGC(...)` deletes fully-unreferenced value-log segments (after a checkpoint in cached mode).
-- **Rewrite**: `treedb.ValueLogRewriteOffline(treedb.Options{Dir: ...})` rewrites live pointers into fresh segments and swaps `Dir/maindb/index.db` to reference the new log (offline; requires a clean commitlog).
+- `value_vlog`: rewrite live pointer-backed values, then GC fully unreachable segments.
+- `leaf_vlog`: pack sparse live leaf generations, then GC fully unreachable generations.
+- `index.db`: vacuum after leaf packing so rewritten roots/internal pages are reflected in the final file.
+- cleanup: remove zero-byte `value_vlog` segment files before final storage accounting.
+
+Use `treemap compact-plan <db-dir>` to preview remaining compaction debt without
+mutating storage.
+
+### Advanced low-level maintenance
+
+The individual maintenance APIs remain available, but they are domain-specific
+building blocks:
+
+- `db.ValueLogGC(...)` deletes fully-unreferenced `value_vlog` segments only.
+- `treedb.ValueLogRewriteOffline(...)` rewrites value-log pointers only.
+- `db.LeafGenerationPack*` packs sparse `leaf_vlog` generations only.
+- `db.LeafGenerationGC(...)` deletes fully unreachable `leaf_vlog` generations only.
+- `treedb.VacuumIndexOffline(...)` or `treemap compact -scope=index -rw` only rebuilds `index.db`.
+
+Do not manually chain these for benchmark storage numbers unless you are
+debugging TreeDB internals; use full storage compaction instead.
 
 Details: `docs/TREEDB_STORAGE_FORMAT.md`.
 

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -336,7 +336,7 @@ without a separate offline tool. These hooks execute inline during shutdown.
 
 - `TREEDB_CLOSE_CHECKPOINT=1`: call `Checkpoint()` before closing
 - `TREEDB_CLOSE_COMPACT_INDEX=1`: call `CompactIndex()` before closing
-- `TREEDB_CLOSE_VACUUM_INDEX_ONLINE=1`: call `VacuumIndexOnline()` (alias to `CompactIndex`) before closing
+- `TREEDB_CLOSE_VACUUM_INDEX_ONLINE=1`: call `VacuumIndexOnline()` before closing; unsupported platforms skip it without failing close
 - `TREEDB_CLOSE_VACUUM_TIMEOUT`: timeout for the online vacuum (duration string or seconds)
 - `TREEDB_CLOSE_LOG=1`: log close-maintenance start/stop messages
 - `TREEDB_CLOSE_SCOPE_CONTAINS`: substring match on `Options.Dir` that scopes which DBs run
@@ -384,6 +384,10 @@ This plans and executes the best-practice sequence across storage domains:
 - `leaf_vlog`: pack sparse live leaf generations, then GC fully unreachable generations.
 - `index.db`: vacuum after leaf packing so rewritten roots/internal pages are reflected in the final file.
 - cleanup: remove zero-byte `value_vlog` segment files before final storage accounting.
+
+If online index vacuum is unsupported on the current platform, `CompactStorage`
+records the `index-vacuum` phase as skipped and still completes the value-log,
+leaf-log, and cleanup phases.
 
 Use `treemap compact-plan <db-dir>` to preview remaining compaction debt without
 mutating storage.

--- a/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
+++ b/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
@@ -14,6 +14,9 @@ treemap compact <db-dir> -rw
 Use `treemap compact-plan <db-dir>` for a read-only preview. The individual
 `vlog-*` and `leafgen-*` commands below are advanced diagnostics and scheduler
 building blocks, not the recommended path for benchmark storage accounting.
+When online index vacuum is unsupported on a platform, `treemap compact` reports
+that phase as skipped and still performs the value-log, leaf-log, and cleanup
+phases.
 
 ## Recommended Defaults
 - `-treedb-maintenance-mode normal` (default)

--- a/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
+++ b/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
@@ -1,9 +1,19 @@
 # TreeDB Generational Value-Log Runbook
 
 ## Goals
-- Keep steady-state `maindb/wal` bounded under churn.
+- Keep steady-state `maindb/value_vlog`, `maindb/leaf_vlog`, and `maindb/wal` bounded under churn.
 - Avoid full-stop rewrite passes; use incremental rewrite + frequent GC.
 - Keep index maintenance policy-linked but independent from value-log GC.
+
+For manual final-footprint maintenance, prefer:
+
+```sh
+treemap compact <db-dir> -rw
+```
+
+Use `treemap compact-plan <db-dir>` for a read-only preview. The individual
+`vlog-*` and `leafgen-*` commands below are advanced diagnostics and scheduler
+building blocks, not the recommended path for benchmark storage accounting.
 
 ## Recommended Defaults
 - `-treedb-maintenance-mode normal` (default)


### PR DESCRIPTION
## Summary

- add a high-level `CompactStorage` API for raw TreeDB, cached TreeDB, and collections
- make `treemap compact` run full storage compaction by default, with `compact-plan` for read-only previews and `-scope=index` for legacy index-only compaction
- include value-log rewrite/GC, leaf-generation pack/GC, index vacuum, final GC settle passes, zero-byte value-log cleanup, and final debt auditing
- make read-only value-log/leaf-generation GC dry-runs work so audit/plan paths do not require writable opens
- update docs/help text to distinguish `wal`, `value_vlog`, and `leaf_vlog`, and demote low-level maintenance commands to advanced usage

Fixes #1434.

## Validation

- `go test ./TreeDB/db -run 'TestCompactStorage|TestLeafGenerationGC'`
- `go test ./TreeDB ./TreeDB/collections ./TreeDB/cmd/treemap`
- `go test ./TreeDB/...`
- `go test ./...`
- JSONBench harness: `go test ./...` in `JSONBench/treedb`
- JSONBench 1M TreeDB all-suite compacted run: `results/run_20260508_120956_compact_api_1m_all_settle/report_fresh_three_engines.md`

## Benchmark sanity

Fresh 1M report used only newly generated result JSONs:

- TreeDB: `JSONBench/treedb/results/run_20260508_120956_compact_api_1m_all_settle`
- DuckDB: `JSONBench/duckdb/local_results/fresh_1m_20260508_121356_duckdb`
- ClickHouse: `JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse`

The TreeDB full-document compacted DB reports `fully_compacted=true`, zero remaining value/leaf compaction debt, and zero zero-byte `value_vlog` files. `du -sk` on the DB reports `192368 KiB` total, with `32516 KiB` in `value_vlog` and `156588 KiB` in `leaf_vlog`.
