### PR TITLE
Buffer safe ordinary update batches

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10054,6 +10054,9 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
+	if mode == updateBatchModeAny {
+		return false
+	}
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9813,11 +9813,20 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode) bool {
-	if c == nil || c.writeDomain == nil || !canBuffer || mode == updateBatchModeAny {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate) bool {
+	if c == nil || c.writeDomain == nil {
 		return false
 	}
 	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+		return false
+	}
+	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
+		if updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
+			return false
+		}
+		canBuffer = true
+	}
+	if !canBuffer {
 		return false
 	}
 	return !persistIndexStateForOptions(opts)
@@ -10042,8 +10051,11 @@ func (c *Collection) withMutationLock(fn func() error) error {
 }
 
 func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMode) bool {
-	if c == nil || c.writeDomain == nil || mode == updateBatchModeAny {
+	if c == nil || c.writeDomain == nil {
 		return false
+	}
+	if mode == updateBatchModeAny {
+		return true
 	}
 	domain := c.writeDomain
 	domain.mu.RLock()
@@ -10345,7 +10357,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	var bufferedTemplateRuns []memtable.Table
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
 	bufferedReadBlocked := false
-	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
+	if domain := c.writeDomain; useBufferedRead && domain != nil {
 		var staleBufferedSnapshot bool
 		bufferedRead, bufferedTemplateRuns, bufferedReadBlocked, staleBufferedSnapshot, err = snapshotUpdateBatchBufferedRead(domain, meta, baseCommitSeq, baseSystemRoot, items, plannerOptions.documentFormat)
 		if err != nil {
@@ -10645,7 +10657,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	if c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode) {
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed)
+	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
 		if len(templateRecords) > 0 {
@@ -10715,7 +10728,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			rootNames:                   rootNames,
 			baseRootIDs:                 baseRootIDs,
 			uniqueSecondaryIndexByRoot:  uniqueSecondary,
-			canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
+			canBufferIndexedUpdateBatch: canBufferDirectUpdateBatch,
 			bufferedBase:                bufferedRead.enabled,
 			bufferedReadGeneration:      bufferedRead.writeGeneration,
 			bufferedReadBlocked:         bufferedReadBlocked,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9669,6 +9669,7 @@ type updateBatchPlan struct {
 	directBufferedUpdate        *directBufferedUpdatePlan
 	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
+	canBufferDirectUpdateBatch  bool
 	bufferedBase                bool
 	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
@@ -11079,7 +11080,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			rootNames:                   rootNames,
 			baseRootIDs:                 baseRootIDs,
 			uniqueSecondaryIndexByRoot:  uniqueSecondary,
-			canBufferIndexedUpdateBatch: canBufferDirectUpdateBatch,
+			canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
+			canBufferDirectUpdateBatch:  canBufferDirectUpdateBatch,
 			bufferedBase:                bufferedRead.enabled,
 			bufferedReadGeneration:      bufferedRead.writeGeneration,
 			bufferedReadBlocked:         bufferedReadBlocked,
@@ -11372,7 +11374,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
-	if c.writeDomain == nil || !plan.canBufferIndexedUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10054,9 +10054,6 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
-	if mode == updateBatchModeAny {
-		return true
-	}
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10085,6 +10085,84 @@ func TestCollectionUpdateBatchPublishesWhenSecondaryUniqueChanges(t *testing.T) 
 	}
 }
 
+func TestCollectionUpdateBatchWithPendingIndexedRunsCallsCallbackOnce(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatBSON,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u1"},
+				{Key: "email", Value: "a@example.com"},
+				{Key: "city", Value: "hnl"},
+			}),
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u2"},
+				{Key: "email", Value: "b@example.com"},
+				{Key: "city", Value: "hnl"},
+			}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u2"),
+		Update:     setBSONField("city", "sea"),
+	}}); err != nil {
+		t.Fatalf("buffered setup UpdateBatch: %v", err)
+	}
+
+	callbackCalls := 0
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			callbackCalls++
+			return setBSONField("email", "c@example.com")(current)
+		},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch with pending indexed runs: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("callback calls=%d want 1", callbackCalls)
+	}
+	ids, err := col.FindByIndex("email", "c@example.com")
+	if err != nil {
+		t.Fatalf("find updated email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("updated email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9941,6 +9941,143 @@ func TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns(t *testing.T
 	}
 }
 
+func TestCollectionUpdateBatchBuffersWhenSecondaryUniqueUnchanged(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatBSON,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "email", Value: "a@example.com"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update:     setBSONField("city", "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered ordinary UpdateBatch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	cityRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "city")])
+	emailRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "email")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 2 || primaryRuns != 1 || cityRuns != 1 || emailRuns != 0 {
+		t.Fatalf("runs root=%d primary=%d city=%d email=%d want 2/1/1/0", rootRunCount, primaryRuns, cityRuns, emailRuns)
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("city ids=%q want [u1]", ids)
+	}
+}
+
+func TestCollectionUpdateBatchPublishesWhenSecondaryUniqueChanges(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatBSON,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "email", Value: "a@example.com"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update:     setBSONField("email", "b@example.com"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("unique UpdateBatch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("rootRunCount=%d want no buffered runs after unique-key publish", rootRunCount)
+	}
+	ids, err := col.FindByIndex("email", "b@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10188,13 +10188,15 @@ func TestCollectionUpdateBatchBuffersWhenSecondaryUniqueUnchanged(t *testing.T) 
 		t.Fatalf("buffered ordinary UpdateBatch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 	col.writeDomain.mu.RLock()
-	rootRunCount := col.writeDomain.rootRunCount
 	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
 	cityRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "city")])
 	emailRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "email")])
 	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 2 || primaryRuns != 1 || cityRuns != 1 || emailRuns != 0 {
-		t.Fatalf("runs root=%d primary=%d city=%d email=%d want 2/1/1/0", rootRunCount, primaryRuns, cityRuns, emailRuns)
+	if primaryRuns == 0 || cityRuns == 0 {
+		t.Fatalf("primary/city runs=%d/%d want buffered primary and changed non-unique index", primaryRuns, cityRuns)
+	}
+	if emailRuns != 0 {
+		t.Fatalf("email runs=%d want unchanged unique index not buffered", emailRuns)
 	}
 	ids, err := col.FindByIndex("city", "sea")
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10049,15 +10049,22 @@ func TestCollectionUpdateBatchPublishesWhenSecondaryUniqueChanges(t *testing.T) 
 	}
 	before := d.State()
 
