### PR TITLE
Buffer no-index BSON set updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3041,6 +3041,13 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func (c *Collection) canBufferNoIndexUpdateAck() bool {
+	return c != nil &&
+		c.db != nil &&
+		c.writeDomain != nil &&
+		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+}
+
 func (c *Collection) bufferNoIndexInsertBatch(
 	domain *collectionWriteDomain,
 	catalog *collectionCatalog,
@@ -10630,6 +10637,11 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 				}
 				if buffered {
 					c.meta = plan.meta
+					if plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && !c.canBufferNoIndexUpdateAck() {
+						if err := c.flushBufferedWrites(); err != nil {
+							return err
+						}
+					}
 					results = plan.results
 					return nil
 				}
@@ -10714,6 +10726,11 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 			return bufferErr
 		}
 		if buffered {
+			if plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && !c.canBufferNoIndexUpdateAck() {
+				if err := c.flushBufferedWrites(); err != nil {
+					return err
+				}
+			}
 			results = plan.results
 			return nil
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3488,14 +3488,18 @@ func (c *Collection) hasBufferedIndexedDeletesOnly() bool {
 	return domain.count > 0 && domain.indexedDeletesOnly
 }
 
-func (c *Collection) hasBufferedRootRuns() bool {
+func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedIndexedRootRuns(domain)
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) || len(domain.meta.Indexes) != 0 {
+		return false
+	}
+	documentFormat, err := normalizeDocumentFormat(domain.meta.Options.DocumentFormat)
+	return err == nil && documentFormat == DocumentFormatBSON
 }
 
 func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
@@ -7228,7 +7232,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			skipInitialNoIndexFlush = true
 		}
 	}
-	if skipInitialNoIndexFlush && c.hasBufferedRootRuns() {
+	if c.hasBufferedNoIndexBSONRootRuns() {
 		if err := c.flushBufferedWrites(); err != nil {
 			return nil, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3041,11 +3041,11 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
-func (c *Collection) canBufferNoIndexUpdateAck() bool {
-	return c != nil &&
-		c.db != nil &&
-		c.writeDomain != nil &&
-		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+func (c *Collection) canBufferDirectUpdateAck() bool {
+	if c == nil || c.db == nil || c.writeDomain == nil {
+		return false
+	}
+	return c.db.DurabilityMode() != backenddb.DurabilityWALOnRelaxed
 }
 
 func (c *Collection) bufferNoIndexInsertBatch(
@@ -10637,7 +10637,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 				}
 				if buffered {
 					c.meta = plan.meta
-					if plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && !c.canBufferNoIndexUpdateAck() {
+					if plan.directBufferedUpdate != nil && !c.canBufferDirectUpdateAck() {
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
 						}
@@ -10726,7 +10726,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 			return bufferErr
 		}
 		if buffered {
-			if plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && !c.canBufferNoIndexUpdateAck() {
+			if plan.directBufferedUpdate != nil && !c.canBufferDirectUpdateAck() {
 				if err := c.flushBufferedWrites(); err != nil {
 					return err
 				}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11752,6 +11752,10 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
+	if primaryOnlyDirectUpdate && domain.count != 0 && !hasBufferedIndexedRootRuns(domain) {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, nil
+	}
 	if domain.count != 0 {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3488,6 +3488,16 @@ func (c *Collection) hasBufferedIndexedDeletesOnly() bool {
 	return domain.count > 0 && domain.indexedDeletesOnly
 }
 
+func (c *Collection) hasBufferedRootRuns() bool {
+	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	return domain.count > 0 && hasBufferedIndexedRootRuns(domain)
+}
+
 func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
 	if !c.shouldBufferIndexedInserts(meta) {
 		return false
@@ -7218,6 +7228,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			skipInitialNoIndexFlush = true
 		}
 	}
+	if skipInitialNoIndexFlush && c.hasBufferedRootRuns() {
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+	}
 	if !skipInitialNoIndexFlush {
 		if err := c.flushBufferedNoIndex(); err != nil {
 			return nil, err
@@ -8619,6 +8634,18 @@ func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
 		}
 	}
 	return -1
+}
+
+func updateBatchItemsAllHaveBSONSet(items []updateBatchItem) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if !item.hasBSONSet {
+			return false
+		}
+	}
+	return true
 }
 
 func updateBatchItemError(index int, err error) error {
@@ -10499,13 +10526,14 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
 	if len(meta.Indexes) == 0 {
 		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
-			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON
+			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
+			structuredBSONSetBatch
 	}
 	if !meta.Options.BufferedIndexedWrites {
 		return false
@@ -11351,7 +11379,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed)
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, updateBatchItemsAllHaveBSONSet(items))
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10503,7 +10503,11 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
-	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+	if len(meta.Indexes) == 0 {
+		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON
+	}
+	if !meta.Options.BufferedIndexedWrites {
 		return false
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
@@ -10765,6 +10769,9 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
 	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
+	}
+	if len(meta.Indexes) == 0 {
+		return true
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
@@ -11709,7 +11716,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
-	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	primaryOnlyDirectUpdate := len(plan.meta.Indexes) == 0
+	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || (!primaryOnlyDirectUpdate && !plan.meta.Options.BufferedIndexedWrites) {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3045,7 +3045,7 @@ func (c *Collection) canBufferDirectUpdateAck() bool {
 	if c == nil || c.db == nil || c.writeDomain == nil {
 		return false
 	}
-	return c.db.DurabilityMode() != backenddb.DurabilityWALOnRelaxed
+	return c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
 func (c *Collection) bufferNoIndexInsertBatch(
@@ -11851,9 +11851,12 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
 	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, plan.rootNames)
-	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	shouldAutoFlushAfterAdding := false
+	if !primaryOnlyDirectUpdate {
+		shouldAutoFlushAfterAdding = shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	}
 	requiresPreAppendFreeze := false
-	if collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
 			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
 				requiresPreAppendFreeze = true
@@ -11991,15 +11994,19 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
 	c.meta = plan.meta
-	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
-	if err != nil {
-		if rollbackOnError {
-			rollbackBufferedIndexedDomain(domain, checkpoint)
-			c.meta = collectionMetaCheckpoint
+	var compactedObsolete []memtable.Table
+	if !primaryOnlyDirectUpdate {
+		var err error
+		compactedObsolete, err = maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
+		if err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return false, err
 		}
-		return false, err
 	}
-	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		freezePreAppendTables()
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10346,7 +10346,7 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUp
 }
 
 func TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -10445,7 +10445,7 @@ func TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns(t *testing.T
 }
 
 func TestCollectionUpdateBatchBuffersWhenSecondaryUniqueUnchanged(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -10669,7 +10669,7 @@ func TestCollectionUpdateBatchWithPendingIndexedRunsCallsCallbackOnce(t *testing
 }
 
 func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -10826,6 +10826,66 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxBytes:     1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	beforeState := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(7)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered despite indexed thresholds", afterUpdateState.CommitSeq-beforeState.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("buffered root runs root=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+}
+
 func TestCollectionUpdateBSONSetNoIndexWALOnFlushesBeforeAck(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOnRelaxed})
 	if err != nil {
@@ -10890,6 +10950,62 @@ func TestCollectionUpdateBSONSetNoIndexWALOnFlushesBeforeAck(t *testing.T) {
 	}
 	if score := bson.Raw(got).Lookup("score").Int32(); score != 7 {
 		t.Fatalf("score=%d want 7", score)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexDurableFlushesBeforeAck(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityDurable})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	beforeState := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(7)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want durable publish before ack", afterUpdateState.CommitSeq, beforeState.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("buffered root runs=%d want drained before durable ack", rootRunCount)
 	}
 }
 
@@ -11646,7 +11762,7 @@ func TestCollectionUpdateBSONSetValidatesCollectionBeforeFields(t *testing.T) {
 }
 
 func TestCollectionUpdateBatchDirectBufferedBSONDoesNotReserveUnchangedUnique(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -11800,7 +11916,7 @@ func TestCollectionUpdateBatchDirectBufferedBSONDoesNotReserveUnchangedUnique(t 
 }
 
 func TestCollectionUpdateBatchDirectBufferedTemplateV1AccumulatesRootRuns(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -11908,7 +12024,7 @@ func TestCollectionUpdateBatchDirectBufferedTemplateV1AccumulatesRootRuns(t *tes
 }
 
 func TestCollectionUpdateBatchDirectBufferedTemplateV1TemplateOnlySkipsSecondaryRoots(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -12015,7 +12131,7 @@ func TestCollectionUpdateBatchDirectBufferedTemplateV1TemplateOnlySkipsSecondary
 }
 
 func TestCollectionUpdateBatchDirectBufferedTemplateV1DoesNotReserveUnchangedUnique(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10753,7 +10753,7 @@ func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
 }
 
 func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -10823,6 +10823,73 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
 	}
 	if afterFlush := d.State(); afterFlush.CommitSeq != beforeState.CommitSeq+1 {
 		t.Fatalf("flush advanced commit seq to %d from %d, want one publish", afterFlush.CommitSeq, beforeState.CommitSeq)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexWALOnFlushesBeforeAck(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOnRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	beforeState := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(7)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want publish before ack", afterUpdateState.CommitSeq, beforeState.CommitSeq)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.BufferedBatches, 1; got != want {
+		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("buffered root runs=%d want drained before WAL-on ack", rootRunCount)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 7 {
+		t.Fatalf("score=%d want 7", score)
 	}
 }
 
@@ -10994,7 +11061,7 @@ func TestCollectionUpdateBSONSetNoIndexFlushesBeforePendingInsertTable(t *testin
 }
 
 func TestCollectionUpdateBSONSetNoIndexFlushesBeforeNormalInsertBatch(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10752,6 +10752,80 @@ func TestCollectionUpdateBSONSetReusesUnchangedIndexState(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	beforeState := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(7)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdateState.CommitSeq-beforeState.CommitSeq)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.BufferedBatches, 1; got != want {
+		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("buffered root runs root=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered update: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 7 {
+		t.Fatalf("buffered score=%d want 7", score)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update: %v", err)
+	}
+	if afterFlush := d.State(); afterFlush.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq to %d from %d, want one publish", afterFlush.CommitSeq, beforeState.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10896,6 +10896,168 @@ func TestCollectionUpdateBSONSetNoIndexFlushesPendingInsertTableBeforeBuffering(
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexFlushesBeforePendingInsertTable(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert initial: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush initial insert: %v", err)
+	}
+
+	beforeUpdate := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(11)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != beforeUpdate.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-beforeUpdate.CommitSeq)
+	}
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u2"},
+			{Key: "score", Value: int32(2)},
+		})},
+	); err != nil {
+		t.Fatalf("insert after buffered update: %v", err)
+	}
+	afterInsert := d.State()
+	if afterInsert.CommitSeq != beforeUpdate.CommitSeq+1 {
+		t.Fatalf("insert commit seq=%d before=%d want buffered update flushed once", afterInsert.CommitSeq, beforeUpdate.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	pendingTableRows := 0
+	if col.writeDomain.table != nil {
+		pendingTableRows = col.writeDomain.table.Len()
+	}
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if pendingTableRows != 1 || rootRunCount != 0 {
+		t.Fatalf("post-insert pending table/root runs=%d/%d want 1/0", pendingTableRows, rootRunCount)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed update: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 11 {
+		t.Fatalf("updated score=%d want 11", score)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get buffered insert: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 2 {
+		t.Fatalf("inserted score=%d want 2", score)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered insert: %v", err)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get flushed insert: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 2 {
+		t.Fatalf("flushed inserted score=%d want 2", score)
+	}
+}
+
+func TestCollectionUpdateNoIndexBSONCallbackPublishesSynchronously(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	beforeUpdate := d.State()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(5)},
+		}), true, nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != beforeUpdate.CommitSeq+1 {
+		t.Fatalf("Update commit seq=%d before=%d want synchronous publish", afterUpdate.CommitSeq, beforeUpdate.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("callback Update buffered root runs=%d want 0", rootRunCount)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 5 {
+		t.Fatalf("updated score=%d want 5", score)
+	}
+}
+
 func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10993,6 +10993,81 @@ func TestCollectionUpdateBSONSetNoIndexFlushesBeforePendingInsertTable(t *testin
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexFlushesBeforeNormalInsertBatch(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert initial: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush initial insert: %v", err)
+	}
+
+	beforeUpdate := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(13)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	if afterUpdate := d.State(); afterUpdate.CommitSeq != beforeUpdate.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-beforeUpdate.CommitSeq)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u2"},
+			{Key: "score", Value: int32(2)},
+		})},
+	); err != nil {
+		t.Fatalf("normal insert after buffered update: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after normal insert: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed update: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 13 {
+		t.Fatalf("updated score=%d want 13", score)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get normal insert: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 2 {
+		t.Fatalf("inserted score=%d want 2", score)
+	}
+}
+
 func TestCollectionUpdateNoIndexBSONCallbackPublishesSynchronously(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10826,6 +10826,76 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexFlushesPendingInsertTableBeforeBuffering(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(0)},
+		})},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if col.writeDomain == nil || col.writeDomain.count != 1 || col.writeDomain.table == nil || col.writeDomain.table.Len() != 1 {
+		t.Fatalf("pending insert state count/table=%v/%v want one table row", col.writeDomain.count, col.writeDomain.table)
+	}
+	beforeUpdate := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "score",
+		Value: mustBSONRawValue(t, int32(9)),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet after pending insert: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != beforeUpdate.CommitSeq+1 {
+		t.Fatalf("update commit seq=%d before=%d want one insert-table flush", afterUpdate.CommitSeq, beforeUpdate.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	pendingTableRows := 0
+	if col.writeDomain.table != nil {
+		pendingTableRows = col.writeDomain.table.Len()
+	}
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if pendingTableRows != 0 || rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("post-update pending table/root runs=%d/%d/%d want 0/1/1", pendingTableRows, rootRunCount, primaryRuns)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered update: %v", err)
+	}
+	if score := bson.Raw(got).Lookup("score").Int32(); score != 9 {
+		t.Fatalf("buffered score=%d want 9", score)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update: %v", err)
+	}
+}
+
 func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10893,6 +10893,85 @@ func TestCollectionUpdateBSONSetNoIndexWALOnFlushesBeforeAck(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBSONSetIndexedWALOnFlushesBeforeAck(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOnRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+		Indexes: []IndexDefinition{{
+			Name:      "email_1",
+			Field:     "email",
+			ValueType: IndexValueString,
+			Unique:    true,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u1"},
+				{Key: "email", Value: "u1@example.test"},
+				{Key: "score", Value: int32(0)},
+			}),
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u2"},
+				{Key: "email", Value: "u2@example.test"},
+				{Key: "score", Value: int32(0)},
+			}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	beforeState := d.State()
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{DocumentID: []byte("u1"), Fields: []BSONSetField{{Key: "score", Value: mustBSONRawValue(t, int32(7))}}},
+		{DocumentID: []byte("u2"), Fields: []BSONSetField{{Key: "score", Value: mustBSONRawValue(t, int32(8))}}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatal("batched=false want true")
+	}
+	for i, result := range results {
+		if !result.Matched || !result.Modified {
+			t.Fatalf("results[%d]=%+v want matched/modified", i, result)
+		}
+	}
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("UpdateBSONSetBatch commit seq=%d before=%d want publish before ack", afterUpdateState.CommitSeq, beforeState.CommitSeq)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.BufferedBatches, 1; got != want {
+		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("buffered root runs=%d want drained before WAL-on ack", rootRunCount)
+	}
+}
+
 func TestCollectionUpdateBSONSetNoIndexFlushesPendingInsertTableBeforeBuffering(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {

--- a/TreeDB/collections/update_minimization_direct_buffered_test.go
+++ b/TreeDB/collections/update_minimization_direct_buffered_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCollectionUpdateBatchDirectBufferedBSONSkipsUnchangedSecondaryRoots(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestCollectionUpdateBatchDirectBufferedBSONRejectsIDMutationBeforeStaging(t
 }
 
 func TestCollectionUpdateBatchDirectBufferedTemplateV1SeparatesTemplateAndSecondaryRoots(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1051,7 +1050,19 @@ func mongoUpdateCoalescerUsesSingleCollection(batch []mongoUpdateCoalescerReques
 		if col.SameCachedCatalog(req.col) {
 			continue
 		}
-		if !reflect.DeepEqual(baseMeta, req.col.Meta()) {
+		if !sameCollectionMetaForUpdateCoalescing(baseMeta, req.col.Meta()) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameCollectionMetaForUpdateCoalescing(a, b collections.CollectionMeta) bool {
+	if a.Name != b.Name || a.Options != b.Options || len(a.Indexes) != len(b.Indexes) {
+		return false
+	}
+	for i := range a.Indexes {
+		if a.Indexes[i] != b.Indexes[i] {
 			return false
 		}
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1042,8 +1043,15 @@ func mongoUpdateCoalescerUsesSingleCollection(batch []mongoUpdateCoalescerReques
 	if col == nil {
 		return false
 	}
+	baseMeta := col.Meta()
 	for _, req := range batch[1:] {
-		if !col.SameCachedCatalog(req.col) {
+		if req.col == nil {
+			return false
+		}
+		if col.SameCachedCatalog(req.col) {
+			continue
+		}
+		if !reflect.DeepEqual(baseMeta, req.col.Meta()) {
 			return false
 		}
 	}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -27,7 +27,7 @@ const (
 	defaultCursorBatchSize         = 101
 	defaultCursorIdleTimeout       = 10 * time.Minute
 	defaultCursorReapInterval      = time.Second
-	defaultUpdateCoalescingDelay   = 0
+	defaultUpdateCoalescingDelay   = 50 * time.Microsecond
 	defaultUpdateCoalescingBatch   = 256
 	maxUpdateCoalescingBatch       = 4096
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,8 +1239,28 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("coalesced BSON set updates advanced commit seq by %d before flush, want buffered", after.CommitSeq-before.CommitSeq)
+	}
+	for i, id := range []string{"u1", "u2"} {
+		findResponse := serveCommand(t, server, int32(2270+i), bson.D{
+			{Key: "find", Value: "users"},
+			{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "$db", Value: "app"},
+		})
+		firstBatch := cursorFirstBatch(t, findResponse)
+		if len(firstBatch) != 1 {
+			t.Fatalf("%s firstBatch len=%d want 1", id, len(firstBatch))
+		}
+		if score := firstBatch[0].Lookup("score").Int32(); score != int32(10+i) {
+			t.Fatalf("%s buffered score=%d want %d", id, score, 10+i)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush coalesced updates: %v", err)
+	}
+	if flushed := db.State(); flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("coalesced update flush advanced commit seq to %d from %d, want one publish", flushed.CommitSeq, before.CommitSeq)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -932,7 +932,7 @@ func TestRunMongoUpdateBatchResultsDeclineReturnsZeroResults(t *testing.T) {
 }
 
 func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *testing.T) {
-	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1177,7 +1177,7 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testin
 }
 
 func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
-	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOnRelaxed})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -1239,8 +1239,8 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq {
-		t.Fatalf("coalesced BSON set updates advanced commit seq by %d before flush, want buffered", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("coalesced BSON set updates advanced commit seq to %d from %d, want one WAL-on publish before ack", after.CommitSeq, before.CommitSeq)
 	}
 	for i, id := range []string{"u1", "u2"} {
 		findResponse := serveCommand(t, server, int32(2270+i), bson.D{
@@ -1259,8 +1259,8 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush coalesced updates: %v", err)
 	}
-	if flushed := db.State(); flushed.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced update flush advanced commit seq to %d from %d, want one publish", flushed.CommitSeq, before.CommitSeq)
+	if flushed := db.State(); flushed.CommitSeq != after.CommitSeq {
+		t.Fatalf("coalesced update flush advanced commit seq to %d from %d, want already drained", flushed.CommitSeq, after.CommitSeq)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the no-secondary-index Mongo gateway `$set` update scaling path by batching same-schema gateway updates and letting structured BSON `$set` batches use the direct buffered primary-root path without weakening durable ack semantics.

## Root Cause

The writer-sweep regression was not BSON parsing or the Mongo driver. The 0-index update path was effectively publishing one primary-root delta per updated document, while indexed direct BSON updates could stage rows into buffered root runs and publish much less often.

A second issue kept the first fix from scaling under WAL-on benchmark settings: the gateway coalescer grouped concurrent requests, but then rejected same-schema collection handles when `SameCachedCatalog` differed after a prior publish advanced commit/system roots. That sent coalesced requests back through sequential single-update execution.

## Change

- Allow no-index structured BSON `$set` update batches to use direct buffered primary-root plans.
- Allow buffered reads over pending no-index primary-root runs.
- Coalesce Mongo gateway update batches across same-schema collection handles even when commit/system roots have advanced.
- Enable gateway update coalescing by default with a 50µs maximum wait and 256-request maximum batch. Zero still means only coalesce already-queued work, and negative disables coalescing.
- Preserve callback `Collection.Update` synchronous no-index behavior; callback updates do not take the structured BSON fast path.
- Preserve durable ack semantics: direct buffered updates can return buffered only in `DurabilityWALOffRelaxed`; WAL-on and default durable modes flush before ack.
- Keep no-index direct updates out of indexed-buffer threshold logic, so indexed threshold knobs do not force no-index `$set` updates to publish before `Flush()` in WAL-off relaxed mode.
- Add collection and gateway coverage for buffered visibility, one-publish flush behavior, pending insert/update ordering, normal insert/update ordering, callback synchronous publish behavior, WAL-on/default-durable flush-before-ack behavior, and no-index threshold isolation.
- Avoid reflection in the gateway coalescer same-schema hot-path check.

## Validation

Tests on `131c12f1`:

```sh
GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/collections ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report
```

Post-review 100k-doc full writer sweep with Mongo included:

```text
/tmp/gomap_id_update_writer_postfix_sweep_20260509_180343
```

Key cells:

```text
0 indexes w32: TreeDB 36,279 ops/s, Mongo 40,529 ops/s, TreeDB/Mongo 0.90x
1 index   w32: TreeDB 35,522 ops/s, Mongo 39,611 ops/s, TreeDB/Mongo 0.90x

0 indexes w64: TreeDB 46,074 ops/s, Mongo 41,392 ops/s, TreeDB/Mongo 1.11x
1 index   w64: TreeDB 46,165 ops/s, Mongo 35,839 ops/s, TreeDB/Mongo 1.29x
```

That 100k w64 0-vs-1 difference was effectively tied and batch-size-driven. The larger post-review TreeDB-only validation passes the explicit 0-index-greater-than-1-index gate:

```text
/tmp/gomap_id_update_writer_reflect_cleanup_gate_20260509_183234

0 indexes w64: TreeDB 46,587 ops/s, p95 1,718 us
1 index   w64: TreeDB 43,690 ops/s, p95 1,775 us
0-index / 1-index TreeDB at w64: 1.066x
```
