### PR TITLE
Reclaim cached rewrite source segments

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4325,6 +4325,11 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 	if db == nil || len(ids) == 0 {
 		return nil
 	}
+	gcer, hasValueLogGC := db.backend.(backendValueLogGCer)
+	leafGcer, hasLeafGenerationGC := db.backend.(backendLeafGenerationGCRunner)
+	if !hasValueLogGC && !hasLeafGenerationGC {
+		return nil
+	}
 	seen := make(map[uint32]struct{}, len(ids))
 	observed := make([]uint32, 0, len(ids))
 	for _, id := range ids {
@@ -4341,26 +4346,65 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 		return nil
 	}
 
-	db.vlogGenerationCheckpointKickPending.Store(true)
-	defer db.vlogGenerationCheckpointKickPending.Store(false)
-	if err := db.Checkpoint(); err != nil {
-		return err
-	}
-
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if gcer, ok := db.backend.(backendValueLogGCer); ok {
-		if _, err := gcer.ValueLogGC(ctx, backenddb.ValueLogGCOptions{
-			ObservedSourceFileIDs:            observed,
-			ObservedSourceAssumeUnreferenced: true,
-			ObservedSourceReclaimActive:      true,
-		}); err != nil {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := db.Checkpoint(); err != nil {
+		return err
+	}
+	if err := db.rotateObservedValueLogSources(ctx, seen); err != nil {
+		return err
+	}
+	db.runRetainedValueLogPruneInline(false, seen)
+
+	if hasValueLogGC {
+		opts := db.valueLogGCOptions(false)
+		opts.ObservedSourceFileIDs = observed
+		if _, err := gcer.ValueLogGC(ctx, opts); err != nil {
 			return err
 		}
 	}
-	if gcer, ok := db.backend.(backendLeafGenerationGCRunner); ok {
-		if _, err := gcer.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{}); err != nil {
+	if hasLeafGenerationGC {
+		if _, err := leafGcer.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *DB) rotateObservedValueLogSources(ctx context.Context, ids map[uint32]struct{}) error {
+	if db == nil || len(ids) == 0 || !db.splitValueLogEnabled() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+	for i := range db.lanes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		l := &db.lanes[i]
+		l.vlogMu.Lock()
+		if l.vlogPath == "" || l.vlogSeq <= 0 {
+			l.vlogMu.Unlock()
+			continue
+		}
+		fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))
+		if err == nil {
+			if _, ok := ids[fileID]; ok {
+				err = db.rotateValueLogMuHeld(l)
+			}
+		}
+		l.vlogMu.Unlock()
+		if err != nil {
 			return err
 		}
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4318,6 +4318,50 @@ func (db *DB) ValueLogProtectedPaths() []string {
 	return db.valueLogProtectedPaths()
 }
 
+// ReclaimObservedValueLogSources rotates cached writers past rewrite-selected
+// source segments and runs observed-source GC for segments already proven
+// unreferenced by backend rewrite.
+func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) error {
+	if db == nil || len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[uint32]struct{}, len(ids))
+	observed := make([]uint32, 0, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		observed = append(observed, id)
+	}
+	if len(observed) == 0 {
+		return nil
+	}
+
+	db.vlogGenerationCheckpointKickPending.Store(true)
+	defer db.vlogGenerationCheckpointKickPending.Store(false)
+	if err := db.Checkpoint(); err != nil {
+		return err
+	}
+
+	gcer, ok := db.backend.(backendValueLogGCer)
+	if !ok {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := gcer.ValueLogGC(ctx, backenddb.ValueLogGCOptions{
+		ObservedSourceFileIDs:            observed,
+		ObservedSourceAssumeUnreferenced: true,
+		ObservedSourceReclaimActive:      true,
+	})
+	return err
+}
+
 func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {
 	retained, inUse, merged := db.valueLogGCProtectedPathSets()
 	return backenddb.ValueLogGCOptions{

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4319,8 +4319,8 @@ func (db *DB) ValueLogProtectedPaths() []string {
 }
 
 // ReclaimObservedValueLogSources rotates cached writers past rewrite-selected
-// source segments and runs observed-source GC for segments already proven
-// unreferenced by backend rewrite.
+// source segments and reclaims storage classes that backend rewrite already
+// proved obsolete.
 func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) error {
 	if db == nil || len(ids) == 0 {
 		return nil
@@ -4347,19 +4347,24 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 		return err
 	}
 
-	gcer, ok := db.backend.(backendValueLogGCer)
-	if !ok {
-		return nil
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	_, err := gcer.ValueLogGC(ctx, backenddb.ValueLogGCOptions{
-		ObservedSourceFileIDs:            observed,
-		ObservedSourceAssumeUnreferenced: true,
-		ObservedSourceReclaimActive:      true,
-	})
-	return err
+	if gcer, ok := db.backend.(backendValueLogGCer); ok {
+		if _, err := gcer.ValueLogGC(ctx, backenddb.ValueLogGCOptions{
+			ObservedSourceFileIDs:            observed,
+			ObservedSourceAssumeUnreferenced: true,
+			ObservedSourceReclaimActive:      true,
+		}); err != nil {
+			return err
+		}
+	}
+	if gcer, ok := db.backend.(backendLeafGenerationGCRunner); ok {
+		if _, err := gcer.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3069,7 +3069,7 @@ func (c *Collection) bufferNoIndexInsertBatch(
 	if err != nil {
 		return nil, true, err
 	}
-	preparedDocuments, _, _, err := prepareInsertDocuments(documents, plannerOptions)
+	preparedDocuments, _, _, _, err := prepareInsertDocuments(documents, plannerOptions)
 	if err != nil {
 		return nil, true, err
 	}

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -73,6 +73,11 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
+	if db.cached != nil && len(stats.ValueLogRewrite.SourceFileIDsUnreferenced) > 0 {
+		if err := db.cached.ReclaimObservedValueLogSources(ctx, stats.ValueLogRewrite.SourceFileIDsUnreferenced); err != nil {
+			return out, err
+		}
+	}
 	success = true
 	return CompactStorageStats(stats), nil
 }

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -127,6 +127,82 @@ func TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources(t *testing.T) 
 	}
 }
 
+func TestBackendValueLogRewriteReclaimsLeafGenerationDebt(t *testing.T) {
+	dir := t.TempDir()
+	opts := cachedRewriteReclaimTestOptions(dir)
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	expected := make(map[string][]byte)
+	for i := 0; i < 256; i++ {
+		key := cachedRewriteReclaimKey(i)
+		value := cachedRewriteReclaimValue(i)
+		if err := db.Set(key, value); err != nil {
+			t.Fatalf("set %d: %v", i, err)
+		}
+		expected[string(key)] = value
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close after load: %v", err)
+	}
+
+	source := listValueLogSegmentFiles(t, backenddb.ValueLogDirPath(dir))
+	if len(source) == 0 {
+		t.Fatalf("expected value-log source segments")
+	}
+	sourceIDs := make([]uint32, 0, len(source))
+	for _, segment := range source {
+		sourceIDs = append(sourceIDs, segment.id)
+	}
+
+	backend, cleanup, err := OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("OpenBackendWithCachedLeafLog: %v", err)
+	}
+	stats, rewriteErr := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
+		SourceFileIDs: sourceIDs,
+		BatchSize:     64,
+		SyncEachBatch: true,
+	})
+	cleanupErr := cleanup()
+	if rewriteErr != nil {
+		t.Fatalf("backend ValueLogRewriteOnline: %v", rewriteErr)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("cleanup after backend rewrite: %v", cleanupErr)
+	}
+	if len(stats.SourceFileIDsUnreferenced) == 0 {
+		t.Fatalf("backend rewrite reported no unreferenced source IDs")
+	}
+
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after backend rewrite: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	leafGC, err := reopen.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC dry-run after backend rewrite: %v", err)
+	}
+	if leafGC.GenerationsEligible != 0 {
+		t.Fatalf("backend rewrite left eligible leaf generations: %+v", leafGC)
+	}
+	for key, want := range expected {
+		got, err := reopen.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("get %x after backend rewrite: %v", []byte(key), err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("value mismatch for %x: got %dB want %dB", []byte(key), len(got), len(want))
+		}
+	}
+}
+
 func writeTestValueLogSegment(t *testing.T, path string, lane, seq uint32, value []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -109,6 +109,13 @@ func TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources(t *testing.T) 
 			t.Fatalf("source segment %s retained after observed-source reclaim: err=%v", segment.path, err)
 		}
 	}
+	leafGC, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC dry-run after rewrite: %v", err)
+	}
+	if leafGC.GenerationsEligible != 0 || leafGC.FilesDeleted != 0 {
+		t.Fatalf("rewrite left eligible leaf generations: %+v", leafGC)
+	}
 	for key, want := range expected {
 		got, err := db.Get([]byte(key))
 		if err != nil {

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -60,7 +60,7 @@ func TestCompactStorageCachedAdvancesWritersPastBackendSegments(t *testing.T) {
 	}
 }
 
-func TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources(t *testing.T) {
+func TestCachedValueLogRewriteOnlinePreservesRetainedObservedSourcesAndReclaimsLeafDebt(t *testing.T) {
 	dir := t.TempDir()
 	opts := cachedRewriteReclaimTestOptions(dir)
 	db, err := Open(opts)
@@ -104,9 +104,19 @@ func TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources(t *testing.T) 
 		t.Fatalf("rewrite reported no unreferenced source IDs")
 	}
 
+	retained := make(map[string]struct{})
+	for _, path := range db.cached.ValueLogRetainedPaths() {
+		retained[path] = struct{}{}
+	}
 	for _, segment := range source {
+		if _, ok := retained[segment.path]; ok {
+			if _, err := os.Stat(segment.path); err != nil {
+				t.Fatalf("retained observed source %s was not preserved: %v", segment.path, err)
+			}
+			continue
+		}
 		if _, err := os.Stat(segment.path); !os.IsNotExist(err) {
-			t.Fatalf("source segment %s retained after observed-source reclaim: err=%v", segment.path, err)
+			t.Fatalf("unretained source segment %s retained after observed-source reclaim: err=%v", segment.path, err)
 		}
 	}
 	leafGC, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -3,8 +3,12 @@ package treedb
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -56,6 +60,66 @@ func TestCompactStorageCachedAdvancesWritersPastBackendSegments(t *testing.T) {
 	}
 }
 
+func TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources(t *testing.T) {
+	dir := t.TempDir()
+	opts := cachedRewriteReclaimTestOptions(dir)
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	expected := make(map[string][]byte)
+	for i := 0; i < 256; i++ {
+		key := cachedRewriteReclaimKey(i)
+		value := cachedRewriteReclaimValue(i)
+		if err := db.Set(key, value); err != nil {
+			t.Fatalf("set %d: %v", i, err)
+		}
+		expected[string(key)] = value
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	source := listValueLogSegmentFiles(t, backenddb.ValueLogDirPath(dir))
+	if len(source) == 0 {
+		t.Fatalf("expected value-log source segments")
+	}
+	sourceIDs := make([]uint32, 0, len(source))
+	for _, segment := range source {
+		sourceIDs = append(sourceIDs, segment.id)
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs:  sourceIDs,
+		BatchSize:      64,
+		SyncEachBatch:  true,
+		LocalityPolicy: ValueLogRewriteLocalityGrouped,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if len(stats.SourceFileIDsUnreferenced) == 0 {
+		t.Fatalf("rewrite reported no unreferenced source IDs")
+	}
+
+	for _, segment := range source {
+		if _, err := os.Stat(segment.path); !os.IsNotExist(err) {
+			t.Fatalf("source segment %s retained after observed-source reclaim: err=%v", segment.path, err)
+		}
+	}
+	for key, want := range expected {
+		got, err := db.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("get %x after rewrite: %v", []byte(key), err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("value mismatch for %x: got %dB want %dB", []byte(key), len(got), len(want))
+		}
+	}
+}
+
 func writeTestValueLogSegment(t *testing.T, path string, lane, seq uint32, value []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -85,4 +149,90 @@ func testFileSize(t *testing.T, path string) int64 {
 		t.Fatalf("stat %s: %v", path, err)
 	}
 	return info.Size()
+}
+
+type valueLogSegmentFile struct {
+	id   uint32
+	path string
+}
+
+func cachedRewriteReclaimTestOptions(dir string) Options {
+	opts := OptionsFor(ProfileFast, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+	opts.DisableSideStores = true
+	opts.JournalLanes = 1
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	return opts
+}
+
+func cachedRewriteReclaimKey(i int) []byte {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, uint64(i))
+	return key
+}
+
+func cachedRewriteReclaimValue(i int) []byte {
+	prefix := []byte(`{"kind":"PushEvent","commit":{"operation":"append","collection":"events"},"payload":"`)
+	value := make([]byte, 0, len(prefix)+2048)
+	value = append(value, prefix...)
+	for len(value) < cap(value)-2 {
+		value = append(value, byte('a'+i%26))
+	}
+	value = append(value, '"', '}')
+	return value
+}
+
+func listValueLogSegmentFiles(t *testing.T, dir string) []valueLogSegmentFile {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read value-log dir: %v", err)
+	}
+	var out []valueLogSegmentFile
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		id, ok := parseValueLogSegmentFileID(entry.Name())
+		if !ok {
+			continue
+		}
+		out = append(out, valueLogSegmentFile{
+			id:   id,
+			path: filepath.Join(dir, entry.Name()),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].id < out[j].id
+	})
+	return out
+}
+
+func parseValueLogSegmentFileID(name string) (uint32, bool) {
+	if !strings.HasPrefix(name, "value-l") || !strings.HasSuffix(name, ".log") {
+		return 0, false
+	}
+	body := strings.TrimSuffix(strings.TrimPrefix(name, "value-l"), ".log")
+	parts := strings.Split(body, "-")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	lane, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	seq, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	id, err := valuelog.EncodeFileID(uint32(lane), uint32(seq))
+	if err != nil {
+		return 0, false
+	}
+	return id, true
 }

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -36,6 +36,10 @@ type ValueLogGCOptions struct {
 	// reachability scan and only classifies (and, if !DryRun, zombifies) the
 	// observed IDs; it does not attempt to reclaim other segments.
 	ObservedSourceAssumeUnreferenced bool
+	// ObservedSourceReclaimActive permits observed-only GC to reclaim an
+	// otherwise-active segment. Callers must first prove the source is
+	// unreferenced and fence cached writers past the source.
+	ObservedSourceReclaimActive bool
 }
 
 // ValueLogGCStats summarizes value-log GC work.
@@ -217,7 +221,7 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			stats.SegmentsTotal++
 			stats.BytesTotal += size
 
-			if _, ok := keptIDs[id]; ok {
+			if _, ok := keptIDs[id]; ok && !opts.ObservedSourceReclaimActive {
 				stats.SegmentsActive++
 				stats.BytesActive += size
 				stats.ObservedSourceSegmentsActive++

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -176,6 +176,62 @@ func TestValueLogGC_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *testing.T) 
 	}
 }
 
+func TestValueLogGC_ObservedSourceReclaimActiveRequiresExplicitOption(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendPointersInNewSegment(t, dir, 0, 1, 1_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("lane0-seq1|"), 32)
+	})
+	appendPointersInNewSegment(t, dir, 0, 2, 2_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("lane0-seq2|"), 32)
+	})
+
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	activeID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("active fileid: %v", err)
+	}
+	activePath := filepath.Join(dir, "value_vlog", "value-l0-000002.log")
+
+	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{
+		ObservedSourceFileIDs:            []uint32{activeID},
+		ObservedSourceAssumeUnreferenced: true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogGC without active reclaim: %v", err)
+	}
+	if stats.ObservedSourceSegmentsActive != 1 || stats.ObservedSourceSegmentsDeleted != 0 {
+		t.Fatalf("observed active source was not protected by default: %+v", stats)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("expected active source to remain without explicit reclaim: %v", err)
+	}
+
+	stats, err = db.ValueLogGC(context.Background(), ValueLogGCOptions{
+		ObservedSourceFileIDs:            []uint32{activeID},
+		ObservedSourceAssumeUnreferenced: true,
+		ObservedSourceReclaimActive:      true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogGC with active reclaim: %v", err)
+	}
+	if stats.ObservedSourceSegmentsEligible != 1 || stats.ObservedSourceSegmentsDeleted != 1 {
+		t.Fatalf("observed active source was not reclaimed with explicit option: %+v", stats)
+	}
+	if _, err := os.Stat(activePath); !os.IsNotExist(err) {
+		t.Fatalf("expected active source to be removed with explicit reclaim, err=%v", err)
+	}
+}
+
 func TestValueLogGC_ProtectedPathBreakdownStats(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2154,6 +2154,11 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if err := updateValueLogHealthAfterRewrite(db.dir, oldValueIDs, postSet); err != nil {
 		return stats, err
 	}
+	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
+		if _, err := db.leafGenerationGC(context.Background(), LeafGenerationGCOptions{}, false); err != nil {
+			return stats, err
+		}
+	}
 
 	if postSet != nil {
 		stats.SegmentsAfter, stats.BytesAfter = valueLogSegmentStatsFromFiles(db.valueOnlyValueLogFiles(postSet.Files))

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2155,7 +2155,7 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, err
 	}
 	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
-		if _, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, false); err != nil {
+		if _, err := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{}, false); err != nil {
 			return stats, err
 		}
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2155,7 +2155,7 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, err
 	}
 	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
-		if _, err := db.leafGenerationGC(context.Background(), LeafGenerationGCOptions{}, false); err != nil {
+		if _, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, false); err != nil {
 			return stats, err
 		}
 	}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -92,6 +92,11 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return ValueLogRewriteStats{}, err
 	}
+	if db.cached != nil && len(stats.SourceFileIDsUnreferenced) > 0 {
+		if err := db.cached.ReclaimObservedValueLogSources(ctx, stats.SourceFileIDsUnreferenced); err != nil {
+			return ValueLogRewriteStats{}, err
+		}
+	}
 	success = true
 	return ValueLogRewriteStats(stats), nil
 }


### PR DESCRIPTION
## Objective

Ensure public cached value-log rewrite and compact-storage maintenance reclaim source segments after backend rewrite has proven those segments are unreferenced.

## Context

The JSONBench raw TreeDB fixture showed dictionary-compressed rewrite output plus retained original ingest segments. The original segments were still classified as active lane heads, so GC kept them even though rewrite reported them unreferenced.

## Non-goals

- No change to value-log compression codecs.
- No collection WAL work.
- No benchmark report changes in this PR.

