### PR TITLE
Optimize small indexed InsertBatch buffering

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5059,7 +5059,7 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 			if pending == nil || pending.len() == 0 {
 				continue
 			}
-			if err := rejectBufferedUniqueValuePrefixConflicts(uniquePlan.indexName, uniquePlan.valueType, pending, uniquePlan.prefixes); err != nil {
+			if err := rejectBufferedUniqueValuePrefixConflicts(uniquePlan.indexName, pending, uniquePlan.prefixes); err != nil {
 				return err
 			}
 		}
@@ -5118,8 +5118,7 @@ func rejectBufferedPrimaryConflicts(pendingIndex *bufferedUniqueValueIndex, pend
 	return nil
 }
 
-func rejectBufferedUniqueValuePrefixConflicts(indexName string, valueType IndexValueType, pending *bufferedUniqueValueIndex, prefixes [][]byte) error {
-	_ = valueType
+func rejectBufferedUniqueValuePrefixConflicts(indexName string, pending *bufferedUniqueValueIndex, prefixes [][]byte) error {
 	for _, prefix := range prefixes {
 		if pending != nil && pending.contains(prefix) {
 			return fmt.Errorf("%w %q", ErrUniqueIndexConflict, indexName)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -57,6 +57,14 @@ const (
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.
 	DefaultIndexedWriteMemtableDirectBatchDocuments = 16000
+	// DefaultIndexedWriteMemtableAccumulatorBatchDocuments keeps small indexed
+	// InsertBatch calls from creating one frozen root run per call. Larger
+	// batches already amortize sorted frozen runs well and keep that path.
+	DefaultIndexedWriteMemtableAccumulatorBatchDocuments = 1024
+	// DefaultIndexedWriteMemtableAccumulatorLockedPlanningDocuments keeps the
+	// single-document accumulator path from reloading collection root metadata
+	// once per insert. Larger calls can release the mutation lock while planning.
+	DefaultIndexedWriteMemtableAccumulatorLockedPlanningDocuments = 1
 	// DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits bounds default
 	// background indexed flush work. When the queue reaches this many immutable
 	// flush units, the triggering writer publishes synchronously to cap memory
@@ -799,6 +807,7 @@ type bufferedIndexedCheckpoint struct {
 	indexedFlushUnits      []indexedFlushUnit
 	primaryRunIndexActive  bool
 	uniqueValueRuns        map[string][]memtable.Table
+	uniqueValueMutableRuns map[string]memtable.Table
 	rootRunCount           int
 }
 
@@ -859,15 +868,16 @@ type collectionWriteDomain struct {
 	primaryIDIndex         *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
-	primaryRunIndex  *bufferedPrimaryRunIndex
-	uniqueValueRuns  map[string][]memtable.Table
-	uniqueValueIndex map[string]*bufferedUniqueValueIndex
-	count            int
-	bufferedBytes    int64
-	mutableCount     int
-	mutableBytes     int64
-	rootRunCount     int
-	writeGeneration  uint64
+	primaryRunIndex        *bufferedPrimaryRunIndex
+	uniqueValueRuns        map[string][]memtable.Table
+	uniqueValueMutableRuns map[string]memtable.Table
+	uniqueValueIndex       map[string]*bufferedUniqueValueIndex
+	count                  int
+	bufferedBytes          int64
+	mutableCount           int
+	mutableBytes           int64
+	rootRunCount           int
+	writeGeneration        uint64
 
 	mutationLockCalls                  atomic.Uint64
 	mutationLockWaitTotalNs            atomic.Uint64
@@ -3347,6 +3357,9 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	if domain.uniqueValueIndex == nil {
 		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 	}
+	if plan.directBufferedInsert != nil {
+		return c.bufferDirectIndexedInsertPlanLocked(domain, catalog, plan)
+	}
 	autoFlushEnabled := bufferedIndexedAutoFlushEnabled(catalog.meta.Options)
 	freezeMutableIndexedRunMapsLocked(domain)
 	var checkpoint bufferedIndexedCheckpoint
@@ -3446,6 +3459,199 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	return 0, nil
 }
 
+func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWriteDomain, catalog *collectionCatalog, plan *insertBatchPlan) (time.Duration, error) {
+	direct := plan.directBufferedInsert
+	if direct == nil {
+		return 0, nil
+	}
+	if len(direct.rootNames) == 0 || len(direct.rootNames) != len(direct.policies) {
+		return 0, fmt.Errorf("collections: InsertBatch collection %q invalid direct plan lengths roots=%d policies=%d", catalog.meta.Name, len(direct.rootNames), len(direct.policies))
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(direct.rootNames))
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, len(direct.rootNames))
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table, len(direct.rootNames))
+	}
+	if domain.uniqueValueRuns == nil {
+		domain.uniqueValueRuns = make(map[string][]memtable.Table)
+	}
+	if domain.uniqueValueIndex == nil {
+		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
+	}
+
+	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, direct.rootNames)
+	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, catalog.meta.Options, len(plan.resultIDs), direct.stagedBytes, addedRootRuns)
+	var preAppendFreezeTables []memtable.Table
+	if shouldAutoFlushAfterAdding {
+		preAppendFreezeTables = detachMutableIndexedRunTablesLocked(domain)
+	}
+	var checkpoint bufferedIndexedCheckpoint
+	collectionMetaCheckpoint := c.meta
+	rollbackOnError := shouldAutoFlushAfterAdding
+	if shouldAutoFlushAfterAdding {
+		checkpoint = checkpointBufferedIndexedDomain(domain)
+	}
+	rollbackGeneration := checkpoint.writeGeneration
+	freezePreAppendTables := func() time.Duration {
+		if len(preAppendFreezeTables) == 0 {
+			return 0
+		}
+		freezeDuration, lockReleased, _ := freezeIndexedRunTablesOutsideLock(domain, preAppendFreezeTables)
+		if lockReleased > 0 && rollbackOnError && domain.writeGeneration != rollbackGeneration {
+			rollbackOnError = false
+		}
+		preAppendFreezeTables = nil
+		return freezeDuration
+	}
+	defer freezePreAppendTables()
+
+	rootTables := make(map[string]memtable.Table, len(direct.rootNames))
+	actualRootRuns := 0
+	for i, rootName := range direct.rootNames {
+		baseRoot := catalog.rootID(rootName)
+		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+			return 0, errBufferedRootBaseMismatch(catalog.meta.Name, rootName)
+		}
+		if _, ok := domain.rootBaseIDs[rootName]; !ok {
+			domain.rootBaseIDs[rootName] = baseRoot
+		}
+		domain.rootPolicies[rootName] = direct.policies[i]
+		table, created := mutableRootRunLocked(domain, rootName)
+		if table == nil {
+			return 0, fmt.Errorf("collections: InsertBatch collection %q failed to allocate direct root accumulator for %q", catalog.meta.Name, rootName)
+		}
+		rootTables[rootName] = table
+		if created {
+			actualRootRuns = saturatingAddNonNegativeInt(actualRootRuns, 1)
+		}
+	}
+	if len(direct.templateEntries) > 0 {
+		templateTable := rootTables[direct.templateRootName]
+		if templateTable == nil {
+			return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct template root accumulator for %q", catalog.meta.Name, direct.templateRootName)
+		}
+		if err := applyDirectBufferedRootEntries(templateTable, direct.templateEntries); err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return 0, err
+		}
+	}
+	if len(direct.indexStateEntries) > 0 {
+		indexStateTable := rootTables[direct.indexStateRootName]
+		if indexStateTable == nil {
+			return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct index-state root accumulator for %q", catalog.meta.Name, direct.indexStateRootName)
+		}
+		if err := applyDirectBufferedRootEntries(indexStateTable, direct.indexStateEntries); err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return 0, err
+		}
+	}
+	primaryTable := rootTables[direct.primaryRootName]
+	if primaryTable == nil {
+		return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct primary root accumulator for %q", catalog.meta.Name, direct.primaryRootName)
+	}
+	if err := applyDirectBufferedRootEntries(primaryTable, direct.primaryEntries); err != nil {
+		if rollbackOnError {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			c.meta = collectionMetaCheckpoint
+		}
+		return 0, err
+	}
+	if domain.primaryIDIndex == nil {
+		domain.primaryIDIndex = newBufferedUniqueValueIndex(max(1, len(plan.primaryKeys)))
+	}
+	addBufferedPrimaryIDKeys(domain.primaryIDIndex, plan.primaryKeys)
+	if domain.primaryRunIndex != nil {
+		addBufferedPrimaryRunIndexKeys(domain.primaryRunIndex, plan.primaryKeys, primaryTable)
+	}
+	for _, secondaryPlan := range direct.secondaryRootPlans {
+		table := rootTables[secondaryPlan.rootName]
+		if table == nil {
+			continue
+		}
+		if err := applyCollectionRunEntriesWithFlags(table, len(secondaryPlan.entries), func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+			entry := secondaryPlan.entries[i]
+			if entry.tombstone {
+				return entry.key, nil, page.ValuePtr{}, node.FlagTombstone, nil
+			}
+			return entry.key, nil, page.ValuePtr{}, node.FlagInline, nil
+		}); err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return 0, err
+		}
+	}
+	for _, uniquePlan := range direct.uniqueValueRootPlans {
+		table, _ := mutableUniqueValueRunLocked(domain, uniquePlan.indexName)
+		if table == nil {
+			return 0, fmt.Errorf("collections: InsertBatch collection %q failed to allocate direct unique accumulator for %q", catalog.meta.Name, uniquePlan.indexName)
+		}
+		if err := applyDirectBufferedUniqueValuePrefixes(table, uniquePlan.prefixes); err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return 0, err
+		}
+		index := domain.uniqueValueIndex[uniquePlan.indexName]
+		if index == nil {
+			index = newBufferedUniqueValueIndex(max(1, len(uniquePlan.prefixes)))
+			domain.uniqueValueIndex[uniquePlan.indexName] = index
+		}
+		index.addAll(uniquePlan.prefixes)
+	}
+
+	domain.loaded = true
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	domain.count += len(plan.resultIDs)
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.writeGeneration++
+	if rollbackOnError {
+		rollbackGeneration = domain.writeGeneration
+	}
+	domain.observeIndexedStage(len(plan.resultIDs), direct.stagedBytes, actualRootRuns)
+	c.meta = catalog.meta
+
+	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, catalog.meta.Options)
+	if err != nil {
+		if rollbackOnError {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			c.meta = collectionMetaCheckpoint
+		}
+		return 0, err
+	}
+	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
+		_ = freezePreAppendTables()
+		flushElapsed, _, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
+		if err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return flushElapsed, err
+		}
+		resetCollectionTables(compactedObsolete)
+		return flushElapsed, nil
+	}
+	resetCollectionTables(compactedObsolete)
+	return 0, nil
+}
+
 func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWriteDomain, catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64) {
 	domain.loaded = true
 	domain.meta = catalog.meta
@@ -3466,6 +3672,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueMutableRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.bufferedBytes = 0
 	domain.mutableCount = 0
@@ -3563,6 +3770,7 @@ func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain,
 	domain.rootRuns = compactedRootRuns
 	domain.rootMutableRuns = nil
 	domain.uniqueValueRuns = compactedUniqueRuns
+	domain.uniqueValueMutableRuns = nil
 	domain.rootRunCount = tableRunMapRunCount(domain.rootRuns)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.bufferedBytes, beforeBytes), afterBytes)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.mutableBytes, beforeBytes), afterBytes)
