### PR TITLE
Buffer no-index BSON  updates on direct update path

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8414,11 +8414,12 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // secondary unique index values may be staged in the write domain and become
 // durable at Flush/Close or auto-flush.
 //
-// For no-secondary-index collections, single-document BSON $set updates may be
-// staged via the direct buffered update path when the request is in BSON-only
-// mode and durability allows staging. Generic callback-based Update operations
-// remain synchronous by design in durable write modes and are still flushed to
-// the primary root before returning.
+// For no-secondary-index collections, generic callback-based Update operations
+// preserve synchronous publish semantics in every durability mode: pending
+// writes are flushed before planning, and modified documents publish to the
+// primary root before Update returns. Single-document BSON $set updates use a
+// separate direct buffered path and may stage only when WAL-off relaxed
+// durability explicitly allows deferred flush/publish behavior.
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10540,7 +10540,8 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if len(meta.Indexes) == 0 {
-		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+		return c.canBufferDirectUpdateAck() &&
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
 			structuredBSONSetBatch
 	}
@@ -11793,12 +11794,12 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	if domain.count != 0 && !primaryOnlyDirectUpdate {
-		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
+	if domain.count != 0 {
+		if !primaryOnlyDirectUpdate && (!plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot)) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
-		if plan.bufferedReadGeneration != domain.writeGeneration {
+		if plan.bufferedBase && plan.bufferedReadGeneration != domain.writeGeneration {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7176,16 +7176,18 @@ func (c *Collection) insertOneViaBatch(id, document []byte) ([]byte, error) {
 }
 
 func (c *Collection) insertOneNoIndexBSONBuffered(id, document []byte) ([]byte, error) {
-	unlockMutation := c.lockMutation()
-	mutationLocked := true
-	ids, err := c.insertBatchOnceWithLockState(
-		[][]byte{id},
-		[][]byte{document},
-		false,
-		nil,
-		&unlockMutation,
-		&mutationLocked,
-	)
+	ids, err := retryInsertBatchMutation(func() ([][]byte, error) {
+		unlockMutation := c.lockMutation()
+		mutationLocked := true
+		return c.insertBatchOnceWithLockState(
+			[][]byte{id},
+			[][]byte{document},
+			false,
+			nil,
+			&unlockMutation,
+			&mutationLocked,
+		)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3041,6 +3041,27 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func (c *Collection) canBufferDirectUpdateAck() bool {
+	if c == nil || c.db == nil || c.writeDomain == nil {
+		return false
+	}
+	return c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+}
+
+func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
+	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) || len(domain.meta.Indexes) != 0 {
+		return false
+	}
+	documentFormat, err := normalizeDocumentFormat(domain.meta.Options.DocumentFormat)
+	return err == nil && documentFormat == DocumentFormatBSON
+}
+
 func (c *Collection) bufferNoIndexInsertBatch(
 	domain *collectionWriteDomain,
 	catalog *collectionCatalog,
@@ -7223,6 +7244,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			return nil, err
 		}
 	}
+	if c.hasBufferedNoIndexBSONRootRuns() {
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+	}
 	if c.hasBufferedIndexedDeletesOnly() {
 		if err := c.flushBufferedWrites(); err != nil {
 			return nil, err
@@ -8375,13 +8401,11 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // secondary unique index values may be staged in the write domain and become
 // durable at Flush/Close or auto-flush.
 //
-// For no-secondary-index collections, single-document Update deliberately
-// preserves the current synchronous publish contract: pending collection-local
-// writes are flushed first, then a modified document is published to the
-// primary root before Update returns. No-index updates may coalesce only
-// opportunistically when callers already reach the existing combiner as a
-// multi-request UpdateBatch-backed batch; they are not staged in the no-index
-// insert buffer or indexed flush queues.
+// For no-secondary-index collections, single-document BSON $set updates may be
+// staged via the direct buffered update path when the request is in BSON-only
+// mode and durability allows staging. Generic callback-based Update operations
+// remain synchronous by design in durable write modes and are still flushed to
+// the primary root before returning.
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
@@ -8619,6 +8643,18 @@ func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
 		}
 	}
 	return -1
+}
+
+func updateBatchItemsAllHaveBSONSet(items []updateBatchItem) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if !item.hasBSONSet {
+			return false
+		}
+	}
+	return true
 }
 
 func updateBatchItemError(index int, err error) error {
@@ -10499,11 +10535,16 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
-	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+	if len(meta.Indexes) == 0 {
+		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
+			structuredBSONSetBatch
+	}
+	if !meta.Options.BufferedIndexedWrites {
 		return false
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
@@ -10598,8 +10639,10 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					return nil
 				}
 				if plan.directBufferedUpdate != nil {
-					if err := c.flushBufferedWrites(); err != nil {
-						return err
+					if !c.canBufferDirectUpdateAck() {
+						if err := c.flushBufferedWrites(); err != nil {
+							return err
+						}
 					}
 					useBufferedRead = false
 					replan = true
@@ -10682,8 +10725,10 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 			return nil
 		}
 		if plan.directBufferedUpdate != nil {
-			if err := c.flushBufferedWrites(); err != nil {
-				return err
+			if !c.canBufferDirectUpdateAck() {
+				if err := c.flushBufferedWrites(); err != nil {
+					return err
+				}
 			}
 			return ErrConcurrentMutation
 		}
@@ -10765,6 +10810,9 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
 	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
+	}
+	if len(meta.Indexes) == 0 {
+		return true
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
@@ -11344,7 +11392,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed)
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, updateBatchItemsAllHaveBSONSet(items))
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
@@ -11709,7 +11757,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
-	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	primaryOnlyDirectUpdate := len(plan.meta.Indexes) == 0
+	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || (!primaryOnlyDirectUpdate && !plan.meta.Options.BufferedIndexedWrites) {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}
@@ -11744,7 +11793,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	if domain.count != 0 {
+	if domain.count != 0 && !primaryOnlyDirectUpdate {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
@@ -11753,6 +11802,10 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
+	}
+	if primaryOnlyDirectUpdate && domain.count != 0 && !hasBufferedIndexedRootRuns(domain) {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, nil
 	}
 	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
@@ -11790,9 +11843,12 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
 	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, plan.rootNames)
-	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	shouldAutoFlushAfterAdding := false
+	if !primaryOnlyDirectUpdate {
+		shouldAutoFlushAfterAdding = shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	}
 	requiresPreAppendFreeze := false
-	if collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
 			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
 				requiresPreAppendFreeze = true
@@ -11930,15 +11986,19 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
 	c.meta = plan.meta
-	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
-	if err != nil {
-		if rollbackOnError {
-			rollbackBufferedIndexedDomain(domain, checkpoint)
-			c.meta = collectionMetaCheckpoint
+	var compactedObsolete []memtable.Table
+	if !primaryOnlyDirectUpdate {
+		var err error
+		compactedObsolete, err = maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
+		if err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return false, err
 		}
-		return false, err
 	}
-	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		freezePreAppendTables()
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2842,9 +2842,6 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(c.meta.Indexes) == 0 {
-		if c.canBufferNoIndexInsertBatchAck() && isBSONDocumentFormat(c.meta.Options.DocumentFormat) {
-			return c.insertOneNoIndexBSONBuffered(id, document)
-		}
 		if c.hasBufferedNoIndexBSONRootRuns() {
 			if err := c.withMutationLock(func() error {
 				return c.flushBufferedWrites()
@@ -3058,7 +3055,12 @@ func (c *Collection) canBufferDirectUpdateAck() bool {
 	if c == nil || c.db == nil || c.writeDomain == nil {
 		return false
 	}
-	return c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+	switch c.db.DurabilityMode() {
+	case backenddb.DurabilityWALOffRelaxed, backenddb.DurabilityWALOnRelaxed:
+		return true
+	default:
+		return false
+	}
 }
 
 func isBSONDocumentFormat(format DocumentFormat) bool {
@@ -7178,28 +7180,6 @@ func (c *Collection) insertOneViaBatch(id, document []byte) ([]byte, error) {
 	return ids[0], nil
 }
 
-func (c *Collection) insertOneNoIndexBSONBuffered(id, document []byte) ([]byte, error) {
-	ids, err := retryInsertBatchMutation(func() ([][]byte, error) {
-		unlockMutation := c.lockMutation()
-		mutationLocked := true
-		return c.insertBatchOnceWithLockState(
-			[][]byte{id},
-			[][]byte{document},
-			false,
-			nil,
-			&unlockMutation,
-			&mutationLocked,
-		)
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(ids) != 1 {
-		return nil, errors.New("collections: insert returned no document id")
-	}
-	return ids[0], nil
-}
-
 // InsertBatch adds a batch of documents and returns the stored document IDs.
 //
 // Under the collection WAL target contract, WAL-on success makes the whole
@@ -8458,8 +8438,8 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // preserve synchronous publish semantics in every durability mode: pending
 // writes are flushed before planning, and modified documents publish to the
 // primary root before Update returns. Single-document BSON $set updates use a
-// separate direct buffered path and may stage only when WAL-off relaxed
-// durability explicitly allows deferred flush/publish behavior.
+// separate direct buffered path and may stage when durability mode allows
+// deferred flush/publish behavior (WAL-off relaxed and WAL-on relaxed).
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
@@ -10597,7 +10577,8 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if len(meta.Indexes) == 0 {
-		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+		return c.canBufferDirectUpdateAck() &&
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2839,6 +2839,11 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, errCollectionDBNil
 	}
 	if len(c.meta.Indexes) == 0 {
+		if c.hasBufferedNoIndexBSONRootRuns() {
+			if err := c.flushBufferedWrites(); err != nil {
+				return nil, err
+			}
+		}
 		return c.insertOneNoIndexBuffered(id, document)
 	}
 	ids, err := c.InsertBatch([][]byte{id}, [][]byte{document})
@@ -10545,6 +10550,9 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 
 func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
 	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	if len(changed) == 0 {
 		return false
 	}
 	if len(meta.Indexes) == 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2839,6 +2839,9 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, errCollectionDBNil
 	}
 	if len(c.meta.Indexes) == 0 {
+		if c.canBufferNoIndexInsertBatchAck() && isBSONDocumentFormat(c.meta.Options.DocumentFormat) {
+			return c.insertOneNoIndexBSONBuffered(id, document)
+		}
 		if c.hasBufferedNoIndexBSONRootRuns() {
 			if err := c.withMutationLock(func() error {
 				return c.flushBufferedWrites()
@@ -7172,6 +7175,26 @@ func (c *Collection) insertOneViaBatch(id, document []byte) ([]byte, error) {
 	return ids[0], nil
 }
 
+func (c *Collection) insertOneNoIndexBSONBuffered(id, document []byte) ([]byte, error) {
+	unlockMutation := c.lockMutation()
+	mutationLocked := true
+	ids, err := c.insertBatchOnceWithLockState(
+		[][]byte{id},
+		[][]byte{document},
+		false,
+		nil,
+		&unlockMutation,
+		&mutationLocked,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) != 1 {
+		return nil, errors.New("collections: insert returned no document id")
+	}
+	return ids[0], nil
+}
+
 // InsertBatch adds a batch of documents and returns the stored document IDs.
 //
 // Under the collection WAL target contract, WAL-on success makes the whole
@@ -7233,10 +7256,20 @@ func retryInsertBatchMutation(run func() ([][]byte, error)) ([][]byte, error) {
 func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder) ([][]byte, error) {
 	unlockMutation := c.lockMutation()
 	mutationLocked := true
+	return c.insertBatchOnceWithLockState(ids, documents, trustedValidBSON, templateEncoder, &unlockMutation, &mutationLocked)
+}
+
+func (c *Collection) insertBatchOnceWithLockState(
+	ids, documents [][]byte,
+	trustedValidBSON bool,
+	templateEncoder *TemplateV1Encoder,
+	unlockMutation *collectionMutationUnlock,
+	mutationLocked *bool,
+) ([][]byte, error) {
 	unlockIfLocked := func() {
-		if mutationLocked {
+		if mutationLocked != nil && *mutationLocked && unlockMutation != nil {
 			unlockMutation.Unlock()
-			mutationLocked = false
+			*mutationLocked = false
 		}
 	}
 	defer unlockIfLocked()
@@ -7464,7 +7497,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
-		pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
+		pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(mutationLocked, unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
 			return nil, err
@@ -7486,7 +7519,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return nil, err
 	}
 
-	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
+	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(mutationLocked, unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
 	if err != nil {
 		resetCollectionRunTables(plan.runs)
 		return nil, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11795,18 +11795,14 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 
 	phaseStart := updateBatchStatsNow(detailedStats)
 	if domain.count != 0 {
-		if !primaryOnlyDirectUpdate && (!plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot)) {
+		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
-		if plan.bufferedBase && plan.bufferedReadGeneration != domain.writeGeneration {
+		if plan.bufferedReadGeneration != domain.writeGeneration {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
-	}
-	if primaryOnlyDirectUpdate && domain.count != 0 && !hasBufferedIndexedRootRuns(domain) {
-		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
-		return false, ErrConcurrentMutation
 	}
 	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11806,7 +11806,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	if primaryOnlyDirectUpdate && domain.count != 0 && !hasBufferedIndexedRootRuns(domain) {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
-		return false, nil
+		return false, ErrConcurrentMutation
 	}
 	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8448,9 +8448,12 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // testing.T.Fatal.
 //
 // Under the collection WAL target contract, WAL-on success is process-crash
-// recoverable. Retry after timeout or commit-ambiguous failure is safe only when
-// the update function is idempotent or protected by an application-level guard
-// or durable idempotency key.
+// recoverable for update operations that publish before returning. Direct-
+// buffered BSON $set updates in WAL-on relaxed mode defer that recoverability
+// boundary until Flush/Close publishes the staged root runs. Retry after timeout
+// or commit-ambiguous failure is safe only when the update function is
+// idempotent or protected by an application-level guard or durable idempotency
+// key.
 func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3048,6 +3048,11 @@ func (c *Collection) canBufferDirectUpdateAck() bool {
 	return c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func isBSONDocumentFormat(format DocumentFormat) bool {
+	normalized, err := normalizeDocumentFormat(format)
+	return err == nil && normalized == DocumentFormatBSON
+}
+
 func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
 	if c == nil || c.writeDomain == nil {
 		return false
@@ -3055,11 +3060,14 @@ func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) || len(domain.meta.Indexes) != 0 {
+	if domain.count == 0 || len(domain.meta.Indexes) != 0 {
 		return false
 	}
-	documentFormat, err := normalizeDocumentFormat(domain.meta.Options.DocumentFormat)
-	return err == nil && documentFormat == DocumentFormatBSON
+	collectionName := bufferedDomainCollectionName(domain, c.meta.Name)
+	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
+		return false
+	}
+	return isBSONDocumentFormat(domain.meta.Options.DocumentFormat)
 }
 
 func (c *Collection) bufferNoIndexInsertBatch(
@@ -7235,7 +7243,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	}
 	skipInitialNoIndexFlush := false
 	if trustedValidBSON && c.canBufferNoIndexInsertBatchAck() && len(c.meta.Indexes) == 0 {
-		if documentFormat, err := normalizeDocumentFormat(c.meta.Options.DocumentFormat); err == nil && documentFormat == DocumentFormatBSON {
+		if isBSONDocumentFormat(c.meta.Options.DocumentFormat) {
 			skipInitialNoIndexFlush = true
 		}
 	}
@@ -10542,7 +10550,7 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 	if len(meta.Indexes) == 0 {
 		return c.canBufferDirectUpdateAck() &&
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
-			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
+			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
 	}
 	if !meta.Options.BufferedIndexedWrites {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11985,6 +11985,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		rollbackGeneration = domain.writeGeneration
 	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
+	if primaryOnlyDirectUpdate {
+		domain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, false, collectionRootDeltaPlanStats{})
+	}
 	c.meta = plan.meta
 	var compactedObsolete []memtable.Table
 	if !primaryOnlyDirectUpdate {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2838,6 +2838,9 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if c.db == nil {
 		return nil, errCollectionDBNil
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, err
+	}
 	if len(c.meta.Indexes) == 0 {
 		if c.canBufferNoIndexInsertBatchAck() && isBSONDocumentFormat(c.meta.Options.DocumentFormat) {
 			return c.insertOneNoIndexBSONBuffered(id, document)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2840,12 +2840,11 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	}
 	if len(c.meta.Indexes) == 0 {
 		if c.hasBufferedNoIndexBSONRootRuns() {
-			unlockMutation := c.lockMutation()
-			if err := c.flushBufferedWrites(); err != nil {
-				unlockMutation.Unlock()
+			if err := c.withMutationLock(func() error {
+				return c.flushBufferedWrites()
+			}); err != nil {
 				return nil, err
 			}
-			unlockMutation.Unlock()
 		}
 		return c.insertOneNoIndexBuffered(id, document)
 	}
@@ -3072,7 +3071,7 @@ func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
 		return false
 	}
 	collectionName := bufferedDomainCollectionName(domain, c.meta.Name)
-	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
+	if collectionName == "" || !hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
 	}
 	return isBSONDocumentFormat(domain.meta.Options.DocumentFormat)
@@ -4673,7 +4672,7 @@ func pendingIndexedRootRunsLocked(domain *collectionWriteDomain, rootName string
 	return out
 }
 
-func hasPendingIndexedRootRunsForRootLocked(domain *collectionWriteDomain, rootName string) bool {
+func hasPendingRootRunsForRootLocked(domain *collectionWriteDomain, rootName string) bool {
 	if domain == nil || rootName == "" {
 		return false
 	}
@@ -10829,7 +10828,7 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 		return false
 	}
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
-	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
+	if collectionName == "" || !hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
 	}
 	if len(meta.Indexes) == 0 {
@@ -11837,7 +11836,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, fmt.Errorf("collections: UpdateBatch collection %q direct plan missing base root for %q", plan.meta.Name, rootName)
 		}
-		if hasPendingIndexedRootRunsForRootLocked(domain, rootName) {
+		if hasPendingRootRunsForRootLocked(domain, rootName) {
 			if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
 				plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
 				return false, errBufferedRootBaseMismatch(plan.meta.Name, rootName)
@@ -12137,7 +12136,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		if table == nil || table.Len() == 0 {
 			continue
 		}
-		if hasPendingIndexedRootRunsForRootLocked(domain, rootName) {
+		if hasPendingRootRunsForRootLocked(domain, rootName) {
 			if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
 				plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
 				return false, errBufferedRootBaseMismatch(plan.meta.Name, rootName)
@@ -13855,7 +13854,7 @@ func hasBufferedPrimaryRootRuns(domain *collectionWriteDomain, fallbackCollectio
 	if collectionName == "" {
 		return false
 	}
-	return hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName))
+	return hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName))
 }
 
 func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain, documentID []byte, dst []byte) ([]byte, bool, bool) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10594,8 +10594,7 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if len(meta.Indexes) == 0 {
-		return c.canBufferDirectUpdateAck() &&
-			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2840,9 +2840,12 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	}
 	if len(c.meta.Indexes) == 0 {
 		if c.hasBufferedNoIndexBSONRootRuns() {
+			unlockMutation := c.lockMutation()
 			if err := c.flushBufferedWrites(); err != nil {
+				unlockMutation.Unlock()
 				return nil, err
 			}
+			unlockMutation.Unlock()
 		}
 		return c.insertOneNoIndexBuffered(id, document)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10822,6 +10822,276 @@ func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-before.CommitSeq)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.BufferedBatches, 1; got != want {
+		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update: %v", err)
+	}
+	afterFlush := d.State()
+	if afterFlush.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq to %d from %d, want one publish", afterFlush.CommitSeq, before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after flush: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxBytes:     1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOnRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want buffered", afterUpdate.CommitSeq, before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 {
+		t.Fatalf("root runs=%d want 1", rootRunCount)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
+func TestCollectionUpdateNoIndexBSONCallbackPublishesSynchronously(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	before := d.State()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "sea"},
+		}), true, nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("Update commit seq=%d before=%d want synchronous publish", after.CommitSeq, before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("callback update root runs=%d want 0", rootRunCount)
+	}
+}
+
 func TestCollectionUpdateBSONSetRequiresBSONFormat(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11032,6 +11032,97 @@ func TestCollectionInsertNoIndexBSONFlushesPendingRootRunsBeforeSingleInsert(t *
 	}
 }
 
+func TestCollectionInsertBatchNoIndexBSONFlushesPendingRootRunsBeforeBatchInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed insert: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("UpdateBSONSet matched=%v modified=%v want true/true", matched, modified)
+	}
+	beforeBatch := d.State()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2"), []byte("u3")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u2"},
+				{Key: "city", Value: "sfo"},
+			}),
+			mustBSONCollectionDocument(t, bson.D{
+				{Key: "_id", Value: "u3"},
+				{Key: "city", Value: "nyc"},
+			}),
+		},
+	); err != nil {
+		t.Fatalf("insert batch after buffered update: %v", err)
+	}
+	afterBatch := d.State()
+	if afterBatch.CommitSeq <= beforeBatch.CommitSeq {
+		t.Fatalf("insert batch commit seq=%d before=%d want buffered update flush publish", afterBatch.CommitSeq, beforeBatch.CommitSeq)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush mixed buffered writes: %v", err)
+	}
+	doc1, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got := bson.Raw(doc1).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("u1 city=%q want sea", got)
+	}
+	doc2, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if got := bson.Raw(doc2).Lookup("city").StringValue(); got != "sfo" {
+		t.Fatalf("u2 city=%q want sfo", got)
+	}
+	doc3, err := col.Get([]byte("u3"))
+	if err != nil {
+		t.Fatalf("get u3: %v", err)
+	}
+	if got := bson.Raw(doc3).Lookup("city").StringValue(); got != "nyc" {
+		t.Fatalf("u3 city=%q want nyc", got)
+	}
+}
+
 func TestCollectionUpdateBSONSetNoIndexNoopSkipsDirectBufferedRetryLoop(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11185,7 +11185,7 @@ func TestCollectionUpdateBSONSetNoIndexNoopSkipsDirectBufferedRetryLoop(t *testi
 	}
 }
 
-func TestCollectionUpdateBSONSetNoIndexWALOnPublishesBeforeAck(t *testing.T) {
+func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),
 		Durability: backenddb.DurabilityWALOnRelaxed,
@@ -11233,14 +11233,14 @@ func TestCollectionUpdateBSONSetNoIndexWALOnPublishesBeforeAck(t *testing.T) {
 		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
 	}
 	afterUpdate := d.State()
-	if afterUpdate.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want synchronous publish", afterUpdate.CommitSeq, before.CommitSeq)
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want buffered", afterUpdate.CommitSeq, before.CommitSeq)
 	}
 	col.writeDomain.mu.RLock()
 	rootRunCount := col.writeDomain.rootRunCount
 	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 0 {
-		t.Fatalf("root runs=%d want 0 after publish", rootRunCount)
+	if rootRunCount != 1 {
+		t.Fatalf("root runs=%d want 1", rootRunCount)
 	}
 	doc, err := col.Get([]byte("u1"))
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10962,7 +10962,7 @@ func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
 	}
 }
 
-func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
+func TestCollectionUpdateBSONSetNoIndexWALOnPublishesBeforeAck(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),
 		Durability: backenddb.DurabilityWALOnRelaxed,
@@ -11010,14 +11010,14 @@ func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
 		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
 	}
 	afterUpdate := d.State()
-	if afterUpdate.CommitSeq != before.CommitSeq {
-		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want buffered", afterUpdate.CommitSeq, before.CommitSeq)
+	if afterUpdate.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want synchronous publish", afterUpdate.CommitSeq, before.CommitSeq)
 	}
 	col.writeDomain.mu.RLock()
 	rootRunCount := col.writeDomain.rootRunCount
 	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 1 {
-		t.Fatalf("root runs=%d want 1", rootRunCount)
+	if rootRunCount != 0 {
+		t.Fatalf("root runs=%d want 0 after publish", rootRunCount)
 	}
 	doc, err := col.Get([]byte("u1"))
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12120,6 +12120,88 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBuffere
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStalePrimaryOnlyDirectPlan(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	spec, err := newBSONSetUpdate([]BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sfo"),
+	}})
+	if err != nil {
+		t.Fatalf("prepare stale primary-only bson set spec: %v", err)
+	}
+	plan, err := col.buildUpdateBatchPlan([]updateBatchItem{
+		newBSONSetUpdateBatchItem([]byte("u1"), spec),
+	}, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build stale primary-only plan: %v", err)
+	}
+	defer plan.close()
+	if plan.bufferedBase {
+		t.Fatalf("plan bufferedBase=%v want false when domain was empty", plan.bufferedBase)
+	}
+	if !plan.canBufferDirectUpdateBatch || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.primaryEntries) == 0 {
+		t.Fatalf("plan direct buffered path unavailable: canBuffer=%v directPlan=%v primaryEntries=%d", plan.canBufferDirectUpdateBatch, plan.directBufferedUpdate != nil, len(plan.directBufferedUpdate.primaryEntries))
+	}
+
+	if _, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	col.writeDomain.mu.RLock()
+	bufferedCount := col.writeDomain.count
+	col.writeDomain.mu.RUnlock()
+	if bufferedCount == 0 {
+		t.Fatalf("expected buffered no-index update to stage pending state")
+	}
+
+	err = col.withMutationLock(func() error {
+		buffered, err := col.bufferUpdateBatchPlanLocked(plan)
+		if buffered {
+			t.Fatalf("stale primary-only plan buffered successfully")
+		}
+		return err
+	})
+	if !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("buffer stale primary-only plan err=%v want ErrConcurrentMutation", err)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleZeroDeltaPlan(t *testing.T) {
 	_, col := newBufferedUsersUpdateCollection(t)
 	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4629,6 +4629,45 @@ func TestCollectionIndexedInsertAccumulatorThresholds(t *testing.T) {
 	}
 }
 
+func TestCollectionInsertNoIndexBSONRejectsClosedWriteDomain(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if col.writeDomain == nil {
+		t.Fatal("missing write domain")
+	}
+	col.writeDomain.closingWrites.Store(true)
+	_, err = col.Insert(
+		[]byte("u1"),
+		mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: int32(1)},
+		}),
+	)
+	if !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("insert err=%v want %v", err, backenddb.ErrClosed)
+	}
+}
+
 func TestCollectionInsertRetryRetriesWrappedConcurrentMutation(t *testing.T) {
 	attempts := 0
 	result, err := retryInsertBatchMutation(func() ([][]byte, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10962,6 +10962,138 @@ func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
 	}
 }
 
+func TestCollectionInsertNoIndexBSONFlushesPendingRootRunsBeforeSingleInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert batch seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed insert: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("UpdateBSONSet matched=%v modified=%v want true/true", matched, modified)
+	}
+	if _, err := col.Insert([]byte("u2"), mustBSONCollectionDocument(t, bson.D{
+		{Key: "_id", Value: "u2"},
+		{Key: "city", Value: "sfo"},
+	})); err != nil {
+		t.Fatalf("single insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush mixed buffered writes: %v", err)
+	}
+	doc1, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got := bson.Raw(doc1).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("u1 city=%q want sea", got)
+	}
+	doc2, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if got := bson.Raw(doc2).Lookup("city").StringValue(); got != "sfo" {
+		t.Fatalf("u2 city=%q want sfo", got)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexNoopSkipsDirectBufferedRetryLoop(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "hnl"),
+	}})
+	if err != nil {
+		t.Fatalf("noop UpdateBSONSet existing doc: %v", err)
+	}
+	if !matched || modified {
+		t.Fatalf("noop existing doc matched=%v modified=%v want true/false", matched, modified)
+	}
+	matched, modified, err = col.UpdateBSONSet([]byte("missing"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("noop UpdateBSONSet missing doc: %v", err)
+	}
+	if matched || modified {
+		t.Fatalf("noop missing doc matched=%v modified=%v want false/false", matched, modified)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("noop BSON updates advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateBSONSetNoIndexWALOnPublishesBeforeAck(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),

--- a/TreeDB/collections/benchmark_update_batch_size1_test.go
+++ b/TreeDB/collections/benchmark_update_batch_size1_test.go
@@ -24,7 +24,10 @@ func benchmarkCollectionUpdateCallbackVsUpdateBatch(b *testing.B, secondaryIndex
 		b.Fatalf("unsupported secondaryIndexes=%d", secondaryIndexes)
 	}
 
-	const docCount = 10000
+	const (
+		docCount         = 10000
+		preloadBatchSize = 1000
+	)
 	indexes := []collections.IndexDefinition{}
 	if secondaryIndexes == 1 {
 		indexes = append(indexes, collections.IndexDefinition{
@@ -71,8 +74,8 @@ func benchmarkCollectionUpdateCallbackVsUpdateBatch(b *testing.B, secondaryIndex
 			ids[i] = []byte("doc-" + strconv.Itoa(i))
 			docs[i] = []byte(`{"_id":"` + string(ids[i]) + `","pad":"static","count":0}`)
 		}
-		for i := 0; i < docCount; i += 16000 {
-			end := i + 16000
+		for i := 0; i < docCount; i += preloadBatchSize {
+			end := i + preloadBatchSize
 			if end > docCount {
 				end = docCount
 			}

--- a/TreeDB/collections/benchmark_update_batch_size1_test.go
+++ b/TreeDB/collections/benchmark_update_batch_size1_test.go
@@ -10,11 +10,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_NoIndex_Size1(b *testing.B) {
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatchJSON_NoIndex_Size1(b *testing.B) {
 	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 0)
 }
 
-func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_OneIndex_Size1(b *testing.B) {
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatchJSON_OneIndex_Size1(b *testing.B) {
 	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 1)
 }
 

--- a/TreeDB/collections/benchmark_update_batch_size1_test.go
+++ b/TreeDB/collections/benchmark_update_batch_size1_test.go
@@ -1,0 +1,238 @@
+package collections_test
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_NoIndex_Size1(b *testing.B) {
+	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 0)
+}
+
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_OneIndex_Size1(b *testing.B) {
+	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 1)
+}
+
+func benchmarkCollectionUpdateCallbackVsUpdateBatch(b *testing.B, secondaryIndexes int) {
+	b.Helper()
+	if secondaryIndexes < 0 || secondaryIndexes > 1 {
+		b.Fatalf("unsupported secondaryIndexes=%d", secondaryIndexes)
+	}
+
+	const docCount = 10000
+	indexes := []collections.IndexDefinition{}
+	if secondaryIndexes == 1 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:      "pad_1",
+			Field:     "pad",
+			ValueType: collections.IndexValueString,
+		})
+	}
+
+	openCollection := func() (*collections.Collection, [][]byte, func()) {
+		dbDir := b.TempDir()
+		opts := treedb.OptionsFor(treedb.ProfileFast, dbDir)
+		opts.IndexOuterLeavesInValueLog = true
+		opts.Durability = treedb.DurabilityWALOffRelaxed
+		backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+		if err != nil {
+			b.Fatalf("open backend: %v", err)
+		}
+		manager := collections.NewCollectionManager(backend)
+		meta := &collections.CollectionMeta{
+			Name: "bench.docs",
+			Options: collections.CollectionOptions{
+				DocumentFormat:          collections.DocumentFormatJSON,
+				DataRootStoragePolicy:   collections.RootStorageCompressed,
+				IndexStateStoragePolicy: collections.RootStorageCompressed,
+				BufferedIndexedWrites:   secondaryIndexes > 0,
+			},
+			Indexes: make([]collections.IndexDefinition, len(indexes)),
+		}
+		copy(meta.Indexes, indexes)
+		if _, err := manager.CreateCollection(meta); err != nil {
+			_ = cleanup()
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench.docs")
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("open collection: %v", err)
+		}
+
+		ids := make([][]byte, docCount)
+		docs := make([][]byte, docCount)
+		for i := 0; i < docCount; i++ {
+			ids[i] = []byte("doc-" + strconv.Itoa(i))
+			docs[i] = []byte(`{"_id":"` + string(ids[i]) + `","pad":"static","count":0}`)
+		}
+		for i := 0; i < docCount; i += 16000 {
+			end := i + 16000
+			if end > docCount {
+				end = docCount
+			}
+			if _, err := collection.InsertBatch(ids[i:end], docs[i:end]); err != nil {
+				_ = cleanup()
+				b.Fatalf("insert batch [%d:%d]: %v", i, end, err)
+			}
+		}
+		if err := manager.FlushAll(); err != nil {
+			_ = cleanup()
+			b.Fatalf("flush preload docs: %v", err)
+		}
+		cleanupClosure := func() { _ = cleanup() }
+		return collection, ids, cleanupClosure
+	}
+
+	updateFn := func(current []byte) ([]byte, bool, error) {
+		next := append([]byte{}, current...)
+		if bytes.Contains(next, []byte(`"count":0`)) {
+			next = bytes.Replace(next, []byte(`"count":0`), []byte(`"count":1`), 1)
+		} else {
+			next = bytes.Replace(next, []byte(`"count":1`), []byte(`"count":0`), 1)
+		}
+		return next, true, nil
+	}
+
+	b.Run("Update", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := ids[i%docCount]
+			if _, _, err := collection.Update(id, updateFn); err != nil {
+				b.Fatalf("update: %v", err)
+			}
+		}
+	})
+
+	b.Run("UpdateBatchSize1", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		items := []collections.UpdateBatchItem{
+			{
+				DocumentID: ids[0],
+				Update:     updateFn,
+			},
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			items[0].DocumentID = ids[i%docCount]
+			if _, err := collection.UpdateBatch(items); err != nil {
+				b.Fatalf("update batch: %v", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkCollectionUpdateBSONSetVsBatch_NoIndex_Size1(b *testing.B) {
+	const docCount = 10000
+	openCollection := func() (*collections.Collection, [][]byte, func()) {
+		dbDir := b.TempDir()
+		opts := treedb.OptionsFor(treedb.ProfileFast, dbDir)
+		opts.IndexOuterLeavesInValueLog = true
+		opts.Durability = treedb.DurabilityWALOffRelaxed
+		backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+		if err != nil {
+			b.Fatalf("open backend: %v", err)
+		}
+		manager := collections.NewCollectionManager(backend)
+		meta := &collections.CollectionMeta{
+			Name: "bench.docs",
+			Options: collections.CollectionOptions{
+				DocumentFormat:          collections.DocumentFormatBSON,
+				DataRootStoragePolicy:   collections.RootStorageCompressed,
+				IndexStateStoragePolicy: collections.RootStorageCompressed,
+			},
+		}
+		if _, err := manager.CreateCollection(meta); err != nil {
+			_ = cleanup()
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench.docs")
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("open collection: %v", err)
+		}
+		ids := make([][]byte, docCount)
+		docs := make([][]byte, docCount)
+		for i := 0; i < docCount; i++ {
+			id := "doc-" + strconv.Itoa(i)
+			ids[i] = []byte(id)
+			doc, err := bson.Marshal(bson.D{
+				{Key: "_id", Value: id},
+				{Key: "city", Value: "hnl"},
+			})
+			if err != nil {
+				_ = cleanup()
+				b.Fatalf("marshal doc: %v", err)
+			}
+			docs[i] = doc
+		}
+		if _, err := collection.InsertBatchValidatedBSON(ids, docs); err != nil {
+			_ = cleanup()
+			b.Fatalf("insert docs: %v", err)
+		}
+		if err := manager.FlushAll(); err != nil {
+			_ = cleanup()
+			b.Fatalf("flush preload docs: %v", err)
+		}
+		cleanupClosure := func() { _ = cleanup() }
+		return collection, ids, cleanupClosure
+	}
+
+	seaType, seaRaw, err := bson.MarshalValue("sea")
+	if err != nil {
+		b.Fatalf("marshal sea value: %v", err)
+	}
+	sfoType, sfoRaw, err := bson.MarshalValue("sfo")
+	if err != nil {
+		b.Fatalf("marshal sfo value: %v", err)
+	}
+	values := []bson.RawValue{
+		{Type: seaType, Value: seaRaw},
+		{Type: sfoType, Value: sfoRaw},
+	}
+
+	b.Run("UpdateBSONSet", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := ids[i%docCount]
+			_, _, err := collection.UpdateBSONSet(id, []collections.BSONSetField{{
+				Key:   "city",
+				Value: values[i%2],
+			}})
+			if err != nil {
+				b.Fatalf("UpdateBSONSet: %v", err)
+			}
+		}
+	})
+
+	b.Run("UpdateBSONSetBatchSize1", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		item := []collections.BSONSetUpdateBatchItem{{
+			DocumentID: ids[0],
+			Fields: []collections.BSONSetField{{
+				Key:   "city",
+				Value: values[0],
+			}},
+		}}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			item[0].DocumentID = ids[i%docCount]
+			item[0].Fields[0].Value = values[i%2]
+			if _, _, err := collection.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(item); err != nil {
+				b.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+			}
+		}
+	})
+}

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -48,6 +48,10 @@ var bsonSetBatchDocumentIDHashSeed = maphash.MakeSeed()
 // return matched=false. If all assigned values already match the stored
 // document, modified=false. Callers must not mutate fields or RawValue byte
 // slices until UpdateBSONSet returns.
+//
+// For no-index collections, this path may stage buffered root runs in WAL-off
+// relaxed and WAL-on relaxed modes; when staged, crash-recoverability is
+// deferred until Flush/Close publishes the buffered runs.
 func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bool, bool, error) {
 	if err := validateCollectionUpdateDocumentInput(c, documentID); err != nil {
 		return false, false, err

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,15 +1239,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 0 before flush", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 1 (synchronous publish in WAL-on mode)", after.CommitSeq-before.CommitSeq)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush coalesced updates: %v", err)
 	}
 	flushed := db.State()
 	if flushed.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+		t.Fatalf("flush should be idempotent after synchronous publish, commit seq delta=%d want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,8 +1239,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush coalesced updates: %v", err)
+	}
+	flushed := db.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,15 +1239,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 1 (synchronous publish in WAL-on mode)", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 0 before flush", after.CommitSeq-before.CommitSeq)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush coalesced updates: %v", err)
 	}
 	flushed := db.State()
 	if flushed.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("flush should be idempotent after synchronous publish, commit seq delta=%d want 1", flushed.CommitSeq-before.CommitSeq)
+		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,15 +1239,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 1 (synchronous publish in WAL-on mode)", after.CommitSeq-before.CommitSeq)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush coalesced updates: %v", err)
 	}
 	flushed := db.State()
 	if flushed.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+		t.Fatalf("flush should be idempotent after synchronous publish, commit seq delta=%d want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable direct buffered update planning for no-index BSON `$set` update batches
- keep generic callback `Update(...)` behavior unchanged while removing the conservative synchronous publish requirement for structured BSON-set updates
- allow buffered-domain reads for no-index BSON direct updates and avoid indexed-only auto-flush/compact logic in primary-only staging
- flush pending no-index BSON staged root-runs before no-index insert batching to avoid mixed-path conflicts
- update gateway coalescing expectation to match buffered commit semantics and explicit flush durability boundary
- add targeted no-index behavior tests and BSON `$set` size-1 microbench coverage

## Why
No-index BSON update throughput was still constrained by synchronous publish behavior even after earlier structured `$set` fast-path routing. This change aligns no-index BSON `$set` updates with the same staged direct-buffer contract used by faster buffered update paths.

## Validation
Executed:
- `GOWORK=off go test ./TreeDB/collections -run '^TestCollectionUpdate|^TestCollectionUpdateBatch' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerUpdateCoalescesConcurrentDistinctIDs|TestServerRunMongoUpdateBatch|TestServerUpdateBatchNoIndex|TestRunMongoUpdateBatch' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionUpdateBSONSetVsBatch_NoIndex_Size1|BenchmarkCollectionUpdate_CallbackVsUpdateBatchJSON_NoIndex_Size1' -benchmem -count=1 -benchtime=3s`
- `OUT_DIR=/tmp/gomap_id_update_0idx_current_20260510_150855 GOWORK=off scripts/mongo_gateway_scaling_bench.sh --indexes 0 --writers "1 2 4 8 16 32 64" --no-reader-sweep --treedb-format bson --client-mode driver-command-raw --maintenance none`

Observed writer sweep wall ops/sec (`concurrent_id_update_set_wN`):
- w1: 15,689
- w2: 27,728
- w4: 41,539
- w8: 61,546
- w16: 92,822
- w32: 113,117
- w64: 124,198

## Notes
- intentionally excluded unrelated local change in `scripts/treedb_benchmark_run_report.sh` from this PR

