### PR TITLE
[codex] Route Mongo BSON set updates through structured path

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -416,8 +416,9 @@ type CollectionUpdateStats struct {
 	Callback        time.Duration
 	// StructuredUpdateApply measures built-in structured update application,
 	// such as BSON $set, separately from user callback time.
-	StructuredUpdateApply time.Duration
-	PrepareDocuments      time.Duration
+	StructuredUpdateApply        time.Duration
+	StructuredUpdateApplications int
+	PrepareDocuments             time.Duration
 	// IndexStateExtraction includes both OldIndexStateExtract and
 	// NewIndexStateExtract; do not add all three together.
 	IndexStateExtraction time.Duration
@@ -9696,6 +9697,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	var changed bool
 	if hasBSONSet {
 		document, changed, err = callBSONSetUpdateApply(bsonSet, currentValue)
+		stats.StructuredUpdateApplications++
 		stats.StructuredUpdateApply += updateBatchStatsSince(detailedStats, phaseStart)
 	} else {
 		document, changed, err = callCollectionUpdateCallback(update, currentValue)
@@ -11172,6 +11174,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		if item.hasBSONSet {
 			phaseStart = updateBatchStatsNow(detailedStats)
 			scratch.bsonSetDocumentScratch, document, changedOne, err = callBSONSetUpdateAppendReplacement(item.bsonSet, scratch.bsonSetDocumentScratch[:0], current.value)
+			stats.StructuredUpdateApplications++
 			stats.StructuredUpdateApply += updateBatchStatsSince(detailedStats, phaseStart)
 			// When changedOne is true, document aliases bsonSetDocumentScratch
 			// until it is copied into the plan document arena below. No-op

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10849,7 +10849,7 @@ func TestCollectionUpdateBSONSetRequiresBSONFormat(t *testing.T) {
 	}
 }
 
-func TestCollectionUpdateBSONSetBatchEmptyReturnsEmptyResults(t *testing.T) {
+func TestCollectionUpdateBSONSetBatchEmptyMatchesUpdateBatchResultShape(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -10875,12 +10875,12 @@ func TestCollectionUpdateBSONSetBatchEmptyReturnsEmptyResults(t *testing.T) {
 	if !batched {
 		t.Fatal("batched=false want true")
 	}
-	if results == nil || len(results) != 0 {
-		t.Fatalf("results=%v want non-nil empty slice", results)
+	if results != nil {
+		t.Fatalf("results=%v want nil empty-batch result", results)
 	}
 }
 
-func TestCollectionUpdateBSONSetBatchDuplicateIDWrapsItemError(t *testing.T) {
+func TestCollectionUpdateBSONSetBatchDuplicateIDMatchesUpdateBatchErrorShape(t *testing.T) {
 	_, err := prepareBSONSetUpdateBatchItems([]BSONSetUpdateBatchItem{
 		{DocumentID: []byte("u1")},
 		{DocumentID: []byte("u1")},
@@ -10889,11 +10889,8 @@ func TestCollectionUpdateBSONSetBatchDuplicateIDWrapsItemError(t *testing.T) {
 		t.Fatalf("duplicate err=%v want ErrDuplicateDocumentID", err)
 	}
 	var itemErr *UpdateBatchItemError
-	if !errors.As(err, &itemErr) {
-		t.Fatalf("duplicate err=%T want UpdateBatchItemError", err)
-	}
-	if itemErr.Index != 1 {
-		t.Fatalf("duplicate item index=%d want 1", itemErr.Index)
+	if errors.As(err, &itemErr) {
+		t.Fatalf("duplicate err=%T want plain duplicate validation error", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10720,6 +10720,9 @@ func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
 		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
 	}
 	stats := col.LastUpdateStats()
+	if got, want := stats.StructuredUpdateApplications, 1; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
+	}
 	if stats.IndexValueChanges != 1 || stats.IndexValueUnchanged != 2 || stats.UniqueIndexCheckSkips != 1 {
 		t.Fatalf("index stats changes=%d unchanged=%d unique skips=%d want 1/2/1", stats.IndexValueChanges, stats.IndexValueUnchanged, stats.UniqueIndexCheckSkips)
 	}
@@ -10789,40 +10792,26 @@ func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.
 		t.Fatalf("flush insert buffer: %v", err)
 	}
 
-	var stats CollectionUpdateStats
-	sawStructuredApply := false
-	lastEmail := ""
-	const updateAttempts = 64
-	for i := 0; i < updateAttempts; i++ {
-		email := fmt.Sprintf("b%03d@example.com", i)
-		lastEmail = email
-		matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
-			Key:   "email",
-			Value: mustBSONRawValue(t, email),
-		}})
-		if err != nil {
-			t.Fatalf("UpdateBSONSet %d: %v", i, err)
-		}
-		if !matched || !modified {
-			t.Fatalf("update %d matched=%v modified=%v want true/true", i, matched, modified)
-		}
-		stats = col.LastUpdateStats()
-		if stats.StructuredUpdateApply > 0 {
-			sawStructuredApply = true
-			break
-		}
+	lastEmail := "b@example.com"
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "email",
+		Value: mustBSONRawValue(t, lastEmail),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
 	}
-	if stats.StructuredUpdateApply <= 0 {
-		t.Fatalf("structured apply duration remained %s after %d direct fallback updates", stats.StructuredUpdateApply, updateAttempts)
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.StructuredUpdateApplications, 1; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
 	}
 	if stats.Callback != 0 {
 		t.Fatalf("callback duration=%s want zero for BSON set direct fallback", stats.Callback)
 	}
 	if got, want := stats.UniqueIndexChecks, 1; got != want {
 		t.Fatalf("unique checks=%d want %d", got, want)
-	}
-	if !sawStructuredApply {
-		t.Fatal("structured apply timing was not observed")
 	}
 	ids, err := col.FindByIndex("email", lastEmail)
 	if err != nil {
@@ -10857,6 +10846,54 @@ func TestCollectionUpdateBSONSetRequiresBSONFormat(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "requires BSON document format") {
 		t.Fatalf("UpdateBSONSet err=%q want BSON format error", err)
+	}
+}
+
+func TestCollectionUpdateBSONSetBatchEmptyReturnsEmptyResults(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(nil)
+	if err != nil {
+		t.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatal("batched=false want true")
+	}
+	if results == nil || len(results) != 0 {
+		t.Fatalf("results=%v want non-nil empty slice", results)
+	}
+}
+
+func TestCollectionUpdateBSONSetBatchDuplicateIDWrapsItemError(t *testing.T) {
+	_, err := prepareBSONSetUpdateBatchItems([]BSONSetUpdateBatchItem{
+		{DocumentID: []byte("u1")},
+		{DocumentID: []byte("u1")},
+	})
+	if !errors.Is(err, ErrDuplicateDocumentID) {
+		t.Fatalf("duplicate err=%v want ErrDuplicateDocumentID", err)
+	}
+	var itemErr *UpdateBatchItemError
+	if !errors.As(err, &itemErr) {
+		t.Fatalf("duplicate err=%T want UpdateBatchItemError", err)
+	}
+	if itemErr.Index != 1 {
+		t.Fatalf("duplicate item index=%d want 1", itemErr.Index)
 	}
 }
 

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -19,6 +19,13 @@ type BSONSetField struct {
 	Value bson.RawValue
 }
 
+// BSONSetUpdateBatchItem describes one structured top-level BSON $set update
+// in a batch. DocumentID must be non-empty and unique within the batch.
+type BSONSetUpdateBatchItem struct {
+	DocumentID []byte
+	Fields     []BSONSetField
+}
+
 type bsonSetUpdate struct {
 	fields       []BSONSetField
 	fieldIndexes map[string]int
@@ -92,6 +99,59 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 		return false, false, fmt.Errorf("collections: BSON $set result count %d for single update", len(results))
 	}
 	return results[0].Matched, results[0].Modified, nil
+}
+
+// UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges applies a batch of
+// structured top-level BSON $set updates only when no secondary unique index
+// value changes in the planning snapshot. This is the BSON-set equivalent of
+// UpdateBatchIfNoSecondaryUniqueIndexChanges.
+func (c *Collection) UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(items []BSONSetUpdateBatchItem) ([]UpdateBatchResult, bool, error) {
+	return c.updateBSONSetBatch(items, updateBatchModeNoSecondaryUniqueIndexChanges)
+}
+
+func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, bool, error) {
+	if c == nil {
+		return nil, false, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, false, errCollectionDBNil
+	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, false, err
+	}
+	if err := c.validateBSONSetDocumentFormat(); err != nil {
+		return nil, false, err
+	}
+	if len(items) == 0 {
+		c.setLastUpdateStats(CollectionUpdateStats{})
+		return nil, true, nil
+	}
+	ownedItems, err := prepareBSONSetUpdateBatchItems(items)
+	if err != nil {
+		return nil, false, err
+	}
+	return c.updateBatchOwnedItems(ownedItems, mode)
+}
+
+func prepareBSONSetUpdateBatchItems(items []BSONSetUpdateBatchItem) ([]updateBatchItem, error) {
+	out := make([]updateBatchItem, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for i, item := range items {
+		if len(item.DocumentID) == 0 {
+			return nil, fmt.Errorf("collections: document id cannot be empty at index %d", i)
+		}
+		key := string(item.DocumentID)
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
+		}
+		seen[key] = struct{}{}
+		spec, err := newBSONSetUpdate(item.Fields)
+		if err != nil {
+			return nil, updateBatchItemError(i, err)
+		}
+		out[i] = newBSONSetUpdateBatchItem(item.DocumentID, spec)
+	}
+	return out, nil
 }
 
 func newBSONSetUpdate(fields []BSONSetField) (bsonSetUpdate, error) {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/maphash"
 	"strings"
 	"unsafe"
 
@@ -39,6 +40,8 @@ const (
 	bsonSetFieldIndexMapThreshold = 8
 	bsonSetReplacementSlackBytes  = 64
 )
+
+var bsonSetBatchDocumentIDHashSeed = maphash.MakeSeed()
 
 // UpdateBSONSet applies a structured top-level BSON $set update to one
 // document. The collection must use DocumentFormatBSON. Missing documents
@@ -124,7 +127,7 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 	}
 	if len(items) == 0 {
 		c.setLastUpdateStats(CollectionUpdateStats{})
-		return nil, true, nil
+		return []UpdateBatchResult{}, true, nil
 	}
 	ownedItems, err := prepareBSONSetUpdateBatchItems(items)
 	if err != nil {
@@ -135,16 +138,26 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 
 func prepareBSONSetUpdateBatchItems(items []BSONSetUpdateBatchItem) ([]updateBatchItem, error) {
 	out := make([]updateBatchItem, len(items))
-	seen := make(map[string]struct{}, len(items))
+	seen := make(map[uint64]int, len(items))
+	collisions := make(map[uint64][]int)
 	for i, item := range items {
 		if len(item.DocumentID) == 0 {
 			return nil, fmt.Errorf("collections: document id cannot be empty at index %d", i)
 		}
-		key := string(item.DocumentID)
-		if _, ok := seen[key]; ok {
-			return nil, fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
+		hash := maphash.Bytes(bsonSetBatchDocumentIDHashSeed, item.DocumentID)
+		if first, ok := seen[hash]; ok {
+			if bytes.Equal(items[first].DocumentID, item.DocumentID) {
+				return nil, updateBatchItemError(i, ErrDuplicateDocumentID)
+			}
+			for _, prev := range collisions[hash] {
+				if bytes.Equal(items[prev].DocumentID, item.DocumentID) {
+					return nil, updateBatchItemError(i, ErrDuplicateDocumentID)
+				}
+			}
+			collisions[hash] = append(collisions[hash], i)
+		} else {
+			seen[hash] = i
 		}
-		seen[key] = struct{}{}
 		spec, err := newBSONSetUpdate(item.Fields)
 		if err != nil {
 			return nil, updateBatchItemError(i, err)

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -127,7 +127,7 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 	}
 	if len(items) == 0 {
 		c.setLastUpdateStats(CollectionUpdateStats{})
-		return []UpdateBatchResult{}, true, nil
+		return nil, true, nil
 	}
 	ownedItems, err := prepareBSONSetUpdateBatchItems(items)
 	if err != nil {
@@ -147,11 +147,11 @@ func prepareBSONSetUpdateBatchItems(items []BSONSetUpdateBatchItem) ([]updateBat
 		hash := maphash.Bytes(bsonSetBatchDocumentIDHashSeed, item.DocumentID)
 		if first, ok := seen[hash]; ok {
 			if bytes.Equal(items[first].DocumentID, item.DocumentID) {
-				return nil, updateBatchItemError(i, ErrDuplicateDocumentID)
+				return nil, fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
 			}
 			for _, prev := range collisions[hash] {
 				if bytes.Equal(items[prev].DocumentID, item.DocumentID) {
-					return nil, updateBatchItemError(i, ErrDuplicateDocumentID)
+					return nil, fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
 				}
 			}
 			collisions[hash] = append(collisions[hash], i)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -447,11 +447,12 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 }
 
 type mongoUpdateItem struct {
-	index       int
-	key         []byte
-	updateDoc   wire.Document
-	setFields   map[string]struct{}
-	setFieldsOK bool
+	index         int
+	key           []byte
+	updateDoc     wire.Document
+	setFields     map[string]struct{}
+	bsonSetFields []collections.BSONSetField
+	setFieldsOK   bool
 }
 
 type mongoUpdateParseError struct {
@@ -491,8 +492,8 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
-	setFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
-	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc, setFields: setFields, setFieldsOK: setFieldsOK}, nil
+	setFields, bsonSetFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
+	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc, setFields: setFields, bsonSetFields: bsonSetFields, setFieldsOK: setFieldsOK}, nil
 }
 
 func mongoUpdateParseCommandError(err error) (wire.Document, error) {
@@ -541,6 +542,10 @@ func mongoUpdateErrorWithIndex(index int, err error) error {
 }
 
 func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
+	if mongoUpdateCanUseBSONSet(col, update) {
+		matched, modified, err := col.UpdateBSONSet(update.key, update.bsonSetFields)
+		return matched, modified, mongoUpdateErrorWithIndex(update.index, err)
+	}
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
 		return false, false, fmt.Errorf("updates[%d]: %w", update.index, err)
@@ -574,6 +579,16 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpdateItem) ([]collections.UpdateBatchResult, bool, error) {
 	if !mongoUpdateItemsCanUseBatch(col, updates) {
 		return make([]collections.UpdateBatchResult, len(updates)), false, nil
+	}
+	if mongoUpdateItemsCanUseBSONSet(col, updates) {
+		items := make([]collections.BSONSetUpdateBatchItem, len(updates))
+		for i, update := range updates {
+			items[i] = collections.BSONSetUpdateBatchItem{
+				DocumentID: update.key,
+				Fields:     update.bsonSetFields,
+			}
+		}
+		return col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(items)
 	}
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
@@ -1075,6 +1090,33 @@ func mongoUpdateCanUseBatch(col *collections.Collection, update mongoUpdateItem)
 	return mongoUpdateCanUseBatchMeta(col.Meta(), update)
 }
 
+func mongoUpdateItemsCanUseBSONSet(col *collections.Collection, updates []mongoUpdateItem) bool {
+	if col == nil || normalizedMongoUpdateDocumentFormat(col) != collections.DocumentFormatBSON {
+		return false
+	}
+	for _, update := range updates {
+		if !update.setFieldsOK {
+			return false
+		}
+	}
+	return true
+}
+
+func mongoUpdateCanUseBSONSet(col *collections.Collection, update mongoUpdateItem) bool {
+	return col != nil && normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.setFieldsOK
+}
+
+func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collections.DocumentFormat {
+	if col == nil {
+		return collections.DocumentFormatDefault
+	}
+	format := col.Meta().Options.DocumentFormat
+	if format == collections.DocumentFormatDefault {
+		return collections.DocumentFormatJSON
+	}
+	return format
+}
+
 func mongoUpdateCanUseBatchMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
 	if !update.setFieldsOK {
 		return false
@@ -1097,28 +1139,33 @@ func mongoUpdateSetFieldsTouchSecondaryUniqueIndexMeta(meta collections.Collecti
 	return false
 }
 
-func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, bool) {
+func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, []collections.BSONSetField, bool) {
 	updateElements, err := bson.Raw(updateDoc).Elements()
 	if err != nil || len(updateElements) != 1 {
-		return nil, false
+		return nil, nil, false
 	}
 	operator, err := updateElements[0].KeyErr()
 	if err != nil || operator != "$set" {
-		return nil, false
+		return nil, nil, false
 	}
 	setDoc, ok := updateElements[0].Value().DocumentOK()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
-	order, err := parseSetFieldNames(setDoc)
+	sets, order, err := parseSetDocument(setDoc)
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
 	out := make(map[string]struct{}, len(order))
+	fields := make([]collections.BSONSetField, 0, len(order))
 	for _, field := range order {
 		out[field] = struct{}{}
+		fields = append(fields, collections.BSONSetField{
+			Key:   field,
+			Value: sets[field],
+		})
 	}
-	return out, true
+	return out, fields, true
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -440,29 +440,23 @@ func TestRunMongoUpdateOneUsesBSONSetFastPath(t *testing.T) {
 		t.Fatalf("flush: %v", err)
 	}
 
-	var stats collections.CollectionUpdateStats
-	for i := 0; i < 64; i++ {
-		update, err := parseMongoUpdateItem(i, mustDocument(t, bson.D{
-			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
-			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: fmt.Sprintf("city-%d", i)}}}}},
-		}))
-		if err != nil {
-			t.Fatalf("parse update %d: %v", i, err)
-		}
-		matched, modified, err := runMongoUpdateOne(col, update)
-		if err != nil {
-			t.Fatalf("run update %d: %v", i, err)
-		}
-		if !matched || !modified {
-			t.Fatalf("update %d matched=%v modified=%v want true/true", i, matched, modified)
-		}
-		stats = col.LastUpdateStats()
-		if stats.StructuredUpdateApply > 0 {
-			break
-		}
+	update, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}},
+	}))
+	if err != nil {
+		t.Fatalf("parse update: %v", err)
 	}