@@ -3879,12 +4087,31 @@ func mutableRootRunLocked(domain *collectionWriteDomain, rootName string) (memta
 	return table, true
 }
 
+func mutableUniqueValueRunLocked(domain *collectionWriteDomain, indexName string) (memtable.Table, bool) {
+	if domain == nil || indexName == "" {
+		return nil, false
+	}
+	if domain.uniqueValueRuns == nil {
+		domain.uniqueValueRuns = make(map[string][]memtable.Table)
+	}
+	if domain.uniqueValueMutableRuns == nil {
+		domain.uniqueValueMutableRuns = make(map[string]memtable.Table)
+	}
+	if table := domain.uniqueValueMutableRuns[indexName]; table != nil {
+		return table, false
+	}
+	table := newCollectionRootAccumulatorRunTable()
+	domain.uniqueValueMutableRuns[indexName] = table
+	domain.uniqueValueRuns[indexName] = append(domain.uniqueValueRuns[indexName], table)
+	return table, true
+}
+
 func newCollectionRootAccumulatorRunTable() memtable.Table {
 	return newFreezeSortRunTable()
 }
 
 func freezeMutableIndexedRunMapsLocked(domain *collectionWriteDomain) {
-	if domain == nil || len(domain.rootMutableRuns) == 0 {
+	if domain == nil || (len(domain.rootMutableRuns) == 0 && len(domain.uniqueValueMutableRuns) == 0) {
 		return
 	}
 	for _, table := range domain.rootMutableRuns {
@@ -3892,20 +4119,32 @@ func freezeMutableIndexedRunMapsLocked(domain *collectionWriteDomain) {
 			table.Freeze()
 		}
 	}
+	for _, table := range domain.uniqueValueMutableRuns {
+		if table != nil {
+			table.Freeze()
+		}
+	}
 	domain.rootMutableRuns = nil
+	domain.uniqueValueMutableRuns = nil
 }
 
 func detachMutableIndexedRunTablesLocked(domain *collectionWriteDomain) []memtable.Table {
-	if domain == nil || len(domain.rootMutableRuns) == 0 {
+	if domain == nil || (len(domain.rootMutableRuns) == 0 && len(domain.uniqueValueMutableRuns) == 0) {
 		return nil
 	}
-	tables := make([]memtable.Table, 0, len(domain.rootMutableRuns))
+	tables := make([]memtable.Table, 0, len(domain.rootMutableRuns)+len(domain.uniqueValueMutableRuns))
 	for _, table := range domain.rootMutableRuns {
 		if table != nil {
 			tables = append(tables, table)
 		}
 	}
+	for _, table := range domain.uniqueValueMutableRuns {
+		if table != nil {
+			tables = append(tables, table)
+		}
+	}
 	domain.rootMutableRuns = nil
+	domain.uniqueValueMutableRuns = nil
 	return tables
 }
 
@@ -4375,6 +4614,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
 		primaryRunIndexActive:  domain.primaryRunIndex != nil,
 		uniqueValueRuns:        cloneTableRunMap(domain.uniqueValueRuns),
+		uniqueValueMutableRuns: cloneMutableRunMap(domain.uniqueValueMutableRuns),
 		rootRunCount:           domain.rootRunCount,
 	}
 }
