### PR TITLE
experiments: validate raw JSON TreeDB fixture

### DIFF
--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -422,6 +422,9 @@ func measureRawJSONTreeDB(ctx context.Context, files []string, rows int, dbDir s
 		out.RewriteValueBytes = rewriteStats.ValueBytesCopied
 		out.RewriteSourceBytes = rewriteStats.SourceBytesRequested
 	}
+	if err := validateRawJSONTreeDB(files, rows, dbDir); err != nil {
+		return out, err
+	}
 	after, afterFiles, err := directoryUsage(dbDir)
 	if err != nil {
 		return out, err
@@ -460,8 +463,9 @@ func insertRawJSONRows(files []string, rows int, db *treedb.DB, out *remainingTr
 				return errStopScan
 			}
 			out.Rows++
-			out.RawDocumentBytes += int64(len(raw))
-			if err := batch.Set(documentID(uint64(out.Rows)), raw); err != nil {
+			rawCopy := append([]byte(nil), raw...)
+			out.RawDocumentBytes += int64(len(rawCopy))
+			if err := batch.Set(documentID(uint64(out.Rows)), rawCopy); err != nil {
 				return fmt.Errorf("set raw JSON row %d: %w", out.Rows, err)
 			}
 			if out.Rows%batchSize == 0 {
@@ -473,6 +477,41 @@ func insertRawJSONRows(files []string, rows int, db *treedb.DB, out *remainingTr
 		}
 	}
 	return flush()
+}
+
+func validateRawJSONTreeDB(files []string, rows int, dbDir string) error {
+	opts := treedb.OptionsFor(treedb.ProfileBench, dbDir)
+	db, err := treedb.Open(opts)
+	if err != nil {
+		return fmt.Errorf("open raw TreeDB for validation: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	var checked int
+	for _, file := range files {
+		if checked >= rows {
+			break
+		}
+		if err := scanJSONBenchFile(file, func(raw []byte) error {
+			if checked >= rows {
+				return errStopScan
+			}
+			checked++
+			value, err := db.Get(documentID(uint64(checked)))
+			if err != nil {
+				return fmt.Errorf("get raw JSON row %d: %w", checked, err)
+			}
+			if !bytes.Equal(value, raw) {
+				return fmt.Errorf("raw JSON row %d validation mismatch: source bytes=%d stored bytes=%d", checked, len(raw), len(value))
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("validate raw JSON %s: %w", file, err)
+		}
+	}
+	if checked != rows {
+		return fmt.Errorf("validated %d raw JSON rows, want %d", checked, rows)
+	}
+	return nil
 }
 
 func valueLogFileIDs(dbDir string) ([]uint32, error) {

--- a/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -121,7 +122,9 @@ func TestRemainingJSONDocumentConservativeOnlyRemovesTimeUS(t *testing.T) {
 }
 
 func TestMeasureRawJSONTreeDBSample(t *testing.T) {
-	result, err := measureRawJSONTreeDB(context.Background(), []string{filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")}, 5, t.TempDir())
+	dbDir := t.TempDir()
+	source := filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")
+	result, err := measureRawJSONTreeDB(context.Background(), []string{source}, 5, dbDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,5 +139,32 @@ func TestMeasureRawJSONTreeDBSample(t *testing.T) {
 	}
 	if !strings.Contains(result.StoredShape, "key/value") {
 		t.Fatalf("stored shape %q does not describe raw key/value storage", result.StoredShape)
+	}
+	if err := validateRawJSONTreeDB([]string{source}, 5, dbDir); err != nil {
+		t.Fatalf("validate raw JSON TreeDB: %v", err)
+	}
+}
+
+func TestValidateRawJSONTreeDBDetectsMismatchedRows(t *testing.T) {
+	dbDir := t.TempDir()
+	source := filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")
+	if _, err := measureRawJSONTreeDB(context.Background(), []string{source}, 5, dbDir); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := filepath.Join(t.TempDir(), "corrupt.jsonl")
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), `"kind":"commit"`, `"kind":"changed"`, 1))
+	if err := os.WriteFile(corrupt, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = validateRawJSONTreeDB([]string{corrupt}, 5, dbDir)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "validation mismatch") {
+		t.Fatalf("validation error %q does not mention mismatch", err)
 	}
 }


### PR DESCRIPTION
## Objective

Prevent the JSONBench raw TreeDB storage comparison from reporting invalid compression results when stored raw JSON rows do not match the source JSONL bytes.

## Context

A local raw TreeDB artifact appeared to compress full raw JSON far better than gzip/zstd. Byte-for-byte validation showed the artifact did not preserve source row contents, so the experiment harness needs to fail closed before publishing disk-footprint numbers.

## Non-goals

- Does not change TreeDB storage, value-log rewrite, or compaction behavior.
- Does not update the checked-in benchmark report numbers.
- Does not claim a new raw JSON compression result.

## Design

- Defensively copy each scanner row before inserting into the raw key/value TreeDB fixture.
- Reopen the raw TreeDB fixture after compaction/rewrite and validate every stored value byte-for-byte against the source rows before measuring final directory usage.
- Return a validation error on the first mismatch instead of producing a misleading report.

## Scope

- Includes: `experiments/colgranule/cmd/jsonbench_compare/main.go`, `experiments/colgranule/cmd/jsonbench_compare/remaining_test.go`.
- Excludes: TreeDB storage internals, value-log rewrite policy, benchmark report regeneration.

## Correctness

- Tests run: `go test ./experiments/colgranule/cmd/jsonbench_compare`.
- Corruption/edge cases covered: raw fixture validation catches source/stored row mismatches.
- Concurrency/race coverage: not applicable; experiment harness validation only.

## Performance

- Benchmarks run: none.
- Results table: not applicable.
- Regressions: raw-report generation now rereads and validates raw rows; acceptable because this is an experiment/reporting path.

## Rollout / Toggle Plan

- Default setting: validation is always on for the raw TreeDB fixture.
- How to disable quickly: revert this harness-only change.

## Follow-ups

- Regenerate the JSONBench comparison report using the validated harness.
- Investigate why value-log rewrite can increase the validated raw fixture footprint after compaction.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `jsonbench_compare` raw fixture load/validation and tests
- [x] Explicit exclude list (files/symbols NOT touched): TreeDB storage internals and report regeneration
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: no `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe): no new encoded length fields
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): no CRC/checksum path touched
- [x] Any concurrency change has a defined state machine and invariants: no concurrency change

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes: no format/parsing change
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: `go test ./experiments/colgranule/cmd/jsonbench_compare`

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change
- [ ] Reported results in PR description (before/after, command, machine)
- [ ] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [ ] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK): no format change

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold): validation fails closed
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness
