### PR TITLE
Split slow CI checks into balanced shards

### DIFF
--- a/.github/ci/treedb_caching_race_weighted_shard0_tests.txt
+++ b/.github/ci/treedb_caching_race_weighted_shard0_tests.txt
@@ -1,0 +1,3 @@
+# Pinned to shard 0 because this caching race test dominated the previous
+# line-count race shard.
+TestCheckpoint_KickSkipsWhenMaintenancePhaseNonSteady

--- a/.github/ci/treedb_db_weighted_shard0_tests.txt
+++ b/.github/ci/treedb_db_weighted_shard0_tests.txt
@@ -1,0 +1,3 @@
+# Pinned to shard 0 because this TreeDB/db test dominated the previous
+# line-count shard on Windows and race runs.
+TestValidateFragmentationReport_EndToEnd

--- a/.github/ci/treedb_root_weighted_shard0_tests.txt
+++ b/.github/ci/treedb_root_weighted_shard0_tests.txt
@@ -1,0 +1,3 @@
+# Pinned to shard 0 because this root-package test dominated the previous
+# line-count shard on Windows and race runs.
+TestProfileFast_BulkRestoreMaintainsKeyValueParity

--- a/.github/ci/treedb_windows_caching_heavy_shard0_tests.txt
+++ b/.github/ci/treedb_windows_caching_heavy_shard0_tests.txt
@@ -1,0 +1,3 @@
+# Isolated because this Windows caching-heavy test takes most of the job
+# wall time by itself.
+TestCachedGenerationalMaintenance_LeafRefsRemainReopenable

--- a/.github/workflows/root-tests.yml
+++ b/.github/workflows/root-tests.yml
@@ -8,11 +8,30 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - name: ubuntu-latest-1
+            os: ubuntu-latest
+            run_docs_check: true
+            run_vet: true
+            test_shard_index: 0
+            test_shard_count: 2
+          - name: ubuntu-latest-2
+            os: ubuntu-latest
+            run_docs_check: false
+            run_vet: false
+            test_shard_index: 1
+            test_shard_count: 2
+          - name: macos-latest
+            os: macos-latest
+            run_docs_check: true
+            run_vet: true
+            test_shard_index: 0
+            test_shard_count: 1
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -27,10 +46,31 @@ jobs:
             go.sum
 
       - name: Docs check
+        if: ${{ matrix.run_docs_check }}
         run: make docs-check
 
       - name: Vet
+        if: ${{ matrix.run_vet }}
         run: go vet ./...
 
       - name: Test
-        run: GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./...
+        shell: bash
+        run: |
+          set -euo pipefail
+          shard_index="${{ matrix.test_shard_index }}"
+          shard_count="${{ matrix.test_shard_count }}"
+          package_file="$(mktemp)"
+          db_test_file="$(mktemp)"
+          go list ./... | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+          go test ./TreeDB/db -list 'Test.*' | grep '^Test' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$db_test_file"
+          if [ -s "$package_file" ]; then
+            echo "root package shard=${shard_index}/${shard_count}"
+            cat "$package_file"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 xargs go test -p 1 < "$package_file"
+          fi
+          if [ -s "$db_test_file" ]; then
+            db_regex="^($(paste -sd'|' "$db_test_file"))$"
+            echo "TreeDB/db test shard=${shard_index}/${shard_count} regex=${db_regex}"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -run "$db_regex"
+          fi
+          rm -f "$package_file" "$db_test_file"

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -91,7 +91,18 @@ jobs:
           GOMEMLIMIT: 4GiB
           GOMAXPROCS: 2
         run: |
-          set -e -o pipefail
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          cleanup() {
+            rm -rf "$tmp_dir"
+          }
+          make_tmp() {
+            mktemp "$tmp_dir/tmp.XXXXXX"
+          }
+          ci_list() {
+            sed -e 's/\r$//' -e '/^#/d' -e '/^$/d' "$1"
+          }
+          trap cleanup EXIT
           case "${{ matrix.shard_kind }}" in
             all)
               go test -json -timeout 30m -p 1 ./... | tee treedb-test.jsonl
@@ -105,23 +116,27 @@ jobs:
               if [ -z "$package_shard_count" ] || [ "$package_shard_count" -lt 1 ]; then
                 package_shard_count=1
               fi
-              package_file="$(mktemp)"
-              root_all_file="$(mktemp)"
-              root_test_file="$(mktemp)"
-              db_all_file="$(mktemp)"
-              db_test_file="$(mktemp)"
+              package_file="$(make_tmp)"
+              root_all_file="$(make_tmp)"
+              root_test_file="$(make_tmp)"
+              root_pin_file="$(make_tmp)"
+              db_all_file="$(make_tmp)"
+              db_test_file="$(make_tmp)"
+              db_pin_file="$(make_tmp)"
               go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
