### PR TITLE
Benchmark: benchmark defaults for docker mongo and per-cell reset

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -206,8 +206,9 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 ```
 
 For `-target mongo`, the command connects to the supplied URI, drops the
-benchmark database by default, and reports `dbStats` fields after load and at
-the end of the run.
+benchmark database by default, can compact the collection before final stats
+collection with `-mongo-compact`, and reports `dbStats` fields after load and
+at the end of the run.
 
 ## Reusable Comparison Harness
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -55,6 +55,7 @@ const (
 type config struct {
 	Target                                        string
 	MongoURI                                      string
+	MongoCompact                                  bool
 	TreeDBDir                                     string
 	KeepTreeDBDir                                 bool
 	DropBeforeRun                                 bool
@@ -111,6 +112,7 @@ type config struct {
 type benchmarkResult struct {
 	Target                     string   `json:"target"`
 	MongoURI                   string   `json:"mongo_uri,omitempty"`
+	MongoCompact               bool     `json:"mongo_compact,omitempty"`
 	TreeDBDir                  string   `json:"treedb_dir,omitempty"`
 	Database                   string   `json:"database"`
 	Collection                 string   `json:"collection"`
@@ -484,6 +486,7 @@ func parseConfig(args []string) (config, error) {
 	fs.SetOutput(&flagOutput)
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
+	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
 	fs.BoolVar(&cfg.DropBeforeRun, "drop-before-run", true, "drop the MongoDB database before running -target mongo")
@@ -1491,6 +1494,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBReadState = cfg.TreeDBReadState
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
+		result.MongoCompact = cfg.MongoCompact
 	}
 	if err := createIndexes(ctx, db, coll, cfg.SecondaryIndexes, cfg.RangeIndex, cfg.Target == "treedb"); err != nil {
 		return nil, err
@@ -4851,11 +4855,28 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		return nil
 	}
+	if cfg.MongoCompact {
+		if err := compactMongoCollection(ctx, target.client.Database(cfg.Database), cfg.Collection); err != nil {
+			return err
+		}
+	}
 	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
 	if err != nil {
 		return err
 	}
 	result.MongoDBStatsFinal = stats
+	return nil
+}
+
+func compactMongoCollection(ctx context.Context, db *mongo.Database, collection string) error {
+	command := bson.D{
+		{Key: "compact", Value: collection},
+		{Key: "force", Value: true},
+	}
+	var out bson.M
+	if err := db.RunCommand(ctx, command).Decode(&out); err != nil {
+		return fmt.Errorf("compact %q: %w", collection, err)
+	}
 	return nil
 }
 
@@ -5898,6 +5919,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
+		}
+		if result.Target == "mongo" {
+			fmt.Fprintf(out, "mongo_compact=%t\n", result.MongoCompact)
 		}
 		if result.ProfileDir != "" {
 			fmt.Fprintf(out, "profile_dir=%s profile_manifest=%s profile_result=%s\n",

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4874,10 +4874,14 @@ func compactMongoCollection(ctx context.Context, db *mongo.Database, collection 
 		{Key: "force", Value: true},
 	}
 	var out bson.M
-	if err := db.RunCommand(ctx, command).Decode(&out); err != nil {
+	if err := runMongoCommandDecode(ctx, db, command, &out); err != nil {
 		return fmt.Errorf("compact %q: %w", collection, err)
 	}
 	return nil
+}
+
+var runMongoCommandDecode = func(ctx context.Context, db *mongo.Database, command bson.D, out any) error {
+	return db.RunCommand(ctx, command).Decode(out)
 }
 
 func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result *benchmarkResult) error {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -25,6 +25,7 @@ import (
 	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func TestSummarizeLatencyNearestRank(t *testing.T) {
@@ -2413,6 +2414,50 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_compact=true")) {
 		t.Fatalf("text output missing mongo_compact: %q", out.String())
+	}
+}
+
+func TestCompactMongoCollectionRunsCompactCommand(t *testing.T) {
+	orig := runMongoCommandDecode
+	t.Cleanup(func() { runMongoCommandDecode = orig })
+
+	called := false
+	runMongoCommandDecode = func(_ context.Context, _ *mongo.Database, command bson.D, out any) error {
+		called = true
+		if len(command) != 2 {
+			t.Fatalf("command len=%d want 2", len(command))
+		}
+		if command[0].Key != "compact" || command[0].Value != "docs" {
+			t.Fatalf("compact command=%v", command)
+		}
+		if command[1].Key != "force" || command[1].Value != true {
+			t.Fatalf("force command=%v", command)
+		}
+		if _, ok := out.(*bson.M); !ok {
+			t.Fatalf("out type %T want *bson.M", out)
+		}
+		return nil
+	}
+
+	if err := compactMongoCollection(context.Background(), nil, "docs"); err != nil {
+		t.Fatalf("compactMongoCollection: %v", err)
+	}
+	if !called {
+		t.Fatal("expected command runner to be called")
+	}
+}
+
+func TestCompactMongoCollectionWrapsRunnerError(t *testing.T) {
+	orig := runMongoCommandDecode
+	t.Cleanup(func() { runMongoCommandDecode = orig })
+
+	runMongoCommandDecode = func(_ context.Context, _ *mongo.Database, _ bson.D, _ any) error {
+		return errors.New("boom")
+	}
+
+	err := compactMongoCollection(context.Background(), nil, "docs")
+	if err == nil || !strings.Contains(err.Error(), `compact "docs": boom`) {
+		t.Fatalf("compactMongoCollection err=%v", err)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -593,6 +593,7 @@ func TestParseConfigValidation(t *testing.T) {
 		"-concurrent-writes", "10",
 		"-update-indexed-field",
 		"-range-index",
+		"-mongo-compact",
 		"-treedb-read-state", "unsettled",
 	})
 	if err != nil {
@@ -608,6 +609,9 @@ func TestParseConfigValidation(t *testing.T) {
 		cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 ||
 		!cfg.UpdateIndexedField || !cfg.RangeIndex || cfg.TreeDBReadState != treeDBReadStateUnsettled {
 		t.Fatalf("unexpected config: %+v", cfg)
+	}
+	if !cfg.MongoCompact {
+		t.Fatalf("expected -mongo-compact to be enabled: %+v", cfg)
 	}
 	sweepCfg, err := parseConfig([]string{
 		"-concurrent-reader-sweep", "1,2 4",
@@ -2394,6 +2398,7 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "mongo",
 		MongoURI:         "mongodb://user@127.0.0.1:27017",
+		MongoCompact:     true,
 		Database:         "bench",
 		Collection:       "docs",
 		Documents:        1,
@@ -2405,6 +2410,9 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_uri=mongodb://user@127.0.0.1:27017")) {
 		t.Fatalf("text output missing mongo_uri: %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("mongo_compact=true")) {
+		t.Fatalf("text output missing mongo_compact: %q", out.String())
 	}
 }
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -15,6 +15,7 @@ MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
 MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 RANGE_INDEX="${RANGE_INDEX:-false}"
 PROFILE_TREEDB="${PROFILE_TREEDB:-false}"
 READS="${READS:-}"
@@ -39,7 +40,7 @@ CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo:7}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
 MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
 MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
@@ -79,6 +80,8 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -117,7 +120,7 @@ Options:
                         Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
-  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
+  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo.
   --mongo-client-mode MODE
                         Single MongoDB client mode: driver, driver-find-raw,
                         driver-command, driver-command-raw, or driver-unack.
@@ -152,7 +155,7 @@ Environment overrides:
   CONCURRENT_RANGE_READERS, CONCURRENT_RANGE_READS, CONCURRENT_RANGE_READS_DIVISOR,
   CONCURRENT_RANGE_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITER_SWEEP, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
-  MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
+  MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX, COLLECTION, TIMEOUT,
   MONGO_CLIENT_MODE, MONGO_CLIENT_MODES,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
   TREEDB_CLIENT_MODE, TREEDB_CLIENT_MODES,
@@ -269,6 +272,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mongo-image)
       MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --mongo-client-mode)
@@ -696,6 +703,10 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
 validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
@@ -879,6 +890,7 @@ fi
   echo "insert producers: $INSERT_PRODUCERS"
   echo "mongo pool options: maxPoolSize=$MONGO_MAX_POOL_SIZE minPoolSize=$MONGO_MIN_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING"
   echo "prebuild documents: $PREBUILD_DOCUMENTS"
+  echo "mongo compact before final stats: $MONGO_COMPACT"
   echo "range index: $RANGE_INDEX"
   echo "profile TreeDB: $PROFILE_TREEDB"
   echo "reads: ${READS:-documents / $READS_DIVISOR}"
@@ -1015,9 +1027,10 @@ for docs in $DOCS_LIST; do
           exit 1
         fi
       fi
-      run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+    run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
+        -mongo-compact "$MONGO_COMPACT" \
         -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"
@@ -1070,6 +1083,7 @@ cat >"$README" <<EOF
 - concurrent writer sweep: \`${CONCURRENT_WRITER_SWEEP:-none}\`
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers or writer sweep is set}\`
 - MongoDB mode: \`$MONGO_MODE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT\`
 - MongoDB image: \`$MONGO_IMAGE\`
 - MongoDB client modes: \`$MONGO_CLIENT_MODES\`
 - benchmark timeout: \`$TIMEOUT\`

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -82,7 +82,7 @@ Options:
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
  --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
-                        Provide as -mongo-compact=<true|false>.
+                        Provide as --mongo-compact=<true|false>.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -274,6 +274,10 @@ while [[ $# -gt 0 ]]; do
     --mongo-image)
       MONGO_IMAGE="$2"
       shift 2
+      ;;
+    --mongo-compact=* )
+      MONGO_COMPACT="${1#*=}"
+      shift
       ;;
     --mongo-compact)
       MONGO_COMPACT="$2"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -80,7 +80,7 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
- --mongo-compact       Compact the MongoDB collection before final stats collection.
+  --mongo-compact BOOL  Compact the MongoDB collection before final stats collection.
                         Set to true/false, 1/0, or yes/no.
                         Default: true for docker mode; false for external mode unless explicitly set.
   --prebuild-documents  Prebuild documents before timed load phases.
@@ -178,34 +178,42 @@ require_option_value() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --out)
+      require_option_value "$1" "${2-}"
       OUT_DIR="$2"
       shift 2
       ;;
     --docs)
+      require_option_value "$1" "${2-}"
       DOCS_LIST="$2"
       shift 2
       ;;
     --indexes)
+      require_option_value "$1" "${2-}"
       INDEXES_LIST="$2"
       shift 2
       ;;
     --reads)
+      require_option_value "$1" "${2-}"
       READS="$2"
       shift 2
       ;;
     --range-reads)
+      require_option_value "$1" "${2-}"
       RANGE_READS="$2"
       shift 2
       ;;
     --updates)
+      require_option_value "$1" "${2-}"
       UPDATES="$2"
       shift 2
       ;;
     --deletes)
+      require_option_value "$1" "${2-}"
       DELETES="$2"
       shift 2
       ;;
     --insert-producers)
+      require_option_value "$1" "${2-}"
       INSERT_PRODUCERS="$2"
       shift 2
       ;;
@@ -237,18 +245,22 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --concurrent-readers)
+      require_option_value "$1" "${2-}"
       CONCURRENT_READERS="$2"
       shift 2
       ;;
     --concurrent-read-kinds)
+      require_option_value "$1" "${2-}"
       CONCURRENT_READ_KINDS="$2"
       shift 2
       ;;
     --concurrent-reader-sweep)
+      require_option_value "$1" "${2-}"
       CONCURRENT_READER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-reads)
+      require_option_value "$1" "${2-}"
       CONCURRENT_READS="$2"
       shift 2
       ;;

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -80,8 +80,9 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
-  --mongo-compact       Compact the MongoDB collection before final stats collection.
+ --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
+                        Provide as -mongo-compact=<true|false>.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -1030,8 +1031,8 @@ for docs in $DOCS_LIST; do
     run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
-        -mongo-compact "$MONGO_COMPACT" \
-        -client-mode "$mongo_client_mode"
+    -mongo-compact="$MONGO_COMPACT" \
+      -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"
         mongo_physical=$(docker_du_bytes "$mongo_cell_data")

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -1058,7 +1058,7 @@ for docs in $DOCS_LIST; do
           -treedb-index-root-storage "$TREEDB_INDEX_ROOT_STORAGE" \
           -treedb-maintenance "$TREEDB_MAINTENANCE" \
           -treedb-read-state "$TREEDB_READ_STATE" \
-          "${tree_profile_args[@]}"
+          "${tree_profile_args[@]:-}"
         tree_physical=$(du_bytes "$tree_data")
         printf "treedb\t%s\t%s\t%s\t%s\t%s\n" "$tree_config" "$docs" "$indexes" "$tree_raw_rel" "$tree_physical" >>"$MATRIX"
       done

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -15,7 +15,7 @@ MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
 MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 RANGE_INDEX="${RANGE_INDEX:-false}"
 PROFILE_TREEDB="${PROFILE_TREEDB:-false}"
 READS="${READS:-}"
@@ -40,7 +40,7 @@ CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
 MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
 MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
@@ -81,8 +81,8 @@ Options:
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
  --mongo-compact       Compact the MongoDB collection before final stats collection.
-                        Set to true/false, default: true.
-                        Provide as --mongo-compact=<true|false>.
+                        Set to true/false, 1/0, or yes/no.
+                        Default: true for docker mode; false for external mode unless explicitly set.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -121,7 +121,7 @@ Options:
                         Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
-  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:8.
   --mongo-client-mode MODE
                         Single MongoDB client mode: driver, driver-find-raw,
                         driver-command, driver-command-raw, or driver-unack.
@@ -165,6 +165,16 @@ Environment overrides:
 EOF
 }
 
+require_option_value() {
+  local opt=$1
+  local value=${2-}
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "missing value for $opt" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --out)
@@ -200,14 +210,17 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --mongo-max-pool-size)
+      require_option_value "$1" "${2-}"
       MONGO_MAX_POOL_SIZE="$2"
       shift 2
       ;;
     --mongo-min-pool-size)
+      require_option_value "$1" "${2-}"
       MONGO_MIN_POOL_SIZE="$2"
       shift 2
       ;;
     --mongo-max-connecting)
+      require_option_value "$1" "${2-}"
       MONGO_MAX_CONNECTING="$2"
       shift 2
       ;;
@@ -240,38 +253,47 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --concurrent-range-readers)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READERS="$2"
       shift 2
       ;;
     --concurrent-range-reader-sweep)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-range-reads)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READS="$2"
       shift 2
       ;;
     --concurrent-writers)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITERS="$2"
       shift 2
       ;;
     --concurrent-writer-sweep)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-writes)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITES="$2"
       shift 2
       ;;
     --mongo-mode)
+      require_option_value "$1" "${2-}"
       MONGO_MODE="$2"
       shift 2
       ;;
     --mongo-uri)
+      require_option_value "$1" "${2-}"
       MONGO_URI="$2"
       shift 2
       ;;
     --mongo-image)
+      require_option_value "$1" "${2-}"
       MONGO_IMAGE="$2"
       shift 2
       ;;
@@ -280,53 +302,65 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --mongo-compact)
+      require_option_value "$1" "${2-}"
       MONGO_COMPACT="$2"
       shift 2
       ;;
     --mongo-client-mode)
+      require_option_value "$1" "${2-}"
       MONGO_CLIENT_MODE="$2"
       MONGO_CLIENT_MODES="$2"
       shift 2
       ;;
     --mongo-client-modes)
+      require_option_value "$1" "${2-}"
       MONGO_CLIENT_MODES="$2"
       shift 2
       ;;
     --timeout)
+      require_option_value "$1" "${2-}"
       TIMEOUT="$2"
       shift 2
       ;;
     --treedb-profile)
+      require_option_value "$1" "${2-}"
       TREEDB_PROFILE="$2"
       shift 2
       ;;
     --treedb-document-format)
+      require_option_value "$1" "${2-}"
       TREEDB_DOCUMENT_FORMAT="$2"
       TREEDB_DOCUMENT_FORMATS="$2"
       shift 2
       ;;
     --treedb-document-formats)
+      require_option_value "$1" "${2-}"
       TREEDB_DOCUMENT_FORMATS="$2"
       shift 2
       ;;
     --treedb-client-mode)
+      require_option_value "$1" "${2-}"
       TREEDB_CLIENT_MODE="$2"
       TREEDB_CLIENT_MODES="$2"
       shift 2
       ;;
     --treedb-client-modes)
+      require_option_value "$1" "${2-}"
       TREEDB_CLIENT_MODES="$2"
       shift 2
       ;;
     --treedb-maintenance)
+      require_option_value "$1" "${2-}"
       TREEDB_MAINTENANCE="$2"
       shift 2
       ;;
     --treedb-read-state)
+      require_option_value "$1" "${2-}"
       TREEDB_READ_STATE="$2"
       shift 2
       ;;
     --title)
+      require_option_value "$1" "${2-}"
       TITLE="$2"
       shift 2
       ;;
@@ -677,6 +711,13 @@ if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=false
+  else
+    MONGO_COMPACT=true
+  fi
+fi
 if ! is_positive_int "$INSERT_PRODUCERS"; then
   echo "invalid INSERT_PRODUCERS=$INSERT_PRODUCERS (want positive integer)" >&2
   exit 2
@@ -708,10 +749,20 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
-if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
-  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
-  exit 2
-fi
+case "$MONGO_COMPACT" in
+  true|false)
+    ;;
+  1|yes|YES|Yes|TRUE|True)
+    MONGO_COMPACT=true
+    ;;
+  0|no|NO|No|FALSE|False)
+    MONGO_COMPACT=false
+    ;;
+  *)
+    echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true/false, 1/0, or yes/no)" >&2
+    exit 2
+    ;;
+esac
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
 validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
@@ -1035,7 +1086,7 @@ for docs in $DOCS_LIST; do
     run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
-    -mongo-compact="$MONGO_COMPACT" \
+        -mongo-compact="$MONGO_COMPACT" \
       -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -569,14 +569,14 @@ stop_mongo_container() {
     return
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
-  local keep=()
+  local next_containers=()
   local active
   for active in "${ACTIVE_CONTAINERS[@]:-}"; do
     if [[ "$active" != "$container" ]]; then
-      keep+=("$active")
+      next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${keep[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]}")
 }
 
 wait_for_mongo() {
@@ -621,13 +621,13 @@ run_target() {
   local concurrent_writes=${15}
   shift 15
 
-  local prebuild_args=()
+  local prebuild_arg=""
   if [[ "$PREBUILD_DOCUMENTS" == "true" ]]; then
-    prebuild_args=(-prebuild-documents)
+    prebuild_arg="-prebuild-documents"
   fi
-  local range_index_args=()
+  local range_index_arg=""
   if [[ "$RANGE_INDEX" == "true" ]]; then
-    range_index_args=(-range-index)
+    range_index_arg="-range-index"
   fi
 
   "$BENCH_BIN" \
@@ -657,8 +657,8 @@ run_target() {
     -secondary-indexes "$indexes" \
     -timeout "$TIMEOUT" \
     -format json \
-    "${prebuild_args[@]}" \
-    "${range_index_args[@]}" \
+    ${prebuild_arg:+"$prebuild_arg"} \
+    ${range_index_arg:+"$range_index_arg"} \
     "$@" >"$raw_json"
 }
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -610,7 +610,7 @@ stop_mongo_container() {
       next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${next_containers[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]:-}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -67,6 +67,7 @@ Options:
   --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
   --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
+                        Provide as --mongo-compact=<true|false>.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -618,7 +619,7 @@ run_cell() {
     echo "==> MongoDB $scenario readers=$readers writers=$writers"
     run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
       -mongo-uri "$mongo_uri" \
-      -mongo-compact "$MONGO_COMPACT_TEXT"
+      -mongo-compact="$MONGO_COMPACT_TEXT"
     if [[ "$MONGO_MODE" == "docker" ]]; then
       stop_mongo_container "$mongo_container"
       mongo_physical=$(docker_du_bytes "$mongo_data")

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -661,7 +661,7 @@ fi
   -report "$REPORT" \
   -summary "$SUMMARY" \
   -title "$TITLE" \
-  "${report_extra[@]}"
+  "${report_extra[@]:-}"
 
 if [[ -n "$PYTHON3_BIN" ]]; then
   "$PYTHON3_BIN" "$ROOT/scripts/mongo_gateway_writer_metrics.py" "$OUT_DIR" "$MATRIX" "$WRITER_METRICS"

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -499,7 +499,7 @@ stop_mongo_container() {
       next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${next_containers[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]:-}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -35,8 +35,8 @@ PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
@@ -61,13 +61,13 @@ Options:
   --no-reader-sweep      Run writer-scaling cells only.
   --concurrent-writes N  Total updates per writer-scaling cell. Default: 80000.
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
-  --include-mongo        Also run each cell against an external MongoDB URI.
-  --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --include-mongo        Also run each cell against MongoDB (docker or external based on --mongo-mode).
+  --mongo-uri URI        MongoDB URI for --mongo-mode external. Default: mongodb://127.0.0.1:27017.
   --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
-  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
   --mongo-compact       Compact the MongoDB collection before final stats collection.
-                        Set to true/false, default: true.
-                        Provide as --mongo-compact=<true|false>.
+                        Set to true/false, 1/0, or yes/no.
+                        Default: true for docker mode; false for external mode unless explicitly set.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -331,13 +331,21 @@ esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
-MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=0
+  else
+    MONGO_COMPACT=1
+  fi
+else
+  MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+fi
 MONGO_COMPACT_TEXT=$(bool_01_text "$MONGO_COMPACT")
 if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
   echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
   exit 2
 fi
-if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+if [[ "$INCLUDE_MONGO" == "1" && "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -65,7 +65,7 @@ Options:
   --mongo-uri URI        MongoDB URI for --mongo-mode external. Default: mongodb://127.0.0.1:27017.
   --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
   --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
-  --mongo-compact       Compact the MongoDB collection before final stats collection.
+  --mongo-compact BOOL  Compact the MongoDB collection before final stats collection.
                         Set to true/false, 1/0, or yes/no.
                         Default: true for docker mode; false for external mode unless explicitly set.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -33,7 +33,10 @@ MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-16}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
+MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
@@ -60,6 +63,10 @@ Options:
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.
   --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -73,7 +80,7 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI, DATABASE_PREFIX,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
 TREEDB_MAINTENANCE, UPDATE_INDEXED_FIELD (0/1, true/false, or yes/no), RUN_READER_SWEEP (0/1, true/false, or yes/no), GOWORK, TIMEOUT, TITLE,
 and related storage/pool settings.
@@ -194,6 +201,20 @@ while [[ $# -gt 0 ]]; do
       MONGO_URI="$2"
       shift 2
       ;;
+    --mongo-mode)
+      require_option_value "$1" "${2-}"
+      MONGO_MODE="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_option_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
+      shift 2
+      ;;
     --database-prefix)
       require_option_value "$1" "${2-}"
       DATABASE_PREFIX="$2"
@@ -299,11 +320,21 @@ case "$UPDATE_INDEXED_FIELD" in
     fi
     ;;
   0)
-    ;;
+  ;;
 esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
+MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+MONGO_COMPACT_TEXT=$(bool_01_text "$MONGO_COMPACT")
+if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
+  echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
+  exit 2
+fi
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
+  exit 2
+fi
 
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
@@ -324,6 +355,7 @@ REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
 TREE_METADATA="$OUT_DIR/treedb-location.txt"
+MONGO_DIR="$OUT_DIR/mongodb_data"
 
 path_is_within() {
   local child=${1%/}
@@ -356,9 +388,26 @@ report_treedb_location_on_exit() {
   fi
 }
 
-trap 'report_treedb_location_on_exit "$?"' EXIT
+ACTIVE_CONTAINERS=()
+STARTED_MONGO_CONTAINER=""
+STARTED_MONGO_URI=""
 
-mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
+cleanup() {
+  local container
+  for container in "${ACTIVE_CONTAINERS[@]:-}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+}
+
+cleanup_all() {
+  local status=$1
+  cleanup
+  report_treedb_location_on_exit "$status"
+}
+
+trap 'cleanup_all "$?"' EXIT
+
+mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR" "$MONGO_DIR"
 
 PYTHON3_BIN=""
 if command -v python3 >/dev/null 2>&1; then
@@ -378,6 +427,89 @@ du_bytes() {
   local kib
   kib=$(du -sk "$dir" | awk '{print $1}')
   echo $((kib * 1024))
+}
+
+docker_du_bytes() {
+  local dir=$1
+  local kib
+  kib=$(docker run --rm -v "$dir:/data/db:ro" "$MONGO_IMAGE" sh -c 'du -sk /data/db' | awk '{print $1}')
+  echo $((kib * 1024))
+}
+
+reset_mongo_data_dir() {
+  local dir=$1
+  mkdir -p "$dir"
+  docker run --rm -v "$dir:/data/db" "$MONGO_IMAGE" sh -c 'find /data/db -mindepth 1 -maxdepth 1 -exec rm -rf {} +' >/dev/null
+}
+
+start_mongo_container() {
+  local cell=$1
+  local data_dir=$2
+  local container="gomap-mongo-scaling-$(safe_label "$cell")-$$"
+  STARTED_MONGO_CONTAINER=""
+  STARTED_MONGO_URI=""
+  reset_mongo_data_dir "$data_dir"
+  echo "starting MongoDB container $container with data dir $data_dir" >&2
+  docker run -d --rm \
+    --name "$container" \
+    -p 127.0.0.1::27017 \
+    -v "$data_dir:/data/db" \
+    "$MONGO_IMAGE" --quiet >/dev/null
+  ACTIVE_CONTAINERS+=("$container")
+  local port=""
+  for _ in $(seq 1 60); do
+    port=$(docker port "$container" 27017/tcp 2>/dev/null | awk -F: 'END {print $NF}')
+    if [[ -n "$port" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$port" ]]; then
+    echo "MongoDB container did not expose a port" >&2
+    exit 1
+  fi
+  STARTED_MONGO_CONTAINER="$container"
+  STARTED_MONGO_URI="mongodb://127.0.0.1:$port"
+}
+
+stop_mongo_container() {
+  local container=$1
+  if [[ -z "$container" ]]; then
+    return
+  fi
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  local keep=()
+  local active
+  for active in "${ACTIVE_CONTAINERS[@]:-}"; do
+    if [[ "$active" != "$container" ]]; then
+      keep+=("$active")
+    fi
+  done
+  ACTIVE_CONTAINERS=("${keep[@]}")
+}
+
+wait_for_mongo() {
+  local uri=$1
+  local database=$2
+  for _ in $(seq 1 90); do
+    if "$BENCH_BIN" \
+      -target mongo \
+      -mongo-uri "$uri" \
+      -database "$database" \
+      -collection "$COLLECTION" \
+      -documents 1 \
+      -reads 0 \
+      -range-reads 0 \
+      -updates 0 \
+      -deletes 0 \
+      -secondary-indexes 0 \
+      -timeout 20s \
+      -format json >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
 }
 
 run_bench() {
@@ -426,6 +558,13 @@ printf "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n
 echo "running Mongo gateway scaling matrix into: $OUT_DIR"
 echo "docs=$DOCS indexes=$INDEXES batch_size=$BATCH_SIZE insert_producers=$INSERT_PRODUCERS"
 echo "writers=$WRITERS_LIST readers=$READERS_LIST run_reader_sweep=$RUN_READER_SWEEP include_mongo=$INCLUDE_MONGO update_indexed_field=$UPDATE_INDEXED_FIELD_TEXT"
+echo "mongo mode: $MONGO_MODE"
+if [[ "$MONGO_MODE" == "docker" ]]; then
+  echo "mongo image: $MONGO_IMAGE"
+else
+  echo "mongo uri: $MONGO_URI"
+fi
+echo "mongo compact before final stats: $MONGO_COMPACT_TEXT"
 
 run_cell() {
   local scenario=$1
@@ -462,10 +601,29 @@ run_cell() {
     local mongo_config="mongo_${config_suffix}"
     local mongo_raw_rel="raw/${mongo_config}.json"
     local mongo_raw="$OUT_DIR/$mongo_raw_rel"
+    local mongo_data="$MONGO_DIR/$config_suffix"
+    local mongo_uri="$MONGO_URI"
+    local mongo_container=""
+    local mongo_physical=0
+
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      start_mongo_container "$config_suffix" "$mongo_data"
+      mongo_uri="$STARTED_MONGO_URI"
+      mongo_container="$STARTED_MONGO_CONTAINER"
+      if ! wait_for_mongo "$mongo_uri" "$database"; then
+        echo "MongoDB container did not become ready for $scenario readers=$readers writers=$writers" >&2
+        exit 1
+      fi
+    fi
     echo "==> MongoDB $scenario readers=$readers writers=$writers"
     run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
-      -mongo-uri "$MONGO_URI"
-    printf "mongo\t%s\t%s\t%s\t%s\t0\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" >>"$MATRIX"
+      -mongo-uri "$mongo_uri" \
+      -mongo-compact "$MONGO_COMPACT_TEXT"
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      stop_mongo_container "$mongo_container"
+      mongo_physical=$(docker_du_bytes "$mongo_data")
+    fi
+    printf "mongo\t%s\t%s\t%s\t%s\t%s\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" "$mongo_physical" >>"$MATRIX"
   fi
 }
 
@@ -531,7 +689,10 @@ cat >"$README" <<EOF
 - TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
 - update indexed field: \`$UPDATE_INDEXED_FIELD_TEXT\`
 - include MongoDB: \`$INCLUDE_MONGO\`
+- MongoDB mode: \`$MONGO_MODE\`
 - MongoDB URI: \`$MONGO_URI\`
+- MongoDB image: \`$MONGO_IMAGE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT_TEXT\`
 - MongoDB database prefix: \`$DATABASE_PREFIX\`
 - GOWORK: \`$GO_WORK_MODE\`
 - timeout: \`$TIMEOUT\`

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -484,14 +484,14 @@ stop_mongo_container() {
     return
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
-  local keep=()
+  local next_containers=()
   local active
   for active in "${ACTIVE_CONTAINERS[@]:-}"; do
     if [[ "$active" != "$container" ]]; then
-      keep+=("$active")
+      next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${keep[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -212,7 +212,12 @@ while [[ $# -gt 0 ]]; do
       MONGO_IMAGE="$2"
       shift 2
       ;;
+    --mongo-compact=*)
+      MONGO_COMPACT="${1#*=}"
+      shift
+      ;;
     --mongo-compact)
+      require_option_value "$1" "${2-}"
       MONGO_COMPACT="$2"
       shift 2
       ;;

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -20,8 +20,8 @@ MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
 MONGO_READERS="${MONGO_READERS:-1,2,4,8,16,32}"
@@ -60,8 +60,10 @@ Options:
   --mongo-docs N         Override Mongo-compatible document count.
   --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
-  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
-  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection. Default: true.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
+  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection.
+                         Set to true/false, 1/0, or yes/no.
+                         Default: true for docker mode; false for external mode unless explicitly set.
   --timeout DURATION     Per-cell timeout for Mongo gateway commands. Default: 120m.
   --title TITLE          HTML report title.
   --skip-raw             Skip raw TreeDB engine profile matrix.
@@ -97,6 +99,14 @@ normalize_list() {
 bool_true() {
   case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_bool_text() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes) printf 'true' ;;
+    0|false|no) printf 'false' ;;
     *) return 1 ;;
   esac
 }
@@ -251,12 +261,20 @@ case "$MONGO_MODE" in
     exit 2
     ;;
 esac
-if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
-  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
-  exit 2
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=false
+  else
+    MONGO_COMPACT=true
+  fi
+else
+  MONGO_COMPACT=$(normalize_bool_text "$MONGO_COMPACT") || {
+    echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true/false, 1/0, or yes/no)" >&2
+    exit 2
+  }
 fi
-if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
-  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+if [[ "$SKIP_MONGO" != "true" && "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
   exit 2
 fi
 
@@ -440,7 +458,7 @@ run_mongo_full_sweep() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -480,7 +498,7 @@ run_mongo_load_modes() {
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -508,7 +526,7 @@ run_mongo_scaling() {
       --include-mongo \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -436,7 +436,7 @@ run_mongo_full_sweep() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -476,7 +476,7 @@ run_mongo_load_modes() {
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -504,7 +504,7 @@ run_mongo_scaling() {
       --include-mongo \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -78,7 +78,7 @@ Options:
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
-MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
+MONGO_MODE, MONGO_URI, MONGO_IMAGE (default: mongo:8), MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
 EOF
 }
 
@@ -254,28 +254,36 @@ case "$TIER" in
     exit 2
     ;;
 esac
-case "$MONGO_MODE" in
-  docker|external) ;;
-  *)
-    echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
-    exit 2
-    ;;
-esac
-if [[ -z "$MONGO_COMPACT" ]]; then
-  if [[ "$MONGO_MODE" == "external" ]]; then
-    MONGO_COMPACT=false
-  else
-    MONGO_COMPACT=true
-  fi
-else
-  MONGO_COMPACT=$(normalize_bool_text "$MONGO_COMPACT") || {
-    echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true/false, 1/0, or yes/no)" >&2
-    exit 2
-  }
-fi
-if [[ "$SKIP_MONGO" != "true" && "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
-  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
+raw_skip_mongo=$SKIP_MONGO
+SKIP_MONGO=$(normalize_bool_text "$SKIP_MONGO") || {
+  echo "invalid SKIP_MONGO=$raw_skip_mongo (want true/false, 1/0, or yes/no)" >&2
   exit 2
+}
+if ! bool_true "$SKIP_MONGO"; then
+  case "$MONGO_MODE" in
+    docker|external) ;;
+    *)
+      echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
+      exit 2
+      ;;
+  esac
+  if [[ -z "$MONGO_COMPACT" ]]; then
+    if [[ "$MONGO_MODE" == "external" ]]; then
+      MONGO_COMPACT=false
+    else
+      MONGO_COMPACT=true
+    fi
+  else
+    raw_mongo_compact=$MONGO_COMPACT
+    MONGO_COMPACT=$(normalize_bool_text "$MONGO_COMPACT") || {
+      echo "invalid MONGO_COMPACT=$raw_mongo_compact (want true/false, 1/0, or yes/no)" >&2
+      exit 2
+    }
+  fi
+  if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+    echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
+    exit 2
+  fi
 fi
 
 INDEXES_LIST=$(normalize_list "$INDEXES_LIST")

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -20,6 +20,8 @@ MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
 MONGO_READERS="${MONGO_READERS:-1,2,4,8,16,32}"
@@ -58,6 +60,8 @@ Options:
   --mongo-docs N         Override Mongo-compatible document count.
   --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection. Default: true.
   --timeout DURATION     Per-cell timeout for Mongo gateway commands. Default: 120m.
   --title TITLE          HTML report title.
   --skip-raw             Skip raw TreeDB engine profile matrix.
@@ -72,7 +76,7 @@ Options:
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
-MONGO_MODE, MONGO_URI, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
+MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
 EOF
 }
 
@@ -142,6 +146,16 @@ while [[ $# -gt 0 ]]; do
     --mongo-uri)
       require_value "$1" "${2-}"
       MONGO_URI="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      require_value "$1" "${2-}"
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --timeout)
@@ -226,6 +240,21 @@ case "$TIER" in
     exit 2
     ;;
 esac
+case "$MONGO_MODE" in
+  docker|external) ;;
+  *)
+    echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
+    exit 2
+    ;;
+esac
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
+  exit 2
+fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 
 INDEXES_LIST=$(normalize_list "$INDEXES_LIST")
 MONGO_READERS=$(normalize_list "$MONGO_READERS")
@@ -285,6 +314,8 @@ write_metadata() {
     echo "- collection_profile_count: $COLLECTION_PROFILE_COUNT"
     echo "- mongo_docs: $MONGO_DOCS"
     echo "- mongo_mode: $MONGO_MODE"
+    echo "- mongo_image: $MONGO_IMAGE"
+    echo "- mongo_compact: $MONGO_COMPACT"
     echo "- mongo_uri: $MONGO_URI"
     echo "- timeout: $TIMEOUT"
     echo "- mongo_readers: $MONGO_READERS"
@@ -314,6 +345,8 @@ write_metadata() {
     printf ' --tier %q' "$TIER"
     printf ' --indexes %q' "$INDEXES_LIST"
     printf ' --mongo-mode %q' "$MONGO_MODE"
+    printf ' --mongo-image %q' "$MONGO_IMAGE"
+    printf ' --mongo-compact %q' "$MONGO_COMPACT"
     printf ' --mongo-uri %q' "$MONGO_URI"
     printf '\n```\n'
   } > "$RUN_ROOT/RUNBOOK.md"
