### PR TITLE
Buffer non-unique indexed deletes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3372,6 +3372,16 @@ func (c *Collection) shouldFlushBeforeIndexedDelete(meta CollectionMeta) bool {
 	return !c.shouldBufferIndexedDeletes(catalog.meta)
 }
 
+func (c *Collection) hasBufferedIndexedDeletesOnly() bool {
+	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	return domain.count > 0 && domain.indexedDeletesOnly
+}
+
 func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
 	if !c.shouldBufferIndexedInserts(meta) {
 		return false
@@ -7089,6 +7099,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return nil, err
 	}
+	if c.hasBufferedIndexedDeletesOnly() {
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+	}
 
 	var bufferedTemplateRuns []memtable.Table
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
@@ -7932,6 +7947,7 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte) (int, error) {
 		_ = snap.Close()
 		if err != nil {
 			resetCollectionTables(deltaTables)
+			return 0, err
 		}
 		return len(existing), err
 	}
@@ -13511,13 +13527,13 @@ func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain
 		var value []byte
 		var flags byte
 		found := false
-		if ref, ok := domain.primaryRunIndex.lookupRef(documentID); ok {
+		if domain.primaryRunIndex == nil {
+			value, _, flags, found = getBufferedRunEntry(pendingIndexedRootRunsLocked(domain, name), documentID)
+		} else if ref, ok := domain.primaryRunIndex.lookupRef(documentID); ok {
 			value, flags, found = ref.value, ref.flags, ref.entryValid
 			if !found && ref.table != nil {
 				value, _, flags, found = ref.table.GetEntry(documentID)
 			}
-		} else if domain.primaryRunIndex == nil {
-			value, _, flags, found = getBufferedRunEntry(pendingIndexedRootRunsLocked(domain, name), documentID)
 		}
 		if found {
 			if flags&node.FlagTombstone != 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -898,15 +898,16 @@ type collectionWriteDomain struct {
 	primaryIDIndex         *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
-	primaryRunIndex  *bufferedPrimaryRunIndex
-	uniqueValueRuns  map[string][]memtable.Table
-	uniqueValueIndex map[string]*bufferedUniqueValueIndex
-	count            int
-	bufferedBytes    int64
-	mutableCount     int
-	mutableBytes     int64
-	rootRunCount     int
-	writeGeneration  uint64
+	primaryRunIndex    *bufferedPrimaryRunIndex
+	uniqueValueRuns    map[string][]memtable.Table
+	uniqueValueIndex   map[string]*bufferedUniqueValueIndex
+	count              int
+	bufferedBytes      int64
+	mutableCount       int
+	mutableBytes       int64
+	rootRunCount       int
+	writeGeneration    uint64
+	indexedDeletesOnly bool
 
 	mutationLockCalls                  atomic.Uint64
 	mutationLockWaitTotalNs            atomic.Uint64
@@ -3321,6 +3322,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
 	domain.count = 0
+	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
 	c.meta = meta
@@ -3331,6 +3333,14 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 
 func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
 	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func (c *Collection) shouldBufferIndexedDeletes(meta CollectionMeta) bool {
+	return c != nil &&
+		c.writeDomain != nil &&
+		meta.Options.BufferedIndexedWrites &&
+		len(meta.Indexes) > 0 &&
+		!collectionMetaHasSecondaryUniqueIndex(meta)
 }
 
 func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
@@ -3481,6 +3491,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
@@ -3519,6 +3530,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
 	domain.rootRunCount = 0
+	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
 	domain.primaryIDIndex = nil
@@ -5735,6 +5747,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
 		domain.count = 0
+		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
 		domain.mutableBytes = 0
@@ -6205,6 +6218,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
 		domain.count = 0
+		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
 		domain.mutableBytes = 0
@@ -6315,6 +6329,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.count = 0
+	domain.indexedDeletesOnly = false
 	domain.bufferedBytes = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
@@ -6353,6 +6368,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.uniqueValueRuns = nil
 	domain.rootValueArenas = nil
 	domain.rootRunCount = 0
+	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
 	return true
@@ -7331,8 +7347,10 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
-	if err := c.flushBufferedWrites(); err != nil {
-		return false, err
+	if !c.shouldBufferIndexedDeletes(c.meta) || !c.writeDomain.indexedDeletesOnly {
+		if err := c.flushBufferedWrites(); err != nil {
+			return false, err
+		}
 	}
 
 	var lastErr error
@@ -7388,8 +7406,10 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
-	if err := c.flushBufferedWrites(); err != nil {
-		return 0, err
+	if !c.shouldBufferIndexedDeletes(c.meta) || !c.writeDomain.indexedDeletesOnly {
+		if err := c.flushBufferedWrites(); err != nil {
+			return 0, err
+		}
 	}
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
@@ -7534,6 +7554,14 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte) (int, error) {
 		}
 	}
 
+	if buffered, err := c.bufferIndexedDeleteTablesLocked(catalog, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, policies, deltaTables, len(existing)); buffered || err != nil {
+		_ = snap.Close()
+		if err != nil {
+			resetCollectionTables(deltaTables)
+		}
+		return len(existing), err
+	}
+
 	defer func() { _ = snap.Close() }()
 	defer func() { resetCollectionTables(deltaTables) }()
 	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
@@ -7667,6 +7695,13 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	}
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
+	if buffered, err := c.bufferIndexedDeleteTablesLocked(catalog, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, policies, deltaTables, 1); buffered || err != nil {
+		_ = snap.Close()
+		if err != nil {
+			resetCollectionTables(deltaTables)
+		}
+		return buffered, err
+	}
 	defer func() { _ = snap.Close() }()
 
 	defer func() {
@@ -11222,6 +11257,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
 	if rollbackOnError {
 		rollbackGeneration = domain.writeGeneration
@@ -11484,6 +11520,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
 	if rollbackOnError {
 		rollbackGeneration = domain.writeGeneration
@@ -11874,6 +11911,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
 	domain.rootRunCount = 0
+	domain.indexedDeletesOnly = false
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
@@ -12126,6 +12164,102 @@ func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
 	}
 	table.Freeze()
 	return table
+}
+
+func (c *Collection) bufferIndexedDeleteTablesLocked(
+	catalog *collectionCatalog,
+	baseCommitSeq uint64,
+	baseSystemRoot uint64,
+	rootNames []string,
+	baseRootIDs map[string]uint64,
+	policies []backenddb.OrderedRootStoragePolicy,
+	deltaTables []memtable.Table,
+	deleted int,
+) (bool, error) {
+	if c == nil || c.writeDomain == nil || catalog == nil || deleted == 0 || len(deltaTables) == 0 {
+		return false, nil
+	}
+	meta := catalog.meta
+	if !c.shouldBufferIndexedDeletes(meta) {
+		return false, nil
+	}
+	if len(rootNames) != len(deltaTables) || len(rootNames) != len(policies) {
+		return false, fmt.Errorf("collections: DeleteBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", meta.Name, len(rootNames), len(deltaTables), len(policies))
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if domain.count != 0 && !domain.indexedDeletesOnly {
+		return false, nil
+	}
+	if err := c.validateRootDescriptorSystemDeltaForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs); err != nil {
+		return false, err
+	}
+	if domain.count == 0 {
+		c.initializeWriteDomainFromCatalogLocked(domain, catalog, baseCommitSeq, baseSystemRoot)
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(rootNames))
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, len(rootNames))
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table, len(rootNames))
+	}
+	freezeMutableIndexedRunMapsLocked(domain)
+	var stagedBytes int64
+	stagedRootRuns := 0
+	for i, rootName := range rootNames {
+		table := deltaTables[i]
+		if table == nil || table.Len() == 0 {
+			continue
+		}
+		baseRoot := baseRootIDs[rootName]
+		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+			return false, errBufferedRootBaseMismatch(meta.Name, rootName)
+		}
+		if _, ok := domain.rootBaseIDs[rootName]; !ok {
+			domain.rootBaseIDs[rootName] = baseRoot
+		}
+		domain.rootPolicies[rootName] = policies[i]
+		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
+		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
+		stagedRootRuns++
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
+		deltaTables[i] = nil
+	}
+	if stagedRootRuns == 0 {
+		return false, nil
+	}
+	domain.loaded = true
+	domain.meta = meta
+	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
+	domain.baseSystemRoot = baseSystemRoot
+	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(meta.Name))
+	domain.count += deleted
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, deleted)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	domain.indexedDeletesOnly = true
+	domain.writeGeneration++
+	domain.observeIndexedStage(deleted, stagedBytes, stagedRootRuns)
+	c.meta = meta
+	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, meta.Options)
+	if err != nil {
+		return false, err
+	}
+	if shouldFlushBufferedIndexedWrites(domain, meta.Options) {
+		flushElapsed, _, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, meta.Options)
+		_ = flushElapsed
+		if err != nil {
+			resetCollectionTables(compactedObsolete)
+			return false, err
+		}
+	}
+	resetCollectionTables(compactedObsolete)
+	return true, nil
 }
 
 func buildCreateIndexBackfillPlan(

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7738,6 +7738,9 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 		deleted, err := c.deleteDocumentOnce(documentID)
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
+			if flushErr := c.flushBufferedWrites(); flushErr != nil {
+				return false, flushErr
+			}
 			waitBeforeCollectionMutationRetry(attempt)
 			continue
 		}
@@ -7796,6 +7799,9 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 		deleted, err := c.deleteBatchOnce(ids)
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
+			if flushErr := c.flushBufferedWrites(); flushErr != nil {
+				return 0, flushErr
+			}
 			waitBeforeCollectionMutationRetry(attempt)
 			continue
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3349,9 +3349,17 @@ func (c *Collection) shouldFlushBeforeIndexedDelete(meta CollectionMeta) bool {
 		return true
 	}
 	domain := c.writeDomain
-	domain.mu.RLock()
-	defer domain.mu.RUnlock()
-	return !domain.indexedDeletesOnly
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if !domain.indexedDeletesOnly {
+		return true
+	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
+	if err != nil {
+		return true
+	}
+	return !c.shouldBufferIndexedDeletes(catalog.meta)
 }
 
 func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
@@ -12252,6 +12260,7 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 		domain.rootRuns = make(map[string][]memtable.Table, len(rootNames))
 	}
 	freezeMutableIndexedRunMapsLocked(domain)
+	domain.primaryRunIndex = nil
 	var stagedBytes int64
 	stagedRootRuns := 0
 	for i, rootName := range rootNames {
@@ -12285,7 +12294,6 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 		rollback()
 		return false, nil
 	}
-	domain.primaryRunIndex = nil
 	domain.loaded = true
 	domain.meta = meta
 	domain.catalog = catalog
