### PR TITLE
Fix stale leaf vlog after compaction

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1432,9 +1432,17 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	}
 	recoverySet := vm.CurrentSet()
 	reader := newValueReader(recoverySet)
-	recoveredLeafReset, err := recoverLeafGenerationResetAfterOfflineVacuum(opts.Dir, p, reader, db.meta.UserRootPageID, db.meta.SystemRootPageID, db.meta.CommitSeq)
-	if recoverySet != nil {
-		vm.Release(recoverySet)
+	releaseRecoverySet := func() error {
+		if recoverySet == nil {
+			return nil
+		}
+		err := vm.Release(recoverySet)
+		recoverySet = nil
+		return err
+	}
+	recoveredLeafReset, err := recoverLeafGenerationResetAfterOfflineVacuum(opts.Dir, p, reader, db.meta.UserRootPageID, db.meta.SystemRootPageID, db.meta.CommitSeq, releaseRecoverySet, vm.EvictSegment)
+	if releaseErr := releaseRecoverySet(); err == nil && releaseErr != nil {
+		err = releaseErr
 	}
 	if err != nil {
 		db.Close()

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1430,23 +1430,23 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		db.Close()
 		return nil, err
 	}
-	if opts.IndexOuterLeavesInValueLog {
-		reader := newValueReader(vm.CurrentSet())
-		hasLeafLogRefs, err := vacuumOutputHasLeafLogRefs(p, reader, db.meta.UserRootPageID, db.meta.SystemRootPageID)
-		if err != nil {
+	recoverySet := vm.CurrentSet()
+	reader := newValueReader(recoverySet)
+	recoveredLeafReset, err := recoverLeafGenerationResetAfterOfflineVacuum(opts.Dir, p, reader, db.meta.UserRootPageID, db.meta.SystemRootPageID, db.meta.CommitSeq)
+	if recoverySet != nil {
+		vm.Release(recoverySet)
+	}
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	if recoveredLeafReset {
+		if err := vm.Refresh(); err != nil {
 			db.Close()
 			return nil, err
 		}
-		if !hasLeafLogRefs {
-			if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, db.meta.CommitSeq); err != nil {
-				db.Close()
-				return nil, err
-			}
-			if err := vm.Refresh(); err != nil {
-				db.Close()
-				return nil, err
-			}
-		}
+	}
+	if opts.IndexOuterLeavesInValueLog {
 		manifest, err := loadOrCreateLeafGenerationManifest(layout.leafVLogDir, db.meta.CommitSeq, false)
 		if err != nil {
 			db.Close()

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1431,6 +1431,22 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		return nil, err
 	}
 	if opts.IndexOuterLeavesInValueLog {
+		reader := newValueReader(vm.CurrentSet())
+		hasLeafLogRefs, err := vacuumOutputHasLeafLogRefs(p, reader, db.meta.UserRootPageID, db.meta.SystemRootPageID)
+		if err != nil {
+			db.Close()
+			return nil, err
+		}
+		if !hasLeafLogRefs {
+			if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, db.meta.CommitSeq); err != nil {
+				db.Close()
+				return nil, err
+			}
+			if err := vm.Refresh(); err != nil {
+				db.Close()
+				return nil, err
+			}
+		}
 		manifest, err := loadOrCreateLeafGenerationManifest(layout.leafVLogDir, db.meta.CommitSeq, false)
 		if err != nil {
 			db.Close()

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1430,7 +1430,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		db.Close()
 		return nil, err
 	}
-	recoverySet := vm.CurrentSet()
+	recoverySet := vm.CurrentSetNoRefresh()
 	reader := newValueReader(recoverySet)
 	releaseRecoverySet := func() error {
 		if recoverySet == nil {

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -322,14 +322,11 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 	if len(files) == 0 && !manifestExists && len(sidecarPaths) == 0 {
 		return nil
 	}
-	if manifestExists {
-		manifestPath := leafGenerationManifestPath(leafDir)
-		if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("vacuum: remove stale leaf generation manifest %s: %w", manifestPath, err)
-		}
-		if err := syncDirFn(leafDir); err != nil {
-			return fmt.Errorf("vacuum: sync leaf_vlog dir after manifest removal: %w", err)
-		}
+	if err := saveLeafGenerationManifest(leafDir, newLeafGenerationManifest(commitSeq)); err != nil {
+		return fmt.Errorf("vacuum: reset leaf generation manifest: %w", err)
+	}
+	if err := syncDirFn(leafDir); err != nil {
+		return fmt.Errorf("vacuum: sync leaf_vlog dir after manifest reset: %w", err)
 	}
 
 	for _, file := range files {
@@ -349,13 +346,6 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 	}
 	if err := syncDirFn(leafDir); err != nil {
 		return fmt.Errorf("vacuum: sync leaf_vlog dir after stale file removal: %w", err)
-	}
-
-	if err := saveLeafGenerationManifest(leafDir, newLeafGenerationManifest(commitSeq)); err != nil {
-		return fmt.Errorf("vacuum: reset leaf generation manifest: %w", err)
-	}
-	if err := syncDirFn(leafDir); err != nil {
-		return fmt.Errorf("vacuum: sync leaf_vlog dir after manifest reset: %w", err)
 	}
 	return nil
 }

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -74,9 +74,14 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		_ = d.Close()
 		return fmt.Errorf("vacuum: missing db state")
 	}
-	if state.ValueLogSet != nil {
-		d.valueLogManager.Acquire(state.ValueLogSet)
-		defer d.valueLogManager.Release(state.ValueLogSet)
+	acquiredValueLogSet := state.ValueLogSet
+	if acquiredValueLogSet != nil {
+		d.valueLogManager.Acquire(acquiredValueLogSet)
+		defer func() {
+			if acquiredValueLogSet != nil {
+				_ = d.valueLogManager.Release(acquiredValueLogSet)
+			}
+		}()
 	}
 
 	indexPath := filepath.Join(opts.Dir, indexFileName)
@@ -195,6 +200,13 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 	if err := newPager.Close(); err != nil {
 		_ = d.Close()
 		return err
+	}
+	if acquiredValueLogSet != nil {
+		if err := d.valueLogManager.Release(acquiredValueLogSet); err != nil {
+			_ = d.Close()
+			return err
+		}
+		acquiredValueLogSet = nil
 	}
 	if err := d.Close(); err != nil {
 		return err

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -238,7 +238,7 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 	}
 
 	if !outputHasLeafLogRefs {
-		if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
+		if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq, nil); err != nil {
 			return err
 		}
 		if err := removeLeafGenerationResetPendingAfterOfflineVacuum(opts.Dir); err != nil {
@@ -317,7 +317,7 @@ func vacuumTreeHasLeafLogRefs(p *pager.Pager, rootID uint64) (bool, error) {
 	return walk(rootID)
 }
 
-func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
+func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64, evictSegment func(uint32) error) error {
 	leafDir := LeafLogDirPath(dir)
 	if leafDir == "" {
 		return nil
@@ -352,6 +352,11 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 	}
 
 	for _, file := range files {
+		if evictSegment != nil {
+			if err := evictSegment(file.rawFileID); err != nil {
+				return fmt.Errorf("vacuum: evict stale leaf generation file %s: %w", leafGenerationFallbackPath(dir, file.rawFileID), err)
+			}
+		}
 		path := leafGenerationFallbackPath(dir, file.rawFileID)
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("vacuum: remove stale leaf generation file %s: %w", path, err)
@@ -405,7 +410,7 @@ func removeLeafGenerationResetPendingAfterOfflineVacuum(dir string) error {
 	return nil
 }
 
-func recoverLeafGenerationResetAfterOfflineVacuum(dir string, p *pager.Pager, reader tree.SlabReader, userRoot, systemRoot, commitSeq uint64) (bool, error) {
+func recoverLeafGenerationResetAfterOfflineVacuum(dir string, p *pager.Pager, reader tree.SlabReader, userRoot, systemRoot, commitSeq uint64, beforeReset func() error, evictSegment func(uint32) error) (bool, error) {
 	markerPath := leafGenerationResetPendingAfterOfflineVacuumPath(dir)
 	if _, err := os.Stat(markerPath); err != nil {
 		if os.IsNotExist(err) {
@@ -418,7 +423,12 @@ func recoverLeafGenerationResetAfterOfflineVacuum(dir string, p *pager.Pager, re
 		return false, err
 	}
 	if !hasLeafLogRefs {
-		if err := resetLeafGenerationAfterOfflineVacuum(dir, commitSeq); err != nil {
+		if beforeReset != nil {
+			if err := beforeReset(); err != nil {
+				return false, err
+			}
+		}
+		if err := resetLeafGenerationAfterOfflineVacuum(dir, commitSeq, evictSegment); err != nil {
 			return false, err
 		}
 	}

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -212,8 +212,10 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		}
 	}
 
-	if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
-		return err
+	if !opts.IndexOuterLeavesInValueLog {
+		if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -246,6 +248,15 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 	if len(files) == 0 && !manifestExists && len(sidecarPaths) == 0 {
 		return nil
 	}
+	if manifestExists {
+		manifestPath := leafGenerationManifestPath(leafDir)
+		if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("vacuum: remove stale leaf generation manifest %s: %w", manifestPath, err)
+		}
+		if err := syncDirFn(leafDir); err != nil {
+			return fmt.Errorf("vacuum: sync leaf_vlog dir after manifest removal: %w", err)
+		}
+	}
 
 	for _, file := range files {
 		path := leafGenerationFallbackPath(dir, file.rawFileID)
@@ -262,21 +273,15 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 			return fmt.Errorf("vacuum: remove stale leaf generation record-length index %s: %w", indexPath, err)
 		}
 	}
-	if runtime.GOOS != "windows" {
-		if dirFile, err := os.Open(leafDir); err == nil {
-			_ = dirFile.Sync()
-			_ = dirFile.Close()
-		}
+	if err := syncDirFn(leafDir); err != nil {
+		return fmt.Errorf("vacuum: sync leaf_vlog dir after stale file removal: %w", err)
 	}
 
 	if err := saveLeafGenerationManifest(leafDir, newLeafGenerationManifest(commitSeq)); err != nil {
 		return fmt.Errorf("vacuum: reset leaf generation manifest: %w", err)
 	}
-	if runtime.GOOS != "windows" {
-		if dirFile, err := os.Open(leafDir); err == nil {
-			_ = dirFile.Sync()
-			_ = dirFile.Close()
-		}
+	if err := syncDirFn(leafDir); err != nil {
+		return fmt.Errorf("vacuum: sync leaf_vlog dir after manifest reset: %w", err)
 	}
 	return nil
 }

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -150,6 +150,12 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		_ = d.Close()
 		return err
 	}
+	outputHasLeafLogRefs, err := vacuumOutputHasLeafLogRefs(newPager, reader, userRoot, sysRoot)
+	if err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
 
 	if err := newPager.Sync(); err != nil {
 		_ = newPager.Close()
@@ -212,13 +218,81 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		}
 	}
 
-	if !opts.IndexOuterLeavesInValueLog {
+	if !outputHasLeafLogRefs {
 		if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func vacuumOutputHasLeafLogRefs(p *pager.Pager, reader tree.SlabReader, userRoot, systemRoot uint64) (bool, error) {
+	for _, rootID := range []uint64{userRoot, systemRoot} {
+		hasRefs, err := vacuumTreeHasLeafLogRefs(p, rootID)
+		if err != nil || hasRefs {
+			return hasRefs, err
+		}
+	}
+	descriptors, err := vacuumCollectCollectionRootDescriptors(p, reader, systemRoot)
+	if err != nil {
+		return false, err
+	}
+	seen := make(map[uint64]struct{}, len(descriptors))
+	for _, descriptor := range descriptors {
+		if descriptor.rootID == 0 {
+			continue
+		}
+		if _, ok := seen[descriptor.rootID]; ok {
+			continue
+		}
+		seen[descriptor.rootID] = struct{}{}
+		hasRefs, err := vacuumTreeHasLeafLogRefs(p, descriptor.rootID)
+		if err != nil || hasRefs {
+			return hasRefs, err
+		}
+	}
+	return false, nil
+}
+
+func vacuumTreeHasLeafLogRefs(p *pager.Pager, rootID uint64) (bool, error) {
+	if p == nil || rootID == 0 {
+		return false, nil
+	}
+	var walk func(uint64) (bool, error)
+	walk = func(id uint64) (bool, error) {
+		data, err := p.Get(id)
+		if err != nil {
+			return false, err
+		}
+		n := node.NewNode(data)
+		switch n.Type() {
+		case page.PageTypeInternal:
+			count := n.Count()
+			for i := uint16(0); i < count; i++ {
+				_, childRef, err := n.GetInternalEntryRefView(i)
+				if err != nil {
+					return false, err
+				}
+				if childRef.Kind == page.ChildRefLeafLog {
+					return true, nil
+				}
+				if childRef.Kind != page.ChildRefPage {
+					return false, fmt.Errorf("vacuum: unexpected child ref kind %d at page %d", childRef.Kind, id)
+				}
+				hasRefs, err := walk(childRef.Page)
+				if err != nil || hasRefs {
+					return hasRefs, err
+				}
+			}
+			return false, nil
+		case page.PageTypeLeaf:
+			return false, nil
+		default:
+			return false, fmt.Errorf("vacuum: unexpected page type %d at page %d", n.Type(), id)
+		}
+	}
+	return walk(rootID)
 }
 
 func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -353,7 +353,7 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64, evictSe
 
 	for _, file := range files {
 		if evictSegment != nil {
-			if err := evictSegment(file.rawFileID); err != nil {
+			if err := evictSegment(page.ValueLogFileID(file.rawFileID)); err != nil {
 				return fmt.Errorf("vacuum: evict stale leaf generation file %s: %w", leafGenerationFallbackPath(dir, file.rawFileID), err)
 			}
 		}

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -212,6 +212,72 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		}
 	}
 
+	if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
+	leafDir := LeafLogDirPath(dir)
+	if leafDir == "" {
+		return nil
+	}
+	if _, err := os.Stat(leafDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("vacuum: stat leaf_vlog dir: %w", err)
+	}
+
+	files, err := listLeafGenerationBootstrapFiles(leafDir)
+	if err != nil {
+		return fmt.Errorf("vacuum: list leaf_vlog files: %w", err)
+	}
+	_, manifestExists, err := loadLeafGenerationManifest(leafDir)
+	if err != nil {
+		return fmt.Errorf("vacuum: load leaf generation manifest: %w", err)
+	}
+	sidecarPaths, err := filepath.Glob(filepath.Join(leafDir, "value-l*.log"+leafGenerationRecordLengthIndexSuffix))
+	if err != nil {
+		return fmt.Errorf("vacuum: list leaf generation record-length indexes: %w", err)
+	}
+	if len(files) == 0 && !manifestExists && len(sidecarPaths) == 0 {
+		return nil
+	}
+
+	for _, file := range files {
+		path := leafGenerationFallbackPath(dir, file.rawFileID)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("vacuum: remove stale leaf generation file %s: %w", path, err)
+		}
+		indexPath := leafGenerationRecordLengthIndexPath(dir, file.rawFileID)
+		if err := os.Remove(indexPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("vacuum: remove stale leaf generation record-length index %s: %w", indexPath, err)
+		}
+	}
+	for _, indexPath := range sidecarPaths {
+		if err := os.Remove(indexPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("vacuum: remove stale leaf generation record-length index %s: %w", indexPath, err)
+		}
+	}
+	if runtime.GOOS != "windows" {
+		if dirFile, err := os.Open(leafDir); err == nil {
+			_ = dirFile.Sync()
+			_ = dirFile.Close()
+		}
+	}
+
+	if err := saveLeafGenerationManifest(leafDir, newLeafGenerationManifest(commitSeq)); err != nil {
+		return fmt.Errorf("vacuum: reset leaf generation manifest: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		if dirFile, err := os.Open(leafDir); err == nil {
+			_ = dirFile.Sync()
+			_ = dirFile.Close()
+		}
+	}
 	return nil
 }
 

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -156,6 +156,13 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		_ = d.Close()
 		return err
 	}
+	if !outputHasLeafLogRefs {
+		if err := writeLeafGenerationResetPendingAfterOfflineVacuum(opts.Dir); err != nil {
+			_ = newPager.Close()
+			_ = d.Close()
+			return err
+		}
+	}
 
 	if err := newPager.Sync(); err != nil {
 		_ = newPager.Close()
@@ -220,6 +227,9 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 
 	if !outputHasLeafLogRefs {
 		if err := resetLeafGenerationAfterOfflineVacuum(opts.Dir, meta.CommitSeq); err != nil {
+			return err
+		}
+		if err := removeLeafGenerationResetPendingAfterOfflineVacuum(opts.Dir); err != nil {
 			return err
 		}
 	}
@@ -348,6 +358,59 @@ func resetLeafGenerationAfterOfflineVacuum(dir string, commitSeq uint64) error {
 		return fmt.Errorf("vacuum: sync leaf_vlog dir after stale file removal: %w", err)
 	}
 	return nil
+}
+
+const leafGenerationOfflineVacuumResetPendingFileName = "offline-vacuum-reset.pending"
+
+func leafGenerationResetPendingAfterOfflineVacuumPath(dir string) string {
+	return filepath.Join(LeafLogDirPath(dir), leafGenerationOfflineVacuumResetPendingFileName)
+}
+
+func writeLeafGenerationResetPendingAfterOfflineVacuum(dir string) error {
+	leafDir := LeafLogDirPath(dir)
+	if err := os.MkdirAll(leafDir, 0o700); err != nil {
+		return fmt.Errorf("vacuum: create leaf_vlog dir for reset marker: %w", err)
+	}
+	path := leafGenerationResetPendingAfterOfflineVacuumPath(dir)
+	if err := os.WriteFile(path, []byte("v1\n"), 0o600); err != nil {
+		return fmt.Errorf("vacuum: write leaf_vlog reset marker: %w", err)
+	}
+	if err := syncDirFn(leafDir); err != nil {
+		return fmt.Errorf("vacuum: sync leaf_vlog dir after reset marker: %w", err)
+	}
+	return nil
+}
+
+func removeLeafGenerationResetPendingAfterOfflineVacuum(dir string) error {
+	leafDir := LeafLogDirPath(dir)
+	path := leafGenerationResetPendingAfterOfflineVacuumPath(dir)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("vacuum: remove leaf_vlog reset marker: %w", err)
+	}
+	if err := syncDirFn(leafDir); err != nil {
+		return fmt.Errorf("vacuum: sync leaf_vlog dir after reset marker removal: %w", err)
+	}
+	return nil
+}
+
+func recoverLeafGenerationResetAfterOfflineVacuum(dir string, p *pager.Pager, reader tree.SlabReader, userRoot, systemRoot, commitSeq uint64) (bool, error) {
+	markerPath := leafGenerationResetPendingAfterOfflineVacuumPath(dir)
+	if _, err := os.Stat(markerPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("vacuum: stat leaf_vlog reset marker: %w", err)
+	}
+	hasLeafLogRefs, err := vacuumOutputHasLeafLogRefs(p, reader, userRoot, systemRoot)
+	if err != nil {
+		return false, err
+	}
+	if !hasLeafLogRefs {
+		if err := resetLeafGenerationAfterOfflineVacuum(dir, commitSeq); err != nil {
+			return false, err
+		}
+	}
+	return true, removeLeafGenerationResetPendingAfterOfflineVacuum(dir)
 }
 
 func writeMetaToPager(p *pager.Pager, pageID uint64, meta page.MetaPageBody) error {

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -202,11 +202,12 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		return err
 	}
 	if acquiredValueLogSet != nil {
-		if err := d.valueLogManager.Release(acquiredValueLogSet); err != nil {
+		releaseSet := acquiredValueLogSet
+		acquiredValueLogSet = nil
+		if err := d.valueLogManager.Release(releaseSet); err != nil {
 			_ = d.Close()
 			return err
 		}
-		acquiredValueLogSet = nil
 	}
 	if err := d.Close(); err != nil {
 		return err

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -431,8 +431,9 @@ func recoverLeafGenerationResetAfterOfflineVacuum(dir string, p *pager.Pager, re
 		if err := resetLeafGenerationAfterOfflineVacuum(dir, commitSeq, evictSegment); err != nil {
 			return false, err
 		}
+		return true, removeLeafGenerationResetPendingAfterOfflineVacuum(dir)
 	}
-	return true, removeLeafGenerationResetPendingAfterOfflineVacuum(dir)
+	return false, removeLeafGenerationResetPendingAfterOfflineVacuum(dir)
 }
 
 func writeMetaToPager(p *pager.Pager, pageID uint64, meta page.MetaPageBody) error {

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -228,7 +228,7 @@ func TestResetLeafGenerationAfterOfflineVacuum_WritesResetManifestBeforeDeletion
 	}
 }
 
-func TestOpen_IndexOuterLeavesInValueLog_ResetsStaleLeafGenerationWithoutLiveRefs(t *testing.T) {
+func TestOpen_IndexOuterLeavesInValueLog_RecoversPendingOfflineVacuumReset(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{Dir: dir, IndexOuterLeavesInValueLog: true}
 	db, err := Open(opts)
@@ -263,6 +263,9 @@ func TestOpen_IndexOuterLeavesInValueLog_ResetsStaleLeafGenerationWithoutLiveRef
 	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
 		t.Fatalf("save stale manifest: %v", err)
 	}
+	if err := writeLeafGenerationResetPendingAfterOfflineVacuum(dir); err != nil {
+		t.Fatalf("write reset marker: %v", err)
+	}
 
 	reopen, err := Open(opts)
 	if err != nil {
@@ -286,5 +289,8 @@ func TestOpen_IndexOuterLeavesInValueLog_ResetsStaleLeafGenerationWithoutLiveRef
 	}
 	if len(reset.Generations) != 1 || len(reset.Generations[0].FileIDs) != 0 {
 		t.Fatalf("unexpected reset manifest: %+v", reset)
+	}
+	if _, err := os.Stat(leafGenerationResetPendingAfterOfflineVacuumPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("reset marker still exists or stat failed: %v", err)
 	}
 }

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -178,3 +178,52 @@ func TestResetLeafGenerationAfterOfflineVacuum_RemovesStaleFilesAfterManifest(t 
 		t.Fatalf("unexpected reset manifest: %+v", reset)
 	}
 }
+
+func TestResetLeafGenerationAfterOfflineVacuum_WritesResetManifestBeforeDeletion(t *testing.T) {
+	dir := t.TempDir()
+	leafDir := LeafLogDirPath(dir)
+	if err := os.MkdirAll(leafDir, 0o700); err != nil {
+		t.Fatalf("mkdir leaf_vlog: %v", err)
+	}
+	rawFileID, err := valuelog.EncodeSegmentID(rewriteLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("encode segment id: %v", err)
+	}
+	segmentPath := leafGenerationFallbackPath(dir, rawFileID)
+	if err := os.WriteFile(segmentPath, []byte("stale leaf segment"), 0o600); err != nil {
+		t.Fatalf("write stale segment: %v", err)
+	}
+	manifest := newLeafGenerationManifest(41)
+	changed, err := manifest.registerCurrentGenerationFileID(rawFileID, 41)
+	if err != nil {
+		t.Fatalf("register stale file id: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected manifest to record stale file id")
+	}
+	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
+		t.Fatalf("save stale manifest: %v", err)
+	}
+
+	origSync := syncDirFn
+	defer func() { syncDirFn = origSync }()
+	syncDirFn = func(_ string) error {
+		return errors.New("stop after reset manifest")
+	}
+	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42); err == nil {
+		t.Fatal("expected injected sync error")
+	}
+	if _, err := os.Stat(segmentPath); err != nil {
+		t.Fatalf("expected stale segment to remain after injected sync error: %v", err)
+	}
+	reset, ok, err := loadLeafGenerationManifest(leafDir)
+	if err != nil {
+		t.Fatalf("load reset manifest: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected reset manifest")
+	}
+	if len(reset.Generations) != 1 || len(reset.Generations[0].FileIDs) != 0 || reset.Generations[0].CreatedCommitSeq != 42 {
+		t.Fatalf("unexpected reset manifest after injected sync error: %+v", reset)
+	}
+}

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
 func TestVacuumIndexOffline_PreservesDataAndShrinksFile(t *testing.T) {
@@ -123,5 +125,56 @@ func TestVacuumIndexOffline_CrashPointsRecoverOnOpen(t *testing.T) {
 				t.Fatalf("bad value: %q", val)
 			}
 		})
+	}
+}
+
+func TestResetLeafGenerationAfterOfflineVacuum_RemovesStaleFilesAfterManifest(t *testing.T) {
+	dir := t.TempDir()
+	leafDir := LeafLogDirPath(dir)
+	if err := os.MkdirAll(leafDir, 0o700); err != nil {
+		t.Fatalf("mkdir leaf_vlog: %v", err)
+	}
+	rawFileID, err := valuelog.EncodeSegmentID(rewriteLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("encode segment id: %v", err)
+	}
+	segmentPath := leafGenerationFallbackPath(dir, rawFileID)
+	if err := os.WriteFile(segmentPath, []byte("stale leaf segment"), 0o600); err != nil {
+		t.Fatalf("write stale segment: %v", err)
+	}
+	indexPath := leafGenerationRecordLengthIndexPath(dir, rawFileID)
+	if err := os.WriteFile(indexPath, []byte("stale index"), 0o600); err != nil {
+		t.Fatalf("write stale length index: %v", err)
+	}
+	manifest := newLeafGenerationManifest(41)
+	changed, err := manifest.registerCurrentGenerationFileID(rawFileID, 41)
+	if err != nil {
+		t.Fatalf("register stale file id: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected manifest to record stale file id")
+	}
+	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
+		t.Fatalf("save stale manifest: %v", err)
+	}
+
+	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42); err != nil {
+		t.Fatalf("reset leaf generation: %v", err)
+	}
+	if _, err := os.Stat(segmentPath); !os.IsNotExist(err) {
+		t.Fatalf("stale segment still exists or stat failed: %v", err)
+	}
+	if _, err := os.Stat(indexPath); !os.IsNotExist(err) {
+		t.Fatalf("stale length index still exists or stat failed: %v", err)
+	}
+	reset, ok, err := loadLeafGenerationManifest(leafDir)
+	if err != nil {
+		t.Fatalf("load reset manifest: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected reset manifest")
+	}
+	if len(reset.Generations) != 1 || len(reset.Generations[0].FileIDs) != 0 || reset.Generations[0].CreatedCommitSeq != 42 {
+		t.Fatalf("unexpected reset manifest: %+v", reset)
 	}
 }

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -158,7 +158,7 @@ func TestResetLeafGenerationAfterOfflineVacuum_RemovesStaleFilesAfterManifest(t 
 		t.Fatalf("save stale manifest: %v", err)
 	}
 