-	if stats.StructuredUpdateApply <= 0 {
-		t.Fatalf("structured apply duration remained %s", stats.StructuredUpdateApply)
+	matched, modified, err := runMongoUpdateOne(col, update)
+	if err != nil {
+		t.Fatalf("run update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.StructuredUpdateApplications, 1; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
 	}
 	if stats.Callback != 0 {
 		t.Fatalf("callback duration=%s want zero for BSON set gateway update", stats.Callback)
@@ -1002,8 +996,8 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
 	}
 	stats := col.LastUpdateStats()
-	if stats.StructuredUpdateApply <= 0 {
-		t.Fatalf("structured apply duration=%s want positive for BSON set gateway batch", stats.StructuredUpdateApply)
+	if got, want := stats.StructuredUpdateApplications, 2; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
 	}
 	if stats.Callback != 0 {
 		t.Fatalf("callback duration=%s want zero for BSON set gateway batch", stats.Callback)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -405,6 +405,70 @@ func TestServerUpdateAndDeleteByID(t *testing.T) {
 	}
 }
 
+func TestRunMongoUpdateOneUsesBSONSetFastPath(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := collections.NewCollectionManager(db)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "app.users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	key, stored, err := prepareInsertDocument(mustDocument(t, bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "city", Value: "hnl"},
+	}), collections.DocumentFormatBSON)
+	if err != nil {
+		t.Fatalf("prepare insert: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{key}, [][]byte{stored}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	var stats collections.CollectionUpdateStats
+	for i := 0; i < 64; i++ {
+		update, err := parseMongoUpdateItem(i, mustDocument(t, bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: fmt.Sprintf("city-%d", i)}}}}},
+		}))
+		if err != nil {
+			t.Fatalf("parse update %d: %v", i, err)
+		}
+		matched, modified, err := runMongoUpdateOne(col, update)
+		if err != nil {
+			t.Fatalf("run update %d: %v", i, err)
+		}
+		if !matched || !modified {
+			t.Fatalf("update %d matched=%v modified=%v want true/true", i, matched, modified)
+		}
+		stats = col.LastUpdateStats()
+		if stats.StructuredUpdateApply > 0 {
+			break
+		}
+	}
+	if stats.StructuredUpdateApply <= 0 {
+		t.Fatalf("structured apply duration remained %s", stats.StructuredUpdateApply)
+	}
+	if stats.Callback != 0 {
+		t.Fatalf("callback duration=%s want zero for BSON set gateway update", stats.Callback)
+	}
+}
+
 func TestServerUpdateTemplateV1DefaultAddsFields(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -828,10 +892,21 @@ func TestRunMongoUpdateBatchDeclinesFreshSecondaryUniqueIndex(t *testing.T) {
 	if _, err := fresh.CreateIndex(collections.IndexDefinition{Name: "email_1", Field: "email", ValueType: collections.IndexValueString, Unique: true}); err != nil {
 		t.Fatalf("create index: %v", err)
 	}
+	buildUpdateItem := func(index int, id string, update bson.D) mongoUpdateItem {
+		t.Helper()
+		item, err := parseMongoUpdateItem(index, mustDocument(t, bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: update},
+		}))
+		if err != nil {
+			t.Fatalf("parse update item: %v", err)
+		}
+		return item
+	}
 
 	matched, modified, batched, err := runMongoUpdateBatch(stale, []mongoUpdateItem{
-		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "c@example.com"}}}})},
-		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "a@example.com"}}}})},
+		buildUpdateItem(0, "u1", bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "c@example.com"}}}}),
+		buildUpdateItem(1, "u2", bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "a@example.com"}}}}),
 	})
 	if err != nil {
 		t.Fatalf("runMongoUpdateBatch: %v", err)
@@ -870,6 +945,7 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 	defer func() { _ = db.Close() }()
 
 	mgr := collections.NewCollectionManager(db)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
 	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
 		Name: "app.users",
 		Options: collections.CollectionOptions{
@@ -924,6 +1000,13 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 	}
 	if !batched || matched != 2 || modified != 2 {
 		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
+	}
+	stats := col.LastUpdateStats()
+	if stats.StructuredUpdateApply <= 0 {
+		t.Fatalf("structured apply duration=%s want positive for BSON set gateway batch", stats.StructuredUpdateApply)
+	}
+	if stats.Callback != 0 {
+		t.Fatalf("callback duration=%s want zero for BSON set gateway batch", stats.Callback)
 	}
 	after := db.State()
 	if after.CommitSeq != before.CommitSeq {


### PR DESCRIPTION
## Summary

- route Mongo gateway BSON `$set` `updateOne` calls through `Collection.UpdateBSONSet`
- add a structured BSON `$set` batch API for gateway coalesced updates
- assert gateway single and batched BSON `$set` paths report structured apply time instead of callback time

## Why

The `ID Update One: Throughput Vs Writer Client Count, 0 Indexes` benchmark goes through the Mongo driver/gateway update path. That path parsed simple `$set` updates for batching eligibility, but still applied them through generic callback materialization. BSON collections already have a preferred structured `$set` update path, so this PR wires the gateway into it.

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/collections`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run '^$' -bench 'BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2' -benchtime=100x -count=1`