@@ -12310,7 +12318,6 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 		_ = flushElapsed
 		if err != nil {
 			rollback()
-			resetCollectionTables(compactedObsolete)
 			return false, err
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6710,7 +6710,6 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.uniqueValueMutableRuns = nil
 	domain.rootValueArenas = nil
 	domain.rootRunCount = 0
-	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
 	return true

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7483,6 +7483,63 @@ func TestCollectionIndexedDeleteBuffersNonUniqueTombstones(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedDeleteRevalidatesBeforeSkippingFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	writerMgr := NewCollectionManager(d)
+	if _, err := writerMgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := writerMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	if _, err := writer.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"a@example.com","city":"hnl"}`),
+			[]byte(`{"email":"b@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush inserts: %v", err)
+	}
+	if deleted, err := writer.DeleteDocument([]byte("u1")); err != nil || !deleted {
+		t.Fatalf("buffer delete deleted=%v err=%v", deleted, err)
+	}
+
+	indexMgr := NewCollectionManager(d)
+	indexer, err := indexMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open indexer: %v", err)
+	}
+	if _, err := indexer.CreateIndex(IndexDefinition{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}); err != nil {
+		t.Fatalf("create unique index: %v", err)
+	}
+
+	if _, err := writer.DeleteDocument([]byte("u2")); err == nil || !strings.Contains(err.Error(), "concurrent schema modification") {
+		t.Fatalf("delete after schema change err=%v want concurrent schema modification", err)
+	}
+	writer.writeDomain.mu.RLock()
+	count := writer.writeDomain.count
+	deleteOnly := writer.writeDomain.indexedDeletesOnly
+	writer.writeDomain.mu.RUnlock()
+	if count != 1 || !deleteOnly {
+		t.Fatalf("write domain count=%d deleteOnly=%v want pending original delete", count, deleteOnly)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentSchemaChange(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3042,6 +3042,10 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	mgr := NewCollectionManager(db)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedAsyncFlush:        true,
+			BufferedIndexedWriteMaxDocuments: 1,
+		},
 		Indexes: []IndexDefinition{
 			{Name: "city", Field: "city", ValueType: IndexValueString},
 		},

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7732,6 +7732,51 @@ func TestCollectionIndexedDeleteRevalidatesBeforeSkippingFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedDeleteThenReinsertFlushesPendingTombstone(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"city":"hnl"}`)); err != nil {
+		t.Fatalf("insert original: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	deleted, err := col.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete reported missing document")
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"city":"sea"}`)}); err != nil {
+		t.Fatalf("reinsert after buffered delete: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reinserted document: %v", err)
+	}
+	if string(got) != `{"city":"sea"}` {
+		t.Fatalf("reinserted document=%s want sea", got)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentSchemaChange(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7386,6 +7386,82 @@ func TestCollectionSingleInsertBufferedNoIndexRejectsBufferedDuplicate(t *testin
 	}
 }
 
+func TestCollectionIndexedDeleteBuffersNonUniqueTombstones(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	reader, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	if _, err := writer.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl"}`),
+			[]byte(`{"city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush inserts: %v", err)
+	}
+
+	deleted, err := writer.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete reported missing document")
+	}
+	if writer.writeDomain == nil {
+		t.Fatal("missing write domain")
+	}
+	if writer.writeDomain.count != 1 || !writer.writeDomain.indexedDeletesOnly {
+		t.Fatalf("write domain delete state count=%d deleteOnly=%v", writer.writeDomain.count, writer.writeDomain.indexedDeletesOnly)
+	}
+	got, err := reader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("reader get pending deleted document: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("reader saw pending deleted document %q", got)
+	}
+	ids, err := reader.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find by city: %v", err)
+	}
+	if !reflect.DeepEqual(ids, [][]byte{[]byte("u2")}) {
+		t.Fatalf("city ids=%q want [u2]", ids)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush delete: %v", err)
+	}
+	got, err = reader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("reader get flushed deleted document: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("reader saw flushed deleted document %q", got)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentSchemaChange(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4162,9 +4162,14 @@ func normalizeNativeWireBenchmarkCollectionMeta(meta collections.CollectionMeta)
 	}
 	if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
+		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedOverlayRoots = false
 		return meta
 	}
 	meta.Options.BufferedIndexedWrites = true
+	if !meta.Options.DisableBufferedIndexedAsyncFlush {
+		meta.Options.BufferedIndexedAsyncFlush = true
+	}
 	defaultMaxDocuments := collections.DefaultIndexedWriteMemtableMaxDocuments
 	defaultMaxRootRuns := collections.DefaultIndexedWriteMemtableMaxRootRuns
 	if meta.Options.BufferedIndexedAsyncFlush {
@@ -4204,9 +4209,14 @@ func normalizeNativeWireBenchmarkOptions(opts collections.CollectionOptions, ind
 	}
 	if !indexed {
 		opts.BufferedIndexedWrites = false
+		opts.BufferedIndexedAsyncFlush = false
+		opts.BufferedIndexedOverlayRoots = false
 		return opts
 	}
 	opts.BufferedIndexedWrites = true
+	if !opts.DisableBufferedIndexedAsyncFlush {
+		opts.BufferedIndexedAsyncFlush = true
+	}
 	defaultMaxDocuments := collections.DefaultIndexedWriteMemtableMaxDocuments
 	defaultMaxRootRuns := collections.DefaultIndexedWriteMemtableMaxRootRuns
 	if opts.BufferedIndexedAsyncFlush {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -886,8 +886,10 @@ func TestValidateNativeWireBenchmarkCollectionNormalizesExpectedMeta(t *testing.
 	}
 	actual := expected
 	actual.Options.BufferedIndexedWrites = true
-	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableMaxDocuments
-	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableMaxRootRuns
+	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableAsyncFlushMaxDocuments
+	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableAsyncFlushMaxRootRuns
+	actual.Options.BufferedIndexedAsyncFlush = true
+	actual.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = collections.DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
 	if err := validateNativeWireBenchmarkCollection(actual, expected); err != nil {
 		t.Fatalf("validateNativeWireBenchmarkCollection normalized expected metadata: %v", err)
 	}
@@ -904,8 +906,10 @@ func TestValidateNativeWireBenchmarkCollectionNormalizesJSONDocumentFormat(t *te
 	actual := expected
 	actual.Options.DocumentFormat = collections.DocumentFormatDefault
 	actual.Options.BufferedIndexedWrites = true
-	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableMaxDocuments
-	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableMaxRootRuns
+	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableAsyncFlushMaxDocuments
+	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableAsyncFlushMaxRootRuns
+	actual.Options.BufferedIndexedAsyncFlush = true
+	actual.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = collections.DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
 	if err := validateNativeWireBenchmarkCollection(actual, expected); err != nil {
 		t.Fatalf("validateNativeWireBenchmarkCollection normalized JSON document format: %v", err)
 	}
@@ -2495,14 +2499,7 @@ func TestEnsureNativeWireBenchmarkCollectionCreatesPrimaryOnlyCollection(t *test
 	if len(meta.Indexes) != 0 {
 		t.Fatalf("indexes=%+v want primary-only collection", meta.Indexes)
 	}
-	if meta.Options.DocumentFormat != collections.DocumentFormatTemplateV1 ||
-		meta.Options.DataRootStoragePolicy != collections.RootStorageCompressed ||
-		meta.Options.IndexStateStoragePolicy != collections.RootStorageCompressed ||
-		meta.Options.BufferedIndexedWriteMaxDocuments != 123 ||
-		meta.Options.BufferedIndexedWriteMaxBytes != 456 ||
-		meta.Options.BufferedIndexedWriteMaxRootRuns != 7 ||
-		!meta.Options.BufferedIndexedAsyncFlush ||
-		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits != 2 {
+	if !sameNativeWireBenchmarkOptions(meta.Options, treeDBBenchmarkCollectionOptions(cfg), false) {
 		t.Fatalf("meta options=%+v", meta.Options)
 	}
 }
@@ -2537,22 +2534,25 @@ func TestEnsureNativeWireBenchmarkCollectionRejectsExistingIndexDrift(t *testing
 	}
 	defer func() { _ = db.Close() }()
 	manager := collections.NewCollectionManager(db)
-	if _, err := manager.CreateCollection(&collections.CollectionMeta{
-		Name: "bench.docs",
-		Indexes: []collections.IndexDefinition{{
-			Name:      "wrong_1",
-			Field:     "email",
-			ValueType: collections.IndexValueString,
-			Unique:    true,
-		}},
-	}); err != nil {
-		t.Fatalf("CreateCollection: %v", err)
-	}
 	cfg := config{
 		Database:             "bench",
 		Collection:           "docs",
 		TreeDBDocumentFormat: collections.DocumentFormatJSON,
 		SecondaryIndexes:     1,
+	}
+	existing := nativeWireBenchmarkCollectionMeta(cfg, "bench.docs")
+	existing.Indexes = []collections.IndexDefinition{{
+		Name:      "wrong_1",
+		Field:     "email",
+		ValueType: collections.IndexValueString,
+		Unique:    true,
+	}}
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name:    existing.Name,
+		Options: existing.Options,
+		Indexes: existing.Indexes,
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
 	}
 	if err := ensureNativeWireBenchmarkCollection(cfg, &benchTarget{collections: manager}); err == nil || !strings.Contains(err.Error(), "missing index") {
 		t.Fatalf("ensureNativeWireBenchmarkCollection err=%v want index drift", err)


### PR DESCRIPTION
## Summary
- stage indexed delete tombstones in the collection write domain for indexed collections without secondary unique indexes
- avoid self-flushing delete-only buffered work before each subsequent delete
- keep secondary-unique delete buffering out of this PR because delete-then-reinsert needs merged unique-conflict preflight over pending tombstones

## Tests
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionIndexedDeleteBuffersNonUniqueTombstones$' -count=1`\n- `GOWORK=off go test ./TreeDB/collections -count=1`\n\n## Benchmark Evidence\nDirect TreeDB BSON benchmark, 100k docs, batch size 1000 load, 100k `deleteOne` operations, no secondary unique index, `-range-index` for one non-unique indexed root, prebuilt documents, no maintenance. Baseline is clean main at `2054722169`; current is this PR.\n\n| branch | phase | docs/sec | ns/op | staged root runs |\n| --- | --- | ---: | ---: | ---: |\n| main | id_delete_one | 1,206 | 828,518 | 0 |\n| PR | id_delete_one | 64,976 | 15,243 | 200,000 |\n\nThis PR removes the immediate publish from the safe non-unique indexed delete path. The remaining staged root-run count is intentionally left visible as follow-up optimization work rather than folding unique semantics and accumulator mechanics into this review.