### PR TITLE
Add TreeDB collection WAL durability plan

### DIFF
--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -1,7 +1,9 @@
 # TreeDB agent notes (current)
 
-TreeDB stores large values in a **persistent value log** under `Options.Dir/maindb/wal/`.
-There is **no legacy alternate value-store path** in TreeDB.
+TreeDB stores large values in a **persistent value log** under
+`Options.Dir/maindb/value_vlog/`. The redo journal/WAL lives under
+`Options.Dir/maindb/wal/`. There is **no legacy alternate value-store path** in
+TreeDB.
 
 ## Project status (pre-alpha)
 
@@ -12,7 +14,7 @@ There is **no legacy alternate value-store path** in TreeDB.
 ## Canonical docs (trust these)
 
 - `TreeDB/docs/spec/README.md` (spec index and scope)
-- `TreeDB/docs/spec/storage-format.md` (on-disk layout + `ValuePtr` + wire formats)
+- `TreeDB/docs/spec/storage-format.md` (on-disk layout + `ValuePtr` + local frame formats)
 - `TreeDB/docs/spec/write-path-and-durability.md` (WAL on/off and sync semantics)
 - `TreeDB/docs/spec/recovery.md` (startup recovery and replay rules)
 - `TreeDB/docs/spec/value-log-lifecycle.md` (GC/rewrite/retention lifecycle)

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -12,7 +12,7 @@ Use that folder for architecture, format, durability, recovery, lifecycle, and v
 
 ## Features
 
--   **ACID Transactions:** Atomic commits using Copy-On-Write (COW) and redundant superblocks (Meta Pages).
+-   **Crash-consistent commits:** Atomic batch commits and recovery behavior according to the selected durability mode.
 -   **Snapshot Isolation:** Lock-free concurrent readers using Multi-Version Concurrency Control (MVCC) and Reference Counting.
 -   **Hybrid Storage:**
     -   **Index:** Memory-mapped B+Tree for keys and small values.
@@ -141,13 +141,19 @@ existing placement rules.
 - Optional hard cap: `Options.ValueLog.MaxRetainedBytesHard` disables value-log pointers for new large values once retained bytes exceed the threshold.
 - TreeDB is pre-alpha; public APIs and on-disk format may change without backward-compatibility guarantees.
 
-### Durability Matrix (Cached Mode)
+### Durability Overview (Cached Mode)
 
-| Mode | Journal | Sync boundary | Power-loss durability | Notes |
-| --- | --- | --- | --- | --- |
-| `DurabilityDurable` (default) | on | fsync | yes | safest default |
-| `DurabilityWALOnRelaxed` | on | flush-only | no | crash-consistent only |
-| `DurabilityWALOffRelaxed` | off | flush-only | no | fastest, least safe; use `Checkpoint()` for durable boundaries |
+The canonical durability-mode matrix is
+`TreeDB/docs/spec/write-path-and-durability.md#1-durability-modes`.
+
+In short: durable mode gives fsync durability at sync/checkpoint boundaries;
+WAL-on relaxed mode is process-crash-oriented and is not a power-loss fsync
+guarantee; WAL-off relaxed mode has no per-write journal replay and relies on
+flush/checkpoint/close boundaries. Collection writes currently remain governed
+by `TreeDB/docs/spec/collections-write-domain.md`; the target durable-at-ack
+collection overlay is gated by
+`TreeDB/docs/spec/collection-wal-durability-plan.md`; it is target behavior
+after the collection WAL gate, not current behavior.
 
 ## Tuning (Cached Mode)
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -69,12 +69,15 @@ const (
 )
 
 var (
-	ErrCollectionNotFound  = errors.New("collections: collection not found")
-	ErrDocumentExists      = errors.New("collections: document already exists")
-	ErrDuplicateDocumentID = errors.New("collections: duplicate document id in batch")
-	ErrIndexNotFound       = errors.New("collections: index not found")
-	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
-	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
+	ErrCollectionNotFound    = errors.New("collections: collection not found")
+	ErrDocumentExists        = errors.New("collections: document already exists")
+	ErrDuplicateDocumentID   = errors.New("collections: duplicate document id in batch")
+	ErrIndexNotFound         = errors.New("collections: index not found")
+	ErrUniqueIndexConflict   = errors.New("collections: unique index conflict")
+	ErrConcurrentMutation    = errors.New("collections: concurrent mutation")
+	ErrDurabilityUnavailable = errors.New("collections: durability unavailable")
+	ErrCommitAmbiguous       = errors.New("collections: commit ambiguous")
+	ErrRecoveryRequired      = errors.New("collections: recovery required")
 
 	errBSONIDMutation                          = errors.New("collections: update replacement cannot modify _id")
 	errCollectionManagerNil                    = errors.New("collections: collection manager is nil")
@@ -91,6 +94,42 @@ var (
 		collectionPprofOperationKey, collectionPprofIndexedAsyncFlushRun,
 	)
 )
+
+// CommitAmbiguousError reports that a collection mutation reached its logical
+// commit point before a later visibility, flush, checkpoint, response, or
+// bookkeeping step failed. The operation may already be visible or recoverable;
+// callers should not blindly retry non-idempotent mutations.
+type CommitAmbiguousError struct {
+	Operation string
+	Err       error
+}
+
+func (e *CommitAmbiguousError) Error() string {
+	if e == nil {
+		return ErrCommitAmbiguous.Error()
+	}
+	if e.Operation == "" {
+		if e.Err == nil {
+			return ErrCommitAmbiguous.Error()
+		}
+		return ErrCommitAmbiguous.Error() + ": " + e.Err.Error()
+	}
+	if e.Err == nil {
+		return ErrCommitAmbiguous.Error() + ": " + e.Operation
+	}
+	return ErrCommitAmbiguous.Error() + ": " + e.Operation + ": " + e.Err.Error()
+}
+
+func (e *CommitAmbiguousError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *CommitAmbiguousError) Is(target error) bool {
+	return target == ErrCommitAmbiguous
+}
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
 // non-empty and unique within the batch. Update receives the current stored
@@ -2080,6 +2119,12 @@ func (unlock collectionMutationUnlock) Unlock() {
 	unlock.domain.observeMutationLock(unlock.wait, hold)
 }
 
+// CreateCollection publishes a collection catalog entry.
+//
+// Current implementations publish metadata through backend roots before
+// success. Under the collection WAL target contract, success remains
+// process-crash recoverable under WAL-on modes and is not an fsync guarantee
+// unless composed with a sync-capable barrier.
 func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
 	if m == nil {
 		return nil, errCollectionManagerNil
@@ -2311,6 +2356,12 @@ func (c *Collection) cachedCatalogIdentity() (name string, systemRoot, commitSeq
 	return c.meta.Name, c.catalogSystemRoot, c.catalogCommitSeq
 }
 
+// CreateIndex creates and backfills one secondary index as a schema barrier.
+//
+// Current implementations drain pending writes before planning the backfill.
+// Under the collection WAL target contract, success means the index descriptor
+// and backfilled roots are atomically recoverable; unique conflicts remain
+// pre-commit errors that expose no partial index state.
 func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	if c == nil {
 		return nil, errCollectionNil
@@ -2525,6 +2576,13 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	return newMeta.copy(), nil
 }
 
+// Insert adds one document and returns the stored document ID.
+//
+// Current durability is mode/path dependent; see docs/spec/contracts.md. Under
+// the collection WAL target contract, WAL-on success is process-crash
+// recoverable but not necessarily published, checkpointed, or fsynced. WAL-off
+// relaxed success remains process-local until Flush, FlushAll, Checkpoint, or
+// Close covers the write.
 func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
@@ -6218,6 +6276,11 @@ func (c *Collection) insertOneViaBatch(id, document []byte) ([]byte, error) {
 	return ids[0], nil
 }
 
+// InsertBatch adds a batch of documents and returns the stored document IDs.
+//
+// Under the collection WAL target contract, WAL-on success makes the whole
+// batch recoverable as one mutation boundary. Ordinary pre-commit errors expose
+// no partial batch. Post-commit failures must be reported as commit-ambiguous.
 func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	return c.insertBatch(ids, documents, false)
 }
@@ -6767,6 +6830,12 @@ func (c *Collection) insertBatchNoIndex(
 	return resultIDs, nil
 }
 
+// Delete removes one document. See DeleteDocument for the matched/deleted
+// result.
+//
+// Under the collection WAL target contract, WAL-on success is process-crash
+// recoverable; WAL-off relaxed success is not durable-at-ack until an explicit
+// persistence boundary covers the write.
 func (c *Collection) Delete(documentID []byte) error {
 	_, err := c.DeleteDocument(documentID)
 	return err
@@ -6810,6 +6879,10 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 // root publish and returns the number of existing documents removed. Missing
 // documents are ignored. Duplicate IDs in the request are rejected so callers do
 // not depend on ordered same-ID semantics.
+//
+// Under the collection WAL target contract, WAL-on success makes the whole
+// delete batch recoverable as one mutation boundary. Pre-commit errors expose no
+// partial batch; post-commit failures must be commit-ambiguous.
 func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 	if c == nil {
 		return 0, errCollectionNil
@@ -7182,6 +7255,11 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // updates, update may run on an internal combiner goroutine. The callback must
 // not rely on caller goroutine behavior such as recover, runtime.Goexit, or
 // testing.T.Fatal.
+//
+// Under the collection WAL target contract, WAL-on success is process-crash
+// recoverable. Retry after timeout or commit-ambiguous failure is safe only when
+// the update function is idempotent or protected by an application-level guard
+// or durable idempotency key.
 func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
@@ -7238,6 +7316,11 @@ func (c *Collection) updateDirect(documentID []byte, update func(current []byte)
 // mutation. Missing documents report Matched=false. Duplicate document IDs are
 // rejected so callers that require same-document ordering can fall back to
 // sequential Update calls.
+//
+// Under the collection WAL target contract, WAL-on success makes the whole
+// batch recoverable as one mutation boundary. Item/callback errors are
+// pre-commit unless explicitly documented otherwise and must expose no partial
+// batch. Post-commit failures must be commit-ambiguous for the whole batch.
 func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
 	results, _, err := c.updateBatch(items, updateBatchModeAny)
 	return results, err

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -171,6 +171,14 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 	return val, err
 }
 
+// DurabilityMode reports the backend durability mode configured at open.
+func (db *DB) DurabilityMode() DurabilityMode {
+	if db == nil {
+		return DurabilityDurable
+	}
+	return db.durability
+}
+
 // GetMany returns values for keys.
 //
 // Semantics: Returns safe copies of values. Missing keys are returned as nil

--- a/TreeDB/db/collectionwal_dirty_test.go
+++ b/TreeDB/db/collectionwal_dirty_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadOnlyOpenRejectsDirtyCollectionWAL(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	writeSyntheticCollectionWALSegment(t, dir)
+
+	_, err = Open(Options{Dir: dir, ReadOnly: true})
+	if !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("Open read-only error=%v, want ErrRecoveryRequired", err)
+	}
+	_, err = openReadOnlyNoLock(Options{Dir: dir, ReadOnly: true})
+	if !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("openReadOnlyNoLock error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
+func TestOfflineMaintenanceRejectsDirtyCollectionWAL(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	writeSyntheticCollectionWALSegment(t, dir)
+
+	if _, err := ValueLogRewriteOffline(Options{Dir: dir}); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("ValueLogRewriteOffline error=%v, want ErrRecoveryRequired", err)
+	}
+	if err := VacuumIndexOffline(Options{Dir: dir}); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("VacuumIndexOffline error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
+func writeSyntheticCollectionWALSegment(t *testing.T, dir string) {
+	t.Helper()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "collection-l0-000001.log"), []byte("dirty collection wal"), 0o600); err != nil {
+		t.Fatalf("write collection WAL segment: %v", err)
+	}
+}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -95,7 +95,8 @@ type DB struct {
 	freelistRegionPages  uint64
 	freelistRegionRadius int
 
-	readOnly bool
+	readOnly   bool
+	durability DurabilityMode
 
 	keepRecent                     uint64
 	policy                         WritePolicy
@@ -631,7 +632,9 @@ type Options struct {
 	IgnoreFormatConfig bool
 	// ReadOnly opens the database without acquiring an exclusive lock and without
 	// modifying on-disk state (no recovery truncation, no WAL replay, no background
-	// maintenance). Only read operations are supported.
+	// maintenance). Only read operations are supported. Under the collection WAL
+	// target contract, read-only open must fail with a recovery-required error if
+	// committed unapplied collection WAL needs mutating recovery.
 	ReadOnly  bool
 	ChunkSize int64 // Default 256KiB
 	// DictDBChunkSize controls the mmap chunk size used for the `dictdb/` side
@@ -1372,6 +1375,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		preferAppendAlloc:              opts.PreferAppendAlloc,
 		freelistRegionPages:            opts.FreelistRegionPages,
 		freelistRegionRadius:           opts.FreelistRegionRadius,
+		durability:                     opts.Durability,
 		policy: WritePolicy{
 			InlineThreshold: inlineThreshold,
 			FlushThreshold:  opts.FlushThreshold,

--- a/TreeDB/db/errors.go
+++ b/TreeDB/db/errors.go
@@ -3,6 +3,7 @@ package db
 import (
 	"errors"
 
+	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 )
 
@@ -13,4 +14,7 @@ var (
 	ErrReadOnly = errors.New("treedb: read-only")
 	// ErrClosed indicates the DB handle is closed or closing for reads.
 	ErrClosed = errors.New("treedb: db is closed")
+	// ErrRecoveryRequired indicates the DB must be opened read-write for recovery
+	// before the requested read-only or offline-maintenance operation can run.
+	ErrRecoveryRequired = collectionwal.ErrCollectionWALRecoveryRequired
 )

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -24,6 +25,10 @@ func openReadOnly(opts Options) (*DB, error) {
 	if l, err := lockfile.AcquireShared(lockPath); err == nil {
 		lock = l
 	} else if !(errors.Is(err, os.ErrNotExist) || errors.Is(err, lockfile.ErrUnsupported)) {
+		return nil, err
+	}
+	if err := collectionwal.RequireCleanForReadOnlyOpen(opts.Dir); err != nil {
+		_ = lock.Close()
 		return nil, err
 	}
 
@@ -151,6 +156,9 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		return nil, err
 	}
 	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
+		return nil, err
+	}
+	if err := collectionwal.RequireCleanForReadOnlyOpen(opts.Dir); err != nil {
 		return nil, err
 	}
 	idxPath := filepath.Join(opts.Dir, indexFileName)

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -56,6 +57,9 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 	defer func() { _ = lock.Close() }()
 
 	if err := recoverIndexSwap(opts.Dir); err != nil {
+		return err
+	}
+	if err := collectionwal.RequireCleanForOfflineMaintenance(opts.Dir); err != nil {
 		return err
 	}
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -20,6 +20,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
@@ -2877,6 +2878,9 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 	defer func() { _ = lock.Close() }()
 
 	if err := recoverIndexSwap(opts.Dir); err != nil {
+		return stats, err
+	}
+	if err := collectionwal.RequireCleanForOfflineMaintenance(opts.Dir); err != nil {
 		return stats, err
 	}
 

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -5,16 +5,73 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
 
-func TestDocs_NoTreeDBSlabTerminology(t *testing.T) {
+func repoRoots(t *testing.T) (treeRoot, repoRoot string) {
+	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatalf("runtime.Caller failed")
 	}
-	treeRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), ".."))
+	treeRoot = filepath.Clean(filepath.Join(filepath.Dir(thisFile), ".."))
+	repoRoot = filepath.Clean(filepath.Join(treeRoot, ".."))
+	return treeRoot, repoRoot
+}
+
+func markdownDocs(t *testing.T) []string {
+	t.Helper()
+	treeRoot, repoRoot := repoRoots(t)
+	roots := []string{
+		filepath.Join(treeRoot, "README.md"),
+		filepath.Join(treeRoot, "AGENTS.md"),
+		filepath.Join(treeRoot, "AUDIT_TRACKING.md"),
+		filepath.Join(treeRoot, "docs", "spec"),
+		filepath.Join(repoRoot, "docs"),
+	}
+
+	seen := make(map[string]bool)
+	var paths []string
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		if err != nil {
+			t.Fatalf("stat %s: %v", root, err)
+		}
+		if !info.IsDir() {
+			if strings.HasSuffix(root, ".md") && !seen[root] {
+				seen[root] = true
+				paths = append(paths, root)
+			}
+			continue
+		}
+		err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "benchmarks" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(path, ".md") && !seen[path] {
+				seen[path] = true
+				paths = append(paths, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func TestDocs_NoTreeDBSlabTerminology(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
 
 	paths := []string{
 		filepath.Join(treeRoot, "README.md"),
@@ -39,6 +96,140 @@ func TestDocs_NoTreeDBSlabTerminology(t *testing.T) {
 		text = allowedLegacyFields.ReplaceAllString(text, "")
 		if strings.Contains(text, "slab") {
 			t.Fatalf("legacy slab terminology found in %s; use persistent value-log wording", p)
+		}
+	}
+}
+
+func TestDocs_CanonicalStoragePaths(t *testing.T) {
+	staleValueLogPath := regexp.MustCompile(`wal/value-l(?:\*|<|\d|-)`)
+	for _, p := range markdownDocs(t) {
+		content, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		for i, line := range strings.Split(string(content), "\n") {
+			lower := strings.ToLower(line)
+			if strings.Contains(lower, "legacy") {
+				continue
+			}
+			if staleValueLogPath.MatchString(lower) || strings.Contains(lower, "maindb/wal/value") {
+				t.Fatalf("%s:%d uses stale value-log path; canonical value-log path is maindb/value_vlog/value-l*.log", p, i+1)
+			}
+			mentionsValueLog := strings.Contains(lower, "value-log") || strings.Contains(lower, "value log") || strings.Contains(lower, "large values")
+			if mentionsValueLog && (strings.Contains(lower, "dir/maindb/wal") || strings.Contains(lower, "options.dir/maindb/wal") || strings.Contains(lower, "maindb/wal/")) {
+				t.Fatalf("%s:%d places value-log data under wal; canonical value-log path is maindb/value_vlog/", p, i+1)
+			}
+		}
+	}
+}
+
+func TestDocs_DurabilityMatrixSingleOwner(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	owner := filepath.Join(treeRoot, "docs", "spec", "write-path-and-durability.md")
+	heading := regexp.MustCompile(`(?im)^#{1,6}\s+.*durability matrix`)
+	for _, p := range markdownDocs(t) {
+		content, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		if p != owner && heading.Match(content) {
+			t.Fatalf("%s defines a durability matrix; link to %s instead", p, owner)
+		}
+	}
+}
+
+func TestDocs_CollectionWALCurrentTargetLabels(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	ownerDocs := map[string]bool{
+		filepath.Join(treeRoot, "docs", "spec", "backup-restore.md"):                 true,
+		filepath.Join(treeRoot, "docs", "spec", "collection-wal-durability-plan.md"): true,
+		filepath.Join(treeRoot, "docs", "spec", "collections-write-domain.md"):       true,
+		filepath.Join(treeRoot, "docs", "spec", "contracts.md"):                      true,
+		filepath.Join(treeRoot, "docs", "spec", "native-query-raft-roadmap.md"):      true,
+		filepath.Join(treeRoot, "docs", "spec", "native-wire-protocol.md"):           true,
+		filepath.Join(treeRoot, "docs", "spec", "recovery.md"):                       true,
+		filepath.Join(treeRoot, "docs", "spec", "storage-format.md"):                 true,
+		filepath.Join(treeRoot, "docs", "spec", "value-log-lifecycle.md"):            true,
+		filepath.Join(treeRoot, "docs", "spec", "verification.md"):                   true,
+		filepath.Join(treeRoot, "docs", "spec", "write-path-and-durability.md"):      true,
+		filepath.Join(treeRoot, "docs", "spec", "GOMAP_TREEDB_COLUMN_STORE_RFC.md"):  true,
+		filepath.Join(treeRoot, "docs", "spec", "COMPRESSION_TECHNOLOGY_SPEC.md"):    true,
+	}
+	terms := []string{"collection wal", "durable-at-ack", "applied watermark", "side ref", "root group"}
+	phaseTerms := []string{"current behavior", "target behavior", "target contract", "planned", "until collection wal lands", "after the collection wal gate", "before collection wal lands", "once collection wal", "target collection", "current shipped", "future collection wal"}
+
+	for _, p := range markdownDocs(t) {
+		if ownerDocs[p] {
+			continue
+		}
+		content, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		text := strings.ToLower(string(content))
+		hasTerm := false
+		for _, term := range terms {
+			if strings.Contains(text, term) {
+				hasTerm = true
+				break
+			}
+		}
+		if !hasTerm {
+			continue
+		}
+		hasPhase := false
+		for _, term := range phaseTerms {
+			if strings.Contains(text, term) {
+				hasPhase = true
+				break
+			}
+		}
+		if !hasPhase {
+			t.Fatalf("%s mentions collection WAL terms without current/target phase language", p)
+		}
+	}
+}
+
+func TestDocs_SpecManifestFilesExist(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	readmePath := filepath.Join(treeRoot, "docs", "spec", "README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", readmePath, err)
+	}
+	re := regexp.MustCompile("TreeDB/docs/spec/([^`\\s]+\\.md)")
+	matches := re.FindAllSubmatch(content, -1)
+	if len(matches) == 0 {
+		t.Fatalf("no spec manifest links found in %s", readmePath)
+	}
+	for _, match := range matches {
+		name := string(match[1])
+		path := filepath.Join(treeRoot, "docs", "spec", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("spec manifest references missing file %s: %v", path, err)
+		}
+	}
+}
+
+func TestDocs_NativeWireRaftLocalWALSeparation(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	paths := []string{
+		filepath.Join(treeRoot, "docs", "spec", "collection-wal-durability-plan.md"),
+		filepath.Join(treeRoot, "docs", "spec", "native-query-raft-roadmap.md"),
+		filepath.Join(treeRoot, "docs", "spec", "native-wire-protocol.md"),
+	}
+	for _, p := range paths {
+		content, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		text := strings.ToLower(string(content))
+		if strings.Contains(text, "raft") && strings.Contains(text, "collection wal") {
+			hasLocalPhysical := strings.Contains(text, "local physical")
+			hasNotRaftLog := strings.Contains(text, "not a raft log")
+			if !hasLocalPhysical || !hasNotRaftLog {
+				t.Fatalf("%s mentions Raft and collection WAL without stating that collection WAL is local physical state and not a Raft log entry", p)
+			}
 		}
 	}
 }

--- a/TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md
+++ b/TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md
@@ -1,0 +1,22 @@
+# TreeDB Compression Technology Spec
+
+Status: canonical placeholder for compression technology decisions. Current
+value-log compression behavior is implemented in code and supporting docs; this
+file owns future cross-storage compression compatibility questions once they are
+promoted to canonical spec status.
+
+Compression codecs, dictionary formats, and template side stores must preserve
+the durability and recovery boundaries defined by `storage-format.md`,
+`value-log-lifecycle.md`, and `recovery.md`. Any compression feature that creates
+external side bytes for collection roots is also blocked by the collection WAL
+side-ref and restore-validation gates in
+`collection-wal-durability-plan.md`.
+
+Production persistent column-store collection writes are blocked until
+`TreeDB/docs/spec/collection-wal-durability-plan.md` M7 sign-off links to green
+M1-M6 collection WAL evidence. Before that gate, column-store work is limited
+to docs, benchmarks, pure codecs, filters/search packages, and isolated
+encode/decode tests that do not publish persistent collection roots. Persistent
+column-store APIs, column part descriptor roots, secondary indexes pointing at
+column-store rows, column-file side refs in published roots, and crash/reopen
+safety claims for column-store writes are blocked.

--- a/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
+++ b/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
@@ -16,3 +16,35 @@ This file exists so the spec index and docs-lint manifest have a stable owner
 for column-store persistence questions. When a full RFC lands, it must keep the
 blocker paragraph above unchanged or explicitly update the WAL gate, verification
 matrix, and spec README in the same change.
+
+## Persistent Descriptor Identity
+
+Persistent column-store roots remain blocked, but any future descriptor format
+must use stable identity and generation guards:
+
+```text
+ColumnPartDescriptorV1 {
+    PartID                         uuid128 or uint128
+    PartGeneration                 uint64
+    OwnerCollectionUID             uuid128
+    CollectionGeneration           uint64
+    SchemaEpoch                    uint64
+    ColumnSchemaDigest             bytes32
+    CompressionDescriptorDigest    bytes32
+    CodecRegistryVersion           uint64
+    DictionaryUIDs                 repeated uuid128
+    DictionaryGenerations          repeated uint64
+    CreatedByCollectionSeq         uint64
+    SupersededByCollectionSeq      uint64 optional
+    CompactionEpoch                uint64 optional
+    RowCount                       uint64
+    PrimaryKeyRange                optional
+    MinMaxStatsDigest              bytes32 optional
+    SideRefDigest                  bytes32
+}
+```
+
+Delete, filter, locator, count, and visibility roots must reference
+`PartID + PartGeneration`, not bare `PartID`. Compaction/recompression must
+create new part IDs or increment part generation and publish source supersession
+plus target descriptors in one collection WAL maintenance transaction.

--- a/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
+++ b/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
@@ -1,0 +1,18 @@
+# TreeDB Column Store RFC
+
+Status: canonical placeholder for column-store persistence scope. Detailed
+format and execution design remains future work.
+
+Production persistent column-store collection writes are blocked until
+`TreeDB/docs/spec/collection-wal-durability-plan.md` M7 sign-off links to green
+M1-M6 collection WAL evidence. Before that gate, column-store work is limited
+to docs, benchmarks, pure codecs, filters/search packages, and isolated
+encode/decode tests that do not publish persistent collection roots. Persistent
+column-store APIs, column part descriptor roots, secondary indexes pointing at
+column-store rows, column-file side refs in published roots, and crash/reopen
+safety claims for column-store writes are blocked.
+
+This file exists so the spec index and docs-lint manifest have a stable owner
+for column-store persistence questions. When a full RFC lands, it must keep the
+blocker paragraph above unchanged or explicitly update the WAL gate, verification
+matrix, and spec README in the same change.

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -78,8 +78,22 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/backup-restore.md`
   - restorable file set, live backup barrier, restore validation, and
     quarantine/purge requirements for collection WAL side refs.
+- `TreeDB/docs/spec/native-wire-protocol.md`
+  - native binary protocol v1 for code that advertises native-wire support;
+    distributed/Raft behavior remains target behavior until cluster mode lands.
 - `TreeDB/docs/spec/verification.md`
   - invariants mapped to tests and benchmark harnesses.
+
+## Target Gates (Normative Target, Not Current Behavior)
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+  - normative target contract and implementation gate for collection
+    WAL/root-group durability.
+  - Until its acceptance milestones pass, current collection writes remain
+    governed by `collections-write-domain.md` and are flush-boundary durable,
+    not durable-at-ack.
+  - Downstream specs may cite this document as a blocker or target contract,
+    but must label referenced behavior as target behavior until the gate lands.
 
 ## Design Proposals (Non-Normative)
 
@@ -102,11 +116,6 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/collections-native-fastpath-baseline-2026-04-25.md`
   - refreshed pre-`R0` baseline note for issue `#768`, including exact
     main/oracle SHAs, artifact dirs, commands, and benchmark baselines.
-- `TreeDB/docs/spec/native-wire-protocol.md`
-  - draft native binary network protocol for TreeDB collections, including
-    framing, command payloads, explicit ack/consistency policies, and the
-    boundary between wire requests and future deterministic Raft command
-    entries.
 - `TreeDB/docs/spec/native-wire-implementation-guidelines.md`
   - implementation playbook for keeping codecs, schema IDs, validation,
     conformance tests, benchmarks, and future Raft entry handling aligned with
@@ -122,10 +131,61 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - R2 deterministic command-entry closeout, including replicated-command
     fixtures, canonical validation, digest stability, benchmarks, and deferred
     Raft apply work.
+
+## Canonical Ownership
+
+| Concept | Canonical owner | Supporting docs |
+|---|---|---|
+| Durability mode matrix | `write-path-and-durability.md` | `contracts.md`, public README and supporting docs summarize only. |
+| Current collection flush-boundary durability | `collections-write-domain.md` | `contracts.md`, `verification.md`. |
+| Target collection durable-at-ack WAL contract | `collection-wal-durability-plan.md` | `write-path-and-durability.md`, `recovery.md`, `verification.md`. |
+| Current recovery algorithm | `recovery.md` | `storage-format.md`, `verification.md`. |
+| Durable bytes and file names | `storage-format.md` | `recovery.md`, `architecture.md`, `backup-restore.md`. |
+| Value-log and split leaf-log lifecycle | `value-log-lifecycle.md` | `storage-format.md`, `collection-wal-durability-plan.md`. |
+| Generic collection WAL side refs and side files | `collection-wal-durability-plan.md` | `value-log-lifecycle.md`, future column-store docs. |
+| Public API semantics | `contracts.md` | `write-path-and-durability.md`, `collections-write-domain.md`. |
+| Native-wire ack policies | `native-wire-protocol.md` | `collection-wal-durability-plan.md`, `native-query-raft-roadmap.md`. |
+| Raft/local apply layering | `native-query-raft-roadmap.md` | `native-wire-protocol.md`, `collection-wal-durability-plan.md`. |
+| Verification mapping | `verification.md` | all normative specs. |
+
+## Terminology Ownership
+
+TreeDB-wide storage terms (`value log`, `leaf log`, `commit log`,
+`ValuePtr`) are owned by `storage-format.md` and `value-log-lifecycle.md`.
+Collection WAL lifecycle terms (`durable-at-ack`, `flush-boundary durable`,
+`recoverable`, `published`, `checkpointed`, `cleanable`, `side ref`,
+`side file`, `root group`, `applied watermark`, `CollectionSeq`, `WALLSN`)
+are owned by `collection-wal-durability-plan.md#3-definitions` until the target
+contract lands; supporting docs must link there instead of redefining them.
+
+## Open Questions Index
+
+Open questions remain in their owner documents, but this index records where
+blocking questions live:
+
+- Collection WAL durability/recovery questions:
+  `collection-wal-durability-plan.md`.
+- Native-wire protocol questions: `native-wire-protocol.md`.
+- Raft sequencing and local recoverability questions:
+  `native-query-raft-roadmap.md`.
+- Column-store persistence questions:
+  `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
+
+A blocking implementation question must be listed in this index and in its
+owner document. Non-blocking future-extension questions must be labeled as
+such.
+
+## Required Spec Files
+
+Docs lint treats this list as a manifest:
+
+- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- `TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md`
 - `TreeDB/docs/spec/collection-wal-durability-plan.md`
-  - proposal and implementation plan for collection WAL/root-group durability,
-    recovery replay, side-file fences, and the hard prerequisite gate for
-    persistent column-store collection writes.
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/verification.md`
 
 ## Relationship to Existing Docs
 

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -119,6 +119,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - R2 deterministic command-entry closeout, including replicated-command
     fixtures, canonical validation, digest stability, benchmarks, and deferred
     Raft apply work.
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+  - proposal and implementation plan for collection WAL/root-group durability,
+    recovery replay, side-file fences, and the hard prerequisite gate for
+    persistent column-store collection writes.
 
 ## Relationship to Existing Docs
 

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -75,6 +75,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - open-time recovery pipeline, replay ordering, truncated tail behavior, failure modes.
 - `TreeDB/docs/spec/value-log-lifecycle.md`
   - retention, GC, rewrite, and operational lifecycle of value-log segments.
+- `TreeDB/docs/spec/backup-restore.md`
+  - restorable file set, live backup barrier, restore validation, and
+    quarantine/purge requirements for collection WAL side refs.
 - `TreeDB/docs/spec/verification.md`
   - invariants mapped to tests and benchmark harnesses.
 

--- a/TreeDB/docs/spec/architecture.md
+++ b/TreeDB/docs/spec/architecture.md
@@ -7,8 +7,12 @@ TreeDB exposes one primary public engine (`treedb.Open`) with a cached write-bac
 The runtime consists of:
 
 - B+Tree index in `index.db` (mmap pager, copy-on-write commits).
-- Value log (`wal/value-l*.log`) for out-of-line large values.
-- Commit log / journal (`wal/commit-l*.log`) for cached-mode replay.
+- Value log (`maindb/value_vlog/value-l*.log`) for out-of-line large values.
+- Optional split leaf log (`maindb/leaf_vlog/value-l*.log`) for outer leaf
+  generations.
+- Commit log / journal (`maindb/wal/commit-l*.log`) for cached-mode replay.
+- Target collection WAL segments (`maindb/wal/collection-l*.log`) once the
+  collection WAL gate lands.
 - Optional side stores:
   - `dictdb/` for persistent dictionary bytes,
   - `templatedb/` for template compression definitions.
@@ -61,6 +65,10 @@ Default root layout:
   - `LOCK`
   - `wal/`
     - `commit-l<lane>-<seq>.log`
+    - `collection-l<lane>-<seq>.log` (target collection WAL)
+  - `value_vlog/`
+    - `value-l<lane>-<seq>.log`
+  - `leaf_vlog/`
     - `value-l<lane>-<seq>.log`
 - `<root>/dictdb/`
   - `index.db`

--- a/TreeDB/docs/spec/backup-restore.md
+++ b/TreeDB/docs/spec/backup-restore.md
@@ -1,0 +1,136 @@
+# Backup and Restore Specification
+
+This document defines the operator-visible backup and restore contract for
+TreeDB directories once collection WAL durable-at-ack is enabled.
+
+## 1. Restorable Directory File Set
+
+A complete restorable root-layout backup includes:
+
+- `maindb/index.db`;
+- `maindb/format.json`, when present;
+- `maindb/wal/commit-l<lane>-<seq>.log` needed for cached replay;
+- `maindb/wal/collection-l<lane>-<seq>.log` ranges not covered by durable
+  collection WAL cleanup metadata;
+- collection WAL segment metadata and cleanup manifests;
+- `maindb/value_vlog/value-l<lane>-<seq>.log` referenced by roots, cached WAL,
+  collection WAL, snapshots/read views represented in the backup manifest, or
+  side-ref protection metadata;
+- `maindb/leaf_vlog/value-l<lane>-<seq>.log` and leaf-generation
+  manifests/indexes when outer leaves are enabled;
+- all collection WAL side-payload files, root-delta payloads, prepared/final
+  side refs, and future column files referenced by roots or non-cleaned
+  collection WAL;
+- `dictdb/**` and `templatedb/**`, including each side store's `index.db`,
+  `format.json`, `wal/`, `value_vlog/`, `leaf_vlog/`, and cleanup metadata,
+  when those stores are enabled;
+- future column-store directories: parts, manifests, filters, delete bitmaps,
+  dictionaries, compression metadata, locator roots, and their cleanup
+  manifests;
+- backup manifest, if the backup was taken with a live WAL-snapshot barrier.
+
+`LOCK` files and transient maintenance files such as `index.db.new`,
+`index.db.bak`, and `index.db.new.ready` are not required in a clean backup. If
+present, restore must run existing index-swap recovery before collection WAL
+recovery.
+
+Copying only `maindb/index.db` is not a backup. Copying only `maindb` is not a
+complete root-layout backup when `dictdb`, `templatedb`, collection WAL side
+payloads, or future column side files are enabled.
+
+## 2. Live Backup Support
+
+A filesystem-level copy or snapshot of a live TreeDB root without a TreeDB
+backup barrier is unsupported. A filesystem-level copy/snapshot of a live root
+is supported only while a TreeDB backup barrier token is held, or after clean
+close.
+
+The backup barrier is backend-owned and coordinates the main DB, side stores,
+collection WAL, side-ref prepare guards, protected side refs, cleanup metadata,
+and backup-retention pins.
+
+### 2.1 Clean-Checkpoint Backup
+
+Procedure:
+
+1. `BeginBackupBarrier(mode=CleanCheckpoint)`.
+2. Fence new collection writers.
+3. Wait for admitted collection writes and side-ref prepares.
+4. Drain async collection publish and `FlushAll`.
+5. Publish root descriptors and applied watermarks.
+6. Force backend checkpoint/meta durability boundary.
+7. Write and fsync collection WAL cleanup metadata for cleanable ranges.
+8. Return a manifest with `collection_wal_debt=0`.
+9. Copy the manifest-listed root directory files or take a filesystem snapshot.
+10. `EndBackupBarrier`.
+
+If the checkpoint cannot publish or watermark pre-cut collection WAL,
+`BeginBackupBarrier(mode=CleanCheckpoint)` must fail or return a manifest that
+is not marked clean. It must not allow operators to infer that collection WAL is
+safe to omit.
+
+### 2.2 WAL-Snapshot Backup
+
+Procedure:
+
+1. `BeginBackupBarrier(mode=WALSnapshot)`.
+2. Fence collection WAL admission at a cut.
+3. Wait for side-ref prepares before the cut to commit/protect or
+   abort/classify.
+4. Rotate/seal WAL, value-log, leaf-log, and side-payload files needed by the
+   cut, or record exact byte ranges plus checksums for active tails.
+5. Fsync every manifest-listed WAL segment/range and side ref to the selected
+   durability boundary.
+6. Write and fsync the backup manifest.
+7. Release writers after the filesystem snapshot is taken, or keep manifest
+   retention pins until `EndBackupBarrier` after file copy completes.
+8. Restore validates and replays committed unapplied collection WAL from the
+   manifest.
+
+The WAL-snapshot manifest includes root layout, file classes, exact
+paths/ranges/sizes/checksums, applied watermarks, collection WAL cleaned ranges,
+collection WAL debt, side-store checkpoints, and backup token generation. The
+manifest itself is a retention root until the barrier token is released.
+
+## 3. Restore Validation
+
+Restore/open validation before serving reads:
+
+1. recover index swap artifacts;
+2. load backup manifest if present;
+3. discover collection WAL segments and cleanup metadata;
+4. treat missing collection WAL segments as valid only when covered by durable
+   cleanup metadata or by the backup manifest's cleaned-range proof;
+5. rebuild protected side-ref index from all committed non-cleaned collection
+   WAL;
+6. for every committed transaction not covered by applied watermark plus
+   cleanup:
+   - validate frame checksum and transaction checksum;
+   - validate `CollectionUID`, generation, schema epoch, catalog digest, and
+     root epochs;
+   - decode embedded root deltas/descriptors and derive the canonical side-ref
+     set;
+   - compare canonical side refs to declared `SideRefs`;
+   - verify every side ref exists, has expected size/checksum/class, and has
+     dictionary/template/column dependency closure;
+7. stop open before serving reads on any missing or corrupt required side ref;
+8. publish descriptors and applied watermarks atomically for unapplied
+   transactions;
+9. classify uncommitted prepared/final side files;
+10. quarantine, but do not immediately purge, files proven orphaned.
+
+Backup/restore validation fails closed on missing collection WAL side refs. A
+restore may accept a missing collection WAL segment only when durable cleanup
+metadata or the backup manifest proves the exact segment/range was safely
+cleaned.
+
+## 4. Quarantine and Purge
+
+Quarantine records must be durable before side files are moved, hidden, or made
+unavailable for normal recovery. A quarantine manifest records source class,
+source registry path, `FileID`/part id, size, checksum, classification reason,
+recovery generation, and the proof that no committed WAL, published root,
+snapshot, read view, or backup manifest references the file.
+
+Quarantined IDs remain reserved until purge is durable. Purge may run only
+after a successful checkpoint/cleanup boundary or an explicit operator command.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -57,29 +57,48 @@ Before this milestone passes, column-store work may proceed only for docs,
 benchmarks, pure codecs, filters, and isolated format encode/decode tests that
 do not publish persistent collection roots.
 
-PR1 makes these decisions normative:
+PR1-min is an explicitly guarded correctness slice, not the full collection WAL
+contract. It may expose durable-at-ack only for small no-index row
+`Insert`/`InsertBatch` mutations under an internal feature flag and capability
+named `NoIndexRowInsertOnly`. The feature flag defaults off.
 
-- use per-write collection WAL transactions with per-collection dependency
-  chains and replay-side accumulation;
-- reject true multi-collection collection WAL transactions before writing side
-  refs or WAL records;
-- use a stable persisted `CollectionUID`, mandatory
-  `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, and per-root
-  `RootGeneration`/root descriptor epochs as replay guards;
-- include a versioned `SystemDeltaTemplate` in every replayable transaction;
-- fail recovery on any complete collection WAL transaction with a missing
-  required side ref in WAL-on modes;
-- maintain a protected side-ref index, rebuilt from WAL during recovery, for
-  PR1 GC/rewrite safety;
-- require a side-ref prepare guard that blocks GC/rewrite/cleanup while side
-  refs are being prepared but not yet committed to WAL;
-- require segment metadata and durable cleanup manifests before missing
-  collection WAL segments can be treated as safely cleaned;
-- make `DB.Checkpoint` call registered collection checkpoint hooks and force
-  publication of replayable collection WAL before reporting a clean collection
-  WAL state;
-- encode overlay compaction as a collection WAL maintenance transaction when it
-  can race with user-visible collection writes.
+PR1-min makes these decisions normative:
+
+- no durable-at-ack path may install read-visible pending state before the
+  collection WAL commit marker is recoverable;
+- the minimal durable transaction still records stable replay identity:
+  `Version`, `WALLSN`, `CollectionUID`, `CollectionGeneration`,
+  `CollectionSeq`, `DependsOnCollectionSeq`, `SchemaEpoch`, `BaseCommitSeq`,
+  `BaseSystemRootID`, `BaseCatalogDigest`, `CatalogDigest`, mutated primary
+  root base id and descriptor epoch, `MutationClass`, inline `RootDeltas`,
+  `SystemDeltaTemplate`, empty canonical `SideRefs`, `ReplayDigest`, and frame
+  checksum;
+- `CollectionName`, created timestamps, and stats are diagnostic only and are
+  not replay identity;
+- root descriptor publication and applied-watermark advancement are one backend
+  commit;
+- recovery is backend-owned and runs before collection APIs serve; read-only
+  open fails when unapplied committed collection WAL exists;
+- root deltas are inline-only; any value-log pointer, leaf-log pointer,
+  root-delta side payload, column-file ref, or other required side ref is a hard
+  error before visibility unless that side-ref class is explicitly implemented;
+- a single global collection WAL publisher serializes planning, WAL append,
+  backend root publish, watermark publish, and visible install, so PR1-min has
+  at most one unwatermarked transaction globally;
+- normal successful PR1-min writes publish descriptors and watermarks before
+  returning success; crash after WAL commit but before publish is recovered on
+  read-write open;
+- collection WAL segment deletion and side-file release are disabled; missing
+  uncleaned collection WAL is corruption/recovery failure;
+- WAL-off mode creates no collection WAL files and makes no durable-at-ack
+  claim.
+
+The full collection WAL contract is a later gate. It adds indexed
+insert/update/delete durable-at-ack, replay-side accumulation, protected
+side-ref indexes for emitted side-ref classes, root-delta side payloads,
+async-publish integration, checkpoint/close cleanup boundaries, overlay
+compaction WAL transactions, persistent column-store side files, and
+native-wire/Raft exposure.
 
 ## 2. Current Facts
 
@@ -401,10 +420,19 @@ blind retry.
 `Collection.Insert`, `InsertBatch`, `Update`, `UpdateBatch`, `Delete`, and
 `DeleteBatch`:
 
-- In WAL-on modes, successful return means the root-delta transaction is
-  recoverable.
-- The write may still be pending in the collection write domain for read
-  performance and publish amortization.
+- In the full WAL-on contract, successful return means the root-delta
+  transaction is recoverable.
+- PR1-min is narrower: only no-index row `Insert` and `InsertBatch` may expose
+  durable-at-ack, and only when the guarded `NoIndexRowInsertOnly` capability is
+  selected. Indexed schemas, update/delete, schema/index mutations,
+  pointerizing storage policies, root-delta side payloads, and column roots must
+  return an unsupported or capacity error before staging any pending state.
+- With the feature off, existing flush-boundary behavior remains unchanged and
+  must not emit collection WAL files for unflushed writes.
+- The full contract may later allow writes to remain pending in the collection
+  write domain for read performance and publish amortization only after the
+  collection WAL transaction is recoverable. PR1-min publishes/watermarks before
+  returning success and does not create durable pending overlays.
 - Batch mutators are all-or-nothing at the collection WAL commit boundary. A
   pre-commit item, validation, side-ref, or WAL append error leaves no batch item
   visible or recoverable. A post-commit failure is commit-ambiguous for the
@@ -431,6 +459,9 @@ blind retry.
 - Advances the applied watermark for all published collection WAL transactions.
 - Enables collection WAL cleanup after the backend checkpoint boundary that
   contains the watermark is durable.
+- Under PR1-min it may publish already retained WAL-backed no-index row
+  transactions, but cleanup deletion remains disabled and existing
+  flush-boundary semantics remain in force when the feature is off.
 
 `CollectionManager.FlushAll`:
 
@@ -439,15 +470,19 @@ blind retry.
 
 `DB.Checkpoint`:
 
-- Must become a full database durability/cleanup boundary for collection WAL.
+- Must become a full database durability/cleanup boundary for collection WAL
+  before the full contract or default enablement.
 - Must call a backend-owned collection WAL checkpoint service, or registered
   hooks that are coordinated by such a service.
-- PR1 checkpoint handling must close admission for the checkpoint cut, wait for
+- Full checkpoint handling must close admission for the checkpoint cut, wait for
   in-flight collection writes admitted before the cut, wait for in-flight async
   publish, drain all known write domains through `FlushAll`, publish root
   groups, advance applied watermarks in backend commits, sync the backend
   boundary required by the selected mode, and only then allow collection WAL
   cleanup.
+- PR1-min does not require checkpoint cleanup semantics. It must not report
+  collection WAL as clean merely because backend `DB.Checkpoint` completed, and
+  it must retain collection WAL files needed for recovery.
 - Writes admitted after the checkpoint cut may remain in retained collection WAL,
   but they are not part of the checkpoint-covered prefix.
 - It must not report a clean WAL state while collection WAL transactions remain
@@ -520,36 +555,45 @@ collection commands must enforce the same document-id, document-byte,
 index-count, catalog-guard, logical-name, and path limits as the collection WAL
 planner.
 
-### 6.3 PR1 Invariants
+### 6.3 PR1-Min Invariants and Full-Contract Extensions
 
-These invariants are normative for PR1 and are the acceptance criteria for
-turning the design into code:
+These invariants are normative for PR1-min and are the acceptance criteria for
+turning the guarded no-index row slice into code. Full-contract extensions keep
+the same invariants and add the deferred side-ref, indexed, async, cleanup, and
+column-store rules.
 
 1. Visibility implies recoverability. In WAL-on modes, any collection mutation
    visible to a read, scan, uniqueness check, update planner, delete planner, or
    schema/index barrier must be recoverable from backend roots or from a
    committed collection WAL transaction.
-2. Side refs precede WAL commit. A collection WAL transaction may reference a
-   side ref only after the bytes are readable at the selected durability boundary
-   and registered as protected against GC, rewrite, cleanup, and compaction.
+2. Side refs precede WAL commit. PR1-min emits no side refs; any physical value
+   that would require a value-log pointer, leaf-log pointer, root-delta side
+   payload, or column-file ref is rejected before visibility. When a later
+   milestone emits side refs, a collection WAL transaction may reference one
+   only after the bytes are readable at the selected durability boundary and
+   registered as protected against GC, rewrite, cleanup, and compaction.
 3. Visible install follows WAL commit. Write-domain install is a short critical
    section after the WAL commit point. If WAL commit fails, the mutation leaves
    no read-visible pending state, uniqueness reservation, queued unit, publishing
    unit, or schema/index barrier state.
 4. `CollectionSeq` is gap-free per collection. Recovery and publication process
-   transactions for a collection in `CollectionSeq` order. PR1 has no
+   transactions for a collection in `CollectionSeq` order. PR1-min has no
    same-collection independence skip.
 5. Watermark coverage is contiguous and atomic. A backend publish may advance
    `applied_collection_seq[CollectionUID]` only over the next contiguous prefix,
    and descriptor updates plus watermark updates must be one backend commit.
-6. Cleanup requires applied plus checkpointed. A collection WAL segment or side
-   ref is cleanable only after every referencing transaction is covered by a
-   durable applied watermark, the backend checkpoint/meta boundary containing the
-   watermark is durable, and side-ref reachability has incorporated the published
-   roots.
-7. `DB.Checkpoint` is collection-aware. PR1 checkpoint drains and publishes
-   checkpoint-admitted collection writes before reporting a clean collection WAL
-   state. A future non-publishing checkpoint must report collection WAL debt.
+6. Cleanup is conservative in PR1-min. Collection WAL segment deletion and
+   WAL-only side-ref release are disabled. The full contract may clean a segment
+   or side ref only after every referencing transaction is covered by a durable
+   applied watermark, the backend checkpoint/meta boundary containing the
+   watermark is durable, and side-ref reachability has incorporated the
+   published roots.
+7. `DB.Checkpoint` must not imply unsupported collection WAL cleanliness.
+   PR1-min retains collection WAL and must not report clean collection WAL state
+   solely because backend checkpoint completed. The full contract's checkpoint
+   gate drains and publishes checkpoint-admitted collection writes before
+   reporting a clean collection WAL state; a non-publishing checkpoint must
+   report collection WAL debt.
 8. `DB.Close` is an admission barrier. A write racing with close either fails
    before visible install or is included in the close drain and survives reopen.
 9. Snapshot readers pin pending state. A collection read view must pin backend
@@ -559,6 +603,16 @@ turning the design into code:
     publish, checkpoint, WAL I/O, side-ref GC, async publish completion, or
     value-log rewrite while holding a lock that those operations need to make
     progress.
+
+Capability matrix:
+
+| Capability | Mutations | Visibility/durability boundary | Status |
+|---|---|---|---|
+| Current flush-boundary collections | Existing row insert/update/delete and indexed write-domain paths | Visible in process; durable after `Flush`, `FlushAll`, compatible checkpoint/close, or synchronous publish path | Current behavior; remains the default when collection WAL durable ack is off |
+| PR1-min `NoIndexRowInsertOnly` | No-index row `Insert`/`InsertBatch` only, inline primary-root deltas only | WAL commit, immediate root publish plus applied watermark, then visible install/success | Internal/experimental, default off |
+| Future indexed durable-at-ack | Indexed insert/update/delete, schema/index barriers | WAL commit before any pending mutable/queued/publishing visibility; later async publish only amortizes publication | Deferred full-contract gate |
+| Future column persistent writes | Column descriptor roots and column side files | Full collection WAL side-ref closure, allocator recovery, cleanup protection, and M7 sign-off | Blocked |
+| Future Raft acknowledgement | Logical replicated command entries, not physical collection WAL bytes | Consensus commit plus local apply/recoverability state | Blocked; `raft_committed` remains unsupported |
 
 ### 6.4 Column-Store Gate
 
@@ -802,7 +856,7 @@ A collection WAL transaction records `CollectionUID`, `CollectionGeneration`,
 transaction whose identity or generation guard does not match the replay state,
 unless the mismatch is explicitly explained by the active replay accumulator. An
 unapplied transaction whose `CollectionUID` is absent from the recovered catalog
-must not be replayed into a collection with the same name; PR1 must stop open or
+must not be replayed into a collection with the same name; PR1-min must stop open or
 quarantine according to a documented recovery-admin procedure rather than
 silently applying the transaction to a later incarnation.
 
@@ -896,7 +950,7 @@ before variable-field parsing, decompression, side-ref validation, or root
 publication. `limits.MaxRecordSize <= 0` and negative max-segment options must
 not disable this cap for collection WAL recovery.
 
-Root kinds are explicit, versioned values. PR1 row-store root kinds include
+Root kinds are explicit, versioned values. PR1-min row-store root kinds include
 `primary`, `template`, `index_state`, `secondary`, `overlay`,
 `overlay_descriptor`, `delete`, and `metadata`.
 
@@ -1054,16 +1108,17 @@ history covered by that watermark.
 A global contiguous `WALLSN` cleanup marker may be used only as a cleanup-scan
 optimization when every lower `WALLSN` is known applied or intentionally absent.
 It must never cause recovery to skip an unapplied lower `CollectionSeq` for any
-collection, and PR1 cleanup must still verify every transaction in a segment
-against the relevant per-collection applied watermark before deleting the
-segment.
+collection. PR1-min does not delete collection WAL segments; the full cleanup
+contract must verify every transaction in a segment against the relevant
+per-collection applied watermark before deleting the segment.
 
 Watermarks advance only in the same backend commit that updates collection root
 descriptors for the root group. A watermark value means every collection
 transaction up to that `CollectionSeq` is fully represented in persisted roots
 and descriptor metadata.
 
-PR1 uses per-write WAL transactions with per-collection dependency chains:
+PR1-min uses per-write WAL transactions with per-collection dependency chains,
+while serializing publication through one global publisher:
 
 ```text
 WALLSN                   uint64  // global append position for diagnostics/cleanup
@@ -1077,7 +1132,7 @@ present in the active replay accumulator, or explicitly known not to exist for a
 new collection. A missing complete transaction blocks later transactions for the
 same collection.
 
-PR1 does not support true multi-collection collection WAL transactions. Any API
+PR1-min does not support true multi-collection collection WAL transactions. Any API
 or internal planner that would need to mutate multiple collections atomically
 must reject the operation before preparing side refs or appending collection WAL.
 A future multi-collection format must declare all participant collections,
@@ -1288,13 +1343,14 @@ required side ref in an unapplied or not-yet-cleanable collection WAL
 transaction as reachable until the transaction is covered by a safe applied
 watermark and the checkpoint/meta boundary needed for cleanup is durable.
 
-PR1 maintains a protected side-ref index updated atomically with WAL append and
-WAL cleanup. GC/rewrite must consult this index plus persisted roots. Recovery
-rebuilds the index by scanning collection WAL before any maintenance starts. If
-a value-log segment or column file is referenced only by pending collection WAL,
-maintenance must keep it in place or abort. A future rewrite mode may rewrite
-protected refs only if it publishes replacement side refs and collection WAL
-metadata atomically under an explicit crash-tested protocol.
+Any milestone that emits side refs maintains a protected side-ref index updated
+atomically with WAL append and WAL cleanup. GC/rewrite must consult this index
+plus persisted roots. Recovery rebuilds the index by scanning collection WAL
+before any maintenance starts. If a value-log segment or column file is
+referenced only by pending collection WAL, maintenance must keep it in place or
+abort. A future rewrite mode may rewrite protected refs only if it publishes
+replacement side refs and collection WAL metadata atomically under an explicit
+crash-tested protocol.
 
 Collection WAL append and side-ref protection registration are one critical
 section with respect to value-log GC, value-log rewrite, leaf-log GC, column-file
@@ -1556,10 +1612,10 @@ For any collection/root dependency chain, async publish and watermark
 advancement must cover a contiguous `CollectionSeq` prefix. A newer transaction
 may remain visible through pending state while an older publishing unit is
 requeued, but it must not become backend-authoritative, watermarked, or
-cleanable ahead of that older dependent transaction. PR1 may publish independent
-roots out of order only when root independence is machine-checkable and the
-collection watermark still advances over a contiguous transaction prefix; the
-default rule is no out-of-prefix advancement.
+cleanable ahead of that older dependent transaction. The full contract may
+publish independent roots out of order only when root independence is
+machine-checkable and the collection watermark still advances over a contiguous
+transaction prefix; the default rule is no out-of-prefix advancement.
 
 ### 8.5 Overlay Roots
 
@@ -1670,7 +1726,7 @@ with explicit consensus semantics.
 
 ### 8.9 Lock Ordering and Goroutine Lifecycle
 
-PR1 must document and test lock ordering before product code depends on
+PR1-min must document and test lock ordering before product code depends on
 collection WAL. Required ordering constraints:
 
 - close/checkpoint admission gate is acquired before admitting new collection
@@ -2216,7 +2272,7 @@ high watermark alone is not sufficient.
 Root descriptors published without the matching applied watermark are not a
 valid state. If an implementation bug or future format can produce that split,
 recovery must stop open unless the format also provides a proven idempotent
-repair protocol. PR1 must make the split unrepresentable by publishing
+repair protocol. PR1-min must make the split unrepresentable by publishing
 descriptor ops and watermark ops through a typed collection-WAL publish wrapper
 in one backend commit.
 
@@ -2289,10 +2345,11 @@ point is after normal cached key/value WAL replay and side-store inventory, but
 before recovered roots are exposed to user-visible state, snapshots, native-wire
 servers, or collection managers.
 
-PR1 recovery must publish all replayable transactions before collection APIs can
-serve reads or writes. If a future implementation chooses to keep recoverable
-transactions as a durable pending overlay after open, it must rebuild primary
-visibility, secondary visibility, and unique-index helper state from WAL before
+PR1-min recovery must publish all replayable transactions before collection APIs
+can serve reads or writes. If a future implementation chooses to keep
+recoverable transactions as a durable pending overlay after open, it must
+rebuild primary visibility, secondary visibility, and unique-index helper state
+from WAL before
 serving any collection API; otherwise duplicate unique values can be admitted
 before pending durable state is published.
 
@@ -2338,10 +2395,16 @@ prepare group is forbidden.
 
 ### 9.4 Buffered Transaction Replay and Accumulation
 
-PR1 uses per-collection replay-side accumulation. Merged flush-unit WAL
-transactions are deferred because they are incompatible with durable-at-ack for
-independently acknowledged buffered writes unless those writes wait for the
-merged unit to become durable.
+Replay-side accumulation is deferred out of PR1-min. PR1-min uses one global
+collection WAL publisher and normally publishes the single committed
+transaction plus its applied watermark before success. A crash in the fault
+window may leave at most one unwatermarked collection WAL transaction globally,
+so recovery does not need to merge multiple same-base-root transactions.
+
+The full collection WAL contract uses per-collection replay-side accumulation.
+Merged flush-unit WAL transactions are deferred because they are incompatible
+with durable-at-ack for independently acknowledged buffered writes unless those
+writes wait for the merged unit to become durable.
 
 Recovery processes transactions in `CollectionUID`, `CollectionSeq` order. A
 transaction may enter the accumulator only if its `DependsOnCollectionSeq` is
@@ -2364,7 +2427,7 @@ the hard cap, recovery must stop before serving collection APIs with
 `ErrCollectionWALRecoveryCapacityExceeded` unless a chunk/spill path has already
 reduced the projected charge.
 
-The PR1 fold order is `(CollectionSeq, RootDeltaOrdinal, EntryOrdinal)`.
+The full-contract fold order is `(CollectionSeq, RootDeltaOrdinal, EntryOrdinal)`.
 `CollectionSeq` is the transaction order key; if a future record also exposes a
 diagnostic `TxnID`, it must not replace `CollectionSeq` for same-collection
 dependency ordering. `RootDeltaOrdinal` is the order of root deltas within the
@@ -2387,12 +2450,13 @@ The applied watermark may advance from `N` to `M` only when the publish covers
 every transaction with `CollectionSeq` in `(N, M]` for that collection, with no
 gaps. A publish that contains merged root deltas, replay accumulators, or async
 flush units must record the covered contiguous range before cleanup can consider
-any transaction in that range applied. Scalar watermark metadata is valid in PR1
-only because every publish is constrained to this contiguous-prefix rule.
+any transaction in that range applied. Scalar watermark metadata is valid in
+PR1-min and the full contract because every publish is constrained to this
+contiguous-prefix rule.
 
-This rule applies to no-index buffered writes, indexed mutable runs, queued
-flush units, async publishing states, overlay compaction, schema/index changes,
-and future column-store delta-part descriptor updates.
+For the full contract, this rule applies to no-index buffered writes, indexed
+mutable runs, queued flush units, async publishing states, overlay compaction,
+schema/index changes, and future column-store delta-part descriptor updates.
 
 ### 9.5 Failure Behavior
 
@@ -2450,7 +2514,12 @@ bytes. Cleanup may stop protecting a side ref only after the transaction is
 covered by a safe applied watermark and the durable checkpoint/meta boundary
 makes the published roots or the discarded incomplete transaction authoritative.
 
-PR1 uses a protected side-ref index:
+PR1-min emits no side refs and therefore does not require a protected side-ref
+index for correctness. If PR1-min scope expands to emit even one side-ref class,
+that class must have the protected index and maintenance barriers before any
+durable ack can use it.
+
+The full contract uses a protected side-ref index:
 
 - WAL append registers every required side ref before the commit marker becomes
   replayable.
@@ -2458,7 +2527,7 @@ PR1 uses a protected side-ref index:
   starts.
 - Cleanup unregisters side refs only after the applied watermark and durable
   checkpoint/meta boundary make the published roots authoritative.
-- Value-log rewrite and column-file rewrite refuse protected refs in PR1 rather
+- Value-log rewrite and column-file rewrite refuse protected refs rather
   than trying to patch WAL records in place.
 
 WAL-only side-ref protection may be released only after all are true:
@@ -2490,7 +2559,7 @@ Column file GC/rewrite must treat these as reachability roots:
   files, reachable descriptors, or pending WAL transactions.
 
 Column file rewrite must not rewrite refs that are protected solely by
-collection WAL in PR1. A future rewrite protocol may update column WAL refs only
+collection WAL in PR1-min. A future rewrite protocol may update column WAL refs only
 with its own crash-tested atomic redirect mechanism.
 
 Column `PartID` and `FileID` allocators are recovery state, not in-memory
@@ -2505,14 +2574,16 @@ fsync. Missing segments are acceptable only for `S6 Cleaned` ranges covered by
 durable cleanup metadata.
 
 `DB.Checkpoint` must coordinate with collection WAL before reporting a clean
-collection WAL state. PR1 checkpoint hooks freeze collection WAL admission for
-the checkpoint cut, force publication of replayable collection WAL admitted
-before the cut, wait for in-flight async publish, drain known write domains,
-advance watermarks, persist the backend checkpoint/meta durability boundary,
-and include collection WAL side refs in value-log and side-file reachability
-before any prune, rewrite, or deletion. If a future checkpoint mode leaves
-replayable collection WAL unpublished, it must report collection WAL debt and
-preserve all side-ref protections; it is not a clean collection-WAL boundary.
+collection WAL state. PR1-min does not report clean collection WAL state and
+does not delete retained segments. The full checkpoint contract freezes
+collection WAL admission for the checkpoint cut, forces publication of
+replayable collection WAL admitted before the cut, waits for in-flight async
+publish, drains known write domains, advances watermarks, persists the backend
+checkpoint/meta durability boundary, and includes collection WAL side refs in
+value-log and side-file reachability before any prune, rewrite, or deletion. If
+a future checkpoint mode leaves replayable collection WAL unpublished, it must
+report collection WAL debt and preserve all side-ref protections; it is not a
+clean collection-WAL boundary.
 
 ### 10.1 Collection WAL Resource Accounting and Admission
 
@@ -2789,10 +2860,10 @@ resume_limit = stop_limit * 0.70
 
 | Limit | Default | Behavior |
 |---|---:|---|
-| `CollectionWAL.MaxInlineRootDeltaBytesPerRoot` | 1 MiB | Spill this root delta to root-delta side payload. |
-| `CollectionWAL.MaxInlineRootDeltaBytesPerTxn` | 4 MiB | Spill root deltas until inline payload is below the limit. |
+| `CollectionWAL.MaxInlineRootDeltaBytesPerRoot` | 1 MiB | PR1-min: hard error before ack. Full contract: spill this root delta to root-delta side payload. |
+| `CollectionWAL.MaxInlineRootDeltaBytesPerTxn` | 4 MiB | PR1-min: hard error before ack. Full contract: spill root deltas until inline payload is below the limit. |
 | `CollectionWAL.MaxEncodedTxnBytes` | 16 MiB | Hard error before ack after spill attempts; hard non-disableable recovery cap. |
-| `CollectionWAL.MaxRootDeltaSidePayloadBytes` | 64 MiB | Hard error before ack; caller must split batch. |
+| `CollectionWAL.MaxRootDeltaSidePayloadBytes` | 64 MiB | PR1-min rejects `RootDeltaPayload` entirely. Full contract: hard error before ack; caller must split batch. |
 | `CollectionWAL.MaxTxnDecodedEntries` | 262,144 | Hard error before ack; recovery rejects/quarantines corrupt oversize WAL. |
 | `CollectionWAL.MaxRootDeltasPerTxn` | 64 | Hard error before ack; caller must split batch. |
 | `CollectionWAL.MaxSideRefsPerTxn` | 16,384 | Hard error before ack; caller must split transaction or column/file operation. |
@@ -2929,7 +3000,7 @@ ColumnWAL.MaxSideRefMetadataBytesPerRow            = formula + 10 percent
 Keep and expand tests that document current behavior:
 
 - checkpoint does not flush pending collection-local no-index inserts before
-  this spec changes that contract;
+  a guarded collection WAL capability changes that contract;
 - close drains queued indexed flush units;
 - `FlushAll` drains queued indexed flush units;
 - async flush backpressure and requeue behavior remains visible and bounded.
@@ -3032,9 +3103,10 @@ Required assertions:
   only by pending collection WAL side refs;
 - declared side refs and embedded side refs match the canonical required set;
 - a missing complete transaction `N` blocks `N+1` for the same collection;
-- same-collection independence skips are rejected in PR1;
+- same-collection independence skips are rejected in PR1-min and remain rejected
+  unless a later machine-checkable independence proof is added;
 - multi-collection transactions are rejected before side refs or WAL are
-  written in PR1;
+  written in PR1-min;
 - drop/recreate with the same collection name does not replay old WAL into the
   new collection;
 - schema epoch and root generation mismatches block stale transactions;
@@ -3086,10 +3158,10 @@ Visibility and WAL append:
 
 Checkpoint and close:
 
-- no-index insert -> `DB.Checkpoint` -> crash/reopen shows the document under
-  WAL-on PR1 semantics;
-- indexed buffered insert with async publish disabled -> `DB.Checkpoint` ->
-  crash/reopen has primary and secondary roots;
+- PR1-min no-index insert -> `DB.Checkpoint` -> crash/reopen shows the
+  document while retained collection WAL remains present;
+- full-contract indexed buffered insert with async publish disabled ->
+  `DB.Checkpoint` -> crash/reopen has primary and secondary roots;
 - checkpoint racing with new writes covers writes before the admission cut and
   retains protected WAL for writes after the cut;
 - checkpoint with async publishing in flight waits, publishes, or safely retries
@@ -3125,7 +3197,7 @@ Read views and retention:
 
 Read-only open:
 
-- crash after WAL commit before publish, then read-only open, returns the PR1
+- crash after WAL commit before publish, then read-only open, returns the PR1-min
   recovery-required error;
 - after read-write recovery completes, read-only reopen sees the recovered write
   without needing collection WAL replay.
@@ -3188,11 +3260,45 @@ publish roots on invalid bytes, never delete/quarantine files from invalid
 bytes, produce deterministic error classes for the same input, and never skip a
 complete corrupt transaction in favor of a later same-collection transaction.
 
-### 11.7 Required Named Acceptance Tests
+### 11.7 PR1-Min Required Named Acceptance Tests
+
+These tests or equivalent subtests are required before the guarded PR1-min
+capability can merge:
+
+| Test | Must prove |
+|---|---|
+| `TestCollectionWALNoIndexInsertAckBeforeFlushRecovers` | Guarded no-index row `Insert` is recoverable after process crash without `Flush`/`Close`. |
+| `TestCollectionWALNoIndexInsertBatchAckBeforeFlushRecovers` | Guarded no-index row `InsertBatch` is recoverable as one mutation boundary. |
+| `TestCollectionWALAppendFailureRejectsBeforeVisibility` | WAL append/commit failure leaves no visible pending state and no uniqueness/planner-visible reservation. |
+| `TestCollectionWALCrashAfterCommitBeforePublishRecovers` | The single unwatermarked PR1-min transaction fault window is recoverable on read-write open. |
+| `TestCollectionWALCrashAfterPublishBeforeResponseIsIdempotent` | Recovery after descriptor plus watermark publish does not double-apply. |
+| `TestCollectionWALDescriptorAndWatermarkPublishAtomically` | Descriptor updates and applied watermark are one backend commit. |
+| `TestCollectionWALCollectionUIDDropRecreateDoesNotReplayByName` | Recovery validates `CollectionUID`/generation and never replays by collection name. |
+| `TestCollectionWALReadOnlyOpenWithPendingWALFails` | Read-only open returns recovery-required when committed unapplied collection WAL exists. |
+| `TestCollectionWALInlineCapRejectsBeforeVisibility` | Oversized inline row delta fails before visibility and is absent after reopen. |
+| `TestCollectionWALMissingUncleanedSegmentFailsOpen` | Deleting a retained uncleaned PR1-min segment makes open fail closed. |
+| `TestCollectionWALIndexedSchemaUnsupportedBeforeStaging` | Durable-at-ack on an indexed schema fails before any `rootRuns`, pending count, or WAL frame exists. |
+| `TestCollectionWALIndexedAsyncUnsupported` | `BufferedIndexedAsyncFlush` plus durable-at-ack is rejected or normalized only under the old flush-boundary profile. |
+| `TestCollectionWALUpdateUnsupportedBeforeMutation` | Update paths are rejected under PR1-min before visible mutation. |
+| `TestCollectionWALDeleteUnsupportedBeforeMutation` | Delete paths are rejected under PR1-min before visible mutation. |
+| `TestCollectionWALValueLogPointerizationUnsupportedBeforeVisibility` | Storage policy or document size that would pointerize returns an unsupported/capacity error before visibility. |
+| `TestCollectionWALColumnRootKindUnsupported` | Column root kinds fail before WAL append or root publication. |
+| `TestCollectionWALRootDeltaPayloadUnsupported` | Root-delta side payload mode is rejected in PR1-min. |
+| `TestCollectionWALWALOffDoesNotCreateCollectionWAL` | WAL-off relaxed mode keeps old flush-boundary semantics and emits no collection WAL for unflushed writes. |
+| `TestCollectionWALCheckpointRetainsSegments` | Checkpoint does not delete PR1-min collection WAL segments. |
+| `TestCollectionWALCloseRetainsSegments` | Close preserves retained segments required for recovery. |
+| `TestCollectionWALCleanupDisabledInPR1` | Collection WAL cleanup deletion path is not invoked in PR1-min. |
+
+Existing flush-boundary regression tests must remain green with the feature off,
+including checkpoint-not-flushing pending no-index inserts, buffered no-index
+reads before flush, indexed memtable reads/unique checks, queued indexed flush
+close, and `FlushAll` draining queued indexed flush units.
+
+### 11.8 Full-Contract Required Named Acceptance Tests
 
 These tests or equivalent subtests must exist before implementation can be
-considered complete. Names are normative so CI, verification docs, and
-acceptance artifacts can point to stable evidence.
+considered complete for the full collection WAL contract. Names are normative
+so CI, verification docs, and acceptance artifacts can point to stable evidence.
 
 | Test | Harness shape | Must prove |
 |---|---|---|
@@ -3224,7 +3330,7 @@ acceptance artifacts can point to stable evidence.
 | `TestCollectionWALDurableSyncBatchCaps` | Run concurrent durable-sync writers. | Group fsync batches respect max delay, byte, and transaction caps while preserving ack semantics. |
 | `TestColumnWALSideRefCapacityLimits` | Plan column side refs beyond file, manifest, and side-ref-per-transaction limits. | Persistent column roots remain blocked and fail before ack/publish. |
 
-### 11.8 Required Fault Points
+### 11.9 Required Fault Points
 
 The crash harness must expose these named fault points. Each point must support
 both "return injected error" and "process exit" modes when the code path can
@@ -3250,11 +3356,27 @@ during_overlay_compaction_publish
 ```
 
 `after_system_root_commit_before_watermark_visible` should be untriggerable in a
-correct PR1 implementation because descriptor changes and watermark advancement
+correct PR1-min implementation because descriptor changes and watermark advancement
 are one backend commit. The fault point exists to prove the implementation does
 not expose or test a two-phase publish path.
 
 ## 12. Benchmark Plan
+
+PR1-min benchmarks are advisory unless a pathological regression blocks
+correctness testing. The guarded feature remains off by default, so PR1-min
+requires metrics and an artifact, not default-enable pass/fail thresholds.
+
+Advisory PR1-min benchmark rows:
+
+- small no-index `Insert` durable-at-ack overhead;
+- small no-index `InsertBatch` durable-at-ack overhead;
+- WAL bytes per inserted document;
+- recovery time for 1K, 10K, and 100K retained PR1-min transactions;
+- inline cap rejection overhead;
+- global publisher contention smoke benchmark.
+
+The pass/fail benchmark gates below apply to the full contract and to default
+enablement, not to the guarded PR1-min merge.
 
 Benchmarks must compare baseline and new implementation on the same host with
 `benchstat`. Use the current `ProfileWALOnFast` / `wal_on_fast` collection
@@ -3493,9 +3615,10 @@ for each mutation class must be less than or equal to the formula-derived budget
 plus 10 percent.
 
 The stronger-default gate is required before enabling WAL-on collection
-durable-at-ack as a default profile. The initial implementation gate is enough
-to merge guarded/internal code paths when all correctness gates are green and
-all metrics above are emitted.
+durable-at-ack as a default profile. The full-contract implementation gate is
+required before broad WAL-on collection write APIs are exposed. PR1-min may
+merge as guarded/internal code when correctness gates are green and the advisory
+metrics above are emitted.
 
 Column-store gates added before persistent column writes:
 
@@ -3527,7 +3650,7 @@ Traceability matrix:
 | Design area | Sections | Milestones | Required evidence |
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
-| Testability decisions | 15 | M0.5 | closed PR1 choices and acceptance artifact |
+| Testability decisions | 15 | M0.5 | closed PR1-min choices and acceptance artifact |
 | Formal state machine | 9.1, 9.2 | M0.5, M1, M5 | abstract model tests, invariant mapping, and counterexample fixtures |
 | WAL format | `storage-format.md` Section 9 plus this doc 7.2, 7.4, 7.5 | M1 | exact-byte golden, fuzz, corrupt-tail, feature-gate, and migration-state tests |
 | Recovery state machine | 9.1, 9.2, 9.3, 9.5 | M1, M5 | crash-state and stop-open tests |
@@ -3565,15 +3688,15 @@ Acceptance matrix:
 | Gate | Required evidence | Pass criteria |
 |---|---|---|
 | M0 Contract and harness freeze | Existing current-contract tests and crash helper skeleton. | Current flush-boundary behavior remains documented; named fault hooks can stop at side prepare, WAL append, staging, publish, watermark, cleanup, and recovery replay. |
-| M0.5 Testability decisions | Closed PR1 decisions in Section 15. | File class, transaction identity, formal model, checkpoint behavior, missing side-ref policy, buffered replay model, GC protection, and overlay compaction rule are testable. |
-| M1 WAL format | Golden fixtures, checksum/corruption/truncation tests, decoder fuzzing. | Decoder is deterministic; safe terminal truncation is accepted; hard corruption fails. |
-| M2 Side-ref fences | Missing-ref, side-payload, and GC/rewrite protection tests. | No root points at missing bytes; WAL-pending side refs are retained. |
-| M3 No-index WAL integration | WAL-on/WAL-off no-index crash tests and append-failure tests. | WAL-on crash recovers acknowledged writes; WAL-off expectations stay relaxed; append failure has no visibility. |
-| M4 Indexed integration | Indexed insert/update/delete atomic recovery tests. | Primary, template/index-state, unique, and nonunique roots agree after reopen. |
-| M4.5 Buffered/async states | Mutable, queued, publishing, requeue, and accumulator tests. | No acknowledged write is lost in any write-domain state. |
-| M5 Watermark/recovery/cleanup | Repeated reopen, watermark, missing segment, and cleanup-crash tests. | Replay is idempotent; no double-apply; no premature cleanup. |
-| M6 Barriers and modes | Flush, FlushAll, checkpoint, close, and read-only open tests. | Chosen barrier semantics are deterministic and documented. |
-| M6.5 Performance | Required benchmark commands and `benchstat` artifacts. | Correctness is green; metrics are emitted; thresholds pass for the selected gate. |
+| M0.5 Testability decisions | PR1-min decisions in Section 15. | Feature flag, capability scope, transaction identity, inline cap, unsupported-path behavior, read-only recovery-required behavior, and no-cleanup rule are testable. |
+| M1 WAL format | Golden fixtures, checksum/corruption/truncation tests, decoder fuzzing. | Decoder is deterministic; safe terminal truncation is accepted; hard corruption fails; v1 includes every replay-identity field required by PR1-min. |
+| M2 PR1-min root-delta envelope | Inline primary-root delta fixtures, cap rejection, empty side-ref-set validation. | PR1-min rejects pointerization, side payloads, column roots, and any non-empty required side-ref set before visibility. |
+| M3 PR1-min no-index WAL integration | WAL-on/WAL-off no-index insert crash tests, append-failure tests, unsupported-path tests. | Guarded no-index inserts recover after crash; unsupported paths fail before staging; WAL-off expectations stay relaxed. |
+| M4 Full side-ref/indexed integration | Side-ref fences plus indexed insert/update/delete atomic recovery tests. | No root points at missing bytes; WAL-pending side refs are retained; primary, template/index-state, unique, and nonunique roots agree after reopen. |
+| M4.5 Full buffered/async states | Mutable, queued, publishing, requeue, and accumulator tests. | No acknowledged write is lost in any write-domain state. |
+| M5 Watermark/recovery/retention | Repeated reopen, watermark, missing uncleaned segment, and disabled-cleanup tests. | Replay is idempotent; no double-apply; PR1-min retains WAL; missing uncleaned WAL fails open. |
+| M6 Full barriers and cleanup modes | Flush, FlushAll, checkpoint, close, read-only open, cleanup-manifest tests. | Full checkpoint/close cleanup semantics are deterministic and documented. |
+| M6.5 Performance | Advisory PR1-min artifact, then required full-contract benchmark commands and `benchstat` artifacts. | PR1-min metrics are emitted; full/default thresholds pass only for the selected later gate. |
 | M7 Column-store sign-off | M1-M6 artifacts, synthetic side-file tests, benchmark artifacts, and column PR checklist links. | Persistent column roots and side refs stay blocked until the sign-off artifact is green. |
 
 ### Milestone 0: Contract Freeze
@@ -3583,7 +3706,7 @@ Deliverables:
 - document current collection flush-boundary behavior;
 - identify every API that can acknowledge collection writes;
 - freeze benchmark fixtures and crash-test harness shape.
-- document PR1 visibility, checkpoint admission, close admission, read-view, and
+- document PR1-min visibility, checkpoint admission, close admission, read-view, and
   lock-order invariants before product code relies on them.
 
 Tests:
@@ -3602,24 +3725,33 @@ Gate:
 - no production column-store persistent work starts before this milestone is
   complete.
 
-### Milestone 0.5: Testability Decisions
+### Milestone 0.5: PR1-Min Testability Decisions
 
-The PR1 decisions in Section 15 are prerequisites for executable tests. Before
-M1 starts, the implementation owner must confirm the exact testable choices for:
+The PR1-min decisions in Section 15 are prerequisites for executable tests.
+Before M1 starts, the implementation owner must confirm the exact testable
+choices for:
 
 - collection WAL segment format and filename class;
 - storage-format feature gates, migration states, and byte envelope;
-- abstract model variables, state predicates, transition guards, invariant list,
-  and counterexample classes from Section 9.1;
+- exact feature flag/API spelling and `NoIndexRowInsertOnly` guarantee text;
+- exact inline encoded-size cap;
+- whether value-log pointers are fully rejected in PR1-min or
+  `ValueLogRecord` side refs are added to the slice;
+- unsupported-method behavior for update/delete/schema/index/column/native-wire
+  paths under the guarded capability;
+- transaction v1 binary layout and digest scope for the replay-identity fields
+  listed in Section 1;
+- where applied watermarks are stored in the system root;
+- recovery error names for unsupported mode, read-only recovery-required,
+  corruption, capacity, and commit ambiguity;
+- abstract model variables, state predicates, transition guards, invariant
+  list, and counterexample classes from Section 9.1;
 - `CollectionSeq` and `WALLSN` allocation and persistence;
-- missing side-ref behavior by durability mode;
-- checkpoint behavior for PR1;
-- buffered replay model;
-- GC/rewrite side-ref protection mechanism;
-- overlay compaction durability rule;
-- resource accounting defaults for transaction size, inline spill, side-payload
-  limits, replay accumulator caps, debt soft/stop/hard limits, and durable-sync
-  group fsync caps.
+- missing segment behavior for retained PR1-min WAL;
+- checkpoint behavior under PR1-min with cleanup disabled;
+- resource accounting defaults for transaction size, inline cap, pending
+  retained WAL debt, and durable-sync group fsync caps if durable sync is in
+  scope.
 
 Gate:
 
@@ -3637,14 +3769,16 @@ Deliverables:
 - persisted `CollectionUID`, `SchemaEpoch`, and root generation descriptor
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
-- segment metadata and cleanup record encoding;
+- segment metadata encoding; cleanup record encoding is full-contract work and
+  must not authorize deletion in PR1-min;
 - exact byte-format documentation in `storage-format.md`;
 - typed `CollectionWALError` categories and minimal
   `CollectionWALStats.Snapshot()` counters/gauges for append, pending,
-  protected side refs, recovery, cleanup debt, and value-log GC blockers;
+  recovery, retained WAL debt, and value-log GC blockers; protected side-ref
+  gauges are required before any side-ref class is emitted;
 - stable root-delta encode/decode APIs independent of transient in-memory
   `batch.Batch` layout;
-- encoder-backed byte estimator, inline/side-payload threshold enforcement,
+- encoder-backed byte estimator, inline-cap enforcement,
   segment rotation defaults, and capacity error names from Section 10.1;
 - small model or property-test harness for descriptor/watermark split,
   WAL-before-visible, side-ref protection, per-collection skip, deterministic
@@ -3672,18 +3806,46 @@ Tests:
 Gate:
 
 - format package has no dependency on collection planners or backend DB.
-- minimal PR1 metrics and error categories from Section 17 are present before
+- minimal PR1-min metrics and error categories from Section 17 are present before
   any WAL-on collection write path is merged.
 
-### Milestone 2: Root Delta and Side-Ref Fences
+### Milestone 2: PR1-Min Root Delta Envelope
 
 Deliverables:
 
-- root-delta batch serialization;
-- inline and side-payload modes;
+- root-delta batch serialization for inline primary-root row puts;
+- sorted unique key-entry encoding with stable entry ordinals;
+- empty canonical side-ref set validation;
+- hard rejection of `RootDeltaPayload` side refs;
+- hard rejection before visibility when final physical entries would require
+  value-log pointers, leaf-log pointers, column-file refs, or any other side
+  ref;
+- encoder-backed inline-size and decoded-entry cap checks before WAL append;
+- fail-hard recovery behavior for missing uncleaned PR1-min WAL segments.
+
+Tests:
+
+- inline no-index row root delta golden files;
+- oversized inline transaction rejects before visibility;
+- pointerizing storage policy or document size rejects before visibility;
+- `RootDeltaPayload` section is rejected in PR1-min;
+- declared side refs must be empty;
+- missing uncleaned WAL segment stops open.
+
+Gate:
+
+- PR1-min cannot emit any external side ref. If product scope adds one side-ref
+  class, the full side-ref fence gate below must move before durable ack for
+  that class.
+
+### Milestone 2.5: Full Side-Ref Fences
+
+Deliverables:
+
 - side-ref availability checker;
 - value-log side-ref integration;
 - leaf-log side-ref validation for pre-existing embedded leaf refs;
+- root-delta side-payload mode;
 - protected side-ref index updated by WAL append/cleanup and rebuilt during
   recovery;
 - side-ref prepare guard that excludes GC/rewrite/cleanup during preparation;
@@ -3708,21 +3870,30 @@ Gate:
   WAL skip behavior: complete missing-side-ref transactions fail recovery rather
   than being skipped.
 
-### Milestone 3: No-Index Collection Integration
+### Milestone 3: PR1-Min No-Index Row Insert Integration
 
 Deliverables:
 
-- WAL-on no-index inserts append collection WAL before acknowledgement;
+- guarded WAL-on no-index row inserts append collection WAL before any
+  visibility or acknowledgement;
+- a single global collection WAL publisher serializes private planning, WAL
+  append/commit marker, backend root publish, applied watermark publish, and
+  visible install;
+- normal success publishes descriptor updates and applied watermark before
+  returning;
 - no-index buffered inserts enter collection mutation serialization before
   `CollectionSeq` allocation and pending visibility;
 - private planning, durable commit, and visible install are separate phases;
 - no collection read, planner, uniqueness check, queued unit, or publishing unit
   can observe a no-index write before its WAL commit marker is complete;
 - final physical primary-root deltas are materialized before the commit marker;
-- pending write-domain visibility remains unchanged;
+- feature-off pending write-domain visibility remains unchanged;
 - direct publish paths log first under WAL-on modes or remain explicitly
   WAL-off/debug-only;
-- `Flush` publishes WAL-backed no-index deltas and advances watermark.
+- `Flush` may publish retained WAL-backed no-index deltas but cleanup deletion
+  remains disabled in PR1-min;
+- no-index update/delete remain unsupported under the guarded durable-at-ack
+  capability unless implemented with the same WAL-before-visible contract.
 
 Tests:
 
@@ -3732,20 +3903,26 @@ Tests:
 - `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility`;
 - `TestCollectionWALNoIndexInsertBatchAckBeforeFlushRecovers`;
 - no-index `Update`, `UpdateBatch`, `Delete`, and `DeleteBatch` either publish
-  synchronously under the documented current rule or are WAL-backed before ack;
-  whichever rule is chosen must have crash/reopen tests;
+  synchronously under the documented current rule with the feature off, or
+  return unsupported before mutation under PR1-min;
 - crash before WAL append does not expose document;
 - concurrent reads and planners blocked around WAL append cannot observe the
   private mutation;
-- checkpoint behavior updated to the new contract;
+- checkpoint retains PR1-min WAL segments and does not claim clean collection
+  WAL merely because backend checkpoint completed;
 - WAL-off mode creates no collection WAL files for unflushed writes.
 
 Gate:
 
-- no-index insert benchmark meets the M6 initial implementation gate and emits
-  all required metrics.
+- PR1-min no-index insert advisory benchmark artifact is emitted; benchmark
+  thresholds are not a pass/fail gate until default enablement.
 
-### Milestone 4: Indexed Insert/Update/Delete Integration
+### Milestone 4: Full Indexed Insert/Update/Delete Integration
+
+This milestone is deferred out of PR1-min. PR1-min must reject indexed schemas,
+indexed async flush, and indexed mutation methods under durable-at-ack before
+any root run, uniqueness helper, pending count, queued unit, or publishing unit
+is staged.
 
 Deliverables:
 
@@ -3761,7 +3938,7 @@ Deliverables:
 - unique helper rebuild after recovery;
 - replay accumulator for multiple buffered transactions that share one persisted
   root base;
-- PR1 rejection of true multi-collection transactions before side refs or WAL
+- PR1-min rejection of true multi-collection transactions before side refs or WAL
   are written;
 - schema/index changes ordered by collection sequence;
 - overlay compaction encoded as a collection WAL maintenance transaction when it
@@ -3799,7 +3976,11 @@ Gate:
   gate and emit all required metrics;
 - async flush cannot lose acknowledged documents under process crash.
 
-### Milestone 4.5: Buffered and Async State Recovery
+### Milestone 4.5: Full Buffered and Async State Recovery
+
+This milestone is deferred out of PR1-min. PR1-min avoids replay-side
+accumulation by allowing at most one unwatermarked transaction globally and by
+publishing/watermarking before success in the normal path.
 
 Deliverables:
 
@@ -3832,7 +4013,7 @@ Gate:
 - no acknowledged write is lost from mutable, queued, or publishing state under
   the required crash harness.
 
-### Milestone 5: Recovery, Watermark, and Cleanup
+### Milestone 5: Recovery, Watermark, and Conservative Retention
 
 Deliverables:
 
@@ -3843,8 +4024,8 @@ Deliverables:
 - backend-owned collection WAL recovery service independent of
   `CollectionManager` construction;
 - collection-specific publish wrapper around ordered-root publish APIs;
-- segment cleanup after safe checkpoint;
-- prepared side-file quarantine/delete;
+- PR1-min disables segment cleanup deletion and prepared side-file release;
+  cleanup manifests and quarantine/delete are full-contract work;
 - read-only open recovery-required error when unapplied committed collection WAL
   exists.
 
@@ -3858,16 +4039,19 @@ Tests:
   double-apply;
 - crash during recovery after publishing a subset of unapplied transactions is
   idempotent after repeated reopen;
-- crash after watermark commit before WAL cleanup leaves the transaction
-  skipped by watermark and cleanup retryable;
-- crash during WAL segment cleanup is idempotent;
-- crash during prepared side-file quarantine/delete is idempotent;
+- crash after watermark commit leaves the transaction skipped by watermark while
+  retained WAL remains available;
+- PR1-min cleanup-disabled tests prove WAL segments are retained after
+  checkpoint and close;
+- crash during WAL segment cleanup and prepared side-file quarantine/delete are
+  full-contract tests once those transitions exist;
 - out-of-order async publish cannot advance a watermark that hides a lower
   unapplied collection sequence;
 - accumulated publishes advance only contiguous `CollectionSeq` prefixes;
 - descriptor update and watermark update cannot split across commits;
 - older segments remain when watermark is not durable;
-- cleanup removes only fully applied segments;
+- cleanup removes no collection WAL segments in PR1-min and only fully applied
+  segments in the full contract;
 - prepared side files without committed transactions do not become visible;
 - missing cleaned segments are accepted only with durable cleanup records;
 - missing uncleaned segments stop open;
@@ -3878,7 +4062,11 @@ Gate:
 
 - repeated reopen after crash is idempotent.
 
-### Milestone 6: Checkpoint and Close Semantics
+### Milestone 6: Full Checkpoint, Close, and Cleanup Semantics
+
+This milestone is deferred out of PR1-min except for the negative guarantee
+that checkpoint/close must not delete retained PR1-min collection WAL or report
+a clean collection-WAL state they did not prove.
 
 Deliverables:
 
@@ -3896,8 +4084,8 @@ Deliverables:
 
 Tests:
 
-- checkpoint forces publication of replayable collection WAL in PR1 or reports
-  nonzero collection WAL debt in future modes;
+- checkpoint forces publication of replayable collection WAL in the full
+  contract or reports nonzero collection WAL debt in future modes;
 - checkpoint-cut tests prove writes before the cut are covered and writes after
   the cut remain protected in retained WAL;
 - close-race tests prove every successful racing write survives reopen and every
@@ -3930,7 +4118,10 @@ Deliverables:
 
 Gate:
 
-- correctness gates M1 through M6 are green;
+- PR1-min may merge after correctness gates for the guarded slice are green and
+  advisory metrics are emitted;
+- full-contract correctness gates M1 through M6 are green before broad API
+  exposure;
 - initial implementation thresholds from Section 12 pass for guarded/internal
   enablement;
 - absolute resource ceilings from Section 10.1 pass in addition to relative
@@ -4038,7 +4229,7 @@ Gate:
 | Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass; fail recovery on missing side refs for complete WAL-on transactions. |
 | Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots through a protected side-ref index until safe applied watermark and checkpoint cleanup. |
 | A global `WALLSN` marker skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep any global `WALLSN` marker cleanup-only and segment-verified. |
-| Buffered transactions share an old persisted `BaseRootID`. | Use per-collection dependency chains plus replay-side accumulation in PR1. |
+| Buffered transactions share an old persisted `BaseRootID`. | PR1-min permits at most one unwatermarked transaction globally; the full contract adds per-collection dependency chains plus replay-side accumulation. |
 | A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, root descriptor epochs, and per-root `RootGeneration` guards and block mismatches. |
 | API returns a normal error after the WAL commit marker. | Reserve fallible state before commit; after commit marker, allow only success, process death, or commit-ambiguous/fatal reporting. |
 | Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
@@ -4049,9 +4240,10 @@ Gate:
 | A node reports a Raft entry applied before its local collection mutation is recoverable. | Tie applied-index/idempotency metadata to local collection WAL durability or replay unapplied committed entries from Raft before serving. |
 | Native-wire acknowledgement policy leaks into recovered logical state. | Treat acknowledgement policy as response/local durability control unless a future deterministic command version explicitly makes it logical state. |
 
-## 15. Closed PR1 Decisions and Future Questions
+## 15. PR1-Min Decisions, Deferred Work, and Open Questions
 
-PR1 closes the correctness-critical questions that block implementation:
+PR1-min closes only the correctness-critical questions needed for the guarded
+no-index row insert slice:
 
 1. Collection WAL uses a dedicated logical file class. It may reuse commit-log
    framing utilities, but it has separate record kinds, commit-marker semantics,
@@ -4061,15 +4253,15 @@ PR1 closes the correctness-critical questions that block implementation:
    cleanup accounting; `CollectionSeq` is the dependency, replay, and skip key.
 3. Complete WAL-on collection transactions with missing required side refs fail
    recovery. They are not skipped like current RID-fenced cached WAL batches.
-4. PR1 uses replay-side accumulation for buffered writes that share a persisted
-   base root.
-5. PR1 uses a protected side-ref index, rebuilt from WAL during recovery, for
-   GC/rewrite safety.
-6. PR1 `DB.Checkpoint` calls collection checkpoint hooks and forces publication
-   of replayable collection WAL before reporting a clean collection WAL state.
-7. Overlay compaction that can race with user-visible collection writes is
-   encoded as a collection WAL maintenance transaction.
-8. True multi-collection collection WAL transactions are unsupported in PR1 and
+4. PR1-min uses a single global collection WAL publisher and permits at most one
+   unwatermarked transaction globally. Replay-side accumulation is deferred.
+5. PR1-min emits empty canonical `SideRefs`; protected side-ref indexes are
+   required only for side-ref classes a later milestone actually emits.
+6. PR1-min uses inline-only root deltas. Root-delta side payloads are rejected
+   before visibility.
+7. PR1-min retains all collection WAL segments. Cleanup manifests and segment
+   deletion are deferred.
+8. True multi-collection collection WAL transactions are unsupported in PR1-min and
    must be rejected before side refs or WAL are written.
 9. Read-only open with unapplied committed collection WAL fails with a
    recovery-required error unless a future explicitly stale mode is requested.
@@ -4078,9 +4270,9 @@ PR1 closes the correctness-critical questions that block implementation:
 11. WAL-on visibility implies recoverability: private planning state is never
     reachable by readers, planners, uniqueness checks, or pending-state merges
     before the WAL commit point.
-12. PR1 checkpoint and close establish admission cuts. A racing write is either
-    outside the cut and protected in retained WAL, inside the cut and drained, or
-    rejected before visible install.
+12. PR1-min checkpoint and close must not delete retained collection WAL or
+    claim clean collection-WAL state without proof. Full admission-cut cleanup
+    semantics are deferred.
 13. Long-running collection reads use `CollectionReadView` pinning for backend
     snapshots, pending collection units, derived index views, and reachable side
     refs.
@@ -4088,8 +4280,8 @@ PR1 closes the correctness-critical questions that block implementation:
     validator, prepare/finalize protocol, allocator recovery, and revised M7
     crash tests pass.
 15. Column compaction, delete-bitmap compaction, and recompression that create
-    external files are collection WAL transactions, not optional backend-only
-    maintenance commits.
+    external files are future collection WAL transactions, not optional
+    backend-only maintenance commits.
 16. `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
     and root descriptor epochs are mandatory replay guards.
 17. Side-ref cleanup resolves files through a class registry by ref class and
@@ -4101,7 +4293,34 @@ PR1 closes the correctness-critical questions that block implementation:
 19. Metadata that affects collection replay must share the collection root-group
     commit or have an explicit total order against collection WAL records.
 
-Future questions that do not weaken PR1 correctness:
+Deferred full-contract work that does not weaken PR1-min correctness:
+
+1. Indexed durable-at-ack, including indexed insert/update/delete and unique
+   helper recovery.
+2. Replay-side accumulation, chunking, and spill.
+3. Async indexed durable publish over already logged transactions.
+4. Root-delta side payloads.
+5. Protected side-ref indexes for side-ref classes PR1-min does not emit.
+6. Full checkpoint/close cleanup boundaries and cleanup manifests.
+7. Overlay compaction WAL maintenance transactions.
+8. Persistent column-store writes.
+9. Native-wire/Raft ack exposure.
+10. Benchmark pass/fail thresholds for default enablement.
+
+Open questions that block PR1-min coding:
+
+1. What is the exact feature flag/API spelling and guarantee text?
+2. What is the exact inline encoded-size cap?
+3. Are value-log pointers fully rejected in PR1-min, or is `ValueLogRecord`
+   side-ref support included?
+4. Are no-index update/delete rejected under the durable capability, or is the
+   capability explicitly insert-only?
+5. What is the exact transaction v1 binary layout and digest scope?
+6. What error names distinguish unsupported mode, recovery-required read-only
+   open, corruption, capacity, and commit-ambiguous failure?
+7. Where are applied watermarks stored in the system root?
+
+Future questions that do not weaken PR1-min correctness:
 
 1. Should `Collection.Flush` gain a sync variant, or should callers use
    `DB.Checkpoint` for fsync-style barriers?
@@ -4111,7 +4330,7 @@ Future questions that do not weaken PR1 correctness:
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
 
-Resolved PR1 decision: native-wire `ack_policy` remains request/local
+Resolved PR1-min decision: native-wire `ack_policy` remains request/local
 durability control and is stripped before deterministic-entry construction. A
 future cluster-visible barrier must be a separate deterministic command or a
 new deterministic command field with explicit state-machine semantics.
@@ -4134,9 +4353,10 @@ Write path:
   WAL-off mode, the code path is explicitly marked relaxed.
 - After WAL append succeeds: ordinary failure returns are disallowed unless the
   return status is explicitly committed/ambiguous.
-- Direct insert/update/delete paths assert either `collectionWALTxn != nil` or
-  `equivalentDurableRootFence == true`, and the latter must be covered by the
-  same crash matrix.
+- Direct insert/update/delete paths assert either `collectionWALTxn != nil`,
+  `equivalentDurableRootFence == true`, or `unsupportedBeforeMutation == true`.
+  The equivalent durable root fence is full-contract work and must be covered by
+  the same crash matrix before use.
 
 Recovery:
 
@@ -4500,8 +4720,8 @@ Module-specific constraints:
 - `TreeDB/internal/valuelog` and future column-file maintenance must consult the
   protected side-ref index and side-ref prepare guard. They must charge both
   logical protected bytes and incremental retained segment bytes to collection
-  WAL backpressure. PR1 rewrite refuses protected refs rather than moving them
-  and patching WAL records.
+  WAL backpressure. The first side-ref-enabled milestone refuses protected refs
+  rather than moving them and patching WAL records.
 - Column-store implementation may not publish persistent column parts until
   part files, descriptor deltas, primary locator deltas, delete bitmap roots,
   secondary roots, filter roots, and schema roots can be committed as one
@@ -4519,7 +4739,7 @@ Runtime assertions required in WAL-on modes:
 
 - Assert no visible install occurs without `CompleteWALFrame`.
 - Assert `CollectionSeq == previous + 1` at allocation and replay.
-- Assert `DependsOnCollectionSeq == CollectionSeq - 1` for PR1 single-write
+- Assert `DependsOnCollectionSeq == CollectionSeq - 1` for PR1-min single-write
   transactions.
 - Assert canonical embedded side refs equal declared required refs before
   append.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -220,6 +220,78 @@ make that write visible after process crash. This does not imply an fsync power
 loss guarantee unless the caller used a sync barrier and the selected durability
 mode requires fsync.
 
+Visible:
+
+Observable by any collection read path, scan, uniqueness check, update planner,
+delete planner, schema/index barrier, or pending-state merge. In WAL-on modes,
+visibility implies recoverability.
+
+Recoverable:
+
+After process crash and read-write recovery, the transaction can be made visible
+from backend roots or from a complete committed collection WAL transaction
+without relying on pre-crash memory.
+
+WAL append commit point:
+
+The exact point at which a collection WAL frame and commit marker are complete,
+checksummed, ordered by `WALLSN`, and recoverable under the selected local
+durability mode.
+
+Side-ref prepared:
+
+The referenced external bytes have been written and are readable at the selected
+side-ref durability boundary.
+
+Side-ref protected:
+
+GC, rewrite, cleanup, compaction, and side-file maintenance must treat the ref as
+reachable.
+
+Published:
+
+The transaction's root effects are represented in backend collection root
+descriptors.
+
+Checkpointed:
+
+The backend checkpoint/meta boundary durably contains the root descriptors,
+applied watermarks, and side-ref reachability tracking needed for cleanup.
+
+Cleanable:
+
+A collection WAL segment or side ref may be removed because every transaction
+that references it is applied, checkpointed, and no live snapshot/read view can
+reach it.
+
+`CollectionSeq`:
+
+A gap-free, monotonically increasing sequence number scoped to one
+`CollectionID`. It is the replay, dependency, and skip key.
+
+`WALLSN`:
+
+A globally monotonically increasing append position used for deterministic WAL
+scan order, diagnostics, and segment cleanup accounting. It is not a dependency
+ordering key and must not be used to skip a transaction for another collection.
+
+`CollectionReadView`:
+
+A pinned read snapshot covering backend snapshot state, collection catalog/root
+metadata, collection-local pending state, derived index views, and every side ref
+reachable from those states.
+
+Close admission cut:
+
+The point in `DB.Close` after which new collection mutations cannot be admitted
+unless they are explicitly included in the close drain set. A racing mutation
+must either fail with a closed error or be drained before close returns.
+
+Clean WAL state:
+
+No collection WAL transaction remains required for crash recovery. This is
+stronger than "normal backend WAL has no files".
+
 ## 4. Goals
 
 1. Make collection durability explicit and testable.
@@ -270,7 +342,10 @@ mode requires fsync.
 | `DurabilityWALOffRelaxed` | No durable-at-ack promise. Collection writes remain flush/checkpoint/close-boundary durable, and docs must say so directly. |
 
 If the engine cannot append the collection WAL transaction in a WAL-on mode, the
-collection write must fail before becoming visible to the caller.
+collection write must fail before becoming visible to any reader, planner, or
+pending-state merge. "Before success is returned" is not strong enough: a
+concurrent read must not observe a write whose WAL transaction is not already
+recoverable.
 
 After the WAL commit marker reaches the durability boundary required by the
 selected mode, the mutation is committed for recovery. The implementation must
@@ -307,10 +382,15 @@ blind retry.
 
 - Must become a full database durability/cleanup boundary for collection WAL.
 - Must call a backend-owned collection WAL checkpoint service, or registered
-  hooks that are coordinated by such a service. PR1 checkpoint handling must
-  publish every replayable collection WAL transaction known to the backend,
-  advance applied watermarks in backend commits, sync the backend boundary
-  required by the selected mode, and only then allow collection WAL cleanup.
+  hooks that are coordinated by such a service.
+- PR1 checkpoint handling must close admission for the checkpoint cut, wait for
+  in-flight collection writes admitted before the cut, wait for in-flight async
+  publish, drain all known write domains through `FlushAll`, publish root
+  groups, advance applied watermarks in backend commits, sync the backend
+  boundary required by the selected mode, and only then allow collection WAL
+  cleanup.
+- Writes admitted after the checkpoint cut may remain in retained collection WAL,
+  but they are not part of the checkpoint-covered prefix.
 - It must not report a clean WAL state while collection WAL transactions remain
   needed for recovery.
 - If a future checkpoint mode chooses not to publish a transaction, it must keep
@@ -319,10 +399,13 @@ blind retry.
 
 `DB.Close`:
 
-- Must stop new collection writers, drain in-flight async publishers, publish
-  replayable collection WAL transactions, advance applied watermarks, reach the
-  selected durability boundary, and only then allow cleanup before backend
-  close.
+- Must establish a close admission cut, reject or explicitly include every
+  racing collection write, wait for admitted in-flight writers, drain in-flight
+  async publishers, publish replayable collection WAL transactions, advance
+  applied watermarks, reach the selected durability boundary, and only then allow
+  cleanup before backend close.
+- No collection write may return success after the close admission cut unless it
+  is included in the close drain and is visible after reopen.
 - Must not discard a collection WAL transaction before its applied watermark and
   cleanup boundary are safely published.
 - Close must use the same backend-owned collection WAL publish/checkpoint path
@@ -354,7 +437,47 @@ Native-wire acknowledgement policies map onto these same local boundaries:
   collection WAL alone; it requires consensus commit plus the cluster's defined
   local apply durability rule.
 
-### 6.3 Column-Store Gate
+### 6.3 PR1 Invariants
+
+These invariants are normative for PR1 and are the acceptance criteria for
+turning the design into code:
+
+1. Visibility implies recoverability. In WAL-on modes, any collection mutation
+   visible to a read, scan, uniqueness check, update planner, delete planner, or
+   schema/index barrier must be recoverable from backend roots or from a
+   committed collection WAL transaction.
+2. Side refs precede WAL commit. A collection WAL transaction may reference a
+   side ref only after the bytes are readable at the selected durability boundary
+   and registered as protected against GC, rewrite, cleanup, and compaction.
+3. Visible install follows WAL commit. Write-domain install is a short critical
+   section after the WAL commit point. If WAL commit fails, the mutation leaves
+   no read-visible pending state, uniqueness reservation, queued unit, publishing
+   unit, or schema/index barrier state.
+4. `CollectionSeq` is gap-free per collection. Recovery and publication process
+   transactions for a collection in `CollectionSeq` order. PR1 has no
+   same-collection independence skip.
+5. Watermark coverage is contiguous and atomic. A backend publish may advance
+   `applied_collection_seq[CollectionID]` only over the next contiguous prefix,
+   and descriptor updates plus watermark updates must be one backend commit.
+6. Cleanup requires applied plus checkpointed. A collection WAL segment or side
+   ref is cleanable only after every referencing transaction is covered by a
+   durable applied watermark, the backend checkpoint/meta boundary containing the
+   watermark is durable, and side-ref reachability has incorporated the published
+   roots.
+7. `DB.Checkpoint` is collection-aware. PR1 checkpoint drains and publishes
+   checkpoint-admitted collection writes before reporting a clean collection WAL
+   state. A future non-publishing checkpoint must report collection WAL debt.
+8. `DB.Close` is an admission barrier. A write racing with close either fails
+   before visible install or is included in the close drain and survives reopen.
+9. Snapshot readers pin pending state. A collection read view must pin backend
+   snapshot state, collection-local pending units, side refs, and derived indexes
+   for the lifetime of the read.
+10. No waits under state locks. The implementation must not wait for backend
+    publish, checkpoint, WAL I/O, side-ref GC, async publish completion, or
+    value-log rewrite while holding a lock that those operations need to make
+    progress.
+
+### 6.4 Column-Store Gate
 
 Production column-store collection implementation is blocked until this
 contract is implemented and tested. Allowed pre-gate work:
@@ -401,7 +524,7 @@ CollectionWALTransaction {
     Version                  uint16
 
     // Identity and ordering.
-    GlobalTxnID              uint64
+    WALLSN                   uint64
     CollectionID             uuid128
     CollectionName           string diagnostic
     CollectionSeq            uint64
@@ -473,7 +596,7 @@ DescriptorOp {
 AppliedWatermarkOp {
     CollectionID             uuid128
     AdvanceCollectionSeqTo   uint64
-    OptionalGlobalTxnID      uint64
+    OptionalWALLSN           uint64
 }
 
 CollectionSideRef {
@@ -493,7 +616,7 @@ CollectionWALAppendOptions {
 
 OrderedRootPublishOptions {
     Sync                     bool
-    GlobalTxnIDsCovered      []uint64
+    WALLSNRange              [2]uint64
     CollectionSeqRange       [2]uint64
     WatermarkOp              AppliedWatermarkOp
 }
@@ -515,6 +638,12 @@ The same backend commit that writes descriptor operations from
 descriptor update without the watermark, or a watermark update without the
 descriptor update, is not a valid collection WAL publish.
 
+`WALLSN` is a global append position, not the replay dependency key. The
+collection-local `CollectionSeq` and `DependsOnCollectionSeq` fields define the
+dependency domain. Recovery may use `WALLSN` to scan and diagnose records, but
+it must not use a higher `WALLSN` from another collection to skip a lower
+unapplied `CollectionSeq`.
+
 `AckMode`, `CreatedUnixNanos`, and `Stats` are local observability and policy
 metadata. They must not change root-delta replay output, idempotency outcomes,
 catalog guard outcomes, or future Raft state-machine results.
@@ -531,7 +660,8 @@ Two digests are required:
 Every collection must have a stable `CollectionID` persisted in collection
 metadata. `CollectionName` is diagnostic and must not be the replay identity.
 Dropping and recreating a collection with the same name creates a new
-`CollectionID`.
+`CollectionID`. Renaming a collection, if supported, preserves `CollectionID`
+and changes only catalog metadata.
 
 Every schema or index metadata change increments `SchemaEpoch`. Every root
 descriptor change increments that root's `RootGeneration`. Overlay descriptor
@@ -541,7 +671,10 @@ A collection WAL transaction records `CollectionID`, `SchemaEpoch`,
 `BaseRootID`, and `BaseRootGeneration` for every root it mutates. Recovery must
 reject or block a transaction whose identity or generation guard does not match
 the replay state, unless the mismatch is explicitly explained by the active
-replay accumulator.
+replay accumulator. An unapplied transaction whose `CollectionID` is absent from
+the recovered catalog must not be replayed into a collection with the same name;
+PR1 must stop open or quarantine according to a documented recovery-admin
+procedure rather than silently applying the transaction to a later incarnation.
 
 Maintenance that rewrites root ids or descriptor values must not run for a
 collection with unapplied WAL transactions unless the maintenance operation is
@@ -602,9 +735,9 @@ Dir/maindb/wal/
 Segment rules:
 
 - Each segment contains framed `CollectionWALTransaction` records.
-- Each transaction has exactly one `GlobalTxnID` and one collection-local
+- Each transaction has exactly one `WALLSN` and one collection-local
   `CollectionSeq`.
-- Transactions are sorted by `GlobalTxnID` during segment scanning, with file
+- Transactions are sorted by `WALLSN` during segment scanning, with file
   order as a deterministic tie breaker only for malformed legacy segments.
 - A short read or EOF is accepted only for the terminal frame of the active
   non-cleaned segment in that lane.
@@ -621,8 +754,8 @@ CollectionWALSegmentMeta {
     Version                       uint16
     Lane                          uint16
     SegmentSeq                    uint64
-    MinGlobalTxnID                uint64
-    MaxGlobalTxnID                uint64
+    MinWALLSN                     uint64
+    MaxWALLSN                     uint64
     ParticipantCollectionIDs      []uuid128
     FirstFrameOffset              uint64
     LastCompleteFrameEndOffset    uint64
@@ -640,8 +773,8 @@ CollectionWALCleanupRecord {
     CleanupEpoch                  uint64
     Lane                          uint16
     SegmentSeq                    uint64
-    MinGlobalTxnID                uint64
-    MaxGlobalTxnID                uint64
+    MinWALLSN                     uint64
+    MaxWALLSN                     uint64
     ParticipantCollectionIDs      []uuid128
     State                         planned | unlinked | dirsynced
     RecordChecksumCRC32C          uint32
@@ -661,19 +794,23 @@ segment.
 The system root stores applied progress by `CollectionID`:
 
 ```text
-treedb/collection-wal/global-contiguous-applied-txn-id -> uint64 optional
+treedb/collection-wal/global-contiguous-cleanup-wallsn -> uint64 optional
 treedb/collection-wal/collection/<collection-id>/applied-collection-seq -> uint64
 ```
 
-`GlobalTxnID` is a unique transaction identity and diagnostic ordering key.
-`CollectionSeq` is the replay and skip key. Recovery may skip a transaction only
-when `txn.CollectionSeq <= applied-collection-seq` for the same `CollectionID`
-and the transaction's `CollectionID`/`SchemaEpoch` guard matches the catalog
-history covered by that watermark.
+`WALLSN` is the globally monotonic append position. It is useful for segment
+ordering, diagnostics, and cleanup scans. `CollectionSeq` is the replay and skip
+key. Recovery may skip a transaction only when
+`txn.CollectionSeq <= applied-collection-seq` for the same `CollectionID` and
+the transaction's `CollectionID`/`SchemaEpoch` guard matches the catalog history
+covered by that watermark.
 
-A global contiguous watermark may be used only as an optimization when every
-lower `GlobalTxnID` is known applied or intentionally absent. It must never
-cause recovery to skip an unapplied lower `CollectionSeq` for any collection.
+A global contiguous `WALLSN` cleanup marker may be used only as a cleanup-scan
+optimization when every lower `WALLSN` is known applied or intentionally absent.
+It must never cause recovery to skip an unapplied lower `CollectionSeq` for any
+collection, and PR1 cleanup must still verify every transaction in a segment
+against the relevant per-collection applied watermark before deleting the
+segment.
 
 Watermarks advance only in the same backend commit that updates collection root
 descriptors for the root group. A watermark value means every collection
@@ -683,7 +820,7 @@ and descriptor metadata.
 PR1 uses per-write WAL transactions with per-collection dependency chains:
 
 ```text
-GlobalTxnID              uint64  // unique identity, diagnostics, segment order
+WALLSN                   uint64  // global append position for diagnostics/cleanup
 CollectionSeq            uint64  // strictly increasing per CollectionID
 DependsOnCollectionSeq   uint64  // previous collection transaction observed
 ```
@@ -792,12 +929,31 @@ conflicting maintenance side of this guard before computing reclaimable refs.
 This prevents in-process maintenance from deleting side refs in the window after
 side-ref creation but before WAL commit.
 
+For every required side ref, the WAL-on write path order is:
+
+1. write side-ref bytes;
+2. reach the selected side-ref durability boundary: process-crash-readable for
+   WAL-on relaxed mode, and the configured flush/sync boundary for durable sync
+   modes;
+3. register the side ref in the protected collection WAL retention set;
+4. append the collection WAL transaction and commit marker that reference it;
+5. install the transaction into read-visible pending state.
+
+The protected-retention registration must happen before the commit marker can be
+considered replayable. If the WAL append aborts before the commit marker, the
+prepared refs are orphan-prepared and may be quarantined or deleted only after
+the guard proves no committed WAL transaction or published root references them.
+
 ### 7.8 Commit Marker and Ack Boundary
 
 A collection WAL record is replayable only after its commit marker is complete.
 The implementation must complete validation, side-ref preparation, side-ref
 flush/sync required by the selected durability mode, memory reservation, and
 hidden write-domain staging before appending the commit marker.
+
+Hidden staging is private. It must not be reachable from any collection read,
+scan, uniqueness check, update/delete planner, schema/index barrier, queued unit,
+publishing unit, or pending-state merge before the commit marker is complete.
 
 After the commit marker reaches the required durability boundary, the mutation is
 committed for recovery. The implementation must not return an ordinary mutation
@@ -845,6 +1001,19 @@ applied under the cluster policy.
 
 ## 8. Write Path
 
+Every WAL-on collection mutation has three phases:
+
+1. Private planning: root deltas, side refs, uniqueness reservations, publish
+   inputs, and schema/index barrier state are built in objects unreachable from
+   any collection read or planner.
+2. Durable commit: required side refs are prepared/protected, `CollectionSeq`
+   and `WALLSN` are assigned, and a complete collection WAL transaction reaches
+   the selected recovery boundary.
+3. Visible install: the already-committed transaction is installed into the
+   collection write domain under a short state lock. This step must be
+   non-failing or commit-ambiguous/fatal; it must not return an ordinary
+   retryable mutation error.
+
 For every WAL-on collection mutation:
 
 1. Validate catalog identity, schema epoch, root descriptor generations,
@@ -858,9 +1027,12 @@ For every WAL-on collection mutation:
    to the selected durability boundary before the WAL commit marker is
    considered replayable.
 4. Reserve hidden write-domain state using the exact serialized root deltas or
-   immutable decoded delta objects.
+   immutable decoded delta objects. Hidden means no collection read path,
+   uniqueness helper, update/delete planner, queued flush unit, publishing unit,
+   or schema/index barrier can reach it.
 5. Append the collection WAL transaction and commit marker.
-6. Mark the reserved write-domain state visible without further fallible work.
+6. Mark the reserved write-domain state visible without further fallible work
+   while holding the collection write-domain state lock only for the install.
 7. Return success.
 
 Flush, async publish, checkpoint, and close are publication and cleanup paths.
@@ -937,10 +1109,10 @@ If async publish fails, in-memory units can be requeued as they are today. The
 collection WAL transaction remains the recovery source until a successful
 publish advances the watermark.
 
-Every queued or publishing flush unit must carry the collection WAL transaction
-identity it covers:
+Every queued or publishing flush unit must carry the collection WAL coverage it
+covers:
 
-- `GlobalTxnID` range for diagnostics and cleanup;
+- `WALLSN` range for diagnostics and cleanup;
 - contiguous `CollectionSeq` range for the owning collection;
 - required side-ref ownership or references to the protected side-ref index;
 - root names and root generations covered by the publish.
@@ -949,6 +1121,15 @@ Async publish completion may advance the applied watermark only for whole
 transactions covered by the successful root publish. Requeue must preserve WAL
 transaction ownership and must not append replacement WAL records for the same
 acknowledged mutation.
+
+For any collection/root dependency chain, async publish and watermark
+advancement must cover a contiguous `CollectionSeq` prefix. A newer transaction
+may remain visible through pending state while an older publishing unit is
+requeued, but it must not become backend-authoritative, watermarked, or
+cleanable ahead of that older dependent transaction. PR1 may publish independent
+roots out of order only when root independence is machine-checkable and the
+collection watermark still advances over a contiguous transaction prefix; the
+default rule is no out-of-prefix advancement.
 
 ### 8.5 Overlay Roots
 
@@ -1034,6 +1215,10 @@ with explicit consensus semantics.
 PR1 must document and test lock ordering before product code depends on
 collection WAL. Required ordering constraints:
 
+- close/checkpoint admission gate is acquired before admitting new collection
+  mutations or selecting a checkpoint drain cut;
+- collection manager domain registry state is consulted before per-collection
+  mutation locks;
 - collection mutation serialization happens before `CollectionSeq` allocation
   and before pending visibility changes;
 - side-ref prepare guard is acquired before writing side refs and is released
@@ -1042,21 +1227,30 @@ collection WAL. Required ordering constraints:
   locks;
 - backend write/commit locks must not be held while waiting for collection
   domain locks or async publisher condition variables;
+- `domain.mu` must be held only for short visible-install or completion
+  bookkeeping critical sections. It must not be held while waiting for async
+  publish, performing collection WAL I/O, registering long-running GC work,
+  calling backend publish, or calling backend checkpoint;
 - async publishers publish already-logged transactions and never allocate new
-  WAL transaction ids for the covered acknowledged writes;
-- close/checkpoint first stop or fence new writers, then drain async publishers,
-  then publish/replay WAL-backed transactions, then advance durable watermarks,
-  then clean;
+  `WALLSN` or `CollectionSeq` values for the covered acknowledged writes;
+- `DB.Checkpoint` must invoke collection drain/checkpoint hooks before acquiring
+  backend locks that async publish needs, or must use a nonblocking protocol that
+  cannot wait on a publisher needing those locks;
+- close/checkpoint first stop or fence new writers, wait for admitted in-flight
+  writers, drain async publishers, publish/replay WAL-backed transactions,
+  advance durable watermarks, create the durable backend boundary, then clean;
 - background goroutines must be owned by the backend collection WAL service or
   be registered with it so recovery/checkpoint/close can quiesce them.
 
 The safe high-level sequence is:
 
 ```text
-prepare final deltas and side refs under collection mutation/domain locks
--> release planner-only locks that are not needed for append
+admit write through DB/collection admission gate
+-> serialize mutation under collection mutationMu
+-> prepare final deltas in private, non-visible objects
+-> prepare/protect required side refs
 -> append/sync collection WAL under collection WAL writer lock
--> mark pre-reserved pending state visible
+-> mark pre-reserved pending state visible under a short domain.mu critical section
 -> later publish logged deltas without holding the WAL append lock
 -> atomically advance root descriptors and watermarks
 -> cleanup only after durable checkpoint/meta boundary
@@ -1064,6 +1258,31 @@ prepare final deltas and side refs under collection mutation/domain locks
 
 Implementations may use finer-grained locks, but they must preserve the same
 deadlock and visibility invariants.
+
+### 8.10 Collection Read Views
+
+Collection reads that span more than a single copied point value must acquire a
+`CollectionReadView`. A point read may avoid a read view only when it copies the
+returned value and does not retain references to pending tables, value-log
+records, column files, filters, delete bitmaps, or publishing units after
+dropping collection locks.
+
+A `CollectionReadView` captures:
+
+- a backend snapshot and collection catalog/root descriptor view;
+- immutable or refcounted views of mutable, queued, and publishing collection
+  write-domain units that were visible at view creation;
+- side refs reachable from those units;
+- generated secondary-index views and unique-helper state needed by the scan or
+  planner;
+- the `CollectionID`, `CollectionSeq`, and `WALLSN` values that own pending
+  visible units.
+
+Flush, async publish completion, rollback, overlay compaction, root rewrite,
+collection WAL cleanup, value-log GC/rewrite, leaf-log GC, and future column-file
+cleanup must not reset, reuse, delete, rewrite, or unprotect any object reachable
+from a live `CollectionReadView`. Mutable state must either be frozen into an
+immutable unit before inclusion in a view or copied into the view.
 
 ## 9. Recovery Algorithm
 
@@ -1121,7 +1340,7 @@ the current invariant that side-store scans run before cached commit-log replay:
 10. Load applied collection-sequence watermark metadata from the recovered system
    root.
 11. Sort unapplied transactions by `CollectionID`, `CollectionSeq`, and
-   `GlobalTxnID` for deterministic diagnostics.
+   `WALLSN` for deterministic diagnostics.
 12. For each uncovered transaction, validate declared side refs and the
    canonical embedded required side-ref set extracted from root deltas and
    descriptors. The sets must match.
@@ -1187,6 +1406,13 @@ advance the collection watermark to the highest contiguous `CollectionSeq`
 covered by the publish. If any root in a transaction cannot be applied, no root
 from that transaction may be considered applied.
 
+The applied watermark may advance from `N` to `M` only when the publish covers
+every transaction with `CollectionSeq` in `(N, M]` for that collection, with no
+gaps. A publish that contains merged root deltas, replay accumulators, or async
+flush units must record the covered contiguous range before cleanup can consider
+any transaction in that range applied. Scalar watermark metadata is valid in PR1
+only because every publish is constrained to this contiguous-prefix rule.
+
 This rule applies to no-index buffered writes, indexed mutable runs, queued
 flush units, async publishing states, overlay compaction, schema/index changes,
 and future column-store delta-part descriptor updates.
@@ -1195,13 +1421,17 @@ and future column-store delta-part descriptor updates.
 
 | Failure point | Required behavior |
 |---|---|
+| Crash or ordinary failure during private planning before side refs or WAL | Return/observe no write. No read-visible pending state, uniqueness reservation, queued unit, or publishing unit exists. |
 | Side-ref preparation fails before WAL commit marker | Return ordinary error. Do not expose mutation. Delete or quarantine prepared side files. |
 | Crash before any side ref or WAL write | `S0 Absent`. No recovery action is required beyond ordinary orphan scan. |
 | WAL append fails before commit marker | Return ordinary error. Do not expose mutation. Side refs remain uncommitted and are deleted or quarantined. |
 | Crash after side refs prepared before commit marker | Recovery ignores transaction. Unreferenced side files are deleted or quarantined. |
+| Concurrent read or planner races before WAL commit marker | Must not observe the private mutation. WAL-on visibility before recoverability is a correctness bug. |
 | Crash after commit marker before response | Recovery may expose transaction. This is committed-before-response ambiguity. |
 | Crash after visible staging before API response | WAL-on modes recover the committed transaction. Visible-without-committed-WAL is not permitted. |
 | In-memory visible staging fails after commit marker | Not permitted as an ordinary error. Implementation must make this step non-failing or report commit-ambiguous/fatal. |
+| Checkpoint races with admitted writer | Writer is either before the checkpoint cut and must be drained/published/watermarked by the checkpoint, or after the cut and must remain protected in retained WAL. |
+| Close races with admitted writer | Writer either fails with closed before visible install or is included in the close drain and visible after reopen. |
 | Root publish fails before backend meta commit | WAL transaction remains unapplied and protected. Retry on flush or recovery. |
 | Root pages are built but backend meta commit fails | Built pages are unreachable. WAL transaction remains source of truth. |
 | Descriptor update succeeds without watermark | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
@@ -1271,10 +1501,12 @@ durable cleanup metadata.
 
 `DB.Checkpoint` must call registered collection checkpoint hooks before
 reporting a clean collection WAL state. PR1 checkpoint hooks force publication
-of replayable collection WAL, advance watermarks, and then allow collection WAL
+of replayable collection WAL admitted before the checkpoint cut, wait for
+in-flight async publish, drain known write domains, advance watermarks, create
+the backend checkpoint/meta durability boundary, and then allow collection WAL
 cleanup. If a future checkpoint mode leaves replayable collection WAL
 unpublished, it must report collection WAL debt and preserve all side-ref
-protections.
+protections; it is not a clean collection-WAL boundary.
 
 ## 11. Test Plan
 
@@ -1304,7 +1536,7 @@ Keep and expand tests that document current behavior:
 - `SystemDeltaTemplate` placeholder instantiation golden tests;
 - descriptor-op precondition failures are reported before any publish is marked
   applied;
-- segment metadata golden tests for min/max `GlobalTxnID`, participant
+- segment metadata golden tests for min/max `WALLSN`, participant
   collections, sealed status, and checksum;
 - cleanup record golden tests for `planned`, `unlinked`, and `dirsynced` states.
 
@@ -1325,8 +1557,8 @@ Crash/fault points:
 10. during column-file prepare once column store exists;
 11. after two or more acknowledged buffered transactions with the same
     persisted `BaseRootID`;
-12. after a higher `GlobalTxnID` from another collection publishes before a
-    lower `GlobalTxnID`;
+12. after a higher `WALLSN` from another collection publishes before a
+    lower `WALLSN`;
 13. after value-log GC/rewrite is requested while an unapplied collection WAL
     transaction is the only owner of a side ref;
 14. after a schema/index change is planned while lower `CollectionSeq`
@@ -1355,11 +1587,11 @@ Required assertions:
 - reads do not need stale in-memory write domains after recovery;
 - roots never reference missing value-log or column-file bytes;
 - collection WAL files are cleaned only after safe watermark/checkpoint
-  boundaries.
+  boundaries;
 - buffered transactions with shared persisted bases replay by accumulation or
   rebasing without losing acknowledged writes;
-- a higher applied `GlobalTxnID` never causes recovery to skip a lower unapplied
-  transaction from another collection;
+- a higher published or cleaned `WALLSN` never causes recovery to skip a lower
+  unapplied transaction from another collection;
 - value-log GC/rewrite cannot remove or move bytes referenced only by pending
   collection WAL side refs;
 - leaf-log GC/rewrite and future column cleanup cannot remove bytes referenced
@@ -1383,7 +1615,69 @@ Required assertions:
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
 
-### 11.4 Fuzz Tests
+### 11.4 Concurrency, Admission, and Snapshot Tests
+
+Visibility and WAL append:
+
+- no-index insert WAL append failure leaves no visible document and no unique or
+  planner-observable state;
+- indexed insert WAL append failure leaves no primary, secondary, unique-helper,
+  queued, or publishing visibility;
+- update/delete WAL append failure leaves no visible old-secondary delete or
+  new-secondary put;
+- race a writer blocked between private planning and WAL commit against reads,
+  unique checks, update planners, delete planners, and pending-state merges;
+  none may observe the write;
+- crash after WAL commit before visible install replays the write; an in-process
+  reader before the crash must not have depended on uncommitted private state.
+
+Checkpoint and close:
+
+- no-index insert -> `DB.Checkpoint` -> crash/reopen shows the document under
+  WAL-on PR1 semantics;
+- indexed buffered insert with async publish disabled -> `DB.Checkpoint` ->
+  crash/reopen has primary and secondary roots;
+- checkpoint racing with new writes covers writes before the admission cut and
+  retains protected WAL for writes after the cut;
+- checkpoint with async publishing in flight waits, publishes, or safely retries
+  without deadlock;
+- close racing no-index insert, indexed insert batch, update, delete,
+  schema/index mutation, and async flush scheduling either returns closed or
+  drains every successful mutation before close returns.
+
+Ordering and async publish:
+
+- two collections with interleaved `WALLSN` values can publish one collection
+  first without causing recovery to skip the other's lower unapplied
+  `CollectionSeq`;
+- a segment containing applied collection B transactions and blocked collection A
+  transactions is retained until every transaction in the segment is cleanable;
+- async publish failure for older transaction `N` blocks watermark advancement
+  for later dependent transaction `N+1`;
+- replay accumulation publishes only contiguous `CollectionSeq` prefixes and
+  blocks on gaps.
+
+Read views and retention:
+
+- long-running index range iterator remains valid while async publish completes
+  and publishing units are reset after the iterator closes;
+- `CollectionReadView` pins mutable, queued, and publishing units during
+  `Flush`, `FlushAll`, overlay compaction, value-log GC/rewrite, and future
+  column-file cleanup;
+- value-log, leaf-log, filter, delete-bitmap, dictionary, and column side refs
+  reachable from a live read view remain protected until the view is released;
+- debug lock-order assertions or stress tests cover concurrent writes,
+  checkpoint, flush, async publish, close, value-log GC, side-ref cleanup, and
+  WAL append under timeouts.
+
+Read-only open:
+
+- crash after WAL commit before publish, then read-only open, returns the PR1
+  recovery-required error;
+- after read-write recovery completes, read-only reopen sees the recovered write
+  without needing collection WAL replay.
+
+### 11.5 Fuzz Tests
 
 - transaction decoder fuzzing;
 - recovery ordering fuzzing with multiple collections and duplicate keys;
@@ -1434,10 +1728,13 @@ Traceability matrix:
 | Side-file fences | 7.7, 10 | M2 | missing-ref and GC protection tests |
 | Segment cleanup metadata | 7.5, 10 | M1, M5 | missing-segment and cleanup-manifest tests |
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
+| Visibility/admission barriers | 6.2, 6.3, 8, 8.9 | M3, M6 | read-race, checkpoint-cut, and close-race tests |
+| Collection read views | 3, 6.3, 8.10, 10 | M4, M6 | long-iterator and side-ref pinning tests |
 | Recovery replay | 9 | M4 | crash matrix, accumulation, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
+| Lock ordering | 8.9, 11.4 | M0, M6 | debug lock assertions and deadlock stress |
 | Performance | 12 | M6 | benchstat gates and artifacts |
-| Column-store unblock | 6.3, 10 | M7 | side-file fence and root-group recovery proof |
+| Column-store unblock | 6.4, 10 | M7 | side-file fence and root-group recovery proof |
 | Native-wire/Raft layering | 2.4, 6.2, 7.9, 8.8 | M8 | deterministic-entry apply and local-WAL durability tests |
 
 ### Milestone 0: Contract Freeze
@@ -1447,6 +1744,8 @@ Deliverables:
 - document current collection flush-boundary behavior;
 - identify every API that can acknowledge collection writes;
 - freeze benchmark fixtures and crash-test harness shape.
+- document PR1 visibility, checkpoint admission, close admission, read-view, and
+  lock-order invariants before product code relies on them.
 
 Tests:
 
@@ -1455,6 +1754,9 @@ Tests:
 - `FlushAll` drains queued indexed flush unit;
 - failpoint hooks compile and can stop execution at side prepare, WAL append,
   staging, publish, watermark, cleanup, and recovery replay boundaries.
+- debug lock-order hooks can identify inverted acquisition for collection
+  `mutationMu`, `domain.mu`, WAL lane locks, side-ref protection locks, backend
+  write/commit locks, checkpoint locks, and close/checkpoint admission gates.
 
 Gate:
 
@@ -1468,7 +1770,7 @@ Deliverables:
 - internal transaction structs;
 - encoder/decoder;
 - segment reader/writer;
-- global transaction id and per-collection sequence allocator interfaces;
+- WALLSN and per-collection sequence allocator interfaces;
 - persisted `CollectionID`, `SchemaEpoch`, and root generation descriptor
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
@@ -1529,6 +1831,9 @@ Deliverables:
 - WAL-on no-index inserts append collection WAL before acknowledgement;
 - no-index buffered inserts enter collection mutation serialization before
   `CollectionSeq` allocation and pending visibility;
+- private planning, durable commit, and visible install are separate phases;
+- no collection read, planner, uniqueness check, queued unit, or publishing unit
+  can observe a no-index write before its WAL commit marker is complete;
 - final physical primary-root deltas are materialized before the commit marker;
 - pending write-domain visibility remains unchanged;
 - direct publish paths log first under WAL-on modes or remain explicitly
@@ -1539,6 +1844,9 @@ Tests:
 
 - crash after ack before flush recovers document;
 - crash before WAL append does not expose document;
+- WAL append failure leaves no visible no-index pending state;
+- concurrent reads and planners blocked around WAL append cannot observe the
+  private mutation;
 - checkpoint behavior updated to the new contract.
 
 Gate:
@@ -1552,8 +1860,12 @@ Deliverables:
 - indexed insert root-group WAL;
 - update/delete root-group WAL;
 - async flush publish uses existing durable transactions;
-- queued/publishing flush units carry `GlobalTxnID` and contiguous
+- queued/publishing flush units carry `WALLSN` and contiguous
   `CollectionSeq` ranges;
+- queued/publishing flush units cannot advance watermark outside a contiguous
+  per-collection prefix;
+- collection read views pin pending mutable, queued, and publishing units plus
+  reachable side refs;
 - unique helper rebuild after recovery;
 - replay accumulator for multiple buffered transactions that share one persisted
   root base;
@@ -1567,6 +1879,10 @@ Tests:
 
 - crash after ack before async publish;
 - crash during async publish;
+- WAL append failure for indexed insert/update/delete leaves no visible primary,
+  secondary, unique-helper, queued, or publishing state;
+- long-running iterators remain valid while async publish completes and cleanup
+  waits for read-view release;
 - unique secondary correctness after recovery;
 - update/delete secondary roots recover atomically;
 - two acknowledged buffered writes against one persisted base both survive
@@ -1589,7 +1905,7 @@ Deliverables:
 
 - applied watermark in system root;
 - per-collection applied sequence watermark plus optional global-contiguous
-  diagnostic watermark;
+  `WALLSN` cleanup marker;
 - collection WAL replay in open path;
 - backend-owned collection WAL recovery service independent of
   `CollectionManager` construction;
@@ -1605,6 +1921,7 @@ Tests:
   double-apply;
 - out-of-order async publish cannot advance a watermark that hides a lower
   unapplied collection sequence;
+- accumulated publishes advance only contiguous `CollectionSeq` prefixes;
 - descriptor update and watermark update cannot split across commits;
 - older segments remain when watermark is not durable;
 - cleanup removes only fully applied segments;
@@ -1623,6 +1940,12 @@ Gate:
 Deliverables:
 
 - `DB.Checkpoint` coordinates with collection WAL;
+- checkpoint establishes an admission cut, waits for in-flight writers admitted
+  before the cut, drains async publish and write domains, publishes/watermarks,
+  creates the backend durable boundary, and only then reports clean collection
+  WAL state;
+- close establishes an admission cut and rejects or drains every racing
+  collection mutator before returning;
 - backend-owned checkpoint service or checkpoint hook registry coordinated by
   that service;
 - `CollectionManager.FlushAll` and close hooks use the same publish path;
@@ -1632,6 +1955,12 @@ Tests:
 
 - checkpoint forces publication of replayable collection WAL in PR1 or reports
   nonzero collection WAL debt in future modes;
+- checkpoint-cut tests prove writes before the cut are covered and writes after
+  the cut remain protected in retained WAL;
+- close-race tests prove every successful racing write survives reopen and every
+  non-surviving write returns closed;
+- concurrent checkpoint/flush/async publish/value-log GC stress tests do not
+  deadlock;
 - close with in-flight async publish is recoverable;
 - WAL-off mode preserves its relaxed contract.
 
@@ -1706,7 +2035,7 @@ Gate:
 | Recovery cannot reconstruct descriptor or watermark updates. | Persist `SystemDeltaTemplate` with descriptor ops, preconditions, root-id placeholders, and watermark op in the WAL transaction. |
 | Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass; fail recovery on missing side refs for complete WAL-on transactions. |
 | Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots through a protected side-ref index until safe applied watermark and checkpoint cleanup. |
-| A global applied watermark skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep global watermarks optional and contiguous only. |
+| A global `WALLSN` marker skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep any global `WALLSN` marker cleanup-only and segment-verified. |
 | Buffered transactions share an old persisted `BaseRootID`. | Use per-collection dependency chains plus replay-side accumulation in PR1. |
 | A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionID`, `SchemaEpoch`, and per-root `RootGeneration` guards and block mismatches. |
 | API returns a normal error after the WAL commit marker. | Reserve fallible state before commit; after commit marker, allow only success, process death, or commit-ambiguous/fatal reporting. |
@@ -1725,9 +2054,9 @@ PR1 closes the correctness-critical questions that block implementation:
 1. Collection WAL uses a dedicated logical file class. It may reuse commit-log
    framing utilities, but it has separate record kinds, commit-marker semantics,
    replay rules, and side-ref behavior.
-2. Transactions use both `GlobalTxnID` and per-collection `CollectionSeq`.
-   `GlobalTxnID` is identity/diagnostics; `CollectionSeq` is the replay and
-   skip key.
+2. Transactions use both `WALLSN` and per-collection `CollectionSeq`.
+   `WALLSN` is the global append position for scan order, diagnostics, and
+   cleanup accounting; `CollectionSeq` is the dependency, replay, and skip key.
 3. Complete WAL-on collection transactions with missing required side refs fail
    recovery. They are not skipped like current RID-fenced cached WAL batches.
 4. PR1 uses replay-side accumulation for buffered writes that share a persisted
@@ -1743,7 +2072,16 @@ PR1 closes the correctness-critical questions that block implementation:
 9. Read-only open with unapplied committed collection WAL fails with a
    recovery-required error unless a future explicitly stale mode is requested.
 10. Missing collection WAL segments are valid only when covered by durable
-   cleanup metadata.
+    cleanup metadata.
+11. WAL-on visibility implies recoverability: private planning state is never
+    reachable by readers, planners, uniqueness checks, or pending-state merges
+    before the WAL commit point.
+12. PR1 checkpoint and close establish admission cuts. A racing write is either
+    outside the cut and protected in retained WAL, inside the cut and drained, or
+    rejected before visible install.
+13. Long-running collection reads use `CollectionReadView` pinning for backend
+    snapshots, pending collection units, derived index views, and reachable side
+    refs.
 
 Future questions that do not weaken PR1 correctness:
 
@@ -1785,7 +2123,7 @@ Future questions that do not weaken PR1 correctness:
 Module-specific constraints:
 
 - `TreeDB/internal/collectionwal` or equivalent owns versioned framing, commit
-  markers, `GlobalTxnID`, per-collection sequence allocation, side-ref
+  markers, `WALLSN`, per-collection sequence allocation, side-ref
   verification, segment metadata, cleanup records, protected side-ref index
   rebuild, missing-segment classification, and segment cleanup after the durable
   applied watermark/checkpoint boundary. It may reuse or extract generic frame

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -63,7 +63,7 @@ PR1 makes these decisions normative:
   chains and replay-side accumulation;
 - reject true multi-collection collection WAL transactions before writing side
   refs or WAL records;
-- use a stable persisted `CollectionID`/`CollectionUID`, mandatory
+- use a stable persisted `CollectionUID`, mandatory
   `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, and per-root
   `RootGeneration`/root descriptor epochs as replay guards;
 - include a versioned `SystemDeltaTemplate` in every replayable transaction;
@@ -570,6 +570,14 @@ It is not a logical insert/update/delete command. Recovery must not rerun user
 callbacks, predicates, JSON extraction, template extraction, secondary-index
 planning, or future column-store planning.
 
+The normative byte encoding for collection WAL segments, frames, transaction
+payloads, side-ref sections, cleanup records, and required feature gates lives
+in `storage-format.md`. The struct below is the semantic payload model used by
+the write-path and recovery contract, not permission to encode fields in ad hoc
+Go-struct order. No implementation PR may write collection WAL bytes until
+`storage-format.md` contains the exact v1 wire format and golden fixture
+expectations.
+
 ```text
 CollectionWALTransaction {
     Version                  uint16
@@ -657,11 +665,14 @@ AppliedWatermarkOp {
 
 CollectionSideRef {
     RefClass                 uint8
+    ClassVersion             uint16
+    Critical                 bool
     RefID                    uint64
     RelativePath             string optional
     Offset                   uint64
     Size                     uint64
-    ChecksumCRC32C           uint32
+    ChecksumKind             uint8
+    Checksum                 bytes
     Required                 bool
 }
 
@@ -679,9 +690,10 @@ OrderedRootPublishOptions {
 ```
 
 This record is not portable across replicas. `CollectionUID` is the durable
-collection identity; existing code or system metadata may call the same value
-`CollectionID`, but `CollectionName` is diagnostic only and must not be used as
-the replay identity. `WALLSN`, `CollectionSeq`, `BaseSystemRootID`,
+collection identity; `CollectionID` is reserved for transient in-memory handles
+or legacy text and must not name a separate durable identity. `CollectionName`
+is diagnostic only and must not be used as the replay identity. `WALLSN`,
+`CollectionSeq`, `BaseSystemRootID`,
 `BaseRootID`, root names as resolved by local storage, side-ref paths/RIDs,
 timestamps, stats, and other local observability metadata are meaningful only in
 the database directory that wrote the record. A follower applying the same
@@ -738,12 +750,12 @@ Two digests are required:
 ### 7.3 Collection Identity and Root Generations
 
 Every collection must have a stable `CollectionUID` persisted in collection
-metadata. The term `CollectionID` in older code/spec text refers to this same
-durable UID, not to the collection name. `CollectionName` is diagnostic and must
-not be the replay identity. Dropping and recreating a collection with the same
-name creates a new `CollectionUID` and a new `CollectionGeneration`. Renaming a
-collection, if supported, preserves `CollectionUID` and increments only the
-catalog metadata required by the rename.
+metadata. `CollectionID` may be used only for transient in-memory handles or
+legacy explanatory text; it must not introduce a second durable identifier.
+`CollectionName` is diagnostic and must not be the replay identity. Dropping and
+recreating a collection with the same name creates a new `CollectionUID` and a
+new `CollectionGeneration`. Renaming a collection, if supported, preserves
+`CollectionUID` and increments only the catalog metadata required by the rename.
 
 Every schema or index metadata change increments `SchemaEpoch`. Every root
 descriptor change increments that root's `RootGeneration` and descriptor epoch.
@@ -841,14 +853,21 @@ Use a dedicated logical collection WAL class. The implementation may reuse
 commit-log framing utilities, but the replay semantics are different from
 normal user-root commit records.
 
-Recommended layout:
+The canonical file layout, segment magic, frame header, transaction payload
+header, section table, commit trailer, compression fields, checksum coverage,
+feature gates, and decoder outcome taxonomy are defined in `storage-format.md`.
+The collection WAL reader must be a dedicated reader with those outcomes; it
+must not inherit cached commit-log RID skip behavior or the commit-log
+length/CRC-only frame semantics.
+
+Canonical main-DB layout:
 
 ```text
 Dir/maindb/wal/
     collection-l<lane>-<seq>.log
 ```
 
-Segment rules:
+Semantic segment rules:
 
 - Each segment contains framed `CollectionWALTransaction` records.
 - Each transaction has exactly one `WALLSN` and one collection-local
@@ -872,7 +891,7 @@ CollectionWALSegmentMeta {
     SegmentSeq                    uint64
     MinWALLSN                     uint64
     MaxWALLSN                     uint64
-    ParticipantCollectionIDs      []uuid128
+    ParticipantCollectionUIDs     []uuid128
     FirstFrameOffset              uint64
     LastCompleteFrameEndOffset    uint64
     Sealed                        bool
@@ -891,7 +910,7 @@ CollectionWALCleanupRecord {
     SegmentSeq                    uint64
     MinWALLSN                     uint64
     MaxWALLSN                     uint64
-    ParticipantCollectionIDs      []uuid128
+    ParticipantCollectionUIDs     []uuid128
     State                         planned | unlinked | dirsynced
     RecordChecksumCRC32C          uint32
 }
@@ -907,8 +926,7 @@ segment.
 
 ### 7.6 Applied Progress and Skip Rules
 
-The system root stores applied progress by `CollectionID`, which is the same
-durable value called `CollectionUID` in the transaction record:
+The system root stores applied progress by `CollectionUID`:
 
 ```text
 treedb/collection-wal/global-contiguous-cleanup-wallsn -> uint64 optional
@@ -1013,6 +1031,18 @@ refs whenever a published payload cannot decode without them. Codec ids,
 parameters, dictionary ids, dictionary registry/version, and codec registry
 version must be persisted in descriptors or manifests and protected until every
 dependent payload is unreachable.
+
+Side-ref compatibility rule:
+
+Each side ref encodes `RefClass`, `ClassVersion`, `Critical`, `FileID`,
+`Offset`, `Length`, `ChecksumKind`, `Checksum`, and optional advisory
+`RelativePath`. Unknown critical `RefClass` or `ClassVersion` makes the
+transaction unsupported-required and recovery fails closed. Unknown noncritical
+refs may be ignored only if no replay-critical section references them and the
+transaction feature bits explicitly allow skipping them. Cleanup, GC, rewrite,
+and quarantine must treat unknown refs from complete unwatermarked transactions
+as protected until the transaction is watermarked and checkpointed or an
+operator performs a destructive rebuild.
 
 Side refs are resolved by `RefClass` and `RefID`/`FileID` through a file-class
 registry. `RelativePath`, when encoded, is advisory validation data. It must
@@ -2176,6 +2206,23 @@ go test ./TreeDB/collections \
   > artifacts/collection-wal/durable-smoke.txt
 ```
 
+Required format and recovery-scan benchmark command:
+
+```bash
+go test ./TreeDB/internal/collectionwal \
+  -run '^$' \
+  -bench '^(BenchmarkCollectionWALEncodeNoIndexInlineRootDelta|BenchmarkCollectionWALDecodeNoIndexInlineRootDelta|BenchmarkCollectionWALEncodeIndexedThreeRoots|BenchmarkCollectionWALDecodeIndexedThreeRoots|BenchmarkCollectionWALReplayDigest|BenchmarkCollectionWALScanEmptySegments|BenchmarkCollectionWALScanWatermarkedTransactions|BenchmarkCollectionWALScanPendingTransactions|BenchmarkCollectionWALRebuildSideRefIndex|BenchmarkCollectionWALLargeInlineRootDelta|BenchmarkCollectionWALLargeSidePayloadRootDelta|BenchmarkCollectionWALZstdLargeRootDelta|BenchmarkCollectionWALSideRefValidation)$' \
+  -benchmem -count=10 \
+  > artifacts/collection-wal/format.txt
+```
+
+Format benchmarks must report bytes/transaction, allocations, encode ns/op,
+decode ns/op, CRC cost, compression cost, segments/sec, frames/sec, bytes/sec,
+time to first recovery error, inline versus side-payload crossover, compression
+ratio, fsync count when applicable, and side-ref verification time. Inline
+thresholds, side-payload thresholds, and compression defaults are not eligible
+for stronger-default status until these artifacts exist.
+
 Every benchmark row must report these metrics when the harness can measure them:
 
 | Metric | Purpose |
@@ -2253,7 +2300,7 @@ Traceability matrix:
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
 | Testability decisions | 15 | M0.5 | closed PR1 choices and acceptance artifact |
-| WAL format | 7.2, 7.4, 7.5 | M1 | golden, fuzz, corrupt-tail tests |
+| WAL format | `storage-format.md` Section 9 plus this doc 7.2, 7.4, 7.5 | M1 | exact-byte golden, fuzz, corrupt-tail, feature-gate, and migration-state tests |
 | Recovery state machine | 9.1, 9.2, 9.4 | M1, M5 | crash-state and stop-open tests |
 | Identity and sequencing | 7.3, 7.6, 9.3 | M1, M5 | collection-seq, epoch, generation tests |
 | System-root template | 7.2, 8.6 | M1, M5 | descriptor-op and watermark atomicity tests |
@@ -2331,6 +2378,7 @@ The PR1 decisions in Section 15 are prerequisites for executable tests. Before
 M1 starts, the implementation owner must confirm the exact testable choices for:
 
 - collection WAL segment format and filename class;
+- storage-format feature gates, migration states, and byte envelope;
 - `CollectionSeq` and `WALLSN` allocation and persistence;
 - missing side-ref behavior by durability mode;
 - checkpoint behavior for PR1;
@@ -2355,13 +2403,17 @@ Deliverables:
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
 - segment metadata and cleanup record encoding;
-- exact format documentation in this file;
+- exact byte-format documentation in `storage-format.md`;
 - stable root-delta encode/decode APIs independent of transient in-memory
   `batch.Batch` layout.
 
 Tests:
 
 - golden files;
+- unsupported required version and unknown critical section fail-closed tests;
+- malformed length rejection before allocation;
+- feature-gate and migration-state fixtures;
+- downgrade detection fixtures;
 - corrupt checksum;
 - truncated tail;
 - decoder fuzzing;
@@ -2925,10 +2977,27 @@ Module-specific constraints:
   applied watermark/checkpoint boundary. It may reuse or extract generic frame
   encoding from `internal/commitlog`, but it must not reuse the key/value
   `commitlog.Record` schema as the collection transaction schema.
+- `TreeDB/internal/collectionwal` decoders must follow the `storage-format.md`
+  envelope order: segment magic, segment version/min-reader, segment header CRC,
+  frame magic, frame version/min-reader, length caps before allocation, frame
+  header CRC, stored payload CRC, commit trailer, transaction fixed-header CRC,
+  section CRCs, replay digest, and side-ref closure. Unsupported required
+  versions, malicious lengths, mixed-version segments, and unknown critical
+  sections or side-ref classes fail closed.
 - The collection WAL transaction builder must require `CollectionUID`,
   `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
   `RootDescriptorEpochs`, `CollectionSeq`, `WALLSN`, root-delta ordinals, and
   canonical side refs before it can encode a replayable record.
+- Required storage-feature gates for `collection_wal_v1` must be written before
+  any WAL-on collection write can be acknowledged. `format.json` is the
+  early-open gate, the system root is the authoritative recovered gate, and WAL
+  headers are the decoder gate. Runtime overrides such as `IgnoreFormatConfig`
+  must not bypass required features except through explicit destructive rebuild
+  tooling.
+- Feature gates, segment metadata, cleanup records, and migration manifests need
+  a durable manifest writer with file fsync, rename, parent-directory fsync, and
+  WAL-directory fsync after segment unlink. Atomic rename without those fsync
+  steps is not enough for missing-segment proof.
 - `TreeDB/collections` owns final physical delta planning before
   acknowledgement. WAL-on collection planners must serialize primary,
   template/index-state, secondary, overlay, delete, schema, and future

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,10 +1,12 @@
 # SPEC: Collection WAL Durability and Root-Group Recovery
 
-Status: normative implementation gate once Milestones 0-7 are complete.
-Sections marked MUST/SHOULD define the production collection durability
-contract; explicitly marked future-work sections remain non-normative. Open
-questions in Section 15 must be resolved before any milestone that depends on
-them can pass.
+Status: normative target contract and implementation gate; not current behavior
+until the milestone evidence named in Section 13 is accepted. Sections marked
+MUST/SHOULD define the target production collection durability contract.
+Sections explicitly marked current behavior describe the repository before the
+collection WAL lands. Future-work sections remain non-normative. Open questions
+in Section 15 must be resolved before any milestone that depends on them can
+pass.
 
 This document defines the minimum implementation contract for durable-at-ack
 collection writes. Until the requirements and crash tests in this document pass,
@@ -12,9 +14,6 @@ TreeDB must not merge production persistent column-store collection APIs, column
 part descriptor roots, column-file side refs in published roots, or
 crash/reopen safety claims for column-store writes.
 
-Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
-Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
-`TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
 Related specs:
 
 - `TreeDB/docs/spec/write-path-and-durability.md`
@@ -33,10 +32,9 @@ they remain only in collection-local mutable, queued, or publishing state. Those
 writes are visible through the owning collection manager, but they are not
 durable-at-ack under the current contract.
 
-This spec proposes a shared collection WAL and root-group recovery protocol.
-The goal is to make acknowledged collection writes recoverable under WAL-on
-profiles without building a separate durability model for future column-store
-collections.
+This document specifies the target shared collection WAL and root-group recovery
+protocol. Until the implementation and verification gates pass, it is a gating
+target rather than a description of current runtime guarantees.
 
 The proposed architecture is a root-delta transaction WAL:
 
@@ -235,6 +233,20 @@ files, dictionaries, and delete bitmap files. Leaf-log/page-log records created
 while publishing replayed B-tree pages are publish outputs, not collection WAL
 side refs.
 
+Side ref:
+
+The typed collection WAL reference naming a side file, offset, size, checksum,
+class, and required/optional status. A side ref is metadata; the side file is
+the referenced storage.
+
+Flush-boundary durable:
+
+Current collection behavior where an acknowledged collection mutation that
+remains only in mutable, queued, or publishing state is visible in-process but
+is not promised after crash until `Collection.Flush`,
+`CollectionManager.FlushAll`, a threshold-triggered synchronous publish,
+checkpoint integration, or close drain publishes it to backend roots.
+
 Applied watermark:
 
 System-root metadata that records the highest contiguous collection sequence
@@ -377,8 +389,9 @@ marked `Required=false` must not be referenced by any published root value.
 - Do not build a separate private WAL only for column-store collections.
 - Do not require old pre-alpha directories to remain cross-version compatible.
 - Do not use collection WAL transactions as Raft log entries. Raft entries are
-  logical deterministic commands; collection WAL transactions are local storage
-  apply artifacts derived from those commands.
+  logical deterministic commands; collection WAL transactions are local physical
+  storage apply artifacts derived from those commands and are not a Raft log
+  entry.
 - Do not make native-wire acknowledgement or response-shaping options part of
   recovered logical collection state.
 
@@ -3260,10 +3273,14 @@ publish roots on invalid bytes, never delete/quarantine files from invalid
 bytes, produce deterministic error classes for the same input, and never skip a
 complete corrupt transaction in favor of a later same-collection transaction.
 
-### 11.7 PR1-Min Required Named Acceptance Tests
+### 11.7 PR1-Min Acceptance Harness Shapes
 
-These tests or equivalent subtests are required before the guarded PR1-min
-capability can merge:
+The canonical list of named acceptance tests lives in
+`TreeDB/docs/spec/verification.md#115-planned-collection-wal-durability-gate`.
+This section lists required harness shapes, fault classes, and design
+invariants. When a test name changes, update `verification.md` and the
+acceptance artifact schema in the same change. The names below mirror the
+current verification matrix but are not a second source of ownership.
 
 | Test | Must prove |
 |---|---|
@@ -3294,11 +3311,12 @@ including checkpoint-not-flushing pending no-index inserts, buffered no-index
 reads before flush, indexed memtable reads/unique checks, queued indexed flush
 close, and `FlushAll` draining queued indexed flush units.
 
-### 11.8 Full-Contract Required Named Acceptance Tests
+### 11.8 Full-Contract Acceptance Harness Shapes
 
 These tests or equivalent subtests must exist before implementation can be
-considered complete for the full collection WAL contract. Names are normative
-so CI, verification docs, and acceptance artifacts can point to stable evidence.
+considered complete for the full collection WAL contract. Canonical test names
+and acceptance status are owned by `verification.md`; this table records the
+required harness shapes and invariants.
 
 | Test | Harness shape | Must prove |
 |---|---|---|

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,7 +1,7 @@
 # SPEC: Collection WAL Durability and Root-Group Recovery
 
-Status: proposal  
-Target repository studied: `/Users/michaelseiler/dev/snissn/gomap`  
+Status: proposal, non-normative
+Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
 Related specs:
@@ -465,16 +465,20 @@ mode:
 
 ## 9. Recovery Algorithm
 
-Startup recovery should extend the existing recovery order:
+Startup recovery should extend the existing recovery order while preserving
+the current invariant that side-store scans run before cached commit-log replay:
 
 1. Recover backend index metadata and choose the valid meta page.
-2. Replay normal cached commit logs as today.
-3. Scan value-log, leaf-log, column-file, and collection-root-delta side files
-   needed by collection WAL fences.
-4. Scan collection WAL segments and decode complete transactions.
-5. Load applied watermark metadata from the recovered system root.
-6. Sort unapplied transactions by `TxnID`.
-7. For each unapplied transaction:
+2. Scan value-log and leaf-log side-store segments used by existing commit-log
+   RID fences, and build the `RID -> side ref` maps required for replay.
+3. Replay normal cached commit logs as today, using the side-ref maps created
+   before replay.
+4. Scan any additional collection WAL side-file classes, such as column-file
+   and collection-root-delta side files, needed by collection WAL fences.
+5. Scan collection WAL segments and decode complete transactions.
+6. Load applied watermark metadata from the recovered system root.
+7. Sort unapplied transactions by `TxnID`.
+8. For each unapplied transaction:
    - validate checksum and format version;
    - validate required side refs;
    - validate collection catalog identity and schema epoch;
@@ -483,9 +487,9 @@ Startup recovery should extend the existing recovery order:
    - materialize `OrderedRootDeltaBatchPublishInput` values;
    - publish the root group with a system-root delta that updates collection
      root descriptors and advances the applied watermark.
-8. After successful replay, clean collection WAL segments whose transactions are
+9. After successful replay, clean collection WAL segments whose transactions are
    fully covered by the durable applied watermark.
-9. Quarantine or delete prepared side files that are not referenced by any
+10. Quarantine or delete prepared side files that are not referenced by any
    committed transaction or reachable root.
 
 Recovery must be deterministic. Replaying the same directory twice must produce

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -9,6 +9,9 @@ Related specs:
 - `TreeDB/docs/spec/write-path-and-durability.md`
 - `TreeDB/docs/spec/recovery.md`
 - `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/docs/spec/native-wire-r2-closeout.md`
 
 ## 1. Summary
 
@@ -109,6 +112,33 @@ The current documented contract is flush-boundary durable, not durable-at-ack.
 That contract is understandable for today's row collections, but it is too weak
 as a foundation for column-store collections with external part files.
 
+### 2.4 Native Wire and Raft Planning
+
+Native-wire R0-R2 work now establishes a separate logical replication layer:
+
+- The native wire protocol is not the Raft log.
+- Deterministic command entries are canonical logical command bytes for future
+  Raft replication.
+- Deterministic entries include metadata and collection mutations such as
+  create collection, create index, drop index, insert batch, replace batch, and
+  delete batch.
+- Deterministic entries intentionally exclude transport frame ids, stream ids,
+  deadlines, trace context, negotiated compression, response shaping, and local
+  physical storage artifacts.
+- `flush_collection`, `flush_all`, `checkpoint`, reads, cursors, stats,
+  value-log GC, value-log rewrite, and physical maintenance remain local-only in
+  v1 unless a future distributed barrier command gives them explicit consensus
+  semantics.
+- `ack_policy=raft_committed` is reserved for distributed mode and is rejected
+  by the current single-node native-wire server.
+- Raft storage, Raft apply, distributed reads, and persistent idempotency record
+  storage are still unimplemented.
+
+Those changes do not replace this collection WAL. They create an upstream
+source of logical commands that, when applied on a node, must still use the
+local collection WAL/root-delta recovery path before the node can safely claim
+that the committed command is locally recoverable.
+
 ## 3. Definitions
 
 Collection WAL transaction:
@@ -164,6 +194,8 @@ mode requires fsync.
 10. Add crash/fault tests that prove roots never point at missing side files.
 11. Keep write overhead bounded with benchmarks before enabling stronger
     defaults broadly.
+12. Define the boundary between future Raft logical command replication and
+    local collection WAL/root-delta durability.
 
 ## 5. Non-Goals
 
@@ -176,6 +208,11 @@ mode requires fsync.
   independent data. They must be reconstructable from WAL transactions or roots.
 - Do not build a separate private WAL only for column-store collections.
 - Do not require old pre-alpha directories to remain cross-version compatible.
+- Do not use collection WAL transactions as Raft log entries. Raft entries are
+  logical deterministic commands; collection WAL transactions are local storage
+  apply artifacts derived from those commands.
+- Do not make native-wire acknowledgement or response-shaping options part of
+  recovered logical collection state.
 
 ## 6. Target Durability Contract
 
@@ -227,6 +264,19 @@ collection write must fail before becoming visible to the caller.
   already require.
 - Must not discard a collection WAL transaction before its applied watermark is
   safely published.
+
+Native-wire acknowledgement policies map onto these same local boundaries:
+
+- `visible` may return after the write is visible through the serving process.
+  In WAL-on collection modes after this spec, it still cannot return before the
+  collection WAL transaction is recoverable.
+- `flushed` must publish affected collection state into backend roots and
+  advance the collection WAL applied watermark for those transactions.
+- `synced` must also reach the backend checkpoint/sync boundary required by the
+  configured local durability mode.
+- `raft_committed` is a cluster-mode policy. It cannot be satisfied by local
+  collection WAL alone; it requires consensus commit plus the cluster's defined
+  local apply durability rule.
 
 ### 6.3 Column-Store Gate
 
@@ -313,6 +363,10 @@ Root delta payloads should use the same canonical sorted delta encoding as
 transaction. Large deltas should use a side payload referenced by RID or by a
 dedicated root-delta payload class.
 
+`AckMode`, `CreatedUnixNanos`, and `Stats` are local observability and policy
+metadata. They must not change root-delta replay output, idempotency outcomes,
+catalog guard outcomes, or future Raft state-machine results.
+
 ### 7.3 File Class
 
 Use a dedicated logical collection WAL class. The implementation may reuse
@@ -380,6 +434,39 @@ If a required side ref is missing during recovery:
 - durable mode should surface an error unless the missing ref is in a clearly
   incomplete tail transaction that can be ignored by the same rules as existing
   commit-log tails.
+
+### 7.6 Native Wire and Raft Layering
+
+The collection WAL is below native-wire and Raft:
+
+```text
+native-wire request
+    -> deterministic command entry for replicated writes
+    -> Raft log entry in cluster mode
+    -> local TreeDB state-machine apply
+    -> local collection WAL root-delta transaction
+    -> backend root publish and applied watermark
+```
+
+The boundary is strict:
+
+- Native-wire deterministic entries replicate logical command input.
+- Raft may store those deterministic entries directly or wrap them in
+  consensus metadata.
+- Collection WAL transactions record local root deltas and side refs generated
+  by applying the logical command on one node.
+- Collection WAL transactions must not be sent through Raft or compared
+  byte-for-byte across replicas.
+- Replica equality must be judged by logical catalog, collection contents,
+  index definitions, idempotency records, and declared logical state digests,
+  not by local value-log offsets, column-file names, root ids, flush timing, or
+  WAL transaction bytes.
+
+On a future follower, applying a committed deterministic entry should derive the
+same logical mutation outcome but may produce different local physical files and
+root ids. That is acceptable only if the local collection WAL makes the derived
+root group recoverable before the node advertises the Raft entry as durably
+applied under the cluster policy.
 
 ## 8. Write Path
 
@@ -462,6 +549,35 @@ mode:
 - `Flush`, `FlushAll`, checkpoint, and close remain the durability boundaries;
 - column-store mutable writes must not be production-enabled under WAL-off
   until explicit benchmark and safety gates are added.
+
+### 8.7 Future Raft Apply Path
+
+For future Raft write replication, the apply path must not replay native-wire
+transport requests. It should consume committed deterministic command-entry
+bytes, validate the command version and catalog guard against applied state, and
+derive local collection root deltas through the same planner/state-machine logic
+used by the single-node path.
+
+A committed Raft entry must not be marked locally durable/applied under a
+cluster durability policy until one of these is true:
+
+1. the derived collection WAL transaction is recoverable locally; or
+2. the Raft recovery design explicitly guarantees that unapplied committed log
+   entries are replayed after every restart before the node serves reads or
+   advertises the corresponding applied index.
+
+The first implementation should prefer the first rule: committed entry, local
+root-delta WAL append, write-domain visibility/publish, then applied-index and
+idempotency metadata advancement. Any persistent idempotency record or catalog
+guard outcome that affects retry/replay behavior must be advanced atomically
+with the logical mutation outcome, either in the same backend root group or in
+an explicitly ordered metadata transaction whose crash behavior is tested with
+the collection WAL.
+
+`flush_collection`, `flush_all`, `checkpoint`, and physical maintenance commands
+remain local barriers. Cluster mode must reject `ack_policy=raft_committed` for
+those commands or define a separate deterministic distributed barrier command
+with explicit consensus semantics.
 
 ## 9. Recovery Algorithm
 
@@ -549,6 +665,9 @@ Crash/fault points:
 7. after applied watermark before WAL cleanup;
 8. during overlay compaction;
 9. during column-file prepare once column store exists.
+10. after Raft commit before local collection WAL append once Raft apply exists.
+11. after local collection WAL append before Raft applied-index/idempotency
+    metadata advancement once Raft apply exists.
 
 Required assertions:
 
@@ -560,6 +679,8 @@ Required assertions:
 - roots never reference missing value-log or column-file bytes;
 - collection WAL files are cleaned only after safe watermark/checkpoint
   boundaries.
+- future Raft apply cannot report an applied index whose logical mutation is
+  neither locally recoverable nor guaranteed to be replayed from the Raft log.
 
 ### 11.4 Fuzz Tests
 
@@ -612,6 +733,7 @@ Traceability matrix:
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
 | Performance | 12 | M6 | benchstat gates and artifacts |
 | Column-store unblock | 6.3, 10 | M7 | side-file fence and root-group recovery proof |
+| Native-wire/Raft layering | 2.4, 6.2, 7.6, 8.7 | M8 | deterministic-entry apply and local-WAL durability tests |
 
 ### Milestone 0: Contract Freeze
 
@@ -769,6 +891,46 @@ Gate:
 
 - production column-store persistent writes may start only after this milestone.
 
+### Milestone 8: Native-Wire and Raft Apply Coordination
+
+This milestone is required before any R3-style `ack_policy=raft_committed`
+collection write is exposed. It is not a prerequisite for the local collection
+WAL or column-store unblock gates unless that work also exposes cluster apply.
+
+Deliverables:
+
+- deterministic-entry apply adapter derives local collection root deltas without
+  reconstructing native-wire transport requests;
+- local collection WAL append is integrated into follower/leader apply before
+  the node advertises the Raft index as locally durable;
+- applied-index, catalog guard outcome, and idempotency metadata are advanced
+  atomically with the logical mutation outcome or are replayed from Raft after
+  restart by a documented rule;
+- cluster `raft_committed` acknowledgement waits for consensus commit plus the
+  selected local apply durability boundary;
+- local-only flush/checkpoint/maintenance commands are rejected for
+  `raft_committed` or replaced by explicit distributed barrier commands.
+
+Tests:
+
+- same committed deterministic entry sequence applied in separate fresh
+  databases produces the same logical catalog/content/index/idempotency digest;
+- crash after Raft commit before local WAL append recovers by replaying the
+  committed entry or never advertises it as applied;
+- crash after local WAL append before applied-index metadata advancement does
+  not double-apply after restart;
+- duplicate idempotency identity with the same digest returns the prior outcome
+  after restart;
+- duplicate idempotency identity with a different digest fails deterministically
+  after restart;
+- `raft_committed` is unavailable for local-only flush, checkpoint, and physical
+  maintenance commands.
+
+Gate:
+
+- no cluster write path may report `raft_committed` until local collection WAL,
+  applied-index metadata, and idempotency replay pass the crash matrix.
+
 ## 14. Risks and Mitigations
 
 | Risk | Mitigation |
@@ -780,6 +942,9 @@ Gate:
 | Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
 | WAL-on throughput regresses too much. | Benchmark each milestone, use side payloads, batching, and async publish before relaxing durability. |
 | WAL-off users assume stronger guarantees. | Keep WAL-off relaxed docs explicit and add tests that preserve the relaxed contract. |
+| Raft log entries are confused with collection WAL transactions. | Keep deterministic entries as logical command input and collection WAL as node-local root-delta durability; test logical digests instead of byte-identical physical layout. |
+| A node reports a Raft entry applied before its local collection mutation is recoverable. | Tie applied-index/idempotency metadata to local collection WAL durability or replay unapplied committed entries from Raft before serving. |
+| Native-wire acknowledgement policy leaks into recovered logical state. | Treat acknowledgement policy as response/local durability control unless a future deterministic command version explicitly makes it logical state. |
 
 ## 15. Open Questions
 
@@ -798,6 +963,13 @@ Gate:
    checkpoint collection WAL without forcing root publication?
 8. What metric names should expose pending collection WAL bytes, applied
    watermark lag, replay count, skipped/fenced transactions, and cleanup debt?
+9. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
+   roots, in a Raft library stable store, or in both with an explicit ordering
+   rule?
+10. Should native-wire `ack_policy` remain purely transport/local durability
+    control for deterministic entries, or should a future command version define
+    an explicit logical barrier flag? This must be resolved before
+    `raft_committed` writes are exposed.
 
 ## 16. Implementation Notes
 
@@ -809,5 +981,12 @@ Gate:
   crash coverage will be too shallow.
 - Preserve existing write-domain read precedence while adding durable backing.
 - Treat side-file fences as part of the storage format, not as cleanup policy.
+- Keep future deterministic-entry apply code above the collection WAL package:
+  it should derive root deltas through a state-machine adapter and then hand the
+  resulting local transaction to the collection WAL layer.
+- Keep Raft applied-index/idempotency metadata and collection WAL watermark
+  updates ordered by a documented crash-recovery rule before enabling
+  `ack_policy=raft_committed`.
 - Update `collections-write-domain.md`, `write-path-and-durability.md`,
-  `recovery.md`, and `verification.md` as implementation milestones land.
+  `recovery.md`, `verification.md`, `native-wire-protocol.md`, and
+  `native-query-raft-roadmap.md` as implementation milestones land.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -5,6 +5,13 @@ Sections marked MUST/SHOULD define the production collection durability
 contract; explicitly marked future-work sections remain non-normative. Open
 questions in Section 15 must be resolved before any milestone that depends on
 them can pass.
+
+This document defines the minimum implementation contract for durable-at-ack
+collection writes. Until the requirements and crash tests in this document pass,
+TreeDB must not merge production persistent column-store collection APIs, column
+part descriptor roots, column-file side refs in published roots, or
+crash/reopen safety claims for column-store writes.
+
 Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
@@ -56,8 +63,9 @@ PR1 makes these decisions normative:
   chains and replay-side accumulation;
 - reject true multi-collection collection WAL transactions before writing side
   refs or WAL records;
-- use a stable persisted `CollectionID`, `SchemaEpoch`, and per-root
-  `RootGeneration` as replay guards;
+- use a stable persisted `CollectionID`/`CollectionUID`, mandatory
+  `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, and per-root
+  `RootGeneration`/root descriptor epochs as replay guards;
 - include a versioned `SystemDeltaTemplate` in every replayable transaction;
 - fail recovery on any complete collection WAL transaction with a missing
   required side ref in WAL-on modes;
@@ -211,7 +219,7 @@ side refs.
 Applied watermark:
 
 System-root metadata that records the highest contiguous collection sequence
-published into backend roots for one `CollectionID`. Recovery uses the watermark
+published into backend roots for one `CollectionUID`. Recovery uses the watermark
 to avoid double-applying transactions after a crash that occurs after root
 publish but before WAL cleanup.
 
@@ -232,7 +240,11 @@ Recoverable:
 
 After process crash and read-write recovery, the transaction can be made visible
 from backend roots or from a complete committed collection WAL transaction
-without relying on pre-crash memory.
+without relying on pre-crash memory. For `DurabilityWALOnRelaxed`, the complete
+collection WAL frame and every required side ref have reached a file-writer
+flush boundary sufficient for a fresh process to open the files, read the exact
+ranges, and verify recorded checksums. Bytes accepted only into in-memory writer
+buffers are not recoverable.
 
 WAL append commit point:
 
@@ -242,8 +254,9 @@ durability mode.
 
 Side-ref prepared:
 
-The referenced external bytes have been written and are readable at the selected
-side-ref durability boundary.
+The referenced external bytes have been written, made readable by a new file
+reader at the selected side-ref durability boundary, and verified against the
+recorded checksum over exactly `[offset, offset+size)`.
 
 Side-ref protected:
 
@@ -269,7 +282,7 @@ reach it.
 `CollectionSeq`:
 
 A gap-free, monotonically increasing sequence number scoped to one
-`CollectionID`. It is the replay, dependency, and skip key.
+`CollectionUID`. It is the replay, dependency, and skip key.
 
 `WALLSN`:
 
@@ -359,6 +372,14 @@ marked `Required=false` must not be referenced by any published root value.
 | `DurabilityDurable` | For non-sync collection APIs, write success means the collection WAL transaction has reached the configured local WAL append/flush boundary needed for process-crash recovery. Non-sync APIs do not imply power-loss durability. Sync barriers additionally fsync according to durable mode. |
 | `DurabilityWALOnRelaxed` | Write success means the collection WAL transaction has left process-local memory and is recoverable under the same process-crash assumptions as the existing WAL-on relaxed commit log. It does not claim power-loss durability. |
 | `DurabilityWALOffRelaxed` | No durable-at-ack promise. Collection writes remain flush/checkpoint/close-boundary durable, and docs must say so directly. In this mode, `visible` acknowledgements are process-local visibility only. |
+
+Recoverable means readable by a fresh process after process crash. For
+`DurabilityWALOnRelaxed`, success requires that the complete collection WAL
+frame and every required side ref have reached a file-writer flush boundary
+sufficient for fresh-process reads. For `DurabilityDurable` sync barriers,
+success additionally requires the configured fsync boundary for the WAL frame
+and required side refs. Bytes accepted only into in-memory writer buffers are
+not recoverable.
 
 If the engine cannot append the collection WAL transaction in a WAL-on mode, the
 collection write must fail before becoming visible to any reader, planner, or
@@ -485,7 +506,7 @@ turning the design into code:
    transactions for a collection in `CollectionSeq` order. PR1 has no
    same-collection independence skip.
 5. Watermark coverage is contiguous and atomic. A backend publish may advance
-   `applied_collection_seq[CollectionID]` only over the next contiguous prefix,
+   `applied_collection_seq[CollectionUID]` only over the next contiguous prefix,
    and descriptor updates plus watermark updates must be one backend commit.
 6. Cleanup requires applied plus checkpointed. A collection WAL segment or side
    ref is cleanable only after every referencing transaction is covered by a
@@ -555,19 +576,20 @@ CollectionWALTransaction {
 
     // Identity and ordering.
     WALLSN                   uint64
-    CollectionID             uuid128
+    CollectionUID            uuid128
     CollectionName           string diagnostic
+    CollectionGeneration     uint64
     CollectionSeq            uint64
     DependsOnCollectionSeq   uint64
 
     // Catalog guard.
     SchemaEpoch              uint64
-    CollectionEpoch          uint64 required for column-store collections
     SchemaVersion            uint32 optional for row-store, required for column-store
     BaseCommitSeq            uint64
     BaseSystemRootID         uint64
-    BaseCatalogDigest        bytes optional
-    CatalogDigest            bytes optional, recommended for column-store
+    BaseCatalogDigest        bytes
+    CatalogDigest            bytes
+    RootDescriptorEpochs     map[root-name]uint64
     MutationClass            uint8
 
     // Physical mutation.
@@ -588,10 +610,11 @@ CollectionWALTransaction {
 CollectionRootDelta {
     RootName                 string
     RootKind                 uint16
-    RootDeltaIndex           uint32
+    RootDeltaOrdinal         uint32
 
     BaseRootID               uint64
     BaseRootGeneration       uint64
+    BaseRootDescriptorEpoch  uint64
     BaseCollectionSeq        uint64
 
     StoragePolicy            uint8
@@ -621,13 +644,13 @@ DescriptorOp {
                              ReplaceRootList | PutMeta | DeleteMeta
     Key                      bytes
     ExpectedValueDigest      bytes optional
-    RootDeltaIndex           uint32 optional
+    RootDeltaOrdinal         uint32 optional
     RootIDPlaceholder        uint32 optional
     RootListPlaceholders     []uint32 optional
 }
 
 AppliedWatermarkOp {
-    CollectionID             uuid128
+    CollectionUID            uuid128
     AdvanceCollectionSeqTo   uint64
     OptionalWALLSN           uint64
 }
@@ -655,17 +678,22 @@ OrderedRootPublishOptions {
 }
 ```
 
-This record is not portable across replicas. `WALLSN`, `CollectionSeq`,
-`BaseSystemRootID`, `BaseRootID`, root names as resolved by local storage,
-side-ref paths/RIDs, timestamps, stats, and other local observability metadata
-are meaningful only in the database directory that wrote the record. A follower
-applying the same deterministic command entry may produce different local root
-ids, side refs, file names, and collection WAL bytes.
+This record is not portable across replicas. `CollectionUID` is the durable
+collection identity; existing code or system metadata may call the same value
+`CollectionID`, but `CollectionName` is diagnostic only and must not be used as
+the replay identity. `WALLSN`, `CollectionSeq`, `BaseSystemRootID`,
+`BaseRootID`, root names as resolved by local storage, side-ref paths/RIDs,
+timestamps, stats, and other local observability metadata are meaningful only in
+the database directory that wrote the record. A follower applying the same
+deterministic command entry may produce different local root ids, side refs,
+file names, and collection WAL bytes.
 
-Column-store transactions must carry enough catalog identity to make replay
-schema-stable. `CollectionEpoch` guards collection incarnation and catalog-level
-schema evolution. `SchemaVersion` guards physical column decode. `CatalogDigest`
-is optional but recommended for debugging and precondition checks. The
+All collection WAL transactions must carry enough catalog identity to make
+replay schema-stable. `CollectionGeneration` guards collection incarnation and
+drop/recreate. `SchemaEpoch` guards catalog-level schema/index evolution.
+`SchemaVersion` guards physical column decode for column-store roots.
+`BaseCatalogDigest`, `CatalogDigest`, and `RootDescriptorEpochs` are mandatory
+replay guards. The
 `MutationClass` values are versioned and include at least `row_insert`,
 `row_update`, `row_delete`, `column_insert`, `column_update_delta`,
 `column_delete`, `column_compaction`, `column_recompression`, and
@@ -675,8 +703,9 @@ A transaction is replayable only when:
 
 1. the record checksum is valid;
 2. every required side ref is present and passes integrity checks;
-3. `CollectionID`, `SchemaEpoch`, base root ids, and base root generations match
-   the current replay state or an explicit replay accumulator state;
+3. `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
+   base root ids, base root generations, and root descriptor epochs match the
+   current replay state or an explicit replay accumulator state;
 4. `DependsOnCollectionSeq` is covered by the collection applied watermark or by
    the active accumulator;
 5. the `SystemDeltaTemplate` can be instantiated with the produced root ids and
@@ -708,24 +737,28 @@ Two digests are required:
 
 ### 7.3 Collection Identity and Root Generations
 
-Every collection must have a stable `CollectionID` persisted in collection
-metadata. `CollectionName` is diagnostic and must not be the replay identity.
-Dropping and recreating a collection with the same name creates a new
-`CollectionID`. Renaming a collection, if supported, preserves `CollectionID`
-and changes only catalog metadata.
+Every collection must have a stable `CollectionUID` persisted in collection
+metadata. The term `CollectionID` in older code/spec text refers to this same
+durable UID, not to the collection name. `CollectionName` is diagnostic and must
+not be the replay identity. Dropping and recreating a collection with the same
+name creates a new `CollectionUID` and a new `CollectionGeneration`. Renaming a
+collection, if supported, preserves `CollectionUID` and increments only the
+catalog metadata required by the rename.
 
 Every schema or index metadata change increments `SchemaEpoch`. Every root
-descriptor change increments that root's `RootGeneration`. Overlay descriptor
-changes and overlay compaction also increment the affected root generation.
+descriptor change increments that root's `RootGeneration` and descriptor epoch.
+Overlay descriptor changes and overlay compaction also increment the affected
+root generation and descriptor epoch.
 
-A collection WAL transaction records `CollectionID`, `SchemaEpoch`,
-`BaseRootID`, and `BaseRootGeneration` for every root it mutates. Recovery must
-reject or block a transaction whose identity or generation guard does not match
-the replay state, unless the mismatch is explicitly explained by the active
-replay accumulator. An unapplied transaction whose `CollectionID` is absent from
-the recovered catalog must not be replayed into a collection with the same name;
-PR1 must stop open or quarantine according to a documented recovery-admin
-procedure rather than silently applying the transaction to a later incarnation.
+A collection WAL transaction records `CollectionUID`, `CollectionGeneration`,
+`SchemaEpoch`, `CatalogDigest`, `RootDescriptorEpochs`, `BaseRootID`, and
+`BaseRootGeneration` for every root it mutates. Recovery must reject or block a
+transaction whose identity or generation guard does not match the replay state,
+unless the mismatch is explicitly explained by the active replay accumulator. An
+unapplied transaction whose `CollectionUID` is absent from the recovered catalog
+must not be replayed into a collection with the same name; PR1 must stop open or
+quarantine according to a documented recovery-admin procedure rather than
+silently applying the transaction to a later incarnation.
 
 Maintenance that rewrites root ids or descriptor values must not run for a
 collection with unapplied WAL transactions unless the maintenance operation is
@@ -747,6 +780,7 @@ but the durable encoding is versioned independently.
 RootDeltaEncodingV1:
   entries sorted by bytewise key;
   keys unique per root delta after intra-transaction merge;
+  stable EntryOrdinal for fold/replay diagnostics;
   entry op: PutInline | PutValuePtr | DeleteTombstone;
   key length + key bytes;
   value length + value bytes OR stable ValuePtr encoding;
@@ -763,6 +797,13 @@ Small deltas may be inline in the WAL transaction. Large deltas should use a
 rules: if two accumulated deltas affect the same key, the later
 `CollectionSeq` wins, and deletes suppress older values according to normal
 collection visibility rules.
+
+A collection WAL transaction has a configured maximum encoded byte size,
+maximum root-delta count, and maximum decoded entry count. Larger root deltas
+must spill to `RootDeltaPayload` side refs with the same side-ref preparation
+and protection rules as value-log or column-file refs. Recovery must be able to
+decode and fold root deltas in bounded memory; a transaction that exceeds the
+configured limits fails before acknowledgement or uses side-payload mode.
 
 Root kinds are explicit, versioned values. PR1 row-store root kinds include
 `primary`, `template`, `index_state`, `secondary`, `overlay`,
@@ -866,7 +907,8 @@ segment.
 
 ### 7.6 Applied Progress and Skip Rules
 
-The system root stores applied progress by `CollectionID`:
+The system root stores applied progress by `CollectionID`, which is the same
+durable value called `CollectionUID` in the transaction record:
 
 ```text
 treedb/collection-wal/global-contiguous-cleanup-wallsn -> uint64 optional
@@ -876,9 +918,9 @@ treedb/collection-wal/collection/<collection-id>/applied-collection-seq -> uint6
 `WALLSN` is the globally monotonic append position. It is useful for segment
 ordering, diagnostics, and cleanup scans. `CollectionSeq` is the replay and skip
 key. Recovery may skip a transaction only when
-`txn.CollectionSeq <= applied-collection-seq` for the same `CollectionID` and
-the transaction's `CollectionID`/`SchemaEpoch` guard matches the catalog history
-covered by that watermark.
+`txn.CollectionSeq <= applied-collection-seq` for the same `CollectionUID` and
+the transaction's `CollectionUID`/`SchemaEpoch` guard matches the catalog
+history covered by that watermark.
 
 A global contiguous `WALLSN` cleanup marker may be used only as a cleanup-scan
 optimization when every lower `WALLSN` is known applied or intentionally absent.
@@ -896,7 +938,7 @@ PR1 uses per-write WAL transactions with per-collection dependency chains:
 
 ```text
 WALLSN                   uint64  // global append position for diagnostics/cleanup
-CollectionSeq            uint64  // strictly increasing per CollectionID
+CollectionSeq            uint64  // strictly increasing per CollectionUID
 DependsOnCollectionSeq   uint64  // previous collection transaction observed
 ```
 
@@ -972,7 +1014,17 @@ parameters, dictionary ids, dictionary registry/version, and codec registry
 version must be persisted in descriptors or manifests and protected until every
 dependent payload is unreachable.
 
-Readable and integrity-passing means class-specific validation:
+Side refs are resolved by `RefClass` and `RefID`/`FileID` through a file-class
+registry. `RelativePath`, when encoded, is advisory validation data. It must
+normalize to a relative path with no `..` components, no absolute prefix, no
+empty path elements after cleaning, and no symlink traversal. It must remain
+confined to the owning file-class root and match the `RefID`/`FileID` registry
+entry. Cleanup and quarantine operations must refuse paths outside the owning
+file-class root, symlinks, and path/FileID mismatches.
+
+Prepared, readable, and integrity-passing means the file-class writer has made
+the referenced range visible to a fresh file reader, and class-specific
+validation passes:
 
 - `ValueLogRecord`: segment exists, offset/length are in bounds, RID or grouped
   sub-index matches when present, and record checksum passes.
@@ -994,6 +1046,11 @@ Readable and integrity-passing means class-specific validation:
 - `ColumnMetadataFile`: metadata bytes exist, checksum matches, and the owning
   descriptor names the expected metadata class and generation.
 
+Collection WAL append must not start until every required side ref in the
+transaction is prepared under this definition. In-memory append buffers,
+unflushed value-log buffers, temp files that are not fresh-process-readable, and
+side files whose checksums have not been verified do not satisfy the boundary.
+
 Column part prepare protocol:
 
 A column part builder must write files into a prepare namespace before the WAL
@@ -1006,7 +1063,7 @@ Dir/maindb/columns/.prepare/txn-<wallsn>/part-<part-id>/
 The prepare group must contain a manifest or prepare record that names every
 file/range, final relative path, size, checksum, `PartID`, `FileID`,
 `SchemaVersion`, compression pipeline, dictionary ids, and owning
-`CollectionID`.
+`CollectionUID`.
 
 Before a WAL-on transaction can be acknowledged:
 
@@ -1026,11 +1083,13 @@ A root descriptor must not be published before the referenced final bytes are
 readable. Temp-only files with no committed WAL/root reference are
 orphan-prepared and may be quarantined or deleted after recovery.
 
-A complete transaction with a missing required side ref is a recovery error in
-WAL-on durable/recoverable modes, except for an incomplete tail transaction that
-lacks a valid commit marker. Recovery must not skip a complete collection
-transaction and continue applying later transactions for the same
-`CollectionID`.
+A complete, unwatermarked transaction with a missing or checksum-invalid
+required side ref is a recovery error in WAL-on durable/recoverable modes and
+must either fail the database open or quarantine the affected collection as
+unavailable under an explicit recovery-admin path. Only a clearly incomplete
+tail transaction whose frame was not made recoverable may be ignored. Recovery
+must not skip a complete collection transaction and continue applying later
+transactions for the same `CollectionUID`.
 
 Collection WAL side refs are also retention roots. Value-log GC, value-log
 rewrite, column-file cleanup, and future side-file maintenance must treat every
@@ -1045,6 +1104,11 @@ a value-log segment or column file is referenced only by pending collection WAL,
 maintenance must keep it in place or abort. A future rewrite mode may rewrite
 protected refs only if it publishes replacement side refs and collection WAL
 metadata atomically under an explicit crash-tested protocol.
+
+Collection WAL append and side-ref protection registration are one critical
+section with respect to value-log GC, value-log rewrite, leaf-log GC, column-file
+GC, and side-file cleanup. A maintenance pass must either see the transaction's
+side refs or be ordered before the transaction can be acknowledged.
 
 A writer preparing side refs must hold a side-ref prepare guard from before the
 first side-ref append/write until either the collection WAL frame referencing
@@ -1081,11 +1145,14 @@ Hidden staging is private. It must not be reachable from any collection read,
 scan, uniqueness check, update/delete planner, schema/index barrier, queued unit,
 publishing unit, or pending-state merge before the commit marker is complete.
 
-After the commit marker reaches the required durability boundary, the mutation is
-committed for recovery. The implementation must not return an ordinary mutation
-error after that point. If the process crashes before the client observes the
-response, recovery may expose the mutation; this is committed-before-response
-ambiguity, not an incomplete transaction.
+After the commit marker reaches the required durability boundary, the complete
+collection WAL transaction is the logical commit point. The implementation must
+not return an ordinary mutation error after that point. It must either stage and
+return success, return an explicit committed/ambiguous status that tells the
+caller the mutation may recover after restart, or terminate before a response is
+observed. If the process crashes before the client observes the response,
+recovery may expose the mutation; this is committed-before-response ambiguity,
+not an incomplete transaction.
 
 The visible in-memory staging step after the commit marker must be non-failing.
 If an implementation cannot guarantee that, it must use a two-phase in-memory
@@ -1140,6 +1207,15 @@ A committed Raft entry has three distinct states:
 
 Raft commit alone is insufficient for `locally_recoverable`.
 
+After collection WAL is enabled, collection catalog metadata, root descriptor
+metadata, idempotency records, catalog guard outcomes, and Raft/local
+applied-index metadata that affect collection mutation replay must be advanced
+in the same collection root-group commit or in a metadata transaction with an
+explicit total order against collection WAL `CollectionSeq`/`WALLSN` records.
+Normal cached commit-log replay must not silently move those metadata values
+past a collection WAL transaction that was planned against an earlier catalog or
+idempotency state.
+
 ## 8. Write Path
 
 Every WAL-on collection mutation has three phases:
@@ -1186,6 +1262,12 @@ model. In WAL-on modes they must either append a collection WAL transaction and
 then publish/watermark it through the same collection-specific publish wrapper,
 or be limited to `DurabilityWALOffRelaxed`/debug paths whose weaker contract is
 explicitly documented. Uniform WAL-on behavior should log first, then publish.
+This no-bypass rule applies to every collection write API path, including
+`Insert`, `InsertBatch`, `Update`, `UpdateBatch`, `Delete`, `DeleteBatch`,
+disabled-memtable paths, large-batch direct publish paths, direct update paths,
+and delete-batch paths. An implementation may claim an equivalent durable
+root-group/side-ref fence only if it is tested at the same crash points as the
+collection WAL path.
 
 ### 8.1 No-Index Inserts
 
@@ -1309,6 +1391,11 @@ metadata removal, count/visibility metadata preservation, and unchanged logical
 secondary-index state in one atomic root group. The optional overlay-compaction
 maintenance shortcut does not apply to physical column parts.
 
+Descriptor replacement, delete-bitmap rewrite, filter rewrite, and side-file
+rewrite are also collection WAL maintenance transactions unless a separate
+backend-only protocol is specified with equivalent side-ref, watermark,
+ordering, and crash-test guarantees.
+
 ### 8.6 Collection-Specific Publish Wrapper
 
 Collection WAL recovery, flush, async publish, checkpoint, close, and
@@ -1317,7 +1404,9 @@ reconstructing ad hoc runtime system-builder closures.
 
 ```text
 PublishCollectionWALTransaction(txn, options) {
-    validate txn.CollectionID, SchemaEpoch, BaseRootGeneration, dependencies
+    validate txn.CollectionUID, CollectionGeneration, SchemaEpoch,
+             CatalogDigest, RootDescriptorEpochs, BaseRootGeneration,
+             dependencies
     materialize root deltas from txn
     apply root deltas
     instantiate txn.SystemDeltaTemplate with produced root ids
@@ -1447,7 +1536,7 @@ A `CollectionReadView` captures:
 - side refs reachable from those units;
 - generated secondary-index views and unique-helper state needed by the scan or
   planner;
-- the `CollectionID`, `CollectionSeq`, and `WALLSN` values that own pending
+- the `CollectionUID`, `CollectionSeq`, and `WALLSN` values that own pending
   visible units.
 
 Flush, async publish completion, rollback, overlay compaction, root rewrite,
@@ -1511,7 +1600,7 @@ the current invariant that side-store scans run before cached commit-log replay:
    any maintenance can run.
 10. Load applied collection-sequence watermark metadata from the recovered system
    root.
-11. Sort unapplied transactions by `CollectionID`, `CollectionSeq`, and
+11. Sort unapplied transactions by `CollectionUID`, `CollectionSeq`, and
    `WALLSN` for deterministic diagnostics.
 12. For each uncovered transaction, validate declared side refs and the
    canonical embedded required side-ref set extracted from root deltas and
@@ -1544,6 +1633,13 @@ point is after normal cached key/value WAL replay and side-store inventory, but
 before recovered roots are exposed to user-visible state, snapshots, native-wire
 servers, or collection managers.
 
+PR1 recovery must publish all replayable transactions before collection APIs can
+serve reads or writes. If a future implementation chooses to keep recoverable
+transactions as a durable pending overlay after open, it must rebuild primary
+visibility, secondary visibility, and unique-index helper state from WAL before
+serving any collection API; otherwise duplicate unique values can be admitted
+before pending durable state is published.
+
 Read-only open cannot perform steps that mutate backend state. If unapplied
 committed collection WAL exists, read-only open must fail with a clear
 recovery-required error unless an explicit stale-read-only mode is requested.
@@ -1557,7 +1653,7 @@ Before collection WAL replay, recovery scans column prepare directories and
 final column file classes and builds a side-file availability map. For each
 complete unapplied column-store transaction, recovery:
 
-1. validates transaction checksum, `CollectionEpoch`, `SchemaVersion`, and
+1. validates transaction checksum, `CollectionGeneration`, `SchemaVersion`, and
    catalog identity;
 2. extracts column file refs from descriptor, manifest, filter, delete bitmap,
    granule/mark, count/visibility, schema, compression metadata, and locator root
@@ -1591,7 +1687,7 @@ transactions are deferred because they are incompatible with durable-at-ack for
 independently acknowledged buffered writes unless those writes wait for the
 merged unit to become durable.
 
-Recovery processes transactions in `CollectionID`, `CollectionSeq` order. A
+Recovery processes transactions in `CollectionUID`, `CollectionSeq` order. A
 transaction may enter the accumulator only if its `DependsOnCollectionSeq` is
 already applied or already present in that accumulator. A complete missing
 transaction blocks later transactions for the same collection.
@@ -1603,16 +1699,24 @@ For each root, the accumulator records:
 - the merged ordered delta entries in transaction order;
 - whether cold-build tombstones must be preserved.
 
-If two accumulated deltas affect the same key, later `CollectionSeq` wins
-according to root-delta merge rules. Deletes/tombstones must suppress older
-values from the same accumulator and from older persisted or overlay roots
-according to normal collection visibility rules.
+The PR1 fold order is `(CollectionSeq, RootDeltaOrdinal, EntryOrdinal)`.
+`CollectionSeq` is the transaction order key; if a future record also exposes a
+diagnostic `TxnID`, it must not replace `CollectionSeq` for same-collection
+dependency ordering. `RootDeltaOrdinal` is the order of root deltas within the
+transaction, and `EntryOrdinal` is the stable operation order exposed by the
+root-delta codec. If two accumulated deltas affect the same key, the last
+operation in fold order wins. Deletes/tombstones are first-class operations and
+must suppress older values from the same accumulator and from older persisted or
+overlay roots according to normal collection visibility rules.
 
 A successful accumulated publish must cover whole transactions, not individual
-roots. The system-root commit must update every affected root descriptor and
-advance the collection watermark to the highest contiguous `CollectionSeq`
-covered by the publish. If any root in a transaction cannot be applied, no root
-from that transaction may be considered applied.
+roots. A transaction is covered only when every root delta in that transaction,
+every catalog/root descriptor update, every required side ref, and the applied
+watermark update have committed in one backend root-group commit. The
+system-root commit must update every affected root descriptor and advance the
+collection watermark to the highest contiguous `CollectionSeq` covered by the
+publish. If any root in a transaction cannot be applied, no root from that
+transaction may be considered applied.
 
 The applied watermark may advance from `N` to `M` only when the publish covers
 every transaction with `CollectionSeq` in `(N, M]` for that collection, with no
@@ -1656,6 +1760,13 @@ Collection WAL cleanup is safe only when both are true:
    applied sequence watermark;
 2. the backend checkpoint/meta boundary containing that watermark is durable for
    the selected mode.
+
+Segment cleanup must decode the candidate segment and prove coverage for every
+complete transaction in that segment. A segment maximum transaction id,
+maximum `WALLSN`, or per-collection high value is not sufficient unless it is
+paired with proof that every complete transaction in the segment is covered by
+that transaction's collection watermark or by a valid global contiguous
+watermark.
 
 Prepared side files use a two-state lifecycle:
 
@@ -1728,14 +1839,15 @@ after cleanup record write, after unlink/rename, and before/after directory
 fsync. Missing segments are acceptable only for `S6 Cleaned` ranges covered by
 durable cleanup metadata.
 
-`DB.Checkpoint` must call registered collection checkpoint hooks before
-reporting a clean collection WAL state. PR1 checkpoint hooks force publication
-of replayable collection WAL admitted before the checkpoint cut, wait for
-in-flight async publish, drain known write domains, advance watermarks, create
-the backend checkpoint/meta durability boundary, and then allow collection WAL
-cleanup. If a future checkpoint mode leaves replayable collection WAL
-unpublished, it must report collection WAL debt and preserve all side-ref
-protections; it is not a clean collection-WAL boundary.
+`DB.Checkpoint` must coordinate with collection WAL before reporting a clean
+collection WAL state. PR1 checkpoint hooks freeze collection WAL admission for
+the checkpoint cut, force publication of replayable collection WAL admitted
+before the cut, wait for in-flight async publish, drain known write domains,
+advance watermarks, persist the backend checkpoint/meta durability boundary,
+and include collection WAL side refs in value-log and side-file reachability
+before any prune, rewrite, or deletion. If a future checkpoint mode leaves
+replayable collection WAL unpublished, it must report collection WAL debt and
+preserve all side-ref protections; it is not a clean collection-WAL boundary.
 
 ## 11. Test Plan
 
@@ -1773,44 +1885,51 @@ Keep and expand tests that document current behavior:
 
 Crash/fault points:
 
-1. before collection WAL append;
-2. after side-file prepare before collection WAL append;
-3. after WAL commit marker before visible staging;
-4. after visible staging before response;
-5. after acknowledgement before root publish;
-6. during async publish;
-7. after root pages are built but before the system-root commit advances the
+1. after side-file append before side-file flush;
+2. after side-file flush before collection WAL append;
+3. before collection WAL append;
+4. after WAL commit marker before visible staging;
+5. after visible staging before response;
+6. after acknowledgement before root publish;
+7. during async publish;
+8. after root pages are built but before the system-root commit advances the
    applied watermark;
-8. after applied watermark before WAL cleanup;
-9. during overlay compaction;
-10. during column-file prepare once column store exists;
-11. after two or more acknowledged buffered transactions with the same
+9. after applied watermark before WAL cleanup;
+10. during overlay compaction;
+11. during column-file prepare once column store exists;
+12. after two or more acknowledged buffered transactions with the same
     persisted `BaseRootID`;
-12. after a higher `WALLSN` from another collection publishes before a
+13. after a higher `WALLSN` from another collection publishes before a
     lower `WALLSN`;
-13. after value-log GC/rewrite is requested while an unapplied collection WAL
+14. after value-log GC/rewrite is requested while an unapplied collection WAL
     transaction is the only owner of a side ref;
-14. after a schema/index change is planned while lower `CollectionSeq`
+15. after a schema/index change is planned while lower `CollectionSeq`
     transactions are durable but unpublished;
-15. after a drop/recreate under the same collection name;
-16. after a root descriptor generation rewrite attempt with unapplied WAL;
-17. after collection WAL cleanup record write before unlink;
-18. after collection WAL segment unlink before directory fsync;
-19. after read-only open observes unapplied committed collection WAL;
-20. after a multi-collection operation reaches the collection WAL planner;
-21. after Raft commit before local collection WAL append once Raft apply exists;
-22. after local collection WAL append before Raft applied-index/idempotency
+16. after a drop/recreate under the same collection name;
+17. after a root descriptor generation rewrite attempt with unapplied WAL;
+18. after collection WAL cleanup record write before unlink;
+19. after collection WAL segment unlink before directory fsync;
+20. after read-only open observes unapplied committed collection WAL;
+21. after a multi-collection operation reaches the collection WAL planner;
+22. after direct `InsertBatch`, `UpdateBatch`, `DeleteBatch`, disabled
+    indexed-memtable path, or large-batch path enters WAL-on execution;
+23. after an oversized inline root delta chooses fail-before-ack or side-payload
+    mode;
+24. after recovery decodes a side ref with `../`, absolute, symlinked, or
+    path/FileID-mismatched `RelativePath`;
+25. after Raft commit before local collection WAL append once Raft apply exists;
+26. after local collection WAL append before Raft applied-index/idempotency
     metadata advancement once Raft apply exists.
-23. midway through a column substream file;
-24. after all column files are written but before manifest write;
-25. after manifest write before final rename;
-26. during update-delta publish with secondary unique/nonunique index changes;
-27. during delete bitmap or filter publish;
-28. during column compaction/recompression after output files are prepared but
+27. midway through a column substream file;
+28. after all column files are written but before manifest write;
+29. after manifest write before final rename;
+30. during update-delta publish with secondary unique/nonunique index changes;
+31. during delete bitmap or filter publish;
+32. during column compaction/recompression after output files are prepared but
     before descriptor supersession;
-29. during column compaction/recompression after descriptor supersession before
+33. during column compaction/recompression after descriptor supersession before
     cleanup;
-30. during column file GC while an old snapshot or `CollectionReadView` still
+34. during column file GC while an old snapshot or `CollectionReadView` still
     references source parts.
 
 Required assertions:
@@ -1826,6 +1945,8 @@ Required assertions:
 - unique indexes reject duplicates after recovery;
 - reads do not need stale in-memory write domains after recovery;
 - roots never reference missing value-log or column-file bytes;
+- side refs with unsafe relative paths, symlinks, or path/FileID mismatches are
+  rejected before recovery or cleanup touches files;
 - collection WAL files are cleaned only after safe watermark/checkpoint
   boundaries;
 - buffered transactions with shared persisted bases replay by accumulation or
@@ -1852,6 +1973,10 @@ Required assertions:
 - missing uncleaned segments stop open;
 - root descriptors published without matching watermarks are unrepresentable or
   stop open under fault injection;
+- direct-publish, disabled-memtable, direct update, delete batch, and large-batch
+  paths pass the same WAL-on crash matrix or are rejected under WAL-on modes;
+- oversized inline transactions fail before ack or spill to side-payload refs
+  with the same side-ref fence;
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
 - descriptor side-ref closure is complete for column manifests, substreams,
@@ -2226,7 +2351,7 @@ Deliverables:
 - encoder/decoder;
 - segment reader/writer;
 - WALLSN and per-collection sequence allocator interfaces;
-- persisted `CollectionID`, `SchemaEpoch`, and root generation descriptor
+- persisted `CollectionUID`, `SchemaEpoch`, and root generation descriptor
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
 - segment metadata and cleanup record encoding;
@@ -2592,7 +2717,7 @@ Gate:
 | Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots through a protected side-ref index until safe applied watermark and checkpoint cleanup. |
 | A global `WALLSN` marker skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep any global `WALLSN` marker cleanup-only and segment-verified. |
 | Buffered transactions share an old persisted `BaseRootID`. | Use per-collection dependency chains plus replay-side accumulation in PR1. |
-| A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionID`, `SchemaEpoch`, and per-root `RootGeneration` guards and block mismatches. |
+| A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, root descriptor epochs, and per-root `RootGeneration` guards and block mismatches. |
 | API returns a normal error after the WAL commit marker. | Reserve fallible state before commit; after commit marker, allow only success, process death, or commit-ambiguous/fatal reporting. |
 | Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
 | Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
@@ -2643,6 +2768,16 @@ PR1 closes the correctness-critical questions that block implementation:
 15. Column compaction, delete-bitmap compaction, and recompression that create
     external files are collection WAL transactions, not optional backend-only
     maintenance commits.
+16. `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
+    and root descriptor epochs are mandatory replay guards.
+17. Side-ref cleanup resolves files through a class registry by ref class and
+    file id; relative paths are confined validation data and cannot authorize
+    cleanup outside the class root.
+18. Direct publish and disabled-memtable write paths are not bypasses under
+    WAL-on modes; they must emit collection WAL or prove an equivalent crash
+    fence.
+19. Metadata that affects collection replay must share the collection root-group
+    commit or have an explicit total order against collection WAL records.
 
 Future questions that do not weaken PR1 correctness:
 
@@ -2659,7 +2794,109 @@ durability control and is stripped before deterministic-entry construction. A
 future cluster-visible barrier must be a separate deterministic command or a
 new deterministic command field with explicit state-machine semantics.
 
-## 16. Implementation Notes
+## 16. Required Runtime Assertions
+
+The implementation should enforce these assertions in debug, fault-injection, or
+always-on validation paths where practical.
+
+Write path:
+
+- Before acknowledging a WAL-on collection write: `CollectionSeq != 0`,
+  `WALLSN != 0`, `CollectionUID != 0`, `CollectionGeneration` and `SchemaEpoch`
+  are present, `CatalogDigest` is present, root delta count is nonzero, and all
+  root names are valid for the catalog epoch.
+- Before appending a collection WAL transaction: every required side ref has
+  reached the fresh-process-readable boundary and checksum verification has
+  succeeded in debug/fault-injection builds.
+- Before staging visible pending state: the WAL transaction is recoverable. In
+  WAL-off mode, the code path is explicitly marked relaxed.
+- After WAL append succeeds: ordinary failure returns are disallowed unless the
+  return status is explicitly committed/ambiguous.
+- Direct insert/update/delete paths assert either `collectionWALTxn != nil` or
+  `equivalentDurableRootFence == true`, and the latter must be covered by the
+  same crash matrix.
+
+Recovery:
+
+- Duplicate `WALLSN` or duplicate `(CollectionUID, CollectionSeq)` is fatal
+  unless covered by an explicit legacy quarantine path.
+- A transaction is skipped only if its own collection watermark or a valid
+  global contiguous watermark covers it.
+- Missing required side ref for a complete unwatermarked transaction is
+  fatal/quarantine, never silent skip.
+- A watermark advance includes every root delta and metadata delta in the
+  covered transaction set.
+- Base root mismatch is allowed only through formal accumulator state;
+  otherwise recovery fails.
+- Replaying the same directory twice produces the same collection root
+  descriptor digest and applied watermark.
+
+Cleanup and GC:
+
+- Before deleting a WAL segment, decode it and prove every complete transaction
+  is covered.
+- Before deleting, moving, or rewriting value-log, leaf-log, column, filter,
+  delete-bitmap, dictionary, or metadata bytes, prove the range is not reachable
+  from current roots, snapshots, live `CollectionReadView`s, unapplied
+  collection WAL, not-yet-cleanable collection WAL, or the protected side-ref
+  index.
+- Cleanup may stop protecting side refs only after applied watermark plus
+  durable checkpoint/meta boundary.
+- Side-file cleanup refuses paths outside the class root, symlinks, and
+  path/FileID mismatches.
+
+Serving:
+
+- No collection API serves after write-open recovery while replayable collection
+  WAL remains unapplied, unless a durable replay overlay with rebuilt primary,
+  secondary, and unique-helper state is installed.
+- Read-only open with pending collection WAL fails or installs a read-only
+  replay overlay.
+- Unique-index checks assert that pending WAL/replay state has rebuilt unique
+  helpers or has already been published.
+
+Column store:
+
+- Every published column part descriptor references readable files with matching
+  checksums, row counts, block directories, and schema epoch.
+- Primary locator rows, part descriptor row counts, delete bitmap counts, and
+  secondary index deltas agree before root-group publish.
+- Column compaction asserts that source descriptors are removed/superseded and
+  target descriptors are added in one covered maintenance transaction.
+- GC asserts old column files remain reachable while any snapshot root,
+  `CollectionReadView`, or unapplied WAL transaction can reference them.
+
+## 17. Production Observability
+
+Expose metrics and structured logs for:
+
+- collection WAL appended transactions, bytes, flush/sync latency, and failed
+  appends;
+- oldest unapplied transaction age and bytes by `CollectionUID`;
+- written `WALLSN`, per-collection applied watermark, and global contiguous
+  cleanup watermark when present;
+- recovery replay count, skipped-tail count, missing side-ref errors, checksum
+  failures, duplicate `WALLSN` failures, and duplicate `(CollectionUID,
+  CollectionSeq)` failures;
+- side refs protected by class, count, bytes, and oldest age;
+- GC bytes blocked by collection WAL side refs;
+- checkpoint blocked time due to pending collection WAL;
+- committed-but-not-staged return count;
+- direct-path writes that used collection WAL versus an equivalent durable
+  fence;
+- recovery accumulator groups, transactions per group, and base-root mismatch
+  failures;
+- read-only opens refused due to pending collection WAL;
+- column side-file prepared, referenced, reachable, quarantined, and deleted
+  counts;
+- overlay and column maintenance WAL transactions and cleanup lag.
+
+Structured log fields should include `wallsn`, `collection_uid`,
+`collection_name`, `collection_generation`, `schema_epoch`, `root_names`,
+`base_root_ids`, `new_root_ids`, `side_ref_class`, `file_id`, `offset`, `size`,
+`checksum`, `durability_mode`, and `watermark_after`.
+
+## 18. Implementation Notes
 
 - Prefer adding the collection WAL package below `TreeDB/internal` until the
   format stabilizes.
@@ -2688,6 +2925,10 @@ Module-specific constraints:
   applied watermark/checkpoint boundary. It may reuse or extract generic frame
   encoding from `internal/commitlog`, but it must not reuse the key/value
   `commitlog.Record` schema as the collection transaction schema.
+- The collection WAL transaction builder must require `CollectionUID`,
+  `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
+  `RootDescriptorEpochs`, `CollectionSeq`, `WALLSN`, root-delta ordinals, and
+  canonical side refs before it can encode a replayable record.
 - `TreeDB/collections` owns final physical delta planning before
   acknowledgement. WAL-on collection planners must serialize primary,
   template/index-state, secondary, overlay, delete, schema, and future
@@ -2725,14 +2966,17 @@ Recommended implementation sequence:
    product behavior is implemented.
 2. Add `internal/collectionwal` plus stable root-delta encode/decode golden
    tests. Keep this package independent from collection planner internals.
-3. Refactor collection write paths into prepare -> WAL append -> stage, starting
+3. Add file-class side-ref preparation APIs for prepare, flush-readable,
+   verify, protect, and quarantine; wire value-log pointerization to flush or
+   sync side refs to the required boundary before collection WAL append.
+4. Refactor collection write paths into prepare -> WAL append -> stage, starting
    with no-index buffered inserts and then indexed insert/update/delete.
-4. Add backend-owned collection WAL recovery and per-collection watermarks in
+5. Add backend-owned collection WAL recovery and per-collection watermarks in
    the backend open path before collection managers or native-wire servers can
    observe state.
-5. Integrate async flush ownership, checkpoint, close, cleanup metadata, and
+6. Integrate async flush ownership, checkpoint, close, cleanup metadata, and
    protected side-ref GC/rewrite behavior.
-6. Add performance gates and tune side-payload thresholds only after correctness
+7. Add performance gates and tune side-payload thresholds only after correctness
    crash tests pass.
-7. Unblock persistent column-store writes only after the row/template collection
+8. Unblock persistent column-store writes only after the row/template collection
    WAL path proves the shared recovery and side-ref protocol.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -139,6 +139,22 @@ The current documented contract is flush-boundary durable, not durable-at-ack.
 That contract is understandable for today's row collections, but it is too weak
 as a foundation for column-store collections with external part files.
 
+Current code also has a clear separation between what can be reused and what
+must be added:
+
+- backend ordered root-group publication is the right executor for final
+  publish and recovery replay;
+- current commit-log records are key/value records, not collection
+  transactions;
+- current collection write-domain state contains enough planning information to
+  build root-local deltas, but it does not preserve those deltas as durable
+  transaction bytes before acknowledgement;
+- current `Flush`, `FlushAll`, close hooks, and checkpoint behavior are
+  flush-boundary mechanisms, not collection-WAL transaction cleanup mechanisms;
+- current recovery has a chronological slot for collection WAL replay after
+  normal cached WAL replay and before state exposure, but no collection WAL
+  replayer API.
+
 ### 2.4 Native Wire and Raft Planning
 
 Native-wire R0-R2 work now establishes a separate logical replication layer:
@@ -290,8 +306,9 @@ blind retry.
 `DB.Checkpoint`:
 
 - Must become a full database durability/cleanup boundary for collection WAL.
-- Must call registered collection checkpoint hooks. PR1 checkpoint hooks must
-  publish every replayable collection WAL transaction known to the manager,
+- Must call a backend-owned collection WAL checkpoint service, or registered
+  hooks that are coordinated by such a service. PR1 checkpoint handling must
+  publish every replayable collection WAL transaction known to the backend,
   advance applied watermarks in backend commits, sync the backend boundary
   required by the selected mode, and only then allow collection WAL cleanup.
 - It must not report a clean WAL state while collection WAL transactions remain
@@ -308,6 +325,9 @@ blind retry.
   close.
 - Must not discard a collection WAL transaction before its applied watermark and
   cleanup boundary are safely published.
+- Close must use the same backend-owned collection WAL publish/checkpoint path
+  as `DB.Checkpoint`; manager-local close hooks may drain visibility domains,
+  but they are not sufficient as the sole source of WAL recovery truth.
 
 Read-only open after crash:
 
@@ -848,6 +868,12 @@ They must publish the exact WAL-backed root deltas and advance watermarks; they
 must not re-plan, re-pointerize, or otherwise transform the acknowledged
 transaction.
 
+Direct synchronous publish paths are not exempt from the WAL-on transaction
+model. In WAL-on modes they must either append a collection WAL transaction and
+then publish/watermark it through the same collection-specific publish wrapper,
+or be limited to `DurabilityWALOffRelaxed`/debug paths whose weaker contract is
+explicitly documented. Uniform WAL-on behavior should log first, then publish.
+
 ### 8.1 No-Index Inserts
 
 Current no-index inserts can remain buffered in `domain.table`. After this
@@ -856,6 +882,11 @@ before acknowledgement. If the value is stored as a value-log pointer, the WAL
 transaction records the stable `ValuePtr` bytes and the required
 `ValueLogRecord` side ref; flush must not later pointerize the raw document into
 a different physical value.
+
+No-index buffered writes must enter the same collection mutation serialization
+path as indexed writes before allocating `CollectionSeq` or making pending state
+visible. Bypassing the mutation serialization path makes per-collection ordering
+and committed-before-visible guarantees too hard to verify.
 
 ### 8.2 Indexed Inserts
 
@@ -906,6 +937,19 @@ If async publish fails, in-memory units can be requeued as they are today. The
 collection WAL transaction remains the recovery source until a successful
 publish advances the watermark.
 
+Every queued or publishing flush unit must carry the collection WAL transaction
+identity it covers:
+
+- `GlobalTxnID` range for diagnostics and cleanup;
+- contiguous `CollectionSeq` range for the owning collection;
+- required side-ref ownership or references to the protected side-ref index;
+- root names and root generations covered by the publish.
+
+Async publish completion may advance the applied watermark only for whole
+transactions covered by the successful root publish. Requeue must preserve WAL
+transaction ownership and must not append replacement WAL records for the same
+acknowledged mutation.
+
 ### 8.5 Overlay Roots
 
 Overlay-root mode should use the same transaction model. The WAL transaction
@@ -939,6 +983,12 @@ PublishCollectionWALTransaction(txn, options) {
 The underlying ordered-root publish APIs may remain the root executor, but the
 collection WAL layer owns validation, template instantiation, watermark
 advancement, sync policy, and side-ref protection.
+
+The existing ordered-root APIs are useful executors, not transaction APIs. The
+collection WAL layer must not expose arbitrary runtime system-builder closures
+as the durable recovery contract. Recovery and flush should call a typed wrapper
+that consumes the recorded transaction, validates its guards, and instantiates
+the recorded `SystemDeltaTemplate`.
 
 ### 8.7 WAL-Off Mode
 
@@ -978,6 +1028,42 @@ the collection WAL.
 remain local barriers. Cluster mode must reject `ack_policy=raft_committed` for
 those commands or define a separate deterministic distributed barrier command
 with explicit consensus semantics.
+
+### 8.9 Lock Ordering and Goroutine Lifecycle
+
+PR1 must document and test lock ordering before product code depends on
+collection WAL. Required ordering constraints:
+
+- collection mutation serialization happens before `CollectionSeq` allocation
+  and before pending visibility changes;
+- side-ref prepare guard is acquired before writing side refs and is released
+  only after committed WAL or abort/quarantine;
+- collection WAL append lock must not be held while acquiring backend publish
+  locks;
+- backend write/commit locks must not be held while waiting for collection
+  domain locks or async publisher condition variables;
+- async publishers publish already-logged transactions and never allocate new
+  WAL transaction ids for the covered acknowledged writes;
+- close/checkpoint first stop or fence new writers, then drain async publishers,
+  then publish/replay WAL-backed transactions, then advance durable watermarks,
+  then clean;
+- background goroutines must be owned by the backend collection WAL service or
+  be registered with it so recovery/checkpoint/close can quiesce them.
+
+The safe high-level sequence is:
+
+```text
+prepare final deltas and side refs under collection mutation/domain locks
+-> release planner-only locks that are not needed for append
+-> append/sync collection WAL under collection WAL writer lock
+-> mark pre-reserved pending state visible
+-> later publish logged deltas without holding the WAL append lock
+-> atomically advance root descriptors and watermarks
+-> cleanup only after durable checkpoint/meta boundary
+```
+
+Implementations may use finer-grained locks, but they must preserve the same
+deadlock and visibility invariants.
 
 ## 9. Recovery Algorithm
 
@@ -1059,6 +1145,13 @@ the same collection roots and applied watermark.
 No side-store cleanup, value-log rewrite, column-file cleanup, or collection WAL
 segment cleanup may run until collection WAL recovery and protected side-ref
 index reconstruction are complete.
+
+The recovery implementation must be backend-owned. It must run before collection
+managers or user collection handles can observe collection state, and it must not
+depend on a caller constructing a `CollectionManager`. The intended insertion
+point is after normal cached key/value WAL replay and side-store inventory, but
+before recovered roots are exposed to user-visible state, snapshots, native-wire
+servers, or collection managers.
 
 Read-only open cannot perform steps that mutate backend state. If unapplied
 committed collection WAL exists, read-only open must fail with a clear
@@ -1359,7 +1452,9 @@ Tests:
 
 - current checkpoint boundary test;
 - close drains queued indexed flush unit;
-- `FlushAll` drains queued indexed flush unit.
+- `FlushAll` drains queued indexed flush unit;
+- failpoint hooks compile and can stop execution at side prepare, WAL append,
+  staging, publish, watermark, cleanup, and recovery replay boundaries.
 
 Gate:
 
@@ -1378,7 +1473,9 @@ Deliverables:
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
 - segment metadata and cleanup record encoding;
-- exact format documentation in this file.
+- exact format documentation in this file;
+- stable root-delta encode/decode APIs independent of transient in-memory
+  `batch.Batch` layout.
 
 Tests:
 
@@ -1430,8 +1527,12 @@ Gate:
 Deliverables:
 
 - WAL-on no-index inserts append collection WAL before acknowledgement;
+- no-index buffered inserts enter collection mutation serialization before
+  `CollectionSeq` allocation and pending visibility;
 - final physical primary-root deltas are materialized before the commit marker;
 - pending write-domain visibility remains unchanged;
+- direct publish paths log first under WAL-on modes or remain explicitly
+  WAL-off/debug-only;
 - `Flush` publishes WAL-backed no-index deltas and advances watermark.
 
 Tests:
@@ -1451,6 +1552,8 @@ Deliverables:
 - indexed insert root-group WAL;
 - update/delete root-group WAL;
 - async flush publish uses existing durable transactions;
+- queued/publishing flush units carry `GlobalTxnID` and contiguous
+  `CollectionSeq` ranges;
 - unique helper rebuild after recovery;
 - replay accumulator for multiple buffered transactions that share one persisted
   root base;
@@ -1488,6 +1591,8 @@ Deliverables:
 - per-collection applied sequence watermark plus optional global-contiguous
   diagnostic watermark;
 - collection WAL replay in open path;
+- backend-owned collection WAL recovery service independent of
+  `CollectionManager` construction;
 - collection-specific publish wrapper around ordered-root publish APIs;
 - segment cleanup after safe checkpoint;
 - prepared side-file quarantine/delete;
@@ -1518,7 +1623,8 @@ Gate:
 Deliverables:
 
 - `DB.Checkpoint` coordinates with collection WAL;
-- checkpoint hook registry analogous to close hooks;
+- backend-owned checkpoint service or checkpoint hook registry coordinated by
+  that service;
 - `CollectionManager.FlushAll` and close hooks use the same publish path;
 - API docs distinguish process-crash recovery from fsync durability.
 
@@ -1682,21 +1788,26 @@ Module-specific constraints:
   markers, `GlobalTxnID`, per-collection sequence allocation, side-ref
   verification, segment metadata, cleanup records, protected side-ref index
   rebuild, missing-segment classification, and segment cleanup after the durable
-  applied watermark/checkpoint boundary.
+  applied watermark/checkpoint boundary. It may reuse or extract generic frame
+  encoding from `internal/commitlog`, but it must not reuse the key/value
+  `commitlog.Record` schema as the collection transaction schema.
 - `TreeDB/collections` owns final physical delta planning before
   acknowledgement. WAL-on collection planners must serialize primary,
   template/index-state, secondary, overlay, delete, schema, and future
   column-store descriptor deltas before the commit marker and must stage the
-  same immutable deltas for visibility.
+  same immutable deltas for visibility. No-index buffered inserts must use the
+  mutation serialization path before pending state becomes visible.
 - `TreeDB/db` owns a collection-specific publish wrapper around ordered-root
   executors. The wrapper validates identity/generation/dependency guards,
   materializes root deltas, instantiates `SystemDeltaTemplate`, publishes
   descriptors and watermark atomically, honors explicit sync options, and makes
   read-only open fail when unapplied committed collection WAL requires mutating
-  recovery.
-- `TreeDB/caching` and checkpoint code must track collection WAL debt. Automatic
-  checkpoint and close paths must not report clean WAL state or prune required
-  bytes while collection WAL transactions remain needed for recovery.
+  recovery. Collection WAL replay and cleanup are backend-owned services, not
+  manager-local behaviors.
+- `TreeDB/caching` and checkpoint code must track collection WAL debt through
+  the backend-owned service. Automatic checkpoint and close paths must not
+  report clean WAL state or prune required bytes while collection WAL
+  transactions remain needed for recovery.
 - `TreeDB/internal/valuelog` and future column-file maintenance must consult the
   protected side-ref index and side-ref prepare guard. PR1 rewrite refuses
   protected refs rather than moving them and patching WAL records.
@@ -1706,3 +1817,23 @@ Module-specific constraints:
   collection WAL transaction. Column files must have temp/final naming, file
   fsync, rename, directory fsync, manifest/checksum validation, and cleanup
   tests before production enablement.
+
+Recommended implementation sequence:
+
+1. Add failpoint/crash harness plumbing around side-ref prepare, WAL append,
+   pending visibility staging, root publish, watermark update, cleanup, and
+   recovery replay. These tests may initially document expected failures before
+   product behavior is implemented.
+2. Add `internal/collectionwal` plus stable root-delta encode/decode golden
+   tests. Keep this package independent from collection planner internals.
+3. Refactor collection write paths into prepare -> WAL append -> stage, starting
+   with no-index buffered inserts and then indexed insert/update/delete.
+4. Add backend-owned collection WAL recovery and per-collection watermarks in
+   the backend open path before collection managers or native-wire servers can
+   observe state.
+5. Integrate async flush ownership, checkpoint, close, cleanup metadata, and
+   protected side-ref GC/rewrite behavior.
+6. Add performance gates and tune side-payload thresholds only after correctness
+   crash tests pass.
+7. Unblock persistent column-store writes only after the row/template collection
+   WAL path proves the shared recovery and side-ref protocol.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -405,6 +405,25 @@ blind retry.
   recoverable.
 - The write may still be pending in the collection write domain for read
   performance and publish amortization.
+- Batch mutators are all-or-nothing at the collection WAL commit boundary. A
+  pre-commit item, validation, side-ref, or WAL append error leaves no batch item
+  visible or recoverable. A post-commit failure is commit-ambiguous for the
+  whole batch.
+
+`CollectionManager.CreateCollection`, `Collection.CreateIndex`, `DropIndex`,
+`DropIndexes`, and `DropAllIndexes`:
+
+- Are public collection metadata mutators.
+- They must either publish atomically through backend roots before success or be
+  encoded as ordered collection WAL transactions.
+- Successful return is recoverable after process crash under WAL-on modes.
+- `CreateIndex` must define its admission cut, backfill snapshot,
+  unique-conflict behavior, and success/reopen guarantee.
+- Unique-index backfill conflicts and schema validation failures are pre-commit
+  errors and must not expose partial schema/index state.
+- Mongo gateway collection auto-create and `createIndexes` inherit the
+  underlying TreeDB mode-relative durability only until explicit Mongo
+  writeConcern handling is implemented.
 
 `Collection.Flush`:
 
@@ -475,6 +494,9 @@ state-machine results, and must not affect collection WAL replay.
   advanced in the same backend commit.
 - `synced` means `flushed` plus the backend checkpoint/fsync boundary required
   by the configured local durability mode. It must not be silently downgraded.
+  A server running `DurabilityWALOnRelaxed` or `DurabilityWALOffRelaxed` must
+  reject `synced` with `durability_unavailable` unless a separate
+  mode-relative policy is explicitly named.
 - Collection WAL append and collection root publication must both expose
   explicit flush/sync options so these acknowledgement policies can be
   implemented without relying on implicit backend defaults.
@@ -2177,6 +2199,7 @@ and future column-store delta-part descriptor updates.
 | Crash after commit marker before response | Recovery may expose transaction. This is committed-before-response ambiguity. |
 | Crash after visible staging before API response | WAL-on modes recover the committed transaction. Visible-without-committed-WAL is not permitted. |
 | In-memory visible staging fails after commit marker | Not permitted as an ordinary error. Implementation must make this step non-failing or report commit-ambiguous/fatal. |
+| Post-commit barrier failure | Not rollback. Public APIs must report commit-ambiguous or committed-but-barrier-failed state. Recovery must either publish the transaction or preserve it as protected WAL debt before serving collection APIs. |
 | Checkpoint races with admitted writer | Writer is either before the checkpoint cut and must be drained/published/watermarked by the checkpoint, or after the cut and must remain protected in retained WAL. |
 | Close races with admitted writer | Writer either fails with closed before visible install or is included in the close drain and visible after reopen. |
 | Root publish fails before backend meta commit | WAL transaction remains unapplied and protected. Retry on flush or recovery. |

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,6 +1,8 @@
 # SPEC: Collection WAL Durability and Root-Group Recovery
 
-Status: draft proposal, non-normative.
+Status: draft proposal. PR1 sections are normative for the planned collection
+WAL implementation; explicitly marked future-work sections remain
+non-normative.
 Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
@@ -34,15 +36,34 @@ The proposed architecture is a root-delta transaction WAL:
    roots, and future column-store descriptor roots.
 2. Any external payloads, such as value-log values or future column files, are
    prepared before the transaction is committed.
-3. The collection WAL transaction records root names, base root ids, ordered
-   root deltas, side-file references, and a transaction sequence.
+3. The collection WAL transaction records collection identity, schema/root
+   generation guards, per-collection sequence dependencies, ordered root deltas,
+   required side-file references, and a replayable system-root delta template.
 4. Recovery replays complete transactions by publishing the same root group and
-   advancing an applied watermark in the system root.
+   advancing an applied collection-sequence watermark in the same system-root
+   commit that updates collection descriptors.
 
 This is a hard prerequisite for production column-store collection writes.
 Before this milestone passes, column-store work may proceed only for docs,
 benchmarks, pure codecs, filters, and isolated format encode/decode tests that
 do not publish persistent collection roots.
+
+PR1 makes these decisions normative:
+
+- use per-write collection WAL transactions with per-collection dependency
+  chains and replay-side accumulation;
+- use a stable persisted `CollectionID`, `SchemaEpoch`, and per-root
+  `RootGeneration` as replay guards;
+- include a versioned `SystemDeltaTemplate` in every replayable transaction;
+- fail recovery on any complete collection WAL transaction with a missing
+  required side ref in WAL-on modes;
+- maintain a protected side-ref index, rebuilt from WAL during recovery, for
+  PR1 GC/rewrite safety;
+- make `DB.Checkpoint` call registered collection checkpoint hooks and force
+  publication of replayable collection WAL before reporting a clean collection
+  WAL state;
+- encode overlay compaction as a collection WAL maintenance transaction when it
+  can race with user-visible collection writes.
 
 ## 2. Current Facts
 
@@ -158,15 +179,17 @@ Side file:
 
 A durable file or byte range referenced by a root group but not stored inline in
 the collection WAL transaction. Current examples are value-log records and
-leaf-log records. Future examples include column part files, filter files, and
-delete bitmap files.
+large root-delta payloads. Future examples include column part files, filter
+files, dictionaries, and delete bitmap files. Leaf-log/page-log records created
+while publishing replayed B-tree pages are publish outputs, not collection WAL
+side refs.
 
 Applied watermark:
 
-System-root metadata that records the latest collection WAL transaction that
-has been published into backend roots. Recovery uses the watermark to avoid
-double-applying transactions after a crash that occurs after root publish but
-before WAL cleanup.
+System-root metadata that records the highest contiguous collection sequence
+published into backend roots for one `CollectionID`. Recovery uses the watermark
+to avoid double-applying transactions after a crash that occurs after root
+publish but before WAL cleanup.
 
 Durable-at-ack:
 
@@ -227,6 +250,15 @@ mode requires fsync.
 If the engine cannot append the collection WAL transaction in a WAL-on mode, the
 collection write must fail before becoming visible to the caller.
 
+After the WAL commit marker reaches the durability boundary required by the
+selected mode, the mutation is committed for recovery. The implementation must
+not return an ordinary retryable mutation error after that point. If the process
+crashes before the caller observes the response, recovery may expose the
+mutation; this is the standard committed-before-response ambiguity. If
+post-commit bookkeeping cannot complete, the implementation must report a
+commit-ambiguous or fatal error, not a normal mutation error that invites a
+blind retry.
+
 ### 6.2 API Boundaries
 
 `Collection.Insert`, `InsertBatch`, `Update`, `UpdateBatch`, `Delete`, and
@@ -252,11 +284,15 @@ collection write must fail before becoming visible to the caller.
 `DB.Checkpoint`:
 
 - Must become a full database durability/cleanup boundary for collection WAL.
-- It may either force `FlushAll` through the registered collection close/flush
-  hook or publish all durable collection WAL transactions before pruning related
-  log segments.
+- Must call registered collection checkpoint hooks. PR1 checkpoint hooks must
+  publish every replayable collection WAL transaction known to the manager,
+  advance applied watermarks in backend commits, sync the backend boundary
+  required by the selected mode, and only then allow collection WAL cleanup.
 - It must not report a clean WAL state while collection WAL transactions remain
   needed for recovery.
+- If a future checkpoint mode chooses not to publish a transaction, it must keep
+  the transaction and all required side refs protected and report nonzero
+  collection WAL debt.
 
 `DB.Close`:
 
@@ -274,6 +310,9 @@ Native-wire acknowledgement policies map onto these same local boundaries:
   advance the collection WAL applied watermark for those transactions.
 - `synced` must also reach the backend checkpoint/sync boundary required by the
   configured local durability mode.
+- Collection WAL append and collection root publication must both expose explicit
+  flush/sync options so these acknowledgement policies can be implemented
+  without relying on implicit backend defaults.
 - `raft_committed` is a cluster-mode policy. It cannot be satisfied by local
   collection WAL alone; it requires consensus commit plus the cluster's defined
   local apply durability rule.
@@ -315,59 +354,202 @@ Reasons:
 
 ### 7.2 Transaction Shape
 
-Logical transaction:
+A collection WAL transaction is a replayable physical root-group transaction.
+It is not a logical insert/update/delete command. Recovery must not rerun user
+callbacks, predicates, JSON extraction, template extraction, secondary-index
+planning, or future column-store planning.
 
 ```text
 CollectionWALTransaction {
-    Version              uint8
-    TxnID                uint64
-    CollectionID         uint64 or stable collection name
-    CollectionName       string
-    BaseCommitSeq        uint64
-    BaseSystemRoot       uint64
-    PlannerEpoch         uint64 optional
-    RootDeltas           []CollectionRootDelta
-    SideRefs             []CollectionSideRef
-    AckMode              uint8
-    CreatedUnixNanos     int64
-    Stats                CollectionWALStats
-    ChecksumCRC32C       uint32
+    Version                  uint16
+
+    // Identity and ordering.
+    GlobalTxnID              uint64
+    CollectionID             uuid128
+    CollectionName           string diagnostic
+    CollectionSeq            uint64
+    DependsOnCollectionSeq   uint64
+
+    // Catalog guard.
+    SchemaEpoch              uint64
+    BaseCommitSeq            uint64
+    BaseSystemRootID         uint64
+    BaseCatalogDigest        bytes optional
+
+    // Physical mutation.
+    RootDeltas               []CollectionRootDelta
+    SystemDeltaTemplate      CollectionSystemDeltaTemplate
+
+    // Required external bytes named by RootDeltas or SystemDeltaTemplate.
+    SideRefs                 []CollectionSideRef
+
+    // Local observability only; excluded from replay identity.
+    AckMode                  uint8
+    CreatedUnixNanos         int64
+    Stats                    CollectionWALStats
+
+    ReplayDigest             bytes
+    RecordChecksumCRC32C     uint32
 }
 
 CollectionRootDelta {
-    RootName             string
-    RootKind             uint8
-    BaseRootID           uint64
-    StoragePolicy        uint8
-    DeltaEncoding        uint8
-    InlineDelta          bytes optional
-    DeltaRID             uint64 optional
-    EntryCount           uint32
-    KeyBytes             uint64
-    ValueBytes           uint64
+    RootName                 string
+    RootKind                 uint16
+    RootDeltaIndex           uint32
+
+    BaseRootID               uint64
+    BaseRootGeneration       uint64
+    BaseCollectionSeq        uint64
+
+    StoragePolicy            uint8
+    DeltaEncoding            uint8
+    IncludeDeletedOnColdBuild bool
+
+    InlineDelta              bytes optional
+    DeltaPayloadRef          CollectionSideRefRef optional
+
+    EntryCount               uint32
+    KeyBytes                 uint64
+    ValueBytes               uint64
+    DeltaDigest              bytes
+}
+
+CollectionSystemDeltaTemplate {
+    BaseSystemRootID         uint64
+    BaseCommitSeq            uint64
+    Preconditions            []SystemPrecondition
+    DescriptorOps            []DescriptorOp
+    WatermarkOp              AppliedWatermarkOp
+    MetaOps                  []SystemMetaOp optional
+}
+
+DescriptorOp {
+    Op                       ReplaceRoot | AppendOverlayRoot | ClearOverlayRoots |
+                             ReplaceRootList | PutMeta | DeleteMeta
+    Key                      bytes
+    ExpectedValueDigest      bytes optional
+    RootDeltaIndex           uint32 optional
+    RootIDPlaceholder        uint32 optional
+    RootListPlaceholders     []uint32 optional
+}
+
+AppliedWatermarkOp {
+    CollectionID             uuid128
+    AdvanceCollectionSeqTo   uint64
+    OptionalGlobalTxnID      uint64
 }
 
 CollectionSideRef {
-    RefClass             uint8
-    FileID               uint64
-    RelativePath         string optional
-    Offset               uint64
-    Size                 uint64
-    ChecksumCRC32C       uint32
-    Required             bool
+    RefClass                 uint8
+    RefID                    uint64
+    RelativePath             string optional
+    Offset                   uint64
+    Size                     uint64
+    ChecksumCRC32C           uint32
+    Required                 bool
+}
+
+CollectionWALAppendOptions {
+    Flush                    bool
+    Sync                     bool
+}
+
+OrderedRootPublishOptions {
+    Sync                     bool
+    GlobalTxnIDsCovered      []uint64
+    CollectionSeqRange       [2]uint64
+    WatermarkOp              AppliedWatermarkOp
 }
 ```
 
-Root delta payloads should use the same canonical sorted delta encoding as
-`OrderedRootDeltaBatchFromIterator`. Small deltas may be inline in the WAL
-transaction. Large deltas should use a side payload referenced by RID or by a
-dedicated root-delta payload class.
+A transaction is replayable only when:
+
+1. the record checksum is valid;
+2. every required side ref is present and passes integrity checks;
+3. `CollectionID`, `SchemaEpoch`, base root ids, and base root generations match
+   the current replay state or an explicit replay accumulator state;
+4. `DependsOnCollectionSeq` is covered by the collection applied watermark or by
+   the active accumulator;
+5. the `SystemDeltaTemplate` can be instantiated with the produced root ids and
+   its preconditions hold.
+
+The same backend commit that writes descriptor operations from
+`SystemDeltaTemplate` must also advance the collection applied watermark. A
+descriptor update without the watermark, or a watermark update without the
+descriptor update, is not a valid collection WAL publish.
 
 `AckMode`, `CreatedUnixNanos`, and `Stats` are local observability and policy
 metadata. They must not change root-delta replay output, idempotency outcomes,
 catalog guard outcomes, or future Raft state-machine results.
 
-### 7.3 File Class
+Two digests are required:
+
+- `RecordChecksumCRC32C`: covers the whole encoded record for corruption
+  detection;
+- `ReplayDigest`: covers replay-critical fields only: identity, dependencies,
+  root deltas, side refs, system delta template, and preconditions.
+
+### 7.3 Collection Identity and Root Generations
+
+Every collection must have a stable `CollectionID` persisted in collection
+metadata. `CollectionName` is diagnostic and must not be the replay identity.
+Dropping and recreating a collection with the same name creates a new
+`CollectionID`.
+
+Every schema or index metadata change increments `SchemaEpoch`. Every root
+descriptor change increments that root's `RootGeneration`. Overlay descriptor
+changes and overlay compaction also increment the affected root generation.
+
+A collection WAL transaction records `CollectionID`, `SchemaEpoch`,
+`BaseRootID`, and `BaseRootGeneration` for every root it mutates. Recovery must
+reject or block a transaction whose identity or generation guard does not match
+the replay state, unless the mismatch is explicitly explained by the active
+replay accumulator.
+
+Maintenance that rewrites root ids or descriptor values must not run for a
+collection with unapplied WAL transactions unless the maintenance operation is
+itself encoded as a collection WAL transaction.
+
+Schema/index changes are collection-sequenced operations. Before a schema change
+becomes visible, all lower `CollectionSeq` transactions must either be published
+and watermarked, or the schema change itself must be a collection WAL
+transaction that depends on the previous `CollectionSeq` and carries schema and
+root descriptor changes atomically.
+
+### 7.4 Root Delta Encoding
+
+The WAL format must not depend on transient in-memory `batch.Batch` internals.
+The backend may convert WAL deltas into `batch.Batch` at replay or publish time,
+but the durable encoding is versioned independently.
+
+```text
+RootDeltaEncodingV1:
+  entries sorted by bytewise key;
+  keys unique per root delta after intra-transaction merge;
+  entry op: PutInline | PutValuePtr | DeleteTombstone;
+  key length + key bytes;
+  value length + value bytes OR stable ValuePtr encoding;
+  per-entry flags;
+  IncludeDeletedOnColdBuild flag recorded on the root delta.
+```
+
+`IncludeDeletedOnColdBuild` must be true for overlay and cold-build roots whose
+tombstones suppress older roots. Delete/tombstone entries are durable logical
+entries in the root delta, not an artifact of the current builder.
+
+Small deltas may be inline in the WAL transaction. Large deltas should use a
+`RootDeltaPayload` side ref. The WAL encoder must preserve deterministic merge
+rules: if two accumulated deltas affect the same key, the later
+`CollectionSeq` wins, and deletes suppress older values according to normal
+collection visibility rules.
+
+Root kinds are explicit, versioned values. PR1 root kinds include primary,
+template/index-state, secondary index, overlay, overlay descriptor, delete, and
+metadata roots. Future column-store root kinds include part descriptor, locator,
+column schema, filter descriptor, delete bitmap, and compression/dictionary
+metadata roots.
+
+### 7.5 File Class
 
 Use a dedicated logical collection WAL class. The implementation may reuse
 commit-log framing utilities, but the replay semantics are different from
@@ -383,72 +565,80 @@ Dir/maindb/wal/
 Segment rules:
 
 - Each segment contains framed `CollectionWALTransaction` records.
-- Each transaction has exactly one `TxnID`.
-- Transactions are sorted by `TxnID` during recovery, with file order as a
-  deterministic tie breaker only for malformed legacy segments.
+- Each transaction has exactly one `GlobalTxnID` and one collection-local
+  `CollectionSeq`.
+- Transactions are sorted by `GlobalTxnID` during segment scanning, with file
+  order as a deterministic tie breaker only for malformed legacy segments.
 - A truncated tail stops scanning that segment after the last complete record.
 - Hard corruption before the tail fails recovery.
 
-### 7.4 Applied Watermark
+### 7.6 Applied Progress and Skip Rules
 
-The system root must store collection WAL progress:
+The system root stores applied progress by `CollectionID`:
 
 ```text
 treedb/collection-wal/global-contiguous-applied-txn-id -> uint64 optional
-treedb/collection-wal/collection/<collection-id>/applied-txn-id -> uint64
+treedb/collection-wal/collection/<collection-id>/applied-collection-seq -> uint64
 ```
 
-PR1 can use one global monotonic transaction id for transaction identity. It
-must not use a single global applied high-watermark unless publication and
-watermark advancement are strictly contiguous in `TxnID` order across all
-collection write domains.
+`GlobalTxnID` is a unique transaction identity and diagnostic ordering key.
+`CollectionSeq` is the replay and skip key. Recovery may skip a transaction only
+when `txn.CollectionSeq <= applied-collection-seq` for the same `CollectionID`
+and the transaction's `CollectionID`/`SchemaEpoch` guard matches the catalog
+history covered by that watermark.
 
-Safe choices:
+A global contiguous watermark may be used only as an optimization when every
+lower `GlobalTxnID` is known applied or intentionally absent. It must never
+cause recovery to skip an unapplied lower `CollectionSeq` for any collection.
 
-1. Enforce one ordered global publisher, so transaction `N+1` cannot advance an
-   applied watermark before transaction `N` is applied.
-2. Track per-collection applied watermarks and advance a separate global
-   contiguous watermark only when every lower `TxnID` is known applied.
+Watermarks advance only in the same backend commit that updates collection root
+descriptors for the root group. A watermark value means every collection
+transaction up to that `CollectionSeq` is fully represented in persisted roots
+and descriptor metadata.
 
-The second choice is preferred if async publishers can run independently per
-collection or write domain. Recovery may skip a transaction only when that
-transaction is covered by its collection watermark or by a global contiguous
-watermark. It must never skip transaction `N` merely because transaction `N+1`
-from another collection was published first.
+PR1 uses per-write WAL transactions with per-collection dependency chains:
 
-When a collection root group is published, the same backend commit that updates
-collection root descriptors must also advance the applied watermark. This is the
-atomic marker that makes WAL cleanup safe.
+```text
+GlobalTxnID              uint64  // unique identity, diagnostics, segment order
+CollectionSeq            uint64  // strictly increasing per CollectionID
+DependsOnCollectionSeq   uint64  // previous collection transaction observed
+```
 
-Recovery skips transactions covered by a safe applied watermark. Transactions
-not covered by a safe watermark are candidates for replay.
+Recovery must process each collection in contiguous `CollectionSeq` order. A
+transaction may be replayed only if all lower collection sequences are applied,
+present in the active replay accumulator, or explicitly known not to exist for a
+new collection. A missing complete transaction blocks later transactions for the
+same collection.
 
-### 7.5 Side-File Fences
+### 7.7 Side-Ref Fences
 
-A collection transaction is replayable only when every required side reference
-is readable and passes its integrity check.
+`CollectionSideRef` names external bytes that must exist before a collection WAL
+transaction can be replayed. Side refs are input dependencies of the
+transaction, not output files produced by backend root publication.
 
-Current side refs:
+Side-ref classes:
 
-- value-log records for large collection document values;
-- leaf-log records when ordered roots store outer leaves in the value log.
+- `ValueLogRecord`: value-log bytes embedded in root-delta values.
+- `RootDeltaPayload`: serialized root-delta payload stored outside the WAL
+  record.
+- `ColumnPartFile`: immutable column payload file.
+- `ColumnFilterFile`: filter file.
+- `DeleteBitmapFile`: delete/tombstone bitmap file.
+- `DictionaryFile`: compression or encoding dictionary file.
 
-Future side refs:
+Leaf-log or page-log records produced while replay builds new B-tree roots are
+not `CollectionSideRefs`. They are publish outputs and must be flushed or synced
+by the backend commit path before descriptors are published.
 
-- column part files;
-- column filter files;
-- delete bitmap files;
-- dictionary files.
+The WAL encoder must derive required side refs from the final root-delta payload
+and from column descriptors. A caller-provided `SideRefs` list is insufficient
+unless the encoder verifies it against the payload.
 
-If a required side ref is missing during recovery:
-
-- no root group from that transaction may be published;
-- recovery must not produce roots pointing to missing bytes;
-- later transactions for the same collection should be blocked unless the
-  implementation can prove they do not depend on the skipped transaction;
-- durable mode should surface an error unless the missing ref is in a clearly
-  incomplete tail transaction that can be ignored by the same rules as existing
-  commit-log tails.
+A complete transaction with a missing required side ref is a recovery error in
+WAL-on durable/recoverable modes, except for an incomplete tail transaction that
+lacks a valid commit marker. Recovery must not skip a complete collection
+transaction and continue applying later transactions for the same
+`CollectionID`.
 
 Collection WAL side refs are also retention roots. Value-log GC, value-log
 rewrite, column-file cleanup, and future side-file maintenance must treat every
@@ -456,20 +646,33 @@ required side ref in an unapplied or not-yet-cleanable collection WAL
 transaction as reachable until the transaction is covered by a safe applied
 watermark and the checkpoint/meta boundary needed for cleanup is durable.
 
-Implementation options:
+PR1 maintains a protected side-ref index updated atomically with WAL append and
+WAL cleanup. GC/rewrite must consult this index plus persisted roots. Recovery
+rebuilds the index by scanning collection WAL before any maintenance starts. If
+a value-log segment or column file is referenced only by pending collection WAL,
+maintenance must keep it in place or abort. A future rewrite mode may rewrite
+protected refs only if it publishes replacement side refs and collection WAL
+metadata atomically under an explicit crash-tested protocol.
 
-1. GC/rewrite scans collection WAL segments and includes required `SideRefs` in
-   its reachability set.
-2. WAL append/update maintains a protected side-ref index that GC/rewrite scans
-   with the normal root reachability set.
+### 7.8 Commit Marker and Ack Boundary
 
-PR1 should prefer protection over rewrite: if a value-log segment or column file
-is referenced only by pending collection WAL, maintenance should keep it in
-place rather than moving it and trying to patch WAL records. A future rewrite
-mode may rewrite protected refs only if it publishes replacement side refs and
-collection WAL metadata atomically under an explicit crash-tested protocol.
+A collection WAL record is replayable only after its commit marker is complete.
+The implementation must complete validation, side-ref preparation, side-ref
+flush/sync required by the selected durability mode, memory reservation, and
+hidden write-domain staging before appending the commit marker.
 
-### 7.6 Native Wire and Raft Layering
+After the commit marker reaches the required durability boundary, the mutation is
+committed for recovery. The implementation must not return an ordinary mutation
+error after that point. If the process crashes before the client observes the
+response, recovery may expose the mutation; this is committed-before-response
+ambiguity, not an incomplete transaction.
+
+The visible in-memory staging step after the commit marker must be non-failing.
+If an implementation cannot guarantee that, it must use a two-phase in-memory
+reservation protocol or expose a commit-ambiguous/fatal error instead of a
+normal retryable mutation error.
+
+### 7.9 Native Wire and Raft Layering
 
 The collection WAL is below native-wire and Raft:
 
@@ -504,20 +707,37 @@ applied under the cluster policy.
 
 ## 8. Write Path
 
+For every WAL-on collection mutation:
+
+1. Validate catalog identity, schema epoch, root descriptor generations,
+   uniqueness, and mutation-specific preconditions.
+2. Build final physical root deltas for every affected root. The deltas must
+   already contain the exact inline values, stable `ValuePtr` encodings,
+   tombstones, secondary-index deletes/puts, template/index-state changes,
+   overlay changes, delete-root changes, and future column descriptor entries
+   that recovery will publish.
+3. Prepare and verify every required side ref. Flush or sync side refs according
+   to the selected durability boundary before the WAL commit marker is
+   considered replayable.
+4. Reserve hidden write-domain state using the exact serialized root deltas or
+   immutable decoded delta objects.
+5. Append the collection WAL transaction and commit marker.
+6. Mark the reserved write-domain state visible without further fallible work.
+7. Return success.
+
+Flush, async publish, checkpoint, and close are publication and cleanup paths.
+They must publish the exact WAL-backed root deltas and advance watermarks; they
+must not re-plan, re-pointerize, or otherwise transform the acknowledged
+transaction.
+
 ### 8.1 No-Index Inserts
 
 Current no-index inserts can remain buffered in `domain.table`. After this
-spec, a WAL-on insert must:
-
-1. validate the collection catalog and primary uniqueness;
-2. build the root-local primary delta entry;
-3. pointerize large values if configured;
-4. append a collection WAL transaction containing the primary delta and side
-   refs;
-5. stage the same delta in the collection write domain for immediate reads;
-6. optionally publish later through `Flush`, threshold, checkpoint, or close.
-
-The key change is that step 4 happens before success is returned to the caller.
+spec, a WAL-on no-index insert must canonicalize the final primary-root entry
+before acknowledgement. If the value is stored as a value-log pointer, the WAL
+transaction records the stable `ValuePtr` bytes and the required
+`ValueLogRecord` side ref; flush must not later pointerize the raw document into
+a different physical value.
 
 ### 8.2 Indexed Inserts
 
@@ -527,10 +747,12 @@ Indexed insert planning already produces root runs for:
 - template/index-state root when needed;
 - secondary index roots.
 
-After this spec, the planner should convert those root runs into a collection
+After this spec, the planner must convert those root runs into one collection
 WAL transaction before adding them to the durable pending write domain. Unique
 probe helpers remain in memory, but they must be rebuildable from the root
-deltas during recovery.
+deltas and persisted roots during recovery. The WAL transaction must contain the
+primary put, template/index-state changes, and every secondary-index put needed
+for the insert.
 
 ### 8.3 Updates and Deletes
 
@@ -544,6 +766,11 @@ Updates and deletes must use the same root-delta transaction model:
 
 The WAL records planned deltas, not the callback or predicate that produced
 them.
+
+Updates that change indexed values must include old secondary-index deletes and
+new secondary-index puts in the same transaction as the primary mutation.
+Deletes must include primary tombstones or deletes, secondary deletes, and any
+delete-root or overlay tombstone entries required to suppress older roots.
 
 ### 8.4 Async Indexed Flush
 
@@ -568,13 +795,34 @@ must identify whether the root ids are base roots or overlay roots, and the
 system-root delta must atomically update overlay descriptors and the applied
 watermark.
 
-Overlay compaction is a separate root-group transaction. It can be WAL logged
-like any other collection root-group publish or treated as a maintenance commit
-that is replayed through backend metadata if it reaches the backend commit
-boundary. The implementation must choose one rule and test crash points around
-it.
+Overlay compaction is a separate collection WAL maintenance transaction when it
+can race with user-visible collection writes. It uses `ReplaceRoot` and
+`ClearOverlayRoots` descriptor operations, advances the collection sequence, and
+updates the affected root generation. Root-rewriting overlay maintenance is
+forbidden while unapplied collection WAL exists unless it is encoded this way.
 
-### 8.6 WAL-Off Mode
+### 8.6 Collection-Specific Publish Wrapper
+
+Collection WAL recovery, flush, async publish, checkpoint, close, and
+maintenance must call a collection-specific transaction executor rather than
+reconstructing ad hoc runtime system-builder closures.
+
+```text
+PublishCollectionWALTransaction(txn, options) {
+    validate txn.CollectionID, SchemaEpoch, BaseRootGeneration, dependencies
+    materialize root deltas from txn
+    apply root deltas
+    instantiate txn.SystemDeltaTemplate with produced root ids
+    atomically publish system descriptors + applied watermark
+    honor options.Sync
+}
+```
+
+The underlying ordered-root publish APIs may remain the root executor, but the
+collection WAL layer owns validation, template instantiation, watermark
+advancement, sync policy, and side-ref protection.
+
+### 8.7 WAL-Off Mode
 
 `DurabilityWALOffRelaxed` should not write collection WAL transactions. In that
 mode:
@@ -584,7 +832,7 @@ mode:
 - column-store mutable writes must not be production-enabled under WAL-off
   until explicit benchmark and safety gates are added.
 
-### 8.7 Future Raft Apply Path
+### 8.8 Future Raft Apply Path
 
 For future Raft write replication, the apply path must not replay native-wire
 transport requests. It should consume committed deterministic command-entry
@@ -623,21 +871,25 @@ the current invariant that side-store scans run before cached commit-log replay:
    RID fences, and build the `RID -> side ref` maps required for replay.
 3. Replay normal cached commit logs as today, using the side-ref maps created
    before replay.
-4. Scan any additional collection WAL side-file classes, such as column-file
-   and collection-root-delta side files, needed by collection WAL fences.
-5. Scan collection WAL segments and decode complete transactions.
-6. Load applied watermark metadata from the recovered system root.
-7. Sort unapplied transactions by `TxnID`.
-8. For each unapplied transaction:
+4. Scan any additional collection WAL side-file classes, such as root-delta
+   payloads, column files, filters, delete bitmaps, and dictionaries, needed by
+   collection WAL fences.
+5. Scan collection WAL segments, decode complete transactions, distinguish
+   incomplete tails from hard corruption, and rebuild the protected side-ref
+   index before any maintenance can run.
+6. Load applied collection-sequence watermark metadata from the recovered system
+   root.
+7. Sort unapplied transactions by `CollectionID`, `CollectionSeq`, and
+   `GlobalTxnID` for deterministic diagnostics.
+8. For each unapplied collection in contiguous `CollectionSeq` order:
    - validate checksum and format version;
    - validate required side refs;
-   - validate collection catalog identity and schema epoch;
-   - verify each named root's current id matches the transaction's `BaseRootID`,
-     unless the transaction is covered by a replay accumulator as described
-     below;
-   - materialize `OrderedRootDeltaBatchPublishInput` values;
-   - publish the root group with a system-root delta that updates collection
-     root descriptors and advances the applied watermark.
+   - validate collection identity, schema epoch, root generation guards, and
+     sequence dependency;
+   - add the transaction to the per-collection replay accumulator;
+   - materialize publish inputs from `RootDeltaEncodingV1`;
+   - instantiate `SystemDeltaTemplate` with produced root ids;
+   - publish descriptor updates and applied watermark in one backend commit.
 9. After successful replay, clean collection WAL segments whose transactions are
    fully covered by the durable applied watermark.
 10. Quarantine or delete prepared side files that are not referenced by any
@@ -646,52 +898,66 @@ the current invariant that side-store scans run before cached commit-log replay:
 Recovery must be deterministic. Replaying the same directory twice must produce
 the same collection roots and applied watermark.
 
-### 9.1 Buffered Transaction Replay and Rebasing
+No side-store cleanup, value-log rewrite, column-file cleanup, or collection WAL
+segment cleanup may run until collection WAL recovery and protected side-ref
+index reconstruction are complete.
 
-Buffered collection writes can create several acknowledged WAL transactions
-whose root deltas all name the same persisted `BaseRootID`. That is valid if
-the write domain recorded each pending mutation relative to the persisted
-catalog root and planned to publish the merged flush unit later. It is not safe
-for recovery to publish transaction 1, update the root id, and then reject
-transaction 2 solely because transaction 2 still names the old persisted base.
+### 9.1 Buffered Transaction Replay and Accumulation
 
-The implementation must choose one of these replay-safe models:
+PR1 uses per-collection replay-side accumulation. Merged flush-unit WAL
+transactions are deferred because they are incompatible with durable-at-ack for
+independently acknowledged buffered writes unless those writes wait for the
+merged unit to become durable.
 
-1. Log only merged flush-unit transactions, so every transaction's `BaseRootID`
-   is the backend root id expected at replay time.
-2. Give each later WAL transaction a logical base that includes earlier pending
-   WAL deltas for that root.
-3. Rebase/accumulate during recovery.
+Recovery processes transactions in `CollectionID`, `CollectionSeq` order. A
+transaction may enter the accumulator only if its `DependsOnCollectionSeq` is
+already applied or already present in that accumulator. A complete missing
+transaction blocks later transactions for the same collection.
 
-The recommended PR1 model is replay-side accumulation. Recovery should process
-unapplied transactions in `TxnID` order, grouped by collection and root. For
-each root, it maintains a virtual replay base seeded from the current catalog
-root and a pending delta accumulator:
+For each root, the accumulator records:
 
-- if a transaction's `BaseRootID` equals the current persisted root, recovery
-  may start or extend the accumulator for that root;
-- if a transaction's `BaseRootID` equals the original buffered base already
-  covered by the accumulator, recovery appends the transaction's root delta to
-  the accumulator instead of treating the root-id mismatch as corruption;
-- if a transaction's `BaseRootID` is neither the current persisted root nor a
-  known buffered base for that accumulator, recovery must block or fail rather
-  than publish an ambiguous delta;
-- recovery publishes accumulated root deltas in one deterministic root group or
-  in a sequence whose later `BaseRootID` values are explicitly rebased to the
-  roots produced by earlier publishes;
-- applied watermarks may advance only for the exact transactions covered by the
-  successful accumulated publish.
+- the persisted base root id and generation;
+- the collection sequence range covered;
+- the merged ordered delta entries in transaction order;
+- whether cold-build tombstones must be preserved.
+
+If two accumulated deltas affect the same key, later `CollectionSeq` wins
+according to root-delta merge rules. Deletes/tombstones must suppress older
+values from the same accumulator and from older persisted or overlay roots
+according to normal collection visibility rules.
+
+A successful accumulated publish must cover whole transactions, not individual
+roots. The system-root commit must update every affected root descriptor and
+advance the collection watermark to the highest contiguous `CollectionSeq`
+covered by the publish. If any root in a transaction cannot be applied, no root
+from that transaction may be considered applied.
 
 This rule applies to no-index buffered writes, indexed mutable runs, queued
-flush units, and async publishing states. It is also the rule future
-column-store delta-part descriptors must follow if several acknowledged deltas
-share one persisted base part-descriptor root.
+flush units, async publishing states, overlay compaction, schema/index changes,
+and future column-store delta-part descriptor updates.
+
+### 9.2 Failure Behavior
+
+| Failure point | Required behavior |
+|---|---|
+| Side-ref preparation fails before WAL commit marker | Return ordinary error. Do not expose mutation. Delete or quarantine prepared side files. |
+| WAL append fails before commit marker | Return ordinary error. Do not expose mutation. Side refs remain uncommitted and are deleted or quarantined. |
+| Crash after side refs prepared before commit marker | Recovery ignores transaction. Unreferenced side files are deleted or quarantined. |
+| Crash after commit marker before response | Recovery may expose transaction. This is committed-before-response ambiguity. |
+| In-memory visible staging fails after commit marker | Not permitted as an ordinary error. Implementation must make this step non-failing or report commit-ambiguous/fatal. |
+| Root publish fails before backend meta commit | WAL transaction remains unapplied and protected. Retry on flush or recovery. |
+| Root pages are built but backend meta commit fails | Built pages are unreachable. WAL transaction remains source of truth. |
+| Descriptor update succeeds without watermark | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
+| Watermark update succeeds without descriptor update | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
+| Cleanup fails after watermark/checkpoint | Safe leak. Retry cleanup later. |
+| GC/rewrite wants a side ref protected by unapplied WAL | Must keep it in place or abort maintenance. Rewrite requires an explicit crash-tested WAL metadata protocol. |
 
 ## 10. Cleanup and Retention
 
 Collection WAL cleanup is safe only when both are true:
 
-1. every transaction in the segment is covered by a safe applied watermark;
+1. every transaction in the segment is covered by the safe per-collection
+   applied sequence watermark;
 2. the backend checkpoint/meta boundary containing that watermark is durable for
    the selected mode.
 
@@ -712,6 +978,24 @@ bytes. Cleanup may stop protecting a side ref only after the transaction is
 covered by a safe applied watermark and the durable checkpoint/meta boundary
 makes the published roots or the discarded incomplete transaction authoritative.
 
+PR1 uses a protected side-ref index:
+
+- WAL append registers every required side ref before the commit marker becomes
+  replayable.
+- Recovery rebuilds the index by scanning collection WAL before maintenance
+  starts.
+- Cleanup unregisters side refs only after the applied watermark and durable
+  checkpoint/meta boundary make the published roots authoritative.
+- Value-log rewrite and column-file rewrite refuse protected refs in PR1 rather
+  than trying to patch WAL records in place.
+
+`DB.Checkpoint` must call registered collection checkpoint hooks before
+reporting a clean collection WAL state. PR1 checkpoint hooks force publication
+of replayable collection WAL, advance watermarks, and then allow collection WAL
+cleanup. If a future checkpoint mode leaves replayable collection WAL
+unpublished, it must report collection WAL debt and preserve all side-ref
+protections.
+
 ## 11. Test Plan
 
 ### 11.1 Current Contract Tests
@@ -726,12 +1010,20 @@ Keep and expand tests that document current behavior:
 
 ### 11.2 Format Tests
 
-- exact-byte collection WAL transaction golden files;
-- corrupt checksum rejection;
-- truncated tail acceptance;
+- exact-byte `CollectionWALTransaction` v1 golden files;
+- corrupt `RecordChecksumCRC32C` rejection;
+- `ReplayDigest` changes when replay-critical fields change and does not change
+  when observability-only fields change;
+- truncated tail without commit marker is ignored;
+- complete transaction with missing side ref fails recovery in WAL-on modes;
+- hard corruption before the tail fails recovery;
 - mixed transaction sequence rejection;
-- large root delta side-payload round trips;
-- unknown future version rejection with clear error.
+- large root-delta `RootDeltaPayload` side-ref round trips;
+- unknown future version rejection with clear error;
+- tombstone/cold-build encoding preserves `IncludeDeletedOnColdBuild`;
+- `SystemDeltaTemplate` placeholder instantiation golden tests;
+- descriptor-op precondition failures are reported before any publish is marked
+  applied.
 
 ### 11.3 Recovery Tests
 
@@ -739,29 +1031,39 @@ Crash/fault points:
 
 1. before collection WAL append;
 2. after side-file prepare before collection WAL append;
-3. after collection WAL append before in-memory staging;
-4. after acknowledgement before root publish;
-5. during async publish;
-6. after root pages are built but before the system-root commit advances the
+3. after WAL commit marker before visible staging;
+4. after visible staging before response;
+5. after acknowledgement before root publish;
+6. during async publish;
+7. after root pages are built but before the system-root commit advances the
    applied watermark;
-7. after applied watermark before WAL cleanup;
-8. during overlay compaction;
-9. during column-file prepare once column store exists.
-10. after two or more acknowledged buffered transactions with the same
+8. after applied watermark before WAL cleanup;
+9. during overlay compaction;
+10. during column-file prepare once column store exists;
+11. after two or more acknowledged buffered transactions with the same
     persisted `BaseRootID`;
-11. after a higher `TxnID` from another collection publishes before a lower
-    `TxnID`;
-12. after value-log GC/rewrite is requested while an unapplied collection WAL
+12. after a higher `GlobalTxnID` from another collection publishes before a
+    lower `GlobalTxnID`;
+13. after value-log GC/rewrite is requested while an unapplied collection WAL
     transaction is the only owner of a side ref;
-13. after Raft commit before local collection WAL append once Raft apply exists.
-14. after local collection WAL append before Raft applied-index/idempotency
+14. after a schema/index change is planned while lower `CollectionSeq`
+    transactions are durable but unpublished;
+15. after a drop/recreate under the same collection name;
+16. after a root descriptor generation rewrite attempt with unapplied WAL;
+17. after Raft commit before local collection WAL append once Raft apply exists;
+18. after local collection WAL append before Raft applied-index/idempotency
     metadata advancement once Raft apply exists.
 
 Required assertions:
 
 - no acknowledged WAL-on collection write is lost after process crash;
-- no unacknowledged incomplete transaction is exposed;
+- incomplete/no-marker transactions are not exposed;
+- a committed-before-response transaction may be recovered and is not treated as
+  a normal retryable failure;
+- post-commit ordinary mutation errors are not returned;
 - primary and secondary roots recover together;
+- primary, template/index-state, overlay, delete, and descriptor roots recover
+  with their watermark in the same logical publish;
 - unique indexes reject duplicates after recovery;
 - reads do not need stale in-memory write domains after recovery;
 - roots never reference missing value-log or column-file bytes;
@@ -769,10 +1071,16 @@ Required assertions:
   boundaries.
 - buffered transactions with shared persisted bases replay by accumulation or
   rebasing without losing acknowledged writes;
-- a higher applied `TxnID` never causes recovery to skip a lower unapplied
+- a higher applied `GlobalTxnID` never causes recovery to skip a lower unapplied
   transaction from another collection;
 - value-log GC/rewrite cannot remove or move bytes referenced only by pending
   collection WAL side refs;
+- a missing complete transaction `N` blocks `N+1` for the same collection;
+- drop/recreate with the same collection name does not replay old WAL into the
+  new collection;
+- schema epoch and root generation mismatches block stale transactions;
+- `DB.Checkpoint` either publishes replayable collection WAL or reports debt
+  while preserving side refs;
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
 
@@ -820,14 +1128,16 @@ Traceability matrix:
 | Design area | Sections | Milestones | Required evidence |
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
-| WAL format | 7.2, 7.3 | M1 | golden, fuzz, corrupt-tail tests |
-| Side-file fences | 7.5, 10 | M2 | missing-ref and GC protection tests |
+| WAL format | 7.2, 7.4, 7.5 | M1 | golden, fuzz, corrupt-tail tests |
+| Identity and sequencing | 7.3, 7.6, 9.1 | M1, M5 | collection-seq, epoch, generation tests |
+| System-root template | 7.2, 8.6 | M1, M5 | descriptor-op and watermark atomicity tests |
+| Side-file fences | 7.7, 10 | M2 | missing-ref and GC protection tests |
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
-| Recovery replay | 9 | M4 | crash matrix, rebasing, and deterministic replay tests |
+| Recovery replay | 9 | M4 | crash matrix, accumulation, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
 | Performance | 12 | M6 | benchstat gates and artifacts |
 | Column-store unblock | 6.3, 10 | M7 | side-file fence and root-group recovery proof |
-| Native-wire/Raft layering | 2.4, 6.2, 7.6, 8.7 | M8 | deterministic-entry apply and local-WAL durability tests |
+| Native-wire/Raft layering | 2.4, 6.2, 7.9, 8.8 | M8 | deterministic-entry apply and local-WAL durability tests |
 
 ### Milestone 0: Contract Freeze
 
@@ -855,7 +1165,10 @@ Deliverables:
 - internal transaction structs;
 - encoder/decoder;
 - segment reader/writer;
-- transaction id allocator interface;
+- global transaction id and per-collection sequence allocator interfaces;
+- persisted `CollectionID`, `SchemaEpoch`, and root generation descriptor
+  encoding;
+- `SystemDeltaTemplate` and descriptor-op encoding;
 - exact format documentation in this file.
 
 Tests:
@@ -863,7 +1176,9 @@ Tests:
 - golden files;
 - corrupt checksum;
 - truncated tail;
-- decoder fuzzing.
+- decoder fuzzing;
+- replay digest tests;
+- descriptor-op placeholder instantiation tests.
 
 Gate:
 
@@ -876,12 +1191,16 @@ Deliverables:
 - root-delta batch serialization;
 - inline and side-payload modes;
 - side-ref availability checker;
-- value-log and leaf-log side-ref integration;
-- value-log GC/rewrite protection for unapplied collection WAL side refs.
+- value-log side-ref integration;
+- protected side-ref index updated by WAL append/cleanup and rebuilt during
+  recovery;
+- value-log GC/rewrite protection for unapplied collection WAL side refs;
+- fail-hard recovery behavior for complete transactions with missing required
+  side refs.
 
 Tests:
 
-- missing side refs skip or fail safely;
+- missing side refs fail recovery for complete WAL-on collection transactions;
 - no root can be published with missing side bytes;
 - large delta side-payload round trips;
 - GC/rewrite cannot delete or move bytes referenced only by unapplied
@@ -889,13 +1208,16 @@ Tests:
 
 Gate:
 
-- side-ref fence behavior matches existing RID fence safety or is stricter.
+- collection side-ref fence behavior is stricter than existing RID-fenced cached
+  WAL skip behavior: complete missing-side-ref transactions fail recovery rather
+  than being skipped.
 
 ### Milestone 3: No-Index Collection Integration
 
 Deliverables:
 
 - WAL-on no-index inserts append collection WAL before acknowledgement;
+- final physical primary-root deltas are materialized before the commit marker;
 - pending write-domain visibility remains unchanged;
 - `Flush` publishes WAL-backed no-index deltas and advances watermark.
 
@@ -917,8 +1239,11 @@ Deliverables:
 - update/delete root-group WAL;
 - async flush publish uses existing durable transactions;
 - unique helper rebuild after recovery;
-- replay accumulator or merged-transaction path for multiple buffered
-  transactions that share one persisted root base.
+- replay accumulator for multiple buffered transactions that share one persisted
+  root base;
+- schema/index changes ordered by collection sequence;
+- overlay compaction encoded as a collection WAL maintenance transaction when it
+  can race with user-visible writes.
 
 Tests:
 
@@ -927,7 +1252,10 @@ Tests:
 - unique secondary correctness after recovery;
 - update/delete secondary roots recover atomically;
 - two acknowledged buffered writes against one persisted base both survive
-  crash/reopen.
+  crash/reopen;
+- insert/update/delete chains preserve secondary deletes and puts after
+  recovery;
+- schema epoch and root generation mismatches block stale transactions.
 
 Gate:
 
@@ -940,9 +1268,10 @@ Gate:
 Deliverables:
 
 - applied watermark in system root;
-- per-collection or global-contiguous watermark safety for out-of-order async
-  publishers;
+- per-collection applied sequence watermark plus optional global-contiguous
+  diagnostic watermark;
 - collection WAL replay in open path;
+- collection-specific publish wrapper around ordered-root publish APIs;
 - segment cleanup after safe checkpoint;
 - prepared side-file quarantine/delete.
 
@@ -951,7 +1280,8 @@ Tests:
 - crash after root page build or watermark commit before cleanup does not
   double-apply;
 - out-of-order async publish cannot advance a watermark that hides a lower
-  unapplied transaction;
+  unapplied collection sequence;
+- descriptor update and watermark update cannot split across commits;
 - older segments remain when watermark is not durable;
 - cleanup removes only fully applied segments;
 - prepared side files without committed transactions do not become visible.
@@ -965,12 +1295,14 @@ Gate:
 Deliverables:
 
 - `DB.Checkpoint` coordinates with collection WAL;
+- checkpoint hook registry analogous to close hooks;
 - `CollectionManager.FlushAll` and close hooks use the same publish path;
 - API docs distinguish process-crash recovery from fsync durability.
 
 Tests:
 
-- checkpoint drains or checkpoints collection WAL according to the chosen rule;
+- checkpoint forces publication of replayable collection WAL in PR1 or reports
+  nonzero collection WAL debt in future modes;
 - close with in-flight async publish is recoverable;
 - WAL-off mode preserves its relaxed contract.
 
@@ -1041,11 +1373,14 @@ Gate:
 | Risk | Mitigation |
 |---|---|
 | Root-delta WAL duplicates data already in memtables. | Start with simple encoding, then move large deltas to side payloads when benchmarks require it. |
-| Replaying old transactions double-applies after crash. | Store applied watermark in the same system-root commit as root descriptor updates. |
-| Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass. |
-| Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots until safe applied watermark and checkpoint cleanup. |
-| A global applied watermark skips lower unapplied transactions. | Enforce contiguous global publication or use per-collection watermarks plus a global contiguous watermark. |
-| Buffered transactions share an old persisted `BaseRootID`. | Log merged flush units, make later transactions depend on earlier pending deltas, or rebase/accumulate deltas during recovery. |
+| Replaying old transactions double-applies after crash. | Store applied collection-sequence watermark in the same system-root commit as root descriptor updates. |
+| Recovery cannot reconstruct descriptor or watermark updates. | Persist `SystemDeltaTemplate` with descriptor ops, preconditions, root-id placeholders, and watermark op in the WAL transaction. |
+| Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass; fail recovery on missing side refs for complete WAL-on transactions. |
+| Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots through a protected side-ref index until safe applied watermark and checkpoint cleanup. |
+| A global applied watermark skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep global watermarks optional and contiguous only. |
+| Buffered transactions share an old persisted `BaseRootID`. | Use per-collection dependency chains plus replay-side accumulation in PR1. |
+| A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionID`, `SchemaEpoch`, and per-root `RootGeneration` guards and block mismatches. |
+| API returns a normal error after the WAL commit marker. | Reserve fallible state before commit; after commit marker, allow only success, process death, or commit-ambiguous/fatal reporting. |
 | Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
 | Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
 | WAL-on throughput regresses too much. | Benchmark each milestone, use side payloads, batching, and async publish before relaxing durability. |
@@ -1054,34 +1389,43 @@ Gate:
 | A node reports a Raft entry applied before its local collection mutation is recoverable. | Tie applied-index/idempotency metadata to local collection WAL durability or replay unapplied committed entries from Raft before serving. |
 | Native-wire acknowledgement policy leaks into recovered logical state. | Treat acknowledgement policy as response/local durability control unless a future deterministic command version explicitly makes it logical state. |
 
-## 15. Open Questions
+## 15. Closed PR1 Decisions and Future Questions
 
-1. Should collection WAL share the existing commit-log segment writer with a new
-   record kind, or use a separate `collection-l<lane>-<seq>.log` file class?
-2. Should the first transaction id be global or per collection?
-3. Should `Collection.Flush` gain a sync variant, or should callers use
+PR1 closes the correctness-critical questions that block implementation:
+
+1. Collection WAL uses a dedicated logical file class. It may reuse commit-log
+   framing utilities, but it has separate record kinds, commit-marker semantics,
+   replay rules, and side-ref behavior.
+2. Transactions use both `GlobalTxnID` and per-collection `CollectionSeq`.
+   `GlobalTxnID` is identity/diagnostics; `CollectionSeq` is the replay and
+   skip key.
+3. Complete WAL-on collection transactions with missing required side refs fail
+   recovery. They are not skipped like current RID-fenced cached WAL batches.
+4. PR1 uses replay-side accumulation for buffered writes that share a persisted
+   base root.
+5. PR1 uses a protected side-ref index, rebuilt from WAL during recovery, for
+   GC/rewrite safety.
+6. PR1 `DB.Checkpoint` calls collection checkpoint hooks and forces publication
+   of replayable collection WAL before reporting a clean collection WAL state.
+7. Overlay compaction that can race with user-visible collection writes is
+   encoded as a collection WAL maintenance transaction.
+
+Future questions that do not weaken PR1 correctness:
+
+1. Should `Collection.Flush` gain a sync variant, or should callers use
    `DB.Checkpoint` for fsync-style barriers?
-4. Should recovery skip missing side-ref transactions like existing RID fences,
-   or fail hard in durable mode?
-5. How large can inline root deltas be before side-payload mode becomes
+2. How large can inline root deltas be before side-payload mode becomes
    mandatory?
-6. Can overlay compaction use ordinary backend commit durability, or should it
-   also be encoded in collection WAL for uniform recovery?
-7. Should `DB.Checkpoint` always call `CollectionManager.FlushAll`, or can it
-   checkpoint collection WAL without forcing root publication?
-8. What metric names should expose pending collection WAL bytes, applied
-   watermark lag, replay count, skipped/fenced transactions, and cleanup debt?
-9. Should PR1 use merged flush-unit WAL records or replay-side accumulation for
-   buffered writes that share one persisted base root?
-10. Should side-ref GC protection scan collection WAL segments directly or
-    maintain a separate protected side-ref index?
-11. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
+3. What metric names should expose pending collection WAL bytes, applied
+   collection-sequence lag, replay count, fenced transactions, protected side
+   refs, and cleanup debt?
+4. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
-12. Should native-wire `ack_policy` remain purely transport/local durability
-    control for deterministic entries, or should a future command version define
-    an explicit logical barrier flag? This must be resolved before
-    `raft_committed` writes are exposed.
+5. Should native-wire `ack_policy` remain purely transport/local durability
+   control for deterministic entries, or should a future command version define
+   an explicit logical barrier flag? This must be resolved before
+   `raft_committed` writes are exposed.
 
 ## 16. Implementation Notes
 
@@ -1102,3 +1446,29 @@ Gate:
 - Update `collections-write-domain.md`, `write-path-and-durability.md`,
   `recovery.md`, `verification.md`, `native-wire-protocol.md`, and
   `native-query-raft-roadmap.md` as implementation milestones land.
+
+Module-specific constraints:
+
+- `TreeDB/internal/collectionwal` or equivalent owns versioned framing, commit
+  markers, `GlobalTxnID`, per-collection sequence allocation, side-ref
+  verification, protected side-ref index rebuild, and segment cleanup after the
+  durable applied watermark/checkpoint boundary.
+- `TreeDB/collections` owns final physical delta planning before
+  acknowledgement. WAL-on collection planners must serialize primary,
+  template/index-state, secondary, overlay, delete, schema, and future
+  column-store descriptor deltas before the commit marker and must stage the
+  same immutable deltas for visibility.
+- `TreeDB/db` owns a collection-specific publish wrapper around ordered-root
+  executors. The wrapper validates identity/generation/dependency guards,
+  materializes root deltas, instantiates `SystemDeltaTemplate`, publishes
+  descriptors and watermark atomically, and honors explicit sync options.
+- `TreeDB/caching` and checkpoint code must track collection WAL debt. Automatic
+  checkpoint and close paths must not report clean WAL state or prune required
+  bytes while collection WAL transactions remain needed for recovery.
+- `TreeDB/internal/valuelog` and future column-file maintenance must consult the
+  protected side-ref index. PR1 rewrite refuses protected refs rather than
+  moving them and patching WAL records.
+- Column-store implementation may not publish persistent column parts until
+  part files, descriptor deltas, primary locator deltas, delete bitmap roots,
+  secondary roots, filter roots, and schema roots can be committed as one
+  collection WAL transaction.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1372,6 +1372,12 @@ If async publish fails, in-memory units can be requeued as they are today. The
 collection WAL transaction remains the recovery source until a successful
 publish advances the watermark.
 
+Async publish failure is not an unbounded admission license. Every acknowledged
+collection WAL transaction continues to count against pending WAL bytes,
+root-delta side-payload bytes, protected side-ref logical bytes, retained
+segment debt, unpublished root-delta entries, and oldest-unapplied age until
+publish, checkpoint, and cleanup release those charges under Section 10.1.
+
 Every queued or publishing flush unit must carry the collection WAL coverage it
 covers:
 
@@ -1729,6 +1735,15 @@ For each root, the accumulator records:
 - the merged ordered delta entries in transaction order;
 - whether cold-build tombstones must be preserved.
 
+Recovery-side accumulation is bounded resource state, not a best-effort heap.
+Before admitting another transaction into an accumulator, recovery must project
+accumulator bytes, decoded entries, and root-group transaction fan-in against the
+Section 10.1 replay limits. At the soft cap, recovery must publish a bounded
+chunk or spill deterministic sorted chunks to temporary replay side payloads. At
+the hard cap, recovery must stop before serving collection APIs with
+`ErrCollectionWALRecoveryCapacityExceeded` unless a chunk/spill path has already
+reduced the projected charge.
+
 The PR1 fold order is `(CollectionSeq, RootDeltaOrdinal, EntryOrdinal)`.
 `CollectionSeq` is the transaction order key; if a future record also exposes a
 diagnostic `TxnID`, it must not replace `CollectionSeq` for same-collection
@@ -1778,7 +1793,7 @@ and future column-store delta-part descriptor updates.
 | Root pages are built but backend meta commit fails | Built pages are unreachable. WAL transaction remains source of truth. |
 | Descriptor update succeeds without watermark | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
 | Watermark update succeeds without descriptor update | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
-| Cleanup fails after watermark/checkpoint | Safe leak. Retry cleanup later. |
+| Cleanup fails after watermark/checkpoint | Safe leak only while cleanup debt remains below the Section 10.1 stop and hard limits. Retry cleanup later and charge the retained bytes. |
 | WAL segment unlink/rename fails during cleanup | Cleanup remains retryable. Startup accepts missing segments only with durable cleanup metadata. |
 | GC/rewrite wants a side ref protected by unapplied WAL | Must keep it in place or abort maintenance. Rewrite requires an explicit crash-tested WAL metadata protocol. |
 
@@ -1878,6 +1893,393 @@ and include collection WAL side refs in value-log and side-file reachability
 before any prune, rewrite, or deletion. If a future checkpoint mode leaves
 replayable collection WAL unpublished, it must report collection WAL debt and
 preserve all side-ref protections; it is not a clean collection-WAL boundary.
+
+### 10.1 Collection WAL Resource Accounting and Admission
+
+Collection WAL durable-at-ack is enabled only when the implementation enforces a
+capacity model for write admission, replay, cleanup, and maintenance. These
+limits are part of the durability contract: an implementation must reject or
+block before acknowledgement rather than accept writes that can create
+unbounded WAL, side-ref, root-delta, replay, or cleanup debt.
+
+#### WAL bytes per document
+
+Definitions:
+
+| Symbol | Meaning |
+|---|---|
+| `N` | Documents in the transaction or measured batch. |
+| `I` | Secondary indexes whose entries are written for a document. |
+| `C` | Secondary indexes whose extracted value changes on update. |
+| `T` | Template or index-state root entries emitted for a document. |
+| `D` | Delete-root or overlay tombstone entries emitted for a document. |
+| `Kp`, `Vp` | Encoded primary key bytes and encoded primary value bytes. |
+| `Ksi[j]`, `Vsi[j]` | Encoded secondary-index key/value bytes for index `j`. |
+| `Htxn` | Encoded transaction and frame metadata bytes. |
+| `Hroot[r]` | Encoded metadata bytes for root delta `r`, excluding payload. |
+| `Href[s]` | Encoded metadata bytes for side ref `s`, excluding referenced file bytes. |
+| `Binline` | Sum of inline root-delta payload bytes. |
+| `BrootSide` | Root-delta side-payload file bytes. |
+| `BsideLogical` | Logical side-ref payload bytes, including value-log records, root-delta payloads, and column files. |
+| `BsideRetained` | Incremental retained segment/file bytes caused by protected side refs. |
+
+Entry encoding must be measured by the actual encoder. The estimator must use
+the same primitive model as the encoder:
+
+```text
+put_entry_bytes(key, value) =
+    1
+  + uvarint_len(len(key)) + len(key)
+  + uvarint_len(len(value)) + len(value)
+  + uvarint_len(entry_ordinal_delta)
+  + entry_flags_bytes
+
+delete_entry_bytes(key) =
+    1
+  + uvarint_len(len(key)) + len(key)
+  + uvarint_len(entry_ordinal_delta)
+  + entry_flags_bytes
+```
+
+Then:
+
+```text
+root_delta_payload_bytes =
+  sum(put_entry_bytes(key, value))
++ sum(delete_entry_bytes(key))
+
+collection_wal_bytes =
+  Htxn
++ sum(Hroot[r])
++ Binline
++ sum(Href[s])
+
+collection_wal_bytes_per_doc =
+  collection_wal_bytes / N
+
+side_ref_metadata_bytes_per_doc =
+  sum(Href[s]) / N
+
+side_ref_payload_bytes_per_doc =
+  BsideLogical / N
+
+retained_side_ref_debt_bytes_per_doc =
+  BsideRetained / N
+
+unpublished_disk_debt_bytes_per_doc =
+  collection_wal_bytes_per_doc
++ root_delta_side_payload_bytes_per_doc
++ side_ref_payload_bytes_per_doc
++ retained_side_ref_debt_bytes_per_doc
+
+collection_wal_byte_amplification =
+  collection_wal_bytes_per_doc / avg_logical_document_bytes
+
+unpublished_disk_debt_amplification =
+  unpublished_disk_debt_bytes_per_doc / avg_logical_document_bytes
+```
+
+Expected root-delta entries per document:
+
+| Workload | Root-delta entries/doc | WAL value bytes | Side-ref bytes/doc |
+|---|---:|---|---|
+| No-index insert | `1 + T` | Primary value inline or stable `ValuePtr` encoding. | `0` when primary value is inline; value-log record bytes when pointer-backed. |
+| One-index insert | `2 + T` | Primary put plus one secondary-index put. | Same as no-index, plus any side refs required by index storage. |
+| Multi-index insert | `1 + I + T` | Primary put plus one secondary put per index. | Same as no-index, plus any side refs required by index storage. |
+| Update, indexed values unchanged | `1 + T` | Primary put only; no secondary delete/put. | New value-log side ref when pointer-backed update writes a new value. |
+| Update, indexed values changed | `1 + 2C + T` | Primary put, old secondary delete, and new secondary put for each changed index. | New value-log side ref when pointer-backed. |
+| Delete | `1 + I + D` | Primary delete/tombstone plus secondary deletes and optional overlay/delete-root tombstone. | No new document side ref; protected old refs remain until cleanup proves unreachable. |
+| Template-v1 insert/update | Above plus `Ttemplate` | Primary value is template-v1 encoded; new or changed template descriptors are root-delta entries. | Template descriptor side refs only when descriptor payload is external. |
+| Future column-store publish | Descriptor/root entries, not full column bytes. | Row locator, part descriptor, delete bitmap, secondary deltas. | Column part files, dictionaries, bloom files, compression metadata, and manifests. |
+
+For pointer-backed document values, value-log debt includes value-log frame
+overhead. With current value-log constants, a single uncompressed value-log
+record is approximately:
+
+```text
+single_vlog_record_bytes = document_value_bytes + 48
+```
+
+For grouped uncompressed frames of `K` records:
+
+```text
+grouped_vlog_record_bytes_per_doc =
+  document_value_bytes + 12 + (36 / K)
+```
+
+Those bytes are side-ref payload debt when the value-log record is required for
+collection WAL recovery.
+
+#### Side-ref debt
+
+Every side ref is charged as metadata, logical payload, and retained segment
+debt:
+
+```text
+side_ref_logical_charge =
+  referenced_payload_bytes
++ encoded_side_ref_metadata_bytes
+
+side_ref_retained_segment_charge =
+  incremental bytes of any value-log, root-delta-payload, or column-file
+  segment that cannot be deleted because this ref is protected
+
+protected_side_ref_charge =
+  side_ref_logical_charge
++ side_ref_retained_segment_charge
+```
+
+For value-log segments, `side_ref_retained_segment_charge` is the incremental
+retained segment bytes if the protected ref prevents deletion of an otherwise
+collectible segment. A tiny protected ref that pins a large segment is charged by
+the segment debt, not only by the referenced byte range.
+
+#### Replay memory bound
+
+Recovery must estimate:
+
+```text
+estimated_replay_accumulator_bytes =
+  accumulator_struct_overhead
++ sum(encoded_or_decoded_entry_bytes)
++ sum(key_bytes_retained)
++ sum(value_or_pointer_bytes_retained)
++ tombstone_bytes
++ per_root_group_overhead
++ per_txn_range_overhead
+```
+
+Recovery must enforce:
+
+```text
+estimated_replay_accumulator_bytes <= CollectionWAL.MaxReplayAccumulatorBytes
+```
+
+If projected accumulator state exceeds the soft limit, recovery must publish a
+bounded chunk or spill deterministic sorted chunks to temporary replay side
+payloads. If projected state would exceed the hard limit and no spill/publish
+path is available, recovery stops before serving collection APIs with
+`ErrCollectionWALRecoveryCapacityExceeded`.
+
+| Limit | Default | Behavior |
+|---|---:|---|
+| `CollectionWAL.ReplayAccumulatorSoftBytes` | 128 MiB | Adaptive chunk publish or spill trigger. |
+| `CollectionWAL.ReplayAccumulatorHardBytes` | 512 MiB | Hard recovery cap before serving APIs. |
+| `CollectionWAL.ReplayAccumulatorMaxEntries` | 2,000,000 | Hard cap unless spilling is active. |
+| `CollectionWAL.ReplayRootGroupMaxTxns` | 250,000 | Adaptive chunk publish trigger; hard cap without spill. |
+
+#### Replay time bound
+
+Recovery must expose the estimate:
+
+```text
+estimated_replay_seconds =
+    pending_collection_wal_bytes / measured_wal_scan_bytes_per_sec
+  + root_delta_entries / measured_replay_entries_per_sec
+  + side_ref_count / measured_side_ref_validation_refs_per_sec
+  + root_publish_count * measured_root_publish_seconds
+```
+
+Replay time is a benchmark gate and warning metric. Replay memory is an enforced
+hard cap.
+
+| Pending docs | No-index recovery gate | Indexed recovery gate | Peak heap gate |
+|---:|---:|---:|---:|
+| 1K | <= 1 s | <= 2 s | <= 128 MiB |
+| 100K | >= 50K docs/s and <= 5 s | >= 20K docs/s and <= 10 s | <= 256 MiB |
+| 1M | >= 50K docs/s and <= 20 s | >= 20K docs/s and <= 50 s | <= 512 MiB |
+| >1M | Must publish/spill in bounded chunks. | Must publish/spill in bounded chunks. | <= configured hard cap |
+
+#### Cleanup debt bound
+
+Cleanup debt is:
+
+```text
+cleanup_debt_bytes =
+  pending_collection_wal_segment_bytes
++ cleanable_but_unremoved_collection_wal_segment_bytes
++ pending_root_delta_side_payload_bytes
++ protected_side_ref_logical_bytes
++ protected_side_ref_retained_segment_bytes
++ protected_column_file_bytes
+```
+
+| Limit | Default | Behavior |
+|---|---:|---|
+| `CollectionWAL.CleanupDebtSoftBytes` | 256 MiB | Adaptive cleanup trigger. |
+| `CollectionWAL.CleanupDebtStopBytes` | 1 GiB | Block collection writes until below resume watermark. |
+| `CollectionWAL.CleanupDebtHardBytes` | 2 GiB | Hard error for new collection writes before ack. |
+| Cleanable segment age warning | 2 checkpoint intervals or 60 s | Metric warning and diagnostic event. |
+| Protected side-ref max age | 5 min | Blocking wait unless a live read view is the only blocker. |
+| Protected side-ref hard age | 30 min | Hard error for new writes; existing refs remain protected. |
+
+Cleanup failure is a safe leak only while the cleanup debt budget permits it.
+When cleanup debt reaches stop or hard limits, new collection writes block or
+fail before acknowledgement.
+
+#### Admission charge and backpressure
+
+Every collection write must reserve projected capacity before the WAL commit
+marker can be acknowledged:
+
+```text
+projected_debt =
+  pending_collection_wal_bytes
++ pending_root_delta_side_payload_bytes
++ protected_side_ref_logical_bytes
++ protected_side_ref_retained_segment_bytes
++ cleanable_but_unremoved_collection_wal_bytes
++ unpublished_root_delta_estimated_bytes
+```
+
+Admission behavior:
+
+```text
+if projected_debt >= hard_limit:
+    reject before ack with ErrCollectionWALCapacityExceeded
+
+else if projected_debt >= stop_limit:
+    block until projected_debt <= resume_limit or context deadline/DB close
+    if deadline:
+        return ErrCollectionWALBackpressure
+
+else if projected_debt >= soft_limit:
+    trigger async publish, checkpoint, cleanup, and optional writer flush assist
+    continue admitting writes
+```
+
+The default resume watermark is:
+
+```text
+resume_limit = stop_limit * 0.70
+```
+
+| Condition | Behavior |
+|---|---|
+| Debt crosses soft limit | Continue writes; trigger publish, checkpoint, and cleanup. |
+| Debt crosses stop limit | Block new collection writes until debt is at or below 70 percent of stop limit. |
+| Caller context expires while blocked | Return `ErrCollectionWALBackpressure`. |
+| DB is closing while blocked | Return close/shutdown error; do not ack. |
+| Debt crosses hard limit | Return `ErrCollectionWALCapacityExceeded` before ack. |
+| Cleanup failure | Preserve files, keep protections, charge debt, and continue only until stop/hard limit. |
+| Async publish failure | Preserve WAL and side refs, charge debt, retry, and block writes at stop limit. |
+| Live read view pins protected refs | Charge retained bytes and block new writes at stop limit rather than deleting pinned refs. |
+
+#### Inline, side-payload, and transaction thresholds
+
+| Limit | Default | Behavior |
+|---|---:|---|
+| `CollectionWAL.MaxInlineRootDeltaBytes` | 64 KiB | Spill this root delta to root-delta side payload. |
+| `CollectionWAL.MaxInlineTxnBytes` | 256 KiB | Spill root deltas until inline payload is below the limit. |
+| `CollectionWAL.MaxEncodedTxnBytes` | 1 MiB | Hard error before ack after spill attempts. |
+| `CollectionWAL.MaxRootDeltaSidePayloadBytes` | 16 MiB | Hard error before ack; caller must split batch. |
+| `CollectionWAL.MaxTxnDecodedEntries` | 100,000 | Hard error before ack; recovery rejects/quarantines corrupt oversize WAL. |
+| `CollectionWAL.MaxRootDeltasPerTxn` | 256 | Hard error before ack; caller must split batch. |
+
+#### Segment, compression, rotation, and sync batching
+
+| Limit | Default | Behavior |
+|---|---:|---|
+| `CollectionWAL.SegmentBytes` | 64 MiB | Rotate before appending a frame that would exceed the segment size. |
+| `CollectionWAL.WriterBufferBytes` | 4 MiB | Flush when full; not a durability boundary by itself. |
+| Max WAL frame bytes | 1 MiB inline metadata; side payload external | Hard error before ack when exceeded. |
+| `CollectionWAL.CompressionMinBytes` | 64 KiB payload | Compression attempted only above threshold. |
+| Compression keep rule | compressed bytes plus metadata < raw bytes | Otherwise store uncompressed. |
+| `DurableSync.MaxBatchDelay` | 1 ms | Group fsync trigger. |
+| `DurableSync.MaxBatchBytes` | 4 MiB | Group fsync trigger. |
+| `DurableSync.MaxBatchTxns` | 4096 | Group fsync trigger. |
+| Rotation on checkpoint | required for a clean checkpoint boundary | Rotate and sync segment metadata. |
+| Rotation after large transaction | required when one transaction exceeds 25 percent of segment size | Avoid pinning unrelated short-lived debt. |
+
+Group commit and write coalescing are allowed only when per-write visibility
+fences are preserved. Durable sync mode may group fsyncs up to the delay, byte,
+or transaction cap above; WAL-on relaxed mode still must make required side refs
+and WAL frames fresh-process-readable before acknowledgement.
+
+#### Mode-specific gates
+
+| Mode | Capacity caps | Sync behavior | Required benchmark gates |
+|---|---|---|---|
+| WAL-on relaxed | Same byte, memory, and debt caps as durable mode. | WAL frame and required side refs must be recoverable to a fresh-process boundary; no per-write fsync unless checkpoint/sync barrier. | WAL bytes/doc, pending debt, replay time, recovery heap, cleanup debt. |
+| Durable sync | Same byte, memory, and debt caps as WAL-on relaxed. | Required side refs and WAL frame must be fsynced or covered by group fsync before ack. | All WAL-on gates plus p50/p95/p99 ack latency and fsync batch efficiency. |
+| WAL-off relaxed | No collection WAL durable-at-ack claim. | Existing relaxed behavior only. | Must not emit collection WAL recovery claims for unflushed writes. |
+
+#### Column-store capacity gates
+
+Persistent column-store roots remain blocked until the capacity table below is
+enforced and the benchmark artifacts prove bounded memory, file count, and
+replay time.
+
+| Limit | Default | Behavior |
+|---|---:|---|
+| `ColumnWAL.MaxFilesPerPart` | 1024 | Hard error before persistent root publish. |
+| `ColumnWAL.MaxSideRefsPerTxn` | 100,000 | Hard error before ack. |
+| `ColumnWAL.MaxManifestBytesPerPart` | 4 MiB | Hard error before persistent root publish. |
+| `ColumnWAL.MaxSideRefMetadataBytesPerRow` | formula plus 10 percent | Benchmark and admission gate. |
+| `ColumnWAL.MaxSideRefValidationPeakHeapBytes` | 512 MiB unless configured lower | Hard validation cap before serving. |
+
+#### Error names and default configuration
+
+Required capacity errors:
+
+| Error | When |
+|---|---|
+| `ErrCollectionWALCapacityExceeded` | Hard capacity limit would be exceeded before ack. |
+| `ErrCollectionWALBackpressure` | Stop limit reached and caller context deadline/cancel occurs before resume. |
+| `ErrCollectionWALOversizedTransaction` | Transaction still exceeds encoded or entry limits after side-payload spill. |
+| `ErrCollectionWALRecoveryCapacityExceeded` | Recovery cannot replay within memory cap and no spill/chunk path is available. |
+| `ErrCollectionWALMissingRequiredSideRef` | Required side ref is missing/corrupt during append validation or recovery. |
+| `ErrColumnWALCapacityExceeded` | Column side-ref, file-count, or manifest limits exceeded before persistent root publish. |
+
+Default configuration:
+
+```text
+CollectionWAL.MaxInlineRootDeltaBytes              = 64 KiB
+CollectionWAL.MaxInlineTxnBytes                    = 256 KiB
+CollectionWAL.MaxEncodedTxnBytes                   = 1 MiB
+CollectionWAL.MaxRootDeltaSidePayloadBytes         = 16 MiB
+CollectionWAL.MaxTxnDecodedEntries                 = 100_000
+CollectionWAL.MaxRootDeltasPerTxn                  = 256
+
+CollectionWAL.SegmentBytes                         = 64 MiB
+CollectionWAL.WriterBufferBytes                    = 4 MiB
+CollectionWAL.CompressionMinBytes                  = 64 KiB
+
+CollectionWAL.PendingDebtSoftBytes                 = 256 MiB
+CollectionWAL.PendingDebtStopBytes                 = 1 GiB
+CollectionWAL.PendingDebtHardBytes                 = 2 GiB
+CollectionWAL.ResumeFraction                       = 0.70
+
+CollectionWAL.ProtectedSideRefSoftBytes            = 512 MiB
+CollectionWAL.ProtectedSideRefStopBytes            = 2 GiB
+CollectionWAL.ProtectedSideRefHardBytes            = 4 GiB
+CollectionWAL.MaxProtectedSideFileCount            = 1_000_000
+
+CollectionWAL.CleanupDebtSoftBytes                 = 256 MiB
+CollectionWAL.CleanupDebtStopBytes                 = 1 GiB
+CollectionWAL.CleanupDebtHardBytes                 = 2 GiB
+
+CollectionWAL.UnpublishedRootDeltaEntriesSoft      = 100_000
+CollectionWAL.UnpublishedRootDeltaEntriesStop      = 500_000
+CollectionWAL.UnpublishedRootDeltaEntriesHard      = 1_000_000
+
+CollectionWAL.OldestUnappliedAgeSoft               = 30 s
+CollectionWAL.OldestUnappliedAgeStop               = 5 min
+
+CollectionWAL.ReplayAccumulatorSoftBytes           = 128 MiB
+CollectionWAL.ReplayAccumulatorHardBytes           = 512 MiB
+CollectionWAL.ReplayAccumulatorMaxEntries          = 2_000_000
+CollectionWAL.ReplayRootGroupMaxTxns               = 250_000
+
+DurableSync.MaxBatchDelay                          = 1 ms
+DurableSync.MaxBatchBytes                          = 4 MiB
+DurableSync.MaxBatchTxns                           = 4096
+
+ColumnWAL.MaxFilesPerPart                          = 1024
+ColumnWAL.MaxSideRefsPerTxn                        = 100_000
+ColumnWAL.MaxManifestBytesPerPart                  = 4 MiB
+ColumnWAL.MaxSideRefMetadataBytesPerRow            = formula + 10 percent
+```
 
 ## 11. Test Plan
 
@@ -2112,6 +2514,14 @@ acceptance artifacts can point to stable evidence.
 | `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied` | Two collections; force higher `WALLSN` publish/watermark before a lower `WALLSN`; crash/reopen. | Per-collection watermark logic cannot skip lower unapplied transactions. |
 | `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent` | Fault hook exits during recovery after N transactions, after watermark commit, and during segment cleanup; reopen repeatedly. | No double-apply, no lost writes, cleanup eventually converges. |
 | `TestCollectionWALGCRewriteCompactionSnapshotsProtectPendingSideRefs` | Create pending WAL transaction whose side ref has no published root owner; pin snapshot/read view; run GC/rewrite/compaction; crash/reopen. | Side refs are protected until watermark plus checkpoint handoff, and snapshots do not observe dangling roots. |
+| `TestCollectionWALPendingDebtSoftStopHardLimits` | Block async publish/checkpoint/cleanup and keep admitting collection writes until each configured debt threshold is crossed. | Soft threshold triggers maintenance, stop threshold blocks, hard threshold rejects before ack. |
+| `TestCollectionWALBackpressureResumeWatermark` | Fill pending debt past stop, release publish/checkpoint/cleanup, then retry blocked writes. | Writes resume only after debt drops to or below 70 percent of the stop limit. |
+| `TestCollectionWALReplayAccumulatorSoftCapChunksOrSpills` | Recover many same-base-root transactions with distinct keys until the soft accumulator cap is reached. | Recovery chunk-publishes or spills deterministically without changing final roots. |
+| `TestCollectionWALReplayAccumulatorHardCapStopsRecovery` | Disable spill/chunk support and recover a backlog projected above the hard cap. | Recovery fails closed before serving APIs with the capacity error. |
+| `TestCollectionWALProtectedSideRefRetainedSegmentDebt` | Protect a tiny value-log side ref that pins an otherwise collectible large segment. | Admission and GC metrics charge retained segment debt, not only logical ref bytes. |
+| `TestCollectionWALSegmentRotationAndCheckpointRotation` | Append frames across the segment limit and force checkpoint boundaries. | Writer rotates at configured limits and checkpoint rotation prevents unrelated long-lived debt from pinning short-lived segments. |
+| `TestCollectionWALDurableSyncBatchCaps` | Run concurrent durable-sync writers. | Group fsync batches respect max delay, byte, and transaction caps while preserving ack semantics. |
+| `TestColumnWALSideRefCapacityLimits` | Plan column side refs beyond file, manifest, and side-ref-per-transaction limits. | Persistent column roots remain blocked and fail before ack/publish. |
 
 ### 11.7 Required Fault Points
 
@@ -2176,7 +2586,7 @@ do
 
   go test ./TreeDB/collections \
     -run '^$' \
-    -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALThreeIndexInsertBatch|BenchmarkCollectionWALUpdateBatchUnchangedIndexedValues|BenchmarkCollectionWALUpdateBatchChangedIndexedValues|BenchmarkCollectionWALDeleteHeavy|BenchmarkCollectionWALAsyncIndexedFlushStalled|BenchmarkCollectionWALFlushPending)$' \
+    -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALThreeIndexInsertBatch|BenchmarkCollectionWALUpdateBatchUnchangedIndexedValues|BenchmarkCollectionWALUpdateBatchChangedIndexedValues|BenchmarkCollectionWALDeleteHeavy|BenchmarkCollectionWALTemplateV1InsertBatch|BenchmarkCollectionWALAsyncIndexedFlushStalled|BenchmarkCollectionWALCleanupLag|BenchmarkCollectionWALFlushPending)$' \
     -benchmem -count=10 \
     > "artifacts/collection-wal/bench-${1}-${2}.txt"
 done
@@ -2201,7 +2611,7 @@ TREEDB_COLLECTION_BENCH_ENGINE=durable \
 TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 \
 go test ./TreeDB/collections \
   -run '^$' \
-  -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALFlushPending)$' \
+  -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALDurableSyncBatch|BenchmarkCollectionWALFlushPending)$' \
   -benchmem -count=5 \
   > artifacts/collection-wal/durable-smoke.txt
 ```
@@ -2223,6 +2633,35 @@ ratio, fsync count when applicable, and side-ref verification time. Inline
 thresholds, side-payload thresholds, and compression defaults are not eligible
 for stronger-default status until these artifacts exist.
 
+Required benchmark/report tools:
+
+- `cmd/collection_workload_bench` runs phase-isolated collection workloads with
+  null-WAL, WAL-on relaxed, and durable-sync modes.
+- `cmd/collection_bench_matrix` expands the storage-policy, document-format,
+  mutation-class, durability-mode, batch-size, and side-ref-class matrix.
+- `cmd/collection_bench_report` reads raw benchmark output plus collection WAL
+  stats snapshots and emits the required JSON/CSV columns below.
+- `cmd/unified_bench` must accept a collection WAL suite or delegate to the
+  collection benchmark commands instead of silently omitting collection WAL
+  resource gates.
+
+Required column-store side-ref benchmark command before persistent column roots:
+
+```bash
+TREEDB_COLLECTION_BENCH_ENGINE=wal_on_fast \
+TREEDB_COLUMN_WAL_SIDE_REFS=1000,100000,1000000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnStoreWALSideRefClosure$' \
+  -benchmem -benchtime=1x -count=5 \
+  > artifacts/collection-wal/column-side-ref-closure.txt
+```
+
+Collection WAL workload benchmarks must isolate phase costs with a null-WAL
+baseline, a WAL-on relaxed run, and a durable-sync run. Required phases are
+planning, side-ref prepare, value-log flush/sync, collection WAL encode, append,
+sync, visible install, async publish, checkpoint, cleanup, and recovery.
+
 Every benchmark row must report these metrics when the harness can measure them:
 
 | Metric | Purpose |
@@ -2242,6 +2681,86 @@ Every benchmark row must report these metrics when the harness can measure them:
 | `cleanup_ns/segment` | Segment cleanup cost. |
 | `allocs/doc`, `bytes_allocated/doc` | Heap regression. |
 
+Every JSON/CSV row emitted by the collection benchmark report must include these
+labels when applicable:
+
+```text
+bench_label
+durability_mode
+storage_cell
+document_format
+mutation_class
+docs
+indexes
+batch_size
+doc_bytes_avg
+primary_key_bytes/doc
+primary_value_bytes/doc
+secondary_key_bytes/doc
+secondary_value_bytes/doc
+secondary_entries/doc
+root_deltas/txn
+root_delta_entries/doc
+root_delta_payload_bytes/doc
+collection_wal_frame_bytes/doc
+collection_wal_metadata_bytes/doc
+collection_wal_bytes/doc
+collection_wal_compressed_bytes/doc
+root_delta_side_payload_bytes/doc
+side_ref_metadata_bytes/doc
+side_ref_payload_bytes/doc
+protected_side_ref_bytes
+protected_side_ref_retained_segment_bytes
+pending_collection_wal_bytes
+pending_root_delta_side_payload_bytes
+cleanable_collection_wal_bytes
+cleanup_debt_bytes
+applied_watermark_lag_txns
+oldest_unapplied_age_ms
+ack_ns_p50
+ack_ns_p95
+ack_ns_p99
+collection_wal_encode_ns/doc
+collection_wal_append_ns/doc
+side_ref_prepare_ns/doc
+visible_install_ns/doc
+publish_ns/doc
+checkpoint_wait_ns
+sync_batch_txns
+sync_batch_bytes
+fsyncs/sec
+recovery_docs/sec
+recovery_root_delta_entries/sec
+recovery_scan_MB/sec
+recovery_side_refs/sec
+recovery_peak_heap_bytes
+recovery_peak_rss_bytes
+replay_accumulator_peak_bytes
+replay_spill_bytes
+cleanup_ns/segment
+cleanup_bytes/sec
+blocked_writes
+backpressure_wait_ns_p99
+errors
+```
+
+Required workload-specific benchmark gates:
+
+| Benchmark | Workload | Gate |
+|---|---|---|
+| `BenchmarkCollectionWALNoIndexInsertBatch` | Batched no-index inserts across JSON, BSON, template-v1, inline values, pointer-backed values, WAL-on relaxed, and durable sync. | Entries/doc = `1 + T`; WAL bytes/doc <= formula plus 10 percent; p99 ack latency below selected absolute limit; no debt over soft limit. |
+| `BenchmarkCollectionWALOneUniqueIndexInsertBatch` | Insert with one unique secondary index. | Entries/doc = `2 + T`; WAL bytes/doc <= formula plus 10 percent. |
+| `BenchmarkCollectionWALThreeIndexInsertBatch` | Insert with unique, nonunique, and multikey secondary indexes when supported. | Entries/doc = `1 + I + T`; WAL bytes/doc <= formula plus 10 percent; p99 ack latency below selected absolute limit. |
+| `BenchmarkCollectionWALUpdateBatchUnchangedIndexedValues` | Update non-indexed fields only. | No secondary delete/put entries; entries/doc = `1 + T`. |
+| `BenchmarkCollectionWALUpdateBatchChangedIndexedValues` | Update indexed fields. | Entries/doc = `1 + 2C + T`; WAL bytes/doc <= formula plus 10 percent. |
+| `BenchmarkCollectionWALDeleteHeavy` | Deletes after indexed inserts. | Entries/doc = `1 + I + D`; cleanup debt remains below stop limit. |
+| `BenchmarkCollectionWALTemplateV1InsertBatch` | Template-v1 repeated-shape and new-shape inserts. | Repeated-shape WAL bytes/doc excludes duplicate template descriptors; new-shape bytes/doc <= formula plus 10 percent. |
+| `BenchmarkCollectionWALAsyncIndexedFlushStalled` | Indexed inserts while async publish is intentionally blocked. | Soft trigger fires; stop limit blocks; hard limit is never exceeded; no unbounded heap growth. |
+| `BenchmarkCollectionWALRecoveryReplayPendingDocs` | Recovery with 1K, 100K, and 1M pending no-index, indexed, update, delete, and template-v1 WAL transactions. | Meets Section 10.1 replay throughput/time gates and peak heap <= 512 MiB for 1M pending documents. |
+| `BenchmarkCollectionWALCleanupLag` | Publish succeeds but cleanup is blocked, then released. | Cleanable debt triggers cleanup; debt drops below stop limit after release; protected refs are not deleted early. |
+| `BenchmarkCollectionWALDurableSyncBatch` | Concurrent durable-sync writers. | Sync batches respect 1 ms, 4 MiB, and 4096 transaction caps; p95/p99 ack latency below selected absolute gates. |
+| `BenchmarkColumnStoreWALSideRefClosure` | 1K, 100K, and 1M column side refs with manifests, dictionaries, bloom files, compression metadata, and delete bitmaps. | Memory <= configured cap; file count <= 1024 per part; metadata bytes/row <= formula plus 10 percent. |
+
 Gate thresholds:
 
 | Metric | Initial implementation gate | Stronger-default gate |
@@ -2255,7 +2774,7 @@ Gate thresholds:
 | Flush pending WAL-backed deltas | <=30 percent | <=20 percent |
 | Recovery, no-index | >=50K docs/sec | >=100K docs/sec target |
 | Recovery, indexed | >=20K docs/sec and >=50K root-delta entries/sec | >=50K docs/sec target |
-| WAL bytes/doc | Reported and below chosen formula threshold | Required; exceeding threshold blocks stronger default |
+| WAL bytes/doc | Reported and below Section 10.1 formula budget plus 10 percent | Required; exceeding threshold blocks stronger default |
 | Async stalled memory | Numeric cap reported; queue bounds enforced | Same, plus no steady-state leak across repeated cycles |
 | Cleanup | No unapplied segment removed; fully applied segments cleaned after safe checkpoint | Same |
 
@@ -2263,6 +2782,14 @@ Use `benchstat -count=10` for microbenchmarks. A performance gate fails only
 when both the mean regression crosses the threshold and `benchstat` reports a
 statistically significant change. Correctness gates do not depend on benchmark
 variance and must pass before any performance gate can be considered.
+
+Regression gates are necessary but insufficient. A collection WAL performance
+gate also fails when any absolute resource ceiling from Section 10.1 is
+exceeded, including encoded transaction size, replay heap, pending debt,
+protected side-ref retained segment debt, cleanup debt, durable-sync p95/p99
+ack latency, replay time, or cleanup time. The measured `collection_wal_bytes/doc`
+for each mutation class must be less than or equal to the formula-derived budget
+plus 10 percent.
 
 The stronger-default gate is required before enabling WAL-on collection
 durable-at-ack as a default profile. The initial implementation gate is enough
@@ -2311,6 +2838,7 @@ Traceability matrix:
 | Collection read views | 3, 6.3, 8.10, 10 | M4, M6 | long-iterator and side-ref pinning tests |
 | Recovery replay | 9 | M4, M4.5 | crash matrix, accumulation, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
+| Resource accounting/admission | 10.1, 12 | M0.5, M1, M2, M4.5, M6.5 | cost-estimator, backpressure, replay-cap, cleanup-debt, and benchmark-report artifacts |
 | Lock ordering | 8.9, 11.4 | M0, M6 | debug lock assertions and deadlock stress |
 | Performance | 12 | M6.5 | benchstat gates and artifacts |
 | Column-store unblock | 6.4, 10 | M7 | side-file fence and root-group recovery proof |
@@ -2385,6 +2913,9 @@ M1 starts, the implementation owner must confirm the exact testable choices for:
 - buffered replay model;
 - GC/rewrite side-ref protection mechanism;
 - overlay compaction durability rule.
+- resource accounting defaults for transaction size, inline spill, side-payload
+  limits, replay accumulator caps, debt soft/stop/hard limits, and durable-sync
+  group fsync caps.
 
 Gate:
 
@@ -2409,6 +2940,8 @@ Deliverables:
   protected side refs, recovery, cleanup debt, and value-log GC blockers;
 - stable root-delta encode/decode APIs independent of transient in-memory
   `batch.Batch` layout.
+- encoder-backed byte estimator, inline/side-payload threshold enforcement,
+  segment rotation defaults, and capacity error names from Section 10.1.
 
 Tests:
 
@@ -2444,6 +2977,8 @@ Deliverables:
 - protected side-ref index updated by WAL append/cleanup and rebuilt during
   recovery;
 - side-ref prepare guard that excludes GC/rewrite/cleanup during preparation;
+- protected side-ref accounting for metadata bytes, logical payload bytes, and
+  retained segment debt;
 - value-log GC/rewrite protection for unapplied collection WAL side refs;
 - fail-hard recovery behavior for complete transactions with missing required
   side refs.
@@ -2562,9 +3097,13 @@ Deliverables:
   `CollectionSeq` ranges;
 - replay-side accumulator handles multiple root deltas sharing the same
   persisted base root;
+- replay accumulator soft and hard caps from Section 10.1 are enforced by
+  chunk publish or deterministic spill before serving APIs;
 - async publish failure requeues without changing WAL identity or cleanup
   eligibility;
-- memory and queue bounds remain enforced when async publish is stalled.
+- memory, queue, pending WAL, protected side-ref, retained segment, cleanup
+  debt, and oldest-unapplied-age bounds remain enforced when async publish is
+  stalled.
 
 Tests:
 
@@ -2573,7 +3112,10 @@ Tests:
 - `TestCollectionWALPublishingUnitCrashRecovers`;
 - `TestCollectionWALAsyncPublishFailureRequeueKeepsWAL`;
 - `TestCollectionWALAsyncPublishNoWatermarkOutOfPrefixOrder`;
-- async stalled benchmark reports numeric memory and queue caps.
+- `TestCollectionWALReplayAccumulatorSoftCapChunksOrSpills`;
+- `TestCollectionWALReplayAccumulatorHardCapStopsRecovery`;
+- async stalled benchmark reports numeric memory, queue, WAL-debt, side-ref,
+  retained-segment, cleanup-debt, and blocked-write caps.
 
 Gate:
 
@@ -2666,8 +3208,12 @@ Deliverables:
 - required collection WAL microbenchmarks implemented under
   `TreeDB/collections`;
 - required recovery benchmarks implemented;
+- `cmd/collection_workload_bench`, `cmd/collection_bench_matrix`, and
+  `cmd/collection_bench_report` implemented or wired into `cmd/unified_bench`;
 - benchmark runner writes artifacts under `artifacts/collection-wal/`;
 - metrics from Section 12 are emitted for each benchmark row;
+- benchmark artifacts include phase-isolated null-WAL, WAL-on relaxed, and
+  durable-sync results;
 - metric presence tests prove every required Section 17 metric and benchmark
   artifact field is emitted with stable names;
 - baseline/new `benchstat` output is attached to the acceptance artifact.
@@ -2677,6 +3223,8 @@ Gate:
 - correctness gates M1 through M6 are green;
 - initial implementation thresholds from Section 12 pass for guarded/internal
   enablement;
+- absolute resource ceilings from Section 10.1 pass in addition to relative
+  `benchstat` thresholds;
 - stronger-default thresholds from Section 12 pass before WAL-on
   durable-at-ack becomes a default profile.
 
@@ -2691,6 +3239,9 @@ Prerequisites:
 - the verification matrix lists every passing collection-WAL test by exact name;
 - baseline/new `benchstat` output exists for the required benchmark rows and
   storage cells;
+- column side-ref capacity benchmarks prove file count, manifest bytes,
+  side-ref metadata bytes/row, validation throughput, and peak heap stay within
+  Section 10.1 column limits;
 - synthetic external side-file tests pass before real column-file writes are
   exposed;
 - the column-store PR checklist links to the exact collection-WAL acceptance
@@ -2970,7 +3521,10 @@ Required aggregate metrics:
 | `treedb.collection_wal.pending.txns_current` | gauge | unapplied transactions required for recovery |
 | `treedb.collection_wal.pending.docs_current` | gauge | documents covered by pending transactions |
 | `treedb.collection_wal.pending.bytes_current` | gauge | pending WAL bytes |
+| `treedb.collection_wal.pending.root_delta_side_payload_bytes_current` | gauge | pending root-delta side-payload bytes |
 | `treedb.collection_wal.pending.side_refs_current` | gauge | pending required side refs |
+| `treedb.collection_wal.pending.side_ref_logical_bytes_current` | gauge | pending required side-ref payload bytes |
+| `treedb.collection_wal.pending.unpublished_root_delta_entries_current` | gauge | unpublished root-delta entry count |
 | `treedb.collection_wal.pending.oldest_age_ms` | gauge | age of oldest pending transaction |
 | `treedb.collection_wal.segment.open_current` | gauge | open collection WAL segments |
 | `treedb.collection_wal.segment.bytes_current` | gauge | bytes retained in collection WAL segments |
@@ -2978,9 +3532,12 @@ Required aggregate metrics:
 | `treedb.collection_wal.segment.blocked_current` | gauge | segments blocked from cleanup |
 | `treedb.collection_wal.side_ref.protected.count_current` | gauge | protected side-ref count |
 | `treedb.collection_wal.side_ref.protected.bytes_current` | gauge | protected side-ref bytes |
+| `treedb.collection_wal.side_ref.protected.logical_bytes_current` | gauge | protected logical referenced bytes |
+| `treedb.collection_wal.side_ref.protected.retained_segment_bytes_current` | gauge | segment/file bytes retained only by protected side refs |
 | `treedb.collection_wal.side_ref.protected.oldest_age_ms` | gauge | oldest protected side-ref age |
 | `treedb.collection_wal.side_ref.protected.by_class.<class>.count_current` | gauge | protected side refs by class |
 | `treedb.collection_wal.side_ref.protected.by_class.<class>.bytes_current` | gauge | protected bytes by class |
+| `treedb.collection_wal.side_ref.protected.by_class.<class>.retained_segment_bytes_current` | gauge | retained segment bytes by side-ref class |
 | `treedb.collection_wal.applied_watermark.lag_txns_current` | gauge | transaction lag between appended and applied |
 | `treedb.collection_wal.applied_watermark.lag_bytes_current` | gauge | byte lag between appended and applied |
 | `treedb.collection_wal.cleanup.debt.bytes_current` | gauge | retained bytes awaiting safe cleanup |
@@ -3005,6 +3562,13 @@ Required aggregate metrics:
 | `treedb.collection_wal.value_log_gc.blocked_side_refs_current` | gauge | value-log side refs blocking GC |
 | `treedb.collection_wal.value_log_gc.blocked_by_pending_txns_current` | gauge | transactions blocking value-log GC |
 | `treedb.collection_wal.value_log_gc.blocked_bytes_total` | counter | cumulative bytes observed as GC-blocked |
+| `treedb.collection_wal.backpressure.blocked_writes_current` | gauge | writes currently blocked by collection WAL capacity limits |
+| `treedb.collection_wal.backpressure.blocked_writes_total` | counter | writes blocked by collection WAL capacity limits |
+| `treedb.collection_wal.backpressure.wait_ns_total` | counter | total writer wait time under collection WAL backpressure |
+| `treedb.collection_wal.backpressure.capacity_errors_total` | counter | writes rejected before ack by hard collection WAL capacity limits |
+| `treedb.collection_wal.replay.accumulator_peak_bytes_current` | gauge | peak replay accumulator bytes from last recovery/open |
+| `treedb.collection_wal.replay.spill_bytes_total` | counter | bytes written to replay spill side payloads |
+| `treedb.collection_wal.replay.chunk_publishes_total` | counter | bounded replay chunk publishes |
 | `treedb.collection_wal.quarantine.files_total` | counter | files quarantined |
 | `treedb.collection_wal.quarantine.bytes_total` | counter | bytes quarantined |
 | `treedb.collection_wal.txn_index.entries_current` | gauge | transaction-summary index entries |
@@ -3039,10 +3603,13 @@ CollectionWALStats {
         latency_ns_total, flush_ns_total, sync_ns_total, failures_total,
         failures_by_category_total;
     pending gauges: txns_current, docs_current, bytes_current,
-        side_refs_current, oldest_unix_nano;
+        root_delta_side_payload_bytes_current, side_refs_current,
+        side_ref_logical_bytes_current, unpublished_root_delta_entries_current,
+        oldest_unix_nano;
     segment gauges: open_current, bytes_current, cleanable_current,
         blocked_current;
     side-ref gauges: protected_count_current, protected_bytes_current,
+        protected_logical_bytes_current, protected_retained_segment_bytes_current,
         protected_oldest_unix_nano, protected_by_class;
     watermark gauges: lag_txns_current, lag_bytes_current;
     cleanup gauges: debt_bytes_current, debt_segments_current,
@@ -3055,6 +3622,10 @@ CollectionWALStats {
     GC blocker stats: blocked_bytes_current, blocked_segments_current,
         blocked_side_refs_current, blocked_by_pending_txns_current,
         blocked_bytes_total;
+    backpressure stats: blocked_writes_current, blocked_writes_total,
+        wait_ns_total, capacity_errors_total;
+    replay capacity stats: accumulator_peak_bytes_current, spill_bytes_total,
+        chunk_publishes_total;
 }
 ```
 
@@ -3135,6 +3706,17 @@ Module-specific constraints:
   `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
   `RootDescriptorEpochs`, `CollectionSeq`, `WALLSN`, root-delta ordinals, and
   canonical side refs before it can encode a replayable record.
+- `TreeDB/internal/collectionwal` owns the encoder-backed cost estimator,
+  inline/side-payload threshold checks, segment rotation policy, compression
+  threshold, durable-sync group-fsync caps, and capacity error classification
+  from Section 10.1. The estimator must compare projected bytes with the actual
+  encoder output in tests.
+- Collection WAL admission must reserve projected pending WAL bytes,
+  root-delta side-payload bytes, side-ref metadata bytes, logical side-ref
+  payload bytes, retained segment debt, unpublished root-delta entries, and
+  oldest-unapplied-age charge before the commit marker can be acknowledged.
+  Soft limits trigger publish/checkpoint/cleanup, stop limits block until the
+  resume watermark, and hard limits reject before ack.
 - Required storage-feature gates for `collection_wal_v1` must be written before
   any WAL-on collection write can be acknowledged. `format.json` is the
   early-open gate, the system root is the authoritative recovered gate, and WAL
@@ -3151,6 +3733,11 @@ Module-specific constraints:
   arbitrary error strings. `_total` metrics are monotonic within one process;
   `_current`, `_age_ms`, `_lag_*_current`, and `_last_*` values are reset-safe
   gauges or diagnostics.
+- Collection WAL recovery must enforce replay accumulator soft and hard caps.
+  At the soft cap it must chunk-publish or spill deterministic sorted chunks to
+  temporary replay side payloads. At the hard cap it must fail closed before
+  collection APIs serve unless the chunk/spill path has reduced the projected
+  charge.
 - `TreeDB/db`, `TreeDB/caching`, expvar, and native-wire stats must expose the
   same `treedb.collection_wal.*` keys. The expvar whitelist must include the
   `treedb.collection_wal.` prefix. High-cardinality per-collection values use
@@ -3181,16 +3768,22 @@ Module-specific constraints:
   report clean WAL state or prune required bytes while collection WAL
   transactions remain needed for recovery.
 - `TreeDB/internal/valuelog` and future column-file maintenance must consult the
-  protected side-ref index and side-ref prepare guard. PR1 rewrite refuses
-  protected refs rather than moving them and patching WAL records.
+  protected side-ref index and side-ref prepare guard. They must charge both
+  logical protected bytes and incremental retained segment bytes to collection
+  WAL backpressure. PR1 rewrite refuses protected refs rather than moving them
+  and patching WAL records.
 - Column-store implementation may not publish persistent column parts until
   part files, descriptor deltas, primary locator deltas, delete bitmap roots,
   secondary roots, filter roots, and schema roots can be committed as one
   collection WAL transaction. Column files must have side-ref closure
   extraction, temp/final naming, file fsync, rename, directory fsync,
   manifest/checksum validation, `PartID`/`FileID` allocator recovery, dictionary
-  and compression metadata protection, and cleanup tests before production
-  enablement.
+  and compression metadata protection, column capacity gates, and cleanup tests
+  before production enablement.
+- `cmd/collection_workload_bench`, `cmd/collection_bench_matrix`, and
+  `cmd/collection_bench_report` own the resource-budget benchmark artifact
+  schema. CI must fail when required columns are absent even if raw Go
+  benchmarks complete successfully.
 
 Recommended implementation sequence:
 
@@ -3199,7 +3792,8 @@ Recommended implementation sequence:
    recovery replay. These tests may initially document expected failures before
    product behavior is implemented.
 2. Add `internal/collectionwal` plus stable root-delta encode/decode golden
-   tests. Keep this package independent from collection planner internals.
+   tests, cost-estimator tests, capacity error names, and segment/sync defaults.
+   Keep this package independent from collection planner internals.
 3. Add file-class side-ref preparation APIs for prepare, flush-readable,
    verify, protect, and quarantine; wire value-log pointerization to flush or
    sync side refs to the required boundary before collection WAL append.
@@ -3209,8 +3803,10 @@ Recommended implementation sequence:
    the backend open path before collection managers or native-wire servers can
    observe state.
 6. Integrate async flush ownership, checkpoint, close, cleanup metadata, and
-   protected side-ref GC/rewrite behavior.
-7. Add performance gates and tune side-payload thresholds only after correctness
+   protected side-ref GC/rewrite behavior, including pending-debt admission and
+   retained-segment accounting.
+7. Add replay accumulator chunk/spill enforcement, performance gates, benchmark
+   reporting commands, and side-payload threshold tuning only after correctness
    crash tests pass.
 8. Unblock persistent column-store writes only after the row/template collection
    WAL path proves the shared recovery and side-ref protocol.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -52,6 +52,8 @@ PR1 makes these decisions normative:
 
 - use per-write collection WAL transactions with per-collection dependency
   chains and replay-side accumulation;
+- reject true multi-collection collection WAL transactions before writing side
+  refs or WAL records;
 - use a stable persisted `CollectionID`, `SchemaEpoch`, and per-root
   `RootGeneration` as replay guards;
 - include a versioned `SystemDeltaTemplate` in every replayable transaction;
@@ -59,6 +61,10 @@ PR1 makes these decisions normative:
   required side ref in WAL-on modes;
 - maintain a protected side-ref index, rebuilt from WAL during recovery, for
   PR1 GC/rewrite safety;
+- require a side-ref prepare guard that blocks GC/rewrite/cleanup while side
+  refs are being prepared but not yet committed to WAL;
+- require segment metadata and durable cleanup manifests before missing
+  collection WAL segments can be treated as safely cleaned;
 - make `DB.Checkpoint` call registered collection checkpoint hooks and force
   publication of replayable collection WAL before reporting a clean collection
   WAL state;
@@ -296,10 +302,21 @@ blind retry.
 
 `DB.Close`:
 
-- Must drain collection write domains before backend close, as current tests
-  already require.
-- Must not discard a collection WAL transaction before its applied watermark is
-  safely published.
+- Must stop new collection writers, drain in-flight async publishers, publish
+  replayable collection WAL transactions, advance applied watermarks, reach the
+  selected durability boundary, and only then allow cleanup before backend
+  close.
+- Must not discard a collection WAL transaction before its applied watermark and
+  cleanup boundary are safely published.
+
+Read-only open after crash:
+
+- Read-only open cannot run mutating collection WAL replay.
+- If unapplied committed collection WAL is present, read-only open must fail
+  with a clear recovery-required error unless a future explicit stale-read-only
+  mode is added.
+- A stale-read-only mode, if added, must be named as stale and must not claim
+  durable-at-ack visibility for unapplied collection WAL writes.
 
 Native-wire acknowledgement policies map onto these same local boundaries:
 
@@ -569,8 +586,55 @@ Segment rules:
   `CollectionSeq`.
 - Transactions are sorted by `GlobalTxnID` during segment scanning, with file
   order as a deterministic tie breaker only for malformed legacy segments.
-- A truncated tail stops scanning that segment after the last complete record.
-- Hard corruption before the tail fails recovery.
+- A short read or EOF is accepted only for the terminal frame of the active
+  non-cleaned segment in that lane.
+- A complete frame with a bad frame checksum or transaction checksum is hard
+  corruption, even when it is the final frame.
+- A short read before a later complete frame, before a later non-cleaned segment,
+  or in a sealed segment is hard corruption.
+- Hard corruption before the terminal tail fails recovery.
+
+Every sealed collection WAL segment must have durable segment metadata:
+
+```text
+CollectionWALSegmentMeta {
+    Version                       uint16
+    Lane                          uint16
+    SegmentSeq                    uint64
+    MinGlobalTxnID                uint64
+    MaxGlobalTxnID                uint64
+    ParticipantCollectionIDs      []uuid128
+    FirstFrameOffset              uint64
+    LastCompleteFrameEndOffset    uint64
+    Sealed                        bool
+    MetadataChecksumCRC32C        uint32
+}
+```
+
+Cleanup requires durable cleanup metadata before a missing segment can be
+accepted during startup:
+
+```text
+CollectionWALCleanupRecord {
+    Version                       uint16
+    CleanupEpoch                  uint64
+    Lane                          uint16
+    SegmentSeq                    uint64
+    MinGlobalTxnID                uint64
+    MaxGlobalTxnID                uint64
+    ParticipantCollectionIDs      []uuid128
+    State                         planned | unlinked | dirsynced
+    RecordChecksumCRC32C          uint32
+}
+```
+
+Startup treats a missing collection WAL segment as valid only when a durable
+cleanup record proves the segment's whole transaction range was safely cleaned.
+A missing non-cleaned segment is recovery corruption and must stop open. Mixed
+collection segments are cleanable only when every transaction in the segment is
+covered by durable per-collection watermarks, or after a future segment-splitting
+protocol rewrites the remaining live transactions into a new crash-tested
+segment.
 
 ### 7.6 Applied Progress and Skip Rules
 
@@ -610,6 +674,14 @@ present in the active replay accumulator, or explicitly known not to exist for a
 new collection. A missing complete transaction blocks later transactions for the
 same collection.
 
+PR1 does not support true multi-collection collection WAL transactions. Any API
+or internal planner that would need to mutate multiple collections atomically
+must reject the operation before preparing side refs or appending collection WAL.
+A future multi-collection format must declare all participant collections,
+validate every participant dependency, and publish all participant root
+descriptor changes plus all participant watermarks in one backend meta/system
+commit.
+
 ### 7.7 Side-Ref Fences
 
 `CollectionSideRef` names external bytes that must exist before a collection WAL
@@ -619,6 +691,8 @@ transaction, not output files produced by backend root publication.
 Side-ref classes:
 
 - `ValueLogRecord`: value-log bytes embedded in root-delta values.
+- `LeafLogRecord`: pre-existing outer-leaf or child-record bytes embedded in a
+  root-delta value or descriptor.
 - `RootDeltaPayload`: serialized root-delta payload stored outside the WAL
   record.
 - `ColumnPartFile`: immutable column payload file.
@@ -628,11 +702,46 @@ Side-ref classes:
 
 Leaf-log or page-log records produced while replay builds new B-tree roots are
 not `CollectionSideRefs`. They are publish outputs and must be flushed or synced
-by the backend commit path before descriptors are published.
+by the backend commit path before descriptors are published. A pre-existing
+leaf-log child ref embedded in a root delta is a `LeafLogRecord` input side ref
+and must be validated like a value-log ref.
 
 The WAL encoder must derive required side refs from the final root-delta payload
 and from column descriptors. A caller-provided `SideRefs` list is insufficient
 unless the encoder verifies it against the payload.
+
+Declared side refs are not trusted. During WAL append and recovery, TreeDB must
+derive the canonical embedded required side-ref set by decoding root deltas,
+root descriptors, column part descriptors, filter descriptors, delete bitmap
+references, dictionary references, value-log pointer payloads, and leaf-log
+pointer payloads. The declared required side-ref set must match the canonical
+set. Missing embedded refs, undeclared embedded refs, and declared refs that are
+not embedded are invalid unless a future format version defines a precise
+optional-ref class.
+
+Readable and integrity-passing means class-specific validation:
+
+- `ValueLogRecord`: segment exists, offset/length are in bounds, RID or grouped
+  sub-index matches when present, and record checksum passes.
+- `LeafLogRecord`: leaf segment exists, referenced child bytes are in bounds,
+  and checksum or page/record validation passes.
+- `RootDeltaPayload`: payload file or value-log record exists, length and
+  checksum match, and decoding yields the `DeltaDigest` named by the root delta.
+- `ColumnPartFile`: final file path exists, file size/checksum match the
+  descriptor or manifest, and compression/dictionary metadata validates.
+- `ColumnFilterFile`: filter file exists, checksum matches, and the filter
+  header names the expected column/part generation.
+- `DeleteBitmapFile`: bitmap file exists, checksum matches, and row-range and
+  generation metadata match the descriptor.
+- `DictionaryFile`: dictionary bytes exist, checksum matches, and codec/dict id
+  match every dependent payload.
+
+Column-like side files use a temp-to-final protocol in PR1 planning: write temp
+file, fsync file, atomically rename to final path, fsync parent directory, then
+allow the collection WAL commit marker to reference the final path. A future
+manifest format must cover final path, length, checksum, compression metadata,
+row range, and generation. Temp-only files with no committed WAL/root reference
+are orphan-prepared and may be quarantined or deleted after recovery.
 
 A complete transaction with a missing required side ref is a recovery error in
 WAL-on durable/recoverable modes, except for an incomplete tail transaction that
@@ -653,6 +762,15 @@ a value-log segment or column file is referenced only by pending collection WAL,
 maintenance must keep it in place or abort. A future rewrite mode may rewrite
 protected refs only if it publishes replacement side refs and collection WAL
 metadata atomically under an explicit crash-tested protocol.
+
+A writer preparing side refs must hold a side-ref prepare guard from before the
+first side-ref append/write until either the collection WAL frame referencing
+those side refs is durable, or the operation aborts and the prepared refs are
+deleted or recorded as orphan-prepared. GC, value-log rewrite, leaf-log GC,
+column cleanup, checkpoint cleanup, and full storage compaction must acquire the
+conflicting maintenance side of this guard before computing reclaimable refs.
+This prevents in-process maintenance from deleting side refs in the window after
+side-ref creation but before WAL commit.
 
 ### 7.8 Commit Marker and Ack Boundary
 
@@ -863,25 +981,65 @@ with explicit consensus semantics.
 
 ## 9. Recovery Algorithm
 
+### 9.1 Collection WAL Recovery States
+
+A collection WAL transaction is in exactly one durable recovery state:
+
+| State | Meaning | Recovery behavior |
+|---|---|---|
+| `S0 Absent` | No complete collection WAL frame exists. | Do not publish roots. Any side files not referenced by a committed WAL transaction or published root are orphan-prepared and may be quarantined or deleted. |
+| `S1 PreparedSideRefs` | Side bytes may exist, but no complete committed WAL frame references them. | Do not publish roots. Reclaim only after proving no complete WAL transaction and no published root references the bytes. |
+| `S2 CommittedWAL` | A complete collection WAL frame with valid checksums exists and is not covered by the durable applied watermark. | Validate all required side refs, identity, schema, generations, and dependencies; then replay in collection sequence order. Missing or corrupt required side refs stop open. |
+| `S3 MaterializedUnpublished` | Recovery or live publish built root pages or publish-output files, but backend meta/system-root commit did not publish root descriptors. | Not externally visible. After crash, retry from `S2` or skip if `S4` is observed. |
+| `S4 Applied` | One backend meta/system-root commit atomically published root descriptor changes and applied watermark entries covering the transaction. | Skip during replay. Reapplying an `S4` transaction is a bug. |
+| `S5 Cleanable` | Transaction is `S4`, and a durable checkpoint/meta boundary exists such that descriptors, watermarks, and side-ref reachability tracking for published roots are durable. | WAL files and WAL-only side-ref protection may be cleaned idempotently. |
+| `S6 Cleaned` | Durable cleanup metadata says the segment or transaction range is safely cleaned. | Missing segment files are acceptable only for ranges covered by this metadata. Missing uncleaned segments stop open. |
+
+Root descriptors published without the matching applied watermark are not a
+valid state. If an implementation bug or future format can produce that split,
+recovery must stop open unless the format also provides a proven idempotent
+repair protocol. PR1 must make the split unrepresentable by publishing
+descriptor ops and watermark ops in one backend commit.
+
+### 9.2 Startup Recovery
+
 Startup recovery should extend the existing recovery order while preserving
 the current invariant that side-store scans run before cached commit-log replay:
 
-1. Recover backend index metadata and choose the valid meta page.
-2. Scan value-log and leaf-log side-store segments used by existing commit-log
+1. Acquire the exclusive recovery/maintenance lock. No GC, rewrite, column
+   cleanup, collection writer, async publisher, checkpoint, or close cleanup may
+   run concurrently with recovery.
+2. Recover backend index metadata and choose the valid meta page.
+3. Load durable collection WAL cleanup metadata.
+4. Discover collection WAL segment files. For each lane, segments are ordered by
+   segment sequence. A missing segment is valid only if covered by durable
+   cleanup metadata. A missing segment not covered by cleanup metadata is
+   corruption and recovery must stop open.
+5. Scan value-log and leaf-log side-store segments used by existing commit-log
    RID fences, and build the `RID -> side ref` maps required for replay.
-3. Replay normal cached commit logs as today, using the side-ref maps created
+6. Replay normal cached commit logs as today, using the side-ref maps created
    before replay.
-4. Scan any additional collection WAL side-file classes, such as root-delta
+7. Scan any additional collection WAL side-file classes, such as root-delta
    payloads, column files, filters, delete bitmaps, and dictionaries, needed by
    collection WAL fences.
-5. Scan collection WAL segments, decode complete transactions, distinguish
-   incomplete tails from hard corruption, and rebuild the protected side-ref
-   index before any maintenance can run.
-6. Load applied collection-sequence watermark metadata from the recovered system
+8. Scan collection WAL frames in segment order:
+   - EOF or short read is allowed only at the terminal frame of the last
+     non-cleaned segment for that lane;
+   - short read before a later complete frame or later non-cleaned segment is
+     corruption;
+   - a complete frame with checksum mismatch is corruption;
+   - unsupported version is corruption unless explicitly marked skippable by a
+     forward-compatible feature flag.
+9. Decode complete transactions and rebuild the protected side-ref index before
+   any maintenance can run.
+10. Load applied collection-sequence watermark metadata from the recovered system
    root.
-7. Sort unapplied transactions by `CollectionID`, `CollectionSeq`, and
+11. Sort unapplied transactions by `CollectionID`, `CollectionSeq`, and
    `GlobalTxnID` for deterministic diagnostics.
-8. For each unapplied collection in contiguous `CollectionSeq` order:
+12. For each uncovered transaction, validate declared side refs and the
+   canonical embedded required side-ref set extracted from root deltas and
+   descriptors. The sets must match.
+13. For each unapplied collection in contiguous `CollectionSeq` order:
    - validate checksum and format version;
    - validate required side refs;
    - validate collection identity, schema epoch, root generation guards, and
@@ -890,9 +1048,9 @@ the current invariant that side-store scans run before cached commit-log replay:
    - materialize publish inputs from `RootDeltaEncodingV1`;
    - instantiate `SystemDeltaTemplate` with produced root ids;
    - publish descriptor updates and applied watermark in one backend commit.
-9. After successful replay, clean collection WAL segments whose transactions are
+14. After successful replay, clean collection WAL segments whose transactions are
    fully covered by the durable applied watermark.
-10. Quarantine or delete prepared side files that are not referenced by any
+15. Quarantine or delete prepared side files that are not referenced by any
    committed transaction or reachable root.
 
 Recovery must be deterministic. Replaying the same directory twice must produce
@@ -902,7 +1060,11 @@ No side-store cleanup, value-log rewrite, column-file cleanup, or collection WAL
 segment cleanup may run until collection WAL recovery and protected side-ref
 index reconstruction are complete.
 
-### 9.1 Buffered Transaction Replay and Accumulation
+Read-only open cannot perform steps that mutate backend state. If unapplied
+committed collection WAL exists, read-only open must fail with a clear
+recovery-required error unless an explicit stale-read-only mode is requested.
+
+### 9.3 Buffered Transaction Replay and Accumulation
 
 PR1 uses per-collection replay-side accumulation. Merged flush-unit WAL
 transactions are deferred because they are incompatible with durable-at-ack for
@@ -936,20 +1098,23 @@ This rule applies to no-index buffered writes, indexed mutable runs, queued
 flush units, async publishing states, overlay compaction, schema/index changes,
 and future column-store delta-part descriptor updates.
 
-### 9.2 Failure Behavior
+### 9.4 Failure Behavior
 
 | Failure point | Required behavior |
 |---|---|
 | Side-ref preparation fails before WAL commit marker | Return ordinary error. Do not expose mutation. Delete or quarantine prepared side files. |
+| Crash before any side ref or WAL write | `S0 Absent`. No recovery action is required beyond ordinary orphan scan. |
 | WAL append fails before commit marker | Return ordinary error. Do not expose mutation. Side refs remain uncommitted and are deleted or quarantined. |
 | Crash after side refs prepared before commit marker | Recovery ignores transaction. Unreferenced side files are deleted or quarantined. |
 | Crash after commit marker before response | Recovery may expose transaction. This is committed-before-response ambiguity. |
+| Crash after visible staging before API response | WAL-on modes recover the committed transaction. Visible-without-committed-WAL is not permitted. |
 | In-memory visible staging fails after commit marker | Not permitted as an ordinary error. Implementation must make this step non-failing or report commit-ambiguous/fatal. |
 | Root publish fails before backend meta commit | WAL transaction remains unapplied and protected. Retry on flush or recovery. |
 | Root pages are built but backend meta commit fails | Built pages are unreachable. WAL transaction remains source of truth. |
 | Descriptor update succeeds without watermark | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
 | Watermark update succeeds without descriptor update | Not permitted. Descriptor updates and watermark update are the same system-root commit. |
 | Cleanup fails after watermark/checkpoint | Safe leak. Retry cleanup later. |
+| WAL segment unlink/rename fails during cleanup | Cleanup remains retryable. Startup accepts missing segments only with durable cleanup metadata. |
 | GC/rewrite wants a side ref protected by unapplied WAL | Must keep it in place or abort maintenance. Rewrite requires an explicit crash-tested WAL metadata protocol. |
 
 ## 10. Cleanup and Retention
@@ -989,6 +1154,28 @@ PR1 uses a protected side-ref index:
 - Value-log rewrite and column-file rewrite refuse protected refs in PR1 rather
   than trying to patch WAL records in place.
 
+WAL-only side-ref protection may be released only after all are true:
+
+1. the transaction is covered by a durable applied watermark;
+2. the root descriptors containing the refs are durable in the backend
+   meta/system root;
+3. the relevant side-ref reachability tracker has incorporated that published
+   root set, or a full reachability scan has completed;
+4. old snapshots and active iterators that could reference either old or new
+   roots are represented in the normal retention system;
+5. durable cleanup metadata records that WAL protection for the segment/range is
+   no longer required.
+
+Column files, filters, delete bitmaps, and dictionaries follow the same
+lifecycle as value-log refs: WAL protection before publish, root/snapshot
+protection after publish, and quarantine/delete only after neither WAL nor any
+published snapshot/iterator can reference them.
+
+Cleanup is idempotent. A cleanup implementation must be safe across crashes
+after cleanup record write, after unlink/rename, and before/after directory
+fsync. Missing segments are acceptable only for `S6 Cleaned` ranges covered by
+durable cleanup metadata.
+
 `DB.Checkpoint` must call registered collection checkpoint hooks before
 reporting a clean collection WAL state. PR1 checkpoint hooks force publication
 of replayable collection WAL, advance watermarks, and then allow collection WAL
@@ -1023,7 +1210,10 @@ Keep and expand tests that document current behavior:
 - tombstone/cold-build encoding preserves `IncludeDeletedOnColdBuild`;
 - `SystemDeltaTemplate` placeholder instantiation golden tests;
 - descriptor-op precondition failures are reported before any publish is marked
-  applied.
+  applied;
+- segment metadata golden tests for min/max `GlobalTxnID`, participant
+  collections, sealed status, and checksum;
+- cleanup record golden tests for `planned`, `unlinked`, and `dirsynced` states.
 
 ### 11.3 Recovery Tests
 
@@ -1050,8 +1240,12 @@ Crash/fault points:
     transactions are durable but unpublished;
 15. after a drop/recreate under the same collection name;
 16. after a root descriptor generation rewrite attempt with unapplied WAL;
-17. after Raft commit before local collection WAL append once Raft apply exists;
-18. after local collection WAL append before Raft applied-index/idempotency
+17. after collection WAL cleanup record write before unlink;
+18. after collection WAL segment unlink before directory fsync;
+19. after read-only open observes unapplied committed collection WAL;
+20. after a multi-collection operation reaches the collection WAL planner;
+21. after Raft commit before local collection WAL append once Raft apply exists;
+22. after local collection WAL append before Raft applied-index/idempotency
     metadata advancement once Raft apply exists.
 
 Required assertions:
@@ -1075,12 +1269,24 @@ Required assertions:
   transaction from another collection;
 - value-log GC/rewrite cannot remove or move bytes referenced only by pending
   collection WAL side refs;
+- leaf-log GC/rewrite and future column cleanup cannot remove bytes referenced
+  only by pending collection WAL side refs;
+- declared side refs and embedded side refs match the canonical required set;
 - a missing complete transaction `N` blocks `N+1` for the same collection;
+- same-collection independence skips are rejected in PR1;
+- multi-collection transactions are rejected before side refs or WAL are
+  written in PR1;
 - drop/recreate with the same collection name does not replay old WAL into the
   new collection;
 - schema epoch and root generation mismatches block stale transactions;
 - `DB.Checkpoint` either publishes replayable collection WAL or reports debt
   while preserving side refs;
+- read-only open fails with recovery-required when unapplied committed
+  collection WAL exists;
+- missing cleaned segments open only when covered by durable cleanup metadata;
+- missing uncleaned segments stop open;
+- root descriptors published without matching watermarks are unrepresentable or
+  stop open under fault injection;
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
 
@@ -1129,9 +1335,11 @@ Traceability matrix:
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
 | WAL format | 7.2, 7.4, 7.5 | M1 | golden, fuzz, corrupt-tail tests |
-| Identity and sequencing | 7.3, 7.6, 9.1 | M1, M5 | collection-seq, epoch, generation tests |
+| Recovery state machine | 9.1, 9.2, 9.4 | M1, M5 | crash-state and stop-open tests |
+| Identity and sequencing | 7.3, 7.6, 9.3 | M1, M5 | collection-seq, epoch, generation tests |
 | System-root template | 7.2, 8.6 | M1, M5 | descriptor-op and watermark atomicity tests |
 | Side-file fences | 7.7, 10 | M2 | missing-ref and GC protection tests |
+| Segment cleanup metadata | 7.5, 10 | M1, M5 | missing-segment and cleanup-manifest tests |
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
 | Recovery replay | 9 | M4 | crash matrix, accumulation, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
@@ -1169,6 +1377,7 @@ Deliverables:
 - persisted `CollectionID`, `SchemaEpoch`, and root generation descriptor
   encoding;
 - `SystemDeltaTemplate` and descriptor-op encoding;
+- segment metadata and cleanup record encoding;
 - exact format documentation in this file.
 
 Tests:
@@ -1178,7 +1387,8 @@ Tests:
 - truncated tail;
 - decoder fuzzing;
 - replay digest tests;
-- descriptor-op placeholder instantiation tests.
+- descriptor-op placeholder instantiation tests;
+- cleanup metadata and missing-segment classification tests.
 
 Gate:
 
@@ -1192,8 +1402,10 @@ Deliverables:
 - inline and side-payload modes;
 - side-ref availability checker;
 - value-log side-ref integration;
+- leaf-log side-ref validation for pre-existing embedded leaf refs;
 - protected side-ref index updated by WAL append/cleanup and rebuilt during
   recovery;
+- side-ref prepare guard that excludes GC/rewrite/cleanup during preparation;
 - value-log GC/rewrite protection for unapplied collection WAL side refs;
 - fail-hard recovery behavior for complete transactions with missing required
   side refs.
@@ -1201,6 +1413,7 @@ Deliverables:
 Tests:
 
 - missing side refs fail recovery for complete WAL-on collection transactions;
+- declared and embedded side-ref set mismatch fails recovery;
 - no root can be published with missing side bytes;
 - large delta side-payload round trips;
 - GC/rewrite cannot delete or move bytes referenced only by unapplied
@@ -1241,6 +1454,8 @@ Deliverables:
 - unique helper rebuild after recovery;
 - replay accumulator for multiple buffered transactions that share one persisted
   root base;
+- PR1 rejection of true multi-collection transactions before side refs or WAL
+  are written;
 - schema/index changes ordered by collection sequence;
 - overlay compaction encoded as a collection WAL maintenance transaction when it
   can race with user-visible writes.
@@ -1253,6 +1468,8 @@ Tests:
 - update/delete secondary roots recover atomically;
 - two acknowledged buffered writes against one persisted base both survive
   crash/reopen;
+- per-collection ordering gaps block later same-collection transactions;
+- multi-collection transaction attempts are rejected before side effects;
 - insert/update/delete chains preserve secondary deletes and puts after
   recovery;
 - schema epoch and root generation mismatches block stale transactions.
@@ -1273,7 +1490,9 @@ Deliverables:
 - collection WAL replay in open path;
 - collection-specific publish wrapper around ordered-root publish APIs;
 - segment cleanup after safe checkpoint;
-- prepared side-file quarantine/delete.
+- prepared side-file quarantine/delete;
+- read-only open recovery-required error when unapplied committed collection WAL
+  exists.
 
 Tests:
 
@@ -1284,7 +1503,11 @@ Tests:
 - descriptor update and watermark update cannot split across commits;
 - older segments remain when watermark is not durable;
 - cleanup removes only fully applied segments;
-- prepared side files without committed transactions do not become visible.
+- prepared side files without committed transactions do not become visible;
+- missing cleaned segments are accepted only with durable cleanup records;
+- missing uncleaned segments stop open;
+- read-only open cannot silently serve stale state when committed collection WAL
+  is unapplied.
 
 Gate:
 
@@ -1409,6 +1632,12 @@ PR1 closes the correctness-critical questions that block implementation:
    of replayable collection WAL before reporting a clean collection WAL state.
 7. Overlay compaction that can race with user-visible collection writes is
    encoded as a collection WAL maintenance transaction.
+8. True multi-collection collection WAL transactions are unsupported in PR1 and
+   must be rejected before side refs or WAL are written.
+9. Read-only open with unapplied committed collection WAL fails with a
+   recovery-required error unless a future explicitly stale mode is requested.
+10. Missing collection WAL segments are valid only when covered by durable
+   cleanup metadata.
 
 Future questions that do not weaken PR1 correctness:
 
@@ -1451,8 +1680,9 @@ Module-specific constraints:
 
 - `TreeDB/internal/collectionwal` or equivalent owns versioned framing, commit
   markers, `GlobalTxnID`, per-collection sequence allocation, side-ref
-  verification, protected side-ref index rebuild, and segment cleanup after the
-  durable applied watermark/checkpoint boundary.
+  verification, segment metadata, cleanup records, protected side-ref index
+  rebuild, missing-segment classification, and segment cleanup after the durable
+  applied watermark/checkpoint boundary.
 - `TreeDB/collections` owns final physical delta planning before
   acknowledgement. WAL-on collection planners must serialize primary,
   template/index-state, secondary, overlay, delete, schema, and future
@@ -1461,14 +1691,18 @@ Module-specific constraints:
 - `TreeDB/db` owns a collection-specific publish wrapper around ordered-root
   executors. The wrapper validates identity/generation/dependency guards,
   materializes root deltas, instantiates `SystemDeltaTemplate`, publishes
-  descriptors and watermark atomically, and honors explicit sync options.
+  descriptors and watermark atomically, honors explicit sync options, and makes
+  read-only open fail when unapplied committed collection WAL requires mutating
+  recovery.
 - `TreeDB/caching` and checkpoint code must track collection WAL debt. Automatic
   checkpoint and close paths must not report clean WAL state or prune required
   bytes while collection WAL transactions remain needed for recovery.
 - `TreeDB/internal/valuelog` and future column-file maintenance must consult the
-  protected side-ref index. PR1 rewrite refuses protected refs rather than
-  moving them and patching WAL records.
+  protected side-ref index and side-ref prepare guard. PR1 rewrite refuses
+  protected refs rather than moving them and patching WAL records.
 - Column-store implementation may not publish persistent column parts until
   part files, descriptor deltas, primary locator deltas, delete bitmap roots,
   secondary roots, filter roots, and schema roots can be committed as one
-  collection WAL transaction.
+  collection WAL transaction. Column files must have temp/final naming, file
+  fsync, rename, directory fsync, manifest/checksum validation, and cleanup
+  tests before production enablement.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -508,6 +508,18 @@ state-machine results, and must not affect collection WAL replay.
   simple numeric extension of the local ordering unless a future cluster spec
   explicitly defines the implied local durability level.
 
+Native-wire collection command ingress must apply collection WAL bounds before
+any side effect. After decoding a command and resolving collection/index names
+to stable catalog identity, but before side-ref preparation, write-domain
+mutation, root publication, or WAL append, the server must compute the exact
+collection-WAL plan size, root-delta counts, side-ref counts, decoded entry
+counts, and side-payload spill plan. A valid 64 MiB wire frame is not permission
+to create a 64 MiB inline collection WAL transaction. The command must spill or
+reject before side effects if the plan would exceed v1 WAL bounds. Native-wire
+collection commands must enforce the same document-id, document-byte,
+index-count, catalog-guard, logical-name, and path limits as the collection WAL
+planner.
+
 ### 6.3 PR1 Invariants
 
 These invariants are normative for PR1 and are the acceptance criteria for
@@ -794,6 +806,17 @@ must not be replayed into a collection with the same name; PR1 must stop open or
 quarantine according to a documented recovery-admin procedure rather than
 silently applying the transaction to a later incarnation.
 
+On decode/replay, the allowed root-name and root-kind set is derived only from
+the recovered catalog entry for `CollectionUID`, `CollectionGeneration`,
+`SchemaEpoch`, catalog digest, and root descriptor epochs. Recovery must reject
+any `RootDelta`, descriptor op, system-delta placeholder, side-ref manifest, or
+root name that is not in that derived set before side-ref validation or root
+publication. `CollectionName` and WAL-provided root-name strings must never be
+used for replay lookup, filesystem path construction, side-file path
+construction, tenant authorization, or deciding which roots may be published.
+Any future tenant namespace must be stable catalog identity, not text parsed
+from a collection name.
+
 Maintenance that rewrites root ids or descriptor values must not run for a
 collection with unapplied WAL transactions unless the maintenance operation is
 itself encoded as a collection WAL transaction.
@@ -832,12 +855,46 @@ rules: if two accumulated deltas affect the same key, the later
 `CollectionSeq` wins, and deletes suppress older values according to normal
 collection visibility rules.
 
-A collection WAL transaction has a configured maximum encoded byte size,
-maximum root-delta count, and maximum decoded entry count. Larger root deltas
-must spill to `RootDeltaPayload` side refs with the same side-ref preparation
-and protection rules as value-log or column-file refs. Recovery must be able to
-decode and fold root deltas in bounded memory; a transaction that exceeds the
-configured limits fails before acknowledgement or uses side-payload mode.
+A v1 collection WAL transaction has a fixed, non-disableable maximum encoded
+byte size, root-delta count, side-ref count, decoded entry count, and
+decompression output size. Larger root deltas must spill to
+`RootDeltaPayload` side refs with the same side-ref preparation and protection
+rules as value-log or column-file refs. Recovery must be able to decode and fold
+root deltas in bounded memory; a transaction that exceeds the v1 limits fails
+before acknowledgement or uses side-payload mode.
+
+Normative v1 bounds:
+
+| Field / structure | v1 bound | Rule |
+|---|---:|---|
+| Encoded `CollectionWALTransaction` | **16 MiB** | Includes all encoded transaction fields and `RecordChecksumCRC32C`; excludes only the outer segment frame header. Hard cap; not configurable upward at runtime. |
+| Collection WAL outer frame payload | 16 MiB | Must equal one encoded transaction or commit-marker record. |
+| Collection WAL segment size | 64 MiB default, 1 GiB absolute max | Segment size may be lower by config; never disables per-frame/per-transaction caps. |
+| Root deltas per transaction | 64 | Count is checked before allocation. |
+| Mutated roots per transaction | 64 | Must be derived from catalog root set for `CollectionUID`. |
+| Inline root-delta bytes per transaction | 4 MiB | Larger deltas must spill to `RootDeltaPayload` side refs. |
+| Inline root-delta bytes per root | 1 MiB | Larger per-root delta spills. |
+| Root-delta payload side ref | 64 MiB | Decoded streaming fold only; no full decoded allocation unless under cap. |
+| Decoded root-delta entries per transaction | 262,144 | Larger mutation must split or use side-payload streaming with the same entry cap per transaction. |
+| Delta key / document ID bytes | 16 KiB | Applies to WAL deltas and native-wire mutation IDs. |
+| Inline delta value bytes | 1 MiB | Larger values must be value-log or side-ref backed. |
+| Side refs per transaction | 16,384 | Includes required direct side refs. Larger column/file operations must split transactions. |
+| Descriptor / system delta ops | 1,024 | Includes descriptor ops, watermark ops, placeholder bindings, and preconditions. |
+| Collection name | 128 UTF-8 bytes | Existing public validator already enforces this. |
+| Index/schema/tenant logical name | 128 UTF-8 bytes | Reject NUL, `/`, `\`, `:`, leading/trailing space. Tenant rule applies if tenant namespace is added. |
+| Root name | 256 UTF-8 bytes | Must be derived, not trusted from WAL name fields. |
+| `RelativePath` | 512 bytes | Advisory only; slash-separated; max 16 components; component max 128 bytes. |
+| Resolved absolute path | 4096 bytes and OS component limits | Reject if exceeded after safe resolution. |
+| Digest fields | exact declared length | `CollectionUID=16`, CRC32C `4`, replay/catalog digest exact algorithm length, e.g. 32 bytes. |
+| Varint/uvarint | max 10 bytes, minimal encoding | Overflow and non-minimal encodings are malformed. |
+| Compressed decoded bytes | 64 MiB per payload | Decode only after checksum; output length must exactly match declared raw length. |
+| Recovery heap budget | 128 MiB per DB open worker | On budget exhaustion: stop open/quarantine; never continue with partial roots. |
+
+The maximum legal encoded collection WAL transaction size is 16,777,216 bytes
+including the transaction checksum. Recovery must reject a larger complete frame
+before variable-field parsing, decompression, side-ref validation, or root
+publication. `limits.MaxRecordSize <= 0` and negative max-segment options must
+not disable this cap for collection WAL recovery.
 
 Root kinds are explicit, versioned values. PR1 row-store root kinds include
 `primary`, `template`, `index_state`, `secondary`, `overlay`,
@@ -903,6 +960,38 @@ Semantic segment rules:
 - A short read before a later complete frame, before a later non-cleaned segment,
   or in a sealed segment is hard corruption.
 - Hard corruption before the terminal tail fails recovery.
+
+Decoder order is mandatory:
+
+1. read the fixed segment frame header;
+2. validate magic, frame type, version, header length, payload length
+   `<= 16 MiB`, and `file_offset + frame_len` overflow;
+3. read at most 16 MiB into a bounded buffer or stream checksum into bounded
+   scratch;
+4. verify frame checksum;
+5. verify transaction `RecordChecksumCRC32C`;
+6. parse only the fixed-width transaction prefix;
+7. validate transaction version, feature flags, digest lengths, and scalar
+   fields;
+8. validate all counts against the bounds table before allocating;
+9. validate all string and path byte lengths before converting to strings;
+10. parse side refs, root deltas, and system template;
+11. derive canonical embedded side refs from decoded replay payload;
+12. compare canonical side refs to declared side refs;
+13. verify side-ref existence, range, checksum, class, path/FileID match, owner,
+    and generation;
+14. validate `CollectionUID`, generation, schema epoch, catalog digest, root
+    descriptor epochs, base roots, and sequence dependency;
+15. only then publish root deltas, system metadata, and watermark.
+
+No string, slice, map, side-ref, root-delta, or decompression allocation may be
+made from transaction-controlled counts before checksum verification. Every
+count multiplication and offset/size addition uses checked arithmetic; reject
+`count > max / elemSize`, `offset > max - size`, and `prefixLen > max - rawLen`.
+Never convert a WAL or side-ref `uint64` offset/length to a signed integer until
+it is proven `<= math.MaxInt64`. Decompression is allowed only after checksum
+verification and only if the declared raw length is `<= 64 MiB` and the output
+length exactly matches the declaration.
 
 Every sealed collection WAL segment must have durable segment metadata:
 
@@ -1002,22 +1091,25 @@ commit.
 transaction can be replayed. Side refs are input dependencies of the
 transaction, not output files produced by backend root publication.
 
-Side-ref classes:
+Side-ref classes are numeric in v1:
 
-- `ValueLogRecord`: value-log bytes embedded in root-delta values.
-- `LeafLogRecord`: pre-existing outer-leaf or child-record bytes embedded in a
-  root-delta value or descriptor.
-- `RootDeltaPayload`: serialized root-delta payload stored outside the WAL
-  record.
-- `ColumnManifest`: manifest or prepare record naming a column part's external
-  files.
-- `ColumnSubstreamFile`: immutable column payload or packed update-delta
-  substream file.
-- `ColumnFilterFile`: persistent filter file.
-- `ColumnDeleteBitmapFile`: delete/tombstone bitmap file.
-- `ColumnDictionaryFile`: compression or encoding dictionary file.
-- `ColumnMetadataFile`: external compression metadata, mark metadata, or future
-  side metadata file.
+| Value | Class | Meaning |
+|---:|---|---|
+| 1 | `ValueLogRecord` | value-log bytes embedded in root-delta values |
+| 2 | `LeafLogRecord` | pre-existing outer-leaf or child-record bytes embedded in a root-delta value or descriptor |
+| 3 | `RootDeltaPayload` | serialized root-delta payload stored outside the WAL record |
+| 4 | `ColumnManifest` | manifest or prepare record naming a column part's external files |
+| 5 | `ColumnSubstreamFile` | immutable column payload or packed update-delta substream file |
+| 6 | `ColumnFilterFile` | persistent filter file |
+| 7 | `ColumnDeleteBitmapFile` | delete/tombstone bitmap file |
+| 8 | `ColumnDictionaryFile` | compression or encoding dictionary file |
+| 9 | `ColumnMetadataFile` | external compression metadata, mark metadata, or future side metadata file |
+
+`0` is invalid. In v1, any unknown `RefClass` in a complete transaction is
+fatal. A future unknown optional ref may be ignored only when all of the
+following are true: `Required=false`, the transaction version/feature says the
+class is advisory/skippable, canonical embedded required-ref derivation proves
+it is not root-reachable, and cleanup/quarantine refuses to act on its path.
 
 Leaf-log or page-log records produced while replay builds new B-tree roots are
 not `CollectionSideRefs`. They are publish outputs and must be flushed or synced
@@ -1058,9 +1150,15 @@ Side-ref compatibility rule:
 
 Each side ref encodes `RefClass`, `ClassVersion`, `Critical`, `FileID`,
 `Offset`, `Length`, `ChecksumKind`, `Checksum`, and optional advisory
-`RelativePath`. Unknown critical `RefClass` or `ClassVersion` makes the
-transaction unsupported-required and recovery fails closed. Unknown noncritical
-refs may be ignored only if no replay-critical section references them and the
+`RelativePath`. Unknown `RefClass` is fatal in v1. Unknown critical
+`ClassVersion`, unknown required fields, unknown replay-critical fields,
+unknown `MutationClass`, unknown compression codec, unknown dictionary codec,
+unknown side-file class, or unknown descriptor op makes the transaction
+unsupported-required and recovery fails closed. Unknown observability-only
+fields may be skipped only after checksum verification and only if their encoded
+length is within `MaxEncodedTransactionBytes`. Future unknown noncritical refs
+may be ignored only if no replay-critical section references them, canonical
+embedded required-ref derivation proves they are not root-reachable, and the
 transaction feature bits explicitly allow skipping them. Cleanup, GC, rewrite,
 and quarantine must treat unknown refs from complete unwatermarked transactions
 as protected until the transaction is watermarked and checkpointed or an
@@ -1068,11 +1166,44 @@ operator performs a destructive rebuild.
 
 Side refs are resolved by `RefClass` and `RefID`/`FileID` through a file-class
 registry. `RelativePath`, when encoded, is advisory validation data. It must
-normalize to a relative path with no `..` components, no absolute prefix, no
-empty path elements after cleaning, and no symlink traversal. It must remain
-confined to the owning file-class root and match the `RefID`/`FileID` registry
-entry. Cleanup and quarantine operations must refuse paths outside the owning
-file-class root, symlinks, and path/FileID mismatches.
+use `/` separators and reject NUL, empty path, `.`, `..`, repeated separators,
+absolute POSIX paths, Windows drive paths, UNC paths, backslashes, components
+longer than 128 bytes, more than 16 components, and total bytes over 512.
+`RelativePath` never authorizes opening, deletion, quarantine, or rewrite.
+Cleanup and quarantine operations resolve only registry-derived files and must
+refuse paths outside the owning file-class root, symlinks, hardlinks for mutable
+WAL/side files, path/FileID mismatches, and owner/generation mismatches.
+
+Collection names, index names, schema names, tenant names, and root names are
+logical identifiers only. They must never be used as filesystem path components.
+Replay lookup, side-file path construction, cleanup authorization, tenant
+authorization, and root publication use `CollectionUID`, generation, schema
+epoch, catalog/root descriptor state, root kind, and registry `FileID`, never
+`CollectionName`.
+
+Collection WAL and side-ref file classes must use a safe local-file API rather
+than the generic commit-log/value-log `os.OpenFile`, `os.Open`, or `os.Remove`
+primitives. Before collection WAL open, fail closed if the DB root, `maindb`,
+`wal`, `value_vlog`, `leaf_vlog`, or any collection side-file class root is a
+symlink, not a directory, not owned by the effective DB user or configured DB
+owner, group-writable, world-writable, or on an unsupported filesystem for the
+required no-follow/openat/fstat guarantees. The safe API stores class-root
+directory fds, resolves registry file names under those fds, uses no-follow
+open/create/rename/unlink operations where available, creates new mutable
+segments with exclusive create, `fstat`s every opened file, requires a regular
+file under the expected class root with expected owner and file identity, and
+requires `nlink == 1` for newly created mutable WAL/side files. Prepared-to-final
+rename must be same-directory/same-device and atomic; cross-device rename is a
+configuration or corruption error. File and parent-directory fsyncs are part of
+the selected durability boundary.
+
+CRC32C and replay digests detect accidental corruption and implementation bugs;
+they do not authenticate malicious local rewrites by a user who can modify DB
+files. Collection WAL's local threat model treats hostile local writers as out
+of scope only when the directory/file ownership and permission checks above
+pass. If hostile same-user or privileged local writers are in scope for a
+deployment, collection WAL must add a keyed MAC or signature over WAL records
+and protected side-ref manifests before claiming tamper resistance.
 
 Prepared, readable, and integrity-passing means the file-class writer has made
 the referenced range visible to a fresh file reader, and class-specific
@@ -1097,6 +1228,14 @@ validation passes:
   codec/dict id match every dependent payload.
 - `ColumnMetadataFile`: metadata bytes exist, checksum matches, and the owning
   descriptor names the expected metadata class and generation.
+
+Collection WAL side-ref validation always verifies checksums and required
+codecs/dictionaries/templates, independent of normal read-path integrity modes.
+`IntegritySkipChecksums`, value-log `DisableChecksum`, debug readers, and
+operator fast-read modes must not disable collection WAL recovery side-ref
+validation. If a side-ref class cannot verify its checksum because a codec,
+dictionary, template, or manifest is unavailable, the complete transaction is
+fatal or quarantined; it is not replayable.
 
 Collection WAL append must not start until every required side ref in the
 transaction is prepared under this definition. In-memory append buffers,
@@ -2043,18 +2182,21 @@ the current invariant that side-store scans run before cached commit-log replay:
      corruption;
    - a complete frame with checksum mismatch is corruption;
    - unsupported version is corruption unless explicitly marked skippable by a
-     forward-compatible feature flag.
-9. Decode complete transactions and rebuild the protected side-ref index before
-   any maintenance can run.
+     forward-compatible feature flag; v1 defines no skippable transaction
+     versions.
+9. For each complete frame, enforce the decoder order from section 7.5:
+   validate length caps and overflow, verify frame checksum and transaction
+   checksum, parse only fixed-width headers until checksums pass, validate all
+   counts before allocation, then decode variable fields.
 10. Load applied collection-sequence watermark metadata from the recovered system
    root.
 11. Sort unapplied transactions by `CollectionUID`, `CollectionSeq`, and
    `WALLSN` for deterministic diagnostics.
 12. For each uncovered transaction, validate declared side refs and the
    canonical embedded required side-ref set extracted from root deltas and
-   descriptors. The sets must match.
+   descriptors. The sets must match. Rebuild the protected side-ref index only
+   from checksum-valid complete transactions before any maintenance can run.
 13. For each unapplied collection in contiguous `CollectionSeq` order:
-   - validate checksum and format version;
    - validate required side refs;
    - validate collection identity, schema epoch, root generation guards, and
      sequence dependency;
@@ -2581,20 +2723,22 @@ resume_limit = stop_limit * 0.70
 
 | Limit | Default | Behavior |
 |---|---:|---|
-| `CollectionWAL.MaxInlineRootDeltaBytes` | 64 KiB | Spill this root delta to root-delta side payload. |
-| `CollectionWAL.MaxInlineTxnBytes` | 256 KiB | Spill root deltas until inline payload is below the limit. |
-| `CollectionWAL.MaxEncodedTxnBytes` | 1 MiB | Hard error before ack after spill attempts. |
-| `CollectionWAL.MaxRootDeltaSidePayloadBytes` | 16 MiB | Hard error before ack; caller must split batch. |
-| `CollectionWAL.MaxTxnDecodedEntries` | 100,000 | Hard error before ack; recovery rejects/quarantines corrupt oversize WAL. |
-| `CollectionWAL.MaxRootDeltasPerTxn` | 256 | Hard error before ack; caller must split batch. |
+| `CollectionWAL.MaxInlineRootDeltaBytesPerRoot` | 1 MiB | Spill this root delta to root-delta side payload. |
+| `CollectionWAL.MaxInlineRootDeltaBytesPerTxn` | 4 MiB | Spill root deltas until inline payload is below the limit. |
+| `CollectionWAL.MaxEncodedTxnBytes` | 16 MiB | Hard error before ack after spill attempts; hard non-disableable recovery cap. |
+| `CollectionWAL.MaxRootDeltaSidePayloadBytes` | 64 MiB | Hard error before ack; caller must split batch. |
+| `CollectionWAL.MaxTxnDecodedEntries` | 262,144 | Hard error before ack; recovery rejects/quarantines corrupt oversize WAL. |
+| `CollectionWAL.MaxRootDeltasPerTxn` | 64 | Hard error before ack; caller must split batch. |
+| `CollectionWAL.MaxSideRefsPerTxn` | 16,384 | Hard error before ack; caller must split transaction or column/file operation. |
 
 #### Segment, compression, rotation, and sync batching
 
 | Limit | Default | Behavior |
 |---|---:|---|
 | `CollectionWAL.SegmentBytes` | 64 MiB | Rotate before appending a frame that would exceed the segment size. |
+| `CollectionWAL.SegmentBytesMax` | 1 GiB | Absolute segment-size ceiling; lower config allowed, higher config rejected. |
 | `CollectionWAL.WriterBufferBytes` | 4 MiB | Flush when full; not a durability boundary by itself. |
-| Max WAL frame bytes | 1 MiB inline metadata; side payload external | Hard error before ack when exceeded. |
+| Max WAL frame payload bytes | 16 MiB | Hard error before ack when exceeded. |
 | `CollectionWAL.CompressionMinBytes` | 64 KiB payload | Compression attempted only above threshold. |
 | Compression keep rule | compressed bytes plus metadata < raw bytes | Otherwise store uncompressed. |
 | `DurableSync.MaxBatchDelay` | 1 ms | Group fsync trigger. |
@@ -2643,17 +2787,36 @@ Required capacity errors:
 | `ErrCollectionWALMissingRequiredSideRef` | Required side ref is missing/corrupt during append validation or recovery. |
 | `ErrColumnWALCapacityExceeded` | Column side-ref, file-count, or manifest limits exceeded before persistent root publish. |
 
+Required decode/recovery hardening errors:
+
+| Error | When |
+|---|---|
+| `ErrCollectionWALTerminalTail` | safe terminal incomplete tail classification |
+| `ErrCollectionWALCorruptMiddle` | non-terminal corruption or short read |
+| `ErrCollectionWALBadChecksum` | bad frame, transaction, section, or side-ref checksum |
+| `ErrCollectionWALUnsupportedVersion` | unsupported required segment/frame/transaction/ref version |
+| `ErrCollectionWALResourceLimit` | v1 cap or checked arithmetic limit exceeded |
+| `ErrCollectionWALUnsafePath` | advisory path or resolved file violates safe-file rules |
+| `ErrCollectionWALMissingSideRef` | required side ref missing or unavailable |
+| `ErrCollectionWALIdentityMismatch` | collection/catalog/schema/root-set identity guard mismatch |
+| `ErrCollectionWALSequenceGap` | missing lower same-collection sequence blocks replay |
+| `ErrCollectionWALRedacted` | raw sensitive detail intentionally withheld |
+
 Default configuration:
 
 ```text
-CollectionWAL.MaxInlineRootDeltaBytes              = 64 KiB
-CollectionWAL.MaxInlineTxnBytes                    = 256 KiB
-CollectionWAL.MaxEncodedTxnBytes                   = 1 MiB
-CollectionWAL.MaxRootDeltaSidePayloadBytes         = 16 MiB
-CollectionWAL.MaxTxnDecodedEntries                 = 100_000
-CollectionWAL.MaxRootDeltasPerTxn                  = 256
+CollectionWAL.MaxInlineRootDeltaBytesPerRoot       = 1 MiB
+CollectionWAL.MaxInlineRootDeltaBytesPerTxn        = 4 MiB
+CollectionWAL.MaxEncodedTxnBytes                   = 16 MiB
+CollectionWAL.MaxRootDeltaSidePayloadBytes         = 64 MiB
+CollectionWAL.MaxTxnDecodedEntries                 = 262_144
+CollectionWAL.MaxRootDeltasPerTxn                  = 64
+CollectionWAL.MaxMutatedRootsPerTxn                = 64
+CollectionWAL.MaxSideRefsPerTxn                    = 16_384
+CollectionWAL.MaxDescriptorOpsPerTxn               = 1_024
 
 CollectionWAL.SegmentBytes                         = 64 MiB
+CollectionWAL.SegmentBytesMax                      = 1 GiB
 CollectionWAL.WriterBufferBytes                    = 4 MiB
 CollectionWAL.CompressionMinBytes                  = 64 KiB
 
@@ -2936,14 +3099,28 @@ Required property tests:
 
 ### 11.6 Fuzz Tests
 
-- transaction decoder fuzzing;
-- recovery ordering fuzzing with multiple collections and duplicate keys;
-- side-ref fence fuzzing with missing and truncated payloads;
-- root-delta replay fuzzing against an in-memory oracle;
+Required fuzz targets before any collection WAL reader/recovery code runs in DB
+open:
+
+- `FuzzCollectionWALDecodeTransaction`;
+- `FuzzCollectionWALDecodeTransactionNoPreChecksumAlloc`;
+- `FuzzCollectionWALDecodeSideRefs`;
+- `FuzzCollectionWALDecodeRootDelta`;
+- `FuzzCollectionWALRootDeltaPayloadStreaming`;
+- `FuzzCollectionWALRecoveryOrdering`;
+- `FuzzCollectionWALUnknownFieldsAndRefClasses`;
+- `FuzzCollectionWALPathCanonicalize`;
+- `FuzzCollectionWALValuePtrSideRefs`;
+- `FuzzNativeWireCollectionCommandToWALPlan`;
 - cleanup manifest fuzzing with missing segments, torn records, overlapping
   ranges, and mixed-collection segments;
 - system-delta template fuzzing with descriptor/watermark split attempts and
   malformed coverage ranges.
+
+Fuzz properties: never panic, never allocate above the configured cap, never
+publish roots on invalid bytes, never delete/quarantine files from invalid
+bytes, produce deterministic error classes for the same input, and never skip a
+complete corrupt transaction in favor of a later same-collection transaction.
 
 ### 11.7 Required Named Acceptance Tests
 
@@ -3862,8 +4039,8 @@ Future questions that do not weaken PR1 correctness:
 
 1. Should `Collection.Flush` gain a sync variant, or should callers use
    `DB.Checkpoint` for fsync-style barriers?
-2. How large can inline root deltas be before side-payload mode becomes
-   mandatory beyond the Section 12 stronger-default threshold?
+2. Should `MaxEncodedTransactionBytes` be lowered after benchmarks? It must not
+   be raised above 16 MiB for v1 without a format revision.
 3. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
@@ -4118,6 +4295,20 @@ id, side-ref file id, offset, length, checksum, replay digest, relative path
 hash, and error category. Raw names and paths require an explicit local-only
 flag such as `--show-sensitive`.
 
+The default redacted name format is:
+
+```text
+name_hash = hex(HMAC-SHA256(redaction_key, name))[0:16]
+```
+
+The redaction key must be process-local or explicitly configured for the
+operator report; it must not be derived from the raw name alone. Duplicate-key
+and unique-index errors expose stable error classes and may include keyed hashes
+of conflicting keys or document ids, never raw bytes. Native-wire error
+messages, panic messages, metrics labels, and forensic artifacts follow the
+same default redaction rule. Forensic tools may expose raw values only behind an
+explicit local admin flag and must print a warning banner before doing so.
+
 Collection WAL stats exported through expvar or native-wire must use
 `db_dir_hash`, `wal_dir_hash`, segment ids, file ids, and relative path hashes.
 Any legacy stats that expose raw local paths remain legacy/local diagnostics and
@@ -4136,13 +4327,18 @@ is enabled.
 
 ## 18. Implementation Notes
 
-- Prefer adding the collection WAL package below `TreeDB/internal` until the
+- Keep v1 constants, ref-class validation, advisory path validation, and the
+  portable class-root safety checks in `TreeDB/internal/collectionwal` until the
   format stabilizes.
 - Keep the transaction encoder independent from collection planner internals.
 - Make root-delta serialization deterministic from the beginning.
 - Add fault-injection hooks before building the full product path; otherwise
   crash coverage will be too shallow.
 - Preserve existing write-domain read precedence while adding durable backing.
+- Treat value-log raw/pre-encoded append APIs as trusted-only internal
+  primitives. Collection WAL side-ref preparation must wrap or follow any raw
+  append with fresh-process readability and checksum validation before the side
+  ref can satisfy `SideRefsReady`.
 - Treat side-file fences as part of the storage format, not as cleanup policy.
 - Keep future deterministic-entry apply code above the collection WAL package:
   it should derive root deltas through a state-machine adapter and then hand the

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -2404,6 +2404,9 @@ Deliverables:
 - `SystemDeltaTemplate` and descriptor-op encoding;
 - segment metadata and cleanup record encoding;
 - exact byte-format documentation in `storage-format.md`;
+- typed `CollectionWALError` categories and minimal
+  `CollectionWALStats.Snapshot()` counters/gauges for append, pending,
+  protected side refs, recovery, cleanup debt, and value-log GC blockers;
 - stable root-delta encode/decode APIs independent of transient in-memory
   `batch.Batch` layout.
 
@@ -2420,10 +2423,14 @@ Tests:
 - replay digest tests;
 - descriptor-op placeholder instantiation tests;
 - cleanup metadata and missing-segment classification tests.
+- metrics emitted for append success, append failure, recovery skip, recovery
+  hard failure, and cleanup failure.
 
 Gate:
 
 - format package has no dependency on collection planners or backend DB.
+- minimal PR1 metrics and error categories from Section 17 are present before
+  any WAL-on collection write path is merged.
 
 ### Milestone 2: Root Delta and Side-Ref Fences
 
@@ -2661,6 +2668,8 @@ Deliverables:
 - required recovery benchmarks implemented;
 - benchmark runner writes artifacts under `artifacts/collection-wal/`;
 - metrics from Section 12 are emitted for each benchmark row;
+- metric presence tests prove every required Section 17 metric and benchmark
+  artifact field is emitted with stable names;
 - baseline/new `benchstat` output is attached to the acceptance artifact.
 
 Gate:
@@ -2920,33 +2929,171 @@ Column store:
 
 ## 17. Production Observability
 
-Expose metrics and structured logs for:
+Collection WAL observability is part of the durability contract. Operators must
+be able to answer, without parsing raw WAL bytes by hand:
 
-- collection WAL appended transactions, bytes, flush/sync latency, and failed
-  appends;
-- oldest unapplied transaction age and bytes by `CollectionUID`;
-- written `WALLSN`, per-collection applied watermark, and global contiguous
-  cleanup watermark when present;
-- recovery replay count, skipped-tail count, missing side-ref errors, checksum
-  failures, duplicate `WALLSN` failures, and duplicate `(CollectionUID,
-  CollectionSeq)` failures;
-- side refs protected by class, count, bytes, and oldest age;
-- GC bytes blocked by collection WAL side refs;
-- checkpoint blocked time due to pending collection WAL;
-- committed-but-not-staged return count;
-- direct-path writes that used collection WAL versus an equivalent durable
-  fence;
-- recovery accumulator groups, transactions per group, and base-root mismatch
-  failures;
-- read-only opens refused due to pending collection WAL;
-- column side-file prepared, referenced, reachable, quarantined, and deleted
-  counts;
-- overlay and column maintenance WAL transactions and cleanup lag.
+- what is durable;
+- what is pending;
+- what side refs are protected;
+- what blocks GC or cleanup;
+- which transaction failed or was skipped;
+- which files are safe to delete.
 
-Structured log fields should include `wallsn`, `collection_uid`,
-`collection_name`, `collection_generation`, `schema_epoch`, `root_names`,
-`base_root_ids`, `new_root_ids`, `side_ref_class`, `file_id`, `offset`, `size`,
-`checksum`, `durability_mode`, and `watermark_after`.
+All collection WAL metrics must be exposed through:
+
+1. internal `CollectionWALStats.Snapshot()`;
+2. `DB.Stats()`;
+3. caching-layer `Stats()`;
+4. expvar under the existing `treedb` expvar object;
+5. native-wire stats responses;
+6. `treemap collection-wal health --json`;
+7. benchmark artifacts where applicable.
+
+Metric names are stable API. Monotonic process-local counters must end in
+`_total`. Current gauges must end in `_current`, `_age_ms`, `_lag_*_current`, or
+`_last_*`. Counters reset on process restart unless explicitly documented as
+persisted. Gauges may decrease after apply, checkpoint, cleanup, or reopen.
+
+Required aggregate metrics:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `treedb.collection_wal.append.txns_total` | counter | transactions appended |
+| `treedb.collection_wal.append.docs_total` | counter | logical documents covered by appended transactions |
+| `treedb.collection_wal.append.bytes_total` | counter | encoded WAL bytes appended |
+| `treedb.collection_wal.append.side_refs_total` | counter | required side refs appended |
+| `treedb.collection_wal.append.latency_ns_total` | counter | total append latency |
+| `treedb.collection_wal.append.flush_ns_total` | counter | total side/WAL flush latency |
+| `treedb.collection_wal.append.sync_ns_total` | counter | total sync latency |
+| `treedb.collection_wal.append.failures_total` | counter | append failures |
+| `treedb.collection_wal.append.failures.<category>_total` | counter | append failures by stable category |
+| `treedb.collection_wal.pending.txns_current` | gauge | unapplied transactions required for recovery |
+| `treedb.collection_wal.pending.docs_current` | gauge | documents covered by pending transactions |
+| `treedb.collection_wal.pending.bytes_current` | gauge | pending WAL bytes |
+| `treedb.collection_wal.pending.side_refs_current` | gauge | pending required side refs |
+| `treedb.collection_wal.pending.oldest_age_ms` | gauge | age of oldest pending transaction |
+| `treedb.collection_wal.segment.open_current` | gauge | open collection WAL segments |
+| `treedb.collection_wal.segment.bytes_current` | gauge | bytes retained in collection WAL segments |
+| `treedb.collection_wal.segment.cleanable_current` | gauge | segments proven cleanable |
+| `treedb.collection_wal.segment.blocked_current` | gauge | segments blocked from cleanup |
+| `treedb.collection_wal.side_ref.protected.count_current` | gauge | protected side-ref count |
+| `treedb.collection_wal.side_ref.protected.bytes_current` | gauge | protected side-ref bytes |
+| `treedb.collection_wal.side_ref.protected.oldest_age_ms` | gauge | oldest protected side-ref age |
+| `treedb.collection_wal.side_ref.protected.by_class.<class>.count_current` | gauge | protected side refs by class |
+| `treedb.collection_wal.side_ref.protected.by_class.<class>.bytes_current` | gauge | protected bytes by class |
+| `treedb.collection_wal.applied_watermark.lag_txns_current` | gauge | transaction lag between appended and applied |
+| `treedb.collection_wal.applied_watermark.lag_bytes_current` | gauge | byte lag between appended and applied |
+| `treedb.collection_wal.cleanup.debt.bytes_current` | gauge | retained bytes awaiting safe cleanup |
+| `treedb.collection_wal.cleanup.debt.segments_current` | gauge | retained segments awaiting safe cleanup |
+| `treedb.collection_wal.cleanup.lag_txns_current` | gauge | transactions applied but not cleanup-safe |
+| `treedb.collection_wal.cleanup.lag_bytes_current` | gauge | bytes applied but not cleanup-safe |
+| `treedb.collection_wal.recovery.opens_total` | counter | recovery/open attempts that scanned collection WAL |
+| `treedb.collection_wal.recovery.duration_last_ms` | gauge | last recovery scan/replay duration |
+| `treedb.collection_wal.recovery.duration_ns_total` | counter | total recovery scan/replay duration |
+| `treedb.collection_wal.recovery.replayed_txns_total` | counter | transactions replayed |
+| `treedb.collection_wal.recovery.skipped_tail_txns_total` | counter | incomplete terminal tail skips |
+| `treedb.collection_wal.recovery.skipped_watermark_txns_total` | counter | already-applied watermark skips |
+| `treedb.collection_wal.recovery.blocked_txns_total` | counter | transactions blocked by dependency or guard |
+| `treedb.collection_wal.recovery.failures.<category>_total` | counter | recovery failures by stable category |
+| `treedb.collection_wal.recovery.last_failure_category` | last value | last failure category enum |
+| `treedb.collection_wal.recovery.last_failure_wallsn` | last value | `WALLSN` for last failure |
+| `treedb.collection_wal.recovery.last_failure_collection_seq` | last value | collection sequence for last failure |
+| `treedb.collection_wal.recovery.artifacts_written_total` | counter | recovery artifacts written |
+| `treedb.collection_wal.recovery.artifact_write_failures_total` | counter | recovery artifact write failures |
+| `treedb.collection_wal.value_log_gc.blocked_bytes_current` | gauge | value-log bytes blocked by collection WAL side refs |
+| `treedb.collection_wal.value_log_gc.blocked_segments_current` | gauge | value-log segments blocked by collection WAL side refs |
+| `treedb.collection_wal.value_log_gc.blocked_side_refs_current` | gauge | value-log side refs blocking GC |
+| `treedb.collection_wal.value_log_gc.blocked_by_pending_txns_current` | gauge | transactions blocking value-log GC |
+| `treedb.collection_wal.value_log_gc.blocked_bytes_total` | counter | cumulative bytes observed as GC-blocked |
+| `treedb.collection_wal.quarantine.files_total` | counter | files quarantined |
+| `treedb.collection_wal.quarantine.bytes_total` | counter | bytes quarantined |
+| `treedb.collection_wal.txn_index.entries_current` | gauge | transaction-summary index entries |
+| `treedb.collection_wal.txn_index.bytes_current` | gauge | transaction-summary index bytes |
+| `treedb.collection_wal.txn_index.lookup_failures_total` | counter | transaction lookup failures |
+
+Column side-file classes must appear in the `side_ref.protected.by_class`
+metric family before column-store persistent writes are enabled. Required class
+labels include `ValueLogRecord`, `LeafLogRecord`, `RootDeltaPayload`,
+`ColumnManifest`, `ColumnSubstreamFile`, `ColumnFilterFile`,
+`ColumnDeleteBitmapFile`, `ColumnDictionaryFile`, and `ColumnMetadataFile`.
+
+High-cardinality per-collection metrics may be emitted only by UID hash, never
+by raw collection name:
+
+- `treedb.collection_wal.by_collection.<collection_uid_hash>.pending_txns_current`;
+- `treedb.collection_wal.by_collection.<collection_uid_hash>.pending_bytes_current`;
+- `treedb.collection_wal.by_collection.<collection_uid_hash>.applied_seq_current`;
+- `treedb.collection_wal.by_collection.<collection_uid_hash>.last_wallsn`.
+
+Future Raft-local apply metrics must not overload local collection WAL metrics.
+Reserve separate fields for `local_durable_seq`, `replicated_seq`,
+`locally_applied_seq`, `cluster_committed_seq`, `checkpointed_seq`, and
+`cleanup_eligible_seq`.
+
+Implementations must maintain process-local stats with atomic counters/gauges
+equivalent to:
+
+```text
+CollectionWALStats {
+    append counters: txns_total, docs_total, bytes_total, side_refs_total,
+        latency_ns_total, flush_ns_total, sync_ns_total, failures_total,
+        failures_by_category_total;
+    pending gauges: txns_current, docs_current, bytes_current,
+        side_refs_current, oldest_unix_nano;
+    segment gauges: open_current, bytes_current, cleanable_current,
+        blocked_current;
+    side-ref gauges: protected_count_current, protected_bytes_current,
+        protected_oldest_unix_nano, protected_by_class;
+    watermark gauges: lag_txns_current, lag_bytes_current;
+    cleanup gauges: debt_bytes_current, debt_segments_current,
+        lag_txns_current, lag_bytes_current;
+    recovery stats: opens_total, duration_last_ms, duration_ns_total,
+        replayed_txns_total, skipped_tail_txns_total,
+        skipped_watermark_txns_total, blocked_txns_total,
+        failures_by_category_total, last_failure fields,
+        artifacts_written_total, artifact_write_failures_total;
+    GC blocker stats: blocked_bytes_current, blocked_segments_current,
+        blocked_side_refs_current, blocked_by_pending_txns_current,
+        blocked_bytes_total;
+}
+```
+
+Failure-category maps are initialized from the recovery category enum in
+`recovery.md`; arbitrary error strings must not create metric keys.
+
+Every collection WAL transaction has a stable diagnostic transaction id:
+
+```text
+TxnID = hex(CollectionUID) + ":" + decimal(CollectionSeq)
+```
+
+`TxnID` may be physically stored or derived by tooling, but reports and
+artifacts must include it. `WALLSN` remains the secondary segment-location and
+cleanup-scan diagnostic.
+
+Default logs, metrics, CLI output, and recovery artifacts must not include raw
+document payloads, raw user keys, raw index keys, raw collection names, raw root
+names, absolute host paths, or tenant-sensitive path components. Default output
+may include `CollectionUID`, `collection_uid_hash`, `root_name_hash`, segment
+id, side-ref file id, offset, length, checksum, replay digest, relative path
+hash, and error category. Raw names and paths require an explicit local-only
+flag such as `--show-sensitive`.
+
+Collection WAL stats exported through expvar or native-wire must use
+`db_dir_hash`, `wal_dir_hash`, segment ids, file ids, and relative path hashes.
+Any legacy stats that expose raw local paths remain legacy/local diagnostics and
+must not be used for collection WAL operator reports.
+
+Structured log fields should include `event`, `error_category`, `txn_id`,
+`wallsn`, `collection_uid`, `collection_uid_hash`, `collection_generation`,
+`collection_seq`, `schema_epoch`, `root_name_hashes`, `base_root_ids`,
+`new_root_ids`, `side_ref_class`, `side_ref_file_id`, `side_ref_offset`,
+`side_ref_length`, `checksum_expected`, `checksum_actual`, `durability_mode`,
+`watermark_before`, `watermark_after`, and `redaction`.
+
+Default structured logs must not include `collection_name`, raw `root_names`, or
+absolute paths unless `--show-sensitive` or an equivalent local diagnostic mode
+is enabled.
 
 ## 18. Implementation Notes
 
@@ -2998,6 +3145,24 @@ Module-specific constraints:
   a durable manifest writer with file fsync, rename, parent-directory fsync, and
   WAL-directory fsync after segment unlink. Atomic rename without those fsync
   steps is not enough for missing-segment proof.
+- `TreeDB/internal/collectionwal` owns process-local `CollectionWALStats` and
+  `CollectionWALRecoveryStats` snapshots. Failure-category counters must come
+  from a bounded enum initialized with every category in `recovery.md`, not from
+  arbitrary error strings. `_total` metrics are monotonic within one process;
+  `_current`, `_age_ms`, `_lag_*_current`, and `_last_*` values are reset-safe
+  gauges or diagnostics.
+- `TreeDB/db`, `TreeDB/caching`, expvar, and native-wire stats must expose the
+  same `treedb.collection_wal.*` keys. The expvar whitelist must include the
+  `treedb.collection_wal.` prefix. High-cardinality per-collection values use
+  `collection_uid_hash`, not raw collection names.
+- Collection WAL recovery must write redacted recovery artifacts before
+  deleting, quarantining, rewriting, or marking clean any collection WAL segment
+  or side-ref file. Artifact write failures increment metrics and must not cause
+  cleanup to destroy the only forensic evidence for a hard recovery failure.
+- `treemap collection-wal health`, `safe-delete`, `txn`, and `classify`, plus
+  `verify --read-only --collection-wal --side-refs`, are required
+  non-mutating operator surfaces before WAL-on collection durability can be
+  enabled by default.
 - `TreeDB/collections` owns final physical delta planning before
   acknowledgement. WAL-on collection planners must serialize primary,
   template/index-state, secondary, overlay, delete, schema, and future

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -2,7 +2,9 @@
 
 Status: normative implementation gate once Milestones 0-7 are complete.
 Sections marked MUST/SHOULD define the production collection durability
-contract; explicitly marked future-work sections remain non-normative.
+contract; explicitly marked future-work sections remain non-normative. Open
+questions in Section 15 must be resolved before any milestone that depends on
+them can pass.
 Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
@@ -1937,39 +1939,173 @@ Read-only open:
 - side-ref fence fuzzing with missing and truncated payloads;
 - root-delta replay fuzzing against an in-memory oracle.
 
+### 11.6 Required Named Acceptance Tests
+
+These tests or equivalent subtests must exist before implementation can be
+considered complete. Names are normative so CI, verification docs, and
+acceptance artifacts can point to stable evidence.
+
+| Test | Harness shape | Must prove |
+|---|---|---|
+| `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers` | Child process opens with `DurabilityWALOnRelaxed`, inserts a no-index document, exits without `Flush`/`Close`; parent reopens. | WAL-on relaxed is durable-at-ack for process crash. |
+| `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery` | Same fixture under `DurabilityWALOffRelaxed`, with a second subtest that calls `Flush` first. | WAL-off remains relaxed before flush; explicit flush remains a persistence boundary. |
+| `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility` | Fault hook fails collection WAL append after private planning; assert API error, `Get` misses, reopen misses. | WAL append precedes visibility and acknowledgement. |
+| `TestCollectionWALIndexedInsertUpdateDeleteRecoverAtomically` | WAL-on crash helper performs indexed insert, update changing indexed values, and delete, then exits before flush. | Primary, template/index-state, unique secondary, and nonunique secondary roots recover as one group. |
+| `TestCollectionWALUniqueNonUniqueSecondaryIndexesAfterRecovery` | Insert two documents with one unique index and one shared nonunique value; crash/reopen; attempt duplicate unique insert and nonunique lookup. | Unique helpers are rebuildable and nonunique indexes preserve multiplicity. |
+| `TestCollectionWALBufferedSameBaseRootTransactionsReplayByAccumulator` | Force multiple acknowledged buffered transactions with the same persisted `BaseRootID`; crash before publish. | Recovery accumulates/rebases rather than losing later transactions or failing on root mismatch. |
+| `TestCollectionWALPartialFrameAndMissingSideRefNoPhantomRoots` | Corrupt/truncate collection WAL tail and remove a required value-log or leaf-log side ref. | Tail truncation is ignored only when safe; missing required side refs never publish phantom roots. |
+| `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied` | Two collections; force higher `WALLSN` publish/watermark before a lower `WALLSN`; crash/reopen. | Per-collection watermark logic cannot skip lower unapplied transactions. |
+| `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent` | Fault hook exits during recovery after N transactions, after watermark commit, and during segment cleanup; reopen repeatedly. | No double-apply, no lost writes, cleanup eventually converges. |
+| `TestCollectionWALGCRewriteCompactionSnapshotsProtectPendingSideRefs` | Create pending WAL transaction whose side ref has no published root owner; pin snapshot/read view; run GC/rewrite/compaction; crash/reopen. | Side refs are protected until watermark plus checkpoint handoff, and snapshots do not observe dangling roots. |
+
+### 11.7 Required Fault Points
+
+The crash harness must expose these named fault points. Each point must support
+both "return injected error" and "process exit" modes when the code path can
+observe both outcomes.
+
+```text
+before_side_file_prepare
+after_side_file_prepare_before_wal_append
+before_collection_wal_append
+after_collection_wal_append_before_visibility
+after_ack_before_root_publish
+queued_flush_unit_before_publish
+publishing_unit_after_state_move_before_publish
+after_root_pages_built_before_system_root_commit
+after_system_root_commit_before_watermark_visible
+after_watermark_commit_before_wal_cleanup
+during_wal_segment_cleanup
+during_prepared_side_file_quarantine
+during_recovery_after_n_transactions
+during_value_log_gc_scan_with_pending_collection_wal
+during_value_log_rewrite_with_pending_collection_wal
+during_overlay_compaction_publish
+```
+
+`after_system_root_commit_before_watermark_visible` should be untriggerable in a
+correct PR1 implementation because descriptor changes and watermark advancement
+are one backend commit. The fault point exists to prove the implementation does
+not expose or test a two-phase publish path.
+
 ## 12. Benchmark Plan
 
-Benchmarks must compare before/after on the same host with `benchstat`.
+Benchmarks must compare baseline and new implementation on the same host with
+`benchstat`. Use the current `ProfileWALOnFast` / `wal_on_fast` collection
+profile as the primary baseline when measuring WAL-on collection overhead, with
+the same storage-policy cell, document format, batch size, and fixture data.
+Durable-mode benchmarks are smoke gates for sync behavior, not the primary
+regression baseline.
 
-Core rows:
+Required storage-policy cells:
 
-- no-index `InsertBatch`;
-- one unique secondary index `InsertBatch`;
-- three secondary indexes `InsertBatch`;
-- `UpdateBatch` with unchanged indexed values;
-- `UpdateBatch` with changed indexed values;
-- delete-heavy workload;
-- async indexed flush workload;
-- `Flush`;
-- crash-recovery replay of 1K, 100K, and 1M pending documents.
+- `data_outer=true,index_outer=false` (production-mainline priority);
+- `data_outer=true,index_outer=true` (fully compressed);
+- `data_outer=false,index_outer=false` (fast/control);
+- `data_outer=false,index_outer=true` (low-priority compatibility cell).
 
-Initial gates:
+Required collection WAL microbenchmark command:
 
-- WAL-on no-index insert throughput regression <= 10 percent after warmup;
-- WAL-on one-index insert throughput regression <= 15 percent;
-- WAL-on three-index insert throughput regression <= 20 percent;
-- recovery throughput >= 50K root-delta entries/sec on the deterministic
-  fixture before optimization;
-- collection WAL bytes/doc reported for every benchmark;
-- no unbounded memory growth when async publish is stalled.
+```bash
+for cell in \
+  "true false" \
+  "true true" \
+  "false false" \
+  "false true"
+do
+  set -- $cell
+  export TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=$1
+  export TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=$2
+  export TREEDB_COLLECTION_BENCH_ENGINE=wal_on_fast
+  export TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000
+
+  go test ./TreeDB/collections \
+    -run '^$' \
+    -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALThreeIndexInsertBatch|BenchmarkCollectionWALUpdateBatchUnchangedIndexedValues|BenchmarkCollectionWALUpdateBatchChangedIndexedValues|BenchmarkCollectionWALDeleteHeavy|BenchmarkCollectionWALAsyncIndexedFlushStalled|BenchmarkCollectionWALFlushPending)$' \
+    -benchmem -count=10 \
+    > "artifacts/collection-wal/bench-${1}-${2}.txt"
+done
+```
+
+Required recovery benchmark command:
+
+```bash
+TREEDB_COLLECTION_BENCH_ENGINE=wal_on_fast \
+TREEDB_COLLECTION_WAL_RECOVERY_DOCS=1000,100000,1000000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkCollectionWALRecoveryReplayPendingDocs$' \
+  -benchmem -benchtime=1x -count=5 \
+  > artifacts/collection-wal/recovery.txt
+```
+
+Required durable-mode smoke benchmark command:
+
+```bash
+TREEDB_COLLECTION_BENCH_ENGINE=durable \
+TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^(BenchmarkCollectionWALNoIndexInsertBatch|BenchmarkCollectionWALOneUniqueIndexInsertBatch|BenchmarkCollectionWALFlushPending)$' \
+  -benchmem -count=5 \
+  > artifacts/collection-wal/durable-smoke.txt
+```
+
+Every benchmark row must report these metrics when the harness can measure them:
+
+| Metric | Purpose |
+|---|---|
+| `docs/sec`, `ns/doc` | Primary throughput. |
+| `ack_ns/doc` | Acknowledgement latency cost. |
+| `collection_wal_append_ns/doc` | WAL append overhead. |
+| `collection_wal_bytes/doc` | Write amplification. |
+| `root_delta_entries/doc` | Workload normalization. |
+| `side_refs/doc` | Side-file pressure. |
+| `pending_collection_wal_bytes` | Cleanup debt. |
+| `applied_watermark_lag_txns` | Recovery debt. |
+| `recovery_docs/sec` | Reopen speed. |
+| `recovery_root_delta_entries/sec` | Replay throughput. |
+| `recovery_peak_rss_bytes` or `recovery_peak_heap_bytes` | Replay memory bound. |
+| `gc_protected_side_ref_bytes` | GC/rewrite retention cost. |
+| `cleanup_ns/segment` | Segment cleanup cost. |
+| `allocs/doc`, `bytes_allocated/doc` | Heap regression. |
+
+Gate thresholds:
+
+| Metric | Initial implementation gate | Stronger-default gate |
+|---|---:|---:|
+| No-index WAL-on insert regression | <=25 percent | <=10 percent |
+| One-unique-index insert regression | <=30 percent | <=15 percent |
+| Three-index insert regression | <=35 percent | <=20 percent |
+| Update unchanged indexed values | <=20 percent | <=10 percent |
+| Update changed indexed values | <=30 percent | <=20 percent |
+| Delete-heavy workload | <=30 percent | <=20 percent |
+| Flush pending WAL-backed deltas | <=30 percent | <=20 percent |
+| Recovery, no-index | >=50K docs/sec | >=100K docs/sec target |
+| Recovery, indexed | >=20K docs/sec and >=50K root-delta entries/sec | >=50K docs/sec target |
+| WAL bytes/doc | Reported and below chosen formula threshold | Required; exceeding threshold blocks stronger default |
+| Async stalled memory | Numeric cap reported; queue bounds enforced | Same, plus no steady-state leak across repeated cycles |
+| Cleanup | No unapplied segment removed; fully applied segments cleaned after safe checkpoint | Same |
+
+Use `benchstat -count=10` for microbenchmarks. A performance gate fails only
+when both the mean regression crosses the threshold and `benchstat` reports a
+statistically significant change. Correctness gates do not depend on benchmark
+variance and must pass before any performance gate can be considered.
+
+The stronger-default gate is required before enabling WAL-on collection
+durable-at-ack as a default profile. The initial implementation gate is enough
+to merge guarded/internal code paths when all correctness gates are green and
+all metrics above are emitted.
 
 Column-store gates added before persistent column writes:
 
-- column part prepare plus WAL append overhead reported as ns/row and bytes/row;
+- column part prepare plus WAL append overhead reported as `ns/row` and
+  `bytes/row`;
 - side-ref closure validation throughput reported on deterministic descriptors
   with 1K, 100K, and 1M file refs;
-- recovery throughput reported by row count and file count;
-- recovery of many small update-delta parts does not grow memory unbounded;
+- recovery throughput reported by row count, root-delta entry count, and file
+  count;
+- recovery of many small update-delta parts has numeric peak memory bounds;
 - file count per default update micro-batch stays under the configured policy;
 - column WAL bytes/row and side-ref metadata bytes/row are reported;
 - orphan cleanup of prepared files has a bounded benchmark target;
@@ -1980,9 +2116,9 @@ Column-store gates added before persistent column writes:
 - read-only recovery-required scan has bounded latency and does not parse full
   column payloads.
 
-These gates are provisional. If the current write path cannot meet them with
-inline root deltas, PR2 should move large deltas to side payloads before
-weakening durability.
+If inline root-delta WAL exceeds 2.5x serialized root-delta payload plus fixed
+frame overhead, side-payload mode must be implemented before the
+stronger-default gate can pass.
 
 ## 13. Roadmap and Gates
 
@@ -1991,6 +2127,7 @@ Traceability matrix:
 | Design area | Sections | Milestones | Required evidence |
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
+| Testability decisions | 15 | M0.5 | closed PR1 choices and acceptance artifact |
 | WAL format | 7.2, 7.4, 7.5 | M1 | golden, fuzz, corrupt-tail tests |
 | Recovery state machine | 9.1, 9.2, 9.4 | M1, M5 | crash-state and stop-open tests |
 | Identity and sequencing | 7.3, 7.6, 9.3 | M1, M5 | collection-seq, epoch, generation tests |
@@ -2000,12 +2137,42 @@ Traceability matrix:
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
 | Visibility/admission barriers | 6.2, 6.3, 8, 8.9 | M3, M6 | read-race, checkpoint-cut, and close-race tests |
 | Collection read views | 3, 6.3, 8.10, 10 | M4, M6 | long-iterator and side-ref pinning tests |
-| Recovery replay | 9 | M4 | crash matrix, accumulation, and deterministic replay tests |
+| Recovery replay | 9 | M4, M4.5 | crash matrix, accumulation, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
 | Lock ordering | 8.9, 11.4 | M0, M6 | debug lock assertions and deadlock stress |
-| Performance | 12 | M6 | benchstat gates and artifacts |
+| Performance | 12 | M6.5 | benchstat gates and artifacts |
 | Column-store unblock | 6.4, 10 | M7 | side-file fence and root-group recovery proof |
 | Native-wire/Raft layering | 2.4, 6.2, 7.9, 8.8 | M8 | deterministic-entry apply and local-WAL durability tests |
+
+Each milestone must produce a machine-readable acceptance artifact at
+`artifacts/collection-wal/<milestone>/acceptance.json` with:
+
+- git commit;
+- test command;
+- test result;
+- benchmark command when applicable;
+- benchmark result path when applicable;
+- enabled durability mode;
+- storage-policy cell;
+- collection document format;
+- fault points exercised;
+- pass/fail decision.
+
+Acceptance matrix:
+
+| Gate | Required evidence | Pass criteria |
+|---|---|---|
+| M0 Contract and harness freeze | Existing current-contract tests and crash helper skeleton. | Current flush-boundary behavior remains documented; named fault hooks can stop at side prepare, WAL append, staging, publish, watermark, cleanup, and recovery replay. |
+| M0.5 Testability decisions | Closed PR1 decisions in Section 15. | File class, transaction identity, checkpoint behavior, missing side-ref policy, buffered replay model, GC protection, and overlay compaction rule are testable. |
+| M1 WAL format | Golden fixtures, checksum/corruption/truncation tests, decoder fuzzing. | Decoder is deterministic; safe terminal truncation is accepted; hard corruption fails. |
+| M2 Side-ref fences | Missing-ref, side-payload, and GC/rewrite protection tests. | No root points at missing bytes; WAL-pending side refs are retained. |
+| M3 No-index WAL integration | WAL-on/WAL-off no-index crash tests and append-failure tests. | WAL-on crash recovers acknowledged writes; WAL-off expectations stay relaxed; append failure has no visibility. |
+| M4 Indexed integration | Indexed insert/update/delete atomic recovery tests. | Primary, template/index-state, unique, and nonunique roots agree after reopen. |
+| M4.5 Buffered/async states | Mutable, queued, publishing, requeue, and accumulator tests. | No acknowledged write is lost in any write-domain state. |
+| M5 Watermark/recovery/cleanup | Repeated reopen, watermark, missing segment, and cleanup-crash tests. | Replay is idempotent; no double-apply; no premature cleanup. |
+| M6 Barriers and modes | Flush, FlushAll, checkpoint, close, and read-only open tests. | Chosen barrier semantics are deterministic and documented. |
+| M6.5 Performance | Required benchmark commands and `benchstat` artifacts. | Correctness is green; metrics are emitted; thresholds pass for the selected gate. |
+| M7 Column-store sign-off | M1-M6 artifacts, synthetic side-file tests, benchmark artifacts, and column PR checklist links. | Persistent column roots and side refs stay blocked until the sign-off artifact is green. |
 
 ### Milestone 0: Contract Freeze
 
@@ -2032,6 +2199,24 @@ Gate:
 
 - no production column-store persistent work starts before this milestone is
   complete.
+
+### Milestone 0.5: Testability Decisions
+
+The PR1 decisions in Section 15 are prerequisites for executable tests. Before
+M1 starts, the implementation owner must confirm the exact testable choices for:
+
+- collection WAL segment format and filename class;
+- `CollectionSeq` and `WALLSN` allocation and persistence;
+- missing side-ref behavior by durability mode;
+- checkpoint behavior for PR1;
+- buffered replay model;
+- GC/rewrite side-ref protection mechanism;
+- overlay compaction durability rule.
+
+Gate:
+
+- no collection-WAL implementation PR may claim milestone completion while an
+  applicable testability decision remains open or has no acceptance artifact.
 
 ### Milestone 1: Collection WAL Format Package
 
@@ -2112,16 +2297,24 @@ Deliverables:
 
 Tests:
 
-- crash after ack before flush recovers document;
+- `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers`;
+- `TestCollectionWALDurableNoIndexAckBeforeFlushRecovers`;
+- `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`;
+- `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility`;
+- `TestCollectionWALNoIndexInsertBatchAckBeforeFlushRecovers`;
+- no-index `Update`, `UpdateBatch`, `Delete`, and `DeleteBatch` either publish
+  synchronously under the documented current rule or are WAL-backed before ack;
+  whichever rule is chosen must have crash/reopen tests;
 - crash before WAL append does not expose document;
-- WAL append failure leaves no visible no-index pending state;
 - concurrent reads and planners blocked around WAL append cannot observe the
   private mutation;
-- checkpoint behavior updated to the new contract.
+- checkpoint behavior updated to the new contract;
+- WAL-off mode creates no collection WAL files for unflushed writes.
 
 Gate:
 
-- no-index insert regression <= 10 percent in WAL-on benchmark fixture.
+- no-index insert benchmark meets the M6 initial implementation gate and emits
+  all required metrics.
 
 ### Milestone 4: Indexed Insert/Update/Delete Integration
 
@@ -2147,14 +2340,22 @@ Deliverables:
 
 Tests:
 
+- `TestCollectionWALIndexedInsertRecoverAtomically`;
+- `TestCollectionWALIndexedUpdateChangedSecondaryRecoverAtomically`;
+- `TestCollectionWALIndexedUpdateUnchangedSecondarySkipsSecondaryRootsAfterRecovery`;
+- `TestCollectionWALIndexedDeleteRecoverAtomically`;
+- `TestCollectionWALUniqueReuseAfterDeleteRecovery`;
+- `TestCollectionWALIndexedInsertUpdateDeleteRecoverAtomically`;
 - crash after ack before async publish;
 - crash during async publish;
-- WAL append failure for indexed insert/update/delete leaves no visible primary,
+- WAL append failure for indexed `Insert`, `InsertBatch`, `Update`,
+  `UpdateBatch`, `Delete`, and `DeleteBatch` leaves no visible primary,
   secondary, unique-helper, queued, or publishing state;
 - long-running iterators remain valid while async publish completes and cleanup
   waits for read-view release;
-- unique secondary correctness after recovery;
-- update/delete secondary roots recover atomically;
+- unique and nonunique secondary correctness after recovery;
+- unchanged indexed-value update, changed unique value, changed nonunique value,
+  delete followed by unique-value reuse, and duplicate conflict after recovery;
 - two acknowledged buffered writes against one persisted base both survive
   crash/reopen;
 - per-collection ordering gaps block later same-collection transactions;
@@ -2165,9 +2366,35 @@ Tests:
 
 Gate:
 
-- one-index insert regression <= 15 percent;
-- three-index insert regression <= 20 percent;
+- one-index and three-index insert benchmarks meet the M6 initial implementation
+  gate and emit all required metrics;
 - async flush cannot lose acknowledged documents under process crash.
+
+### Milestone 4.5: Buffered and Async State Recovery
+
+Deliverables:
+
+- mutable, queued, and publishing units carry WAL ownership and contiguous
+  `CollectionSeq` ranges;
+- replay-side accumulator handles multiple root deltas sharing the same
+  persisted base root;
+- async publish failure requeues without changing WAL identity or cleanup
+  eligibility;
+- memory and queue bounds remain enforced when async publish is stalled.
+
+Tests:
+
+- `TestCollectionWALBufferedSameBaseRootTransactionsReplayByAccumulator`;
+- `TestCollectionWALQueuedFlushUnitCrashRecovers`;
+- `TestCollectionWALPublishingUnitCrashRecovers`;
+- `TestCollectionWALAsyncPublishFailureRequeueKeepsWAL`;
+- `TestCollectionWALAsyncPublishNoWatermarkOutOfPrefixOrder`;
+- async stalled benchmark reports numeric memory and queue caps.
+
+Gate:
+
+- no acknowledged write is lost from mutable, queued, or publishing state under
+  the required crash harness.
 
 ### Milestone 5: Recovery, Watermark, and Cleanup
 
@@ -2187,8 +2414,18 @@ Deliverables:
 
 Tests:
 
+- `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied`;
+- `TestCollectionWALRecoveryCrashAfterNTransactionsIdempotent`;
+- `TestCollectionWALCleanupCrashIdempotent`;
+- `TestCollectionWALPreparedUncommittedSideFilesQuarantined`;
 - crash after root page build or watermark commit before cleanup does not
   double-apply;
+- crash during recovery after publishing a subset of unapplied transactions is
+  idempotent after repeated reopen;
+- crash after watermark commit before WAL cleanup leaves the transaction
+  skipped by watermark and cleanup retryable;
+- crash during WAL segment cleanup is idempotent;
+- crash during prepared side-file quarantine/delete is idempotent;
 - out-of-order async publish cannot advance a watermark that hides a lower
   unapplied collection sequence;
 - accumulated publishes advance only contiguous `CollectionSeq` prefixes;
@@ -2238,9 +2475,42 @@ Gate:
 
 - no stale collection WAL files after clean close and checkpoint.
 
-### Milestone 7: Column-Store Unblock Gate
+### Milestone 6.5: Performance Acceptance
 
 Deliverables:
+
+- required collection WAL microbenchmarks implemented under
+  `TreeDB/collections`;
+- required recovery benchmarks implemented;
+- benchmark runner writes artifacts under `artifacts/collection-wal/`;
+- metrics from Section 12 are emitted for each benchmark row;
+- baseline/new `benchstat` output is attached to the acceptance artifact.
+
+Gate:
+
+- correctness gates M1 through M6 are green;
+- initial implementation thresholds from Section 12 pass for guarded/internal
+  enablement;
+- stronger-default thresholds from Section 12 pass before WAL-on
+  durable-at-ack becomes a default profile.
+
+### Milestone 7: Column-Store Persistent Write Unblock Sign-Off
+
+M7 is a release gate, not a standalone implementation milestone. It cannot pass
+unless M1 through M6, including the required benchmark artifacts, are complete.
+
+Prerequisites:
+
+- M1 through M6 acceptance artifacts are present and green;
+- the verification matrix lists every passing collection-WAL test by exact name;
+- baseline/new `benchstat` output exists for the required benchmark rows and
+  storage cells;
+- synthetic external side-file tests pass before real column-file writes are
+  exposed;
+- the column-store PR checklist links to the exact collection-WAL acceptance
+  artifact.
+
+Additional column-store evidence:
 
 - explicit column root-kind inventory for parts, granules, locators, deletes,
   schema, filters, count/visibility metadata, compression metadata, primary, and
@@ -2259,30 +2529,11 @@ Deliverables:
 - column compaction, delete-bitmap compaction, and recompression modeled as
   collection WAL transactions.
 
-Tests:
-
-- crash before side-file prepare completes;
-- crash after side-file prepare before WAL append;
-- crash after final rename before WAL append;
-- crash after WAL append before root publish;
-- crash during root publish before watermark;
-- crash after watermark before WAL cleanup;
-- missing/corrupt required manifest, substream, filter, delete bitmap,
-  dictionary, compression metadata, or metadata side ref;
-- descriptor side-ref closure mismatch;
-- orphan prepare/final column directories are quarantined or deleted;
-- read-only open refuses unapplied collection WAL;
-- GC/rewrite cannot delete bytes referenced only by pending collection WAL or
-  live `CollectionReadView`;
-- update-delta publish with primary locator changes, delete bitmaps,
-  count/visibility metadata, and secondary unique/nonunique changes;
-- compaction/recompression publish cannot expose duplicate rows from both source
-  and compacted parts.
-
 Gate:
 
-- persistent column-store writes may start only after these tests pass under
-  WAL-on durable and WAL-on relaxed profiles.
+- no production or public-facing column-store collection API may publish
+  persistent roots, descriptor roots, secondary indexes to column rows, or
+  column-file side refs until this sign-off gate is green.
 
 ### Milestone 8: Native-Wire and Raft Apply Coordination
 
@@ -2398,11 +2649,8 @@ Future questions that do not weaken PR1 correctness:
 1. Should `Collection.Flush` gain a sync variant, or should callers use
    `DB.Checkpoint` for fsync-style barriers?
 2. How large can inline root deltas be before side-payload mode becomes
-   mandatory?
-3. What metric names should expose pending collection WAL bytes, applied
-   collection-sequence lag, replay count, fenced transactions, protected side
-   refs, and cleanup debt?
-4. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
+   mandatory beyond the Section 12 stronger-default threshold?
+3. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
 

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,8 +1,8 @@
 # SPEC: Collection WAL Durability and Root-Group Recovery
 
-Status: draft proposal. PR1 sections are normative for the planned collection
-WAL implementation; explicitly marked future-work sections remain
-non-normative.
+Status: normative implementation gate once Milestones 0-7 are complete.
+Sections marked MUST/SHOULD define the production collection durability
+contract; explicitly marked future-work sections remain non-normative.
 Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
@@ -292,6 +292,23 @@ Clean WAL state:
 No collection WAL transaction remains required for crash recovery. This is
 stronger than "normal backend WAL has no files".
 
+Column side-ref closure:
+
+For any collection WAL transaction that publishes column-store descriptors,
+locator roots, delete roots, filter roots, granule roots, count/visibility
+metadata, compression metadata, or schema roots, the transaction's required side
+refs are the complete transitive closure of every external file or byte range
+referenced by root values added or modified by the transaction.
+
+A root value must not reference a column file, manifest, delete bitmap, filter
+file, dictionary file, or external compression metadata object unless that
+object is listed as a required side ref in the same transaction or is already
+reachable from a durable root visible to the transaction's base snapshot.
+
+Optional or rebuildable filters may be omitted or rebuilt, but a published root
+entry that names external filter bytes makes those bytes required. A side ref
+marked `Required=false` must not be referenced by any published root value.
+
 ## 4. Goals
 
 1. Make collection durability explicit and testable.
@@ -532,9 +549,13 @@ CollectionWALTransaction {
 
     // Catalog guard.
     SchemaEpoch              uint64
+    CollectionEpoch          uint64 required for column-store collections
+    SchemaVersion            uint32 optional for row-store, required for column-store
     BaseCommitSeq            uint64
     BaseSystemRootID         uint64
     BaseCatalogDigest        bytes optional
+    CatalogDigest            bytes optional, recommended for column-store
+    MutationClass            uint8
 
     // Physical mutation.
     RootDeltas               []CollectionRootDelta
@@ -621,6 +642,15 @@ OrderedRootPublishOptions {
     WatermarkOp              AppliedWatermarkOp
 }
 ```
+
+Column-store transactions must carry enough catalog identity to make replay
+schema-stable. `CollectionEpoch` guards collection incarnation and catalog-level
+schema evolution. `SchemaVersion` guards physical column decode. `CatalogDigest`
+is optional but recommended for debugging and precondition checks. The
+`MutationClass` values are versioned and include at least `row_insert`,
+`row_update`, `row_delete`, `column_insert`, `column_update_delta`,
+`column_delete`, `column_compaction`, `column_recompression`, and
+`schema_change`.
 
 A transaction is replayable only when:
 
@@ -713,11 +743,35 @@ rules: if two accumulated deltas affect the same key, the later
 `CollectionSeq` wins, and deletes suppress older values according to normal
 collection visibility rules.
 
-Root kinds are explicit, versioned values. PR1 root kinds include primary,
-template/index-state, secondary index, overlay, overlay descriptor, delete, and
-metadata roots. Future column-store root kinds include part descriptor, locator,
-column schema, filter descriptor, delete bitmap, and compression/dictionary
-metadata roots.
+Root kinds are explicit, versioned values. PR1 row-store root kinds include
+`primary`, `template`, `index_state`, `secondary`, `overlay`,
+`overlay_descriptor`, `delete`, and `metadata`.
+
+Column-store root kinds are part of the production gate and include at least:
+
+- `primary_locator`: authoritative `id -> row_locator` primary root;
+- `column_parts`: immutable part descriptor root;
+- `column_granules`: optional part/granule mark root;
+- `column_locator`: optional auxiliary primary-id locator root;
+- `column_deletes`: tombstone and delete-bitmap descriptor root;
+- `column_schema`: physical column schema and schema-evolution root;
+- `column_filter`: persistent filter descriptor root;
+- `column_count_visibility`: exact count and visibility aggregate metadata root;
+- `column_compression_metadata`: external compression metadata or dictionary
+  descriptor root when not represented in part descriptors;
+- `secondary`: existing secondary index roots, column-store aware;
+- `template` and `index_state`: existing template/index-state roots when the
+  collection format requires them.
+
+Recommended enum names are `RootKindPrimaryLocator`,
+`RootKindColumnParts`, `RootKindColumnGranules`, `RootKindColumnLocator`,
+`RootKindColumnDeletes`, `RootKindColumnSchema`, `RootKindColumnFilter`,
+`RootKindColumnCountVisibility`, and `RootKindColumnCompressionMetadata`.
+
+Every locator, part descriptor, granule/mark, delete, filter, count/visibility,
+schema, compression metadata, primary, and secondary-index change for one
+column-store mutation must be represented in the same collection WAL transaction
+and the same backend root-group publish.
 
 ### 7.5 File Class
 
@@ -852,10 +906,15 @@ Side-ref classes:
   root-delta value or descriptor.
 - `RootDeltaPayload`: serialized root-delta payload stored outside the WAL
   record.
-- `ColumnPartFile`: immutable column payload file.
-- `ColumnFilterFile`: filter file.
-- `DeleteBitmapFile`: delete/tombstone bitmap file.
-- `DictionaryFile`: compression or encoding dictionary file.
+- `ColumnManifest`: manifest or prepare record naming a column part's external
+  files.
+- `ColumnSubstreamFile`: immutable column payload or packed update-delta
+  substream file.
+- `ColumnFilterFile`: persistent filter file.
+- `ColumnDeleteBitmapFile`: delete/tombstone bitmap file.
+- `ColumnDictionaryFile`: compression or encoding dictionary file.
+- `ColumnMetadataFile`: external compression metadata, mark metadata, or future
+  side metadata file.
 
 Leaf-log or page-log records produced while replay builds new B-tree roots are
 not `CollectionSideRefs`. They are publish outputs and must be flushed or synced
@@ -876,6 +935,22 @@ set. Missing embedded refs, undeclared embedded refs, and declared refs that are
 not embedded are invalid unless a future format version defines a precise
 optional-ref class.
 
+Column-store descriptor validation is transitive. The canonical embedded
+side-ref set must include every external file or byte range reachable from added
+or modified column descriptors, manifests, substream block directories, filter
+descriptors, delete bitmap descriptors, dictionary ids, compression metadata,
+granule/mark roots, locator roots, and count/visibility metadata. Recovery must
+reject a transaction whose root delta publishes any column descriptor graph that
+is not side-ref closed.
+
+Side refs must be sorted and unique by `(RefClass, RefID, RelativePath, Offset,
+Size)`. Recovery must reject duplicate required refs with conflicting checksums
+or metadata. External dictionaries and compression metadata are required side
+refs whenever a published payload cannot decode without them. Codec ids,
+parameters, dictionary ids, dictionary registry/version, and codec registry
+version must be persisted in descriptors or manifests and protected until every
+dependent payload is unreachable.
+
 Readable and integrity-passing means class-specific validation:
 
 - `ValueLogRecord`: segment exists, offset/length are in bounds, RID or grouped
@@ -884,21 +959,51 @@ Readable and integrity-passing means class-specific validation:
   and checksum or page/record validation passes.
 - `RootDeltaPayload`: payload file or value-log record exists, length and
   checksum match, and decoding yields the `DeltaDigest` named by the root delta.
-- `ColumnPartFile`: final file path exists, file size/checksum match the
+- `ColumnManifest`: final manifest exists, checksum matches, and the manifest's
+  collection id, part id, schema version, file list, and side-ref digest match
+  the root descriptor.
+- `ColumnSubstreamFile`: final file path exists, size/checksum match the
   descriptor or manifest, and compression/dictionary metadata validates.
 - `ColumnFilterFile`: filter file exists, checksum matches, and the filter
   header names the expected column/part generation.
-- `DeleteBitmapFile`: bitmap file exists, checksum matches, and row-range and
-  generation metadata match the descriptor.
-- `DictionaryFile`: dictionary bytes exist, checksum matches, and codec/dict id
-  match every dependent payload.
+- `ColumnDeleteBitmapFile`: bitmap file exists, checksum matches, and row-range
+  and generation metadata match the descriptor.
+- `ColumnDictionaryFile`: dictionary bytes exist, checksum matches, and
+  codec/dict id match every dependent payload.
+- `ColumnMetadataFile`: metadata bytes exist, checksum matches, and the owning
+  descriptor names the expected metadata class and generation.
 
-Column-like side files use a temp-to-final protocol in PR1 planning: write temp
-file, fsync file, atomically rename to final path, fsync parent directory, then
-allow the collection WAL commit marker to reference the final path. A future
-manifest format must cover final path, length, checksum, compression metadata,
-row range, and generation. Temp-only files with no committed WAL/root reference
-are orphan-prepared and may be quarantined or deleted after recovery.
+Column part prepare protocol:
+
+A column part builder must write files into a prepare namespace before the WAL
+transaction is appended:
+
+```text
+Dir/maindb/columns/.prepare/txn-<wallsn>/part-<part-id>/
+```
+
+The prepare group must contain a manifest or prepare record that names every
+file/range, final relative path, size, checksum, `PartID`, `FileID`,
+`SchemaVersion`, compression pipeline, dictionary ids, and owning
+`CollectionID`.
+
+Before a WAL-on transaction can be acknowledged:
+
+1. all required column files and ranges have been written;
+2. checksums and lengths have been computed;
+3. the manifest or prepare record has been written and included in the side-ref
+   closure;
+4. durable mode has fsynced required files and containing directories according
+   to the configured durability boundary;
+5. the implementation has atomically renamed or otherwise finalized prepared
+   files to their final paths and fsynced containing directories when final-path
+   descriptors are used;
+6. the WAL transaction containing the matching canonical side-ref set has
+   reached the configured WAL boundary.
+
+A root descriptor must not be published before the referenced final bytes are
+readable. Temp-only files with no committed WAL/root reference are
+orphan-prepared and may be quarantined or deleted after recovery.
 
 A complete transaction with a missing required side ref is a recovery error in
 WAL-on durable/recoverable modes, except for an incomplete tail transaction that
@@ -1093,6 +1198,16 @@ new secondary-index puts in the same transaction as the primary mutation.
 Deletes must include primary tombstones or deletes, secondary deletes, and any
 delete-root or overlay tombstone entries required to suppress older roots.
 
+Column-store update-delta writes are a named mutation class. A
+`column_update_delta` transaction must include new update-delta part descriptor
+puts, all required column side refs for those parts, primary locator puts for
+replacement rows, old-locator tombstones or delete bitmap updates, secondary
+index deletes for old indexed values, secondary index puts for new indexed
+values, count/visibility metadata deltas when present, and the applied
+watermark update in one WAL transaction and one backend publish. The durable
+crash-recovery representation must be the column update-delta part plus
+visibility changes, not a permanent row-oriented overlay.
+
 ### 8.4 Async Indexed Flush
 
 Async flush becomes a publication optimization, not a durability boundary.
@@ -1143,6 +1258,14 @@ can race with user-visible collection writes. It uses `ReplaceRoot` and
 `ClearOverlayRoots` descriptor operations, advances the collection sequence, and
 updates the affected root generation. Root-rewriting overlay maintenance is
 forbidden while unapplied collection WAL exists unless it is encoded this way.
+
+Column-store compaction, delete-bitmap compaction, and recompression are always
+collection WAL maintenance transactions when they create external files or
+change active part descriptors. They must include new side refs, new descriptors,
+descriptor supersession/deletion for source parts, obsolete delete/mark/filter
+metadata removal, count/visibility metadata preservation, and unchanged logical
+secondary-index state in one atomic root group. The optional overlay-compaction
+maintenance shortcut does not apply to physical column parts.
 
 ### 8.6 Collection-Specific Publish Wrapper
 
@@ -1375,6 +1498,42 @@ servers, or collection managers.
 Read-only open cannot perform steps that mutate backend state. If unapplied
 committed collection WAL exists, read-only open must fail with a clear
 recovery-required error unless an explicit stale-read-only mode is requested.
+Read-only open must scan enough collection WAL metadata to detect unapplied
+collection WAL transactions. Production column-store read-only open must not
+silently hide acknowledged WAL-on writes after crash.
+
+### 9.2.1 Column Side-File Recovery
+
+Before collection WAL replay, recovery scans column prepare directories and
+final column file classes and builds a side-file availability map. For each
+complete unapplied column-store transaction, recovery:
+
+1. validates transaction checksum, `CollectionEpoch`, `SchemaVersion`, and
+   catalog identity;
+2. extracts column file refs from descriptor, manifest, filter, delete bitmap,
+   granule/mark, count/visibility, schema, compression metadata, and locator root
+   deltas;
+3. verifies that extracted refs are covered by the transaction's required
+   `SideRefs`;
+4. verifies side-ref existence, size, checksum, manifest consistency, file
+   class, codec registry version, and dictionary identity;
+5. publishes the entire root group and applied watermark in one backend commit;
+6. records every published side ref as reachable from roots after the commit.
+
+Recovery classifies column prepare/final files after replay:
+
+| Column file state | Meaning | Recovery behavior |
+|---|---|---|
+| `building` | Incomplete prepare group or missing manifest/prepare record. | Quarantine or delete after proving no committed WAL/root references it. |
+| `prepared` | Complete prepare group exists, but no committed WAL transaction references it. | Quarantine or delete; allocator ids remain reserved until classification finishes. |
+| `wal_committed` | Complete WAL transaction references the prepare/final group, but applied watermark does not cover it. | Keep, validate side-ref closure, replay, or stop open on missing/corrupt required bytes. |
+| `published` | Reachable from active roots or live snapshots/read views. | Keep and represent in normal column reachability. |
+| `orphan_final` | Final-path file is not referenced by roots, live snapshots, read views, or not-yet-cleanable WAL. | Quarantine or delete after cleanup manifest/checkpoint rules allow it. |
+
+`PartID` and `FileID` allocators must be advanced during open from every
+reachable root, pending WAL transaction, and prepared or orphaned column
+directory. Reusing a `PartID` or `FileID` that appears in an unclassified
+prepare group is forbidden.
 
 ### 9.3 Buffered Transaction Replay and Accumulation
 
@@ -1494,6 +1653,27 @@ lifecycle as value-log refs: WAL protection before publish, root/snapshot
 protection after publish, and quarantine/delete only after neither WAL nor any
 published snapshot/iterator can reference them.
 
+Column file GC/rewrite must treat these as reachability roots:
+
+- active backend roots and all live snapshot roots;
+- live `CollectionReadView` roots and pinned pending units;
+- collection WAL transactions not covered by a safe applied watermark and
+  durable checkpoint/meta boundary;
+- protected prepare groups whose committed/uncommitted status has not been
+  classified;
+- external dictionaries and compression metadata referenced by reachable column
+  files, reachable descriptors, or pending WAL transactions.
+
+Column file rewrite must not rewrite refs that are protected solely by
+collection WAL in PR1. A future rewrite protocol may update column WAL refs only
+with its own crash-tested atomic redirect mechanism.
+
+Column `PartID` and `FileID` allocators are recovery state, not in-memory
+counters. Open must advance allocator high watermarks from active roots, old
+snapshot roots that remain retained, unapplied or not-yet-cleanable WAL
+transactions, and prepared/orphan column directories before accepting new column
+part writes.
+
 Cleanup is idempotent. A cleanup implementation must be safe across crashes
 after cleanup record write, after unlink/rename, and before/after directory
 fsync. Missing segments are acceptable only for `S6 Cleaned` ranges covered by
@@ -1572,6 +1752,17 @@ Crash/fault points:
 21. after Raft commit before local collection WAL append once Raft apply exists;
 22. after local collection WAL append before Raft applied-index/idempotency
     metadata advancement once Raft apply exists.
+23. midway through a column substream file;
+24. after all column files are written but before manifest write;
+25. after manifest write before final rename;
+26. during update-delta publish with secondary unique/nonunique index changes;
+27. during delete bitmap or filter publish;
+28. during column compaction/recompression after output files are prepared but
+    before descriptor supersession;
+29. during column compaction/recompression after descriptor supersession before
+    cleanup;
+30. during column file GC while an old snapshot or `CollectionReadView` still
+    references source parts.
 
 Required assertions:
 
@@ -1614,6 +1805,21 @@ Required assertions:
   stop open under fault injection;
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
+- descriptor side-ref closure is complete for column manifests, substreams,
+  filters, delete bitmaps, dictionaries, compression metadata, and granule roots;
+- missing or corrupt required column side refs fail recovery for complete
+  transactions;
+- prepared but uncommitted parts and final-path orphan files are quarantined or
+  deleted only after no committed WAL/root/read view references them;
+- `PartID` and `FileID` allocators do not reuse pending, reachable, or
+  unclassified orphan ids;
+- primary locators, part descriptors, delete bitmaps, filters, exact
+  count/visibility metadata, and secondary indexes recover atomically;
+- update-delta rows are stored in column files after reopen, with no permanent
+  row overlay;
+- compaction does not expose duplicate rows from source and compacted parts;
+- GC/rewrite never deletes root-reachable, snapshot-reachable,
+  read-view-reachable, or WAL-pending column side refs.
 
 ### 11.4 Concurrency, Admission, and Snapshot Tests
 
@@ -1709,6 +1915,23 @@ Initial gates:
   fixture before optimization;
 - collection WAL bytes/doc reported for every benchmark;
 - no unbounded memory growth when async publish is stalled.
+
+Column-store gates added before persistent column writes:
+
+- column part prepare plus WAL append overhead reported as ns/row and bytes/row;
+- side-ref closure validation throughput reported on deterministic descriptors
+  with 1K, 100K, and 1M file refs;
+- recovery throughput reported by row count and file count;
+- recovery of many small update-delta parts does not grow memory unbounded;
+- file count per default update micro-batch stays under the configured policy;
+- column WAL bytes/row and side-ref metadata bytes/row are reported;
+- orphan cleanup of prepared files has a bounded benchmark target;
+- GC protected-byte debt is reported by payload, filter, delete bitmap,
+  dictionary, manifest, and compression metadata class;
+- compaction publish crash/recover benchmark reports duplicate-row checks and
+  reclaimed bytes;
+- read-only recovery-required scan has bounded latency and does not parse full
+  column payloads.
 
 These gates are provisional. If the current write path cannot meet them with
 inline root deltas, PR2 should move large deltas to side payloads before
@@ -1972,19 +2195,47 @@ Gate:
 
 Deliverables:
 
-- side refs support future column file classes;
-- root-group WAL accepts column-store roots without a separate WAL path;
-- column-store PR checklist points to this milestone.
+- explicit column root-kind inventory for parts, granules, locators, deletes,
+  schema, filters, count/visibility metadata, compression metadata, primary, and
+  secondary roots;
+- side-ref closure validator for descriptors, manifests, substreams, filters,
+  delete bitmaps, dictionaries, compression metadata, granule roots, and
+  root-delta payloads;
+- column prepare-group scanner and orphan cleanup;
+- `PartID` and `FileID` allocator recovery from roots, WAL, snapshots/read
+  views, and prepare directories;
+- read-only recovery-required behavior for unapplied collection WAL;
+- GC/rewrite protection for WAL-pending and read-view-pinned column side refs;
+- synthetic column-file class or minimal real column-file class exercising
+  manifest, substream, filter, delete bitmap, dictionary, and compression
+  metadata refs;
+- column compaction, delete-bitmap compaction, and recompression modeled as
+  collection WAL transactions.
 
 Tests:
 
-- synthetic external side file fence test;
-- recovery refuses roots with missing external side files;
-- cleanup of prepared but unpublished external files.
+- crash before side-file prepare completes;
+- crash after side-file prepare before WAL append;
+- crash after final rename before WAL append;
+- crash after WAL append before root publish;
+- crash during root publish before watermark;
+- crash after watermark before WAL cleanup;
+- missing/corrupt required manifest, substream, filter, delete bitmap,
+  dictionary, compression metadata, or metadata side ref;
+- descriptor side-ref closure mismatch;
+- orphan prepare/final column directories are quarantined or deleted;
+- read-only open refuses unapplied collection WAL;
+- GC/rewrite cannot delete bytes referenced only by pending collection WAL or
+  live `CollectionReadView`;
+- update-delta publish with primary locator changes, delete bitmaps,
+  count/visibility metadata, and secondary unique/nonunique changes;
+- compaction/recompression publish cannot expose duplicate rows from both source
+  and compacted parts.
 
 Gate:
 
-- production column-store persistent writes may start only after this milestone.
+- persistent column-store writes may start only after these tests pass under
+  WAL-on durable and WAL-on relaxed profiles.
 
 ### Milestone 8: Native-Wire and Raft Apply Coordination
 
@@ -2082,6 +2333,12 @@ PR1 closes the correctness-critical questions that block implementation:
 13. Long-running collection reads use `CollectionReadView` pinning for backend
     snapshots, pending collection units, derived index views, and reachable side
     refs.
+14. Column-store persistent writes are blocked until the column side-ref closure
+    validator, prepare/finalize protocol, allocator recovery, and revised M7
+    crash tests pass.
+15. Column compaction, delete-bitmap compaction, and recompression that create
+    external files are collection WAL transactions, not optional backend-only
+    maintenance commits.
 
 Future questions that do not weaken PR1 correctness:
 
@@ -2152,9 +2409,11 @@ Module-specific constraints:
 - Column-store implementation may not publish persistent column parts until
   part files, descriptor deltas, primary locator deltas, delete bitmap roots,
   secondary roots, filter roots, and schema roots can be committed as one
-  collection WAL transaction. Column files must have temp/final naming, file
-  fsync, rename, directory fsync, manifest/checksum validation, and cleanup
-  tests before production enablement.
+  collection WAL transaction. Column files must have side-ref closure
+  extraction, temp/final naming, file fsync, rename, directory fsync,
+  manifest/checksum validation, `PartID`/`FileID` allocator recovery, dictionary
+  and compression metadata protection, and cleanup tests before production
+  enablement.
 
 Recommended implementation sequence:
 

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -66,11 +66,12 @@ PR1-min makes these decisions normative:
   collection WAL commit marker is recoverable;
 - the minimal durable transaction still records stable replay identity:
   `Version`, `WALLSN`, `CollectionUID`, `CollectionGeneration`,
-  `CollectionSeq`, `DependsOnCollectionSeq`, `SchemaEpoch`, `BaseCommitSeq`,
-  `BaseSystemRootID`, `BaseCatalogDigest`, `CatalogDigest`, mutated primary
-  root base id and descriptor epoch, `MutationClass`, inline `RootDeltas`,
-  `SystemDeltaTemplate`, empty canonical `SideRefs`, `ReplayDigest`, and frame
-  checksum;
+  `CollectionSeq`, `DependsOnCollectionSeq`, `CatalogEpoch`, `SchemaEpoch`,
+  `BaseCommitSeq`, `BaseSystemRootID`, `BaseCatalogDigest`,
+  `CatalogDigest`, `LogicalCatalogDigest`, `LocalReplayCatalogDigest`, stable
+  primary `RootRef` including root UID/kind/generation/descriptor epoch,
+  `MutationClass`, inline `RootDeltas`, `SystemDeltaTemplate`, empty canonical
+  `SideRefs`, `ReplayDigest`, and frame checksum;
 - `CollectionName`, created timestamps, and stats are diagnostic only and are
   not replay identity;
 - root descriptor publication and applied-watermark advancement are one backend
@@ -646,6 +647,35 @@ Blocked pre-gate work:
 - column-file side refs in published roots;
 - any crash/reopen safety claim for column-store writes.
 
+Column descriptor future-proofing:
+
+```text
+ColumnPartDescriptorV1 {
+    PartID                         uuid128 or uint128
+    PartGeneration                 uint64
+    OwnerCollectionUID             uuid128
+    CollectionGeneration           uint64
+    SchemaEpoch                    uint64
+    ColumnSchemaDigest             bytes32
+    CompressionDescriptorDigest    bytes32
+    CodecRegistryVersion           uint64
+    DictionaryUIDs                 repeated uuid128
+    DictionaryGenerations          repeated uint64
+    CreatedByCollectionSeq         uint64
+    SupersededByCollectionSeq      uint64 optional
+    CompactionEpoch                uint64 optional
+    RowCount                       uint64
+    PrimaryKeyRange                optional
+    MinMaxStatsDigest              bytes32 optional
+    SideRefDigest                  bytes32
+}
+```
+
+Delete, filter, locator, count, and visibility roots must reference
+`PartID + PartGeneration`, not bare `PartID`. Compaction/recompression must
+create new part IDs or increment part generation and publish source supersession
+plus target descriptors in one collection WAL maintenance transaction.
+
 ## 7. Architecture
 
 ### 7.1 Chosen Model: Root-Delta Transaction WAL
@@ -692,13 +722,16 @@ CollectionWALTransaction {
     DependsOnCollectionSeq   uint64
 
     // Catalog guard.
+    CatalogEpoch             uint64
     SchemaEpoch              uint64
     SchemaVersion            uint32 optional for row-store, required for column-store
     BaseCommitSeq            uint64
     BaseSystemRootID         uint64
-    BaseCatalogDigest        bytes
-    CatalogDigest            bytes
-    RootDescriptorEpochs     map[root-name]uint64
+    BaseCatalogDigest        bytes32
+    CatalogDigest            bytes32
+    LogicalCatalogDigest     bytes32
+    LocalReplayCatalogDigest bytes32
+    RootDescriptorEpochs     map[RootUID]uint64
     MutationClass            uint8
 
     // Physical mutation.
@@ -716,14 +749,22 @@ CollectionWALTransaction {
     RecordChecksumCRC32C     uint32
 }
 
-CollectionRootDelta {
-    RootName                 string
-    RootKind                 uint16
-    RootDeltaOrdinal         uint32
+RootRef {
+    CollectionUID             uuid128
+    RootUID                   uuid128
+    RootKind                  uint16
+    IndexUID                  uuid128 optional
+    ColumnDescriptorUID       uuid128 optional
+    BaseRootID                uint64
+    BaseRootGeneration        uint64
+    BaseRootDescriptorEpoch   uint64
+    BaseRootDescriptorDigest  bytes32
+}
 
-    BaseRootID               uint64
-    BaseRootGeneration       uint64
-    BaseRootDescriptorEpoch  uint64
+CollectionRootDelta {
+    Root                    RootRef
+    RootName                string diagnostic
+    RootDeltaOrdinal         uint32
     BaseCollectionSeq        uint64
 
     StoragePolicy            uint8
@@ -794,19 +835,22 @@ This record is not portable across replicas. `CollectionUID` is the durable
 collection identity; `CollectionID` is reserved for transient in-memory handles
 or legacy text and must not name a separate durable identity. `CollectionName`
 is diagnostic only and must not be used as the replay identity. `WALLSN`,
-`CollectionSeq`, `BaseSystemRootID`,
-`BaseRootID`, root names as resolved by local storage, side-ref paths/RIDs,
-timestamps, stats, and other local observability metadata are meaningful only in
-the database directory that wrote the record. A follower applying the same
-deterministic command entry may produce different local root ids, side refs,
-file names, and collection WAL bytes.
+`CollectionSeq`, `BaseSystemRootID`, `BaseRootID`, diagnostic root names,
+side-ref paths/RIDs, timestamps, stats, and other local observability metadata
+are meaningful only in the database directory that wrote the record. A follower
+applying the same deterministic command entry may produce different local root
+ids, side refs, file names, and collection WAL bytes.
 
 All collection WAL transactions must carry enough catalog identity to make
 replay schema-stable. `CollectionGeneration` guards collection incarnation and
-drop/recreate. `SchemaEpoch` guards catalog-level schema/index evolution.
-`SchemaVersion` guards physical column decode for column-store roots.
-`BaseCatalogDigest`, `CatalogDigest`, and `RootDescriptorEpochs` are mandatory
-replay guards. The
+drop/recreate. `CatalogEpoch` guards collection catalog metadata changes.
+`SchemaEpoch` guards catalog-level schema/index evolution. `SchemaVersion`
+guards physical column decode for column-store roots. `BaseCatalogDigest`,
+`CatalogDigest`, `LogicalCatalogDigest`, `LocalReplayCatalogDigest`, and
+`RootDescriptorEpochs` keyed by stable `RootUID` are mandatory replay guards.
+`LogicalCatalogDigest` is the deterministic logical digest suitable for
+native-wire/Raft catalog guards. `LocalReplayCatalogDigest` may include local
+physical root ids and is used only for same-directory collection WAL replay. The
 `MutationClass` values are versioned and include at least `row_insert`,
 `row_update`, `row_delete`, `column_insert`, `column_update_delta`,
 `column_delete`, `column_compaction`, `column_recompression`, and
@@ -816,9 +860,11 @@ A transaction is replayable only when:
 
 1. the record checksum is valid;
 2. every required side ref is present and passes integrity checks;
-3. `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
-   base root ids, base root generations, and root descriptor epochs match the
-   current replay state or an explicit replay accumulator state;
+3. `CollectionUID`, `CollectionGeneration`, `CatalogEpoch`, `SchemaEpoch`,
+   catalog digests, root UIDs, root kinds, base root ids, base root
+   generations, root descriptor epochs, descriptor digests, index UIDs, index
+   definition digests, and column descriptor generations match the current
+   replay state or an explicit replay accumulator state;
 4. `DependsOnCollectionSeq` is covered by the collection applied watermark or by
    the active accumulator;
 5. the `SystemDeltaTemplate` can be instantiated with the produced root ids and
@@ -848,41 +894,155 @@ Two digests are required:
 - `ReplayDigest`: covers replay-critical fields only: identity, dependencies,
   root deltas, side refs, system delta template, and preconditions.
 
-### 7.3 Collection Identity and Root Generations
+### 7.3 Collection, Index, and Root Identity
 
-Every collection must have a stable `CollectionUID` persisted in collection
-metadata. `CollectionID` may be used only for transient in-memory handles or
-legacy explanatory text; it must not introduce a second durable identifier.
-`CollectionName` is diagnostic and must not be the replay identity. Dropping and
-recreating a collection with the same name creates a new `CollectionUID` and a
-new `CollectionGeneration`. Renaming a collection, if supported, preserves
-`CollectionUID` and increments only the catalog metadata required by the rename.
+`CollectionName` is not replay identity.
 
-Every schema or index metadata change increments `SchemaEpoch`. Every root
-descriptor change increments that root's `RootGeneration` and descriptor epoch.
-Overlay descriptor changes and overlay compaction also increment the affected
-root generation and descriptor epoch.
+Every collection descriptor must persist:
+
+```text
+CollectionUID              uuid128
+CollectionGeneration       uint64
+CatalogEpoch               uint64
+SchemaEpoch                uint64
+LogicalCatalogDigest       bytes32
+LocalReplayCatalogDigest   bytes32
+CollectionName             string diagnostic
+```
+
+`CollectionUID` is assigned at collection creation and is never reused.
+`CollectionGeneration` changes on drop/recreate and is recorded in tombstones.
+`CollectionName` is a lookup/display field. Rename preserves `CollectionUID` and
+`CollectionGeneration`, increments `CatalogEpoch`, and updates
+`LogicalCatalogDigest`. If root paths remain name-derived, rename is also a
+root descriptor change. A `uint64 CollectionID` is acceptable only as an
+internal catalog object id if it is durable, never reused, included in a
+database/cluster namespace to form a unique `CollectionUID`, and
+deterministically assigned for Raft. A stable collection name is never
+sufficient.
+
+Dropping a collection records a tombstone for `CollectionUID` with the previous
+name, `CollectionGeneration`, drop `CatalogEpoch`, drop `CollectionSeq` or
+metadata log position, and the highest applied collection WAL sequence known at
+drop time. Recreate with the same name creates a new `CollectionUID` and new
+`CollectionGeneration`. Recovery must never apply a transaction for an absent
+`CollectionUID` into a same-name collection. It must stop open or quarantine the
+old collection/WAL according to an explicit admin recovery path.
+
+Root identity is a tuple, not a string:
+
+```text
+RootDescriptorV1 {
+    RootUID                 uuid128
+    OwnerCollectionUID      uuid128
+    RootKind                enum
+    LogicalName             string diagnostic
+    IndexUID                uuid128 optional
+    ColumnDescriptorUID     uuid128 optional
+    RootGeneration          uint64
+    RootDescriptorEpoch     uint64
+    RootID                  uint64 local physical root id
+    StoragePolicy           uint8
+    DescriptorDigest        bytes32
+}
+```
+
+`CollectionRootDelta.RootRef` carries `CollectionUID`, `RootUID`, `RootKind`,
+optional `IndexUID`/`ColumnDescriptorUID`, `BaseRootID`,
+`BaseRootGeneration`, `BaseRootDescriptorEpoch`, and
+`BaseRootDescriptorDigest`. `RootName` may remain as diagnostic text, but
+recovery must validate `RootUID`, `RootKind`, owner UID, generation, epoch, and
+descriptor digest. `RootDescriptorEpochs map[root-name]uint64` is invalid for
+new WAL formats; the guard map is keyed by `RootUID`.
+
+Schema and index identity rules:
+
+```text
+IndexDescriptorV1 {
+    IndexUID                uuid128
+    OwnerCollectionUID      uuid128
+    Name                    string
+    IndexGeneration         uint64
+    CreatedAtSchemaEpoch    uint64
+    DroppedAtSchemaEpoch    uint64 optional
+    DefinitionDigest        bytes32
+    FieldPath               canonical path
+    ValueType               enum
+    Unique                  bool
+    MultiKey                bool
+    StoragePolicy           uint8
+    SecondaryRootUID        uuid128
+}
+```
+
+`SchemaEpoch` increments for every change that affects mutation planning,
+document decode, index extraction, uniqueness, multikey behavior, root set, or
+column physical schema. This includes `CreateIndex`, `DropIndex`, index
+definition changes, document format changes, template root descriptor
+reset/format evolution, column schema changes, and column
+compression/dictionary descriptor changes when they affect decode or planning.
+Dropping an index tombstones the `IndexUID`. Recreating an index with the same
+name creates a new `IndexUID`, new generation, new root UID, and new definition
+digest. Unique and multikey helper state is keyed by `IndexUID`; index names are
+API lookup and diagnostic text only.
 
 A collection WAL transaction records `CollectionUID`, `CollectionGeneration`,
-`SchemaEpoch`, `CatalogDigest`, `RootDescriptorEpochs`, `BaseRootID`, and
-`BaseRootGeneration` for every root it mutates. Recovery must reject or block a
-transaction whose identity or generation guard does not match the replay state,
-unless the mismatch is explicitly explained by the active replay accumulator. An
-unapplied transaction whose `CollectionUID` is absent from the recovered catalog
-must not be replayed into a collection with the same name; PR1-min must stop open or
-quarantine according to a documented recovery-admin procedure rather than
-silently applying the transaction to a later incarnation.
+`CatalogEpoch`, `SchemaEpoch`, catalog digests, root refs, index UID/digest
+guards where relevant, and column part/dictionary/compression generations where
+relevant. Recovery must reject or block a transaction whose identity,
+generation, epoch, digest, root, index, or column guard does not match the
+replay state unless the mismatch is explicitly explained by the active replay
+accumulator.
 
-On decode/replay, the allowed root-name and root-kind set is derived only from
-the recovered catalog entry for `CollectionUID`, `CollectionGeneration`,
-`SchemaEpoch`, catalog digest, and root descriptor epochs. Recovery must reject
+On decode/replay, the allowed root set is derived only from the recovered
+catalog entry for `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`,
+catalog digest, root UID/kind, and root descriptor epochs. Recovery must reject
 any `RootDelta`, descriptor op, system-delta placeholder, side-ref manifest, or
-root name that is not in that derived set before side-ref validation or root
+root reference not in that derived set before side-ref validation or root
 publication. `CollectionName` and WAL-provided root-name strings must never be
 used for replay lookup, filesystem path construction, side-file path
 construction, tenant authorization, or deciding which roots may be published.
 Any future tenant namespace must be stable catalog identity, not text parsed
 from a collection name.
+
+Catalog changes that affect replay identity are durable barriers. Before the
+catalog change becomes visible, either:
+
+1. all lower `CollectionSeq` transactions for the collection are published and
+   watermarked; or
+2. the catalog change is encoded as a collection WAL transaction with
+   `MutationClass=schema_change`, `DependsOnCollectionSeq=previous sequence`,
+   and descriptor ops plus watermark in the same root-group commit.
+
+Required durable barriers include create/drop/rename collection,
+create/drop/recreate index, unique/multikey/index definition changes, document
+format/schema changes, template root descriptor creation/reset/evolution, root
+descriptor replacement not tied to an ordinary WAL-covered mutation, overlay
+descriptor changes and overlay compaction, column schema/compression/dictionary,
+part descriptor, delete bitmap, filter, locator, and count/visibility descriptor
+changes, and WAL cleanup metadata that allows segment deletion.
+
+Recovery validates in this order:
+
+1. WAL checksum and `ReplayDigest`;
+2. required side-ref closure and checksums;
+3. `CollectionUID` exists or is recoverable through an explicit tombstone path;
+4. `CollectionGeneration` matches;
+5. `CollectionSeq` is exactly the next sequence after durable watermark or
+   active accumulator state;
+6. `SchemaEpoch` and catalog digest match base replay state;
+7. every `RootRef` matches `RootUID`, `RootKind`, `RootGeneration`,
+   `RootDescriptorEpoch`, `DescriptorDigest`, and `BaseRootID`;
+8. every touched `IndexUID`/`DefinitionDigest` matches the guarded schema
+   epoch;
+9. column part/dictionary/compression descriptor generations match;
+10. `SystemDeltaTemplate` preconditions hold;
+11. descriptor updates and applied watermark publish in one backend commit.
+
+A transaction created before a schema/index change may replay only before that
+schema/index change in contiguous `CollectionSeq` order. It must not be applied
+after the current catalog has advanced past its guarded schema epoch unless the
+active replay accumulator contains the intervening schema-change transaction.
 
 Maintenance that rewrites root ids or descriptor values must not run for a
 collection with unapplied WAL transactions unless the maintenance operation is
@@ -1614,7 +1774,8 @@ covers:
 - `WALLSN` range for diagnostics and cleanup;
 - contiguous `CollectionSeq` range for the owning collection;
 - required side-ref ownership or references to the protected side-ref index;
-- root names and root generations covered by the publish.
+- root UIDs, root kinds, root descriptor epochs, descriptor digests, and root
+  generations covered by the publish.
 
 Async publish completion may advance the applied watermark only for whole
 transactions covered by the successful root publish. Requeue must preserve WAL
@@ -1670,9 +1831,11 @@ reconstructing ad hoc runtime system-builder closures.
 
 ```text
 PublishCollectionWALTransaction(txn, options) {
-    validate txn.CollectionUID, CollectionGeneration, SchemaEpoch,
-             CatalogDigest, RootDescriptorEpochs, BaseRootGeneration,
-             dependencies
+    validate txn.CollectionUID, CollectionGeneration, CatalogEpoch,
+             SchemaEpoch, catalog digests, RootUID/RootKind,
+             RootDescriptorEpochs, BaseRootGeneration,
+             RootDescriptorDigest, IndexUID/DefinitionDigest,
+             column descriptor generations, dependencies
     materialize root deltas from txn
     apply root deltas
     instantiate txn.SystemDeltaTemplate with produced root ids
@@ -1827,7 +1990,8 @@ Mode in {DurabilityDurable, DurabilityWALOnRelaxed,
 
 Txn identity:
   CollectionUID, CollectionSeq, WALLSN, CollectionGeneration,
-  SchemaEpoch, CatalogDigest
+  CatalogEpoch, SchemaEpoch, CatalogDigest, RootUID, RootKind,
+  RootDescriptorEpoch, RootDescriptorDigest
 
 Transaction existence:
   PlannedHidden(t)
@@ -3391,6 +3555,7 @@ Advisory PR1-min benchmark rows:
 - WAL bytes per inserted document;
 - recovery time for 1K, 10K, and 100K retained PR1-min transactions;
 - inline cap rejection overhead;
+- catalog/root descriptor guard construction overhead;
 - global publisher contention smoke benchmark.
 
 The pass/fail benchmark gates below apply to the full contract and to default
@@ -3600,7 +3765,11 @@ Required workload-specific benchmark gates:
 | `BenchmarkCollectionWALRecoveryReplayPendingDocs` | Recovery with 1K, 100K, and 1M pending no-index, indexed, update, delete, and template-v1 WAL transactions. | Meets Section 10.1 replay throughput/time gates and peak heap <= 512 MiB for 1M pending documents. |
 | `BenchmarkCollectionWALCleanupLag` | Publish succeeds but cleanup is blocked, then released. | Cleanable debt triggers cleanup; debt drops below stop limit after release; protected refs are not deleted early. |
 | `BenchmarkCollectionWALDurableSyncBatch` | Concurrent durable-sync writers. | Sync batches respect 1 ms, 4 MiB, and 4096 transaction caps; p95/p99 ack latency below selected absolute gates. |
+| `BenchmarkCollectionWALCatalogDigest` | Canonical digest computation for collections with 0, 1, 10, 100, and 1,000 indexes. | Digesting remains bounded and amortized by schema changes; hot-row mutation paths use cached fixed-size guard comparisons. |
+| `BenchmarkCollectionWALGuardConstruction` | WAL append guard construction for insert/update/delete with primary, template, index-state, and multiple secondary roots. | Fixed-size guard comparison overhead is reported separately from root-delta encoding. |
+| `BenchmarkCollectionWALRecoveryGuardValidation` | Recovery validation over many small transactions with UID/generation/schema/root/index guards. | Validation throughput is reported separately from side-ref checksum and root-delta materialization. |
 | `BenchmarkColumnStoreWALSideRefClosure` | 1K, 100K, and 1M column side refs with manifests, dictionaries, bloom files, compression metadata, and delete bitmaps. | Memory <= configured cap; file count <= 1024 per part; metadata bytes/row <= formula plus 10 percent. |
+| `BenchmarkColumnPartDescriptorDigest` | Column part descriptor digesting with many columns, dictionaries, filters, and side refs. | Descriptor digest cost is reported separately from file checksum/manifest validation. |
 
 Gate thresholds:
 
@@ -4248,7 +4417,7 @@ Gate:
 | Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots through a protected side-ref index until safe applied watermark and checkpoint cleanup. |
 | A global `WALLSN` marker skips lower unapplied transactions. | Use per-collection `CollectionSeq` watermarks as the replay key; keep any global `WALLSN` marker cleanup-only and segment-verified. |
 | Buffered transactions share an old persisted `BaseRootID`. | PR1-min permits at most one unwatermarked transaction globally; the full contract adds per-collection dependency chains plus replay-side accumulation. |
-| A drop/recreate or schema change makes an old WAL transaction look applicable. | Persist `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`, root descriptor epochs, and per-root `RootGeneration` guards and block mismatches. |
+| A drop/recreate, same-name index recreate, or schema change makes an old WAL transaction look applicable. | Persist `CollectionUID`, `CollectionGeneration`, `CatalogEpoch`, `SchemaEpoch`, catalog digests, `IndexUID`/definition digests, root UIDs/kinds, root descriptor epochs, descriptor digests, and per-root `RootGeneration` guards and block mismatches. |
 | API returns a normal error after the WAL commit marker. | Reserve fallible state before commit; after commit marker, allow only success, process death, or commit-ambiguous/fatal reporting. |
 | Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
 | Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
@@ -4300,8 +4469,10 @@ no-index row insert slice:
 15. Column compaction, delete-bitmap compaction, and recompression that create
     external files are future collection WAL transactions, not optional
     backend-only maintenance commits.
-16. `CollectionUID`, `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
-    and root descriptor epochs are mandatory replay guards.
+16. `CollectionUID`, `CollectionGeneration`, `CatalogEpoch`, `SchemaEpoch`,
+    catalog digests, `IndexUID`/definition digests, root UIDs/kinds,
+    root generations, descriptor epochs, and descriptor digests are mandatory
+    replay guards.
 17. Side-ref cleanup resolves files through a class registry by ref class and
     file id; relative paths are confined validation data and cannot authorize
     cleanup outside the class root.
@@ -4361,9 +4532,10 @@ always-on validation paths where practical.
 Write path:
 
 - Before acknowledging a WAL-on collection write: `CollectionSeq != 0`,
-  `WALLSN != 0`, `CollectionUID != 0`, `CollectionGeneration` and `SchemaEpoch`
-  are present, `CatalogDigest` is present, root delta count is nonzero, and all
-  root names are valid for the catalog epoch.
+  `WALLSN != 0`, `CollectionUID != 0`, `CollectionGeneration`,
+  `CatalogEpoch`, and `SchemaEpoch` are present, catalog digests are present,
+  root delta count is nonzero, and all root refs are valid for the catalog
+  epoch.
 - Before appending a collection WAL transaction: every required side ref has
   reached the fresh-process-readable boundary and checksum verification has
   succeeded in debug/fault-injection builds.
@@ -4671,9 +4843,10 @@ Module-specific constraints:
   versions, malicious lengths, mixed-version segments, and unknown critical
   sections or side-ref classes fail closed.
 - The collection WAL transaction builder must require `CollectionUID`,
-  `CollectionGeneration`, `SchemaEpoch`, `CatalogDigest`,
-  `RootDescriptorEpochs`, `CollectionSeq`, `WALLSN`, root-delta ordinals, and
-  canonical side refs before it can encode a replayable record.
+  `CollectionGeneration`, `CatalogEpoch`, `SchemaEpoch`, catalog digests,
+  `RootUID`, `RootKind`, `RootDescriptorEpochs`, descriptor digests,
+  `CollectionSeq`, `WALLSN`, root-delta ordinals, and canonical side refs
+  before it can encode a replayable record.
 - `TreeDB/internal/collectionwal` owns the encoder-backed cost estimator,
   inline/side-payload threshold checks, segment rotation policy, compression
   threshold, durable-sync group-fsync caps, and capacity error classification
@@ -4766,8 +4939,8 @@ Runtime assertions required in WAL-on modes:
 - Assert every collection root descriptor commit carries a typed coverage range
   and matching watermark op.
 - Assert async flush units carry immutable WAL coverage: `CollectionUID`,
-  contiguous sequence range, root names, root generations, required refs, and
-  `WALLSN` range.
+  contiguous sequence range, root UIDs/kinds, root generations, descriptor
+  epochs/digests, required refs, and `WALLSN` range.
 - Assert cleanup decodes every complete transaction in candidate segments and
   proves same-collection watermark/checkpoint coverage.
 - Assert recovery skip never uses global `WALLSN`.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1583,27 +1583,417 @@ immutable unit before inclusion in a view or copied into the view.
 
 ## 9. Recovery Algorithm
 
-### 9.1 Collection WAL Recovery States
+### 9.1 Abstract Model and State Machine
 
-A collection WAL transaction is in exactly one durable recovery state:
+This section is normative for WAL-on collection durability. Product code may use
+different internal types, but every implementation and test model must be able
+to express these variables, predicates, transitions, and invariants.
 
-| State | Meaning | Recovery behavior |
+State variables:
+
+```text
+Mode in {DurabilityDurable, DurabilityWALOnRelaxed,
+         DurabilityWALOffRelaxed}
+
+Txn identity:
+  CollectionUID, CollectionSeq, WALLSN, CollectionGeneration,
+  SchemaEpoch, CatalogDigest
+
+Transaction existence:
+  PlannedHidden(t)
+  PreparedSideRefsExist(t)
+  CompleteWALFrame(t)
+  CommitMarkerDurable(t)
+  VisiblePending(t)
+  VisibleInstalled(t)
+  VisibleInstallWasAfterWALCommit(t)
+  PublishingInFlight(t)
+  MaterializedUnpublished(t)
+  Applied(t)
+  CheckpointCovered(t)
+  Cleaned(t)
+  Quarantined(CollectionUID)
+
+Root group:
+  RootDeltas(t)
+  RootDescriptorBefore(root)
+  RootDescriptorAfter(root)
+  RootGeneration(root)
+  SystemDeltaTemplate(t)
+  DescriptorCommitID(t)
+  DescWrites(commit, CollectionUID)
+  Cover(commit, CollectionUID)
+
+Watermarks:
+  AppliedSeq[CollectionUID]
+  CheckpointSeq[CollectionUID]
+  CleanupManifestRanges
+  GlobalWALLSNRanges     // cleanup scan aid only, never replay dependency
+
+Side refs:
+  RequiredRefs(t)
+  DeclaredRefs(t)
+  EmbeddedRefs(t)
+  Prepared(ref)
+  FreshReadable(ref)
+  ChecksumOK(ref)
+  PrepareGuardHeld(ref)
+  ProtectedByWAL(ref,t)
+  RootReachable(ref)
+  ReadViewPinned(ref)
+
+Checkpoint and cleanup:
+  BackendMetaBoundaryID
+  BackendBoundaryDurable(boundary)
+  SegmentCleanupState in {None, Planned, Unlinked, DirSynced}
+  SegmentDecodedTransactions(segment)
+
+Raft extension:
+  ConsensusCommitted(index)
+  LocalWALRecoverable(index)
+  LocalOutcomeDurable(index)
+  IdempotencyResultDurable(index)
+  CatalogGuardOutcomeDurable(index)
+  PersistentAppliedIndex
+```
+
+State predicates:
+
+```text
+CanonicalSideRefClosure(t) :=
+    all side refs reachable from encoded root values, column descriptors,
+    value pointers, external page/log descriptors, and transitive descriptor refs
+
+SideRefsReady(t) :=
+    RequiredRefs(t) = CanonicalSideRefClosure(t)
+  and DeclaredRefs(t) = RequiredRefs(t)
+  and DeclaredRefs(t) are sorted and unique
+  and for every ref in RequiredRefs(t):
+        Prepared(ref) and FreshReadable(ref) and ChecksumOK(ref)
+
+SideRefsProtected(t) :=
+    for every ref in RequiredRefs(t):
+        ProtectedByWAL(ref,t) or PrepareGuardHeld(ref)
+
+Recoverable(t) :=
+    Applied(t)
+  or (Mode in {DurabilityDurable, DurabilityWALOnRelaxed}
+      and CompleteWALFrame(t)
+      and CommitMarkerDurable(t)
+      and SideRefsReady(t))
+
+Visible(t) :=
+    VisiblePending(t) or VisibleInstalled(t)
+
+CanAppendWAL(t) :=
+    PlannedHidden(t)
+  and CanonicalRootDelta(t)
+  and for every ref in RequiredRefs(t):
+        Prepared(ref)
+        and FreshReadable(ref)
+        and ChecksumOK(ref)
+        and PrepareGuardHeld(ref)
+
+CanInstallVisible(t) :=
+    if Mode = DurabilityWALOffRelaxed:
+        VisibleInstallIsNonFailing(t)
+    else:
+        PlannedHidden(t)
+        and CanonicalRootDelta(t)
+        and RequiredRefs(t) = CanonicalSideRefClosure(t)
+        and SideRefsReady(t)
+        and SideRefsProtected(t)
+        and CompleteWALFrame(t)
+        and CommitMarkerDurable(t)
+        and VisibleInstallIsNonFailing(t)
+
+CanAck(t) :=
+    if Mode = DurabilityWALOffRelaxed:
+        VisibleInstalled(t)
+    else:
+        CanInstallVisible(t)
+        and VisibleInstalled(t)
+        and VisibleInstallWasAfterWALCommit(t)
+
+CanReplay(t,A) :=
+    Mode in {DurabilityDurable, DurabilityWALOnRelaxed}
+  and CompleteWALFrame(t)
+  and not Applied(t)
+  and SideRefsReady(t)
+  and t.CollectionSeq = A.NextSeq(t.CollectionUID)
+  and t.DependsOnCollectionSeq = t.CollectionSeq - 1
+  and (t.DependsOnCollectionSeq <= AppliedSeq[t.CollectionUID]
+       or t.DependsOnCollectionSeq in A.CoveredSeqs(t.CollectionUID))
+  and IdentitySchemaCatalogGuardsHold(t,A)
+  and RootGenerationGuardsHold(t,A)
+  and SystemDeltaTemplatePreconditionsHold(t,A)
+
+CanPublish(c,N,M,A) :=
+    N = AppliedSeq_before[c]
+  and M >= N
+  and transactions {c,N+1 ... c,M} are all present in accumulator A
+  and no gaps exist in [N+1, M]
+  and all root deltas for all covered transactions are folded
+  and SystemDeltaTemplate produces exactly descriptor updates for folded roots
+  and the same backend commit advances AppliedSeq[c] to M
+
+CanSkipReplay(t) :=
+    CompleteWALFrame(t)
+  and AppliedSeq[t.CollectionUID] >= t.CollectionSeq
+  and CollectionIdentityGuardOK(t)
+  and CatalogHistoryAllows(t)
+  and if segment is missing then CleanupManifestCovers(t)
+
+CanCleanSideRef(ref,t) :=
+    Applied(t)
+  and CheckpointCovered(t)
+  and RootReachabilityTrackerContainsOrFullScanProves(ref)
+  and not ReadViewPinned(ref)
+  and DurableCleanupMetadataWillRelease(ref,t)
+  and no uncleaned complete transaction references ref
+
+CanClean(segment) :=
+    for every complete transaction t in SegmentDecodedTransactions(segment):
+        Applied(t)
+        and CheckpointCovered(t)
+        and for every ref in RequiredRefs(t): CanCleanSideRef(ref,t)
+    and cleanup manifest update is durable before a missing segment is accepted
+
+CanStartMaintenance(op, object) :=
+    RecoveryComplete
+  and no PrepareGuardHeld(object)
+  and no CompleteUncleanedTxnReferences(object)
+  and no LiveReadViewPins(object)
+  and if op rewrites published root descriptors then op has its own
+      collection maintenance transaction and CollectionSeq
+
+CanAdvanceRaftAppliedIndex(i) :=
+    for every command entry e <= i assigned to this node:
+        LocalOutcomeDurable(e)
+        and IdempotencyResultDurable(e)
+        and CatalogGuardOutcomeDurable(e)
+        and (CollectionWALRecoverable(e)
+             or StableRaftReplayBeforeServingProven(e))
+```
+
+Append/protect happens-before rule:
+
+```text
+AppendWAL(t) postcondition:
+    CompleteWALFrame(t)
+  and for every ref in RequiredRefs(t): ProtectedByWAL(ref,t)
+
+ReleasePrepareGuard(ref,t) is allowed only after:
+    CompleteWALFrame(t) and ProtectedByWAL(ref,t)
+or:
+    AbortPreparedSideRef(ref,t) and no complete WAL frame can reference ref
+```
+
+Descriptor/watermark atomicity rule:
+
+```text
+For every backend commit K and collection c:
+
+DescWrites(K,c) is non-empty
+  iff there exist N,M such that:
+       N = AppliedSeq_before[c]
+       and M > N
+       and Cover(K,c) = { txn(c,s) | N < s and s <= M }
+       and no gaps exist in [N+1, M]
+       and DescWrites(K,c) = DescriptorResult(Fold(Cover(K,c)))
+       and AppliedSeq_after[c] = M
+
+AppliedSeq_after[c] > AppliedSeq_before[c]
+  implies DescWrites(K,c) is exactly the descriptor/root metadata produced by
+  the same covered transaction range.
+
+Descriptor-only and watermark-only backend commits are invalid states in
+WAL-on modes.
+```
+
+Transition table:
+
+| Transition | Guard | Postcondition |
 |---|---|---|
-| `S0 Absent` | No complete collection WAL frame exists. | Do not publish roots. Any side files not referenced by a committed WAL transaction or published root are orphan-prepared and may be quarantined or deleted. |
-| `S1 PreparedSideRefs` | Side bytes may exist, but no complete committed WAL frame references them. | Do not publish roots. Reclaim only after proving no complete WAL transaction and no published root references the bytes. |
-| `S2 CommittedWAL` | A complete collection WAL frame with valid checksums exists and is not covered by the durable applied watermark. | Validate all required side refs, identity, schema, generations, and dependencies; then replay in collection sequence order. Missing or corrupt required side refs stop open. |
-| `S3 MaterializedUnpublished` | Recovery or live publish built root pages or publish-output files, but backend meta/system-root commit did not publish root descriptors. | Not externally visible. After crash, retry from `S2` or skip if `S4` is observed. |
-| `S4 Applied` | One backend meta/system-root commit atomically published root descriptor changes and applied watermark entries covering the transaction. | Skip during replay. Reapplying an `S4` transaction is a bug. |
-| `S5 Cleanable` | Transaction is `S4`, and a durable checkpoint/meta boundary exists such that descriptors, watermarks, and side-ref reachability tracking for published roots are durable. | WAL files and WAL-only side-ref protection may be cleaned idempotently. |
-| `S6 Cleaned` | Durable cleanup metadata says the segment or transaction range is safely cleaned. | Missing segment files are acceptable only for ranges covered by this metadata. Missing uncleaned segments stop open. |
+| `PlanWrite` | Collection open, admission gate allows write, schema/catalog guards captured. | `PlannedHidden(t)`; no reader can observe it. |
+| `PrepareSideRefs` | `PlannedHidden(t)` and canonical side-ref set known. | Side bytes readable/checksummed; prepare guards held. |
+| `AppendWAL` | `CanAppendWAL(t)`. | Complete frame and commit marker exist; refs are WAL-protected before guard release. |
+| `InstallVisible` | WAL-off: local policy allows. WAL-on: `CanInstallVisible(t)`. | `VisiblePending(t)`; WAL-on `Visible(t) implies Recoverable(t)`. |
+| `Ack` | `CanAck(t)`. | Client success is legal; post-commit bookkeeping failures become fatal/ambiguous, not ordinary mutation errors. |
+| `PublishRootGroup` | `CanPublish(c,N,M,A)`. | One backend commit writes all affected root descriptors and advances applied watermark. |
+| `AdvanceWatermark` | Not a standalone transition in WAL-on. | Happens only inside `PublishRootGroup`. |
+| `Checkpoint` | Admission cut selected; admitted writes drained or excluded by cut. | Durable backend boundary covers descriptors, watermarks, and reachability state. |
+| `CleanWALSegment` | `CanClean(segment)`. | Cleanup metadata durable; segment may be unlinked; missing segment acceptable only if metadata covers it. |
+| `RecoveryScan` | Exclusive recovery/maintenance lock. | Reads cleanup metadata, segments, watermarks, refs; classifies every transaction. |
+| `Replay` | `CanReplay(t,A)`. | Accumulator includes `t`; eventual publish covers whole transactions only. |
+| `SkipApplied` | `CanSkipReplay(t)`. | Transaction is not replayed. |
+| `BlockRecovery` | Missing lower same-collection transaction or corrupt required side ref. | Open fails or collection is explicitly quarantined. |
+| `Quarantine` | Recovery policy permits per-collection quarantine. | Collection unavailable; no normal reads/writes until repair. |
+| `MaintenanceRewrite` | `CanStartMaintenance(op, object)`. | No change, or a WAL-covered maintenance transaction with its own `CollectionSeq`. |
+| `WALOffFlushPublish` | WAL-off mode and flush/close/checkpoint boundary. | Backend roots become durable; no collection-WAL replay state is created. |
+| `AdvanceRaftAppliedIndex` | `CanAdvanceRaftAppliedIndex(i)`. | Persistent applied-index/idempotency state cannot outrun local recoverability. |
+
+Invariants:
+
+```text
+I1. Gap-free sequence:
+    For every collection c, recovery never applies c:s+1 before c:s.
+
+I2. WAL-before-visible in WAL-on:
+    Mode != DurabilityWALOffRelaxed implies Visible(t) implies Recoverable(t).
+
+I3. Side refs before WAL:
+    CompleteWALFrame(t) implies SideRefsReady(t) was true at append time.
+
+I4. WAL side-ref protection:
+    CompleteWALFrame(t) and not CanCleanSideRef(ref,t)
+    implies ProtectedByWAL(ref,t).
+
+I5. Descriptor/watermark atomicity:
+    No backend commit may publish collection root descriptors without the
+    matching applied-watermark advance, and no watermark may advance without the
+    matching descriptor result.
+
+I6. Per-collection skip:
+    Replay skip is based only on same-collection applied watermark plus guard
+    history, never on global WALLSN.
+
+I7. Whole-transaction publish:
+    A transaction is applied only if every root delta, descriptor update,
+    side-ref dependency, and watermark update for that transaction committed
+    together.
+
+I8. Checkpoint before cleanup:
+    WAL files and WAL-only side-ref protections are cleanable only after applied
+    watermark plus durable checkpoint boundary plus reachability/read-view proof.
+
+I9. Deterministic replay:
+    Live publish and recovery replay of the same valid committed transaction
+    prefix produce the same logical root descriptors, catalog digest, watermark,
+    and replay digest.
+
+I10. No double apply:
+    AppliedSeq[c] >= s implies recovery must not reapply txn(c,s).
+
+I11. Maintenance is serialized:
+    Maintenance cannot delete, rewrite, reset, or unprotect an object reachable
+    from complete uncleaned WAL, published roots, or live read views.
+
+I12. Raft local metadata:
+    Persistent applied-index/idempotency state cannot move past local collection
+    mutation recoverability unless a future stable Raft replay proof replaces
+    that local-WAL requirement.
+
+I13. WAL-off exception:
+    WAL-off visible pending writes are allowed to be unrecoverable, but they
+    must not create collection-WAL files or claim durable-at-ack.
+```
+
+Deterministic replay theorem:
+
+```text
+Given the same durable backend base state B, the same valid committed
+transaction prefix P for a collection, the same verified side-ref bytes,
+canonical root-delta decoding, and no free-form system builders, Fold(P,B)
+produces the same logical root descriptors, catalog digest, applied watermark,
+and ReplayDigest independent of process, crash point, batching, async flush
+timing, or recovery pass count.
+```
+
+Commutativity and total-order rules:
+
+```text
+Total order required:
+  same CollectionUID mutations by CollectionSeq;
+  schema/index/catalog changes relative to same-collection mutations;
+  overlay compaction and maintenance txns relative to same-collection writes;
+  checkpoint admission cuts relative to admitted writes;
+  cleanup relative to checkpoint metadata;
+  Raft applied-index relative to local mutation outcome.
+
+Commutative only if:
+  operations touch disjoint CollectionUIDs,
+  do not share catalog/schema/root descriptor keys,
+  do not share side refs or maintenance guards,
+  and their backend commits can be serialized without changing each operation's
+  guards or digest.
+```
+
+WAL-off branch:
+
+```text
+Mode = DurabilityWALOffRelaxed:
+  CanAck(t) := VisibleInstalled(t)
+  CompleteWALFrame(t) must be false for unflushed writes
+  CanReplay(t) := false for unflushed writes
+  CanPublish(t) uses normal backend root publish at Flush/Close/Checkpoint
+  Visible(t) does not imply Recoverable(t)
+  Published(t) implies RecoverableFromBackendRoots(t)
+```
+
+### 9.2 Collection WAL Recovery State Classifier
+
+A collection WAL transaction is classified into exactly one durable recovery
+state by priority:
+
+| Priority | State | Predicate | Recovery behavior |
+|---:|---|---|---|
+| 1 | `S6 Cleaned` | `CleanupManifestCovers(t)`. | Missing segment files are acceptable only for ranges covered by this metadata. Missing uncleaned segments stop open. |
+| 2 | `S5 Cleanable` | `Applied(t)` and `CheckpointCovered(t)`. | WAL files and WAL-only side-ref protection may be cleaned idempotently when read-view and side-ref guards allow it. |
+| 3 | `S4 Applied` | One backend meta/system-root commit atomically published root descriptor changes and applied watermark entries covering the transaction. | Skip during replay. Reapplying an `S4` transaction is a bug. |
+| 4 | `S3 MaterializedUnpublished` | Recovery or live publish built root pages or publish-output files, but backend meta/system-root commit did not publish root descriptors. | Not externally visible. After crash, retry from `S2` or skip if `S4` is observed. |
+| 5 | `S2 CommittedWAL` | A complete collection WAL frame with valid checksums exists and is not covered by the durable applied watermark. | Validate all required side refs, identity, schema, generations, and dependencies; then replay in collection sequence order. Missing or corrupt required side refs stop open. |
+| 6 | `S1 PreparedSideRefs` | Side bytes may exist, but no complete committed WAL frame references them. | Do not publish roots. Reclaim only after proving no complete WAL transaction and no published root references the bytes. |
+| 7 | `S0 Absent` | No complete collection WAL frame exists. | Do not publish roots. Any side files not referenced by a committed WAL transaction or published root are orphan-prepared and may be quarantined or deleted. |
+
+Orthogonal volatile predicates are not durable states and must be modeled
+separately: `VisiblePending(t)`, `ReadViewPinned(t)`, `PublishingInFlight(t)`,
+`MaintenanceGuardHeld(ref)`, `Quarantined(CollectionUID)`, and
+`CloseAdmitted(t)`.
+
+Crash/recovery rules:
+
+| Crash point | Durable state after restart | Recovery rule |
+|---|---|---|
+| Before side-ref prepare | `S0 Absent` | Nothing to replay. |
+| After side bytes, before complete WAL marker | `S1 PreparedSideRefs` | Do not publish; delete/quarantine only after proving no complete WAL/root ref. |
+| After complete WAL marker, before visible install | `S2 CommittedWAL` | Validate refs/guards; replay in `CollectionSeq` order. |
+| After visible install, before client response | `S2 CommittedWAL` unless already applied | Replay may make write visible after reopen; client result is commit-ambiguous. |
+| After client ack, before publish | `S2 CommittedWAL` | Replay required. |
+| After root pages/files materialized, before backend meta commit | `S3 MaterializedUnpublished` | Materialized outputs are not authoritative; retry from WAL. |
+| After descriptor plus watermark backend commit | `S4 Applied` | Skip; reapply is a bug. |
+| Descriptor without watermark, or watermark without descriptor | Invalid | Stop open unless a proven repair protocol exists. |
+| After durable checkpoint boundary covers applied state | `S5 Cleanable` | WAL and WAL-only side-ref protection may be cleaned if read-view/reachability guards pass. |
+| During cleanup before durable cleanup metadata | Still not safely cleaned | Missing segment is not acceptable. |
+| After durable cleanup metadata covers range | `S6 Cleaned` | Missing segment is acceptable only for covered range. |
+| Complete WAL with missing/corrupt required side ref | Corrupt or quarantinable | Stop open or explicitly quarantine affected collection; do not skip later same-collection txns. |
+
+Cleanup rule:
+
+```text
+A WAL segment is cleanable only if every complete transaction in the segment is
+individually proven safe:
+
+for each transaction t in segment:
+  AppliedSeq[t.CollectionUID] >= t.CollectionSeq
+  and CheckpointSeq[t.CollectionUID] >= t.CollectionSeq
+  and all required side refs are root-reachable, still retained, or proven no
+      longer needed
+  and no live CollectionReadView pins roots, pending state, side refs, or
+      snapshots requiring the WAL segment
+  and cleanup metadata will be durable before the segment may be missing
+
+Global segment MaxWALLSN may speed scanning, but it is not proof of cleanup.
+```
 
 Root descriptors published without the matching applied watermark are not a
 valid state. If an implementation bug or future format can produce that split,
 recovery must stop open unless the format also provides a proven idempotent
 repair protocol. PR1 must make the split unrepresentable by publishing
-descriptor ops and watermark ops in one backend commit.
+descriptor ops and watermark ops through a typed collection-WAL publish wrapper
+in one backend commit.
 
-### 9.2 Startup Recovery
+### 9.3 Startup Recovery
 
 Startup recovery should extend the existing recovery order while preserving
 the current invariant that side-store scans run before cached commit-log replay:
@@ -1683,7 +2073,7 @@ Read-only open must scan enough collection WAL metadata to detect unapplied
 collection WAL transactions. Production column-store read-only open must not
 silently hide acknowledged WAL-on writes after crash.
 
-### 9.2.1 Column Side-File Recovery
+### 9.3.1 Column Side-File Recovery
 
 Before collection WAL replay, recovery scans column prepare directories and
 final column file classes and builds a side-file availability map. For each
@@ -1716,7 +2106,7 @@ reachable root, pending WAL transaction, and prepared or orphaned column
 directory. Reusing a `PartID` or `FileID` that appears in an unclassified
 prepare group is forbidden.
 
-### 9.3 Buffered Transaction Replay and Accumulation
+### 9.4 Buffered Transaction Replay and Accumulation
 
 PR1 uses per-collection replay-side accumulation. Merged flush-unit WAL
 transactions are deferred because they are incompatible with durable-at-ack for
@@ -1774,7 +2164,7 @@ This rule applies to no-index buffered writes, indexed mutable runs, queued
 flush units, async publishing states, overlay compaction, schema/index changes,
 and future column-store delta-part descriptor updates.
 
-### 9.4 Failure Behavior
+### 9.5 Failure Behavior
 
 | Failure point | Required behavior |
 |---|---|
@@ -1810,8 +2200,7 @@ Segment cleanup must decode the candidate segment and prove coverage for every
 complete transaction in that segment. A segment maximum transaction id,
 maximum `WALLSN`, or per-collection high value is not sufficient unless it is
 paired with proof that every complete transaction in the segment is covered by
-that transaction's collection watermark or by a valid global contiguous
-watermark.
+that transaction's own collection watermark and durable checkpoint boundary.
 
 Prepared side files use a two-state lifecycle:
 
@@ -2410,7 +2799,7 @@ Required assertions:
 - oversized inline transactions fail before ack or spill to side-payload refs
   with the same side-ref fence;
 - future Raft apply cannot report an applied index whose logical mutation is
-  neither locally recoverable nor guaranteed to be replayed from the Raft log.
+  neither locally recoverable nor guaranteed to be replayed from the Raft log;
 - descriptor side-ref closure is complete for column manifests, substreams,
   filters, delete bitmaps, dictionaries, compression metadata, and granule roots;
 - missing or corrupt required column side refs fail recovery for complete
@@ -2489,14 +2878,51 @@ Read-only open:
 - after read-write recovery completes, read-only reopen sees the recovered write
   without needing collection WAL replay.
 
-### 11.5 Fuzz Tests
+### 11.5 Model and Property Tests
+
+The formal model may be an abstract Go model, a TLA/PlusCal model, or another
+checked transition system, but it must generate machine-readable artifacts for
+the acceptance gate. The model must include variables for `mode`,
+`txn[collection][seq]`, side-ref state, visible state, `appliedSeq`,
+`checkpointSeq`, cleanup manifests, read views, maintenance operations, and
+future `raftAppliedIndex`.
+
+Required counterexample classes:
+
+- descriptor-only commit;
+- watermark-only commit;
+- global-`WALLSN` replay skip;
+- side-ref deletion before `CanCleanSideRef`;
+- double apply after applied watermark;
+- WAL-on visible-before-recoverable;
+- WAL-off visible-unrecoverable allowed and unreplayed;
+- same-base replay accumulation with overlapping keys;
+- cleanup crash before durable manifest;
+- Raft applied-index before local recoverability.
+
+Required property tests:
+
+- for each generated committed prefix, live publish digest equals recovery
+  replay digest;
+- replaying after `AppliedSeq[c] >= s` never changes roots;
+- interleaved collections cannot cause cross-collection skip;
+- cleanup proof is monotonic with checkpoints and read-view releases, but
+  maintenance cannot make an uncleaned required ref disappear;
+- async flush requeue preserves the exact original WAL coverage range and side
+  refs.
+
+### 11.6 Fuzz Tests
 
 - transaction decoder fuzzing;
 - recovery ordering fuzzing with multiple collections and duplicate keys;
 - side-ref fence fuzzing with missing and truncated payloads;
-- root-delta replay fuzzing against an in-memory oracle.
+- root-delta replay fuzzing against an in-memory oracle;
+- cleanup manifest fuzzing with missing segments, torn records, overlapping
+  ranges, and mixed-collection segments;
+- system-delta template fuzzing with descriptor/watermark split attempts and
+  malformed coverage ranges.
 
-### 11.6 Required Named Acceptance Tests
+### 11.7 Required Named Acceptance Tests
 
 These tests or equivalent subtests must exist before implementation can be
 considered complete. Names are normative so CI, verification docs, and
@@ -2514,6 +2940,15 @@ acceptance artifacts can point to stable evidence.
 | `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied` | Two collections; force higher `WALLSN` publish/watermark before a lower `WALLSN`; crash/reopen. | Per-collection watermark logic cannot skip lower unapplied transactions. |
 | `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent` | Fault hook exits during recovery after N transactions, after watermark commit, and during segment cleanup; reopen repeatedly. | No double-apply, no lost writes, cleanup eventually converges. |
 | `TestCollectionWALGCRewriteCompactionSnapshotsProtectPendingSideRefs` | Create pending WAL transaction whose side ref has no published root owner; pin snapshot/read view; run GC/rewrite/compaction; crash/reopen. | Side refs are protected until watermark plus checkpoint handoff, and snapshots do not observe dangling roots. |
+| `TestCollectionWALModelDescriptorWatermarkSplitRejected` | Abstract model and backend wrapper try descriptor-only and watermark-only commits for `c:1` and `c:2`. | Split descriptor/watermark states are unrepresentable or rejected before recovery can skip/replay incorrectly. |
+| `TestCollectionWALModelVisibleImpliesRecoverable` | Fault model injects crashes after planning, side-ref prepare, before marker, after marker, before visible install, and after visible install. | WAL-on traces never contain `Visible(t)` without `Recoverable(t)`; WAL-off traces may, but are labeled non-durable and unreplayed. |
+| `TestCollectionWALModelSideRefProtectHappensBeforeGuardRelease` | Interleave prepare, append, guard release, GC delete, crash, and recover. | Complete WAL frames always have protected side refs before maintenance can delete or rewrite them. |
+| `TestCollectionWALModelDeterministicReplayDigest` | Generate same-base transactions with overlapping keys, deletes, index deltas, and schema guards; compare live publish and recovery. | Fold order produces the same descriptor digest and watermark across crashes and repeated recovery. |
+| `TestCollectionWALModelStateClassifierExclusive` | Randomly add applied, checkpoint, cleanup, visibility, read-view, and quarantine predicates. | Durable state classifier returns exactly one `S0` through `S6`; volatile predicates remain orthogonal. |
+| `TestCollectionWALModelSkipUsesCollectionSeqOnly` | Interleave two collections and try to skip using global `WALLSN` or another collection's watermark. | Model rejects any skip not proven by the same collection's applied sequence and guard history. |
+| `TestCollectionWALModelMaintenanceGuardBlocksRewrite` | Interleave value-log rewrite, overlay compaction, side-file cleanup, committed WAL refs, and live read views. | Maintenance delete/rewrite occurs only after `CanStartMaintenance`. |
+| `TestCollectionWALModelRaftAppliedIndexRequiresLocalRecoverability` | Future Raft model crashes after consensus commit, local planning, WAL append, idempotency write, and applied-index write. | `PersistentAppliedIndex` cannot outrun local mutation recoverability and durable idempotency/catalog outcomes. |
+| `TestCollectionWALTypedPublishWrapperRejectsFreeFormSystemDelta` | Attempt to publish WAL-on collection descriptors through a free-form system builder without coverage metadata. | Only typed collection-WAL covered publish can update descriptors and applied watermark in WAL-on modes. |
 | `TestCollectionWALPendingDebtSoftStopHardLimits` | Block async publish/checkpoint/cleanup and keep admitting collection writes until each configured debt threshold is crossed. | Soft threshold triggers maintenance, stop threshold blocks, hard threshold rejects before ack. |
 | `TestCollectionWALBackpressureResumeWatermark` | Fill pending debt past stop, release publish/checkpoint/cleanup, then retry blocked writes. | Writes resume only after debt drops to or below 70 percent of the stop limit. |
 | `TestCollectionWALReplayAccumulatorSoftCapChunksOrSpills` | Recover many same-base-root transactions with distinct keys until the soft accumulator cap is reached. | Recovery chunk-publishes or spills deterministically without changing final roots. |
@@ -2523,7 +2958,7 @@ acceptance artifacts can point to stable evidence.
 | `TestCollectionWALDurableSyncBatchCaps` | Run concurrent durable-sync writers. | Group fsync batches respect max delay, byte, and transaction caps while preserving ack semantics. |
 | `TestColumnWALSideRefCapacityLimits` | Plan column side refs beyond file, manifest, and side-ref-per-transaction limits. | Persistent column roots remain blocked and fail before ack/publish. |
 
-### 11.7 Required Fault Points
+### 11.8 Required Fault Points
 
 The crash harness must expose these named fault points. Each point must support
 both "return injected error" and "process exit" modes when the code path can
@@ -2827,16 +3262,17 @@ Traceability matrix:
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
 | Testability decisions | 15 | M0.5 | closed PR1 choices and acceptance artifact |
+| Formal state machine | 9.1, 9.2 | M0.5, M1, M5 | abstract model tests, invariant mapping, and counterexample fixtures |
 | WAL format | `storage-format.md` Section 9 plus this doc 7.2, 7.4, 7.5 | M1 | exact-byte golden, fuzz, corrupt-tail, feature-gate, and migration-state tests |
-| Recovery state machine | 9.1, 9.2, 9.4 | M1, M5 | crash-state and stop-open tests |
-| Identity and sequencing | 7.3, 7.6, 9.3 | M1, M5 | collection-seq, epoch, generation tests |
+| Recovery state machine | 9.1, 9.2, 9.3, 9.5 | M1, M5 | crash-state and stop-open tests |
+| Identity and sequencing | 7.3, 7.6, 9.4 | M1, M5 | collection-seq, epoch, generation tests |
 | System-root template | 7.2, 8.6 | M1, M5 | descriptor-op and watermark atomicity tests |
 | Side-file fences | 7.7, 10 | M2 | missing-ref and GC protection tests |
 | Segment cleanup metadata | 7.5, 10 | M1, M5 | missing-segment and cleanup-manifest tests |
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
 | Visibility/admission barriers | 6.2, 6.3, 8, 8.9 | M3, M6 | read-race, checkpoint-cut, and close-race tests |
 | Collection read views | 3, 6.3, 8.10, 10 | M4, M6 | long-iterator and side-ref pinning tests |
-| Recovery replay | 9 | M4, M4.5 | crash matrix, accumulation, and deterministic replay tests |
+| Recovery replay | 9 | M4, M4.5 | crash matrix, accumulation, deterministic replay, and replay theorem tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
 | Resource accounting/admission | 10.1, 12 | M0.5, M1, M2, M4.5, M6.5 | cost-estimator, backpressure, replay-cap, cleanup-debt, and benchmark-report artifacts |
 | Lock ordering | 8.9, 11.4 | M0, M6 | debug lock assertions and deadlock stress |
@@ -2863,7 +3299,7 @@ Acceptance matrix:
 | Gate | Required evidence | Pass criteria |
 |---|---|---|
 | M0 Contract and harness freeze | Existing current-contract tests and crash helper skeleton. | Current flush-boundary behavior remains documented; named fault hooks can stop at side prepare, WAL append, staging, publish, watermark, cleanup, and recovery replay. |
-| M0.5 Testability decisions | Closed PR1 decisions in Section 15. | File class, transaction identity, checkpoint behavior, missing side-ref policy, buffered replay model, GC protection, and overlay compaction rule are testable. |
+| M0.5 Testability decisions | Closed PR1 decisions in Section 15. | File class, transaction identity, formal model, checkpoint behavior, missing side-ref policy, buffered replay model, GC protection, and overlay compaction rule are testable. |
 | M1 WAL format | Golden fixtures, checksum/corruption/truncation tests, decoder fuzzing. | Decoder is deterministic; safe terminal truncation is accepted; hard corruption fails. |
 | M2 Side-ref fences | Missing-ref, side-payload, and GC/rewrite protection tests. | No root points at missing bytes; WAL-pending side refs are retained. |
 | M3 No-index WAL integration | WAL-on/WAL-off no-index crash tests and append-failure tests. | WAL-on crash recovers acknowledged writes; WAL-off expectations stay relaxed; append failure has no visibility. |
@@ -2907,12 +3343,14 @@ M1 starts, the implementation owner must confirm the exact testable choices for:
 
 - collection WAL segment format and filename class;
 - storage-format feature gates, migration states, and byte envelope;
+- abstract model variables, state predicates, transition guards, invariant list,
+  and counterexample classes from Section 9.1;
 - `CollectionSeq` and `WALLSN` allocation and persistence;
 - missing side-ref behavior by durability mode;
 - checkpoint behavior for PR1;
 - buffered replay model;
 - GC/rewrite side-ref protection mechanism;
-- overlay compaction durability rule.
+- overlay compaction durability rule;
 - resource accounting defaults for transaction size, inline spill, side-payload
   limits, replay accumulator caps, debt soft/stop/hard limits, and durable-sync
   group fsync caps.
@@ -2939,9 +3377,12 @@ Deliverables:
   `CollectionWALStats.Snapshot()` counters/gauges for append, pending,
   protected side refs, recovery, cleanup debt, and value-log GC blockers;
 - stable root-delta encode/decode APIs independent of transient in-memory
-  `batch.Batch` layout.
+  `batch.Batch` layout;
 - encoder-backed byte estimator, inline/side-payload threshold enforcement,
-  segment rotation defaults, and capacity error names from Section 10.1.
+  segment rotation defaults, and capacity error names from Section 10.1;
+- small model or property-test harness for descriptor/watermark split,
+  WAL-before-visible, side-ref protection, per-collection skip, deterministic
+  replay, maintenance guards, WAL-off exception, and future Raft local metadata.
 
 Tests:
 
@@ -2954,8 +3395,11 @@ Tests:
 - truncated tail;
 - decoder fuzzing;
 - replay digest tests;
+- abstract model counterexample tests for descriptor-only commits,
+  watermark-only commits, global-`WALLSN` skip, side-ref deletion before
+  cleanability, visible-before-recoverable, and WAL-off unrecovered visibility;
 - descriptor-op placeholder instantiation tests;
-- cleanup metadata and missing-segment classification tests.
+- cleanup metadata and missing-segment classification tests;
 - metrics emitted for append success, append failure, recovery skip, recovery
   hard failure, and cleanup failure.
 
@@ -3432,8 +3876,9 @@ Recovery:
 
 - Duplicate `WALLSN` or duplicate `(CollectionUID, CollectionSeq)` is fatal
   unless covered by an explicit legacy quarantine path.
-- A transaction is skipped only if its own collection watermark or a valid
-  global contiguous watermark covers it.
+- A transaction is skipped only if its own collection watermark and guard
+  history cover it. Global `WALLSN` ranges are cleanup-scan aids only and are
+  never replay-skip proof.
 - Missing required side ref for a complete unwatermarked transaction is
   fatal/quarantine, never silent skip.
 - A watermark advance includes every root delta and metadata delta in the
@@ -3784,6 +4229,59 @@ Module-specific constraints:
   `cmd/collection_bench_report` own the resource-budget benchmark artifact
   schema. CI must fail when required columns are absent even if raw Go
   benchmarks complete successfully.
+
+Runtime assertions required in WAL-on modes:
+
+- Assert no visible install occurs without `CompleteWALFrame`.
+- Assert `CollectionSeq == previous + 1` at allocation and replay.
+- Assert `DependsOnCollectionSeq == CollectionSeq - 1` for PR1 single-write
+  transactions.
+- Assert canonical embedded side refs equal declared required refs before
+  append.
+- Assert every required side ref is prepared and protected before a WAL marker
+  becomes replayable.
+- Assert every collection root descriptor commit carries a typed coverage range
+  and matching watermark op.
+- Assert async flush units carry immutable WAL coverage: `CollectionUID`,
+  contiguous sequence range, root names, root generations, required refs, and
+  `WALLSN` range.
+- Assert cleanup decodes every complete transaction in candidate segments and
+  proves same-collection watermark/checkpoint coverage.
+- Assert recovery skip never uses global `WALLSN`.
+- Assert read-only open fails when committed unapplied collection WAL exists,
+  unless explicit stale/read-only mode is selected.
+
+Internal APIs that must enforce transition guards:
+
+- `appendCollectionWALTransaction(t)` enforces `CanAppendWAL`.
+- `installCollectionVisible(t)` enforces `CanInstallVisible`.
+- `publishCollectionWALCoveredGroup(c,N,M,txns)` is the only WAL-on collection
+  root publish path.
+- `advanceAppliedWatermark` is not public; it is part of
+  `publishCollectionWALCoveredGroup`.
+- `recoverCollectionWAL()` owns replay, skip, block, fail, and quarantine
+  transitions.
+- `cleanupCollectionWALSegment(segment)` owns cleanup proof and manifest
+  update.
+- `prepareSideRefs` and maintenance APIs share the same guard/protected-index
+  mechanism.
+- Future Raft apply must call the same local WAL append and publish wrappers
+  before persistent applied-index advancement.
+
+Forbidden state transitions:
+
+- `PlannedHidden -> VisiblePending` in WAL-on without complete WAL.
+- `PreparedSideRefs -> VisiblePending` without complete WAL.
+- `CompleteWALFrame -> ReleaseGuard` without `ProtectedByWAL`.
+- `RootDescriptorCommit -> AppliedWatermarkUnchanged` in WAL-on.
+- `AppliedWatermarkAdvance -> MissingDescriptorCommit`.
+- `AppliedSeq[c] = N -> M` with any missing `CollectionSeq` in `(N,M]`.
+- `CommittedWAL -> Cleaned` without `Applied` and `CheckpointCovered`.
+- `S2 CommittedWAL` skip based on `WALLSN`.
+- `PersistentRaftAppliedIndex >= i` before local recoverability and
+  idempotency durability for entry `i`.
+- Maintenance delete/rewrite while a ref is WAL-protected, root-reachable, or
+  read-view pinned.
 
 Recommended implementation sequence:
 

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -2129,6 +2129,50 @@ Crash/recovery rules:
 | After durable cleanup metadata covers range | `S6 Cleaned` | Missing segment is acceptable only for covered range. |
 | Complete WAL with missing/corrupt required side ref | Corrupt or quarantinable | Stop open or explicitly quarantine affected collection; do not skip later same-collection txns. |
 
+Collection WAL side-ref lifecycle:
+
+```text
+S0 Absent
+  No complete committed collection WAL frame exists.
+
+S1 PreparedSideRefs
+  Side bytes may exist. No committed frame references them.
+  Protected by the side-ref prepare guard.
+  Backup: include only if referenced by a backup manifest, otherwise classify.
+  Maintenance: must not delete until classified.
+
+S2 WALCommitted
+  Commit marker and transaction checksum are valid.
+  Required side refs are recovery roots.
+  Backup: include WAL segment/range plus every required side ref.
+  Maintenance: GC/rewrite/cleanup must retain or skip every required side ref.
+
+S3 MaterializedUnpublished
+  Recovery/live publish has built pages/files but has not committed descriptors
+  plus applied watermark.
+  Backup/maintenance: treat as S2 unless the publish commit is observed.
+
+S4 Applied
+  One backend commit atomically published root descriptors and applied
+  collection watermarks.
+  Maintenance: still retain WAL-only side-ref protection until checkpoint and
+  reachability handoff.
+
+S5 Cleanable
+  S4 plus durable backend checkpoint/meta boundary plus root reachability
+  tracker/full scan has incorporated the published roots.
+  Cleanup: may write durable cleanup records and release WAL-only protection.
+
+S6 Cleaned
+  Durable cleanup metadata covers the segment/range and directory fsync
+  completed. Missing covered collection WAL segments are acceptable.
+
+Q Quarantined
+  Prepared/final side file is proven not referenced by any committed WAL,
+  published root, snapshot, read view, or backup manifest. IDs remain reserved
+  until purge is durable.
+```
+
 Cleanup rule:
 
 ```text
@@ -2145,6 +2189,28 @@ for each transaction t in segment:
   and cleanup metadata will be durable before the segment may be missing
 
 Global segment MaxWALLSN may speed scanning, but it is not proof of cleanup.
+
+A collection WAL segment, collection WAL transaction, or WAL-only side-ref
+protection is safe to delete/release only when all are true:
+
+1. every complete transaction in the candidate segment/range is covered by the
+   per-collection applied sequence watermark;
+2. descriptor updates and applied watermark updates were committed atomically;
+3. the backend checkpoint/meta boundary containing those descriptors/watermarks
+   is durable for the selected mode;
+4. value-log, leaf-log, column-file, dictionary, and template reachability
+   tracking has incorporated the published roots, or a full reachability scan
+   completed under the collection WAL maintenance barrier;
+5. no live backend snapshot, collection read view, pending publish unit, or
+   backup manifest token can reference the old or WAL-only side refs;
+6. durable cleanup metadata for the exact segment/range has been written and
+   fsynced;
+7. directory fsync after unlink/rename has completed where the platform
+   requires it.
+
+Segment cleanup must decode each candidate segment and prove coverage for every
+complete transaction. Segment max `WALLSN`, max `CollectionSeq`, or a global
+high watermark alone is not sufficient.
 ```
 
 Root descriptors published without the matching applied watermark are not a

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -354,9 +354,9 @@ marked `Required=false` must not be referenced by any published root value.
 
 | Mode | Collection write acknowledgement after this spec |
 |---|---|
-| `DurabilityDurable` | Write returns only after the collection WAL transaction reaches the configured durable boundary. Sync barriers fsync according to durable mode. |
-| `DurabilityWALOnRelaxed` | Write returns after the collection WAL transaction is appended/flushed enough for process-crash recovery. It does not claim power-loss durability. |
-| `DurabilityWALOffRelaxed` | No durable-at-ack promise. Collection writes remain flush/checkpoint/close-boundary durable, and docs must say so directly. |
+| `DurabilityDurable` | For non-sync collection APIs, write success means the collection WAL transaction has reached the configured local WAL append/flush boundary needed for process-crash recovery. Non-sync APIs do not imply power-loss durability. Sync barriers additionally fsync according to durable mode. |
+| `DurabilityWALOnRelaxed` | Write success means the collection WAL transaction has left process-local memory and is recoverable under the same process-crash assumptions as the existing WAL-on relaxed commit log. It does not claim power-loss durability. |
+| `DurabilityWALOffRelaxed` | No durable-at-ack promise. Collection writes remain flush/checkpoint/close-boundary durable, and docs must say so directly. In this mode, `visible` acknowledgements are process-local visibility only. |
 
 If the engine cannot append the collection WAL transaction in a WAL-on mode, the
 collection write must fail before becoming visible to any reader, planner, or
@@ -438,21 +438,30 @@ Read-only open after crash:
 - A stale-read-only mode, if added, must be named as stale and must not claim
   durable-at-ack visibility for unapplied collection WAL writes.
 
-Native-wire acknowledgement policies map onto these same local boundaries:
+Native-wire `ack_policy` is request/response policy only. It must not be
+encoded into deterministic command entries, must not affect logical
+state-machine results, and must not affect collection WAL replay.
 
-- `visible` may return after the write is visible through the serving process.
-  In WAL-on collection modes after this spec, it still cannot return before the
-  collection WAL transaction is recoverable.
-- `flushed` must publish affected collection state into backend roots and
-  advance the collection WAL applied watermark for those transactions.
-- `synced` must also reach the backend checkpoint/sync boundary required by the
-  configured local durability mode.
-- Collection WAL append and collection root publication must both expose explicit
-  flush/sync options so these acknowledgement policies can be implemented
-  without relying on implicit backend defaults.
-- `raft_committed` is a cluster-mode policy. It cannot be satisfied by local
-  collection WAL alone; it requires consensus commit plus the cluster's defined
-  local apply durability rule.
+- `visible` means the mutation is visible through the serving process or owning
+  write domain. In WAL-on collection modes after this spec, `visible` still
+  waits for the local collection WAL transaction to be recoverable because the
+  underlying collection API is durable-at-ack. In WAL-off mode, `visible` is not
+  crash-durable.
+- `flushed` means affected collection state has been published into backend
+  roots and the collection WAL applied watermark for those transactions has
+  advanced in the same backend commit.
+- `synced` means `flushed` plus the backend checkpoint/fsync boundary required
+  by the configured local durability mode. It must not be silently downgraded.
+- Collection WAL append and collection root publication must both expose
+  explicit flush/sync options so these acknowledgement policies can be
+  implemented without relying on implicit backend defaults.
+- `raft_committed` is a cluster-mode policy, not a local WAL policy. It requires
+  consensus commit plus the cluster's defined local apply durability rule. Local
+  collection WAL alone cannot satisfy it.
+- Local policies are ordered as `visible < flushed < synced`.
+  `raft_committed` is a separate cluster policy and must not be implemented as a
+  simple numeric extension of the local ordering unless a future cluster spec
+  explicitly defines the implied local durability level.
 
 ### 6.3 PR1 Invariants
 
@@ -531,6 +540,8 @@ Reasons:
 
 ### 7.2 Transaction Shape
 
+Local physical collection WAL record:
+
 A collection WAL transaction is a replayable physical root-group transaction.
 It is not a logical insert/update/delete command. Recovery must not rerun user
 callbacks, predicates, JSON extraction, template extraction, secondary-index
@@ -565,7 +576,6 @@ CollectionWALTransaction {
     SideRefs                 []CollectionSideRef
 
     // Local observability only; excluded from replay identity.
-    AckMode                  uint8
     CreatedUnixNanos         int64
     Stats                    CollectionWALStats
 
@@ -643,6 +653,13 @@ OrderedRootPublishOptions {
 }
 ```
 
+This record is not portable across replicas. `WALLSN`, `CollectionSeq`,
+`BaseSystemRootID`, `BaseRootID`, root names as resolved by local storage,
+side-ref paths/RIDs, timestamps, stats, and other local observability metadata
+are meaningful only in the database directory that wrote the record. A follower
+applying the same deterministic command entry may produce different local root
+ids, side refs, file names, and collection WAL bytes.
+
 Column-store transactions must carry enough catalog identity to make replay
 schema-stable. `CollectionEpoch` guards collection incarnation and catalog-level
 schema evolution. `SchemaVersion` guards physical column decode. `CatalogDigest`
@@ -674,9 +691,11 @@ dependency domain. Recovery may use `WALLSN` to scan and diagnose records, but
 it must not use a higher `WALLSN` from another collection to skip a lower
 unapplied `CollectionSeq`.
 
-`AckMode`, `CreatedUnixNanos`, and `Stats` are local observability and policy
-metadata. They must not change root-delta replay output, idempotency outcomes,
-catalog guard outcomes, or future Raft state-machine results.
+`CreatedUnixNanos` and `Stats` are local observability metadata. If an
+implementation retains an acknowledgement-related field, it must be encoded as
+an ignored observability field, not as replay input. Replay, idempotency,
+catalog guards, Raft command digests, and logical state digests must not depend
+on it.
 
 Two digests are required:
 
@@ -1098,11 +1117,26 @@ The boundary is strict:
   not by local value-log offsets, column-file names, root ids, flush timing, or
   WAL transaction bytes.
 
+Collection WAL golden files test the local storage format only. They are not
+cross-replica fixtures and must not require byte-identical apply output across
+nodes.
+
 On a future follower, applying a committed deterministic entry should derive the
 same logical mutation outcome but may produce different local physical files and
 root ids. That is acceptable only if the local collection WAL makes the derived
 root group recoverable before the node advertises the Raft entry as durably
 applied under the cluster policy.
+
+A committed Raft entry has three distinct states:
+
+- `consensus_committed`: the Raft algorithm has committed the deterministic
+  command-entry bytes.
+- `locally_applied`: this node has evaluated the command against local TreeDB
+  state.
+- `locally_recoverable`: after restart, this node can reconstruct the applied
+  logical outcome before serving reads or advertising the applied index.
+
+Raft commit alone is insufficient for `locally_recoverable`.
 
 ## 8. Write Path
 
@@ -1258,6 +1292,12 @@ can race with user-visible collection writes. It uses `ReplaceRoot` and
 `ClearOverlayRoots` descriptor operations, advances the collection sequence, and
 updates the affected root generation. Root-rewriting overlay maintenance is
 forbidden while unapplied collection WAL exists unless it is encoded this way.
+Overlay compaction and other layout-only root rewrites are local physical
+maintenance transactions. They must not be appended as deterministic Raft
+command entries and must not change the logical collection digest except by
+preserving equivalent contents. A future distributed compaction/checkpoint
+barrier must be specified as a separate deterministic barrier command if
+cluster-visible semantics are required.
 
 Column-store compaction, delete-bitmap compaction, and recompression are always
 collection WAL maintenance transactions when they create external files or
@@ -1312,21 +1352,28 @@ bytes, validate the command version and catalog guard against applied state, and
 derive local collection root deltas through the same planner/state-machine logic
 used by the single-node path.
 
-A committed Raft entry must not be marked locally durable/applied under a
-cluster durability policy until one of these is true:
+A node must not advance persistent applied-index metadata, return a
+`raft_committed` client success from that node, or advertise the command as
+locally recoverable until one of these is true:
 
-1. the derived collection WAL transaction is recoverable locally; or
-2. the Raft recovery design explicitly guarantees that unapplied committed log
-   entries are replayed after every restart before the node serves reads or
-   advertises the corresponding applied index.
+1. the local collection WAL transaction and any required idempotency/catalog
+   result metadata are recoverable locally; or
+2. the Raft stable-store recovery design explicitly guarantees that
+   committed-but-not-locally-applied entries are replayed after every restart
+   before the node serves reads or advertises the corresponding applied index.
 
-The first implementation should prefer the first rule: committed entry, local
-root-delta WAL append, write-domain visibility/publish, then applied-index and
-idempotency metadata advancement. Any persistent idempotency record or catalog
-guard outcome that affects retry/replay behavior must be advanced atomically
-with the logical mutation outcome, either in the same backend root group or in
-an explicitly ordered metadata transaction whose crash behavior is tested with
-the collection WAL.
+The first implementation should use rule 1: committed entry, local root-delta
+WAL append, write-domain visibility/publish, then applied-index and idempotency
+metadata advancement. Any persistent idempotency record or catalog guard outcome
+that affects retry/replay behavior must be advanced atomically with the logical
+mutation outcome, either in the same backend root group or in an explicitly
+ordered metadata transaction whose crash behavior is tested with the collection
+WAL.
+
+If local collection WAL append fails after Raft commit, the command must remain
+committed-but-not-locally-applied on that node. The node must retry local apply
+or fail/step down according to the future Raft recovery policy; it must not
+report local recoverability.
 
 `flush_collection`, `flush_all`, `checkpoint`, and physical maintenance commands
 remain local barriers. Cluster mode must reject `ack_policy=raft_committed` for
@@ -2249,6 +2296,8 @@ Deliverables:
   reconstructing native-wire transport requests;
 - local collection WAL append is integrated into follower/leader apply before
   the node advertises the Raft index as locally durable;
+- apply state distinguishes `consensus_committed`, `locally_applied`, and
+  `locally_recoverable`;
 - applied-index, catalog guard outcome, and idempotency metadata are advanced
   atomically with the logical mutation outcome or are replayed from Raft after
   restart by a documented rule;
@@ -2261,6 +2310,10 @@ Tests:
 
 - same committed deterministic entry sequence applied in separate fresh
   databases produces the same logical catalog/content/index/idempotency digest;
+- deterministic-entry fixtures prove that changing `ack_policy`,
+  `consistency_policy`, deadlines, trace context, compression choices, request
+  ids, and response-shaping flags does not change canonical command bytes or
+  command digest;
 - crash after Raft commit before local WAL append recovers by replaying the
   committed entry or never advertises it as applied;
 - crash after local WAL append before applied-index metadata advancement does
@@ -2352,10 +2405,11 @@ Future questions that do not weaken PR1 correctness:
 4. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
-5. Should native-wire `ack_policy` remain purely transport/local durability
-   control for deterministic entries, or should a future command version define
-   an explicit logical barrier flag? This must be resolved before
-   `raft_committed` writes are exposed.
+
+Resolved PR1 decision: native-wire `ack_policy` remains request/local
+durability control and is stripped before deterministic-entry construction. A
+future cluster-visible barrier must be a separate deterministic command or a
+new deterministic command field with explicit state-machine semantics.
 
 ## 16. Implementation Notes
 

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,6 +1,6 @@
 # SPEC: Collection WAL Durability and Root-Group Recovery
 
-Status: proposal, non-normative
+Status: draft proposal, non-normative.
 Target repository studied: `https://github.com/snissn/gomap/tree/7431ba92f7a1a456c15f70ac019314090e22af31`
 Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
 `TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
@@ -394,19 +394,34 @@ Segment rules:
 The system root must store collection WAL progress:
 
 ```text
-treedb/collection-wal/global-applied-txn-id -> uint64
-treedb/collection-wal/collection/<collection-id>/applied-txn-id -> uint64 optional
+treedb/collection-wal/global-contiguous-applied-txn-id -> uint64 optional
+treedb/collection-wal/collection/<collection-id>/applied-txn-id -> uint64
 ```
 
-PR1 can use one global monotonic transaction id. Per-collection watermarks can
-be added later if recovery or cleanup needs more concurrency.
+PR1 can use one global monotonic transaction id for transaction identity. It
+must not use a single global applied high-watermark unless publication and
+watermark advancement are strictly contiguous in `TxnID` order across all
+collection write domains.
+
+Safe choices:
+
+1. Enforce one ordered global publisher, so transaction `N+1` cannot advance an
+   applied watermark before transaction `N` is applied.
+2. Track per-collection applied watermarks and advance a separate global
+   contiguous watermark only when every lower `TxnID` is known applied.
+
+The second choice is preferred if async publishers can run independently per
+collection or write domain. Recovery may skip a transaction only when that
+transaction is covered by its collection watermark or by a global contiguous
+watermark. It must never skip transaction `N` merely because transaction `N+1`
+from another collection was published first.
 
 When a collection root group is published, the same backend commit that updates
 collection root descriptors must also advance the applied watermark. This is the
 atomic marker that makes WAL cleanup safe.
 
-Recovery skips transactions at or below the applied watermark. Transactions
-above the watermark are candidates for replay.
+Recovery skips transactions covered by a safe applied watermark. Transactions
+not covered by a safe watermark are candidates for replay.
 
 ### 7.5 Side-File Fences
 
@@ -434,6 +449,25 @@ If a required side ref is missing during recovery:
 - durable mode should surface an error unless the missing ref is in a clearly
   incomplete tail transaction that can be ignored by the same rules as existing
   commit-log tails.
+
+Collection WAL side refs are also retention roots. Value-log GC, value-log
+rewrite, column-file cleanup, and future side-file maintenance must treat every
+required side ref in an unapplied or not-yet-cleanable collection WAL
+transaction as reachable until the transaction is covered by a safe applied
+watermark and the checkpoint/meta boundary needed for cleanup is durable.
+
+Implementation options:
+
+1. GC/rewrite scans collection WAL segments and includes required `SideRefs` in
+   its reachability set.
+2. WAL append/update maintains a protected side-ref index that GC/rewrite scans
+   with the normal root reachability set.
+
+PR1 should prefer protection over rewrite: if a value-log segment or column file
+is referenced only by pending collection WAL, maintenance should keep it in
+place rather than moving it and trying to patch WAL records. A future rewrite
+mode may rewrite protected refs only if it publishes replacement side refs and
+collection WAL metadata atomically under an explicit crash-tested protocol.
 
 ### 7.6 Native Wire and Raft Layering
 
@@ -599,7 +633,8 @@ the current invariant that side-store scans run before cached commit-log replay:
    - validate required side refs;
    - validate collection catalog identity and schema epoch;
    - verify each named root's current id matches the transaction's `BaseRootID`,
-     unless the transaction is already covered by the applied watermark;
+     unless the transaction is covered by a replay accumulator as described
+     below;
    - materialize `OrderedRootDeltaBatchPublishInput` values;
    - publish the root group with a system-root delta that updates collection
      root descriptors and advances the applied watermark.
@@ -611,11 +646,52 @@ the current invariant that side-store scans run before cached commit-log replay:
 Recovery must be deterministic. Replaying the same directory twice must produce
 the same collection roots and applied watermark.
 
+### 9.1 Buffered Transaction Replay and Rebasing
+
+Buffered collection writes can create several acknowledged WAL transactions
+whose root deltas all name the same persisted `BaseRootID`. That is valid if
+the write domain recorded each pending mutation relative to the persisted
+catalog root and planned to publish the merged flush unit later. It is not safe
+for recovery to publish transaction 1, update the root id, and then reject
+transaction 2 solely because transaction 2 still names the old persisted base.
+
+The implementation must choose one of these replay-safe models:
+
+1. Log only merged flush-unit transactions, so every transaction's `BaseRootID`
+   is the backend root id expected at replay time.
+2. Give each later WAL transaction a logical base that includes earlier pending
+   WAL deltas for that root.
+3. Rebase/accumulate during recovery.
+
+The recommended PR1 model is replay-side accumulation. Recovery should process
+unapplied transactions in `TxnID` order, grouped by collection and root. For
+each root, it maintains a virtual replay base seeded from the current catalog
+root and a pending delta accumulator:
+
+- if a transaction's `BaseRootID` equals the current persisted root, recovery
+  may start or extend the accumulator for that root;
+- if a transaction's `BaseRootID` equals the original buffered base already
+  covered by the accumulator, recovery appends the transaction's root delta to
+  the accumulator instead of treating the root-id mismatch as corruption;
+- if a transaction's `BaseRootID` is neither the current persisted root nor a
+  known buffered base for that accumulator, recovery must block or fail rather
+  than publish an ambiguous delta;
+- recovery publishes accumulated root deltas in one deterministic root group or
+  in a sequence whose later `BaseRootID` values are explicitly rebased to the
+  roots produced by earlier publishes;
+- applied watermarks may advance only for the exact transactions covered by the
+  successful accumulated publish.
+
+This rule applies to no-index buffered writes, indexed mutable runs, queued
+flush units, and async publishing states. It is also the rule future
+column-store delta-part descriptors must follow if several acknowledged deltas
+share one persisted base part-descriptor root.
+
 ## 10. Cleanup and Retention
 
 Collection WAL cleanup is safe only when both are true:
 
-1. every transaction in the segment is at or below the applied watermark;
+1. every transaction in the segment is covered by a safe applied watermark;
 2. the backend checkpoint/meta boundary containing that watermark is durable for
    the selected mode.
 
@@ -629,6 +705,12 @@ prepared side file -> no committed transaction -> quarantine or delete
 Column-store files should use the same lifecycle when they are introduced. A
 root descriptor must never be published before the referenced file bytes are
 readable at the required durability boundary.
+
+Value-log and side-file GC must include collection WAL side refs in the
+reachability set before deleting, truncating, rewriting, or moving any protected
+bytes. Cleanup may stop protecting a side ref only after the transaction is
+covered by a safe applied watermark and the durable checkpoint/meta boundary
+makes the published roots or the discarded incomplete transaction authoritative.
 
 ## 11. Test Plan
 
@@ -665,8 +747,14 @@ Crash/fault points:
 7. after applied watermark before WAL cleanup;
 8. during overlay compaction;
 9. during column-file prepare once column store exists.
-10. after Raft commit before local collection WAL append once Raft apply exists.
-11. after local collection WAL append before Raft applied-index/idempotency
+10. after two or more acknowledged buffered transactions with the same
+    persisted `BaseRootID`;
+11. after a higher `TxnID` from another collection publishes before a lower
+    `TxnID`;
+12. after value-log GC/rewrite is requested while an unapplied collection WAL
+    transaction is the only owner of a side ref;
+13. after Raft commit before local collection WAL append once Raft apply exists.
+14. after local collection WAL append before Raft applied-index/idempotency
     metadata advancement once Raft apply exists.
 
 Required assertions:
@@ -679,6 +767,12 @@ Required assertions:
 - roots never reference missing value-log or column-file bytes;
 - collection WAL files are cleaned only after safe watermark/checkpoint
   boundaries.
+- buffered transactions with shared persisted bases replay by accumulation or
+  rebasing without losing acknowledged writes;
+- a higher applied `TxnID` never causes recovery to skip a lower unapplied
+  transaction from another collection;
+- value-log GC/rewrite cannot remove or move bytes referenced only by pending
+  collection WAL side refs;
 - future Raft apply cannot report an applied index whose logical mutation is
   neither locally recoverable nor guaranteed to be replayed from the Raft log.
 
@@ -727,9 +821,9 @@ Traceability matrix:
 |---|---|---|---|
 | Current contract | 2, 6 | M0 | existing behavior tests and docs |
 | WAL format | 7.2, 7.3 | M1 | golden, fuzz, corrupt-tail tests |
-| Side-file fences | 7.5, 10 | M2 | missing-ref recovery tests |
+| Side-file fences | 7.5, 10 | M2 | missing-ref and GC protection tests |
 | Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
-| Recovery replay | 9 | M4 | crash matrix and deterministic replay tests |
+| Recovery replay | 9 | M4 | crash matrix, rebasing, and deterministic replay tests |
 | Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
 | Performance | 12 | M6 | benchstat gates and artifacts |
 | Column-store unblock | 6.3, 10 | M7 | side-file fence and root-group recovery proof |
@@ -782,13 +876,16 @@ Deliverables:
 - root-delta batch serialization;
 - inline and side-payload modes;
 - side-ref availability checker;
-- value-log and leaf-log side-ref integration.
+- value-log and leaf-log side-ref integration;
+- value-log GC/rewrite protection for unapplied collection WAL side refs.
 
 Tests:
 
 - missing side refs skip or fail safely;
 - no root can be published with missing side bytes;
-- large delta side-payload round trips.
+- large delta side-payload round trips;
+- GC/rewrite cannot delete or move bytes referenced only by unapplied
+  collection WAL side refs.
 
 Gate:
 
@@ -819,14 +916,18 @@ Deliverables:
 - indexed insert root-group WAL;
 - update/delete root-group WAL;
 - async flush publish uses existing durable transactions;
-- unique helper rebuild after recovery.
+- unique helper rebuild after recovery;
+- replay accumulator or merged-transaction path for multiple buffered
+  transactions that share one persisted root base.
 
 Tests:
 
 - crash after ack before async publish;
 - crash during async publish;
 - unique secondary correctness after recovery;
-- update/delete secondary roots recover atomically.
+- update/delete secondary roots recover atomically;
+- two acknowledged buffered writes against one persisted base both survive
+  crash/reopen.
 
 Gate:
 
@@ -839,6 +940,8 @@ Gate:
 Deliverables:
 
 - applied watermark in system root;
+- per-collection or global-contiguous watermark safety for out-of-order async
+  publishers;
 - collection WAL replay in open path;
 - segment cleanup after safe checkpoint;
 - prepared side-file quarantine/delete.
@@ -847,6 +950,8 @@ Tests:
 
 - crash after root page build or watermark commit before cleanup does not
   double-apply;
+- out-of-order async publish cannot advance a watermark that hides a lower
+  unapplied transaction;
 - older segments remain when watermark is not durable;
 - cleanup removes only fully applied segments;
 - prepared side files without committed transactions do not become visible.
@@ -938,6 +1043,9 @@ Gate:
 | Root-delta WAL duplicates data already in memtables. | Start with simple encoding, then move large deltas to side payloads when benchmarks require it. |
 | Replaying old transactions double-applies after crash. | Store applied watermark in the same system-root commit as root descriptor updates. |
 | Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass. |
+| Value-log GC/rewrite removes bytes referenced only by pending collection WAL. | Treat required collection WAL side refs as GC/rewrite roots until safe applied watermark and checkpoint cleanup. |
+| A global applied watermark skips lower unapplied transactions. | Enforce contiguous global publication or use per-collection watermarks plus a global contiguous watermark. |
+| Buffered transactions share an old persisted `BaseRootID`. | Log merged flush units, make later transactions depend on earlier pending deltas, or rebase/accumulate deltas during recovery. |
 | Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
 | Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
 | WAL-on throughput regresses too much. | Benchmark each milestone, use side payloads, batching, and async publish before relaxing durability. |
@@ -963,10 +1071,14 @@ Gate:
    checkpoint collection WAL without forcing root publication?
 8. What metric names should expose pending collection WAL bytes, applied
    watermark lag, replay count, skipped/fenced transactions, and cleanup debt?
-9. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
+9. Should PR1 use merged flush-unit WAL records or replay-side accumulation for
+   buffered writes that share one persisted base root?
+10. Should side-ref GC protection scan collection WAL segments directly or
+    maintain a separate protected side-ref index?
+11. For Raft R3, should applied-index/idempotency metadata live in TreeDB system
    roots, in a Raft library stable store, or in both with an explicit ordering
    rule?
-10. Should native-wire `ack_policy` remain purely transport/local durability
+12. Should native-wire `ack_policy` remain purely transport/local durability
     control for deterministic entries, or should a future command version define
     an explicit logical barrier flag? This must be resolved before
     `raft_committed` writes are exposed.

--- a/TreeDB/docs/spec/collection-wal-durability-plan.md
+++ b/TreeDB/docs/spec/collection-wal-durability-plan.md
@@ -1,0 +1,809 @@
+# SPEC: Collection WAL Durability and Root-Group Recovery
+
+Status: proposal  
+Target repository studied: `/Users/michaelseiler/dev/snissn/gomap`  
+Primary code paths studied: `TreeDB/collections`, `TreeDB/db`,
+`TreeDB/caching`, `TreeDB/internal/commitlog`, `TreeDB/internal/valuelog`  
+Related specs:
+
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+
+## 1. Summary
+
+TreeDB collection writes currently have a different durability shape from normal
+cached key/value writes. The base cached write path has a commit log and
+value-log RID fence. The collection write domain can acknowledge writes while
+they remain only in collection-local mutable, queued, or publishing state. Those
+writes are visible through the owning collection manager, but they are not
+durable-at-ack under the current contract.
+
+This spec proposes a shared collection WAL and root-group recovery protocol.
+The goal is to make acknowledged collection writes recoverable under WAL-on
+profiles without building a separate durability model for future column-store
+collections.
+
+The proposed architecture is a root-delta transaction WAL:
+
+1. Collection write planning builds the exact root-local deltas for the primary
+   root, template/index-state root, secondary roots, delete roots, overlay
+   roots, and future column-store descriptor roots.
+2. Any external payloads, such as value-log values or future column files, are
+   prepared before the transaction is committed.
+3. The collection WAL transaction records root names, base root ids, ordered
+   root deltas, side-file references, and a transaction sequence.
+4. Recovery replays complete transactions by publishing the same root group and
+   advancing an applied watermark in the system root.
+
+This is a hard prerequisite for production column-store collection writes.
+Before this milestone passes, column-store work may proceed only for docs,
+benchmarks, pure codecs, filters, and isolated format encode/decode tests that
+do not publish persistent collection roots.
+
+## 2. Current Facts
+
+### 2.1 Base WAL and Recovery
+
+Current TreeDB cached-mode writes already have a WAL model:
+
+- `Options.Durability` chooses durable, WAL-on relaxed, or WAL-off relaxed
+  behavior.
+- Commit-log records live under `maindb/wal`.
+- Value-log records live in persistent value-log storage. The value log is not
+  an ephemeral WAL.
+- Commit-log batches can carry a nonzero `Seq`.
+- Sequence-numbered commit batches form a fence for RID-backed records.
+- Recovery scans value-log segments, builds a `RID -> ValuePtr` map, reads
+  commit-log batches, sorts sequence-numbered batches by `Seq`, and replays
+  complete batches with `WriteSync`.
+- If a sequence-numbered commit batch references a missing RID, recovery skips
+  that batch instead of publishing phantom pointers.
+- Replayed commit-log files are removed only after successful replay.
+- Value-log files remain persistent storage after replay.
+
+This model is strong enough for normal key/value writes because the commit log
+contains user-root key/value mutations. It does not currently encode a
+collection root group as a first-class transaction.
+
+### 2.2 Backend Root-Group Publishing
+
+Collections publish several B-tree roots as one logical group. Relevant backend
+APIs include:
+
+- `PublishOrderedRootGroup`
+- `PublishOrderedRootGroupWithSystemBuilder`
+- `PublishOrderedRootDeltaGroupWithSystemBuilder`
+- `PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`
+- `PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder`
+
+The indexed collection flush path materializes root-local delta batches, then
+calls `PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder`. The system-root
+delta records the produced root ids in collection descriptors.
+
+That backend publish path is useful and should be retained. The missing piece is
+an ahead-of-publish collection transaction log that lets recovery finish or
+discard in-flight collection root groups coherently.
+
+### 2.3 Collection Write Domain
+
+Current collection write-domain facts:
+
+- Indexed collections use collection-local write memtables by default.
+- Pending writes are visible in-process through the collection manager.
+- Reads, unique checks, updates, and deletes merge mutable, queued, publishing,
+  and persisted roots newest-to-oldest.
+- Flush units are visibility and publish-amortization units, not durable log
+  records.
+- `BufferedIndexedAsyncFlush` can move queued units into a publishing state
+  before backend root publication completes.
+- `Collection.Flush`, `CollectionManager.FlushAll`, backend close hooks, and
+  threshold-triggered synchronous publish paths drain pending work.
+- `DB.Checkpoint()` currently does not flush a pending collection-local
+  no-index insert. The pending document remains visible in-process and only
+  publishes when `Collection.Flush()` runs.
+- Existing tests verify that `Close` and `FlushAll` drain queued indexed flush
+  units before reopen.
+
+The current documented contract is flush-boundary durable, not durable-at-ack.
+That contract is understandable for today's row collections, but it is too weak
+as a foundation for column-store collections with external part files.
+
+## 3. Definitions
+
+Collection WAL transaction:
+
+An atomic durable record describing one ordered collection root-group mutation.
+It is not a logical SQL/JSON operation. It contains the root-local deltas needed
+to publish the mutation after recovery.
+
+Root group:
+
+The set of B-tree roots that must change together for one collection mutation.
+For existing collections this can include primary, template, index-state, and
+secondary index roots. For future column-store collections this also includes
+part descriptor, locator, delete, filter, and schema roots.
+
+Side file:
+
+A durable file or byte range referenced by a root group but not stored inline in
+the collection WAL transaction. Current examples are value-log records and
+leaf-log records. Future examples include column part files, filter files, and
+delete bitmap files.
+
+Applied watermark:
+
+System-root metadata that records the latest collection WAL transaction that
+has been published into backend roots. Recovery uses the watermark to avoid
+double-applying transactions after a crash that occurs after root publish but
+before WAL cleanup.
+
+Durable-at-ack:
+
+Under WAL-on profiles, once a collection write API returns success, recovery can
+make that write visible after process crash. This does not imply an fsync power
+loss guarantee unless the caller used a sync barrier and the selected durability
+mode requires fsync.
+
+## 4. Goals
+
+1. Make collection durability explicit and testable.
+2. Provide a shared collection commit/recovery protocol for row-store and
+   column-store collections.
+3. Preserve existing collection visibility semantics for pending writes.
+4. Preserve secondary index correctness across insert, update, delete, flush,
+   async publish, recovery, and close.
+5. Avoid re-running user update callbacks or JSON/template planning during
+   recovery.
+6. Reuse backend ordered root-group publish APIs for the final recovered commit.
+7. Extend the existing WAL/RID fence idea to collection root deltas and side
+   files.
+8. Make `DB.Checkpoint`, `Collection.Flush`, `CollectionManager.FlushAll`, and
+   `Close` coherent with collection WAL cleanup.
+9. Provide a hard gate for production column-store collection implementation.
+10. Add crash/fault tests that prove roots never point at missing side files.
+11. Keep write overhead bounded with benchmarks before enabling stronger
+    defaults broadly.
+
+## 5. Non-Goals
+
+- Do not replace the B-tree or ordered root-group publish APIs.
+- Do not make WAL-off relaxed mode durable-at-ack.
+- Do not promise fsync durability for non-sync collection APIs.
+- Do not replay logical collection operations by re-parsing documents or
+  re-running update callbacks.
+- Do not persist in-memory helper structures such as unique-value probe maps as
+  independent data. They must be reconstructable from WAL transactions or roots.
+- Do not build a separate private WAL only for column-store collections.
+- Do not require old pre-alpha directories to remain cross-version compatible.
+
+## 6. Target Durability Contract
+
+### 6.1 Mode Matrix
+
+| Mode | Collection write acknowledgement after this spec |
+|---|---|
+| `DurabilityDurable` | Write returns only after the collection WAL transaction reaches the configured durable boundary. Sync barriers fsync according to durable mode. |
+| `DurabilityWALOnRelaxed` | Write returns after the collection WAL transaction is appended/flushed enough for process-crash recovery. It does not claim power-loss durability. |
+| `DurabilityWALOffRelaxed` | No durable-at-ack promise. Collection writes remain flush/checkpoint/close-boundary durable, and docs must say so directly. |
+
+If the engine cannot append the collection WAL transaction in a WAL-on mode, the
+collection write must fail before becoming visible to the caller.
+
+### 6.2 API Boundaries
+
+`Collection.Insert`, `InsertBatch`, `Update`, `UpdateBatch`, `Delete`, and
+`DeleteBatch`:
+
+- In WAL-on modes, successful return means the root-delta transaction is
+  recoverable.
+- The write may still be pending in the collection write domain for read
+  performance and publish amortization.
+
+`Collection.Flush`:
+
+- Drains the collection write domain into backend roots.
+- Advances the applied watermark for all published collection WAL transactions.
+- Enables collection WAL cleanup after the backend checkpoint boundary that
+  contains the watermark is durable.
+
+`CollectionManager.FlushAll`:
+
+- Applies the same rule across all known write domains.
+- Must wait for in-flight async indexed publishing units.
+
+`DB.Checkpoint`:
+
+- Must become a full database durability/cleanup boundary for collection WAL.
+- It may either force `FlushAll` through the registered collection close/flush
+  hook or publish all durable collection WAL transactions before pruning related
+  log segments.
+- It must not report a clean WAL state while collection WAL transactions remain
+  needed for recovery.
+
+`DB.Close`:
+
+- Must drain collection write domains before backend close, as current tests
+  already require.
+- Must not discard a collection WAL transaction before its applied watermark is
+  safely published.
+
+### 6.3 Column-Store Gate
+
+Production column-store collection implementation is blocked until this
+contract is implemented and tested. Allowed pre-gate work:
+
+- docs and design review;
+- benchmark fixtures;
+- pure compression codecs;
+- reusable fast filter/search packages;
+- isolated `TCS1` encode/decode tests that do not publish collection roots.
+
+Blocked pre-gate work:
+
+- persistent column-store collection APIs;
+- column part descriptor roots;
+- secondary indexes pointing at column-store rows;
+- column-file side refs in published roots;
+- any crash/reopen safety claim for column-store writes.
+
+## 7. Architecture
+
+### 7.1 Chosen Model: Root-Delta Transaction WAL
+
+The collection WAL should log root deltas, not logical operations.
+
+Reasons:
+
+- Recovery must not re-run user callbacks.
+- Recovery must not depend on current JSON/template extraction code producing
+  identical root deltas after a future code change.
+- Secondary index updates are already planned as root-local mutations.
+- The same transaction shape works for row-store roots and future column-store
+  roots.
+- Root-delta replay can reuse existing backend publish APIs.
+
+### 7.2 Transaction Shape
+
+Logical transaction:
+
+```text
+CollectionWALTransaction {
+    Version              uint8
+    TxnID                uint64
+    CollectionID         uint64 or stable collection name
+    CollectionName       string
+    BaseCommitSeq        uint64
+    BaseSystemRoot       uint64
+    PlannerEpoch         uint64 optional
+    RootDeltas           []CollectionRootDelta
+    SideRefs             []CollectionSideRef
+    AckMode              uint8
+    CreatedUnixNanos     int64
+    Stats                CollectionWALStats
+    ChecksumCRC32C       uint32
+}
+
+CollectionRootDelta {
+    RootName             string
+    RootKind             uint8
+    BaseRootID           uint64
+    StoragePolicy        uint8
+    DeltaEncoding        uint8
+    InlineDelta          bytes optional
+    DeltaRID             uint64 optional
+    EntryCount           uint32
+    KeyBytes             uint64
+    ValueBytes           uint64
+}
+
+CollectionSideRef {
+    RefClass             uint8
+    FileID               uint64
+    RelativePath         string optional
+    Offset               uint64
+    Size                 uint64
+    ChecksumCRC32C       uint32
+    Required             bool
+}
+```
+
+Root delta payloads should use the same canonical sorted delta encoding as
+`OrderedRootDeltaBatchFromIterator`. Small deltas may be inline in the WAL
+transaction. Large deltas should use a side payload referenced by RID or by a
+dedicated root-delta payload class.
+
+### 7.3 File Class
+
+Use a dedicated logical collection WAL class. The implementation may reuse
+commit-log framing utilities, but the replay semantics are different from
+normal user-root commit records.
+
+Recommended layout:
+
+```text
+Dir/maindb/wal/
+    collection-l<lane>-<seq>.log
+```
+
+Segment rules:
+
+- Each segment contains framed `CollectionWALTransaction` records.
+- Each transaction has exactly one `TxnID`.
+- Transactions are sorted by `TxnID` during recovery, with file order as a
+  deterministic tie breaker only for malformed legacy segments.
+- A truncated tail stops scanning that segment after the last complete record.
+- Hard corruption before the tail fails recovery.
+
+### 7.4 Applied Watermark
+
+The system root must store collection WAL progress:
+
+```text
+treedb/collection-wal/global-applied-txn-id -> uint64
+treedb/collection-wal/collection/<collection-id>/applied-txn-id -> uint64 optional
+```
+
+PR1 can use one global monotonic transaction id. Per-collection watermarks can
+be added later if recovery or cleanup needs more concurrency.
+
+When a collection root group is published, the same backend commit that updates
+collection root descriptors must also advance the applied watermark. This is the
+atomic marker that makes WAL cleanup safe.
+
+Recovery skips transactions at or below the applied watermark. Transactions
+above the watermark are candidates for replay.
+
+### 7.5 Side-File Fences
+
+A collection transaction is replayable only when every required side reference
+is readable and passes its integrity check.
+
+Current side refs:
+
+- value-log records for large collection document values;
+- leaf-log records when ordered roots store outer leaves in the value log.
+
+Future side refs:
+
+- column part files;
+- column filter files;
+- delete bitmap files;
+- dictionary files.
+
+If a required side ref is missing during recovery:
+
+- no root group from that transaction may be published;
+- recovery must not produce roots pointing to missing bytes;
+- later transactions for the same collection should be blocked unless the
+  implementation can prove they do not depend on the skipped transaction;
+- durable mode should surface an error unless the missing ref is in a clearly
+  incomplete tail transaction that can be ignored by the same rules as existing
+  commit-log tails.
+
+## 8. Write Path
+
+### 8.1 No-Index Inserts
+
+Current no-index inserts can remain buffered in `domain.table`. After this
+spec, a WAL-on insert must:
+
+1. validate the collection catalog and primary uniqueness;
+2. build the root-local primary delta entry;
+3. pointerize large values if configured;
+4. append a collection WAL transaction containing the primary delta and side
+   refs;
+5. stage the same delta in the collection write domain for immediate reads;
+6. optionally publish later through `Flush`, threshold, checkpoint, or close.
+
+The key change is that step 4 happens before success is returned to the caller.
+
+### 8.2 Indexed Inserts
+
+Indexed insert planning already produces root runs for:
+
+- primary document root;
+- template/index-state root when needed;
+- secondary index roots.
+
+After this spec, the planner should convert those root runs into a collection
+WAL transaction before adding them to the durable pending write domain. Unique
+probe helpers remain in memory, but they must be rebuildable from the root
+deltas during recovery.
+
+### 8.3 Updates and Deletes
+
+Updates and deletes must use the same root-delta transaction model:
+
+- primary root put/delete;
+- old secondary index deletes;
+- new secondary index puts;
+- template/index-state changes when document format requires them;
+- delete/tombstone roots where applicable.
+
+The WAL records planned deltas, not the callback or predicate that produced
+them.
+
+### 8.4 Async Indexed Flush
+
+Async flush becomes a publication optimization, not a durability boundary.
+
+Allowed states:
+
+1. durable pending transaction exists in collection WAL;
+2. transaction is visible through mutable/queued/publishing write-domain state;
+3. async worker publishes root group;
+4. system root advances applied watermark;
+5. cleanup retires published in-memory units and eventually WAL bytes.
+
+If async publish fails, in-memory units can be requeued as they are today. The
+collection WAL transaction remains the recovery source until a successful
+publish advances the watermark.
+
+### 8.5 Overlay Roots
+
+Overlay-root mode should use the same transaction model. The WAL transaction
+must identify whether the root ids are base roots or overlay roots, and the
+system-root delta must atomically update overlay descriptors and the applied
+watermark.
+
+Overlay compaction is a separate root-group transaction. It can be WAL logged
+like any other collection root-group publish or treated as a maintenance commit
+that is replayed through backend metadata if it reaches the backend commit
+boundary. The implementation must choose one rule and test crash points around
+it.
+
+### 8.6 WAL-Off Mode
+
+`DurabilityWALOffRelaxed` should not write collection WAL transactions. In that
+mode:
+
+- pending collection writes are visible in-process only until published;
+- `Flush`, `FlushAll`, checkpoint, and close remain the durability boundaries;
+- column-store mutable writes must not be production-enabled under WAL-off
+  until explicit benchmark and safety gates are added.
+
+## 9. Recovery Algorithm
+
+Startup recovery should extend the existing recovery order:
+
+1. Recover backend index metadata and choose the valid meta page.
+2. Replay normal cached commit logs as today.
+3. Scan value-log, leaf-log, column-file, and collection-root-delta side files
+   needed by collection WAL fences.
+4. Scan collection WAL segments and decode complete transactions.
+5. Load applied watermark metadata from the recovered system root.
+6. Sort unapplied transactions by `TxnID`.
+7. For each unapplied transaction:
+   - validate checksum and format version;
+   - validate required side refs;
+   - validate collection catalog identity and schema epoch;
+   - verify each named root's current id matches the transaction's `BaseRootID`,
+     unless the transaction is already covered by the applied watermark;
+   - materialize `OrderedRootDeltaBatchPublishInput` values;
+   - publish the root group with a system-root delta that updates collection
+     root descriptors and advances the applied watermark.
+8. After successful replay, clean collection WAL segments whose transactions are
+   fully covered by the durable applied watermark.
+9. Quarantine or delete prepared side files that are not referenced by any
+   committed transaction or reachable root.
+
+Recovery must be deterministic. Replaying the same directory twice must produce
+the same collection roots and applied watermark.
+
+## 10. Cleanup and Retention
+
+Collection WAL cleanup is safe only when both are true:
+
+1. every transaction in the segment is at or below the applied watermark;
+2. the backend checkpoint/meta boundary containing that watermark is durable for
+   the selected mode.
+
+Prepared side files use a two-state lifecycle:
+
+```text
+prepared side file -> referenced by committed transaction -> reachable from root
+prepared side file -> no committed transaction -> quarantine or delete
+```
+
+Column-store files should use the same lifecycle when they are introduced. A
+root descriptor must never be published before the referenced file bytes are
+readable at the required durability boundary.
+
+## 11. Test Plan
+
+### 11.1 Current Contract Tests
+
+Keep and expand tests that document current behavior:
+
+- checkpoint does not flush pending collection-local no-index inserts before
+  this spec changes that contract;
+- close drains queued indexed flush units;
+- `FlushAll` drains queued indexed flush units;
+- async flush backpressure and requeue behavior remains visible and bounded.
+
+### 11.2 Format Tests
+
+- exact-byte collection WAL transaction golden files;
+- corrupt checksum rejection;
+- truncated tail acceptance;
+- mixed transaction sequence rejection;
+- large root delta side-payload round trips;
+- unknown future version rejection with clear error.
+
+### 11.3 Recovery Tests
+
+Crash/fault points:
+
+1. before collection WAL append;
+2. after side-file prepare before collection WAL append;
+3. after collection WAL append before in-memory staging;
+4. after acknowledgement before root publish;
+5. during async publish;
+6. after root pages are built but before the system-root commit advances the
+   applied watermark;
+7. after applied watermark before WAL cleanup;
+8. during overlay compaction;
+9. during column-file prepare once column store exists.
+
+Required assertions:
+
+- no acknowledged WAL-on collection write is lost after process crash;
+- no unacknowledged incomplete transaction is exposed;
+- primary and secondary roots recover together;
+- unique indexes reject duplicates after recovery;
+- reads do not need stale in-memory write domains after recovery;
+- roots never reference missing value-log or column-file bytes;
+- collection WAL files are cleaned only after safe watermark/checkpoint
+  boundaries.
+
+### 11.4 Fuzz Tests
+
+- transaction decoder fuzzing;
+- recovery ordering fuzzing with multiple collections and duplicate keys;
+- side-ref fence fuzzing with missing and truncated payloads;
+- root-delta replay fuzzing against an in-memory oracle.
+
+## 12. Benchmark Plan
+
+Benchmarks must compare before/after on the same host with `benchstat`.
+
+Core rows:
+
+- no-index `InsertBatch`;
+- one unique secondary index `InsertBatch`;
+- three secondary indexes `InsertBatch`;
+- `UpdateBatch` with unchanged indexed values;
+- `UpdateBatch` with changed indexed values;
+- delete-heavy workload;
+- async indexed flush workload;
+- `Flush`;
+- crash-recovery replay of 1K, 100K, and 1M pending documents.
+
+Initial gates:
+
+- WAL-on no-index insert throughput regression <= 10 percent after warmup;
+- WAL-on one-index insert throughput regression <= 15 percent;
+- WAL-on three-index insert throughput regression <= 20 percent;
+- recovery throughput >= 50K root-delta entries/sec on the deterministic
+  fixture before optimization;
+- collection WAL bytes/doc reported for every benchmark;
+- no unbounded memory growth when async publish is stalled.
+
+These gates are provisional. If the current write path cannot meet them with
+inline root deltas, PR2 should move large deltas to side payloads before
+weakening durability.
+
+## 13. Roadmap and Gates
+
+Traceability matrix:
+
+| Design area | Sections | Milestones | Required evidence |
+|---|---|---|---|
+| Current contract | 2, 6 | M0 | existing behavior tests and docs |
+| WAL format | 7.2, 7.3 | M1 | golden, fuzz, corrupt-tail tests |
+| Side-file fences | 7.5, 10 | M2 | missing-ref recovery tests |
+| Write-domain integration | 8 | M3, M4 | insert/update/delete recovery tests |
+| Recovery replay | 9 | M4 | crash matrix and deterministic replay tests |
+| Checkpoint/cleanup | 10 | M5 | watermark and segment cleanup tests |
+| Performance | 12 | M6 | benchstat gates and artifacts |
+| Column-store unblock | 6.3, 10 | M7 | side-file fence and root-group recovery proof |
+
+### Milestone 0: Contract Freeze
+
+Deliverables:
+
+- document current collection flush-boundary behavior;
+- identify every API that can acknowledge collection writes;
+- freeze benchmark fixtures and crash-test harness shape.
+
+Tests:
+
+- current checkpoint boundary test;
+- close drains queued indexed flush unit;
+- `FlushAll` drains queued indexed flush unit.
+
+Gate:
+
+- no production column-store persistent work starts before this milestone is
+  complete.
+
+### Milestone 1: Collection WAL Format Package
+
+Deliverables:
+
+- internal transaction structs;
+- encoder/decoder;
+- segment reader/writer;
+- transaction id allocator interface;
+- exact format documentation in this file.
+
+Tests:
+
+- golden files;
+- corrupt checksum;
+- truncated tail;
+- decoder fuzzing.
+
+Gate:
+
+- format package has no dependency on collection planners or backend DB.
+
+### Milestone 2: Root Delta and Side-Ref Fences
+
+Deliverables:
+
+- root-delta batch serialization;
+- inline and side-payload modes;
+- side-ref availability checker;
+- value-log and leaf-log side-ref integration.
+
+Tests:
+
+- missing side refs skip or fail safely;
+- no root can be published with missing side bytes;
+- large delta side-payload round trips.
+
+Gate:
+
+- side-ref fence behavior matches existing RID fence safety or is stricter.
+
+### Milestone 3: No-Index Collection Integration
+
+Deliverables:
+
+- WAL-on no-index inserts append collection WAL before acknowledgement;
+- pending write-domain visibility remains unchanged;
+- `Flush` publishes WAL-backed no-index deltas and advances watermark.
+
+Tests:
+
+- crash after ack before flush recovers document;
+- crash before WAL append does not expose document;
+- checkpoint behavior updated to the new contract.
+
+Gate:
+
+- no-index insert regression <= 10 percent in WAL-on benchmark fixture.
+
+### Milestone 4: Indexed Insert/Update/Delete Integration
+
+Deliverables:
+
+- indexed insert root-group WAL;
+- update/delete root-group WAL;
+- async flush publish uses existing durable transactions;
+- unique helper rebuild after recovery.
+
+Tests:
+
+- crash after ack before async publish;
+- crash during async publish;
+- unique secondary correctness after recovery;
+- update/delete secondary roots recover atomically.
+
+Gate:
+
+- one-index insert regression <= 15 percent;
+- three-index insert regression <= 20 percent;
+- async flush cannot lose acknowledged documents under process crash.
+
+### Milestone 5: Recovery, Watermark, and Cleanup
+
+Deliverables:
+
+- applied watermark in system root;
+- collection WAL replay in open path;
+- segment cleanup after safe checkpoint;
+- prepared side-file quarantine/delete.
+
+Tests:
+
+- crash after root page build or watermark commit before cleanup does not
+  double-apply;
+- older segments remain when watermark is not durable;
+- cleanup removes only fully applied segments;
+- prepared side files without committed transactions do not become visible.
+
+Gate:
+
+- repeated reopen after crash is idempotent.
+
+### Milestone 6: Checkpoint and Close Semantics
+
+Deliverables:
+
+- `DB.Checkpoint` coordinates with collection WAL;
+- `CollectionManager.FlushAll` and close hooks use the same publish path;
+- API docs distinguish process-crash recovery from fsync durability.
+
+Tests:
+
+- checkpoint drains or checkpoints collection WAL according to the chosen rule;
+- close with in-flight async publish is recoverable;
+- WAL-off mode preserves its relaxed contract.
+
+Gate:
+
+- no stale collection WAL files after clean close and checkpoint.
+
+### Milestone 7: Column-Store Unblock Gate
+
+Deliverables:
+
+- side refs support future column file classes;
+- root-group WAL accepts column-store roots without a separate WAL path;
+- column-store PR checklist points to this milestone.
+
+Tests:
+
+- synthetic external side file fence test;
+- recovery refuses roots with missing external side files;
+- cleanup of prepared but unpublished external files.
+
+Gate:
+
+- production column-store persistent writes may start only after this milestone.
+
+## 14. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Root-delta WAL duplicates data already in memtables. | Start with simple encoding, then move large deltas to side payloads when benchmarks require it. |
+| Replaying old transactions double-applies after crash. | Store applied watermark in the same system-root commit as root descriptor updates. |
+| Side-file ordering creates dangling pointers. | Require side refs to be readable before WAL commit is replayable; never publish roots until side refs pass. |
+| Async flush races with WAL cleanup. | Treat async flush as publish-only; cleanup requires applied watermark and checkpoint boundary. |
+| Unique index helpers are lost on crash. | Rebuild helpers from durable root deltas or persisted roots during recovery. |
+| WAL-on throughput regresses too much. | Benchmark each milestone, use side payloads, batching, and async publish before relaxing durability. |
+| WAL-off users assume stronger guarantees. | Keep WAL-off relaxed docs explicit and add tests that preserve the relaxed contract. |
+
+## 15. Open Questions
+
+1. Should collection WAL share the existing commit-log segment writer with a new
+   record kind, or use a separate `collection-l<lane>-<seq>.log` file class?
+2. Should the first transaction id be global or per collection?
+3. Should `Collection.Flush` gain a sync variant, or should callers use
+   `DB.Checkpoint` for fsync-style barriers?
+4. Should recovery skip missing side-ref transactions like existing RID fences,
+   or fail hard in durable mode?
+5. How large can inline root deltas be before side-payload mode becomes
+   mandatory?
+6. Can overlay compaction use ordinary backend commit durability, or should it
+   also be encoded in collection WAL for uniform recovery?
+7. Should `DB.Checkpoint` always call `CollectionManager.FlushAll`, or can it
+   checkpoint collection WAL without forcing root publication?
+8. What metric names should expose pending collection WAL bytes, applied
+   watermark lag, replay count, skipped/fenced transactions, and cleanup debt?
+
+## 16. Implementation Notes
+
+- Prefer adding the collection WAL package below `TreeDB/internal` until the
+  format stabilizes.
+- Keep the transaction encoder independent from collection planner internals.
+- Make root-delta serialization deterministic from the beginning.
+- Add fault-injection hooks before building the full product path; otherwise
+  crash coverage will be too shallow.
+- Preserve existing write-domain read precedence while adding durable backing.
+- Treat side-file fences as part of the storage format, not as cleanup policy.
+- Update `collections-write-domain.md`, `write-path-and-durability.md`,
+  `recovery.md`, and `verification.md` as implementation milestones land.

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -145,6 +145,25 @@ creation, and future schema mutations are public barriers. They must state
 whether they drain lower collection sequences, become their own WAL transaction,
 or fail before exposing schema changes.
 
+Under collection WAL, catalog changes that affect replay identity are durable
+barriers. Until schema-change WAL transactions are implemented, `CreateIndex`,
+`DropIndex`, collection drop/recreate, rename, document-format changes,
+template root descriptor resets/evolution, and future column descriptor changes
+must publish and watermark all lower `CollectionSeq` transactions before
+becoming visible. A later schema-change WAL transaction must depend on the
+previous sequence and carry descriptor ops plus the applied watermark in the
+same root-group commit.
+
+Every collection has stable replay identity independent of its display name:
+`CollectionUID`, `CollectionGeneration`, `CatalogEpoch`, `SchemaEpoch`,
+`LogicalCatalogDigest`, and `LocalReplayCatalogDigest`. `CollectionName` is
+lookup/display text only. Every index has `IndexUID`, `IndexGeneration`, and a
+definition digest; unique and multikey helper state is keyed by `IndexUID`, not
+index name. Every root has a stable `RootUID`, `RootKind`, generation,
+descriptor epoch, and descriptor digest. Pending write-domain units and future
+WAL-backed flush units must carry these guards so a drop/recreate or
+same-name index recreate cannot replay into the wrong catalog incarnation.
+
 ## Read Views
 
 The current implementation often protects pending state by copying point values

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -86,11 +86,11 @@ Durability is established when one of these barriers returns successfully:
 A background async publish may complete before an explicit flush, but that is an
 implementation outcome, not a durable-at-ack API guarantee.
 
-If TreeDB later needs durable-at-ack async collection writes, it MUST add a
-replayable collection mutation log or equivalent recovery mechanism before
-advertising that stronger contract.
+If TreeDB later needs durable-at-ack async collection writes, it MUST add the
+collection WAL root-delta recovery mechanism before advertising that stronger
+contract.
 
-The draft collection WAL plan strengthens this future contract by making
+The collection WAL plan strengthens this future contract by making
 acknowledged WAL-on mutations durable as collection-local root-delta
 transactions. Under that plan, mutable/queued/publishing state remains a
 visibility and publish-amortization mechanism, but it must be backed by exact

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -1,11 +1,15 @@
 # Collections Write-Domain Contract
 
-Status: normative for the current implementation.
+Status:
 
-This document specifies the current collection-local write-domain behavior for
-indexed collections. It intentionally does not promise a durable-at-ack
-collection mutation log; that is a future architecture option, not the current
-contract.
+- Current implementation: flush-boundary durable for pending collection-local
+  write-domain state.
+- PR1 collection WAL target: WAL-on collection mutator success is process-crash
+  recoverable before visibility; WAL-off remains flush-boundary.
+
+This document specifies collection-local write-domain behavior for indexed
+collections. It distinguishes the current shipped contract from the PR1
+collection WAL target contract.
 
 ## Indexed Write Memtables
 
@@ -90,21 +94,17 @@ If TreeDB later needs durable-at-ack async collection writes, it MUST add the
 collection WAL root-delta recovery mechanism before advertising that stronger
 contract.
 
-The collection WAL plan strengthens this future contract by making
-acknowledged WAL-on mutations durable as collection-local root-delta
-transactions. Under that plan, mutable/queued/publishing state remains a
-visibility and publish-amortization mechanism, but it must be backed by exact
-physical deltas already committed to collection WAL.
+In WAL-on modes, write-domain mutable/queued/publishing state is a visibility
+and publication-amortization layer over already committed collection WAL
+transactions. It is not the first durable record. No read, unique check,
+update/delete planner, schema/index barrier, queued unit, publishing unit, or
+pending-state merge may observe a mutation until its collection WAL transaction
+is committed and recoverable.
 
-That future contract requires WAL-before-visibility ordering. WAL-on collection
-writers must use private planning, durable commit, and visible install phases.
-The visible install guard is the `CanInstallVisible` predicate in
-`collection-wal-durability-plan.md`: no mutable, queued, publishing, planner, or
-unique-check state may observe a WAL-on mutation until its canonical root delta,
-required side-ref closure, side-ref protection, and complete collection WAL
-frame are recoverable. WAL-off relaxed writes keep the current weaker
-flush-boundary contract and must not create collection WAL frames for unflushed
-visible state.
+In WAL-off relaxed mode, write-domain state is not backed by collection WAL.
+Acknowledged pending writes are process-local until published. `Flush`,
+`FlushAll`, `Checkpoint`, and `Close` are the public persistence boundaries.
+
 During private planning, root deltas, side refs, uniqueness reservations,
 publish inputs, and schema/index barrier state are not reachable from any read,
 scan, uniqueness check, update/delete planner, queued unit, publishing unit, or
@@ -134,6 +134,11 @@ collection-local WAL progress. They either publish and watermark all lower
 collection WAL sequences before becoming visible, or are encoded as their own
 collection WAL transaction that depends on the previous sequence and carries the
 schema/root descriptor changes atomically.
+
+`CreateIndex`, `DropIndex`, `DropIndexes`, `DropAllIndexes`, collection
+creation, and future schema mutations are public barriers. They must state
+whether they drain lower collection sequences, become their own WAL transaction,
+or fail before exposing schema changes.
 
 ## Read Views
 

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -90,6 +90,12 @@ If TreeDB later needs durable-at-ack async collection writes, it MUST add a
 replayable collection mutation log or equivalent recovery mechanism before
 advertising that stronger contract.
 
+The draft collection WAL plan strengthens this future contract by making
+acknowledged WAL-on mutations durable as collection-local root-delta
+transactions. Under that plan, mutable/queued/publishing state remains a
+visibility and publish-amortization mechanism, but it must be backed by exact
+physical deltas already committed to collection WAL.
+
 ## Barrier Semantics
 
 Operations that require persisted roots as their planning input MUST first drain
@@ -99,6 +105,12 @@ This includes schema/index changes and other operations that take a fresh
 snapshot after calling the flush barrier. Those barriers MUST wait for in-flight
 async publishing units; silently skipping publishing units can make a new index
 backfill miss documents that were already acknowledged in the write domain.
+
+Under the collection WAL plan, schema/index changes must also respect
+collection-local WAL progress. They either publish and watermark all lower
+collection WAL sequences before becoming visible, or are encoded as their own
+collection WAL transaction that depends on the previous sequence and carries the
+schema/root descriptor changes atomically.
 
 ## Close And Reopen
 

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -97,11 +97,20 @@ visibility and publish-amortization mechanism, but it must be backed by exact
 physical deltas already committed to collection WAL.
 
 That future contract requires WAL-before-visibility ordering. WAL-on collection
-writers must validate, prepare final root deltas and side refs, append the
-collection WAL commit marker, and only then make mutable/queued/publishing state
-visible to reads and unique-index helpers. Async flush remains a publication
-optimization over already-logged transactions; it is not the first durable
-record for those writes.
+writers must use private planning, durable commit, and visible install phases.
+During private planning, root deltas, side refs, uniqueness reservations,
+publish inputs, and schema/index barrier state are not reachable from any read,
+scan, uniqueness check, update/delete planner, queued unit, publishing unit, or
+pending-state merge. After side refs are prepared and protected, the writer
+appends the collection WAL commit marker. Only then may it make
+mutable/queued/publishing state visible to reads and unique-index helpers. Async
+flush remains a publication optimization over already-logged transactions; it is
+not the first durable record for those writes.
+
+In WAL-on modes, visibility implies recoverability. If collection WAL commit
+fails, the mutation must leave no read-visible pending state and no uniqueness
+reservation. A concurrent reader or planner must never observe a write whose WAL
+transaction is not committed/recoverable.
 
 ## Barrier Semantics
 
@@ -119,6 +128,22 @@ collection WAL sequences before becoming visible, or are encoded as their own
 collection WAL transaction that depends on the previous sequence and carries the
 schema/root descriptor changes atomically.
 
+## Read Views
+
+The current implementation often protects pending state by copying point values
+under domain locks or by holding write-domain read locks for scans. The
+collection WAL plan makes this a named retention contract:
+`CollectionReadView`.
+
+A collection read view pins the backend snapshot, collection catalog/root
+descriptor view, immutable or refcounted pending mutable/queued/publishing
+units, derived secondary-index views, and side refs reachable from those units.
+Flush, async publish completion, rollback, overlay compaction, collection WAL
+cleanup, value-log GC/rewrite, leaf-log GC, and future column-file cleanup must
+not reset, reuse, delete, rewrite, or unprotect objects reachable from a live
+read view. A single point read can avoid a read view only when it copies the
+result and retains no pending-state or side-ref handles after dropping locks.
+
 ## Close And Reopen
 
 Backend close runs the collection manager close hook while writes are still
@@ -127,3 +152,8 @@ backend closes.
 
 After successful close and reopen, collection primary and secondary indexes MUST
 reflect all writes that were visible before close returned.
+
+Under the collection WAL plan, close also establishes an admission cut. After
+that cut, every collection mutator either fails before visible install or is
+included in the close drain. No write may return success during a close race and
+then be absent after reopen.

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -98,6 +98,13 @@ physical deltas already committed to collection WAL.
 
 That future contract requires WAL-before-visibility ordering. WAL-on collection
 writers must use private planning, durable commit, and visible install phases.
+The visible install guard is the `CanInstallVisible` predicate in
+`collection-wal-durability-plan.md`: no mutable, queued, publishing, planner, or
+unique-check state may observe a WAL-on mutation until its canonical root delta,
+required side-ref closure, side-ref protection, and complete collection WAL
+frame are recoverable. WAL-off relaxed writes keep the current weaker
+flush-boundary contract and must not create collection WAL frames for unflushed
+visible state.
 During private planning, root deltas, side refs, uniqueness reservations,
 publish inputs, and schema/index barrier state are not reachable from any read,
 scan, uniqueness check, update/delete planner, queued unit, publishing unit, or

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -96,6 +96,13 @@ transactions. Under that plan, mutable/queued/publishing state remains a
 visibility and publish-amortization mechanism, but it must be backed by exact
 physical deltas already committed to collection WAL.
 
+That future contract requires WAL-before-visibility ordering. WAL-on collection
+writers must validate, prepare final root deltas and side refs, append the
+collection WAL commit marker, and only then make mutable/queued/publishing state
+visible to reads and unique-index helpers. Async flush remains a publication
+optimization over already-logged transactions; it is not the first durable
+record for those writes.
+
 ## Barrier Semantics
 
 Operations that require persisted roots as their planning input MUST first drain

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -4,12 +4,14 @@ Status:
 
 - Current implementation: flush-boundary durable for pending collection-local
   write-domain state.
-- PR1 collection WAL target: WAL-on collection mutator success is process-crash
-  recoverable before visibility; WAL-off remains flush-boundary.
+- PR1-min collection WAL target: only an explicitly guarded no-index row
+  insert/batch capability is process-crash recoverable before visibility.
+  Indexed write-domain durable-at-ack is a later full-contract gate; WAL-off
+  remains flush-boundary.
 
 This document specifies collection-local write-domain behavior for indexed
-collections. It distinguishes the current shipped contract from the PR1
-collection WAL target contract.
+collections. It distinguishes the current shipped contract from PR1-min and the
+later full collection WAL target contract.
 
 ## Indexed Write Memtables
 
@@ -94,12 +96,14 @@ If TreeDB later needs durable-at-ack async collection writes, it MUST add the
 collection WAL root-delta recovery mechanism before advertising that stronger
 contract.
 
-In WAL-on modes, write-domain mutable/queued/publishing state is a visibility
-and publication-amortization layer over already committed collection WAL
-transactions. It is not the first durable record. No read, unique check,
+In the full WAL-on contract, write-domain mutable/queued/publishing state is a
+visibility and publication-amortization layer over already committed collection
+WAL transactions. It is not the first durable record. No read, unique check,
 update/delete planner, schema/index barrier, queued unit, publishing unit, or
 pending-state merge may observe a mutation until its collection WAL transaction
-is committed and recoverable.
+is committed and recoverable. PR1-min does not enable indexed write-domain
+durable-at-ack; durable-at-ack requested for indexed schemas or async indexed
+flush must fail before staging.
 
 In WAL-off relaxed mode, write-domain state is not backed by collection WAL.
 Acknowledged pending writes are process-local until published. `Flush`,
@@ -111,13 +115,14 @@ scan, uniqueness check, update/delete planner, queued unit, publishing unit, or
 pending-state merge. After side refs are prepared and protected, the writer
 appends the collection WAL commit marker. Only then may it make
 mutable/queued/publishing state visible to reads and unique-index helpers. Async
-flush remains a publication optimization over already-logged transactions; it is
-not the first durable record for those writes.
+flush remains a publication optimization over already-logged transactions in the
+full contract; it is not part of PR1-min.
 
-In WAL-on modes, visibility implies recoverability. If collection WAL commit
-fails, the mutation must leave no read-visible pending state and no uniqueness
-reservation. A concurrent reader or planner must never observe a write whose WAL
-transaction is not committed/recoverable.
+In WAL-on modes for enabled collection WAL capabilities, visibility implies
+recoverability. If collection WAL commit fails, the mutation must leave no
+read-visible pending state and no uniqueness reservation. A concurrent reader or
+planner must never observe a write whose WAL transaction is not
+committed/recoverable.
 
 ## Barrier Semantics
 

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -42,7 +42,7 @@ Details:
 Primary model:
 - concurrent foreground writers,
 - sharded mutable memtables,
-- lane-partitioned WAL/value-log appends,
+- lane-partitioned commit-log and value-log appends,
 - asynchronous flush and maintenance workers.
 
 Details:

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -243,6 +243,24 @@ Current order constraints:
 
 Any refactor that changes this order MUST preserve deadlock freedom.
 
+Planned collection WAL lock-order constraints add a separate collection layer
+above backend publish locks:
+
+1. DB close/checkpoint admission gate,
+2. collection manager domain registry,
+3. per-collection mutation serialization,
+4. side-ref reservation/protection,
+5. collection WAL lane/segment append lock,
+6. short per-domain state install/completion lock,
+7. backend publish/commit/checkpoint locks.
+
+The collection domain state lock must not be held while performing collection
+WAL I/O, waiting for async publish, registering long-running GC work, calling
+backend publish, or calling backend checkpoint. `DB.Checkpoint` must invoke
+collection drain/checkpoint hooks before taking backend locks that async
+publishers need, or use a nonblocking protocol that cannot wait on those
+publishers while holding the locks they need.
+
 ### 4.3 Backend lock roles
 
 - `writeMu`:

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -93,6 +93,10 @@ When the cached layer is enabled:
 - Snapshots are point-in-time readers and MUST be closed to release retention pressure.
 - In cached mode, snapshots MUST include buffered memtable writes and MUST be snapshot-isolated (writes after snapshot acquisition are not visible through the snapshot).
 - `Snapshot.Get` / `Snapshot.GetAppend` return `ErrKeyNotFound` for missing/tombstoned keys (unlike `DB.Get`, which returns `(nil, nil)` on miss).
+- Under the planned collection WAL contract, collection scans and snapshots that
+  can read pending collection-local state use a `CollectionReadView`. The view
+  pins backend snapshot state, pending mutable/queued/publishing collection
+  units, derived index views, and reachable side refs until the read closes.
 
 ## 6. Concurrency and Locking
 
@@ -173,6 +177,11 @@ write-domain state must not be advertised as crash-durable.
 Operations that need persisted roots as planning input, including schema/index
 changes, must drain pending indexed write-domain state and wait for in-flight
 async publish units before taking their planning snapshot.
+
+Under the planned collection WAL contract, WAL-on collection visibility implies
+recoverability. No read, uniqueness check, update/delete planner, or pending
+merge may observe a mutation before its collection WAL transaction is
+committed/recoverable.
 
 Detailed indexed collection write-domain semantics are in
 `TreeDB/docs/spec/collections-write-domain.md`.

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -2,6 +2,15 @@
 
 This document specifies externally-observable behavior expected by callers.
 
+Status:
+
+- Current shipped contract: sections that describe existing key/value, cached,
+  read-only, and collection write-domain behavior are normative for current
+  code.
+- PR1 collection WAL target contract: section 7.1 defines the public semantics
+  that collection WAL implementation must satisfy before WAL-on collection
+  durable-at-ack can be advertised or enabled by default.
+
 ## 1. Key Model
 
 - Keys are byte slices.
@@ -124,6 +133,83 @@ Durability mode controls guarantees for sync calls:
 
 Detailed semantics are in `TreeDB/docs/spec/write-path-and-durability.md`.
 
+### 7.1 Collection Write Acknowledgement Contract
+
+Terms:
+
+- `visible`: observable by collection reads, scans, secondary-index lookups,
+  unique-index checks, update planners, delete planners, schema/index barriers,
+  or pending-state merges in the serving process.
+- `recoverable`: after process crash and read-write reopen, TreeDB can make the
+  write visible without relying on pre-crash memory.
+- `published`: root descriptors for the collection state have been committed to
+  backend roots.
+- `checkpointed`: the backend durability boundary includes the published roots,
+  collection WAL applied watermarks, and required side-ref reachability
+  metadata.
+- `fsynced`: the selected durable-mode fsync boundary has completed. Non-sync
+  collection APIs do not imply fsync.
+
+Collection data mutators:
+
+| Method | `DurabilityDurable` and `DurabilityWALOnRelaxed` target contract | `DurabilityWALOffRelaxed` contract |
+|---|---|---|
+| `Collection.Insert` | Successful return means the whole mutation has a committed collection WAL transaction and is recoverable after process crash. It may still be unpublished pending state and is not necessarily checkpointed or fsynced. | Successful return means process-local visibility according to the path that executed it. Crash recovery is promised only after `Flush`, `FlushAll`, `Checkpoint`, or `Close` covers the mutation. |
+| `Collection.InsertBatch` | Successful return means the whole batch is recoverable as one logical mutation boundary. | Successful return is process-local visibility until an explicit persistence boundary covers the batch. |
+| `Collection.Update` / `UpdateBatch` | Successful return means the resulting primary, secondary, template/index-state, and tombstone deltas are recoverable as one mutation boundary. Update callbacks must be safe for retry before commit. | Successful return is process-local visibility until a public persistence boundary. |
+| `Collection.Delete` / `DeleteBatch` | Successful return means the whole delete mutation, including secondary-index deletes and tombstones, is recoverable. | Successful return is process-local visibility until a public persistence boundary. |
+
+Batch mutators are all-or-nothing at the durable/recovery boundary. An ordinary
+pre-commit error means no item from that batch became visible or recoverable. A
+post-commit failure must be reported as commit-ambiguous for the whole batch.
+
+Collection metadata mutators:
+
+| Method | Contract |
+|---|---|
+| `CollectionManager.CreateCollection` | Successful return means the collection catalog entry is published and recoverable under the selected non-sync durability mode. It is not fsynced unless followed by a sync-capable barrier. Retrying creation with identical metadata is idempotent; retrying with incompatible metadata fails without changing the existing collection. |
+| `Collection.CreateIndex` and index-drop methods | These methods establish an index/schema barrier. They drain collection writes admitted before the barrier before taking the backfill/planning snapshot, or are encoded as ordered collection WAL transactions. Successful `CreateIndex` means the index definition, root descriptors, and backfilled index contents for the barrier snapshot are published atomically and recoverable. A unique-index conflict is an ordinary pre-commit error and must not expose partial schema/index state. |
+
+Barrier methods:
+
+| Method | Contract |
+|---|---|
+| `Collection.Flush` | Publishes all pending collection write-domain state for that collection admitted before the flush cut, waits for in-flight async indexed publishing for that collection, and advances the collection WAL applied watermark for the published transactions. It does not imply fsync unless composed with a sync/checkpoint boundary that requires fsync. |
+| `CollectionManager.FlushAll` | Applies the `Flush` contract to every collection write domain known to the manager at the flush cut. Future backend-owned collection WAL services must use a global domain registry when the contract needs to cover all collection handles, not only one manager instance. |
+| `DB.Checkpoint` | Successful return is a database-wide durability/cleanup boundary for all collection writes and collection metadata admitted before the checkpoint cut. With the current `Checkpoint() error` signature, `nil` means no pre-cut committed collection WAL debt remains unpublished or required for recovery. If publication/watermark/checkpoint coverage cannot be completed, `Checkpoint` must return an error unless a future result type explicitly exposes nonzero collection WAL debt. |
+| `DB.Close` | Establishes a close admission cut. Every collection write racing with the cut either fails before visible install with `ErrClosed` or is included in the close drain. If `Close` returns `nil`, every included successful collection mutation is visible after read-write reopen. Physical cleanup may remain a safe leak, but WAL/side refs needed for recovery must not be removed. |
+
+Public durability errors:
+
+- `ErrDurabilityUnavailable`: a requested durability boundary cannot be
+  satisfied before any logical commit.
+- `CommitAmbiguousError` / `ErrCommitAmbiguous`: the mutation may already be
+  committed or recoverable. Callers must not blindly retry non-idempotent
+  operations.
+- `ErrRecoveryRequired`: read-only open found committed collection WAL that
+  requires mutating recovery before collection APIs can be served.
+
+Retry guidance:
+
+- TreeDB does not provide exactly-once mutation semantics without a durable
+  idempotency key.
+- After timeout, disconnect, or commit-ambiguous error, duplicate document ID or
+  unique-index conflict can mean the prior attempt committed.
+- Updates are safe to retry only when the update function is idempotent, guarded
+  by a version/compare predicate, or protected by a durable idempotency key.
+
+Mongo gateway:
+
+- Until explicit Mongo `writeConcern` support exists, gateway write success is
+  the underlying TreeDB collection API success for the configured durability
+  mode. It must not imply Mongo-compatible writeConcern or fsync semantics.
+- Ordered update/delete commands must document whether earlier items can remain
+  applied after a later item error. If partial ordered semantics are intentional,
+  responses must report the applied prefix; otherwise validation must complete
+  before applying any item.
+- Gateway collection auto-create and `createIndexes` inherit the collection
+  metadata mutator contracts above.
+
 ## 8. Read-only Open Contract
 
 When opened read-only:
@@ -131,6 +217,8 @@ When opened read-only:
 - write operations must fail,
 - no mutating recovery steps run,
 - no background maintenance mutates on-disk state.
+- if committed unapplied collection WAL exists, read-only open must fail with
+  `ErrRecoveryRequired` unless an explicit stale read-only mode is selected.
 
 ## 9. Collections Native Fast Path
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -7,9 +7,10 @@ Status:
 - Current shipped contract: sections that describe existing key/value, cached,
   read-only, and collection write-domain behavior are normative for current
   code.
-- PR1 collection WAL target contract: section 7.1 defines the public semantics
-  that collection WAL implementation must satisfy before WAL-on collection
-  durable-at-ack can be advertised or enabled by default.
+- PR1-min collection WAL target contract: section 7.1 defines the guarded
+  no-index row insert slice. The full target semantics must be satisfied before
+  broad WAL-on collection durable-at-ack can be advertised or enabled by
+  default.
 
 ## 1. Key Model
 
@@ -152,7 +153,15 @@ Terms:
 
 Collection data mutators:
 
-| Method | `DurabilityDurable` and `DurabilityWALOnRelaxed` target contract | `DurabilityWALOffRelaxed` contract |
+The full WAL-on target contract below is not the same as the first guarded
+implementation slice. PR1-min may expose durable-at-ack only for no-index row
+`Insert` and `InsertBatch` under an explicit `NoIndexRowInsertOnly` capability.
+With that capability, indexed schemas, update/delete, schema/index changes,
+pointerizing storage policies, root-delta side payloads, column roots, and
+native-wire/Raft exposure must fail before any visible mutation. With the
+feature off, existing flush-boundary behavior remains the public contract.
+
+| Method | Full `DurabilityDurable` and `DurabilityWALOnRelaxed` target contract | `DurabilityWALOffRelaxed` contract |
 |---|---|---|
 | `Collection.Insert` | Successful return means the whole mutation has a committed collection WAL transaction and is recoverable after process crash. It may still be unpublished pending state and is not necessarily checkpointed or fsynced. | Successful return means process-local visibility according to the path that executed it. Crash recovery is promised only after `Flush`, `FlushAll`, `Checkpoint`, or `Close` covers the mutation. |
 | `Collection.InsertBatch` | Successful return means the whole batch is recoverable as one logical mutation boundary. | Successful return is process-local visibility until an explicit persistence boundary covers the batch. |
@@ -176,7 +185,7 @@ Barrier methods:
 |---|---|
 | `Collection.Flush` | Publishes all pending collection write-domain state for that collection admitted before the flush cut, waits for in-flight async indexed publishing for that collection, and advances the collection WAL applied watermark for the published transactions. It does not imply fsync unless composed with a sync/checkpoint boundary that requires fsync. |
 | `CollectionManager.FlushAll` | Applies the `Flush` contract to every collection write domain known to the manager at the flush cut. Future backend-owned collection WAL services must use a global domain registry when the contract needs to cover all collection handles, not only one manager instance. |
-| `DB.Checkpoint` | Successful return is a database-wide durability/cleanup boundary for all collection writes and collection metadata admitted before the checkpoint cut. With the current `Checkpoint() error` signature, `nil` means no pre-cut committed collection WAL debt remains unpublished or required for recovery. If publication/watermark/checkpoint coverage cannot be completed, `Checkpoint` must return an error unless a future result type explicitly exposes nonzero collection WAL debt. |
+| `DB.Checkpoint` | Full target: successful return is a database-wide durability/cleanup boundary for all collection writes and collection metadata admitted before the checkpoint cut. With the current `Checkpoint() error` signature, `nil` means no pre-cut committed collection WAL debt remains unpublished or required for recovery. PR1-min does not implement the full cleanup boundary; it must retain collection WAL needed for recovery and must not claim clean collection-WAL state merely because backend checkpoint completed. If publication/watermark/checkpoint coverage cannot be completed, `Checkpoint` must return an error unless a future result type explicitly exposes nonzero collection WAL debt. |
 | `DB.Close` | Establishes a close admission cut. Every collection write racing with the cut either fails before visible install with `ErrClosed` or is included in the close drain. If `Close` returns `nil`, every included successful collection mutation is visible after read-write reopen. Physical cleanup may remain a safe leak, but WAL/side refs needed for recovery must not be removed. |
 
 Public durability errors:

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -134,6 +134,13 @@ Durability mode controls guarantees for sync calls:
 
 Detailed semantics are in `TreeDB/docs/spec/write-path-and-durability.md`.
 
+Collection APIs currently have a separate write-domain durability boundary:
+acknowledged writes that remain in mutable, queued, or publishing
+collection-local state are visible in-process but not durable-at-ack. That
+current behavior is owned by `collections-write-domain.md`. The target WAL-on
+durable-at-ack collection contract is owned by
+`collection-wal-durability-plan.md` until it lands, then summarized here.
+
 ### 7.1 Collection Write Acknowledgement Contract
 
 Terms:

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -219,6 +219,9 @@ When opened read-only:
 - no background maintenance mutates on-disk state.
 - if committed unapplied collection WAL exists, read-only open must fail with
   `ErrRecoveryRequired` unless an explicit stale read-only mode is selected.
+- stale read-only mode, if added, must be explicitly named stale, must report
+  collection WAL debt, and must be rejected by backup and offline maintenance
+  entry points.
 
 ## 9. Collections Native Fast Path
 

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -41,6 +41,16 @@ system should replicate boring, deterministic metadata and mutation commands.
 8. Every roadmap round must end with a dedicated performance pass before the
    next round starts.
 
+Collection WAL is local physical durability state and is not a Raft log entry.
+Applying a committed deterministic command to TreeDB must use the local
+collection WAL/root-delta path defined by
+`collection-wal-durability-plan.md` when the command mutates collections. A node
+must not report `locally_recoverable`, advance durable
+applied-index/idempotency metadata, or return `ack_policy=raft_committed`
+success from that node until the local collection WAL transaction and any
+metadata ordering rule are recoverable, unless a later Raft stable-store
+recovery spec explicitly guarantees replay before serving reads.
+
 ## 3. Phase-Close Performance Passes
 
 Each roadmap round, such as R0, R1, R2, and R3, MUST reserve its final sprint

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -223,6 +223,10 @@ Acceptance:
 - a node distinguishes `consensus_committed`, `locally_applied`, and
   `locally_recoverable`; client `raft_committed` success is not returned until
   the responding node satisfies the selected local apply durability rule,
+- persistent applied-index, idempotency-result, and catalog-guard outcome
+  metadata cannot advance past a collection mutation unless that mutation is
+  `CollectionWALRecoverable` locally, or a later stable-Raft replay design proves
+  the entry is replayed before serving;
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -526,8 +526,9 @@ affect routing, snapshots, or catch-up behavior.
 - Choose Raft library or implementation boundary.
 - Define `CommandEntryV1` bytes.
 - Define idempotency record storage.
-- Define applied-index and idempotency metadata ordering relative to local
-  collection WAL append and backend root publish.
+- Finalize the stable-store byte format for the required applied-index and
+  idempotency ordering rule: those metadata records must not advance past local
+  collection WAL recoverability for collection mutations.
 - Define stable store and log store mappings.
 - Define snapshot/export/restore format.
 - Define read-index or equivalent linearizable-read mechanism.

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -182,8 +182,9 @@ Acceptance:
 - cross-process/cross-map-order stability tests,
 - idempotency-key tests,
 - same logical mutation encoded from shuffled sections, different request IDs,
-  deadlines, compression choices, and trace metadata produces the same canonical
-  entry digest,
+  acknowledgement policies, consistency policies, deadlines, compression
+  choices, response-shaping flags, and trace metadata produces the same
+  canonical entry digest,
 - rejection tests for non-deterministic sections, duplicate singleton sections,
   unsupported command versions, local handles, and missing guards.
 
@@ -219,6 +220,9 @@ Acceptance:
   guard-failure results on every replica,
 - failed leadership changes do not double-apply mutations,
 - restart tests preserve Raft log, stable metadata, and applied collection state,
+- a node distinguishes `consensus_committed`, `locally_applied`, and
+  `locally_recoverable`; client `raft_committed` success is not returned until
+  the responding node satisfies the selected local apply durability rule,
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest
@@ -508,6 +512,8 @@ affect routing, snapshots, or catch-up behavior.
 - Choose Raft library or implementation boundary.
 - Define `CommandEntryV1` bytes.
 - Define idempotency record storage.
+- Define applied-index and idempotency metadata ordering relative to local
+  collection WAL append and backend root publish.
 - Define stable store and log store mappings.
 - Define snapshot/export/restore format.
 - Define read-index or equivalent linearizable-read mechanism.

--- a/TreeDB/docs/spec/native-wire-implementation-guidelines.md
+++ b/TreeDB/docs/spec/native-wire-implementation-guidelines.md
@@ -70,7 +70,10 @@ boundaries:
   behavior and owns parity tests against direct collection calls.
 - **Deterministic entry codec:** encodes and decodes canonical Raft command-entry
   bytes. It must not depend on connection state, negotiated compression, request
-  IDs, cursor state, deadlines, or tracing.
+  IDs, cursor state, deadlines, tracing, local durability policy, or response
+  shaping. It strips `ack_policy`, `consistency_policy`, deadlines, tracing,
+  compression, response shaping, request IDs, stream IDs, and local handles
+  before deterministic-entry construction.
 - **Conformance fixtures:** stores golden wire frames, canonical entries, and
   rejection cases that can be reused by future clients or compatibility tests.
 
@@ -184,8 +187,13 @@ caps so malformed input cannot turn into unbounded allocation.
 Before Raft, add deterministic-entry tests that prove:
 
 - the same logical mutation encoded with different request IDs, deadlines, trace
-  metadata, compression choices, and section order produces the same canonical
-  entry digest;
+  metadata, compression choices, acknowledgement policies, consistency policies,
+  response-shaping flags, and section order produces the same canonical entry
+  digest;
+- `ack_policy=visible`, `flushed`, `synced`, and absent/default do not produce
+  different deterministic command bytes, while rejected single-node
+  `raft_committed` handling remains a request-validation/server-admission error
+  rather than deterministic-entry semantics;
 - shuffled Go map iteration and cross-process execution produce the same bytes;
 - unsupported command versions and non-deterministic sections are rejected before
   append;

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -258,6 +258,12 @@ Initial common section IDs:
 12 cursor_meta
 ```
 
+`ack_policy`, `consistency_policy`, deadlines, tracing, compression, and
+response-shaping sections are common request/transport policy. They are not
+deterministic command input. Schema registries must mark `ack_policy`
+non-deterministic for every command version, and deterministic-entry encoders
+must strip it before canonical entry construction.
+
 Command-specific sections start at `100`.
 
 Initial command-specific section IDs used by v1 commands and responses:
@@ -531,6 +537,8 @@ handles.
 commands. `flush_collection`, `flush_all`, and `checkpoint` are local durability
 barriers in v1 and MUST NOT be replicated as Raft state-machine commands unless
 a future distributed barrier command gives them explicit consensus semantics.
+An `ack_policy` common section may be present on mutation requests, but it is
+request/response policy only and is not part of deterministic command identity.
 
 `insert_batch` sections:
 
@@ -679,26 +687,36 @@ mutation:
 ```
 
 `visible` means the mutation is visible to reads through the serving process or
-owning write domain. It is not necessarily crash-durable.
+owning write domain. Whether this is crash-durable depends on the configured
+storage durability mode. For collection writes under WAL-on modes after the
+collection WAL contract lands, `visible` still waits for local collection WAL
+recoverability. Under WAL-off relaxed mode, it is process-local visibility only.
 
 `flushed` means collection write-domain state has been published to backend
-roots for that collection or all touched roots.
+roots for that collection or all touched roots. For collection WAL-backed
+writes, the collection WAL applied watermark for those transactions must
+advance in the same backend commit.
 
 `synced` means the operation reached the strongest local durability boundary
 available under the server's configured TreeDB durability mode.
 
-`raft_committed` is reserved for distributed mode. It means the command has been
-committed by consensus and applied according to the cluster's state-machine
-policy.
+`raft_committed` is reserved for distributed mode. It means the deterministic
+command entry has been committed by consensus and the responding node has
+satisfied the cluster's defined local apply/recoverability rule. It is not
+satisfied by local collection WAL alone and it is not encoded into the
+deterministic command entry.
 
 If `ack_policy` is absent, the server uses its advertised default. The initial
-single-node native server SHOULD default to `visible` to match current
-collection API behavior, but clients that need a durability boundary SHOULD ask
-for `flushed` or `synced` explicitly.
+single-node native server SHOULD default to `visible`, but clients that need a
+publication or sync boundary SHOULD ask for `flushed` or `synced` explicitly.
 
 A server MUST either satisfy the requested minimum policy or fail the request.
 It MUST NOT silently downgrade `synced` to a relaxed or checkpoint-only
 guarantee. Successful responses SHOULD report `actual_ack_policy`.
+Local policies are ordered only within the local family:
+`visible < flushed < synced`. `raft_committed` is a named cluster policy and
+must not be treated as a numeric extension of local durability ordering unless a
+future cluster spec explicitly defines the implied local durability level.
 
 Read `consistency_policy` values:
 
@@ -811,6 +829,9 @@ be copied into the deterministic entry. Optional fields MUST either be omitted
 or encoded with explicit defaults according to the command schema; both forms
 MUST NOT be accepted for the same `command_version`.
 
+`ack_policy` is a common request section, but it is never deterministic command
+input. Encoders must strip it before deterministic-entry construction.
+
 The deterministic Raft command set is an allowlist. Logical metadata mutations
 and logical collection mutations MAY be replicated. Reads, cursors, explain,
 stats, open/close handles, `ack_policy`, `consistency_policy`, deadlines,
@@ -825,6 +846,7 @@ The following MUST NOT be included in deterministic command entries:
 - stream IDs,
 - transport deadlines,
 - trace context,
+- `ack_policy` and `consistency_policy`,
 - negotiated compression choices,
 - non-deterministic server timestamps,
 - response-shaping hints that do not change state.

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -786,6 +786,13 @@ Machine-readable request or stream metadata MAY be carried in a sibling
 future command or negotiated feature must define a separate critical detail
 section before typed details are emitted.
 
+Default error messages and metadata must be redacted. They must not include raw
+documents, raw user keys, raw document IDs, raw collection names, raw index
+names, raw root names, tenant-sensitive path components, or absolute host paths.
+Use stable error codes, counts, sizes, collection UIDs, file IDs, offsets,
+checksums, and keyed hashes by default. Raw diagnostic values require an
+explicit local admin/debug mode outside the default wire response.
+
 Initial error classes:
 
 ```text

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -296,6 +296,8 @@ Initial command-specific section IDs used by v1 commands and responses:
 116 presence_bitmap           bitset, least-significant bit first
 117 truncated                 bool
 118 status_vector             byte_vector of per-item status records, reserved
+119 catalog_guard             CatalogGuardV1
+120 existence_guard           ExistenceGuardV1
 ```
 
 `cursor_limits` encodes both fields. A zero `max_items` or `max_bytes` means
@@ -492,10 +494,12 @@ representation.
 2 connection_local_handle
 ```
 
-Collection names are stable command input. Connection-local handles are a
+Collection names are request input and API/display text. They are not replay
+identity for replicated mutating commands. Connection-local handles are a
 transport optimization returned by `open_collection`; they are never valid
 outside the connection that received them and MUST NOT appear in deterministic
-command entries.
+command entries. Before a mutating command is appended as a deterministic entry,
+names and handles must be resolved to `CatalogGuardV1` stable IDs.
 
 Collection metadata commands SHOULD use the same logical fields as the current
 `CollectionMeta` and `IndexDefinition` model:
@@ -516,15 +520,45 @@ index_storage_policy
 ```
 
 Metadata mutation responses SHOULD include the resulting catalog version or
-equivalent schema guard. Later mutation requests MAY use
+equivalent schema guard. Later single-node mutation requests MAY use
 `expected_catalog_version` to fail fast when a client planned against stale
-metadata.
+metadata. Replicated deterministic mutation entries MUST use `CatalogGuardV1`.
 
 For distributed mode, collection and index mutation entries MUST include a
-deterministic catalog guard: either `expected_catalog_version` or an equivalent
-catalog epoch plus stable collection/index IDs resolved from committed metadata.
+deterministic catalog guard with stable IDs resolved from committed metadata.
 Connection-local handles and unguarded client names MUST be resolved before
 append and MUST NOT be stored in the deterministic entry.
+
+Canonical guard sections:
+
+```text
+CatalogGuardV1 {
+    CollectionUID           uuid128
+    CollectionGeneration    uint64
+    SchemaEpoch             uint64
+    LogicalCatalogDigest    bytes32
+    ExpectedName            string optional diagnostic/existence guard
+    IndexGuards             repeated {
+        IndexUID            uuid128
+        IndexGeneration     uint64
+        DefinitionDigest    bytes32
+    }
+}
+
+ExistenceGuardV1 {
+    TargetKind              collection | index
+    ExpectedState           absent | present
+    StableName              string
+    ExistingUID             uuid128 optional
+    AssignedUID             uuid128 optional for create
+    CatalogEpoch            uint64
+}
+```
+
+Metadata commands must include deterministic existence guards and stable
+assigned IDs when they are encoded as replicated commands. Guard mismatch is a
+deterministic state-machine result and must update idempotency state with the
+failure outcome.
 
 ## 10. Initial Command Set
 
@@ -576,6 +610,7 @@ request/response policy only and is not part of deterministic command identity.
 103 documents byte_vector
 104 template_records optional byte_vector
 105 expected_catalog_version optional
+119 catalog_guard required for distributed mode
 ```
 
 `replace_batch` sections:
@@ -588,6 +623,7 @@ request/response policy only and is not part of deterministic command identity.
 104 template_records optional byte_vector
 105 expected_catalog_version optional
 106 replacement_mode
+119 catalog_guard required for distributed mode
 ```
 
 `delete_batch` sections:
@@ -596,6 +632,7 @@ request/response policy only and is not part of deterministic command identity.
 100 collection_ref
 102 document_ids byte_vector
 105 expected_catalog_version optional
+119 catalog_guard required for distributed mode
 ```
 
 Duplicate IDs in one mutation batch MUST be rejected unless a future command
@@ -909,7 +946,7 @@ The following SHOULD be included when present:
 
 - collection metadata mutation input,
 - collection mutation IDs and document bytes,
-- expected catalog version or equivalent conflict guard,
+- `CatalogGuardV1` or legacy `expected_catalog_version` conflict guard,
 - idempotency key or `client_id + client_sequence`,
 - deterministic command flags.
 

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -1,11 +1,13 @@
 # TreeDB Native Wire Protocol v1
 
-Status: draft proposal, non-normative.
+Status: normative for code that advertises native-wire v1. Distributed/Raft
+behavior remains target/non-normative until cluster mode lands.
 
 TreeDB is pre-alpha. This document defines the target native network protocol
 shape for TreeDB collections and raw ordered-key operations. It is intended to
 guide implementation, benchmark work, and the future Raft/distributed database
-surface. It does not describe current shipped server behavior.
+surface. Sections marked distributed or Raft target do not describe current
+single-node server behavior.
 
 Normative keywords are conformance requirements for code that advertises
 native-wire v1. Until a phase lands, unmatched requirements are design
@@ -74,6 +76,12 @@ Only layer 3 is eligible for Raft log storage. Layer 1 MUST be excluded from
 Raft entries. Layer 2 MAY contain optional client/server convenience sections
 that are also excluded from deterministic entries unless explicitly marked as
 deterministic command input.
+
+Collection WAL is local physical durability state and is not a Raft log entry.
+Native-wire deterministic command entries describe logical mutations; each node
+that applies such a command must still satisfy the local collection WAL
+recoverability rule before reporting local or Raft-backed success for collection
+mutations.
 
 Protocol compatibility is based on explicit version and feature negotiation, not
 best-effort decoding of unknown required fields. Unknown required frame flags,

--- a/TreeDB/docs/spec/native-wire-protocol.md
+++ b/TreeDB/docs/spec/native-wire-protocol.md
@@ -330,11 +330,30 @@ Initial response metadata fields:
 ```text
 actual_ack_policy        uvarint optional
 actual_consistency       uvarint optional
+commit_state             uvarint optional
+durability_mode          uvarint optional
 commit_seq              uvarint optional
 catalog_version         uvarint optional
 applied_log_index       uvarint optional
 serving_node_id         bytes optional
 leader_node_id          bytes optional
+```
+
+`commit_state` values:
+
+```text
+0 unknown
+1 not_committed
+2 committed_recoverable
+3 committed_or_unknown_after_commit
+```
+
+`durability_mode` values:
+
+```text
+1 durable
+2 wal_on_relaxed
+3 wal_off_relaxed
 ```
 
 Single-node implementations may omit cluster fields. Cluster implementations
@@ -581,6 +600,13 @@ with the same canonical command digest MUST return the prior outcome. Reuse with
 a different digest MUST fail with `idempotency_conflict`. Transport `request_id`
 MUST NOT participate in this identity.
 
+Single-node mutation retries are not exactly-once unless the server persists a
+durable idempotency record with the logical mutation outcome. If a client times
+out or disconnects after commit but before response, retry may observe duplicate
+document IDs or unique-index conflicts from the prior commit. Non-idempotent
+updates must be guarded by application-level version/compare predicates or a
+durable idempotency key before clients can treat blind retry as safe.
+
 Mutation responses SHOULD include:
 
 ```text
@@ -687,24 +713,22 @@ mutation:
 ```
 
 `visible` means the mutation is visible to reads through the serving process or
-owning write domain. Whether this is crash-durable depends on the configured
-storage durability mode. For collection writes under WAL-on modes after the
-collection WAL contract lands, `visible` still waits for local collection WAL
-recoverability. Under WAL-off relaxed mode, it is process-local visibility only.
+owning write domain. For WAL-on collection modes this also requires local
+collection WAL recoverability. For WAL-off relaxed mode this is process-local
+visibility only.
 
-`flushed` means collection write-domain state has been published to backend
-roots for that collection or all touched roots. For collection WAL-backed
-writes, the collection WAL applied watermark for those transactions must
-advance in the same backend commit.
+`flushed` means all touched collection state for the command has been published
+to backend roots, and WAL-backed transactions have their applied watermark
+advanced in the same backend commit.
 
-`synced` means the operation reached the strongest local durability boundary
-available under the server's configured TreeDB durability mode.
+`synced` means `flushed` plus an fsync-capable local durability boundary. A
+server running a mode that cannot provide fsync for the touched state MUST fail
+with `durability_unavailable`; it must not reinterpret `synced` as a relaxed
+checkpoint.
 
-`raft_committed` is reserved for distributed mode. It means the deterministic
-command entry has been committed by consensus and the responding node has
-satisfied the cluster's defined local apply/recoverability rule. It is not
-satisfied by local collection WAL alone and it is not encoded into the
-deterministic command entry.
+`raft_committed` is reserved for distributed mode. It means consensus commit
+plus the cluster-defined local apply/recoverability rule. It is not local WAL
+append and is not part of deterministic command identity.
 
 If `ack_policy` is absent, the server uses its advertised default. The initial
 single-node native server SHOULD default to `visible`, but clients that need a
@@ -717,6 +741,20 @@ Local policies are ordered only within the local family:
 `visible < flushed < synced`. `raft_committed` is a named cluster policy and
 must not be treated as a numeric extension of local durability ordering unless a
 future cluster spec explicitly defines the implied local durability level.
+
+If validation succeeds but collection WAL append fails before the commit marker,
+the server returns `durability_unavailable`, `retryable=true`,
+`commit_state=not_committed`, and the mutation must not be visible.
+
+If the commit marker reached the required local boundary but visible install,
+flush, publication, checkpoint, or response construction fails, the server
+returns `commit_ambiguous`, `retryable=false` unless a durable idempotency record
+makes replay safe, and `commit_state=committed_or_unknown_after_commit`.
+
+If a command requested `ack_policy=flushed` or `ack_policy=synced` and the
+logical mutation committed but the requested barrier failed, the error must
+still expose the post-commit state. It must not look like an ordinary mutation
+rejection.
 
 Read `consistency_policy` values:
 
@@ -773,6 +811,7 @@ Initial error classes:
 20 cursor_not_found
 21 catalog_changed
 22 idempotency_conflict
+23 commit_ambiguous
 ```
 
 Errors that map to current collection duplicate-key conditions SHOULD preserve a

--- a/TreeDB/docs/spec/native-wire-r2-closeout.md
+++ b/TreeDB/docs/spec/native-wire-r2-closeout.md
@@ -17,8 +17,8 @@ R2 adds and hardens:
   names,
 - SHA-256 digest helper over exact canonical entry bytes,
 - stability tests proving transport-only sections, response-shaping flags,
-  deadlines, trace metadata, compression choices, and shuffled sections do not
-  alter canonical bytes,
+  deadlines, trace metadata, compression choices, acknowledgement policy
+  changes, and shuffled sections do not alter canonical bytes,
 - replicated-command append/decode/digest benchmarks.
 
 The replicated v1 command fixture set is:
@@ -32,6 +32,10 @@ The replicated v1 command fixture set is:
 
 `drop_collection`, flush, checkpoint, reads, cursors, stats, and collection
 handle commands remain local-only in v1.
+
+`ack_policy` is a request-local durability/response policy in R2. It is excluded
+from deterministic-entry fixtures; changing only acknowledgement policy must not
+change canonical command-entry bytes or digest.
 
 ## Validation
 
@@ -137,3 +141,5 @@ allocates 128 times/op.
 - Metadata payloads remain opaque at the internal codec layer. R3 should either
   move canonical metadata/index payload decoding into the deterministic-entry
   layer or define a separate state-machine decoder with the same fixture gate.
+- Raft apply must define consensus commit, local apply, and local recoverability
+  ordering before exposing `ack_policy=raft_committed`.

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -113,13 +113,22 @@ Recovery must fail on:
 
 1. both meta pages invalid,
 2. no structurally valid root candidate,
-3. missing RID for a commit-log RID record,
+3. missing RID for a commit-log RID record that is not covered by an allowed
+   sequence-fence skip rule,
 4. missing required dictionary bytes for compressed frame decode/validation,
 5. hard corruption in non-tail portions.
 
 Recovery may continue past:
 
 - truncated tail records in final value/commit segments.
+- current cached key/value commit-log batches whose sequence-numbered RID fence
+  is unsatisfied and whose replay rules explicitly skip the whole fenced batch.
+
+Collection WAL recovery is intentionally stricter than the current cached
+key/value RID fence. A complete WAL-on collection transaction with a missing
+required side ref is a recovery error unless it is an incomplete tail without a
+valid commit marker. Recovery must not skip that complete collection transaction
+and continue applying later transactions for the same collection.
 
 ## 6. Post-Recovery Expectations
 

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -143,6 +143,17 @@ Collection WAL recovery must also validate the canonical embedded side-ref set
 decoded from root deltas and descriptors against the declared side-ref set.
 Declared refs alone are not trusted.
 
+Collection WAL recovery uses `CollectionSeq` as the dependency and skip key.
+`WALLSN` is only a global append position for deterministic scanning,
+diagnostics, and cleanup accounting. A higher cleaned or published `WALLSN` from
+one collection must never cause recovery to skip a lower unapplied
+`CollectionSeq` from another collection.
+
+Read-write recovery must run collection WAL replay before collection managers,
+native-wire servers, or user collection handles can observe collection state.
+Read-only open must fail with recovery-required if unapplied committed
+collection WAL exists, unless an explicit stale read-only mode is added.
+
 ## 6. Post-Recovery Expectations
 
 After successful open:

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -13,7 +13,11 @@ High-level order:
 3. expose recovered state,
 4. clean replayed commit-log segments.
 
-Read-only opens do not run mutating recovery.
+Read-only opens do not run mutating recovery. If future collection WAL segments
+contain committed unapplied transactions, read-only open must fail with a
+recovery-required error unless the caller explicitly requests a stale read-only
+mode. Silent stale read-only open is incompatible with collection
+durable-at-ack semantics.
 
 ## 2. Backend Index Recovery
 
@@ -58,6 +62,11 @@ Accepted patterns include:
 - legacy accepted: `commit-<seq>.log`, `value-<seq>.log`, `wal-<seq>.log`, `vlog-<seq>.log`
 
 Discovered segments are sorted by `(lane, seq)`.
+
+Collection WAL segments use their own cleanup metadata. A missing collection WAL
+segment is acceptable only when covered by durable cleanup metadata that proves
+the segment's transaction range was safely cleaned. A missing non-cleaned
+collection WAL segment is recovery corruption.
 
 ## 4. Replay Algorithm
 
@@ -129,6 +138,10 @@ key/value RID fence. A complete WAL-on collection transaction with a missing
 required side ref is a recovery error unless it is an incomplete tail without a
 valid commit marker. Recovery must not skip that complete collection transaction
 and continue applying later transactions for the same collection.
+
+Collection WAL recovery must also validate the canonical embedded side-ref set
+decoded from root deltas and descriptors against the declared side-ref set.
+Declared refs alone are not trusted.
 
 ## 6. Post-Recovery Expectations
 

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -147,11 +147,15 @@ Collection WAL decoder outcomes are distinct from commit-log outcomes:
 
 | Outcome | Recovery behavior |
 |---|---|
-| `CompleteSupported` | validate side refs and replay, or skip only by collection watermark |
-| `IncompleteTerminalTail` | ignore only if terminal active segment and no later non-cleaned segment exists |
-| `UnsupportedRequiredVersion` | fail closed; durable acknowledged writes may be present |
+| `CompleteValid` | validate side refs and replay, or skip only by collection watermark |
+| `CompleteCorrupt` | fail closed; a complete bad checksum/digest/closure is not a tail |
+| `TerminalIncompleteTail` | ignore only if terminal active segment and no later non-cleaned segment exists |
+| `NonTerminalShortRead` | fail closed |
+| `UnsupportedVersion` | fail closed; durable acknowledged writes may be present |
 | `UnsupportedSkippableRecord` | skip only when record feature bits and cleanup metadata permit |
-| `HardCorruption` | fail closed |
+| `MissingSegment` | fail closed unless durable cleanup metadata covers the segment/range |
+| `DuplicateWALLSN` | fail closed |
+| `DuplicateCollectionSeq` | fail closed |
 | `MaliciousLength` | fail closed before allocation |
 | `MixedVersionSegment` | fail closed unless an explicit migration reader supports both versions |
 
@@ -294,7 +298,73 @@ native-wire servers, or user collection handles can observe collection state.
 Read-only open must fail with recovery-required if unapplied committed
 collection WAL exists, unless an explicit stale read-only mode is added.
 
-## 6. Post-Recovery Expectations
+## 6. Restore and Backup-Manifest Validation
+
+Restore/open validation before serving reads:
+
+1. recover index swap artifacts;
+2. load backup manifest if present;
+3. discover collection WAL segments and cleanup metadata;
+4. validate missing collection WAL segments only when covered by durable cleanup
+   metadata or by the backup manifest's cleaned-range proof;
+5. rebuild the protected side-ref index from all committed non-cleaned
+   collection WAL;
+6. for every committed transaction not covered by applied watermark plus
+   cleanup:
+   - validate frame checksum and transaction checksum;
+   - validate `CollectionUID`, generation, schema epoch, catalog digest, and
+     root epochs;
+   - decode embedded root deltas/descriptors and derive the canonical side-ref
+     set;
+   - compare canonical side refs to declared `SideRefs`;
+   - verify every side ref exists, has expected size/checksum/class, and has
+     dictionary/template/column dependency closure;
+7. stop open before serving reads on any missing or corrupt required side ref;
+8. publish descriptors and applied watermarks atomically for unapplied
+   transactions;
+9. classify uncommitted prepared/final side files;
+10. quarantine, but do not immediately purge, files proven orphaned.
+
+Backup/restore validation must fail closed on missing side refs. A restore may
+accept a missing collection WAL segment only when durable cleanup metadata or
+the backup manifest proves the exact segment/range was safely cleaned.
+
+## 7. Read-Only Open
+
+Read-only open must not perform mutating collection WAL replay.
+
+Before exposing state, read-only open must scan collection WAL segment metadata,
+cleanup metadata, and applied watermarks enough to determine whether any
+complete committed collection WAL transaction is not covered by the durable
+applied watermark/cleanup boundary.
+
+Default behavior:
+
+- if dirty committed collection WAL exists, return public
+  `ErrRecoveryRequired` with a collection-WAL recovery reason.
+
+Read-only stale mode:
+
+- a future explicit option may expose only checkpointed roots;
+- the option name must include `Stale`;
+- it must report collection WAL debt;
+- it must be rejected by backup, restore validation, and offline maintenance
+  tools.
+
+## 8. Offline Maintenance Preconditions
+
+Offline value-log rewrite, offline index vacuum, and any offline compaction or
+root rewrite must prove collection WAL cleanliness before opening the DB
+read-only as a maintenance source. Clean means no committed unapplied
+collection WAL, no uncleaned committed collection WAL segment needed for
+recovery, no active/incomplete prepare group whose committed/uncommitted status
+is unclassified, and durable cleanup metadata for any missing segment.
+
+Offline tools may alternatively run full read-write recovery first, then reopen
+the clean directory for maintenance. They must not proceed using stale
+read-only roots.
+
+## 9. Post-Recovery Expectations
 
 After successful open:
 
@@ -303,7 +373,7 @@ After successful open:
 - value-log files used by pointers remain present,
 - future writes proceed on freshly rotated active segments.
 
-## 7. Recovery Invariants
+## 10. Recovery Invariants
 
 1. Replay order for equal keys must honor commit sequence ordering semantics.
 2. RID join (when present) must be exact; no synthetic value reconstruction is permitted.

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -159,6 +159,113 @@ Read-only open must scan collection WAL gates and committed frames. If complete
 unapplied collection WAL exists, read-only open fails with recovery-required
 unless a future read-only replay overlay is explicitly implemented.
 
+Every collection WAL recovery skip, block, or hard failure must be assigned one
+stable category:
+
+| Category | Severity |
+|---|---|
+| `incomplete_tail` | safe skip only for terminal tail without durable commit marker |
+| `already_applied_watermark` | safe skip when covered by durable applied watermark |
+| `record_checksum_mismatch` | hard failure |
+| `unsupported_wal_version` | hard failure unless explicitly skippable |
+| `segment_gap_without_cleanup` | hard failure |
+| `missing_required_side_ref` | hard failure |
+| `corrupt_required_side_ref` | hard failure |
+| `side_ref_closure_mismatch` | hard failure |
+| `collection_identity_mismatch` | hard failure |
+| `collection_generation_mismatch` | hard failure |
+| `schema_epoch_mismatch` | hard failure |
+| `base_root_mismatch` | hard failure unless handled by formal accumulator state |
+| `root_descriptor_epoch_mismatch` | hard failure |
+| `base_system_root_mismatch` | hard failure |
+| `watermark_inconsistency` | hard failure |
+| `duplicate_wallsn` | hard failure |
+| `duplicate_collection_seq` | hard failure |
+| `dependency_gap` | block/fail for later same-collection transactions |
+| `system_delta_precondition_failed` | hard failure |
+| `replay_publish_failure` | retryable recovery failure only before descriptor/watermark commit |
+| `cleanup_manifest_missing` | cleanup blocked; missing segment hard-fails open |
+| `cleanup_manifest_corrupt` | cleanup blocked or hard-fails if needed for missing segment proof |
+| `cleanup_failure` | safe leak/debt after watermark/checkpoint |
+| `orphan_prepared_side_ref` | quarantine candidate when no committed WAL/root references it |
+| `read_only_recovery_required` | read-only open failure |
+
+`missing_required_side_ref`, `corrupt_required_side_ref`,
+`side_ref_closure_mismatch`, schema/root/identity mismatches, and watermark
+inconsistency are hard recovery failures for complete committed collection WAL
+records.
+
+Implementations must expose typed errors equivalent to:
+
+```go
+type CollectionWALErrorCategory string
+
+type CollectionWALError struct {
+    Category          CollectionWALErrorCategory
+    TxnID             string
+    WALLSN            uint64
+    CollectionUID     string
+    CollectionUIDHash string
+    CollectionSeq     uint64
+    SegmentID         string
+    SegmentOffset     uint64
+    SideRef           *SideRefSummary
+    Cause             error
+}
+```
+
+The implementation must provide helpers equivalent to `IsIncompleteTail(err)`,
+`IsRecoveryRequired(err)`, and `IsCollectionWALCorruption(err)`. Error category
+strings are metric suffixes and artifact fields; they must not be built from
+arbitrary error messages.
+
+Before recovery deletes, quarantines, rewrites, or marks clean any collection WAL
+segment or side-ref file, it must write and fsync a forensic artifact.
+
+Artifact directory:
+
+```text
+collection_wal/recovery-artifacts/<unix_nano>-<pid>-<open_uuid>/
+```
+
+Required files:
+
+- `recovery-report.json`;
+- `segments.json`;
+- `transactions.json`;
+- `side-refs.json`;
+- `watermarks.json`;
+- `cleanup-decisions.json`;
+- `quarantine-manifest.json` when quarantine occurs.
+
+The artifact directory, every required file, and the parent directory entry must
+be fsynced before recovery performs the side effect that the artifact explains.
+If artifact creation fails, recovery must leave WAL and side files untouched
+unless the failure is part of an explicit operator-approved destructive repair.
+
+Artifacts must not contain document payloads, raw user keys, raw index keys, raw
+collection names, raw root names, or absolute host paths by default. They must
+include metadata, checksums, digests, redacted names, segment ids, offsets,
+lengths, watermarks, and error categories sufficient to reconstruct:
+
+- which transaction failed or was skipped;
+- which side refs were required;
+- which side refs were missing, corrupt, protected, released, or quarantined;
+- current applied watermark per collection;
+- segment offset and checksum state;
+- cleanup eligibility;
+- `safe_to_restart`, `safe_to_backup`, `safe_to_compact`,
+  `safe_to_delete_files`, and `requires_operator_action`.
+
+Skipped transactions must be auditable through a redacted
+`SkippedTransactionRecord` in the recovery artifact and CLI reports. Required
+skip categories are `incomplete_tail`, `already_applied_watermark`,
+`duplicate_collection_seq`, and `orphan_prepared_side_ref`. Required fields are
+`skip_id`, `skip_category`, `txn_id`, `wallsn`, `collection_uid`,
+`collection_uid_hash`, `collection_seq`, `segment_id`, `segment_offset`,
+`record_length`, `commit_marker_present`, `record_checksum_valid`,
+`side_ref_summaries`, `watermark_before`, and `watermark_after`.
+
 Collection WAL recovery must also validate the canonical embedded side-ref set
 decoded from root deltas and descriptors against the declared side-ref set.
 Declared refs alone are not trusted.

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -17,7 +17,7 @@ High-level order:
 7. expose recovered state,
 8. clean replayed commit-log and safely watermarked collection WAL segments.
 
-Read-only opens do not run mutating recovery. If future collection WAL segments
+Read-only opens do not run mutating recovery. If collection WAL segments
 contain committed unapplied transactions, read-only open must fail with a
 recovery-required error unless the caller explicitly requests a stale read-only
 mode. Silent stale read-only open is incompatible with collection
@@ -142,6 +142,22 @@ key/value RID fence. A complete WAL-on collection transaction with a missing
 required side ref is a recovery error unless it is an incomplete tail without a
 valid commit marker. Recovery must not skip that complete collection transaction
 and continue applying later transactions for the same collection.
+
+Collection WAL decoder outcomes are distinct from commit-log outcomes:
+
+| Outcome | Recovery behavior |
+|---|---|
+| `CompleteSupported` | validate side refs and replay, or skip only by collection watermark |
+| `IncompleteTerminalTail` | ignore only if terminal active segment and no later non-cleaned segment exists |
+| `UnsupportedRequiredVersion` | fail closed; durable acknowledged writes may be present |
+| `UnsupportedSkippableRecord` | skip only when record feature bits and cleanup metadata permit |
+| `HardCorruption` | fail closed |
+| `MaliciousLength` | fail closed before allocation |
+| `MixedVersionSegment` | fail closed unless an explicit migration reader supports both versions |
+
+Read-only open must scan collection WAL gates and committed frames. If complete
+unapplied collection WAL exists, read-only open fails with recovery-required
+unless a future read-only replay overlay is explicitly implemented.
 
 Collection WAL recovery must also validate the canonical embedded side-ref set
 decoded from root deltas and descriptors against the declared side-ref set.

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -6,16 +6,24 @@ This document defines startup recovery behavior.
 
 Recovery is executed during `Open` for read-write handles.
 
-High-level order:
+Current high-level order for non-collection cached WAL:
 
 1. recover index metadata/root state,
-2. scan value-log, leaf-log, and future side-store availability,
-3. replay cached commit logs (if WAL mode permits),
-4. scan collection WAL transactions and cleanup metadata,
-5. load applied collection watermarks,
-6. validate required side refs and replay unapplied collection WAL transactions,
-7. expose recovered state,
-8. clean replayed commit-log and safely watermarked collection WAL segments.
+2. discover value-log and commit-log segments from their canonical directories,
+3. validate reachable value-log and split leaf-log records needed by replay,
+4. replay cached commit logs if WAL mode permits,
+5. expose recovered backend roots and memtables,
+6. clean obsolete commit-log segments only after replay permits it.
+
+Target collection WAL extension:
+
+Collection WAL replay is target behavior owned by
+`collection-wal-durability-plan.md` until the implementation gate lands. In
+that target, recovery also discovers collection WAL segments and cleanup
+metadata, validates required side refs, publishes committed root groups,
+advances per-collection applied watermarks atomically with root descriptors, and
+refuses read-only open when committed unapplied collection WAL would be required
+for a correct view.
 
 Read-only opens do not run mutating recovery. If collection WAL segments
 contain committed unapplied transactions, read-only open must fail with a
@@ -58,12 +66,17 @@ From chosen meta:
 
 ## 3. WAL Segment Discovery
 
-Segments are discovered from `<dir>/wal` by filename parsing.
+Commit-log segments are discovered from `<maindb>/wal` by filename parsing.
+Value-log segments are discovered from `<maindb>/value_vlog`; split leaf-log
+segments are discovered from `<maindb>/leaf_vlog`.
 
 Accepted patterns include:
 
-- canonical: `commit-l<lane>-<seq>.log`, `value-l<lane>-<seq>.log`
-- legacy accepted: `commit-<seq>.log`, `value-<seq>.log`, `wal-<seq>.log`, `vlog-<seq>.log`
+- canonical commit log: `commit-l<lane>-<seq>.log`
+- legacy accepted commit-log aliases: `commit-<seq>.log`, `wal-<seq>.log`
+- legacy value-log aliases accepted only by explicit legacy parsers:
+  `value-<seq>.log`, `vlog-<seq>.log`, and legacy mixed `wal/value-l*.log`
+  names
 
 Discovered segments are sorted by `(lane, seq)`.
 

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -276,6 +276,19 @@ diagnostics, and cleanup accounting. A higher cleaned or published `WALLSN` from
 one collection must never cause recovery to skip a lower unapplied
 `CollectionSeq` from another collection.
 
+Collection WAL recovery must enforce the abstract state machine in
+`collection-wal-durability-plan.md`. In particular:
+
+- descriptor-only and watermark-only backend commits are invalid in WAL-on
+  modes and must stop open unless a future format provides an explicit repair
+  protocol;
+- replay skip requires the same collection's applied sequence plus matching
+  guard history, never global `WALLSN` ranges;
+- side refs referenced by complete uncleaned WAL remain protected until
+  `CanCleanSideRef` is true;
+- read-only recovery detection uses `CanSkipReplay` and `CanReplay`, not raw file
+  presence alone.
+
 Read-write recovery must run collection WAL replay before collection managers,
 native-wire servers, or user collection handles can observe collection state.
 Read-only open must fail with recovery-required if unapplied committed

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -9,9 +9,13 @@ Recovery is executed during `Open` for read-write handles.
 High-level order:
 
 1. recover index metadata/root state,
-2. replay cached commit logs (if WAL mode permits),
-3. expose recovered state,
-4. clean replayed commit-log segments.
+2. scan value-log, leaf-log, and future side-store availability,
+3. replay cached commit logs (if WAL mode permits),
+4. scan collection WAL transactions and cleanup metadata,
+5. load applied collection watermarks,
+6. validate required side refs and replay unapplied collection WAL transactions,
+7. expose recovered state,
+8. clean replayed commit-log and safely watermarked collection WAL segments.
 
 Read-only opens do not run mutating recovery. If future collection WAL segments
 contain committed unapplied transactions, read-only open must fail with a

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -3,6 +3,10 @@
 This document defines the current on-disk and wire formats used by TreeDB.
 
 TreeDB is pre-alpha; format compatibility between versions is not guaranteed.
+That disclaimer does not permit fail-open handling of acknowledged durable
+writes. Once a directory advertises a required storage feature such as
+`collection_wal_v1`, unsupported binaries must fail closed instead of serving,
+cleaning, compacting, or rewriting the directory.
 
 ## 1. Top-Level Storage Objects
 
@@ -10,21 +14,22 @@ A TreeDB deployment uses:
 
 - `index.db` (paged B+Tree index and metadata),
 - commit-log segments under `wal/commit-l*.log`,
-- future collection WAL segments under `wal/collection-l*.log`,
+- collection WAL segments under `wal/collection-l*.log` once
+  `collection_wal_v1` is enabled,
 - value-log segments under `value_vlog/value-l*.log`,
 - optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
   when `IndexOuterLeavesInValueLog` is enabled,
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
-The collection WAL format is proposed in
-`TreeDB/docs/spec/collection-wal-durability-plan.md`. It is a distinct logical
-record class from the cached key/value commit log. Collection WAL records need
-segment metadata, complete-frame checksums, transaction checksums, commit
-markers, per-collection `CollectionSeq` dependency ordering, global `WALLSN`
-append positions for scan/cleanup accounting, side-ref validation, and durable
-cleanup metadata before missing collection WAL segments can be treated as safely
-cleaned. `WALLSN` is not a replay skip key; recovery skips only by durable
-per-collection applied sequence watermarks.
+Collection WAL is a distinct physical file class from the cached key/value
+commit log. Its byte envelope, feature gates, migration states, and cleanup
+metadata are defined in this document. The semantic write/recovery contract is
+defined in `TreeDB/docs/spec/collection-wal-durability-plan.md`. Collection WAL
+records use per-collection `CollectionSeq` dependency ordering, global `WALLSN`
+append positions only for scan/cleanup accounting, side-ref validation, and
+durable cleanup metadata before missing collection WAL segments can be treated
+as safely cleaned. `WALLSN` is not a replay skip key; recovery skips only by
+durable per-collection applied sequence watermarks.
 
 ## 2. Index Page Basics
 
@@ -411,17 +416,321 @@ Validation rules:
 - `OpSetInline`: `RID == 0`.
 - `OpDelete`: `RID == 0`, `ValueLen == 0`.
 
-## 9. File Naming Conventions
+## 9. Collection WAL v1 Segment and Frame Format
+
+Collection WAL is a separate file class from the key/value commit log. It must
+not be decoded with the commit-log `Record` schema, and cached commit-log RID
+skip behavior must not apply to complete collection WAL transactions.
+
+All multi-byte integers in collection WAL are little-endian. Decoders must
+reject nonzero reserved fields. Length caps are checked before allocation.
+Unknown required versions, critical sections, critical side-ref classes, and
+compression codecs fail closed before replay, cleanup, or serving.
+
+### 9.1 Segment File Header
+
+Every `collection-l<lane>-<seq>.log` file begins with:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | Magic bytes `54 44 42 43 57 41 4c 01` (`TDBCWAL\x01`) |
+| 8 | 2 | `SegmentHeaderLen`, currently `64` |
+| 10 | 2 | `SegmentFormatVersion`, currently `1` |
+| 12 | 2 | `MinReaderVersion`, currently `1` |
+| 14 | 2 | `SegmentFlags` |
+| 16 | 4 | `HeaderCRC32C` over bytes `[0,64)`, with this field zeroed |
+| 20 | 4 | `FileClass`, `1 = collection_wal` |
+| 24 | 4 | `Lane` |
+| 28 | 8 | `SegmentSeq` |
+| 36 | 8 | `FirstWALLSN`, or `0` while unsealed |
+| 44 | 8 | `LastWALLSN`, or `0` while unsealed |
+| 52 | 12 | reserved zero |
+
+### 9.2 Transaction Frame
+
+After the segment header, the file contains zero or more frames:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | Magic bytes `54 44 42 43 57 54 58 01` (`TDBCWTX\x01`) |
+| 8 | 2 | `FrameHeaderLen`, currently `96` |
+| 10 | 2 | `FrameFormatVersion`, currently `1` |
+| 12 | 2 | `MinReaderVersion` |
+| 14 | 2 | `RecordType`: `1 = transaction`, `2 = segment_metadata`, `3 = cleanup_record` |
+| 16 | 4 | `FrameFlags`: bit 0 compressed, bit 1 commit trailer required |
+| 20 | 2 | `CompressionCodec`: `0 = none`, `1 = zstd` |
+| 22 | 2 | `SectionTableVersion`, currently `1` |
+| 24 | 8 | `WALLSN` |
+| 32 | 16 | `CollectionUID`, zero only for non-transaction record types |
+| 48 | 8 | `CollectionSeq`, zero only for non-transaction record types |
+| 56 | 8 | `StoredPayloadLen` |
+| 64 | 8 | `RawPayloadLen` |
+| 72 | 4 | `HeaderCRC32C` over `[0,96)`, with this field zeroed |
+| 76 | 4 | `StoredPayloadCRC32C` |
+| 80 | 4 | `ReplayDigestCRC32C` for transaction records, zero otherwise |
+| 84 | 4 | `RequiredFeatureBitsLow` |
+| 88 | 8 | reserved zero |
+
+Compression is not encoded by stealing bits from the length field. A compressed
+frame records both `CompressionCodec` and `RawPayloadLen`. Unknown compression
+codec on a required record fails closed. The frame header must be integrity
+checked before payload allocation, and `StoredPayloadLen`/`RawPayloadLen` must
+respect the configured collection WAL transaction limits.
+
+The frame is committed only if the header, stored payload, and commit trailer
+are present and valid. The commit trailer is:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | Magic bytes `54 44 42 43 57 43 4d 01` (`TDBCWCM\x01`) |
+| 8 | 4 | `TrailerLen`, currently `16` |
+| 12 | 4 | `WholeFrameCRC32C` over frame header, stored payload, and trailer bytes `[0,12)` with all CRC fields already populated |
+
+A short read of the header, stored payload, or trailer is an incomplete tail only
+when it occurs in the terminal active segment and no later non-cleaned
+collection WAL segment exists. Otherwise it is hard corruption.
+
+### 9.3 Transaction Payload Header
+
+A v1 transaction payload begins with a fixed header followed by a section table.
+The first root-delta byte is not before the fixed header and section table.
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | `PayloadMagic` `54 44 42 43 57 50 31 01` (`TDBCWP1\x01`) |
+| 8 | 2 | `TransactionVersion`, currently `1` |
+| 10 | 2 | `FixedHeaderLen`, currently `192` |
+| 12 | 4 | `TransactionFlags` |
+| 16 | 16 | `CollectionUID` |
+| 32 | 8 | `CollectionGeneration` |
+| 40 | 8 | `CollectionSeq` |
+| 48 | 8 | `DependsOnCollectionSeq` |
+| 56 | 8 | `SchemaEpoch` |
+| 64 | 8 | `SchemaVersion` |
+| 72 | 8 | `BaseCommitSeq` |
+| 80 | 8 | `BaseSystemRootID` |
+| 88 | 32 | `BaseCatalogDigest` |
+| 120 | 32 | `CatalogDigest` |
+| 152 | 4 | `MutationClass` |
+| 156 | 4 | `RootDeltaCount` |
+| 160 | 4 | `SideRefCount` |
+| 164 | 4 | `DescriptorOpCount` |
+| 168 | 4 | `SectionCount` |
+| 172 | 4 | `FixedHeaderCRC32C` over `[0,192)`, with this field zeroed |
+| 176 | 16 | reserved zero |
+
+The section table immediately follows the fixed header. Each section table entry
+is:
+
+| Size | Field |
+|---:|---|
+| 2 | `SectionType` |
+| 2 | `SectionVersion` |
+| 4 | `SectionFlags`: bit 0 critical, bit 1 replay-critical |
+| 8 | `SectionOffset` from start of payload |
+| 8 | `SectionLength` |
+| 4 | `SectionCRC32C` |
+| 4 | reserved zero |
+
+Known v1 section types are:
+
+- `1 = root_delta_table`
+- `2 = side_ref_table`
+- `3 = system_delta_template`
+- `4 = descriptor_ops`
+- `5 = stats`
+- `6 = unknown_preserved`
+
+Unknown critical sections make recovery fail closed. Unknown noncritical
+sections may be skipped only when not replay-critical and not referenced by any
+known section. Encoders and quarantine/metadata-rewrite tools must preserve
+unknown sections byte-for-byte unless the format explicitly proves they are
+discardable.
+
+Root deltas are encoded only inside `root_delta_table`; the first byte of the
+first root delta is the byte at `SectionOffset` for that section.
+
+### 9.4 Root Delta and Side-Ref Section Constraints
+
+Root-delta sections are deterministic byte sequences. A root-delta table must
+carry root kind, root name, root descriptor epoch, storage policy,
+`RootDeltaOrdinal`, key comparator identity, delta encoding version,
+`IncludeDeletedOnColdBuild`, entry count, encoded byte length, and delta digest
+before the entry payload. Entries must encode operation kind, `EntryOrdinal`,
+key length, value length, and either inline value bytes, stable `ValuePtr`
+bytes, or a `RootDeltaPayload` side-ref index. Tombstones are first-class
+operations.
+
+Side refs encode `RefClass`, `ClassVersion`, `Critical`, `FileID`, `Offset`,
+`Length`, `ChecksumKind`, `Checksum`, and optional advisory `RelativePath`.
+Unknown critical `RefClass` or `ClassVersion` makes the transaction
+unsupported-required and recovery fails closed. Unknown noncritical refs may be
+ignored only if no replay-critical section references them and the transaction
+feature bits explicitly allow skipping them. Cleanup, GC, rewrite, and
+quarantine must treat unknown refs from complete unwatermarked transactions as
+protected until the transaction is watermarked and checkpointed or an operator
+performs a destructive rebuild.
+
+### 9.5 Required Storage Features and Compatibility Gates
+
+Collection WAL is a required storage feature once any WAL-on collection write
+can be acknowledged before its root group is checkpointed.
+
+A directory with collection WAL enabled must contain all of:
+
+1. `format.json` with an incompatible `Version` that older binaries reject and
+   `required_features` containing `collection_wal_v1`;
+2. a recovered system-root feature key
+   `treedb/storage-format/required-features/collection_wal_v1 = true`;
+3. collection WAL segment headers carrying `FileClass = collection_wal` and
+   `MinReaderVersion <= reader_version`.
+
+`format.json` is the early-open/downgrade gate before pager recovery. The
+system root is the authoritative recovered feature state. WAL headers are the
+decoder gate. The current meta page is not a feature gate unless a future
+meta-page format explicitly adds feature bits.
+
+A binary that does not support every required feature must fail before serving,
+checkpointing, compacting, vacuuming, cleaning WAL, or rewriting side files.
+`IgnoreFormatConfig` and similar runtime overrides must not bypass required
+on-disk features; destructive rebuild tooling must be explicit.
+
+Downgrade from a directory with `collection_wal_v1` is unsupported and must be
+detected. Missing or inconsistent gates are recovery errors, except during an
+explicit migration state defined below.
+
+### 9.6 Collection WAL Migration States
+
+The system root and `format.json` must agree on one of these states:
+
+| State | Allowed files | Open behavior |
+|---|---|---|
+| `NoCollectionWAL` | no `collection-l*.log`; no collection WAL cleanup metadata | old behavior |
+| `CollectionWALSupportedButDisabled` | no committed collection WAL required for recovery | open allowed; writes may choose WAL-off behavior |
+| `CollectionWALRequiredPreparing` | feature gate durable; admission closed for upgrade; no acknowledged WAL-on collection writes until finalized | only upgrading binary may open read-write |
+| `CollectionWALRequired` | committed collection WAL may exist and must be recovered | unsupported binaries fail; supported binaries replay or fail closed |
+| `CollectionWALRecoveryRequired` | complete unapplied collection WAL exists | read-write open must recover; read-only open must fail unless an explicit replay overlay exists |
+| `CollectionWALCleanupPending` | segments may be deleted only according to durable cleanup records | cleanup resumes idempotently |
+
+Activation from `NoCollectionWAL` to `CollectionWALRequired` must:
+
+1. close collection write admission;
+2. checkpoint existing roots and current commit WAL;
+3. durably write the new `format.json` gate and fsync its directory;
+4. durably commit the system-root feature state;
+5. fsync the database directory containing the new markers;
+6. continue only with a binary that supports collection WAL;
+7. acknowledge WAL-on collection writes only after the final state is durable.
+
+Crash during activation must reopen into either the old state, a preparing state
+that cannot acknowledge WAL-on collection writes, or the final required state.
+Any other mixture is a recovery error until an admin repair or destructive
+rebuild path is invoked.
+
+### 9.7 Collection Descriptor Record
+
+Every persisted collection descriptor must include:
+
+| Field | Meaning |
+|---|---|
+| `CollectionUID uuid128` | durable identity; never derived from name |
+| `CollectionGeneration uint64` | increments on drop/recreate; rename preserves UID |
+| `SchemaEpoch uint64` | increments on schema/index descriptor changes |
+| `SchemaVersion uint64` | logical schema version if distinct from epoch |
+| `CatalogDigest bytes32` | digest of replay-relevant catalog descriptor |
+| `RootDescriptorEpochs` | per-root descriptor generation map |
+| `RootGeneration` | per-root physical generation guard |
+| `CollectionName` | diagnostic only; not replay identity |
+| `DroppedAtEpoch optional uint64` | tombstone for deleted collections |
+
+Recovery must reject an unapplied collection WAL transaction when the recovered
+descriptor for its `CollectionUID` is absent, tombstoned, or has mismatching
+generation, schema epoch, catalog digest, or root descriptor epoch, unless an
+explicit migration record maps the old descriptor to a new one.
+
+### 9.8 Durable Manifest Writes and Cleanup Metadata
+
+Feature gates, segment metadata, cleanup records, and migration-state manifests
+must be written with a crash-durable manifest protocol:
+
+1. write a temp file in the target directory;
+2. fsync the temp file;
+3. rename to the final path;
+4. fsync the parent directory;
+5. for segment deletion, unlink the segment and fsync the WAL directory;
+6. record cleanup state transitions so crashes during cleanup are idempotent.
+
+The generic atomic-rename helper is not sufficient unless it performs the fsync
+steps above. Startup accepts a missing collection WAL segment only when durable
+cleanup metadata proves the whole segment was safely cleaned.
+
+### 9.9 Collection WAL Decoder Outcomes
+
+A collection WAL reader must report one of these outcomes for each frame or
+segment boundary:
+
+| Outcome | Meaning |
+|---|---|
+| `CompleteSupported` | complete frame, supported required version, checksums valid |
+| `IncompleteTerminalTail` | incomplete frame in terminal active segment with no later non-cleaned segment |
+| `UnsupportedRequiredVersion` | complete frame or segment requires a newer reader |
+| `UnsupportedSkippableRecord` | record is explicitly noncritical and skippable |
+| `HardCorruption` | bad magic, CRC, digest, non-tail truncation, or impossible structure |
+| `MaliciousLength` | length exceeds cap or overflows before allocation |
+| `MixedVersionSegment` | segment mixes versions without an explicit migration reader |
+
+Only `IncompleteTerminalTail` in the active terminal segment may be ignored.
+Complete unsupported required records fail closed because they may contain
+durable acknowledged writes.
+
+### 9.10 File Classes and Layout
+
+Collection WAL files are recognized only by the exact name pattern
+`collection-l<lane>-<seq>.log` and only in the main DB WAL directory.
+
+Root layout:
+
+- main DB: `<root>/maindb`
+- collection WAL: `<root>/maindb/wal/collection-l<lane>-<seq>.log`
+- commit WAL: `<root>/maindb/wal/commit-l<lane>-<seq>.log`
+- value log: `<root>/maindb/value_vlog/value-l<lane>-<seq>.log`
+- leaf log: `<root>/maindb/leaf_vlog/value-l<lane>-<seq>.log`
+- side stores: `<root>/dictdb`, `<root>/templatedb`
+
+Flat layout:
+
+- main DB: `<dir>`
+- collection WAL: `<dir>/wal/collection-l<lane>-<seq>.log`
+- side stores disabled unless explicitly migrated to root layout
+
+`dictdb` and `templatedb` must not contain collection WAL files. Legacy `wal-*`
+and `vlog-*` names are never collection WAL. Unknown `.log` files in a WAL
+directory are unsupported future files and must not be deleted or ignored when a
+required feature gate is present.
+
+### 9.11 Allocator Recovery
+
+The next `WALLSN` must be recovered from durable segment metadata plus every
+complete frame. The next `CollectionSeq` for a collection must be recovered from
+the collection descriptor, applied watermark, and every complete pending WAL
+transaction for that `CollectionUID`. Duplicate `WALLSN` or duplicate
+`(CollectionUID, CollectionSeq)` is fatal unless covered by an explicit legacy
+quarantine path. Gaps in `CollectionSeq` block later transactions for the same
+collection.
+
+## 10. File Naming Conventions
 
 Current canonical names:
 
 - commit log: `wal/commit-l<lane>-<seq>.log`
+- collection WAL: `wal/collection-l<lane>-<seq>.log`
 - value log: `value_vlog/value-l<lane>-<seq>.log`
 - split leaf log: `leaf_vlog/value-l<lane>-<seq>.log`
 
 Recovery parser also accepts legacy names (`commit-`, `value-`, `wal-`, `vlog-`) for backward compatibility during pre-alpha evolution.
+Legacy names are never collection WAL.
 
-## 10. Storage Compaction Lifecycle
+## 11. Storage Compaction Lifecycle
 
 `DB.CompactStorage` is the canonical online storage compaction entry point. It
 does not introduce a new on-disk format; it coordinates the existing storage

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -31,6 +31,11 @@ durable cleanup metadata before missing collection WAL segments can be treated
 as safely cleaned. `WALLSN` is not a replay skip key; recovery skips only by
 durable per-collection applied sequence watermarks.
 
+The operator restorable file set, live backup barrier, and restore validation
+procedure are defined in `TreeDB/docs/spec/backup-restore.md`. A live
+filesystem-level copy without that barrier is unsupported once collection WAL
+side refs can exist.
+
 ## 2. Index Page Basics
 
 ### 2.1 Fixed page size

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -1,6 +1,8 @@
 # TreeDB Storage Format
 
-This document defines the current on-disk and wire formats used by TreeDB.
+This document defines TreeDB's durable on-disk formats and local frame formats.
+The native client/server wire protocol is owned by
+`TreeDB/docs/spec/native-wire-protocol.md`.
 
 TreeDB is pre-alpha; format compatibility between versions is not guaranteed.
 That disclaimer does not permit fail-open handling of acknowledged durable
@@ -21,15 +23,20 @@ A TreeDB deployment uses:
   when `IndexOuterLeavesInValueLog` is enabled,
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
-Collection WAL is a distinct physical file class from the cached key/value
-commit log. Its byte envelope, feature gates, migration states, and cleanup
-metadata are defined in this document. The semantic write/recovery contract is
-defined in `TreeDB/docs/spec/collection-wal-durability-plan.md`. Collection WAL
-records use per-collection `CollectionSeq` dependency ordering, global `WALLSN`
-append positions only for scan/cleanup accounting, side-ref validation, and
-durable cleanup metadata before missing collection WAL segments can be treated
-as safely cleaned. `WALLSN` is not a replay skip key; recovery skips only by
-durable per-collection applied sequence watermarks.
+Collection WAL is a target storage class, not yet a current committed on-disk
+byte format. This document owns the reserved file class name
+`wal/collection-l<lane>-<seq>.log` plus the target local frame format once the
+M1 gate in `collection-wal-durability-plan.md` lands. Until then, the WAL plan
+owns the target logical transaction semantics. When M1 lands, exact frame
+bytes, checksums, commit markers, segment metadata, cleanup records, and golden
+encodings must be maintained here and mapped to tests in
+`TreeDB/docs/spec/verification.md`.
+
+Collection WAL records use per-collection `CollectionSeq` dependency ordering,
+global `WALLSN` append positions only for scan/cleanup accounting, side-ref
+validation, and durable cleanup metadata before missing collection WAL segments
+can be treated as safely cleaned. `WALLSN` is not a replay skip key; recovery
+skips only by durable per-collection applied sequence watermarks.
 
 The operator restorable file set, live backup barrier, and restore validation
 procedure are defined in `TreeDB/docs/spec/backup-restore.md`. A live
@@ -423,6 +430,8 @@ Validation rules:
 
 ## 9. Collection WAL v1 Segment and Frame Format
 
+This is the target local frame format for the M1 collection WAL gate. It is not
+current runtime behavior until `collection_wal_v1` is accepted and advertised.
 Collection WAL is a separate file class from the key/value commit log. It must
 not be decoded with the commit-log `Record` schema, and cached commit-log RID
 skip behavior must not apply to complete collection WAL transactions.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -515,25 +515,28 @@ The first root-delta byte is not before the fixed header and section table.
 |---:|---:|---|
 | 0 | 8 | `PayloadMagic` `54 44 42 43 57 50 31 01` (`TDBCWP1\x01`) |
 | 8 | 2 | `TransactionVersion`, currently `1` |
-| 10 | 2 | `FixedHeaderLen`, currently `192` |
+| 10 | 2 | `FixedHeaderLen`, currently `288` |
 | 12 | 4 | `TransactionFlags` |
 | 16 | 16 | `CollectionUID` |
 | 32 | 8 | `CollectionGeneration` |
 | 40 | 8 | `CollectionSeq` |
 | 48 | 8 | `DependsOnCollectionSeq` |
-| 56 | 8 | `SchemaEpoch` |
-| 64 | 8 | `SchemaVersion` |
-| 72 | 8 | `BaseCommitSeq` |
-| 80 | 8 | `BaseSystemRootID` |
-| 88 | 32 | `BaseCatalogDigest` |
-| 120 | 32 | `CatalogDigest` |
-| 152 | 4 | `MutationClass` |
-| 156 | 4 | `RootDeltaCount` |
-| 160 | 4 | `SideRefCount` |
-| 164 | 4 | `DescriptorOpCount` |
-| 168 | 4 | `SectionCount` |
-| 172 | 4 | `FixedHeaderCRC32C` over `[0,192)`, with this field zeroed |
-| 176 | 16 | reserved zero |
+| 56 | 8 | `CatalogEpoch` |
+| 64 | 8 | `SchemaEpoch` |
+| 72 | 8 | `SchemaVersion` |
+| 80 | 8 | `BaseCommitSeq` |
+| 88 | 8 | `BaseSystemRootID` |
+| 96 | 32 | `BaseCatalogDigest` |
+| 128 | 32 | `CatalogDigest` |
+| 160 | 32 | `LogicalCatalogDigest` |
+| 192 | 32 | `LocalReplayCatalogDigest` |
+| 224 | 4 | `MutationClass` |
+| 228 | 4 | `RootDeltaCount` |
+| 232 | 4 | `SideRefCount` |
+| 236 | 4 | `DescriptorOpCount` |
+| 240 | 4 | `SectionCount` |
+| 244 | 4 | `FixedHeaderCRC32C` over `[0,288)`, with this field zeroed |
+| 248 | 40 | reserved zero |
 
 V1 readers must validate in this order: segment magic, segment header
 length/version/min-reader, segment header CRC, frame magic, frame header
@@ -598,13 +601,16 @@ first root delta is the byte at `SectionOffset` for that section.
 ### 9.4 Root Delta and Side-Ref Section Constraints
 
 Root-delta sections are deterministic byte sequences. A root-delta table must
-carry root kind, root name, root descriptor epoch, storage policy,
+carry stable `RootRef` identity before any root-local entry payload:
+`CollectionUID`, `RootUID`, `RootKind`, optional `IndexUID`, optional
+`ColumnDescriptorUID`, `BaseRootID`, `BaseRootGeneration`,
+`BaseRootDescriptorEpoch`, `BaseRootDescriptorDigest`, storage policy,
 `RootDeltaOrdinal`, key comparator identity, delta encoding version,
-`IncludeDeletedOnColdBuild`, entry count, encoded byte length, and delta digest
-before the entry payload. Entries must encode operation kind, `EntryOrdinal`,
-key length, value length, and either inline value bytes, stable `ValuePtr`
-bytes, or a `RootDeltaPayload` side-ref index. Tombstones are first-class
-operations.
+`IncludeDeletedOnColdBuild`, entry count, encoded byte length, and delta digest.
+`RootName` may be present only as diagnostic text. Entries must encode
+operation kind, `EntryOrdinal`, key length, value length, and either inline
+value bytes, stable `ValuePtr` bytes, or a `RootDeltaPayload` side-ref index.
+Tombstones are first-class operations.
 
 Side refs encode `RefClass`, `ClassVersion`, `Critical`, `FileID`, `Offset`,
 `Length`, `ChecksumKind`, `Checksum`, and optional advisory `RelativePath`.
@@ -691,18 +697,60 @@ Every persisted collection descriptor must include:
 |---|---|
 | `CollectionUID uuid128` | durable identity; never derived from name |
 | `CollectionGeneration uint64` | increments on drop/recreate; rename preserves UID |
-| `SchemaEpoch uint64` | increments on schema/index descriptor changes |
+| `CatalogEpoch uint64` | increments on catalog metadata changes such as rename |
+| `SchemaEpoch uint64` | increments on mutation-planning, schema, index, template, or column descriptor changes |
 | `SchemaVersion uint64` | logical schema version if distinct from epoch |
-| `CatalogDigest bytes32` | digest of replay-relevant catalog descriptor |
-| `RootDescriptorEpochs` | per-root descriptor generation map |
-| `RootGeneration` | per-root physical generation guard |
+| `LogicalCatalogDigest bytes32` | deterministic digest of logical catalog descriptor for native/Raft guards |
+| `LocalReplayCatalogDigest bytes32` | digest of local replay descriptor; may include physical root IDs |
+| `RootDescriptors []RootDescriptorV1` | stable root descriptors keyed by `RootUID`, not root name |
+| `IndexDescriptors []IndexDescriptorV1` | stable index descriptors keyed by `IndexUID`, not index name |
 | `CollectionName` | diagnostic only; not replay identity |
 | `DroppedAtEpoch optional uint64` | tombstone for deleted collections |
+| `DropCollectionSeq optional uint64` | sequence/log position for drop tombstone |
+| `HighestAppliedSeqAtDrop optional uint64` | applied sequence known at drop time |
 
 Recovery must reject an unapplied collection WAL transaction when the recovered
 descriptor for its `CollectionUID` is absent, tombstoned, or has mismatching
-generation, schema epoch, catalog digest, or root descriptor epoch, unless an
-explicit migration record maps the old descriptor to a new one.
+generation, catalog epoch, schema epoch, catalog digest, root descriptor epoch,
+root descriptor digest, index UID/digest, or column descriptor generation,
+unless an explicit migration record maps the old descriptor to a new one.
+
+`RootDescriptorV1` fields:
+
+| Field | Meaning |
+|---|---|
+| `RootUID uuid128` | stable root identity |
+| `OwnerCollectionUID uuid128` | owning collection |
+| `RootKind enum` | primary, template, index-state, secondary, delete, locator, filter, column descriptor, etc. |
+| `LogicalName string` | diagnostic/API display only |
+| `IndexUID uuid128 optional` | secondary/index-owned root owner |
+| `ColumnDescriptorUID uuid128 optional` | column-owned root owner |
+| `RootGeneration uint64` | increments when the root descriptor is replaced |
+| `RootDescriptorEpoch uint64` | monotonic descriptor version |
+| `RootID uint64` | local physical root id |
+| `StoragePolicy uint8` | root storage policy |
+| `DescriptorDigest bytes32` | digest over canonical descriptor bytes |
+
+`IndexDescriptorV1` fields:
+
+| Field | Meaning |
+|---|---|
+| `IndexUID uuid128` | stable index identity |
+| `OwnerCollectionUID uuid128` | owning collection |
+| `Name string` | API/display name |
+| `IndexGeneration uint64` | increments on same-name recreate |
+| `CreatedAtSchemaEpoch uint64` | schema epoch at creation |
+| `DroppedAtSchemaEpoch optional uint64` | tombstone epoch |
+| `DefinitionDigest bytes32` | digest over name, field path, type, uniqueness, multikey, storage policy, collation/normalization, and owning schema epoch |
+| `FieldPath canonical` | canonical field path |
+| `ValueType enum` | indexed value type |
+| `Unique bool` | uniqueness flag |
+| `MultiKey bool` | multikey flag |
+| `StoragePolicy uint8` | secondary root storage policy |
+| `SecondaryRootUID uuid128` | root identity for the secondary index |
+
+Dropping an index tombstones the `IndexUID`. Recreating the same display name
+creates a new `IndexUID`, generation, root UID, and definition digest.
 
 ### 9.8 Durable Manifest Writes and Cleanup Metadata
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -20,9 +20,11 @@ The collection WAL format is proposed in
 `TreeDB/docs/spec/collection-wal-durability-plan.md`. It is a distinct logical
 record class from the cached key/value commit log. Collection WAL records need
 segment metadata, complete-frame checksums, transaction checksums, commit
-markers, per-collection sequence ordering, side-ref validation, and durable
-cleanup metadata before missing collection WAL segments can be treated as
-safely cleaned.
+markers, per-collection `CollectionSeq` dependency ordering, global `WALLSN`
+append positions for scan/cleanup accounting, side-ref validation, and durable
+cleanup metadata before missing collection WAL segments can be treated as safely
+cleaned. `WALLSN` is not a replay skip key; recovery skips only by durable
+per-collection applied sequence watermarks.
 
 ## 2. Index Page Basics
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -10,10 +10,19 @@ A TreeDB deployment uses:
 
 - `index.db` (paged B+Tree index and metadata),
 - commit-log segments under `wal/commit-l*.log`,
+- future collection WAL segments under `wal/collection-l*.log`,
 - value-log segments under `value_vlog/value-l*.log`,
 - optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
   when `IndexOuterLeavesInValueLog` is enabled,
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
+
+The collection WAL format is proposed in
+`TreeDB/docs/spec/collection-wal-durability-plan.md`. It is a distinct logical
+record class from the cached key/value commit log. Collection WAL records need
+segment metadata, complete-frame checksums, transaction checksums, commit
+markers, per-collection sequence ordering, side-ref validation, and durable
+cleanup metadata before missing collection WAL segments can be treated as
+safely cleaned.
 
 ## 2. Index Page Basics
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -475,7 +475,9 @@ Compression is not encoded by stealing bits from the length field. A compressed
 frame records both `CompressionCodec` and `RawPayloadLen`. Unknown compression
 codec on a required record fails closed. The frame header must be integrity
 checked before payload allocation, and `StoredPayloadLen`/`RawPayloadLen` must
-respect the configured collection WAL transaction limits.
+respect the fixed collection WAL transaction limits. In v1, both
+`StoredPayloadLen` and the encoded `CollectionWALTransaction` are capped at
+16,777,216 bytes. This cap is hard and non-disableable during recovery.
 
 The frame is committed only if the header, stored payload, and commit trailer
 are present and valid. The commit trailer is:
@@ -518,6 +520,35 @@ The first root-delta byte is not before the fixed header and section table.
 | 168 | 4 | `SectionCount` |
 | 172 | 4 | `FixedHeaderCRC32C` over `[0,192)`, with this field zeroed |
 | 176 | 16 | reserved zero |
+
+V1 readers must validate in this order: segment magic, segment header
+length/version/min-reader, segment header CRC, frame magic, frame header
+length/version/min-reader, length caps and overflow before allocation, frame
+header CRC, payload CRC, commit trailer, transaction fixed-header CRC, section
+CRCs, replay digest, and side-ref closure. No transaction-controlled string,
+slice, map, side-ref, root-delta, or decompression allocation may occur before
+the frame and transaction checksums pass. Unknown required versions, unknown
+critical sections, unknown replay-critical fields, unknown required features,
+unknown v1 `RefClass` values, and unknown compression codecs fail closed.
+
+V1 bounds are:
+
+| Field / structure | Bound |
+|---|---:|
+| Encoded transaction and outer frame payload | 16 MiB |
+| Segment size | 64 MiB default, 1 GiB absolute max |
+| Root deltas / mutated roots | 64 |
+| Inline root-delta bytes per transaction | 4 MiB |
+| Inline root-delta bytes per root | 1 MiB |
+| Root-delta payload side ref | 64 MiB |
+| Decoded root-delta entries per transaction | 262,144 |
+| Delta key / document ID | 16 KiB |
+| Inline delta value | 1 MiB |
+| Side refs per transaction | 16,384 |
+| Descriptor / system delta ops | 1,024 |
+| `RelativePath` | 512 bytes, 16 components, 128 bytes per component |
+| Compressed decoded bytes | 64 MiB |
+| Recovery heap budget | 128 MiB per DB open worker |
 
 The section table immediately follows the fixed header. Each section table entry
 is:
@@ -563,13 +594,24 @@ operations.
 
 Side refs encode `RefClass`, `ClassVersion`, `Critical`, `FileID`, `Offset`,
 `Length`, `ChecksumKind`, `Checksum`, and optional advisory `RelativePath`.
-Unknown critical `RefClass` or `ClassVersion` makes the transaction
-unsupported-required and recovery fails closed. Unknown noncritical refs may be
-ignored only if no replay-critical section references them and the transaction
-feature bits explicitly allow skipping them. Cleanup, GC, rewrite, and
-quarantine must treat unknown refs from complete unwatermarked transactions as
-protected until the transaction is watermarked and checkpointed or an operator
-performs a destructive rebuild.
+Known v1 `RefClass` values are `1=ValueLogRecord`, `2=LeafLogRecord`,
+`3=RootDeltaPayload`, `4=ColumnManifest`, `5=ColumnSubstreamFile`,
+`6=ColumnFilterFile`, `7=ColumnDeleteBitmapFile`,
+`8=ColumnDictionaryFile`, and `9=ColumnMetadataFile`; `0` is invalid. Any
+unknown `RefClass` in a complete v1 transaction is fatal. Future optional refs
+may be ignored only if no replay-critical section references them, canonical
+embedded side-ref derivation proves they are not root-reachable, and the
+transaction feature bits explicitly allow skipping them. Cleanup, GC, rewrite,
+and quarantine must treat unknown refs from complete unwatermarked transactions
+as protected until the transaction is watermarked and checkpointed or an
+operator performs a destructive rebuild.
+
+`RelativePath` is advisory validation data only. It must use `/` separators and
+reject NUL, empty path, `.`, `..`, repeated separators, absolute POSIX paths,
+Windows drive paths, UNC paths, backslashes, components longer than 128 bytes,
+more than 16 components, and total bytes over 512. Cleanup and quarantine must
+resolve deletion targets only through `(RefClass, RefID/FileID)` and the trusted
+file-class registry, never through WAL-provided path strings.
 
 ### 9.5 Required Storage Features and Compatibility Gates
 
@@ -671,17 +713,24 @@ segment boundary:
 
 | Outcome | Meaning |
 |---|---|
-| `CompleteSupported` | complete frame, supported required version, checksums valid |
-| `IncompleteTerminalTail` | incomplete frame in terminal active segment with no later non-cleaned segment |
-| `UnsupportedRequiredVersion` | complete frame or segment requires a newer reader |
+| `CompleteValid` | complete frame, supported required version, checksums valid |
+| `CompleteCorrupt` | complete frame with bad checksum, digest, impossible structure, unknown required field, or side-ref closure failure |
+| `TerminalIncompleteTail` | incomplete frame in terminal active segment with no later non-cleaned segment |
+| `NonTerminalShortRead` | short read before a later frame, in a sealed segment, or before a later non-cleaned segment |
+| `UnsupportedVersion` | complete frame or segment requires a newer reader |
 | `UnsupportedSkippableRecord` | record is explicitly noncritical and skippable |
-| `HardCorruption` | bad magic, CRC, digest, non-tail truncation, or impossible structure |
+| `MissingSegment` | segment is absent and no durable cleanup metadata covers every transaction it contained |
+| `DuplicateWALLSN` | duplicate global append location appears in complete frames |
+| `DuplicateCollectionSeq` | duplicate `(CollectionUID, CollectionSeq)` appears in complete frames |
 | `MaliciousLength` | length exceeds cap or overflows before allocation |
 | `MixedVersionSegment` | segment mixes versions without an explicit migration reader |
 
-Only `IncompleteTerminalTail` in the active terminal segment may be ignored.
-Complete unsupported required records fail closed because they may contain
-durable acknowledged writes.
+Only `TerminalIncompleteTail` in the active terminal segment may be ignored.
+`CompleteCorrupt`, `NonTerminalShortRead`, `UnsupportedVersion`,
+`MissingSegment`, `DuplicateWALLSN`, `DuplicateCollectionSeq`, and
+`MaliciousLength` fail database open or quarantine the affected collection
+before roots can be published. Missing transaction `N` blocks `N+1` for the
+same `CollectionUID`.
 
 ### 9.10 File Classes and Layout
 
@@ -707,6 +756,19 @@ Flat layout:
 and `vlog-*` names are never collection WAL. Unknown `.log` files in a WAL
 directory are unsupported future files and must not be deleted or ignored when a
 required feature gate is present.
+
+Collection WAL and collection side-file classes require safe local-file
+resolution. Open must fail before collection WAL recovery if the DB root,
+`maindb`, WAL directory, value-log directory, leaf-log directory, or collection
+side-file class root is a symlink, not owned by the effective DB user or
+configured DB owner, group-writable, world-writable, or not a directory.
+Collection WAL writers/readers/cleanup must use directory-fd based no-follow
+resolution where available, create new mutable files with exclusive create,
+`fstat` every opened file, require regular files under the expected class root,
+and require `nlink == 1` for new mutable WAL/side files. Cleanup, quarantine,
+and rewrite must unlink or rename only registry-resolved file names under the
+class-root fd; WAL-provided `RelativePath` can only validate, never select, a
+target.
 
 ### 9.11 Allocator Recovery
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -44,6 +44,15 @@ durable applied collection watermark, the root descriptors containing the refs
 are durable, and the value-log reachability tracker has incorporated those
 published roots or a full reachability scan has completed.
 
+Collection WAL protected value-log refs are also capacity charges. Admission,
+GC, rewrite, checkpoint, and cleanup must charge both the logical referenced
+bytes and the incremental retained segment bytes that cannot be deleted because
+of the protected ref. A tiny protected byte range that pins an otherwise
+collectible large value-log segment is charged by the retained segment debt, not
+only by the byte range. When protected value-log debt reaches the collection WAL
+soft threshold, maintenance is triggered; at the stop threshold, new collection
+writes block; at the hard threshold, new collection writes fail before ack.
+
 Collection read views are also retention roots. If a live `CollectionReadView`
 can reach a pending mutable, queued, or publishing unit that references a
 value-log record, GC and rewrite must retain that record even if the collection
@@ -70,7 +79,9 @@ Health states:
 blocked by collection WAL side refs. Required collection WAL blocker fields are
 `gc_blocked`, `gc_blocked_bytes`, `gc_blocked_segments`,
 `gc_blocked_side_refs`, `oldest_blocking_age_ms`, `blocking_txn_ids`,
-`blocking_side_refs`, and `blocking_reason`.
+`blocking_side_refs`, `blocking_reason`,
+`protected_side_ref_logical_bytes`, and
+`protected_side_ref_retained_segment_bytes`.
 
 ### 3.2 Incremental Accounting Fast Path
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -50,7 +50,29 @@ value-log record, GC and rewrite must retain that record even if the collection
 WAL transaction has already been applied and WAL-only protection is otherwise
 eligible for release.
 
-### 3.1 Incremental Accounting Fast Path
+### 3.1 Collection WAL Operator Runbook
+
+Operators must use `treemap collection-wal health --json` before manual cleanup,
+backup triage, compaction triage, or restart triage for a directory that has
+`collection_wal_v1` enabled.
+
+Health states:
+
+| State | Meaning | Operator rule |
+|---|---|---|
+| `clean` | no pending collection WAL, cleanup debt below threshold | restart, backup, compaction, and ordinary maintenance are safe under normal rules |
+| `pending` | committed WAL or protected side refs are required for recovery | restart and backup are safe only when the whole directory, collection WAL, and protected side refs are included; manual deletion is unsafe |
+| `recovery_required` | complete unapplied collection WAL exists | read-only open fails; take a whole-directory copy, then run read-write recovery |
+| `corrupt` | hard collection WAL or required side-ref failure | no manual deletion; preserve WAL, side refs, cleanup manifests, and artifacts; restore missing files or escalate |
+| `cleanup_debt` | data is durable but obsolete files remain | run checkpoint/cleanup; delete files only when `safe-delete` reports `safe_to_delete=true` |
+
+`ValueLogGC` and value-log rewrite reports must include whether bytes are
+blocked by collection WAL side refs. Required collection WAL blocker fields are
+`gc_blocked`, `gc_blocked_bytes`, `gc_blocked_segments`,
+`gc_blocked_side_refs`, `oldest_blocking_age_ms`, `blocking_txn_ids`,
+`blocking_side_refs`, and `blocking_reason`.
+
+### 3.2 Incremental Accounting Fast Path
 
 TreeDB maintains commit-time reference counters per value-log segment.
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -44,6 +44,12 @@ durable applied collection watermark, the root descriptors containing the refs
 are durable, and the value-log reachability tracker has incorporated those
 published roots or a full reachability scan has completed.
 
+Collection read views are also retention roots. If a live `CollectionReadView`
+can reach a pending mutable, queued, or publishing unit that references a
+value-log record, GC and rewrite must retain that record even if the collection
+WAL transaction has already been applied and WAL-only protection is otherwise
+eligible for release.
+
 ### 3.1 Incremental Accounting Fast Path
 
 TreeDB maintains commit-time reference counters per value-log segment.

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -27,9 +27,22 @@ Reachability is defined by pointer references found in index trees.
 - user tree,
 - system tree,
 - collection root trees referenced by system-tree descriptors under
-  `collections/root/...`.
+  `collections/root/...`,
+- committed but unapplied collection WAL side refs, once collection WAL is
+  implemented.
 
 Entries with `node.FlagPointer` and `IsValueLogFileID(ptr.FileID)` mark a segment as referenced.
+
+Collection WAL side refs are retention roots before they are reachable from
+published roots. GC and rewrite must consult the protected collection-WAL
+side-ref index and the side-ref prepare guard before deleting, truncating,
+rewriting, or moving value-log bytes. PR1 rewrite must skip value-log records
+protected only by collection WAL rather than patching WAL records in place.
+
+WAL-only protection may be released only after the transaction is covered by a
+durable applied collection watermark, the root descriptors containing the refs
+are durable, and the value-log reachability tracker has incorporated those
+published roots or a full reachability scan has completed.
 
 ### 3.1 Incremental Accounting Fast Path
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -1,6 +1,10 @@
 # Value-Log Lifecycle Specification
 
-This document defines the lifecycle of value-log segments and pointers.
+This document owns value-log and split leaf-log lifecycle. Generic
+collection-WAL side-ref preparation, protection, cleanup, and column-file
+side-ref closure are owned by `collection-wal-durability-plan.md`; this
+document specifies how value-log and leaf-log segments participate in that
+lifecycle.
 
 ## 1. Persistent Pointer Model
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -59,7 +59,47 @@ value-log record, GC and rewrite must retain that record even if the collection
 WAL transaction has already been applied and WAL-only protection is otherwise
 eligible for release.
 
-### 3.1 Collection WAL Operator Runbook
+### 3.1 Collection WAL Maintenance Barrier
+
+Every physical maintenance operation that can delete, rewrite, move, truncate,
+rename, or stop protecting value-log, leaf-log, side-payload, column,
+dictionary, or template bytes must acquire the backend collection WAL
+maintenance barrier before computing candidates.
+
+The barrier must:
+
+1. wait for active side-ref prepare guards to either commit/protect or
+   abort/classify;
+2. rebuild or refresh the protected side-ref index if recovery has not already
+   done so;
+3. return an immutable protection snapshot containing WAL-only refs, read-view
+   refs, pending publish refs, unclassified prepare groups, and active backup
+   manifest refs;
+4. hold a retention token until the operation has finished all destructive
+   steps.
+
+If the barrier cannot be acquired or recovery/protection state is incomplete,
+maintenance must fail closed. Dry-run may report debt but must not delete.
+
+Operation-specific rules:
+
+| Operation | Collection WAL precondition |
+|---|---|
+| `ValueLogGC` | Merge protected collection WAL value-log file IDs into the referenced set. A protected segment is not eligible even when no published root references it. |
+| `ValueLogRewriteOnline` | Source records protected solely by collection WAL must be skipped in PR1. Rewriting and patching collection WAL refs is forbidden until a separate crash-tested redirect protocol exists. |
+| `LeafGenerationGC` | Leaf-log generations referenced by collection WAL or collection read views are live generations. |
+| online index vacuum | Require collection WAL debt zero for the roots being rewritten, or publish/checkpoint dirty collection WAL first. A future root-remap maintenance WAL transaction may relax this only with crash tests. |
+| offline index vacuum | Reject dirty collection WAL and unclassified prepared side refs before read-only open. |
+| `CompactStorage` | The initial checkpoint must be collection-aware. If it reports collection WAL debt, compaction must abort before value-log rewrite, GC, leaf GC, index vacuum, or zero-byte cleanup. |
+| zero-byte cleanup | Check protected side-ref index and backup manifest pins before unlinking. |
+
+Maintenance lock order is: acquire backend `maintenanceMu`, acquire the
+collection WAL maintenance barrier, take the immutable protection snapshot and
+retention token, compute candidates, perform the destructive phase, then release
+the token. No collection WAL append lock may be held while acquiring backend
+publish locks.
+
+### 3.2 Collection WAL Operator Runbook
 
 Operators must use `treemap collection-wal health --json` before manual cleanup,
 backup triage, compaction triage, or restart triage for a directory that has
@@ -83,7 +123,7 @@ blocked by collection WAL side refs. Required collection WAL blocker fields are
 `protected_side_ref_logical_bytes`, and
 `protected_side_ref_retained_segment_bytes`.
 
-### 3.2 Incremental Accounting Fast Path
+### 3.3 Incremental Accounting Fast Path
 
 TreeDB maintains commit-time reference counters per value-log segment.
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -256,6 +256,15 @@ Required coverage:
 - `TestCollectionWALValueLogGCBlockedByPendingSideRef`
 - `TestCollectionWALValueLogGCReleasedAfterWatermarkCheckpoint`
 - `TestCollectionWALArtifactRedaction`
+- `TestCollectionWALModelDescriptorWatermarkSplitRejected`
+- `TestCollectionWALModelVisibleImpliesRecoverable`
+- `TestCollectionWALModelSideRefProtectHappensBeforeGuardRelease`
+- `TestCollectionWALModelDeterministicReplayDigest`
+- `TestCollectionWALModelStateClassifierExclusive`
+- `TestCollectionWALModelSkipUsesCollectionSeqOnly`
+- `TestCollectionWALModelMaintenanceGuardBlocksRewrite`
+- `TestCollectionWALModelRaftAppliedIndexRequiresLocalRecoverability`
+- `TestCollectionWALTypedPublishWrapperRejectsFreeFormSystemDelta`
 - `TestCollectionWALCostEstimatorMatchesEncoder`
 - `TestCollectionWALRootDeltaSpillThresholds`
 - `TestCollectionWALOversizedTransactionFailsBeforeAck`
@@ -268,6 +277,28 @@ Required coverage:
 - `TestCollectionWALSegmentRotationAndCheckpointRotation`
 - `TestCollectionWALDurableSyncBatchCaps`
 - `TestColumnWALSideRefCapacityLimits`
+
+Formal invariant mapping:
+
+| Invariant | Required evidence |
+|---|---|
+| `I1` gap-free sequence | `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied`; model transition test for missing lower same-collection sequence. |
+| `I2` WAL-before-visible | `TestCollectionWALModelVisibleImpliesRecoverable`; fault injection before/after side-ref prepare, WAL marker, and visible install. |
+| `I3` side refs before WAL | `TestCollectionWALPartialFrameAndMissingSideRefNoPhantomRoots`; side-ref closure fuzz target. |
+| `I4` WAL side-ref protection | `TestCollectionWALModelSideRefProtectHappensBeforeGuardRelease`; GC/rewrite interleaving model test. |
+| `I5` descriptor/watermark atomicity | `TestCollectionWALModelDescriptorWatermarkSplitRejected`; `TestCollectionWALTypedPublishWrapperRejectsFreeFormSystemDelta`. |
+| `I6` per-collection skip | `TestCollectionWALModelSkipUsesCollectionSeqOnly`; mixed-collection segment cleanup model test. |
+| `I7` whole-transaction publish | Indexed insert/update/delete recovery tests and root-group publish fault tests. |
+| `I8` checkpoint before cleanup | `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent`; cleanup manifest corruption fixtures. |
+| `I9` deterministic replay | `TestCollectionWALModelDeterministicReplayDigest`; replay accumulator property test comparing live and recovery digests. |
+| `I10` no double apply | Repeated recovery after `S4 Applied` watermark and crash-after-publish tests. |
+| `I11` maintenance serialized | `TestCollectionWALModelMaintenanceGuardBlocksRewrite`; value-log GC/rewrite blocked-by-pending-side-ref tests. |
+| `I12` Raft local metadata | `TestCollectionWALModelRaftAppliedIndexRequiresLocalRecoverability`; future Raft apply crash matrix. |
+| `I13` WAL-off exception | `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`; WAL-off model branch. |
+
+The invariant table is evidence only when each entry points to an executable Go
+test, model-checkable transition test, fuzz target, or generated proof artifact
+recorded in `artifacts/collection-wal/<milestone>/acceptance.json`.
 
 Acceptance artifacts:
 - The collection WAL gate requires exact byte fixtures, not only round-trip

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -221,9 +221,26 @@ Required coverage:
 - `TestCollectionWALFormatRejectsMalformedLengthBeforeAllocation`
 - `TestCollectionWALFormatRejectsHeaderPayloadReplayAndTrailerCRCMismatch`
 - `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers`
+- `TestCollectionWALOnRelaxedInsertAckBeforeFlushRecovers`
+- `TestCollectionWALOnRelaxedInsertBatchAckBeforeFlushRecovers`
+- `TestCollectionWALOnRelaxedUpdateBatchAckBeforeFlushRecovers`
+- `TestCollectionWALOnRelaxedDeleteBatchAckBeforeFlushRecovers`
+- `TestCollectionWALOnRelaxedCreateCollectionAckReopens`
+- `TestCollectionWALOnRelaxedCreateIndexBackfillAckReopens`
+- `TestCollectionWALOnRelaxedCreateIndexUniqueConflictNoSchemaAfterReopen`
 - `TestCollectionWALDurableNoIndexAckBeforeFlushRecovers`
 - `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`
+- `TestCollectionWALOffRelaxedBufferedInsertLostWithoutFlush`
+- `TestCollectionWALOffRelaxedFlushEstablishesReopenBoundary`
+- `TestCollectionWALOffRelaxedCheckpointDrainsKnownDomains`
+- `TestCollectionWALOffRelaxedCloseDrainsSuccessfulWrites`
 - `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility`
+- `TestCollectionWALSideRefFailureRejectsWriteBeforeVisibility`
+- `TestCollectionWALPostCommitVisibleInstallFailureCommitAmbiguous`
+- `TestCollectionWALPublishFailureReportedByFlushCheckpointClose`
+- `TestInsertBatchUniqueConflictBeforeWALLeavesNoPartialItems`
+- `TestUpdateBatchItemErrorBeforeWALLeavesNoPartialItems`
+- `TestDeleteBatchWALAppendFailureLeavesAllDocuments`
 - `TestCollectionWALIndexedInsertRecoverAtomically`
 - `TestCollectionWALIndexedUpdateChangedSecondaryRecoverAtomically`
 - `TestCollectionWALIndexedUpdateUnchangedSecondarySkipsSecondaryRootsAfterRecovery`
@@ -235,6 +252,13 @@ Required coverage:
 - `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent`
 - `TestCollectionWALGCRewriteCompactionSnapshotsProtectPendingSideRefs`
 - `TestCollectionWALCheckpointChosenRule`
+- `TestCollectionWALFlushPublishesAndAdvancesWatermark`
+- `TestCollectionWALFlushAllWaitsForAsyncPublishAndReopens`
+- `TestDBCheckpointPublishesPreCutCollectionWALAndReopens`
+- `TestDBCheckpointDoesNotReturnCleanWithUnpublishedPreCutDebt`
+- `TestDBCheckpointRacingWriteCut`
+- `TestDBCloseRacingInsertUpdateDeleteIndex`
+- `TestDBCloseSafeCleanupLeak`
 - `TestCollectionWALCloseSuccessfulWritesReopenVisible`
 - `TestCollectionWALReadOnlyOpenWithPendingWAL`
 - `TestCollectionWALStatsAppendSuccess`
@@ -277,6 +301,15 @@ Required coverage:
 - `TestCollectionWALSegmentRotationAndCheckpointRotation`
 - `TestCollectionWALDurableSyncBatchCaps`
 - `TestColumnWALSideRefCapacityLimits`
+- `TestNativewireInsertBatchWALAppendFailureNotCommitted`
+- `TestNativewireInsertBatchAckFlushedPublishFailureCommitAmbiguous`
+- `TestNativewireInsertBatchAckSyncedCheckpointFailureCommitAmbiguous`
+- `TestNativewireAckSyncedRejectedInWALOnRelaxed`
+- `TestNativewireResponseMetaActualAckAndCommitState`
+- `TestMongoGatewayInsertDocumentsDurabilityModeDocumented`
+- `TestMongoGatewayUpdateOrderedPartialSemantics`
+- `TestMongoGatewayDeleteOrderedPartialSemantics`
+- `TestMongoGatewayCreateIndexesUniqueConflictNoPartialSchema`
 
 Formal invariant mapping:
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -194,6 +194,25 @@ matrix:
 
 ## 11.5 Planned Collection WAL Durability Gate
 
+This section owns the canonical names of collection WAL acceptance tests. Design
+documents may list fault classes and invariants, but named tests and acceptance
+evidence are maintained here.
+
+Normative coverage matrix:
+
+| Normative statement | Owner section | Required test/evidence | Status |
+|---|---|---|---|
+| WAL-on visibility implies process-crash recoverability for enabled collection WAL capabilities. | `collection-wal-durability-plan.md` target durability contract | `TestCollectionWALNoIndexInsertAckBeforeFlushRecovers`, `TestCollectionWALNoIndexInsertBatchAckBeforeFlushRecovers`, full-contract indexed recovery tests | planned |
+| WAL append failure before commit marker is not visible. | `collection-wal-durability-plan.md` failure contract | `TestCollectionWALAppendFailureRejectsBeforeVisibility` | planned |
+| Post-commit failure returns commit-ambiguous/fatal, not an ordinary retryable mutation error. | `collection-wal-durability-plan.md` failure contract | `TestCollectionWALPostCommitVisibleInstallFailureCommitAmbiguous`, native-wire post-commit ack-failure tests | planned |
+| Missing required side ref for a complete WAL transaction is a recovery error. | `collection-wal-durability-plan.md` side-ref recovery | `TestCollectionWALPartialFrameAndMissingSideRefNoPhantomRoots`, `TestRecoveryMissingRequiredSideRefFailsHard` | planned |
+| Applied watermark advances only across contiguous applied collection sequence. | `collection-wal-durability-plan.md` watermark contract | `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied` | planned |
+| Root descriptors and applied watermark publish atomically. | `collection-wal-durability-plan.md` recovery states | `TestCollectionWALDescriptorAndWatermarkPublishAtomically`, `TestCollectionWALModelDescriptorWatermarkSplitRejected` | planned |
+| Drop/recreate with the same collection name does not replay old transactions. | `collection-wal-durability-plan.md` identity guards | `TestCollectionWALCollectionUIDDropRecreateDoesNotReplayByName` | planned |
+| Direct publish, disabled-memtable, and large-batch paths cannot bypass WAL-on guards. | `collection-wal-durability-plan.md` write-path coverage | `TestCollectionWALDirectPublishAndDisabledMemtablePathsCannotBypassWAL` | planned |
+| Read views pin pending value-log, leaf-log, and future column side refs until released. | `collection-wal-durability-plan.md`, `value-log-lifecycle.md` | `TestCollectionWALReadViewPinsLeafAndColumnSideRefs` | planned |
+| Raft/local recoverability is not reported before local collection WAL durability. | `collection-wal-durability-plan.md`, `native-query-raft-roadmap.md` | `TestRaftApplyDoesNotAdvanceLocalRecoverableBeforeCollectionWAL` | future |
+
 Invariant:
 - Current indexed collection writes remain flush-boundary durable until the
   full indexed collection WAL implementation lands.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -237,6 +237,25 @@ Required coverage:
 - `TestCollectionWALCheckpointChosenRule`
 - `TestCollectionWALCloseSuccessfulWritesReopenVisible`
 - `TestCollectionWALReadOnlyOpenWithPendingWAL`
+- `TestCollectionWALStatsAppendSuccess`
+- `TestCollectionWALStatsAppendFailureBeforeCommit`
+- `TestCollectionWALStatsExpvarWhitelist`
+- `TestCollectionWALStatsNativeWire`
+- `TestCollectionWALErrorCategoriesStable`
+- `TestCollectionWALRedaction`
+- `TestCollectionWALMetricMonotonicity`
+- `TestRecoveryMissingRequiredSideRefFailsHard`
+- `TestRecoveryCorruptRequiredSideRefFailsHard`
+- `TestRecoveryUnsupportedVersionFailsWithCategory`
+- `TestRecoveryCleanupFailureSafeLeak`
+- `TestCollectionWALHealthCleanGolden`
+- `TestCollectionWALHealthPendingGolden`
+- `TestCollectionWALSafeDeleteDryRunGolden`
+- `TestCollectionWALTxnLookupGolden`
+- `TestVerifyCollectionWALSideRefsGolden`
+- `TestCollectionWALValueLogGCBlockedByPendingSideRef`
+- `TestCollectionWALValueLogGCReleasedAfterWatermarkCheckpoint`
+- `TestCollectionWALArtifactRedaction`
 
 Acceptance artifacts:
 - The collection WAL gate requires exact byte fixtures, not only round-trip
@@ -260,8 +279,81 @@ Acceptance artifacts:
 - Benchmark artifacts must include the storage matrix above, baseline/new
   `benchstat` output, required metric rows from
   `collection-wal-durability-plan.md`, and the pass/fail decision.
+- Benchmark artifacts must include a JSON record with `durability_mode`,
+  `sync_policy`, `segment_size_bytes`, `batch_docs`, `doc_size_bytes`,
+  `side_ref_classes`, `collection_count`, `backend`, `go_version`, and
+  `commit`. Required metric names include `collection_wal_append_ns/doc`,
+  `collection_wal_bytes/doc`, `collection_wal_docs/sec`,
+  `collection_wal_side_refs/doc`, `pending_collection_wal_bytes`,
+  `applied_watermark_lag_txns`, `gc_protected_side_ref_bytes`,
+  `cleanup_ns/segment`, `recovery_docs/sec`,
+  `recovery_root_delta_entries/sec`, `recovery_peak_heap_bytes`, `allocs/doc`,
+  and `bytes_allocated/doc`.
+- Collection WAL observability tests must prove every required metric is emitted
+  on successful append, append failure before commit marker, replay success,
+  incomplete-tail skip, missing side-ref hard failure, and cleanup failure after
+  watermark/checkpoint.
 - Production persistent column-store writes may start only after the M7
   column-store sign-off artifact links to green M1-M6 collection WAL evidence.
+
+Required non-mutating collection WAL CLI tooling:
+
+- `treemap collection-wal health --dir <db> --json` reports `db_dir_hash`,
+  `format_version`, `generated_at_unix_nano`, `overall_state`,
+  `safe_to_restart`, `safe_to_backup`, `safe_to_compact`,
+  `requires_recovery`, `requires_operator_action`, `metrics`, `collections`,
+  `segments`, `pending_transactions`, `protected_side_refs`, `cleanup_debt`,
+  `gc_blockers`, `last_recovery`, and `errors`.
+- `treemap collection-wal safe-delete --dir <db> --json --dry-run` classifies
+  files without mutation. Per-file fields are `file_id`, `relative_path`,
+  `path_hash`, `class`, `bytes`, `status`, `safe_to_delete`, `delete_reason`,
+  `blocking_reason`, `blocking_txn_ids`, `blocking_collection_uid_hashes`,
+  `blocking_side_ref_ids`, `blocking_snapshot_ids`, `requires_checkpoint`,
+  `requires_recovery`, and `requires_quarantine`.
+- `treemap collection-wal txn --dir <db> --txn-id <id> --json` and
+  `treemap collection-wal txn --dir <db> --wallsn <n> --json` map one
+  transaction to `txn_id`, `wallsn`, `segment_id`, `segment_offset`,
+  `collection_uid`, `collection_uid_hash`, `collection_generation`,
+  `collection_seq`, `depends_on_collection_seq`, `schema_epoch`,
+  `catalog_epoch`, `base_root_id`, `base_root_digest`, `root_name_hashes`,
+  `root_delta_count`, `side_refs`, `record_checksum_crc32c`, `replay_digest`,
+  `applied_watermark_seq`, `watermark_state`, `replay_state`, and
+  `cleanup_state`.
+- `verify --dir <db> --read-only --collection-wal --side-refs --json` verifies
+  collection WAL side-ref closure without mutation. JSON fields include
+  `collection_wal_checked`, `roots_checked`, `root_deltas_checked`,
+  `side_refs_declared`, `side_refs_canonical`, `side_refs_present`,
+  `side_refs_missing`, `side_refs_corrupt`, `side_ref_closure_errors`,
+  `watermark_errors`, `cleanup_manifest_errors`, and `result`.
+  It must detect declared/canonical side-ref mismatches, missing side-ref files,
+  checksum/digest mismatches, roots that point past the applied watermark, and
+  cleanup manifests that claim safe deletion while a root or pending WAL
+  transaction still references the side file.
+- `treemap collection-wal classify --dir <db> --json` parses collection WAL
+  segment headers, frames, decoder outcomes, error categories, side-ref
+  summaries, and redacted transaction summaries. The existing `wal_classify`
+  value-log-oriented command must either be renamed to `vlog_classify` or kept
+  explicitly documented as value-log-only to avoid operator confusion.
+
+Required safe-delete statuses are `safe_cleaned_segment`,
+`pending_collection_wal`, `protected_side_ref`, `orphan_prepared_side_ref`,
+`missing_required_side_ref`, `corrupt_required_side_ref`,
+`cleanup_manifest_required`, `snapshot_pinned`, and `unknown_unclassified`.
+
+The collection WAL verification mode is read-only by default. Any repair,
+vacuum, cleanup, or quarantine mutation must require an explicit mutating flag
+such as `--repair`, `--vacuum-index`, or a future `--mutate`.
+
+Docs lint should enforce the observability contract once the collection WAL
+implementation starts. Required lint checks:
+
+- `collection-wal-durability-plan.md` contains the stable
+  `treedb.collection_wal.` metric prefix table;
+- `recovery.md` contains the stable recovery error category table;
+- `verification.md` contains the required `treemap collection-wal health`,
+  `safe-delete`, `txn`, `classify`, and `verify --collection-wal` command names;
+- the operator runbook states include `clean`, `pending`, `recovery_required`,
+  `corrupt`, and `cleanup_debt`.
 
 ## 12. Collections Document Formats
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -196,10 +196,13 @@ matrix:
 
 Invariant:
 - Current indexed collection writes remain flush-boundary durable until the
-  collection WAL implementation lands.
-- Under the collection WAL PR1 contract, WAL-on collection write visibility
-  implies crash recoverability from either backend roots or a committed
-  collection WAL transaction.
+  full indexed collection WAL implementation lands.
+- Under the PR1-min guarded `NoIndexRowInsertOnly` capability, WAL-on
+  no-index row insert visibility implies crash recoverability from either
+  backend roots or a committed collection WAL transaction.
+- Under the full collection WAL contract, the same visibility-implies-
+  recoverability rule extends to indexed writes, update/delete, schema/index
+  barriers, async publishing, and future column roots.
 - Under `DurabilityWALOffRelaxed`, acknowledged writes before flush are not
   promised after process crash, and collection WAL files must not be created for
   unflushed writes.
@@ -207,34 +210,55 @@ Invariant:
   atomically, validate declared and embedded side refs, and clean only after a
   safe watermark plus checkpoint boundary.
 
-Required coverage:
+PR1-min required coverage:
+
 - `TestCollectionWALFormatGoldenV1EmptySegment`
 - `TestCollectionWALFormatGoldenV1NoIndexInlineRootDelta`
-- `TestCollectionWALFormatGoldenV1ValueLeafAndRootDeltaSideRefs`
 - `TestCollectionWALFormatGoldenV1DescriptorOpAndWatermark`
-- `TestCollectionWALFormatGoldenV1LargeRootDeltaSidePayload`
-- `TestCollectionWALFormatGoldenV1TombstoneDelete`
-- `TestCollectionWALFormatGoldenV1CleanupRecordAndSegmentMetadata`
 - `TestCollectionWALFormatRejectsUnsupportedRequiredVersion`
 - `TestCollectionWALFormatRejectsUnknownCriticalSection`
 - `TestCollectionWALFormatSkipsUnknownNonCriticalSectionOnlyWhenAllowed`
 - `TestCollectionWALFormatRejectsMalformedLengthBeforeAllocation`
 - `TestCollectionWALFormatRejectsHeaderPayloadReplayAndTrailerCRCMismatch`
-- `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers`
-- `TestCollectionWALOnRelaxedInsertAckBeforeFlushRecovers`
-- `TestCollectionWALOnRelaxedInsertBatchAckBeforeFlushRecovers`
+- `TestCollectionWALNoIndexInsertAckBeforeFlushRecovers`
+- `TestCollectionWALNoIndexInsertBatchAckBeforeFlushRecovers`
+- `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`
+- `TestCollectionWALAppendFailureRejectsBeforeVisibility`
+- `TestCollectionWALCrashAfterCommitBeforePublishRecovers`
+- `TestCollectionWALCrashAfterPublishBeforeResponseIsIdempotent`
+- `TestCollectionWALDescriptorAndWatermarkPublishAtomically`
+- `TestCollectionWALCollectionUIDDropRecreateDoesNotReplayByName`
+- `TestCollectionWALReadOnlyOpenWithPendingWALFails`
+- `TestCollectionWALInlineCapRejectsBeforeVisibility`
+- `TestCollectionWALMissingUncleanedSegmentFailsOpen`
+- `TestCollectionWALIndexedSchemaUnsupportedBeforeStaging`
+- `TestCollectionWALIndexedAsyncUnsupported`
+- `TestCollectionWALUpdateUnsupportedBeforeMutation`
+- `TestCollectionWALDeleteUnsupportedBeforeMutation`
+- `TestCollectionWALValueLogPointerizationUnsupportedBeforeVisibility`
+- `TestCollectionWALColumnRootKindUnsupported`
+- `TestCollectionWALRootDeltaPayloadUnsupported`
+- `TestCollectionWALWALOffDoesNotCreateCollectionWAL`
+- `TestCollectionWALCheckpointRetainsSegments`
+- `TestCollectionWALCloseRetainsSegments`
+- `TestCollectionWALCleanupDisabledInPR1`
+- current flush-boundary regression tests remain green with the feature off.
+
+Full-contract required coverage:
+
+- `TestCollectionWALFormatGoldenV1ValueLeafAndRootDeltaSideRefs`
+- `TestCollectionWALFormatGoldenV1LargeRootDeltaSidePayload`
+- `TestCollectionWALFormatGoldenV1TombstoneDelete`
+- `TestCollectionWALFormatGoldenV1CleanupRecordAndSegmentMetadata`
 - `TestCollectionWALOnRelaxedUpdateBatchAckBeforeFlushRecovers`
 - `TestCollectionWALOnRelaxedDeleteBatchAckBeforeFlushRecovers`
 - `TestCollectionWALOnRelaxedCreateCollectionAckReopens`
 - `TestCollectionWALOnRelaxedCreateIndexBackfillAckReopens`
 - `TestCollectionWALOnRelaxedCreateIndexUniqueConflictNoSchemaAfterReopen`
-- `TestCollectionWALDurableNoIndexAckBeforeFlushRecovers`
-- `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`
 - `TestCollectionWALOffRelaxedBufferedInsertLostWithoutFlush`
 - `TestCollectionWALOffRelaxedFlushEstablishesReopenBoundary`
 - `TestCollectionWALOffRelaxedCheckpointDrainsKnownDomains`
 - `TestCollectionWALOffRelaxedCloseDrainsSuccessfulWrites`
-- `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility`
 - `TestCollectionWALSideRefFailureRejectsWriteBeforeVisibility`
 - `TestCollectionWALPostCommitVisibleInstallFailureCommitAmbiguous`
 - `TestCollectionWALPublishFailureReportedByFlushCheckpointClose`

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -256,6 +256,18 @@ Required coverage:
 - `TestCollectionWALValueLogGCBlockedByPendingSideRef`
 - `TestCollectionWALValueLogGCReleasedAfterWatermarkCheckpoint`
 - `TestCollectionWALArtifactRedaction`
+- `TestCollectionWALCostEstimatorMatchesEncoder`
+- `TestCollectionWALRootDeltaSpillThresholds`
+- `TestCollectionWALOversizedTransactionFailsBeforeAck`
+- `TestCollectionWALPendingDebtSoftStopHardLimits`
+- `TestCollectionWALBackpressureResumeWatermark`
+- `TestCollectionWALReplayAccumulatorSoftCapChunksOrSpills`
+- `TestCollectionWALReplayAccumulatorHardCapStopsRecovery`
+- `TestCollectionWALProtectedSideRefRetainedSegmentDebt`
+- `TestCollectionWALCleanupDebtBackpressure`
+- `TestCollectionWALSegmentRotationAndCheckpointRotation`
+- `TestCollectionWALDurableSyncBatchCaps`
+- `TestColumnWALSideRefCapacityLimits`
 
 Acceptance artifacts:
 - The collection WAL gate requires exact byte fixtures, not only round-trip
@@ -289,6 +301,26 @@ Acceptance artifacts:
   `cleanup_ns/segment`, `recovery_docs/sec`,
   `recovery_root_delta_entries/sec`, `recovery_peak_heap_bytes`, `allocs/doc`,
   and `bytes_allocated/doc`.
+- Resource-budget benchmark artifacts must include the phase-isolated columns
+  from `collection-wal-durability-plan.md`: mutation class, storage cell,
+  document format, doc bytes, key/value bytes, root deltas/transaction,
+  root-delta entries/doc, root-delta payload bytes/doc, collection WAL frame and
+  metadata bytes/doc, compressed bytes/doc, root-delta side-payload bytes/doc,
+  side-ref metadata bytes/doc, side-ref payload bytes/doc, protected side-ref
+  retained segment bytes, pending WAL bytes, pending side-payload bytes,
+  cleanable WAL bytes, cleanup debt bytes, applied watermark lag, oldest
+  unapplied age, ack p50/p95/p99, encode/append/prepare/publish/checkpoint
+  phase timings, sync batch txns/bytes, fsyncs/sec, recovery scan MB/sec,
+  recovery side refs/sec, peak heap/RSS, replay spill bytes, cleanup bytes/sec,
+  blocked writes, backpressure wait p99, and error count.
+- The benchmark gate fails when required columns are missing, when
+  formula-derived bytes/doc is exceeded by more than 10 percent, or when an
+  absolute ceiling from the resource accounting section is exceeded, even when
+  relative `benchstat` regression thresholds pass.
+- Required resource benchmark commands include
+  `cmd/collection_workload_bench`, `cmd/collection_bench_matrix`, and
+  `cmd/collection_bench_report`, or an equivalent `cmd/unified_bench`
+  collection WAL suite that emits the same schema.
 - Collection WAL observability tests must prove every required metric is emitted
   on successful append, append failure before commit marker, replay success,
   incomplete-tail skip, missing side-ref hard failure, and cleanup failure after

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -192,6 +192,49 @@ matrix:
 - `data_outer=false,index_outer=false` (fast/control),
 - `data_outer=false,index_outer=true` (low-priority compatibility cell).
 
+## 11.5 Planned Collection WAL Durability Gate
+
+Invariant:
+- Current indexed collection writes remain flush-boundary durable until the
+  collection WAL implementation lands.
+- Under the collection WAL PR1 contract, WAL-on collection write visibility
+  implies crash recoverability from either backend roots or a committed
+  collection WAL transaction.
+- Under `DurabilityWALOffRelaxed`, acknowledged writes before flush are not
+  promised after process crash, and collection WAL files must not be created for
+  unflushed writes.
+- Collection WAL recovery must publish root groups and applied watermarks
+  atomically, validate declared and embedded side refs, and clean only after a
+  safe watermark plus checkpoint boundary.
+
+Required coverage:
+- `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers`
+- `TestCollectionWALDurableNoIndexAckBeforeFlushRecovers`
+- `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`
+- `TestCollectionWALAppendFailureRejectsWriteBeforeVisibility`
+- `TestCollectionWALIndexedInsertRecoverAtomically`
+- `TestCollectionWALIndexedUpdateChangedSecondaryRecoverAtomically`
+- `TestCollectionWALIndexedUpdateUnchangedSecondarySkipsSecondaryRootsAfterRecovery`
+- `TestCollectionWALIndexedDeleteRecoverAtomically`
+- `TestCollectionWALUniqueReuseAfterDeleteRecovery`
+- `TestCollectionWALBufferedSameBaseRootTransactionsReplayByAccumulator`
+- `TestCollectionWALPartialFrameAndMissingSideRefNoPhantomRoots`
+- `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied`
+- `TestCollectionWALRecoveryCrashAndCleanupAreIdempotent`
+- `TestCollectionWALGCRewriteCompactionSnapshotsProtectPendingSideRefs`
+- `TestCollectionWALCheckpointChosenRule`
+- `TestCollectionWALCloseSuccessfulWritesReopenVisible`
+- `TestCollectionWALReadOnlyOpenWithPendingWAL`
+
+Acceptance artifacts:
+- Every completed milestone must write
+  `artifacts/collection-wal/<milestone>/acceptance.json`.
+- Benchmark artifacts must include the storage matrix above, baseline/new
+  `benchstat` output, required metric rows from
+  `collection-wal-durability-plan.md`, and the pass/fail decision.
+- Production persistent column-store writes may start only after the M7
+  column-store sign-off artifact links to green M1-M6 collection WAL evidence.
+
 ## 12. Collections Document Formats
 
 Invariant:

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -392,6 +392,77 @@ Acceptance artifacts:
 - Production persistent column-store writes may start only after the M7
   column-store sign-off artifact links to green M1-M6 collection WAL evidence.
 
+Required collection WAL hardening fuzz targets:
+
+- `FuzzCollectionWALDecodeTransaction`;
+- `FuzzCollectionWALDecodeTransactionNoPreChecksumAlloc`;
+- `FuzzCollectionWALDecodeSideRefs`;
+- `FuzzCollectionWALDecodeRootDelta`;
+- `FuzzCollectionWALRootDeltaPayloadStreaming`;
+- `FuzzCollectionWALRecoveryOrdering`;
+- `FuzzCollectionWALUnknownFieldsAndRefClasses`;
+- `FuzzCollectionWALPathCanonicalize`;
+- `FuzzCollectionWALValuePtrSideRefs`;
+- `FuzzNativeWireCollectionCommandToWALPlan`.
+
+Required fuzz properties: no panic, bounded allocation, no root publish on
+invalid bytes, no file deletion/quarantine from invalid bytes, deterministic
+error class for identical input, and no skip of a complete corrupt transaction
+in favor of a later same-collection transaction.
+
+Required collection WAL hardening fixtures and tests:
+
+- `TestCollectionWALMaxEncodedTxnRejectsBeforeAlloc`;
+- `TestCollectionWALFrameLengthOverflowRejects`;
+- `TestCollectionWALVarintOverflowRejects`;
+- `TestCollectionWALRootDeltaCountLimitRejects`;
+- `TestCollectionWALSideRefCountLimitRejects`;
+- `TestCollectionWALDuplicateSideRefConflictingChecksumRejects`;
+- `TestCollectionWALUnknownRequiredRefClassFatal`;
+- `TestCollectionWALUnknownOptionalRefClassCannotCleanup`;
+- `TestCollectionWALBadFrameCRCCompleteRecordFailsOpen`;
+- `TestCollectionWALBadTxnCRCCompleteRecordFailsOpen`;
+- `TestCollectionWALTruncatedActiveTailIgnoredOnlyWithoutCommitMarker`;
+- `TestCollectionWALTruncatedSealedSegmentFailsOpen`;
+- `TestCollectionWALMiddleCorruptionBlocksLaterSeq`;
+- `TestCollectionWALMissingSeqNBlocksSeqNPlusOne`;
+- `TestCollectionWALDropRecreateSameNameDifferentUIDRejectsOldTxn`;
+- `TestCollectionWALRootNameOutsideCatalogSetRejects`;
+- `TestCollectionWALPublishRequiresAllChecks`;
+- `TestCollectionWALSideRefRelativePathDotDotRejects`;
+- `TestCollectionWALSideRefRelativePathAbsoluteRejects`;
+- `TestCollectionWALSideRefRelativePathWindowsDriveRejects`;
+- `TestCollectionWALSideRefRelativePathUNCRejects`;
+- `TestCollectionWALSideRefRelativePathBackslashRejects`;
+- `TestCollectionWALSideRefRelativePathNULRejects`;
+- `TestCollectionWALSideRefRelativePathEmptyComponentRejects`;
+- `TestCollectionWALSideRefPathFileIDMismatchRejects`;
+- `TestCollectionWALCollectionNameNeverUsedAsPath`;
+- `TestCollectionWALOpenRejectsSymlinkDBRoot`;
+- `TestCollectionWALOpenRejectsSymlinkWALDir`;
+- `TestCollectionWALOpenRejectsWorldWritableWALDir`;
+- `TestCollectionWALOpenRejectsGroupWritableClassRoot`;
+- `TestCollectionWALSideRefOpenRejectsSymlinkComponent`;
+- `TestCollectionWALSideRefOpenRejectsSymlinkFinalFile`;
+- `TestCollectionWALSideRefCleanupDoesNotFollowSymlink`;
+- `TestCollectionWALSideRefCleanupRejectsHardlink`;
+- `TestCollectionWALPreparedRenameRejectsCrossDevice`;
+- `TestCollectionWALLockfileRejectsSymlink`;
+- `TestCollectionWALNoAllocBeforeChecksumForHugeRootCount`;
+- `TestCollectionWALNoAllocBeforeChecksumForHugeSideRefCount`;
+- `TestCollectionWALNoAllocBeforeChecksumForHugeStringLength`;
+- `TestCollectionWALCompressedRawLenBombRejectsBeforeDecode`;
+- `TestCollectionWALOffsetSizeOverflowRejects`;
+- `TestCollectionWALUint64ToInt64OffsetOverflowRejects`;
+- `TestCollectionWALLimitsMaxRecordSizeDisabledDoesNotDisableWALCap`;
+- `TestCollectionWALNativeWire64MiBCommandSpillsOrRejectsBeforeSideEffects`;
+- `TestCollectionWALCorruptErrorRedactsCollectionName`;
+- `TestCollectionWALMissingSideRefErrorRedactsRelativePathUnlessAdmin`;
+- `TestCollectionWALDuplicateKeyErrorRedactsDocumentID`;
+- `TestNativeWireErrorRedactsDocuments`;
+- `TestCollectionWALMetricsUseUIDAndHashesNotNames`;
+- `TestForensicToolRawOutputRequiresExplicitFlag`.
+
 Required non-mutating collection WAL CLI tooling:
 
 - `treemap collection-wal health --dir <db> --json` reports `db_dir_hash`,

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -209,8 +209,10 @@ Normative coverage matrix:
 | Applied watermark advances only across contiguous applied collection sequence. | `collection-wal-durability-plan.md` watermark contract | `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied` | planned |
 | Root descriptors and applied watermark publish atomically. | `collection-wal-durability-plan.md` recovery states | `TestCollectionWALDescriptorAndWatermarkPublishAtomically`, `TestCollectionWALModelDescriptorWatermarkSplitRejected` | planned |
 | Drop/recreate with the same collection name does not replay old transactions. | `collection-wal-durability-plan.md` identity guards | `TestCollectionWALCollectionUIDDropRecreateDoesNotReplayByName` | planned |
+| Root, index, and catalog replay identity use stable UIDs/generations/digests, not names. | `collection-wal-durability-plan.md` identity guards, `storage-format.md` descriptor records | `TestCollectionWALCatalogDescriptorPersistsUIDGenerationEpochDigests`, `TestCollectionWALRootRefRejectsNameOnlyIdentity`, `TestCollectionWALIndexSameNameRecreateUsesNewUID` | planned |
 | Direct publish, disabled-memtable, and large-batch paths cannot bypass WAL-on guards. | `collection-wal-durability-plan.md` write-path coverage | `TestCollectionWALDirectPublishAndDisabledMemtablePathsCannotBypassWAL` | planned |
 | Read views pin pending value-log, leaf-log, and future column side refs until released. | `collection-wal-durability-plan.md`, `value-log-lifecycle.md` | `TestCollectionWALReadViewPinsLeafAndColumnSideRefs` | planned |
+| Native-wire replicated mutations carry `CatalogGuardV1` with resolved stable identities. | `native-wire-protocol.md` catalog guard section | `TestNativeWireCatalogGuardV1CanonicalizesStableIDs`, `TestNativeWireNameDropRecreateRaceDeterministicGuardFailure` | future |
 | Raft/local recoverability is not reported before local collection WAL durability. | `collection-wal-durability-plan.md`, `native-query-raft-roadmap.md` | `TestRaftApplyDoesNotAdvanceLocalRecoverableBeforeCollectionWAL` | future |
 
 Invariant:
@@ -246,6 +248,8 @@ PR1-min required coverage:
 - `TestCollectionWALCrashAfterCommitBeforePublishRecovers`
 - `TestCollectionWALCrashAfterPublishBeforeResponseIsIdempotent`
 - `TestCollectionWALDescriptorAndWatermarkPublishAtomically`
+- `TestCollectionWALCatalogDescriptorPersistsUIDGenerationEpochDigests`
+- `TestCollectionWALRootRefRejectsNameOnlyIdentity`
 - `TestCollectionWALCollectionUIDDropRecreateDoesNotReplayByName`
 - `TestCollectionWALReadOnlyOpenWithPendingWALFails`
 - `TestCollectionWALInlineCapRejectsBeforeVisibility`
@@ -289,6 +293,13 @@ Full-contract required coverage:
 - `TestCollectionWALIndexedUpdateUnchangedSecondarySkipsSecondaryRootsAfterRecovery`
 - `TestCollectionWALIndexedDeleteRecoverAtomically`
 - `TestCollectionWALUniqueReuseAfterDeleteRecovery`
+- `TestCollectionWALIndexSameNameRecreateUsesNewUID`
+- `TestCollectionWALSchemaChangeDrainsLowerSeqBeforeVisible`
+- `TestCollectionWALDropIndexWithPendingOldIndexUIDCannotResurrectRoot`
+- `TestCollectionWALTemplateRootGuardRequired`
+- `TestCollectionWALTemplatePrimaryAndTemplateRootRecoverAtomically`
+- `TestColumnPartDescriptorGenerationDigestGuards`
+- `TestColumnCompactionPublishesSupersessionAndTargetDescriptorsAtomically`
 - `TestCollectionWALBufferedSameBaseRootTransactionsReplayByAccumulator`
 - `TestCollectionWALPartialFrameAndMissingSideRefNoPhantomRoots`
 - `TestCollectionWALWatermarkOutOfOrderTxnDoesNotSkipLowerUnapplied`
@@ -470,7 +481,10 @@ Required collection WAL hardening fixtures and tests:
 - `TestCollectionWALMiddleCorruptionBlocksLaterSeq`;
 - `TestCollectionWALMissingSeqNBlocksSeqNPlusOne`;
 - `TestCollectionWALDropRecreateSameNameDifferentUIDRejectsOldTxn`;
-- `TestCollectionWALRootNameOutsideCatalogSetRejects`;
+- `TestCollectionWALRootRefOutsideCatalogSetRejects`;
+- `TestCollectionWALRootUIDKindGenerationMismatchRejects`;
+- `TestCollectionWALSchemaEpochMismatchRejects`;
+- `TestCollectionWALIndexDefinitionDigestMismatchRejects`;
 - `TestCollectionWALPublishRequiresAllChecks`;
 - `TestCollectionWALSideRefRelativePathDotDotRejects`;
 - `TestCollectionWALSideRefRelativePathAbsoluteRejects`;
@@ -481,6 +495,9 @@ Required collection WAL hardening fixtures and tests:
 - `TestCollectionWALSideRefRelativePathEmptyComponentRejects`;
 - `TestCollectionWALSideRefPathFileIDMismatchRejects`;
 - `TestCollectionWALCollectionNameNeverUsedAsPath`;
+- `TestNativeWireCatalogGuardV1CanonicalizesStableIDs`;
+- `TestNativeWireNameDropRecreateRaceDeterministicGuardFailure`;
+- `TestRaftMetadataIDsDeterministicAcrossReplicas`;
 - `TestCollectionWALOpenRejectsSymlinkDBRoot`;
 - `TestCollectionWALOpenRejectsSymlinkWALDir`;
 - `TestCollectionWALOpenRejectsWorldWritableWALDir`;

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -463,6 +463,36 @@ Required collection WAL hardening fixtures and tests:
 - `TestCollectionWALMetricsUseUIDAndHashesNotNames`;
 - `TestForensicToolRawOutputRequiresExplicitFlag`.
 
+Required collection WAL maintenance, backup, restore, and offline precondition
+tests:
+
+- `TestCollectionWALValueLogGCSkipsWALOnlySideRef`;
+- `TestCollectionWALValueLogRewriteSkipsProtectedWALOnlySource`;
+- `TestCollectionWALCompactStorageAbortsOnCheckpointDebt`;
+- `TestCollectionWALSideRefPrepareGuardBlocksGCWindow`;
+- `TestCollectionWALLeafGenerationGCKeepsPendingLeafRef`;
+- `TestCollectionWALVacuumOnlinePublishesOrRejectsDirtyWAL`;
+- `TestCollectionWALBackupBarrierCleanCheckpointRestoresWithoutWALDebt`;
+- `TestCollectionWALBackupBarrierWALSnapshotRestoresPendingTxn`;
+- `TestCollectionWALFilesystemBackupWithoutBarrierUnsupported`;
+- `TestCollectionWALBackupIncludesValueLeafDictTemplateAndColumnSideRefs`;
+- `TestCollectionWALRestoreFailsWhenWALTxnMissingSidePayload`;
+- `TestCollectionWALRestoreAcceptsMissingCleanedSegmentOnlyWithCleanupManifest`;
+- `TestReadOnlyOpenRejectsUnappliedCollectionWAL`;
+- `TestReadOnlyOpenAllowsCleanCollectionWAL`;
+- `TestReadOnlyStaleModeReportsDebtAndIsRejectedByMaintenance`;
+- `TestOpenReadOnlyNoLockRejectsDirtyCollectionWALForOfflineRewrite`;
+- `TestValueLogRewriteOfflineRejectsDirtyCollectionWAL`;
+- `TestVacuumIndexOfflineRejectsDirtyCollectionWAL`;
+- `TestOfflineMaintenanceRejectsUnclassifiedPreparedSideRefs`;
+- `TestOfflineMaintenanceAllowsCleanedCollectionWALWithManifest`;
+- `TestCollectionWALCheckpointPublishesBeforeCleanup`;
+- `TestCollectionWALCleanupRequiresDurableCheckpointBoundary`;
+- `TestCollectionWALSegmentCleanupDecodesEveryFrame`;
+- `TestCollectionWALCleanupDoesNotReleaseProtectionBeforeReachabilityHandoff`;
+- `TestCollectionWALPreparedUncommittedSideFilesQuarantinedAfterRestore`;
+- `TestCollectionWALQuarantinePurgeRequiresCheckpoint`.
+
 Required non-mutating collection WAL CLI tooling:
 
 - `treemap collection-wal health --dir <db> --json` reports `db_dir_hash`,

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -208,6 +208,18 @@ Invariant:
   safe watermark plus checkpoint boundary.
 
 Required coverage:
+- `TestCollectionWALFormatGoldenV1EmptySegment`
+- `TestCollectionWALFormatGoldenV1NoIndexInlineRootDelta`
+- `TestCollectionWALFormatGoldenV1ValueLeafAndRootDeltaSideRefs`
+- `TestCollectionWALFormatGoldenV1DescriptorOpAndWatermark`
+- `TestCollectionWALFormatGoldenV1LargeRootDeltaSidePayload`
+- `TestCollectionWALFormatGoldenV1TombstoneDelete`
+- `TestCollectionWALFormatGoldenV1CleanupRecordAndSegmentMetadata`
+- `TestCollectionWALFormatRejectsUnsupportedRequiredVersion`
+- `TestCollectionWALFormatRejectsUnknownCriticalSection`
+- `TestCollectionWALFormatSkipsUnknownNonCriticalSectionOnlyWhenAllowed`
+- `TestCollectionWALFormatRejectsMalformedLengthBeforeAllocation`
+- `TestCollectionWALFormatRejectsHeaderPayloadReplayAndTrailerCRCMismatch`
 - `TestCollectionWALOnRelaxedNoIndexAckBeforeFlushRecovers`
 - `TestCollectionWALDurableNoIndexAckBeforeFlushRecovers`
 - `TestCollectionWALOffRelaxedNoIndexAckBeforeFlushDoesNotClaimRecovery`
@@ -227,6 +239,22 @@ Required coverage:
 - `TestCollectionWALReadOnlyOpenWithPendingWAL`
 
 Acceptance artifacts:
+- The collection WAL gate requires exact byte fixtures, not only round-trip
+  tests. Each fixture must include raw bytes, decoded JSON or Go struct
+  expectation, replay digest expectation, checksum expectation, and a
+  re-encode-identical assertion.
+- Required fixture families:
+  - segment header v1 empty segment;
+  - minimal no-index transaction with one inline root delta;
+  - transaction with value-log, leaf-log, and root-delta side refs;
+  - transaction with descriptor op and watermark system-delta template;
+  - large root delta using side-payload ref;
+  - transaction with tombstone/delete entry;
+  - cleanup record and segment metadata;
+  - future unknown critical section rejection;
+  - future unknown noncritical section skip;
+  - unsupported version fail-closed;
+  - malformed length, header CRC, payload CRC, replay digest, and trailer CRC.
 - Every completed milestone must write
   `artifacts/collection-wal/<milestone>/acceptance.json`.
 - Benchmark artifacts must include the storage matrix above, baseline/new

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -25,6 +25,14 @@ This document defines write semantics for TreeDB cached mode and backend mode.
 - Sync operations are relaxed.
 - Durable boundary for recent writes is checkpoint/flush based, not per-write journal replay.
 
+This document owns the canonical durability-mode matrix. Other docs may
+summarize these modes but should not maintain independent durability matrices.
+Collection APIs currently have an additional write-domain distinction: before
+collection WAL lands, acknowledged collection writes can remain flush-boundary
+durable rather than durable-at-ack. That current behavior is owned by
+`collections-write-domain.md`; the target WAL-on collection overlay is owned by
+`collection-wal-durability-plan.md` until accepted.
+
 ## 2. Value Placement (Inline vs Pointer)
 
 ### 2.1 Threshold selection
@@ -115,7 +123,10 @@ Commit visibility sequence:
 ### 5.3 Collection API Durability
 
 Collection mutators do not have separate `*Sync` Go methods. Their baseline
-acknowledgement is mode-dependent:
+acknowledgement is mode-dependent. Current shipped collection write-domain
+behavior is flush-boundary durable, as defined in
+`collections-write-domain.md`. The bullets below describe the target collection
+WAL overlay for paths that have passed the collection WAL gate:
 
 - `DurabilityDurable`: non-sync collection mutator success is process-crash
   recoverable through collection WAL. It is not by itself a power-loss fsync
@@ -163,7 +174,8 @@ WAL state merely because backend checkpoint completed. A future
 checkpoint-without-publication mode must report collection WAL debt and retain
 all required WAL segments and side refs.
 
-`DB.Checkpoint()` success must cover collection WAL. A checkpoint that cannot
+Under the full collection WAL target, `DB.Checkpoint()` success must cover
+collection WAL. A checkpoint that cannot
 publish or watermark pre-cut collection WAL transactions must return an error
 or expose explicit collection WAL debt through a new API; it must not return
 `nil` and call the collection WAL state clean.

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -72,6 +72,12 @@ a complete WAL-on collection transaction with a missing required side ref is a
 recovery error, not a skipped batch, because later same-collection transactions
 depend on collection-local sequencing and root-group atomicity.
 
+WAL-on collection writes add a stronger visibility boundary: no collection read,
+scan, uniqueness check, update/delete planner, or pending-state merge may observe
+a mutation before its collection WAL transaction is committed/recoverable. The
+write path is private planning, side-ref preparation/protection, collection WAL
+commit, then visible install.
+
 ## 4. Backend Commit Model
 
 Backend applies flushed operations through copy-on-write zipper merge.
@@ -109,6 +115,15 @@ Current behavior:
 7. run value-log retention checks and pruning.
 
 In backend-only mode, checkpoint is implemented as an empty sync batch write.
+
+Under the planned collection WAL contract, `DB.Checkpoint()` is also a
+collection-aware boundary. PR1 must close admission for the checkpoint cut, wait
+for in-flight collection writes admitted before the cut, drain async publish and
+write domains, publish root groups, advance applied watermarks, create the
+backend durability boundary containing those watermarks, and only then report a
+clean collection WAL state or clean collection WAL segments. A future
+checkpoint-without-publication mode must report collection WAL debt and retain
+all required WAL segments and side refs.
 
 ## 7. Auto-Checkpoint Defaults (Cached Mode)
 

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -66,6 +66,12 @@ sequence acts as a durable commit fence:
 This prevents replaying partial pointer commits and avoids phantom pointer
 visibility after crash recovery.
 
+This skip behavior is specific to the existing cached key/value commit log and
+its RID fence. Collection WAL transactions use stricter side-ref semantics:
+a complete WAL-on collection transaction with a missing required side ref is a
+recovery error, not a skipped batch, because later same-collection transactions
+depend on collection-local sequencing and root-group atomicity.
+
 ## 4. Backend Commit Model
 
 Backend applies flushed operations through copy-on-write zipper merge.

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -109,6 +109,30 @@ Commit visibility sequence:
 
 - `SetSync`, `DeleteSync`, `Batch.WriteSync`: in durable mode, fsync durability boundary; in relaxed modes, relaxed boundary only.
 
+### 5.3 Collection API Durability
+
+Collection mutators do not have separate `*Sync` Go methods. Their baseline
+acknowledgement is mode-dependent:
+
+- `DurabilityDurable`: non-sync collection mutator success is process-crash
+  recoverable through collection WAL. It is not by itself a power-loss fsync
+  guarantee. `Flush`, `FlushAll`, `Checkpoint`, `Close`, or native-wire
+  `ack_policy=synced` can add the configured fsync boundary when the server can
+  actually satisfy that boundary.
+- `DurabilityWALOnRelaxed`: collection mutator success is process-crash
+  recoverable through collection WAL once the WAL frame and required side refs
+  are fresh-process-readable. It is not a power-loss guarantee. Native-wire
+  `synced` must be rejected unless the server advertises a separately named
+  mode-relative relaxed sync policy.
+- `DurabilityWALOffRelaxed`: collection mutator success is not durable-at-ack.
+  `Flush`, `FlushAll`, `Checkpoint`, and `Close` are the public persistence
+  boundaries for pending collection state.
+
+`Flush` and `FlushAll` publish roots and watermarks. `Checkpoint` is the
+database-wide durability/cleanup boundary. `Close` is a final admission-cut and
+safe-reopen boundary, not a promise that every safe-to-delete WAL file was
+physically removed.
+
 ## 6. Checkpoint Semantics
 
 `DB.Checkpoint()` in cached mode is a forced durability/cleanup boundary.
@@ -134,6 +158,11 @@ clean collection WAL state or clean collection WAL segments. A future
 checkpoint-without-publication mode must report collection WAL debt and retain
 all required WAL segments and side refs.
 
+`DB.Checkpoint()` success must cover collection WAL. A checkpoint that cannot
+publish or watermark pre-cut collection WAL transactions must return an error
+or expose explicit collection WAL debt through a new API; it must not return
+`nil` and call the collection WAL state clean.
+
 ## 7. Auto-Checkpoint Defaults (Cached Mode)
 
 When WAL is enabled, public `treedb.Open` defaults to:
@@ -149,8 +178,8 @@ These bound uncheckpointed log growth in long-running workloads.
 Profiles map high-level intent to durability/integrity bundles:
 
 - `ProfileDurable`: durable mode + checksum verification.
-- `ProfileFast`: WAL off relaxed + checksum skip + index optimization bundle + 4 MiB pager chunks with moderate pager sync parallelism + the current run_celestia value-log compression defaults (`auto` / balanced / snappy / medium autotune).
-- `ProfileWALOnFast`: WAL on relaxed + checksum skip + the same index + pager chunk/sync + value-log compression bundle.
+- `ProfileFast`: WAL off relaxed + checksum skip + index optimization bundle + 4 MiB pager chunks with moderate pager sync parallelism + the current run_celestia value-log compression defaults (`auto` / balanced / snappy / medium autotune). Collection write success is not durable-at-ack; use `Flush`, `FlushAll`, `Checkpoint`, or `Close` for a persistence boundary.
+- `ProfileWALOnFast`: WAL on relaxed + checksum skip + the same index + pager chunk/sync + value-log compression bundle. After the collection WAL contract lands, collection write success is recoverable after process crash but not after power loss.
 - `ProfileBench`: fast profile plus disabled background checkpoint/prune triggers for determinism.
 
 ## 9. Required Invariants

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -78,6 +78,12 @@ a mutation before its collection WAL transaction is committed/recoverable. The
 write path is private planning, side-ref preparation/protection, collection WAL
 commit, then visible install.
 
+The collection WAL is a local storage apply log, not a Raft log and not a
+native-wire deterministic command entry. Non-sync collection APIs under WAL-on
+modes provide process-crash recoverability after local collection WAL commit;
+they do not imply power-loss fsync durability unless a sync/checkpoint boundary
+is requested by the configured durability mode.
+
 ## 4. Backend Commit Model
 
 Backend applies flushed operations through copy-on-write zipper merge.

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -76,7 +76,10 @@ WAL-on collection writes add a stronger visibility boundary: no collection read,
 scan, uniqueness check, update/delete planner, or pending-state merge may observe
 a mutation before its collection WAL transaction is committed/recoverable. The
 write path is private planning, side-ref preparation/protection, collection WAL
-commit, then visible install.
+commit, then visible install. The authoritative guard is `CanInstallVisible` in
+`collection-wal-durability-plan.md`; WAL-on implementations must reject any
+path that can return success or expose pending visibility without satisfying
+that predicate.
 
 The collection WAL is a local storage apply log, not a Raft log and not a
 native-wire deterministic command entry. Non-sync collection APIs under WAL-on

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -83,9 +83,12 @@ that predicate.
 
 The collection WAL is a local storage apply log, not a Raft log and not a
 native-wire deterministic command entry. Non-sync collection APIs under WAL-on
-modes provide process-crash recoverability after local collection WAL commit;
-they do not imply power-loss fsync durability unless a sync/checkpoint boundary
-is requested by the configured durability mode.
+modes provide process-crash recoverability after local collection WAL commit
+only for capabilities explicitly enabled by the collection WAL plan. The
+PR1-min capability is no-index row `Insert`/`InsertBatch` only; unsupported
+paths must retain the old flush-boundary contract or fail before visibility.
+These APIs do not imply power-loss fsync durability unless a sync/checkpoint
+boundary is requested by the configured durability mode.
 
 ## 4. Backend Commit Model
 
@@ -149,12 +152,14 @@ Current behavior:
 
 In backend-only mode, checkpoint is implemented as an empty sync batch write.
 
-Under the planned collection WAL contract, `DB.Checkpoint()` is also a
-collection-aware boundary. PR1 must close admission for the checkpoint cut, wait
-for in-flight collection writes admitted before the cut, drain async publish and
-write domains, publish root groups, advance applied watermarks, create the
-backend durability boundary containing those watermarks, and only then report a
-clean collection WAL state or clean collection WAL segments. A future
+Under the full collection WAL contract, `DB.Checkpoint()` is also a
+collection-aware boundary. That later gate must close admission for the
+checkpoint cut, wait for in-flight collection writes admitted before the cut,
+drain async publish and write domains, publish root groups, advance applied
+watermarks, create the backend durability boundary containing those watermarks,
+and only then report a clean collection WAL state or clean collection WAL
+segments. PR1-min retains collection WAL and must not report clean collection
+WAL state merely because backend checkpoint completed. A future
 checkpoint-without-publication mode must report collection WAL debt and retain
 all required WAL segments and side refs.
 

--- a/TreeDB/errors.go
+++ b/TreeDB/errors.go
@@ -14,6 +14,9 @@ var (
 
 	// ErrClosed indicates the DB handle has been closed.
 	ErrClosed = db.ErrClosed
+	// ErrRecoveryRequired indicates the DB must be opened read-write for recovery
+	// before the requested read-only or offline-maintenance operation can run.
+	ErrRecoveryRequired = db.ErrRecoveryRequired
 
 	// ErrKeyNotFound indicates the key does not exist.
 	ErrKeyNotFound = tree.ErrKeyNotFound

--- a/TreeDB/internal/collectionwal/capability.go
+++ b/TreeDB/internal/collectionwal/capability.go
@@ -1,0 +1,23 @@
+package collectionwal
+
+type DurableAckCapability uint8
+
+const (
+	DurableAckDisabled DurableAckCapability = iota
+	DurableAckNoIndexRowInsertOnly
+)
+
+func (c DurableAckCapability) String() string {
+	switch c {
+	case DurableAckDisabled:
+		return "disabled"
+	case DurableAckNoIndexRowInsertOnly:
+		return "NoIndexRowInsertOnly"
+	default:
+		return "unknown"
+	}
+}
+
+func (c DurableAckCapability) Enabled() bool {
+	return c != DurableAckDisabled
+}

--- a/TreeDB/internal/collectionwal/capability_test.go
+++ b/TreeDB/internal/collectionwal/capability_test.go
@@ -1,0 +1,24 @@
+package collectionwal
+
+import "testing"
+
+func TestDurableAckCapabilityNames(t *testing.T) {
+	tests := map[DurableAckCapability]string{
+		DurableAckDisabled:             "disabled",
+		DurableAckNoIndexRowInsertOnly: "NoIndexRowInsertOnly",
+	}
+	for capability, want := range tests {
+		if got := capability.String(); got != want {
+			t.Fatalf("capability %d String()=%q want %q", capability, got, want)
+		}
+	}
+}
+
+func TestDurableAckCapabilityEnabled(t *testing.T) {
+	if DurableAckDisabled.Enabled() {
+		t.Fatal("disabled capability must not be enabled")
+	}
+	if !DurableAckNoIndexRowInsertOnly.Enabled() {
+		t.Fatal("NoIndexRowInsertOnly capability must be enabled")
+	}
+}

--- a/TreeDB/internal/collectionwal/dirty.go
+++ b/TreeDB/internal/collectionwal/dirty.go
@@ -1,0 +1,78 @@
+package collectionwal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	segmentPrefix = "collection-l"
+	segmentSuffix = ".log"
+)
+
+// IsSegmentName reports whether name is a canonical collection WAL segment
+// name. The v1 cleanup scanner treats any such segment as dirty until the full
+// segment classifier and cleanup-manifest reader are available.
+func IsSegmentName(name string) bool {
+	if !strings.HasPrefix(name, segmentPrefix) || !strings.HasSuffix(name, segmentSuffix) {
+		return false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(name, segmentPrefix), segmentSuffix)
+	parts := strings.SplitN(rest, "-", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	lane, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil || lane > uint64(^uint32(0)) {
+		return false
+	}
+	_, err = strconv.ParseUint(parts[1], 10, 64)
+	return err == nil
+}
+
+// DirtySegments returns collection WAL segments in dbDir/wal. It intentionally
+// does not consult cleanup metadata yet; until that reader exists, every
+// collection WAL segment is treated as requiring read-write recovery.
+func DirtySegments(dbDir string) ([]string, error) {
+	walDir := filepath.Join(dbDir, "wal")
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var dirty []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if IsSegmentName(name) {
+			dirty = append(dirty, filepath.Join(walDir, name))
+		}
+	}
+	return dirty, nil
+}
+
+func RequireCleanForReadOnlyOpen(dbDir string) error {
+	return requireNoDirtySegments(dbDir, "read-only open")
+}
+
+func RequireCleanForOfflineMaintenance(dbDir string) error {
+	return requireNoDirtySegments(dbDir, "offline maintenance")
+}
+
+func requireNoDirtySegments(dbDir, operation string) error {
+	dirty, err := DirtySegments(dbDir)
+	if err != nil {
+		return err
+	}
+	if len(dirty) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s found collection WAL segment %s", ErrCollectionWALRecoveryRequired, operation, filepath.Base(dirty[0]))
+}

--- a/TreeDB/internal/collectionwal/dirty_test.go
+++ b/TreeDB/internal/collectionwal/dirty_test.go
@@ -1,0 +1,61 @@
+package collectionwal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsSegmentName(t *testing.T) {
+	valid := []string{
+		"collection-l0-000000.log",
+		"collection-l1-000123.log",
+		"collection-l4294967295-18446744073709551615.log",
+	}
+	for _, name := range valid {
+		if !IsSegmentName(name) {
+			t.Fatalf("IsSegmentName(%q)=false, want true", name)
+		}
+	}
+
+	invalid := []string{
+		"collection-0-1.log",
+		"collection-l-1.log",
+		"collection-l0-.log",
+		"collection-l0-1.tmp",
+		"collection-l4294967296-1.log",
+		"commit-l0-1.log",
+	}
+	for _, name := range invalid {
+		if IsSegmentName(name) {
+			t.Fatalf("IsSegmentName(%q)=true, want false", name)
+		}
+	}
+}
+
+func TestRequireCleanRejectsCollectionWALSegment(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "commit-l0-000001.log"), []byte("commit"), 0o600); err != nil {
+		t.Fatalf("write commit segment: %v", err)
+	}
+	if err := RequireCleanForReadOnlyOpen(dir); err != nil {
+		t.Fatalf("commit WAL must not be classified as collection WAL: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "collection-l0-000001.log"), []byte("collection"), 0o600); err != nil {
+		t.Fatalf("write collection segment: %v", err)
+	}
+
+	err := RequireCleanForReadOnlyOpen(dir)
+	if !errors.Is(err, ErrCollectionWALRecoveryRequired) {
+		t.Fatalf("RequireCleanForReadOnlyOpen error=%v, want ErrCollectionWALRecoveryRequired", err)
+	}
+	err = RequireCleanForOfflineMaintenance(dir)
+	if !errors.Is(err, ErrCollectionWALRecoveryRequired) {
+		t.Fatalf("RequireCleanForOfflineMaintenance error=%v, want ErrCollectionWALRecoveryRequired", err)
+	}
+}

--- a/TreeDB/internal/collectionwal/errors.go
+++ b/TreeDB/internal/collectionwal/errors.go
@@ -1,0 +1,16 @@
+package collectionwal
+
+import "errors"
+
+var (
+	ErrCollectionWALTerminalTail       = errors.New("collectionwal: terminal incomplete tail")
+	ErrCollectionWALCorruptMiddle      = errors.New("collectionwal: corrupt middle")
+	ErrCollectionWALBadChecksum        = errors.New("collectionwal: bad checksum")
+	ErrCollectionWALUnsupportedVersion = errors.New("collectionwal: unsupported version")
+	ErrCollectionWALResourceLimit      = errors.New("collectionwal: resource limit")
+	ErrCollectionWALUnsafePath         = errors.New("collectionwal: unsafe path")
+	ErrCollectionWALMissingSideRef     = errors.New("collectionwal: missing side ref")
+	ErrCollectionWALIdentityMismatch   = errors.New("collectionwal: identity mismatch")
+	ErrCollectionWALSequenceGap        = errors.New("collectionwal: sequence gap")
+	ErrCollectionWALRedacted           = errors.New("collectionwal: redacted")
+)

--- a/TreeDB/internal/collectionwal/errors.go
+++ b/TreeDB/internal/collectionwal/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrCollectionWALIdentityMismatch   = errors.New("collectionwal: identity mismatch")
 	ErrCollectionWALSequenceGap        = errors.New("collectionwal: sequence gap")
 	ErrCollectionWALRedacted           = errors.New("collectionwal: redacted")
+	ErrCollectionWALRecoveryRequired   = errors.New("collectionwal: recovery required")
 )

--- a/TreeDB/internal/collectionwal/errors.go
+++ b/TreeDB/internal/collectionwal/errors.go
@@ -14,4 +14,5 @@ var (
 	ErrCollectionWALSequenceGap        = errors.New("collectionwal: sequence gap")
 	ErrCollectionWALRedacted           = errors.New("collectionwal: redacted")
 	ErrCollectionWALRecoveryRequired   = errors.New("collectionwal: recovery required")
+	ErrCollectionWALUnsupportedMode    = errors.New("collectionwal: unsupported mode")
 )

--- a/TreeDB/internal/collectionwal/lifecycle.go
+++ b/TreeDB/internal/collectionwal/lifecycle.go
@@ -1,0 +1,107 @@
+package collectionwal
+
+type SideRefLifecycleState uint8
+
+const (
+	SideRefStateAbsent SideRefLifecycleState = iota
+	SideRefStatePrepared
+	SideRefStateWALCommitted
+	SideRefStateMaterializedUnpublished
+	SideRefStateApplied
+	SideRefStateCleanable
+	SideRefStateCleaned
+	SideRefStateQuarantined
+)
+
+func (s SideRefLifecycleState) String() string {
+	switch s {
+	case SideRefStateAbsent:
+		return "S0 Absent"
+	case SideRefStatePrepared:
+		return "S1 PreparedSideRefs"
+	case SideRefStateWALCommitted:
+		return "S2 WALCommitted"
+	case SideRefStateMaterializedUnpublished:
+		return "S3 MaterializedUnpublished"
+	case SideRefStateApplied:
+		return "S4 Applied"
+	case SideRefStateCleanable:
+		return "S5 Cleanable"
+	case SideRefStateCleaned:
+		return "S6 Cleaned"
+	case SideRefStateQuarantined:
+		return "Q Quarantined"
+	default:
+		return "unknown"
+	}
+}
+
+type ProtectionReason uint8
+
+const (
+	ProtectionPrepared ProtectionReason = iota + 1
+	ProtectionWALCommitted
+	ProtectionPendingPublish
+	ProtectionCollectionReadView
+	ProtectionBackupManifest
+	ProtectionCleanupPending
+)
+
+func (r ProtectionReason) String() string {
+	switch r {
+	case ProtectionPrepared:
+		return "prepared"
+	case ProtectionWALCommitted:
+		return "wal_committed"
+	case ProtectionPendingPublish:
+		return "pending_publish"
+	case ProtectionCollectionReadView:
+		return "collection_read_view"
+	case ProtectionBackupManifest:
+		return "backup_manifest"
+	case ProtectionCleanupPending:
+		return "cleanup_pending"
+	default:
+		return "unknown"
+	}
+}
+
+type BackupMode uint8
+
+const (
+	BackupModeCleanCheckpoint BackupMode = iota + 1
+	BackupModeWALSnapshot
+)
+
+func (m BackupMode) String() string {
+	switch m {
+	case BackupModeCleanCheckpoint:
+		return "CleanCheckpoint"
+	case BackupModeWALSnapshot:
+		return "WALSnapshot"
+	default:
+		return "unknown"
+	}
+}
+
+type ProtectedRef struct {
+	Class         RefClass
+	FileID        uint64
+	Offset        uint64
+	Length        uint64
+	ChecksumCRC32 uint32
+	CollectionSeq uint64
+	WALLSN        uint64
+	Reason        ProtectionReason
+}
+
+type MaintenanceBarrierSnapshot struct {
+	ProtectedRefs        []ProtectedRef
+	UnclassifiedPrepares int
+	BackupPins           int
+	RecoveryComplete     bool
+}
+
+func (s MaintenanceBarrierSnapshot) CanMutate() bool {
+	return s.RecoveryComplete && s.UnclassifiedPrepares == 0
+}

--- a/TreeDB/internal/collectionwal/lifecycle_test.go
+++ b/TreeDB/internal/collectionwal/lifecycle_test.go
@@ -1,0 +1,58 @@
+package collectionwal
+
+import "testing"
+
+func TestSideRefLifecycleStateNames(t *testing.T) {
+	tests := map[SideRefLifecycleState]string{
+		SideRefStateAbsent:                  "S0 Absent",
+		SideRefStatePrepared:                "S1 PreparedSideRefs",
+		SideRefStateWALCommitted:            "S2 WALCommitted",
+		SideRefStateMaterializedUnpublished: "S3 MaterializedUnpublished",
+		SideRefStateApplied:                 "S4 Applied",
+		SideRefStateCleanable:               "S5 Cleanable",
+		SideRefStateCleaned:                 "S6 Cleaned",
+		SideRefStateQuarantined:             "Q Quarantined",
+	}
+	for state, want := range tests {
+		if got := state.String(); got != want {
+			t.Fatalf("state %d String()=%q want %q", state, got, want)
+		}
+	}
+}
+
+func TestProtectionReasonNames(t *testing.T) {
+	tests := map[ProtectionReason]string{
+		ProtectionPrepared:           "prepared",
+		ProtectionWALCommitted:       "wal_committed",
+		ProtectionPendingPublish:     "pending_publish",
+		ProtectionCollectionReadView: "collection_read_view",
+		ProtectionBackupManifest:     "backup_manifest",
+		ProtectionCleanupPending:     "cleanup_pending",
+	}
+	for reason, want := range tests {
+		if got := reason.String(); got != want {
+			t.Fatalf("reason %d String()=%q want %q", reason, got, want)
+		}
+	}
+}
+
+func TestBackupModeNames(t *testing.T) {
+	if got := BackupModeCleanCheckpoint.String(); got != "CleanCheckpoint" {
+		t.Fatalf("CleanCheckpoint String()=%q", got)
+	}
+	if got := BackupModeWALSnapshot.String(); got != "WALSnapshot" {
+		t.Fatalf("WALSnapshot String()=%q", got)
+	}
+}
+
+func TestMaintenanceBarrierSnapshotCanMutate(t *testing.T) {
+	if (MaintenanceBarrierSnapshot{}).CanMutate() {
+		t.Fatal("zero snapshot must not permit mutation before recovery complete")
+	}
+	if (MaintenanceBarrierSnapshot{RecoveryComplete: true, UnclassifiedPrepares: 1}).CanMutate() {
+		t.Fatal("unclassified prepares must block mutation")
+	}
+	if !(MaintenanceBarrierSnapshot{RecoveryComplete: true}).CanMutate() {
+		t.Fatal("recovered clean snapshot should permit mutation")
+	}
+}

--- a/TreeDB/internal/collectionwal/limits.go
+++ b/TreeDB/internal/collectionwal/limits.go
@@ -1,0 +1,52 @@
+package collectionwal
+
+import "fmt"
+
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)
+
+const (
+	MaxEncodedTransactionBytes            = 16 * MiB
+	MaxOuterFramePayloadBytes             = MaxEncodedTransactionBytes
+	DefaultSegmentBytes                   = 64 * MiB
+	MaxSegmentBytes                       = 1 * GiB
+	MaxRootDeltasPerTransaction           = 64
+	MaxMutatedRootsPerTransaction         = 64
+	MaxInlineRootDeltaBytesPerTransaction = 4 * MiB
+	MaxInlineRootDeltaBytesPerRoot        = 1 * MiB
+	MaxRootDeltaPayloadSideRefBytes       = 64 * MiB
+	MaxDecodedRootDeltaEntriesPerTxn      = 262_144
+	MaxDeltaKeyBytes                      = 16 * KiB
+	MaxDocumentIDBytes                    = MaxDeltaKeyBytes
+	MaxInlineDeltaValueBytes              = 1 * MiB
+	MaxSideRefsPerTransaction             = 16_384
+	MaxDescriptorOpsPerTransaction        = 1_024
+	MaxLogicalNameBytes                   = 128
+	MaxRootNameBytes                      = 256
+	MaxRelativePathBytes                  = 512
+	MaxRelativePathComponents             = 16
+	MaxRelativePathComponentBytes         = 128
+	MaxResolvedAbsolutePathBytes          = 4096
+	MaxVarintBytes                        = 10
+	MaxCompressedDecodedBytes             = 64 * MiB
+	DefaultRecoveryHeapBudgetBytes        = 128 * MiB
+	CollectionUIDBytes                    = 16
+	CRC32CBytes                           = 4
+)
+
+func ValidateEncodedTransactionSize(n uint64) error {
+	if n > MaxEncodedTransactionBytes {
+		return fmt.Errorf("%w: encoded transaction bytes %d exceeds %d", ErrCollectionWALResourceLimit, n, MaxEncodedTransactionBytes)
+	}
+	return nil
+}
+
+func ValidateFramePayloadSize(n uint64) error {
+	if n > MaxOuterFramePayloadBytes {
+		return fmt.Errorf("%w: frame payload bytes %d exceeds %d", ErrCollectionWALResourceLimit, n, MaxOuterFramePayloadBytes)
+	}
+	return nil
+}

--- a/TreeDB/internal/collectionwal/limits_test.go
+++ b/TreeDB/internal/collectionwal/limits_test.go
@@ -1,0 +1,44 @@
+package collectionwal
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestV1Limits(t *testing.T) {
+	if MaxEncodedTransactionBytes != 16*MiB {
+		t.Fatalf("MaxEncodedTransactionBytes=%d want %d", MaxEncodedTransactionBytes, 16*MiB)
+	}
+	if MaxOuterFramePayloadBytes != MaxEncodedTransactionBytes {
+		t.Fatalf("MaxOuterFramePayloadBytes=%d want encoded txn cap %d", MaxOuterFramePayloadBytes, MaxEncodedTransactionBytes)
+	}
+	if MaxSegmentBytes != GiB {
+		t.Fatalf("MaxSegmentBytes=%d want %d", MaxSegmentBytes, GiB)
+	}
+	if MaxRootDeltasPerTransaction != 64 {
+		t.Fatalf("MaxRootDeltasPerTransaction=%d want 64", MaxRootDeltasPerTransaction)
+	}
+	if MaxSideRefsPerTransaction != 16_384 {
+		t.Fatalf("MaxSideRefsPerTransaction=%d want 16384", MaxSideRefsPerTransaction)
+	}
+}
+
+func TestValidateEncodedTransactionSize(t *testing.T) {
+	if err := ValidateEncodedTransactionSize(MaxEncodedTransactionBytes); err != nil {
+		t.Fatalf("ValidateEncodedTransactionSize(cap): %v", err)
+	}
+	err := ValidateEncodedTransactionSize(MaxEncodedTransactionBytes + 1)
+	if !errors.Is(err, ErrCollectionWALResourceLimit) {
+		t.Fatalf("ValidateEncodedTransactionSize(over)=%v want resource limit", err)
+	}
+}
+
+func TestValidateFramePayloadSize(t *testing.T) {
+	if err := ValidateFramePayloadSize(MaxOuterFramePayloadBytes); err != nil {
+		t.Fatalf("ValidateFramePayloadSize(cap): %v", err)
+	}
+	err := ValidateFramePayloadSize(MaxOuterFramePayloadBytes + 1)
+	if !errors.Is(err, ErrCollectionWALResourceLimit) {
+		t.Fatalf("ValidateFramePayloadSize(over)=%v want resource limit", err)
+	}
+}

--- a/TreeDB/internal/collectionwal/path.go
+++ b/TreeDB/internal/collectionwal/path.go
@@ -1,0 +1,52 @@
+package collectionwal
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ValidateRelativePath validates advisory side-ref path metadata. A valid path
+// is still not authority to open or delete a file; collection WAL cleanup must
+// resolve the file through the trusted RefClass/FileID registry.
+func ValidateRelativePath(p string) error {
+	if p == "" {
+		return fmt.Errorf("%w: empty relative path", ErrCollectionWALUnsafePath)
+	}
+	if len(p) > MaxRelativePathBytes {
+		return fmt.Errorf("%w: relative path length %d exceeds %d", ErrCollectionWALUnsafePath, len(p), MaxRelativePathBytes)
+	}
+	if strings.ContainsRune(p, '\x00') {
+		return fmt.Errorf("%w: relative path contains NUL", ErrCollectionWALUnsafePath)
+	}
+	if strings.Contains(p, "\\") {
+		return fmt.Errorf("%w: relative path contains backslash", ErrCollectionWALUnsafePath)
+	}
+	if path.IsAbs(p) || strings.HasPrefix(p, "//") {
+		return fmt.Errorf("%w: relative path is absolute", ErrCollectionWALUnsafePath)
+	}
+	if hasWindowsDrivePrefix(p) {
+		return fmt.Errorf("%w: relative path has Windows drive prefix", ErrCollectionWALUnsafePath)
+	}
+	if strings.Contains(p, "//") {
+		return fmt.Errorf("%w: relative path contains empty component", ErrCollectionWALUnsafePath)
+	}
+	parts := strings.Split(p, "/")
+	if len(parts) > MaxRelativePathComponents {
+		return fmt.Errorf("%w: relative path component count %d exceeds %d", ErrCollectionWALUnsafePath, len(parts), MaxRelativePathComponents)
+	}
+	for _, part := range parts {
+		switch part {
+		case "", ".", "..":
+			return fmt.Errorf("%w: relative path contains invalid component", ErrCollectionWALUnsafePath)
+		}
+		if len(part) > MaxRelativePathComponentBytes {
+			return fmt.Errorf("%w: relative path component length %d exceeds %d", ErrCollectionWALUnsafePath, len(part), MaxRelativePathComponentBytes)
+		}
+	}
+	return nil
+}
+
+func hasWindowsDrivePrefix(p string) bool {
+	return len(p) >= 2 && p[1] == ':' && ((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z'))
+}

--- a/TreeDB/internal/collectionwal/path_test.go
+++ b/TreeDB/internal/collectionwal/path_test.go
@@ -1,0 +1,47 @@
+package collectionwal
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateRelativePathAcceptsSafePaths(t *testing.T) {
+	for _, p := range []string{
+		"value-l0-1.log",
+		"side/part-0001.bin",
+		"a/b/c/d",
+		strings.Repeat("a/", MaxRelativePathComponents-1) + "z",
+	} {
+		if err := ValidateRelativePath(p); err != nil {
+			t.Fatalf("ValidateRelativePath(%q): %v", p, err)
+		}
+	}
+}
+
+func TestValidateRelativePathRejectsTraversalAndHostPaths(t *testing.T) {
+	cases := []string{
+		"",
+		"../x",
+		"a/../x",
+		"/absolute",
+		"//server/share",
+		`C:\db\file`,
+		`C:/db/file`,
+		`\\server\share`,
+		`a\b`,
+		"a\x00b",
+		"a//b",
+		"./x",
+		"x/.",
+		strings.Repeat("a/", MaxRelativePathComponents) + "z",
+		strings.Repeat("a", MaxRelativePathComponentBytes+1),
+		strings.Repeat("a", MaxRelativePathBytes+1),
+	}
+	for _, p := range cases {
+		err := ValidateRelativePath(p)
+		if !errors.Is(err, ErrCollectionWALUnsafePath) {
+			t.Fatalf("ValidateRelativePath(%q)=%v want unsafe path", p, err)
+		}
+	}
+}

--- a/TreeDB/internal/collectionwal/refclass.go
+++ b/TreeDB/internal/collectionwal/refclass.go
@@ -1,0 +1,67 @@
+package collectionwal
+
+import "fmt"
+
+type RefClass uint8
+
+const (
+	RefClassInvalid RefClass = iota
+	RefClassValueLogRecord
+	RefClassLeafLogRecord
+	RefClassRootDeltaPayload
+	RefClassColumnManifest
+	RefClassColumnSubstreamFile
+	RefClassColumnFilterFile
+	RefClassColumnDeleteBitmapFile
+	RefClassColumnDictionaryFile
+	RefClassColumnMetadataFile
+)
+
+func (c RefClass) KnownV1() bool {
+	switch c {
+	case RefClassValueLogRecord,
+		RefClassLeafLogRecord,
+		RefClassRootDeltaPayload,
+		RefClassColumnManifest,
+		RefClassColumnSubstreamFile,
+		RefClassColumnFilterFile,
+		RefClassColumnDeleteBitmapFile,
+		RefClassColumnDictionaryFile,
+		RefClassColumnMetadataFile:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateV1RefClass(c RefClass) error {
+	if c.KnownV1() {
+		return nil
+	}
+	return fmt.Errorf("%w: unknown ref class %d", ErrCollectionWALUnsupportedVersion, c)
+}
+
+func (c RefClass) String() string {
+	switch c {
+	case RefClassValueLogRecord:
+		return "ValueLogRecord"
+	case RefClassLeafLogRecord:
+		return "LeafLogRecord"
+	case RefClassRootDeltaPayload:
+		return "RootDeltaPayload"
+	case RefClassColumnManifest:
+		return "ColumnManifest"
+	case RefClassColumnSubstreamFile:
+		return "ColumnSubstreamFile"
+	case RefClassColumnFilterFile:
+		return "ColumnFilterFile"
+	case RefClassColumnDeleteBitmapFile:
+		return "ColumnDeleteBitmapFile"
+	case RefClassColumnDictionaryFile:
+		return "ColumnDictionaryFile"
+	case RefClassColumnMetadataFile:
+		return "ColumnMetadataFile"
+	default:
+		return fmt.Sprintf("RefClass(%d)", c)
+	}
+}

--- a/TreeDB/internal/collectionwal/refclass_test.go
+++ b/TreeDB/internal/collectionwal/refclass_test.go
@@ -1,0 +1,34 @@
+package collectionwal
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateV1RefClass(t *testing.T) {
+	wantNames := map[RefClass]string{
+		RefClassValueLogRecord:         "ValueLogRecord",
+		RefClassLeafLogRecord:          "LeafLogRecord",
+		RefClassRootDeltaPayload:       "RootDeltaPayload",
+		RefClassColumnManifest:         "ColumnManifest",
+		RefClassColumnSubstreamFile:    "ColumnSubstreamFile",
+		RefClassColumnFilterFile:       "ColumnFilterFile",
+		RefClassColumnDeleteBitmapFile: "ColumnDeleteBitmapFile",
+		RefClassColumnDictionaryFile:   "ColumnDictionaryFile",
+		RefClassColumnMetadataFile:     "ColumnMetadataFile",
+	}
+	for c := RefClassValueLogRecord; c <= RefClassColumnMetadataFile; c++ {
+		if err := ValidateV1RefClass(c); err != nil {
+			t.Fatalf("ValidateV1RefClass(%s): %v", c, err)
+		}
+		if c.String() != wantNames[c] {
+			t.Fatalf("RefClass(%d).String()=%q want %q", c, c.String(), wantNames[c])
+		}
+	}
+	for _, c := range []RefClass{RefClassInvalid, 10, 255} {
+		err := ValidateV1RefClass(c)
+		if !errors.Is(err, ErrCollectionWALUnsupportedVersion) {
+			t.Fatalf("ValidateV1RefClass(%d)=%v want unsupported version", c, err)
+		}
+	}
+}

--- a/TreeDB/internal/collectionwal/safefs.go
+++ b/TreeDB/internal/collectionwal/safefs.go
@@ -1,0 +1,27 @@
+package collectionwal
+
+import (
+	"fmt"
+	"os"
+)
+
+// ValidateClassRootDir performs the portable subset of the collection WAL class
+// root safety checks. OS-specific openat/no-follow/owner/inode validation must
+// run in the actual file opener before collection WAL can use a class root.
+func ValidateClassRootDir(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("%w: stat class root: %w", ErrCollectionWALUnsafePath, err)
+	}
+	mode := info.Mode()
+	if mode&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: class root is symlink", ErrCollectionWALUnsafePath)
+	}
+	if !mode.IsDir() {
+		return fmt.Errorf("%w: class root is not a directory", ErrCollectionWALUnsafePath)
+	}
+	if mode.Perm()&0o022 != 0 {
+		return fmt.Errorf("%w: class root is group/world writable", ErrCollectionWALUnsafePath)
+	}
+	return nil
+}

--- a/TreeDB/internal/collectionwal/safefs.go
+++ b/TreeDB/internal/collectionwal/safefs.go
@@ -3,11 +3,13 @@ package collectionwal
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
 
 // ValidateClassRootDir performs the portable subset of the collection WAL class
-// root safety checks. OS-specific openat/no-follow/owner/inode validation must
-// run in the actual file opener before collection WAL can use a class root.
+// root safety checks, including POSIX permission bits on platforms where those
+// bits are authoritative. OS-specific openat/no-follow/owner/inode validation
+// must run in the actual file opener before collection WAL can use a class root.
 func ValidateClassRootDir(dir string) error {
 	info, err := os.Lstat(dir)
 	if err != nil {
@@ -20,7 +22,7 @@ func ValidateClassRootDir(dir string) error {
 	if !mode.IsDir() {
 		return fmt.Errorf("%w: class root is not a directory", ErrCollectionWALUnsafePath)
 	}
-	if mode.Perm()&0o022 != 0 {
+	if runtime.GOOS != "windows" && mode.Perm()&0o022 != 0 {
 		return fmt.Errorf("%w: class root is group/world writable", ErrCollectionWALUnsafePath)
 	}
 	return nil

--- a/TreeDB/internal/collectionwal/safefs_test.go
+++ b/TreeDB/internal/collectionwal/safefs_test.go
@@ -1,0 +1,64 @@
+package collectionwal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestValidateClassRootDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod safe dir: %v", err)
+	}
+	if err := ValidateClassRootDir(dir); err != nil {
+		t.Fatalf("ValidateClassRootDir(safe): %v", err)
+	}
+
+	file := filepath.Join(dir, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := ValidateClassRootDir(file); !errors.Is(err, ErrCollectionWALUnsafePath) {
+		t.Fatalf("ValidateClassRootDir(file)=%v want unsafe path", err)
+	}
+}
+
+func TestValidateClassRootDirRejectsWritableModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits are not authoritative on windows")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o770); err != nil {
+		t.Fatalf("chmod group writable: %v", err)
+	}
+	if err := ValidateClassRootDir(dir); !errors.Is(err, ErrCollectionWALUnsafePath) {
+		t.Fatalf("ValidateClassRootDir(group writable)=%v want unsafe path", err)
+	}
+	if err := os.Chmod(dir, 0o707); err != nil {
+		t.Fatalf("chmod world writable: %v", err)
+	}
+	if err := ValidateClassRootDir(dir); !errors.Is(err, ErrCollectionWALUnsafePath) {
+		t.Fatalf("ValidateClassRootDir(world writable)=%v want unsafe path", err)
+	}
+}
+
+func TestValidateClassRootDirRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink privileges are environment-dependent on windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := ValidateClassRootDir(link); !errors.Is(err, ErrCollectionWALUnsafePath) {
+		t.Fatalf("ValidateClassRootDir(symlink)=%v want unsafe path", err)
+	}
+}

--- a/TreeDB/internal/nativewire/deterministic.go
+++ b/TreeDB/internal/nativewire/deterministic.go
@@ -903,17 +903,6 @@ func validateDeterministicSectionPayload(section Section, limits Limits) error {
 			return validateDeterministicDocumentIDs(section.Bytes, limits)
 		}
 		return validateByteVector(section.Bytes, limits)
-	case SectionAckPolicy:
-		policy, n, err := readUvarint(section.Bytes)
-		if err != nil {
-			return err
-		}
-		if n != len(section.Bytes) {
-			return protocolError(ErrMalformedFrame, "section %d has %d trailing bytes", section.ID, len(section.Bytes)-n)
-		}
-		if err := validateDeterministicAckPolicyEnum(policy); err != nil {
-			return err
-		}
 	case SectionCollectionMeta:
 		if err := validateDeterministicOpaquePayload("collection_meta", section.Bytes, limits); err != nil {
 			return err
@@ -1117,15 +1106,6 @@ func validateDeterministicIndexValueTypeEnum(value uint64) error {
 		return nil
 	default:
 		return protocolError(ErrInvalidCommand, "unsupported index_value_type enum %d", value)
-	}
-}
-
-func validateDeterministicAckPolicyEnum(value uint64) error {
-	switch AckPolicy(value) {
-	case 0, AckVisible, AckFlushed, AckSynced, AckRaftCommitted:
-		return nil
-	default:
-		return protocolError(ErrInvalidCommand, "unsupported ack_policy enum %d", value)
 	}
 }
 

--- a/TreeDB/internal/nativewire/deterministic_test.go
+++ b/TreeDB/internal/nativewire/deterministic_test.go
@@ -431,6 +431,8 @@ func TestDeterministicEntryStableAcrossTransportOnlySections(t *testing.T) {
 		t.Fatalf("AppendDeterministicEntry: %v", err)
 	}
 	variant := []Section{
+		{ID: SectionAckPolicy, Bytes: deterministicUvarintPayload(uint64(AckSynced))},
+		{ID: SectionConsistencyPolicy, Bytes: deterministicUvarintPayload(3)},
 		{ID: SectionCompression, Bytes: []byte{1}},
 		{ID: SectionTraceContext, Bytes: []byte("trace")},
 		{ID: SectionDeadline, Bytes: []byte("deadline")},
@@ -1323,41 +1325,45 @@ func TestDeterministicEntryRejectsNonCanonicalSectionPayloads(t *testing.T) {
 	}
 }
 
-func TestDeterministicEntryIncludesAckPolicy(t *testing.T) {
+func TestDeterministicEntryStripsAckPolicy(t *testing.T) {
 	registry := MustV1Registry()
-	sections := append(insertBatchDeterministicSections(), Section{ID: SectionAckPolicy, Bytes: []byte{byte(AckVisible)}})
-	cmd, err := registry.ValidateRequestSections(sections)
+	baseSections := insertBatchDeterministicSections()
+	cmd, err := registry.ValidateRequestSections(baseSections)
 	if err != nil {
-		t.Fatalf("ValidateRequestSections visible ack: %v", err)
+		t.Fatalf("ValidateRequestSections base: %v", err)
 	}
-	visible, err := AppendDeterministicEntry(nil, cmd)
+	base, err := AppendDeterministicEntry(nil, cmd)
 	if err != nil {
-		t.Fatalf("AppendDeterministicEntry visible ack: %v", err)
+		t.Fatalf("AppendDeterministicEntry base: %v", err)
 	}
 
-	sections[len(sections)-1].Bytes = []byte{byte(AckFlushed)}
-	cmd, err = registry.ValidateRequestSections(sections)
-	if err != nil {
-		t.Fatalf("ValidateRequestSections flushed ack: %v", err)
-	}
-	flushed, err := AppendDeterministicEntry(nil, cmd)
-	if err != nil {
-		t.Fatalf("AppendDeterministicEntry flushed ack: %v", err)
-	}
-	if bytes.Equal(visible, flushed) {
-		t.Fatalf("deterministic entry did not include ack_policy")
+	for _, policy := range []AckPolicy{AckVisible, AckFlushed, AckSynced} {
+		sections := append(insertBatchDeterministicSections(), Section{ID: SectionAckPolicy, Bytes: deterministicUvarintPayload(uint64(policy))})
+		cmd, err := registry.ValidateRequestSections(sections)
+		if err != nil {
+			t.Fatalf("ValidateRequestSections ack=%d: %v", policy, err)
+		}
+		entry, err := AppendDeterministicEntry(nil, cmd)
+		if err != nil {
+			t.Fatalf("AppendDeterministicEntry ack=%d: %v", policy, err)
+		}
+		if !bytes.Equal(entry, base) {
+			t.Fatalf("ack_policy=%d changed deterministic entry\ngot  %s\nwant %s", policy, hex.EncodeToString(entry), hex.EncodeToString(base))
+		}
+		if DeterministicEntryDigest(entry) != DeterministicEntryDigest(base) {
+			t.Fatalf("ack_policy=%d changed deterministic digest", policy)
+		}
 	}
 }
 
-func TestDeterministicEntryRejectsUnsupportedAckPolicy(t *testing.T) {
-	registry := MustV1Registry()
-	sections := append(insertBatchDeterministicSections(), Section{ID: SectionAckPolicy, Bytes: []byte{99}})
-	cmd, err := registry.ValidateRequestSections(sections)
-	if err != nil {
-		t.Fatalf("ValidateRequestSections: %v", err)
-	}
-	if _, err := AppendDeterministicEntry(nil, cmd); codeOf(err) != ErrInvalidCommand {
-		t.Fatalf("unsupported ack_policy err=%v code=%d want invalid command", err, codeOf(err))
+func TestDecodeDeterministicEntryRejectsAckPolicySection(t *testing.T) {
+	sections := append(deterministicEntrySectionsOnly(insertBatchDeterministicSections()),
+		Section{ID: SectionAckPolicy, Bytes: deterministicUvarintPayload(uint64(AckVisible))},
+	)
+	sortSectionsByID(sections)
+	raw := deterministicEntryTestRaw(CommandInsertBatch, sections...)
+	if _, err := DecodeDeterministicEntry(raw, Limits{}); codeOf(err) != ErrInvalidCommand {
+		t.Fatalf("DecodeDeterministicEntry ack_policy err=%v code=%d want invalid command", err, codeOf(err))
 	}
 }
 

--- a/TreeDB/internal/nativewire/schema.go
+++ b/TreeDB/internal/nativewire/schema.go
@@ -473,7 +473,7 @@ func v1CommandSchemas() []CommandSchema {
 				{ID: SectionDocuments, Name: "documents", Required: true, Deterministic: true},
 				{ID: SectionTemplateRecords, Name: "template_records", Deterministic: true},
 				{ID: SectionExpectedCatalogVersion, Name: "expected_catalog_version", Deterministic: true},
-				{ID: SectionAckPolicy, Name: "ack_policy", Deterministic: true},
+				{ID: SectionAckPolicy, Name: "ack_policy"},
 			},
 		},
 		{
@@ -493,7 +493,7 @@ func v1CommandSchemas() []CommandSchema {
 				{ID: SectionTemplateRecords, Name: "template_records", Deterministic: true},
 				{ID: SectionExpectedCatalogVersion, Name: "expected_catalog_version", Deterministic: true},
 				{ID: SectionReplacementMode, Name: "replacement_mode", Required: true, Deterministic: true},
-				{ID: SectionAckPolicy, Name: "ack_policy", Deterministic: true},
+				{ID: SectionAckPolicy, Name: "ack_policy"},
 			},
 		},
 		{
@@ -509,7 +509,7 @@ func v1CommandSchemas() []CommandSchema {
 				{ID: SectionCollectionRef, Name: "collection_ref", Required: true, Deterministic: true},
 				{ID: SectionDocumentIDs, Name: "document_ids", Required: true, Deterministic: true},
 				{ID: SectionExpectedCatalogVersion, Name: "expected_catalog_version", Deterministic: true},
-				{ID: SectionAckPolicy, Name: "ack_policy", Deterministic: true},
+				{ID: SectionAckPolicy, Name: "ack_policy"},
 			},
 		},
 		{

--- a/TreeDB/internal/nativewire/types.go
+++ b/TreeDB/internal/nativewire/types.go
@@ -157,6 +157,7 @@ const (
 	ErrCursorNotFound
 	ErrCatalogChanged
 	ErrIdempotencyConflict
+	ErrCommitAmbiguous
 	errCodeSentinel
 )
 

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -60,6 +60,12 @@ func errorCodeFor(err error) iwire.ErrorCode {
 		return iwire.ErrDocumentExists
 	case errors.Is(err, collections.ErrUniqueIndexConflict):
 		return iwire.ErrUniqueIndexConflict
+	case errors.Is(err, collections.ErrDurabilityUnavailable):
+		return iwire.ErrDurabilityUnavailable
+	case errors.Is(err, collections.ErrCommitAmbiguous):
+		return iwire.ErrCommitAmbiguous
+	case errors.Is(err, collections.ErrRecoveryRequired):
+		return iwire.ErrDurabilityUnavailable
 	case errors.Is(err, backenddb.ErrClosed), errors.Is(err, ErrServerClosed), errors.Is(err, net.ErrClosed), errors.Is(err, io.ErrClosedPipe):
 		return iwire.ErrCanceled
 	}

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -737,6 +737,41 @@ func TestMutationBarrierAckAPIs(t *testing.T) {
 	}
 }
 
+func TestNativewireAckSyncedRejectedInWALOnRelaxed(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOnRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := collections.NewCollectionManager(db)
+	server := NewServer(ServerOptions{Collections: mgr, Backend: db})
+	client, _ := servePipe(t, server)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	_, err = client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":1}`)},
+		AckSynced,
+	)
+	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+		t.Fatalf("InsertBatch synced relaxed err=%v want durability unavailable", err)
+	}
+	assertDocumentMissing(t, mgr, "users", "u1")
+	if err := client.CheckpointWithAck(ctx, AckSynced); !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+		t.Fatalf("CheckpointWithAck synced relaxed err=%v want durability unavailable", err)
+	}
+}
+
 func TestMutationCatalogVersionCacheSurvivesSuccessfulDataMutation(t *testing.T) {
 	client, _, db := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -416,6 +416,34 @@ func TestMutationExplicitZeroAckUsesDefault(t *testing.T) {
 	}
 }
 
+func TestMutationUnsupportedAckPolicyRejectedBeforeWrite(t *testing.T) {
+	client, mgr, _ := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	guard, err := client.replicatedMutationGuard(ctx, "insert_batch_bad_ack")
+	if err != nil {
+		t.Fatalf("mutation guard: %v", err)
+	}
+	req := append(guard,
+		collectionNameRef("users"),
+		documentFormatSection(collections.DocumentFormatJSON),
+		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, []byte("u1"))},
+		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, []byte(`{"x":1}`))},
+		ackSection(AckPolicy(99)),
+	)
+	_, err = client.commandSections(ctx, iwire.CommandInsertBatch, req...)
+	if !isRemoteError(err, iwire.ErrInvalidCommand) {
+		t.Fatalf("InsertBatch unsupported ack err=%v want invalid command", err)
+	}
+	assertDocumentMissing(t, mgr, "users", "u1")
+}
+
 func TestMutationTemplateRecordsSectionFeedsTemplateV1Insert(t *testing.T) {
 	client, mgr, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -794,6 +794,8 @@ func wireErrorMessage(code iwire.ErrorCode, err error) string {
 		return "catalog changed"
 	case iwire.ErrIdempotencyConflict:
 		return "idempotency conflict"
+	case iwire.ErrCommitAmbiguous:
+		return "commit ambiguous"
 	default:
 		return "internal error"
 	}

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -2,6 +2,7 @@ package nativewire
 
 import (
 	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -456,11 +457,15 @@ func (s *Server) handleCheckpoint(sections []iwire.Section) ([]iwire.Section, er
 	if s.backend == nil {
 		return nil, protocolError(iwire.ErrDurabilityUnavailable, "checkpoint requires a backend DB")
 	}
+	actualAck := iwire.AckSynced
+	if s.backend.DurabilityMode() != backenddb.DurabilityDurable {
+		actualAck = iwire.AckFlushed
+	}
 	ack, err := ackPolicyFromSections(sections, s.defaultBarrierAck(iwire.AckSynced))
 	if err != nil {
 		return nil, err
 	}
-	if err := s.admitBarrierAck(iwire.AckSynced, ack); err != nil {
+	if err := s.admitBarrierAck(actualAck, ack); err != nil {
 		return nil, err
 	}
 	if s.collections != nil {
@@ -471,7 +476,7 @@ func (s *Server) handleCheckpoint(sections []iwire.Section) ([]iwire.Section, er
 	if err := s.backend.Checkpoint(); err != nil {
 		return nil, metadataWrap(err)
 	}
-	return []iwire.Section{s.ackMeta(iwire.AckSynced)}, nil
+	return []iwire.Section{s.ackMeta(actualAck)}, nil
 }
 
 func (s *Server) admitBarrierAck(actual, requested iwire.AckPolicy) error {
@@ -500,10 +505,7 @@ func (s *Server) admitMutationAck(requested iwire.AckPolicy) error {
 	case 0, iwire.AckVisible, iwire.AckFlushed:
 		return nil
 	case iwire.AckSynced:
-		if s.backend == nil {
-			return protocolError(iwire.ErrDurabilityUnavailable, "synced ack requires a backend DB")
-		}
-		return nil
+		return s.admitSyncedAck()
 	case iwire.AckRaftCommitted:
 		return protocolError(iwire.ErrDurabilityUnavailable, "raft_committed ack is unavailable in single-node nativewire R1")
 	default:
@@ -537,8 +539,8 @@ func (s *Server) satisfyAck(collection interface{ Flush() error }, requested iwi
 				return 0, metadataWrap(err)
 			}
 		}
-		if s.backend == nil {
-			return 0, protocolError(iwire.ErrDurabilityUnavailable, "synced ack requires a backend DB")
+		if err := s.admitSyncedAck(); err != nil {
+			return 0, err
 		}
 		if err := s.backend.Checkpoint(); err != nil {
 			return 0, metadataWrap(err)
@@ -549,4 +551,14 @@ func (s *Server) satisfyAck(collection interface{ Flush() error }, requested iwi
 	default:
 		return 0, protocolError(iwire.ErrInvalidCommand, "unsupported ack policy %d", requested)
 	}
+}
+
+func (s *Server) admitSyncedAck() error {
+	if s.backend == nil {
+		return protocolError(iwire.ErrDurabilityUnavailable, "synced ack requires a backend DB")
+	}
+	if s.backend.DurabilityMode() != backenddb.DurabilityDurable {
+		return protocolError(iwire.ErrDurabilityUnavailable, "synced ack requires DurabilityDurable")
+	}
+	return nil
 }

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -62,6 +62,10 @@ const (
 	//   - you are exploring performance limits, and crashes/corruption detection
 	//     are acceptable trade-offs.
 	//
+	// Collection writes under this profile use DurabilityWALOffRelaxed. A
+	// successful collection write is not a durable-at-ack promise; use Flush,
+	// FlushAll, Checkpoint, or Close for a persistence boundary.
+	//
 	// It also pins the current run_celestia-style value-log compression policy:
 	// auto compression, balanced auto policy, snappy block fallback, and medium
 	// autotune.
@@ -74,6 +78,10 @@ const (
 	// write-heavy benchmarks and ingest workloads.
 	//
 	// It keeps WAL enabled but disables fsync and value-log read checksums.
+	// After collection WAL lands, successful collection writes in this profile
+	// are process-crash recoverable but still do not have a power-loss fsync
+	// guarantee.
+	//
 	// It also pins the same value-log compression policy as ProfileFast.
 	ProfileWALOnFast Profile = "wal_on_fast"
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1696,6 +1696,12 @@ func (db *DB) Print() error {
 //
 // In cached mode this flushes queued memtables with backend sync and resets the
 // WAL to a fresh segment. In backend mode it forces a sync boundary.
+//
+// Current collection-local pending writes may have their own flush-boundary
+// behavior; see docs/spec/contracts.md for the current collection contract and
+// the PR1 collection WAL target contract. After collection WAL lands,
+// Checkpoint returning nil must also cover pre-cut collection WAL transactions
+// or return/report explicit collection WAL debt.
 func (db *DB) Checkpoint() error {
 	if err := db.ensureOpen(); err != nil {
 		return err

--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -9,7 +9,7 @@ Active roadmap is tracked in `TODO.md`.
 - **Goal**: Continue hardening Windows-specific file-locking and mmap edge cases (crash recovery, file rename semantics, and cleanup).
 
 ### TreeDB Compression
-- **Current Status**: TreeDB stores values inline in the B+Tree or out-of-line in the persistent value log (`Dir/maindb/wal/`). The value log supports Zstandard compression and optional dictionary training/autotune.
+- **Current Status**: TreeDB stores values inline in the B+Tree or out-of-line in the persistent value log (`Dir/maindb/value_vlog/`). The value log supports Zstandard compression and optional dictionary training/autotune.
 - **Goal**: Evaluate additional compression opportunities (e.g., page-level compression) and improve operator ergonomics (GC/rewrite tooling and observability).
 
 ### TreeDB Index Compaction (Online)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -36,7 +36,7 @@ The default `treedb.Open()` mode wraps a durable B+Tree backend with a high-thro
 │ TreeDB                                │
 │                                       │
 │  ┌─────────────┐   ┌──────────────┐   │
-│  │  index.db   │   │  wal/value   │   │
+│  │  index.db   │   │ value_vlog   │   │
 │  │ (B+Tree)    │   │ (Large Vals) │   │
 │  └─────────────┘   └──────────────┘   │
 └───────────────────────────────────────┘
@@ -47,7 +47,10 @@ The default `treedb.Open()` mode wraps a durable B+Tree backend with a high-thro
 - **Flush**: Memtables are converted to backend batches and merged into the B+Tree via the "Zipper" (COW merge).
 
 On disk, `Options.Dir` is a root directory containing:
-- `Dir/maindb/index.db` + `Dir/maindb/wal/*.log`
+- `Dir/maindb/index.db`
+- `Dir/maindb/wal/*.log` for commit journal segments and future collection WAL
+- `Dir/maindb/value_vlog/*.log` for value-log segments
+- `Dir/maindb/leaf_vlog/*.log` for optional split leaf-log segments
 - `Dir/dictdb/index.db` (dictionary store for value-log compression)
 
 ### 2. HashDB (Sharded)

--- a/docs/TREEDB_CONCEPTS.md
+++ b/docs/TREEDB_CONCEPTS.md
@@ -73,8 +73,10 @@ not the recommended user-facing way to obtain a fully compacted storage number.
 
 ### Inline vs value-log values
 
-TreeDB stores small values inline in leaf pages up to an internal threshold (currently `256` bytes).
-Larger values are stored out-of-line in the value log and referenced by a pointer stored in the tree.
+TreeDB stores small values inline in leaf pages up to the canonical inline
+threshold defined in `TreeDB/docs/spec/write-path-and-durability.md#21-threshold-selection`.
+Larger values are stored out-of-line in the value log and referenced by a
+pointer stored in the tree.
 
 ### Copy-on-write and the “zipper” merge
 

--- a/docs/TREEDB_RECOVERY.md
+++ b/docs/TREEDB_RECOVERY.md
@@ -9,7 +9,10 @@ For the canonical TreeDB recovery spec, see:
 ## TL;DR
 
 - TreeDB takes an **exclusive directory lock** on `Open` (one process at a time).
-- Cached mode persists writes to `Dir/maindb/wal/` (journal + value-log segments) and flushes them into the backend in the background.
+- Cached mode persists redo records to `Dir/maindb/wal/`.
+- Cached mode persists value-log records to `Dir/maindb/value_vlog/` and
+  optional split leaf-log records to
+  `Dir/maindb/leaf_vlog/`, then flushes them into the backend in the background.
 - On open, TreeDB always performs a single coherent recovery path:
   1) backend recovery (meta validation + torn-tail handling)
   2) cached journal discovery + replay into the backend (synced commits)
@@ -22,7 +25,9 @@ This makes “last writer was cached vs backend” unambiguous: the next opener 
 Depending on timing, after an unclean shutdown the DB directory may contain:
 
 - A consistent backend state (index pages), possibly missing the most recent cached writes that hadn’t flushed yet.
-- One or more journal/value-log segments in `Dir/maindb/wal/` representing cached writes that are not yet reflected in the backend.
+- One or more journal segments in `Dir/maindb/wal/`.
+- Referenced value-log segments in `Dir/maindb/value_vlog/` representing cached
+  writes that are not yet reflected in the backend.
 - A torn/partial final journal record (e.g. crash mid-write).
 
 ## Recovery Pipeline

--- a/docs/TREEDB_WRITE_PATHS.md
+++ b/docs/TREEDB_WRITE_PATHS.md
@@ -14,10 +14,11 @@ For the canonical TreeDB spec, see:
 
 ## Write-path modes (cached mode)
 
-| Mode | Journal (WAL) | Value log | Durability | Status |
-| --- | --- | --- | --- | --- |
-| **WAL on** | ON | ON | Durable after `*Sync` or `Checkpoint()` | **Default** |
-| **WAL off** | OFF | ON | Unsafe (recent writes may be lost) | **Opt-in via `Options.Durability`** |
+This supporting document does not own the durability matrix. Use
+`TreeDB/docs/spec/write-path-and-durability.md` for the canonical three-mode
+matrix and `TreeDB/docs/spec/collections-write-domain.md` for current
+collection flush-boundary behavior. The target collection WAL overlay is in
+`TreeDB/docs/spec/collection-wal-durability-plan.md`.
 
 Legacy modes (value-log off / backend-only) have been removed.
 
@@ -67,7 +68,9 @@ TreeDB `Options.Dir` is a *root* directory. `treedb.Open` manages:
 
 - `Dir/maindb/`: main DB (index + journal + value log)
   - `Dir/maindb/index.db`: B+Tree pages + metadata.
-  - `Dir/maindb/wal/`: journal + value-log segments (internal file naming may change).
+  - `Dir/maindb/wal/`: commit journal segments and future collection WAL segments.
+  - `Dir/maindb/value_vlog/`: value-log segments for large values.
+  - `Dir/maindb/leaf_vlog/`: optional split leaf-log segments.
   - `Dir/maindb/LOCK`: cross-process exclusive-open lock.
 - `Dir/dictdb/`: dictionary store (for value-log compression)
   - `Dir/dictdb/index.db`: dictionary metadata (internal).

--- a/review-prompts/09-format-versioning-migration.md
+++ b/review-prompts/09-format-versioning-migration.md
@@ -1,0 +1,143 @@
+# On-Disk Format, Versioning, Migration, and Compatibility Review
+
+## Role / persona
+
+You are a storage-format maintainer responsible for preventing accidental format
+forks, unrecoverable upgrades, ambiguous WAL decoding, and future migration dead
+ends.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/db/layout.go`
+- `TreeDB/dir_layout.go`
+- `TreeDB/db/format_config.go`
+- `TreeDB/db/wal_recovery.go`
+- `TreeDB/internal/commitlog/commitlog.go`
+- `TreeDB/internal/commitlog/writer.go`
+- `TreeDB/internal/commitlog/reader.go`
+- `TreeDB/internal/atomicfile/atomicfile.go`
+- `TreeDB/page/meta.go`
+- existing format and recovery tests under `TreeDB/db`, `TreeDB/page`, and
+  `TreeDB/internal/commitlog`
+
+## Task
+
+Review whether the proposed collection WAL can be safely encoded, decoded,
+versioned, upgraded, skipped, quarantined, or migrated over time. Do not
+re-litigate whether root-delta WAL is the right architecture except where the
+chosen architecture creates concrete format risks.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- WAL transaction envelope format: magic bytes, version, flags, length,
+  checksum coverage, endian choice, compression marker, record type, and
+  segment-level versus record-level CRC.
+- Whether `Version uint8` in `CollectionWALTransaction` is sufficient for
+  future optional fields, unknown field preservation, old reader rejection, and
+  forward/backward compatibility.
+- Segment naming and discovery: interaction between `commit-l*.log`,
+  `collection-l*.log`, value-log files, leaf-log files, flat layout, root
+  layout, `maindb`, `dictdb`, and `templatedb`.
+- How format changes are gated by `storage-format.md`, `format_config.go`,
+  metadata roots, feature flags, or explicit pre-alpha "rebuild required"
+  behavior.
+- How recovery distinguishes incomplete tail, old unsupported segment, unknown
+  future segment, hard corruption, malicious length, and mixed-version WAL.
+- Whether collection identity uses stable names, IDs, schema epochs, or
+  descriptors in a way that survives rename, delete/recreate, restore, and
+  future migrations.
+- Whether on-disk paths and side references can be canonicalized without locking
+  in unsafe path semantics.
+- Whether there is a clear upgrade story from "no collection WAL exists" to
+  "collection WAL required under WAL-on profiles."
+- Whether downgrade behavior is explicitly unsupported, detected, or safe-failed.
+- Whether golden fixtures are required for WAL transactions, watermarks, side
+  refs, root deltas, and malformed cases.
+
+## Focus questions
+
+1. What exact bytes are written before the first root delta?
+2. Can a future implementation add a new side-ref class without older binaries
+   silently deleting or ignoring it?
+3. Does recovery fail closed when the format is unknown but might contain
+   durable acknowledged writes?
+4. Is "pre-alpha compatibility not guaranteed" precise enough for this feature,
+   or does the spec need explicit migration states?
+5. Are mixed directories possible after crash during an upgrade?
+6. Can collection WAL cleanup accidentally remove files that a newer format
+   would still need?
+7. Are version and feature gates stored in the system root, meta page, WAL
+   header, or all three?
+8. What test fixture would prove that a transaction encoded today remains
+   decodable after future refactors?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Must fix before implementation
+For each finding:
+- Finding:
+- Evidence from files:
+- Failure mode:
+- Why existing prompts may miss it:
+- Required remediation:
+
+## P1 - Must fix before enabling WAL-on collection durability
+
+## P2 - Should fix before column-store gate
+
+## P3 - Nice-to-have / documentation polish
+
+# Solution phase
+
+## Exact spec edits
+For each edit:
+- File:
+- Section:
+- Replace/add text:
+- Rationale:
+
+## Implementation constraints
+- Required encoder/decoder constraints:
+- Required migration/upgrade constraints:
+- Required cleanup constraints:
+
+## Tests and fixtures
+- Golden fixtures:
+- Corruption fixtures:
+- Upgrade/downgrade fixtures:
+- Recovery fixtures:
+
+## Benchmarks
+- Encoding/decoding overhead:
+- Recovery scan overhead:
+- Large-transaction overhead:
+
+## Sequencing
+- Before PR1:
+- Before WAL-on default:
+- Before column-store writes:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every P0/P1 finding, propose concrete remediations including exact spec
+edits, implementation constraints, tests, benchmarks where relevant, sequencing,
+and open questions. Be explicit about what must be added to `storage-format.md`
+versus `collection-wal-durability-plan.md`.
+

--- a/review-prompts/10-observability-forensics-operator-debugging.md
+++ b/review-prompts/10-observability-forensics-operator-debugging.md
@@ -1,0 +1,140 @@
+# Observability, Operator Debugging, and Corruption Forensics Review
+
+## Role / persona
+
+You are an on-call database operator and forensic tooling engineer. Your concern
+is not just correctness, but whether a production incident can be diagnosed
+without guessing.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/value-log-lifecycle.md`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/caching/expvar_stats.go`
+- `TreeDB/caching/vlog_queue_metrics.go`
+- `TreeDB/db/publish_watermark_metrics.go`
+- `TreeDB/db/vlog_health.go`
+- `TreeDB/cmd/treemap/vlog_audit.go`
+- `TreeDB/cmd/verify/main.go`
+- `TreeDB/cmd/wal_classify/main.go`
+- `TreeDB/nativewire/stats.go`
+- `TreeDB/internal/commitlog`
+- tests for stats, verification, WAL recovery, value-log audit, and docs
+  linting
+
+## Task
+
+Review whether operators and developers will be able to answer: "What is
+durable?", "What is pending?", "Why did recovery skip/fail?", "What side files
+are protected?", "What cleanup debt exists?", and "Can I safely compact, backup,
+or restart?"
+
+Avoid duplicating crash matrix review. Focus on observability, diagnostics,
+forensic data, audit commands, logs, counters, and operator runbooks.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Required metrics for collection WAL append latency, bytes/doc, pending txns,
+  pending bytes, segment count, side-ref count, protected side bytes, applied
+  watermark lag, checkpoint cleanup lag, replay duration, replayed/skipped/
+  blocked transactions, corruption counters, and cleanup debt.
+- Whether metrics are exposed consistently through existing stats patterns,
+  expvar, native-wire stats, benchmark reports, and CLI tools.
+- Whether errors distinguish incomplete tail, missing required side ref,
+  corrupted side ref, unsupported version, collection identity mismatch, schema
+  epoch mismatch, base-root mismatch, watermark inconsistency, and cleanup
+  failure.
+- Whether recovery leaves enough forensic evidence before deleting or
+  quarantining WAL/side files.
+- Whether `verify`, `treemap`, or `wal_classify` should understand collection
+  WAL segments and side-ref protection.
+- Whether operator commands can produce a safe "collection WAL health report."
+- Whether logs/metrics avoid leaking document contents or tenant-sensitive keys.
+- Whether runbooks define what to do when recovery fails hard versus when a tail
+  transaction is safely ignored.
+- Whether benchmark and test artifacts report collection WAL overhead in a way
+  that can be compared across PRs.
+
+## Focus questions
+
+1. What metric names should exist, and at what layer?
+2. What forensic artifact remains after a failed recovery?
+3. Can an operator tell whether `ValueLogGC` is blocked by pending collection
+   WAL side refs?
+4. Can a developer map a `TxnID` to collection name, root names, side refs, and
+   applied watermark state?
+5. Are skipped transactions auditable without exposing raw user document
+   payloads?
+6. Does `verify` detect roots pointing at missing collection WAL side refs?
+7. Is there a command that answers "which files are safe to delete?" without
+   mutating the DB?
+8. Are metrics monotonic where needed and reset-safe where not?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Incident-blocking observability gaps
+- Finding:
+- Evidence:
+- Incident scenario:
+- Missing metric/log/tooling:
+- Required remediation:
+
+## P1 - Required before WAL-on collection durability
+
+## P2 - Required before column-store or Raft-local apply
+
+## P3 - Operator polish
+
+# Solution phase
+
+## Exact spec edits
+Include proposed sections for:
+- Metrics
+- Error taxonomy
+- Forensic retention
+- Operator runbook
+- CLI/audit tooling
+
+## Implementation constraints
+- Required stats structs/counters:
+- Required error types:
+- Required log redaction rules:
+- Required audit output fields:
+
+## Tests
+- Unit tests:
+- Recovery failure tests:
+- CLI golden-output tests:
+- Redaction tests:
+- Metric monotonicity/reset tests:
+
+## Benchmarks
+- Metrics overhead:
+- Audit command scan overhead:
+- Recovery reporting overhead:
+
+## Sequencing
+- Minimal metrics for PR1:
+- Metrics required before default enablement:
+- Tooling required before column-store:
+
+## Open questions
+```
+
+## Required solution phase
+
+For each P0/P1, specify exact metric names or naming patterns, error categories,
+CLI output fields, spec sections to edit, and tests that prove the telemetry is
+emitted under both success and failure paths.
+

--- a/review-prompts/11-resource-cost-capacity-model.md
+++ b/review-prompts/11-resource-cost-capacity-model.md
@@ -1,0 +1,140 @@
+# Resource Cost, Capacity, Replay Budget, and Backpressure Review
+
+## Role / persona
+
+You are a database performance engineer responsible for bounding write
+amplification, replay time, memory growth, disk-retention debt, and backpressure
+behavior under worst-case collection workloads.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/value-log-lifecycle.md`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/caching/backpressure.go`
+- `TreeDB/caching/vlog_queue_metrics.go`
+- `TreeDB/caching/log_writer.go`
+- `TreeDB/internal/commitlog/writer.go`
+- `TreeDB/internal/commitlog/writer_bench_test.go`
+- `TreeDB/internal/valuelog/encode_cost_model.go`
+- `TreeDB/internal/valuelog/writer.go`
+- `TreeDB/collections/overhead_bench_test.go`
+- `TreeDB/collections/bench_test.go`
+- `cmd/collection_workload_bench`
+- `cmd/collection_bench_matrix`
+- `cmd/collection_bench_report`
+- `cmd/unified_bench`
+
+## Task
+
+Review whether the spec provides enough cost modeling to keep collection WAL
+durable-at-ack from creating unbounded disk growth, replay stalls, memory
+blowups, or throughput collapse. This prompt complements the existing
+benchmark/test prompt by demanding a predictive cost model and capacity limits,
+not only benchmark cases.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Bytes written per document for no-index, one-index, multi-index, update,
+  delete, template-v1, and future column-store parts.
+- Inline root-delta threshold versus side-payload threshold.
+- Segment size, rotation policy, compression policy, sync batching, and write
+  coalescing.
+- Replay memory bounds when many transactions share one base root and require
+  accumulation/rebasing.
+- Worst-case replay CPU and IO for 1K, 100K, 1M, and larger pending documents.
+- Disk-retention debt when checkpointing, async publish, side-ref protection, or
+  cleanup is stalled.
+- Backpressure rules for pending WAL bytes, pending side-ref bytes, unpublished
+  root deltas, replay accumulator size, and protected side files.
+- Whether WAL-on relaxed versus durable sync modes need different cost gates.
+- Whether existing benchmark commands can isolate collection WAL overhead from
+  value-log, memtable, index, and native-wire overhead.
+- Whether "regression <= X%" gates are enough without absolute latency, tail
+  latency, memory, disk, and replay-time ceilings.
+- Whether column-store side files require a separate capacity model before they
+  are allowed to publish persistent roots.
+
+## Focus questions
+
+1. What is the expected WAL byte amplification per indexed document?
+2. What happens if a collection receives acknowledged writes for hours while
+   async publish is blocked?
+3. What is the maximum memory recovery may use for replay-side accumulation?
+4. At what size must root deltas move from inline WAL to side payload?
+5. How are protected side refs charged to backpressure?
+6. Can cleanup lag create unbounded value-log retention?
+7. What exact benchmark labels and output columns should be added?
+8. What capacity limits are enforced versus merely observed?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Unbounded resource risk
+- Finding:
+- Evidence:
+- Worst-case workload:
+- Bound missing:
+- Required remediation:
+
+## P1 - Required capacity model before WAL-on enablement
+
+## P2 - Benchmark/reporting gaps
+
+## P3 - Optimization opportunities
+
+# Solution phase
+
+## Exact spec edits
+Include proposed formulas or tables for:
+- WAL bytes/doc
+- Side-ref bytes/doc
+- Replay memory bound
+- Replay time bound
+- Cleanup debt bound
+- Backpressure trigger
+
+## Implementation constraints
+- Hard limits:
+- Soft limits:
+- Backpressure behavior:
+- Error behavior:
+- Config defaults:
+
+## Tests
+- Unit tests:
+- Stress tests:
+- Fault/backpressure tests:
+- Cleanup-lag tests:
+
+## Benchmarks
+For each benchmark:
+- Command/package:
+- Workload:
+- Required columns:
+- Gate:
+- Reason:
+
+## Sequencing
+- Cost model required before PR1:
+- Backpressure required before async/default enablement:
+- Column-store capacity gates:
+
+## Open questions
+```
+
+## Required solution phase
+
+Propose concrete cost formulas, default limits, benchmark additions, and
+backpressure constraints. For every limit, say whether it is a hard error,
+blocking wait, adaptive flush trigger, or metric-only warning.
+

--- a/review-prompts/12-formal-invariants-state-machine.md
+++ b/review-prompts/12-formal-invariants-state-machine.md
@@ -1,0 +1,134 @@
+# Formal Invariants and State-Machine Specification Review
+
+## Role / persona
+
+You are a formal methods reviewer. Your goal is to turn the prose durability
+plan into a small, checkable state machine that exposes missing states, invalid
+transitions, and ambiguous invariants.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/value-log-lifecycle.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/db/ordered_root_publish.go`
+- `TreeDB/db/system_root_publish.go`
+- `TreeDB/db/wal_recovery.go`
+- `TreeDB/collections/api.go`
+- `TreeDB/collections/*flush*`
+- relevant tests for publish, recovery, snapshots, close, checkpoint, and async
+  flush
+
+## Task
+
+Review whether the spec defines a precise enough state machine for collection
+WAL transactions, root groups, watermarks, side refs, checkpoints, cleanup, and
+future Raft apply metadata.
+
+This is not a general architecture review. Assume the root-delta design and
+extract formal states, transitions, guards, and invariants.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- State variables for transaction existence, transaction completeness, side-ref
+  readiness, root publish state, applied watermark state, checkpoint durability,
+  cleanup eligibility, and side-file protection.
+- Allowed transitions for write planning, side-file prepare, WAL append, ack,
+  publish, watermark advance, checkpoint, cleanup, recovery replay, skip, block,
+  fail, quarantine, and maintenance.
+- Atomicity requirements: what changes in one backend commit, one fsync, one
+  system-root update, or one cleanup operation.
+- Whether the spec distinguishes "visible," "recoverable," "published,"
+  "watermarked," "checkpoint-durable," and "cleanable" with formal guards.
+- Whether per-collection and global watermarks can be modeled without unsafe
+  skip behavior.
+- Whether replay-side accumulation has precise preconditions and postconditions.
+- Whether maintenance operations are transitions in the same state machine
+  rather than external side effects.
+- Whether future Raft applied-index and idempotency state can be added without
+  violating local invariants.
+- Whether the verification matrix maps every invariant to at least one
+  executable test, fuzz target, small model, or proof obligation.
+
+## Focus questions
+
+1. What states can a transaction occupy after every crash point?
+2. What is the exact predicate for `CanAck`, `CanReplay`, `CanPublish`,
+   `CanAdvanceWatermark`, `CanCheckpoint`, and `CanClean`?
+3. Which operations are commutative, and which require total order?
+4. Is "replay deterministic" a theorem with stated assumptions or just a prose
+   goal?
+5. Can a small model generate counterexamples for watermark skip, side-ref
+   deletion, or double apply?
+6. What minimal abstract model should live in docs or tests?
+7. Which invariants should be asserted in Go tests at runtime?
+8. Where does WAL-off relaxed mode fit in the same model?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Missing or inconsistent invariant
+- Finding:
+- Evidence:
+- Counterexample or ambiguous transition:
+- Required remediation:
+
+## P1 - State-machine ambiguity
+
+## P2 - Missing proof/test mapping
+
+## P3 - Formalization polish
+
+# Solution phase
+
+## Exact spec edits
+Include:
+- State variables
+- State predicates
+- Transition table
+- Invariants
+- Crash/recovery rules
+- Cleanup rules
+
+## Implementation constraints
+- Runtime assertions:
+- Internal APIs that must enforce transition guards:
+- Forbidden state transitions:
+
+## Tests / models
+- Small model tests:
+- Property tests:
+- Fuzz targets:
+- Runtime invariant tests:
+- Deterministic replay tests:
+
+## Benchmarks
+State whether formal checks are debug-only or production-safe; propose overhead
+gates if production assertions are required.
+
+## Sequencing
+- Formal model before implementation:
+- Runtime assertions before integration:
+- Model extensions before column-store/Raft:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every P0/P1, write the missing invariant or transition rule in precise
+predicate form. Include at least one proposed model-checkable or
+property-testable scenario for each critical invariant.
+

--- a/review-prompts/13-public-api-user-contract.md
+++ b/review-prompts/13-public-api-user-contract.md
@@ -1,0 +1,137 @@
+# Public API, User-Visible Semantics, and Error Contract Review
+
+## Role / persona
+
+You are an API contract reviewer representing application developers. Your goal
+is to ensure callers know exactly what success, failure, flush, checkpoint,
+close, reopen, sync, WAL-off, WAL-on, and future native-wire acknowledgements
+mean.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/contracts.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/collections/api.go`
+- `TreeDB/db/api.go`
+- `TreeDB/public.go`
+- `TreeDB/options_aliases.go`
+- `TreeDB/profiles.go`
+- `TreeDB/nativewire/*`
+- `TreeDB/mongo_gateway/*` if collection semantics leak through gateway
+  behavior
+- public API tests under `TreeDB/collections`, `TreeDB/db`,
+  `TreeDB/nativewire`, and `TreeDB/internal/contracttest`
+
+## Task
+
+Review whether the proposed WAL durability changes are reflected in
+application-visible contracts. Focus on what users can rely on, which errors
+they see, and how public methods compose. Do not duplicate the existing
+concurrency/visibility prompt; focus on user-facing promises and API boundaries.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- What `Insert`, `InsertBatch`, `UpdateBatch`, `DeleteBatch`, index creation,
+  collection creation, `Flush`, `FlushAll`, `Checkpoint`, `Close`, and reopen
+  guarantee under each durability mode.
+- Whether "durable-at-ack" is exposed in method docs, profiles, option names,
+  native-wire responses, and gateway semantics.
+- Whether non-sync APIs, sync APIs, and barriers have crisp distinctions.
+- Whether successful return means recoverable, visible, indexed, published,
+  checkpointed, fsynced, or merely accepted.
+- Whether WAL-off relaxed mode is explicit enough to avoid user confusion.
+- Whether errors are returned synchronously, deferred to flush/close/checkpoint,
+  or only discovered during recovery.
+- Whether partial batch failure semantics are defined for unique indexes,
+  side-ref failure, WAL append failure, publish failure, and checkpoint failure.
+- Whether idempotency or retry guidance exists for application-level retries
+  after timeout, crash, or native-wire disconnect.
+- Whether future `ack_policy` values can be documented without conflating
+  transport ack, local durability, and Raft commit.
+- Whether public tests assert contracts using only public APIs and reopen
+  behavior.
+
+## Focus questions
+
+1. After `InsertBatch` returns success in WAL-on relaxed mode, what can the user
+   assume after process crash?
+2. After `InsertBatch` returns success in durable sync mode, what additional
+   guarantee exists?
+3. If WAL append succeeds but publish later fails, which public method reports
+   the failure?
+4. Can `Checkpoint()` return success while collection WAL transactions remain
+   unpublished but recoverable?
+5. Does `Close()` guarantee collection WAL cleanup, publication, checkpoint, or
+   only safe recovery?
+6. What does a native-wire client see when local WAL append fails after command
+   validation?
+7. Are retry semantics deterministic for unique indexes and updates?
+8. Are user docs consistent with tests?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Misleading or unsafe public contract
+- Finding:
+- Evidence:
+- User-visible bad outcome:
+- Required remediation:
+
+## P1 - Missing API/error semantics
+
+## P2 - Missing public contract test
+
+## P3 - Documentation polish
+
+# Solution phase
+
+## Exact spec edits
+Include edits for:
+- `contracts.md`
+- `write-path-and-durability.md`
+- `collections-write-domain.md`
+- `native-wire-protocol.md`
+- WAL plan API-boundary sections
+
+## Implementation constraints
+- Public method behavior:
+- Error propagation:
+- Retry/idempotency behavior:
+- Mode-specific behavior:
+
+## Tests
+- Public API reopen tests:
+- Flush/checkpoint/close tests:
+- Error-injection tests:
+- Native-wire response tests:
+- WAL-off relaxed negative-contract tests:
+
+## Benchmarks
+Mention any API-path overhead gates, especially for sync barriers and batch ack
+paths.
+
+## Sequencing
+- Contracts to freeze before implementation:
+- Tests required before default behavior changes:
+- Native-wire contract blockers:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every public-method ambiguity, propose exact contract wording and at least
+one public API test that would fail under the ambiguous behavior.
+

--- a/review-prompts/14-malformed-input-security-hardening.md
+++ b/review-prompts/14-malformed-input-security-hardening.md
@@ -1,0 +1,138 @@
+# Malformed File, Path Safety, Security, and Abuse-Resistance Review
+
+## Role / persona
+
+You are a security and robustness reviewer. Your job is to harden the collection
+WAL against corrupt files, malicious local directories, path traversal, symlink
+surprises, decompression bombs, integer overflow, excessive allocation, and
+tenant/name confusion.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/db/permissions.go`
+- `TreeDB/dir_layout.go`
+- `TreeDB/db/layout.go`
+- `TreeDB/internal/commitlog/reader.go`
+- `TreeDB/internal/commitlog/writer.go`
+- `TreeDB/internal/valuelog/reader.go`
+- `TreeDB/internal/valuelog/block_codec.go`
+- `TreeDB/internal/limits/record.go`
+- `TreeDB/internal/crc/crc.go`
+- `TreeDB/internal/lockfile`
+- `TreeDB/internal/nativewire/*`
+- `TreeDB/collections/api.go`
+- fuzz and corruption tests under `TreeDB/internal/commitlog`,
+  `TreeDB/internal/valuelog`, `TreeDB/internal/nativewire`, `TreeDB/page`, and
+  `TreeDB/internal/memtable`
+
+## Task
+
+Review whether the collection WAL spec and likely implementation are robust
+against malformed on-disk data and hostile or confused local environments. This
+prompt is distinct from crash red-team review: focus on invalid inputs, bounds,
+isolation, and fail-closed behavior.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Transaction length limits, field length limits, root count limits, delta count
+  limits, side-ref count limits, collection name limits, path length limits, and
+  allocation caps.
+- Integer overflow in offset, size, checksum range, length prefix, varint,
+  count, and memory preallocation calculations.
+- Decompression or decoding bombs if WAL or side payloads are compressed.
+- Path traversal or absolute-path leakage through `RelativePath` side refs.
+- Symlink, hardlink, world-writable directory, and cross-device rename risks for
+  WAL and side files.
+- Multi-tenant or multi-collection isolation: one collection's WAL transaction
+  must not be able to publish roots or side refs for another collection by name
+  collision.
+- Malicious or corrupt unknown side-ref classes.
+- Error behavior for corrupt middle record versus corrupt tail.
+- Native-wire command fields that eventually feed collection names, index names,
+  schema names, or side-effect paths.
+- Redaction of sensitive document contents in errors, logs, metrics, and
+  forensic tools.
+- Fuzz coverage for collection WAL decode, side-ref decode, root-delta decode,
+  and recovery ordering.
+
+## Focus questions
+
+1. What is the maximum legal encoded transaction size?
+2. Can a corrupt WAL record force unbounded allocation before checksum
+   verification?
+3. Can a side ref escape the DB root through `../`, symlink, or absolute path?
+4. Are collection names used as paths or only as logical identifiers?
+5. Can an unknown future `RefClass` be ignored safely?
+6. Does recovery fail closed when corruption appears before the tail?
+7. Are all checks performed before publishing roots?
+8. Can logs disclose raw keys, documents, or tenant names?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Security or fail-open corruption risk
+- Finding:
+- Evidence:
+- Exploit/corruption scenario:
+- Required remediation:
+
+## P1 - Required hardening before WAL decode/recovery
+
+## P2 - Required fuzz/bounds coverage
+
+## P3 - Defense-in-depth
+
+# Solution phase
+
+## Exact spec edits
+Include:
+- Bounds table
+- Path rules
+- Unknown-field and unknown-ref behavior
+- Redaction rules
+- Corruption handling rules
+
+## Implementation constraints
+- Decoder order of checks:
+- Allocation caps:
+- Path canonicalization:
+- Directory permission checks:
+- Error classification:
+
+## Tests
+- Fuzz targets:
+- Corrupt fixture tests:
+- Path traversal tests:
+- Symlink/permission tests:
+- Allocation cap tests:
+- Redaction tests:
+
+## Benchmarks
+- Bounds-check overhead:
+- Fuzz corpus minimization if relevant:
+
+## Sequencing
+- Hardening required before any reader lands:
+- Hardening required before operator tooling:
+- Hardening required before native-wire integration:
+
+## Open questions
+```
+
+## Required solution phase
+
+Every P0/P1 remediation must include a concrete bound, fail-closed rule, path
+rule, or decoder-order constraint. Include exact tests for malformed files that
+must not allocate excessive memory, publish roots, or delete files.
+

--- a/review-prompts/15-maintenance-backup-restore-lifecycle.md
+++ b/review-prompts/15-maintenance-backup-restore-lifecycle.md
@@ -1,0 +1,140 @@
+# Maintenance Lifecycle, Backup, Restore, and Cleanup Safety Review
+
+## Role / persona
+
+You are a lifecycle and disaster-recovery reviewer. Your job is to ensure
+collection WAL interacts safely with checkpoint, compaction, value-log GC,
+rewrite, vacuum, snapshots, read-only open, backups, restore, and offline
+maintenance.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/value-log-lifecycle.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/db/compact_storage.go`
+- `TreeDB/db/vlog_gc.go`
+- `TreeDB/db/vlog_gc_incremental.go`
+- `TreeDB/db/vlog_rewrite.go`
+- `TreeDB/db/vacuum_online.go`
+- `TreeDB/db/vacuum_offline.go`
+- `TreeDB/db/index_swap.go`
+- `TreeDB/db/checkpoint_test.go`
+- `TreeDB/db/open_readonly.go`
+- `TreeDB/offline_maintenance_*`
+- `TreeDB/snapshot.go`
+- `TreeDB/caching/checkpoint_test.go`
+- maintenance tests under `TreeDB/db`, `TreeDB/caching`, and top-level `TreeDB`
+
+## Task
+
+Review whether collection WAL becomes a first-class participant in every
+maintenance lifecycle. This complements crash and side-ref review by focusing on
+operator workflows and long-running maintenance, not individual crash points.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Whether `Checkpoint` publishes, fsyncs, preserves, or merely makes collection
+  WAL cleanup eligible.
+- Whether `CompactStorage`, `ValueLogGC`, `ValueLogRewriteOnline`,
+  `ValueLogRewriteOffline`, `LeafGenerationGC`, index vacuum, and zero-byte
+  cleanup scan or protect pending collection WAL side refs.
+- Whether maintenance can run concurrently with collection WAL append, async
+  publish, replay, cleanup, backup, or read-only open.
+- Whether backup instructions include `maindb/wal/collection-l*.log`, side
+  payloads, value-log refs, leaf-log refs, `dictdb`, `templatedb`, and future
+  column files.
+- Whether a filesystem-level backup taken during writes has a documented safe
+  procedure or is explicitly unsupported.
+- Whether read-only open should replay collection WAL, reject dirty collection
+  WAL, or expose only checkpointed roots.
+- Whether offline maintenance has preconditions about clean WAL and pending
+  collection transactions.
+- Whether restore validation can detect missing side refs before serving reads.
+- Whether quarantine/delete of uncommitted prepared side files is safe after
+  backup restore.
+- Whether lifecycle docs state when files become safe to delete.
+
+## Focus questions
+
+1. What exact file set constitutes a restorable TreeDB directory after
+   collection WAL lands?
+2. Can `ValueLogGC` delete a segment referenced only by an unapplied collection
+   WAL transaction?
+3. Can offline rewrite run with dirty collection WAL?
+4. What does read-only open do when collection WAL exists?
+5. Does checkpoint make WAL cleanup durable, or does it force root publication?
+6. Can a backup include a WAL transaction but miss its side payload?
+7. Is there a safe backup barrier API?
+8. How are quarantined side files handled after restore?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Data loss or unrestorable backup risk
+- Finding:
+- Evidence:
+- Lifecycle scenario:
+- Required remediation:
+
+## P1 - Required maintenance precondition/guard
+
+## P2 - Missing restore/verify coverage
+
+## P3 - Runbook/documentation gap
+
+# Solution phase
+
+## Exact spec edits
+Include edits for:
+- Lifecycle state diagram
+- Maintenance preconditions
+- Backup procedure
+- Restore validation
+- Read-only open behavior
+- Cleanup eligibility
+
+## Implementation constraints
+- Locks/serialization:
+- Maintenance guards:
+- Side-ref protection:
+- Backup barrier behavior:
+- Read-only behavior:
+
+## Tests
+- Maintenance concurrency tests:
+- Backup/restore tests:
+- Read-only dirty-WAL tests:
+- Offline maintenance precondition tests:
+- Cleanup eligibility tests:
+
+## Benchmarks
+- Maintenance scan overhead:
+- Backup barrier overhead:
+- Restore validation overhead:
+
+## Sequencing
+- Required before value-log GC/rewrite integration:
+- Required before operator compaction path:
+- Required before column-store files:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every risky lifecycle, propose an exact maintenance precondition or guard,
+the spec text that documents it, and the test that proves it. Include
+backup/restore procedures that are safe even with pending collection WAL
+transactions.
+

--- a/review-prompts/16-minimal-correctness-preserving-slice.md
+++ b/review-prompts/16-minimal-correctness-preserving-slice.md
@@ -15,7 +15,8 @@ Inspect at minimum:
   Gates`, `15. Open Questions`, and `16. Implementation Notes`
 - `TreeDB/docs/spec/verification.md`
 - `TreeDB/docs/spec/collections-write-domain.md`
-- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- column-store specs/RFCs when present; this repository snapshot does not
+  include a dedicated column-store RFC file
 - `TreeDB/docs/spec/native-query-raft-roadmap.md`
 - `TreeDB/collections/api.go`
 - `TreeDB/db/ordered_root_publish.go`
@@ -133,4 +134,3 @@ Include:
 Produce a concrete minimal-slice plan. For every proposed deferral, state why
 deferral is safe, what guard prevents accidental use, and what test proves the
 guard.
-

--- a/review-prompts/16-minimal-correctness-preserving-slice.md
+++ b/review-prompts/16-minimal-correctness-preserving-slice.md
@@ -1,0 +1,136 @@
+# Minimal Implementation Slice and Scope-Control Review
+
+## Role / persona
+
+You are a technical lead responsible for landing the smallest correct
+implementation without leaving traps for column-store, native-wire, or Raft
+follow-up work.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- especially sections `11. Test Plan`, `12. Benchmark Plan`, `13. Roadmap and
+  Gates`, `15. Open Questions`, and `16. Implementation Notes`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/collections/api.go`
+- `TreeDB/db/ordered_root_publish.go`
+- `TreeDB/db/system_root_publish.go`
+- `TreeDB/internal/commitlog`
+- current collection tests and WAL/recovery tests
+
+## Task
+
+Review the proposed roadmap and identify the minimal implementation slice that
+preserves correctness while reducing scope. This is not a code feasibility
+review. The goal is to separate must-have correctness from optional performance,
+ergonomics, and future extensibility.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Which features are essential for PR1 correctness versus deferred optimization.
+- Whether no-index row collections can be made durable-at-ack before indexed
+  collections, or whether that creates incompatible semantics.
+- Whether PR1 should use inline-only root deltas, side payloads, or an enforced
+  size cap.
+- Whether replay-side accumulation is required in the first slice or can be
+  avoided by logging merged flush-unit transactions.
+- Whether async indexed flush can be disabled or forced synchronous in the first
+  durable implementation.
+- Whether column-store gating can be stated as "blocked until X exact invariants
+  pass" without implementing column files.
+- Whether native-wire/Raft hooks should be stubbed, explicitly blocked, or
+  ignored until later.
+- Whether cleanup can be conservative in PR1 by retaining more WAL/side files
+  until checkpoint.
+- Whether benchmarks can be advisory in PR1 but gating before default
+  enablement.
+- Whether open questions must be resolved before coding or can be deferred
+  safely.
+
+## Focus questions
+
+1. What is the smallest set of transaction fields that must be stable in PR1?
+2. Can PR1 forbid large side-payload root deltas and still be useful?
+3. Can PR1 serialize all collection WAL publication through one global publisher
+   to avoid watermark complexity?
+4. Which concurrency or async paths can be disabled without breaking existing
+   tests?
+5. Which cleanup can be conservative to avoid unsafe deletion?
+6. Which APIs should keep old flush-boundary semantics until a later gate?
+7. What exact milestone unblocks column-store format tests versus persistent
+   writes?
+8. What open questions are actually blockers?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Scope item that must be included for correctness
+- Finding:
+- Evidence:
+- Why deferring is unsafe:
+- Required remediation:
+
+## P1 - Scope item that should be deferred to reduce risk
+
+## P2 - Roadmap/gate ambiguity
+
+## P3 - Nice-to-have sequencing cleanup
+
+# Solution phase
+
+## Minimal slice proposal
+Include:
+- In scope:
+- Explicitly out of scope:
+- Conservative defaults:
+- Forbidden modes/paths:
+- Required invariants:
+
+## Exact spec edits
+- Roadmap edits:
+- Non-goal edits:
+- Gate edits:
+- Open-question edits:
+
+## Implementation constraints
+- Required feature flags:
+- Required hard errors:
+- Required fallback behavior:
+- Required cleanup conservatism:
+
+## Tests
+- Minimal-slice correctness tests:
+- Tests proving disabled paths fail safely:
+- Tests for conservative cleanup:
+- Regression tests for old behavior where retained:
+
+## Benchmarks
+- Advisory PR1 benchmarks:
+- Gating benchmarks before default enablement:
+
+## Sequencing
+- PR1:
+- PR2:
+- Before column-store persistent writes:
+- Before native-wire/Raft exposure:
+
+## Open questions
+```
+
+## Required solution phase
+
+Produce a concrete minimal-slice plan. For every proposed deferral, state why
+deferral is safe, what guard prevents accidental use, and what test proves the
+guard.
+

--- a/review-prompts/17-documentation-source-of-truth-consistency.md
+++ b/review-prompts/17-documentation-source-of-truth-consistency.md
@@ -1,0 +1,129 @@
+# Canonical Documentation and Cross-Spec Consistency Review
+
+## Role / persona
+
+You are a spec editor and documentation integrity reviewer. Your job is to make
+sure every durability, recovery, lifecycle, and API claim has one canonical home
+and no contradictory wording elsewhere.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/README.md`
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/docs/spec/write-path-and-durability.md`
+- `TreeDB/docs/spec/recovery.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/contracts.md`
+- `TreeDB/docs/spec/value-log-lifecycle.md`
+- `TreeDB/docs/spec/verification.md`
+- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- `TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md`
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/docs/docs_lint_test.go`
+- `README.md`, `TreeDB/README.md`, and relevant package docs if they mention
+  durability
+
+## Task
+
+Review the documentation set for contradictions, stale claims, missing
+cross-links, undefined terms, and unclear canonical ownership. This prompt
+complements all technical reviews by preventing spec drift.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Whether `collection-wal-durability-plan.md` is non-normative draft, normative
+  contract, roadmap, or design note.
+- Which document owns the durability mode matrix.
+- Which document owns recovery algorithm truth.
+- Which document owns storage format bytes.
+- Which document owns value-log and side-ref lifecycle.
+- Which document owns public API semantics.
+- Whether "durable-at-ack," "flush-boundary durable," "published,"
+  "checkpointed," "recoverable," "cleanable," "side ref," "side file,"
+  "value log," "leaf log," "root group," and "watermark" are defined
+  consistently.
+- Whether column-store RFC depends on WAL plan using precise blocker language.
+- Whether native-wire and Raft docs describe local collection WAL without
+  conflating it with logical command replication.
+- Whether verification matrix includes every new invariant introduced by the WAL
+  plan.
+- Whether docs linting should grow beyond legacy terminology checks.
+
+## Focus questions
+
+1. What is the canonical source for each key concept?
+2. Which docs currently make claims that will become false after collection WAL
+   lands?
+3. Which docs should say "current behavior" versus "target behavior"?
+4. Which docs need migration notes from flush-boundary durable to durable-at-ack?
+5. Are all open questions collected in one place or duplicated?
+6. Does `verification.md` map every normative statement to test coverage?
+7. Should docs lint detect inconsistent durability terminology?
+8. Are column-store and native-wire blockers stated identically across docs?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Contradictory or dangerously stale documentation
+- Finding:
+- Evidence:
+- User/implementer confusion:
+- Required remediation:
+
+## P1 - Missing canonical ownership
+
+## P2 - Missing cross-link or verification mapping
+
+## P3 - Editorial cleanup
+
+# Solution phase
+
+## Canonical ownership table
+For each concept:
+- Concept:
+- Canonical doc/section:
+- Supporting docs:
+- Required wording changes:
+
+## Exact spec edits
+For each edit:
+- File:
+- Section:
+- Replace/add text:
+- Reason:
+
+## Docs-lint proposals
+- New lint rule:
+- Files covered:
+- False-positive exceptions:
+- Tests:
+
+## Implementation/test implications
+- Verification matrix updates:
+- Contract test updates:
+- Benchmark doc updates:
+
+## Sequencing
+- Docs to update before implementation:
+- Docs to update as milestones land:
+- Docs to update before column-store/native-wire gates:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every contradiction or stale claim, propose exact replacement wording and
+name the canonical document that should own the concept going forward. Include
+at least one docs-lint or verification-matrix improvement where useful.
+

--- a/review-prompts/17-documentation-source-of-truth-consistency.md
+++ b/review-prompts/17-documentation-source-of-truth-consistency.md
@@ -19,8 +19,10 @@ Inspect at minimum:
 - `TreeDB/docs/spec/contracts.md`
 - `TreeDB/docs/spec/value-log-lifecycle.md`
 - `TreeDB/docs/spec/verification.md`
-- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
-- `TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md`
+- column-store specs/RFCs when present; this repository snapshot does not
+  include a dedicated column-store RFC file
+- compression specs/RFCs when present; this repository snapshot does not
+  include a dedicated compression technology spec file
 - `TreeDB/docs/spec/native-wire-protocol.md`
 - `TreeDB/docs/spec/native-query-raft-roadmap.md`
 - `TreeDB/docs/docs_lint_test.go`
@@ -126,4 +128,3 @@ For each edit:
 For every contradiction or stale claim, propose exact replacement wording and
 name the canonical document that should own the concept going forward. Include
 at least one docs-lint or verification-matrix improvement where useful.
-

--- a/review-prompts/18-schema-catalog-identity-evolution.md
+++ b/review-prompts/18-schema-catalog-identity-evolution.md
@@ -14,7 +14,8 @@ Inspect at minimum:
 - `TreeDB/docs/spec/collection-wal-durability-plan.md`
 - `TreeDB/docs/spec/collections-write-domain.md`
 - `TreeDB/docs/spec/collections-document-formats.md`
-- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- column-store specs/RFCs when present; this repository snapshot does not
+  include a dedicated column-store RFC file
 - `TreeDB/docs/spec/native-wire-protocol.md`
 - `TreeDB/docs/spec/native-query-raft-roadmap.md`
 - `TreeDB/collections/api.go`
@@ -138,4 +139,3 @@ Mention any overhead from descriptor digesting or catalog guard validation.
 For every identity ambiguity, propose the exact stable identifier, epoch, or
 descriptor digest rule that should be added. Include tests that prove
 transactions cannot replay against the wrong collection or schema.
-

--- a/review-prompts/18-schema-catalog-identity-evolution.md
+++ b/review-prompts/18-schema-catalog-identity-evolution.md
@@ -1,0 +1,141 @@
+# Collection Catalog, Schema Epoch, Identity, Rename/Drop, and Recreate Review
+
+## Role / persona
+
+You are a catalog and schema-evolution reviewer. Your goal is to prevent
+collection WAL replay from applying a valid physical transaction to the wrong
+logical collection, wrong schema epoch, wrong index definition, or wrong
+recreated collection.
+
+## Primary files
+
+Inspect at minimum:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+- `TreeDB/docs/spec/collections-write-domain.md`
+- `TreeDB/docs/spec/collections-document-formats.md`
+- `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md`
+- `TreeDB/docs/spec/native-wire-protocol.md`
+- `TreeDB/docs/spec/native-query-raft-roadmap.md`
+- `TreeDB/collections/api.go`
+- `TreeDB/collections/planner.go`
+- `TreeDB/collections/template_v1.go`
+- `TreeDB/collections/stats_schema_change_test.go`
+- `TreeDB/collections/*index*`
+- `TreeDB/collections/*template*`
+- `TreeDB/db/system_root_publish.go`
+- `TreeDB/db/ordered_root_publish.go`
+- collection tests for create index, drop index, unique indexes, template
+  roots, schema changes, delete/update, and reopen
+
+## Task
+
+Review whether collection WAL transaction identity and catalog validation are
+strong enough for schema/index evolution, collection drop/recreate, template
+evolution, future column descriptors, and native-wire deterministic commands.
+
+This complements architecture, recovery, and column-store prompts by focusing
+specifically on logical identity and catalog epochs.
+
+## Review phase
+
+Find issues, risks, ambiguities, or missing evidence around:
+
+- Whether `CollectionID uint64 or stable collection name` is sufficient.
+- Whether collection rename, drop, recreate, create index, drop index, schema
+  change, template root change, and column-store descriptor change have explicit
+  epochs.
+- Whether root deltas name root kinds in a way that cannot collide across
+  primary, template, index-state, secondary, delete, locator, filter, and column
+  descriptor roots.
+- Whether recovery validates catalog identity before applying root deltas.
+- Whether transactions created before an index/schema change can be replayed
+  after the change.
+- Whether schema/index changes must drain pending collection WAL or can be
+  encoded as WAL transactions.
+- Whether unique indexes and multikey indexes have stable identities across
+  drop/recreate with the same name.
+- Whether template-v1 persisted template IDs are protected by schema/catalog
+  epoch rules.
+- Whether future deterministic native-wire commands carry enough catalog guards
+  to produce equivalent logical outcomes.
+- Whether column-store part descriptors require per-part generation IDs, schema
+  epochs, or compaction epochs.
+
+## Focus questions
+
+1. Can a WAL transaction for collection `users` apply after `users` is dropped
+   and recreated?
+2. Are secondary index roots identified by name, stable ID, creation epoch, or
+   descriptor digest?
+3. What happens to pending transactions when `CreateIndex` or `DropIndex` runs?
+4. Does recovery block if schema epoch changed after WAL append but before
+   publish?
+5. Are template ID maps part of the same root group and epoch?
+6. How should future column parts reference schema and compression metadata?
+7. Are catalog guard outcomes deterministic for future Raft apply?
+8. Which catalog changes must be durable barriers?
+
+## Output format
+
+Start with severity-ranked findings. Do not put a summary first.
+
+```markdown
+# Severity-ranked findings
+
+## P0 - Wrong-collection or wrong-schema replay risk
+- Finding:
+- Evidence:
+- Concrete replay scenario:
+- Required remediation:
+
+## P1 - Missing catalog/schema epoch rule
+
+## P2 - Missing tests for identity evolution
+
+## P3 - Naming/descriptor cleanup
+
+# Solution phase
+
+## Exact spec edits
+Include:
+- Collection identity rules
+- Root identity rules
+- Schema/index epoch rules
+- Drop/recreate rules
+- Catalog barrier rules
+- Recovery validation rules
+
+## Implementation constraints
+- Stable ID generation:
+- Descriptor digest or epoch storage:
+- Required catalog guards:
+- Forbidden replay cases:
+- Required drain/barrier behavior:
+
+## Tests
+- Drop/recreate recovery tests:
+- Create/drop index with pending WAL tests:
+- Template root epoch tests:
+- Unique/multikey identity tests:
+- Native-wire deterministic catalog guard tests:
+- Column descriptor future-proof tests:
+
+## Benchmarks
+Mention any overhead from descriptor digesting or catalog guard validation.
+
+## Sequencing
+- Required before indexed WAL:
+- Required before template-v1 WAL:
+- Required before column-store:
+- Required before Raft/native-wire distributed apply:
+
+## Open questions
+```
+
+## Required solution phase
+
+For every identity ambiguity, propose the exact stable identifier, epoch, or
+descriptor digest rule that should be added. Include tests that prove
+transactions cannot replay against the wrong collection or schema.
+

--- a/review-prompts/README.md
+++ b/review-prompts/README.md
@@ -1,0 +1,24 @@
+# Collection WAL Review Prompts
+
+These prompts complement the first eight collection WAL review prompts. They
+focus on the remaining maintainability gates: format evolution, diagnostics,
+resource bounds, formal invariants, public API semantics, malformed input
+hardening, maintenance lifecycle, MVP scope control, documentation consistency,
+and catalog identity evolution.
+
+Recommended run order:
+
+1. `09-format-versioning-migration.md`
+2. `12-formal-invariants-state-machine.md`
+3. `18-schema-catalog-identity-evolution.md`
+4. `16-minimal-correctness-preserving-slice.md`
+5. `14-malformed-input-security-hardening.md`
+6. `15-maintenance-backup-restore-lifecycle.md`
+7. `11-resource-cost-capacity-model.md`
+8. `10-observability-forensics-operator-debugging.md`
+9. `17-documentation-source-of-truth-consistency.md`
+
+The prompts assume the current canonical spec is:
+
+- `TreeDB/docs/spec/collection-wal-durability-plan.md`
+


### PR DESCRIPTION
## Summary
- add the collection WAL/root-group durability spec and hardening updates
- add review prompts 09-18 as markdown files under `review-prompts/`
- keep generated zip artifacts out of the repository

## Context
This is the clean replacement PR for #1439. The prior PR branch is intentionally left unchanged, including its accidentally committed generated zip. This branch preserves the source/spec/prompt changes without any `.zip` artifact in the PR diff.

## Checks
- `git diff --check`
- ASCII scan for `review-prompts/`
- pre-commit hook ran `go-fmt`
- confirmed PR diff contains no `.zip` files