-              go test . -list 'Test.*' | tr -d '\r' | grep '^Test' > "$root_all_file"
+              go test . -list '^(Test|Example).*' | tr -d '\r' | grep -E '^(Test|Example)' > "$root_all_file"
               go test ./db -list 'Test.*' | tr -d '\r' | grep '^Test' > "$db_all_file"
+              ci_list ../.github/ci/treedb_root_weighted_shard0_tests.txt > "$root_pin_file"
+              ci_list ../.github/ci/treedb_db_weighted_shard0_tests.txt > "$db_pin_file"
               if [ "$package_shard_count" -eq 2 ]; then
                 case "$package_shard_index" in
                   0)
-                    grep -F -x 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file" || true
-                    grep -F -x 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file" || true
+                    grep -F -x -f "$root_pin_file" "$root_all_file" > "$root_test_file" || true
+                    grep -F -x -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                     ;;
                   1)
-                    grep -F -x -v 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file"
-                    grep -F -x -v 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file"
+                    grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file"
+                    grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file"
                     ;;
                   *)
                     : > "$root_test_file"
@@ -133,23 +148,34 @@ jobs:
                 awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$db_all_file" > "$db_test_file"
               fi
               echo "TreeDB windows-core package shard=${package_shard_index}/${package_shard_count}"
-              xargs go test -json -timeout 30m -p 1 < "$package_file" | tee treedb-test.jsonl
+              ran_tests=false
+              if [ -s "$package_file" ]; then
+                xargs go test -json -timeout 30m -p 1 < "$package_file" | tee treedb-test.jsonl
+                ran_tests=true
+              fi
               if [ -s "$root_test_file" ]; then
                 root_regex="^($(paste -sd'|' "$root_test_file"))$"
                 echo "TreeDB root test shard=${package_shard_index}/${package_shard_count} regex=${root_regex}"
                 go test -json -timeout 30m -p 1 . -run "$root_regex" | tee -a treedb-test.jsonl
+                ran_tests=true
               fi
               if [ -s "$db_test_file" ]; then
                 db_regex="^($(paste -sd'|' "$db_test_file"))$"
                 echo "TreeDB/db test shard=${package_shard_index}/${package_shard_count} regex=${db_regex}"
                 go test -json -timeout 30m -p 1 ./db -run "$db_regex" | tee -a treedb-test.jsonl
+                ran_tests=true
               fi
-              rm -f "$package_file" "$root_all_file" "$root_test_file" "$db_all_file" "$db_test_file"
+              if [ "$ran_tests" = false ]; then
+                echo "no TreeDB windows-core tests found for shard ${package_shard_index}/${package_shard_count}; skipping"
+                printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-test.jsonl
+              fi
               ;;
             windows-caching-heavy)
-              heavy_file="$(mktemp)"
-              heavy_shard_file="$(mktemp)"
-              tr -d '\r' < ../.github/ci/treedb_windows_caching_heavy_tests.txt | grep -v '^#' | sed '/^$/d' > "$heavy_file"
+              heavy_file="$(make_tmp)"
+              heavy_pin_file="$(make_tmp)"
+              heavy_shard_file="$(make_tmp)"
+              ci_list ../.github/ci/treedb_windows_caching_heavy_tests.txt > "$heavy_file"
+              ci_list ../.github/ci/treedb_windows_caching_heavy_shard0_tests.txt > "$heavy_pin_file"
               heavy_shard_index="${{ matrix.heavy_shard_index }}"
               heavy_shard_count="${{ matrix.heavy_shard_count }}"
               if [ -z "$heavy_shard_index" ]; then
@@ -161,10 +187,10 @@ jobs:
               if [ "$heavy_shard_count" -eq 2 ]; then
                 case "$heavy_shard_index" in
                   0)
-                    grep -F -x 'TestCachedGenerationalMaintenance_LeafRefsRemainReopenable' "$heavy_file" > "$heavy_shard_file"
+                    grep -F -x -f "$heavy_pin_file" "$heavy_file" > "$heavy_shard_file"
                     ;;
                   1)
-                    grep -F -x -v 'TestCachedGenerationalMaintenance_LeafRefsRemainReopenable' "$heavy_file" > "$heavy_shard_file"
+                    grep -F -x -v -f "$heavy_pin_file" "$heavy_file" > "$heavy_shard_file"
                     ;;
                   *)
                     : > "$heavy_shard_file"
@@ -176,19 +202,17 @@ jobs:
               if ! [ -s "$heavy_shard_file" ]; then
                 echo "no heavy caching tests found for shard ${heavy_shard_index}/${heavy_shard_count}; skipping"
                 printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB/caching"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-test.jsonl
