### PR TITLE
valuelog: clean grouped-read hitrate recovery

### DIFF
--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -950,8 +950,8 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	if s.backendFallback != nil && rootID == s.backendRootID {
-		snap.published = s.backendFallback
+	if rootID == s.backendRootID {
+		snap.published = &s.backendFallback
 		return
 	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -950,6 +950,10 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
+	if s.backendFallback != nil && rootID == s.backendRootID {
+		snap.published = s.backendFallback
+		return
+	}
 	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -33,6 +33,8 @@ type Snapshot struct {
 	db              *DB
 	view            *memtableView
 	backend         *backenddb.Snapshot
+	backendRootID   uint64
+	backendFallback rootDomainLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -162,10 +164,16 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
+	var backendRootID uint64
+	if state := backendSnap.State(); state != nil {
+		backendRootID = state.RootPageID
+	}
 	snap := &Snapshot{
-		db:      db,
-		view:    view,
-		backend: backendSnap,
+		db:              db,
+		view:            view,
+		backend:         backendSnap,
+		backendRootID:   backendRootID,
+		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -495,6 +503,12 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		// tombstones remain not-found.
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
+		}
+		// Hot miss path: when this snapshot has no in-memory root-domain state,
+		// a published not-found cannot be shadowed by queued tombstones.
+		// Avoid an extra GetEntry probe that re-materializes leaf pages.
+		if !rootDomainSnapshotHasInMemoryState(snap) {
+			return dst, tree.ErrKeyNotFound
 		}
 		checkedPublishedEntry = true
 		if shouldShortCircuitPublishedAppendMiss(true, publishedRoots, snap) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -34,7 +34,7 @@ type Snapshot struct {
 	view            *memtableView
 	backend         *backenddb.Snapshot
 	backendRootID   uint64
-	backendFallback rootDomainLookup
+	backendFallback backendSnapshotLookup
 	rootVersion     uint64
 	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
 	rootSystem      rootDomainSnapshot
@@ -173,7 +173,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		view:            view,
 		backend:         backendSnap,
 		backendRootID:   backendRootID,
-		backendFallback: &backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+		backendFallback: backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
 	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
@@ -507,7 +507,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		// Hot miss path: when this snapshot has no in-memory root-domain state,
 		// a published not-found cannot be shadowed by queued tombstones.
 		// Avoid an extra GetEntry probe that re-materializes leaf pages.
-		if !rootDomainSnapshotHasInMemoryState(snap) {
+		if !rootDomainSnapshotHasInMemoryState(snap) && rootDomainPublishedUsesBackendLookup(snap) {
 			return dst, tree.ErrKeyNotFound
 		}
 		checkedPublishedEntry = true

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -158,14 +158,24 @@ func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) 
 	// Parallel read misses can race: another goroutine may populate this exact
 	// slot/key before we reach admission. Fast-path that case with only a read
 	// lock to avoid unnecessary writer lock traffic in the miss hot path.
-	slot.mu.RLock()
-	if slot.valid && slot.key == key {
+	if slot.mu.TryRLock() {
+		if slot.valid && slot.key == key {
+			slot.mu.RUnlock()
+			return
+		}
 		slot.mu.RUnlock()
+	} else {
+		c.readMissAdmissionSkips.Add(1)
 		return
 	}
-	slot.mu.RUnlock()
 
-	slot.mu.Lock()
+	// Read-miss cache admission is best effort. If this slot is currently under
+	// heavy contention, skip admission rather than queuing behind a writer lock
+	// in the random-read miss hot path.
+	if !slot.mu.TryLock() {
+		c.readMissAdmissionSkips.Add(1)
+		return
+	}
 	if slot.valid && slot.key == key {
 		slot.mu.Unlock()
 		return

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -554,7 +554,7 @@ func TestLeafPageReadCacheStoreReadMissSkipsWhenSlotLockContended(t *testing.T) 
 
 	select {
 	case <-done:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		t.Fatalf("storeReadMiss blocked on contended slot lock; expected non-blocking skip")
 	}
 

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -528,6 +528,45 @@ func TestValueReaderLeafLogPageUnsafeToOneOffReadMissDoesNotEvictStoredLeaf(t *t
 	}
 }
 
+func TestLeafPageReadCacheStoreReadMissSkipsWhenSlotLockContended(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	ptr := page.LeafLogPtr{FileID: 9, Offset: 512, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x66}, page.PageSize)
+	key := newLeafPageReadCacheKey(ptr)
+	slot := &cache.slots[cache.slotIndex(key)]
+
+	// First read miss only arms the admission fingerprint and should skip.
+	cache.storeReadMiss(ptr, leaf)
+	if stats := cache.stats(); stats.ReadMissAdmissionSkips != 1 || stats.ReadMissAdmissionStores != 0 {
+		t.Fatalf("stats after first miss=%+v, want one admission skip and no stores", stats)
+	}
+
+	// Contend slot lock before second miss; with TryLock-based admission this
+	// should return quickly and record another skip instead of blocking.
+	slot.mu.Lock()
+	defer slot.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		cache.storeReadMiss(ptr, leaf)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("storeReadMiss blocked on contended slot lock; expected non-blocking skip")
+	}
+
+	stats := cache.stats()
+	if stats.ReadMissAdmissionSkips < 2 {
+		t.Fatalf("expected additional skip on lock contention, stats=%+v", stats)
+	}
+	if stats.ReadMissAdmissionStores != 0 {
+		t.Fatalf("unexpected admission store under lock contention, stats=%+v", stats)
+	}
+}
+
 func TestConfiguredLeafPageReadCacheEntriesReadsEnvAtOpenTime(t *testing.T) {
 	prev := LeafPageReadCacheEntries
 	LeafPageReadCacheEntries = 8

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -69,6 +69,8 @@ type File struct {
 	compactLeafPayloadAllowedSet bool
 
 	cacheMu    sync.RWMutex
+	groupedMu  sync.RWMutex
+	scratchMu  sync.Mutex
 	cacheStart atomic.Int64
 	cacheK     int
 	cacheFlags byte
@@ -211,13 +213,13 @@ func currentScanSegmentPaths() func(string) ([]segmentInfo, error) {
 
 func (f *File) setCacheRawLocked(raw []byte, pooled bool) {
 	if f.cacheRawPooled && cap(f.cacheRaw) > 0 {
-		f.stashDecodeScratchLocked(f.cacheRaw)
+		f.stashDecodeScratch(f.cacheRaw)
 	}
 	f.cacheRaw = raw
 	f.cacheRawPooled = pooled
 }
 
-func (f *File) stashDecodeScratchLocked(buf []byte) {
+func (f *File) stashDecodeScratch(buf []byte) {
 	if cap(buf) == 0 {
 		return
 	}
@@ -225,6 +227,8 @@ func (f *File) stashDecodeScratchLocked(buf []byte) {
 		putDecodeScratch(buf)
 		return
 	}
+	f.scratchMu.Lock()
+	defer f.scratchMu.Unlock()
 	buf = buf[:0]
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
@@ -243,10 +247,10 @@ func (f *File) takeDecodeScratch(minCap int) []byte {
 	if minCap <= 0 {
 		return nil
 	}
-	f.cacheMu.Lock()
+	f.scratchMu.Lock()
 	scratch := f.decodeScratch
 	f.decodeScratch = nil
-	f.cacheMu.Unlock()
+	f.scratchMu.Unlock()
 	if cap(scratch) >= minCap {
 		return scratch[:0]
 	}
@@ -265,27 +269,27 @@ func (f *File) releaseDecodeScratch(buf []byte) {
 		return
 	}
 	buf = buf[:0]
-	f.cacheMu.Lock()
+	f.scratchMu.Lock()
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
-		f.cacheMu.Unlock()
+		f.scratchMu.Unlock()
 		return
 	}
 	if cap(buf) > cap(f.decodeScratch) {
 		old := f.decodeScratch
 		f.decodeScratch = buf
-		f.cacheMu.Unlock()
+		f.scratchMu.Unlock()
 		putDecodeScratch(old)
 		return
 	}
-	f.cacheMu.Unlock()
+	f.scratchMu.Unlock()
 	putDecodeScratch(buf)
 }
 
-func (f *File) clearGroupedFrameCacheLocked() {
+func (f *File) clearGroupedFrameCacheLocked() (pooled [][]byte) {
 	for i := range f.groupedFrameCache {
 		if f.groupedFrameCache[i].rawPooled {
-			f.stashDecodeScratchLocked(f.groupedFrameCache[i].raw)
+			pooled = append(pooled, f.groupedFrameCache[i].raw)
 		}
 		f.groupedFrameCache[i].raw = nil
 		f.groupedFrameCache[i].k = 0
@@ -293,32 +297,37 @@ func (f *File) clearGroupedFrameCacheLocked() {
 	}
 	f.groupedFrameCache = nil
 	f.groupedFrameCacheClock = 0
+	return pooled
 }
 
 func (f *File) setGroupedFrameCacheEntries(entries int) {
 	if entries < 0 {
 		entries = 0
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	f.groupedMu.Lock()
 	if f.groupedFrameCacheEntries == entries {
+		f.groupedMu.Unlock()
 		return
 	}
-	f.clearGroupedFrameCacheLocked()
+	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheEntries = entries
 	f.groupedFrameCacheHits.Store(0)
 	f.groupedFrameCacheMisses.Store(0)
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
 }
 
 func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int, dst []byte) (out []byte, usedDst bool, err error, hit bool) {
-	f.cacheMu.RLock()
+	f.groupedMu.RLock()
 	if f.groupedFrameCacheEntries <= 0 {
-		f.cacheMu.RUnlock()
+		f.groupedMu.RUnlock()
 		return nil, false, nil, false
 	}
 	if len(f.groupedFrameCache) == 0 {
-		f.cacheMu.RUnlock()
 		f.groupedFrameCacheMisses.Add(1)
+		f.groupedMu.RUnlock()
 		return nil, false, nil, false
 	}
 	for i := range f.groupedFrameCache {
@@ -337,8 +346,8 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 			// Copy payload while holding cacheMu so callers do not race with cache
 			// entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
-			f.cacheMu.RUnlock()
 			f.groupedFrameCacheHits.Add(1)
+			f.groupedMu.RUnlock()
 			decoded, decErr := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
@@ -350,18 +359,18 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		if dst != nil && cap(dst) >= len(val) {
 			out := dst[:len(val)]
 			copy(out, val)
-			f.cacheMu.RUnlock()
 			f.groupedFrameCacheHits.Add(1)
+			f.groupedMu.RUnlock()
 			return out, true, nil, true
 		}
 		out := make([]byte, len(val))
 		copy(out, val)
-		f.cacheMu.RUnlock()
 		f.groupedFrameCacheHits.Add(1)
+		f.groupedMu.RUnlock()
 		return out, false, nil, true
 	}
-	f.cacheMu.RUnlock()
 	f.groupedFrameCacheMisses.Add(1)
+	f.groupedMu.RUnlock()
 	return nil, false, nil, false
 }
 
@@ -369,12 +378,21 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 	if k <= 0 || len(raw) == 0 {
 		return false
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	// Opportunistic hot-path policy: under heavy read parallelism, avoid
+	// queuing behind grouped-cache metadata lock just to populate cache.
+	// Skipping a store here may reduce hit rate slightly, but prevents large
+	// lock convoy effects in random-read miss bursts.
+	if !f.groupedMu.TryLock() {
+		return false
+	}
+	var oldPooledRaw []byte
+	stored := false
 	if f.groupedFrameCacheEntries <= 0 {
+		f.groupedMu.Unlock()
 		return false
 	}
 	if f.groupedFrameCacheMaxRaw > 0 && len(raw) > f.groupedFrameCacheMaxRaw {
+		f.groupedMu.Unlock()
 		return false
 	}
 
@@ -385,50 +403,58 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 		e := &f.groupedFrameCache[i]
 		if e.k > 0 && e.start == start && e.verifyCRC == verifyCRC {
 			if e.rawPooled {
-				f.stashDecodeScratchLocked(e.raw)
+				oldPooledRaw = e.raw
 			}
 			e.k = k
 			e.offsets = offsets
 			e.raw = raw
 			e.rawPooled = pooled
 			e.used = used
-			return true
+			stored = true
+			break
 		}
 	}
-
-	idx := -1
-	if len(f.groupedFrameCache) < f.groupedFrameCacheEntries {
-		f.groupedFrameCache = append(f.groupedFrameCache, groupedFrameCacheEntry{})
-		idx = len(f.groupedFrameCache) - 1
-	} else {
-		oldest := f.groupedFrameCache[0].used
-		idx = 0
-		for i := 1; i < len(f.groupedFrameCache); i++ {
-			if f.groupedFrameCache[i].used < oldest {
-				oldest = f.groupedFrameCache[i].used
-				idx = i
+	if !stored {
+		idx := -1
+		if len(f.groupedFrameCache) < f.groupedFrameCacheEntries {
+			f.groupedFrameCache = append(f.groupedFrameCache, groupedFrameCacheEntry{})
+			idx = len(f.groupedFrameCache) - 1
+		} else {
+			oldest := f.groupedFrameCache[0].used
+			idx = 0
+			for i := 1; i < len(f.groupedFrameCache); i++ {
+				if f.groupedFrameCache[i].used < oldest {
+					oldest = f.groupedFrameCache[i].used
+					idx = i
+				}
 			}
 		}
-	}
 
-	if idx >= 0 && idx < len(f.groupedFrameCache) && f.groupedFrameCache[idx].rawPooled {
-		f.stashDecodeScratchLocked(f.groupedFrameCache[idx].raw)
+		if idx >= 0 && idx < len(f.groupedFrameCache) && f.groupedFrameCache[idx].rawPooled {
+			oldPooledRaw = f.groupedFrameCache[idx].raw
+		}
+		f.groupedFrameCache[idx] = groupedFrameCacheEntry{
+			start:     start,
+			verifyCRC: verifyCRC,
+			k:         k,
+			offsets:   offsets,
+			raw:       raw,
+			rawPooled: pooled,
+			used:      used,
+		}
+		stored = true
 	}
-	f.groupedFrameCache[idx] = groupedFrameCacheEntry{
-		start:     start,
-		verifyCRC: verifyCRC,
-		k:         k,
-		offsets:   offsets,
-		raw:       raw,
-		rawPooled: pooled,
-		used:      used,
+	f.groupedMu.Unlock()
+	if oldPooledRaw != nil {
+		// Avoid doing scratch handoff while holding cacheMu on the hot path.
+		f.releaseDecodeScratch(oldPooledRaw)
 	}
-	return true
+	return stored
 }
 
 func (f *File) groupedFrameCacheStats() (hits, misses uint64, entries, capacity int) {
-	f.cacheMu.RLock()
-	defer f.cacheMu.RUnlock()
+	f.groupedMu.RLock()
+	defer f.groupedMu.RUnlock()
 	return f.groupedFrameCacheHits.Load(), f.groupedFrameCacheMisses.Load(), len(f.groupedFrameCache), f.groupedFrameCacheEntries
 }
 
@@ -436,15 +462,28 @@ func (f *File) setGroupedFrameCacheMaxRawBytes(maxRaw int) {
 	if maxRaw < 0 {
 		maxRaw = 0
 	}
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
+	f.groupedMu.Lock()
 	if f.groupedFrameCacheMaxRaw == maxRaw {
+		f.groupedMu.Unlock()
 		return
 	}
-	f.clearGroupedFrameCacheLocked()
+	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedFrameCacheMaxRaw = maxRaw
 	f.groupedFrameCacheHits.Store(0)
 	f.groupedFrameCacheMisses.Store(0)
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
+}
+
+func (f *File) groupedFrameCacheAllowsRaw(rawLen int) bool {
+	f.groupedMu.RLock()
+	defer f.groupedMu.RUnlock()
+	if f.groupedFrameCacheEntries <= 0 {
+		return false
+	}
+	return f.groupedFrameCacheMaxRaw <= 0 || rawLen <= f.groupedFrameCacheMaxRaw
 }
 
 func (f *File) Close() error {
@@ -462,9 +501,14 @@ func (f *File) Close() error {
 	f.setCacheRawLocked(nil, false)
 	scratch = f.decodeScratch
 	f.decodeScratch = nil
-	f.clearGroupedFrameCacheLocked()
 	f.cacheStart.Store(0)
 	f.cacheMu.Unlock()
+	f.groupedMu.Lock()
+	pooled := f.clearGroupedFrameCacheLocked()
+	f.groupedMu.Unlock()
+	for _, raw := range pooled {
+		f.releaseDecodeScratch(raw)
+	}
 	if scratch != nil {
 		putDecodeScratch(scratch)
 	}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -493,10 +493,12 @@ func (f *File) Close() error {
 	f.cacheFlags = 0
 	f.cacheLen = 0
 	f.setCacheRawLocked(nil, false)
-	scratch = f.decodeScratch
-	f.decodeScratch = nil
 	f.cacheStart.Store(0)
 	f.cacheMu.Unlock()
+	f.scratchMu.Lock()
+	scratch = f.decodeScratch
+	f.decodeScratch = nil
+	f.scratchMu.Unlock()
 	f.groupedMu.Lock()
 	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedMu.Unlock()

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -343,8 +343,8 @@ func (f *File) groupedFrameCacheReadTo(start int64, verifyCRC bool, subIndex int
 		}
 		val := e.raw[valStart:valEnd]
 		if f.templateLookup != nil && templ.IsEncodedPayload(val) {
-			// Copy payload while holding cacheMu so callers do not race with cache
-			// entry eviction/reuse after unlock.
+			// Copy payload while holding groupedMu so callers do not race with
+			// cache entry eviction/reuse after unlock.
 			encoded := append([]byte(nil), val...)
 			f.groupedFrameCacheHits.Add(1)
 			f.groupedMu.RUnlock()
@@ -440,7 +440,7 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 	}
 	f.groupedMu.Unlock()
 	if oldPooledRaw != nil {
-		// Avoid doing scratch handoff while holding cacheMu on the hot path.
+		// Avoid doing scratch handoff while holding groupedMu on the hot path.
 		f.releaseDecodeScratch(oldPooledRaw)
 	}
 	return stored

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -378,13 +378,7 @@ func (f *File) groupedFrameCacheStore(start int64, verifyCRC bool, k int, offset
 	if k <= 0 || len(raw) == 0 {
 		return false
 	}
-	// Opportunistic hot-path policy: under heavy read parallelism, avoid
-	// queuing behind grouped-cache metadata lock just to populate cache.
-	// Skipping a store here may reduce hit rate slightly, but prevents large
-	// lock convoy effects in random-read miss bursts.
-	if !f.groupedMu.TryLock() {
-		return false
-	}
+	f.groupedMu.Lock()
 	var oldPooledRaw []byte
 	stored := false
 	if f.groupedFrameCacheEntries <= 0 {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -503,7 +503,7 @@ func (f *File) Close() error {
 	pooled := f.clearGroupedFrameCacheLocked()
 	f.groupedMu.Unlock()
 	for _, raw := range pooled {
-		f.releaseDecodeScratch(raw)
+		putDecodeScratch(raw)
 	}
 	if scratch != nil {
 		putDecodeScratch(scratch)

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1015,14 +1015,15 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
 	cacheableRaw := false
-	if copyValueToDst {
-		f.cacheMu.Lock()
-		cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
-		f.cacheMu.Unlock()
-	}
+	f.cacheMu.Lock()
+	cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
+	f.cacheMu.Unlock()
+
+	// When raw payload may be cached, decode into pooled scratch so the grouped
+	// cache can retain ownership and return buffers to the pool on eviction.
 	decodeDst := dst
 	rawPooled := false
-	if copyValueToDst {
+	if copyValueToDst || cacheableRaw {
 		decodeDst = f.takeDecodeScratch(int(rawLen))
 		rawPooled = true
 	}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1064,21 +1064,6 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return out, true, nil, true
 	}
-	if rawPooled {
-		// If grouped-cache store was skipped (or disabled) and we decoded into
-		// pooled scratch, do not return a view that aliases pooled memory.
-		// Copy the selected value out and return scratch to the pool.
-		if dst != nil && cap(dst) >= valLen {
-			out := dst[:valLen]
-			copy(out, val)
-			f.releaseDecodeScratch(raw)
-			return out, true, nil, true
-		}
-		out := make([]byte, valLen)
-		copy(out, val)
-		f.releaseDecodeScratch(raw)
-		return out, false, nil, true
-	}
 	// dst is used iff it was provided with enough capacity to hold rawLen.
 	return val, dst != nil && cap(dst) >= int(rawLen), nil, true
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -728,12 +728,7 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 			return out, nil, true
 		}
 
-		cacheableRaw := false
-		f.cacheMu.Lock()
-		if f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw) {
-			cacheableRaw = true
-		}
-		f.cacheMu.Unlock()
+		cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 		retainRaw := cacheableRaw || readViaMmapViewPrefixCacheEnabled
 		pooledRaw := !retainRaw
@@ -1014,10 +1009,7 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
-	cacheableRaw := false
-	f.cacheMu.Lock()
-	cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
-	f.cacheMu.Unlock()
+	cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// When raw payload may be cached, decode into pooled scratch so the grouped
 	// cache can retain ownership and return buffers to the pool on eviction.
@@ -1068,6 +1060,21 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 			f.releaseDecodeScratch(raw)
 		}
 		return out, true, nil, true
+	}
+	if rawPooled {
+		// If grouped-cache store was skipped (or disabled) and we decoded into
+		// pooled scratch, do not return a view that aliases pooled memory.
+		// Copy the selected value out and return scratch to the pool.
+		if dst != nil && cap(dst) >= valLen {
+			out := dst[:valLen]
+			copy(out, val)
+			f.releaseDecodeScratch(raw)
+			return out, true, nil, true
+		}
+		out := make([]byte, valLen)
+		copy(out, val)
+		f.releaseDecodeScratch(raw)
+		return out, false, nil, true
 	}
 	// dst is used iff it was provided with enough capacity to hold rawLen.
 	return val, dst != nil && cap(dst) >= int(rawLen), nil, true
@@ -1336,14 +1343,9 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return dst, nil, true
 	}
-	cacheableRaw := false
-	f.cacheMu.Lock()
 	// One-shot reads (dst=nil) are typically point gets. Avoid caching decoded
 	// grouped frames there to limit memory overhead in random-read-heavy paths.
-	if dst != nil && f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw) {
-		cacheableRaw = true
-	}
-	f.cacheMu.Unlock()
+	cacheableRaw := dst != nil && f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// Decode into pooled scratch even when we plan to cache decoded raw bytes.
 	// When cached, ownership transfers to groupedFrameCacheStore(..., pooled=true)

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1344,14 +1344,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	f.cacheMu.Unlock()
 
-	var raw []byte
-	pooledRaw := false
-	if cacheableRaw {
-		raw = make([]byte, 0, int(rawLen))
-	} else {
-		raw = f.takeDecodeScratch(int(rawLen))
-		pooledRaw = true
-	}
+	// Decode into pooled scratch even when we plan to cache decoded raw bytes.
+	// When cached, ownership transfers to groupedFrameCacheStore(..., pooled=true)
+	// and is returned to scratch pool on eviction; this avoids per-read heap
+	// allocations in random-read parallel miss paths.
+	raw := f.takeDecodeScratch(int(rawLen))
+	pooledRaw := true
 	raw, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, raw)
 	if err != nil {
 		if pooledRaw {
@@ -1366,7 +1364,8 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, ErrCorrupt, true
 	}
 	if cacheableRaw {
-		f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, false)
+		f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true)
+		pooledRaw = false
 	}
 
 	oldLen := len(dst)
@@ -1377,7 +1376,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	f.cacheLen = prefixLen
 	f.cacheOffs = offsets
 	if cacheableRaw {
-		f.setCacheRawLocked(raw, false)
+		f.setCacheRawLocked(raw, true)
 	} else {
 		f.setCacheRawLocked(nil, false)
 	}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1369,8 +1369,11 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return nil, ErrCorrupt, true
 	}
+	groupedStored := false
 	if cacheableRaw {
-		f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true)
+		groupedStored = f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true)
+	}
+	if groupedStored {
 		pooledRaw = false
 	}
 
@@ -1381,11 +1384,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	f.cacheFlags = fFlags
 	f.cacheLen = prefixLen
 	f.cacheOffs = offsets
-	if cacheableRaw {
-		f.setCacheRawLocked(raw, true)
-	} else {
-		f.setCacheRawLocked(nil, false)
-	}
+	f.setCacheRawLocked(nil, false)
 	f.cacheStart.Store(start)
 	f.cacheMu.Unlock()
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1354,14 +1354,6 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return nil, ErrCorrupt, true
 	}
-	groupedStored := false
-	if cacheableRaw {
-		groupedStored = f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true)
-	}
-	if groupedStored {
-		pooledRaw = false
-	}
-
 	oldLen := len(dst)
 
 	f.cacheMu.Lock()
@@ -1374,18 +1366,34 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	f.cacheMu.Unlock()
 
 	dst, err = appendDecodedTemplatePayload(dst, raw[valStart:valEnd], f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
-	if pooledRaw {
-		f.releaseDecodeScratch(raw)
-	}
 	if err != nil {
+		if pooledRaw {
+			f.releaseDecodeScratch(raw)
+		}
 		return nil, err, true
 	}
 	if len(dst) < oldLen {
+		if pooledRaw {
+			f.releaseDecodeScratch(raw)
+		}
 		return nil, ErrCorrupt, true
 	}
 	dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 	if err != nil {
+		if pooledRaw {
+			f.releaseDecodeScratch(raw)
+		}
 		return nil, err, true
+	}
+	if cacheableRaw {
+		// Publish after copying the selected value. Once grouped cache accepts a
+		// pooled raw buffer, another reader may evict and recycle it.
+		if f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, true) {
+			pooledRaw = false
+		}
+	}
+	if pooledRaw {
+		f.releaseDecodeScratch(raw)
 	}
 	return dst, nil, true
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1042,15 +1042,15 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		}
 		return nil, false, err, true
 	}
-	if cacheableRaw {
-		cachedRaw := f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, rawPooled)
-		if rawPooled && cachedRaw {
+	publishRaw := func() {
+		if cacheableRaw && f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, rawPooled) && rawPooled {
 			rawPooled = false
 		}
 	}
 	// Template decoding allocates new bytes; the returned slice is no longer
 	// backed by dst even if we decoded into it.
 	if decoded {
+		publishRaw()
 		if rawPooled {
 			f.releaseDecodeScratch(raw)
 		}
@@ -1059,6 +1059,9 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	if copyValueToDst {
 		out := dst[:valLen]
 		copy(out, val)
+		// Publish after copying the selected value. Once grouped cache accepts a
+		// pooled raw buffer, another reader may evict and recycle it.
+		publishRaw()
 		if rawPooled {
 			f.releaseDecodeScratch(raw)
 		}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1009,7 +1009,10 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	valLen := int(valEnd - valStart)
 	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
-	cacheableRaw := f.groupedFrameCacheAllowsRaw(int(rawLen))
+	// One-off read paths (dst=nil) should avoid grouped-cache writeback; this
+	// path is dominated by high-concurrency point reads where cache-store lock
+	// traffic can outweigh reuse.
+	cacheableRaw := copyValueToDst && f.groupedFrameCacheAllowsRaw(int(rawLen))
 
 	// When raw payload may be cached, decode into pooled scratch so the grouped
 	// cache can retain ownership and return buffers to the pool on eviction.

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -170,8 +171,8 @@ func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
 	if hits1 != hits0 {
 		t.Fatalf("unexpected grouped-frame hit on first read: before=%d after=%d", hits0, hits1)
 	}
-	if entries1 == 0 {
-		t.Fatalf("expected grouped-frame cache entry after first read")
+	if entries1 != 0 {
+		t.Fatalf("expected no grouped-frame cache entry for nil dst read, got entries=%d", entries1)
 	}
 
 	got2, usedDst2, err, ok := f.readViaMmapViewTo(ptrs[1], false, nil)
@@ -186,11 +187,92 @@ func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
 	}
 
 	hits2, misses2, _, _ := f.groupedFrameCacheStats()
-	if hits2 <= hits1 {
-		t.Fatalf("expected grouped-frame cache hit on second read: before=%d after=%d", hits1, hits2)
+	if hits2 != hits1 {
+		t.Fatalf("unexpected grouped-frame cache hit on second nil-dst read: before=%d after=%d", hits1, hits2)
 	}
-	if misses2 != misses1 {
-		t.Fatalf("unexpected grouped-frame miss increase on second read: before=%d after=%d", misses1, misses2)
+	if misses2 <= misses1 {
+		t.Fatalf("expected grouped-frame miss increase on second nil-dst read: before=%d after=%d", misses1, misses2)
+	}
+}
+
+func TestValueLogGroupedReadParallelThenAppend_NoCorruption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+
+	const frames = 256
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	want := make([][]byte, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, fv := appendCompressedFrameForCacheTestsTB(t, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+		want = append(want, fv...)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(64)
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for w := 0; w < workers; w++ {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := w; i < len(ptrs); i += workers {
+				got, _, readErr := f.ReadUnsafeTo(ptrs[i], false, nil)
+				if readErr != nil {
+					errCh <- fmt.Errorf("unsafe read[%d]: %w", i, readErr)
+					return
+				}
+				if !bytes.Equal(got, want[i]) {
+					errCh <- fmt.Errorf("unsafe read[%d]: payload mismatch", i)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for readErr := range errCh {
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+	}
+
+	var dst []byte
+	for i := range ptrs {
+		dst, err = m.ReadAppend(ptrs[i], dst[:0])
+		if err != nil {
+			t.Fatalf("append read[%d]: %v", i, err)
+		}
+		if !bytes.Equal(dst, want[i]) {
+			t.Fatalf("append read[%d]: payload mismatch", i)
+		}
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -119,7 +119,7 @@ func TestBenchmarkValueLogRandomReadGroupedFrame_ReadUnsafeTo_AllocsBudget(t *te
 	}
 }
 
-func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
+func TestFileReadViaMmapViewTo_DoesNotCacheGroupedFrameWithNilDst(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -1,0 +1,276 @@
+package valuelog
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func appendCompressedFrameForCacheTestsTB(tb testing.TB, writer *Writer, frame int, n int) ([]page.ValuePtr, [][]byte) {
+	tb.Helper()
+	records := make([]Record, n)
+	want := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		v := make([]byte, 384)
+		copy(v, []byte(fmt.Sprintf("frame-%02d-record-%02d:", frame, i)))
+		for j := 48; j < len(v); j++ {
+			v[j] = byte('a' + frame)
+		}
+		records[i] = Record{RID: uint64(frame*100 + i + 1), Value: v}
+		want[i] = append([]byte(nil), v...)
+	}
+	dst := make([]page.ValuePtr, len(records))
+	ptrs, stats, err := writer.AppendFrameWithStatsInto(0, nil, records, dst)
+	if err != nil {
+		tb.Fatalf("append frame %d: %v", frame, err)
+	}
+	if !stats.Kept {
+		tb.Fatalf("expected block-compressed frame %d to be kept", frame)
+	}
+	return ptrs, want
+}
+
+func benchmarkRandomReadGroupedFrameReadUnsafeTo(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("mmap not supported on windows")
+	}
+
+	dir := b.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		b.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		b.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	const frames = 512
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, _ := appendCompressedFrameForCacheTestsTB(b, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+	}
+	if err := writer.Close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		b.Fatalf("new manager: %v", err)
+	}
+	b.Cleanup(func() { _ = m.Close() })
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(4096)
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	// Warm grouped-frame decode cache.
+	dst := make([]byte, 0, 512)
+	for _, ptr := range ptrs {
+		var used bool
+		dst, used, err = f.ReadUnsafeTo(ptr, false, dst[:0])
+		if err != nil {
+			b.Fatalf("warm read: %v", err)
+		}
+		if !used {
+			b.Fatalf("expected warm ReadUnsafeTo to reuse dst")
+		}
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptr := ptrs[rng.Intn(len(ptrs))]
+		var used bool
+		dst, used, err = f.ReadUnsafeTo(ptr, false, dst[:0])
+		if err != nil {
+			b.Fatalf("read: %v", err)
+		}
+		if !used {
+			b.Fatalf("expected ReadUnsafeTo to reuse dst")
+		}
+	}
+}
+
+func BenchmarkValueLogRandomReadGroupedFrame_ReadUnsafeTo(b *testing.B) {
+	benchmarkRandomReadGroupedFrameReadUnsafeTo(b)
+}
+
+func TestBenchmarkValueLogRandomReadGroupedFrame_ReadUnsafeTo_AllocsBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip benchmark alloc gate in short mode")
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		benchmarkRandomReadGroupedFrameReadUnsafeTo(b)
+	})
+	if allocs := res.AllocsPerOp(); allocs > 0 {
+		t.Fatalf("alloc regression: allocs/op=%d want 0", allocs)
+	}
+}
+
+func TestFileReadViaMmapViewTo_CachesGroupedFrameWithNilDst(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	ptrs, want := appendCompressedFrameForCacheTestsTB(t, writer, 0, 4)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(8)
+
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	hits0, misses0, _, _ := f.groupedFrameCacheStats()
+	got1, usedDst1, err, ok := f.readViaMmapViewTo(ptrs[0], false, nil)
+	if err != nil || !ok {
+		t.Fatalf("first read failed: ok=%v err=%v", ok, err)
+	}
+	if usedDst1 {
+		t.Fatalf("expected usedDst=false with nil dst")
+	}
+	if !bytes.Equal(got1, want[0]) {
+		t.Fatalf("first read mismatch")
+	}
+
+	hits1, misses1, entries1, _ := f.groupedFrameCacheStats()
+	if misses1 <= misses0 {
+		t.Fatalf("expected grouped-frame miss on first read: before=%d after=%d", misses0, misses1)
+	}
+	if hits1 != hits0 {
+		t.Fatalf("unexpected grouped-frame hit on first read: before=%d after=%d", hits0, hits1)
+	}
+	if entries1 == 0 {
+		t.Fatalf("expected grouped-frame cache entry after first read")
+	}
+
+	got2, usedDst2, err, ok := f.readViaMmapViewTo(ptrs[1], false, nil)
+	if err != nil || !ok {
+		t.Fatalf("second read failed: ok=%v err=%v", ok, err)
+	}
+	if usedDst2 {
+		t.Fatalf("expected usedDst=false with nil dst")
+	}
+	if !bytes.Equal(got2, want[1]) {
+		t.Fatalf("second read mismatch")
+	}
+
+	hits2, misses2, _, _ := f.groupedFrameCacheStats()
+	if hits2 <= hits1 {
+		t.Fatalf("expected grouped-frame cache hit on second read: before=%d after=%d", hits1, hits2)
+	}
+	if misses2 != misses1 {
+		t.Fatalf("unexpected grouped-frame miss increase on second read: before=%d after=%d", misses1, misses2)
+	}
+}
+
+func TestValueLogManager_RandomReadGroupedFrameAllocBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	const frames = 512
+	const perFrame = 4
+	ptrs := make([]page.ValuePtr, 0, frames*perFrame)
+	want := make([][]byte, 0, frames*perFrame)
+	for i := 0; i < frames; i++ {
+		fp, fv := appendCompressedFrameForCacheTestsTB(t, writer, i, perFrame)
+		ptrs = append(ptrs, fp...)
+		want = append(want, fv...)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(4096)
+
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	// Warm grouped-frame decode cache.
+	for _, ptr := range ptrs {
+		v, err := m.ReadUnsafe(ptr)
+		if err != nil {
+			t.Fatalf("warm read: %v", err)
+		}
+		if len(v) == 0 {
+			t.Fatalf("warm read returned empty value")
+		}
+	}
+	hitsWarm, missesWarm, _, _ := f.groupedFrameCacheStats()
+	if hitsWarm == 0 || missesWarm == 0 {
+		t.Fatalf("expected grouped-frame cache warm-up to produce hits/misses, hits=%d misses=%d", hitsWarm, missesWarm)
+	}
+
+	const readsPerRun = 4000
+	allocsPerRun := testing.AllocsPerRun(20, func() {
+		rng := rand.New(rand.NewSource(1))
+		dst := make([]byte, 0, 512)
+		for i := 0; i < readsPerRun; i++ {
+			idx := rng.Intn(len(ptrs))
+			v, usedDst, err := f.ReadUnsafeTo(ptrs[idx], false, dst[:0])
+			if err != nil {
+				t.Fatalf("read idx=%d: %v", idx, err)
+			}
+			if !usedDst {
+				t.Fatalf("expected ReadUnsafeTo to reuse dst on grouped frame path")
+			}
+			if !bytes.Equal(v, want[idx]) {
+				t.Fatalf("value mismatch idx=%d", idx)
+			}
+			dst = v[:0]
+		}
+	})
+	allocsPerRead := allocsPerRun / float64(readsPerRun)
+	if allocsPerRead > 0.005 {
+		t.Fatalf("alloc regression: allocs/read=%f (allocs/run=%f, reads/run=%d)", allocsPerRead, allocsPerRun, readsPerRun)
+	}
+}

--- a/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
+++ b/TreeDB/internal/valuelog/reader_mmap_alloc_regression_test.go
@@ -276,6 +276,69 @@ func TestValueLogGroupedReadParallelThenAppend_NoCorruption(t *testing.T) {
 	}
 }
 
+func TestValueLogReadAppendDoesNotDoubleOwnGroupedCacheScratch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+
+	ptrs1, want1 := appendCompressedFrameForCacheTestsTB(t, writer, 1, 4)
+	ptrs2, want2 := appendCompressedFrameForCacheTestsTB(t, writer, 2, 4)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(8)
+
+	f := m.files[fileID]
+	f.remapToFileSize()
+
+	dst := make([]byte, 0, 512)
+	dst, err = m.ReadAppend(ptrs1[0], dst[:0])
+	if err != nil {
+		t.Fatalf("first append read: %v", err)
+	}
+	if !bytes.Equal(dst, want1[0]) {
+		t.Fatalf("first append read mismatch")
+	}
+
+	dst, err = m.ReadAppend(ptrs2[0], dst[:0])
+	if err != nil {
+		t.Fatalf("second append read: %v", err)
+	}
+	if !bytes.Equal(dst, want2[0]) {
+		t.Fatalf("second append read mismatch")
+	}
+
+	got, usedDst, readErr := f.ReadUnsafeTo(ptrs1[1], false, dst[:0])
+	if readErr != nil {
+		t.Fatalf("grouped cache read: %v", readErr)
+	}
+	if !usedDst {
+		t.Fatalf("expected grouped cache read to reuse dst")
+	}
+	if !bytes.Equal(got, want1[1]) {
+		t.Fatalf("grouped cache read mismatch after second append read")
+	}
+}
+
 func TestValueLogManager_RandomReadGroupedFrameAllocBudget(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1359,6 +1359,22 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 		"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
 		"treedb.cache.vlog_mmap.read.fallback_readat",
 		"treedb.cache.vlog_mmap.read.hit_ratio",
+		"treedb.vlog.grouped_frame_cache.hits",
+		"treedb.vlog.grouped_frame_cache.misses",
+		"treedb.vlog.grouped_frame_cache.entries",
+		"treedb.vlog.grouped_frame_cache.capacity",
+		"treedb.vlog.grouped_frame_cache.hit_ratio",
+		"treedb.process.read_path.outer_leaf.cache.hits",
+		"treedb.process.read_path.outer_leaf.cache.misses",
+		"treedb.process.read_path.outer_leaf.cache.stores",
+		"treedb.process.read_path.outer_leaf.cache.evictions",
+		"treedb.process.read_path.outer_leaf.cache.entries",
+		"treedb.process.read_path.outer_leaf.cache.capacity",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores",
+		"treedb.vlog.decode_buffer_grow.calls_total",
+		"treedb.vlog.decode_buffer_grow.realloc_calls_total",
+		"treedb.vlog.decode_buffer_grow.realloc_rate",
 		"treedb.cache.vlog_generation.enabled",
 		"treedb.cache.vlog_generation.policy",
 		"treedb.cache.vlog_generation.scheduler_state",
@@ -3886,6 +3902,14 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					vacuumIndexBytes[testName] = bytesMap
 				}
 			}
+
+			// For read tests we want the post-checkpoint state to reflect settled
+			// persisted-tree reads rather than transient queued memtables.
+			if isSettleBeforeScanTest(testName) {
+				if err := waitForTreeDBQueueDrain(instances, 2*time.Second); err != nil {
+					return BenchRun{}, err
+				}
+			}
 		}
 
 		if err := liveTbl.Render(results); err != nil {
@@ -5910,6 +5934,53 @@ func settleBenchInstances(instances []*DBInstance) error {
 		inst.Wrapper = newWrapper
 	}
 	return nil
+}
+
+func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		pending := false
+		for _, inst := range instances {
+			if inst == nil || inst.Wrapper == nil || !isTreeDBInstance(inst) {
+				continue
+			}
+			sp, ok := inst.Wrapper.(kvstore.StatsProvider)
+			if !ok {
+				continue
+			}
+			stats := sp.Stats()
+			if len(stats) == 0 {
+				continue
+			}
+			if parseStatInt(stats, "treedb.cache.queue_len") > 0 {
+				pending = true
+				break
+			}
+			if parseStatInt(stats, "treedb.cache.queue_backlog_bytes") > 0 {
+				pending = true
+				break
+			}
+		}
+		if !pending {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("checkpoint settle timeout: treedb cache queue did not drain within %s", timeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func parseStatInt(stats map[string]string, key string) int64 {
+	raw, ok := stats[key]
+	if !ok {
+		return 0
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }
 
 func containsAny(list []string, items ...string) bool {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -5952,11 +5952,11 @@ func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) err
 			if len(stats) == 0 {
 				continue
 			}
-			if parseStatInt(stats, "treedb.cache.queue_len") > 0 {
+			if queueLen, ok := parseStatInt64(stats, "treedb.cache.queue_len"); ok && queueLen > 0 {
 				pending = true
 				break
 			}
-			if parseStatInt(stats, "treedb.cache.queue_backlog_bytes") > 0 {
+			if backlogBytes, ok := parseStatInt64(stats, "treedb.cache.queue_backlog_bytes"); ok && backlogBytes > 0 {
 				pending = true
 				break
 			}
@@ -5969,18 +5969,6 @@ func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) err
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-}
-
-func parseStatInt(stats map[string]string, key string) int64 {
-	raw, ok := stats[key]
-	if !ok {
-		return 0
-	}
-	v, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return v
 }
 
 func containsAny(list []string, items ...string) bool {


### PR DESCRIPTION
## Summary

This is a clean replacement path for #1485/#1482, rebuilt directly on current `main` after #1468, #1475, #1476, #1478, #1479, and #1480 landed.

It keeps the intended read-path delta without the old mixed-track merge history:

- reduce random-read decode allocation churn
- add mmap/grouped-read allocation regression coverage
- split grouped-frame cache and decode scratch locking away from the general cache lock
- fix grouped-read corruption while preserving random-read parallel hitrate
- preserve published miss fallback semantics and the `AcquireSnapshot` warm-path allocation budget after the port
- address AI review ownership issues in grouped-cache pooled-buffer handoff paths

Supersedes the noisy/conflicting #1485/#1482 branch shape.

## Validation

Targeted tests:

- `GOWORK=off go test ./TreeDB/internal/valuelog -count=1`
- `GOWORK=off go test ./TreeDB/caching ./cmd/unified_bench -count=1`
- Prior branch validation after port: `GOWORK=off go test ./TreeDB/db -count=1`

Focused perf/parity gate:

- baseline: `origin/main` at `08f62b28`
- branch head: `d742404e`
- command shape: `unified-bench -dbs treedb -profile fast -keys 200000 -test sequential_write,random_read_parallel -read-workers 8 -read-require-hit -path-label native-fastpath -progress=false -keep=false -seed 1 -profile-dir ...`
- measured rounds after warmup:
  - main mean random_read_parallel: `4,503,520 ops/s`
  - branch mean random_read_parallel: `4,847,614 ops/s` (`+7.64%`)
  - main median: `4,478,728 ops/s`
  - branch median: `4,844,560 ops/s` (`+8.17%`)
  - sampled alloc profile: main `28.56MB`, branch `8.37MB`

Perf artifacts: `/tmp/gomap_1485_clean_perf_20260512_130246/`
