### PR TITLE
db: reduce read-miss cache admission lock contention

### DIFF
--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -657,7 +657,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.read_path.outer_leaf.cache.capacity"] = fmt.Sprintf("%d", cacheStats.Capacity)
 	stats["treedb.process.read_path.outer_leaf.cache.bytes"] = fmt.Sprintf("%d", cacheStats.Bytes)
 	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionSkips)
-	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stale"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionStale)
+	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_candidate_skips"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionCandidateSkips)
 	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionStores)
 
 	if db.valueLogManager != nil {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -657,6 +657,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.read_path.outer_leaf.cache.capacity"] = fmt.Sprintf("%d", cacheStats.Capacity)
 	stats["treedb.process.read_path.outer_leaf.cache.bytes"] = fmt.Sprintf("%d", cacheStats.Bytes)
 	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionSkips)
+	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stale"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionStale)
 	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionStores)
 
 	if db.valueLogManager != nil {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -17,6 +17,7 @@ const (
 	leafPageReadCacheEntriesEnvKey  = "TREEDB_LEAF_PAGE_CACHE_ENTRIES"
 	defaultLeafPageReadCacheEntries = 4096
 	maxLeafPageReadCacheEntries     = 1 << 18
+	maxReadMissOddEpochSpins        = 64
 )
 
 var LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
@@ -91,22 +92,22 @@ type leafPageReadCache struct {
 	evictions atomic.Uint64
 	entries   atomic.Uint64
 
-	readMissAdmissionSkips  atomic.Uint64
-	readMissAdmissionStale  atomic.Uint64
-	readMissAdmissionStores atomic.Uint64
+	readMissAdmissionSkips          atomic.Uint64
+	readMissAdmissionCandidateSkips atomic.Uint64
+	readMissAdmissionStores         atomic.Uint64
 }
 
 type leafPageReadCacheStats struct {
-	Hits                    uint64
-	Misses                  uint64
-	Stores                  uint64
-	Evictions               uint64
-	Entries                 uint64
-	Capacity                uint64
-	Bytes                   uint64
-	ReadMissAdmissionSkips  uint64
-	ReadMissAdmissionStale  uint64
-	ReadMissAdmissionStores uint64
+	Hits                            uint64
+	Misses                          uint64
+	Stores                          uint64
+	Evictions                       uint64
+	Entries                         uint64
+	Capacity                        uint64
+	Bytes                           uint64
+	ReadMissAdmissionSkips          uint64
+	ReadMissAdmissionCandidateSkips uint64
+	ReadMissAdmissionStores         uint64
 }
 
 func newLeafPageReadCache(entries int) *leafPageReadCache {
@@ -164,12 +165,11 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 		return
 	}
 	if !slot.readMissCandidateStillCurrent(fp, epoch) {
-		// A writer/read admission race can repurpose this slot and reset the
-		// candidate between miss observation and lock acquisition. Track epoch
-		// resets so a same-key first miss after reset cannot resurrect stale
-		// admission.
+		// A writer/read race can repurpose this slot between miss observation and
+		// lock acquisition. Candidate mismatches include epoch resets and same-epoch
+		// candidate churn under concurrent misses.
 		slot.mu.Unlock()
-		c.readMissAdmissionStale.Add(1)
+		c.readMissAdmissionCandidateSkips.Add(1)
 		return
 	}
 	result := slot.storeLocked(key, leafPage)
@@ -200,13 +200,19 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 }
 
 func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
+	oddEpochSpins := 0
 	for {
 		epoch = s.readMissEpoch.Load()
 		if epoch&1 != 0 {
 			// Writer is resetting this slot's admission candidate.
+			oddEpochSpins++
+			if oddEpochSpins >= maxReadMissOddEpochSpins {
+				return epoch, false
+			}
 			runtime.Gosched()
 			continue
 		}
+		oddEpochSpins = 0
 		candidateToken := readMissCandidateToken(fp, epoch)
 		candidate := s.readMissCandidateFP.Load()
 		if candidate == candidateToken {
@@ -307,16 +313,16 @@ func (c *leafPageReadCache) stats() leafPageReadCacheStats {
 	}
 	entries := c.entries.Load()
 	return leafPageReadCacheStats{
-		Hits:                    c.hits.Load(),
-		Misses:                  c.misses.Load(),
-		Stores:                  c.stores.Load(),
-		Evictions:               c.evictions.Load(),
-		Entries:                 entries,
-		Capacity:                uint64(len(c.slots)),
-		Bytes:                   entries * page.PageSize,
-		ReadMissAdmissionSkips:  c.readMissAdmissionSkips.Load(),
-		ReadMissAdmissionStale:  c.readMissAdmissionStale.Load(),
-		ReadMissAdmissionStores: c.readMissAdmissionStores.Load(),
+		Hits:                            c.hits.Load(),
+		Misses:                          c.misses.Load(),
+		Stores:                          c.stores.Load(),
+		Evictions:                       c.evictions.Load(),
+		Entries:                         entries,
+		Capacity:                        uint64(len(c.slots)),
+		Bytes:                           entries * page.PageSize,
+		ReadMissAdmissionSkips:          c.readMissAdmissionSkips.Load(),
+		ReadMissAdmissionCandidateSkips: c.readMissAdmissionCandidateSkips.Load(),
+		ReadMissAdmissionStores:         c.readMissAdmissionStores.Load(),
 	}
 }
 
@@ -347,8 +353,12 @@ func leafPageReadMissFingerprint(key leafPageReadCacheKey) uint64 {
 func readMissCandidateToken(fp, epoch uint64) uint64 {
 	token := fp ^ (epoch * 0x9e3779b97f4a7c15)
 	if token == 0 {
-		// Keep zero reserved for "no candidate recorded".
-		return 1
+		// Keep zero reserved for "no candidate recorded" without collapsing every
+		// zero-token case onto a single sentinel value.
+		token = (fp << 1) ^ (epoch >> 1) ^ 0x9e3779b97f4a7c15
+		if token == 0 {
+			token = 0x9e3779b97f4a7c15
+		}
 	}
 	return token
 }

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -156,6 +156,14 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 		slot.mu.Unlock()
 		return
 	}
+	if slot.readMissCandidateFP.Load() != fp {
+		// A writer/read admission race can repurpose this slot and reset the
+		// candidate between Swap(fp) and lock acquisition. Avoid admitting a stale
+		// read miss into the now-replaced slot.
+		slot.mu.Unlock()
+		c.readMissAdmissionSkips.Add(1)
+		return
+	}
 	result := slot.storeLocked(key, leafPage)
 	slot.mu.Unlock()
 	c.readMissAdmissionStores.Add(1)

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -206,6 +206,8 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
 	oddEpochSpins := 0
 	stableEpochSpins := 0
+	lastStableEpoch := uint64(0)
+	observedEpochAdvance := false
 	for {
 		epoch = s.readMissEpoch.Load()
 		if epoch&1 != 0 {
@@ -218,10 +220,22 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 			continue
 		}
 		oddEpochSpins = 0
+		if lastStableEpoch == 0 {
+			lastStableEpoch = epoch
+		} else if epoch != lastStableEpoch {
+			// Crossing into a new stable epoch means this observer raced a reset.
+			// Treat subsequent matches as first-miss observations in the new epoch.
+			lastStableEpoch = epoch
+			stableEpochSpins = 0
+			observedEpochAdvance = true
+		}
 		candidateToken := readMissCandidateToken(fp, epoch)
 		candidate := s.readMissCandidateFP.Load()
 		if candidate == candidateToken {
 			if s.readMissEpoch.Load() == epoch {
+				if observedEpochAdvance {
+					return epoch, false
+				}
 				return epoch, true
 			}
 		} else if s.readMissEpoch.Load() == epoch {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -257,6 +257,9 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 				return epoch, true
 			}
 		} else if s.readMissEpoch.Load() == epoch {
+			if observedEpochAdvance {
+				return epoch, false
+			}
 			if s.readMissCandidateFP.CompareAndSwap(candidate, candidateToken) {
 				if s.readMissEpoch.Load() == epoch {
 					return epoch, false

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -270,10 +270,16 @@ func (c *leafPageReadCache) slotIndex(key leafPageReadCacheKey) int {
 }
 
 func leafPageReadMissFingerprint(key leafPageReadCacheKey) uint64 {
-	// Keep this intentionally cheap and stable: collisions are acceptable because
-	// they only cause occasional extra lock/store attempts, never wrong results.
-	h := uint64(key.fileID)*0x9e3779b97f4a7c15 ^ key.offset
-	h ^= uint64(key.subIndex) * 0xc2b2ae3d27d4eb4f
+	// Admission is intentionally probabilistic under collisions, so keep this
+	// hash stable but well-mixed to reduce accidental first-miss admissions when
+	// unrelated keys map to the same slot.
+	h := uint64(key.fileID)*0x9e3779b97f4a7c15 + key.offset*0xbf58476d1ce4e5b9
+	h ^= uint64(key.subIndex) * 0x94d049bb133111eb
+	h ^= h >> 30
+	h *= 0xbf58476d1ce4e5b9
+	h ^= h >> 27
+	h *= 0x94d049bb133111eb
+	h ^= h >> 31
 	if h == 0 {
 		return 1
 	}

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -19,9 +19,11 @@ const (
 	maxLeafPageReadCacheEntries     = 1 << 18
 	// Bound miss-admission observer retries so high contention yields a skipped
 	// admission instead of unbounded reader spinning. 64 odd-epoch yields cover
-	// transient reset windows; 256 stable-epoch retries bound CAS churn.
+	// transient reset windows; 256 stable-epoch retries bound CAS churn; and a
+	// hard total-iteration cap guarantees termination under sustained churn.
 	maxReadMissOddEpochSpins    = 64
 	maxReadMissStableEpochSpins = 256
+	maxReadMissTotalSpins       = 1024
 )
 
 var LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
@@ -203,13 +205,27 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 	return result
 }
 
+// observeReadMissCandidate implements the read-miss admission state machine for
+// one cache slot:
+//   - odd readMissEpoch values mean writer reset in progress (slot unstable),
+//   - even values mean stable epoch (candidate token can be observed/published),
+//   - repeated=true is only returned when the token matches in a stable epoch
+//     without crossing into a newer stable epoch mid-observation.
+//
+// The multiple epoch reads fence reset races; bounded retry counters ensure this
+// path eventually gives up and reports non-repeated under heavy contention.
 func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
+	totalSpins := 0
 	oddEpochSpins := 0
 	stableEpochSpins := 0
 	lastStableEpoch := uint64(0)
 	haveStableEpoch := false
 	observedEpochAdvance := false
 	for {
+		totalSpins++
+		if totalSpins >= maxReadMissTotalSpins {
+			return epoch, false
+		}
 		epoch = s.readMissEpoch.Load()
 		if epoch&1 != 0 {
 			// Writer is resetting this slot's admission candidate.

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -78,6 +78,7 @@ type leafPageReadCacheSlot struct {
 	data                []byte
 	valid               bool
 	readMissCandidateFP atomic.Uint64
+	readMissEpoch       atomic.Uint64
 }
 
 type leafPageReadCache struct {
@@ -136,7 +137,8 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 	slot := &c.slots[c.slotIndex(key)]
 
 	fp := leafPageReadMissFingerprint(key)
-	if slot.readMissCandidateFP.Swap(fp) != fp {
+	epoch, repeated := slot.observeReadMissCandidate(fp)
+	if !repeated {
 		c.readMissAdmissionSkips.Add(1)
 		return
 	}
@@ -156,10 +158,11 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 		slot.mu.Unlock()
 		return
 	}
-	if slot.readMissCandidateFP.Load() != fp {
+	if !slot.readMissCandidateStillCurrent(fp, epoch) {
 		// A writer/read admission race can repurpose this slot and reset the
-		// candidate between Swap(fp) and lock acquisition. Avoid admitting a stale
-		// read miss into the now-replaced slot.
+		// candidate between miss observation and lock acquisition. Track epoch
+		// resets so a same-key first miss after reset cannot resurrect stale
+		// admission.
 		slot.mu.Unlock()
 		c.readMissAdmissionSkips.Add(1)
 		return
@@ -187,8 +190,31 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 	copy(s.data, leafPage)
 	s.key = key
 	s.valid = true
-	s.readMissCandidateFP.Store(0)
+	s.resetReadMissCandidateLocked()
 	return result
+}
+
+func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
+	epoch = s.readMissEpoch.Load()
+	for {
+		candidate := s.readMissCandidateFP.Load()
+		if candidate == fp {
+			return epoch, true
+		}
+		if s.readMissCandidateFP.CompareAndSwap(candidate, fp) {
+			return epoch, false
+		}
+		epoch = s.readMissEpoch.Load()
+	}
+}
+
+func (s *leafPageReadCacheSlot) readMissCandidateStillCurrent(fp, epoch uint64) bool {
+	return s.readMissEpoch.Load() == epoch && s.readMissCandidateFP.Load() == fp
+}
+
+func (s *leafPageReadCacheSlot) resetReadMissCandidateLocked() {
+	s.readMissEpoch.Add(1)
+	s.readMissCandidateFP.Store(0)
 }
 
 func (c *leafPageReadCache) recordStore(result leafPageReadCacheStoreResult, key leafPageReadCacheKey) {
@@ -271,8 +297,8 @@ func (c *leafPageReadCache) slotIndex(key leafPageReadCacheKey) int {
 
 func leafPageReadMissFingerprint(key leafPageReadCacheKey) uint64 {
 	// Admission is intentionally probabilistic under collisions, so keep this
-	// hash stable but well-mixed to reduce accidental first-miss admissions when
-	// unrelated keys map to the same slot.
+	// hash stable but well-mixed (SplitMix64-style finalizer constants) to reduce
+	// accidental first-miss admissions when unrelated keys map to the same slot.
 	h := uint64(key.fileID)*0x9e3779b97f4a7c15 + key.offset*0xbf58476d1ce4e5b9
 	h ^= uint64(key.subIndex) * 0x94d049bb133111eb
 	h ^= h >> 30

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -73,12 +73,11 @@ func newLeafPageReadCacheKey(ptr page.LeafLogPtr) leafPageReadCacheKey {
 }
 
 type leafPageReadCacheSlot struct {
-	mu                     sync.RWMutex
-	key                    leafPageReadCacheKey
-	data                   []byte
-	valid                  bool
-	readMissCandidate      leafPageReadCacheKey
-	readMissCandidateValid bool
+	mu                  sync.RWMutex
+	key                 leafPageReadCacheKey
+	data                []byte
+	valid               bool
+	readMissCandidateFP atomic.Uint64
 }
 
 type leafPageReadCache struct {
@@ -135,16 +134,26 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 	}
 	key := newLeafPageReadCacheKey(ptr)
 	slot := &c.slots[c.slotIndex(key)]
+
+	fp := leafPageReadMissFingerprint(key)
+	if slot.readMissCandidateFP.Swap(fp) != fp {
+		c.readMissAdmissionSkips.Add(1)
+		return
+	}
+
+	// Parallel read misses can race: another goroutine may populate this exact
+	// slot/key before we reach admission. Fast-path that case with only a read
+	// lock to avoid unnecessary writer lock traffic in the miss hot path.
+	slot.mu.RLock()
+	if slot.valid && slot.key == key {
+		slot.mu.RUnlock()
+		return
+	}
+	slot.mu.RUnlock()
+
 	slot.mu.Lock()
 	if slot.valid && slot.key == key {
 		slot.mu.Unlock()
-		return
-	}
-	if !slot.readMissCandidateValid || slot.readMissCandidate != key {
-		slot.readMissCandidate = key
-		slot.readMissCandidateValid = true
-		slot.mu.Unlock()
-		c.readMissAdmissionSkips.Add(1)
 		return
 	}
 	result := slot.storeLocked(key, leafPage)
@@ -170,7 +179,7 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 	copy(s.data, leafPage)
 	s.key = key
 	s.valid = true
-	s.readMissCandidateValid = false
+	s.readMissCandidateFP.Store(0)
 	return result
 }
 
@@ -250,6 +259,17 @@ func (c *leafPageReadCache) slotIndex(key leafPageReadCacheKey) int {
 	h ^= key.offset + 0x9e3779b97f4a7c15 + (h << 6) + (h >> 2)
 	h ^= uint64(key.subIndex) + 0x9e3779b97f4a7c15 + (h << 6) + (h >> 2)
 	return int(h % uint64(len(c.slots)))
+}
+
+func leafPageReadMissFingerprint(key leafPageReadCacheKey) uint64 {
+	// Keep this intentionally cheap and stable: collisions are acceptable because
+	// they only cause occasional extra lock/store attempts, never wrong results.
+	h := uint64(key.fileID)*0x9e3779b97f4a7c15 ^ key.offset
+	h ^= uint64(key.subIndex) * 0xc2b2ae3d27d4eb4f
+	if h == 0 {
+		return 1
+	}
+	return h
 }
 
 type cachedLeafPageReader struct {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -195,28 +195,44 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 }
 
 func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
-	epoch = s.readMissEpoch.Load()
 	for {
+		epoch = s.readMissEpoch.Load()
+		if epoch&1 != 0 {
+			// Writer is resetting this slot's admission candidate.
+			continue
+		}
 		candidate := s.readMissCandidateFP.Load()
 		if candidate == fp {
-			return epoch, true
+			if s.readMissEpoch.Load() == epoch {
+				return epoch, true
+			}
+			continue
 		}
 		if s.readMissCandidateFP.CompareAndSwap(candidate, fp) {
-			return epoch, false
+			if s.readMissEpoch.Load() == epoch {
+				return epoch, false
+			}
 		}
-		epoch = s.readMissEpoch.Load()
 	}
 }
 
 func (s *leafPageReadCacheSlot) readMissCandidateStillCurrent(fp, epoch uint64) bool {
+	if epoch&1 != 0 {
+		return false
+	}
 	return s.readMissEpoch.Load() == epoch && s.readMissCandidateFP.Load() == fp
 }
 
 func (s *leafPageReadCacheSlot) resetReadMissCandidateLocked() {
+	// Mark reset in-progress, clear candidate, then publish the next stable epoch.
+	// observeReadMissCandidate() only accepts even (stable) epochs.
+	start := s.readMissEpoch.Load()
+	if start&1 != 0 {
+		start++
+	}
+	s.readMissEpoch.Store(start + 1)
 	s.readMissCandidateFP.Store(0)
-	// Publish a fresh epoch only after clearing the prior fingerprint so new
-	// misses cannot observe (new epoch, stale fingerprint) as a false repeat.
-	s.readMissEpoch.Add(1)
+	s.readMissEpoch.Store(start + 2)
 }
 
 func (c *leafPageReadCache) recordStore(result leafPageReadCacheStoreResult, key leafPageReadCacheKey) {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -207,6 +207,7 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 	oddEpochSpins := 0
 	stableEpochSpins := 0
 	lastStableEpoch := uint64(0)
+	haveStableEpoch := false
 	observedEpochAdvance := false
 	for {
 		epoch = s.readMissEpoch.Load()
@@ -220,8 +221,9 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 			continue
 		}
 		oddEpochSpins = 0
-		if lastStableEpoch == 0 {
+		if !haveStableEpoch {
 			lastStableEpoch = epoch
+			haveStableEpoch = true
 		} else if epoch != lastStableEpoch {
 			// Crossing into a new stable epoch means this observer raced a reset.
 			// Treat subsequent matches as first-miss observations in the new epoch.

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -208,10 +208,17 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 			}
 			continue
 		}
+		if s.readMissEpoch.Load() != epoch {
+			continue
+		}
 		if s.readMissCandidateFP.CompareAndSwap(candidate, fp) {
-			if s.readMissEpoch.Load() == epoch {
+			currentEpoch := s.readMissEpoch.Load()
+			if currentEpoch == epoch {
 				return epoch, false
 			}
+			// If the epoch moved while this CAS raced, best-effort restore the
+			// prior candidate so a stale CAS cannot publish fp into the newer epoch.
+			s.readMissCandidateFP.CompareAndSwap(fp, candidate)
 		}
 	}
 }

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -3,6 +3,7 @@ package db
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,6 +92,7 @@ type leafPageReadCache struct {
 	entries   atomic.Uint64
 
 	readMissAdmissionSkips  atomic.Uint64
+	readMissAdmissionStale  atomic.Uint64
 	readMissAdmissionStores atomic.Uint64
 }
 
@@ -103,6 +105,7 @@ type leafPageReadCacheStats struct {
 	Capacity                uint64
 	Bytes                   uint64
 	ReadMissAdmissionSkips  uint64
+	ReadMissAdmissionStale  uint64
 	ReadMissAdmissionStores uint64
 }
 
@@ -164,7 +167,7 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 		// resets so a same-key first miss after reset cannot resurrect stale
 		// admission.
 		slot.mu.Unlock()
-		c.readMissAdmissionSkips.Add(1)
+		c.readMissAdmissionStale.Add(1)
 		return
 	}
 	result := slot.storeLocked(key, leafPage)
@@ -199,6 +202,7 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 		epoch = s.readMissEpoch.Load()
 		if epoch&1 != 0 {
 			// Writer is resetting this slot's admission candidate.
+			runtime.Gosched()
 			continue
 		}
 		candidateToken := readMissCandidateToken(fp, epoch)
@@ -309,6 +313,7 @@ func (c *leafPageReadCache) stats() leafPageReadCacheStats {
 		Capacity:                uint64(len(c.slots)),
 		Bytes:                   entries * page.PageSize,
 		ReadMissAdmissionSkips:  c.readMissAdmissionSkips.Load(),
+		ReadMissAdmissionStale:  c.readMissAdmissionStale.Load(),
 		ReadMissAdmissionStores: c.readMissAdmissionStores.Load(),
 	}
 }

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -213,8 +213,10 @@ func (s *leafPageReadCacheSlot) readMissCandidateStillCurrent(fp, epoch uint64) 
 }
 
 func (s *leafPageReadCacheSlot) resetReadMissCandidateLocked() {
-	s.readMissEpoch.Add(1)
 	s.readMissCandidateFP.Store(0)
+	// Publish a fresh epoch only after clearing the prior fingerprint so new
+	// misses cannot observe (new epoch, stale fingerprint) as a false repeat.
+	s.readMissEpoch.Add(1)
 }
 
 func (c *leafPageReadCache) recordStore(result leafPageReadCacheStoreResult, key leafPageReadCacheKey) {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -201,8 +201,9 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 			// Writer is resetting this slot's admission candidate.
 			continue
 		}
+		candidateToken := readMissCandidateToken(fp, epoch)
 		candidate := s.readMissCandidateFP.Load()
-		if candidate == fp {
+		if candidate == candidateToken {
 			if s.readMissEpoch.Load() == epoch {
 				return epoch, true
 			}
@@ -211,14 +212,13 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 		if s.readMissEpoch.Load() != epoch {
 			continue
 		}
-		if s.readMissCandidateFP.CompareAndSwap(candidate, fp) {
-			currentEpoch := s.readMissEpoch.Load()
-			if currentEpoch == epoch {
+		if s.readMissCandidateFP.CompareAndSwap(candidate, candidateToken) {
+			if s.readMissEpoch.Load() == epoch {
 				return epoch, false
 			}
-			// If the epoch moved while this CAS raced, best-effort restore the
-			// prior candidate so a stale CAS cannot publish fp into the newer epoch.
-			s.readMissCandidateFP.CompareAndSwap(fp, candidate)
+			// Epoch-scoped tokens fence stale publishes: even if this CAS raced with
+			// reset and landed in a newer epoch, token mismatch prevents first-miss
+			// admission in the newer epoch.
 		}
 	}
 }
@@ -227,7 +227,7 @@ func (s *leafPageReadCacheSlot) readMissCandidateStillCurrent(fp, epoch uint64) 
 	if epoch&1 != 0 {
 		return false
 	}
-	return s.readMissEpoch.Load() == epoch && s.readMissCandidateFP.Load() == fp
+	return s.readMissEpoch.Load() == epoch && s.readMissCandidateFP.Load() == readMissCandidateToken(fp, epoch)
 }
 
 func (s *leafPageReadCacheSlot) resetReadMissCandidateLocked() {
@@ -335,6 +335,15 @@ func leafPageReadMissFingerprint(key leafPageReadCacheKey) uint64 {
 		return 1
 	}
 	return h
+}
+
+func readMissCandidateToken(fp, epoch uint64) uint64 {
+	token := fp ^ (epoch * 0x9e3779b97f4a7c15)
+	if token == 0 {
+		// Keep zero reserved for "no candidate recorded".
+		return 1
+	}
+	return token
 }
 
 type cachedLeafPageReader struct {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -17,7 +17,11 @@ const (
 	leafPageReadCacheEntriesEnvKey  = "TREEDB_LEAF_PAGE_CACHE_ENTRIES"
 	defaultLeafPageReadCacheEntries = 4096
 	maxLeafPageReadCacheEntries     = 1 << 18
-	maxReadMissOddEpochSpins        = 64
+	// Bound miss-admission observer retries so high contention yields a skipped
+	// admission instead of unbounded reader spinning. 64 odd-epoch yields cover
+	// transient reset windows; 256 stable-epoch retries bound CAS churn.
+	maxReadMissOddEpochSpins    = 64
+	maxReadMissStableEpochSpins = 256
 )
 
 var LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
@@ -201,6 +205,7 @@ func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage [
 
 func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint64, repeated bool) {
 	oddEpochSpins := 0
+	stableEpochSpins := 0
 	for {
 		epoch = s.readMissEpoch.Load()
 		if epoch&1 != 0 {
@@ -219,18 +224,22 @@ func (s *leafPageReadCacheSlot) observeReadMissCandidate(fp uint64) (epoch uint6
 			if s.readMissEpoch.Load() == epoch {
 				return epoch, true
 			}
-			continue
-		}
-		if s.readMissEpoch.Load() != epoch {
-			continue
-		}
-		if s.readMissCandidateFP.CompareAndSwap(candidate, candidateToken) {
-			if s.readMissEpoch.Load() == epoch {
-				return epoch, false
+		} else if s.readMissEpoch.Load() == epoch {
+			if s.readMissCandidateFP.CompareAndSwap(candidate, candidateToken) {
+				if s.readMissEpoch.Load() == epoch {
+					return epoch, false
+				}
+				// Epoch-scoped tokens fence stale publishes: even if this CAS raced
+				// with reset and landed in a newer epoch, token mismatch prevents
+				// first-miss admission in the newer epoch.
 			}
-			// Epoch-scoped tokens fence stale publishes: even if this CAS raced with
-			// reset and landed in a newer epoch, token mismatch prevents first-miss
-			// admission in the newer epoch.
+		}
+		stableEpochSpins++
+		if stableEpochSpins >= maxReadMissStableEpochSpins {
+			return epoch, false
+		}
+		if stableEpochSpins&15 == 0 {
+			runtime.Gosched()
 		}
 	}
 }

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -128,10 +128,12 @@ func (c *leafPageReadCache) store(ptr page.LeafLogPtr, leafPage []byte) {
 	c.recordStore(result, key)
 }
 
-// storeReadMiss admits read-miss pages only after a repeated miss to the same
-// direct-mapped slot/key. Write-side stores remain immediate; this keeps
-// one-off sparse reads from copying 4KiB pages into the cache and evicting
-// recently-written leaves that are likely to be reused during publish/apply.
+// storeReadMiss admits read-miss pages only after a repeated miss in the same
+// direct-mapped slot with a matching fingerprint token in the same admission
+// epoch (probabilistic under collisions). Write-side stores remain immediate;
+// this keeps one-off sparse reads from copying 4KiB pages into the cache and
+// evicting recently-written leaves that are likely to be reused during
+// publish/apply.
 func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) {
 	if c == nil || len(c.slots) == 0 || len(leafPage) != page.PageSize {
 		return

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -376,6 +376,38 @@ func TestValueReaderLeafLogPageUnsafeToAdmitsRepeatedReadMiss(t *testing.T) {
 	}
 }
 
+func TestLeafPageReadCacheReadMissCandidateEpochPreventsStaleAdmission(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	slot := &cache.slots[0]
+	keyA := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096})
+	keyB := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 9, Offset: 512, RecordLengthHint: 4096})
+	fpA := leafPageReadMissFingerprint(keyA)
+
+	slot.readMissCandidateFP.Store(fpA)
+	epochBefore, repeated := slot.observeReadMissCandidate(fpA)
+	if !repeated {
+		t.Fatal("expected matching candidate to be treated as repeated miss")
+	}
+
+	slot.mu.Lock()
+	_ = slot.storeLocked(keyB, bytes.Repeat([]byte{0x61}, page.PageSize))
+	slot.mu.Unlock()
+
+	epochAfterReset, repeated := slot.observeReadMissCandidate(fpA)
+	if repeated {
+		t.Fatal("expected first post-reset miss to be non-repeated")
+	}
+	if epochAfterReset == epochBefore {
+		t.Fatalf("read miss epoch did not advance after reset: before=%d after=%d", epochBefore, epochAfterReset)
+	}
+	if slot.readMissCandidateStillCurrent(fpA, epochBefore) {
+		t.Fatal("stale pre-reset candidate unexpectedly considered current")
+	}
+	if !slot.readMissCandidateStillCurrent(fpA, epochAfterReset) {
+		t.Fatal("fresh post-reset candidate should be current")
+	}
+}
+
 func TestValueReaderLeafLogPageUnsafeToOneOffReadMissDoesNotEvictStoredLeaf(t *testing.T) {
 	cache := newLeafPageReadCache(1)
 	hotPtr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -383,7 +383,7 @@ func TestLeafPageReadCacheReadMissCandidateEpochPreventsStaleAdmission(t *testin
 	keyB := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 9, Offset: 512, RecordLengthHint: 4096})
 	fpA := leafPageReadMissFingerprint(keyA)
 
-	slot.readMissCandidateFP.Store(fpA)
+	slot.readMissCandidateFP.Store(readMissCandidateToken(fpA, slot.readMissEpoch.Load()))
 	epochBefore, repeated := slot.observeReadMissCandidate(fpA)
 	if !repeated {
 		t.Fatal("expected matching candidate to be treated as repeated miss")
@@ -405,6 +405,52 @@ func TestLeafPageReadCacheReadMissCandidateEpochPreventsStaleAdmission(t *testin
 	}
 	if !slot.readMissCandidateStillCurrent(fpA, epochAfterReset) {
 		t.Fatal("fresh post-reset candidate should be current")
+	}
+}
+
+func TestLeafPageReadCacheReadMissCandidateEpochTokenRejectsStaleCAS(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	slot := &cache.slots[0]
+	keyA := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 11, Offset: 64, RecordLengthHint: 4096})
+	keyB := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 12, Offset: 96, RecordLengthHint: 4096})
+	fpA := leafPageReadMissFingerprint(keyA)
+	fpB := leafPageReadMissFingerprint(keyB)
+	oldEpoch := slot.readMissEpoch.Load()
+	oldTokenA := readMissCandidateToken(fpA, oldEpoch)
+	oldTokenB := readMissCandidateToken(fpB, oldEpoch)
+
+	slot.readMissCandidateFP.Store(oldTokenA)
+
+	slot.mu.Lock()
+	slot.resetReadMissCandidateLocked()
+	slot.mu.Unlock()
+
+	newEpoch := slot.readMissEpoch.Load()
+	if newEpoch == oldEpoch {
+		t.Fatalf("epoch did not advance across reset: old=%d new=%d", oldEpoch, newEpoch)
+	}
+	newTokenA := readMissCandidateToken(fpA, newEpoch)
+	if newTokenA == oldTokenA {
+		t.Fatalf("candidate token unexpectedly reused across epochs: epoch=%d token=%d", newEpoch, newTokenA)
+	}
+
+	observedEpoch, repeated := slot.observeReadMissCandidate(fpA)
+	if repeated {
+		t.Fatal("expected first post-reset miss for key A to be non-repeated")
+	}
+	if observedEpoch != newEpoch {
+		t.Fatalf("observeReadMissCandidate epoch=%d, want %d", observedEpoch, newEpoch)
+	}
+	if got := slot.readMissCandidateFP.Load(); got != newTokenA {
+		t.Fatalf("post-reset candidate token=%d, want %d", got, newTokenA)
+	}
+
+	// Simulate a stale observer from oldEpoch trying to publish into newEpoch.
+	if slot.readMissCandidateFP.CompareAndSwap(oldTokenA, oldTokenB) {
+		t.Fatal("stale epoch compare-and-swap unexpectedly succeeded")
+	}
+	if got := slot.readMissCandidateFP.Load(); got != newTokenA {
+		t.Fatalf("candidate token changed after stale CAS: got=%d want=%d", got, newTokenA)
 	}
 }
 

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -472,6 +472,8 @@ func TestLeafPageReadCacheReadMissCandidateOddEpochSpinBound(t *testing.T) {
 		done <- result{epoch: epoch, repeated: repeated}
 	}()
 
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
 	select {
 	case got := <-done:
 		if got.repeated {
@@ -480,7 +482,7 @@ func TestLeafPageReadCacheReadMissCandidateOddEpochSpinBound(t *testing.T) {
 		if got.epoch&1 == 0 {
 			t.Fatalf("observeReadMissCandidate epoch=%d, want odd epoch while reset is in progress", got.epoch)
 		}
-	case <-time.After(2 * time.Second):
+	case <-timer.C:
 		t.Fatal("observeReadMissCandidate did not return under sustained odd-epoch contention")
 	}
 }

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -451,6 +452,36 @@ func TestLeafPageReadCacheReadMissCandidateEpochTokenRejectsStaleCAS(t *testing.
 	}
 	if got := slot.readMissCandidateFP.Load(); got != newTokenA {
 		t.Fatalf("candidate token changed after stale CAS: got=%d want=%d", got, newTokenA)
+	}
+}
+
+func TestLeafPageReadCacheReadMissCandidateOddEpochSpinBound(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	slot := &cache.slots[0]
+	key := newLeafPageReadCacheKey(page.LeafLogPtr{FileID: 13, Offset: 4096, RecordLengthHint: 4096})
+	fp := leafPageReadMissFingerprint(key)
+	slot.readMissEpoch.Store(1) // odd epoch simulates reset in progress
+
+	type result struct {
+		epoch    uint64
+		repeated bool
+	}
+	done := make(chan result, 1)
+	go func() {
+		epoch, repeated := slot.observeReadMissCandidate(fp)
+		done <- result{epoch: epoch, repeated: repeated}
+	}()
+
+	select {
+	case got := <-done:
+		if got.repeated {
+			t.Fatal("odd-epoch spin bound should return non-repeated miss")
+		}
+		if got.epoch&1 == 0 {
+			t.Fatalf("observeReadMissCandidate epoch=%d, want odd epoch while reset is in progress", got.epoch)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("observeReadMissCandidate did not return under sustained odd-epoch contention")
 	}
 }
 


### PR DESCRIPTION
## Summary
- reduce write-lock pressure in outer-leaf `storeReadMiss`
- add lock-free first-stage miss fingerprint filter so first misses skip without taking slot write lock
- keep two-hit admission semantics while reducing coordination overhead under parallel random reads

## Validation
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/caching -run 'TestAcquireSnapshot_AllocsBoundedAfterWarmPath|TestSnapshotGetAppend' -count=1`
- focused perf A/B vs pass2 baseline (`-test random_read_parallel`): head higher in local runs
