### PR TITLE
caching: remove GetAppend fallback entry-materialization overhead

### DIFF
--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -692,6 +692,8 @@ type backendSnapshotLookup struct {
 	rootID   uint64
 }
 
+func (backendSnapshotLookup) rootDomainPublishedBackendLookupMarker() {}
+
 func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	if l.snapshot == nil {
 		return nil, page.ValuePtr{}, 0, false

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,6 +948,10 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
+	if s.backendFallback != nil && rootID == s.backendRootID {
+		snap.published = s.backendFallback
+		return
+	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,10 +948,6 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	if s.backendFallback != nil && rootID == s.backendRootID {
-		snap.published = s.backendFallback
-		return
-	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -317,8 +317,8 @@ func rootDomainPublishedUsesBackendLookup(snap rootDomainSnapshot) bool {
 	return ok
 }
 
-func shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry bool, publishedRoots *publishedRootSet, snap rootDomainSnapshot) bool {
-	return checkedPublishedEntry && publishedRoots == nil && rootDomainPublishedUsesBackendLookup(snap)
+func shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry bool, publishedRoots *publishedRootSet, domainSnap rootDomainSnapshot) bool {
+	return checkedPublishedEntry && publishedRoots == nil && rootDomainPublishedUsesBackendLookup(domainSnap)
 }
 
 func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, dst []byte, oldLen int) ([]byte, bool, error) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -452,6 +452,9 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
 	}
+	if s == nil {
+		return dst, tree.ErrKeyNotFound
+	}
 
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	origDst := dst

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -414,6 +414,12 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
 	checkedPublishedEntry := false
 	if ok {
+		if err != nil {
+			// Published append lookups should not leak partial dst appends across
+			// fallback paths when they report misses/errors.
+			out = out[:oldLen]
+			dst = out
+		}
 		if err == nil {
 			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
 			return out, nil

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -460,6 +460,8 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		return append(dst, val...), nil
 	}
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	// backendSnapshotLookup (used when no published root set is pinned) flushes
+	// value-log state before serving backend snapshot reads.
 	origDst := dst
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -423,11 +423,38 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
 	if ok {
-		if err != nil {
+		if err == nil {
+			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
+			return out, nil
+		}
+		// Preserve historical miss semantics: published append misses should still
+		// fall through to backend lookup when the key is absent, while true
+		// tombstones remain not-found.
+		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
-		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
-		return out, nil
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
+			}
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
+			}
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
+		}
 	}
 	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 		if flags&node.FlagTombstone != 0 {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -304,6 +304,33 @@ func rootDomainPublishedGetUnsafe(snap rootDomainSnapshot, key []byte) ([]byte, 
 	return out, true, err
 }
 
+func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, dst []byte, oldLen int) ([]byte, bool, error) {
+	val, ptr, flags, found, source := snap.getEntryWithSource(key)
+	if !found {
+		return dst, false, nil
+	}
+	if flags&node.FlagTombstone != 0 {
+		return dst, true, tree.ErrKeyNotFound
+	}
+	if flags&node.FlagPointer != 0 {
+		if s.db == nil {
+			return dst, true, errors.New("caching snapshot: value-log reader unavailable")
+		}
+		out, err := s.db.readValueLogAppend(key, ptr, dst)
+		if err != nil {
+			return dst, true, err
+		}
+		recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+		return out, true, nil
+	}
+	if val == nil {
+		recordSnapshotRootDomainRead(source, false, 0)
+		return dst, true, nil
+	}
+	recordSnapshotRootDomainRead(source, false, len(val))
+	return append(dst, val...), true, nil
+}
+
 func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.IteratorSource, error) {
 	if s == nil || s.backend == nil {
 		return nil, backenddb.ErrClosed
@@ -410,6 +437,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	}
 
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	origDst := dst
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
 	checkedPublishedEntry := false
@@ -417,8 +445,10 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if err != nil {
 			// Published append lookups should not leak partial dst appends across
 			// fallback paths when they report misses/errors.
-			out = out[:oldLen]
-			dst = out
+			dst = origDst[:oldLen]
+			if len(out) >= oldLen {
+				dst = out[:oldLen]
+			}
 		}
 		if err == nil {
 			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
@@ -431,51 +461,13 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, err
 		}
 		checkedPublishedEntry = true
-		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
-			if flags&node.FlagTombstone != 0 {
-				return dst, tree.ErrKeyNotFound
-			}
-			if flags&node.FlagPointer != 0 {
-				if s.db == nil {
-					return dst, errors.New("caching snapshot: value-log reader unavailable")
-				}
-				out, err := s.db.readValueLogAppend(key, ptr, dst)
-				if err != nil {
-					return dst, err
-				}
-				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-				return out, nil
-			}
-			if val == nil {
-				recordSnapshotRootDomainRead(source, false, 0)
-				return dst, nil
-			}
-			recordSnapshotRootDomainRead(source, false, len(val))
-			return append(dst, val...), nil
+		if out, found, err := s.getAppendFromEntryWithSource(snap, key, dst, oldLen); found {
+			return out, err
 		}
 	}
 	if !checkedPublishedEntry {
-		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
-			if flags&node.FlagTombstone != 0 {
-				return dst, tree.ErrKeyNotFound
-			}
-			if flags&node.FlagPointer != 0 {
-				if s.db == nil {
-					return dst, errors.New("caching snapshot: value-log reader unavailable")
-				}
-				out, err := s.db.readValueLogAppend(key, ptr, dst)
-				if err != nil {
-					return dst, err
-				}
-				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-				return out, nil
-			}
-			if val == nil {
-				recordSnapshotRootDomainRead(source, false, 0)
-				return dst, nil
-			}
-			recordSnapshotRootDomainRead(source, false, len(val))
-			return append(dst, val...), nil
+		if out, found, err := s.getAppendFromEntryWithSource(snap, key, dst, oldLen); found {
+			return out, err
 		}
 	}
 	if checkedPublishedEntry && s.publishedRoots == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -531,7 +531,7 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 			maybeRecordSnapshotGetCallerSample(len(out))
 			return ownedReadResult(out, scratch), nil
 		}
-		if val == nil {
+		if len(val) == 0 {
 			recordSnapshotRootDomainRead(source, false, len(val))
 			return nil, nil
 		}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -280,6 +280,10 @@ type rootDomainPublishedValueLookup interface {
 	GetValueUnsafe(key []byte) ([]byte, error)
 }
 
+type rootDomainPublishedBackendLookupMarker interface {
+	rootDomainPublishedBackendLookupMarker()
+}
+
 func rootDomainPublishedGetAppend(snap rootDomainSnapshot, key, dst []byte) ([]byte, bool, error) {
 	if snap.published == nil {
 		return dst, false, nil
@@ -302,6 +306,19 @@ func rootDomainPublishedGetUnsafe(snap rootDomainSnapshot, key []byte) ([]byte, 
 	}
 	out, err := lookup.GetValueUnsafe(key)
 	return out, true, err
+}
+
+func rootDomainPublishedUsesBackendLookup(snap rootDomainSnapshot) bool {
+	lookup, ok := snap.published.(rootDomainPublishedValueLookup)
+	if !ok {
+		return false
+	}
+	_, ok = lookup.(rootDomainPublishedBackendLookupMarker)
+	return ok
+}
+
+func shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry bool, publishedRoots *publishedRootSet, snap rootDomainSnapshot) bool {
+	return checkedPublishedEntry && publishedRoots == nil && rootDomainPublishedUsesBackendLookup(snap)
 }
 
 func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, dst []byte, oldLen int) ([]byte, bool, error) {
@@ -470,7 +487,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return out, err
 		}
 	}
-	if checkedPublishedEntry && s.publishedRoots == nil {
+	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, s.publishedRoots, snap) {
 		// rootDomainSnapshotFromCachedSnapshot() installs backendSnapshotLookup as
 		// the published lookup when no published root set is pinned. A not-found
 		// from that lookup already queried the backend snapshot, so avoid an extra

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -487,7 +487,11 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return out, err
 		}
 	}
-	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, s.publishedRoots, snap) {
+	var publishedRoots *publishedRootSet
+	if s != nil {
+		publishedRoots = s.publishedRoots
+	}
+	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, publishedRoots, snap) {
 		// rootDomainSnapshotFromCachedSnapshot() installs backendSnapshotLookup as
 		// the published lookup when no published root set is pinned. A not-found
 		// from that lookup already queried the backend snapshot, so avoid an extra

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,6 +33,8 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
+	backendRootID   uint64
+	backendFallback rootDomainLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -162,7 +164,17 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	snap := &Snapshot{db: db, view: view, backend: backendSnap}
+	var backendRootID uint64
+	if state := backendSnap.State(); state != nil {
+		backendRootID = state.RootPageID
+	}
+	snap := &Snapshot{
+		db:              db,
+		view:            view,
+		backend:         backendSnap,
+		backendRootID:   backendRootID,
+		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
 	snap.rootSystem = viewRootSystem
@@ -376,23 +388,16 @@ func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) 
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
-	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
+	// Critical fast path for parallel point reads:
+	// consult only mutable/immutable memtables first, then query published/backend
+	// directly via append APIs. This avoids a published GetEntry pre-read that can
+	// materialize leaf-log pages before the actual GetAppend pointer read.
+	val, ptr, flags, found := s.lookupCachedRootDomainEntry(key)
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return dst, tree.ErrKeyNotFound
 		}
 		if flags&node.FlagPointer != 0 {
-			if source == rootDomainEntrySourcePublished {
-				oldLen := len(dst)
-				out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
-				if ok {
-					if err != nil {
-						return dst, err
-					}
-					recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-					return out, nil
-				}
-			}
 			if s.db == nil {
 				return dst, errors.New("caching snapshot: value-log reader unavailable")
 			}
@@ -401,15 +406,26 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			if err != nil {
 				return dst, err
 			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, true, len(out)-oldLen)
 			return out, nil
 		}
 		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
+			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, 0)
 			return dst, nil
 		}
-		recordSnapshotRootDomainRead(source, false, len(val))
+		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
+	}
+
+	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	oldLen := len(dst)
+	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
+	if ok {
+		if err != nil {
+			return dst, err
+		}
+		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
+		return out, nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -418,8 +434,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	if err := s.db.flushValueLogForBackendRead(); err != nil {
 		return dst, err
 	}
-	oldLen := len(dst)
-	out, err := s.backend.GetAppend(key, dst)
+	out, err = s.backend.GetAppend(key, dst)
 	if err != nil {
 		return dst, err
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -460,8 +460,9 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		return append(dst, val...), nil
 	}
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
-	// backendSnapshotLookup (used when no published root set is pinned) flushes
-	// value-log state before serving backend snapshot reads.
+	// backendSnapshotLookup (used when a published ref falls back to backend
+	// snapshot lookup) flushes value-log state before backend snapshot reads.
+	publishedRoots := s.publishedRoots
 	origDst := dst
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
@@ -486,7 +487,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, err
 		}
 		checkedPublishedEntry = true
-		if shouldShortCircuitPublishedAppendMiss(true, s.publishedRoots, snap) {
+		if shouldShortCircuitPublishedAppendMiss(true, publishedRoots, snap) {
 			// Published backend append miss already probed the relevant root.
 			return dst, tree.ErrKeyNotFound
 		}
@@ -499,10 +500,6 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return out, err
 		}
 	}
-	var publishedRoots *publishedRootSet
-	if s != nil {
-		publishedRoots = s.publishedRoots
-	}
 	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, publishedRoots, snap) {
 		// rootDomainSnapshotFromCachedSnapshot() installs backendSnapshotLookup as
 		// the published lookup when no published root set is pinned. A not-found
@@ -512,7 +509,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		return dst, tree.ErrKeyNotFound
 	}
 
-	if s == nil || s.backend == nil || s.db == nil {
+	if s.backend == nil || s.db == nil {
 		return dst, tree.ErrKeyNotFound
 	}
 	if err := s.db.flushValueLogForBackendRead(); err != nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -221,6 +221,8 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
+	s.backendRootID = 0
+	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err
@@ -426,6 +428,28 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
 		return out, nil
+	}
+	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+		if flags&node.FlagTombstone != 0 {
+			return dst, tree.ErrKeyNotFound
+		}
+		if flags&node.FlagPointer != 0 {
+			if s.db == nil {
+				return dst, errors.New("caching snapshot: value-log reader unavailable")
+			}
+			out, err := s.db.readValueLogAppend(key, ptr, dst)
+			if err != nil {
+				return dst, err
+			}
+			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			return out, nil
+		}
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, 0)
+			return dst, nil
+		}
+		recordSnapshotRootDomainRead(source, false, len(val))
+		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,8 +33,6 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
-	backendRootID   uint64
-	backendFallback rootDomainLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -164,16 +162,10 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	var backendRootID uint64
-	if state := backendSnap.State(); state != nil {
-		backendRootID = state.RootPageID
-	}
 	snap := &Snapshot{
-		db:              db,
-		view:            view,
-		backend:         backendSnap,
-		backendRootID:   backendRootID,
-		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+		db:      db,
+		view:    view,
+		backend: backendSnap,
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -221,8 +213,6 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
-	s.backendRootID = 0
-	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -428,6 +428,9 @@ func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) 
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
+	if s == nil {
+		return dst, tree.ErrKeyNotFound
+	}
 	// Critical fast path for parallel point reads:
 	// consult only mutable/immutable memtables first, then query published/backend
 	// directly via append APIs. This avoids a published GetEntry pre-read that can
@@ -456,10 +459,6 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
 	}
-	if s == nil {
-		return dst, tree.ErrKeyNotFound
-	}
-
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	origDst := dst
 	oldLen := len(dst)
@@ -505,8 +504,9 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, publishedRoots, snap) {
 		// rootDomainSnapshotFromCachedSnapshot() installs backendSnapshotLookup as
 		// the published lookup when no published root set is pinned. A not-found
-		// from that lookup already queried the backend snapshot, so avoid an extra
-		// backend GetAppend miss probe here.
+		// from that lookup already queried the backend snapshot (after
+		// flushValueLogForBackendRead inside backendSnapshotLookup.GetValueAppend), so
+		// avoid an extra backend GetAppend miss probe here.
 		return dst, tree.ErrKeyNotFound
 	}
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -412,6 +412,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
+	checkedPublishedEntry := false
 	if ok {
 		if err == nil {
 			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
@@ -423,6 +424,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
+		checkedPublishedEntry = true
 		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 			if flags&node.FlagTombstone != 0 {
 				return dst, tree.ErrKeyNotFound
@@ -446,27 +448,29 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return append(dst, val...), nil
 		}
 	}
-	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
-		if flags&node.FlagTombstone != 0 {
-			return dst, tree.ErrKeyNotFound
-		}
-		if flags&node.FlagPointer != 0 {
-			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
+	if !checkedPublishedEntry {
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
 			}
-			out, err := s.db.readValueLogAppend(key, ptr, dst)
-			if err != nil {
-				return dst, err
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
 			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-			return out, nil
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
 		}
-		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
-			return dst, nil
-		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -527,10 +531,11 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 			maybeRecordSnapshotGetCallerSample(len(out))
 			return ownedReadResult(out, scratch), nil
 		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		if len(val) == 0 {
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, len(val))
 			return nil, nil
 		}
+		recordSnapshotRootDomainRead(source, false, len(val))
 		maybeRecordSnapshotGetCallerSample(len(val))
 		owned := make([]byte, len(val))
 		copy(owned, val)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -478,6 +478,13 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return append(dst, val...), nil
 		}
 	}
+	if checkedPublishedEntry && s.publishedRoots == nil {
+		// rootDomainSnapshotFromCachedSnapshot() installs backendSnapshotLookup as
+		// the published lookup when no published root set is pinned. A not-found
+		// from that lookup already queried the backend snapshot, so avoid an extra
+		// backend GetAppend miss probe here.
+		return dst, tree.ErrKeyNotFound
+	}
 
 	if s == nil || s.backend == nil || s.db == nil {
 		return dst, tree.ErrKeyNotFound

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -330,10 +330,14 @@ func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, ds
 		return dst, true, tree.ErrKeyNotFound
 	}
 	if flags&node.FlagPointer != 0 {
-		if s.db == nil {
+		var valueLogDB *DB
+		if s != nil {
+			valueLogDB = s.db
+		}
+		if valueLogDB == nil {
 			return dst, true, errors.New("caching snapshot: value-log reader unavailable")
 		}
-		out, err := s.db.readValueLogAppend(key, ptr, dst)
+		out, err := valueLogDB.readValueLogAppend(key, ptr, dst)
 		if err != nil {
 			return dst, true, err
 		}
@@ -481,6 +485,10 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, err
 		}
 		checkedPublishedEntry = true
+		if shouldShortCircuitPublishedAppendMiss(true, s.publishedRoots, snap) {
+			// Published backend append miss already probed the relevant root.
+			return dst, tree.ErrKeyNotFound
+		}
 		if out, found, err := s.getAppendFromEntryWithSource(snap, key, dst, oldLen); found {
 			return out, err
 		}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -27,6 +27,20 @@ func (p publishedAppendMissWithPrefix) GetValueUnsafe(_ []byte) ([]byte, error) 
 	return nil, tree.ErrKeyNotFound
 }
 
+type publishedAppendMissNilOutput struct{}
+
+func (publishedAppendMissNilOutput) GetEntry(_ []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	return nil, page.ValuePtr{}, 0, false
+}
+
+func (publishedAppendMissNilOutput) GetValueAppend(_ []byte, _ []byte) ([]byte, error) {
+	return nil, tree.ErrKeyNotFound
+}
+
+func (publishedAppendMissNilOutput) GetValueUnsafe(_ []byte) ([]byte, error) {
+	return nil, tree.ErrKeyNotFound
+}
+
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
 	dir, err := os.MkdirTemp("", "treedb-snapshot-rotate-fail-")
 	if err != nil {
@@ -378,6 +392,58 @@ func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
 		t.Fatal("AcquireSnapshot=nil")
 	}
 	published := publishedAppendMissWithPrefix{prefix: []byte("bad:")}
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "prefix:backend-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
+func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-short-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	published := publishedAppendMissNilOutput{}
 
 	snap := &Snapshot{
 		db:      cached,

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -41,6 +41,71 @@ func (publishedAppendMissNilOutput) GetValueUnsafe(_ []byte) ([]byte, error) {
 	return nil, tree.ErrKeyNotFound
 }
 
+type publishedAppendHit struct {
+	value       []byte
+	appendCalls int
+}
+
+func (p *publishedAppendHit) GetEntry(_ []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	return nil, page.ValuePtr{}, 0, false
+}
+
+func (p *publishedAppendHit) GetValueAppend(_ []byte, dst []byte) ([]byte, error) {
+	p.appendCalls++
+	return append(dst, p.value...), nil
+}
+
+func (p *publishedAppendHit) GetValueUnsafe(_ []byte) ([]byte, error) {
+	return append([]byte(nil), p.value...), nil
+}
+
+func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte) (*DB, *db.Snapshot, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-fixture-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		_ = backend.Close()
+		_ = os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	if seedKey != nil {
+		if err := cached.SetSync(seedKey, seedValue); err != nil {
+			_ = cached.Close()
+			_ = backend.Close()
+			_ = os.RemoveAll(dir)
+			t.Fatalf("SetSync: %v", err)
+		}
+		if err := cached.Checkpoint(); err != nil {
+			_ = cached.Close()
+			_ = backend.Close()
+			_ = os.RemoveAll(dir)
+			t.Fatalf("Checkpoint: %v", err)
+		}
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		_ = cached.Close()
+		_ = backend.Close()
+		_ = os.RemoveAll(dir)
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	cleanup := func() {
+		_ = backendSnap.Close()
+		_ = cached.Close()
+		_ = backend.Close()
+		_ = os.RemoveAll(dir)
+	}
+	return cached, backendSnap, cleanup
+}
+
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
 	dir, err := os.MkdirTemp("", "treedb-snapshot-rotate-fail-")
 	if err != nil {
@@ -310,35 +375,29 @@ func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppend_PublishedAppendHitReturnsWithoutFallback(t *testing.T) {
+	published := &publishedAppendHit{value: []byte("published-v")}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{published: published},
+		},
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "prefix:published-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+	if got, want := published.appendCalls, 1; got != want {
+		t.Fatalf("published append calls=%d want %d", got, want)
+	}
+}
+
 func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
-	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	backend, err := db.Open(db.Options{Dir: dir})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer backend.Close()
-
-	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cached.Close()
-
-	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
-		t.Fatalf("SetSync: %v", err)
-	}
-	if err := cached.Checkpoint(); err != nil {
-		t.Fatalf("Checkpoint: %v", err)
-	}
-	backendSnap := backend.AcquireSnapshot()
-	if backendSnap == nil {
-		t.Fatal("AcquireSnapshot=nil")
-	}
+	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	defer cleanup()
 	published := newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})
 
 	snap := &Snapshot{
@@ -363,34 +422,8 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 }
 
 func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
-	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-dst-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	backend, err := db.Open(db.Options{Dir: dir})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer backend.Close()
-
-	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cached.Close()
-
-	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
-		t.Fatalf("SetSync: %v", err)
-	}
-	if err := cached.Checkpoint(); err != nil {
-		t.Fatalf("Checkpoint: %v", err)
-	}
-	backendSnap := backend.AcquireSnapshot()
-	if backendSnap == nil {
-		t.Fatal("AcquireSnapshot=nil")
-	}
+	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	defer cleanup()
 	published := publishedAppendMissWithPrefix{prefix: []byte("bad:")}
 
 	snap := &Snapshot{
@@ -415,34 +448,8 @@ func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
 }
 
 func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testing.T) {
-	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-short-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	backend, err := db.Open(db.Options{Dir: dir})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer backend.Close()
-
-	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cached.Close()
-
-	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
-		t.Fatalf("SetSync: %v", err)
-	}
-	if err := cached.Checkpoint(); err != nil {
-		t.Fatalf("Checkpoint: %v", err)
-	}
-	backendSnap := backend.AcquireSnapshot()
-	if backendSnap == nil {
-		t.Fatal("AcquireSnapshot=nil")
-	}
+	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	defer cleanup()
 	published := publishedAppendMissNilOutput{}
 
 	snap := &Snapshot{
@@ -463,6 +470,22 @@ func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testi
 	}
 	if want := "prefix:backend-v"; string(got) != want {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
+func TestSnapshotGetAppend_BackendLookupMissWithoutPublishedRootsReturnsNotFound(t *testing.T) {
+	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("present"), []byte("value"))
+	defer cleanup()
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+	}
+	defer func() { _ = snap.Close() }()
+
+	_, err := snap.GetAppend([]byte("missing"), []byte("prefix:"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(missing) err=%v want ErrKeyNotFound", err)
 	}
 }
 

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -7,8 +7,25 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
+
+type publishedAppendMissWithPrefix struct {
+	prefix []byte
+}
+
+func (p publishedAppendMissWithPrefix) GetEntry(_ []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	return nil, page.ValuePtr{}, 0, false
+}
+
+func (p publishedAppendMissWithPrefix) GetValueAppend(_ []byte, dst []byte) ([]byte, error) {
+	return append(dst, p.prefix...), tree.ErrKeyNotFound
+}
+
+func (p publishedAppendMissWithPrefix) GetValueUnsafe(_ []byte) ([]byte, error) {
+	return nil, tree.ErrKeyNotFound
+}
 
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
 	dir, err := os.MkdirTemp("", "treedb-snapshot-rotate-fail-")
@@ -327,6 +344,58 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 		t.Fatalf("GetAppend(k): %v", err)
 	}
 	if want := "backend-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
+func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-dst-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	published := publishedAppendMissWithPrefix{prefix: []byte("bad:")}
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "prefix:backend-v"; string(got) != want {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
 	}
 }

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -504,6 +504,19 @@ func TestShouldShortCircuitPublishedAppendMiss_BackendLookupOnly(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppend_NilReceiverMissReturnsNotFound(t *testing.T) {
+	var snap *Snapshot
+
+	dst := []byte("prefix:")
+	got, err := snap.GetAppend([]byte("missing"), dst)
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(missing) err=%v want ErrKeyNotFound", err)
+	}
+	if string(got) != "prefix:" {
+		t.Fatalf("GetAppend(missing) dst=%q want %q", string(got), "prefix:")
+	}
+}
+
 func TestSnapshotGet_PublishedEmptyInlineValueReturnsNil(t *testing.T) {
 	published := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: ""})
 	snap := &Snapshot{

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -80,7 +80,7 @@ func (p *publishedBackendLookupMissCounter) GetValueUnsafe(_ []byte) ([]byte, er
 	return nil, tree.ErrKeyNotFound
 }
 
-func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte) (*DB, *db.Snapshot, func()) {
+func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte) (*Snapshot, func()) {
 	t.Helper()
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})
@@ -110,13 +110,16 @@ func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte)
 		_ = backend.Close()
 		t.Fatal("AcquireSnapshot=nil")
 	}
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+	}
 	cleanup := func() {
-		// backendSnap ownership stays with this fixture cleanup.
-		_ = backendSnap.Close()
+		_ = snap.Close()
 		_ = cached.Close()
 		_ = backend.Close()
 	}
-	return cached, backendSnap, cleanup
+	return snap, cleanup
 }
 
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
@@ -409,19 +412,15 @@ func TestSnapshotGetAppend_PublishedAppendHitReturnsWithoutFallback(t *testing.T
 }
 
 func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
-	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	snap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
 	defer cleanup()
 	published := newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})
 
-	snap := &Snapshot{
-		db:      cached,
-		backend: backendSnap,
-		rootPointShards: []rootDomainSnapshot{
-			{publishedRootID: 1, published: published},
-		},
-		publishedRoots: &publishedRootSet{
-			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
-		},
+	snap.rootPointShards = []rootDomainSnapshot{
+		{publishedRootID: 1, published: published},
+	}
+	snap.publishedRoots = &publishedRootSet{
+		pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 	}
 	got, err := snap.GetAppend([]byte("k"), nil)
 	if err != nil {
@@ -433,19 +432,15 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 }
 
 func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
-	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	snap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
 	defer cleanup()
 	published := publishedAppendMissWithPrefix{prefix: []byte("bad:")}
 
-	snap := &Snapshot{
-		db:      cached,
-		backend: backendSnap,
-		rootPointShards: []rootDomainSnapshot{
-			{publishedRootID: 1, published: published},
-		},
-		publishedRoots: &publishedRootSet{
-			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
-		},
+	snap.rootPointShards = []rootDomainSnapshot{
+		{publishedRootID: 1, published: published},
+	}
+	snap.publishedRoots = &publishedRootSet{
+		pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 	}
 	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
 	if err != nil {
@@ -457,19 +452,15 @@ func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
 }
 
 func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testing.T) {
-	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
+	snap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("k"), []byte("backend-v"))
 	defer cleanup()
 	published := publishedAppendMissNilOutput{}
 
-	snap := &Snapshot{
-		db:      cached,
-		backend: backendSnap,
-		rootPointShards: []rootDomainSnapshot{
-			{publishedRootID: 1, published: published},
-		},
-		publishedRoots: &publishedRootSet{
-			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
-		},
+	snap.rootPointShards = []rootDomainSnapshot{
+		{publishedRootID: 1, published: published},
+	}
+	snap.publishedRoots = &publishedRootSet{
+		pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 	}
 	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
 	if err != nil {
@@ -481,13 +472,8 @@ func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testi
 }
 
 func TestSnapshotGetAppend_BackendLookupMissWithoutPublishedRootsReturnsNotFound(t *testing.T) {
-	cached, backendSnap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("present"), []byte("value"))
+	snap, cleanup := newSnapshotGetAppendBackendFixture(t, []byte("present"), []byte("value"))
 	defer cleanup()
-
-	snap := &Snapshot{
-		db:      cached,
-		backend: backendSnap,
-	}
 	_, err := snap.GetAppend([]byte("missing"), []byte("prefix:"))
 	if !errors.Is(err, tree.ErrKeyNotFound) {
 		t.Fatalf("GetAppend(missing) err=%v want ErrKeyNotFound", err)

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -279,6 +279,54 @@ func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{published: newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.GetAppend([]byte("k"), nil)
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "backend-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
 func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
 	snap := &Snapshot{
 		backendRootID:   123,

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -326,19 +326,3 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
 	}
 }
-
-func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
-	snap := &Snapshot{
-		backendRootID:   123,
-		backendFallback: backendSnapshotLookup{rootID: 123},
-	}
-	if err := snap.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if snap.backendRootID != 0 {
-		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
-	}
-	if snap.backendFallback != (backendSnapshotLookup{}) {
-		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
-	}
-}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -82,32 +82,25 @@ func (p *publishedBackendLookupMissCounter) GetValueUnsafe(_ []byte) ([]byte, er
 
 func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte) (*DB, *db.Snapshot, func()) {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-fixture-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})
 	if err != nil {
-		_ = os.RemoveAll(dir)
 		t.Fatal(err)
 	}
 	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
 	if err != nil {
 		_ = backend.Close()
-		_ = os.RemoveAll(dir)
 		t.Fatal(err)
 	}
 	if seedKey != nil {
 		if err := cached.SetSync(seedKey, seedValue); err != nil {
 			_ = cached.Close()
 			_ = backend.Close()
-			_ = os.RemoveAll(dir)
 			t.Fatalf("SetSync: %v", err)
 		}
 		if err := cached.Checkpoint(); err != nil {
 			_ = cached.Close()
 			_ = backend.Close()
-			_ = os.RemoveAll(dir)
 			t.Fatalf("Checkpoint: %v", err)
 		}
 	}
@@ -115,14 +108,13 @@ func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte)
 	if backendSnap == nil {
 		_ = cached.Close()
 		_ = backend.Close()
-		_ = os.RemoveAll(dir)
 		t.Fatal("AcquireSnapshot=nil")
 	}
 	cleanup := func() {
+		// backendSnap ownership stays with this fixture cleanup.
 		_ = backendSnap.Close()
 		_ = cached.Close()
 		_ = backend.Close()
-		_ = os.RemoveAll(dir)
 	}
 	return cached, backendSnap, cleanup
 }
@@ -431,8 +423,6 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 		},
 	}
-	defer func() { _ = snap.Close() }()
-
 	got, err := snap.GetAppend([]byte("k"), nil)
 	if err != nil {
 		t.Fatalf("GetAppend(k): %v", err)
@@ -457,8 +447,6 @@ func TestSnapshotGetAppend_PublishedMissFallbackTruncatesDst(t *testing.T) {
 			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 		},
 	}
-	defer func() { _ = snap.Close() }()
-
 	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
 	if err != nil {
 		t.Fatalf("GetAppend(k): %v", err)
@@ -483,8 +471,6 @@ func TestSnapshotGetAppend_PublishedMissFallbackHandlesShortErrorOutput(t *testi
 			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 		},
 	}
-	defer func() { _ = snap.Close() }()
-
 	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
 	if err != nil {
 		t.Fatalf("GetAppend(k): %v", err)
@@ -502,8 +488,6 @@ func TestSnapshotGetAppend_BackendLookupMissWithoutPublishedRootsReturnsNotFound
 		db:      cached,
 		backend: backendSnap,
 	}
-	defer func() { _ = snap.Close() }()
-
 	_, err := snap.GetAppend([]byte("missing"), []byte("prefix:"))
 	if !errors.Is(err, tree.ErrKeyNotFound) {
 		t.Fatalf("GetAppend(missing) err=%v want ErrKeyNotFound", err)

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -1,11 +1,13 @@
 package caching
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
@@ -248,5 +250,47 @@ func TestSnapshotClose_Idempotent(t *testing.T) {
 	}
 	if err := next.Close(); err != nil {
 		t.Fatalf("close second snapshot: %v", err)
+	}
+}
+
+func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{
+				published: newRootDomainTestTable(t,
+					rootDomainTestOp{key: "k1", value: "published-v1"},
+					rootDomainTestOp{key: "k2", tombstone: true},
+				),
+			},
+		},
+	}
+
+	got, err := snap.GetAppend([]byte("k1"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k1): %v", err)
+	}
+	if want := "prefix:published-v1"; string(got) != want {
+		t.Fatalf("GetAppend(k1)=%q want %q", string(got), want)
+	}
+
+	_, err = snap.GetAppend([]byte("k2"), nil)
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(k2) err=%v want ErrKeyNotFound", err)
+	}
+}
+
+func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
+	snap := &Snapshot{
+		backendRootID:   123,
+		backendFallback: backendSnapshotLookup{rootID: 123},
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if snap.backendRootID != 0 {
+		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
+	}
+	if snap.backendFallback != (backendSnapshotLookup{}) {
+		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
 	}
 }

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -489,6 +489,21 @@ func TestSnapshotGetAppend_BackendLookupMissWithoutPublishedRootsReturnsNotFound
 	}
 }
 