-                rm -f "$heavy_file" "$heavy_shard_file"
                 exit 0
               fi
               regex="^($(paste -sd'|' "$heavy_shard_file"))$"
               echo "TreeDB/caching heavy shard=${heavy_shard_index}/${heavy_shard_count} regex=${regex}"
               go test -json -timeout 30m -p 1 ./caching -run "$regex" | tee treedb-test.jsonl
-              rm -f "$heavy_file" "$heavy_shard_file"
               ;;
             windows-caching-rest)
-              heavy_file="$(mktemp)"
-              rest_file="$(mktemp)"
-              rest_shard_file="$(mktemp)"
-              tr -d '\r' < ../.github/ci/treedb_windows_caching_heavy_tests.txt | grep -v '^#' | sed '/^$/d' > "$heavy_file"
+              heavy_file="$(make_tmp)"
+              rest_file="$(make_tmp)"
+              rest_shard_file="$(make_tmp)"
+              ci_list ../.github/ci/treedb_windows_caching_heavy_tests.txt > "$heavy_file"
               go test ./caching -list 'Test.*' | tr -d '\r' | grep '^Test' | grep -F -x -v -f "$heavy_file" > "$rest_file"
               rest_shard_index="${{ matrix.rest_shard_index }}"
               rest_shard_count="${{ matrix.rest_shard_count }}"
@@ -203,12 +227,10 @@ jobs:
               if [ "$rest_regex" = '^()$' ]; then
                 echo "no non-heavy caching tests found for shard ${rest_shard_index}/${rest_shard_count}; skipping"
                 printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB/caching"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-test.jsonl
-                rm -f "$heavy_file" "$rest_file" "$rest_shard_file"
                 exit 0
               fi
               echo "TreeDB/caching rest shard=${rest_shard_index}/${rest_shard_count} regex=${rest_regex}"
               go test -json -timeout 30m -p 1 ./caching -run "$rest_regex" | tee treedb-test.jsonl
-              rm -f "$heavy_file" "$rest_file" "$rest_shard_file"
               ;;
             *)
               echo "unknown shard kind: ${{ matrix.shard_kind }}" >&2
@@ -267,31 +289,48 @@ jobs:
         working-directory: TreeDB
         shell: bash
         run: |
-          set -e -o pipefail
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          cleanup() {
+            rm -rf "$tmp_dir"
+          }
+          make_tmp() {
+            mktemp "$tmp_dir/tmp.XXXXXX"
+          }
+          ci_list() {
+            sed -e 's/\r$//' -e '/^#/d' -e '/^$/d' "$1"
+          }
+          trap cleanup EXIT
           shard_index="${{ matrix.shard_index }}"
           shard_count="${{ matrix.shard_count }}"
-          package_file="$(mktemp)"
-          root_all_file="$(mktemp)"
-          root_test_file="$(mktemp)"
-          caching_all_file="$(mktemp)"
-          caching_test_file="$(mktemp)"
-          db_all_file="$(mktemp)"
-          db_test_file="$(mktemp)"
+          package_file="$(make_tmp)"
+          root_all_file="$(make_tmp)"
+          root_test_file="$(make_tmp)"
+          root_pin_file="$(make_tmp)"
+          caching_all_file="$(make_tmp)"
+          caching_test_file="$(make_tmp)"
+          caching_pin_file="$(make_tmp)"
+          db_all_file="$(make_tmp)"
+          db_test_file="$(make_tmp)"
+          db_pin_file="$(make_tmp)"
           go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
-          go test . -list 'Test.*' | grep '^Test' > "$root_all_file"
+          go test . -list '^(Test|Example).*' | grep -E '^(Test|Example)' > "$root_all_file"
           go test ./caching -list 'Test.*' | grep '^Test' > "$caching_all_file"
           go test ./db -list 'Test.*' | grep '^Test' > "$db_all_file"
+          ci_list ../.github/ci/treedb_root_weighted_shard0_tests.txt > "$root_pin_file"
+          ci_list ../.github/ci/treedb_caching_race_weighted_shard0_tests.txt > "$caching_pin_file"
+          ci_list ../.github/ci/treedb_db_weighted_shard0_tests.txt > "$db_pin_file"
           if [ "$shard_count" -eq 2 ]; then
             case "$shard_index" in
               0)
-                grep -F -x 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file" || true
-                grep -F -x 'TestCheckpoint_KickSkipsWhenMaintenancePhaseNonSteady' "$caching_all_file" > "$caching_test_file" || true
-                grep -F -x 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file" || true
+                grep -F -x -f "$root_pin_file" "$root_all_file" > "$root_test_file" || true
+                grep -F -x -f "$caching_pin_file" "$caching_all_file" > "$caching_test_file" || true
+                grep -F -x -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                 ;;
               1)
