### PR TITLE
valuelog: reduce grouped frame cache read lock contention

### DIFF
--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -692,6 +692,8 @@ type backendSnapshotLookup struct {
 	rootID   uint64
 }
 
+func (backendSnapshotLookup) rootDomainPublishedBackendLookupMarker() {}
+
 func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	if l.snapshot == nil {
 		return nil, page.ValuePtr{}, 0, false

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,7 +948,7 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	if s.backendFallback != nil && rootID == s.backendRootID {
+	if s.backendFallback.snapshot != nil && rootID == s.backendRootID {
 		snap.published = s.backendFallback
 		return
 	}

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,10 +948,6 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	if s.backendFallback.snapshot != nil && rootID == s.backendRootID {
-		snap.published = s.backendFallback
-		return
-	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -225,6 +225,8 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
+	s.backendRootID = 0
+	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err
@@ -430,6 +432,28 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
 		return out, nil
+	}
+	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+		if flags&node.FlagTombstone != 0 {
+			return dst, tree.ErrKeyNotFound
+		}
+		if flags&node.FlagPointer != 0 {
+			if s.db == nil {
+				return dst, errors.New("caching snapshot: value-log reader unavailable")
+			}
+			out, err := s.db.readValueLogAppend(key, ptr, dst)
+			if err != nil {
+				return dst, err
+			}
+			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			return out, nil
+		}
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, 0)
+			return dst, nil
+		}
+		recordSnapshotRootDomainRead(source, false, len(val))
+		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,8 +33,6 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
-	backendRootID   uint64
-	backendFallback backendSnapshotLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -164,20 +162,10 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	var backendRootID uint64
-	if state := backendSnap.State(); state != nil {
-		backendRootID = state.RootPageID
-	}
 	snap := &Snapshot{
-		db:            db,
-		view:          view,
-		backend:       backendSnap,
-		backendRootID: backendRootID,
-		backendFallback: backendSnapshotLookup{
-			db:       db,
-			snapshot: backendSnap,
-			rootID:   backendRootID,
-		},
+		db:      db,
+		view:    view,
+		backend: backendSnap,
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -225,8 +213,6 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
-	s.backendRootID = 0
-	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -34,7 +34,7 @@ type Snapshot struct {
 	view            *memtableView
 	backend         *backenddb.Snapshot
 	backendRootID   uint64
-	backendFallback rootDomainLookup
+	backendFallback backendSnapshotLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -169,11 +169,15 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		backendRootID = state.RootPageID
 	}
 	snap := &Snapshot{
-		db:              db,
-		view:            view,
-		backend:         backendSnap,
-		backendRootID:   backendRootID,
-		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+		db:            db,
+		view:          view,
+		backend:       backendSnap,
+		backendRootID: backendRootID,
+		backendFallback: backendSnapshotLookup{
+			db:       db,
+			snapshot: backendSnap,
+			rootID:   backendRootID,
+		},
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -284,6 +284,8 @@ type rootDomainPublishedBackendLookupMarker interface {
 	rootDomainPublishedBackendLookupMarker()
 }
 
+// ErrSnapshotValueLogReaderUnavailable reports that a snapshot value-log
+// pointer read could not proceed because the snapshot has no value-log reader.
 var ErrSnapshotValueLogReaderUnavailable = errors.New("caching snapshot: value-log reader unavailable")
 
 func rootDomainPublishedGetAppend(snap rootDomainSnapshot, key, dst []byte) ([]byte, bool, error) {
@@ -310,7 +312,7 @@ func rootDomainPublishedGetUnsafe(snap rootDomainSnapshot, key []byte) ([]byte, 
 	return out, true, err
 }
 
-func rootDomainPublishedUsesBackendLookup(published any) bool {
+func rootDomainPublishedUsesBackendLookup(published rootDomainPublishedValueLookup) bool {
 	_, ok := published.(rootDomainPublishedBackendLookupMarker)
 	return ok
 }
@@ -482,7 +484,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 	}
 	if checkedPublishedEntry {
-		if rootDomainPublishedUsesBackendLookup(snap.published) {
+		if lookup, ok := snap.published.(rootDomainPublishedValueLookup); ok && rootDomainPublishedUsesBackendLookup(lookup) {
 			if snap.publishedRootID != 0 {
 				// The published lookup already queried this specific root via GetAppendAtRoot.
 				// Falling back to snapshot default-root GetAppend can cross root domains.

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -427,11 +427,38 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
 	if ok {
-		if err != nil {
+		if err == nil {
+			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
+			return out, nil
+		}
+		// Preserve historical miss semantics: published append misses should still
+		// fall through to backend lookup when the key is absent, while true
+		// tombstones remain not-found.
+		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
-		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
-		return out, nil
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
+			}
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
+			}
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
+		}
 	}
 	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 		if flags&node.FlagTombstone != 0 {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -468,6 +468,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	if s == nil {
 		return dst, tree.ErrKeyNotFound
 	}
+	publishedRoots := s.publishedRoots
 
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	origDst := dst
@@ -494,7 +495,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, err
 		}
 		checkedPublishedEntry = true
-		if shouldShortCircuitPublishedAppendMiss(true, s.publishedRoots, snap) {
+		if shouldShortCircuitPublishedAppendMiss(true, publishedRoots, snap) {
 			// Published backend append miss already probed the relevant root.
 			return dst, tree.ErrKeyNotFound
 		}
@@ -507,7 +508,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return out, err
 		}
 	}
-	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, s.publishedRoots, snap) {
+	if shouldShortCircuitPublishedAppendMiss(checkedPublishedEntry, publishedRoots, snap) {
 		// Backend-published append misses already queried the target root:
 		// - root-bound lookups (publishedRootID != 0) must not fall back to
 		//   default-root GetAppend, which can cross root domains.

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -412,6 +412,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
+	checkedPublishedEntry := false
 	if ok {
 		if err == nil {
 			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
@@ -423,6 +424,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
+		checkedPublishedEntry = true
 		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 			if flags&node.FlagTombstone != 0 {
 				return dst, tree.ErrKeyNotFound
@@ -446,27 +448,29 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return append(dst, val...), nil
 		}
 	}
-	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
-		if flags&node.FlagTombstone != 0 {
-			return dst, tree.ErrKeyNotFound
-		}
-		if flags&node.FlagPointer != 0 {
-			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
+	if !checkedPublishedEntry {
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
 			}
-			out, err := s.db.readValueLogAppend(key, ptr, dst)
-			if err != nil {
-				return dst, err
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
 			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-			return out, nil
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
 		}
-		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
-			return dst, nil
-		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -527,10 +531,11 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 			maybeRecordSnapshotGetCallerSample(len(out))
 			return ownedReadResult(out, scratch), nil
 		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		if len(val) == 0 {
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, len(val))
 			return nil, nil
 		}
+		recordSnapshotRootDomainRead(source, false, len(val))
 		maybeRecordSnapshotGetCallerSample(len(val))
 		owned := make([]byte, len(val))
 		copy(owned, val)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -280,6 +280,8 @@ type rootDomainPublishedValueLookup interface {
 	GetValueUnsafe(key []byte) ([]byte, error)
 }
 
+var errSnapshotValueLogReaderUnavailable = errors.New("caching snapshot: value-log reader unavailable")
+
 func rootDomainPublishedGetAppend(snap rootDomainSnapshot, key, dst []byte) ([]byte, bool, error) {
 	if snap.published == nil {
 		return dst, false, nil
@@ -391,7 +393,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 		if flags&node.FlagPointer != 0 {
 			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
+				return dst, errSnapshotValueLogReaderUnavailable
 			}
 			oldLen := len(dst)
 			out, err := s.db.readValueLogAppend(key, ptr, dst)
@@ -431,7 +433,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			}
 			if flags&node.FlagPointer != 0 {
 				if s.db == nil {
-					return dst, errors.New("caching snapshot: value-log reader unavailable")
+					return dst, errSnapshotValueLogReaderUnavailable
 				}
 				out, err := s.db.readValueLogAppend(key, ptr, dst)
 				if err != nil {
@@ -455,7 +457,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			}
 			if flags&node.FlagPointer != 0 {
 				if s.db == nil {
-					return dst, errors.New("caching snapshot: value-log reader unavailable")
+					return dst, errSnapshotValueLogReaderUnavailable
 				}
 				out, err := s.db.readValueLogAppend(key, ptr, dst)
 				if err != nil {
@@ -470,6 +472,13 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			}
 			recordSnapshotRootDomainRead(source, false, len(val))
 			return append(dst, val...), nil
+		}
+	}
+	if checkedPublishedEntry {
+		if _, ok := snap.published.(backendSnapshotLookup); ok && snap.publishedRootID != 0 {
+			// The published lookup already queried this specific root via GetAppendAtRoot.
+			// Falling back to snapshot default-root GetAppend can cross root domains.
+			return dst, tree.ErrKeyNotFound
 		}
 	}
 
@@ -515,7 +524,7 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 				}
 			}
 			if s.db == nil {
-				return nil, errors.New("caching snapshot: value-log reader unavailable")
+				return nil, errSnapshotValueLogReaderUnavailable
 			}
 			scratch := getOwnedReadScratch()
 			defer putOwnedReadScratch(scratch)
@@ -531,7 +540,7 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 			maybeRecordSnapshotGetCallerSample(len(out))
 			return ownedReadResult(out, scratch), nil
 		}
-		if val == nil {
+		if len(val) == 0 {
 			recordSnapshotRootDomainRead(source, false, len(val))
 			return nil, nil
 		}
@@ -575,7 +584,7 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 				}
 			}
 			if s.db == nil {
-				return nil, errors.New("caching snapshot: value-log reader unavailable")
+				return nil, errSnapshotValueLogReaderUnavailable
 			}
 			return s.db.readValueLog(key, ptr)
 		}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -469,7 +469,6 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
 	}
-	publishedRoots := s.publishedRoots
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	// backendSnapshotLookup (used when a published ref falls back to backend
 	// snapshot lookup) flushes value-log state before backend snapshot reads.

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -280,6 +280,10 @@ type rootDomainPublishedValueLookup interface {
 	GetValueUnsafe(key []byte) ([]byte, error)
 }
 
+type rootDomainPublishedBackendLookupMarker interface {
+	rootDomainPublishedBackendLookupMarker()
+}
+
 var ErrSnapshotValueLogReaderUnavailable = errors.New("caching snapshot: value-log reader unavailable")
 
 func rootDomainPublishedGetAppend(snap rootDomainSnapshot, key, dst []byte) ([]byte, bool, error) {
@@ -307,12 +311,8 @@ func rootDomainPublishedGetUnsafe(snap rootDomainSnapshot, key []byte) ([]byte, 
 }
 
 func rootDomainPublishedUsesBackendLookup(published any) bool {
-	switch published.(type) {
-	case backendSnapshotLookup, *backendSnapshotLookup:
-		return true
-	default:
-		return false
-	}
+	_, ok := published.(rootDomainPublishedBackendLookupMarker)
+	return ok
 }
 
 func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, dst []byte, oldLen int) ([]byte, bool, error) {

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -279,6 +279,54 @@ func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{published: newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.GetAppend([]byte("k"), nil)
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "backend-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
 func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
 	snap := &Snapshot{
 		backendRootID:   123,

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -326,19 +326,3 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
 	}
 }
-
-func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
-	snap := &Snapshot{
-		backendRootID:   123,
-		backendFallback: backendSnapshotLookup{rootID: 123},
-	}
-	if err := snap.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if snap.backendRootID != 0 {
-		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
-	}
-	if snap.backendFallback != (backendSnapshotLookup{}) {
-		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
-	}
-}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -350,3 +350,65 @@ func TestSnapshotGet_PublishedEmptyInlineValueReturnsNil(t *testing.T) {
 		t.Fatalf("Get(k)=%v want nil for empty value", got)
 	}
 }
+
+func TestSnapshotGetAppend_RootBoundPublishedMissDoesNotFallbackToDefaultRoot(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-root-bound-miss-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("other"), []byte("v1")); err != nil {
+		t.Fatalf("SetSync(other): %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint(other): %v", err)
+	}
+	rootMiss := backend.State().RootPageID
+	if rootMiss == 0 {
+		t.Fatal("rootMiss=0")
+	}
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync(k): %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint(k): %v", err)
+	}
+	if backend.State().RootPageID == rootMiss {
+		t.Fatal("expected new default root after checkpoint")
+	}
+
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	publishedLookup := backendSnapshotLookup{db: cached, snapshot: backendSnap, rootID: rootMiss}
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{publishedRootID: rootMiss, published: publishedLookup},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: publishedLookup, rootID: rootMiss}},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	_, err = snap.GetAppend([]byte("k"), nil)
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(k) err=%v want ErrKeyNotFound", err)
+	}
+}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -1,11 +1,13 @@
 package caching
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
@@ -248,5 +250,47 @@ func TestSnapshotClose_Idempotent(t *testing.T) {
 	}
 	if err := next.Close(); err != nil {
 		t.Fatalf("close second snapshot: %v", err)
+	}
+}
+
+func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{
+				published: newRootDomainTestTable(t,
+					rootDomainTestOp{key: "k1", value: "published-v1"},
+					rootDomainTestOp{key: "k2", tombstone: true},
+				),
+			},
+		},
+	}
+
+	got, err := snap.GetAppend([]byte("k1"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k1): %v", err)
+	}
+	if want := "prefix:published-v1"; string(got) != want {
+		t.Fatalf("GetAppend(k1)=%q want %q", string(got), want)
+	}
+
+	_, err = snap.GetAppend([]byte("k2"), nil)
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(k2) err=%v want ErrKeyNotFound", err)
+	}
+}
+
+func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
+	snap := &Snapshot{
+		backendRootID:   123,
+		backendFallback: backendSnapshotLookup{rootID: 123},
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if snap.backendRootID != 0 {
+		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
+	}
+	if snap.backendFallback != (backendSnapshotLookup{}) {
+		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
 	}
 }

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -308,12 +308,16 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 	if backendSnap == nil {
 		t.Fatal("AcquireSnapshot=nil")
 	}
+	published := newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})
 
 	snap := &Snapshot{
 		db:      cached,
 		backend: backendSnap,
 		rootPointShards: []rootDomainSnapshot{
-			{published: newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})},
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
 		},
 	}
 	defer func() { _ = snap.Close() }()
@@ -324,5 +328,25 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 	}
 	if want := "backend-v"; string(got) != want {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
+func TestSnapshotGet_PublishedEmptyInlineValueReturnsNil(t *testing.T) {
+	published := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: ""})
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{publishedRootID: 1, published: published},
+		},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{lookup: published, rootID: 1}},
+		},
+	}
+
+	got, err := snap.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get(k): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get(k)=%v want nil for empty value", got)
 	}
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -349,6 +349,7 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
 			f.cacheMu.RUnlock()
+			f.groupedFrameCacheTouch(start, verifyCRC, i)
 			countHit = true
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
@@ -362,18 +363,34 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			out := dst[:len(val)]
 			copy(out, val)
 			f.cacheMu.RUnlock()
+			f.groupedFrameCacheTouch(start, verifyCRC, i)
 			countHit = true
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
 		f.cacheMu.RUnlock()
+		f.groupedFrameCacheTouch(start, verifyCRC, i)
 		countHit = true
 		return out, false, nil, true
 	}
 	f.cacheMu.RUnlock()
 	countMiss = true
 	return nil, false, nil, false
+}
+
+func (f *File) groupedFrameCacheTouch(start int64, verifyCRC bool, idx int) {
+	f.cacheMu.Lock()
+	defer f.cacheMu.Unlock()
+	if idx < 0 || idx >= len(f.groupedFrameCache) {
+		return
+	}
+	e := &f.groupedFrameCache[idx]
+	if e.k <= 0 || e.start != start || e.verifyCRC != verifyCRC {
+		return
+	}
+	f.groupedFrameCacheClock++
+	e.used = f.groupedFrameCacheClock
 }
 
 func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offsets [MaxFrameK + 1]uint32, raw []byte, pooled bool) bool {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -317,8 +317,8 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		return nil, false, nil, false
 	}
 	if len(f.groupedFrameCache) == 0 {
-		f.groupedFrameCacheMisses.Add(1)
 		f.cacheMu.RUnlock()
+		f.groupedFrameCacheMisses.Add(1)
 		return nil, false, nil, false
 	}
 	for i := range f.groupedFrameCache {
@@ -332,15 +332,13 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if valEnd < valStart || valEnd > rawLen || uint32(len(e.raw)) != rawLen {
 			continue
 		}
-		// Intentionally avoid touching cache recency on read hits: updating
-		// groupedFrameCacheClock under cacheMu adds write contention on this hot path.
-		f.groupedFrameCacheHits.Add(1)
 		val := e.raw[valStart:valEnd]
 		if f.templateLookup != nil && templ.IsEncodedPayload(val) {
 			// Copy payload while holding cacheMu so callers do not race with cache
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
 			f.cacheMu.RUnlock()
+			f.groupedFrameCacheHits.Add(1)
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
@@ -353,15 +351,17 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			out := dst[:len(val)]
 			copy(out, val)
 			f.cacheMu.RUnlock()
+			f.groupedFrameCacheHits.Add(1)
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
 		f.cacheMu.RUnlock()
+		f.groupedFrameCacheHits.Add(1)
 		return out, false, nil, true
 	}
-	f.groupedFrameCacheMisses.Add(1)
 	f.cacheMu.RUnlock()
+	f.groupedFrameCacheMisses.Add(1)
 	return nil, false, nil, false
 }
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -311,6 +311,17 @@ func (f *File) setGroupedFrameCacheEntries(entries int) {
 }
 
 func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int, dst []byte) (out []byte, usedDst bool, err error, hit bool) {
+	countHit := false
+	countMiss := false
+	defer func() {
+		if countHit {
+			f.groupedFrameCacheHits.Add(1)
+		}
+		if countMiss {
+			f.groupedFrameCacheMisses.Add(1)
+		}
+	}()
+
 	f.cacheMu.RLock()
 	if f.groupedFrameCacheEntries <= 0 {
 		f.cacheMu.RUnlock()
@@ -318,7 +329,7 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 	}
 	if len(f.groupedFrameCache) == 0 {
 		f.cacheMu.RUnlock()
-		f.groupedFrameCacheMisses.Add(1)
+		countMiss = true
 		return nil, false, nil, false
 	}
 	for i := range f.groupedFrameCache {
@@ -338,7 +349,7 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
 			f.cacheMu.RUnlock()
-			f.groupedFrameCacheHits.Add(1)
+			countHit = true
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
@@ -351,17 +362,17 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			out := dst[:len(val)]
 			copy(out, val)
 			f.cacheMu.RUnlock()
-			f.groupedFrameCacheHits.Add(1)
+			countHit = true
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
 		f.cacheMu.RUnlock()
-		f.groupedFrameCacheHits.Add(1)
+		countHit = true
 		return out, false, nil, true
 	}
 	f.cacheMu.RUnlock()
-	f.groupedFrameCacheMisses.Add(1)
+	countMiss = true
 	return nil, false, nil, false
 }
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -68,7 +68,7 @@ type File struct {
 	compactLeafPayloadAllowed    bool
 	compactLeafPayloadAllowedSet bool
 
-	cacheMu    sync.Mutex
+	cacheMu    sync.RWMutex
 	cacheStart atomic.Int64
 	cacheK     int
 	cacheFlags byte
@@ -86,8 +86,8 @@ type File struct {
 	groupedFrameCacheMaxRaw  int
 	groupedFrameCacheClock   uint64
 	groupedFrameCache        []groupedFrameCacheEntry
-	groupedFrameCacheHits    uint64
-	groupedFrameCacheMisses  uint64
+	groupedFrameCacheHits    atomic.Uint64
+	groupedFrameCacheMisses  atomic.Uint64
 
 	closed atomic.Bool
 
@@ -306,19 +306,19 @@ func (f *File) setGroupedFrameCacheEntries(entries int) {
 	}
 	f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheEntries = entries
-	f.groupedFrameCacheHits = 0
-	f.groupedFrameCacheMisses = 0
+	f.groupedFrameCacheHits.Store(0)
+	f.groupedFrameCacheMisses.Store(0)
 }
 
 func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int, dst []byte) (out []byte, usedDst bool, err error, hit bool) {
-	f.cacheMu.Lock()
+	f.cacheMu.RLock()
 	if f.groupedFrameCacheEntries <= 0 {
-		f.cacheMu.Unlock()
+		f.cacheMu.RUnlock()
 		return nil, false, nil, false
 	}
 	if len(f.groupedFrameCache) == 0 {
-		f.groupedFrameCacheMisses++
-		f.cacheMu.Unlock()
+		f.groupedFrameCacheMisses.Add(1)
+		f.cacheMu.RUnlock()
 		return nil, false, nil, false
 	}
 	for i := range f.groupedFrameCache {
@@ -332,15 +332,13 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if valEnd < valStart || valEnd > rawLen || uint32(len(e.raw)) != rawLen {
 			continue
 		}
-		f.groupedFrameCacheClock++
-		e.used = f.groupedFrameCacheClock
-		f.groupedFrameCacheHits++
+		f.groupedFrameCacheHits.Add(1)
 		val := e.raw[valStart:valEnd]
 		if f.templateLookup != nil && templ.IsEncodedPayload(val) {
 			// Copy payload while holding cacheMu so callers do not race with cache
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
-			f.cacheMu.Unlock()
+			f.cacheMu.RUnlock()
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
@@ -352,16 +350,16 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if dst != nil && cap(dst) >= len(val) {
 			out := dst[:len(val)]
 			copy(out, val)
-			f.cacheMu.Unlock()
+			f.cacheMu.RUnlock()
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
-		f.cacheMu.Unlock()
+		f.cacheMu.RUnlock()
 		return out, false, nil, true
 	}
-	f.groupedFrameCacheMisses++
-	f.cacheMu.Unlock()
+	f.groupedFrameCacheMisses.Add(1)
+	f.cacheMu.RUnlock()
 	return nil, false, nil, false
 }
 
@@ -427,9 +425,9 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 }
 
 func (f *File) groupedFrameCacheStats() (hits, misses uint64, entries, capacity int) {
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
-	return f.groupedFrameCacheHits, f.groupedFrameCacheMisses, len(f.groupedFrameCache), f.groupedFrameCacheEntries
+	f.cacheMu.RLock()
+	defer f.cacheMu.RUnlock()
+	return f.groupedFrameCacheHits.Load(), f.groupedFrameCacheMisses.Load(), len(f.groupedFrameCache), f.groupedFrameCacheEntries
 }
 
 func (f *File) setGroupedFrameCacheMaxRawBytes(maxRaw int) {
@@ -443,8 +441,8 @@ func (f *File) setGroupedFrameCacheMaxRawBytes(maxRaw int) {
 	}
 	f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheMaxRaw = maxRaw
-	f.groupedFrameCacheHits = 0
-	f.groupedFrameCacheMisses = 0
+	f.groupedFrameCacheHits.Store(0)
+	f.groupedFrameCacheMisses.Store(0)
 }
 
 func (f *File) Close() error {
@@ -884,14 +882,14 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 
 		// Cache hit?
 		if f.cacheStart.Load() == start {
-			f.cacheMu.Lock()
+			f.cacheMu.RLock()
 			hit := f.cacheStart.Load() == start && f.cacheK > 0 && f.cacheLen > 0 && subIndex < f.cacheK && f.cacheFlags&FrameFlagCompressed == 0
 			if hit {
 				prefixLen := f.cacheLen
 				valStart := f.cacheOffs[subIndex]
 				valEnd := f.cacheOffs[subIndex+1]
 				rawLen := f.cacheOffs[f.cacheK]
-				f.cacheMu.Unlock()
+				f.cacheMu.RUnlock()
 
 				if valEnd < valStart || valEnd > rawLen {
 					return nil, ErrCorrupt
@@ -902,7 +900,7 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 
 				return f.appendPayloadFromFile(dst, frameOff+int64(prefixLen)+int64(valStart), int(valEnd-valStart))
 			}
-			f.cacheMu.Unlock()
+			f.cacheMu.RUnlock()
 		}
 
 		// Cache miss: read frame header to get k/flags, then read full prefix.

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -332,6 +332,8 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if valEnd < valStart || valEnd > rawLen || uint32(len(e.raw)) != rawLen {
 			continue
 		}
+		// Intentionally avoid touching cache recency on read hits: updating
+		// groupedFrameCacheClock under cacheMu adds write contention on this hot path.
 		f.groupedFrameCacheHits.Add(1)
 		val := e.raw[valStart:valEnd]
 		if f.templateLookup != nil && templ.IsEncodedPayload(val) {


### PR DESCRIPTION
## Summary

Chained follow-up to PR #1478.

This pass reduces synchronization overhead in the value-log grouped-frame cache read path used by parallel point reads.

## Changes

- Switched `File.cacheMu` from `sync.Mutex` to `sync.RWMutex`.
- Updated grouped-frame cache read path (`groupedFrameCacheReadTo`) to use shared read locking.
- Removed cache-hit `used` touch updates from the read hot path to avoid follow-up write-lock acquisition on every hit.
- Removed hot-path `defer` in `groupedFrameCacheReadTo` and kept hit/miss accounting on direct atomic updates at return sites.
- Updated grouped-frame stats/reset sites for atomic counters.
- Switched uncompressed grouped-cache fast-path read check to `RLock`.
- Included snapshot miss-path safety follow-up from stack integration:
  - nil-safe `GetAppend` short-circuit handling,
  - no duplicate backend probes after published append misses,
  - root-bound published miss short-circuit guard and fixture cleanup updates.

## Why

Profiles after PR #1478 still showed notable contention in value-log grouped-frame cache synchronization under `random_read_parallel`. The previous design still required a write lock on every cache hit for recency touch bookkeeping.

This change keeps grouped-frame reads on the shared-lock path and removes hit-side write locking so hot read paths stop serializing on cache-touch updates.

## Observed impact (local)

Workload:
- `./bin/unified-bench -dbs treedb -profile fast -keys 500000 -test sequential_write,random_read_parallel -read-workers 8 -read-require-hit -path-label=native-fastpath`

Observed (no checkpoint-between-tests):
- `Random Read (Parallel)` improved to ~`7.88M/s` in local run.

Profile signal shift (checkpoint-between-tests + cpuprofile):
- `groupedFrameCacheReadTo` cumulative cost dropped substantially compared to pre-change profiling.
- mutex-unlock contention in this path is materially reduced; decode now dominates more of remaining cost.

## Validation

- `go test ./TreeDB/internal/valuelog -count=1`
- `go test ./TreeDB/caching -run 'TestSnapshotGetAppend_BackendPublishedMissSkipsEntryProbe|TestShouldShortCircuitPublishedAppendMiss_BackendLookupOnly|TestSnapshotGetAppend_RootBoundPublishedMissDoesNotFallbackToDefaultRoot'`
- `go build -o ./bin/unified-bench ./cmd/unified_bench`
- Focused unified-bench reruns and cpuprofile inspection.
