### PR TITLE
fix queued snapshot memtable retirement

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6536,6 +6536,9 @@ type DB struct {
 	appendOnlyDirectArenaLeaseMu     sync.Mutex
 	appendOnlyDirectArenaLeasesByMem map[memtable.Table]*appendOnlyDirectArenaLease
 	pendingRetiredMems               []memtable.Table
+	retiredMemtablesMu               sync.Mutex
+	deferredRetiredMemtables         []memtable.Table
+	memtableViewReaders              atomic.Int64
 	// closingEmptyMemsMu guards closingEmptyByView. The map holds per-view
 	// lists of mutable memtables that should be released once the last reader
 	// drops the view, registered by releaseClosingEmptyMemtables at DB close.
@@ -7591,6 +7594,7 @@ func (db *DB) retainMemtableView() *memtableView {
 		// Fast path: published views keep a baseline ref, so this is usually one
 		// atomic add and return.
 		if n := view.refs.Add(1); n > 1 {
+			db.memtableViewReaders.Add(1)
 			db.noteMemtableViewRetain()
 			return view
 		}
@@ -7601,6 +7605,7 @@ func (db *DB) retainMemtableView() *memtableView {
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
+			db.memtableViewReaders.Add(1)
 			db.noteMemtableViewRetain()
 			return view
 		}
@@ -7617,6 +7622,7 @@ func (db *DB) retainMemtableViewUntracked() *memtableView {
 			return nil
 		}
 		if n := view.refs.Add(1); n > 1 {
+			db.memtableViewReaders.Add(1)
 			return view
 		}
 		view.refs.Add(-1)
@@ -7624,25 +7630,35 @@ func (db *DB) retainMemtableViewUntracked() *memtableView {
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
+			db.memtableViewReaders.Add(1)
 			return view
 		}
 	}
 }
 
 func (db *DB) releaseMemtableView(view *memtableView) {
-	db.releaseMemtableViewRef(view, true)
+	db.releaseMemtableViewRef(view, true, true)
 }
 
 func (db *DB) releasePublishedMemtableView(view *memtableView) {
-	db.releaseMemtableViewRef(view, false)
+	db.releaseMemtableViewRef(view, false, false)
 }
 
-func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool) {
+func (db *DB) releaseUntrackedMemtableView(view *memtableView) {
+	db.releaseMemtableViewRef(view, false, true)
+}
+
+func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, readerRelease bool) {
 	if db == nil || view == nil {
 		return
 	}
 	if leaseRelease {
 		db.noteMemtableViewRelease()
+	}
+	if readerRelease {
+		if readers := db.memtableViewReaders.Add(-1); readers == 0 {
+			defer db.drainDeferredRetiredMemtables()
+		}
 	}
 	if refs := view.refs.Add(-1); refs != 0 {
 		if refs > 0 && view.deferredRetiredMemtables.Load() > 0 {
@@ -7662,6 +7678,34 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool) {
 	}
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
+}
+
+func (db *DB) deferRetiredMemtables(mems []memtable.Table) {
+	if db == nil || len(mems) == 0 {
+		return
+	}
+	db.retiredMemtablesMu.Lock()
+	db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, mems...)
+	shouldDrain := db.memtableViewReaders.Load() == 0
+	db.retiredMemtablesMu.Unlock()
+	if shouldDrain {
+		db.drainDeferredRetiredMemtables()
+	}
+}
+
+func (db *DB) drainDeferredRetiredMemtables() {
+	if db == nil || db.memtableViewReaders.Load() != 0 {
+		return
+	}
+	db.retiredMemtablesMu.Lock()
+	if db.memtableViewReaders.Load() != 0 || len(db.deferredRetiredMemtables) == 0 {
+		db.retiredMemtablesMu.Unlock()
+		return
+	}
+	mems := db.deferredRetiredMemtables
+	db.deferredRetiredMemtables = nil
+	db.retiredMemtablesMu.Unlock()
+	db.recycleMemtables(mems)
 }
 
 func (db *DB) releaseClosingEmptyMemtables() {
@@ -8199,14 +8243,27 @@ func (db *DB) publishMemtablesLocked() {
 	old := db.memtables.Swap(view)
 	if old != nil {
 		if len(retired) > 0 {
-			old.retiredMems = append(old.retiredMems, retired...)
-			old.deferredRetiredMemtables.Store(int64(len(old.retiredMems)))
-			old.deferredRetiredBytes.Add(memtableBytesTotal(retired))
+			// A retained snapshot can reference queued memtables through an older
+			// view than the one being unpublished here. If any external view is in
+			// flight, hold retired memtables at DB scope until all views drain;
+			// otherwise a later flush can recycle a table still visible to that
+			// older snapshot.
+			if db.memtableViewReaders.Load() > 0 || old.refs.Load() > 1 {
+				db.deferRetiredMemtables(retired)
+			} else {
+				old.retiredMems = append(old.retiredMems, retired...)
+				old.deferredRetiredMemtables.Store(int64(len(old.retiredMems)))
+				old.deferredRetiredBytes.Add(memtableBytesTotal(retired))
+			}
 		}
 		db.releasePublishedMemtableView(old)
 		return
 	}
-	db.recycleMemtables(retired)
+	if db.memtableViewReaders.Load() > 0 {
+		db.deferRetiredMemtables(retired)
+	} else {
+		db.recycleMemtables(retired)
+	}
 }
 
 // ensureQueueLaneIDsLocked keeps queueLaneIDs aligned with queue length.
@@ -23853,7 +23910,7 @@ func (db *DB) Stats() map[string]string {
 	if view := db.retainMemtableViewUntracked(); view != nil {
 		mutableTables = append(mutableTables, view.mutables...)
 		queueTables = append(queueTables, view.queue...)
-		db.releaseMemtableViewRef(view, false)
+		db.releaseUntrackedMemtableView(view)
 	} else {
 		db.mu.RLock()
 		if len(db.mutableShards) > 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6458,6 +6458,11 @@ type memtableViewLifecycleTelemetry struct {
 	oldestDeferredUnixNano atomic.Int64
 }
 
+type deferredRetiredMemtables struct {
+	mems  []memtable.Table
+	views map[*memtableView]struct{}
+}
+
 type DB struct {
 	mu          sync.RWMutex
 	flushMu     sync.Mutex
@@ -6537,7 +6542,8 @@ type DB struct {
 	appendOnlyDirectArenaLeasesByMem map[memtable.Table]*appendOnlyDirectArenaLease
 	pendingRetiredMems               []memtable.Table
 	retiredMemtablesMu               sync.Mutex
-	deferredRetiredMemtables         []memtable.Table
+	retainedMemtableViews            map[*memtableView]int
+	deferredRetiredMemtables         []deferredRetiredMemtables
 	memtableViewReaders              atomic.Int64
 	// closingEmptyMemsMu guards closingEmptyByView. The map holds per-view
 	// lists of mutable memtables that should be released once the last reader
@@ -7592,10 +7598,10 @@ func (db *DB) retainMemtableView() *memtableView {
 			return nil
 		}
 		// Register the external reader before making the view ref visible. The
-		// retire path uses this counter to decide whether queued memtables can be
-		// recycled globally, so refs must not briefly exceed the published baseline
-		// while the reader counter is still zero.
-		db.memtableViewReaders.Add(1)
+		// retire path records exactly which retained views still reference a
+		// retired table, so refs must not briefly exceed the published baseline
+		// while the reader registry cannot see the view yet.
+		db.registerMemtableViewReader(view)
 		// Fast path: published views keep a baseline ref, so this is usually one
 		// atomic add and return.
 		if n := view.refs.Add(1); n > 1 {
@@ -7606,14 +7612,14 @@ func (db *DB) retainMemtableView() *memtableView {
 		// published view, in which case self-heal by restoring baseline+caller refs.
 		view.refs.Add(-1)
 		if db.memtables.Load() != view {
-			db.releaseAbandonedMemtableViewReader()
+			db.releaseAbandonedMemtableViewReader(view)
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
 			db.noteMemtableViewRetain()
 			return view
 		}
-		db.releaseAbandonedMemtableViewReader()
+		db.releaseAbandonedMemtableViewReader(view)
 	}
 }
 
@@ -7626,19 +7632,19 @@ func (db *DB) retainMemtableViewUntracked() *memtableView {
 		if view == nil {
 			return nil
 		}
-		db.memtableViewReaders.Add(1)
+		db.registerMemtableViewReader(view)
 		if n := view.refs.Add(1); n > 1 {
 			return view
 		}
 		view.refs.Add(-1)
 		if db.memtables.Load() != view {
-			db.releaseAbandonedMemtableViewReader()
+			db.releaseAbandonedMemtableViewReader(view)
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
 			return view
 		}
-		db.releaseAbandonedMemtableViewReader()
+		db.releaseAbandonedMemtableViewReader(view)
 	}
 }
 
@@ -7662,9 +7668,7 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, read
 		db.noteMemtableViewRelease()
 	}
 	if readerRelease {
-		if readers := db.memtableViewReaders.Add(-1); readers == 0 {
-			defer db.drainDeferredRetiredMemtables()
-		}
+		defer db.unregisterMemtableViewReader(view)
 	}
 	if refs := view.refs.Add(-1); refs != 0 {
 		if refs > 0 && view.deferredRetiredMemtables.Load() > 0 {
@@ -7686,41 +7690,132 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, read
 	view.retiredMems = nil
 }
 
-func (db *DB) releaseAbandonedMemtableViewReader() {
+func (db *DB) releaseAbandonedMemtableViewReader(view *memtableView) {
 	if db == nil {
 		return
 	}
-	if readers := db.memtableViewReaders.Add(-1); readers == 0 {
-		db.drainDeferredRetiredMemtables()
+	db.unregisterMemtableViewReader(view)
+}
+
+func (db *DB) registerMemtableViewReader(view *memtableView) {
+	if db == nil || view == nil {
+		return
 	}
+	db.retiredMemtablesMu.Lock()
+	if db.retainedMemtableViews == nil {
+		db.retainedMemtableViews = make(map[*memtableView]int)
+	}
+	db.retainedMemtableViews[view]++
+	db.memtableViewReaders.Add(1)
+	db.retiredMemtablesMu.Unlock()
+}
+
+func (db *DB) unregisterMemtableViewReader(view *memtableView) {
+	if db == nil {
+		return
+	}
+	var reclaim []memtable.Table
+	released := false
+	db.retiredMemtablesMu.Lock()
+	if view != nil && db.retainedMemtableViews != nil {
+		if refs := db.retainedMemtableViews[view]; refs > 1 {
+			db.retainedMemtableViews[view] = refs - 1
+			released = true
+		} else {
+			delete(db.retainedMemtableViews, view)
+			reclaim = append(reclaim, db.releaseDeferredRetiredMemtablesForViewLocked(view)...)
+			released = refs == 1
+		}
+	}
+	if released {
+		db.memtableViewReaders.Add(-1)
+	}
+	db.retiredMemtablesMu.Unlock()
+	db.recycleMemtables(reclaim)
 }
 
 func (db *DB) deferRetiredMemtables(mems []memtable.Table) {
 	if db == nil || len(mems) == 0 {
 		return
 	}
+	var reclaim []memtable.Table
 	db.retiredMemtablesMu.Lock()
-	db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, mems...)
-	shouldDrain := db.memtableViewReaders.Load() == 0
-	db.retiredMemtablesMu.Unlock()
-	if shouldDrain {
-		db.drainDeferredRetiredMemtables()
+	views := db.retainedViewsReferencingMemtablesLocked(mems)
+	if len(views) == 0 {
+		reclaim = append(reclaim, mems...)
+	} else {
+		db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, deferredRetiredMemtables{
+			mems:  mems,
+			views: views,
+		})
 	}
+	db.retiredMemtablesMu.Unlock()
+	db.recycleMemtables(reclaim)
 }
 
-func (db *DB) drainDeferredRetiredMemtables() {
-	if db == nil || db.memtableViewReaders.Load() != 0 {
-		return
+func (db *DB) retainedViewsReferencingMemtablesLocked(mems []memtable.Table) map[*memtableView]struct{} {
+	if db == nil || len(mems) == 0 || len(db.retainedMemtableViews) == 0 {
+		return nil
 	}
-	db.retiredMemtablesMu.Lock()
-	if db.memtableViewReaders.Load() != 0 || len(db.deferredRetiredMemtables) == 0 {
-		db.retiredMemtablesMu.Unlock()
-		return
+	memSet := make(map[memtable.Table]struct{}, len(mems))
+	for _, mt := range mems {
+		if mt != nil {
+			memSet[mt] = struct{}{}
+		}
 	}
-	mems := db.deferredRetiredMemtables
-	db.deferredRetiredMemtables = nil
-	db.retiredMemtablesMu.Unlock()
-	db.recycleMemtables(mems)
+	if len(memSet) == 0 {
+		return nil
+	}
+	var views map[*memtableView]struct{}
+	for view, refs := range db.retainedMemtableViews {
+		if refs <= 0 || !memtableViewReferencesAny(view, memSet) {
+			continue
+		}
+		if views == nil {
+			views = make(map[*memtableView]struct{})
+		}
+		views[view] = struct{}{}
+	}
+	return views
+}
+
+func memtableViewReferencesAny(view *memtableView, memSet map[memtable.Table]struct{}) bool {
+	if view == nil || len(memSet) == 0 {
+		return false
+	}
+	for _, mt := range view.mutables {
+		if _, ok := memSet[mt]; ok {
+			return true
+		}
+	}
+	for _, mt := range view.queue {
+		if _, ok := memSet[mt]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (db *DB) releaseDeferredRetiredMemtablesForViewLocked(view *memtableView) []memtable.Table {
+	if db == nil || view == nil || len(db.deferredRetiredMemtables) == 0 {
+		return nil
+	}
+	var reclaim []memtable.Table
+	dst := db.deferredRetiredMemtables[:0]
+	for i := range db.deferredRetiredMemtables {
+		held := db.deferredRetiredMemtables[i]
+		delete(held.views, view)
+		if len(held.views) == 0 {
+			reclaim = append(reclaim, held.mems...)
+			continue
+		}
+		dst = append(dst, held)
+	}
+	for i := len(dst); i < len(db.deferredRetiredMemtables); i++ {
+		db.deferredRetiredMemtables[i] = deferredRetiredMemtables{}
+	}
+	db.deferredRetiredMemtables = dst
+	return reclaim
 }
 
 func (db *DB) releaseClosingEmptyMemtables() {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6461,6 +6461,8 @@ type memtableViewLifecycleTelemetry struct {
 type deferredRetiredMemtablesHold struct {
 	mems          []memtable.Table
 	views         map[*memtableView]struct{}
+	memtables     int64
+	bytes         int64
 	sinceUnixNano int64
 }
 
@@ -7633,19 +7635,16 @@ func (db *DB) retainMemtableViewUntracked() *memtableView {
 		if view == nil {
 			return nil
 		}
-		db.registerMemtableViewReader(view)
 		if n := view.refs.Add(1); n > 1 {
 			return view
 		}
 		view.refs.Add(-1)
 		if db.memtables.Load() != view {
-			db.releaseAbandonedMemtableViewReader(view)
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
 			return view
 		}
-		db.releaseAbandonedMemtableViewReader(view)
 	}
 }
 
@@ -7735,24 +7734,26 @@ func (db *DB) unregisterMemtableViewReader(view *memtableView) {
 	db.recycleMemtables(reclaim)
 }
 
-func (db *DB) deferRetiredMemtables(mems []memtable.Table) {
+func (db *DB) deferRetiredMemtables(mems []memtable.Table) bool {
 	if db == nil || len(mems) == 0 {
-		return
+		return false
 	}
-	var reclaim []memtable.Table
+	held := false
 	db.retiredMemtablesMu.Lock()
 	views := db.retainedViewsReferencingMemtablesLocked(mems)
-	if len(views) == 0 {
-		reclaim = append(reclaim, mems...)
-	} else {
+	if len(views) > 0 {
+		heldMems := append([]memtable.Table(nil), mems...)
 		db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, deferredRetiredMemtablesHold{
-			mems:          mems,
+			mems:          heldMems,
 			views:         views,
+			memtables:     int64(len(heldMems)),
+			bytes:         memtableBytesTotal(heldMems),
 			sinceUnixNano: time.Now().UnixNano(),
 		})
+		held = true
 	}
 	db.retiredMemtablesMu.Unlock()
-	db.recycleMemtables(reclaim)
+	return held
 }
 
 func (db *DB) retainedViewsReferencingMemtablesLocked(mems []memtable.Table) map[*memtableView]struct{} {
@@ -7828,8 +7829,8 @@ func (db *DB) deferredRetiredMemtableHoldStats() (groups int64, memtables int64,
 	defer db.retiredMemtablesMu.Unlock()
 	for _, held := range db.deferredRetiredMemtables {
 		groups++
-		memtables += int64(len(held.mems))
-		bytes += memtableBytesTotal(held.mems)
+		memtables += held.memtables
+		bytes += held.bytes
 		if held.sinceUnixNano > 0 && (oldestUnixNano == 0 || held.sinceUnixNano < oldestUnixNano) {
 			oldestUnixNano = held.sinceUnixNano
 		}
@@ -8374,12 +8375,11 @@ func (db *DB) publishMemtablesLocked() {
 		if len(retired) > 0 {
 			// A retained snapshot can reference queued memtables through an older
 			// view than the one being unpublished here. If any external view is in
-			// flight, hold retired memtables at DB scope until all views drain;
-			// otherwise a later flush can recycle a table still visible to that
-			// older snapshot.
-			if db.memtableViewReaders.Load() > 0 || old.refs.Load() > 1 {
-				db.deferRetiredMemtables(retired)
-			} else {
+			// flight, first try to hold retired memtables at DB scope until all
+			// referencing views drain. If the only retain is the immediate old view
+			// itself, attach the retired tables to that view so short-lived
+			// internal/untracked retains do not create DB-scope retired holds.
+			if db.memtableViewReaders.Load() == 0 || !db.deferRetiredMemtables(retired) {
 				old.retiredMems = append(old.retiredMems, retired...)
 				old.deferredRetiredMemtables.Store(int64(len(old.retiredMems)))
 				old.deferredRetiredBytes.Add(memtableBytesTotal(retired))
@@ -8389,7 +8389,9 @@ func (db *DB) publishMemtablesLocked() {
 		return
 	}
 	if db.memtableViewReaders.Load() > 0 {
-		db.deferRetiredMemtables(retired)
+		if !db.deferRetiredMemtables(retired) {
+			db.recycleMemtables(retired)
+		}
 	} else {
 		db.recycleMemtables(retired)
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7657,7 +7657,7 @@ func (db *DB) releasePublishedMemtableView(view *memtableView) {
 }
 
 func (db *DB) releaseUntrackedMemtableView(view *memtableView) {
-	db.releaseMemtableViewRef(view, false, true)
+	db.releaseMemtableViewRef(view, false, false)
 }
 
 func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, readerRelease bool) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7686,8 +7686,10 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, read
 	for _, mt := range closingMems {
 		db.releaseClosingEmptyMemtable(mt)
 	}
-	db.recycleMemtables(view.retiredMems)
+	reclaim := view.retiredMems
 	view.retiredMems = nil
+	reclaim = append(reclaim, db.releaseDeferredRetiredMemtablesForReleasedView(view)...)
+	db.recycleMemtables(reclaim)
 }
 
 func (db *DB) releaseAbandonedMemtableViewReader(view *memtableView) {
@@ -7803,6 +7805,9 @@ func (db *DB) releaseDeferredRetiredMemtablesForViewLocked(view *memtableView) [
 	if db == nil || view == nil || len(db.deferredRetiredMemtables) == 0 {
 		return nil
 	}
+	if view.refs.Load() > 0 {
+		return nil
+	}
 	var reclaim []memtable.Table
 	dst := db.deferredRetiredMemtables[:0]
 	for i := range db.deferredRetiredMemtables {
@@ -7818,6 +7823,16 @@ func (db *DB) releaseDeferredRetiredMemtablesForViewLocked(view *memtableView) [
 		db.deferredRetiredMemtables[i] = deferredRetiredMemtablesHold{}
 	}
 	db.deferredRetiredMemtables = dst
+	return reclaim
+}
+
+func (db *DB) releaseDeferredRetiredMemtablesForReleasedView(view *memtableView) []memtable.Table {
+	if db == nil || view == nil {
+		return nil
+	}
+	db.retiredMemtablesMu.Lock()
+	reclaim := db.releaseDeferredRetiredMemtablesForViewLocked(view)
+	db.retiredMemtablesMu.Unlock()
 	return reclaim
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7591,10 +7591,14 @@ func (db *DB) retainMemtableView() *memtableView {
 		if view == nil {
 			return nil
 		}
+		// Register the external reader before making the view ref visible. The
+		// retire path uses this counter to decide whether queued memtables can be
+		// recycled globally, so refs must not briefly exceed the published baseline
+		// while the reader counter is still zero.
+		db.memtableViewReaders.Add(1)
 		// Fast path: published views keep a baseline ref, so this is usually one
 		// atomic add and return.
 		if n := view.refs.Add(1); n > 1 {
-			db.memtableViewReaders.Add(1)
 			db.noteMemtableViewRetain()
 			return view
 		}
@@ -7602,13 +7606,14 @@ func (db *DB) retainMemtableView() *memtableView {
 		// published view, in which case self-heal by restoring baseline+caller refs.
 		view.refs.Add(-1)
 		if db.memtables.Load() != view {
+			db.releaseAbandonedMemtableViewReader()
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
-			db.memtableViewReaders.Add(1)
 			db.noteMemtableViewRetain()
 			return view
 		}
+		db.releaseAbandonedMemtableViewReader()
 	}
 }
 
@@ -7621,18 +7626,19 @@ func (db *DB) retainMemtableViewUntracked() *memtableView {
 		if view == nil {
 			return nil
 		}
+		db.memtableViewReaders.Add(1)
 		if n := view.refs.Add(1); n > 1 {
-			db.memtableViewReaders.Add(1)
 			return view
 		}
 		view.refs.Add(-1)
 		if db.memtables.Load() != view {
+			db.releaseAbandonedMemtableViewReader()
 			continue
 		}
 		if view.refs.CompareAndSwap(0, 2) {
-			db.memtableViewReaders.Add(1)
 			return view
 		}
+		db.releaseAbandonedMemtableViewReader()
 	}
 }
 
@@ -7678,6 +7684,15 @@ func (db *DB) releaseMemtableViewRef(view *memtableView, leaseRelease bool, read
 	}
 	db.recycleMemtables(view.retiredMems)
 	view.retiredMems = nil
+}
+
+func (db *DB) releaseAbandonedMemtableViewReader() {
+	if db == nil {
+		return
+	}
+	if readers := db.memtableViewReaders.Add(-1); readers == 0 {
+		db.drainDeferredRetiredMemtables()
+	}
 }
 
 func (db *DB) deferRetiredMemtables(mems []memtable.Table) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6458,9 +6458,10 @@ type memtableViewLifecycleTelemetry struct {
 	oldestDeferredUnixNano atomic.Int64
 }
 
-type deferredRetiredMemtables struct {
-	mems  []memtable.Table
-	views map[*memtableView]struct{}
+type deferredRetiredMemtablesHold struct {
+	mems          []memtable.Table
+	views         map[*memtableView]struct{}
+	sinceUnixNano int64
 }
 
 type DB struct {
@@ -6543,7 +6544,7 @@ type DB struct {
 	pendingRetiredMems               []memtable.Table
 	retiredMemtablesMu               sync.Mutex
 	retainedMemtableViews            map[*memtableView]int
-	deferredRetiredMemtables         []deferredRetiredMemtables
+	deferredRetiredMemtables         []deferredRetiredMemtablesHold
 	memtableViewReaders              atomic.Int64
 	// closingEmptyMemsMu guards closingEmptyByView. The map holds per-view
 	// lists of mutable memtables that should be released once the last reader
@@ -7744,9 +7745,10 @@ func (db *DB) deferRetiredMemtables(mems []memtable.Table) {
 	if len(views) == 0 {
 		reclaim = append(reclaim, mems...)
 	} else {
-		db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, deferredRetiredMemtables{
-			mems:  mems,
-			views: views,
+		db.deferredRetiredMemtables = append(db.deferredRetiredMemtables, deferredRetiredMemtablesHold{
+			mems:          mems,
+			views:         views,
+			sinceUnixNano: time.Now().UnixNano(),
 		})
 	}
 	db.retiredMemtablesMu.Unlock()
@@ -7812,10 +7814,27 @@ func (db *DB) releaseDeferredRetiredMemtablesForViewLocked(view *memtableView) [
 		dst = append(dst, held)
 	}
 	for i := len(dst); i < len(db.deferredRetiredMemtables); i++ {
-		db.deferredRetiredMemtables[i] = deferredRetiredMemtables{}
+		db.deferredRetiredMemtables[i] = deferredRetiredMemtablesHold{}
 	}
 	db.deferredRetiredMemtables = dst
 	return reclaim
+}
+
+func (db *DB) deferredRetiredMemtableHoldStats() (groups int64, memtables int64, bytes int64, oldestUnixNano int64) {
+	if db == nil {
+		return 0, 0, 0, 0
+	}
+	db.retiredMemtablesMu.Lock()
+	defer db.retiredMemtablesMu.Unlock()
+	for _, held := range db.deferredRetiredMemtables {
+		groups++
+		memtables += int64(len(held.mems))
+		bytes += memtableBytesTotal(held.mems)
+		if held.sinceUnixNano > 0 && (oldestUnixNano == 0 || held.sinceUnixNano < oldestUnixNano) {
+			oldestUnixNano = held.sinceUnixNano
+		}
+	}
+	return groups, memtables, bytes, oldestUnixNano
 }
 
 func (db *DB) releaseClosingEmptyMemtables() {
@@ -24232,10 +24251,17 @@ func (db *DB) Stats() map[string]string {
 	memViewDeferredBytesMax := db.memtableViewTelemetry.deferredBytesMax.Load()
 	memViewDeferredBytesTotal := db.memtableViewTelemetry.deferredBytesTotal.Load()
 	memViewOldestDeferredUnixNano := db.memtableViewTelemetry.oldestDeferredUnixNano.Load()
+	retiredHoldGroupsCurrent, retiredHoldMemtablesCurrent, retiredHoldBytesCurrent, retiredHoldOldestUnixNano := db.deferredRetiredMemtableHoldStats()
 	memViewOldestDeferredAgeMS := 0.0
 	if memViewOldestDeferredUnixNano > 0 {
 		if ageNS := time.Now().UnixNano() - memViewOldestDeferredUnixNano; ageNS > 0 {
 			memViewOldestDeferredAgeMS = float64(ageNS) / float64(time.Millisecond)
+		}
+	}
+	retiredHoldOldestAgeMS := 0.0
+	if retiredHoldOldestUnixNano > 0 {
+		if ageNS := time.Now().UnixNano() - retiredHoldOldestUnixNano; ageNS > 0 {
+			retiredHoldOldestAgeMS = float64(ageNS) / float64(time.Millisecond)
 		}
 	}
 	stats["treedb.cache.memtable_stats.writes"] = fmt.Sprintf("%d", memWrites)
@@ -24280,6 +24306,10 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.memtable_view.deferred_bytes_max"] = fmt.Sprintf("%d", memViewDeferredBytesMax)
 	stats["treedb.cache.memtable_view.deferred_bytes_total"] = fmt.Sprintf("%d", memViewDeferredBytesTotal)
 	stats["treedb.cache.memtable_view.deferred_oldest_age_ms"] = fmt.Sprintf("%.3f", memViewOldestDeferredAgeMS)
+	stats["treedb.cache.retired_memtable_hold.groups_current"] = fmt.Sprintf("%d", retiredHoldGroupsCurrent)
+	stats["treedb.cache.retired_memtable_hold.memtables_current"] = fmt.Sprintf("%d", retiredHoldMemtablesCurrent)
+	stats["treedb.cache.retired_memtable_hold.bytes_current"] = fmt.Sprintf("%d", retiredHoldBytesCurrent)
+	stats["treedb.cache.retired_memtable_hold.oldest_age_ms"] = fmt.Sprintf("%.3f", retiredHoldOldestAgeMS)
 	stats["treedb.cache.memtable_warmup_active"] = fmt.Sprintf("%t", memtableWarmupActive)
 	stats["treedb.cache.max_queued_memtables"] = fmt.Sprintf("%d", maxQueued)
 	poolPressure := currentPoolPressureSnapshot()

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -148,35 +148,32 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 		t.Fatalf("queued memtable reset too early len=%d want=2", got)
 	}
 	deferredStats := db.Stats()
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 1 {
-		t.Fatalf("deferred_views_current after publish=%d want=1", got)
+	db.retiredMemtablesMu.Lock()
+	deferredRetired := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 1 {
+		t.Fatalf("global deferred retired memtables after publish=%d want=1", deferredRetired)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore+1 {
-		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore+1)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 0 {
+		t.Fatalf("deferred_views_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_max"); got < 1 {
-		t.Fatalf("deferred_views_max after publish=%d want>=1", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore {
+		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 1 {
-		t.Fatalf("deferred_memtables_current after publish=%d want=1", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 0 {
+		t.Fatalf("deferred_memtables_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore+1 {
-		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore+1)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore {
+		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_max"); got < 1 {
-		t.Fatalf("deferred_memtables_max after publish=%d want>=1", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got != 0 {
+		t.Fatalf("deferred_bytes_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got <= 0 {
-		t.Fatalf("deferred_bytes_current after publish=%d want>0", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got != deferredBytesTotalBefore {
+		t.Fatalf("deferred_bytes_total after publish=%d want=%d", got, deferredBytesTotalBefore)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got <= deferredBytesTotalBefore {
-		t.Fatalf("deferred_bytes_total after publish=%d want>%d", got, deferredBytesTotalBefore)
-	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_max"); got <= 0 {
-		t.Fatalf("deferred_bytes_max after publish=%d want>0", got)
-	}
-	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got < 0 {
-		t.Fatalf("deferred_oldest_age_ms after publish=%f want>=0", got)
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got != 0 {
+		t.Fatalf("deferred_oldest_age_ms after publish=%f want=0 with global retired hold", got)
 	}
 
 	seen := map[string]string{}
@@ -199,6 +196,12 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	}
 	if got := queued.Len(); got != 0 {
 		t.Fatalf("queued memtable len after first close=%d want=0", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredRetired = len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 0 {
+		t.Fatalf("global deferred retired memtables after iterator close=%d want=0", deferredRetired)
 	}
 	closedStats := db.Stats()
 	if got := mustIteratorLeaseStatInt64(t, closedStats, "treedb.cache.memtable_view.release_total"); got != releaseBefore+1 {

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -103,6 +103,15 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	if deferredBytesCurrent := mustIteratorLeaseStatInt64(t, baselineStats, "treedb.cache.memtable_view.deferred_bytes_current"); deferredBytesCurrent != 0 {
 		t.Fatalf("deferred bytes before iterator=%d want=0", deferredBytesCurrent)
 	}
+	if got := mustIteratorLeaseStatInt64(t, baselineStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 0 {
+		t.Fatalf("retired hold groups before iterator=%d want=0", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, baselineStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 0 {
+		t.Fatalf("retired hold memtables before iterator=%d want=0", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, baselineStats, "treedb.cache.retired_memtable_hold.bytes_current"); got != 0 {
+		t.Fatalf("retired hold bytes before iterator=%d want=0", got)
+	}
 
 	it, err := db.Iterator(nil, nil)
 	if err != nil {
@@ -175,6 +184,18 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got != 0 {
 		t.Fatalf("deferred_oldest_age_ms after publish=%f want=0 with global retired hold", got)
 	}
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 1 {
+		t.Fatalf("retired hold groups after publish=%d want=1", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 1 {
+		t.Fatalf("retired hold memtables after publish=%d want=1", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.bytes_current"); got <= 0 {
+		t.Fatalf("retired hold bytes after publish=%d want >0", got)
+	}
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got < 0 {
+		t.Fatalf("retired hold oldest age after publish=%f want >=0", got)
+	}
 
 	seen := map[string]string{}
 	for it.Valid() {
@@ -221,6 +242,18 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	}
 	if got := mustIteratorLeaseStatFloat64(t, closedStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got != 0 {
 		t.Fatalf("deferred_oldest_age_ms after iterator close=%f want=0", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, closedStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 0 {
+		t.Fatalf("retired hold groups after iterator close=%d want=0", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, closedStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 0 {
+		t.Fatalf("retired hold memtables after iterator close=%d want=0", got)
+	}
+	if got := mustIteratorLeaseStatInt64(t, closedStats, "treedb.cache.retired_memtable_hold.bytes_current"); got != 0 {
+		t.Fatalf("retired hold bytes after iterator close=%d want=0", got)
+	}
+	if got := mustIteratorLeaseStatFloat64(t, closedStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got != 0 {
+		t.Fatalf("retired hold oldest age after iterator close=%f want=0", got)
 	}
 
 	if err := it.Close(); err != nil {

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -160,41 +160,41 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	db.retiredMemtablesMu.Lock()
 	deferredRetired := len(db.deferredRetiredMemtables)
 	db.retiredMemtablesMu.Unlock()
-	if deferredRetired != 0 {
-		t.Fatalf("global deferred retired memtables after publish=%d want=0 for immediate old view hold", deferredRetired)
+	if deferredRetired != 1 {
+		t.Fatalf("global deferred retired memtables after publish=%d want=1", deferredRetired)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 1 {
-		t.Fatalf("deferred_views_current after publish=%d want=1 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 0 {
+		t.Fatalf("deferred_views_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore+1 {
-		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore+1)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore {
+		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 1 {
-		t.Fatalf("deferred_memtables_current after publish=%d want=1 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 0 {
+		t.Fatalf("deferred_memtables_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore+1 {
-		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore+1)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore {
+		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got <= 0 {
-		t.Fatalf("deferred_bytes_current after publish=%d want >0 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got != 0 {
+		t.Fatalf("deferred_bytes_current after publish=%d want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got <= deferredBytesTotalBefore {
-		t.Fatalf("deferred_bytes_total after publish=%d want >%d", got, deferredBytesTotalBefore)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got != deferredBytesTotalBefore {
+		t.Fatalf("deferred_bytes_total after publish=%d want=%d", got, deferredBytesTotalBefore)
 	}
-	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got < 0 {
-		t.Fatalf("deferred_oldest_age_ms after publish=%f want >=0", got)
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got != 0 {
+		t.Fatalf("deferred_oldest_age_ms after publish=%f want=0 with global retired hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 0 {
-		t.Fatalf("retired hold groups after publish=%d want=0 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 1 {
+		t.Fatalf("retired hold groups after publish=%d want=1", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 0 {
-		t.Fatalf("retired hold memtables after publish=%d want=0 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 1 {
+		t.Fatalf("retired hold memtables after publish=%d want=1", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.bytes_current"); got != 0 {
-		t.Fatalf("retired hold bytes after publish=%d want=0 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.bytes_current"); got <= 0 {
+		t.Fatalf("retired hold bytes after publish=%d want >0", got)
 	}
-	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got != 0 {
-		t.Fatalf("retired hold oldest age after publish=%f want=0 for immediate old view hold", got)
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got < 0 {
+		t.Fatalf("retired hold oldest age after publish=%f want >=0", got)
 	}
 
 	seen := map[string]string{}
@@ -332,6 +332,60 @@ func TestUntrackedMemtableViewRetainDoesNotCreateGlobalRetiredHold(t *testing.T)
 	db.releaseUntrackedMemtableView(untracked)
 	if got := queued.Len(); got != 0 {
 		t.Fatalf("queued memtable len after untracked release=%d want=0", got)
+	}
+}
+
+func TestUntrackedMemtableViewReleaseDoesNotUnregisterExternalReader(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	view := db.memtables.Load()
+	if view == nil {
+		t.Fatal("expected published memtable view")
+	}
+
+	db.registerMemtableViewReader(view)
+	view.refs.Add(1)
+	untracked := db.retainMemtableViewUntracked()
+	if untracked != view {
+		t.Fatalf("retainMemtableViewUntracked()=%p want current view %p", untracked, view)
+	}
+
+	db.releaseUntrackedMemtableView(untracked)
+
+	if readers := db.memtableViewReaders.Load(); readers != 1 {
+		t.Fatalf("external reader count after untracked release=%d want=1", readers)
+	}
+	db.retiredMemtablesMu.Lock()
+	retainedRefs := db.retainedMemtableViews[view]
+	db.retiredMemtablesMu.Unlock()
+	if retainedRefs != 1 {
+		t.Fatalf("retained view refs after untracked release=%d want=1", retainedRefs)
+	}
+
+	db.releaseMemtableViewRef(view, false, true)
+	if readers := db.memtableViewReaders.Load(); readers != 0 {
+		t.Fatalf("external reader count after external release=%d want=0", readers)
 	}
 }
 

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -160,41 +160,41 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	db.retiredMemtablesMu.Lock()
 	deferredRetired := len(db.deferredRetiredMemtables)
 	db.retiredMemtablesMu.Unlock()
-	if deferredRetired != 1 {
-		t.Fatalf("global deferred retired memtables after publish=%d want=1", deferredRetired)
+	if deferredRetired != 0 {
+		t.Fatalf("global deferred retired memtables after publish=%d want=0 for immediate old view hold", deferredRetired)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 0 {
-		t.Fatalf("deferred_views_current after publish=%d want=0 with global retired hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_current"); got != 1 {
+		t.Fatalf("deferred_views_current after publish=%d want=1 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore {
-		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_views_total"); got != deferredViewsTotalBefore+1 {
+		t.Fatalf("deferred_views_total after publish=%d want=%d", got, deferredViewsTotalBefore+1)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 0 {
-		t.Fatalf("deferred_memtables_current after publish=%d want=0 with global retired hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_current"); got != 1 {
+		t.Fatalf("deferred_memtables_current after publish=%d want=1 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore {
-		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_memtables_total"); got != deferredMemtablesTotalBefore+1 {
+		t.Fatalf("deferred_memtables_total after publish=%d want=%d", got, deferredMemtablesTotalBefore+1)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got != 0 {
-		t.Fatalf("deferred_bytes_current after publish=%d want=0 with global retired hold", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_current"); got <= 0 {
+		t.Fatalf("deferred_bytes_current after publish=%d want >0 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got != deferredBytesTotalBefore {
-		t.Fatalf("deferred_bytes_total after publish=%d want=%d", got, deferredBytesTotalBefore)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.memtable_view.deferred_bytes_total"); got <= deferredBytesTotalBefore {
+		t.Fatalf("deferred_bytes_total after publish=%d want >%d", got, deferredBytesTotalBefore)
 	}
-	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got != 0 {
-		t.Fatalf("deferred_oldest_age_ms after publish=%f want=0 with global retired hold", got)
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.memtable_view.deferred_oldest_age_ms"); got < 0 {
+		t.Fatalf("deferred_oldest_age_ms after publish=%f want >=0", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 1 {
-		t.Fatalf("retired hold groups after publish=%d want=1", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.groups_current"); got != 0 {
+		t.Fatalf("retired hold groups after publish=%d want=0 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 1 {
-		t.Fatalf("retired hold memtables after publish=%d want=1", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.memtables_current"); got != 0 {
+		t.Fatalf("retired hold memtables after publish=%d want=0 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.bytes_current"); got <= 0 {
-		t.Fatalf("retired hold bytes after publish=%d want >0", got)
+	if got := mustIteratorLeaseStatInt64(t, deferredStats, "treedb.cache.retired_memtable_hold.bytes_current"); got != 0 {
+		t.Fatalf("retired hold bytes after publish=%d want=0 for immediate old view hold", got)
 	}
-	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got < 0 {
-		t.Fatalf("retired hold oldest age after publish=%f want >=0", got)
+	if got := mustIteratorLeaseStatFloat64(t, deferredStats, "treedb.cache.retired_memtable_hold.oldest_age_ms"); got != 0 {
+		t.Fatalf("retired hold oldest age after publish=%f want=0 for immediate old view hold", got)
 	}
 
 	seen := map[string]string{}
@@ -265,6 +265,140 @@ func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
 	secondCloseStats := db.Stats()
 	if got := mustIteratorLeaseStatInt64(t, secondCloseStats, "treedb.cache.memtable_view.release_total"); got != releaseBefore+1 {
 		t.Fatalf("release_total after second close=%d want=%d", got, releaseBefore+1)
+	}
+}
+
+func TestUntrackedMemtableViewRetainDoesNotCreateGlobalRetiredHold(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := db.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	view := db.memtables.Load()
+	if view == nil || len(view.queue) != 1 {
+		t.Fatalf("expected one queued memtable view, got=%v", view)
+	}
+	queued, ok := view.queue[0].(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
+	}
+
+	untracked := db.retainMemtableViewUntracked()
+	if untracked != view {
+		t.Fatalf("retainMemtableViewUntracked()=%p want current view %p", untracked, view)
+	}
+	if readers := db.memtableViewReaders.Load(); readers != 0 {
+		t.Fatalf("untracked retain registered memtable readers=%d want=0", readers)
+	}
+
+	db.mu.Lock()
+	db.queueRetiredMemtableLocked(queued)
+	clearQueueLockedForIteratorLeaseTest(db)
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	db.retiredMemtablesMu.Lock()
+	deferredRetired := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 0 {
+		t.Fatalf("global deferred retired memtables after untracked retain publish=%d want=0", deferredRetired)
+	}
+	if got := queued.Len(); got != 2 {
+		t.Fatalf("queued memtable reset while untracked retain open len=%d want=2", got)
+	}
+
+	db.releaseUntrackedMemtableView(untracked)
+	if got := queued.Len(); got != 0 {
+		t.Fatalf("queued memtable len after untracked release=%d want=0", got)
+	}
+}
+
+func TestDeferRetiredMemtablesCopiesHeldSlice(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := db.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	view := db.memtables.Load()
+	if view == nil || len(view.queue) != 1 {
+		t.Fatalf("expected one queued memtable view, got=%v", view)
+	}
+	queued, ok := view.queue[0].(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
+	}
+
+	db.registerMemtableViewReader(view)
+	retired := []memtable.Table{queued}
+	if !db.deferRetiredMemtables(retired) {
+		t.Fatal("deferRetiredMemtables did not hold retained view memtable")
+	}
+	retired[0] = nil
+
+	db.retiredMemtablesMu.Lock()
+	if len(db.deferredRetiredMemtables) != 1 {
+		db.retiredMemtablesMu.Unlock()
+		t.Fatalf("deferred retired holds=%d want=1", len(db.deferredRetiredMemtables))
+	}
+	held := db.deferredRetiredMemtables[0]
+	db.retiredMemtablesMu.Unlock()
+	if len(held.mems) != 1 || held.mems[0] != queued {
+		t.Fatalf("held memtables mutated with caller slice: %+v", held.mems)
+	}
+	if held.memtables != 1 {
+		t.Fatalf("held memtable count=%d want=1", held.memtables)
+	}
+	if held.bytes <= 0 {
+		t.Fatalf("held bytes=%d want >0", held.bytes)
+	}
+
+	db.unregisterMemtableViewReader(view)
+	if got := queued.Len(); got != 0 {
+		t.Fatalf("queued memtable len after retained view release=%d want=0", got)
 	}
 }
 

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -335,6 +335,105 @@ func TestUntrackedMemtableViewRetainDoesNotCreateGlobalRetiredHold(t *testing.T)
 	}
 }
 
+func TestRetiredMemtableHoldWaitsForUntrackedRetainAfterTrackedRelease(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := db.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	view := db.memtables.Load()
+	if view == nil || len(view.queue) != 1 {
+		t.Fatalf("expected one queued memtable view, got=%v", view)
+	}
+	queued, ok := view.queue[0].(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
+	}
+
+	tracked := db.retainMemtableView()
+	if tracked != view {
+		t.Fatalf("retainMemtableView()=%p want current view %p", tracked, view)
+	}
+	untracked := db.retainMemtableViewUntracked()
+	if untracked != view {
+		t.Fatalf("retainMemtableViewUntracked()=%p want current view %p", untracked, view)
+	}
+
+	db.mu.Lock()
+	db.queueRetiredMemtableLocked(queued)
+	clearQueueLockedForIteratorLeaseTest(db)
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	if refs := view.refs.Load(); refs != 2 {
+		t.Fatalf("view refs after publish with tracked+untracked retains=%d want=2", refs)
+	}
+	if got := queued.Len(); got != 2 {
+		t.Fatalf("queued memtable reset before releases len=%d want=2", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredRetired := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 1 {
+		t.Fatalf("global deferred retired memtables after publish=%d want=1", deferredRetired)
+	}
+
+	db.releaseMemtableView(tracked)
+
+	if refs := view.refs.Load(); refs != 1 {
+		t.Fatalf("view refs after tracked release=%d want=1", refs)
+	}
+	if readers := db.memtableViewReaders.Load(); readers != 0 {
+		t.Fatalf("external reader count after tracked release=%d want=0", readers)
+	}
+	if got := queued.Len(); got != 2 {
+		t.Fatalf("queued memtable reset while untracked retain remains len=%d want=2", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredRetired = len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 1 {
+		t.Fatalf("global deferred retired memtables after tracked release=%d want=1", deferredRetired)
+	}
+
+	db.releaseUntrackedMemtableView(untracked)
+
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after untracked release=%d want=0", refs)
+	}
+	if got := queued.Len(); got != 0 {
+		t.Fatalf("queued memtable len after untracked release=%d want=0", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredRetired = len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredRetired != 0 {
+		t.Fatalf("global deferred retired memtables after untracked release=%d want=0", deferredRetired)
+	}
+}
+
 func TestUntrackedMemtableViewReleaseDoesNotUnregisterExternalReader(t *testing.T) {
 	backend := NewMockBackend()
 	db, err := Open(t.TempDir(), backend, Options{
@@ -426,7 +525,10 @@ func TestDeferRetiredMemtablesCopiesHeldSlice(t *testing.T) {
 		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
 	}
 
-	db.registerMemtableViewReader(view)
+	tracked := db.retainMemtableView()
+	if tracked != view {
+		t.Fatalf("retainMemtableView()=%p want current view %p", tracked, view)
+	}
 	retired := []memtable.Table{queued}
 	if !db.deferRetiredMemtables(retired) {
 		t.Fatal("deferRetiredMemtables did not hold retained view memtable")
@@ -450,7 +552,8 @@ func TestDeferRetiredMemtablesCopiesHeldSlice(t *testing.T) {
 		t.Fatalf("held bytes=%d want >0", held.bytes)
 	}
 
-	db.unregisterMemtableViewReader(view)
+	db.releasePublishedMemtableView(view)
+	db.releaseMemtableView(tracked)
 	if got := queued.Len(); got != 0 {
 		t.Fatalf("queued memtable len after retained view release=%d want=0", got)
 	}

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -79,8 +79,14 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 	if refs := published.refs.Load(); refs != 1 {
 		t.Fatalf("retained old view refs=%d want=1", refs)
 	}
-	if got := len(published.retiredMems); got != 1 || published.retiredMems[0] != retired {
-		t.Fatalf("old view retired memtables=%v want [%p]", published.retiredMems, retired)
+	if got := len(published.retiredMems); got != 0 {
+		t.Fatalf("old view retired memtables=%d want=0 while global reader hold is active", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredBefore := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredBefore != 1 {
+		t.Fatalf("global deferred retired memtables=%d want=1", deferredBefore)
 	}
 	if got := retired.Len(); got != 1 {
 		t.Fatalf("retired memtable reset too early len=%d want=1", got)
@@ -103,6 +109,12 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 	if got := len(published.retiredMems); got != 0 {
 		t.Fatalf("old view retired memtables not cleared len=%d", got)
 	}
+	db.retiredMemtablesMu.Lock()
+	deferredAfter := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredAfter != 0 {
+		t.Fatalf("global deferred retired memtables after final release=%d want=0", deferredAfter)
+	}
 	db.appendOnlyMemLeaseMu.Lock()
 	leasesAfter := len(db.appendOnlyMemLeases)
 	var leased *memtable.AppendOnly
@@ -115,6 +127,60 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 	}
 	if leased != retired {
 		t.Fatalf("leased memtable=%p want retired=%p", leased, retired)
+	}
+}
+
+func TestRetiredMemtableRecycleWaitsForOlderRetainedViewAcrossPublishes(t *testing.T) {
+	db := &DB{}
+	initial := &memtableView{}
+	initial.refs.Store(1)
+	db.memtables.Store(initial)
+
+	held := db.retainMemtableView()
+	if held != initial {
+		t.Fatalf("retainMemtableView returned %p want %p", held, initial)
+	}
+
+	retiredA := memtable.NewAppendOnlyWithCapacity(0)
+	retiredA.Set([]byte("a"), []byte("value-a"))
+	retiredA.Freeze()
+	retiredB := memtable.NewAppendOnlyWithCapacity(0)
+	retiredB.Set([]byte("b"), []byte("value-b"))
+	retiredB.Freeze()
+
+	db.mu.Lock()
+	db.queueRetiredMemtableLocked(retiredA)
+	db.publishMemtablesLocked()
+	db.queueRetiredMemtableLocked(retiredB)
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	if got := retiredA.Len(); got != 1 {
+		t.Fatalf("first retired memtable reset before older view release len=%d want=1", got)
+	}
+	if got := retiredB.Len(); got != 1 {
+		t.Fatalf("second retired memtable reset before older view release len=%d want=1", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredBefore := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredBefore != 2 {
+		t.Fatalf("global deferred retired memtables=%d want=2", deferredBefore)
+	}
+
+	db.releaseMemtableView(held)
+
+	if got := retiredA.Len(); got != 0 {
+		t.Fatalf("first retired memtable len after older view release=%d want=0", got)
+	}
+	if got := retiredB.Len(); got != 0 {
+		t.Fatalf("second retired memtable len after older view release=%d want=0", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredAfter := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredAfter != 0 {
+		t.Fatalf("global deferred retired memtables after release=%d want=0", deferredAfter)
 	}
 }
 

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -48,7 +48,14 @@ func TestRetainMemtableViewSelfHealsZeroRefPublishedView(t *testing.T) {
 
 func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testing.T) {
 	db := &DB{}
-	published := &memtableView{}
+	retired := memtable.NewAppendOnlyWithCapacity(0)
+	retired.Set([]byte("k"), []byte("v"))
+	retired.Freeze()
+	if got := retired.Len(); got != 1 {
+		t.Fatalf("retired memtable len=%d want=1 before publish", got)
+	}
+
+	published := &memtableView{queue: []memtable.Table{retired}}
 	published.refs.Store(1)
 	db.memtables.Store(published)
 
@@ -58,13 +65,6 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 	}
 	if refs := published.refs.Load(); refs != 2 {
 		t.Fatalf("published refs after retain=%d want=2", refs)
-	}
-
-	retired := memtable.NewAppendOnlyWithCapacity(0)
-	retired.Set([]byte("k"), []byte("v"))
-	retired.Freeze()
-	if got := retired.Len(); got != 1 {
-		t.Fatalf("retired memtable len=%d want=1 before publish", got)
 	}
 
 	db.mu.Lock()
@@ -132,7 +132,14 @@ func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testin
 
 func TestRetiredMemtableRecycleWaitsForOlderRetainedViewAcrossPublishes(t *testing.T) {
 	db := &DB{}
-	initial := &memtableView{}
+	retiredA := memtable.NewAppendOnlyWithCapacity(0)
+	retiredA.Set([]byte("a"), []byte("value-a"))
+	retiredA.Freeze()
+	retiredB := memtable.NewAppendOnlyWithCapacity(0)
+	retiredB.Set([]byte("b"), []byte("value-b"))
+	retiredB.Freeze()
+
+	initial := &memtableView{queue: []memtable.Table{retiredA, retiredB}}
 	initial.refs.Store(1)
 	db.memtables.Store(initial)
 
@@ -140,13 +147,6 @@ func TestRetiredMemtableRecycleWaitsForOlderRetainedViewAcrossPublishes(t *testi
 	if held != initial {
 		t.Fatalf("retainMemtableView returned %p want %p", held, initial)
 	}
-
-	retiredA := memtable.NewAppendOnlyWithCapacity(0)
-	retiredA.Set([]byte("a"), []byte("value-a"))
-	retiredA.Freeze()
-	retiredB := memtable.NewAppendOnlyWithCapacity(0)
-	retiredB.Set([]byte("b"), []byte("value-b"))
-	retiredB.Freeze()
 
 	db.mu.Lock()
 	db.queueRetiredMemtableLocked(retiredA)
@@ -181,6 +181,48 @@ func TestRetiredMemtableRecycleWaitsForOlderRetainedViewAcrossPublishes(t *testi
 	db.retiredMemtablesMu.Unlock()
 	if deferredAfter != 0 {
 		t.Fatalf("global deferred retired memtables after release=%d want=0", deferredAfter)
+	}
+}
+
+func TestRetiredMemtableRecycleDoesNotWaitForUnrelatedNewerView(t *testing.T) {
+	db := &DB{}
+	retired := memtable.NewAppendOnlyWithCapacity(0)
+	retired.Set([]byte("old"), []byte("value"))
+	retired.Freeze()
+
+	oldView := &memtableView{queue: []memtable.Table{retired}}
+	oldView.refs.Store(1)
+	db.memtables.Store(oldView)
+
+	heldOld := db.retainMemtableView()
+	if heldOld != oldView {
+		t.Fatalf("old retained view=%p want %p", heldOld, oldView)
+	}
+
+	db.mu.Lock()
+	db.queueRetiredMemtableLocked(retired)
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	heldNew := db.retainMemtableView()
+	if heldNew == nil || heldNew == oldView {
+		t.Fatalf("new retained view=%p old=%p", heldNew, oldView)
+	}
+	defer db.releaseMemtableView(heldNew)
+
+	if got := retired.Len(); got != 1 {
+		t.Fatalf("retired memtable reset before old view release len=%d want=1", got)
+	}
+	db.releaseMemtableView(heldOld)
+
+	if got := retired.Len(); got != 0 {
+		t.Fatalf("retired memtable len after old view release with newer reader active=%d want=0", got)
+	}
+	db.retiredMemtablesMu.Lock()
+	deferredAfter := len(db.deferredRetiredMemtables)
+	db.retiredMemtablesMu.Unlock()
+	if deferredAfter != 0 {
+		t.Fatalf("deferred retired memtables after old view release=%d want=0", deferredAfter)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the queued snapshot read-after-write miss exposed by #1490.

The bug was not in root-domain lookup. A retained snapshot can hold an older `memtableView` while background flush publishes newer views. Retired queued memtables were only attached to the immediately previous published view, so a later flush could recycle/reset a memtable that the older snapshot still referenced.

This change adds a DB-level retired-memtable hold while any external memtable view reader is active, then drains those retired tables only after the last retained view is released.

## Changes

- Track external retained memtable views separately from the published baseline ref.
- Defer retired queued memtable recycling at DB scope when snapshots/iterators/readers are in flight.
- Drain deferred retired memtables when the last external view releases.
- Update iterator lifecycle expectations for the global retired hold.
- Add a regression test covering multiple publishes while an older view remains retained.

## Validation

- `GOWORK=off go test ./TreeDB/caching -run 'Test(PublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease|RetiredMemtableRecycleWaitsForOlderRetainedViewAcrossPublishes)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run '^TestIterator_QueuedViewLeaseHeldUntilClose$' -count=1`
- `GOWORK=off go test ./TreeDB -run 'Test(ProfileFast_ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_AccessMatrix|ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_ProfileMatrix|ReadSnapshotsSeeQueuedWritesAfterCheckpoint_Control)' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run '^TestRunBenchmark_ProfileFastReadRequireHitBeforeCheckpoint$' -count=1`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/internal/memtable ./TreeDB ./cmd/unified_bench -count=1`
- `GOWORK=off go test -race ./TreeDB -run '^TestProfileFast_ReadSnapshotsSeeQueuedWritesBeforeCheckpoint_AccessMatrix/shared_snapshot_get$' -count=1`
- `GOWORK=off go run ./cmd/unified_bench -dbs treedb -profile fast -keys 200000 -test sequential_write,random_read_parallel -read-workers 8 -read-require-hit -path-label native-fastpath -progress=false -keep=false -seed 1`