+func TestShouldShortCircuitPublishedAppendMiss_BackendLookupOnly(t *testing.T) {
+	if !shouldShortCircuitPublishedAppendMiss(true, nil, rootDomainSnapshot{published: backendSnapshotLookup{}}) {
+		t.Fatal("backend lookup miss should short-circuit duplicate backend probes")
+	}
+	if shouldShortCircuitPublishedAppendMiss(true, nil, rootDomainSnapshot{published: publishedAppendMissWithPrefix{prefix: []byte("bad:")}}) {
+		t.Fatal("non-backend published lookup should not short-circuit backend fallback")
+	}
+	if shouldShortCircuitPublishedAppendMiss(true, &publishedRootSet{}, rootDomainSnapshot{published: backendSnapshotLookup{}}) {
+		t.Fatal("pinned published roots should not use nil-root short-circuit")
+	}
+	if shouldShortCircuitPublishedAppendMiss(false, nil, rootDomainSnapshot{published: backendSnapshotLookup{}}) {
+		t.Fatal("unchecked published misses should not short-circuit")
+	}
+}
+
 func TestSnapshotGet_PublishedEmptyInlineValueReturnsNil(t *testing.T) {
 	published := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: ""})
 	snap := &Snapshot{

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -59,6 +59,27 @@ func (p *publishedAppendHit) GetValueUnsafe(_ []byte) ([]byte, error) {
 	return append([]byte(nil), p.value...), nil
 }
 
+type publishedBackendLookupMissCounter struct {
+	appendCalls int
+	entryCalls  int
+}
+
+func (publishedBackendLookupMissCounter) rootDomainPublishedBackendLookupMarker() {}
+
+func (p *publishedBackendLookupMissCounter) GetEntry(_ []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	p.entryCalls++
+	return nil, page.ValuePtr{}, 0, false
+}
+
+func (p *publishedBackendLookupMissCounter) GetValueAppend(_ []byte, dst []byte) ([]byte, error) {
+	p.appendCalls++
+	return dst, tree.ErrKeyNotFound
+}
+
+func (p *publishedBackendLookupMissCounter) GetValueUnsafe(_ []byte) ([]byte, error) {
+	return nil, tree.ErrKeyNotFound
+}
+
 func newSnapshotGetAppendBackendFixture(t *testing.T, seedKey, seedValue []byte) (*DB, *db.Snapshot, func()) {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-fixture-")
@@ -501,6 +522,26 @@ func TestShouldShortCircuitPublishedAppendMiss_BackendLookupOnly(t *testing.T) {
 	}
 	if shouldShortCircuitPublishedAppendMiss(false, nil, rootDomainSnapshot{published: backendSnapshotLookup{}}) {
 		t.Fatal("unchecked published misses should not short-circuit")
+	}
+}
+
+func TestSnapshotGetAppend_BackendPublishedMissSkipsEntryProbe(t *testing.T) {
+	lookup := &publishedBackendLookupMissCounter{}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{published: lookup},
+		},
+	}
+
+	_, err := snap.GetAppend([]byte("missing"), []byte("prefix:"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(missing) err=%v want ErrKeyNotFound", err)
+	}
+	if got, want := lookup.appendCalls, 1; got != want {
+		t.Fatalf("published GetValueAppend calls=%d want %d", got, want)
+	}
+	if got := lookup.entryCalls; got != 0 {
+		t.Fatalf("published GetEntry calls=%d want 0", got)
 	}
 }
 

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -308,12 +308,16 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 	if backendSnap == nil {
 		t.Fatal("AcquireSnapshot=nil")
 	}
+	published := newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})
 
 	snap := &Snapshot{
 		db:      cached,
 		backend: backendSnap,
 		rootPointShards: []rootDomainSnapshot{
-			{published: newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})},
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 		},
 	}
 	defer func() { _ = snap.Close() }()
@@ -324,5 +328,25 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 	}
 	if want := "backend-v"; string(got) != want {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
+func TestSnapshotGet_PublishedEmptyInlineValueReturnsNil(t *testing.T) {
+	published := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: ""})
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
+		},
+	}
+
+	got, err := snap.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get(k): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get(k)=%v want nil for empty value", got)
 	}
 }


### PR DESCRIPTION
## Summary

This PR reduces structural overhead in cached snapshot point reads, focused on `Snapshot.GetAppend`, while preserving miss/empty-value semantics.

## What changed

1. `Snapshot.GetAppend` hot-path routing
- Read cached memtables first (`lookupCachedRootDomainEntry`).
- Query published/backing state through append APIs before backend fallback.
- Avoid pre-reading entries that materialize work before the actual value read.

2. Miss-path correctness/efficiency guards
- Preserve published lookups that do not implement append APIs.
- Preserve backend fallback behavior for true published misses.
- Reset `dst` after published append misses/errors before fallback.
- Avoid duplicate backend miss probes when no published root set is pinned and the published lookup already queried backend snapshot state.

3. Empty-value semantics
- Preserve `Snapshot.Get` behavior returning `nil` for present empty inline values.

## Validation

- `go test ./TreeDB/caching -run TestSnapshot -count=1`
- Focused regression tests around published miss fallback and empty-value behavior.
