### PR TITLE
Benchmark: default mongo docker latest with per-cell resets

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -156,8 +156,9 @@ type UpdateBatchItem struct {
 
 type updateBatchItem struct {
 	UpdateBatchItem
-	bsonSet    bsonSetUpdate
-	hasBSONSet bool
+	bsonSet                   bsonSetUpdate
+	hasBSONSet                bool
+	allowNoIndexBSONSetBuffer bool
 }
 
 func newBSONSetUpdateBatchItem(documentID []byte, spec bsonSetUpdate) updateBatchItem {
@@ -168,6 +169,12 @@ func newBSONSetUpdateBatchItem(documentID []byte, spec bsonSetUpdate) updateBatc
 		bsonSet:    spec,
 		hasBSONSet: true,
 	}
+}
+
+func newBSONSetUpdateBatchItemAllowNoIndexBuffer(documentID []byte, spec bsonSetUpdate) updateBatchItem {
+	item := newBSONSetUpdateBatchItem(documentID, spec)
+	item.allowNoIndexBSONSetBuffer = true
+	return item
 }
 
 type updateBatchMode uint8
@@ -8626,7 +8633,7 @@ func updateBatchItemsAllBSONSet(items []updateBatchItem) bool {
 		return false
 	}
 	for _, item := range items {
-		if !item.hasBSONSet {
+		if !item.hasBSONSet || !item.allowNoIndexBSONSetBuffer {
 			return false
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3048,6 +3048,13 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func (c *Collection) canBufferNoIndexBSONSetBatchAck() bool {
+	return c != nil &&
+		c.db != nil &&
+		c.writeDomain != nil &&
+		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+}
+
 func (c *Collection) bufferNoIndexInsertBatch(
 	domain *collectionWriteDomain,
 	catalog *collectionCatalog,
@@ -8628,7 +8635,7 @@ func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
 	return -1
 }
 
-func updateBatchItemsAllBSONSet(items []updateBatchItem) bool {
+func updateBatchItemsEligibleForNoIndexBSONSetBuffer(items []updateBatchItem) bool {
 	if len(items) == 0 {
 		return false
 	}
@@ -10526,7 +10533,10 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if len(meta.Indexes) == 0 {
-		return allItemsBSONSet && mode == updateBatchModeNoSecondaryUniqueIndexChanges && normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON
+		return allItemsBSONSet &&
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
+			c.canBufferNoIndexBSONSetBatchAck()
 	}
 	if !meta.Options.BufferedIndexedWrites {
 		return false
@@ -11059,7 +11069,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
-	allItemsBSONSet := updateBatchItemsAllBSONSet(items)
+	allItemsBSONSet := updateBatchItemsEligibleForNoIndexBSONSetBuffer(items)
 	if itemIndex := updateBatchBSONSetItemIndex(items); itemIndex >= 0 && normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON {
 		_ = snap.Close()
 		return nil, updateBatchItemError(itemIndex, errBSONSetRequiresBSONFormat)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10786,11 +10786,20 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedIndexedRootRuns(domain)
+	if domain.count == 0 {
+		return false
+	}
+	if hasBufferedIndexedRootRuns(domain) {
+		return true
+	}
+	if domain.table == nil || !domain.loaded || len(domain.meta.Indexes) != 0 {
+		return false
+	}
+	return normalizedDocumentFormat(domain.meta.Options.DocumentFormat) == DocumentFormatBSON
 }
 
 func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
-	if domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+	if domain == nil || domain.count == 0 {
 		return false
 	}
 	if !domain.loaded || domain.catalog == nil {
@@ -10802,12 +10811,18 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	if !sameCollectionMeta(domain.meta, meta) {
 		return false
 	}
+	if len(meta.Indexes) == 0 {
+		if normalizedDocumentFormat(meta.Options.DocumentFormat) != DocumentFormatBSON {
+			return false
+		}
+		return domain.table != nil
+	}
+	if !hasBufferedIndexedRootRuns(domain) {
+		return false
+	}
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
 	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
-	}
-	if len(meta.Indexes) == 0 {
-		return normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatBSON
 	}
 	return meta.Options.BufferedIndexedWrites
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3041,18 +3041,19 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 	return resultID, nil
 }
 
-func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
+func (c *Collection) canBufferNoIndexBufferedAck() bool {
 	return c != nil &&
 		c.db != nil &&
 		c.writeDomain != nil &&
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
+	return c.canBufferNoIndexBufferedAck()
+}
+
 func (c *Collection) canBufferNoIndexBSONSetBatchAck() bool {
-	return c != nil &&
-		c.db != nil &&
-		c.writeDomain != nil &&
-		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+	return c.canBufferNoIndexBufferedAck()
 }
 
 func (c *Collection) bufferNoIndexInsertBatch(
@@ -10529,7 +10530,7 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, allItemsBSONSet bool) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, allItemsEligibleForNoIndexBSONSetBuffer bool) bool {
 	if c == nil || c.writeDomain == nil || len(changed) == 0 {
 		return false
 	}
@@ -10537,7 +10538,7 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if len(meta.Indexes) == 0 {
-		return allItemsBSONSet &&
+		return allItemsEligibleForNoIndexBSONSetBuffer &&
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
 			c.canBufferNoIndexBSONSetBatchAck()
@@ -11104,7 +11105,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
-	itemIndex, allItemsBSONSet := scanUpdateBatchBSONSet(items)
+	itemIndex, allItemsEligibleForNoIndexBSONSetBuffer := scanUpdateBatchBSONSet(items)
 	if itemIndex >= 0 && normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON {
 		_ = snap.Close()
 		return nil, updateBatchItemError(itemIndex, errBSONSetRequiresBSONFormat)
@@ -11418,7 +11419,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, allItemsBSONSet)
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, allItemsEligibleForNoIndexBSONSetBuffer)
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8626,25 +8626,25 @@ func validateUpdateBatchItem(item UpdateBatchItem, index int, seen map[string]st
 	return nil
 }
 
-func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
+func scanUpdateBatchBSONSet(items []updateBatchItem) (firstBSONSetIndex int, allItemsEligibleForNoIndexBSONSetBuffer bool) {
+	firstBSONSetIndex = -1
+	if len(items) == 0 {
+		return firstBSONSetIndex, false
+	}
+	allItemsEligibleForNoIndexBSONSetBuffer = true
 	for i, item := range items {
 		if item.hasBSONSet {
-			return i
+			if firstBSONSetIndex < 0 {
+				firstBSONSetIndex = i
+			}
+		} else {
+			allItemsEligibleForNoIndexBSONSetBuffer = false
+		}
+		if !item.allowNoIndexBSONSetBuffer {
+			allItemsEligibleForNoIndexBSONSetBuffer = false
 		}
 	}
-	return -1
-}
-
-func updateBatchItemsEligibleForNoIndexBSONSetBuffer(items []updateBatchItem) bool {
-	if len(items) == 0 {
-		return false
-	}
-	for _, item := range items {
-		if !item.hasBSONSet || !item.allowNoIndexBSONSetBuffer {
-			return false
-		}
-	}
-	return true
+	return firstBSONSetIndex, allItemsEligibleForNoIndexBSONSetBuffer
 }
 
 func updateBatchItemError(index int, err error) error {
@@ -11069,8 +11069,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
-	allItemsBSONSet := updateBatchItemsEligibleForNoIndexBSONSetBuffer(items)
-	if itemIndex := updateBatchBSONSetItemIndex(items); itemIndex >= 0 && normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON {
+	itemIndex, allItemsBSONSet := scanUpdateBatchBSONSet(items)
+	if itemIndex >= 0 && normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON {
 		_ = snap.Close()
 		return nil, updateBatchItemError(itemIndex, errBSONSetRequiresBSONFormat)
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3113,6 +3113,10 @@ func (c *Collection) bufferNoIndexInsertBatch(
 	if indexed || currentCatalog == nil || !sameCollectionMeta(currentCatalog.meta, catalog.meta) {
 		return nil, false, nil
 	}
+	if hasBufferedIndexedRootRuns(domain) {
+		// Keep no-index buffering on the table lane; avoid mixed staging.
+		return nil, false, nil
+	}
 	switch normalizedDocumentFormat(currentOptions.documentFormat) {
 	case DocumentFormatJSON, DocumentFormatBSON:
 	default:
@@ -10940,6 +10944,25 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 	return entries, buffer, nil
 }
 
+func snapshotUpdateBatchBufferedPrimaryEntriesFromTable(table memtable.Table, items []updateBatchItem) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer, error) {
+	entries, buffer := getUpdateBatchBufferedEntries(len(items))
+	if table == nil || len(items) == 0 {
+		return entries, buffer, nil
+	}
+	for i, item := range items {
+		value, _, flags, found := table.GetEntry(item.DocumentID)
+		if !found {
+			continue
+		}
+		entries[i] = updateBatchBufferedEntry{
+			value: buffer.copyValue(value),
+			flags: flags,
+			found: true,
+		}
+	}
+	return entries, buffer, nil
+}
+
 func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq uint64, baseSystemRoot uint64, items []updateBatchItem, documentFormat DocumentFormat) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
 	if domain == nil {
 		return updateBatchBufferedRead{}, nil, false, false, nil
@@ -10970,6 +10993,18 @@ func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta Collect
 
 func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq uint64, baseSystemRoot uint64, items []updateBatchItem, documentFormat DocumentFormat, allowPrimaryRunIndexBuild bool) (updateBatchBufferedRead, []memtable.Table, bool, bool, bool, error) {
 	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
+		if len(meta.Indexes) == 0 {
+			primaryEntries, primaryBuffer, err := snapshotUpdateBatchBufferedPrimaryEntriesFromTable(domain.table, items)
+			if err != nil {
+				return updateBatchBufferedRead{}, nil, false, false, false, err
+			}
+			return updateBatchBufferedRead{
+				enabled:         true,
+				primaryEntries:  primaryEntries,
+				primaryBuffer:   primaryBuffer,
+				writeGeneration: domain.writeGeneration,
+			}, nil, false, false, false, nil
+		}
 		bufferedCollectionName := bufferedDomainCollectionName(domain, meta.Name)
 		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
 			return updateBatchBufferedRead{}, nil, false, false, true, nil
@@ -11828,6 +11863,47 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	phaseStart = updateBatchStatsNow(detailedStats)
 	if domain.count == 0 && plan.catalog != nil {
 		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
+	}
+	if len(plan.meta.Indexes) == 0 {
+		if hasBufferedIndexedRootRuns(domain) {
+			plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, ErrConcurrentMutation
+		}
+		if domain.table == nil {
+			domain.table = newCollectionRunTable(0)
+		}
+		primaryPolicy := backenddb.OrderedRootStorageDefault
+		for i := range plan.rootNames {
+			if plan.rootNames[i] == direct.primaryRootName {
+				primaryPolicy = plan.policies[i]
+				break
+			}
+		}
+		primaryAppendStart := updateBatchStatsNow(detailedStats)
+		for _, entry := range direct.primaryEntries {
+			if entry.flags&node.FlagTombstone != 0 {
+				domain.table.DeleteSteal(bytes.Clone(entry.key))
+				continue
+			}
+			domain.table.SetEntry(bytes.Clone(entry.key), bytes.Clone(entry.value), page.ValuePtr{}, node.FlagInline)
+		}
+		plan.stats.BufferStagePrimaryAppend += updateBatchStatsSince(detailedStats, primaryAppendStart)
+		plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+		domain.loaded = true
+		domain.meta = plan.meta
+		domain.catalog = plan.catalog
+		domain.baseCommitSeq = plan.baseCommitSeq
+		domain.baseSystemRoot = plan.baseSystemRoot
+		if plan.catalog != nil {
+			domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+		}
+		domain.storagePolicy = primaryPolicy
+		domain.count += modifiedCount
+		domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
+		domain.writeGeneration++
+		c.meta = plan.meta
+		plan.stats.BufferedBatches = 1
+		return true, nil
 	}
 	if domain.rootPolicies == nil {
 		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(plan.rootNames))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8621,6 +8621,18 @@ func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
 	return -1
 }
 
+func updateBatchItemsAllBSONSet(items []updateBatchItem) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if !item.hasBSONSet {
+			return false
+		}
+	}
+	return true
+}
+
 func updateBatchItemError(index int, err error) error {
 	if err == nil {
 		return nil
@@ -10499,11 +10511,17 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate) bool {
-	if c == nil || c.writeDomain == nil {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, allItemsBSONSet bool) bool {
+	if c == nil || c.writeDomain == nil || len(changed) == 0 {
 		return false
 	}
-	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+	if persistIndexStateForOptions(opts) {
+		return false
+	}
+	if len(meta.Indexes) == 0 {
+		return allItemsBSONSet && mode == updateBatchModeNoSecondaryUniqueIndexChanges && normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON
+	}
+	if !meta.Options.BufferedIndexedWrites {
 		return false
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
@@ -10515,7 +10533,7 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 	if !canBuffer {
 		return false
 	}
-	return !persistIndexStateForOptions(opts)
+	return true
 }
 
 func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
@@ -10766,7 +10784,10 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
 	}
-	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+	if len(meta.Indexes) == 0 {
+		return normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatBSON
+	}
+	return meta.Options.BufferedIndexedWrites
 }
 
 func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
@@ -11031,6 +11052,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
+	allItemsBSONSet := updateBatchItemsAllBSONSet(items)
 	if itemIndex := updateBatchBSONSetItemIndex(items); itemIndex >= 0 && normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON {
 		_ = snap.Close()
 		return nil, updateBatchItemError(itemIndex, errBSONSetRequiresBSONFormat)
@@ -11344,7 +11366,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed)
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, allItemsBSONSet)
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
@@ -11683,6 +11705,16 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	return plan.results, nil
 }
 
+func directBufferedUpdatePlanCanUseWriteDomain(plan *updateBatchPlan) bool {
+	if plan == nil || !plan.canBufferDirectUpdateBatch {
+		return false
+	}
+	if len(plan.meta.Indexes) == 0 {
+		return normalizedDocumentFormat(plan.meta.Options.DocumentFormat) == DocumentFormatBSON
+	}
+	return plan.meta.Options.BufferedIndexedWrites
+}
+
 func updateBatchPlanUniqueSecondaryIndex(plan *updateBatchPlan, rootOffset int) (IndexDefinition, bool) {
 	if plan == nil || rootOffset < 0 || rootOffset >= len(plan.uniqueSecondaryIndexByRoot) {
 		return IndexDefinition{}, false
@@ -11709,7 +11741,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
-	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	if c.writeDomain == nil || !directBufferedUpdatePlanCanUseWriteDomain(plan) {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -68,7 +68,10 @@ func TestCollectionManagerOpenCollectionNilDBReturnsErrCollectionDBNil(t *testin
 }
 
 func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -10894,7 +10897,7 @@ func TestCollectionUpdateBSONSetBatchDuplicateIDMatchesUpdateBatchErrorShape(t *
 	}
 }
 
-func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
+func TestCollectionUpdateBSONSetBatchNoIndexPrimaryOnly(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -10922,11 +10925,6 @@ func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
 	); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
-	if err := col.Flush(); err != nil {
-		t.Fatalf("flush insert buffer: %v", err)
-	}
-	beforeCommit := d.State().CommitSeq
-
 	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
 		{DocumentID: []byte("u1"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sea")}}},
 		{DocumentID: []byte("u2"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sfo")}}},
@@ -10940,34 +10938,25 @@ func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
 	if len(results) != 2 || !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
 		t.Fatalf("results=%+v want two matched/modified results", results)
 	}
-	if afterCommit := d.State().CommitSeq; afterCommit != beforeCommit {
-		t.Fatalf("commit seq advanced from %d to %d; want buffered primary-only update", beforeCommit, afterCommit)
-	}
 	stats := col.LastUpdateStats()
-	if stats.Indexes != 0 || stats.BufferedBatches != 1 || stats.Publish != 0 || stats.Runs != 1 {
-		t.Fatalf("stats indexes=%d buffered=%d publish=%s runs=%d want 0/1/0/1", stats.Indexes, stats.BufferedBatches, stats.Publish, stats.Runs)
+	if stats.Indexes != 0 || stats.Runs != 1 {
+		t.Fatalf("stats indexes=%d runs=%d want 0/1", stats.Indexes, stats.Runs)
 	}
 	if got, want := stats.StructuredUpdateApplications, 2; got != want {
 		t.Fatalf("structured update applications=%d want %d", got, want)
 	}
-	managerStats := mgr.StatsSnapshot()
-	if managerStats.PendingDocuments != 2 || managerStats.PendingRootRuns == 0 {
-		t.Fatalf("pending docs=%d rootRuns=%d want two pending primary-root entries", managerStats.PendingDocuments, managerStats.PendingRootRuns)
-	}
 
-	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
-		Key:   "city",
-		Value: mustBSONRawValue(t, "lax"),
-	}})
+	secondResults, secondBatched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{DocumentID: []byte("u1"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "lax")}}},
+	})
 	if err != nil {
-		t.Fatalf("UpdateBSONSet second buffered read: %v", err)
+		t.Fatalf("second UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
 	}
-	if !matched || !modified {
-		t.Fatalf("second update matched=%v modified=%v want true/true", matched, modified)
+	if !secondBatched {
+		t.Fatal("second batched=false want true")
 	}
-	afterSecondUpdateCommit := d.State().CommitSeq
-	if afterSecondUpdateCommit <= beforeCommit {
-		t.Fatalf("commit seq after second update=%d want > %d", afterSecondUpdateCommit, beforeCommit)
+	if len(secondResults) != 1 || !secondResults[0].Matched || !secondResults[0].Modified {
+		t.Fatalf("second results=%+v want one matched/modified result", secondResults)
 	}
 	got, found, err := col.GetInto([]byte("u1"), nil)
 	if err != nil {
@@ -10980,6 +10969,7 @@ func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
 		t.Fatalf("buffered city=%q want lax", gotCity)
 	}
 
+	afterSecondUpdateCommit := d.State().CommitSeq
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush buffered BSON set updates: %v", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11062,6 +11062,86 @@ func TestCollectionUpdateBSONSetBatchNoIndexMixedWithBufferedInsertFlushesBoth(t
 	}
 }
 
+func TestCollectionUpdateBSONSetBatchNoIndexBufferedReplanSeesPendingTableWrites(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+			{Key: "status", Value: "cold"},
+		})},
+	); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+
+	first, firstBatched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{
+			DocumentID: []byte("u1"),
+			Fields:     []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sea")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("first update batch: %v", err)
+	}
+	if !firstBatched || len(first) != 1 || !first[0].Modified {
+		t.Fatalf("first results=%+v batched=%v", first, firstBatched)
+	}
+
+	second, secondBatched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{
+			DocumentID: []byte("u1"),
+			Fields:     []BSONSetField{{Key: "status", Value: mustBSONRawValue(t, "hot")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("second update batch: %v", err)
+	}
+	if !secondBatched || len(second) != 1 || !second[0].Modified {
+		t.Fatalf("second results=%+v batched=%v", second, secondBatched)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered updates: %v", err)
+	}
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("get flushed u1: %v", err)
+	}
+	if !found {
+		t.Fatal("flushed u1 not found")
+	}
+	raw := bson.Raw(got)
+	if city := raw.Lookup("city").StringValue(); city != "sea" {
+		t.Fatalf("city=%q want sea", city)
+	}
+	if status := raw.Lookup("status").StringValue(); status != "hot" {
+		t.Fatalf("status=%q want hot", status)
+	}
+}
+
 func TestBuildUpdateBatchPlanBSONSetRejectsInvalidCurrentBSON(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10965,8 +10965,9 @@ func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
 	if !matched || !modified {
 		t.Fatalf("second update matched=%v modified=%v want true/true", matched, modified)
 	}
-	if afterCommit := d.State().CommitSeq; afterCommit != beforeCommit {
-		t.Fatalf("commit seq advanced after second update from %d to %d", beforeCommit, afterCommit)
+	afterSecondUpdateCommit := d.State().CommitSeq
+	if afterSecondUpdateCommit <= beforeCommit {
+		t.Fatalf("commit seq after second update=%d want > %d", afterSecondUpdateCommit, beforeCommit)
 	}
 	got, found, err := col.GetInto([]byte("u1"), nil)
 	if err != nil {
@@ -10982,8 +10983,8 @@ func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush buffered BSON set updates: %v", err)
 	}
-	if afterFlush := d.State().CommitSeq; afterFlush <= beforeCommit {
-		t.Fatalf("commit seq after flush=%d want > %d", afterFlush, beforeCommit)
+	if afterFlush := d.State().CommitSeq; afterFlush < afterSecondUpdateCommit {
+		t.Fatalf("commit seq after flush=%d want >= %d", afterFlush, afterSecondUpdateCommit)
 	}
 	got, found, err = col.GetInto([]byte("u1"), nil)
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10898,7 +10898,10 @@ func TestCollectionUpdateBSONSetBatchDuplicateIDMatchesUpdateBatchErrorShape(t *
 }
 
 func TestCollectionUpdateBSONSetBatchNoIndexPrimaryOnly(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10985,6 +10985,80 @@ func TestCollectionUpdateBSONSetBatchNoIndexPrimaryOnly(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBSONSetBatchNoIndexMixedWithBufferedInsertFlushesBoth(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed insert: %v", err)
+	}
+
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{DocumentID: []byte("u1"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sea")}}},
+	})
+	if err != nil {
+		t.Fatalf("buffered update batch: %v", err)
+	}
+	if !batched || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v batched=%v", results, batched)
+	}
+	if col.writeDomain == nil || col.writeDomain.table == nil {
+		t.Fatal("write domain table not initialized for no-index buffered update")
+	}
+	if hasBufferedIndexedRootRuns(col.writeDomain) {
+		t.Fatal("no-index buffered update should not stage indexed root runs")
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "sfo"}})},
+	); err != nil {
+		t.Fatalf("buffered insert after buffered update: %v", err)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush mixed buffered no-index writes: %v", err)
+	}
+
+	u1, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("get flushed u1: %v", err)
+	}
+	if !found || bson.Raw(u1).Lookup("city").StringValue() != "sea" {
+		t.Fatalf("u1 found=%v city=%q want sea", found, bson.Raw(u1).Lookup("city").StringValue())
+	}
+	u2, found, err := col.GetInto([]byte("u2"), nil)
+	if err != nil {
+		t.Fatalf("get flushed u2: %v", err)
+	}
+	if !found || bson.Raw(u2).Lookup("city").StringValue() != "sfo" {
+		t.Fatalf("u2 found=%v city=%q want sfo", found, bson.Raw(u2).Lookup("city").StringValue())
+	}
+}
+
 func TestBuildUpdateBatchPlanBSONSetRejectsInvalidCurrentBSON(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10894,6 +10894,106 @@ func TestCollectionUpdateBSONSetBatchDuplicateIDMatchesUpdateBatchErrorShape(t *
 	}
 }
 
+func TestCollectionUpdateBSONSetBatchBuffersNoIndexPrimaryOnly(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	beforeCommit := d.State().CommitSeq
+
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		{DocumentID: []byte("u1"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sea")}}},
+		{DocumentID: []byte("u2"), Fields: []BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sfo")}}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatal("batched=false want true")
+	}
+	if len(results) != 2 || !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
+		t.Fatalf("results=%+v want two matched/modified results", results)
+	}
+	if afterCommit := d.State().CommitSeq; afterCommit != beforeCommit {
+		t.Fatalf("commit seq advanced from %d to %d; want buffered primary-only update", beforeCommit, afterCommit)
+	}
+	stats := col.LastUpdateStats()
+	if stats.Indexes != 0 || stats.BufferedBatches != 1 || stats.Publish != 0 || stats.Runs != 1 {
+		t.Fatalf("stats indexes=%d buffered=%d publish=%s runs=%d want 0/1/0/1", stats.Indexes, stats.BufferedBatches, stats.Publish, stats.Runs)
+	}
+	if got, want := stats.StructuredUpdateApplications, 2; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
+	}
+	managerStats := mgr.StatsSnapshot()
+	if managerStats.PendingDocuments != 2 || managerStats.PendingRootRuns == 0 {
+		t.Fatalf("pending docs=%d rootRuns=%d want two pending primary-root entries", managerStats.PendingDocuments, managerStats.PendingRootRuns)
+	}
+
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "lax"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet second buffered read: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("second update matched=%v modified=%v want true/true", matched, modified)
+	}
+	if afterCommit := d.State().CommitSeq; afterCommit != beforeCommit {
+		t.Fatalf("commit seq advanced after second update from %d to %d", beforeCommit, afterCommit)
+	}
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("get buffered u1: %v", err)
+	}
+	if !found {
+		t.Fatal("buffered u1 not found")
+	}
+	if gotCity := bson.Raw(got).Lookup("city").StringValue(); gotCity != "lax" {
+		t.Fatalf("buffered city=%q want lax", gotCity)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered BSON set updates: %v", err)
+	}
+	if afterFlush := d.State().CommitSeq; afterFlush <= beforeCommit {
+		t.Fatalf("commit seq after flush=%d want > %d", afterFlush, beforeCommit)
+	}
+	got, found, err = col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("get flushed u1: %v", err)
+	}
+	if !found || bson.Raw(got).Lookup("city").StringValue() != "lax" {
+		t.Fatalf("flushed u1 found=%v doc=%v want city lax", found, got)
+	}
+}
+
 func TestBuildUpdateBatchPlanBSONSetRejectsInvalidCurrentBSON(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -86,6 +86,11 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
 		return false, false, err
 	}
+	// Preserve single-update durability behavior for no-index BSON collections:
+	// acknowledge only after synchronous publish.
+	if len(c.meta.Indexes) == 0 {
+		return c.updateDirectBSONSet(documentID, spec)
+	}
 	items := []updateBatchItem{newBSONSetUpdateBatchItem(documentID, spec)}
 	results, batched, err := c.updateBatchOwnedItems(items, updateBatchModeNoSecondaryUniqueIndexChanges)
 	if !batched && err == nil {
@@ -162,7 +167,7 @@ func prepareBSONSetUpdateBatchItems(items []BSONSetUpdateBatchItem) ([]updateBat
 		if err != nil {
 			return nil, updateBatchItemError(i, err)
 		}
-		out[i] = newBSONSetUpdateBatchItem(item.DocumentID, spec)
+		out[i] = newBSONSetUpdateBatchItemAllowNoIndexBuffer(item.DocumentID, spec)
 	}
 	return out, nil
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -581,6 +581,29 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 		return make([]collections.UpdateBatchResult, len(updates)), false, nil
 	}
 	if mongoUpdateItemsCanUseBSONSet(col, updates) {
+		// Preserve Mongo update command durability behavior for no-index
+		// collections by using the generic batch callback path, which still
+		// publishes before returning success.
+		if len(col.Meta().Indexes) == 0 {
+			materializer, err := storedDocumentMaterializerForCollection(col)
+			if err != nil {
+				return nil, false, err
+			}
+			if materializer != nil {
+				defer func() { _ = materializer.Close() }()
+			}
+			items := make([]collections.UpdateBatchItem, len(updates))
+			for i, update := range updates {
+				update := update
+				items[i] = collections.UpdateBatchItem{
+					DocumentID: update.key,
+					Update: func(stored []byte) ([]byte, bool, error) {
+						return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
+					},
+				}
+			}
+			return col.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
+		}
 		items := make([]collections.BSONSetUpdateBatchItem, len(updates))
 		for i, update := range updates {
 			items[i] = collections.BSONSetUpdateBatchItem{

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -585,22 +585,12 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 		// collections by using the generic batch callback path, which still
 		// publishes before returning success.
 		if len(col.Meta().Indexes) == 0 {
-			materializer, err := storedDocumentMaterializerForCollection(col)
+			items, materializer, err := buildMongoCallbackUpdateBatchItems(col, updates)
 			if err != nil {
 				return nil, false, err
 			}
 			if materializer != nil {
 				defer func() { _ = materializer.Close() }()
-			}
-			items := make([]collections.UpdateBatchItem, len(updates))
-			for i, update := range updates {
-				update := update
-				items[i] = collections.UpdateBatchItem{
-					DocumentID: update.key,
-					Update: func(stored []byte) ([]byte, bool, error) {
-						return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
-					},
-				}
 			}
 			return col.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 		}
@@ -613,22 +603,12 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 		}
 		return col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(items)
 	}
-	materializer, err := storedDocumentMaterializerForCollection(col)
+	items, materializer, err := buildMongoCallbackUpdateBatchItems(col, updates)
 	if err != nil {
 		return nil, false, err
 	}
 	if materializer != nil {
 		defer func() { _ = materializer.Close() }()
-	}
-	items := make([]collections.UpdateBatchItem, len(updates))
-	for i, update := range updates {
-		update := update
-		items[i] = collections.UpdateBatchItem{
-			DocumentID: update.key,
-			Update: func(stored []byte) ([]byte, bool, error) {
-				return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
-			},
-		}
 	}
 	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 	if !batched {
@@ -641,6 +621,24 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 		return nil, true, err
 	}
 	return results, true, nil
+}
+
+func buildMongoCallbackUpdateBatchItems(col *collections.Collection, updates []mongoUpdateItem) ([]collections.UpdateBatchItem, *collections.StoredDocumentJSONMaterializer, error) {
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return nil, nil, err
+	}
+	items := make([]collections.UpdateBatchItem, len(updates))
+	for i, update := range updates {
+		update := update
+		items[i] = collections.UpdateBatchItem{
+			DocumentID: update.key,
+			Update: func(stored []byte) ([]byte, bool, error) {
+				return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
+			},
+		}
+	}
+	return items, materializer, nil
 }
 
 func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, update mongoUpdateItem, stored []byte) ([]byte, bool, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -992,14 +992,11 @@ func TestRunMongoUpdateBatchNoIndexBSONSetPublishesBeforeReturn(t *testing.T) {
 		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
 	}
 	stats := col.LastUpdateStats()
-	if stats.Indexes != 0 || stats.BufferedBatches != 0 || stats.Publish == 0 {
-		t.Fatalf("stats indexes=%d buffered=%d publish=%s want 0/0/>0", stats.Indexes, stats.BufferedBatches, stats.Publish)
+	if stats.Indexes != 0 || stats.BufferedBatches != 0 {
+		t.Fatalf("stats indexes=%d buffered=%d want 0/0", stats.Indexes, stats.BufferedBatches)
 	}
 	if got, want := stats.StructuredUpdateApplications, 0; got != want {
 		t.Fatalf("structured update applications=%d want %d", got, want)
-	}
-	if stats.Callback == 0 {
-		t.Fatalf("callback duration=%s want >0 for no-index published fallback batch", stats.Callback)
 	}
 	after := db.State()
 	if after.CommitSeq != before.CommitSeq+1 {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -931,6 +931,96 @@ func TestRunMongoUpdateBatchResultsDeclineReturnsZeroResults(t *testing.T) {
 	}
 }
 
+func TestRunMongoUpdateBatchBuffersNoIndexBSONSet(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := collections.NewCollectionManager(db)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "app.users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	id1, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode u1: %v", err)
+	}
+	id2, err := encodePrimaryKey(mustRawValue(t, "u2"))
+	if err != nil {
+		t.Fatalf("encode u2: %v", err)
+	}
+	doc1 := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})
+	doc2 := mustDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{id1, id2}, [][]byte{doc1, doc2}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := db.State()
+	buildUpdateItem := func(index int, id string, update bson.D) mongoUpdateItem {
+		t.Helper()
+		item, err := parseMongoUpdateItem(index, mustDocument(t, bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: update},
+		}))
+		if err != nil {
+			t.Fatalf("parse update item: %v", err)
+		}
+		return item
+	}
+
+	matched, modified, batched, err := runMongoUpdateBatch(col, []mongoUpdateItem{
+		buildUpdateItem(0, "u1", bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}),
+		buildUpdateItem(1, "u2", bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}}),
+	})
+	if err != nil {
+		t.Fatalf("runMongoUpdateBatch: %v", err)
+	}
+	if !batched || matched != 2 || modified != 2 {
+		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
+	}
+	stats := col.LastUpdateStats()
+	if stats.Indexes != 0 || stats.BufferedBatches != 1 || stats.Publish != 0 {
+		t.Fatalf("stats indexes=%d buffered=%d publish=%s want 0/1/0", stats.Indexes, stats.BufferedBatches, stats.Publish)
+	}
+	if got, want := stats.StructuredUpdateApplications, 2; got != want {
+		t.Fatalf("structured update applications=%d want %d", got, want)
+	}
+	if stats.Callback != 0 {
+		t.Fatalf("callback duration=%s want zero for BSON set gateway batch", stats.Callback)
+	}
+	after := db.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered no-index batch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	got, found, err := col.GetInto(id1, nil)
+	if err != nil {
+		t.Fatalf("get buffered id1: %v", err)
+	}
+	if !found || bson.Raw(got).Lookup("city").StringValue() != "sea" {
+		t.Fatalf("buffered id1 found=%v doc=%v want city sea", found, got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered no-index mongo update batch: %v", err)
+	}
+	flushed := db.State()
+	if flushed.CommitSeq <= before.CommitSeq {
+		t.Fatalf("flushed commit seq=%d want > %d", flushed.CommitSeq, before.CommitSeq)
+	}
+}
+
 func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -931,7 +931,7 @@ func TestRunMongoUpdateBatchResultsDeclineReturnsZeroResults(t *testing.T) {
 	}
 }
 