+	callbackCalls := 0
 	results, err := col.UpdateBatch([]UpdateBatchItem{{
 		DocumentID: []byte("u1"),
-		Update:     setBSONField("email", "b@example.com"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			callbackCalls++
+			return setBSONField("email", "b@example.com")(current)
+		},
 	}})
 	if err != nil {
 		t.Fatalf("UpdateBatch: %v", err)
 	}
 	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
 		t.Fatalf("results=%+v want one modified row", results)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("callback calls=%d want 1", callbackCalls)
 	}
 	after := d.State()
 	if after.CommitSeq != before.CommitSeq+1 {


### PR DESCRIPTION
## Summary

Allows ordinary `UpdateBatch` to use the direct buffered indexed update path when planning proves that no secondary unique index value changes.

This keeps the conservative publish/fallback behavior for secondary unique key mutations, but removes the artificial split where `UpdateBatchIfNoSecondaryUniqueIndexChanges` could buffer the same safe update while plain `UpdateBatch` had to publish.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateBatchBuffersWhenSecondaryUniqueUnchanged|TestCollectionUpdateBatchPublishesWhenSecondaryUniqueChanges|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges|TestCollectionUpdateBatchAllowsDurableUniqueHandoff|TestCollectionUpdateBatchRejectsDuplicateFinalUniqueOwnersAfterHandoff|TestCollectionUpdateBatchAllowsUniqueHandoff' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -bench 'BenchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape/batch_80$' -run '^$' -benchtime=1000x -count=3`

Benchmark smoke on Apple M3, batch 80 direct-buffered template-v1 update path: 198k, 281k, 349k docs/sec across three short runs. This is a smoke check for the shared direct-buffered machinery; the PR's primary gate is the regression coverage showing plain `UpdateBatch` now buffers only when secondary unique roots are unchanged.
