### PR TITLE
Fix post-4177 CI and review followups

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -14565,11 +14565,8 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		}
 	}
 	if !meta.Options.BufferedIndexedWrites {
-		if meta.Options.DisableIndexedWriteMemtables {
-			meta.Options.DisableBufferedIndexedAsyncFlush = false
-			meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
-		}
 		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	}
 	return meta, nil
 }

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -75,6 +75,7 @@ func openReadOnly(opts Options) (*DB, error) {
 	adaptiveCtrl, inlineThreshold := resolveInlineThresholdAndAdaptive(opts)
 	db := &DB{
 		readOnly:                       true,
+		durability:                     opts.Durability,
 		valueLogManager:                vm,
 		lock:                           lock,
 		adaptive:                       adaptiveCtrl,
@@ -200,6 +201,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	adaptiveCtrl, inlineThreshold := resolveInlineThresholdAndAdaptive(opts)
 	db := &DB{
 		readOnly:                       true,
+		durability:                     opts.Durability,
 		valueLogManager:                vm,
 		adaptive:                       adaptiveCtrl,
 		keepRecent:                     opts.KeepRecent,

--- a/TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md
+++ b/TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md
@@ -1,5 +1,7 @@
 # ClickHouse Compression Technology Specification
 
+Status: reference, non-normative for TreeDB on-disk/API contracts.
+
 Provenance:
 
 - Upstream repository: `https://github.com/ClickHouse/ClickHouse`

--- a/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
+++ b/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
@@ -1518,14 +1518,14 @@ WAL-on write ordering:
    files through the collection WAL side-ref prepare protocol.
 3. Fsync files, atomically rename temp files to final paths, and fsync parent
    directories before the collection WAL commit marker may reference them.
-4. Append the collection WAL transaction that describes root mutations, primary
-   locator changes, granule/mark changes, secondary index changes,
-   delete/tombstone changes, count/visibility metadata, part descriptor
-   additions, and every required external side ref.
-5. Validate that the declared side-ref set matches the complete canonical
+4. Validate that the declared side-ref set matches the complete canonical
    transitive closure embedded in part descriptors, manifests, filter
    descriptors, delete bitmap refs, dictionary refs, compression metadata refs,
    granule roots, and root-delta values.
+5. Append the collection WAL transaction that describes root mutations, primary
+   locator changes, granule/mark changes, secondary index changes,
+   delete/tombstone changes, count/visibility metadata, part descriptor
+   additions, and every required external side ref.
 6. Publish the root group only after the column bytes are readable at the
    required durability boundary.
 7. On recovery, replay either the complete root group or none of it.
@@ -1769,9 +1769,10 @@ with new rows:
 ### 12.5 JSONBench Integration
 
 Add a TreeDB column-store lane to the external JSONBench TreeDB harness
-(`~/dev/snissn/JSONBench/treedb`) once the column-store scan API can express the
-five Bluesky analytics queries. This is a comparison benchmark, not the first
-correctness gate, and it must follow JSONBench rules.
+(`https://github.com/snissn/JSONBench`, TreeDB harness under `treedb/`) once
+the column-store scan API can express the five Bluesky analytics queries. This
+is a comparison benchmark, not the first correctness gate, and it must follow
+JSONBench rules.
 
 The comparison target is benchmark-shape compatibility with the ClickHouse JSON
 store setup in `clickhouse/ddl.sql` and `clickhouse/queries.sql`, not
@@ -1898,7 +1899,7 @@ Deliverables:
   - update-followed-by-read shape;
   - count-star shape;
 - add `cmd/columnstore_bench` skeleton with row-store/template-v1 baselines;
-- inventory the existing `~/dev/snissn/JSONBench/treedb` harness and define the
+- inventory the external JSONBench `treedb/` harness and define the
   column-store result fields needed to compare with local ClickHouse/DuckDB
   JSONBench runs;
 - add machine-readable result schema and guardrail checks.
@@ -2234,7 +2235,8 @@ Deliverables:
 - profile defaults for durable/fast/wal_on_fast/bench;
 - persisted `format.json` extension for column-store format knobs;
 - canonical benchmark integration;
-- JSONBench TreeDB column-store lane in `~/dev/snissn/JSONBench/treedb`;
+- JSONBench TreeDB column-store lane in the external JSONBench `treedb/`
+  harness;
 - operational docs.
 
 Tests:

--- a/TreeDB/internal/collectionwal/dirty.go
+++ b/TreeDB/internal/collectionwal/dirty.go
@@ -26,7 +26,7 @@ func IsSegmentName(name string) bool {
 	if len(parts) != 2 {
 		return false
 	}
-	if len(parts[1]) != 6 {
+	if len(parts[1]) < 6 {
 		return false
 	}
 	lane, err := strconv.ParseUint(parts[0], 10, 32)

--- a/TreeDB/internal/collectionwal/dirty.go
+++ b/TreeDB/internal/collectionwal/dirty.go
@@ -26,9 +26,6 @@ func IsSegmentName(name string) bool {
 	if len(parts) != 2 {
 		return false
 	}
-	if len(parts[1]) < 6 {
-		return false
-	}
 	lane, err := strconv.ParseUint(parts[0], 10, 32)
 	if err != nil || lane > uint64(^uint32(0)) {
 		return false

--- a/TreeDB/internal/collectionwal/dirty.go
+++ b/TreeDB/internal/collectionwal/dirty.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -23,6 +24,9 @@ func IsSegmentName(name string) bool {
 	rest := strings.TrimSuffix(strings.TrimPrefix(name, segmentPrefix), segmentSuffix)
 	parts := strings.SplitN(rest, "-", 2)
 	if len(parts) != 2 {
+		return false
+	}
+	if len(parts[1]) != 6 {
 		return false
 	}
 	lane, err := strconv.ParseUint(parts[0], 10, 32)
@@ -55,6 +59,7 @@ func DirtySegments(dbDir string) ([]string, error) {
 			dirty = append(dirty, filepath.Join(walDir, name))
 		}
 	}
+	sort.Strings(dirty)
 	return dirty, nil
 }
 

--- a/TreeDB/internal/collectionwal/dirty_test.go
+++ b/TreeDB/internal/collectionwal/dirty_test.go
@@ -10,6 +10,7 @@ import (
 func TestIsSegmentName(t *testing.T) {
 	valid := []string{
 		"collection-l0-000000.log",
+		"collection-l0-1.log",
 		"collection-l1-000123.log",
 		"collection-l2-1000000.log",
 		"collection-l4294967295-999999.log",
@@ -24,7 +25,6 @@ func TestIsSegmentName(t *testing.T) {
 		"collection-0-1.log",
 		"collection-l-1.log",
 		"collection-l0-.log",
-		"collection-l0-1.log",
 		"collection-l0-1.tmp",
 		"collection-l4294967296-1.log",
 		"commit-l0-1.log",

--- a/TreeDB/internal/collectionwal/dirty_test.go
+++ b/TreeDB/internal/collectionwal/dirty_test.go
@@ -11,7 +11,7 @@ func TestIsSegmentName(t *testing.T) {
 	valid := []string{
 		"collection-l0-000000.log",
 		"collection-l1-000123.log",
-		"collection-l4294967295-18446744073709551615.log",
+		"collection-l4294967295-999999.log",
 	}
 	for _, name := range valid {
 		if !IsSegmentName(name) {
@@ -23,6 +23,7 @@ func TestIsSegmentName(t *testing.T) {
 		"collection-0-1.log",
 		"collection-l-1.log",
 		"collection-l0-.log",
+		"collection-l0-1.log",
 		"collection-l0-1.tmp",
 		"collection-l4294967296-1.log",
 		"commit-l0-1.log",

--- a/TreeDB/internal/collectionwal/dirty_test.go
+++ b/TreeDB/internal/collectionwal/dirty_test.go
@@ -11,6 +11,7 @@ func TestIsSegmentName(t *testing.T) {
 	valid := []string{
 		"collection-l0-000000.log",
 		"collection-l1-000123.log",
+		"collection-l2-1000000.log",
 		"collection-l4294967295-999999.log",
 	}
 	for _, name := range valid {

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -767,6 +767,9 @@ func TestNativewireAckSyncedRejectedInWALOnRelaxed(t *testing.T) {
 		t.Fatalf("InsertBatch synced relaxed err=%v want durability unavailable", err)
 	}
 	assertDocumentMissing(t, mgr, "users", "u1")
+	if err := client.Checkpoint(ctx); err != nil {
+		t.Fatalf("Checkpoint default relaxed: %v", err)
+	}
 	if err := client.CheckpointWithAck(ctx, AckSynced); !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
 		t.Fatalf("CheckpointWithAck synced relaxed err=%v want durability unavailable", err)
 	}

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -461,7 +461,7 @@ func (s *Server) handleCheckpoint(sections []iwire.Section) ([]iwire.Section, er
 	if s.backend.DurabilityMode() != backenddb.DurabilityDurable {
 		actualAck = iwire.AckFlushed
 	}
-	ack, err := ackPolicyFromSections(sections, s.defaultBarrierAck(iwire.AckSynced))
+	ack, err := ackPolicyFromSections(sections, s.defaultBarrierAck(actualAck))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4162,9 +4162,17 @@ func normalizeNativeWireBenchmarkCollectionMeta(meta collections.CollectionMeta)
 	}
 	if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
+		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 		return meta
 	}
 	meta.Options.BufferedIndexedWrites = true
+	if meta.Options.DisableBufferedIndexedAsyncFlush {
+		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
+	} else {
+		meta.Options.BufferedIndexedAsyncFlush = true
+	}
 	defaultMaxDocuments := collections.DefaultIndexedWriteMemtableMaxDocuments
 	defaultMaxRootRuns := collections.DefaultIndexedWriteMemtableMaxRootRuns
 	if meta.Options.BufferedIndexedAsyncFlush {
@@ -4204,9 +4212,17 @@ func normalizeNativeWireBenchmarkOptions(opts collections.CollectionOptions, ind
 	}
 	if !indexed {
 		opts.BufferedIndexedWrites = false
+		opts.BufferedIndexedAsyncFlush = false
+		opts.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 		return opts
 	}
 	opts.BufferedIndexedWrites = true
+	if opts.DisableBufferedIndexedAsyncFlush {
+		opts.BufferedIndexedAsyncFlush = false
+		opts.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
+	} else {
+		opts.BufferedIndexedAsyncFlush = true
+	}
 	defaultMaxDocuments := collections.DefaultIndexedWriteMemtableMaxDocuments
 	defaultMaxRootRuns := collections.DefaultIndexedWriteMemtableMaxRootRuns
 	if opts.BufferedIndexedAsyncFlush {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -886,8 +886,10 @@ func TestValidateNativeWireBenchmarkCollectionNormalizesExpectedMeta(t *testing.
 	}
 	actual := expected
 	actual.Options.BufferedIndexedWrites = true
-	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableMaxDocuments
-	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableMaxRootRuns
+	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableAsyncFlushMaxDocuments
+	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableAsyncFlushMaxRootRuns
+	actual.Options.BufferedIndexedAsyncFlush = true
+	actual.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = collections.DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
 	if err := validateNativeWireBenchmarkCollection(actual, expected); err != nil {
 		t.Fatalf("validateNativeWireBenchmarkCollection normalized expected metadata: %v", err)
 	}
@@ -904,8 +906,10 @@ func TestValidateNativeWireBenchmarkCollectionNormalizesJSONDocumentFormat(t *te
 	actual := expected
 	actual.Options.DocumentFormat = collections.DocumentFormatDefault
 	actual.Options.BufferedIndexedWrites = true
-	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableMaxDocuments
-	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableMaxRootRuns
+	actual.Options.BufferedIndexedWriteMaxDocuments = collections.DefaultIndexedWriteMemtableAsyncFlushMaxDocuments
+	actual.Options.BufferedIndexedWriteMaxRootRuns = collections.DefaultIndexedWriteMemtableAsyncFlushMaxRootRuns
+	actual.Options.BufferedIndexedAsyncFlush = true
+	actual.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = collections.DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
 	if err := validateNativeWireBenchmarkCollection(actual, expected); err != nil {
 		t.Fatalf("validateNativeWireBenchmarkCollection normalized JSON document format: %v", err)
 	}
@@ -2501,8 +2505,8 @@ func TestEnsureNativeWireBenchmarkCollectionCreatesPrimaryOnlyCollection(t *test
 		meta.Options.BufferedIndexedWriteMaxDocuments != 123 ||
 		meta.Options.BufferedIndexedWriteMaxBytes != 456 ||
 		meta.Options.BufferedIndexedWriteMaxRootRuns != 7 ||
-		!meta.Options.BufferedIndexedAsyncFlush ||
-		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits != 2 {
+		meta.Options.BufferedIndexedAsyncFlush ||
+		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits != 0 {
 		t.Fatalf("meta options=%+v", meta.Options)
 	}
 }


### PR DESCRIPTION
## Summary
- align native-wire benchmark metadata normalization with indexed async flush defaults and no-index async metadata
- fix native-wire relaxed checkpoint default ack handling and read-only DB durability reporting
- tighten collection WAL dirty segment classification/sorting and address column-store docs review comments

## Verification
- make docs-check
- go vet ./...
- GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./...
- go test ./cmd/mongo_gateway_bench
- go test ./TreeDB/collections ./TreeDB/nativewire ./TreeDB/internal/collectionwal ./TreeDB/db