-                grep -F -x -v 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file"
-                grep -F -x -v 'TestCheckpoint_KickSkipsWhenMaintenancePhaseNonSteady' "$caching_all_file" > "$caching_test_file"
-                grep -F -x -v 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file"
+                grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file"
+                grep -F -x -v -f "$caching_pin_file" "$caching_all_file" > "$caching_test_file"
+                grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file"
                 ;;
               *)
                 : > "$root_test_file"
@@ -304,31 +343,35 @@ jobs:
             awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$caching_all_file" > "$caching_test_file"
             awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$db_all_file" > "$db_test_file"
           fi
-          if ! [ -s "$package_file" ]; then
-            echo "no packages found for race shard ${shard_index}/${shard_count}; skipping"
-            printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-race.jsonl
-            rm -f "$package_file" "$root_all_file" "$root_test_file" "$caching_all_file" "$caching_test_file" "$db_all_file" "$db_test_file"
-            exit 0
-          fi
           echo "TreeDB race package shard=${shard_index}/${shard_count}"
-          cat "$package_file"
-          GOMEMLIMIT=4GiB GOMAXPROCS=2 xargs go test -json -race -p 1 < "$package_file" | tee treedb-race.jsonl
+          ran_tests=false
+          if [ -s "$package_file" ]; then
+            cat "$package_file"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 xargs go test -json -race -p 1 < "$package_file" | tee treedb-race.jsonl
+            ran_tests=true
+          fi
           if [ -s "$root_test_file" ]; then
             root_regex="^($(paste -sd'|' "$root_test_file"))$"
             echo "TreeDB root race test shard=${shard_index}/${shard_count} regex=${root_regex}"
             GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 . -run "$root_regex" | tee -a treedb-race.jsonl
+            ran_tests=true
           fi
           if [ -s "$caching_test_file" ]; then
             caching_regex="^($(paste -sd'|' "$caching_test_file"))$"
             echo "TreeDB/caching race test shard=${shard_index}/${shard_count} regex=${caching_regex}"
             GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./caching -run "$caching_regex" | tee -a treedb-race.jsonl
+            ran_tests=true
           fi
           if [ -s "$db_test_file" ]; then
             db_regex="^($(paste -sd'|' "$db_test_file"))$"
             echo "TreeDB/db race test shard=${shard_index}/${shard_count} regex=${db_regex}"
             GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./db -run "$db_regex" | tee -a treedb-race.jsonl
+            ran_tests=true
           fi
-          rm -f "$package_file" "$root_all_file" "$root_test_file" "$caching_all_file" "$caching_test_file" "$db_all_file" "$db_test_file"
+          if [ "$ran_tests" = false ]; then
+            echo "no TreeDB race tests found for shard ${shard_index}/${shard_count}; skipping"
+            printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-race.jsonl
+          fi
 
       - name: Summarize race timing
         if: always()

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -22,14 +22,30 @@ jobs:
             os: macos-latest
             timeout: 15
             shard_kind: all
-          - name: windows-core
+          - name: windows-core-1
             os: windows-latest
             timeout: 25
             shard_kind: windows-core
-          - name: windows-caching-heavy
+            package_shard_index: 0
+            package_shard_count: 2
+          - name: windows-core-2
+            os: windows-latest
+            timeout: 25
+            shard_kind: windows-core
+            package_shard_index: 1
+            package_shard_count: 2
+          - name: windows-caching-heavy-1
             os: windows-latest
             timeout: 25
             shard_kind: windows-caching-heavy
+            heavy_shard_index: 0
+            heavy_shard_count: 2
+          - name: windows-caching-heavy-2
+            os: windows-latest
+            timeout: 25
+            shard_kind: windows-caching-heavy
+            heavy_shard_index: 1
+            heavy_shard_count: 2
           - name: windows-caching-rest-1
             os: windows-latest
             timeout: 25
@@ -79,16 +95,50 @@ jobs:
               go test -json -timeout 30m -p 1 ./... | tee treedb-test.jsonl
               ;;
             windows-core)
-              packages=$(go list ./... | grep -v '^github.com/snissn/gomap/TreeDB/caching$')
-              go test -json -timeout 30m -p 1 $packages | tee treedb-test.jsonl
+              package_shard_index="${{ matrix.package_shard_index }}"
+              package_shard_count="${{ matrix.package_shard_count }}"
+              if [ -z "$package_shard_index" ]; then
+                package_shard_index=0
+              fi
+              if [ -z "$package_shard_count" ] || [ "$package_shard_count" -lt 1 ]; then
+                package_shard_count=1
+              fi
+              package_file="$(mktemp)"
+              db_test_file="$(mktemp)"
+              go list ./... | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+              go test ./db -list 'Test.*' | tr -d '\r' | grep '^Test' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$db_test_file"
+              echo "TreeDB windows-core package shard=${package_shard_index}/${package_shard_count}"
+              xargs go test -json -timeout 30m -p 1 < "$package_file" | tee treedb-test.jsonl
+              if [ -s "$db_test_file" ]; then
+                db_regex="^($(paste -sd'|' "$db_test_file"))$"
+                echo "TreeDB/db test shard=${package_shard_index}/${package_shard_count} regex=${db_regex}"
+                go test -json -timeout 30m -p 1 ./db -run "$db_regex" | tee -a treedb-test.jsonl
+              fi
+              rm -f "$package_file" "$db_test_file"
               ;;
             windows-caching-heavy)
               heavy_file="$(mktemp)"
+              heavy_shard_file="$(mktemp)"
               tr -d '\r' < ../.github/ci/treedb_windows_caching_heavy_tests.txt | grep -v '^#' | sed '/^$/d' > "$heavy_file"
-              regex="^($(paste -sd'|' "$heavy_file"))$"
-              echo "TreeDB/caching heavy regex=${regex}"
+              heavy_shard_index="${{ matrix.heavy_shard_index }}"
+              heavy_shard_count="${{ matrix.heavy_shard_count }}"
+              if [ -z "$heavy_shard_index" ]; then
+                heavy_shard_index=0
+              fi
+              if [ -z "$heavy_shard_count" ] || [ "$heavy_shard_count" -lt 1 ]; then
+                heavy_shard_count=1
+              fi
+              awk -v idx="$heavy_shard_index" -v n="$heavy_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$heavy_file" > "$heavy_shard_file"
+              if ! [ -s "$heavy_shard_file" ]; then
+                echo "no heavy caching tests found for shard ${heavy_shard_index}/${heavy_shard_count}; skipping"
+                printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB/caching"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-test.jsonl
+                rm -f "$heavy_file" "$heavy_shard_file"
+                exit 0
+              fi
+              regex="^($(paste -sd'|' "$heavy_shard_file"))$"
+              echo "TreeDB/caching heavy shard=${heavy_shard_index}/${heavy_shard_count} regex=${regex}"
               go test -json -timeout 30m -p 1 ./caching -run "$regex" | tee treedb-test.jsonl
-              rm -f "$heavy_file"
+              rm -f "$heavy_file" "$heavy_shard_file"
               ;;
             windows-caching-rest)
               heavy_file="$(mktemp)"
@@ -144,8 +194,18 @@ jobs:
             TreeDB/treedb-test.jsonl.summary.md
 
   race:
-    name: race-check (linux)
+    name: race-check (linux)-${{ matrix.shard }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            shard_index: 0
+            shard_count: 2
+          - shard: 2
+            shard_index: 1
+            shard_count: 2
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -164,7 +224,27 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./... | tee treedb-race.jsonl
+          shard_index="${{ matrix.shard_index }}"
+          shard_count="${{ matrix.shard_count }}"
+          package_file="$(mktemp)"
+          db_test_file="$(mktemp)"
+          go list ./... | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+          go test ./db -list 'Test.*' | grep '^Test' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$db_test_file"
+          if ! [ -s "$package_file" ]; then
+            echo "no packages found for race shard ${shard_index}/${shard_count}; skipping"
+            printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-race.jsonl
+            rm -f "$package_file" "$db_test_file"
+            exit 0
+          fi
+          echo "TreeDB race package shard=${shard_index}/${shard_count}"
+          cat "$package_file"
+          GOMEMLIMIT=4GiB GOMAXPROCS=2 xargs go test -json -race -p 1 < "$package_file" | tee treedb-race.jsonl
+          if [ -s "$db_test_file" ]; then
+            db_regex="^($(paste -sd'|' "$db_test_file"))$"
+            echo "TreeDB/db race test shard=${shard_index}/${shard_count} regex=${db_regex}"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./db -run "$db_regex" | tee -a treedb-race.jsonl
+          fi
+          rm -f "$package_file" "$db_test_file"
 
       - name: Summarize race timing
         if: always()
@@ -182,7 +262,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: treedb-race-json-linux
+          name: treedb-race-json-linux-${{ matrix.shard }}
           path: |
             TreeDB/treedb-race.jsonl
             TreeDB/treedb-race.jsonl.summary.md

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -18,10 +18,12 @@ jobs:
             os: ubuntu-latest
             timeout: 15
             shard_kind: all
+            run_vet: true
           - name: macos-latest
             os: macos-latest
             timeout: 15
             shard_kind: all
+            run_vet: true
           - name: windows-core-1
             os: windows-latest
             timeout: 25

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -22,14 +22,32 @@ jobs:
             os: macos-latest
             timeout: 15
             shard_kind: all
-          - name: windows-core
+          - name: windows-core-1
             os: windows-latest
             timeout: 25
             shard_kind: windows-core
-          - name: windows-caching-heavy
+            package_shard_index: 0
+            package_shard_count: 2
+            run_vet: true
+          - name: windows-core-2
+            os: windows-latest
+            timeout: 25
+            shard_kind: windows-core
+            package_shard_index: 1
+            package_shard_count: 2
+            run_vet: false
+          - name: windows-caching-heavy-1
             os: windows-latest
             timeout: 25
             shard_kind: windows-caching-heavy
+            heavy_shard_index: 0
+            heavy_shard_count: 2
+          - name: windows-caching-heavy-2
+            os: windows-latest
+            timeout: 25
+            shard_kind: windows-caching-heavy
+            heavy_shard_index: 1
+            heavy_shard_count: 2
           - name: windows-caching-rest-1
             os: windows-latest
             timeout: 25
@@ -62,7 +80,7 @@ jobs:
             go.sum
 
       - name: Vet
-        if: ${{ matrix.shard_kind != 'windows-caching-heavy' && matrix.shard_kind != 'windows-caching-rest' }}
+        if: ${{ matrix.run_vet != false && matrix.shard_kind != 'windows-caching-heavy' && matrix.shard_kind != 'windows-caching-rest' }}
         working-directory: TreeDB
         run: go vet ./...
 
@@ -79,16 +97,92 @@ jobs:
               go test -json -timeout 30m -p 1 ./... | tee treedb-test.jsonl
               ;;
             windows-core)
-              packages=$(go list ./... | grep -v '^github.com/snissn/gomap/TreeDB/caching$')
-              go test -json -timeout 30m -p 1 $packages | tee treedb-test.jsonl
+              package_shard_index="${{ matrix.package_shard_index }}"
+              package_shard_count="${{ matrix.package_shard_count }}"
+              if [ -z "$package_shard_index" ]; then
+                package_shard_index=0
+              fi
+              if [ -z "$package_shard_count" ] || [ "$package_shard_count" -lt 1 ]; then
+                package_shard_count=1
+              fi
+              package_file="$(mktemp)"
+              root_all_file="$(mktemp)"
+              root_test_file="$(mktemp)"
+              db_all_file="$(mktemp)"
+              db_test_file="$(mktemp)"
+              go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+              go test . -list 'Test.*' | tr -d '\r' | grep '^Test' > "$root_all_file"
+              go test ./db -list 'Test.*' | tr -d '\r' | grep '^Test' > "$db_all_file"
+              if [ "$package_shard_count" -eq 2 ]; then
+                case "$package_shard_index" in
+                  0)
+                    grep -F -x 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file" || true
+                    grep -F -x 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file" || true
+                    ;;
+                  1)
+                    grep -F -x -v 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file"
+                    grep -F -x -v 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file"
+                    ;;
+                  *)
+                    : > "$root_test_file"
+                    : > "$db_test_file"
+                    ;;
+                esac
+              else
+                awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$root_all_file" > "$root_test_file"
+                awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$db_all_file" > "$db_test_file"
+              fi
+              echo "TreeDB windows-core package shard=${package_shard_index}/${package_shard_count}"
+              xargs go test -json -timeout 30m -p 1 < "$package_file" | tee treedb-test.jsonl
+              if [ -s "$root_test_file" ]; then
+                root_regex="^($(paste -sd'|' "$root_test_file"))$"
+                echo "TreeDB root test shard=${package_shard_index}/${package_shard_count} regex=${root_regex}"
+                go test -json -timeout 30m -p 1 . -run "$root_regex" | tee -a treedb-test.jsonl
+              fi
+              if [ -s "$db_test_file" ]; then
+                db_regex="^($(paste -sd'|' "$db_test_file"))$"
+                echo "TreeDB/db test shard=${package_shard_index}/${package_shard_count} regex=${db_regex}"
+                go test -json -timeout 30m -p 1 ./db -run "$db_regex" | tee -a treedb-test.jsonl
+              fi
+              rm -f "$package_file" "$root_all_file" "$root_test_file" "$db_all_file" "$db_test_file"
               ;;
             windows-caching-heavy)
               heavy_file="$(mktemp)"
+              heavy_shard_file="$(mktemp)"
               tr -d '\r' < ../.github/ci/treedb_windows_caching_heavy_tests.txt | grep -v '^#' | sed '/^$/d' > "$heavy_file"
-              regex="^($(paste -sd'|' "$heavy_file"))$"
-              echo "TreeDB/caching heavy regex=${regex}"
+              heavy_shard_index="${{ matrix.heavy_shard_index }}"
+              heavy_shard_count="${{ matrix.heavy_shard_count }}"
+              if [ -z "$heavy_shard_index" ]; then
+                heavy_shard_index=0
+              fi
+              if [ -z "$heavy_shard_count" ] || [ "$heavy_shard_count" -lt 1 ]; then
+                heavy_shard_count=1
+              fi
+              if [ "$heavy_shard_count" -eq 2 ]; then
+                case "$heavy_shard_index" in
+                  0)
+                    grep -F -x 'TestCachedGenerationalMaintenance_LeafRefsRemainReopenable' "$heavy_file" > "$heavy_shard_file"
+                    ;;
+                  1)
+                    grep -F -x -v 'TestCachedGenerationalMaintenance_LeafRefsRemainReopenable' "$heavy_file" > "$heavy_shard_file"
+                    ;;
+                  *)
+                    : > "$heavy_shard_file"
+                    ;;
+                esac
+              else
+                awk -v idx="$heavy_shard_index" -v n="$heavy_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$heavy_file" > "$heavy_shard_file"
+              fi
+              if ! [ -s "$heavy_shard_file" ]; then
+                echo "no heavy caching tests found for shard ${heavy_shard_index}/${heavy_shard_count}; skipping"
+                printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB/caching"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-test.jsonl
+                rm -f "$heavy_file" "$heavy_shard_file"
+                exit 0
+              fi
+              regex="^($(paste -sd'|' "$heavy_shard_file"))$"
+              echo "TreeDB/caching heavy shard=${heavy_shard_index}/${heavy_shard_count} regex=${regex}"
               go test -json -timeout 30m -p 1 ./caching -run "$regex" | tee treedb-test.jsonl
-              rm -f "$heavy_file"
+              rm -f "$heavy_file" "$heavy_shard_file"
               ;;
             windows-caching-rest)
               heavy_file="$(mktemp)"
@@ -144,8 +238,18 @@ jobs:
             TreeDB/treedb-test.jsonl.summary.md
 
   race:
-    name: race-check (linux)
+    name: race-check (linux)-${{ matrix.shard }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            shard_index: 0
+            shard_count: 2
+          - shard: 2
+            shard_index: 1
+            shard_count: 2
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -164,7 +268,67 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./... | tee treedb-race.jsonl
+          shard_index="${{ matrix.shard_index }}"
+          shard_count="${{ matrix.shard_count }}"
+          package_file="$(mktemp)"
+          root_all_file="$(mktemp)"
+          root_test_file="$(mktemp)"
+          caching_all_file="$(mktemp)"
+          caching_test_file="$(mktemp)"
+          db_all_file="$(mktemp)"
+          db_test_file="$(mktemp)"
+          go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+          go test . -list 'Test.*' | grep '^Test' > "$root_all_file"
+          go test ./caching -list 'Test.*' | grep '^Test' > "$caching_all_file"
+          go test ./db -list 'Test.*' | grep '^Test' > "$db_all_file"
+          if [ "$shard_count" -eq 2 ]; then
+            case "$shard_index" in
+              0)
+                grep -F -x 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file" || true
+                grep -F -x 'TestCheckpoint_KickSkipsWhenMaintenancePhaseNonSteady' "$caching_all_file" > "$caching_test_file" || true
+                grep -F -x 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file" || true
+                ;;
+              1)
+                grep -F -x -v 'TestProfileFast_BulkRestoreMaintainsKeyValueParity' "$root_all_file" > "$root_test_file"
+                grep -F -x -v 'TestCheckpoint_KickSkipsWhenMaintenancePhaseNonSteady' "$caching_all_file" > "$caching_test_file"
+                grep -F -x -v 'TestValidateFragmentationReport_EndToEnd' "$db_all_file" > "$db_test_file"
+                ;;
+              *)
+                : > "$root_test_file"
+                : > "$caching_test_file"
+                : > "$db_test_file"
+                ;;
+            esac
+          else
+            awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$root_all_file" > "$root_test_file"
+            awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$caching_all_file" > "$caching_test_file"
+            awk -v idx="$shard_index" -v n="$shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$db_all_file" > "$db_test_file"
+          fi
+          if ! [ -s "$package_file" ]; then
+            echo "no packages found for race shard ${shard_index}/${shard_count}; skipping"
+            printf '{"Time":"%s","Action":"skip","Package":"github.com/snissn/gomap/TreeDB"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > treedb-race.jsonl
+            rm -f "$package_file" "$root_all_file" "$root_test_file" "$caching_all_file" "$caching_test_file" "$db_all_file" "$db_test_file"
+            exit 0
+          fi
+          echo "TreeDB race package shard=${shard_index}/${shard_count}"
+          cat "$package_file"
+          GOMEMLIMIT=4GiB GOMAXPROCS=2 xargs go test -json -race -p 1 < "$package_file" | tee treedb-race.jsonl
+          if [ -s "$root_test_file" ]; then
+            root_regex="^($(paste -sd'|' "$root_test_file"))$"
+            echo "TreeDB root race test shard=${shard_index}/${shard_count} regex=${root_regex}"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 . -run "$root_regex" | tee -a treedb-race.jsonl
+          fi
+          if [ -s "$caching_test_file" ]; then
+            caching_regex="^($(paste -sd'|' "$caching_test_file"))$"
+            echo "TreeDB/caching race test shard=${shard_index}/${shard_count} regex=${caching_regex}"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./caching -run "$caching_regex" | tee -a treedb-race.jsonl
+          fi
+          if [ -s "$db_test_file" ]; then
+            db_regex="^($(paste -sd'|' "$db_test_file"))$"
+            echo "TreeDB/db race test shard=${shard_index}/${shard_count} regex=${db_regex}"
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./db -run "$db_regex" | tee -a treedb-race.jsonl
+          fi
+          rm -f "$package_file" "$root_all_file" "$root_test_file" "$caching_all_file" "$caching_test_file" "$db_all_file" "$db_test_file"
 
       - name: Summarize race timing
         if: always()
@@ -182,7 +346,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: treedb-race-json-linux
+          name: treedb-race-json-linux-${{ matrix.shard }}
           path: |
             TreeDB/treedb-race.jsonl
             TreeDB/treedb-race.jsonl.summary.md

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -137,8 +137,8 @@ jobs:
                     grep -F -x -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                     ;;
                   1)
-                    grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file"
-                    grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file"
+                    grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file" || true
+                    grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                     ;;
                   *)
                     : > "$root_test_file"
@@ -192,7 +192,7 @@ jobs:
                     grep -F -x -f "$heavy_pin_file" "$heavy_file" > "$heavy_shard_file"
                     ;;
                   1)
-                    grep -F -x -v -f "$heavy_pin_file" "$heavy_file" > "$heavy_shard_file"
+                    grep -F -x -v -f "$heavy_pin_file" "$heavy_file" > "$heavy_shard_file" || true
                     ;;
                   *)
                     : > "$heavy_shard_file"
@@ -330,9 +330,9 @@ jobs:
                 grep -F -x -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                 ;;
               1)
-                grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file"
-                grep -F -x -v -f "$caching_pin_file" "$caching_all_file" > "$caching_test_file"
-                grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file"
+                grep -F -x -v -f "$root_pin_file" "$root_all_file" > "$root_test_file" || true
+                grep -F -x -v -f "$caching_pin_file" "$caching_all_file" > "$caching_test_file" || true
+                grep -F -x -v -f "$db_pin_file" "$db_all_file" > "$db_test_file" || true
                 ;;
               *)
                 : > "$root_test_file"

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -91,7 +91,7 @@ jobs:
           GOMEMLIMIT: 4GiB
           GOMAXPROCS: 2
         run: |
-          set -o pipefail
+          set -e -o pipefail
           case "${{ matrix.shard_kind }}" in
             all)
               go test -json -timeout 30m -p 1 ./... | tee treedb-test.jsonl
@@ -267,7 +267,7 @@ jobs:
         working-directory: TreeDB
         shell: bash
         run: |
-          set -o pipefail
+          set -e -o pipefail
           shard_index="${{ matrix.shard_index }}"
           shard_count="${{ matrix.shard_count }}"
           package_file="$(mktemp)"


### PR DESCRIPTION
## Summary
- split the root Ubuntu workflow into two test shards
- split TreeDB Windows core, Windows caching-heavy, and Linux race jobs into paired shards
- use weighted regex shards for the known slow TreeDB packages/tests so paired children have closer wall time

## Validation
- ruby YAML parse for edited workflows
- actionlint for edited workflows
- git diff --check
- previous pushed CI passed for the split branch before merging latest main

## Latest observed split timings before refresh
- Root Ubuntu: ~5m -> ~2m38s max
- TreeDB race-check: ~7m -> ~5m17s max
- TreeDB windows-core: ~5m -> ~4m32s max
- TreeDB windows-caching-heavy: ~7m -> ~6m00s max, still bounded by one single long test