-	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42); err != nil {
+	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42, nil); err != nil {
 		t.Fatalf("reset leaf generation: %v", err)
 	}
 	if _, err := os.Stat(segmentPath); !os.IsNotExist(err) {
@@ -210,7 +210,7 @@ func TestResetLeafGenerationAfterOfflineVacuum_WritesResetManifestBeforeDeletion
 	syncDirFn = func(_ string) error {
 		return errors.New("stop after reset manifest")
 	}
-	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42); err == nil {
+	if err := resetLeafGenerationAfterOfflineVacuum(dir, 42, nil); err == nil {
 		t.Fatal("expected injected sync error")
 	}
 	if _, err := os.Stat(segmentPath); err != nil {

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -227,3 +227,64 @@ func TestResetLeafGenerationAfterOfflineVacuum_WritesResetManifestBeforeDeletion
 		t.Fatalf("unexpected reset manifest after injected sync error: %+v", reset)
 	}
 }
+
+func TestOpen_IndexOuterLeavesInValueLog_ResetsStaleLeafGenerationWithoutLiveRefs(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir, IndexOuterLeavesInValueLog: true}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	leafDir := LeafLogDirPath(dir)
+	rawFileID, err := valuelog.EncodeSegmentID(rewriteLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("encode segment id: %v", err)
+	}
+	segmentPath := leafGenerationFallbackPath(dir, rawFileID)
+	if err := os.WriteFile(segmentPath, []byte("stale leaf segment"), 0o600); err != nil {
+		t.Fatalf("write stale segment: %v", err)
+	}
+	indexPath := leafGenerationRecordLengthIndexPath(dir, rawFileID)
+	if err := os.WriteFile(indexPath, []byte("stale index"), 0o600); err != nil {
+		t.Fatalf("write stale length index: %v", err)
+	}
+	manifest := newLeafGenerationManifest(1)
+	changed, err := manifest.registerCurrentGenerationFileID(rawFileID, 1)
+	if err != nil {
+		t.Fatalf("register stale file id: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected manifest to record stale file id")
+	}
+	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
+		t.Fatalf("save stale manifest: %v", err)
+	}
+
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := reopen.Close(); err != nil {
+		t.Fatalf("close reopen: %v", err)
+	}
+	if _, err := os.Stat(segmentPath); !os.IsNotExist(err) {
+		t.Fatalf("stale segment still exists or stat failed: %v", err)
+	}
+	if _, err := os.Stat(indexPath); !os.IsNotExist(err) {
+		t.Fatalf("stale length index still exists or stat failed: %v", err)
+	}
+	reset, ok, err := loadLeafGenerationManifest(leafDir)
+	if err != nil {
+		t.Fatalf("load reset manifest: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected reset manifest")
+	}
+	if len(reset.Generations) != 1 || len(reset.Generations[0].FileIDs) != 0 {
+		t.Fatalf("unexpected reset manifest: %+v", reset)
+	}
+}

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -197,6 +197,11 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 	if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir, KeepRecent: 1}); err != nil {
 		t.Fatalf("VacuumIndexOffline: %v", err)
 	}
+	for _, path := range leafPathsBefore {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("stale leaf_vlog file %s still exists or stat failed: %v", path, err)
+		}
+	}
 
 	reopen, err := treedb.Open(opts)
 	if err != nil {

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -198,14 +198,6 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 		t.Fatalf("VacuumIndexOffline: %v", err)
 	}
 
-	leafPathsAfter, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
-	if err != nil {
-		t.Fatalf("glob leaf_vlog after vacuum: %v", err)
-	}
-	if len(leafPathsAfter) == 0 {
-		t.Fatalf("offline vacuum removed live leaf_vlog files for outer-leaf storage")
-	}
-
 	reopen, err := treedb.Open(opts)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -185,8 +185,25 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
+	mainDir := filepath.Dir(mainIndexPath(dir))
+	leafPathsBefore, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog before vacuum: %v", err)
+	}
+	if len(leafPathsBefore) == 0 {
+		t.Fatalf("expected leaf_vlog files before vacuum")
+	}
+
 	if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir, KeepRecent: 1}); err != nil {
 		t.Fatalf("VacuumIndexOffline: %v", err)
+	}
+
+	leafPathsAfter, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog after vacuum: %v", err)
+	}
+	if len(leafPathsAfter) != 0 {
+		t.Fatalf("offline vacuum should reset stale leaf_vlog files after pager-backed rewrite, got %v", leafPathsAfter)
 	}
 
 	reopen, err := treedb.Open(opts)

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -202,8 +202,8 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob leaf_vlog after vacuum: %v", err)
 	}
-	if len(leafPathsAfter) != 0 {
-		t.Fatalf("offline vacuum should reset stale leaf_vlog files after pager-backed rewrite, got %v", leafPathsAfter)
+	if len(leafPathsAfter) == 0 {
+		t.Fatalf("offline vacuum removed live leaf_vlog files for outer-leaf storage")
 	}
 
 	reopen, err := treedb.Open(opts)

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -26,7 +26,7 @@ const runDirSentinel = ".collection_canonical_bench_run"
 const (
 	phasePostInsert               = "post_insert"
 	phaseOnlineOnePassMaintenance = "online_one_pass_maintenance"
-	phaseOfflineRewrite           = "offline_rewrite"
+	phaseOfflineRewrite           = "offline_compact"
 	phaseFullLeafgenPackGC        = "full_leafgen_pack_gc"
 	phaseSQLiteVacuum             = "sqlite_vacuum"
 )
@@ -371,7 +371,7 @@ func prepareRunDir(cfg config) error {
 	paths := []string{
 		"logs",
 		"timed_matrix",
-		"offline_rewrite",
+		"offline_compact",
 		"full_leafgen_pack_gc",
 		"benchmark_results.json",
 		"benchmark_summary.md",
@@ -455,7 +455,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.FullLeafgenMaxGenerations, "leafgen-pack-max-generations", cfg.FullLeafgenMaxGenerations, "Max generations to pack in full leafgen phase; 0 means no limit")
 	fs.StringVar(&cfg.FullLeafgenIndexVacuum, "index-vacuum", cfg.FullLeafgenIndexVacuum, "Index vacuum mode for full leafgen fixture: offline, online, auto, or none")
 	fs.BoolVar(&cfg.SkipTimedMatrix, "skip-timed-matrix", false, "Skip timed TreeDB/SQLite benchmark matrix")
-	fs.BoolVar(&cfg.SkipOfflineRewrite, "skip-offline-rewrite", false, "Skip PR 1096-style offline rewrite matrix")
+	fs.BoolVar(&cfg.SkipOfflineRewrite, "skip-offline-rewrite", false, "Skip high-level offline compact matrix")
 	fs.BoolVar(&cfg.SkipFullLeafgen, "skip-full-leafgen", false, "Skip full leafgen pack/GC fixture")
 	fs.BoolVar(&cfg.SkipSQLite, "skip-sqlite", false, "Skip SQLite cells in timed matrix")
 	fs.BoolVar(&cfg.AllowIncomplete, "allow-incomplete", false, "Write report even when guardrail checks fail")
@@ -525,7 +525,7 @@ func runTimedMatrix(cfg config, canon *canonicalRun) error {
 }
 
 func runOfflineRewriteMatrix(cfg config, canon *canonicalRun) error {
-	rewriteDir := filepath.Join(cfg.OutDir, "offline_rewrite")
+	rewriteDir := filepath.Join(cfg.OutDir, "offline_compact")
 	env := map[string]string{
 		"RUN_DIR":            rewriteDir,
 		"DOCS":               strconv.Itoa(cfg.Docs),
@@ -533,11 +533,11 @@ func runOfflineRewriteMatrix(cfg config, canon *canonicalRun) error {
 		"PROFILE":            cfg.Profile,
 		"COLLECTION_INDEXES": strings.Join(offlineRewriteIndexArgs(cfg.Indexes), " "),
 	}
-	if err := runLoggedCommand(cfg, canon, "offline_rewrite_matrix", env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
+	if err := runLoggedCommand(cfg, canon, "offline_compact_matrix", env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
 		return err
 	}
-	canon.Artifacts["offline_rewrite_dir"] = rewriteDir
-	canon.Artifacts["offline_rewrite_tsv"] = filepath.Join(rewriteDir, "compression_matrix.tsv")
+	canon.Artifacts["offline_compact_dir"] = rewriteDir
+	canon.Artifacts["offline_compact_tsv"] = filepath.Join(rewriteDir, "compression_matrix.tsv")
 	return parseOfflineRewriteTSV(canon, filepath.Join(rewriteDir, "compression_matrix.tsv"), cfg)
 }
 
@@ -878,17 +878,17 @@ func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config) error 
 		docs := cfg.Docs
 		phase := phasePostInsert
 		maintenance := "none"
-		note := "offline rewrite matrix before-rewrite size; not compacted"
+		note := "offline compact matrix before-compact size; not compacted"
 		flags := map[string]string(nil)
-		if row["phase"] == "after_rewrite" {
+		if row["phase"] == "after_compact" || row["phase"] == "after_rewrite" {
 			phase = phaseOfflineRewrite
-			maintenance = "treemap_vlog_rewrite_rw"
-			note = "PR 1096-style offline rewrite using treemap vlog-rewrite -rw"
+			maintenance = "treemap_compact_rw"
+			note = "High-level CompactStorage path using treemap compact -rw"
 			flags = map[string]string{
-				"treemap":                   "vlog-rewrite -rw",
+				"treemap":                   "compact -rw",
 				"template-mode":             "off",
 				"leaf-segment-target-bytes": "persisted/default",
-				"index-vacuum":              "offline index swap from rewrite",
+				"index-vacuum":              "via CompactStorage/offline vacuum path",
 			}
 		}
 		extra := map[string]string{
@@ -1251,7 +1251,7 @@ func renderMarkdownReport(canon *canonicalRun) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Fair Compacted-State Comparison\n\n")
-	sb.WriteString("TreeDB fully compacted rows are compared with SQLite after `VACUUM`. Do not compare TreeDB `offline_rewrite` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.\n\n")
+	sb.WriteString("TreeDB fully compacted rows are compared with SQLite after `VACUUM`. Do not compare TreeDB `offline_compact` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.\n\n")
 	writeFairComparison(&sb, canon)
 	sb.WriteString("\n")
 
@@ -1260,7 +1260,7 @@ func renderMarkdownReport(canon *canonicalRun) string {
 	sb.WriteString("| --- | --- | --- |\n")
 	sb.WriteString("| `post_insert` | Size after insert benchmark/fixture and correctness flush/checkpoint. | Compare with other post-insert rows only. |\n")
 	sb.WriteString("| `online_one_pass_maintenance` | Partial online maintenance from benchmark harness; currently one online rewrite/GC path and one leafgen-pack pass. | Do not present as full compaction. |\n")
-	sb.WriteString("| `offline_rewrite` | PR 1096-style `treemap vlog-rewrite <dir> -rw`. | Compare with SQLite `sqlite_vacuum`. |\n")
+	sb.WriteString("| `offline_compact` | High-level `treemap compact <dir> -rw` path. | Compare with SQLite `sqlite_vacuum`. |\n")
 	sb.WriteString("| `full_leafgen_pack_gc` | Forced/full leaf generation pack/GC with explicit knobs and configured index vacuum. | Compare with SQLite `sqlite_vacuum`. |\n")
 	sb.WriteString("| `sqlite_vacuum` | SQLite compacted baseline after `VACUUM`. | Required baseline for compacted-state comparison. |\n\n")
 	sb.WriteString("Full leafgen knobs recorded for this run:\n\n")
@@ -1335,10 +1335,10 @@ func renderExecutiveSummary(canon *canonicalRun) string {
 		fullNative := *sqliteNative.BytesPerDoc / *full.BytesPerDoc
 		offlineJSON := *sqliteJSON.BytesPerDoc / *offline.BytesPerDoc
 		fullJSON := *sqliteJSON.BytesPerDoc / *full.BytesPerDoc
-		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted %s %s collection storage is %.1f B/doc via PR 1096-style offline rewrite and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline rewrite is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
+		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted %s %s collection storage is %.1f B/doc via high-level offline compact and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline compact is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
 			engine, indexCountLabel(canonicalIndexCount(canon)), primaryFormat(canon), *offline.BytesPerDoc, *full.BytesPerDoc, offlineNative, offlineJSON, fullNative, fullJSON)
 	}
-	return "This report separates post-insert, partial online maintenance, offline rewrite, full leafgen pack/GC, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
+	return "This report separates post-insert, partial online maintenance, offline compact, full leafgen pack/GC, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
 }
 
 func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -26,7 +26,7 @@ const runDirSentinel = ".collection_canonical_bench_run"
 const (
 	phasePostInsert               = "post_insert"
 	phaseOnlineOnePassMaintenance = "online_one_pass_maintenance"
-	phaseOfflineRewrite           = "offline_compact"
+	phaseOfflineCompact           = "offline_compact"
 	phaseFullLeafgenPackGC        = "full_leafgen_pack_gc"
 	phaseSQLiteVacuum             = "sqlite_vacuum"
 )
@@ -881,7 +881,7 @@ func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config) error 
 		note := "offline compact matrix before-compact size; not compacted"
 		flags := map[string]string(nil)
 		if row["phase"] == "after_compact" || row["phase"] == "after_rewrite" {
-			phase = phaseOfflineRewrite
+			phase = phaseOfflineCompact
 			maintenance = "treemap_compact_rw"
 			note = "High-level CompactStorage path using treemap compact -rw"
 			flags = map[string]string{
@@ -1033,7 +1033,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 		if r.Shape != "collection" && r.Shape != "raw" {
 			add("error", "missing_shape_label", fmt.Sprintf("%s/%s has non-canonical shape label %q", r.ConfigName, r.Phase, r.Shape))
 		}
-		if (r.Phase == phaseOfflineRewrite || r.Phase == phaseFullLeafgenPackGC || r.Phase == phaseSQLiteVacuum) && len(r.CompactionFlags) == 0 {
+		if (r.Phase == phaseOfflineCompact || r.Phase == phaseFullLeafgenPackGC || r.Phase == phaseSQLiteVacuum) && len(r.CompactionFlags) == 0 {
 			add("error", "missing_compaction_flags", fmt.Sprintf("%s/%s is missing compaction flags", r.ConfigName, r.Phase))
 		}
 	}
@@ -1054,14 +1054,14 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 		}
 		if findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
 			for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-				if findResult(canon.Results, treeDBConfig, phaseOfflineRewrite) != nil {
+				if findResult(canon.Results, treeDBConfig, phaseOfflineCompact) != nil {
 					add("error", "unfair_compacted_comparison", "TreeDB offline/full compaction must be compared against SQLite after VACUUM, not SQLite post-insert")
 					break
 				}
 			}
 		}
 	}
-	if findResult(canon.Results, "treedb_template_v1_raw", phaseOfflineRewrite) != nil {
+	if findResult(canon.Results, "treedb_template_v1_raw", phaseOfflineCompact) != nil {
 		add("info", "raw_shape_labeled", "raw TreeDB rows are labeled shape=raw and should not be mixed with collection rows without that label")
 	}
 	for _, cmp := range comparisonsForReport(canon) {
@@ -1071,7 +1071,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 	}
 	if !sqliteSkipped {
 		for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-			for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+			for _, treedbPhase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
 				if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
 					continue
 				}
@@ -1124,7 +1124,7 @@ func buildCompactedComparisons(canon *canonicalRun) []comparisonRow {
 	var comparisons []comparisonRow
 	sqliteConfigs := []string{sqliteNativeConfigName(canon), sqliteJSONConfigName(canon)}
 	for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-		for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+		for _, treedbPhase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
 			treeRow := findResult(canon.Results, treeDBConfig, treedbPhase)
 			if !hasPositiveBytesPerDoc(treeRow) {
 				continue
@@ -1174,7 +1174,7 @@ func findComparison(comparisons []comparisonRow, treeConfig, treePhase, sqliteCo
 }
 
 func isTreeDBCompactedPhase(phase string) bool {
-	return phase == phaseOfflineRewrite || phase == phaseFullLeafgenPackGC
+	return phase == phaseOfflineCompact || phase == phaseFullLeafgenPackGC
 }
 
 func writeOutputs(canon *canonicalRun) error {
@@ -1321,7 +1321,7 @@ func renderMarkdownReport(canon *canonicalRun) string {
 
 func renderExecutiveSummary(canon *canonicalRun) string {
 	fastest := fastestThroughput(canon.Results)
-	offline := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseOfflineRewrite)
+	offline := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseOfflineCompact)
 	full := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseFullLeafgenPackGC)
 	sqliteJSON := findResult(canon.Results, sqliteJSONConfigName(canon), phaseSQLiteVacuum)
 	sqliteNative := findResult(canon.Results, sqliteNativeConfigName(canon), phaseSQLiteVacuum)
@@ -1360,7 +1360,7 @@ func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
 	sb.WriteString("| TreeDB config | Phase | B/doc | vs SQLite native-columns VACUUM | vs SQLite JSON VACUUM |\n")
 	sb.WriteString("| --- | --- | ---: | ---: | ---: |\n")
 	for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-		for _, phase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+		for _, phase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
 			nativeCmp := findComparison(comparisons, treeDBConfig, phase, sqliteNativeConfig, phaseSQLiteVacuum)
 			jsonCmp := findComparison(comparisons, treeDBConfig, phase, sqliteJSONConfig, phaseSQLiteVacuum)
 			if nativeCmp == nil && jsonCmp == nil {
@@ -1558,7 +1558,7 @@ func compactedTreeDBConfigNames(canon *canonicalRun) []string {
 		if row.IndexCount != canonicalIndexCount(canon) {
 			continue
 		}
-		if row.Phase != phaseOfflineRewrite && row.Phase != phaseFullLeafgenPackGC {
+		if row.Phase != phaseOfflineCompact && row.Phase != phaseFullLeafgenPackGC {
 			continue
 		}
 		add(row.ConfigName)
@@ -1728,7 +1728,7 @@ func sortResults(rows []resultRow) {
 	phaseRank := map[string]int{
 		phasePostInsert:               0,
 		phaseOnlineOnePassMaintenance: 1,
-		phaseOfflineRewrite:           2,
+		phaseOfflineCompact:           2,
 		phaseFullLeafgenPackGC:        3,
 		phaseSQLiteVacuum:             4,
 	}

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -234,9 +234,9 @@ func TestCanonicalDerivedCompactedComparisons(t *testing.T) {
 		sqliteConfig string
 		wantRatio    float64
 	}{
-		{phaseOfflineRewrite, "sqlite_native_columns_2_indexes", 156.7 / 44.3},
+		{phaseOfflineCompact, "sqlite_native_columns_2_indexes", 156.7 / 44.3},
 		{phaseFullLeafgenPackGC, "sqlite_native_columns_2_indexes", 156.7 / 31.7},
-		{phaseOfflineRewrite, "sqlite_json_2_indexes", 231.7 / 44.3},
+		{phaseOfflineCompact, "sqlite_json_2_indexes", 231.7 / 44.3},
 		{phaseFullLeafgenPackGC, "sqlite_json_2_indexes", 231.7 / 31.7},
 	}
 	for _, tc := range cases {
@@ -261,10 +261,10 @@ func TestCanonicalDerivedCompactedComparisonsUseConfiguredIndexCount(t *testing.
 	finalizeRunMetadata(canon)
 
 	comparisons := buildCompactedComparisons(canon)
-	if got := findComparison(comparisons, "treedb_template_v1_collection_1_indexes", phaseOfflineRewrite, "sqlite_native_columns_1_indexes", phaseSQLiteVacuum); got == nil {
+	if got := findComparison(comparisons, "treedb_template_v1_collection_1_indexes", phaseOfflineCompact, "sqlite_native_columns_1_indexes", phaseSQLiteVacuum); got == nil {
 		t.Fatalf("missing configured one-index comparison, got %#v", comparisons)
 	}
-	if got := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum); got != nil {
+	if got := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phaseOfflineCompact, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum); got != nil {
 		t.Fatalf("unexpected hardcoded two-index comparison: %#v", got)
 	}
 }
@@ -285,7 +285,7 @@ func TestGuardrailAllowsDetachedHeadBranchMetadata(t *testing.T) {
 func TestExecutiveSummarySkipsZeroBytesPerDocRatios(t *testing.T) {
 	canon := knownExampleRun()
 	for i := range canon.Results {
-		if canon.Results[i].ConfigName == "treedb_template_v1_collection_2_indexes" && canon.Results[i].Phase == phaseOfflineRewrite {
+		if canon.Results[i].ConfigName == "treedb_template_v1_collection_2_indexes" && canon.Results[i].Phase == phaseOfflineCompact {
 			canon.Results[i].BytesPerDoc = floatPtr(0)
 			break
 		}
@@ -563,10 +563,10 @@ func knownExampleRun() *canonicalRun {
 				MeasurementKind: "benchmark_post_processing",
 				CompactionFlags: map[string]string{"leafgen-pack-max-generations": "1"},
 			},
-			row("treedb_template_v1_raw", "treedb_fast", "template-v1", "raw", phaseOfflineRewrite, 0, 1983120, 19.8),
-			row("treedb_template_v1_collection_0_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 0, 1948075, 19.5),
-			row("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 1, 3751406, 37.5),
-			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 2, 4434451, 44.3),
+			row("treedb_template_v1_raw", "treedb_fast", "template-v1", "raw", phaseOfflineCompact, 0, 1983120, 19.8),
+			row("treedb_template_v1_collection_0_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 0, 1948075, 19.5),
+			row("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 1, 3751406, 37.5),
+			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 2, 4434451, 44.3),
 			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 2, 3174681, 31.7),
 			row("sqlite_json_2_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 2, 23166976, 231.7),
 			row("sqlite_native_columns_2_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 2, 15671296, 156.7),

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -14,12 +14,12 @@ func TestCanonicalReportKnownCompressionShape(t *testing.T) {
 
 	required := []string{
 		"| `command_line` | `./scripts/bench_collections_canonical.sh -docs 100000` |",
-		"44.3 B/doc via PR 1096-style offline rewrite and 31.7 B/doc via full leafgen pack/GC",
-		"offline rewrite is about 3.5x smaller than SQLite native columns and 5.2x smaller than SQLite JSON",
+		"44.3 B/doc via high-level offline compact and 31.7 B/doc via full leafgen pack/GC",
+		"offline compact is about 3.5x smaller than SQLite native columns and 5.2x smaller than SQLite JSON",
 		"full leafgen pack/GC is about 4.9x and 7.3x smaller, respectively",
 		"`online_one_pass_maintenance`",
-		"Do not compare TreeDB `offline_rewrite` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.",
-		"`treedb_template_v1_collection_2_indexes` | `offline_rewrite` | 44.3",
+		"Do not compare TreeDB `offline_compact` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.",
+		"`treedb_template_v1_collection_2_indexes` | `offline_compact` | 44.3",
 		"`treedb_template_v1_collection_2_indexes` | `full_leafgen_pack_gc` | 31.7",
 		"make bench-collections-canonical",
 	}

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -22,9 +22,9 @@ Default load shape:
   direct publish by default because they already amortize publish overhead well
 - `fast` TreeDB profile
 - final checkpoint and reopen verification
-- automatic offline index vacuum when `-vlog-rewrite` or `-leafgen-pack-gc`
-  is requested, so post-maintenance size comparisons include both value/leaf-log
-  cleanup and index compaction
+- optional low-level `value_vlog` and `leaf_vlog` maintenance probes, with
+  automatic offline index vacuum when `-vlog-rewrite` or `-leafgen-pack-gc` is
+  requested
 
 Example:
 
@@ -106,14 +106,19 @@ Useful variants:
   -cpuprofile /tmp/collection_fixture_cpu.pprof \
   -memprofile /tmp/collection_fixture_heap.pprof
 
-# Compact the persistent value_vlog after loading, then run index vacuum and
-# report before/after disk usage.
+# Low-level value_vlog probe: rewrite the persistent value_vlog after loading,
+# then run index vacuum and report before/after disk usage.
 ./bin/collection-load-fixture -vlog-rewrite -dir /tmp/treedb_fixture_rewritten -reset
 
-# Pack leaf_vlog generations after loading, then run leaf-generation GC and report
-# the before/after disk usage separately from value_vlog rewrite. The default
-# -index-vacuum=auto follows this with offline index vacuum.
+# Low-level leaf_vlog probe: pack leaf_vlog generations after loading, then run
+# leaf-generation GC and report the before/after disk usage separately from
+# value_vlog rewrite. The default -index-vacuum=auto follows this with offline
+# index vacuum.
 ./bin/collection-load-fixture -leafgen-pack-gc -dir /tmp/treedb_fixture_leafgen_packed -reset
+
+# For final storage-footprint measurement, prefer the high-level compaction path
+# after creating the fixture.
+treemap compact /tmp/treedb_two_index_template_v1_index_vlog -rw
 
 # Keep the pre-vacuum index.db shape for debugging.
 ./bin/collection-load-fixture -leafgen-pack-gc -index-vacuum=none -dir /tmp/treedb_fixture_leafgen_no_vacuum -reset

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -130,12 +130,11 @@ collection benchmark profile:
 The TreeDB target always opens with outer leaves in the leaf value log and the
 cached leaf-log backend, so collection and secondary-index roots exercise the
 same leaf-vlog path as the optimized collection benchmarks. The `full`
-maintenance mode reports each post-load compaction step: value-log rewrite,
-value-log GC, leaf-generation pack, leaf-generation GC, and offline index
-vacuum. The final vacuum closes the benchmark gateway before rewriting
-`index.db`, matching the documented compacted-state maintenance command. Use
-`-treedb-maintenance checkpoint` to reproduce the older checkpoint-only disk
-metric, or `none` to skip final TreeDB disk reporting.
+maintenance mode runs the high-level `CompactStorage` path first, then closes
+the benchmark gateway and runs offline index vacuum to shrink `index.db` for
+final-footprint reporting. Use `-treedb-maintenance checkpoint` to reproduce the
+older checkpoint-only disk metric, or `none` to skip final TreeDB disk
+reporting.
 
 `-treedb-document-format` accepts `json`, `template-v1`/`collections-v1`, and `bson`. BSON mode
 stores Mongo wire documents as native BSON collection records, avoiding the

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4584,53 +4584,19 @@ func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result 
 	if target == nil || target.db == nil {
 		return nil
 	}
-	if err := appendTreeDBMaintenanceStep(ctx, target, result, "vlog_rewrite", func() (map[string]int64, string, error) {
-		stats, err := target.db.ValueLogRewriteOnline(ctx, backenddb.ValueLogRewriteOnlineOptions{})
-		if err != nil {
-			return nil, "", err
-		}
-		return valueLogRewriteMetrics(stats), "", nil
-	}); err != nil {
-		return err
-	}
-	if err := appendTreeDBMaintenanceStep(ctx, target, result, "vlog_gc", func() (map[string]int64, string, error) {
-		stats, err := target.db.ValueLogGC(ctx, backenddb.ValueLogGCOptions{})
-		if err != nil {
-			return nil, "", err
-		}
-		return valueLogGCMetrics(stats), "", nil
-	}); err != nil {
-		return err
-	}
-	if err := appendTreeDBMaintenanceStep(ctx, target, result, "leafgen_pack", func() (map[string]int64, string, error) {
-		stats, err := target.db.LeafGenerationPackRunOnce(ctx, backenddb.LeafGenerationPackFromPlanOptions{
-			Force: true,
-			Sync:  true,
+	if err := appendTreeDBMaintenanceStep(ctx, target, result, "compact_storage", func() (map[string]int64, string, error) {
+		stats, err := target.db.CompactStorage(ctx, backenddb.CompactStorageOptions{
+			Mode:          backenddb.CompactStorageFull,
+			SyncEachPhase: true,
 		})
 		if err != nil {
 			return nil, "", err
 		}
-		skipped := ""
-		if !stats.Ran {
-			skipped = stats.SkipReason
-			if skipped == "" {
-				skipped = "not_applicable"
-			}
-		}
-		return leafGenerationPackRunOnceMetrics(stats), skipped, nil
+		return compactStorageMetrics(stats), compactStorageSkipReason(stats), nil
 	}); err != nil {
 		return err
 	}
-	if err := appendTreeDBMaintenanceStep(ctx, target, result, "leafgen_gc", func() (map[string]int64, string, error) {
-		stats, err := target.db.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{})
-		if err != nil {
-			return nil, "", err
-		}
-		return leafGenerationGCMetrics(stats), "", nil
-	}); err != nil {
-		return err
-	}
-	if err := appendTreeDBMaintenanceStep(ctx, target, result, "index_vacuum", func() (map[string]int64, string, error) {
+	if err := appendTreeDBMaintenanceStep(ctx, target, result, "index_vacuum_offline", func() (map[string]int64, string, error) {
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancelCleanup()
 		if err := closeBenchTargetKeepDir(cleanupCtx, target); err != nil {
@@ -4644,6 +4610,67 @@ func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result 
 		return err
 	}
 	return nil
+}
+
+func compactStorageMetrics(stats backenddb.CompactStorageStats) map[string]int64 {
+	metrics := map[string]int64{
+		"fully_compacted":                             boolInt64(stats.FullyCompacted),
+		"phases":                                      int64(len(stats.Phases)),
+		"remaining_value_log_rewrite_segments":        int64(stats.RemainingDebt.ValueLogRewriteSegments),
+		"remaining_value_log_rewrite_bytes":           stats.RemainingDebt.ValueLogRewriteBytes,
+		"remaining_value_log_gc_segments":             int64(stats.RemainingDebt.ValueLogGCSegments),
+		"remaining_value_log_gc_bytes":                stats.RemainingDebt.ValueLogGCBytes,
+		"remaining_leaf_pack_generations":             int64(stats.RemainingDebt.LeafPackGenerations),
+		"remaining_leaf_pack_bytes":                   stats.RemainingDebt.LeafPackBytes,
+		"remaining_leaf_gc_generations":               int64(stats.RemainingDebt.LeafGCGenerations),
+		"remaining_leaf_gc_bytes":                     stats.RemainingDebt.LeafGCBytes,
+		"zero_byte_value_log_files_deleted":           int64(stats.ZeroByteValueLogFilesDeleted),
+		"value_log_rewrite_records_copied":            int64(stats.ValueLogRewrite.RecordsCopied),
+		"value_log_rewrite_value_records_copied":      int64(stats.ValueLogRewrite.ValueRecordsCopied),
+		"value_log_rewrite_value_bytes_copied":        stats.ValueLogRewrite.ValueBytesCopied,
+		"value_log_gc_segments_deleted":               int64(stats.ValueLogGC.SegmentsDeleted),
+		"value_log_gc_bytes_deleted":                  stats.ValueLogGC.BytesDeleted,
+		"leaf_generation_gc_generations_deleted":      int64(stats.LeafGenerationGC.GenerationsDeleted),
+		"leaf_generation_gc_files_deleted":            int64(stats.LeafGenerationGC.FilesDeleted),
+		"leaf_generation_gc_bytes_deleted":            stats.LeafGenerationGC.BytesDeleted,
+		"leaf_generation_pack_runs":                   int64(len(stats.LeafGenerationPacks)),
+		"leaf_generation_plan_candidate_generations":  int64(len(stats.LeafGenerationPlan.CandidateGenerationIDs)),
+		"leaf_generation_plan_expected_reclaim_bytes": stats.LeafGenerationPlan.ExpectedReclaimBytes,
+	}
+	var packRan int64
+	var packPages int64
+	var packFrames int64
+	var packBytes int64
+	for _, pack := range stats.LeafGenerationPacks {
+		if pack.Ran {
+			packRan++
+		}
+		packPages += int64(pack.Pack.LeafPagesCopied)
+		packFrames += int64(pack.Pack.LeafFramesWritten)
+		packBytes += pack.Pack.BytesCopied
+	}
+	metrics["leaf_generation_pack_runs_executed"] = packRan
+	metrics["leaf_generation_pack_leaf_pages_copied"] = packPages
+	metrics["leaf_generation_pack_leaf_frames_written"] = packFrames
+	metrics["leaf_generation_pack_bytes_copied"] = packBytes
+	return metrics
+}
+
+func compactStorageSkipReason(stats backenddb.CompactStorageStats) string {
+	if stats.FullyCompacted {
+		return ""
+	}
+	if stats.RemainingDebt.Empty() {
+		return ""
+	}
+	return "remaining_debt"
+}
+
+func boolInt64(v bool) int64 {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]string, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4592,7 +4592,7 @@ func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result 
 		if err != nil {
 			return nil, "", err
 		}
-		return compactStorageMetrics(stats), compactStorageSkipReason(stats), nil
+		return compactStorageMetrics(stats), "", nil
 	}); err != nil {
 		return err
 	}
@@ -4654,16 +4654,6 @@ func compactStorageMetrics(stats backenddb.CompactStorageStats) map[string]int64
 	metrics["leaf_generation_pack_leaf_frames_written"] = packFrames
 	metrics["leaf_generation_pack_bytes_copied"] = packBytes
 	return metrics
-}
-
-func compactStorageSkipReason(stats backenddb.CompactStorageStats) string {
-	if stats.FullyCompacted {
-		return ""
-	}
-	if stats.RemainingDebt.Empty() {
-		return ""
-	}
-	return "remaining_debt"
 }
 
 func boolInt64(v bool) int64 {

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -146,7 +146,7 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
 - `-max-rss-mb` abort the run if RSS exceeds this many MiB (guardrail; `0` = disabled; Linux-only)
 - `-checkpoint-between-tests` force a best-effort durability checkpoint between tests (DBs that support `Checkpoint()`), and also once after the final test so end-of-run disk usage reflects a settled state
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
-- `-treedb-vlog-rewrite-after-run` run a full TreeDB value-log rewrite after the run and report before/after disk usage + the data directory path
+- `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility
 - `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`)
 - `-checkpoint-every-bytes` force a best-effort durability checkpoint every N approx bytes during write-heavy tests (DBs that support `Checkpoint()`)
 - `-suite` named suite:

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -95,7 +95,7 @@ var (
 	settleBeforeScans               = flag.Bool("settle-before-scans", false, "Close+reopen DBs before scan tests to measure settled scan performance (flushes caches/WAL)")
 	treedbCacheStatsBeforeReads     = flag.Bool("treedb-cache-stats-before-reads", false, "Print select treedb.cache.* stats before read/scan tests (treedb only)")
 	treedbCacheStatsAfterTests      = flag.Bool("treedb-cache-stats-after-tests", false, "Print select treedb.cache.* stats after each benchmark test (treedb only)")
-	treedbVlogRewriteAfterRun       = flag.Bool("treedb-vlog-rewrite-after-run", false, "Run a full TreeDB value-log rewrite after the benchmark run and report before/after disk usage (treedb only)")
+	treedbVlogRewriteAfterRun       = flag.Bool("treedb-vlog-rewrite-after-run", false, "Run full TreeDB CompactStorage after the benchmark run and report before/after disk usage (treedb only; flag name kept for compatibility)")
 	treedbVacuumAfterVlogRewriteRun = flag.Bool("treedb-vacuum-after-vlog-rewrite-run", true, "Run offline TreeDB index vacuum after -treedb-vlog-rewrite-after-run before reporting final compacted disk usage")
 )
 
@@ -743,7 +743,7 @@ func main() {
 		}
 		if len(run.TreeDBVlogRewrite) > 0 {
 			fmt.Println()
-			fmt.Println("TreeDB ValueLog Rewrite (After Run)")
+			fmt.Println("TreeDB CompactStorage (After Run)")
 			fmt.Print(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 		}
 		if run.Config.KeepDir {
@@ -804,7 +804,7 @@ func main() {
 			}
 			if len(run.TreeDBVlogRewrite) > 0 {
 				fmt.Println()
-				fmt.Println("TreeDB ValueLog Rewrite (After Run)")
+				fmt.Println("TreeDB CompactStorage (After Run)")
 				fmt.Print(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 			}
 			if run.Config.KeepDir {
@@ -4156,9 +4156,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			if err != nil {
 				return BenchRun{}, err
 			}
-			stats, err := treedb.ValueLogRewriteOffline(opts)
+			db, err := treedb.Open(opts)
 			if err != nil {
-				return BenchRun{}, err
+				return BenchRun{}, fmt.Errorf("open treedb for compact storage: %w", err)
+			}
+			stats, compactErr := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+				Mode:          treedb.CompactStorageFull,
+				SyncEachPhase: true,
+			})
+			closeErr := db.Close()
+			if compactErr != nil {
+				return BenchRun{}, fmt.Errorf("treedb compact storage: %w", compactErr)
+			}
+			if closeErr != nil {
+				return BenchRun{}, fmt.Errorf("close treedb after compact storage: %w", closeErr)
 			}
 
 			afterUsage, _ := computeDirDiskUsage(inst.Dir)
@@ -4183,11 +4194,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				BeforeTree:      beforeTree,
 				AfterTree:       afterTree,
 				AfterVacuumTree: afterVacuumTree,
-				SegmentsBefore:  stats.SegmentsBefore,
-				SegmentsAfter:   stats.SegmentsAfter,
-				BytesBefore:     stats.BytesBefore,
-				BytesAfter:      stats.BytesAfter,
-				RecordsCopied:   stats.RecordsCopied,
+				SegmentsBefore:  stats.ValueLogRewrite.SegmentsBefore,
+				SegmentsAfter:   stats.ValueLogRewrite.SegmentsAfter,
+				BytesBefore:     stats.ValueLogRewrite.BytesBefore,
+				BytesAfter:      stats.ValueLogRewrite.BytesAfter,
+				RecordsCopied:   stats.ValueLogRewrite.RecordsCopied,
 			}
 		}
 		if usage, err := computeDirDiskUsage(inst.Dir); err == nil {
@@ -4507,7 +4518,7 @@ func renderTreeDBVlogRewriteString(reports map[string]treeDBVlogRewriteReport) s
 		if rep.BeforeTree.MainLeafLog.TotalBytes > 0 || rep.AfterTree.MainLeafLog.TotalBytes > 0 {
 			sb.WriteString(fmt.Sprintf("  maindb/leaf_vlog: %s -> %s\n", formatBytes(rep.BeforeTree.MainLeafLog.TotalBytes), formatBytes(rep.AfterTree.MainLeafLog.TotalBytes)))
 		}
-		sb.WriteString(fmt.Sprintf("  vlog-rewrite: segments %d -> %d bytes %s -> %s records=%d\n",
+		sb.WriteString(fmt.Sprintf("  compact-storage value-log rewrite: segments %d -> %d bytes %s -> %s records=%d\n",
 			rep.SegmentsBefore, rep.SegmentsAfter,
 			formatBytesSigned(rep.BytesBefore), formatBytesSigned(rep.BytesAfter),
 			rep.RecordsCopied))
@@ -4712,7 +4723,7 @@ func renderMarkdownSingle(run BenchRun) string {
 	}
 	if len(run.TreeDBVlogRewrite) > 0 {
 		sb.WriteString("\n")
-		sb.WriteString("## TreeDB ValueLog Rewrite (After Run)\n\n")
+		sb.WriteString("## TreeDB CompactStorage (After Run)\n\n")
 		sb.WriteString("```text\n")
 		sb.WriteString(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 		sb.WriteString("```\n")
@@ -4972,7 +4983,7 @@ func renderMarkdownSweep(runs []BenchRun) string {
 		}
 	}
 	if anyRewrite {
-		sb.WriteString("## TreeDB ValueLog Rewrite (After Run)\n\n")
+		sb.WriteString("## TreeDB CompactStorage (After Run)\n\n")
 		for _, run := range runs {
 			if len(run.TreeDBVlogRewrite) == 0 {
 				continue

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -31,7 +31,7 @@ another location such as `$TMPDIR` on macOS) and writes:
 - `benchmark_summary.md`: human-readable report.
 - `benchmark_matrix.csv`: flat table for spreadsheet/diff tooling.
 - `timed_matrix/`: existing timed TreeDB/SQLite benchmark matrix artifacts.
-- `offline_rewrite/`: PR 1096-style offline rewrite artifacts.
+- `offline_compact/`: high-level TreeDB compaction artifacts.
 - `full_leafgen_pack_gc/`: full leaf-generation pack/GC fixture artifacts.
 
 Use `-out-dir <dir>` to keep a specific run directory:
@@ -58,16 +58,16 @@ The current benchmark harness's online maintenance path. It is useful for
 tracking what a bounded online maintenance pass accomplishes, but it is partial
 maintenance and must not be described as full compaction.
 
-`offline_rewrite`
+`offline_compact`
 
-The PR 1096-style offline path:
+The high-level TreeDB compaction path:
 
 ```bash
-treemap vlog-rewrite <dir> -rw
+treemap compact <dir> -rw
 ```
 
-This is a full/offline rewrite comparison point. Compare it with SQLite after
-`VACUUM`, not SQLite post-insert.
+This is the preferred full/offline compaction comparison point. Compare it with
+SQLite after `VACUUM`, not SQLite post-insert.
 
 `full_leafgen_pack_gc`
 
@@ -87,7 +87,7 @@ after `VACUUM`.
 `sqlite_vacuum`
 
 SQLite compacted baseline after `VACUUM`. This is the required SQLite baseline
-when comparing against TreeDB `offline_rewrite` or `full_leafgen_pack_gc`.
+when comparing against TreeDB `offline_compact` or `full_leafgen_pack_gc`.
 
 ## Fair Comparisons
 
@@ -98,7 +98,7 @@ Fair post-insert comparison:
 
 Fair compacted-state comparison:
 
-- TreeDB `offline_rewrite`
+- TreeDB `offline_compact`
 - TreeDB `full_leafgen_pack_gc`
 - SQLite `sqlite_vacuum`
 

--- a/docs/benchmarks/collections_harness.md
+++ b/docs/benchmarks/collections_harness.md
@@ -147,10 +147,13 @@ scripts/bench_collections_harness.sh \
   --include-sqlite
 ```
 
-TreeDB maintenance rows run value-log rewrite, checkpoint, then value-log GC and
-checkpoint after the timed benchmark iteration. SQLite maintenance rows run
-`VACUUM` and a WAL checkpoint. These metrics are opt-in because they add
-substantial untimed I/O and can perturb cache state between cells.
+TreeDB maintenance rows in this harness are low-level diagnostics for specific
+maintenance primitives (`value_vlog` rewrite/GC and `leaf_vlog` generation
+pack/GC). Use the high-level `CompactStorage` path, for example
+`treemap compact <db-dir> -rw`, for final storage-footprint measurements.
+SQLite maintenance rows run `VACUUM` and a WAL checkpoint. These metrics are
+opt-in because they add substantial untimed I/O and can perturb cache state
+between cells.
 
 ## Focused Profiles
 
@@ -187,8 +190,8 @@ includes a disk-usage section that compares total bytes, collection bytes, and
 index bytes; when an engine does not expose a direct object split, index bytes
 are derived from the per-doc delta against the matching zero-index row.
 
-The maintenance summary reports untimed TreeDB total disk bytes before online
-value-log rewrite, after rewrite, and after value-log GC. SQLite rows report
-total disk bytes before and after `VACUUM`. Latency columns in both the per-cell
-reports and matrix summaries include adjacent throughput columns such as
-`ns/op` plus `ops/sec`.
+The maintenance summary reports untimed TreeDB total disk bytes around the
+selected low-level maintenance primitive. SQLite rows report total disk bytes
+before and after `VACUUM`. Latency columns in both the per-cell reports and
+matrix summaries include adjacent throughput columns such as `ns/op` plus
+`ops/sec`.

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -15,7 +15,7 @@ evidence.
 - Report both throughput and disk. For latency-sensitive phases, include p50,
   p95, and p99 when the harness emits them.
 - Keep TreeDB maintenance phases named exactly. Do not call a row "compacted"
-  unless the row is from `offline_rewrite`, `full_leafgen_pack_gc`,
+  unless the row is from `offline_compact`, `full_leafgen_pack_gc`,
   `sqlite_vacuum`, or another explicitly documented full-maintenance phase.
 - Keep raw artifacts. Markdown tables are for review; JSON, TSV, profiles, and
   data directories are the durable evidence.
@@ -147,7 +147,7 @@ The canonical runner emits:
 - `benchmark_summary.md`
 - `benchmark_matrix.csv`
 - `timed_matrix/`
-- `offline_rewrite/`
+- `offline_compact/`
 - `full_leafgen_pack_gc/` with per-format full leafgen/GC fixture summaries
 
 For broader matrix work, build and run:
@@ -192,7 +192,7 @@ The canonical collection maintenance phases are:
 - `post_insert`: after insert plus the flush/checkpoint needed for correctness.
 - `online_one_pass_maintenance`: bounded online maintenance; useful, but not a
   full compaction state.
-- `offline_rewrite`: full/offline TreeDB value-log rewrite comparison point.
+- `offline_compact`: high-level `treemap compact <dir> -rw` comparison point.
 - `full_leafgen_pack_gc`: full leaf-generation pack/GC comparison point.
 - `sqlite_vacuum`: SQLite compacted baseline after `VACUUM`.
 
@@ -203,7 +203,7 @@ Fair post-insert comparison:
 
 Fair compacted-state comparison:
 
-- TreeDB `offline_rewrite`
+- TreeDB `offline_compact`
 - TreeDB `full_leafgen_pack_gc`
 - SQLite `sqlite_vacuum`
 

--- a/scripts/compare_application_db_rebuilds.sh
+++ b/scripts/compare_application_db_rebuilds.sh
@@ -8,7 +8,7 @@ Usage:
 
 Environment:
   OUT_DIR                          Output directory. Default: /home/mikers/.application-db-compare-<timestamp>
-  TREEDB_REPO                      TreeDB repo to use for rebuild/rewrite. Default: /home/mikers/dev/snissn/gomap-phasehook-active
+  TREEDB_REPO                      TreeDB repo to use for rebuild/compact. Default: /home/mikers/dev/snissn/gomap-phasehook-active
   COSMOS_DB_REPO                   Cosmos DB repo to use. Default: /home/mikers/dev/snissn/cosmos-db
   TREEDB_PROFILE                   TreeDB open profile. Default: wal_on_fast
   TREEDB_FORCE_CHECKPOINT_ON_WRITE Forwarded to cosmos-db TreeDB adapter. Default: 0
@@ -87,6 +87,7 @@ cat > "${HELPER_DIR}/main.go" <<'GOEOF'
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -120,21 +121,21 @@ type stepResult struct {
 	WallSeconds      float64        `json:"wall_seconds"`
 	MaxRSSKBObserved int64          `json:"max_rss_kb_observed,omitempty"`
 	Extra            map[string]any `json:"extra,omitempty"`
-	RewriteStats     map[string]any `json:"rewrite_stats,omitempty"`
+	CompactStats     map[string]any `json:"compact_stats,omitempty"`
 }
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	if len(os.Args) < 2 {
-		fatalf("expected subcommand: rebuild | compact-leveldb | rewrite-treedb")
+		fatalf("expected subcommand: rebuild | compact-leveldb | compact-treedb")
 	}
 	switch os.Args[1] {
 	case "rebuild":
 		runRebuild(os.Args[2:])
 	case "compact-leveldb":
 		runCompactLevelDB(os.Args[2:])
-	case "rewrite-treedb":
-		runRewriteTreeDB(os.Args[2:])
+	case "compact-treedb":
+		runCompactTreeDB(os.Args[2:])
 	default:
 		fatalf("unknown subcommand %q", os.Args[1])
 	}
@@ -316,8 +317,8 @@ func runCompactLevelDB(args []string) {
 	writeJSON(res)
 }
 
-func runRewriteTreeDB(args []string) {
-	fs := flag.NewFlagSet("rewrite-treedb", flag.ExitOnError)
+func runCompactTreeDB(args []string) {
+	fs := flag.NewFlagSet("compact-treedb", flag.ExitOnError)
 	destParent := fs.String("dest-parent", "", "destination parent directory")
 	profileRaw := fs.String("profile", "wal_on_fast", "fast or wal_on_fast")
 	if err := fs.Parse(args); err != nil {
@@ -333,24 +334,44 @@ func runRewriteTreeDB(args []string) {
 
 	start := time.Now()
 	opts := treedb.OptionsFor(profile, filepath.Join(*destParent, "application.db"))
-	stats, err := treedb.ValueLogRewriteOffline(opts)
+	db, err := treedb.Open(opts)
 	if err != nil {
-		fatalErr(fmt.Errorf("treedb offline rewrite: %w", err))
+		fatalErr(fmt.Errorf("open treedb for compaction: %w", err))
+	}
+	stats, compactErr := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+		Mode:          treedb.CompactStorageFull,
+		SyncEachPhase: true,
+	})
+	closeErr := db.Close()
+	if compactErr != nil {
+		fatalErr(fmt.Errorf("treedb compact storage: %w", compactErr))
+	}
+	if closeErr != nil {
+		fatalErr(fmt.Errorf("close treedb after compact storage: %w", closeErr))
+	}
+	if err := treedb.VacuumIndexOffline(opts); err != nil {
+		fatalErr(fmt.Errorf("treedb offline index vacuum after compact storage: %w", err))
 	}
 	res := stepResult{
-		Mode:             "rewrite-treedb",
+		Mode:             "compact-treedb",
 		Backend:          string(dbm.TreeDBBackend),
 		Profile:          profileName,
 		DestParent:       *destParent,
 		DestDBPath:       filepath.Join(*destParent, "application.db"),
 		WallSeconds:      time.Since(start).Seconds(),
 		MaxRSSKBObserved: maxRSSKB(),
-		RewriteStats: map[string]any{
-			"segments_before": stats.SegmentsBefore,
-			"segments_after":  stats.SegmentsAfter,
-			"bytes_before":    stats.BytesBefore,
-			"bytes_after":     stats.BytesAfter,
-			"records_copied":  stats.RecordsCopied,
+		CompactStats: map[string]any{
+			"fully_compacted":                      stats.FullyCompacted,
+			"phase_count":                          len(stats.Phases),
+			"value_log_rewrite_records_copied":     stats.ValueLogRewrite.RecordsCopied,
+			"value_log_rewrite_bytes_after":        stats.ValueLogRewrite.BytesAfter,
+			"value_log_gc_segments_deleted":        stats.ValueLogGC.SegmentsDeleted,
+			"leaf_generation_gc_files_deleted":     stats.LeafGenerationGC.FilesDeleted,
+			"zero_byte_value_log_files_deleted":    stats.ZeroByteValueLogFilesDeleted,
+			"remaining_value_log_rewrite_segments": stats.RemainingDebt.ValueLogRewriteSegments,
+			"remaining_value_log_gc_segments":      stats.RemainingDebt.ValueLogGCSegments,
+			"remaining_leaf_pack_generations":      stats.RemainingDebt.LeafPackGenerations,
+			"remaining_leaf_gc_generations":        stats.RemainingDebt.LeafGCGenerations,
 		},
 	}
 	writeJSON(res)
@@ -478,13 +499,13 @@ run_timed_step rebuild_treedb \
 TREEDB_BUILD_BYTES="$(safe_du_bytes "${TREEDB_PARENT}/application.db")"
 TREEDB_BUILD_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/rebuild_treedb.time.txt")"
 
-run_timed_step rewrite_treedb \
-  "${HELPER_BIN}" rewrite-treedb \
+run_timed_step compact_treedb \
+  "${HELPER_BIN}" compact-treedb \
   -dest-parent "${TREEDB_PARENT}" \
   -profile "${TREEDB_PROFILE}"
 
 TREEDB_FINAL_BYTES="$(safe_du_bytes "${TREEDB_PARENT}/application.db")"
-TREEDB_FINAL_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/rewrite_treedb.time.txt")"
+TREEDB_FINAL_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/compact_treedb.time.txt")"
 
 python3 - <<'PY' \
   "${SOURCE_APP_DB}" \
@@ -556,7 +577,7 @@ def gib(n):
 rebuild_leveldb = load_json("rebuild_leveldb")
 compact_leveldb = load_json("compact_leveldb")
 rebuild_treedb = load_json("rebuild_treedb")
-rewrite_treedb = load_json("rewrite_treedb")
+compact_treedb = load_json("compact_treedb")
 
 summary = {
     "source": {
@@ -598,14 +619,14 @@ summary = {
             "max_rss_kb": int(treedb_build_max_rss_kb or load_time_maxrss("rebuild_treedb")),
             "max_rss_gib": gib(int(treedb_build_max_rss_kb or load_time_maxrss("rebuild_treedb")) * 1024),
         },
-        "final_rewrite": {
-            **rewrite_treedb,
+        "final_compact": {
+            **compact_treedb,
             "disk_bytes_after": int(treedb_final_bytes),
             "disk_gib_after": gib(int(treedb_final_bytes)),
             "disk_bytes_delta_vs_rebuild": int(treedb_final_bytes) - int(treedb_build_bytes),
             "disk_gib_delta_vs_rebuild": gib(int(treedb_final_bytes) - int(treedb_build_bytes)),
-            "max_rss_kb": int(treedb_final_max_rss_kb or load_time_maxrss("rewrite_treedb")),
-            "max_rss_gib": gib(int(treedb_final_max_rss_kb or load_time_maxrss("rewrite_treedb")) * 1024),
+            "max_rss_kb": int(treedb_final_max_rss_kb or load_time_maxrss("compact_treedb")),
+            "max_rss_gib": gib(int(treedb_final_max_rss_kb or load_time_maxrss("compact_treedb")) * 1024),
         },
     },
 }
@@ -614,9 +635,9 @@ summary["comparison"] = {
     "rebuild_time_seconds_delta_treedb_minus_leveldb": summary["treedb"]["rebuild"]["wall_seconds"] - summary["leveldb"]["rebuild"]["wall_seconds"],
     "rebuild_disk_bytes_delta_treedb_minus_leveldb": summary["treedb"]["rebuild"]["disk_bytes_after"] - summary["leveldb"]["rebuild"]["disk_bytes_after"],
     "rebuild_max_rss_kb_delta_treedb_minus_leveldb": summary["treedb"]["rebuild"]["max_rss_kb"] - summary["leveldb"]["rebuild"]["max_rss_kb"],
-    "final_disk_bytes_delta_treedb_minus_leveldb": summary["treedb"]["final_rewrite"]["disk_bytes_after"] - summary["leveldb"]["final_compact"]["disk_bytes_after"],
-    "final_step_time_seconds_delta_treedb_minus_leveldb": summary["treedb"]["final_rewrite"]["wall_seconds"] - summary["leveldb"]["final_compact"]["wall_seconds"],
-    "final_step_max_rss_kb_delta_treedb_minus_leveldb": summary["treedb"]["final_rewrite"]["max_rss_kb"] - summary["leveldb"]["final_compact"]["max_rss_kb"],
+    "final_disk_bytes_delta_treedb_minus_leveldb": summary["treedb"]["final_compact"]["disk_bytes_after"] - summary["leveldb"]["final_compact"]["disk_bytes_after"],
+    "final_step_time_seconds_delta_treedb_minus_leveldb": summary["treedb"]["final_compact"]["wall_seconds"] - summary["leveldb"]["final_compact"]["wall_seconds"],
+    "final_step_max_rss_kb_delta_treedb_minus_leveldb": summary["treedb"]["final_compact"]["max_rss_kb"] - summary["leveldb"]["final_compact"]["max_rss_kb"],
 }
 
 results_json = pathlib.Path(results_json_path)
@@ -646,7 +667,7 @@ md.append(
     f"| treedb rebuild | {summary['treedb']['rebuild']['wall_seconds']:.2f} | {summary['treedb']['rebuild']['max_rss_gib']:.3f} | {summary['treedb']['rebuild']['disk_gib_after']:.3f} | {summary['treedb']['rebuild']['disk_gib_after'] - summary['source']['gib']:+.3f} |"
 )
 md.append(
-    f"| treedb final rewrite | {summary['treedb']['final_rewrite']['wall_seconds']:.2f} | {summary['treedb']['final_rewrite']['max_rss_gib']:.3f} | {summary['treedb']['final_rewrite']['disk_gib_after']:.3f} | {summary['treedb']['final_rewrite']['disk_gib_after'] - summary['source']['gib']:+.3f} |"
+    f"| treedb final compact | {summary['treedb']['final_compact']['wall_seconds']:.2f} | {summary['treedb']['final_compact']['max_rss_gib']:.3f} | {summary['treedb']['final_compact']['disk_gib_after']:.3f} | {summary['treedb']['final_compact']['disk_gib_after'] - summary['source']['gib']:+.3f} |"
 )
 md.append("")
 md.append("## Direct deltas")
@@ -657,12 +678,12 @@ md.append(f"- treedb rebuild max rss minus goleveldb rebuild: {gib(summary['comp
 md.append(f"- treedb final disk minus goleveldb final disk: {gib(summary['comparison']['final_disk_bytes_delta_treedb_minus_leveldb']):+.3f} GiB")
 md.append(f"- treedb final step wall time minus goleveldb final step: {summary['comparison']['final_step_time_seconds_delta_treedb_minus_leveldb']:+.2f} s")
 md.append(f"- treedb final step max rss minus goleveldb final step: {gib(summary['comparison']['final_step_max_rss_kb_delta_treedb_minus_leveldb'] * 1024):+.3f} GiB")
-if summary["treedb"]["final_rewrite"].get("rewrite_stats"):
-    rs = summary["treedb"]["final_rewrite"]["rewrite_stats"]
+if summary["treedb"]["final_compact"].get("compact_stats"):
+    rs = summary["treedb"]["final_compact"]["compact_stats"]
     md.append("")
-    md.append("## TreeDB rewrite stats")
+    md.append("## TreeDB compact stats")
     md.append("")
-    for key in ["segments_before", "segments_after", "bytes_before", "bytes_after", "records_copied"]:
+    for key in ["fully_compacted", "phase_count", "value_log_rewrite_records_copied", "value_log_gc_segments_deleted", "leaf_generation_gc_files_deleted", "zero_byte_value_log_files_deleted"]:
         md.append(f"- {key}: {rs.get(key)}")
 results_md.write_text("\n".join(md) + "\n")
 shutil.copyfile(results_json, tmp_results_json_path)

--- a/scripts/run_application_db_engine_matrix.sh
+++ b/scripts/run_application_db_engine_matrix.sh
@@ -8,7 +8,7 @@ Usage:
 
 Environment:
   OUT_DIR                          Output directory. Default: /home/mikers/.application-db-engine-matrix-<timestamp>
-  TREEDB_REPO                      TreeDB repo to use for rebuild/rewrite. Default: /home/mikers/dev/snissn/gomap-phasehook-active
+  TREEDB_REPO                      TreeDB repo to use for rebuild/compact. Default: /home/mikers/dev/snissn/gomap-phasehook-active
   COSMOS_DB_REPO                   Cosmos DB repo to use. Default: /home/mikers/dev/snissn/cosmos-db
   TREEDB_PROFILE                   TreeDB open profile. Default: wal_on_fast
   TREEDB_FORCE_CHECKPOINT_ON_WRITE Forwarded to cosmos-db TreeDB adapter. Default: 0
@@ -95,6 +95,7 @@ cat > "${HELPER_DIR}/main.go" <<'GOEOF'
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -129,7 +130,7 @@ type stepResult struct {
 	WallSeconds      float64        `json:"wall_seconds"`
 	MaxRSSKBObserved int64          `json:"max_rss_kb_observed,omitempty"`
 	Extra            map[string]any `json:"extra,omitempty"`
-	RewriteStats     map[string]any `json:"rewrite_stats,omitempty"`
+	CompactStats     map[string]any `json:"compact_stats,omitempty"`
 }
 
 type batchWriter interface {
@@ -173,7 +174,7 @@ func (*silentPebbleLogger) Infof(_ string, _ ...interface{}) {}
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	if len(os.Args) < 2 {
-		fatalf("expected subcommand: rebuild | compact-leveldb | compact-pebble | rewrite-treedb")
+		fatalf("expected subcommand: rebuild | compact-leveldb | compact-pebble | compact-treedb")
 	}
 	switch os.Args[1] {
 	case "rebuild":
@@ -182,8 +183,8 @@ func main() {
 		runCompactLevelDB(os.Args[2:])
 	case "compact-pebble":
 		runCompactPebble(os.Args[2:])
-	case "rewrite-treedb":
-		runRewriteTreeDB(os.Args[2:])
+	case "compact-treedb":
+		runCompactTreeDB(os.Args[2:])
 	default:
 		fatalf("unknown subcommand %q", os.Args[1])
 	}
@@ -476,8 +477,8 @@ func keySuccessor(key []byte) []byte {
 	return append(out, 0)
 }
 
-func runRewriteTreeDB(args []string) {
-	fs := flag.NewFlagSet("rewrite-treedb", flag.ExitOnError)
+func runCompactTreeDB(args []string) {
+	fs := flag.NewFlagSet("compact-treedb", flag.ExitOnError)
 	destParent := fs.String("dest-parent", "", "destination parent directory")
 	profileRaw := fs.String("profile", "wal_on_fast", "fast or wal_on_fast")
 	if err := fs.Parse(args); err != nil {
@@ -493,24 +494,44 @@ func runRewriteTreeDB(args []string) {
 
 	start := time.Now()
 	opts := treedb.OptionsFor(profile, filepath.Join(*destParent, "application.db"))
-	stats, err := treedb.ValueLogRewriteOffline(opts)
+	db, err := treedb.Open(opts)
 	if err != nil {
-		fatalErr(fmt.Errorf("treedb offline rewrite: %w", err))
+		fatalErr(fmt.Errorf("open treedb for compaction: %w", err))
+	}
+	stats, compactErr := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+		Mode:          treedb.CompactStorageFull,
+		SyncEachPhase: true,
+	})
+	closeErr := db.Close()
+	if compactErr != nil {
+		fatalErr(fmt.Errorf("treedb compact storage: %w", compactErr))
+	}
+	if closeErr != nil {
+		fatalErr(fmt.Errorf("close treedb after compact storage: %w", closeErr))
+	}
+	if err := treedb.VacuumIndexOffline(opts); err != nil {
+		fatalErr(fmt.Errorf("treedb offline index vacuum after compact storage: %w", err))
 	}
 	res := stepResult{
-		Mode:             "rewrite-treedb",
+		Mode:             "compact-treedb",
 		Backend:          string(dbm.TreeDBBackend),
 		Profile:          profileName,
 		DestParent:       *destParent,
 		DestDBPath:       filepath.Join(*destParent, "application.db"),
 		WallSeconds:      time.Since(start).Seconds(),
 		MaxRSSKBObserved: maxRSSKB(),
-		RewriteStats: map[string]any{
-			"segments_before": stats.SegmentsBefore,
-			"segments_after":  stats.SegmentsAfter,
-			"bytes_before":    stats.BytesBefore,
-			"bytes_after":     stats.BytesAfter,
-			"records_copied":  stats.RecordsCopied,
+		CompactStats: map[string]any{
+			"fully_compacted":                      stats.FullyCompacted,
+			"phase_count":                          len(stats.Phases),
+			"value_log_rewrite_records_copied":     stats.ValueLogRewrite.RecordsCopied,
+			"value_log_rewrite_bytes_after":        stats.ValueLogRewrite.BytesAfter,
+			"value_log_gc_segments_deleted":        stats.ValueLogGC.SegmentsDeleted,
+			"leaf_generation_gc_files_deleted":     stats.LeafGenerationGC.FilesDeleted,
+			"zero_byte_value_log_files_deleted":    stats.ZeroByteValueLogFilesDeleted,
+			"remaining_value_log_rewrite_segments": stats.RemainingDebt.ValueLogRewriteSegments,
+			"remaining_value_log_gc_segments":      stats.RemainingDebt.ValueLogGCSegments,
+			"remaining_leaf_pack_generations":      stats.RemainingDebt.LeafPackGenerations,
+			"remaining_leaf_gc_generations":        stats.RemainingDebt.LeafGCGenerations,
 		},
 	}
 	writeJSON(res)
@@ -686,12 +707,12 @@ run_timed_step rebuild_treedb \
 TREEDB_BUILD_BYTES="$(safe_du_bytes "${TREEDB_PARENT}/application.db")"
 TREEDB_BUILD_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/rebuild_treedb.time.txt")"
 
-run_timed_step rewrite_treedb \
-  "${HELPER_BIN}" rewrite-treedb \
+run_timed_step compact_treedb \
+  "${HELPER_BIN}" compact-treedb \
   -dest-parent "${TREEDB_PARENT}" \
   -profile "${TREEDB_PROFILE}"
 TREEDB_FINAL_BYTES="$(safe_du_bytes "${TREEDB_PARENT}/application.db")"
-TREEDB_FINAL_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/rewrite_treedb.time.txt")"
+TREEDB_FINAL_MAX_RSS_KB="$(extract_max_rss_kb "${OUT_DIR}/logs/compact_treedb.time.txt")"
 
 python3 - <<'PY' \
   "${SOURCE_APP_DB}" \
@@ -779,7 +800,7 @@ compact_leveldb = load_json('compact_leveldb')
 rebuild_pebble = load_json('rebuild_pebble')
 compact_pebble = load_json('compact_pebble')
 rebuild_treedb = load_json('rebuild_treedb')
-rewrite_treedb = load_json('rewrite_treedb')
+compact_treedb = load_json('compact_treedb')
 
 summary = {
     'source': {
@@ -842,14 +863,14 @@ summary = {
             'max_rss_kb': int(treedb_build_max_rss_kb or load_time_maxrss('rebuild_treedb')),
             'max_rss_gib': gib(int(treedb_build_max_rss_kb or load_time_maxrss('rebuild_treedb')) * 1024),
         },
-        'final_rewrite': {
-            **rewrite_treedb,
+        'final_compact': {
+            **compact_treedb,
             'disk_bytes_after': int(treedb_final_bytes),
             'disk_gib_after': gib(int(treedb_final_bytes)),
             'disk_bytes_delta_vs_rebuild': int(treedb_final_bytes) - int(treedb_build_bytes),
             'disk_gib_delta_vs_rebuild': gib(int(treedb_final_bytes) - int(treedb_build_bytes)),
-            'max_rss_kb': int(treedb_final_max_rss_kb or load_time_maxrss('rewrite_treedb')),
-            'max_rss_gib': gib(int(treedb_final_max_rss_kb or load_time_maxrss('rewrite_treedb')) * 1024),
+            'max_rss_kb': int(treedb_final_max_rss_kb or load_time_maxrss('compact_treedb')),
+            'max_rss_gib': gib(int(treedb_final_max_rss_kb or load_time_maxrss('compact_treedb')) * 1024),
         },
     },
 }
@@ -877,7 +898,7 @@ md.append(f'| goleveldb | final compact | {summary["leveldb"]["final_compact"]["
 md.append(f'| pebbledb | rebuild | {summary["pebble"]["rebuild"]["wall_seconds"]:.2f} | {summary["pebble"]["rebuild"]["max_rss_gib"]:.3f} | {summary["pebble"]["rebuild"]["disk_gib_after"]:.3f} | {summary["pebble"]["rebuild"]["disk_gib_after"] - summary["source"]["gib"]:+.3f} |')
 md.append(f'| pebbledb | final compact | {summary["pebble"]["final_compact"]["wall_seconds"]:.2f} | {summary["pebble"]["final_compact"]["max_rss_gib"]:.3f} | {summary["pebble"]["final_compact"]["disk_gib_after"]:.3f} | {summary["pebble"]["final_compact"]["disk_gib_after"] - summary["source"]["gib"]:+.3f} |')
 md.append(f'| treedb | rebuild | {summary["treedb"]["rebuild"]["wall_seconds"]:.2f} | {summary["treedb"]["rebuild"]["max_rss_gib"]:.3f} | {summary["treedb"]["rebuild"]["disk_gib_after"]:.3f} | {summary["treedb"]["rebuild"]["disk_gib_after"] - summary["source"]["gib"]:+.3f} |')
-md.append(f'| treedb | final rewrite | {summary["treedb"]["final_rewrite"]["wall_seconds"]:.2f} | {summary["treedb"]["final_rewrite"]["max_rss_gib"]:.3f} | {summary["treedb"]["final_rewrite"]["disk_gib_after"]:.3f} | {summary["treedb"]["final_rewrite"]["disk_gib_after"] - summary["source"]["gib"]:+.3f} |')
+md.append(f'| treedb | final compact | {summary["treedb"]["final_compact"]["wall_seconds"]:.2f} | {summary["treedb"]["final_compact"]["max_rss_gib"]:.3f} | {summary["treedb"]["final_compact"]["disk_gib_after"]:.3f} | {summary["treedb"]["final_compact"]["disk_gib_after"] - summary["source"]["gib"]:+.3f} |')
 results_md.write_text('\n'.join(md) + '\n')
 shutil.copyfile(results_json, tmp_results_json_path)
 shutil.copyfile(results_md, tmp_results_md_path)

--- a/scripts/treedb_collection_compression_matrix.sh
+++ b/scripts/treedb_collection_compression_matrix.sh
@@ -248,11 +248,11 @@ measure_tsv_row() {
 		"$leaf" "$(ratio "$leaf" "$leaf_gzip")" "$index_db" "$value_vlog"
 }
 
-run_rewrite() {
-	local case_name="$1"
-	local db_dir="$2"
-	"$treemap" vlog-rewrite "$db_dir" -rw >"$RUN_DIR/logs/${case_name}.rewrite.log" 2>&1
-}
+	run_compact() {
+		local case_name="$1"
+		local db_dir="$2"
+		"$treemap" compact "$db_dir" -rw >"$RUN_DIR/logs/${case_name}.compact.log" 2>&1
+	}
 
 run_raw_case() {
 	local case_name="raw_treedb"
@@ -262,11 +262,11 @@ run_raw_case() {
 		cd "$repo_root"
 		go run "$raw_loader" -dir "$db_dir" -reset -docs "$DOCS" -batch-size "$BATCH" -profile "$PROFILE"
 	) >"$RUN_DIR/logs/${case_name}.load.log" 2>&1
-	measure_tsv_row "raw_treedb" "-" "$db_dir" "before_rewrite" >>"$tsv"
-	echo "Rewriting $case_name..."
-	run_rewrite "$case_name" "$db_dir"
-	measure_tsv_row "raw_treedb" "-" "$db_dir" "after_rewrite" >>"$tsv"
-}
+		measure_tsv_row "raw_treedb" "-" "$db_dir" "before_compact" >>"$tsv"
+		echo "Compacting $case_name..."
+		run_compact "$case_name" "$db_dir"
+		measure_tsv_row "raw_treedb" "-" "$db_dir" "after_compact" >>"$tsv"
+	}
 
 run_collection_case() {
 	local indexes="$1"
@@ -284,11 +284,11 @@ run_collection_case() {
 		-profile "$PROFILE" \
 		-progress=false \
 		>"$RUN_DIR/logs/${case_name}.load.json" 2>"$RUN_DIR/logs/${case_name}.load.stderr"
-	measure_tsv_row "collection" "$indexes" "$db_dir" "before_rewrite" >>"$tsv"
-	echo "Rewriting $case_name..."
-	run_rewrite "$case_name" "$db_dir"
-	measure_tsv_row "collection" "$indexes" "$db_dir" "after_rewrite" >>"$tsv"
-}
+		measure_tsv_row "collection" "$indexes" "$db_dir" "before_compact" >>"$tsv"
+		echo "Compacting $case_name..."
+		run_compact "$case_name" "$db_dir"
+		measure_tsv_row "collection" "$indexes" "$db_dir" "after_compact" >>"$tsv"
+	}
 
 printf 'mode\tindexes\tphase\ttotal_bytes\ttotal_gzip_bytes\ttotal_bytes_per_gzip_byte\tleaf_vlog_bytes\tleaf_vlog_bytes_per_gzip_byte\tindex_db_bytes\tvalue_vlog_bytes\n' >"$tsv"
 
@@ -315,10 +315,10 @@ done
 	printf -- '- Document shape: template-v1 fixture fields `name`, `email`, `city`, `pad`\n'
 	printf -- '- Raw TreeDB case: generated template-v1 payloads stored directly by key\n'
 	printf -- '- Collection cases: generated template-v1 payloads inserted through collection mode with indexes `%s`\n' "$COLLECTION_INDEXES"
-	printf -- '- Offline rewrite: `treemap vlog-rewrite <dir> -rw`\n'
-	printf -- '- Gzip ratio is `bytes/gzip_bytes`; lower is closer to gzip-compressed density already being present on disk.\n\n'
-	printf '| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After rewrite bytes | After rewrite gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |\n'
-	printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'
+		printf -- '- Compaction: `treemap compact <dir> -rw`\n'
+		printf -- '- Gzip ratio is `bytes/gzip_bytes`; lower is closer to gzip-compressed density already being present on disk.\n\n'
+		printf '| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After compact bytes | After compact gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |\n'
+		printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'
 	for mode in raw_treedb collection; do
 		if [[ "$mode" == "raw_treedb" ]]; then
 			index_values=("-")
@@ -326,8 +326,8 @@ done
 			index_values=("${collection_index_values[@]}")
 		fi
 		for indexes in "${index_values[@]}"; do
-			before_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "before_rewrite" { print; exit }' "$tsv")"
-			after_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "after_rewrite" { print; exit }' "$tsv")"
+				before_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "before_compact" { print; exit }' "$tsv")"
+				after_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "after_compact" { print; exit }' "$tsv")"
 			IFS=$'\t' read -r _ _ _ before_total before_gzip before_ratio _ _ _ _ <<<"$before_line"
 			IFS=$'\t' read -r _ _ _ after_total after_gzip after_ratio after_leaf after_leaf_ratio after_index_db after_value_vlog <<<"$after_line"
 			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \


### PR DESCRIPTION
## Objective

Fix stale split `leaf_vlog` retention after offline index vacuum and route final-footprint benchmark maintenance through the high-level TreeDB storage compaction path.

## Context

A benchmark run showed `maindb/leaf_vlog/value-l255-000001.log` remaining at about 19 MiB after full maintenance, while gzip compressed it to about 4 MiB. Investigation found that offline index vacuum rebuilds roots into pager-backed `index.db` leaves, but left the old writable split `leaf_vlog` generation on disk. The benchmark `full` maintenance path also hand-chained low-level rewrite/GC/leaf-pack/vacuum primitives instead of using `CompactStorage`.

## Non-goals

- This PR does not change live foreground leaf-log write encoding.
- This PR does not remove low-level maintenance APIs or diagnostic benchmark rows that intentionally measure individual primitives.
- This PR does not add new compression codecs.

## Design

- Reset split leaf-generation files, `.lenidx` sidecars, and manifest after successful `VacuumIndexOffline` swaps in a pager-backed rebuilt `index.db`.
- Change `mongo_gateway_bench -treedb-maintenance full` to run `CompactStorage` first, then close and run offline index vacuum for final-footprint shrink.
- Route application-db comparison scripts and the unified benchmark after-run storage report through `CompactStorage` instead of treating value-log rewrite as final compaction.
- Update scripts/docs that were using value-log rewrite as generic “compaction” guidance to point final-footprint workflows at `CompactStorage` / `treemap compact`.

## Scope

- Includes (files/symbols): `TreeDB/db/vacuum_offline.go`, `TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity`, `cmd/mongo_gateway_bench` full maintenance, `cmd/unified_bench` after-run storage reporting, application-db comparison scripts, canonical collection benchmark phase labels, `scripts/treedb_collection_compression_matrix.sh`, related docs.
- Excludes (files/symbols): live `leaf_vlog` append batching, low-level `ValueLogRewrite*`, `LeafGenerationPack*`, and scheduler internals.

## Correctness

- Tests run (exact commands):
  - `go test ./TreeDB -run TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity`
  - `go test ./TreeDB/db -run 'TestVacuumIndexOffline|TestLeafGenerationManifest|TestLeafGenerationGC'`
  - `go test ./cmd/collection_load_fixture -run 'TestRunFixtureLeafGenerationReportsDiskTotals|TestVacuumIndexOfflinePreservesTemplateV1TwoIndexDatabase' -count=1`
  - `go test ./TreeDB/...`
  - `go test ./cmd/mongo_gateway_bench`
  - `go test ./cmd/unified_bench`
  - `go test ./cmd/collection_canonical_bench`
  - `bash -n scripts/compare_application_db_rebuilds.sh scripts/run_application_db_engine_matrix.sh scripts/treedb_collection_compression_matrix.sh`
  - `go run ./cmd/mongo_gateway_bench -target treedb -documents 200 -batch-size 100 -reads 0 -range-reads 0 -updates 0 -secondary-indexes 2 -treedb-maintenance full -timeout 0 -format json`
- Corruption/edge cases covered: offline vacuum reopen parity now asserts stale `leaf_vlog` segment files are removed and reads still succeed after reopen.
- Concurrency/race coverage (if applicable): cleanup runs only after offline vacuum has closed the DB and completed the index swap.

## Performance

- Benchmarks run (exact commands): not run; this is a correctness/maintenance-path fix.
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`): N/A.
- Regressions (if any) and why acceptable: `-treedb-maintenance full` now runs the fuller high-level path, so it may do more maintenance work than the previous bespoke chain. That is intentional for final storage-footprint reporting.

## Rollout / Toggle Plan

- Default setting: `mongo_gateway_bench` already defaults to `-treedb-maintenance full`; it now uses the recommended path.
- How to disable quickly: use `-treedb-maintenance checkpoint` or `-treedb-maintenance none` in the benchmark.

## Follow-ups

- Historical benchmark reports still mention the old value-log rewrite workflows as historical measurements; this PR does not rewrite past result artifacts.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): listed above
- [x] Explicit exclude list (files/symbols NOT touched): listed above
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [ ] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [ ] All new length fields are capped before allocation (OOM-safe)
- [ ] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [ ] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: listed above

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change
- [ ] Reported results in PR description (before/after, command, machine)
- [ ] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [ ] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK): no format change

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness
