### PR TITLE
test: expose TreeDB queued snapshot read-after-write misses

### DIFF
--- a/TreeDB/read_after_write_snapshot_contract_test.go
+++ b/TreeDB/read_after_write_snapshot_contract_test.go
@@ -1,0 +1,215 @@
+package treedb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+const queuedSnapshotContractValueSize = 128
+
+func queuedSnapshotContractKey(dst []byte, n int) {
+	binary.BigEndian.PutUint64(dst, uint64(n))
+}
+
+type queuedSnapshotContractGetter interface {
+	Get(key []byte) ([]byte, error)
+}
+
+type queuedSnapshotContractAppendGetter interface {
+	GetAppend(key, dst []byte) ([]byte, error)
+}
+
+func openQueuedSnapshotContractDB(t *testing.T, profile Profile, keys int) *DB {
+	t.Helper()
+
+	opts := OptionsFor(profile, t.TempDir())
+	opts.FlushThreshold = 1 << 30
+	opts.MemtableMode = "adaptive"
+	opts.MemtableShards = 16
+	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.DisableBackgroundPrune = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open(%s): %v", profile, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	value := bytes.Repeat([]byte{0x5a}, queuedSnapshotContractValueSize)
+	var key [8]byte
+	for i := 0; i < keys; i++ {
+		queuedSnapshotContractKey(key[:], i)
+		if err := db.Set(key[:], value); err != nil {
+			t.Fatalf("Set(%d): %v", i, err)
+		}
+	}
+	return db
+}
+
+func runQueuedSnapshotContractWorkers(t *testing.T, workers int, workerFn func(worker int, stop *atomic.Bool) error) {
+	t.Helper()
+
+	var stop atomic.Bool
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := workerFn(worker, &stop); err != nil && stop.CompareAndSwap(false, true) {
+				select {
+				case errCh <- fmt.Errorf("worker %d: %w", worker, err):
+				default:
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func assertQueuedSnapshotContractGet(t *testing.T, getter queuedSnapshotContractGetter, keys, reads int, seed int64, stop *atomic.Bool) error {
+	t.Helper()
+
+	rng := rand.New(rand.NewSource(seed))
+	var key [8]byte
+	for i := 0; i < reads; i++ {
+		if stop != nil && stop.Load() {
+			return nil
+		}
+		idx := rng.Intn(keys)
+		queuedSnapshotContractKey(key[:], idx)
+		got, err := getter.Get(key[:])
+		if err != nil {
+			return fmt.Errorf("iter=%d key=%d: %w", i, idx, err)
+		}
+		if len(got) != queuedSnapshotContractValueSize {
+			return fmt.Errorf("iter=%d key=%d: len=%d want=%d", i, idx, len(got), queuedSnapshotContractValueSize)
+		}
+	}
+	return nil
+}
+
+func assertQueuedSnapshotContractGetAppend(t *testing.T, getter queuedSnapshotContractAppendGetter, keys, reads int, seed int64, stop *atomic.Bool) error {
+	t.Helper()
+
+	rng := rand.New(rand.NewSource(seed))
+	var key [8]byte
+	buf := make([]byte, 0, queuedSnapshotContractValueSize)
+	for i := 0; i < reads; i++ {
+		if stop != nil && stop.Load() {
+			return nil
+		}
+		idx := rng.Intn(keys)
+		queuedSnapshotContractKey(key[:], idx)
+		var err error
+		buf, err = getter.GetAppend(key[:], buf[:0])
+		if err != nil {
+			return fmt.Errorf("iter=%d key=%d: %w", i, idx, err)
+		}
+		if len(buf) != queuedSnapshotContractValueSize {
+			return fmt.Errorf("iter=%d key=%d: len=%d want=%d", i, idx, len(buf), queuedSnapshotContractValueSize)
+		}
+	}
+	return nil
+}
+
+func TestProfileFast_ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_AccessMatrix(t *testing.T) {
+	const (
+		keys    = 140_000
+		workers = 8
+	)
+
+	t.Run("shared_snapshot_get", func(t *testing.T) {
+		db := openQueuedSnapshotContractDB(t, ProfileFast, keys)
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("AcquireSnapshot returned nil")
+		}
+		defer func() { _ = snap.Close() }()
+
+		runQueuedSnapshotContractWorkers(t, workers, func(worker int, stop *atomic.Bool) error {
+			return assertQueuedSnapshotContractGet(t, snap, keys, keys, 1+int64(worker), stop)
+		})
+	})
+
+	t.Run("per_worker_snapshot_get", func(t *testing.T) {
+		db := openQueuedSnapshotContractDB(t, ProfileFast, keys)
+		runQueuedSnapshotContractWorkers(t, workers, func(worker int, stop *atomic.Bool) error {
+			snap := db.AcquireSnapshot()
+			if snap == nil {
+				return fmt.Errorf("AcquireSnapshot returned nil")
+			}
+			defer func() { _ = snap.Close() }()
+			return assertQueuedSnapshotContractGet(t, snap, keys, keys, 1+int64(worker), stop)
+		})
+	})
+
+	t.Run("per_worker_snapshot_getappend", func(t *testing.T) {
+		db := openQueuedSnapshotContractDB(t, ProfileFast, keys)
+		runQueuedSnapshotContractWorkers(t, workers, func(worker int, stop *atomic.Bool) error {
+			snap := db.AcquireSnapshot()
+			if snap == nil {
+				return fmt.Errorf("AcquireSnapshot returned nil")
+			}
+			defer func() { _ = snap.Close() }()
+			return assertQueuedSnapshotContractGetAppend(t, snap, keys, keys, 1+int64(worker), stop)
+		})
+	})
+}
+
+func TestReadSnapshotsSeeQueuedWritesBeforeCheckpoint_ProfileMatrix(t *testing.T) {
+	const (
+		keys    = 140_000
+		workers = 8
+	)
+
+	profiles := []Profile{ProfileFast, ProfileWALOnFast, ProfileDurable}
+	for _, profile := range profiles {
+		profile := profile
+		t.Run(string(profile), func(t *testing.T) {
+			db := openQueuedSnapshotContractDB(t, profile, keys)
+			runQueuedSnapshotContractWorkers(t, workers, func(worker int, stop *atomic.Bool) error {
+				snap := db.AcquireSnapshot()
+				if snap == nil {
+					return fmt.Errorf("AcquireSnapshot returned nil")
+				}
+				defer func() { _ = snap.Close() }()
+				return assertQueuedSnapshotContractGetAppend(t, snap, keys, keys, 1+int64(worker), stop)
+			})
+		})
+	}
+}
+
+func TestReadSnapshotsSeeQueuedWritesAfterCheckpoint_Control(t *testing.T) {
+	const (
+		keys    = 140_000
+		workers = 8
+	)
+
+	db := openQueuedSnapshotContractDB(t, ProfileFast, keys)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	runQueuedSnapshotContractWorkers(t, workers, func(worker int, stop *atomic.Bool) error {
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			return fmt.Errorf("AcquireSnapshot returned nil")
+		}
+		defer func() { _ = snap.Close() }()
+		return assertQueuedSnapshotContractGetAppend(t, snap, keys, keys, 1+int64(worker), stop)
+	})
+}

--- a/TreeDB/read_after_write_snapshot_contract_test.go
+++ b/TreeDB/read_after_write_snapshot_contract_test.go
@@ -26,6 +26,9 @@ type queuedSnapshotContractAppendGetter interface {
 
 func openQueuedSnapshotContractDB(t *testing.T, profile Profile, keys int) *DB {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("queued snapshot read-after-write regression matrix is intentionally heavy")
+	}
 
 	opts := OptionsFor(profile, t.TempDir())
 	opts.FlushThreshold = 1 << 30

--- a/TreeDB/read_after_write_snapshot_contract_test.go
+++ b/TreeDB/read_after_write_snapshot_contract_test.go
@@ -35,6 +35,9 @@ func openQueuedSnapshotContractDB(t *testing.T, profile Profile, keys int) *DB {
 	opts.MemtableMode = "adaptive"
 	opts.MemtableShards = 16
 	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
 	opts.BackgroundIndexVacuumInterval = -1
 	opts.DisableBackgroundPrune = true
 

--- a/cmd/unified_bench/read_snapshot_guardrail_test.go
+++ b/cmd/unified_bench/read_snapshot_guardrail_test.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
 )
 
 func TestRunBenchmark_ReadSnapshotAppendOnlyGuardrail(t *testing.T) {
@@ -147,20 +149,10 @@ func withTreeDBFastReadRequireHitFlags(t *testing.T) {
 		*treedbValueLogThreshold = prevValueLogThreshold
 	})
 
+	applyTreeDBProfileIfUnset(treedb.ProfileFast, map[string]bool{})
+
 	*readWorkers = 8
 	*treedbAllowUnsafe = true
-	*treedbDisableWAL = true
-	*treedbRelaxedSync = true
-	*treedbDisableReadChecksum = true
-	*treedbIndexOptimizations = true
-	*treedbIndexOuterLeavesInVlog = true
-	*treedbPreferAppendAlloc = false
-	*treedbVlogCompression = "default"
-	*treedbVlogBlockCodec = "snappy"
-	*treedbVlogAutoPolicy = "balanced"
-	*treedbVlogCompressionAutotune = "medium"
-	*treedbVlogDictIncompressibleHoldBytes = 64 << 20
-	*treedbVlogDictProbeIntervalBytes = 8 << 20
 	*treedbVlogGenerationPolicy = "default"
 	*treedbFlushThreshold = 64 << 20
 	*treedbMaxQueuedMems = 0

--- a/cmd/unified_bench/read_snapshot_guardrail_test.go
+++ b/cmd/unified_bench/read_snapshot_guardrail_test.go
@@ -69,6 +69,9 @@ func TestRunBenchmark_ReadSnapshotAppendOnlyGuardrail(t *testing.T) {
 }
 
 func TestRunBenchmark_ProfileFastReadRequireHitBeforeCheckpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("profile-fast read-require-hit regression guardrail is intentionally heavy")
+	}
 	withTreeDBFastReadRequireHitFlags(t)
 
 	for attempt := 1; attempt <= 3; attempt++ {

--- a/cmd/unified_bench/read_snapshot_guardrail_test.go
+++ b/cmd/unified_bench/read_snapshot_guardrail_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -65,4 +66,102 @@ func TestRunBenchmark_ReadSnapshotAppendOnlyGuardrail(t *testing.T) {
 	}
 	t.Logf("append-only snapshot guardrail ops/s: parallel=%.0f snapshot=%.0f ratio=%.6f",
 		parallelRead, snapshotRead, ratio)
+}
+
+func TestRunBenchmark_ProfileFastReadRequireHitBeforeCheckpoint(t *testing.T) {
+	withTreeDBFastReadRequireHitFlags(t)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		attempt := attempt
+		t.Run(fmt.Sprintf("attempt_%d", attempt), func(t *testing.T) {
+			_, err := runBenchmark(BenchConfig{
+				Keys:           160_000,
+				ValueSize:      128,
+				BatchSize:      8_000,
+				ReadWorkers:    8,
+				ReadRequireHit: true,
+				RangeQueries:   0,
+				RangeSpan:      0,
+				DBsArg:         "treedb",
+				TestsArg:       "sequential_write,random_read_parallel",
+				Profile:        "fast",
+				KeepDir:        false,
+				Progress:       false,
+				SeedUsed:       1,
+				MaxWall:        30 * time.Second,
+			})
+			if err != nil {
+				t.Fatalf("TreeDB read-after-write hit contract failed before checkpoint: %v", err)
+			}
+		})
+	}
+}
+
+func withTreeDBFastReadRequireHitFlags(t *testing.T) {
+	t.Helper()
+
+	prevReadWorkers := *readWorkers
+	prevAllowUnsafe := *treedbAllowUnsafe
+	prevDisableWAL := *treedbDisableWAL
+	prevRelaxedSync := *treedbRelaxedSync
+	prevDisableReadChecksum := *treedbDisableReadChecksum
+	prevIndexOptimizations := *treedbIndexOptimizations
+	prevIndexOuterLeavesInVlog := *treedbIndexOuterLeavesInVlog
+	prevPreferAppendAlloc := *treedbPreferAppendAlloc
+	prevVlogCompression := *treedbVlogCompression
+	prevVlogBlockCodec := *treedbVlogBlockCodec
+	prevVlogAutoPolicy := *treedbVlogAutoPolicy
+	prevVlogCompressionAutotune := *treedbVlogCompressionAutotune
+	prevVlogDictIncompressibleHoldBytes := *treedbVlogDictIncompressibleHoldBytes
+	prevVlogDictProbeIntervalBytes := *treedbVlogDictProbeIntervalBytes
+	prevVlogGenerationPolicy := *treedbVlogGenerationPolicy
+	prevFlushThreshold := *treedbFlushThreshold
+	prevMaxQueuedMems := *treedbMaxQueuedMems
+	prevMemtableMode := *treedbMemtableMode
+	prevForcePointers := *treedbForceValuePointers
+	prevValueLogThreshold := *treedbValueLogThreshold
+
+	t.Cleanup(func() {
+		*readWorkers = prevReadWorkers
+		*treedbAllowUnsafe = prevAllowUnsafe
+		*treedbDisableWAL = prevDisableWAL
+		*treedbRelaxedSync = prevRelaxedSync
+		*treedbDisableReadChecksum = prevDisableReadChecksum
+		*treedbIndexOptimizations = prevIndexOptimizations
+		*treedbIndexOuterLeavesInVlog = prevIndexOuterLeavesInVlog
+		*treedbPreferAppendAlloc = prevPreferAppendAlloc
+		*treedbVlogCompression = prevVlogCompression
+		*treedbVlogBlockCodec = prevVlogBlockCodec
+		*treedbVlogAutoPolicy = prevVlogAutoPolicy
+		*treedbVlogCompressionAutotune = prevVlogCompressionAutotune
+		*treedbVlogDictIncompressibleHoldBytes = prevVlogDictIncompressibleHoldBytes
+		*treedbVlogDictProbeIntervalBytes = prevVlogDictProbeIntervalBytes
+		*treedbVlogGenerationPolicy = prevVlogGenerationPolicy
+		*treedbFlushThreshold = prevFlushThreshold
+		*treedbMaxQueuedMems = prevMaxQueuedMems
+		*treedbMemtableMode = prevMemtableMode
+		*treedbForceValuePointers = prevForcePointers
+		*treedbValueLogThreshold = prevValueLogThreshold
+	})
+
+	*readWorkers = 8
+	*treedbAllowUnsafe = true
+	*treedbDisableWAL = true
+	*treedbRelaxedSync = true
+	*treedbDisableReadChecksum = true
+	*treedbIndexOptimizations = true
+	*treedbIndexOuterLeavesInVlog = true
+	*treedbPreferAppendAlloc = false
+	*treedbVlogCompression = "default"
+	*treedbVlogBlockCodec = "snappy"
+	*treedbVlogAutoPolicy = "balanced"
+	*treedbVlogCompressionAutotune = "medium"
+	*treedbVlogDictIncompressibleHoldBytes = 64 << 20
+	*treedbVlogDictProbeIntervalBytes = 8 << 20
+	*treedbVlogGenerationPolicy = "default"
+	*treedbFlushThreshold = 64 << 20
+	*treedbMaxQueuedMems = 0
+	*treedbMemtableMode = ""
+	*treedbForceValuePointers = false
+	*treedbValueLogThreshold = 0
 }


### PR DESCRIPTION
## Summary

Adds failing regression coverage for the queued snapshot read-after-write contract bug on current `main`.

The tests intentionally assert the contract we expect to restore: after sequential writes, TreeDB read snapshots must see all queued writes before an explicit checkpoint. A checkpointed control test is included and passes, which distinguishes this from permanent data loss.

## Coverage added

- Public TreeDB API access matrix:
  - shared snapshot + `Get`
  - per-worker snapshots + `Get`
  - per-worker snapshots + `GetAppend`
- Public TreeDB durability profile matrix:
  - `ProfileFast`
  - `ProfileWALOnFast`
  - `ProfileDurable`
- Unified benchmark guardrail matching the failing shape:
  - `sequential_write,random_read_parallel`
  - `ReadRequireHit=true`
  - profile-fast TreeDB options
  - no `CheckpointBetweenTests`

## Current validation

Expected red tests on current main:

```sh
GOWORK=off go test ./TreeDB -run 'Test(ProfileFast_ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_AccessMatrix|ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_ProfileMatrix|ReadSnapshotsSeeQueuedWritesAfterCheckpoint_Control)' -count=1
```

Fails the before-checkpoint access/profile matrix with `key not found`; the checkpoint control passes when run alone:

```sh
GOWORK=off go test ./TreeDB -run '^TestReadSnapshotsSeeQueuedWritesAfterCheckpoint_Control$' -count=1
```

Expected red benchmark guardrail:

```sh
GOWORK=off go test ./cmd/unified_bench -run '^TestRunBenchmark_ProfileFastReadRequireHitBeforeCheckpoint$' -count=1
```

Fails with `random_read_parallel: key not found`.

## Notes

This PR is intentionally draft/red. It is the TDD harness for the follow-up fix.