@@ -402,6 +435,8 @@ run_mongo_full_sweep() {
       --concurrent-writer-sweep "$MONGO_WRITERS" \
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -440,6 +475,8 @@ run_mongo_load_modes() {
       --docs "$MONGO_DOCS" \
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -465,6 +502,9 @@ run_mongo_scaling() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --concurrent-reads "$MONGO_CONCURRENT_READS" \
       --include-mongo \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -153,6 +153,10 @@ while [[ $# -gt 0 ]]; do
       MONGO_IMAGE="$2"
       shift 2
       ;;
+    --mongo-compact=*)
+      MONGO_COMPACT="${1#*=}"
+      shift
+      ;;
     --mongo-compact)
       require_value "$1" "${2-}"
       MONGO_COMPACT="$2"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -426,7 +426,7 @@ run_collections() {
       -formats template-v1,bson,json \
       -benchtime "${COLLECTION_BENCHTIME:-${COLLECTION_DOCS}x}" \
       -count "${COLLECTION_COUNT:-1}" \
-      "${profile_args[@]}"
+      "${profile_args[@]:-}"
   done
 }
 


### PR DESCRIPTION
## Summary
- Default benchmark Mongo execution mode to Docker and set default Mongo image to `mongo:8` in benchmark orchestration scripts.
- Add/propagate `MONGO_IMAGE`/`--mongo-image`, `MONGO_COMPACT`/`--mongo-compact`, and `MONGO_MODE`/`--mongo-mode` through deep benchmark, full compare, and scaling paths.
- Keep per-cell container-backed MongoDB isolation in compare/scaling so runs do not collide across concurrent cells.
- Preserve `external` mode behavior when explicitly selected.

## Scope
This PR intentionally contains only benchmark-orchestration changes and is split out from prior mixed work so it does not include PR #1470's TreeDB-focused changes.

