### PR TITLE
Fix compact storage retained value-log reclaim

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4257,6 +4257,12 @@ func (db *DB) ValueLogRetainedPaths() []string {
 	return db.valueLogRetainedPaths()
 }
 
+// PruneRetainedValueLogsForMaintenance runs a synchronous retained value-log
+// prune before full backend maintenance computes reclaim candidates.
+func (db *DB) PruneRetainedValueLogsForMaintenance() {
+	db.runRetainedValueLogPruneInline(true, nil)
+}
+
 func mergeUniqueNonEmptyStrings(pathSets ...[]string) []string {
 	seen := make(map[string]struct{})
 	var out []string
@@ -4358,11 +4364,13 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 	if err := db.rotateObservedValueLogSources(ctx, seen); err != nil {
 		return err
 	}
-	db.runRetainedValueLogPruneInline(false, seen)
+	db.runRetainedValueLogPruneInline(true, seen)
 
 	if hasValueLogGC {
 		opts := db.valueLogGCOptions(false)
 		opts.ObservedSourceFileIDs = observed
+		opts.ObservedSourceAssumeUnreferenced = true
+		opts.ObservedSourceReclaimActive = true
 		if _, err := gcer.ValueLogGC(ctx, opts); err != nil {
 			return err
 		}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4435,6 +4435,7 @@ func (db *DB) BeginValueLogMaintenanceFence(ctx context.Context) (func(), error)
 		l := &db.lanes[i]
 		l.vlogMu.Lock()
 		if l.vlogPath != "" {
+			db.markValueLogRetain(l.vlogPath)
 			err := db.rotateValueLogMuHeld(l)
 			l.vlogMu.Unlock()
 			if err != nil {
@@ -4449,6 +4450,7 @@ func (db *DB) BeginValueLogMaintenanceFence(ctx context.Context) (func(), error)
 		l := &db.leafLog
 		l.vlogMu.Lock()
 		if l.vlogPath != "" {
+			db.markValueLogRetain(l.vlogPath)
 			err := db.rotateValueLogMuHeld(l)
 			l.vlogMu.Unlock()
 			if err != nil {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4340,6 +4340,14 @@ func (db *DB) ValueLogProtectedPaths() []string {
 	return db.valueLogProtectedPaths()
 }
 
+// ValueLogInUsePaths returns value-log segment paths currently backing cached
+// mutable/queued writer state. It excludes retained lifecycle paths so callers
+// that already hold a writer fence can still reclaim independently proven
+// unreachable retained sources.
+func (db *DB) ValueLogInUsePaths() []string {
+	return db.valueOnlyLogPaths(db.valueLogInUsePaths())
+}
+
 // ReclaimObservedValueLogSources rotates cached writers past rewrite-selected
 // source segments and reclaims storage classes that backend rewrite already
 // proved obsolete.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4260,7 +4260,23 @@ func (db *DB) ValueLogRetainedPaths() []string {
 // PruneRetainedValueLogsForMaintenance runs a synchronous retained value-log
 // prune before full backend maintenance computes reclaim candidates.
 func (db *DB) PruneRetainedValueLogsForMaintenance() {
-	db.runRetainedValueLogPruneInline(true, nil)
+	if db == nil || !db.valueLogEnabled() {
+		return
+	}
+	for {
+		db.waitForRetainedValueLogPrune()
+		if _, ran := db.runRetainedValueLogPruneInline(true, nil); ran {
+			return
+		}
+		db.retainedPruneMu.Lock()
+		done := db.retainedPruneDone
+		closing := db.closing.Load()
+		db.retainedPruneMu.Unlock()
+		if closing || done == nil {
+			return
+		}
+		<-done
+	}
 }
 
 func mergeUniqueNonEmptyStrings(pathSets ...[]string) []string {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4383,6 +4383,61 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 	return nil
 }
 
+// BeginValueLogMaintenanceFence blocks cached writers and rotates current
+// value-log writers so backend maintenance can reclaim formerly active
+// unreachable segments without racing mutable cached state.
+func (db *DB) BeginValueLogMaintenanceFence(ctx context.Context) (func(), error) {
+	if db == nil {
+		return func() {}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	db.writeMu.Lock()
+	unlock := func() {
+		db.writeMu.Unlock()
+	}
+	if !db.splitValueLogEnabled() {
+		return unlock, nil
+	}
+	for i := range db.lanes {
+		if err := ctx.Err(); err != nil {
+			unlock()
+			return nil, err
+		}
+		l := &db.lanes[i]
+		l.vlogMu.Lock()
+		if l.vlogPath != "" {
+			err := db.rotateValueLogMuHeld(l)
+			l.vlogMu.Unlock()
+			if err != nil {
+				unlock()
+				return nil, err
+			}
+			continue
+		}
+		l.vlogMu.Unlock()
+	}
+	if db.indexOuterLeavesInValueLog {
+		l := &db.leafLog
+		l.vlogMu.Lock()
+		if l.vlogPath != "" {
+			err := db.rotateValueLogMuHeld(l)
+			l.vlogMu.Unlock()
+			if err != nil {
+				unlock()
+				return nil, err
+			}
+		} else {
+			l.vlogMu.Unlock()
+		}
+	}
+	return unlock, nil
+}
+
 func (db *DB) rotateObservedValueLogSources(ctx context.Context, ids map[uint32]struct{}) error {
 	if db == nil || len(ids) == 0 || !db.splitValueLogEnabled() {
 		return nil

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -89,11 +89,11 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		}
 	}()
 	stats, err := db.backend.CompactStorage(ctx, treedbdb.CompactStorageOptions(opts))
-	finishValueLogFence()
-	fenceActive = false
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
+	finishValueLogFence()
+	fenceActive = false
 	if db.cached != nil && len(stats.ValueLogRewrite.SourceFileIDsUnreferenced) > 0 {
 		if err := db.cached.ReclaimObservedValueLogSources(ctx, stats.ValueLogRewrite.SourceFileIDsUnreferenced); err != nil {
 			return out, err

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -135,7 +135,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
 		opts.UnsafeValueLogReclaimFencedUnreferenced = true
 		if opts.ValueLogFencedProtectedPathsFunc == nil {
-			opts.ValueLogFencedProtectedPathsFunc = db.cached.ValueLogProtectedPaths
+			opts.ValueLogFencedProtectedPathsFunc = db.cached.ValueLogInUsePaths
 		}
 	}
 	return nil

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -92,6 +92,9 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		}
 	}
 	explicitProtectedPaths := append([]string(nil), opts.ValueLogProtectedPaths...)
+	if checkpoint && len(explicitProtectedPaths) == 0 {
+		db.cached.PruneRetainedValueLogsForMaintenance()
+	}
 	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
@@ -110,6 +113,9 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	opts.ValueLogProtectedPaths = explicitProtectedPaths
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+	}
+	if len(explicitProtectedPaths) == 0 {
+		opts.ValueLogReclaimFencedUnreferenced = true
 	}
 	return nil
 }

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -70,7 +70,7 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return out, err
 	}
 	finishValueLogFence := func() {}
-	if db.cached != nil && opts.ValueLogReclaimFencedUnreferenced {
+	if db.cached != nil && opts.UnsafeValueLogReclaimFencedUnreferenced {
 		var err error
 		finishValueLogFence, err = db.cached.BeginValueLogMaintenanceFence(ctx)
 		if err != nil {
@@ -136,7 +136,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
 	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
-		opts.ValueLogReclaimFencedUnreferenced = true
+		opts.UnsafeValueLogReclaimFencedUnreferenced = true
 		if opts.ValueLogFencedProtectedPathsFunc == nil {
 			opts.ValueLogFencedProtectedPathsFunc = func() []string { return nil }
 		}

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -69,7 +69,28 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if err := db.applyCachedCompactStorageOptions(&opts, true); err != nil {
 		return out, err
 	}
+	finishValueLogFence := func() {}
+	if db.cached != nil && opts.ValueLogReclaimFencedUnreferenced {
+		var err error
+		finishValueLogFence, err = db.cached.BeginValueLogMaintenanceFence(ctx)
+		if err != nil {
+			return out, err
+		}
+		db.cached.PruneRetainedValueLogsForMaintenance()
+		if err := db.backend.RefreshValueLogSet(); err != nil {
+			finishValueLogFence()
+			return out, err
+		}
+	}
+	fenceActive := true
+	defer func() {
+		if fenceActive {
+			finishValueLogFence()
+		}
+	}()
 	stats, err := db.backend.CompactStorage(ctx, treedbdb.CompactStorageOptions(opts))
+	finishValueLogFence()
+	fenceActive = false
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
@@ -92,10 +113,10 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		}
 	}
 	explicitProtectedPaths := append([]string(nil), opts.ValueLogProtectedPaths...)
-	if checkpoint && len(explicitProtectedPaths) == 0 {
+	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
+	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
 		db.cached.PruneRetainedValueLogsForMaintenance()
 	}
-	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
 		if userProtectedPathsFunc != nil {
@@ -114,8 +135,11 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
-	if checkpoint && len(explicitProtectedPaths) == 0 {
+	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
 		opts.ValueLogReclaimFencedUnreferenced = true
+		if opts.ValueLogFencedProtectedPathsFunc == nil {
+			opts.ValueLogFencedProtectedPathsFunc = func() []string { return nil }
+		}
 	}
 	return nil
 }

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -138,7 +138,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
 		opts.UnsafeValueLogReclaimFencedUnreferenced = true
 		if opts.ValueLogFencedProtectedPathsFunc == nil {
-			opts.ValueLogFencedProtectedPathsFunc = func() []string { return nil }
+			opts.ValueLogFencedProtectedPathsFunc = db.cached.ValueLogInUsePaths
 		}
 	}
 	return nil

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -135,7 +135,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
 		opts.UnsafeValueLogReclaimFencedUnreferenced = true
 		if opts.ValueLogFencedProtectedPathsFunc == nil {
-			opts.ValueLogFencedProtectedPathsFunc = db.cached.ValueLogInUsePaths
+			opts.ValueLogFencedProtectedPathsFunc = db.cached.ValueLogProtectedPaths
 		}
 	}
 	return nil

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -114,9 +114,6 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	}
 	explicitProtectedPaths := append([]string(nil), opts.ValueLogProtectedPaths...)
 	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
-	if checkpoint && len(explicitProtectedPaths) == 0 && userProtectedPathsFunc == nil {
-		db.cached.PruneRetainedValueLogsForMaintenance()
-	}
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
 		if userProtectedPathsFunc != nil {

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -114,7 +114,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
-	if len(explicitProtectedPaths) == 0 {
+	if checkpoint && len(explicitProtectedPaths) == 0 {
 		opts.ValueLogReclaimFencedUnreferenced = true
 	}
 	return nil

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"sort"
@@ -225,11 +226,15 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 	const rows = 20_000
 	const batchSize = 16_000
 	batch := db.NewBatchWithSize(batchSize)
-	expected := make(map[string][]byte)
+	type expectedValue struct {
+		size int
+		sum  uint32
+	}
+	expected := make(map[string]expectedValue)
 	for i := 0; i < rows; i++ {
 		key := cachedRewriteReclaimKey(i)
 		value := cachedRewriteReclaimValue(i)
-		expected[string(key)] = value
+		expected[string(key)] = expectedValue{size: len(value), sum: crc32.ChecksumIEEE(value)}
 		if err := batch.Set(key, value); err != nil {
 			t.Fatalf("batch set %d: %v", i, err)
 		}
@@ -314,9 +319,9 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 			_ = reopened.Close()
 			t.Fatalf("get %x after CompactStorage: %v", []byte(key), err)
 		}
-		if !bytes.Equal(got, want) {
+		if len(got) != want.size || crc32.ChecksumIEEE(got) != want.sum {
 			_ = reopened.Close()
-			t.Fatalf("value mismatch for %x: got %dB want %dB", []byte(key), len(got), len(want))
+			t.Fatalf("value mismatch for %x: got len=%d crc=%08x want len=%d crc=%08x", []byte(key), len(got), crc32.ChecksumIEEE(got), want.size, want.sum)
 		}
 	}
 	if err := reopened.Close(); err != nil {

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -213,6 +213,117 @@ func TestBackendValueLogRewriteReclaimsLeafGenerationDebt(t *testing.T) {
 	}
 }
 
+func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing.T) {
+	dir := t.TempDir()
+	opts := cachedRewriteReclaimTestOptions(dir)
+	opts.JournalLanes = 2
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	const rows = 20_000
+	const batchSize = 16_000
+	batch := db.NewBatchWithSize(batchSize)
+	expected := make(map[string][]byte)
+	for i := 0; i < rows; i++ {
+		key := cachedRewriteReclaimKey(i)
+		value := cachedRewriteReclaimValue(i)
+		expected[string(key)] = value
+		if err := batch.Set(key, value); err != nil {
+			t.Fatalf("batch set %d: %v", i, err)
+		}
+		if (i+1)%batchSize == 0 {
+			if err := batch.Write(); err != nil {
+				t.Fatalf("batch write %d: %v", i, err)
+			}
+			if err := batch.Close(); err != nil {
+				t.Fatalf("batch close %d: %v", i, err)
+			}
+			batch = db.NewBatchWithSize(batchSize)
+		}
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("final batch write: %v", err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatalf("final batch close: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	source := listValueLogSegmentFiles(t, backenddb.ValueLogDirPath(dir))
+	if len(source) == 0 {
+		t.Fatalf("expected value-log source segments")
+	}
+	sourceIDs := make([]uint32, 0, len(source))
+	for _, segment := range source {
+		sourceIDs = append(sourceIDs, segment.id)
+	}
+	rewrite, err := db.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
+		SourceFileIDs: sourceIDs,
+		BatchSize:     batchSize,
+		SyncEachBatch: true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if rewrite.ValueRecordsCopied == 0 {
+		t.Fatalf("rewrite copied no value records: %+v", rewrite)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close after rewrite: %v", err)
+	}
+
+	compactor, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open compactor: %v", err)
+	}
+	compact, err := compactor.CompactStorage(context.Background(), CompactStorageOptions{
+		ValueLogRewriteBatchSize:        batchSize,
+		LeafPackMinExpectedReclaimBytes: 1,
+		LeafPackMinReclaimPerCopyPPM:    1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !compact.FullyCompacted {
+		t.Fatalf("CompactStorage reported remaining debt before close: %+v", compact.RemainingDebt)
+	}
+	if err := compactor.Close(); err != nil {
+		t.Fatalf("close compactor: %v", err)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after compaction: %v", err)
+	}
+	gc, err := reopened.ValueLogGC(context.Background(), ValueLogGCOptions{DryRun: true})
+	if err != nil {
+		_ = reopened.Close()
+		t.Fatalf("ValueLogGC dry-run after compaction: %v", err)
+	}
+	if gc.SegmentsEligible != 0 || gc.BytesEligible != 0 {
+		_ = reopened.Close()
+		t.Fatalf("CompactStorage left post-reopen GC debt: segments=%d bytes=%d stats=%+v", gc.SegmentsEligible, gc.BytesEligible, gc)
+	}
+	for key, want := range expected {
+		got, err := reopened.Get([]byte(key))
+		if err != nil {
+			_ = reopened.Close()
+			t.Fatalf("get %x after CompactStorage: %v", []byte(key), err)
+		}
+		if !bytes.Equal(got, want) {
+			_ = reopened.Close()
+			t.Fatalf("value mismatch for %x: got %dB want %dB", []byte(key), len(got), len(want))
+		}
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatalf("close reopened: %v", err)
+	}
+}
+
 func writeTestValueLogSegment(t *testing.T, path string, lane, seq uint32, value []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -45,6 +45,11 @@ type CompactStorageOptions struct {
 	// this so foreground writer rotations that happen during a multi-phase
 	// compaction cannot leave newly queued value-log segments unprotected.
 	ValueLogProtectedPathsFunc func() []string
+	// ValueLogFencedProtectedPathsFunc refreshes paths that remain unsafe for
+	// fenced observed-only reclaim after the caller has performed its write
+	// fence. Cached callers use this to protect in-use writer paths without
+	// preserving retained paths that are independently proven unreachable.
+	ValueLogFencedProtectedPathsFunc func() []string
 
 	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
 	// single compaction request finite while still draining ordinary debt.
@@ -325,7 +330,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		})
 	} else {
 		if err := db.runCompactStoragePhase(&stats, "prune-empty-value-log-files", func() error {
-			deleted, err := db.pruneZeroByteValueLogFiles(compactStorageValueLogProtectedPaths(opts))
+			deleted, err := db.pruneZeroByteValueLogFiles(compactStorageCleanupValueLogProtectedPaths(opts))
 			stats.ZeroByteValueLogFilesDeleted = deleted
 			return err
 		}); err != nil {
@@ -385,14 +390,15 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 			phaseName := fmt.Sprintf("settle-fenced-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				// Fenced IDs are independently proven unreachable by a fresh
-				// root scan below. ReclaimActive is intentional here: these
-				// are the active-per-lane files that make CompactStorage look
-				// clean only until close/reopen unless reclaimed before the
-				// compaction boundary returns.
+				// root scan below. Cached callers rotate and block writers
+				// before enabling this path, so ReclaimActive can collect the
+				// formerly-active files that would otherwise reappear as debt
+				// after close/reopen.
 				gc, err := db.valueLogGC(ctx, ValueLogGCOptions{
 					ObservedSourceFileIDs:            fencedIDs,
 					ObservedSourceAssumeUnreferenced: true,
 					ObservedSourceReclaimActive:      true,
+					ProtectedPaths:                   compactStorageFencedValueLogProtectedPaths(opts),
 				}, lockMaintenance)
 				stats.ValueLogGC = gc
 				return err
@@ -491,7 +497,7 @@ func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOn
 
 func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
-	protectedPaths := compactStorageValueLogProtectedPaths(opts)
+	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
 	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(protectedPaths))
 	if err != nil {
 		return debt, err
@@ -580,6 +586,14 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 	defer func() { _ = db.valueLogManager.Release(set) }()
 
 	files := db.valueOnlyValueLogFiles(set.Files)
+	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
+	protected := make(map[string]struct{}, len(protectedPaths))
+	for _, path := range protectedPaths {
+		if path == "" {
+			continue
+		}
+		protected[path] = struct{}{}
+	}
 	ids := make([]uint32, 0, len(files))
 	var bytes int64
 	for id, f := range files {
@@ -587,6 +601,9 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 			continue
 		}
 		if f == nil {
+			continue
+		}
+		if _, ok := protected[f.Path]; ok {
 			continue
 		}
 		size := fileSize(f)
@@ -749,6 +766,24 @@ func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 		out = append(out, path)
 	}
 	return out
+}
+
+func compactStorageFencedValueLogProtectedPaths(opts CompactStorageOptions) []string {
+	if opts.ValueLogFencedProtectedPathsFunc == nil {
+		return compactStorageValueLogProtectedPaths(opts)
+	}
+	dynamic := opts.ValueLogFencedProtectedPathsFunc()
+	if len(dynamic) == 0 {
+		return nil
+	}
+	return dynamic
+}
+
+func compactStorageCleanupValueLogProtectedPaths(opts CompactStorageOptions) []string {
+	if opts.ValueLogReclaimFencedUnreferenced {
+		return compactStorageFencedValueLogProtectedPaths(opts)
+	}
+	return compactStorageValueLogProtectedPaths(opts)
 }
 
 func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -900,13 +900,16 @@ func (db *DB) currentValueLogProtectedRefs() ([]string, []uint32) {
 	if db == nil {
 		return nil, nil
 	}
+	var fileIDs []uint32
+	if db.valueLogManager != nil {
+		fileIDs = append(fileIDs, db.valueLogManager.CurrentWritableFileIDs()...)
+	}
 	appender := db.currentValueLogAppender()
 	if appender == nil {
-		return nil, nil
+		return nil, fileIDs
 	}
 	path, fileID, ok := appender.CurrentValueLogSegment()
 	var paths []string
-	var fileIDs []uint32
 	if ok && path != "" {
 		paths = []string{path}
 	}

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -774,10 +774,36 @@ func compactStorageFencedValueLogProtectedPaths(opts CompactStorageOptions) []st
 		return compactStorageValueLogProtectedPaths(opts)
 	}
 	dynamic := opts.ValueLogFencedProtectedPathsFunc()
+	if len(opts.ValueLogProtectedPaths) > 0 {
+		if len(dynamic) == 0 {
+			return opts.ValueLogProtectedPaths
+		}
+		return compactStorageMergeProtectedPaths(opts.ValueLogProtectedPaths, dynamic)
+	}
 	if len(dynamic) == 0 {
 		return []string{""}
 	}
 	return dynamic
+}
+
+func compactStorageMergeProtectedPaths(static, dynamic []string) []string {
+	seen := make(map[string]struct{}, len(static)+len(dynamic))
+	out := make([]string, 0, len(static)+len(dynamic))
+	for _, path := range static {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	for _, path := range dynamic {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	return out
 }
 
 func compactStorageCleanupValueLogProtectedPaths(opts CompactStorageOptions) []string {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -58,6 +59,12 @@ type CompactStorageOptions struct {
 	// ReserveRIDs lets cached-mode callers share the live RID allocator with
 	// foreground writers.
 	ReserveRIDs func(count int) (start uint64, err error)
+
+	// ValueLogReclaimFencedUnreferenced permits CompactStorage to reclaim
+	// unreferenced value-log segments that cached retained/current-writer
+	// protection would otherwise hide. Cached-mode callers set this only after
+	// checkpointing and fencing writers; backend-only callers leave it disabled.
+	ValueLogReclaimFencedUnreferenced bool
 
 	// DisableZeroByteValueLogCleanup leaves zero-byte value_vlog segment files in
 	// place. This is intended for specialty diagnostics that need to inspect
@@ -352,13 +359,36 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if err != nil {
 			return err
 		}
-		if debt.ValueLogGCSegments == 0 && debt.LeafGCGenerations == 0 {
+		fencedIDs, _, err := db.compactStorageFencedUnreferencedValueLogIDs(ctx, opts)
+		if err != nil {
+			return err
+		}
+		if debt.ValueLogGCSegments == 0 && debt.LeafGCGenerations == 0 && len(fencedIDs) == 0 {
 			return nil
 		}
 		if debt.ValueLogGCSegments > 0 {
 			phaseName := fmt.Sprintf("settle-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				gc, err := db.valueLogGC(ctx, ValueLogGCOptions{ProtectedPaths: compactStorageValueLogProtectedPaths(opts)}, lockMaintenance)
+				stats.ValueLogGC = gc
+				return err
+			}); err != nil {
+				return err
+			}
+			if err := db.runCompactStoragePhase(stats, fmt.Sprintf("checkpoint-after-%s", phaseName), func() error {
+				return db.Checkpoint()
+			}); err != nil {
+				return err
+			}
+		}
+		if len(fencedIDs) > 0 {
+			phaseName := fmt.Sprintf("settle-fenced-value-log-gc-%d", pass+1)
+			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
+				gc, err := db.valueLogGC(ctx, ValueLogGCOptions{
+					ObservedSourceFileIDs:            fencedIDs,
+					ObservedSourceAssumeUnreferenced: true,
+					ObservedSourceReclaimActive:      true,
+				}, lockMaintenance)
 				stats.ValueLogGC = gc
 				return err
 			}); err != nil {
@@ -475,6 +505,12 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	stats.ValueLogGC = valueGC
 	debt.ValueLogGCSegments = valueGC.SegmentsEligible
 	debt.ValueLogGCBytes = valueGC.BytesEligible
+	fencedValueLogIDs, fencedValueLogBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(ctx, opts)
+	if err != nil {
+		return debt, err
+	}
+	debt.ValueLogGCSegments += len(fencedValueLogIDs)
+	debt.ValueLogGCBytes += fencedValueLogBytes
 
 	leafPlan, err := db.LeafGenerationPlan(ctx, LeafGenerationPlanOptions{
 		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
@@ -510,6 +546,52 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.ZeroByteValueLogFiles = zeroBytes
 	}
 	return debt, nil
+}
+
+func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, opts CompactStorageOptions) ([]uint32, int64, error) {
+	if db == nil || !opts.ValueLogReclaimFencedUnreferenced || db.valueLogManager == nil {
+		return nil, 0, nil
+	}
+	referenced, err := db.referencedValueLogSegments(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	set := db.valueLogManager.CurrentSetNoRefresh()
+	if set == nil || len(set.Files) == 0 {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
+		if err := db.valueLogManager.Refresh(); err != nil {
+			return nil, 0, err
+		}
+		set = db.valueLogManager.CurrentSetNoRefresh()
+	}
+	if set == nil || len(set.Files) == 0 {
+		return nil, 0, nil
+	}
+	defer func() { _ = db.valueLogManager.Release(set) }()
+
+	files := db.valueOnlyValueLogFiles(set.Files)
+	ids := make([]uint32, 0, len(files))
+	var bytes int64
+	for id, f := range files {
+		if _, ok := referenced[id]; ok {
+			continue
+		}
+		if f == nil {
+			continue
+		}
+		size := fileSize(f)
+		if size <= 0 {
+			continue
+		}
+		ids = append(ids, id)
+		bytes += size
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+	return ids, bytes, nil
 }
 
 func (db *DB) runCompactStoragePhase(stats *CompactStorageStats, name string, fn func() error) error {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -551,7 +551,9 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		return debt, err
 	}
 	if !opts.DisableZeroByteValueLogCleanup {
-		zeroBytes, err := zeroByteValueLogFilesFromUsage(usage, mergeUniqueNonEmptyPaths(protectedPaths, db.currentValueLogProtectedPaths()))
+		currentPaths, currentIDs := db.currentValueLogProtectedRefs()
+		allProtectedPaths := mergeUniqueNonEmptyPaths(protectedPaths, currentPaths)
+		zeroBytes, err := zeroByteValueLogFilesFromUsage(usage, allProtectedPaths, currentIDs)
 		if err != nil {
 			return debt, err
 		}
@@ -724,10 +726,10 @@ func compactStoragePathUsage(name, path string) (CompactStorageUsage, error) {
 	return usage, err
 }
 
-func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage, protectedPaths []string) (int, error) {
+func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage, protectedPaths []string, protectedFileIDs []uint32) (int, error) {
 	for _, domain := range usage {
 		if domain.Name == "value_vlog" {
-			return zeroByteValueLogSegmentFiles(domain.Path, protectedPaths)
+			return zeroByteValueLogSegmentFiles(domain.Path, protectedPaths, protectedFileIDs)
 		}
 	}
 	return 0, nil
@@ -822,7 +824,10 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		}
 		return 0, err
 	}
-	protected := compactStorageProtectedPathSet(mergeUniqueNonEmptyPaths(protectedPaths, db.currentValueLogProtectedPaths()))
+	currentPaths, currentIDs := db.currentValueLogProtectedRefs()
+	protectedPaths = mergeUniqueNonEmptyPaths(protectedPaths, currentPaths)
+	protected := compactStorageProtectedPathSet(protectedPaths)
+	protectedFileIDs := compactStorageProtectedFileIDSet(protectedPaths, currentIDs)
 	deleted := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -835,6 +840,11 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		path := filepath.Join(layout.valueVLogDir, name)
 		if _, ok := protected[filepath.Clean(path)]; ok {
 			continue
+		}
+		if fileID, ok := compactStorageValueLogFileID(name); ok {
+			if _, ok := protectedFileIDs[fileID]; ok {
+				continue
+			}
 		}
 		info, err := entry.Info()
 		if err != nil {
@@ -886,22 +896,27 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 	return deleted, nil
 }
 
-func (db *DB) currentValueLogProtectedPaths() []string {
+func (db *DB) currentValueLogProtectedRefs() ([]string, []uint32) {
 	if db == nil {
-		return nil
+		return nil, nil
 	}
 	appender := db.currentValueLogAppender()
 	if appender == nil {
-		return nil
+		return nil, nil
 	}
-	path, _, ok := appender.CurrentValueLogSegment()
-	if !ok || path == "" {
-		return nil
+	path, fileID, ok := appender.CurrentValueLogSegment()
+	var paths []string
+	var fileIDs []uint32
+	if ok && path != "" {
+		paths = []string{path}
 	}
-	return []string{path}
+	if ok && fileID != 0 {
+		fileIDs = []uint32{fileID}
+	}
+	return paths, fileIDs
 }
 
-func zeroByteValueLogSegmentFiles(dir string, protectedPaths []string) (int, error) {
+func zeroByteValueLogSegmentFiles(dir string, protectedPaths []string, protectedFileIDs []uint32) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -910,12 +925,19 @@ func zeroByteValueLogSegmentFiles(dir string, protectedPaths []string) (int, err
 		return 0, err
 	}
 	protected := compactStorageProtectedPathSet(protectedPaths)
+	protectedIDs := compactStorageProtectedFileIDSet(protectedPaths, protectedFileIDs)
 	count := 0
 	for _, entry := range entries {
-		if entry.IsDir() || !compactStorageIsValueLogSegmentName(entry.Name()) {
+		name := entry.Name()
+		if entry.IsDir() || !compactStorageIsValueLogSegmentName(name) {
 			continue
 		}
-		path := filepath.Join(dir, entry.Name())
+		if fileID, ok := compactStorageValueLogFileID(name); ok {
+			if _, ok := protectedIDs[fileID]; ok {
+				continue
+			}
+		}
+		path := filepath.Join(dir, name)
 		if _, ok := protected[filepath.Clean(path)]; ok {
 			continue
 		}
@@ -937,6 +959,25 @@ func compactStorageProtectedPathSet(paths []string) map[string]struct{} {
 			continue
 		}
 		protected[filepath.Clean(path)] = struct{}{}
+	}
+	return protected
+}
+
+func compactStorageProtectedFileIDSet(paths []string, fileIDs []uint32) map[uint32]struct{} {
+	protected := make(map[uint32]struct{}, len(paths)+len(fileIDs))
+	for _, fileID := range fileIDs {
+		if fileID == 0 {
+			continue
+		}
+		protected[fileID] = struct{}{}
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if fileID, ok := compactStorageValueLogFileID(filepath.Base(path)); ok {
+			protected[fileID] = struct{}{}
+		}
 	}
 	return protected
 }

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -775,7 +775,7 @@ func compactStorageFencedValueLogProtectedPaths(opts CompactStorageOptions) []st
 	}
 	dynamic := opts.ValueLogFencedProtectedPathsFunc()
 	if len(dynamic) == 0 {
-		return nil
+		return []string{""}
 	}
 	return dynamic
 }

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -65,11 +65,12 @@ type CompactStorageOptions struct {
 	// foreground writers.
 	ReserveRIDs func(count int) (start uint64, err error)
 
-	// ValueLogReclaimFencedUnreferenced permits CompactStorage to reclaim
+	// UnsafeValueLogReclaimFencedUnreferenced permits CompactStorage to reclaim
 	// unreferenced value-log segments that cached retained/current-writer
-	// protection would otherwise hide. Cached-mode callers set this only after
-	// checkpointing and fencing writers; backend-only callers leave it disabled.
-	ValueLogReclaimFencedUnreferenced bool
+	// protection would otherwise hide. Callers must first checkpoint, fence
+	// writers, rotate away from any candidate writer segment, and refresh the
+	// value-log set. Backend-only callers should leave it disabled.
+	UnsafeValueLogReclaimFencedUnreferenced bool
 
 	// DisableZeroByteValueLogCleanup leaves zero-byte value_vlog segment files in
 	// place. This is intended for specialty diagnostics that need to inspect
@@ -187,7 +188,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	stats.Before = before
 
-	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats, !maintenanceLocked)
+	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats, !maintenanceLocked, nil)
 	if err != nil {
 		return stats, err
 	}
@@ -345,7 +346,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	stats.After = after
 
 	var finalAudit CompactStorageStats
-	finalDebt, err := db.populateCompactStorageAudit(ctx, opts, &finalAudit, !maintenanceLocked)
+	finalDebt, err := db.populateCompactStorageAudit(ctx, opts, &finalAudit, !maintenanceLocked, nil)
 	if err != nil {
 		return stats, err
 	}
@@ -360,11 +361,8 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 	const maxSettlePasses = 4
 	for pass := 0; pass < maxSettlePasses; pass++ {
 		var audit CompactStorageStats
-		debt, err := db.populateCompactStorageAudit(ctx, opts, &audit, lockMaintenance)
-		if err != nil {
-			return err
-		}
-		fencedIDs, _, err := db.compactStorageFencedUnreferencedValueLogIDs(ctx, opts)
+		var fencedIDs []uint32
+		debt, err := db.populateCompactStorageAudit(ctx, opts, &audit, lockMaintenance, &fencedIDs)
 		if err != nil {
 			return err
 		}
@@ -495,7 +493,7 @@ func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOn
 	}
 }
 
-func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool) (CompactStorageDebt, error) {
+func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool, fencedIDsOut *[]uint32) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
 	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
 	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(protectedPaths))
@@ -519,6 +517,9 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	fencedValueLogIDs, fencedValueLogBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(ctx, opts)
 	if err != nil {
 		return debt, err
+	}
+	if fencedIDsOut != nil {
+		*fencedIDsOut = append((*fencedIDsOut)[:0], fencedValueLogIDs...)
 	}
 	debt.ValueLogGCSegments += len(fencedValueLogIDs)
 	debt.ValueLogGCBytes += fencedValueLogBytes
@@ -560,7 +561,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 }
 
 func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, opts CompactStorageOptions) ([]uint32, int64, error) {
-	if db == nil || !opts.ValueLogReclaimFencedUnreferenced || db.valueLogManager == nil {
+	if db == nil || !opts.UnsafeValueLogReclaimFencedUnreferenced || db.valueLogManager == nil {
 		return nil, 0, nil
 	}
 	referenced, err := db.compactStorageScannedValueLogRefs(ctx)
@@ -780,7 +781,7 @@ func compactStorageFencedValueLogProtectedPaths(opts CompactStorageOptions) []st
 }
 
 func compactStorageCleanupValueLogProtectedPaths(opts CompactStorageOptions) []string {
-	if opts.ValueLogReclaimFencedUnreferenced {
+	if opts.UnsafeValueLogReclaimFencedUnreferenced {
 		return compactStorageFencedValueLogProtectedPaths(opts)
 	}
 	return compactStorageValueLogProtectedPaths(opts)

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -551,7 +551,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		return debt, err
 	}
 	if !opts.DisableZeroByteValueLogCleanup {
-		zeroBytes, err := zeroByteValueLogFilesFromUsage(usage, protectedPaths)
+		zeroBytes, err := zeroByteValueLogFilesFromUsage(usage, mergeUniqueNonEmptyPaths(protectedPaths, db.currentValueLogProtectedPaths()))
 		if err != nil {
 			return debt, err
 		}
@@ -796,7 +796,7 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		}
 		return 0, err
 	}
-	protected := compactStorageProtectedPathSet(protectedPaths)
+	protected := compactStorageProtectedPathSet(mergeUniqueNonEmptyPaths(protectedPaths, db.currentValueLogProtectedPaths()))
 	deleted := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -858,6 +858,21 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		}
 	}
 	return deleted, nil
+}
+
+func (db *DB) currentValueLogProtectedPaths() []string {
+	if db == nil {
+		return nil
+	}
+	appender := db.currentValueLogAppender()
+	if appender == nil {
+		return nil
+	}
+	path, _, ok := appender.CurrentValueLogSegment()
+	if !ok || path == "" {
+		return nil
+	}
+	return []string{path}
 }
 
 func zeroByteValueLogSegmentFiles(dir string, protectedPaths []string) (int, error) {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -384,6 +384,11 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if len(fencedIDs) > 0 {
 			phaseName := fmt.Sprintf("settle-fenced-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
+				// Fenced IDs are independently proven unreachable by a fresh
+				// root scan below. ReclaimActive is intentional here: these
+				// are the active-per-lane files that make CompactStorage look
+				// clean only until close/reopen unless reclaimed before the
+				// compaction boundary returns.
 				gc, err := db.valueLogGC(ctx, ValueLogGCOptions{
 					ObservedSourceFileIDs:            fencedIDs,
 					ObservedSourceAssumeUnreferenced: true,
@@ -567,6 +572,9 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 		set = db.valueLogManager.CurrentSetNoRefresh()
 	}
 	if set == nil || len(set.Files) == 0 {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
 		return nil, 0, nil
 	}
 	defer func() { _ = db.valueLogManager.Release(set) }()

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -552,7 +552,7 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 	if db == nil || !opts.ValueLogReclaimFencedUnreferenced || db.valueLogManager == nil {
 		return nil, 0, nil
 	}
-	referenced, err := db.referencedValueLogSegments(ctx)
+	referenced, err := db.compactStorageScannedValueLogRefs(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -592,6 +592,27 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 		return ids[i] < ids[j]
 	})
 	return ids, bytes, nil
+}
+
+func (db *DB) compactStorageScannedValueLogRefs(ctx context.Context) (map[uint32]struct{}, error) {
+	counts, _, err := db.scanValueLogRefCounts(ctx)
+	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
+		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
+			return nil, refreshErr
+		}
+		counts, _, err = db.scanValueLogRefCounts(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	refs := make(map[uint32]struct{}, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		refs[fileID] = struct{}{}
+	}
+	return refs, nil
 }
 
 func (db *DB) runCompactStoragePhase(stats *CompactStorageStats, name string, fn func() error) error {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -590,13 +590,8 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 
 	files := db.valueOnlyValueLogFiles(set.Files)
 	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
-	protected := make(map[string]struct{}, len(protectedPaths))
-	for _, path := range protectedPaths {
-		if path == "" {
-			continue
-		}
-		protected[path] = struct{}{}
-	}
+	protected := compactStorageProtectedPathSet(protectedPaths)
+	protectedFileIDs := compactStorageProtectedFileIDSet(protectedPaths, nil)
 	ids := make([]uint32, 0, len(files))
 	var bytes int64
 	for id, f := range files {
@@ -606,7 +601,10 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 		if f == nil {
 			continue
 		}
-		if _, ok := protected[f.Path]; ok {
+		if _, ok := protected[filepath.Clean(f.Path)]; ok {
+			continue
+		}
+		if _, ok := protectedFileIDs[id]; ok {
 			continue
 		}
 		size := fileSize(f)
@@ -881,10 +879,13 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 			}
 		}
 		if err := os.Remove(path); err != nil {
-			if !os.IsNotExist(err) {
-				return deleted, err
+			if os.IsNotExist(err) {
+				continue
 			}
-			continue
+			if compactStorageIsBusyRemoveError(err) {
+				continue
+			}
+			return deleted, err
 		}
 		deleted++
 	}
@@ -914,7 +915,7 @@ func (db *DB) currentValueLogProtectedRefs() ([]string, []uint32) {
 		paths = []string{path}
 	}
 	if ok && fileID != 0 {
-		fileIDs = []uint32{fileID}
+		fileIDs = append(fileIDs, fileID)
 	}
 	return paths, fileIDs
 }

--- a/TreeDB/db/compact_storage_file_errors.go
+++ b/TreeDB/db/compact_storage_file_errors.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package db
+
+func compactStorageIsBusyRemoveError(error) bool {
+	return false
+}

--- a/TreeDB/db/compact_storage_file_errors_windows.go
+++ b/TreeDB/db/compact_storage_file_errors_windows.go
@@ -7,6 +7,11 @@ import (
 	"syscall"
 )
 
+const (
+	windowsErrorAccessDenied     syscall.Errno = 5
+	windowsErrorSharingViolation syscall.Errno = 32
+)
+
 func compactStorageIsBusyRemoveError(err error) bool {
-	return errors.Is(err, syscall.ERROR_SHARING_VIOLATION) || errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+	return errors.Is(err, windowsErrorSharingViolation) || errors.Is(err, windowsErrorAccessDenied)
 }

--- a/TreeDB/db/compact_storage_file_errors_windows.go
+++ b/TreeDB/db/compact_storage_file_errors_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package db
+
+import (
+	"errors"
+	"syscall"
+)
+
+func compactStorageIsBusyRemoveError(err error) bool {
+	return errors.Is(err, syscall.ERROR_SHARING_VIOLATION) || errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -465,6 +465,32 @@ func TestCompactStorageFencedProtectedPathsIncludeExplicitPaths(t *testing.T) {
 	}
 }
 
+func TestZeroByteValueLogCleanupProtectsByFileID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000002.log")
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatalf("write zero-byte value log: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("encode file ID: %v", err)
+	}
+	count, err := zeroByteValueLogSegmentFiles(dir, nil, []uint32{fileID})
+	if err != nil {
+		t.Fatalf("zero-byte scan with protected file ID: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("protected zero-byte count=%d want 0", count)
+	}
+	count, err = zeroByteValueLogSegmentFiles(dir, nil, nil)
+	if err != nil {
+		t.Fatalf("zero-byte scan without protection: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("unprotected zero-byte count=%d want 1", count)
+	}
+}
+
 func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -448,6 +449,19 @@ func TestCompactStorageDefaultProtectedPathsActivatesActiveProtection(t *testing
 	paths := compactStorageValueLogProtectedPaths(CompactStorageOptions{})
 	if len(paths) != 1 || paths[0] != "" {
 		t.Fatalf("default protected paths=%q want sentinel", paths)
+	}
+}
+
+func TestCompactStorageFencedProtectedPathsIncludeExplicitPaths(t *testing.T) {
+	paths := compactStorageFencedValueLogProtectedPaths(CompactStorageOptions{
+		ValueLogProtectedPaths: []string{"explicit-a", "shared"},
+		ValueLogFencedProtectedPathsFunc: func() []string {
+			return []string{"dynamic-a", "shared"}
+		},
+	})
+	want := []string{"explicit-a", "shared", "dynamic-a"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("fenced protected paths=%q want %q", paths, want)
 	}
 }
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -491,6 +491,52 @@ func TestZeroByteValueLogCleanupProtectsByFileID(t *testing.T) {
 	}
 }
 
+func TestCompactStorageKeepsCurrentWritableZeroByteValueLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	path := filepath.Join(valueLogDir, "value-l0-000002.log")
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatalf("write zero-byte value log: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("encode file ID: %v", err)
+	}
+	if err := d.valueLogManager.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("register segment: %v", err)
+	}
+	if err := d.valueLogManager.PromoteCurrentWritable(fileID); err != nil {
+		t.Fatalf("promote current writable: %v", err)
+	}
+
+	plan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.RemainingDebt.ZeroByteValueLogFiles; got != 0 {
+		t.Fatalf("current writable zero-byte debt=%d want 0", got)
+	}
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("current writable zero-byte file was removed: %v", err)
+	}
+	if stats.ZeroByteValueLogFilesDeleted != 0 {
+		t.Fatalf("deleted current writable zero-byte files=%d want 0", stats.ZeroByteValueLogFilesDeleted)
+	}
+}
+
 func TestCompactStoragePlanReadOnlyDoesNotDeleteZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -465,6 +465,44 @@ func TestCompactStorageFencedProtectedPathsIncludeExplicitPaths(t *testing.T) {
 	}
 }
 
+func TestCompactStorageFencedReclaimProtectsByFileID(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	path := filepath.Join(valueLogDir, "value-l0-000002.log")
+	if err := os.WriteFile(path, []byte("value-log-bytes"), 0644); err != nil {
+		t.Fatalf("write value log: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("encode file ID: %v", err)
+	}
+	if err := d.valueLogManager.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("register segment: %v", err)
+	}
+
+	ids, _, err := d.compactStorageFencedUnreferencedValueLogIDs(context.Background(), CompactStorageOptions{
+		UnsafeValueLogReclaimFencedUnreferenced: true,
+		ValueLogFencedProtectedPathsFunc: func() []string {
+			return []string{filepath.Join(t.TempDir(), "value-l0-000002.log")}
+		},
+	})
+	if err != nil {
+		t.Fatalf("compactStorageFencedUnreferencedValueLogIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("fenced reclaim IDs=%v want none", ids)
+	}
+}
+
 func TestZeroByteValueLogCleanupProtectsByFileID(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-l0-000002.log")

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1478,6 +1478,31 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	return nil
 }
 
+// CurrentWritableFileIDs returns the registered current writable value-log
+// segment IDs. These files may still be held open or mapped and must not be
+// physically removed by maintenance cleanup.
+func (m *Manager) CurrentWritableFileIDs() []uint32 {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.currentWritableByLane) == 0 {
+		return nil
+	}
+	ids := make([]uint32, 0, len(m.currentWritableByLane))
+	for _, id := range m.currentWritableByLane {
+		if id == 0 {
+			continue
+		}
+		if f := m.files[id]; f != nil && !f.IsZombie.Load() && f.currentWritable.Load() {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
 // RewriteLaneHint returns a best-effort lane/start-seq hint for creating new
 // rewrite segments without scanning the filesystem.
 //

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -485,8 +485,8 @@ func validateRawJSONTreeDB(files []string, rows int, dbDir string) error {
 	if err != nil {
 		return fmt.Errorf("open raw TreeDB for validation: %w", err)
 	}
-	defer func() { _ = db.Close() }()
 	var checked int
+	var scanErr error
 	for _, file := range files {
 		if checked >= rows {
 			break
@@ -505,11 +505,22 @@ func validateRawJSONTreeDB(files []string, rows int, dbDir string) error {
 			}
 			return nil
 		}); err != nil {
-			return fmt.Errorf("validate raw JSON %s: %w", file, err)
+			scanErr = fmt.Errorf("validate raw JSON %s: %w", file, err)
+			break
 		}
 	}
-	if checked != rows {
-		return fmt.Errorf("validated %d raw JSON rows, want %d", checked, rows)
+	if scanErr == nil && checked != rows {
+		scanErr = fmt.Errorf("validated %d raw JSON rows, want %d", checked, rows)
+	}
+	closeErr := db.Close()
+	if scanErr != nil {
+		if closeErr != nil {
+			return errors.Join(scanErr, fmt.Errorf("close raw TreeDB validation DB: %w", closeErr))
+		}
+		return scanErr
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close raw TreeDB validation DB: %w", closeErr)
 	}
 	return nil
 }

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -422,6 +422,9 @@ func measureRawJSONTreeDB(ctx context.Context, files []string, rows int, dbDir s
 		out.RewriteValueBytes = rewriteStats.ValueBytesCopied
 		out.RewriteSourceBytes = rewriteStats.SourceBytesRequested
 	}
+	if err := validateRawJSONTreeDB(files, rows, dbDir); err != nil {
+		return out, err
+	}
 	after, afterFiles, err := directoryUsage(dbDir)
 	if err != nil {
 		return out, err
@@ -460,8 +463,9 @@ func insertRawJSONRows(files []string, rows int, db *treedb.DB, out *remainingTr
 				return errStopScan
 			}
 			out.Rows++
-			out.RawDocumentBytes += int64(len(raw))
-			if err := batch.Set(documentID(uint64(out.Rows)), raw); err != nil {
+			rawCopy := append([]byte(nil), raw...)
+			out.RawDocumentBytes += int64(len(rawCopy))
+			if err := batch.Set(documentID(uint64(out.Rows)), rawCopy); err != nil {
 				return fmt.Errorf("set raw JSON row %d: %w", out.Rows, err)
 			}
 			if out.Rows%batchSize == 0 {
@@ -473,6 +477,41 @@ func insertRawJSONRows(files []string, rows int, db *treedb.DB, out *remainingTr
 		}
 	}
 	return flush()
+}
+
+func validateRawJSONTreeDB(files []string, rows int, dbDir string) error {
+	opts := treedb.OptionsFor(treedb.ProfileBench, dbDir)
+	db, err := treedb.Open(opts)
+	if err != nil {
+		return fmt.Errorf("open raw TreeDB for validation: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	var checked int
+	for _, file := range files {
+		if checked >= rows {
+			break
+		}
+		if err := scanJSONBenchFile(file, func(raw []byte) error {
+			if checked >= rows {
+				return errStopScan
+			}
+			checked++
+			value, err := db.Get(documentID(uint64(checked)))
+			if err != nil {
+				return fmt.Errorf("get raw JSON row %d: %w", checked, err)
+			}
+			if !bytes.Equal(value, raw) {
+				return fmt.Errorf("raw JSON row %d validation mismatch: source bytes=%d stored bytes=%d", checked, len(raw), len(value))
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("validate raw JSON %s: %w", file, err)
+		}
+	}
+	if checked != rows {
+		return fmt.Errorf("validated %d raw JSON rows, want %d", checked, rows)
+	}
+	return nil
 }
 
 func valueLogFileIDs(dbDir string) ([]uint32, error) {

--- a/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -121,7 +122,9 @@ func TestRemainingJSONDocumentConservativeOnlyRemovesTimeUS(t *testing.T) {
 }
 
 func TestMeasureRawJSONTreeDBSample(t *testing.T) {
-	result, err := measureRawJSONTreeDB(context.Background(), []string{filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")}, 5, t.TempDir())
+	dbDir := t.TempDir()
+	source := filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")
+	result, err := measureRawJSONTreeDB(context.Background(), []string{source}, 5, dbDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,5 +139,32 @@ func TestMeasureRawJSONTreeDBSample(t *testing.T) {
 	}
 	if !strings.Contains(result.StoredShape, "key/value") {
 		t.Fatalf("stored shape %q does not describe raw key/value storage", result.StoredShape)
+	}
+	if err := validateRawJSONTreeDB([]string{source}, 5, dbDir); err != nil {
+		t.Fatalf("validate raw JSON TreeDB: %v", err)
+	}
+}
+
+func TestValidateRawJSONTreeDBDetectsMismatchedRows(t *testing.T) {
+	dbDir := t.TempDir()
+	source := filepath.Join("..", "..", "testdata", "jsonbench_sample.jsonl")
+	if _, err := measureRawJSONTreeDB(context.Background(), []string{source}, 5, dbDir); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := filepath.Join(t.TempDir(), "corrupt.jsonl")
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), `"kind":"commit"`, `"kind":"changed"`, 1))
+	if err := os.WriteFile(corrupt, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = validateRawJSONTreeDB([]string{corrupt}, 5, dbDir)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "validation mismatch") {
+		t.Fatalf("validation error %q does not mention mismatch", err)
 	}
 }

--- a/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
@@ -140,9 +140,6 @@ func TestMeasureRawJSONTreeDBSample(t *testing.T) {
 	if !strings.Contains(result.StoredShape, "key/value") {
 		t.Fatalf("stored shape %q does not describe raw key/value storage", result.StoredShape)
 	}
-	if err := validateRawJSONTreeDB([]string{source}, 5, dbDir); err != nil {
-		t.Fatalf("validate raw JSON TreeDB: %v", err)
-	}
 }
 
 func TestValidateRawJSONTreeDBDetectsMismatchedRows(t *testing.T) {
@@ -156,7 +153,11 @@ func TestValidateRawJSONTreeDBDetectsMismatchedRows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data = []byte(strings.Replace(string(data), `"kind":"commit"`, `"kind":"changed"`, 1))
+	corrupted := strings.Replace(string(data), `"kind":"commit"`, `"kind":"changed"`, 1)
+	if corrupted == string(data) {
+		t.Fatal("sample fixture did not contain the expected corruption target")
+	}
+	data = []byte(corrupted)
 	if err := os.WriteFile(corrupt, data, 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Objective

Fix the two JSONBench/compaction correctness issues tracked in #1458 and #1459 in one landing PR:

- #1458: raw JSON TreeDB fixture could report suspiciously-small artifacts unless every stored row was validated byte-for-byte against the source.
- #1459: public cached `CompactStorage` could report fully compacted while standalone rewrite-source value-log debt reappeared after close/reopen.

## Context

The JSONBench raw fixture showed two separate failure classes:

1. Raw fixture reporting was not trustworthy without byte validation because scanner-owned row buffers could be reused before insertion.
2. Compressed rewrite output was valid, but old ingest/rewrite source segments could survive the preferred compaction path and become eligible only after reopening.

Together these made storage-size reports too easy to trust before proving both data identity and post-reopen compaction state.

## Design

- Copy scanned raw JSON rows before batching into TreeDB.
- Validate raw TreeDB fixtures after maintenance by reopening and comparing every stored row byte-for-byte with the source rows before reporting size.
- Public cached `CompactStorage` now runs a synchronous retained value-log prune after its checkpoint when the caller did not provide explicit protected paths.
- Cached `CompactStorage` marks backend options as fenced, allowing backend compaction to reclaim unreferenced value-log files that retained/current-writer protection would otherwise hide.
- Fenced reclaim uses a fresh full reachability scan instead of trusting the in-memory value-log ref tracker, so final compaction state matches post-reopen state.
- Observed rewrite-source reclaim uses observed-only GC and active-source reclaim after rotating writers past observed sources.
- Explicit `ValueLogProtectedPaths` still disables fenced reclaim so caller-protected segments remain protected.

## Scope

- Includes:
  - `TreeDB/caching/db.go`
  - `TreeDB/compact_storage.go`
  - `TreeDB/db/compact_storage.go`
  - `TreeDB/compact_storage_cached_internal_test.go`
  - `experiments/colgranule/cmd/jsonbench_compare/main.go`
  - `experiments/colgranule/cmd/jsonbench_compare/remaining_test.go`
- Excludes:
  - compression format changes
  - collection WAL
  - ClickHouse/MongoDB comparison report work

## Correctness

Local tests run:

```sh
go test ./TreeDB -run 'TestCompactStorageCachedAdvancesWritersPastBackendSegments|TestCachedValueLogRewriteOnlinePreservesRetainedObservedSourcesAndReclaimsLeafDebt|TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters' -count=1 -v
go test ./TreeDB -run TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters -count=1 -v
go test ./TreeDB -count=1
go test ./experiments/colgranule/cmd/jsonbench_compare -run 'TestMeasureRawJSONTreeDBSample|TestValidateRawJSONTreeDBDetectsMismatchedRows' -count=1 -v
go test ./experiments/colgranule/cmd/jsonbench_compare -count=1
```

Regression coverage:

- raw fixture validation passes for a valid sample and fails on a deliberate source/stored mismatch;
- compaction regression closes and reopens after `CompactStorage`, dry-runs public `ValueLogGC`, and requires zero eligible segments/bytes while validating every value;
- explicit protected-path regression remains green, proving caller-protected paths are not reclaimed by the fenced path.

## Performance

Benchmarks run: none. This is maintenance correctness and experiment validation, not a hot-path optimization.

Expected cost: the fresh reachability scan is only used by cached full compaction's fenced reclaim path, not ordinary reads/writes.

## Rollout / Toggle Plan

- Default behavior applies inside public cached `CompactStorage` after checkpoint/fencing.
- To keep old conservative protection for caller-owned files, provide explicit `ValueLogProtectedPaths`; that disables fenced reclaim.

## Follow-ups

- Once this PR is green, #1456 can be closed as superseded because its raw JSON validation commit is included here.
- Re-run the full JSONBench storage comparison from a clean checkout and attach final artifact sizes to #1462.

Fixes #1458.
Fixes #1459.