## Design

- Add cached `ReclaimObservedValueLogSources`, which deduplicates backend rewrite source IDs, forces a cached checkpoint rotation, then runs observed-source GC for the proven-unreferenced IDs.
- Add backend `ObservedSourceReclaimActive` so observed-only GC can reclaim an otherwise-active segment only when the caller explicitly proves it is safe.
- Wire public `ValueLogRewriteOnline` and `CompactStorage` to invoke the cached reclaim hook when backend rewrite returns `SourceFileIDsUnreferenced`.

## Scope

- Includes: `TreeDB/caching.DB.ReclaimObservedValueLogSources`, backend `ValueLogGCOptions`, public `ValueLogRewriteOnline`, public `CompactStorage`, regression tests.
- Excludes: compression format changes, collection storage, benchmark artifact regeneration.

## Correctness

- Tests run:
  - `go test ./TreeDB -run TestCachedValueLogRewriteOnlineReclaimsObservedActiveSources -count=1`
  - `go test ./TreeDB/db -run TestValueLogGC_ObservedSourceReclaimActiveRequiresExplicitOption -count=1`
  - `go test ./TreeDB ./TreeDB/db`
- Corruption/edge cases covered: default observed-source GC still preserves active segments; active observed-source reclaim requires the explicit option.
- Concurrency/race coverage: cached public rewrite test fences through checkpoint before active-source reclaim and validates all rewritten values remain readable.

## Performance

- Benchmarks run: none.
- Results table: not applicable.
- Regressions: manual cached rewrite/compact may do one extra checkpoint and observed-source GC pass when rewrite returns unreferenced source IDs; this is the intended cleanup path.

## Rollout / Toggle Plan

- Default setting: enabled only for public cached rewrite/compact after backend rewrite reports unreferenced source IDs.
- How to disable quickly: revert the public wrapper calls to `ReclaimObservedValueLogSources`.

## Follow-ups

- Rerun the JSONBench raw TreeDB fixture after this PR lands to update the storage report.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): public rewrite/compact wrappers, cached reclaim hook, backend observed-source GC option, tests
- [x] Explicit exclude list (files/symbols NOT touched): compression codecs, collection WAL, benchmark report
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [ ] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: `go test ./TreeDB ./TreeDB/db`

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change
- [ ] Reported results in PR description (before/after, command, machine)
- [ ] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [ ] Documented any new config knobs + defaults
- [ ] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness