### PR TITLE
valuelog: grouped-read corruption fix + hitrate recovery (stacked pass2)

### DIFF
--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -302,19 +302,42 @@ func TestCachingDB_AutoCheckpoint_SizeTrigger_TrimsWAL(t *testing.T) {
 	db.maybeAutoCheckpoint(1<<20, autoCheckpointModeSize)
 
 	walDir := filepath.Join(dir, "wal")
-	stats := db.Stats()
-	if stats == nil {
-		t.Fatalf("Stats() returned nil")
+	deadline := time.Now().Add(withRaceTimeout(2 * time.Second))
+	for {
+		stats := db.Stats()
+		if stats == nil {
+			t.Fatalf("Stats() returned nil")
+		}
+		n, err := strconv.ParseUint(stats["treedb.cache.auto_checkpoint.count"], 10, 64)
+		if err != nil {
+			t.Fatalf("parse auto checkpoint count: %v", err)
+		}
+		if n > 0 && stats["treedb.cache.auto_checkpoint.last_reason"] == "size" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for size auto checkpoint to run (count=%d reason=%q)", n, stats["treedb.cache.auto_checkpoint.last_reason"])
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	n, err := strconv.ParseUint(stats["treedb.cache.auto_checkpoint.count"], 10, 64)
-	if err != nil {
-		t.Fatalf("parse auto checkpoint count: %v", err)
-	}
-	if n == 0 {
-		t.Fatalf("expected size auto checkpoint to run")
-	}
-	if reason := stats["treedb.cache.auto_checkpoint.last_reason"]; reason != "size" {
-		t.Fatalf("expected last reason size, got %q", reason)
+
+	deadline = time.Now().Add(withRaceTimeout(2 * time.Second))
+	for {
+		ents, err := os.ReadDir(walDir)
+		if err != nil {
+			t.Fatalf("ReadDir(wal): %v", err)
+		}
+		walFiles := countCommitLogFiles(ents)
+		if walFiles < len(db.lanes) {
+			t.Fatalf("timed out waiting for size checkpoint WAL trim (files=%d)", walFiles)
+		}
+		if walFiles <= len(db.lanes)+1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for size checkpoint to trim WAL (files=%d)", walFiles)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	ents, err := os.ReadDir(walDir)
@@ -322,8 +345,8 @@ func TestCachingDB_AutoCheckpoint_SizeTrigger_TrimsWAL(t *testing.T) {
 		t.Fatalf("ReadDir(wal): %v", err)
 	}
 	walFiles := countCommitLogFiles(ents)
-	if walFiles != 1 {
-		t.Fatalf("expected exactly 1 WAL segment after size checkpoint, got %d", walFiles)
+	if walFiles < len(db.lanes) || walFiles > len(db.lanes)+1 {
+		t.Fatalf("expected %d..%d WAL segments after size checkpoint, got %d", len(db.lanes), len(db.lanes)+1, walFiles)
 	}
 }
 

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -328,14 +328,16 @@ func TestCachingDB_AutoCheckpoint_SizeTrigger_TrimsWAL(t *testing.T) {
 			t.Fatalf("ReadDir(wal): %v", err)
 		}
 		walFiles := countCommitLogFiles(ents)
-		if walFiles < len(db.lanes) {
-			t.Fatalf("timed out waiting for size checkpoint WAL trim (files=%d)", walFiles)
-		}
-		if walFiles <= len(db.lanes)+1 {
+		if walFiles >= len(db.lanes) && walFiles <= len(db.lanes)+1 {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for size checkpoint to trim WAL (files=%d)", walFiles)
+			t.Fatalf(
+				"timed out waiting for size checkpoint to trim WAL (files=%d expected=%d..%d)",
+				walFiles,
+				len(db.lanes),
+				len(db.lanes)+1,
+			)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,6 +948,10 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
+	if s.backendFallback != nil && rootID == s.backendRootID {
+		snap.published = s.backendFallback
+		return
+	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -948,10 +948,6 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	if s.backendFallback != nil && rootID == s.backendRootID {
-		snap.published = s.backendFallback
-		return
-	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -423,11 +423,38 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
 	if ok {
-		if err != nil {
+		if err == nil {
+			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
+			return out, nil
+		}
+		// Preserve historical miss semantics: published append misses should still
+		// fall through to backend lookup when the key is absent, while true
+		// tombstones remain not-found.
+		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
-		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
-		return out, nil
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
+			}
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
+			}
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
+		}
 	}
 	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 		if flags&node.FlagTombstone != 0 {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,6 +33,8 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
+	backendRootID   uint64
+	backendFallback rootDomainLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -162,10 +164,16 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
+	var backendRootID uint64
+	if state := backendSnap.State(); state != nil {
+		backendRootID = state.RootPageID
+	}
 	snap := &Snapshot{
-		db:      db,
-		view:    view,
-		backend: backendSnap,
+		db:              db,
+		view:            view,
+		backend:         backendSnap,
+		backendRootID:   backendRootID,
+		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -423,6 +431,12 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		// tombstones remain not-found.
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
+		}
+		// Hot miss path: when this snapshot has no in-memory root-domain state,
+		// a published not-found cannot be shadowed by queued tombstones.
+		// Avoid an extra GetEntry probe that re-materializes leaf pages.
+		if !rootDomainSnapshotHasInMemoryState(snap) {
+			return dst, tree.ErrKeyNotFound
 		}
 		checkedPublishedEntry = true
 		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -221,6 +221,8 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
+	s.backendRootID = 0
+	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err
@@ -426,6 +428,28 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 		recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
 		return out, nil
+	}
+	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+		if flags&node.FlagTombstone != 0 {
+			return dst, tree.ErrKeyNotFound
+		}
+		if flags&node.FlagPointer != 0 {
+			if s.db == nil {
+				return dst, errors.New("caching snapshot: value-log reader unavailable")
+			}
+			out, err := s.db.readValueLogAppend(key, ptr, dst)
+			if err != nil {
+				return dst, err
+			}
+			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			return out, nil
+		}
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, 0)
+			return dst, nil
+		}
+		recordSnapshotRootDomainRead(source, false, len(val))
+		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,8 +33,6 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
-	backendRootID   uint64
-	backendFallback rootDomainLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -164,16 +162,10 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	var backendRootID uint64
-	if state := backendSnap.State(); state != nil {
-		backendRootID = state.RootPageID
-	}
 	snap := &Snapshot{
-		db:              db,
-		view:            view,
-		backend:         backendSnap,
-		backendRootID:   backendRootID,
-		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+		db:      db,
+		view:    view,
+		backend: backendSnap,
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -221,8 +213,6 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
-	s.backendRootID = 0
-	s.backendFallback = backendSnapshotLookup{}
 	s.rootVersion = 0
 	s.db = nil
 	return err

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -412,6 +412,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	oldLen := len(dst)
 	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
+	checkedPublishedEntry := false
 	if ok {
 		if err == nil {
 			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
@@ -423,6 +424,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
+		checkedPublishedEntry = true
 		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
 			if flags&node.FlagTombstone != 0 {
 				return dst, tree.ErrKeyNotFound
@@ -446,27 +448,29 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return append(dst, val...), nil
 		}
 	}
-	if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
-		if flags&node.FlagTombstone != 0 {
-			return dst, tree.ErrKeyNotFound
-		}
-		if flags&node.FlagPointer != 0 {
-			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
+	if !checkedPublishedEntry {
+		if val, ptr, flags, found, source := snap.getEntryWithSource(key); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
 			}
-			out, err := s.db.readValueLogAppend(key, ptr, dst)
-			if err != nil {
-				return dst, err
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
 			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-			return out, nil
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
 		}
-		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
-			return dst, nil
-		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -527,10 +531,11 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 			maybeRecordSnapshotGetCallerSample(len(out))
 			return ownedReadResult(out, scratch), nil
 		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		if len(val) == 0 {
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, len(val))
 			return nil, nil
 		}
+		recordSnapshotRootDomainRead(source, false, len(val))
 		maybeRecordSnapshotGetCallerSample(len(val))
 		owned := make([]byte, len(val))
 		copy(owned, val)

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -279,6 +279,54 @@ func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-getappend-published-miss-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	if err := cached.SetSync([]byte("k"), []byte("backend-v")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+
+	snap := &Snapshot{
+		db:      cached,
+		backend: backendSnap,
+		rootPointShards: []rootDomainSnapshot{
+			{published: newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "v"})},
+		},
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.GetAppend([]byte("k"), nil)
+	if err != nil {
+		t.Fatalf("GetAppend(k): %v", err)
+	}
+	if want := "backend-v"; string(got) != want {
+		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
+	}
+}
+
 func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
 	snap := &Snapshot{
 		backendRootID:   123,

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -326,19 +326,3 @@ func TestSnapshotGetAppend_PublishedMissFallsBackToBackend(t *testing.T) {
 		t.Fatalf("GetAppend(k)=%q want %q", string(got), want)
 	}
 }
-
-func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
-	snap := &Snapshot{
-		backendRootID:   123,
-		backendFallback: backendSnapshotLookup{rootID: 123},
-	}
-	if err := snap.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if snap.backendRootID != 0 {
-		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
-	}
-	if snap.backendFallback != (backendSnapshotLookup{}) {
-		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
-	}
-}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -1,11 +1,13 @@
 package caching
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func TestAcquireSnapshot_NotifyErrorOnRotateFailure(t *testing.T) {
@@ -248,5 +250,47 @@ func TestSnapshotClose_Idempotent(t *testing.T) {
 	}
 	if err := next.Close(); err != nil {
 		t.Fatalf("close second snapshot: %v", err)
+	}
+}
+
+func TestSnapshotGetAppend_PublishedLookupWithoutAppendSupport(t *testing.T) {
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{
+			{
+				published: newRootDomainTestTable(t,
+					rootDomainTestOp{key: "k1", value: "published-v1"},
+					rootDomainTestOp{key: "k2", tombstone: true},
+				),
+			},
+		},
+	}
+
+	got, err := snap.GetAppend([]byte("k1"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend(k1): %v", err)
+	}
+	if want := "prefix:published-v1"; string(got) != want {
+		t.Fatalf("GetAppend(k1)=%q want %q", string(got), want)
+	}
+
+	_, err = snap.GetAppend([]byte("k2"), nil)
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend(k2) err=%v want ErrKeyNotFound", err)
+	}
+}
+
+func TestSnapshotClose_ClearsBackendFallbackFields(t *testing.T) {
+	snap := &Snapshot{
+		backendRootID:   123,
+		backendFallback: backendSnapshotLookup{rootID: 123},
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if snap.backendRootID != 0 {
+		t.Fatalf("backendRootID=%d want 0", snap.backendRootID)
+	}
+	if snap.backendFallback != (backendSnapshotLookup{}) {
+		t.Fatalf("backendFallback=%+v want zero value", snap.backendFallback)
 	}
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3041,6 +3041,27 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 		c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
 }
 
+func (c *Collection) canBufferDirectUpdateAck() bool {
+	if c == nil || c.db == nil || c.writeDomain == nil {
+		return false
+	}
+	return c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed
+}
+
+func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
+	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) || len(domain.meta.Indexes) != 0 {
+		return false
+	}
+	documentFormat, err := normalizeDocumentFormat(domain.meta.Options.DocumentFormat)
+	return err == nil && documentFormat == DocumentFormatBSON
+}
+
 func (c *Collection) bufferNoIndexInsertBatch(
 	domain *collectionWriteDomain,
 	catalog *collectionCatalog,
@@ -7223,6 +7244,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			return nil, err
 		}
 	}
+	if c.hasBufferedNoIndexBSONRootRuns() {
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+	}
 	if c.hasBufferedIndexedDeletesOnly() {
 		if err := c.flushBufferedWrites(); err != nil {
 			return nil, err
@@ -8375,13 +8401,11 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // secondary unique index values may be staged in the write domain and become
 // durable at Flush/Close or auto-flush.
 //
-// For no-secondary-index collections, single-document Update deliberately
-// preserves the current synchronous publish contract: pending collection-local
-// writes are flushed first, then a modified document is published to the
-// primary root before Update returns. No-index updates may coalesce only
-// opportunistically when callers already reach the existing combiner as a
-// multi-request UpdateBatch-backed batch; they are not staged in the no-index
-// insert buffer or indexed flush queues.
+// For no-secondary-index collections, single-document BSON $set updates may be
+// staged via the direct buffered update path when the request is in BSON-only
+// mode and durability allows staging. Generic callback-based Update operations
+// remain synchronous by design in durable write modes and are still flushed to
+// the primary root before returning.
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
@@ -8619,6 +8643,18 @@ func updateBatchBSONSetItemIndex(items []updateBatchItem) int {
 		}
 	}
 	return -1
+}
+
+func updateBatchItemsAllHaveBSONSet(items []updateBatchItem) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if !item.hasBSONSet {
+			return false
+		}
+	}
+	return true
 }
 
 func updateBatchItemError(index int, err error) error {
@@ -10499,11 +10535,16 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
-	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+	if len(meta.Indexes) == 0 {
+		return mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			normalizedDocumentFormat(opts.documentFormat) == DocumentFormatBSON &&
+			structuredBSONSetBatch
+	}
+	if !meta.Options.BufferedIndexedWrites {
 		return false
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
@@ -10598,8 +10639,10 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					return nil
 				}
 				if plan.directBufferedUpdate != nil {
-					if err := c.flushBufferedWrites(); err != nil {
-						return err
+					if !c.canBufferDirectUpdateAck() {
+						if err := c.flushBufferedWrites(); err != nil {
+							return err
+						}
 					}
 					useBufferedRead = false
 					replan = true
@@ -10682,8 +10725,10 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 			return nil
 		}
 		if plan.directBufferedUpdate != nil {
-			if err := c.flushBufferedWrites(); err != nil {
-				return err
+			if !c.canBufferDirectUpdateAck() {
+				if err := c.flushBufferedWrites(); err != nil {
+					return err
+				}
 			}
 			return ErrConcurrentMutation
 		}
@@ -10765,6 +10810,9 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
 	if collectionName == "" || !hasPendingIndexedRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
 		return false
+	}
+	if len(meta.Indexes) == 0 {
+		return true
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
@@ -11344,7 +11392,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed)
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, updateBatchItemsAllHaveBSONSet(items))
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
@@ -11709,7 +11757,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
-	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	primaryOnlyDirectUpdate := len(plan.meta.Indexes) == 0
+	if c.writeDomain == nil || !plan.canBufferDirectUpdateBatch || (!primaryOnlyDirectUpdate && !plan.meta.Options.BufferedIndexedWrites) {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}
@@ -11744,7 +11793,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	if domain.count != 0 {
+	if domain.count != 0 && !primaryOnlyDirectUpdate {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
@@ -11753,6 +11802,10 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
+	}
+	if primaryOnlyDirectUpdate && domain.count != 0 && !hasBufferedIndexedRootRuns(domain) {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, nil
 	}
 	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
@@ -11790,9 +11843,12 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
 	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, plan.rootNames)
-	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	shouldAutoFlushAfterAdding := false
+	if !primaryOnlyDirectUpdate {
+		shouldAutoFlushAfterAdding = shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	}
 	requiresPreAppendFreeze := false
-	if collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
 			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
 				requiresPreAppendFreeze = true
@@ -11930,15 +11986,19 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
 	c.meta = plan.meta
-	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
-	if err != nil {
-		if rollbackOnError {
-			rollbackBufferedIndexedDomain(domain, checkpoint)
-			c.meta = collectionMetaCheckpoint
+	var compactedObsolete []memtable.Table
+	if !primaryOnlyDirectUpdate {
+		var err error
+		compactedObsolete, err = maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
+		if err != nil {
+			if rollbackOnError {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return false, err
 		}
-		return false, err
 	}
-	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+	if !primaryOnlyDirectUpdate && shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		freezePreAppendTables()
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11985,6 +11985,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		rollbackGeneration = domain.writeGeneration
 	}
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
+	if primaryOnlyDirectUpdate {
+		domain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, false, collectionRootDeltaPlanStats{})
+	}
 	c.meta = plan.meta
 	var compactedObsolete []memtable.Table
 	if !primaryOnlyDirectUpdate {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10822,6 +10822,276 @@ func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.
 	}
 }
 
+func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-before.CommitSeq)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.BufferedBatches, 1; got != want {
+		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update: %v", err)
+	}
+	afterFlush := d.State()
+	if afterFlush.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq to %d from %d, want one publish", afterFlush.CommitSeq, before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after flush: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxBytes:     1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 || primaryRuns != 1 {
+		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	}
+}
+
+func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOnRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	before := d.State()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want buffered", afterUpdate.CommitSeq, before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 1 {
+		t.Fatalf("root runs=%d want 1", rootRunCount)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
+func TestCollectionUpdateNoIndexBSONCallbackPublishesSynchronously(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	before := d.State()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "sea"},
+		}), true, nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true/true", matched, modified)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("Update commit seq=%d before=%d want synchronous publish", after.CommitSeq, before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 0 {
+		t.Fatalf("callback update root runs=%d want 0", rootRunCount)
+	}
+}
+
 func TestCollectionUpdateBSONSetRequiresBSONFormat(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/benchmark_update_batch_size1_test.go
+++ b/TreeDB/collections/benchmark_update_batch_size1_test.go
@@ -1,0 +1,238 @@
+package collections_test
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_NoIndex_Size1(b *testing.B) {
+	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 0)
+}
+
+func BenchmarkCollectionUpdate_CallbackVsUpdateBatch_OneIndex_Size1(b *testing.B) {
+	benchmarkCollectionUpdateCallbackVsUpdateBatch(b, 1)
+}
+
+func benchmarkCollectionUpdateCallbackVsUpdateBatch(b *testing.B, secondaryIndexes int) {
+	b.Helper()
+	if secondaryIndexes < 0 || secondaryIndexes > 1 {
+		b.Fatalf("unsupported secondaryIndexes=%d", secondaryIndexes)
+	}
+
+	const docCount = 10000
+	indexes := []collections.IndexDefinition{}
+	if secondaryIndexes == 1 {
+		indexes = append(indexes, collections.IndexDefinition{
+			Name:      "pad_1",
+			Field:     "pad",
+			ValueType: collections.IndexValueString,
+		})
+	}
+
+	openCollection := func() (*collections.Collection, [][]byte, func()) {
+		dbDir := b.TempDir()
+		opts := treedb.OptionsFor(treedb.ProfileFast, dbDir)
+		opts.IndexOuterLeavesInValueLog = true
+		opts.Durability = treedb.DurabilityWALOffRelaxed
+		backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+		if err != nil {
+			b.Fatalf("open backend: %v", err)
+		}
+		manager := collections.NewCollectionManager(backend)
+		meta := &collections.CollectionMeta{
+			Name: "bench.docs",
+			Options: collections.CollectionOptions{
+				DocumentFormat:          collections.DocumentFormatJSON,
+				DataRootStoragePolicy:   collections.RootStorageCompressed,
+				IndexStateStoragePolicy: collections.RootStorageCompressed,
+				BufferedIndexedWrites:   secondaryIndexes > 0,
+			},
+			Indexes: make([]collections.IndexDefinition, len(indexes)),
+		}
+		copy(meta.Indexes, indexes)
+		if _, err := manager.CreateCollection(meta); err != nil {
+			_ = cleanup()
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench.docs")
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("open collection: %v", err)
+		}
+
+		ids := make([][]byte, docCount)
+		docs := make([][]byte, docCount)
+		for i := 0; i < docCount; i++ {
+			ids[i] = []byte("doc-" + strconv.Itoa(i))
+			docs[i] = []byte(`{"_id":"` + string(ids[i]) + `","pad":"static","count":0}`)
+		}
+		for i := 0; i < docCount; i += 16000 {
+			end := i + 16000
+			if end > docCount {
+				end = docCount
+			}
+			if _, err := collection.InsertBatch(ids[i:end], docs[i:end]); err != nil {
+				_ = cleanup()
+				b.Fatalf("insert batch [%d:%d]: %v", i, end, err)
+			}
+		}
+		if err := manager.FlushAll(); err != nil {
+			_ = cleanup()
+			b.Fatalf("flush preload docs: %v", err)
+		}
+		cleanupClosure := func() { _ = cleanup() }
+		return collection, ids, cleanupClosure
+	}
+
+	updateFn := func(current []byte) ([]byte, bool, error) {
+		next := append([]byte{}, current...)
+		if bytes.Contains(next, []byte(`"count":0`)) {
+			next = bytes.Replace(next, []byte(`"count":0`), []byte(`"count":1`), 1)
+		} else {
+			next = bytes.Replace(next, []byte(`"count":1`), []byte(`"count":0`), 1)
+		}
+		return next, true, nil
+	}
+
+	b.Run("Update", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := ids[i%docCount]
+			if _, _, err := collection.Update(id, updateFn); err != nil {
+				b.Fatalf("update: %v", err)
+			}
+		}
+	})
+
+	b.Run("UpdateBatchSize1", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		items := []collections.UpdateBatchItem{
+			{
+				DocumentID: ids[0],
+				Update:     updateFn,
+			},
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			items[0].DocumentID = ids[i%docCount]
+			if _, err := collection.UpdateBatch(items); err != nil {
+				b.Fatalf("update batch: %v", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkCollectionUpdateBSONSetVsBatch_NoIndex_Size1(b *testing.B) {
+	const docCount = 10000
+	openCollection := func() (*collections.Collection, [][]byte, func()) {
+		dbDir := b.TempDir()
+		opts := treedb.OptionsFor(treedb.ProfileFast, dbDir)
+		opts.IndexOuterLeavesInValueLog = true
+		opts.Durability = treedb.DurabilityWALOffRelaxed
+		backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+		if err != nil {
+			b.Fatalf("open backend: %v", err)
+		}
+		manager := collections.NewCollectionManager(backend)
+		meta := &collections.CollectionMeta{
+			Name: "bench.docs",
+			Options: collections.CollectionOptions{
+				DocumentFormat:          collections.DocumentFormatBSON,
+				DataRootStoragePolicy:   collections.RootStorageCompressed,
+				IndexStateStoragePolicy: collections.RootStorageCompressed,
+			},
+		}
+		if _, err := manager.CreateCollection(meta); err != nil {
+			_ = cleanup()
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench.docs")
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("open collection: %v", err)
+		}
+		ids := make([][]byte, docCount)
+		docs := make([][]byte, docCount)
+		for i := 0; i < docCount; i++ {
+			id := "doc-" + strconv.Itoa(i)
+			ids[i] = []byte(id)
+			doc, err := bson.Marshal(bson.D{
+				{Key: "_id", Value: id},
+				{Key: "city", Value: "hnl"},
+			})
+			if err != nil {
+				_ = cleanup()
+				b.Fatalf("marshal doc: %v", err)
+			}
+			docs[i] = doc
+		}
+		if _, err := collection.InsertBatchValidatedBSON(ids, docs); err != nil {
+			_ = cleanup()
+			b.Fatalf("insert docs: %v", err)
+		}
+		if err := manager.FlushAll(); err != nil {
+			_ = cleanup()
+			b.Fatalf("flush preload docs: %v", err)
+		}
+		cleanupClosure := func() { _ = cleanup() }
+		return collection, ids, cleanupClosure
+	}
+
+	seaType, seaRaw, err := bson.MarshalValue("sea")
+	if err != nil {
+		b.Fatalf("marshal sea value: %v", err)
+	}
+	sfoType, sfoRaw, err := bson.MarshalValue("sfo")
+	if err != nil {
+		b.Fatalf("marshal sfo value: %v", err)
+	}
+	values := []bson.RawValue{
+		{Type: seaType, Value: seaRaw},
+		{Type: sfoType, Value: sfoRaw},
+	}
+
+	b.Run("UpdateBSONSet", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := ids[i%docCount]
+			_, _, err := collection.UpdateBSONSet(id, []collections.BSONSetField{{
+				Key:   "city",
+				Value: values[i%2],
+			}})
+			if err != nil {
+				b.Fatalf("UpdateBSONSet: %v", err)
+			}
+		}
+	})
+
+	b.Run("UpdateBSONSetBatchSize1", func(b *testing.B) {
+		collection, ids, cleanup := openCollection()
+		b.Cleanup(cleanup)
+		item := []collections.BSONSetUpdateBatchItem{{
+			DocumentID: ids[0],
+			Fields: []collections.BSONSetField{{
+				Key:   "city",
+				Value: values[0],
+			}},
+		}}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			item[0].DocumentID = ids[i%docCount]
+			item[0].Fields[0].Value = values[i%2]
+			if _, _, err := collection.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges(item); err != nil {
+				b.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+			}
+		}
+	})
+}

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -120,12 +120,6 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 			out = appendCompactStorageProtectedPaths(out, userProtectedPathsFunc())
 		}
 		out = appendCompactStorageProtectedPaths(out, db.cached.ValueLogProtectedPaths())
-		if len(out) == 0 && len(explicitProtectedPaths) == 0 {
-			// Cached-mode callers may have concurrent writers even when there
-			// are no protected paths yet; pass a non-empty slice to activate
-			// the backend rewrite/GC active-segment protection.
-			out = append(out, "")
-		}
 		return out
 	}
 	opts.ValueLogProtectedPaths = explicitProtectedPaths

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestCompactStorageCachedAdvancesWritersPastBackendSegments(t *testing.T) {
@@ -58,6 +59,134 @@ func TestCompactStorageCachedAdvancesWritersPastBackendSegments(t *testing.T) {
 	nextPath := filepath.Join(valueLogDir, "value-l0-000002.log")
 	if got := testFileSize(t, nextPath); got == 0 {
 		t.Fatalf("next cached value-log segment was not written: %s", nextPath)
+	}
+}
+
+func TestCompactStorageDefaultPathReclaimsDeadTopSegment(t *testing.T) {
+	dir := t.TempDir()
+	opts := cachedRewriteReclaimTestOptions(dir)
+	opts.IndexOuterLeavesInValueLog = false
+
+	openBackend := func() (*backenddb.DB, func() error, error) {
+		db, cleanup, err := OpenBackend(opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		var closeOnce bool
+		closeBackend := func() error {
+			if closeOnce {
+				return nil
+			}
+			closeOnce = true
+			if db != nil {
+				if err := db.Close(); err != nil {
+					return err
+				}
+			}
+			if cleanup != nil {
+				return cleanup()
+			}
+			return nil
+		}
+		return db, closeBackend, nil
+	}
+
+	backend, cleanupBackend, err := openBackend()
+	if err != nil {
+		t.Fatalf("open backend (for write pointers): %v", err)
+	}
+
+	valueLogDir := backenddb.ValueLogDirPath(dir)
+	segment1 := filepath.Join(valueLogDir, "value-l0-000001.log")
+	segment2 := filepath.Join(valueLogDir, "value-l0-000002.log")
+
+	deadPtr := writeTestValueLogSegmentWithPointer(t, segment1, 0, 1, bytes.Repeat([]byte("dead"), 512))
+	livePtr := writeTestValueLogSegmentWithPointer(t, segment2, 0, 2, bytes.Repeat([]byte("live"), 1024))
+
+	backendBatch := backend.NewBatch()
+	firstBatch, ok := backendBatch.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+		Write() error
+		Close() error
+	})
+	if !ok {
+		t.Fatalf("missing pointer batch on backend %T", backendBatch)
+	}
+	if err := firstBatch.SetPointer([]byte("dead"), deadPtr); err != nil {
+		t.Fatalf("set dead pointer: %v", err)
+	}
+	if err := firstBatch.Write(); err != nil {
+		t.Fatalf("batch write (dead pointer): %v", err)
+	}
+	if err := firstBatch.Close(); err != nil {
+		t.Fatalf("batch close (dead pointer): %v", err)
+	}
+
+	backendBatch = backend.NewBatch()
+	secondBatch, ok := backendBatch.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+		Write() error
+		Close() error
+	})
+	if !ok {
+		t.Fatalf("missing pointer batch for live pointer %T", backendBatch)
+	}
+	if err := secondBatch.SetPointer([]byte("dead"), livePtr); err != nil {
+		t.Fatalf("set updated dead pointer: %v", err)
+	}
+	if err := secondBatch.SetPointer([]byte("live"), livePtr); err != nil {
+		t.Fatalf("set live pointer: %v", err)
+	}
+	if err := secondBatch.Write(); err != nil {
+		t.Fatalf("batch write (live pointer): %v", err)
+	}
+	if err := secondBatch.Close(); err != nil {
+		t.Fatalf("batch close (live pointer): %v", err)
+	}
+	if err := cleanupBackend(); err != nil {
+		t.Fatalf("close backend (write pointers): %v", err)
+	}
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close cached db: %v", err)
+		}
+	})
+	if _, err := db.Get([]byte("live")); err != nil {
+		t.Fatalf("expected live key present before compact: %v", err)
+	}
+
+	if _, err := os.Stat(segment1); err != nil {
+		t.Fatalf("expected initial dead segment to exist: %v", err)
+	}
+	if _, err := os.Stat(segment2); err != nil {
+		t.Fatalf("expected initial live segment to exist: %v", err)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+
+	if _, err := os.Stat(segment1); !os.IsNotExist(err) {
+		t.Fatalf("compact did not remove dead top segment %s (err=%v), stats=%+v", segment1, err, stats)
+	}
+	if _, err := os.Stat(segment2); err != nil {
+		t.Fatalf("expected live segment retained: %v", err)
+	}
+	if got, err := db.Get([]byte("live")); err != nil {
+		t.Fatalf("live key missing after compact: %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("live"), 1024)) {
+		t.Fatalf("live key value changed after compact")
+	}
+	if got, err := db.Get([]byte("dead")); err != nil {
+		t.Fatalf("dead key missing after compact: %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("live"), 1024)) {
+		t.Fatalf("dead key value changed after compact")
 	}
 }
 
@@ -349,6 +478,30 @@ func writeTestValueLogSegment(t *testing.T, path string, lane, seq uint32, value
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close writer: %v", err)
 	}
+}
+
+func writeTestValueLogSegmentWithPointer(t *testing.T, path string, lane, seq uint32, value []byte) page.ValuePtr {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir value-log dir: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(lane, seq)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ptr, err := writer.Append(0, nil, uint64(seq), value)
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	return ptr
 }
 
 func testFileSize(t *testing.T, path string) int64 {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -736,14 +736,14 @@ func zeroByteValueLogFilesFromUsage(usage []CompactStorageUsage, protectedPaths 
 func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 	if opts.ValueLogProtectedPathsFunc == nil {
 		if len(opts.ValueLogProtectedPaths) == 0 {
-			return []string{""}
+			return nil
 		}
 		return opts.ValueLogProtectedPaths
 	}
 	dynamic := opts.ValueLogProtectedPathsFunc()
 	if len(opts.ValueLogProtectedPaths) == 0 {
 		if len(dynamic) == 0 {
-			return []string{""}
+			return nil
 		}
 		return dynamic
 	}
@@ -781,7 +781,7 @@ func compactStorageFencedValueLogProtectedPaths(opts CompactStorageOptions) []st
 		return compactStorageMergeProtectedPaths(opts.ValueLogProtectedPaths, dynamic)
 	}
 	if len(dynamic) == 0 {
-		return []string{""}
+		return nil
 	}
 	return dynamic
 }

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -445,10 +445,10 @@ func TestCompactStorageKeepsProtectedZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
-func TestCompactStorageDefaultProtectedPathsActivatesActiveProtection(t *testing.T) {
+func TestCompactStorageDefaultProtectedPathsAreEmpty(t *testing.T) {
 	paths := compactStorageValueLogProtectedPaths(CompactStorageOptions{})
-	if len(paths) != 1 || paths[0] != "" {
-		t.Fatalf("default protected paths=%q want sentinel", paths)
+	if len(paths) != 0 {
+		t.Fatalf("default protected paths=%q want none", paths)
 	}
 }
 
@@ -462,6 +462,17 @@ func TestCompactStorageFencedProtectedPathsIncludeExplicitPaths(t *testing.T) {
 	want := []string{"explicit-a", "shared", "dynamic-a"}
 	if !reflect.DeepEqual(paths, want) {
 		t.Fatalf("fenced protected paths=%q want %q", paths, want)
+	}
+}
+
+func TestCompactStorageFencedValueLogProtectedPathsDefaultWhenDynamicEmpty(t *testing.T) {
+	paths := compactStorageFencedValueLogProtectedPaths(CompactStorageOptions{
+		ValueLogFencedProtectedPathsFunc: func() []string {
+			return nil
+		},
+	})
+	if len(paths) != 0 {
+		t.Fatalf("fenced protected paths=%q want none when both static and dynamic are empty", paths)
 	}
 }
 

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -144,14 +144,24 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 	// Parallel read misses can race: another goroutine may populate this exact
 	// slot/key before we reach admission. Fast-path that case with only a read
 	// lock to avoid unnecessary writer lock traffic in the miss hot path.
-	slot.mu.RLock()
-	if slot.valid && slot.key == key {
+	if slot.mu.TryRLock() {
+		if slot.valid && slot.key == key {
+			slot.mu.RUnlock()
+			return
+		}
 		slot.mu.RUnlock()
+	} else {
+		c.readMissAdmissionSkips.Add(1)
 		return
 	}
-	slot.mu.RUnlock()
 
-	slot.mu.Lock()
+	// Read-miss cache admission is best effort. If this slot is currently under
+	// heavy contention, skip admission rather than queuing behind a writer lock
+	// in the random-read miss hot path.
+	if !slot.mu.TryLock() {
+		c.readMissAdmissionSkips.Add(1)
+		return
+	}
 	if slot.valid && slot.key == key {
 		slot.mu.Unlock()
 		return

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -414,6 +415,45 @@ func TestValueReaderLeafLogPageUnsafeToOneOffReadMissDoesNotEvictStoredLeaf(t *t
 	}
 	if stats := cache.stats(); stats.Hits != 1 || stats.Stores != 1 || stats.Evictions != 0 {
 		t.Fatalf("stats=%+v, want hot cache entry retained", stats)
+	}
+}
+
+func TestLeafPageReadCacheStoreReadMissSkipsWhenSlotLockContended(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	ptr := page.LeafLogPtr{FileID: 9, Offset: 512, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x66}, page.PageSize)
+	key := newLeafPageReadCacheKey(ptr)
+	slot := &cache.slots[cache.slotIndex(key)]
+
+	// First read miss only arms the admission fingerprint and should skip.
+	cache.storeReadMiss(ptr, leaf)
+	if stats := cache.stats(); stats.ReadMissAdmissionSkips != 1 || stats.ReadMissAdmissionStores != 0 {
+		t.Fatalf("stats after first miss=%+v, want one admission skip and no stores", stats)
+	}
+
+	// Contend slot lock before second miss; with TryLock-based admission this
+	// should return quickly and record another skip instead of blocking.
+	slot.mu.Lock()
+	defer slot.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		cache.storeReadMiss(ptr, leaf)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("storeReadMiss blocked on contended slot lock; expected non-blocking skip")
+	}
+
+	stats := cache.stats()
+	if stats.ReadMissAdmissionSkips < 2 {
+		t.Fatalf("expected additional skip on lock contention, stats=%+v", stats)
+	}
+	if stats.ReadMissAdmissionStores != 0 {
+		t.Fatalf("unexpected admission store under lock contention, stats=%+v", stats)
 	}
 }
 

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -128,14 +128,46 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 		return err
 	}
 
-	userIter := tree.New(d.Pager(), reader, state.RootPageID).
-		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	userRoot, err := bulk.BuildWithOptions(userIter, alloc, newPager, buildOpts)
-	_ = userIter.Close()
-	if err != nil {
-		_ = newPager.Close()
-		_ = d.Close()
-		return err
+	var userRoot uint64
+	if opts.IndexOuterLeavesInValueLog {
+		rootData, err := d.Pager().Get(state.RootPageID)
+		if err != nil {
+			_ = newPager.Close()
+			_ = d.Close()
+			return err
+		}
+		rootNode := node.NewNode(rootData)
+		if rootNode.Type() == page.PageTypeLeaf {
+			userRoot, err = vacuumClonePagerTreeWithLeafRefs(d.Pager(), state.RootPageID, alloc, newPager)
+			if err != nil {
+				_ = newPager.Close()
+				_ = d.Close()
+				return err
+			}
+		} else {
+			leafChildren, err := vacuumCollectLeafRefChildren(d.Pager(), state.RootPageID)
+			if err != nil {
+				_ = newPager.Close()
+				_ = d.Close()
+				return err
+			}
+			userRoot, err = vacuumBuildInternalTreeFromChildren(newPager, alloc, leafChildren, opts.IndexInternalBaseDelta)
+			if err != nil {
+				_ = newPager.Close()
+				_ = d.Close()
+				return err
+			}
+		}
+	} else {
+		userIter := tree.New(d.Pager(), reader, state.RootPageID).
+			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		userRoot, err = bulk.BuildWithOptions(userIter, alloc, newPager, buildOpts)
+		_ = userIter.Close()
+		if err != nil {
+			_ = newPager.Close()
+			_ = d.Close()
+			return err
+		}
 	}
 
 	meta := d.meta

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -97,6 +97,7 @@ func TestVacuumIndexOffline_OuterLeavesInValueLog_PreservesLeafRefs(t *testing.T
 	if err := baseLeafLog.ensureWriter(); err != nil {
 		t.Fatalf("ensure leaf writer: %v", err)
 	}
+	defer func() { _ = baseLeafLog.Close() }()
 	d.SetLeafPageLog(baseLeafLog)
 
 	val := bytes.Repeat([]byte("v"), 64)

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -78,6 +78,109 @@ func TestVacuumIndexOffline_PreservesDataAndShrinksFile(t *testing.T) {
 	}
 }
 
+func TestVacuumIndexOffline_OuterLeavesInValueLog_PreservesLeafRefs(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                        dir,
+		KeepRecent:                 1,
+		Durability:                 DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		PreferAppendAlloc:          true,
+	}
+
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	baseLeafLog := &registeredLeafPageLog{db: d, dir: dir}
+	if err := baseLeafLog.ensureWriter(); err != nil {
+		t.Fatalf("ensure leaf writer: %v", err)
+	}
+	d.SetLeafPageLog(baseLeafLog)
+
+	val := bytes.Repeat([]byte("v"), 64)
+	for version := 1; version <= 24; version++ {
+		b := d.NewBatch()
+		for i := 0; i < 256; i++ {
+			key := []byte(fmt.Sprintf("s/k:store/n/%08d/%08d", version, i))
+			val[0] = byte(version)
+			if err := b.Set(key, val); err != nil {
+				t.Fatalf("set version=%d key=%d: %v", version, i, err)
+			}
+		}
+		if err := b.WriteSync(); err != nil {
+			t.Fatalf("writesync version=%d: %v", version, err)
+		}
+		_ = b.Close()
+	}
+
+	stateBefore := d.State()
+	if stateBefore == nil {
+		t.Fatalf("missing state before vacuum")
+	}
+	leafRefsBefore := collectLeafRefIDsFromRoot(t, d, stateBefore.RootPageID)
+	if len(leafRefsBefore) == 0 {
+		t.Fatalf("expected outer-leaf refs before offline vacuum")
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	infoBefore, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close before vacuum: %v", err)
+	}
+
+	if err := VacuumIndexOffline(opts); err != nil {
+		t.Fatalf("vacuum offline: %v", err)
+	}
+
+	infoAfter, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if infoAfter.Size() > infoBefore.Size()*4 {
+		t.Fatalf("offline vacuum index inflation too large: before=%d after=%d", infoBefore.Size(), infoAfter.Size())
+	}
+
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after vacuum: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+
+	stateAfter := reopen.State()
+	if stateAfter == nil {
+		t.Fatalf("missing state after vacuum")
+	}
+	leafRefsAfter := collectLeafRefIDsFromRoot(t, reopen, stateAfter.RootPageID)
+	if len(leafRefsAfter) == 0 {
+		t.Fatalf("expected outer-leaf refs after offline vacuum")
+	}
+	if len(leafRefsAfter) != len(leafRefsBefore) {
+		t.Fatalf("leaf-ref count changed across offline vacuum: before=%d after=%d", len(leafRefsBefore), len(leafRefsAfter))
+	}
+
+	for _, version := range []int{1, 12, 24} {
+		for _, idx := range []int{0, 127, 255} {
+			key := []byte(fmt.Sprintf("s/k:store/n/%08d/%08d", version, idx))
+			got, err := reopen.Get(key)
+			if err != nil {
+				t.Fatalf("get version=%d key=%d after vacuum: %v", version, idx, err)
+			}
+			if len(got) != len(val) {
+				t.Fatalf("value length mismatch version=%d key=%d: got=%d want=%d", version, idx, len(got), len(val))
+			}
+			if got[0] != byte(version) {
+				t.Fatalf("value content mismatch version=%d key=%d: got[0]=%d want=%d", version, idx, got[0], byte(version))
+			}
+		}
+	}
+}
+
 func TestVacuumIndexOffline_CrashPointsRecoverOnOpen(t *testing.T) {
 	failpoints := []vacuumFailpoint{
 		vacuumFailAfterNewSync,

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -185,9 +185,9 @@ type ValueLogRewriteOnlineOptions struct {
 	// ProtectedPaths are value-log segment paths that must not be marked zombie
 	// during rewrite cleanup.
 	//
-	// When non-empty, cleanup also avoids zombifying currently-active pre-existing
-	// segments (cached-mode maintenance), since concurrent writers may still be
-	// appending records whose pointers are not yet visible in the backend index.
+	// Cleanup also avoids zombifying currently-active pre-existing segments
+	// because concurrent writers may still be appending records whose pointers
+	// are not yet visible in the backend index.
 	ProtectedPaths []string
 	// MaxSourceSegments bounds the number of source segments selected by sparse
 	// segment selection. Applies only when SourceFileIDs is empty.
@@ -2092,8 +2092,7 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 	}
 	var protectedPaths map[string]struct{}
-	allowActiveSkip := len(opts.ProtectedPaths) > 0
-	if allowActiveSkip {
+	if len(opts.ProtectedPaths) > 0 {
 		protectedPaths = make(map[string]struct{}, len(opts.ProtectedPaths))
 		for _, path := range opts.ProtectedPaths {
 			if path == "" {
@@ -2106,16 +2105,14 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		protectedIDs map[uint32]struct{}
 		activeIDs    map[uint32]struct{}
 	)
-	if allowActiveSkip || len(protectedPaths) > 0 {
+	{
 		currentSet := db.valueLogManager.CurrentSetNoRefresh()
 		if currentSet != nil {
-			if allowActiveSkip {
+			if len(protectedPaths) > 0 {
 				activeIDs = recentValueLogIDsForProtectedPaths(currentSet, valueLogKeepRecentSegmentsPerLane, opts.ProtectedPaths)
 				if len(activeIDs) == 0 {
 					activeIDs = currentValueLogIDs(currentSet)
 				}
-			}
-			if len(protectedPaths) > 0 {
 				protectedIDs = make(map[uint32]struct{})
 				for id, f := range currentSet.Files {
 					if f == nil || f.Path == "" {
@@ -2125,6 +2122,8 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 						protectedIDs[id] = struct{}{}
 					}
 				}
+			} else {
+				activeIDs = currentValueLogIDs(currentSet)
 			}
 			_ = db.valueLogManager.Release(currentSet)
 		}
@@ -2136,11 +2135,10 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if _, ok := protectedIDs[id]; ok {
 			return nil
 		}
-		// Never mark currently-active pre-existing segments zombie when callers
-		// provide ProtectedPaths (cached-mode maintenance). Concurrent writers may
-		// still be appending records whose pointers are not yet visible in the
-		// backend index.
-		if allowActiveSkip && existedBefore {
+		// Never mark currently-active pre-existing segments zombie.
+		// Concurrent writers may still be appending records whose pointers are
+		// not yet visible in the backend index.
+		if existedBefore {
 			if _, ok := activeIDs[id]; ok {
 				return nil
 			}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2105,13 +2105,16 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		protectedIDs map[uint32]struct{}
 		activeIDs    map[uint32]struct{}
 	)
+	allowActiveSkip := len(opts.ProtectedPaths) > 0 || len(opts.SourceFileIDs) > 0 || len(opts.SourceChunks) > 0
 	{
 		currentSet := db.valueLogManager.CurrentSetNoRefresh()
 		if currentSet != nil {
 			if len(protectedPaths) > 0 {
-				activeIDs = recentValueLogIDsForProtectedPaths(currentSet, valueLogKeepRecentSegmentsPerLane, opts.ProtectedPaths)
-				if len(activeIDs) == 0 {
-					activeIDs = currentValueLogIDs(currentSet)
+				if allowActiveSkip {
+					activeIDs = recentValueLogIDsForProtectedPaths(currentSet, valueLogKeepRecentSegmentsPerLane, opts.ProtectedPaths)
+					if len(activeIDs) == 0 {
+						activeIDs = currentValueLogIDs(currentSet)
+					}
 				}
 				protectedIDs = make(map[uint32]struct{})
 				for id, f := range currentSet.Files {
@@ -2122,7 +2125,7 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 						protectedIDs[id] = struct{}{}
 					}
 				}
-			} else {
+			} else if allowActiveSkip {
 				activeIDs = currentValueLogIDs(currentSet)
 			}
 			_ = db.valueLogManager.Release(currentSet)
@@ -2138,7 +2141,7 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		// Never mark currently-active pre-existing segments zombie.
 		// Concurrent writers may still be appending records whose pointers are
 		// not yet visible in the backend index.
-		if existedBefore {
+		if existedBefore && allowActiveSkip {
 			if _, ok := activeIDs[id]; ok {
 				return nil
 			}

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -1942,6 +1942,61 @@ func TestValueLogRewriteOnline_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *
 	}
 }
 
+func TestValueLogRewriteOnline_DefaultProtectedPathsDoNotProtectExistedBeforeActiveSegments(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 200_000, 1, func(_ int) []byte {
+		return bytes.Repeat([]byte("active-protected|"), 64)
+	})
+	targetPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+
+	b := db.NewBatch()
+	ptrBatch, ok := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch")
+	}
+	if err := ptrBatch.SetPointer([]byte("k"), ptrs[0]); err != nil {
+		t.Fatalf("set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write pointer key: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.Delete([]byte("k")); err != nil {
+		t.Fatalf("delete pointer key: %v", err)
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptrs[0].FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.SourceSegmentsUnreferenced != 1 {
+		t.Fatalf("source segment unreferenced=%d want 1", stats.SourceSegmentsUnreferenced)
+	}
+
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, err=%v", filepath.Base(targetPath), err)
+	}
+}
+
 func TestValueLogRewriteOnline_UsesBlockCompressionWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -1942,7 +1942,7 @@ func TestValueLogRewriteOnline_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *
 	}
 }
 
-func TestValueLogRewriteOnline_DefaultProtectedPathsDoNotProtectExistedBeforeActiveSegments(t *testing.T) {
+func TestValueLogRewriteOnline_ExplicitSourceDoesNotDeleteActiveSegment(t *testing.T) {
 	dir := t.TempDir()
 
 	db, err := Open(Options{
@@ -1992,8 +1992,8 @@ func TestValueLogRewriteOnline_DefaultProtectedPathsDoNotProtectExistedBeforeAct
 		t.Fatalf("source segment unreferenced=%d want 1", stats.SourceSegmentsUnreferenced)
 	}
 
-	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
-		t.Fatalf("expected %s to be removed, err=%v", filepath.Base(targetPath), err)
+	if _, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("expected active segment %s to remain, stat=%v", filepath.Base(targetPath), err)
 	}
 }
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -69,6 +69,8 @@ type File struct {
 	compactLeafPayloadAllowedSet bool
 
 	cacheMu    sync.RWMutex
+	groupedMu  sync.RWMutex
+	scratchMu  sync.Mutex
 	cacheStart atomic.Int64
 	cacheK     int
 	cacheFlags byte
@@ -211,13 +213,13 @@ func currentScanSegmentPaths() func(string) ([]segmentInfo, error) {
 
 func (f *File) setCacheRawLocked(raw []byte, pooled bool) {
 	if f.cacheRawPooled && cap(f.cacheRaw) > 0 {
-		f.stashDecodeScratchLocked(f.cacheRaw)
+		f.stashDecodeScratch(f.cacheRaw)
 	}
 	f.cacheRaw = raw
 	f.cacheRawPooled = pooled
 }
 
-func (f *File) stashDecodeScratchLocked(buf []byte) {
+func (f *File) stashDecodeScratch(buf []byte) {
 	if cap(buf) == 0 {
 		return
 	}
@@ -225,6 +227,8 @@ func (f *File) stashDecodeScratchLocked(buf []byte) {
 		putDecodeScratch(buf)
 		return
 	}
+	f.scratchMu.Lock()
+	defer f.scratchMu.Unlock()
 	buf = buf[:0]
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
@@ -243,10 +247,10 @@ func (f *File) takeDecodeScratch(minCap int) []byte {
 	if minCap <= 0 {
 		return nil
 	}
-	f.cacheMu.Lock()
+	f.scratchMu.Lock()
 	scratch := f.decodeScratch
 	f.decodeScratch = nil
-	f.cacheMu.Unlock()
+	f.scratchMu.Unlock()
 	if cap(scratch) >= minCap {
 		return scratch[:0]
 	}
@@ -265,27 +269,27 @@ func (f *File) releaseDecodeScratch(buf []byte) {
 		return
 	}
 	buf = buf[:0]
-	f.cacheMu.Lock()
+	f.scratchMu.Lock()
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
-		f.cacheMu.Unlock()
+		f.scratchMu.Unlock()
 		return
 	}
 	if cap(buf) > cap(f.decodeScratch) {
 		old := f.decodeScratch
 		f.decodeScratch = buf
-		f.cacheMu.Unlock()
+		f.scratchMu.Unlock()
 		putDecodeScratch(old)
 		return
 	}
-	f.cacheMu.Unlock()
+	f.scratchMu.Unlock()
 	putDecodeScratch(buf)
 }
 
-func (f *File) clearGroupedFrameCacheLocked() {
+func (f *File) clearGroupedFrameCacheLocked() (pooled [][]byte) {
 	for i := range f.groupedFrameCache {
 		if f.groupedFrameCache[i].rawPooled {
-			f.stashDecodeScratchLocked(f.groupedFrameCache[i].raw)
+			pooled = append(pooled, f.groupedFrameCache[i].raw)
 		}
 		f.groupedFrameCache[i].raw = nil
 		f.groupedFrameCache[i].k = 0
@@ -293,32 +297,37 @@ func (f *File) clearGroupedFrameCacheLocked() {
 	}
 	f.groupedFrameCache = nil
 	f.groupedFrameCacheClock = 0
+	return pooled
 }
 
 func (f *File) setGroupedFrameCacheEntries(entries int) {
 	if entries < 0 {
 		entries = 0
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	f.groupedMu.Lock()
 	if f.groupedFrameCacheEntries == entries {
+		f.groupedMu.Unlock()
 		return
 	}
-	f.clearGroupedFrameCacheLocked()
+	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheEntries = entries
 	f.groupedFrameCacheHits.Store(0)
 	f.groupedFrameCacheMisses.Store(0)
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
 }
 
 func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int, dst []byte) (out []byte, usedDst bool, err error, hit bool) {
-	f.cacheMu.RLock()
+	f.groupedMu.RLock()
 	if f.groupedFrameCacheEntries <= 0 {
-		f.cacheMu.RUnlock()
+		f.groupedMu.RUnlock()
 		return nil, false, nil, false
 	}
 	if len(f.groupedFrameCache) == 0 {
 		f.groupedFrameCacheMisses.Add(1)
-		f.cacheMu.RUnlock()
+		f.groupedMu.RUnlock()
 		return nil, false, nil, false
 	}
 	for i := range f.groupedFrameCache {
@@ -338,7 +347,7 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			// Copy payload while holding cacheMu so callers do not race with cache
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
-			f.cacheMu.RUnlock()
+			f.groupedMu.RUnlock()
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
@@ -350,16 +359,16 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if dst != nil && cap(dst) >= len(val) {
 			out := dst[:len(val)]
 			copy(out, val)
-			f.cacheMu.RUnlock()
+			f.groupedMu.RUnlock()
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
-		f.cacheMu.RUnlock()
+		f.groupedMu.RUnlock()
 		return out, false, nil, true
 	}
 	f.groupedFrameCacheMisses.Add(1)
-	f.cacheMu.RUnlock()
+	f.groupedMu.RUnlock()
 	return nil, false, nil, false
 }
 
@@ -367,12 +376,21 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 	if k <= 0 || len(raw) == 0 {
 		return false
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	// Opportunistic hot-path policy: under heavy read parallelism, avoid
+	// queuing behind grouped-cache metadata lock just to populate cache.
+	// Skipping a store here may reduce hit rate slightly, but prevents large
+	// lock convoy effects in random-read miss bursts.
+	if !f.groupedMu.TryLock() {
+		return false
+	}
+	var oldPooledRaw []byte
+	stored := false
 	if f.groupedFrameCacheEntries <= 0 {
+		f.groupedMu.Unlock()
 		return false
 	}
 	if f.groupedFrameCacheMaxRaw > 0 && len(raw) > f.groupedFrameCacheMaxRaw {
+		f.groupedMu.Unlock()
 		return false
 	}
 
@@ -383,50 +401,58 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 		e := &f.groupedFrameCache[i]
 		if e.k > 0 && e.start == start && e.verifyCRC == verifyCRC {
 			if e.rawPooled {
-				f.stashDecodeScratchLocked(e.raw)
+				oldPooledRaw = e.raw
 			}
 			e.k = k
 			e.offsets = offsets
 			e.raw = raw
 			e.rawPooled = pooled
 			e.used = used
-			return true
+			stored = true
+			break
 		}
 	}
-
-	idx := -1
-	if len(f.groupedFrameCache) < f.groupedFrameCacheEntries {
-		f.groupedFrameCache = append(f.groupedFrameCache, groupedFrameCacheEntry{})
-		idx = len(f.groupedFrameCache) - 1
-	} else {
-		oldest := f.groupedFrameCache[0].used
-		idx = 0
-		for i := 1; i < len(f.groupedFrameCache); i++ {
-			if f.groupedFrameCache[i].used < oldest {
-				oldest = f.groupedFrameCache[i].used
-				idx = i
+	if !stored {
+		idx := -1
+		if len(f.groupedFrameCache) < f.groupedFrameCacheEntries {
+			f.groupedFrameCache = append(f.groupedFrameCache, groupedFrameCacheEntry{})
+			idx = len(f.groupedFrameCache) - 1
+		} else {
+			oldest := f.groupedFrameCache[0].used
+			idx = 0
+			for i := 1; i < len(f.groupedFrameCache); i++ {
+				if f.groupedFrameCache[i].used < oldest {
+					oldest = f.groupedFrameCache[i].used
+					idx = i
+				}
 			}
 		}
-	}
 
-	if idx >= 0 && idx < len(f.groupedFrameCache) && f.groupedFrameCache[idx].rawPooled {
-		f.stashDecodeScratchLocked(f.groupedFrameCache[idx].raw)
+		if idx >= 0 && idx < len(f.groupedFrameCache) && f.groupedFrameCache[idx].rawPooled {
+			oldPooledRaw = f.groupedFrameCache[idx].raw
+		}
+		f.groupedFrameCache[idx] = groupedFrameCacheEntry{
+			start:     start,
+			verifyCRC: verifyCRC,
+			k:         k,
+			offsets:   offsets,
+			raw:       raw,
+			rawPooled: pooled,
+			used:      used,
+		}
+		stored = true
 	}
-	f.groupedFrameCache[idx] = groupedFrameCacheEntry{
-		start:     start,
-		verifyCRC: verifyCRC,
-		k:         k,
-		offsets:   offsets,
-		raw:       raw,
-		rawPooled: pooled,
-		used:      used,
+	f.groupedMu.Unlock()
+	if oldPooledRaw != nil {
+		// Avoid doing scratch handoff while holding cacheMu on the hot path.
+		f.releaseDecodeScratch(oldPooledRaw)
 	}
-	return true
+	return stored
 }
 
 func (f *File) groupedFrameCacheStats() (hits, misses uint64, entries, capacity int) {
-	f.cacheMu.RLock()
-	defer f.cacheMu.RUnlock()
+	f.groupedMu.RLock()
+	defer f.groupedMu.RUnlock()
 	return f.groupedFrameCacheHits.Load(), f.groupedFrameCacheMisses.Load(), len(f.groupedFrameCache), f.groupedFrameCacheEntries
 }
 
@@ -434,15 +460,28 @@ func (f *File) setGroupedFrameCacheMaxRawBytes(maxRaw int) {
 	if maxRaw < 0 {
 		maxRaw = 0
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	f.groupedMu.Lock()
 	if f.groupedFrameCacheMaxRaw == maxRaw {
+		f.groupedMu.Unlock()
 		return
 	}
-	f.clearGroupedFrameCacheLocked()
+	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheMaxRaw = maxRaw
 	f.groupedFrameCacheHits.Store(0)
 	f.groupedFrameCacheMisses.Store(0)
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
+}
+
+func (f *File) groupedFrameCacheAllowsRaw(rawLen int) bool {
+	f.groupedMu.RLock()
+	defer f.groupedMu.RUnlock()
+	if f.groupedFrameCacheEntries <= 0 {
+		return false
+	}
+	return f.groupedFrameCacheMaxRaw <= 0 || rawLen <= f.groupedFrameCacheMaxRaw
 }
 
 func (f *File) Close() error {
@@ -460,9 +499,14 @@ func (f *File) Close() error {
 	f.setCacheRawLocked(nil, false)
 	scratch = f.decodeScratch
 	f.decodeScratch = nil
-	f.clearGroupedFrameCacheLocked()
 	f.cacheStart.Store(0)
 	f.cacheMu.Unlock()
+	f.groupedMu.Lock()
+	pooled := f.clearGroupedFrameCacheLocked()
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
 	if scratch != nil {
 		putDecodeScratch(scratch)
 	}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -376,13 +376,7 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 	if k <= 0 || len(raw) == 0 {
 		return false
 	}
-	// Opportunistic hot-path policy: under heavy read parallelism, avoid
-	// queuing behind grouped-cache metadata lock just to populate cache.
-	// Skipping a store here may reduce hit rate slightly, but prevents large
-	// lock convoy effects in random-read miss bursts.
-	if !f.groupedMu.TryLock() {
-		return false
-	}
+	f.groupedMu.Lock()
 	var oldPooledRaw []byte
 	stored := false
 	if f.groupedFrameCacheEntries <= 0 {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1015,14 +1015,15 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
 	cacheableRaw := false
-	if copyValueToDst {
-		f.cacheMu.Lock()
-		cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
-		f.cacheMu.Unlock()
-	}
+	f.cacheMu.Lock()
+	cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
+	f.cacheMu.Unlock()
+
+	// When raw payload may be cached, decode into pooled scratch so the grouped
+	// cache can retain ownership and return buffers to the pool on eviction.
 	decodeDst := dst
 	rawPooled := false
-	if copyValueToDst {
+	if copyValueToDst || cacheableRaw {
 		decodeDst = f.takeDecodeScratch(int(rawLen))
 		rawPooled = true
 	}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -728,12 +728,7 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 			return out, nil, true
 		}
 
-		cacheableRaw := false
-		f.cacheMu.Lock()
-		if f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw) {
-			cacheableRaw = true
-		}
-		f.cacheMu.Unlock()
+		cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 		retainRaw := cacheableRaw || readViaMmapViewPrefixCacheEnabled
 		pooledRaw := !retainRaw
@@ -1014,10 +1009,7 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
-	cacheableRaw := false
-	f.cacheMu.Lock()
-	cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
-	f.cacheMu.Unlock()
+	cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// When raw payload may be cached, decode into pooled scratch so the grouped
 	// cache can retain ownership and return buffers to the pool on eviction.
@@ -1068,6 +1060,21 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 			f.releaseDecodeScratch(raw)
 		}
 		return out, true, nil, true
+	}
+	if rawPooled {
+		// If grouped-cache store was skipped (or disabled) and we decoded into
+		// pooled scratch, do not return a view that aliases pooled memory.
+		// Copy the selected value out and return scratch to the pool.
+		if dst != nil && cap(dst) >= valLen {
+			out := dst[:valLen]
+			copy(out, val)
+			f.releaseDecodeScratch(raw)
+			return out, true, nil, true
+		}
+		out := make([]byte, valLen)
+		copy(out, val)
+		f.releaseDecodeScratch(raw)
+		return out, false, nil, true
 	}
 	// dst is used iff it was provided with enough capacity to hold rawLen.
 	return val, dst != nil && cap(dst) >= int(rawLen), nil, true
@@ -1336,14 +1343,9 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return dst, nil, true
 	}
-	cacheableRaw := false
-	f.cacheMu.Lock()
 	// One-shot reads (dst=nil) are typically point gets. Avoid caching decoded
 	// grouped frames there to limit memory overhead in random-read-heavy paths.
-	if dst != nil && f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw) {
-		cacheableRaw = true
-	}
-	f.cacheMu.Unlock()
+	cacheableRaw := dst != nil && f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// Decode into pooled scratch even when we plan to cache decoded raw bytes.
 	// When cached, ownership transfers to groupedFrameCacheStore(..., pooled=true)

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1344,14 +1344,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	f.cacheMu.Unlock()
 
-	var raw []byte
-	pooledRaw := false
-	if cacheableRaw {
-		raw = make([]byte, 0, int(rawLen))
-	} else {
-		raw = f.takeDecodeScratch(int(rawLen))
-		pooledRaw = true
-	}
+	// Decode into pooled scratch even when we plan to cache decoded raw bytes.
+	// When cached, ownership transfers to groupedFrameCacheStore(..., pooled=true)
+	// and is returned to scratch pool on eviction; this avoids per-read heap
+	// allocations in random-read parallel miss paths.
+	raw := f.takeDecodeScratch(int(rawLen))
+	pooledRaw := true
 	raw, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, raw)
 	if err != nil {
 		if pooledRaw {
@@ -1366,7 +1364,8 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, ErrCorrupt, true
 	}
 	if cacheableRaw {
-		f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, false)
+		f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true)
+		pooledRaw = false
 	}
 
 	oldLen := len(dst)
@@ -1377,7 +1376,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	f.cacheLen = prefixLen
 	f.cacheOffs = offsets
 	if cacheableRaw {
-		f.setCacheRawLocked(raw, false)
+		f.setCacheRawLocked(raw, true)
 	} else {
 		f.setCacheRawLocked(nil, false)
 	}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1009,7 +1009,10 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
-	cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
+	// One-off read paths (dst=nil) should avoid grouped-cache writeback; this
+	// path is dominated by high-concurrency point reads where cache-store lock
+	// traffic can outweigh reuse.
+	cacheableRaw := copyValueToDst && f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// When raw payload may be cached, decode into pooled scratch so the grouped
 	// cache can retain ownership and return buffers to the pool on eviction.

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -170,8 +171,8 @@ func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
 	if hits1 != hits0 {
 		t.Fatalf("unexpected grouped-frame hit on first read: before=%d after=%d", hits0, hits1)
 	}
-	if entries1 == 0 {
-		t.Fatalf("expected grouped-frame cache entry after first read")
+	if entries1 != 0 {
+		t.Fatalf("expected no grouped-frame cache entry for nil dst read, got entries=%d", entries1)
 	}
 
 	got2, usedDst2, err, ok := f.readViaMmapViewTo(ptrs[1], false, nil)
@@ -186,11 +187,92 @@ func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
 	}
 
 	hits2, misses2, _, _ := f.groupedFrameCacheStats()
-	if hits2 <= hits1 {
-		t.Fatalf("expected grouped-frame cache hit on second read: before=%d after=%d", hits1, hits2)
+	if hits2 != hits1 {
+		t.Fatalf("unexpected grouped-frame cache hit on second nil-dst read: before=%d after=%d", hits1, hits2)
 	}
-	if misses2 != misses1 {
-		t.Fatalf("unexpected grouped-frame miss increase on second read: before=%d after=%d", misses1, misses2)
+	if misses2 <= misses1 {
+		t.Fatalf("expected grouped-frame miss increase on second nil-dst read: before=%d after=%d", misses1, misses2)
+	}
+}
+
+func TestValueLogGroupedReadParallelThenAppend_NoCorruption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+
+	const frames = 256
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	want := make([][]byte, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, fv := appendCompressedFrameForCacheTestsTB(t, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+		want = append(want, fv...)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(64)
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for w := 0; w < workers; w++ {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := w; i < len(ptrs); i += workers {
+				got, _, readErr := f.ReadUnsafeTo(ptrs[i], false, nil)
+				if readErr != nil {
+					errCh <- fmt.Errorf("unsafe read[%d]: %w", i, readErr)
+					return
+				}
+				if !bytes.Equal(got, want[i]) {
+					errCh <- fmt.Errorf("unsafe read[%d]: payload mismatch", i)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for readErr := range errCh {
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+	}
+
+	var dst []byte
+	for i := range ptrs {
+		dst, err = m.ReadAppend(ptrs[i], dst[:0])
+		if err != nil {
+			t.Fatalf("append read[%d]: %v", i, err)
+		}
+		if !bytes.Equal(dst, want[i]) {
+			t.Fatalf("append read[%d]: payload mismatch", i)
+		}
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -1,0 +1,276 @@
+package valuelog
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func appendCompressedFrameForCacheTestsTB(tb testing.TB, writer *Writer, frame int, n int) ([]page.ValuePtr, [][]byte) {
+	tb.Helper()
+	records := make([]Record, n)
+	want := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		v := make([]byte, 384)
+		copy(v, []byte(fmt.Sprintf("frame-%02d-record-%02d:", frame, i)))
+		for j := 48; j < len(v); j++ {
+			v[j] = byte('a' + frame)
+		}
+		records[i] = Record{RID: uint64(frame*100 + i + 1), Value: v}
+		want[i] = append([]byte(nil), v...)
+	}
+	dst := make([]page.ValuePtr, len(records))
+	ptrs, stats, err := writer.AppendFrameWithStatsInto(0, nil, records, dst)
+	if err != nil {
+		tb.Fatalf("append frame %d: %v", frame, err)
+	}
+	if !stats.Kept {
+		tb.Fatalf("expected block-compressed frame %d to be kept", frame)
+	}
+	return ptrs, want
+}
+
+func benchmarkRandomReadGroupedFrameReadUnsafeTo(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("mmap not supported on windows")
+	}
+
+	dir := b.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		b.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		b.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	const frames = 512
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, _ := appendCompressedFrameForCacheTestsTB(b, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+	}
+	if err := writer.Close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		b.Fatalf("new manager: %v", err)
+	}
+	b.Cleanup(func() { _ = m.Close() })
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(4096)
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	// Warm grouped-frame decode cache.
+	dst := make([]byte, 0, 512)
+	for _, ptr := range ptrs {
+		var used bool
+		dst, used, err = f.ReadUnsafeTo(ptr, false, dst[:0])
+		if err != nil {
+			b.Fatalf("warm read: %v", err)
+		}
+		if !used {
+			b.Fatalf("expected warm ReadUnsafeTo to reuse dst")
+		}
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptr := ptrs[rng.Intn(len(ptrs))]
+		var used bool
+		dst, used, err = f.ReadUnsafeTo(ptr, false, dst[:0])
+		if err != nil {
+			b.Fatalf("read: %v", err)
+		}
+		if !used {
+			b.Fatalf("expected ReadUnsafeTo to reuse dst")
+		}
+	}
+}
+
+func BenchmarkValueLogRandomReadGroupedFrame_ReadUnsafeTo(b *testing.B) {
+	benchmarkRandomReadGroupedFrameReadUnsafeTo(b)
+}
+
+func TestBenchmarkValueLogRandomReadGroupedFrame_ReadUnsafeTo_AllocsBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip benchmark alloc gate in short mode")
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		benchmarkRandomReadGroupedFrameReadUnsafeTo(b)
+	})
+	if allocs := res.AllocsPerOp(); allocs > 0 {
+		t.Fatalf("alloc regression: allocs/op=%d want 0", allocs)
+	}
+}
+
+func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	ptrs, want := appendCompressedFrameForCacheTestsTB(t, writer, 0, 4)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(8)
+
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	hits0, misses0, _, _ := f.groupedFrameCacheStats()
+	got1, usedDst1, err, ok := f.readViaMmapViewTo(ptrs[0], false, nil)
+	if err != nil || !ok {
+		t.Fatalf("first read failed: ok=%v err=%v", ok, err)
+	}
+	if usedDst1 {
+		t.Fatalf("expected usedDst=false with nil dst")
+	}
+	if !bytes.Equal(got1, want[0]) {
+		t.Fatalf("first read mismatch")
+	}
+
+	hits1, misses1, entries1, _ := f.groupedFrameCacheStats()
+	if misses1 <= misses0 {
+		t.Fatalf("expected grouped-frame miss on first read: before=%d after=%d", misses0, misses1)
+	}
+	if hits1 != hits0 {
+		t.Fatalf("unexpected grouped-frame hit on first read: before=%d after=%d", hits0, hits1)
+	}
+	if entries1 == 0 {
+		t.Fatalf("expected grouped-frame cache entry after first read")
+	}
+
+	got2, usedDst2, err, ok := f.readViaMmapViewTo(ptrs[1], false, nil)
+	if err != nil || !ok {
+		t.Fatalf("second read failed: ok=%v err=%v", ok, err)
+	}
+	if usedDst2 {
+		t.Fatalf("expected usedDst=false with nil dst")
+	}
+	if !bytes.Equal(got2, want[1]) {
+		t.Fatalf("second read mismatch")
+	}
+
+	hits2, misses2, _, _ := f.groupedFrameCacheStats()
+	if hits2 <= hits1 {
+		t.Fatalf("expected grouped-frame cache hit on second read: before=%d after=%d", hits1, hits2)
+	}
+	if misses2 != misses1 {
+		t.Fatalf("unexpected grouped-frame miss increase on second read: before=%d after=%d", misses1, misses2)
+	}
+}
+
+func TestValueLogManager_RandomReadGroupedFrameAllocBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	const frames = 512
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	want := make([][]byte, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, fv := appendCompressedFrameForCacheTestsTB(t, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+		want = append(want, fv...)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(4096)
+
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	// Warm grouped-frame decode cache.
+	for _, ptr := range ptrs {
+		v, err := m.ReadUnsafe(ptr)
+		if err != nil {
+			t.Fatalf("warm read: %v", err)
+		}
+		if len(v) == 0 {
+			t.Fatalf("warm read returned empty value")
+		}
+	}
+	hitsWarm, missesWarm, _, _ := f.groupedFrameCacheStats()
+	if hitsWarm == 0 || missesWarm == 0 {
+		t.Fatalf("expected grouped-frame cache warm-up to produce hits/misses, hits=%d misses=%d", hitsWarm, missesWarm)
+	}
+
+	const readsPerRun = 4000
+	allocsPerRun := testing.AllocsPerRun(20, func() {
+		rng := rand.New(rand.NewSource(1))
+		dst := make([]byte, 0, 512)
+		for i := 0; i < readsPerRun; i++ {
+			idx := rng.Intn(len(ptrs))
+			v, usedDst, err := f.ReadUnsafeTo(ptrs[idx], false, dst[:0])
+			if err != nil {
+				t.Fatalf("read idx=%d: %v", idx, err)
+			}
+			if !usedDst {
+				t.Fatalf("expected ReadUnsafeTo to reuse dst on grouped frame path")
+			}
+			if !bytes.Equal(v, want[idx]) {
+				t.Fatalf("value mismatch idx=%d", idx)
+			}
+			dst = v[:0]
+		}
+	})
+	allocsPerRead := allocsPerRun / float64(readsPerRun)
+	if allocsPerRead > 0.005 {
+		t.Fatalf("alloc regression: allocs/read=%f (allocs/run=%f, reads/run=%d)", allocsPerRead, allocsPerRun, readsPerRun)
+	}
+}

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -197,10 +197,12 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 	if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir, KeepRecent: 1}); err != nil {
 		t.Fatalf("VacuumIndexOffline: %v", err)
 	}
-	for _, path := range leafPathsBefore {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			t.Fatalf("stale leaf_vlog file %s still exists or stat failed: %v", path, err)
-		}
+	leafPathsAfter, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog after vacuum: %v", err)
+	}
+	if len(leafPathsAfter) == 0 {
+		t.Fatalf("expected leaf_vlog files after vacuum")
 	}
 
 	reopen, err := treedb.Open(opts)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1239,8 +1239,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush coalesced updates: %v", err)
+	}
+	flushed := db.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -78,12 +78,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if len(backendOpts.ProtectedPaths) == 0 {
 			backendOpts.ProtectedPaths = db.cached.ValueLogProtectedPaths()
 		}
-		if len(backendOpts.ProtectedPaths) == 0 {
-			// Cached-mode callers may have concurrent writers even when there are
-			// no protected paths yet; pass a non-empty slice to activate the
-			// backend rewrite's active-segment protection.
-			backendOpts.ProtectedPaths = []string{""}
-		}
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -77,6 +77,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 		if len(backendOpts.ProtectedPaths) == 0 {
 			backendOpts.ProtectedPaths = db.cached.ValueLogProtectedPaths()
+			if len(backendOpts.ProtectedPaths) == 0 {
+				backendOpts.ProtectedPaths = []string{""}
+			}
 		}
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -206,8 +206,9 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 ```
 
 For `-target mongo`, the command connects to the supplied URI, drops the
-benchmark database by default, and reports `dbStats` fields after load and at
-the end of the run.
+benchmark database by default, can compact the collection before final stats
+collection with `-mongo-compact`, and reports `dbStats` fields after load and
+at the end of the run.
 
 ## Reusable Comparison Harness
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -55,6 +55,7 @@ const (
 type config struct {
 	Target                                        string
 	MongoURI                                      string
+	MongoCompact                                  bool
 	TreeDBDir                                     string
 	KeepTreeDBDir                                 bool
 	DropBeforeRun                                 bool
@@ -111,6 +112,7 @@ type config struct {
 type benchmarkResult struct {
 	Target                     string   `json:"target"`
 	MongoURI                   string   `json:"mongo_uri,omitempty"`
+	MongoCompact               bool     `json:"mongo_compact,omitempty"`
 	TreeDBDir                  string   `json:"treedb_dir,omitempty"`
 	Database                   string   `json:"database"`
 	Collection                 string   `json:"collection"`
@@ -484,6 +486,7 @@ func parseConfig(args []string) (config, error) {
 	fs.SetOutput(&flagOutput)
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
+	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
 	fs.BoolVar(&cfg.DropBeforeRun, "drop-before-run", true, "drop the MongoDB database before running -target mongo")
@@ -1491,6 +1494,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBReadState = cfg.TreeDBReadState
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
+		result.MongoCompact = cfg.MongoCompact
 	}
 	if err := createIndexes(ctx, db, coll, cfg.SecondaryIndexes, cfg.RangeIndex, cfg.Target == "treedb"); err != nil {
 		return nil, err
@@ -4851,11 +4855,28 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		return nil
 	}
+	if cfg.MongoCompact {
+		if err := compactMongoCollection(ctx, target.client.Database(cfg.Database), cfg.Collection); err != nil {
+			return err
+		}
+	}
 	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
 	if err != nil {
 		return err
 	}
 	result.MongoDBStatsFinal = stats
+	return nil
+}
+
+func compactMongoCollection(ctx context.Context, db *mongo.Database, collection string) error {
+	command := bson.D{
+		{Key: "compact", Value: collection},
+		{Key: "force", Value: true},
+	}
+	var out bson.M
+	if err := db.RunCommand(ctx, command).Decode(&out); err != nil {
+		return fmt.Errorf("compact %q: %w", collection, err)
+	}
 	return nil
 }
 
@@ -5898,6 +5919,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
+		}
+		if result.Target == "mongo" {
+			fmt.Fprintf(out, "mongo_compact=%t\n", result.MongoCompact)
 		}
 		if result.ProfileDir != "" {
 			fmt.Fprintf(out, "profile_dir=%s profile_manifest=%s profile_result=%s\n",

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -4874,10 +4874,14 @@ func compactMongoCollection(ctx context.Context, db *mongo.Database, collection 
 		{Key: "force", Value: true},
 	}
 	var out bson.M
-	if err := db.RunCommand(ctx, command).Decode(&out); err != nil {
+	if err := runMongoCommandDecode(ctx, db, command, &out); err != nil {
 		return fmt.Errorf("compact %q: %w", collection, err)
 	}
 	return nil
+}
+
+var runMongoCommandDecode = func(ctx context.Context, db *mongo.Database, command bson.D, out any) error {
+	return db.RunCommand(ctx, command).Decode(out)
 }
 
 func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result *benchmarkResult) error {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -25,6 +25,7 @@ import (
 	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func TestSummarizeLatencyNearestRank(t *testing.T) {
@@ -2413,6 +2414,50 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_compact=true")) {
 		t.Fatalf("text output missing mongo_compact: %q", out.String())
+	}
+}
+
+func TestCompactMongoCollectionRunsCompactCommand(t *testing.T) {
+	orig := runMongoCommandDecode
+	t.Cleanup(func() { runMongoCommandDecode = orig })
+
+	called := false
+	runMongoCommandDecode = func(_ context.Context, _ *mongo.Database, command bson.D, out any) error {
+		called = true
+		if len(command) != 2 {
+			t.Fatalf("command len=%d want 2", len(command))
+		}
+		if command[0].Key != "compact" || command[0].Value != "docs" {
+			t.Fatalf("compact command=%v", command)
+		}
+		if command[1].Key != "force" || command[1].Value != true {
+			t.Fatalf("force command=%v", command)
+		}
+		if _, ok := out.(*bson.M); !ok {
+			t.Fatalf("out type %T want *bson.M", out)
+		}
+		return nil
+	}
+
+	if err := compactMongoCollection(context.Background(), nil, "docs"); err != nil {
+		t.Fatalf("compactMongoCollection: %v", err)
+	}
+	if !called {
+		t.Fatal("expected command runner to be called")
+	}
+}
+
+func TestCompactMongoCollectionWrapsRunnerError(t *testing.T) {
+	orig := runMongoCommandDecode
+	t.Cleanup(func() { runMongoCommandDecode = orig })
+
+	runMongoCommandDecode = func(_ context.Context, _ *mongo.Database, _ bson.D, _ any) error {
+		return errors.New("boom")
+	}
+
+	err := compactMongoCollection(context.Background(), nil, "docs")
+	if err == nil || !strings.Contains(err.Error(), `compact "docs": boom`) {
+		t.Fatalf("compactMongoCollection err=%v", err)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -593,6 +593,7 @@ func TestParseConfigValidation(t *testing.T) {
 		"-concurrent-writes", "10",
 		"-update-indexed-field",
 		"-range-index",
+		"-mongo-compact",
 		"-treedb-read-state", "unsettled",
 	})
 	if err != nil {
@@ -608,6 +609,9 @@ func TestParseConfigValidation(t *testing.T) {
 		cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 ||
 		!cfg.UpdateIndexedField || !cfg.RangeIndex || cfg.TreeDBReadState != treeDBReadStateUnsettled {
 		t.Fatalf("unexpected config: %+v", cfg)
+	}
+	if !cfg.MongoCompact {
+		t.Fatalf("expected -mongo-compact to be enabled: %+v", cfg)
 	}
 	sweepCfg, err := parseConfig([]string{
 		"-concurrent-reader-sweep", "1,2 4",
@@ -2394,6 +2398,7 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "mongo",
 		MongoURI:         "mongodb://user@127.0.0.1:27017",
+		MongoCompact:     true,
 		Database:         "bench",
 		Collection:       "docs",
 		Documents:        1,
@@ -2405,6 +2410,9 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_uri=mongodb://user@127.0.0.1:27017")) {
 		t.Fatalf("text output missing mongo_uri: %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("mongo_compact=true")) {
+		t.Fatalf("text output missing mongo_compact: %q", out.String())
 	}
 }
 

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -147,7 +147,7 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
 - `-checkpoint-between-tests` force a best-effort durability checkpoint between tests (DBs that support `Checkpoint()`), and also once after the final test so end-of-run disk usage reflects a settled state
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
 - `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility
-- `-treedb-vacuum-after-vlog-rewrite-run` optionally run offline TreeDB index vacuum after `-treedb-vlog-rewrite-after-run` before final reporting; disabled by default
+- `-treedb-vacuum-after-vlog-rewrite-run` run offline TreeDB index vacuum after `-treedb-vlog-rewrite-after-run` before final reporting (disable explicitly with `-treedb-vacuum-after-vlog-rewrite-run=false`)
 - `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`)
 - `-checkpoint-every-bytes` force a best-effort durability checkpoint every N approx bytes during write-heavy tests (DBs that support `Checkpoint()`)
 - `-suite` named suite:

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -147,7 +147,8 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
 - `-checkpoint-between-tests` force a best-effort durability checkpoint between tests (DBs that support `Checkpoint()`), and also once after the final test so end-of-run disk usage reflects a settled state
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
 - `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility
-- `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`)
+- `-treedb-vacuum-after-vlog-rewrite-run` optionally run offline TreeDB index vacuum after `-treedb-vlog-rewrite-after-run` before final reporting; disabled by default
+- `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`) 
 - `-checkpoint-every-bytes` force a best-effort durability checkpoint every N approx bytes during write-heavy tests (DBs that support `Checkpoint()`)
 - `-suite` named suite:
   - `readme` — generates the README graphs + sweep tables

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -148,7 +148,7 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
 - `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility
 - `-treedb-vacuum-after-vlog-rewrite-run` optionally run offline TreeDB index vacuum after `-treedb-vlog-rewrite-after-run` before final reporting; disabled by default
-- `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`) 
+- `-checkpoint-every-ops` force a best-effort durability checkpoint every N ops during write-heavy tests (DBs that support `Checkpoint()`)
 - `-checkpoint-every-bytes` force a best-effort durability checkpoint every N approx bytes during write-heavy tests (DBs that support `Checkpoint()`)
 - `-suite` named suite:
   - `readme` — generates the README graphs + sweep tables

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -96,7 +96,7 @@ var (
 	treedbCacheStatsBeforeReads     = flag.Bool("treedb-cache-stats-before-reads", false, "Print select treedb.cache.* stats before read/scan tests (treedb only)")
 	treedbCacheStatsAfterTests      = flag.Bool("treedb-cache-stats-after-tests", false, "Print select treedb.cache.* stats after each benchmark test (treedb only)")
 	treedbVlogRewriteAfterRun       = flag.Bool("treedb-vlog-rewrite-after-run", false, "Run full TreeDB CompactStorage after the benchmark run and report before/after disk usage (treedb only; flag name kept for compatibility)")
-	treedbVacuumAfterVlogRewriteRun = flag.Bool("treedb-vacuum-after-vlog-rewrite-run", false, "Run offline TreeDB index vacuum after -treedb-vlog-rewrite-after-run before reporting final compacted disk usage")
+	treedbVacuumAfterVlogRewriteRun = flag.Bool("treedb-vacuum-after-vlog-rewrite-run", true, "Run offline TreeDB index vacuum after -treedb-vlog-rewrite-after-run before reporting final compacted disk usage")
 )
 
 var explicitFlags = map[string]bool{}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1359,6 +1359,22 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 		"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
 		"treedb.cache.vlog_mmap.read.fallback_readat",
 		"treedb.cache.vlog_mmap.read.hit_ratio",
+		"treedb.vlog.grouped_frame_cache.hits",
+		"treedb.vlog.grouped_frame_cache.misses",
+		"treedb.vlog.grouped_frame_cache.entries",
+		"treedb.vlog.grouped_frame_cache.capacity",
+		"treedb.vlog.grouped_frame_cache.hit_ratio",
+		"treedb.process.read_path.outer_leaf.cache.hits",
+		"treedb.process.read_path.outer_leaf.cache.misses",
+		"treedb.process.read_path.outer_leaf.cache.stores",
+		"treedb.process.read_path.outer_leaf.cache.evictions",
+		"treedb.process.read_path.outer_leaf.cache.entries",
+		"treedb.process.read_path.outer_leaf.cache.capacity",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores",
+		"treedb.vlog.decode_buffer_grow.calls_total",
+		"treedb.vlog.decode_buffer_grow.realloc_calls_total",
+		"treedb.vlog.decode_buffer_grow.realloc_rate",
 		"treedb.cache.vlog_generation.enabled",
 		"treedb.cache.vlog_generation.policy",
 		"treedb.cache.vlog_generation.scheduler_state",
@@ -3886,6 +3902,14 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					vacuumIndexBytes[testName] = bytesMap
 				}
 			}
+
+			// For read tests we want the post-checkpoint state to reflect settled
+			// persisted-tree reads rather than transient queued memtables.
+			if isSettleBeforeScanTest(testName) {
+				if err := waitForTreeDBQueueDrain(instances, 2*time.Second); err != nil {
+					return BenchRun{}, err
+				}
+			}
 		}
 
 		if err := liveTbl.Render(results); err != nil {
@@ -5910,6 +5934,53 @@ func settleBenchInstances(instances []*DBInstance) error {
 		inst.Wrapper = newWrapper
 	}
 	return nil
+}
+
+func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		pending := false
+		for _, inst := range instances {
+			if inst == nil || inst.Wrapper == nil || !isTreeDBInstance(inst) {
+				continue
+			}
+			sp, ok := inst.Wrapper.(kvstore.StatsProvider)
+			if !ok {
+				continue
+			}
+			stats := sp.Stats()
+			if len(stats) == 0 {
+				continue
+			}
+			if parseStatInt(stats, "treedb.cache.queue_len") > 0 {
+				pending = true
+				break
+			}
+			if parseStatInt(stats, "treedb.cache.queue_backlog_bytes") > 0 {
+				pending = true
+				break
+			}
+		}
+		if !pending {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("checkpoint settle timeout: treedb cache queue did not drain within %s", timeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func parseStatInt(stats map[string]string, key string) int64 {
+	raw, ok := stats[key]
+	if !ok {
+		return 0
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }
 
 func containsAny(list []string, items ...string) bool {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -96,7 +96,7 @@ var (
 	treedbCacheStatsBeforeReads     = flag.Bool("treedb-cache-stats-before-reads", false, "Print select treedb.cache.* stats before read/scan tests (treedb only)")
 	treedbCacheStatsAfterTests      = flag.Bool("treedb-cache-stats-after-tests", false, "Print select treedb.cache.* stats after each benchmark test (treedb only)")
 	treedbVlogRewriteAfterRun       = flag.Bool("treedb-vlog-rewrite-after-run", false, "Run full TreeDB CompactStorage after the benchmark run and report before/after disk usage (treedb only; flag name kept for compatibility)")
-	treedbVacuumAfterVlogRewriteRun = flag.Bool("treedb-vacuum-after-vlog-rewrite-run", true, "Run offline TreeDB index vacuum after -treedb-vlog-rewrite-after-run before reporting final compacted disk usage")
+	treedbVacuumAfterVlogRewriteRun = flag.Bool("treedb-vacuum-after-vlog-rewrite-run", false, "Run offline TreeDB index vacuum after -treedb-vlog-rewrite-after-run before reporting final compacted disk usage")
 )
 
 var explicitFlags = map[string]bool{}

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -943,6 +943,36 @@ func TestRunBenchmark_CapturesTreeDBStatsAfterClose(t *testing.T) {
 	}
 }
 
+func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumByDefault(t *testing.T) {
+	report, err := runBenchmark(BenchConfig{
+		Keys:         2_000,
+		ValueSize:    16,
+		BatchSize:    100,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+
+		TreeDBVlogRewriteAfterRun: true,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	rep, ok := report.TreeDBVlogRewrite["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB rewrite report in run result")
+	}
+	if rep.VacuumRan {
+		t.Fatalf("expected offline vacuum not to run by default, got vacuum path enabled")
+	}
+	if rep.AfterVacuum.TotalBytes != 0 || rep.AfterVacuum.TotalFiles != 0 {
+		t.Fatalf("expected no post-vacuum usage report when vacuum is disabled, got=%#v", rep.AfterVacuum)
+	}
+}
+
 func TestRunBenchmark_PropagatesCloseError(t *testing.T) {
 	const dbName = "close_error_mock"
 	closeErr := errors.New("close failed")

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -944,6 +944,12 @@ func TestRunBenchmark_CapturesTreeDBStatsAfterClose(t *testing.T) {
 }
 
 func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumByDefault(t *testing.T) {
+	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
+	t.Cleanup(func() {
+		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
+	})
+	*treedbVacuumAfterVlogRewriteRun = false
+
 	report, err := runBenchmark(BenchConfig{
 		Keys:         2_000,
 		ValueSize:    16,
@@ -970,6 +976,39 @@ func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumByDefault(t *te
 	}
 	if rep.AfterVacuum.TotalBytes != 0 || rep.AfterVacuum.TotalFiles != 0 {
 		t.Fatalf("expected no post-vacuum usage report when vacuum is disabled, got=%#v", rep.AfterVacuum)
+	}
+}
+
+func TestRunBenchmark_TreeDBVlogRewriteAfterRunRunsOfflineVacuumWhenEnabled(t *testing.T) {
+	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
+	t.Cleanup(func() {
+		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
+	})
+	*treedbVacuumAfterVlogRewriteRun = true
+
+	report, err := runBenchmark(BenchConfig{
+		Keys:         2_000,
+		ValueSize:    16,
+		BatchSize:    100,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+
+		TreeDBVlogRewriteAfterRun: true,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	rep, ok := report.TreeDBVlogRewrite["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB rewrite report in run result")
+	}
+	if !rep.VacuumRan {
+		t.Fatalf("expected offline vacuum to run when enabled")
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -943,7 +943,42 @@ func TestRunBenchmark_CapturesTreeDBStatsAfterClose(t *testing.T) {
 	}
 }
 
-func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumByDefault(t *testing.T) {
+func TestRunBenchmark_TreeDBVlogRewriteAfterRunRunsOfflineVacuumByDefault(t *testing.T) {
+	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
+	t.Cleanup(func() {
+		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
+	})
+	if !*treedbVacuumAfterVlogRewriteRun {
+		t.Fatalf("expected offline vacuum default to be enabled")
+	}
+
+	report, err := runBenchmark(BenchConfig{
+		Keys:         2_000,
+		ValueSize:    16,
+		BatchSize:    100,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+
+		TreeDBVlogRewriteAfterRun: true,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	rep, ok := report.TreeDBVlogRewrite["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB rewrite report in run result")
+	}
+	if !rep.VacuumRan {
+		t.Fatalf("expected offline vacuum to run by default")
+	}
+}
+
+func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumWhenDisabled(t *testing.T) {
 	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
 	t.Cleanup(func() {
 		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
@@ -972,43 +1007,10 @@ func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumByDefault(t *te
 		t.Fatalf("expected TreeDB rewrite report in run result")
 	}
 	if rep.VacuumRan {
-		t.Fatalf("expected offline vacuum not to run by default, got vacuum path enabled")
+		t.Fatalf("expected offline vacuum to be skipped when disabled")
 	}
 	if rep.AfterVacuum.TotalBytes != 0 || rep.AfterVacuum.TotalFiles != 0 {
 		t.Fatalf("expected no post-vacuum usage report when vacuum is disabled, got=%#v", rep.AfterVacuum)
-	}
-}
-
-func TestRunBenchmark_TreeDBVlogRewriteAfterRunRunsOfflineVacuumWhenEnabled(t *testing.T) {
-	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
-	t.Cleanup(func() {
-		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
-	})
-	*treedbVacuumAfterVlogRewriteRun = true
-
-	report, err := runBenchmark(BenchConfig{
-		Keys:         2_000,
-		ValueSize:    16,
-		BatchSize:    100,
-		RangeQueries: 0,
-		RangeSpan:    0,
-		DBsArg:       "treedb",
-		TestsArg:     "sequential_write",
-		KeepDir:      false,
-		Progress:     false,
-		SeedUsed:     1,
-
-		TreeDBVlogRewriteAfterRun: true,
-	})
-	if err != nil {
-		t.Fatalf("runBenchmark: %v", err)
-	}
-	rep, ok := report.TreeDBVlogRewrite["TreeDB"]
-	if !ok {
-		t.Fatalf("expected TreeDB rewrite report in run result")
-	}
-	if !rep.VacuumRan {
-		t.Fatalf("expected offline vacuum to run when enabled")
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1014,6 +1014,63 @@ func TestRunBenchmark_TreeDBVlogRewriteAfterRunSkipsOfflineVacuumWhenDisabled(t 
 	}
 }
 
+func TestRunBenchmark_TreeDBVlogRewriteAfterRun_OfflineVacuumNoCatastrophicIndexGrowthE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e vacuum regression in short mode")
+	}
+
+	oldVacuumFlag := *treedbVacuumAfterVlogRewriteRun
+	t.Cleanup(func() {
+		*treedbVacuumAfterVlogRewriteRun = oldVacuumFlag
+	})
+	*treedbVacuumAfterVlogRewriteRun = true
+
+	report, err := runBenchmark(BenchConfig{
+		Keys:         5_000_000,
+		ValueSize:    128,
+		BatchSize:    8_000,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "batch_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+		Profile:      "fast",
+
+		TreeDBVlogRewriteAfterRun: true,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	rep, ok := report.TreeDBVlogRewrite["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB rewrite report in run result")
+	}
+	if !rep.VacuumRan {
+		t.Fatalf("expected offline vacuum to run")
+	}
+
+	beforeIndex := rep.AfterTree.MainIndexBytes
+	afterIndex := rep.AfterVacuumTree.MainIndexBytes
+	if beforeIndex <= 0 || afterIndex <= 0 {
+		t.Fatalf("expected non-zero index sizes, before=%d after=%d", beforeIndex, afterIndex)
+	}
+
+	// Regression guard for issue #1467: offline vacuum must not explode index
+	// size by materializing outer leaf-log data into index.db.
+	const maxIndexGrowthMultiple uint64 = 8
+	if afterIndex > beforeIndex*maxIndexGrowthMultiple {
+		t.Fatalf(
+			"catastrophic post-vacuum index growth: before=%d after=%d multiple=%.2f (> %dx)",
+			beforeIndex,
+			afterIndex,
+			float64(afterIndex)/float64(beforeIndex),
+			maxIndexGrowthMultiple,
+		)
+	}
+}
+
 func TestRunBenchmark_PropagatesCloseError(t *testing.T) {
 	const dbName = "close_error_mock"
 	closeErr := errors.New("close failed")

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -15,6 +15,7 @@ MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
 MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 RANGE_INDEX="${RANGE_INDEX:-false}"
 PROFILE_TREEDB="${PROFILE_TREEDB:-false}"
 READS="${READS:-}"
@@ -39,7 +40,7 @@ CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo:7}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
 MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
 MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
@@ -79,6 +80,8 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -117,7 +120,7 @@ Options:
                         Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
-  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
+  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo.
   --mongo-client-mode MODE
                         Single MongoDB client mode: driver, driver-find-raw,
                         driver-command, driver-command-raw, or driver-unack.
@@ -152,7 +155,7 @@ Environment overrides:
   CONCURRENT_RANGE_READERS, CONCURRENT_RANGE_READS, CONCURRENT_RANGE_READS_DIVISOR,
   CONCURRENT_RANGE_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITER_SWEEP, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
-  MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
+  MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX, COLLECTION, TIMEOUT,
   MONGO_CLIENT_MODE, MONGO_CLIENT_MODES,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
   TREEDB_CLIENT_MODE, TREEDB_CLIENT_MODES,
@@ -269,6 +272,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mongo-image)
       MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --mongo-client-mode)
@@ -696,6 +703,10 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
 validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
@@ -879,6 +890,7 @@ fi
   echo "insert producers: $INSERT_PRODUCERS"
   echo "mongo pool options: maxPoolSize=$MONGO_MAX_POOL_SIZE minPoolSize=$MONGO_MIN_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING"
   echo "prebuild documents: $PREBUILD_DOCUMENTS"
+  echo "mongo compact before final stats: $MONGO_COMPACT"
   echo "range index: $RANGE_INDEX"
   echo "profile TreeDB: $PROFILE_TREEDB"
   echo "reads: ${READS:-documents / $READS_DIVISOR}"
@@ -1015,9 +1027,10 @@ for docs in $DOCS_LIST; do
           exit 1
         fi
       fi
-      run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+    run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
+        -mongo-compact "$MONGO_COMPACT" \
         -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"
@@ -1070,6 +1083,7 @@ cat >"$README" <<EOF
 - concurrent writer sweep: \`${CONCURRENT_WRITER_SWEEP:-none}\`
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers or writer sweep is set}\`
 - MongoDB mode: \`$MONGO_MODE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT\`
 - MongoDB image: \`$MONGO_IMAGE\`
 - MongoDB client modes: \`$MONGO_CLIENT_MODES\`
 - benchmark timeout: \`$TIMEOUT\`

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -82,7 +82,7 @@ Options:
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
  --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
-                        Provide as -mongo-compact=<true|false>.
+                        Provide as --mongo-compact=<true|false>.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -274,6 +274,10 @@ while [[ $# -gt 0 ]]; do
     --mongo-image)
       MONGO_IMAGE="$2"
       shift 2
+      ;;
+    --mongo-compact=* )
+      MONGO_COMPACT="${1#*=}"
+      shift
       ;;
     --mongo-compact)
       MONGO_COMPACT="$2"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -80,8 +80,9 @@ Options:
                         MongoDB Go driver minPoolSize. Default: 0, use driver default.
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
-  --mongo-compact       Compact the MongoDB collection before final stats collection.
+ --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
+                        Provide as -mongo-compact=<true|false>.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -1030,8 +1031,8 @@ for docs in $DOCS_LIST; do
     run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
-        -mongo-compact "$MONGO_COMPACT" \
-        -client-mode "$mongo_client_mode"
+    -mongo-compact="$MONGO_COMPACT" \
+      -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"
         mongo_physical=$(docker_du_bytes "$mongo_cell_data")

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -1058,7 +1058,7 @@ for docs in $DOCS_LIST; do
           -treedb-index-root-storage "$TREEDB_INDEX_ROOT_STORAGE" \
           -treedb-maintenance "$TREEDB_MAINTENANCE" \
           -treedb-read-state "$TREEDB_READ_STATE" \
-          "${tree_profile_args[@]}"
+          "${tree_profile_args[@]:-}"
         tree_physical=$(du_bytes "$tree_data")
         printf "treedb\t%s\t%s\t%s\t%s\t%s\n" "$tree_config" "$docs" "$indexes" "$tree_raw_rel" "$tree_physical" >>"$MATRIX"
       done

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -15,7 +15,7 @@ MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
 MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 RANGE_INDEX="${RANGE_INDEX:-false}"
 PROFILE_TREEDB="${PROFILE_TREEDB:-false}"
 READS="${READS:-}"
@@ -40,7 +40,7 @@ CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
 CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
 MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
 MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
@@ -81,8 +81,8 @@ Options:
   --mongo-max-connecting N
                         MongoDB Go driver maxConnecting. Default: 0, use driver default.
  --mongo-compact       Compact the MongoDB collection before final stats collection.
-                        Set to true/false, default: true.
-                        Provide as --mongo-compact=<true|false>.
+                        Set to true/false, 1/0, or yes/no.
+                        Default: true for docker mode; false for external mode unless explicitly set.
   --prebuild-documents  Prebuild documents before timed load phases.
   --range-index         Create age_1 for the range-read phase.
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
@@ -121,7 +121,7 @@ Options:
                         Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
-  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:8.
   --mongo-client-mode MODE
                         Single MongoDB client mode: driver, driver-find-raw,
                         driver-command, driver-command-raw, or driver-unack.
@@ -165,6 +165,16 @@ Environment overrides:
 EOF
 }
 
+require_option_value() {
+  local opt=$1
+  local value=${2-}
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "missing value for $opt" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --out)
@@ -200,14 +210,17 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --mongo-max-pool-size)
+      require_option_value "$1" "${2-}"
       MONGO_MAX_POOL_SIZE="$2"
       shift 2
       ;;
     --mongo-min-pool-size)
+      require_option_value "$1" "${2-}"
       MONGO_MIN_POOL_SIZE="$2"
       shift 2
       ;;
     --mongo-max-connecting)
+      require_option_value "$1" "${2-}"
       MONGO_MAX_CONNECTING="$2"
       shift 2
       ;;
@@ -240,38 +253,47 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --concurrent-range-readers)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READERS="$2"
       shift 2
       ;;
     --concurrent-range-reader-sweep)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-range-reads)
+      require_option_value "$1" "${2-}"
       CONCURRENT_RANGE_READS="$2"
       shift 2
       ;;
     --concurrent-writers)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITERS="$2"
       shift 2
       ;;
     --concurrent-writer-sweep)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-writes)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITES="$2"
       shift 2
       ;;
     --mongo-mode)
+      require_option_value "$1" "${2-}"
       MONGO_MODE="$2"
       shift 2
       ;;
     --mongo-uri)
+      require_option_value "$1" "${2-}"
       MONGO_URI="$2"
       shift 2
       ;;
     --mongo-image)
+      require_option_value "$1" "${2-}"
       MONGO_IMAGE="$2"
       shift 2
       ;;
@@ -280,53 +302,65 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --mongo-compact)
+      require_option_value "$1" "${2-}"
       MONGO_COMPACT="$2"
       shift 2
       ;;
     --mongo-client-mode)
+      require_option_value "$1" "${2-}"
       MONGO_CLIENT_MODE="$2"
       MONGO_CLIENT_MODES="$2"
       shift 2
       ;;
     --mongo-client-modes)
+      require_option_value "$1" "${2-}"
       MONGO_CLIENT_MODES="$2"
       shift 2
       ;;
     --timeout)
+      require_option_value "$1" "${2-}"
       TIMEOUT="$2"
       shift 2
       ;;
     --treedb-profile)
+      require_option_value "$1" "${2-}"
       TREEDB_PROFILE="$2"
       shift 2
       ;;
     --treedb-document-format)
+      require_option_value "$1" "${2-}"
       TREEDB_DOCUMENT_FORMAT="$2"
       TREEDB_DOCUMENT_FORMATS="$2"
       shift 2
       ;;
     --treedb-document-formats)
+      require_option_value "$1" "${2-}"
       TREEDB_DOCUMENT_FORMATS="$2"
       shift 2
       ;;
     --treedb-client-mode)
+      require_option_value "$1" "${2-}"
       TREEDB_CLIENT_MODE="$2"
       TREEDB_CLIENT_MODES="$2"
       shift 2
       ;;
     --treedb-client-modes)
+      require_option_value "$1" "${2-}"
       TREEDB_CLIENT_MODES="$2"
       shift 2
       ;;
     --treedb-maintenance)
+      require_option_value "$1" "${2-}"
       TREEDB_MAINTENANCE="$2"
       shift 2
       ;;
     --treedb-read-state)
+      require_option_value "$1" "${2-}"
       TREEDB_READ_STATE="$2"
       shift 2
       ;;
     --title)
+      require_option_value "$1" "${2-}"
       TITLE="$2"
       shift 2
       ;;
@@ -677,6 +711,13 @@ if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=false
+  else
+    MONGO_COMPACT=true
+  fi
+fi
 if ! is_positive_int "$INSERT_PRODUCERS"; then
   echo "invalid INSERT_PRODUCERS=$INSERT_PRODUCERS (want positive integer)" >&2
   exit 2
@@ -708,10 +749,20 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
-if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
-  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
-  exit 2
-fi
+case "$MONGO_COMPACT" in
+  true|false)
+    ;;
+  1|yes|YES|Yes|TRUE|True)
+    MONGO_COMPACT=true
+    ;;
+  0|no|NO|No|FALSE|False)
+    MONGO_COMPACT=false
+    ;;
+  *)
+    echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true/false, 1/0, or yes/no)" >&2
+    exit 2
+    ;;
+esac
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
 validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
@@ -1035,7 +1086,7 @@ for docs in $DOCS_LIST; do
     run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
         "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_RANGE_READERS" "$concurrent_range_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
         -mongo-uri "$mongo_uri" \
-    -mongo-compact="$MONGO_COMPACT" \
+        -mongo-compact="$MONGO_COMPACT" \
       -client-mode "$mongo_client_mode"
       if [[ "$MONGO_MODE" == "docker" ]]; then
         stop_mongo_container "$mongo_container"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -569,14 +569,14 @@ stop_mongo_container() {
     return
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
-  local keep=()
+  local next_containers=()
   local active
   for active in "${ACTIVE_CONTAINERS[@]:-}"; do
     if [[ "$active" != "$container" ]]; then
-      keep+=("$active")
+      next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${keep[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]}")
 }
 
 wait_for_mongo() {
@@ -621,13 +621,13 @@ run_target() {
   local concurrent_writes=${15}
   shift 15
 
-  local prebuild_args=()
+  local prebuild_arg=""
   if [[ "$PREBUILD_DOCUMENTS" == "true" ]]; then
-    prebuild_args=(-prebuild-documents)
+    prebuild_arg="-prebuild-documents"
   fi
-  local range_index_args=()
+  local range_index_arg=""
   if [[ "$RANGE_INDEX" == "true" ]]; then
-    range_index_args=(-range-index)
+    range_index_arg="-range-index"
   fi
 
   "$BENCH_BIN" \
@@ -657,8 +657,8 @@ run_target() {
     -secondary-indexes "$indexes" \
     -timeout "$TIMEOUT" \
     -format json \
-    "${prebuild_args[@]}" \
-    "${range_index_args[@]}" \
+    ${prebuild_arg:+"$prebuild_arg"} \
+    ${range_index_arg:+"$range_index_arg"} \
     "$@" >"$raw_json"
 }
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -610,7 +610,7 @@ stop_mongo_container() {
       next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${next_containers[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]:-}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -67,6 +67,7 @@ Options:
   --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
   --mongo-compact       Compact the MongoDB collection before final stats collection.
                         Set to true/false, default: true.
+                        Provide as --mongo-compact=<true|false>.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -618,7 +619,7 @@ run_cell() {
     echo "==> MongoDB $scenario readers=$readers writers=$writers"
     run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
       -mongo-uri "$mongo_uri" \
-      -mongo-compact "$MONGO_COMPACT_TEXT"
+      -mongo-compact="$MONGO_COMPACT_TEXT"
     if [[ "$MONGO_MODE" == "docker" ]]; then
       stop_mongo_container "$mongo_container"
       mongo_physical=$(docker_du_bytes "$mongo_data")

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -661,7 +661,7 @@ fi
   -report "$REPORT" \
   -summary "$SUMMARY" \
   -title "$TITLE" \
-  "${report_extra[@]}"
+  "${report_extra[@]:-}"
 
 if [[ -n "$PYTHON3_BIN" ]]; then
   "$PYTHON3_BIN" "$ROOT/scripts/mongo_gateway_writer_metrics.py" "$OUT_DIR" "$MATRIX" "$WRITER_METRICS"

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -499,7 +499,7 @@ stop_mongo_container() {
       next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${next_containers[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]:-}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -35,8 +35,8 @@ PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
@@ -61,13 +61,13 @@ Options:
   --no-reader-sweep      Run writer-scaling cells only.
   --concurrent-writes N  Total updates per writer-scaling cell. Default: 80000.
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
-  --include-mongo        Also run each cell against an external MongoDB URI.
-  --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --include-mongo        Also run each cell against MongoDB (docker or external based on --mongo-mode).
+  --mongo-uri URI        MongoDB URI for --mongo-mode external. Default: mongodb://127.0.0.1:27017.
   --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
-  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
   --mongo-compact       Compact the MongoDB collection before final stats collection.
-                        Set to true/false, default: true.
-                        Provide as --mongo-compact=<true|false>.
+                        Set to true/false, 1/0, or yes/no.
+                        Default: true for docker mode; false for external mode unless explicitly set.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -331,13 +331,21 @@ esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
-MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=0
+  else
+    MONGO_COMPACT=1
+  fi
+else
+  MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+fi
 MONGO_COMPACT_TEXT=$(bool_01_text "$MONGO_COMPACT")
 if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
   echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
   exit 2
 fi
-if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+if [[ "$INCLUDE_MONGO" == "1" && "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -33,7 +33,10 @@ MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-16}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
+MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
@@ -60,6 +63,10 @@ Options:
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.
   --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --mongo-mode MODE      MongoDB mode for mongo runs: docker or external. Default: docker.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact       Compact the MongoDB collection before final stats collection.
+                        Set to true/false, default: true.
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
@@ -73,7 +80,7 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI, DATABASE_PREFIX,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, DATABASE_PREFIX,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
 TREEDB_MAINTENANCE, UPDATE_INDEXED_FIELD (0/1, true/false, or yes/no), RUN_READER_SWEEP (0/1, true/false, or yes/no), GOWORK, TIMEOUT, TITLE,
 and related storage/pool settings.
@@ -194,6 +201,20 @@ while [[ $# -gt 0 ]]; do
       MONGO_URI="$2"
       shift 2
       ;;
+    --mongo-mode)
+      require_option_value "$1" "${2-}"
+      MONGO_MODE="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_option_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      MONGO_COMPACT="$2"
+      shift 2
+      ;;
     --database-prefix)
       require_option_value "$1" "${2-}"
       DATABASE_PREFIX="$2"
@@ -299,11 +320,21 @@ case "$UPDATE_INDEXED_FIELD" in
     fi
     ;;
   0)
-    ;;
+  ;;
 esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
+MONGO_COMPACT=$(normalize_bool_01 MONGO_COMPACT "$MONGO_COMPACT")
+MONGO_COMPACT_TEXT=$(bool_01_text "$MONGO_COMPACT")
+if [[ "$MONGO_MODE" != "docker" && "$MONGO_MODE" != "external" ]]; then
+  echo "unknown MONGO_MODE=$MONGO_MODE (want docker or external)" >&2
+  exit 2
+fi
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
+  exit 2
+fi
 
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
@@ -324,6 +355,7 @@ REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
 TREE_METADATA="$OUT_DIR/treedb-location.txt"
+MONGO_DIR="$OUT_DIR/mongodb_data"
 
 path_is_within() {
   local child=${1%/}
@@ -356,9 +388,26 @@ report_treedb_location_on_exit() {
   fi
 }
 
-trap 'report_treedb_location_on_exit "$?"' EXIT
+ACTIVE_CONTAINERS=()
+STARTED_MONGO_CONTAINER=""
+STARTED_MONGO_URI=""
 
-mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
+cleanup() {
+  local container
+  for container in "${ACTIVE_CONTAINERS[@]:-}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+}
+
+cleanup_all() {
+  local status=$1
+  cleanup
+  report_treedb_location_on_exit "$status"
+}
+
+trap 'cleanup_all "$?"' EXIT
+
+mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR" "$MONGO_DIR"
 
 PYTHON3_BIN=""
 if command -v python3 >/dev/null 2>&1; then
@@ -378,6 +427,89 @@ du_bytes() {
   local kib
   kib=$(du -sk "$dir" | awk '{print $1}')
   echo $((kib * 1024))
+}
+
+docker_du_bytes() {
+  local dir=$1
+  local kib
+  kib=$(docker run --rm -v "$dir:/data/db:ro" "$MONGO_IMAGE" sh -c 'du -sk /data/db' | awk '{print $1}')
+  echo $((kib * 1024))
+}
+
+reset_mongo_data_dir() {
+  local dir=$1
+  mkdir -p "$dir"
+  docker run --rm -v "$dir:/data/db" "$MONGO_IMAGE" sh -c 'find /data/db -mindepth 1 -maxdepth 1 -exec rm -rf {} +' >/dev/null
+}
+
+start_mongo_container() {
+  local cell=$1
+  local data_dir=$2
+  local container="gomap-mongo-scaling-$(safe_label "$cell")-$$"
+  STARTED_MONGO_CONTAINER=""
+  STARTED_MONGO_URI=""
+  reset_mongo_data_dir "$data_dir"
+  echo "starting MongoDB container $container with data dir $data_dir" >&2
+  docker run -d --rm \
+    --name "$container" \
+    -p 127.0.0.1::27017 \
+    -v "$data_dir:/data/db" \
+    "$MONGO_IMAGE" --quiet >/dev/null
+  ACTIVE_CONTAINERS+=("$container")
+  local port=""
+  for _ in $(seq 1 60); do
+    port=$(docker port "$container" 27017/tcp 2>/dev/null | awk -F: 'END {print $NF}')
+    if [[ -n "$port" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$port" ]]; then
+    echo "MongoDB container did not expose a port" >&2
+    exit 1
+  fi
+  STARTED_MONGO_CONTAINER="$container"
+  STARTED_MONGO_URI="mongodb://127.0.0.1:$port"
+}
+
+stop_mongo_container() {
+  local container=$1
+  if [[ -z "$container" ]]; then
+    return
+  fi
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  local keep=()
+  local active
+  for active in "${ACTIVE_CONTAINERS[@]:-}"; do
+    if [[ "$active" != "$container" ]]; then
+      keep+=("$active")
+    fi
+  done
+  ACTIVE_CONTAINERS=("${keep[@]}")
+}
+
+wait_for_mongo() {
+  local uri=$1
+  local database=$2
+  for _ in $(seq 1 90); do
+    if "$BENCH_BIN" \
+      -target mongo \
+      -mongo-uri "$uri" \
+      -database "$database" \
+      -collection "$COLLECTION" \
+      -documents 1 \
+      -reads 0 \
+      -range-reads 0 \
+      -updates 0 \
+      -deletes 0 \
+      -secondary-indexes 0 \
+      -timeout 20s \
+      -format json >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
 }
 
 run_bench() {
@@ -426,6 +558,13 @@ printf "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n
 echo "running Mongo gateway scaling matrix into: $OUT_DIR"
 echo "docs=$DOCS indexes=$INDEXES batch_size=$BATCH_SIZE insert_producers=$INSERT_PRODUCERS"
 echo "writers=$WRITERS_LIST readers=$READERS_LIST run_reader_sweep=$RUN_READER_SWEEP include_mongo=$INCLUDE_MONGO update_indexed_field=$UPDATE_INDEXED_FIELD_TEXT"
+echo "mongo mode: $MONGO_MODE"
+if [[ "$MONGO_MODE" == "docker" ]]; then
+  echo "mongo image: $MONGO_IMAGE"
+else
+  echo "mongo uri: $MONGO_URI"
+fi
+echo "mongo compact before final stats: $MONGO_COMPACT_TEXT"
 
 run_cell() {
   local scenario=$1
@@ -462,10 +601,29 @@ run_cell() {
     local mongo_config="mongo_${config_suffix}"
     local mongo_raw_rel="raw/${mongo_config}.json"
     local mongo_raw="$OUT_DIR/$mongo_raw_rel"
+    local mongo_data="$MONGO_DIR/$config_suffix"
+    local mongo_uri="$MONGO_URI"
+    local mongo_container=""
+    local mongo_physical=0
+
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      start_mongo_container "$config_suffix" "$mongo_data"
+      mongo_uri="$STARTED_MONGO_URI"
+      mongo_container="$STARTED_MONGO_CONTAINER"
+      if ! wait_for_mongo "$mongo_uri" "$database"; then
+        echo "MongoDB container did not become ready for $scenario readers=$readers writers=$writers" >&2
+        exit 1
+      fi
+    fi
     echo "==> MongoDB $scenario readers=$readers writers=$writers"
     run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
-      -mongo-uri "$MONGO_URI"
-    printf "mongo\t%s\t%s\t%s\t%s\t0\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" >>"$MATRIX"
+      -mongo-uri "$mongo_uri" \
+      -mongo-compact "$MONGO_COMPACT_TEXT"
+    if [[ "$MONGO_MODE" == "docker" ]]; then
+      stop_mongo_container "$mongo_container"
+      mongo_physical=$(docker_du_bytes "$mongo_data")
+    fi
+    printf "mongo\t%s\t%s\t%s\t%s\t%s\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" "$mongo_physical" >>"$MATRIX"
   fi
 }
 
@@ -531,7 +689,10 @@ cat >"$README" <<EOF
 - TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
 - update indexed field: \`$UPDATE_INDEXED_FIELD_TEXT\`
 - include MongoDB: \`$INCLUDE_MONGO\`
+- MongoDB mode: \`$MONGO_MODE\`
 - MongoDB URI: \`$MONGO_URI\`
+- MongoDB image: \`$MONGO_IMAGE\`
+- MongoDB compact before final stats: \`$MONGO_COMPACT_TEXT\`
 - MongoDB database prefix: \`$DATABASE_PREFIX\`
 - GOWORK: \`$GO_WORK_MODE\`
 - timeout: \`$TIMEOUT\`

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -484,14 +484,14 @@ stop_mongo_container() {
     return
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
-  local keep=()
+  local next_containers=()
   local active
   for active in "${ACTIVE_CONTAINERS[@]:-}"; do
     if [[ "$active" != "$container" ]]; then
-      keep+=("$active")
+      next_containers+=("$active")
     fi
   done
-  ACTIVE_CONTAINERS=("${keep[@]}")
+  ACTIVE_CONTAINERS=("${next_containers[@]}")
 }
 
 wait_for_mongo() {

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -212,7 +212,12 @@ while [[ $# -gt 0 ]]; do
       MONGO_IMAGE="$2"
       shift 2
       ;;
+    --mongo-compact=*)
+      MONGO_COMPACT="${1#*=}"
+      shift
+      ;;
     --mongo-compact)
+      require_option_value "$1" "${2-}"
       MONGO_COMPACT="$2"
       shift 2
       ;;

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -20,8 +20,8 @@ MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
-MONGO_COMPACT="${MONGO_COMPACT:-true}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
 MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
 MONGO_READERS="${MONGO_READERS:-1,2,4,8,16,32}"
@@ -60,8 +60,10 @@ Options:
   --mongo-docs N         Override Mongo-compatible document count.
   --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
-  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
-  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection. Default: true.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
+  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection.
+                         Set to true/false, 1/0, or yes/no.
+                         Default: true for docker mode; false for external mode unless explicitly set.
   --timeout DURATION     Per-cell timeout for Mongo gateway commands. Default: 120m.
   --title TITLE          HTML report title.
   --skip-raw             Skip raw TreeDB engine profile matrix.
@@ -97,6 +99,14 @@ normalize_list() {
 bool_true() {
   case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_bool_text() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes) printf 'true' ;;
+    0|false|no) printf 'false' ;;
     *) return 1 ;;
   esac
 }
@@ -251,12 +261,20 @@ case "$MONGO_MODE" in
     exit 2
     ;;
 esac
-if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
-  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
-  exit 2
+if [[ -z "$MONGO_COMPACT" ]]; then
+  if [[ "$MONGO_MODE" == "external" ]]; then
+    MONGO_COMPACT=false
+  else
+    MONGO_COMPACT=true
+  fi
+else
+  MONGO_COMPACT=$(normalize_bool_text "$MONGO_COMPACT") || {
+    echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true/false, 1/0, or yes/no)" >&2
+    exit 2
+  }
 fi
-if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
-  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+if [[ "$SKIP_MONGO" != "true" && "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
   exit 2
 fi
 
@@ -440,7 +458,7 @@ run_mongo_full_sweep() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -480,7 +498,7 @@ run_mongo_load_modes() {
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -508,7 +526,7 @@ run_mongo_scaling() {
       --include-mongo \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact="$MONGO_COMPACT" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -436,7 +436,7 @@ run_mongo_full_sweep() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -476,7 +476,7 @@ run_mongo_load_modes() {
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -504,7 +504,7 @@ run_mongo_scaling() {
       --include-mongo \
       --mongo-mode "$MONGO_MODE" \
       --mongo-image "$MONGO_IMAGE" \
-      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-compact="$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -20,6 +20,8 @@ MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo}"
+MONGO_COMPACT="${MONGO_COMPACT:-true}"
 MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
 MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
 MONGO_READERS="${MONGO_READERS:-1,2,4,8,16,32}"
@@ -58,6 +60,8 @@ Options:
   --mongo-docs N         Override Mongo-compatible document count.
   --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
+  --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo.
+  --mongo-compact BOOL   Compact the MongoDB collection before final stats collection. Default: true.
   --timeout DURATION     Per-cell timeout for Mongo gateway commands. Default: 120m.
   --title TITLE          HTML report title.
   --skip-raw             Skip raw TreeDB engine profile matrix.
@@ -72,7 +76,7 @@ Options:
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
-MONGO_MODE, MONGO_URI, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
+MONGO_MODE, MONGO_URI, MONGO_IMAGE, MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
 EOF
 }
 
@@ -142,6 +146,16 @@ while [[ $# -gt 0 ]]; do
     --mongo-uri)
       require_value "$1" "${2-}"
       MONGO_URI="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact)
+      require_value "$1" "${2-}"
+      MONGO_COMPACT="$2"
       shift 2
       ;;
     --timeout)
@@ -226,6 +240,21 @@ case "$TIER" in
     exit 2
     ;;
 esac
+case "$MONGO_MODE" in
+  docker|external) ;;
+  *)
+    echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
+    exit 2
+    ;;
+esac
+if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
+  echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI" >&2
+  exit 2
+fi
+if [[ "$MONGO_COMPACT" != "true" && "$MONGO_COMPACT" != "false" ]]; then
+  echo "invalid MONGO_COMPACT=$MONGO_COMPACT (want true or false)" >&2
+  exit 2
+fi
 
 INDEXES_LIST=$(normalize_list "$INDEXES_LIST")
 MONGO_READERS=$(normalize_list "$MONGO_READERS")
@@ -285,6 +314,8 @@ write_metadata() {
     echo "- collection_profile_count: $COLLECTION_PROFILE_COUNT"
     echo "- mongo_docs: $MONGO_DOCS"
     echo "- mongo_mode: $MONGO_MODE"
+    echo "- mongo_image: $MONGO_IMAGE"
+    echo "- mongo_compact: $MONGO_COMPACT"
     echo "- mongo_uri: $MONGO_URI"
     echo "- timeout: $TIMEOUT"
     echo "- mongo_readers: $MONGO_READERS"
@@ -314,6 +345,8 @@ write_metadata() {
     printf ' --tier %q' "$TIER"
     printf ' --indexes %q' "$INDEXES_LIST"
     printf ' --mongo-mode %q' "$MONGO_MODE"
+    printf ' --mongo-image %q' "$MONGO_IMAGE"
+    printf ' --mongo-compact %q' "$MONGO_COMPACT"
     printf ' --mongo-uri %q' "$MONGO_URI"
     printf '\n```\n'
   } > "$RUN_ROOT/RUNBOOK.md"
@@ -402,6 +435,8 @@ run_mongo_full_sweep() {
       --concurrent-writer-sweep "$MONGO_WRITERS" \
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Full Sweep"
@@ -440,6 +475,8 @@ run_mongo_load_modes() {
       --docs "$MONGO_DOCS" \
       --indexes "$INDEXES_LIST" \
       --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Client-Mode Load Matrix"
@@ -465,6 +502,9 @@ run_mongo_scaling() {
       --concurrent-writes "$MONGO_CONCURRENT_WRITES" \
       --concurrent-reads "$MONGO_CONCURRENT_READS" \
       --include-mongo \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
       --mongo-uri "$MONGO_URI" \
       --timeout "$TIMEOUT" \
       --title "Mongo API Reader/Writer Scaling, ${indexes} indexes"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -153,6 +153,10 @@ while [[ $# -gt 0 ]]; do
       MONGO_IMAGE="$2"
       shift 2
       ;;
+    --mongo-compact=*)
+      MONGO_COMPACT="${1#*=}"
+      shift
+      ;;
     --mongo-compact)
       require_value "$1" "${2-}"
       MONGO_COMPACT="$2"

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -426,7 +426,7 @@ run_collections() {
       -formats template-v1,bson,json \
       -benchtime "${COLLECTION_BENCHTIME:-${COLLECTION_DOCS}x}" \
       -count "${COLLECTION_COUNT:-1}" \
-      "${profile_args[@]}"
+      "${profile_args[@]:-}"
   done
 }
 


### PR DESCRIPTION
## Summary
This PR publishes the current `codex/randread-parallel-hitrate-pass2` head as a stacked follow-on to `perf/treedb-randread-pass3` (PR #1480), without changing existing PRs in the main stack.

Changes included here:
- fix grouped-read corruption regression seen in `-checkpoint-between-tests` sequences (`random_read_parallel -> random_read_batch`)
- preserve/readjust grouped-frame cache behavior for one-off `dst=nil` read paths
- add regression coverage for parallel grouped reads followed by append reads

## Stack Position
- **Base:** `perf/treedb-randread-pass3`
- Intended review order: #1478 -> #1479 -> #1480 -> this PR

## Validation
- `go test ./TreeDB/internal/valuelog -count=1`
- unified bench gate comparisons run on:
  - `-profile fast -keys 500000 -read-workers 8 -checkpoint-between-tests -test random_write,random_read_parallel`
  - `-profile fast -keys 500000 -checkpoint-between-tests -test random_read_parallel,random_read_batch`