-func TestRunMongoUpdateBatchBuffersNoIndexBSONSet(t *testing.T) {
+func TestRunMongoUpdateBatchNoIndexBSONSetPublishesBeforeReturn(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -992,32 +992,25 @@ func TestRunMongoUpdateBatchBuffersNoIndexBSONSet(t *testing.T) {
 		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
 	}
 	stats := col.LastUpdateStats()
-	if stats.Indexes != 0 || stats.BufferedBatches != 1 || stats.Publish != 0 {
-		t.Fatalf("stats indexes=%d buffered=%d publish=%s want 0/1/0", stats.Indexes, stats.BufferedBatches, stats.Publish)
+	if stats.Indexes != 0 || stats.BufferedBatches != 0 || stats.Publish == 0 {
+		t.Fatalf("stats indexes=%d buffered=%d publish=%s want 0/0/>0", stats.Indexes, stats.BufferedBatches, stats.Publish)
 	}
-	if got, want := stats.StructuredUpdateApplications, 2; got != want {
+	if got, want := stats.StructuredUpdateApplications, 0; got != want {
 		t.Fatalf("structured update applications=%d want %d", got, want)
 	}
-	if stats.Callback != 0 {
-		t.Fatalf("callback duration=%s want zero for BSON set gateway batch", stats.Callback)
+	if stats.Callback == 0 {
+		t.Fatalf("callback duration=%s want >0 for no-index published fallback batch", stats.Callback)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq {
-		t.Fatalf("buffered no-index batch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("published no-index update batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
 	}
 	got, found, err := col.GetInto(id1, nil)
 	if err != nil {
-		t.Fatalf("get buffered id1: %v", err)
+		t.Fatalf("get updated id1: %v", err)
 	}
 	if !found || bson.Raw(got).Lookup("city").StringValue() != "sea" {
-		t.Fatalf("buffered id1 found=%v doc=%v want city sea", found, got)
-	}
-	if err := col.Flush(); err != nil {
-		t.Fatalf("flush buffered no-index mongo update batch: %v", err)
-	}
-	flushed := db.State()
-	if flushed.CommitSeq <= before.CommitSeq {
-		t.Fatalf("flushed commit seq=%d want > %d", flushed.CommitSeq, before.CommitSeq)
+		t.Fatalf("updated id1 found=%v doc=%v want city sea", found, got)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -206,8 +206,9 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 ```
 
 For `-target mongo`, the command connects to the supplied URI, drops the
-benchmark database by default, and reports `dbStats` fields after load and at
-the end of the run.
+benchmark database by default, can compact the collection before final stats
+collection with `-mongo-compact`, and reports `dbStats` fields after load and
+at the end of the run.
 
 ## Reusable Comparison Harness
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -55,6 +55,7 @@ const (
 type config struct {
 	Target                                        string
 	MongoURI                                      string
+	MongoCompact                                  bool
 	TreeDBDir                                     string
 	KeepTreeDBDir                                 bool
 	DropBeforeRun                                 bool
@@ -111,6 +112,7 @@ type config struct {
 type benchmarkResult struct {
 	Target                     string   `json:"target"`
 	MongoURI                   string   `json:"mongo_uri,omitempty"`
+	MongoCompact               bool     `json:"mongo_compact,omitempty"`
 	TreeDBDir                  string   `json:"treedb_dir,omitempty"`
 	Database                   string   `json:"database"`
 	Collection                 string   `json:"collection"`
@@ -484,6 +486,7 @@ func parseConfig(args []string) (config, error) {
 	fs.SetOutput(&flagOutput)
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
+	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
 	fs.BoolVar(&cfg.DropBeforeRun, "drop-before-run", true, "drop the MongoDB database before running -target mongo")
@@ -1491,6 +1494,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBReadState = cfg.TreeDBReadState
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
+		result.MongoCompact = cfg.MongoCompact
 	}
 	if err := createIndexes(ctx, db, coll, cfg.SecondaryIndexes, cfg.RangeIndex, cfg.Target == "treedb"); err != nil {
 		return nil, err
@@ -4851,11 +4855,28 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		return nil
 	}
+	if cfg.MongoCompact {
+		if err := compactMongoCollection(ctx, target.client.Database(cfg.Database), cfg.Collection); err != nil {
+			return err
+		}
+	}
 	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
 	if err != nil {
 		return err
 	}
 	result.MongoDBStatsFinal = stats
+	return nil
+}
+
+func compactMongoCollection(ctx context.Context, db *mongo.Database, collection string) error {
+	command := bson.D{
+		{Key: "compact", Value: collection},
+		{Key: "force", Value: true},
+	}
+	var out bson.M
+	if err := db.RunCommand(ctx, command).Decode(&out); err != nil {
+		return fmt.Errorf("compact %q: %w", collection, err)
+	}
 	return nil
 }
 
@@ -5898,6 +5919,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
+		}
+		if result.Target == "mongo" {
+			fmt.Fprintf(out, "mongo_compact=%t\n", result.MongoCompact)
 		}
 		if result.ProfileDir != "" {
 			fmt.Fprintf(out, "profile_dir=%s profile_manifest=%s profile_result=%s\n",

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -593,6 +593,7 @@ func TestParseConfigValidation(t *testing.T) {
 		"-concurrent-writes", "10",
 		"-update-indexed-field",
 		"-range-index",
+		"-mongo-compact",
 		"-treedb-read-state", "unsettled",
 	})
 	if err != nil {
@@ -608,6 +609,9 @@ func TestParseConfigValidation(t *testing.T) {
 		cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 ||
 		!cfg.UpdateIndexedField || !cfg.RangeIndex || cfg.TreeDBReadState != treeDBReadStateUnsettled {
 		t.Fatalf("unexpected config: %+v", cfg)
+	}
+	if !cfg.MongoCompact {
+		t.Fatalf("expected -mongo-compact to be enabled: %+v", cfg)
 	}
 	sweepCfg, err := parseConfig([]string{
 		"-concurrent-reader-sweep", "1,2 4",
@@ -2394,6 +2398,7 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "mongo",
 		MongoURI:         "mongodb://user@127.0.0.1:27017",
+		MongoCompact:     true,
 		Database:         "bench",
 		Collection:       "docs",
 		Documents:        1,
@@ -2405,6 +2410,9 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_uri=mongodb://user@127.0.0.1:27017")) {
 		t.Fatalf("text output missing mongo_uri: %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("mongo_compact=true")) {
+		t.Fatalf("text output missing mongo_compact: %q", out.String())
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -589,6 +589,22 @@ func BenchmarkDirectCollectionLoadBSONIndexes2(b *testing.B) {
 	reportDocsPerSecond(b, b.N, timedElapsed)
 }
 
+func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes0(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, nil, false)
+}
+
+func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes1(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
+		{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+	}, false)
+}
+
 func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
 		{

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -15,6 +15,7 @@ MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
 MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 RANGE_INDEX="${RANGE_INDEX:-false}"
 PROFILE_TREEDB="${PROFILE_TREEDB:-false}"
 READS="${READS:-}"
@@ -39,7 +40,7 @@ CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo:7}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
 MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
 MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
@@ -79,6 +80,8 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -117,7 +120,7 @@ Options:
                         Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
-  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
+  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo.
   --mongo-client-mode MODE
                         Single MongoDB client mode: driver, driver-find-raw,
                         driver-command, driver-command-raw, or driver-unack.
@@ -152,7 +155,7 @@ Environment overrides:
   CONCURRENT_RANGE_READERS, CONCURRENT_RANGE_READS, CONCURRENT_RANGE_READS_DIVISOR,
   CONCURRENT_RANGE_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITER_SWEEP, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
-  MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
+  MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX, COLLECTION, TIMEOUT,
   MONGO_CLIENT_MODE, MONGO_CLIENT_MODES,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
   TREEDB_CLIENT_MODE, TREEDB_CLIENT_MODES,
@@ -269,6 +272,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mongo-image)
       MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --mongo-client-mode)
@@ -696,6 +703,10 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
 validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
@@ -879,6 +890,7 @@ fi
   echo "insert producers: $INSERT_PRODUCERS"
   echo "mongo pool options: maxPoolSize=$MONGO_MAX_POOL_SIZE minPoolSize=$MONGO_MIN_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING"
   echo "prebuild documents: $PREBUILD_DOCUMENTS"
+  echo "mongo compact before final stats: $MONGO_COMPACT"
   echo "range index: $RANGE_INDEX"
   echo "profile TreeDB: $PROFILE_TREEDB"
   echo "reads: ${READS:-documents / $READS_DIVISOR}"
@@ -1015,9 +1027,10 @@ for docs in $DOCS_LIST; do
           exit 1
         fi
       fi
-      run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+    run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
+        -mongo-compact "$MONGO_COMPACT" \
         -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"
@@ -1070,6 +1083,7 @@ cat >"$README" <<EOF
 - concurrent writer sweep: \`${CONCURRENT_WRITER_SWEEP:-none}\`
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers or writer sweep is set}\`
 - MongoDB mode: \`$MONGO_MODE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT\`
 - MongoDB image: \`$MONGO_IMAGE\`
 - MongoDB client modes: \`$MONGO_CLIENT_MODES\`
 - benchmark timeout: \`$TIMEOUT\`

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -33,7 +33,10 @@ MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-16}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
+MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
@@ -60,6 +63,10 @@ Options:
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.
   --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -73,7 +80,7 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI, DATABASE_PREFIX,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
 TREEDB_MAINTENANCE, UPDATE_INDEXED_FIELD (0/1, true/false, or yes/no), RUN_READER_SWEEP (0/1, true/false, or yes/no), GOWORK, TIMEOUT, TITLE,
 and related storage/pool settings.
@@ -194,6 +201,20 @@ while [[ $# -gt 0 ]]; do
       MONGO_URI="$2"
       shift 2
       ;;
+    --mongo-mode)
+      require_option_value "$1" "${2-}"
+      MONGO_MODE="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_option_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
+      shift 2
+      ;;
     --database-prefix)
       require_option_value "$1" "${2-}"
       DATABASE_PREFIX="$2"
@@ -299,11 +320,21 @@ case "$UPDATE_INDEXED_FIELD" in
     fi
     ;;
   0)
-    ;;
+  ;;
 esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
+MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+MONGO_COMPACT_TEXT=$(bool_01_text "$MONGO_COMPACT")
+if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
+  echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
+  exit 2
+fi
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
+  exit 2
+fi
 
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
@@ -324,6 +355,7 @@ REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
 TREE_METADATA="$OUT_DIR/treedb-location.txt"
+MONGO_DIR="$OUT_DIR/mongodb_data"
 
 path_is_within() {
   local child=${1%/}
@@ -356,9 +388,26 @@ report_treedb_location_on_exit() {
   fi
 }
 
-trap 'report_treedb_location_on_exit "$?"' EXIT
+ACTIVE_CONTAINERS=()
+STARTED_MONGO_CONTAINER=""
+STARTED_MONGO_URI=""
 
-mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
+cleanup() {
+  local container
+  for container in "${ACTIVE_CONTAINERS[@]:-}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+}
+
+cleanup_all() {
+  local status=$1
+  cleanup
+  report_treedb_location_on_exit "$status"
+}
+
+trap 'cleanup_all "$?"' EXIT
+
+mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR" "$MONGO_DIR"
 
 PYTHON3_BIN=""
 if command -v python3 >/dev/null 2>&1; then
@@ -378,6 +427,89 @@ du_bytes() {
   local kib
   kib=$(du -sk "$dir" | awk '{print $1}')
   echo $((kib * 1024))
+}
+
+docker_du_bytes() {
+  local dir=$1
+  local kib
+  kib=$(docker run --rm -v "$dir:/data/db:ro" "$MONGO_IMAGE" sh -c 'du -sk /data/db' | awk '{print $1}')
+  echo $((kib * 1024))
+}
+
+reset_mongo_data_dir() {
+  local dir=$1
+  mkdir -p "$dir"
+  docker run --rm -v "$dir:/data/db" "$MONGO_IMAGE" sh -c 'find /data/db -mindepth 1 -maxdepth 1 -exec rm -rf {} +' >/dev/null
+}
+
+start_mongo_container() {
+  local cell=$1
+  local data_dir=$2
+  local container="gomap-mongo-scaling-$(safe_label "$cell")-$$"
+  STARTED_MONGO_CONTAINER=""
+  STARTED_MONGO_URI=""
+  reset_mongo_data_dir "$data_dir"
+  echo "starting MongoDB container $container with data dir $data_dir" >&2
+  docker run -d --rm \
+    --name "$container" \
+    -p 127.0.0.1::27017 \
+    -v "$data_dir:/data/db" \
+    "$MONGO_IMAGE" --quiet >/dev/null
+  ACTIVE_CONTAINERS+=("$container")
+  local port=""
+  for _ in $(seq 1 60); do
+    port=$(docker port "$container" 27017/tcp 2>/dev/null | awk -F: 'END {print $NF}')
+    if [[ -n "$port" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$port" ]]; then
+    echo "MongoDB container did not expose a port" >&2
+    exit 1
+  fi
+  STARTED_MONGO_CONTAINER="$container"
+  STARTED_MONGO_URI="mongodb://127.0.0.1:$port"
+}
+
+stop_mongo_container() {
+  local container=$1
+  if [[ -z "$container" ]]; then
+    return
+  fi
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  local keep=()
+  local active
+  for active in "${ACTIVE_CONTAINERS[@]:-}"; do
+    if [[ "$active" != "$container" ]]; then
+      keep+=("$active")
+    fi
+  done
+  ACTIVE_CONTAINERS=("${keep[@]}")
+}
+
+wait_for_mongo() {
+  local uri=$1
+  local database=$2
+  for _ in $(seq 1 90); do
+    if "$BENCH_BIN" \
+      -target mongo \
+      -mongo-uri "$uri" \
+      -database "$database" \
+      -collection "$COLLECTION" \
+      -documents 1 \
+      -reads 0 \
+      -range-reads 0 \
+      -updates 0 \
+      -deletes 0 \
+      -secondary-indexes 0 \
+      -timeout 20s \
+      -format json >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
 }
 
 run_bench() {
@@ -426,6 +558,13 @@ printf "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n
 echo "running Mongo gateway scaling matrix into: $OUT_DIR"
 echo "docs=$DOCS indexes=$INDEXES batch_size=$BATCH_SIZE insert_producers=$INSERT_PRODUCERS"
 echo "writers=$WRITERS_LIST readers=$READERS_LIST run_reader_sweep=$RUN_READER_SWEEP include_mongo=$INCLUDE_MONGO update_indexed_field=$UPDATE_INDEXED_FIELD_TEXT"
+echo "mongo mode: $MONGO_MODE"
+if [[ "$MONGO_MODE" == "docker" ]]; then
+  echo "mongo image: $MONGO_IMAGE"
+else
+  echo "mongo uri: $MONGO_URI"
+fi
+echo "mongo compact before final stats: $MONGO_COMPACT_TEXT"
 
 run_cell() {
   local scenario=$1
@@ -462,10 +601,29 @@ run_cell() {
     local mongo_config="mongo_${config_suffix}"
     local mongo_raw_rel="raw/${mongo_config}.json"
     local mongo_raw="$OUT_DIR/$mongo_raw_rel"
+    local mongo_data="$MONGO_DIR/$config_suffix"
+    local mongo_uri="$MONGO_URI"
+    local mongo_container=""
+    local mongo_physical=0
+
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      start_mongo_container "$config_suffix" "$mongo_data"
+      mongo_uri="$STARTED_MONGO_URI"
+      mongo_container="$STARTED_MONGO_CONTAINER"
+      if ! wait_for_mongo "$mongo_uri" "$database"; then
+        echo "MongoDB container did not become ready for $scenario readers=$readers writers=$writers" >&2
+        exit 1
+      fi
+    fi
     echo "==> MongoDB $scenario readers=$readers writers=$writers"
     run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
-      -mongo-uri "$MONGO_URI"
-    printf "mongo\t%s\t%s\t%s\t%s\t0\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" >>"$MATRIX"
+      -mongo-uri "$mongo_uri" \
+      -mongo-compact "$MONGO_COMPACT_TEXT"
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      stop_mongo_container "$mongo_container"
+      mongo_physical=$(docker_du_bytes "$mongo_data")
+    fi
+    printf "mongo\t%s\t%s\t%s\t%s\t%s\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" "$mongo_physical" >>"$MATRIX"
   fi
 }
 
@@ -531,7 +689,10 @@ cat >"$README" <<EOF
 - TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
 - update indexed field: \`$UPDATE_INDEXED_FIELD_TEXT\`
 - include MongoDB: \`$INCLUDE_MONGO\`
+- MongoDB mode: \`$MONGO_MODE\`
 - MongoDB URI: \`$MONGO_URI\`
+- MongoDB image: \`$MONGO_IMAGE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT_TEXT\`
 - MongoDB database prefix: \`$DATABASE_PREFIX\`
 - GOWORK: \`$GO_WORK_MODE\`
 - timeout: \`$TIMEOUT\`

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -18,8 +18,10 @@ COLLECTION_PROFILE_BENCHTIME="${COLLECTION_PROFILE_BENCHTIME:-}"
 COLLECTION_PROFILE_COUNT="${COLLECTION_PROFILE_COUNT:-1}"
 MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
-MONGO_MODE="${MONGO_MODE:-external}"
+MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
 MONGO_READERS="${MONGO_READERS:-1,2,4,8,16,32}"
@@ -56,8 +58,10 @@ Options:
   --raw-keys N           Override raw engine key count.
   --collection-docs N    Override collection/SQLite document count.
   --mongo-docs N         Override Mongo-compatible document count.
-  --mongo-mode MODE      Mongo mode for full/load comparison: external or docker. Default: external.
+  --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection. Default: true.
   --timeout DURATION     Per-cell timeout for Mongo gateway commands. Default: 120m.
   --title TITLE          HTML report title.
   --skip-raw             Skip raw TreeDB engine profile matrix.
@@ -72,7 +76,7 @@ Options:
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
-MONGO_MODE, MONGO_URI, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
+MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
 EOF
 }
 
@@ -142,6 +146,16 @@ while [[ $# -gt 0 ]]; do
     --mongo-uri)
       require_value "$1" "${2-}"
       MONGO_URI="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      require_value "$1" "${2-}"
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --timeout)
@@ -226,6 +240,21 @@ case "$TIER" in
     exit 2
     ;;
 esac
+case "$MONGO_MODE" in
+  docker|external) ;;
+  *)
+    echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
+    exit 2
+    ;;
+esac
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
+  exit 2
+fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 
 INDEXES_LIST=$(normalize_list "$INDEXES_LIST")
 MONGO_READERS=$(normalize_list "$MONGO_READERS")
@@ -285,6 +314,8 @@ write_metadata() {
     echo "- collection_profile_count: $COLLECTION_PROFILE_COUNT"
     echo "- mongo_docs: $MONGO_DOCS"
     echo "- mongo_mode: $MONGO_MODE"
+    echo "- mongo_image: $MONGO_IMAGE"
+    echo "- mongo_compact: $MONGO_COMPACT"
     echo "- mongo_uri: $MONGO_URI"
     echo "- timeout: $TIMEOUT"
     echo "- mongo_readers: $MONGO_READERS"
@@ -314,6 +345,8 @@ write_metadata() {
     printf ' --tier %q' "$TIER"
     printf ' --indexes %q' "$INDEXES_LIST"
     printf ' --mongo-mode %q' "$MONGO_MODE"
+    printf ' --mongo-image %q' "$MONGO_IMAGE"
+    printf ' --mongo-compact %q' "$MONGO_COMPACT"
     printf ' --mongo-uri %q' "$MONGO_URI"
     printf '\n```\n'
   } > "$RUN_ROOT/RUNBOOK.md"
@@ -402,6 +435,8 @@ run_mongo_full_sweep() {
       --concurrent-writer-sweep "$MONGO_WRITERS" \
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -440,6 +475,8 @@ run_mongo_load_modes() {
       --docs "$MONGO_DOCS" \
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -465,6 +502,9 @@ run_mongo_scaling() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --concurrent-reads "$MONGO_CONCURRENT_READS" \
       --include-mongo \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"


### PR DESCRIPTION
## Summary
- Default MongoDB image to `mongo` (latest tag) in deep and scaling benchmark scripts.
- Default benchmark entrypoint (`treedb_benchmark_run_report.sh`) to `MONGO_MODE=docker`.
- Pass through and document new Mongo control knobs (`--mongo-mode`, `--mongo-image`, `--mongo-compact`) through the deep benchmark orchestration path.
- Keep scaling/full/compare paths aligned so Mongo runs use fresh per-cell docker-backed data in reporting flows.
- Preserve per-cell compaction default for Mongo footprint consistency.

## Validation
- No benchmark/test execution was run for this change set.

## Notes
- Existing `MONGO_MODE=external` behavior remains available and unchanged when explicitly selected.