@@ -4420,6 +4660,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 		domain.primaryRunIndex = nil
 	}
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
+	domain.uniqueValueMutableRuns = checkpoint.uniqueValueMutableRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.uniqueValueRuns))
 }
 
@@ -4738,15 +4979,33 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 	}
 	primaryName := collectionPrimaryRootName(meta.Name)
 	if pendingPrimary := pendingIndexedRootRunsLocked(domain, primaryName); len(pendingPrimary) > 0 {
-		for _, run := range plan.runs {
-			if run.name != primaryName {
-				continue
-			}
-			if err := rejectBufferedPrimaryConflicts(domain.primaryIDIndex, pendingPrimary, run.table); err != nil {
+		if direct := plan.directBufferedInsert; direct != nil {
+			if err := rejectBufferedPrimaryConflictKeys(domain.primaryIDIndex, pendingPrimary, plan.primaryKeys); err != nil {
 				return err
 			}
-			break
+		} else {
+			for _, run := range plan.runs {
+				if run.name != primaryName {
+					continue
+				}
+				if err := rejectBufferedPrimaryConflicts(domain.primaryIDIndex, pendingPrimary, run.table); err != nil {
+					return err
+				}
+				break
+			}
 		}
+	}
+	if direct := plan.directBufferedInsert; direct != nil {
+		for _, uniquePlan := range direct.uniqueValueRootPlans {
+			pending := pendingUniqueReservationIndexLocked(domain, uniquePlan.indexName, true)
+			if pending == nil || pending.len() == 0 {
+				continue
+			}
+			if err := rejectBufferedUniqueValuePrefixConflicts(uniquePlan.indexName, uniquePlan.valueType, pending, uniquePlan.prefixes); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	uniqueIndexes := uniqueCollectionIndexNames(meta)
 	for _, run := range plan.runs {
@@ -4762,6 +5021,20 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 		}
 		if err := rejectBufferedUniqueIndexConflicts(run.indexName, run.indexValueType, pending, run.table); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func rejectBufferedPrimaryConflictKeys(pendingIndex *bufferedUniqueValueIndex, pendingPrimary []memtable.Table, keys [][]byte) error {
+	for _, key := range keys {
+		if pendingIndex != nil && pendingIndex.contains(key) {
+			return ErrDocumentExists
+		}
+		if pendingIndex == nil {
+			if _, _, flags, found := getBufferedRunEntry(pendingPrimary, key); found && flags&node.FlagTombstone == 0 {
+				return ErrDocumentExists
+			}
 		}
 	}
 	return nil
@@ -4787,6 +5060,16 @@ func rejectBufferedPrimaryConflicts(pendingIndex *bufferedUniqueValueIndex, pend
 	return nil
 }
 
+func rejectBufferedUniqueValuePrefixConflicts(indexName string, valueType IndexValueType, pending *bufferedUniqueValueIndex, prefixes [][]byte) error {
+	_ = valueType
+	for _, prefix := range prefixes {
+		if pending != nil && pending.contains(prefix) {
+			return fmt.Errorf("%w %q", ErrUniqueIndexConflict, indexName)
+		}
+	}
+	return nil
+}
+
 func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtable.Table) error {
 	if index == nil || batchPrimary == nil {
 		return nil
@@ -4808,6 +5091,33 @@ func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtabl
 		index.arenas = append(index.arenas, arena)
 	}
 	return nil
+}
+
+func addBufferedPrimaryIDKeys(index *bufferedUniqueValueIndex, keys [][]byte) {
+	if index == nil || len(keys) == 0 {
+		return
+	}
+	arena := make([]byte, 0, bufferedPrimaryIDArenaCap(len(keys)))
+	for _, key := range keys {
+		if len(key) == 0 {
+			continue
+		}
+		start := len(arena)
+		arena = append(arena, key...)
+		index.add(arena[start:len(arena)])
+	}
+	if len(arena) > 0 {
+		index.arenas = append(index.arenas, arena)
+	}
+}
+
+func applyDirectBufferedUniqueValuePrefixes(table memtable.Table, prefixes [][]byte) error {
+	if len(prefixes) == 0 {
+		return nil
+	}
+	return applyCollectionRunEntries(table, len(prefixes), func(i int) (key, value []byte, err error) {
+		return prefixes[i], nil, nil
+	})
 }
 
 func newBufferedPrimaryRunIndex(capacity int) *bufferedPrimaryRunIndex {
@@ -6255,6 +6565,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.primaryRunIndex = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueMutableRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.count = 0
 	domain.bufferedBytes = 0
@@ -6293,6 +6604,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueMutableRuns = nil
 	domain.rootValueArenas = nil
 	domain.rootRunCount = 0
 	domain.mutableCount = 0
@@ -6786,7 +7098,9 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
 
-	unlockForPlanning := shouldUnlockInsertPlanning(plannerOptions, indexedMemtablesEnabled, bufferIndexedInserts)
+	directBufferedInsertAccumulators := bufferIndexedInserts && shouldUseDirectBufferedInsertAccumulators(len(documents))
+	keepDirectBufferedInsertPlanningLocked := directBufferedInsertAccumulators && shouldPlanDirectBufferedInsertAccumulatorsWithMutationLocked(len(documents))
+	unlockForPlanning := shouldUnlockInsertPlanning(plannerOptions, indexedMemtablesEnabled, bufferIndexedInserts, keepDirectBufferedInsertPlanningLocked)
 	if unlockForPlanning {
 		closePlanningSnapshot()
 		unlockIfLocked()
@@ -6803,6 +7117,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	if bufferIndexedInserts {
 		planner.buildPrimaryVal = clonePrimaryDocument
 		planner.cloneTemplateRunValues = true
+		planner.directBufferedRuns = directBufferedInsertAccumulators
 	}
 	plan, err := planner.planInsertBatch(ids, documents)
 	if err != nil {
@@ -6814,7 +7129,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	} else if indexedMemtablesEnabled {
 		plan.stats.BufferedIndexedBypassBatches = 1
 	}
-	if len(plan.runs) == 0 {
+	if !insertBatchPlanHasRootWork(plan) {
 		closePlanningSnapshot()
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
@@ -6902,8 +7217,19 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	return plan.resultIDs, nil
 }
 
-func shouldUnlockInsertPlanning(opts collectionOptions, indexedMemtablesEnabled, bufferIndexedInserts bool) bool {
+func shouldUseDirectBufferedInsertAccumulators(documentCount int) bool {
+	return documentCount > 0 && documentCount <= DefaultIndexedWriteMemtableAccumulatorBatchDocuments
+}
+
+func shouldPlanDirectBufferedInsertAccumulatorsWithMutationLocked(documentCount int) bool {
+	return documentCount > 0 && documentCount <= DefaultIndexedWriteMemtableAccumulatorLockedPlanningDocuments
+}
+
+func shouldUnlockInsertPlanning(opts collectionOptions, indexedMemtablesEnabled, bufferIndexedInserts, keepDirectBufferedInsertPlanningLocked bool) bool {
 	if opts.documentFormat == DocumentFormatTemplateV1 {
+		return false
+	}
+	if keepDirectBufferedInsertPlanningLocked {
 		return false
 	}
 	if indexedMemtablesEnabled && !bufferIndexedInserts {
@@ -6971,6 +7297,16 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 	if plan == nil {
 		return nil, nil
 	}
+	if direct := plan.directBufferedInsert; direct != nil && len(direct.rootNames) > 0 {
+		rootNames := append([]string(nil), direct.rootNames...)
+		baseRootIDs := make(map[string]uint64, len(rootNames))
+		for _, rootName := range rootNames {
+			if catalog != nil {
+				baseRootIDs[rootName] = catalog.rootID(rootName)
+			}
+		}
+		return rootNames, baseRootIDs
+	}
 	rootNames := make([]string, len(plan.runs))
 	baseRootIDs := make(map[string]uint64, len(plan.runs))
 	for i, run := range plan.runs {
@@ -6980,6 +7316,16 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 		}
 	}
 	return rootNames, baseRootIDs
+}
+
+func insertBatchPlanHasRootWork(plan *insertBatchPlan) bool {
+	if plan == nil {
+		return false
+	}
+	if len(plan.runs) > 0 {
+		return true
+	}
+	return plan.directBufferedInsert != nil && len(plan.directBufferedInsert.rootNames) > 0
 }
 
 type insertBatchValidationContext struct {
@@ -9266,6 +9612,9 @@ type directBufferedSecondaryRootPlan struct {
 	rootName   string
 	entries    []directBufferedSecondaryRootEntry
 	arena      []byte
+	indexName  string
+	valueType  IndexValueType
+	unique     bool
 	deletes    int
 	sets       int
 	keyBytes   int
@@ -9368,6 +9717,9 @@ func buildDirectBufferedSecondaryRootPlans(collectionName string, runtimes []ind
 			rootName:   runtimeSecondaryRootName(collectionName, runtime),
 			entries:    make([]directBufferedSecondaryRootEntry, 0, entryCount),
 			arena:      make([]byte, 0, runStats.KeyBytes),
+			indexName:  runtime.def.name,
+			valueType:  runtime.def.valueType,
+			unique:     runtime.def.unique,
 			deletes:    runStats.Deletes,
 			sets:       runStats.Sets,
 			keyBytes:   runStats.KeyBytes,
@@ -11787,6 +12139,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.storagePolicy = options.dataStoragePolicy
 	domain.indexedFlushUnits = nil
 	domain.rootRuns = nil
+	domain.rootMutableRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
@@ -11794,6 +12147,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueMutableRuns = nil
 	domain.uniqueValueIndex = nil
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4433,6 +4433,7 @@ func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T)
 		documentFormat          DocumentFormat
 		indexedMemtablesEnabled bool
 		bufferIndexedInserts    bool
+		keepDirectPlanningLock  bool
 		wantUnlock              bool
 	}{
 		{
@@ -4441,11 +4442,19 @@ func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T)
 			wantUnlock:     true,
 		},
 		{
-			name:                    "json-buffered-indexed-memtables",
+			name:                    "json-buffered-indexed-memtables-large-batch",
 			documentFormat:          DocumentFormatJSON,
 			indexedMemtablesEnabled: true,
 			bufferIndexedInserts:    true,
 			wantUnlock:              true,
+		},
+		{
+			name:                    "json-buffered-indexed-memtables-direct-accumulator",
+			documentFormat:          DocumentFormatJSON,
+			indexedMemtablesEnabled: true,
+			bufferIndexedInserts:    true,
+			keepDirectPlanningLock:  true,
+			wantUnlock:              false,
 		},
 		{
 			name:                    "json-direct-indexed-memtable-bypass",
@@ -4478,11 +4487,30 @@ func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T)
 				collectionOptions{documentFormat: tt.documentFormat},
 				tt.indexedMemtablesEnabled,
 				tt.bufferIndexedInserts,
+				tt.keepDirectPlanningLock,
 			)
 			if got != tt.wantUnlock {
 				t.Fatalf("shouldUnlockInsertPlanning()=%v want %v", got, tt.wantUnlock)
 			}
 		})
+	}
+}
+
+func TestCollectionIndexedInsertAccumulatorThresholds(t *testing.T) {
+	if !shouldUseDirectBufferedInsertAccumulators(1) {
+		t.Fatal("single-document insert should use direct buffered accumulators")
+	}
+	if !shouldUseDirectBufferedInsertAccumulators(DefaultIndexedWriteMemtableAccumulatorBatchDocuments) {
+		t.Fatal("accumulator threshold should be inclusive")
+	}
+	if shouldUseDirectBufferedInsertAccumulators(DefaultIndexedWriteMemtableAccumulatorBatchDocuments + 1) {
+		t.Fatal("large insert should keep frozen-run path")
+	}
+	if !shouldPlanDirectBufferedInsertAccumulatorsWithMutationLocked(1) {
+		t.Fatal("single-document accumulator insert should keep planning lock")
+	}
+	if shouldPlanDirectBufferedInsertAccumulatorsWithMutationLocked(2) {
+		t.Fatal("multi-document accumulator insert should release planning lock")
 	}
 }
 
@@ -6689,6 +6717,170 @@ func TestCollectionIndexedWriteMemtablesCompactRootRunsBeforeDocumentFlush(t *te
 	}
 	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
 		t.Fatal("primary root was not persisted after document threshold")
+	}
+}
+
+func TestCollectionIndexedInsertBatchUsesMutableBufferedRootAccumulators(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 100,
+			BufferedIndexedWriteMaxRootRuns:  100,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	for i, id := range []string{"u1", "u2", "u3"} {
+		doc := fmt.Sprintf(`{"email":"user%d@example.com","city":"hnl"}`, i+1)
+		if _, err := col.InsertBatch([][]byte{[]byte(id)}, [][]byte{[]byte(doc)}); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	primaryRoot := collectionPrimaryRootName("users")
+	indexStateRoot := collectionIndexStateRootName("users")
+	emailRoot := collectionSecondaryRootName("users", "email")
+	cityRoot := collectionSecondaryRootName("users", "city")
+
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	rootRuns := map[string]int{
+		primaryRoot:    len(col.writeDomain.rootRuns[primaryRoot]),
+		indexStateRoot: len(col.writeDomain.rootRuns[indexStateRoot]),
+		emailRoot:      len(col.writeDomain.rootRuns[emailRoot]),
+		cityRoot:       len(col.writeDomain.rootRuns[cityRoot]),
+	}
+	mutableRuns := len(col.writeDomain.rootMutableRuns)
+	uniqueRuns := len(col.writeDomain.uniqueValueRuns["email"])
+	uniqueMutableRuns := len(col.writeDomain.uniqueValueMutableRuns)
+	col.writeDomain.mu.RUnlock()
+
+	if rootRunCount != 4 {
+		t.Fatalf("rootRunCount=%d want 4 mutable root accumulators", rootRunCount)
+	}
+	for rootName, count := range rootRuns {
+		if count != 1 {
+			t.Fatalf("root %q runs=%d want 1 mutable accumulator", rootName, count)
+		}
+	}
+	if mutableRuns != 4 {
+		t.Fatalf("mutable root accumulators=%d want 4", mutableRuns)
+	}
+	if uniqueRuns != 1 || uniqueMutableRuns != 1 {
+		t.Fatalf("unique value runs=%d mutable=%d want 1/1", uniqueRuns, uniqueMutableRuns)
+	}
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedStageRootRuns; got != 4 {
+		t.Fatalf("indexed staged root runs=%d want 4 newly-created accumulators", got)
+	}
+	if got := stats.IndexedStageBatches; got != 3 {
+		t.Fatalf("indexed staged batches=%d want 3", got)
+	}
+
+	got, err := col.Get([]byte("u3"))
+	if err != nil {
+		t.Fatalf("get pending buffered doc: %v", err)
+	}
+	if got == nil {
+		t.Fatal("pending buffered doc not visible")
+	}
+	ids, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find pending city: %v", err)
+	}
+	if !reflect.DeepEqual(ids, [][]byte{[]byte("u1"), []byte("u2"), []byte("u3")}) {
+		t.Fatalf("pending city ids=%q want [u1 u2 u3]", ids)
+	}
+	_, err = col.InsertBatch([][]byte{[]byte("u4")}, [][]byte{[]byte(`{"email":"user2@example.com","city":"hnl"}`)})
+	if !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate pending unique insert err=%v want ErrUniqueIndexConflict", err)
+	}
+}
+
+func TestCollectionIndexedInsertBatchKeepsLargeBatchesAsFrozenRuns(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: DefaultIndexedWriteMemtableAccumulatorBatchDocuments * 4,
+			BufferedIndexedWriteMaxRootRuns:  DefaultIndexedWriteMemtableAccumulatorBatchDocuments * 4,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	count := DefaultIndexedWriteMemtableAccumulatorBatchDocuments + 1
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("u%04d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"email":"user%04d@example.com"}`, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("insert large batch: %v", err)
+	}
+
+	primaryRoot := collectionPrimaryRootName("users")
+	indexStateRoot := collectionIndexStateRootName("users")
+	emailRoot := collectionSecondaryRootName("users", "email")
+
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	rootRuns := map[string]int{
+		primaryRoot:    len(col.writeDomain.rootRuns[primaryRoot]),
+		indexStateRoot: len(col.writeDomain.rootRuns[indexStateRoot]),
+		emailRoot:      len(col.writeDomain.rootRuns[emailRoot]),
+	}
+	mutableRuns := len(col.writeDomain.rootMutableRuns)
+	uniqueRuns := len(col.writeDomain.uniqueValueRuns["email"])
+	uniqueMutableRuns := len(col.writeDomain.uniqueValueMutableRuns)
+	col.writeDomain.mu.RUnlock()
+
+	if rootRunCount != 3 {
+		t.Fatalf("rootRunCount=%d want 3 frozen runs", rootRunCount)
+	}
+	for rootName, count := range rootRuns {
+		if count != 1 {
+			t.Fatalf("root %q runs=%d want 1 frozen run", rootName, count)
+		}
+	}
+	if mutableRuns != 0 {
+		t.Fatalf("mutable root accumulators=%d want 0 for large batch", mutableRuns)
+	}
+	if uniqueRuns != 1 || uniqueMutableRuns != 0 {
+		t.Fatalf("unique value runs=%d mutable=%d want 1/0", uniqueRuns, uniqueMutableRuns)
 	}
 }
 

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -80,12 +80,14 @@ type insertBatchPlanner struct {
 	options                collectionOptions
 	buildPrimaryVal        func(documentID, document []byte) ([]byte, error)
 	cloneTemplateRunValues bool
+	directBufferedRuns     bool
 }
 
 type insertBatchPlan struct {
 	resultIDs                  [][]byte
 	primaryKeys                [][]byte
 	runs                       []collectionRootRun
+	directBufferedInsert       *directBufferedInsertPlan
 	uniqueProbeCandidates      []uniqueProbeCandidate
 	uniqueProbeCandidatesBuilt bool
 	uniqueProbeRuns            []collectionUniqueProbeRun
@@ -107,6 +109,27 @@ type collectionRootRun struct {
 	indexValueType IndexValueType
 	table          memtable.Table
 	storagePolicy  backenddb.OrderedRootStoragePolicy
+}
+
+type directBufferedInsertPlan struct {
+	templateEntries      []directBufferedRootEntry
+	primaryEntries       []directBufferedRootEntry
+	indexStateEntries    []directBufferedRootEntry
+	secondaryRootPlans   []directBufferedSecondaryRootPlan
+	uniqueValueRootPlans []directBufferedUniqueValueRootPlan
+	rootNames            []string
+	policies             []backenddb.OrderedRootStoragePolicy
+	templateRootName     string
+	primaryRootName      string
+	indexStateRootName   string
+	stagedBytes          int64
+}
+
+type directBufferedUniqueValueRootPlan struct {
+	indexName string
+	valueType IndexValueType
+	prefixes  [][]byte
+	keyBytes  int
 }
 
 type collectionUniqueProbeRun struct {
@@ -265,6 +288,15 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		allUniqueProbeRunsBuilt:    allUniqueProbeRunsBuilt,
 		templateRecords:            templateRecords,
 		stats:                      insertBatchPlanStats{CollectionInsertStats: stats},
+	}
+	if p.directBufferedRuns {
+		if err := p.buildDirectBufferedInsertPlan(plan, items, primaryOrder, runtimes, persistIndexState, templateRecords); err != nil {
+			return nil, err
+		}
+		if plan.directBufferedInsert != nil {
+			plan.stats.Runs = len(plan.directBufferedInsert.rootNames)
+		}
+		return plan, nil
 	}
 	if len(templateRecords) > 0 {
 		phaseStart = time.Now()
@@ -719,6 +751,270 @@ func (p insertBatchPlanner) emitTemplateRun(plan *insertBatchPlan, records []tem
 		storagePolicy: p.options.dataStoragePolicy,
 	})
 	return nil
+}
+
+func (p insertBatchPlanner) buildDirectBufferedInsertPlan(plan *insertBatchPlan, items []insertBatchItem, primaryOrder []int, runtimes []indexRuntime, persistIndexState bool, templateRecords []templateV1Record) error {
+	direct := &directBufferedInsertPlan{
+		templateRootName:   p.templateRoot,
+		primaryRootName:    p.primaryRoot,
+		indexStateRootName: p.indexStateRoot,
+	}
+	if len(templateRecords) > 0 {
+		phaseStart := time.Now()
+		entries, err := p.directBufferedTemplateRootEntries(templateRecords)
+		if err != nil {
+			return err
+		}
+		direct.templateEntries = entries
+		direct.addRoot(p.templateRoot, p.options.dataStoragePolicy)
+		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, directBufferedRootEntriesSize(entries))
+		plan.stats.TemplateRunBuild = time.Since(phaseStart)
+	}
+
+	phaseStart := time.Now()
+	primaryEntries, err := p.directBufferedPrimaryRootEntries(plan, items, primaryOrder)
+	if err != nil {
+		return err
+	}
+	direct.primaryEntries = primaryEntries
+	direct.addRoot(p.primaryRoot, p.options.dataStoragePolicy)
+	direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, directBufferedRootEntriesSize(primaryEntries))
+	plan.stats.PrimaryRunBuild = time.Since(phaseStart)
+
+	if len(runtimes) > 0 {
+		if persistIndexState {
+			phaseStart = time.Now()
+			entries, err := p.directBufferedIndexStateRootEntries(items, runtimes)
+			if err != nil {
+				return err
+			}
+			direct.indexStateEntries = entries
+			direct.addRoot(p.indexStateRoot, p.options.indexStateStoragePolicy)
+			direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, directBufferedRootEntriesSize(entries))
+			plan.stats.IndexStateRunBuild = time.Since(phaseStart)
+		}
+		phaseStart = time.Now()
+		secondaryPlans, secondaryBytes, err := p.directBufferedSecondaryRootPlans(items, runtimes, &plan.stats.CollectionInsertStats)
+		if err != nil {
+			return err
+		}
+		direct.secondaryRootPlans = secondaryPlans
+		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, secondaryBytes)
+		for _, secondaryPlan := range secondaryPlans {
+			runtimeIdx := secondaryPlan.runtimeIdx
+			if runtimeIdx < 0 || runtimeIdx >= len(runtimes) {
+				return fmt.Errorf("collections: invalid direct buffered secondary runtime index %d", runtimeIdx)
+			}
+			direct.addRoot(secondaryPlan.rootName, runtimes[runtimeIdx].def.storagePolicy)
+		}
+		direct.uniqueValueRootPlans = directBufferedUniqueValueRootPlans(plan.allUniqueProbeRuns, runtimes)
+		for _, uniquePlan := range direct.uniqueValueRootPlans {
+			direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, int64(uniquePlan.keyBytes))
+		}
+		plan.stats.SecondaryRunBuild = time.Since(phaseStart)
+	}
+	plan.directBufferedInsert = direct
+	return nil
+}
+
+func (p insertBatchPlanner) directBufferedTemplateRootEntries(records []templateV1Record) ([]directBufferedRootEntry, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+	sortTemplateV1Records(records)
+	records, err := dedupeTemplateV1Records(records)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]directBufferedRootEntry, len(records))
+	for i := range records {
+		raw := records[i].raw
+		if p.cloneTemplateRunValues {
+			raw = bytes.Clone(raw)
+		}
+		entries[i] = directBufferedRootEntry{
+			key:   bytes.Clone(records[i].id[:]),
+			value: raw,
+			flags: node.FlagInline,
+		}
+	}
+	return entries, nil
+}
+
+func (p insertBatchPlanner) directBufferedPrimaryRootEntries(plan *insertBatchPlan, items []insertBatchItem, order []int) ([]directBufferedRootEntry, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	entries := make([]directBufferedRootEntry, len(items))
+	for i := range items {
+		idx := orderedItemIndex(order, i)
+		value, err := p.buildPrimaryVal(items[idx].id, items[idx].document)
+		if err != nil {
+			return nil, err
+		}
+		if plan != nil {
+			plan.stats.payloadBuilds++
+		}
+		entries[i] = directBufferedRootEntry{
+			key:   items[idx].id,
+			value: value,
+			flags: node.FlagInline,
+		}
+	}
+	return entries, nil
+}
+
+func (p insertBatchPlanner) directBufferedIndexStateRootEntries(items []insertBatchItem, runtimes []indexRuntime) ([]directBufferedRootEntry, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	counts := make([]int, len(items))
+	valueBytes := 0
+	for i := range items {
+		idx := orderedItemIndex(order, i)
+		count, size, err := runtimeOrderedDocumentIndexStateStats(items[idx].state, runtimes)
+		if err != nil {
+			return nil, err
+		}
+		counts[i] = count
+		valueBytes += size
+	}
+	entries := make([]directBufferedRootEntry, len(items))
+	valueArena := make([]byte, 0, valueBytes)
+	for i := range items {
+		idx := orderedItemIndex(order, i)
+		var value []byte
+		valueArena, value = appendRuntimeOrderedDocumentIndexState(valueArena, items[idx].state, runtimes, counts[i])
+		entries[i] = directBufferedRootEntry{
+			key:   items[idx].id,
+			value: value,
+			flags: node.FlagInline,
+		}
+	}
+	return entries, nil
+}
+
+func (p insertBatchPlanner) directBufferedSecondaryRootPlans(items []insertBatchItem, runtimes []indexRuntime, stats *CollectionInsertStats) ([]directBufferedSecondaryRootPlan, int64, error) {
+	if len(items) == 0 || len(runtimes) == 0 {
+		return nil, 0, nil
+	}
+	plans := make([]directBufferedSecondaryRootPlan, 0, len(runtimes))
+	var stagedBytes int64
+	for runtimeIdx, runtime := range runtimes {
+		runStart := time.Now()
+		entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, runtimeIdx, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+		runStats := CollectionSecondaryRunStats{
+			IndexName:     runtime.def.name,
+			Entries:       entryCount,
+			KeyBytes:      keyBytes,
+			AlreadySorted: alreadySorted,
+		}
+		if entryCount == 0 {
+			runStats.Build = time.Since(runStart)
+			if stats != nil {
+				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			}
+			continue
+		}
+		rootName := runtime.secondaryRootName
+		if rootName == "" {
+			rootName = collectionSecondaryRootName(p.collection, runtime.def.name)
+		}
+		secondaryPlan := directBufferedSecondaryRootPlan{
+			rootName:   rootName,
+			entries:    make([]directBufferedSecondaryRootEntry, 0, entryCount),
+			arena:      make([]byte, 0, keyBytes),
+			indexName:  runtime.def.name,
+			valueType:  runtime.def.valueType,
+			unique:     runtime.def.unique,
+			sets:       entryCount,
+			keyBytes:   keyBytes,
+			runtimeIdx: runtimeIdx,
+		}
+		for i := range items {
+			for _, encoded := range items[i].state.valuesAt(runtimeIdx) {
+				var key []byte
+				secondaryPlan.arena, key, err = appendIndexEntryKey(secondaryPlan.arena, encoded, items[i].id)
+				if err != nil {
+					return nil, 0, err
+				}
+				secondaryPlan.entries = append(secondaryPlan.entries, directBufferedSecondaryRootEntry{key: key})
+			}
+		}
+		runStats.Build = time.Since(runStart)
+		if stats != nil {
+			stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			stats.SecondaryEntries += entryCount
+			stats.SecondaryKeyBytes += keyBytes
+			if alreadySorted {
+				stats.SecondarySortedRuns++
+			} else {
+				stats.SecondaryUnsortedRuns++
+			}
+		}
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(keyBytes))
+		plans = append(plans, secondaryPlan)
+	}
+	return plans, stagedBytes, nil
+}
+
+func directBufferedUniqueValueRootPlans(runs []collectionUniqueProbeRun, runtimes []indexRuntime) []directBufferedUniqueValueRootPlan {
+	if len(runs) == 0 || len(runtimes) == 0 {
+		return nil
+	}
+	valueTypes := make(map[string]IndexValueType, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime.def.unique {
+			valueTypes[runtime.def.name] = runtime.def.valueType
+		}
+	}
+	if len(valueTypes) == 0 {
+		return nil
+	}
+	plans := make([]directBufferedUniqueValueRootPlan, 0, len(runs))
+	for _, run := range runs {
+		valueType, ok := valueTypes[run.indexName]
+		if !ok || len(run.prefixes) == 0 {
+			continue
+		}
+		keyBytes := 0
+		for _, prefix := range run.prefixes {
+			keyBytes += len(prefix)
+		}
+		plans = append(plans, directBufferedUniqueValueRootPlan{
+			indexName: run.indexName,
+			valueType: valueType,
+			prefixes:  run.prefixes,
+			keyBytes:  keyBytes,
+		})
+	}
+	return plans
+}
+
+func (plan *directBufferedInsertPlan) addRoot(rootName string, policy backenddb.OrderedRootStoragePolicy) {
+	if plan == nil || rootName == "" {
+		return
+	}
+	for i, existing := range plan.rootNames {
+		if existing == rootName {
+			plan.policies[i] = policy
+			return
+		}
+	}
+	plan.rootNames = append(plan.rootNames, rootName)
+	plan.policies = append(plan.policies, policy)
+}
+
+func directBufferedRootEntriesSize(entries []directBufferedRootEntry) int64 {
+	var total int64
+	for _, entry := range entries {
+		total = saturatingAddNonNegativeInt64(total, int64(len(entry.key)+len(entry.value)))
+	}
+	return total
 }
 
 func setCollectionRunValue(table memtable.Table, key, value []byte) {


### PR DESCRIPTION
## Summary
- route small indexed `InsertBatch` calls through mutable buffered root accumulators instead of creating one frozen run per call
- accumulate unique-value conflict runs alongside root runs so pending uniqueness checks still work
- keep large batches on the existing frozen-run path and only keep planning under the mutation lock for single-document batches

## Tests
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionIndexedInsertBatch(UsesMutableBufferedRootAccumulators|KeepsLargeBatchesAsFrozenRuns)$|TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass$|TestCollectionIndexedInsertAccumulatorThresholds$' -count=1`\n- `GOWORK=off go test ./TreeDB/collections -count=1`\n\n## Benchmark Evidence\nDirect TreeDB BSON insert benchmark, 300k docs, 1 secondary index, prebuilt documents, no maintenance. Baseline is clean main at `2054722169`; current is this PR.\n\n| branch | producers | batch | docs/sec | ns/op | staged root runs | mutation lock hold |\n| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n| main | 1 | 1 | 25,543 | 37,988 | 600,000 | 9.85s |\n| PR | 1 | 1 | 317,883 | 3,017 | 8 | 0.90s |\n| main | 2 | 1 | 23,863 | 80,659 | 600,000 | 10.57s |\n| PR | 2 | 1 | 241,737 | 7,999 | 8 | 1.12s |\n| main | 1 | 64 | 651,553 | 937 | 9,376 | 0.20s |\n| PR | 1 | 64 | 788,019 | 891 | 6 | 0.19s |\n| main | 2 | 64 | 763,632 | 1,784 | 9,376 | 0.23s |\n| PR | 2 | 64 | 750,237 | 1,795 | 6 | 0.23s |\n| main | 1 | 8000 | 907,301 | 680 | 76 | 0.13s |\n| PR | 1 | 8000 | 899,529 | 705 | 76 | 0.13s |\n| main | 2 | 8000 | 1,042,103 | 1,037 | 76 | 0.13s |\n| PR | 2 | 8000 | 988,743 | 1,064 | 76 | 0.13s |\n\n500k canary, 1 producer, batch=1: 223,639 docs/sec, 4,140 ns/op, 8 staged root runs, 2.16s mutation lock hold.\n\nThe important shape is that batch=1 no longer creates per-document frozen root runs, while large batches retain the existing path to avoid regressing the already-amortized case.