### PR TITLE
[codex] Add read-mode bottleneck gates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1907,6 +1907,20 @@ func (domain *collectionWriteDomain) addCountLocked(delta int) {
 	domain.setCountLocked(domain.count + delta)
 }
 
+func (domain *collectionWriteDomain) markPendingMutationLocked(delta int) {
+	if domain == nil {
+		return
+	}
+	pending := domain.count
+	if delta > pending {
+		pending = delta
+	}
+	if pending <= 0 {
+		pending = 1
+	}
+	domain.pendingCount.Store(int64(pending))
+}
+
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
 	if domain == nil {
 		return
@@ -3071,6 +3085,7 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 		}
 	}
 	domain.storagePolicy = plannerOptions.dataStoragePolicy
+	domain.markPendingMutationLocked(1)
 	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
 	domain.addCountLocked(1)
 	resultID := bytes.Clone(id)
@@ -3205,6 +3220,7 @@ func (c *Collection) bufferNoIndexInsertBatch(
 		}
 	}
 	domain.storagePolicy = currentOptions.dataStoragePolicy
+	domain.markPendingMutationLocked(len(entries))
 	for _, entry := range entries {
 		domain.table.SetEntry(entry.id, entry.document, page.ValuePtr{}, node.FlagInline)
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -914,6 +914,7 @@ type collectionWriteDomain struct {
 	uniqueValueMutableRuns map[string]memtable.Table
 	uniqueValueIndex       map[string]*bufferedUniqueValueIndex
 	count                  int
+	pendingCount           atomic.Int64
 	bufferedBytes          int64
 	mutableCount           int
 	mutableBytes           int64
@@ -1888,6 +1889,24 @@ func collectionUpdateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) b
 		stats.BufferStageFlush != 0
 }
 
+func (domain *collectionWriteDomain) setCountLocked(count int) {
+	if domain == nil {
+		return
+	}
+	domain.count = count
+	if count < 0 {
+		count = 0
+	}
+	domain.pendingCount.Store(int64(count))
+}
+
+func (domain *collectionWriteDomain) addCountLocked(delta int) {
+	if domain == nil || delta == 0 {
+		return
+	}
+	domain.setCountLocked(domain.count + delta)
+}
+
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
 	if domain == nil {
 		return
@@ -2595,6 +2614,21 @@ func (c *Collection) SameCachedCatalog(other *Collection) bool {
 		cCommitSeq == otherCommitSeq
 }
 
+// CachedCatalogIsCurrent reports whether this handle is cached against the DB's
+// current committed catalog state. It is intended for handle caches that want to
+// avoid reopening collections on hot read paths without serving stale schemas.
+func (c *Collection) CachedCatalogIsCurrent() bool {
+	if c == nil || c.db == nil {
+		return false
+	}
+	commitSeq, systemRoot := dbCommitSeqAndSystemRoot(c.db)
+	if systemRoot == 0 {
+		return false
+	}
+	_, cachedSystemRoot, cachedCommitSeq := c.cachedCatalogIdentity()
+	return cachedSystemRoot == systemRoot && cachedCommitSeq == commitSeq
+}
+
 func (c *Collection) cachedCatalogIdentity() (name string, systemRoot, commitSeq uint64) {
 	if c == nil {
 		return "", 0, 0
@@ -3038,7 +3072,7 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 	}
 	domain.storagePolicy = plannerOptions.dataStoragePolicy
 	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
-	domain.count++
+	domain.addCountLocked(1)
 	resultID := bytes.Clone(id)
 	domain.mu.Unlock()
 	return resultID, nil
@@ -3174,7 +3208,7 @@ func (c *Collection) bufferNoIndexInsertBatch(
 	for _, entry := range entries {
 		domain.table.SetEntry(entry.id, entry.document, page.ValuePtr{}, node.FlagInline)
 	}
-	domain.count += len(entries)
+	domain.addCountLocked(len(entries))
 	c.setLastInsertStats(CollectionInsertStats{
 		Documents: len(entries),
 		Indexes:   0,
@@ -3360,6 +3394,9 @@ func (c *Collection) flushBufferedNoIndex() error {
 	if domain == nil {
 		return nil
 	}
+	if domain.pendingCount.Load() == 0 {
+		return nil
+	}
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if hasBufferedIndexedRootRuns(domain) {
@@ -3482,7 +3519,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
-	domain.count = 0
+	domain.setCountLocked(0)
 	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
@@ -3679,7 +3716,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.meta = catalog.meta
 	domain.catalog = catalog
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
-	domain.count += len(plan.resultIDs)
+	domain.addCountLocked(len(plan.resultIDs))
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
@@ -3864,7 +3901,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 	domain.meta = catalog.meta
 	domain.catalog = catalog
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
-	domain.count += len(plan.resultIDs)
+	domain.addCountLocked(len(plan.resultIDs))
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
@@ -4883,7 +4920,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.baseCommitSeq = checkpoint.baseCommitSeq
 	domain.baseSystemRoot = checkpoint.baseSystemRoot
 	domain.primaryRoot = checkpoint.primaryRoot
-	domain.count = checkpoint.count
+	domain.setCountLocked(checkpoint.count)
 	domain.bufferedBytes = checkpoint.bufferedBytes
 	domain.mutableCount = checkpoint.mutableCount
 	domain.mutableBytes = checkpoint.mutableBytes
@@ -6236,7 +6273,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
-		domain.count = 0
+		domain.setCountLocked(0)
 		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -6638,7 +6675,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(work.meta.Name))
-	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
+	domain.setCountLocked(subtractNonNegativeInt(domain.count, work.docCount))
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
 	domain.clearIndexedAsyncFlushError()
 	if !overlayPublish {
@@ -6707,7 +6744,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
-		domain.count = 0
+		domain.setCountLocked(0)
 		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -6819,7 +6856,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueMutableRuns = nil
 	domain.uniqueValueIndex = nil
-	domain.count = 0
+	domain.setCountLocked(0)
 	domain.indexedDeletesOnly = false
 	domain.bufferedBytes = 0
 	domain.mutableCount = 0
@@ -12012,7 +12049,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if plan.catalog != nil {
 		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
 	}
-	domain.count += modifiedCount
+	domain.addCountLocked(modifiedCount)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
@@ -12282,7 +12319,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if plan.catalog != nil {
 		domain.primaryRoot = plan.catalog.rootID(primaryRootName)
 	}
-	domain.count += modifiedCount
+	domain.addCountLocked(modifiedCount)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
@@ -13030,7 +13067,7 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(meta.Name))
-	domain.count += deleted
+	domain.addCountLocked(deleted)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, deleted)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1893,10 +1893,10 @@ func (domain *collectionWriteDomain) setCountLocked(count int) {
 	if domain == nil {
 		return
 	}
-	domain.count = count
 	if count < 0 {
 		count = 0
 	}
+	domain.count = count
 	domain.pendingCount.Store(int64(count))
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7766,7 +7766,7 @@ func TestFlushBufferedNoIndexCleanDomainSkipsWriteDomainLock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("flush clean domain: %v", err)
 		}
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(collectionTestTimeout(t, time.Second)):
 		t.Fatal("flushBufferedNoIndex blocked on a clean write domain")
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7774,9 +7774,9 @@ func TestFlushBufferedNoIndexCleanDomainSkipsWriteDomainLock(t *testing.T) {
 func TestFlushBufferedNoIndexPendingMutationSynchronizesWithWriteDomainLock(t *testing.T) {
 	domain := &collectionWriteDomain{}
 	col := &Collection{writeDomain: domain}
-	domain.markPendingMutationLocked(1)
 
 	domain.mu.Lock()
+	domain.markPendingMutationLocked(1)
 	unlocked := false
 	unlock := func() {
 		if !unlocked {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -92,6 +92,53 @@ func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
 	}
 }
 
+func TestCollectionCachedCatalogIsCurrent(t *testing.T) {
+	var nilCol *Collection
+	if nilCol.CachedCatalogIsCurrent() {
+		t.Fatal("nil collection reported current catalog")
+	}
+	if (&Collection{}).CachedCatalogIsCurrent() {
+		t.Fatal("collection with nil DB reported current catalog")
+	}
+
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	stale, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open stale users handle: %v", err)
+	}
+	if !stale.CachedCatalogIsCurrent() {
+		t.Fatal("freshly opened users handle reported stale catalog")
+	}
+
+	mutator, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open mutator users handle: %v", err)
+	}
+	if _, err := mutator.CreateIndex(IndexDefinition{Name: "email", Field: "email", ValueType: IndexValueString}); err != nil {
+		t.Fatalf("create email index: %v", err)
+	}
+	if stale.CachedCatalogIsCurrent() {
+		t.Fatal("pre-schema-change users handle reported current catalog")
+	}
+
+	current, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open current users handle: %v", err)
+	}
+	if !current.CachedCatalogIsCurrent() {
+		t.Fatal("post-schema-change users handle reported stale catalog")
+	}
+}
+
 func TestCollectionMetaReturnsDefensiveIndexCopyAcrossHandles(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7771,6 +7771,47 @@ func TestFlushBufferedNoIndexCleanDomainSkipsWriteDomainLock(t *testing.T) {
 	}
 }
 
+func TestFlushBufferedNoIndexPendingMutationSynchronizesWithWriteDomainLock(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	col := &Collection{writeDomain: domain}
+	domain.markPendingMutationLocked(1)
+
+	domain.mu.Lock()
+	unlocked := false
+	unlock := func() {
+		if !unlocked {
+			domain.mu.Unlock()
+			unlocked = true
+		}
+	}
+	defer unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- col.flushBufferedNoIndex()
+	}()
+
+	select {
+	case err := <-done:
+		unlock()
+		if err != nil {
+			t.Fatalf("flush pending mutation: %v", err)
+		}
+		t.Fatal("flushBufferedNoIndex returned while a pending mutation held the write domain")
+	case <-time.After(collectionTestTimeout(t, 50*time.Millisecond)):
+	}
+
+	unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush pending mutation after unlock: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, time.Second)):
+		t.Fatal("flushBufferedNoIndex did not complete after pending mutation lock released")
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexRejectsBufferedDuplicate(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4932,7 +4932,7 @@ func TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone(t *t
 	table.Freeze()
 	domain := col.writeDomain
 	domain.mu.Lock()
-	domain.count = 1
+	domain.setCountLocked(1)
 	domain.meta = col.Meta()
 	domain.rootRuns = map[string][]memtable.Table{
 		collectionSecondaryRootName("users", "city"): {table},
@@ -5005,7 +5005,7 @@ func TestCollectionIndexedWriteMemtablesFindLimitFiltersOnlyBufferedTombstone(t 
 	table.Freeze()
 	domain := col.writeDomain
 	domain.mu.Lock()
-	domain.count = 1
+	domain.setCountLocked(1)
 	domain.meta = col.Meta()
 	domain.rootRuns = map[string][]memtable.Table{
 		collectionSecondaryRootName("users", "city"): {table},
@@ -7436,7 +7436,7 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	domain.baseCommitSeq = 100
 	domain.baseSystemRoot = 200
 	domain.primaryRoot = 300
-	domain.count = 400
+	domain.setCountLocked(400)
 	domain.bufferedBytes = 500
 	domain.mutableCount = 501
 	domain.mutableBytes = 502
@@ -7500,7 +7500,7 @@ func TestRollbackBufferedIndexedDomainRestoresPreRotationRuns(t *testing.T) {
 
 	domain.rootRuns[primaryName] = append(domain.rootRuns[primaryName], newTable)
 	domain.rootRunCount = 2
-	domain.count = 2
+	domain.setCountLocked(2)
 	if !rotateIndexedMutableToFlushUnitLocked(domain) {
 		t.Fatal("rotate indexed mutable state returned false")
 	}
@@ -7699,6 +7699,28 @@ func TestCollectionSingleInsertBufferedNoIndexCloseFlushes(t *testing.T) {
 	}
 	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
 		t.Fatalf("reopened close-flushed doc=%q want %q", got, want)
+	}
+}
+
+func TestFlushBufferedNoIndexCleanDomainSkipsWriteDomainLock(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	col := &Collection{writeDomain: domain}
+
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- col.flushBufferedNoIndex()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush clean domain: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("flushBufferedNoIndex blocked on a clean write domain")
 	}
 }
 
@@ -15612,7 +15634,7 @@ func TestCollectionFindDocumentsByIndexRangeUniqueExactBufferedTombstone(t *test
 
 	domain := col.writeDomain
 	domain.mu.Lock()
-	domain.count = 1
+	domain.setCountLocked(1)
 	domain.meta = col.Meta()
 	domain.rootRuns = map[string][]memtable.Table{
 		collectionPrimaryRootName("users"):            {primaryTable},
@@ -15699,7 +15721,7 @@ func TestCollectionFindDocumentsByIndexRangeExactBufferedTombstoneAfterLimit(t *
 
 	domain := col.writeDomain
 	domain.mu.Lock()
-	domain.count = 1
+	domain.setCountLocked(1)
 	domain.meta = col.Meta()
 	domain.rootRuns = map[string][]memtable.Table{
 		collectionPrimaryRootName("users"):            {primaryTable},
@@ -16007,7 +16029,7 @@ func TestCollectionFindByIndexRangeSkipsBufferedTombstone(t *testing.T) {
 	table.Freeze()
 	domain := col.writeDomain
 	domain.mu.Lock()
-	domain.count = 1
+	domain.setCountLocked(1)
 	domain.meta = col.Meta()
 	domain.rootRuns = map[string][]memtable.Table{
 		collectionSecondaryRootName("users", "score"): {table},

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7812,6 +7812,19 @@ func TestFlushBufferedNoIndexPendingMutationSynchronizesWithWriteDomainLock(t *t
 	}
 }
 
+func TestCollectionWriteDomainSetCountLockedClampsNegative(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	domain.mu.Lock()
+	domain.setCountLocked(-1)
+	domain.mu.Unlock()
+	if domain.count != 0 {
+		t.Fatalf("domain.count=%d want 0", domain.count)
+	}
+	if pending := domain.pendingCount.Load(); pending != 0 {
+		t.Fatalf("pendingCount=%d want 0", pending)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexRejectsBufferedDuplicate(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -17,13 +17,14 @@ import (
 )
 
 const (
-	commandCodeBadValue            int32 = 2
-	commandCodeFailedToParse       int32 = 9
-	commandCodeNamespaceNotFound   int32 = 26
-	commandCodeIndexNotFound       int32 = 27
-	commandCodeCursorNotFound      int32 = 43
-	commandCodeDuplicateKey        int32 = 11000
-	maxWireMessageLengthInt32Limit       = int64(1<<31 - 1)
+	commandCodeBadValue                        int32 = 2
+	commandCodeFailedToParse                   int32 = 9
+	commandCodeNamespaceNotFound               int32 = 26
+	commandCodeIndexNotFound                   int32 = 27
+	commandCodeCursorNotFound                  int32 = 43
+	commandCodeDuplicateKey                    int32 = 11000
+	maxWireMessageLengthInt32Limit                   = int64(1<<31 - 1)
+	mongoGatewayCollectionManagerNotConfigured       = "Mongo gateway collection manager is not configured"
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -32,7 +33,7 @@ var maxInt = int(^uint(0) >> 1)
 
 func (s *Server) insertResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "insert")
 	if err != nil {
@@ -283,7 +284,7 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 
 func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {
 	if s.Collections == nil {
-		doc, err := commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		doc, err := commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 		return findResponsePayload{document: doc}, err
 	}
 	collection, err := commandString(command, "find")
@@ -442,7 +443,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "update")
 	if err != nil {
@@ -1237,7 +1238,7 @@ func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, []colle
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "delete")
 	if err != nil {
@@ -1296,7 +1297,7 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 
 func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	db, err := commandString(command, "$db")
 	if err != nil {
@@ -1339,7 +1340,7 @@ func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, 
 
 func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "createIndexes")
 	if err != nil {
@@ -1421,7 +1422,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 
 func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "listIndexes")
 	if err != nil {
@@ -1447,7 +1448,7 @@ func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, erro
 
 func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, error) {
 	if s.Collections == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+		return commandError(commandCodeBadValue, "BadValue", mongoGatewayCollectionManagerNotConfigured)
 	}
 	collection, err := commandString(command, "dropIndexes")
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -53,7 +53,7 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 
 	var col *collections.Collection
 	format := s.DefaultCollectionOptions.DocumentFormat
-	if existing, err := s.Collections.OpenCollection(name); err == nil {
+	if existing, err := s.openCollection(name); err == nil {
 		col = existing
 		format = existing.Meta().Options.DocumentFormat
 	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
@@ -113,6 +113,7 @@ type rawCursorDocumentsResponse struct {
 	cursorID int64
 	batchKey string
 	batch    []wire.Document
+	single   wire.Document
 }
 
 type findResponsePayloadKind uint8
@@ -133,7 +134,7 @@ type findResponsePayload struct {
 func (p findResponsePayload) marshalDocument() (wire.Document, error) {
 	switch p.kind {
 	case findResponsePayloadRaw:
-		return marshalCursorDocumentsResponseWithID(p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch)
+		return p.raw.marshalDocument()
 	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalDocument()
 	default:
@@ -152,7 +153,7 @@ func (p findResponsePayload) marshalMsgInto(dst []byte, requestID, responseTo in
 func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, responseTo int32, maxMessageLength int) ([]byte, error) {
 	switch p.kind {
 	case findResponsePayloadRaw:
-		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, p.raw.ns, p.raw.cursorID, p.raw.batchKey, p.raw.batch, maxMessageLength)
+		return p.raw.marshalMsgInto(dst, requestID, responseTo, maxMessageLength)
 	case findResponsePayloadIndexedRange:
 		return p.indexedRange.marshalMsgIntoWithMaxLength(dst, requestID, responseTo, maxMessageLength)
 	default:
@@ -173,6 +174,59 @@ func (p findResponsePayload) marshalMsgIntoWithMaxLength(dst []byte, requestID, 
 		}
 		return msg, nil
 	}
+}
+
+func (r rawCursorDocumentsResponse) marshalDocument() (wire.Document, error) {
+	if r.single == nil {
+		return marshalCursorDocumentsResponseWithID(r.ns, r.cursorID, r.batchKey, r.batch)
+	}
+	builder := newRawCursorDocumentBuilder(make([]byte, 0, cursorDocumentsMsgResponseLength(r.ns, r.batchKey, findBatchOverheadBytes+findBatchDocumentBytes(r.single, 0))), r.ns, r.batchKey, maxInt)
+	if _, err := builder.appendDocument(r.single); err != nil {
+		return nil, err
+	}
+	builder.setCursorID(r.cursorID)
+	msg, err := builder.finish()
+	return wire.Document(msg), err
+}
+
+func (r rawCursorDocumentsResponse) marshalMsgInto(dst []byte, requestID, responseTo int32, maxMessageLength int) ([]byte, error) {
+	if r.single == nil {
+		return marshalCursorDocumentsMsgResponseWithIDInto(dst, requestID, responseTo, r.ns, r.cursorID, r.batchKey, r.batch, maxMessageLength)
+	}
+	if maxMessageLength <= 0 || maxMessageLength > wire.DefaultMaxMessageLength {
+		maxMessageLength = wire.DefaultMaxMessageLength
+	}
+	batchBytes := findBatchOverheadBytes + findBatchDocumentBytes(r.single, 0)
+	need := cursorDocumentsMsgResponseLength(r.ns, r.batchKey, batchBytes)
+	if int64(need) > maxWireMessageLengthInt32Limit {
+		return nil, fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, need)
+	}
+	if need > maxMessageLength {
+		return nil, fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, need, maxMessageLength)
+	}
+	dst = ensureWireAppendCapacity(dst, need)
+	base := len(dst)
+	msg := appendWireInt32(dst, 0)
+	msg = appendWireInt32(msg, requestID)
+	msg = appendWireInt32(msg, responseTo)
+	msg = appendWireInt32(msg, int32(wire.OpMsg))
+	msg = appendWireInt32(msg, 0)
+	msg = append(msg, wire.MsgSectionBody)
+	builder := newRawCursorDocumentBuilder(msg, r.ns, r.batchKey, maxMessageLength)
+	if _, err := builder.appendDocument(r.single); err != nil {
+		return msg[:base], err
+	}
+	builder.setCursorID(r.cursorID)
+	msg, err := builder.finish()
+	if err != nil {
+		return msg[:base], err
+	}
+	messageLength := len(msg) - base
+	if messageLength > maxMessageLength {
+		return msg[:base], fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
+	}
+	binary.LittleEndian.PutUint32(msg[base:base+4], uint32(messageLength))
+	return msg, nil
 }
 
 func (p findResponsePayload) documentPayload() (wire.Document, error) {
@@ -217,7 +271,7 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 	}
 	base := len(dst)
 	msg, err := payload.marshalMsgIntoWithMaxLength(dst, requestID, responseTo, int(s.maxMessageLength()))
-	if err != nil && payload.kind == findResponsePayloadIndexedRange {
+	if err != nil {
 		doc, docErr := commandError(commandCodeBadValue, "BadValue", err.Error())
 		if docErr != nil {
 			return nil, docErr
@@ -257,7 +311,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 		return findResponsePayload{document: doc}, err
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if errors.Is(err, collections.ErrCollectionNotFound) {
 		doc, err := marshalCursorResponse(db, collection, bson.A{})
 		return findResponsePayload{document: doc}, err
@@ -277,6 +331,34 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return findResponsePayload{document: doc}, err
 	}
 	ns := db + "." + collection
+	normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
+	if err != nil {
+		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+		return findResponsePayload{document: doc}, err
+	}
+	if normalizedBatchSize > 0 && !plan.projection.present {
+		if idValue, ok := singlePrimaryIDPredicateValue(plan); ok {
+			doc, found, err := singlePrimaryIDDocument(col, idValue)
+			if err != nil {
+				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+				return findResponsePayload{document: doc}, err
+			}
+			if !found {
+				return findResponsePayload{
+					kind: findResponsePayloadRaw,
+					raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"},
+				}, nil
+			}
+			if err := ensureSingleFindBatchDocumentFits(doc, s.maxFindBatchBytes()); err != nil {
+				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+				return findResponsePayload{document: doc}, err
+			}
+			return findResponsePayload{
+				kind: findResponsePayloadRaw,
+				raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", single: doc},
+			}, nil
+		}
+	}
 	if !plan.projection.present {
 		idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
 		if err != nil {
@@ -284,11 +366,6 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 			return findResponsePayload{document: doc}, err
 		}
 		if ok {
-			normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
-			if err != nil {
-				doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
-				return findResponsePayload{document: doc}, err
-			}
 			if empty {
 				return findResponsePayload{
 					kind: findResponsePayloadRaw,
@@ -320,11 +397,6 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return findResponsePayload{document: doc}, err
 	}
 	if singleBatch {
-		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
-		if err != nil {
-			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
-			return findResponsePayload{document: doc}, err
-		}
 		if !results.projection.present {
 			consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
 			if err != nil {
@@ -345,11 +417,6 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return findResponsePayload{document: doc}, err
 	}
 	if !results.projection.present {
-		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
-		if err != nil {
-			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
-			return findResponsePayload{document: doc}, err
-		}
 		if normalizedBatchSize >= len(results.docs) {
 			consumed, err := rawDocumentsBatchLimit(results.docs, normalizedBatchSize, s.maxFindBatchBytes())
 			if err != nil {
@@ -394,7 +461,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalUpdateResponse(0, 0)
@@ -1189,7 +1256,7 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalDeleteResponse(0)
@@ -1303,7 +1370,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	}
 
 	createdAutomatically := false
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err != nil {
 		if !errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -1315,7 +1382,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			// If another request created the collection after our miss, fall
 			// through to the idempotent add-index path below.
 			createErr := err
-			col, err = s.Collections.OpenCollection(name)
+			col, err = s.openCollection(name)
 			if err != nil {
 				return commandError(commandCodeBadValue, "BadValue", createErr.Error())
 			}
@@ -1368,7 +1435,7 @@ func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, erro
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
@@ -1394,7 +1461,7 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
@@ -2178,14 +2245,14 @@ func rawDocumentsBatchLimit(docs []wire.Document, maxDocs int, maxBytes int) (in
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollection(name)
 	if err == nil {
 		return col, nil
 	}
 	if _, createErr := s.Collections.CreateCollection(s.defaultCollectionMeta(name)); createErr != nil {
 		return nil, createErr
 	}
-	return s.Collections.OpenCollection(name)
+	return s.openCollection(name)
 }
 
 func (s *Server) defaultCollectionMeta(name string) *collections.CollectionMeta {
@@ -2495,6 +2562,45 @@ func storedDocumentMaterializerForCollection(col *collections.Collection) (*coll
 	default:
 		return col.NewStoredDocumentJSONMaterializer()
 	}
+}
+
+func singlePrimaryIDDocument(col *collections.Collection, value bson.RawValue) (wire.Document, bool, error) {
+	if col == nil {
+		return nil, false, errors.New("mongo gateway: collection handle is nil")
+	}
+	key, err := encodePrimaryKey(value)
+	if err != nil {
+		return nil, false, err
+	}
+	stored, err := col.Get(key)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(stored) == 0 {
+		return nil, false, nil
+	}
+	if col.Meta().Options.DocumentFormat == collections.DocumentFormatBSON {
+		if err := validateStoredBSONFrame(stored); err != nil {
+			return nil, false, err
+		}
+		return wire.Document(stored), true, nil
+	}
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return nil, false, err
+	}
+	if materializer != nil {
+		defer func() { _ = materializer.Close() }()
+	}
+	doc, err := storedDocumentToBSON(col, materializer, stored)
+	return doc, err == nil, err
+}
+
+func ensureSingleFindBatchDocumentFits(doc wire.Document, maxBatchBytes int) error {
+	if findBatchOverheadBytes+findBatchDocumentBytes(doc, 0) > maxBatchBytes {
+		return fmt.Errorf("mongo gateway cursor document exceeds max batch bytes: docBytes=%d maxBatchBytes=%d", findBatchDocumentBytes(doc, 0), maxBatchBytes)
+	}
+	return nil
 }
 
 func borrowedStoredDocumentToBSON(materializer *collections.StoredDocumentJSONMaterializer, stored []byte) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -223,6 +223,12 @@ func (r rawCursorDocumentsResponse) marshalMsgInto(dst []byte, requestID, respon
 		return msg[:base], err
 	}
 	messageLength := len(msg) - base
+	if messageLength != need {
+		return msg[:base], fmt.Errorf("mongo gateway raw cursor response length mismatch: got=%d want=%d", messageLength, need)
+	}
+	if int64(messageLength) > maxWireMessageLengthInt32Limit {
+		return msg[:base], fmt.Errorf("%w: length=%d", wire.ErrMessageTooLarge, messageLength)
+	}
 	if messageLength > maxMessageLength {
 		return msg[:base], fmt.Errorf("%w: length=%d max=%d", wire.ErrMessageTooLarge, messageLength, maxMessageLength)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2573,11 +2573,11 @@ func singlePrimaryIDDocument(col *collections.Collection, value bson.RawValue) (
 	if err != nil {
 		return nil, false, err
 	}
-	stored, err := col.Get(key)
+	stored, found, err := col.GetInto(key, nil)
 	if err != nil {
 		return nil, false, err
 	}
-	if len(stored) == 0 {
+	if !found {
 		return nil, false, nil
 	}
 	if col.Meta().Options.DocumentFormat == collections.DocumentFormatBSON {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -711,6 +711,17 @@ func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool)
 	return findPredicate{}, false
 }
 
+func singlePrimaryIDPredicateValue(plan findPlan) (bson.RawValue, bool) {
+	if plan.projection.present || plan.sort.field != "" || plan.skip != 0 || len(plan.predicates) != 1 {
+		return bson.RawValue{}, false
+	}
+	pred := plan.predicates[0]
+	if pred.field != "_id" || pred.op != findPredicateEq || len(pred.values) != 1 {
+		return bson.RawValue{}, false
+	}
+	return pred.values[0], true
+}
+
 func documentsForPrimaryPredicate(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, pred findPredicate, maxDocuments int) ([]wire.Document, error) {
 	out := make([]wire.Document, 0, len(pred.values))
 	seen := make(map[string]struct{}, len(pred.values))

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -97,7 +97,7 @@ func NewServer() *Server {
 
 func (s *Server) openCollection(name string) (*collections.Collection, error) {
 	if s == nil || s.Collections == nil {
-		return nil, errors.New("mongo gateway collection manager is not configured")
+		return nil, errors.New(mongoGatewayCollectionManagerNotConfigured)
 	}
 	s.collectionMu.RLock()
 	cached := s.collections[name]

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -70,6 +70,8 @@ type Server struct {
 	lastCursorReap   time.Time
 	updateMu         sync.Mutex
 	updateCoalescers map[string]*mongoUpdateCoalescer
+	collectionMu     sync.RWMutex
+	collections      map[string]*collections.Collection
 	closed           atomic.Bool
 }
 
@@ -93,6 +95,48 @@ func NewServer() *Server {
 	return s
 }
 
+func (s *Server) openCollection(name string) (*collections.Collection, error) {
+	if s == nil || s.Collections == nil {
+		return nil, errors.New("mongo gateway collection manager is not configured")
+	}
+	s.collectionMu.RLock()
+	cached := s.collections[name]
+	s.collectionMu.RUnlock()
+	if cached != nil && cached.CachedCatalogIsCurrent() {
+		return cached, nil
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			s.forgetCollection(name)
+		}
+		return nil, err
+	}
+	s.rememberCollection(name, col)
+	return col, nil
+}
+
+func (s *Server) rememberCollection(name string, col *collections.Collection) {
+	if s == nil || name == "" || col == nil {
+		return
+	}
+	s.collectionMu.Lock()
+	if s.collections == nil {
+		s.collections = make(map[string]*collections.Collection)
+	}
+	s.collections[name] = col
+	s.collectionMu.Unlock()
+}
+
+func (s *Server) forgetCollection(name string) {
+	if s == nil || name == "" {
+		return
+	}
+	s.collectionMu.Lock()
+	delete(s.collections, name)
+	s.collectionMu.Unlock()
+}
+
 func (s *Server) Close() error {
 	if s == nil {
 		return nil
@@ -100,6 +144,9 @@ func (s *Server) Close() error {
 	s.closed.Store(true)
 	s.closeActiveConns()
 	s.closeUpdateCoalescers()
+	s.collectionMu.Lock()
+	s.collections = nil
+	s.collectionMu.Unlock()
 	s.cursorMu.Lock()
 	s.cursors = nil
 	s.cursorCount.Store(0)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2962,6 +2962,23 @@ func TestServerFindRawBSONOPMsgResponseHonorsMaxMessageLength(t *testing.T) {
 	if !errors.Is(err, wire.ErrMessageTooLarge) {
 		t.Fatalf("marshal small max err=%v want ErrMessageTooLarge", err)
 	}
+
+	rawSingle := rawCursorDocumentsResponse{ns: "app.users", cursorID: 0, batchKey: "firstBatch", single: rawDoc}
+	msg, err := rawSingle.marshalMsgInto(nil, 1, 250, wire.DefaultMaxMessageLength)
+	if err != nil {
+		t.Fatalf("marshal raw single default max response: %v", err)
+	}
+	h, _, err := wire.ReadMessage(bytes.NewReader(msg), 0)
+	if err != nil {
+		t.Fatalf("read raw single response: %v", err)
+	}
+	if h.MessageLength != int32(len(msg)) {
+		t.Fatalf("raw single message length=%d want %d", h.MessageLength, len(msg))
+	}
+	_, err = rawSingle.marshalMsgInto(nil, 1, 250, 128)
+	if !errors.Is(err, wire.ErrMessageTooLarge) {
+		t.Fatalf("marshal raw single small max err=%v want ErrMessageTooLarge", err)
+	}
 }
 
 func TestFindResponsePayloadOPMsgHonorsMaxMessageLength(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1572,6 +1572,62 @@ func TestMongoUpdateCoalescerUsesSingleCollection(t *testing.T) {
 	}
 }
 
+func TestServerOpenCollectionCacheInvalidatesOnCatalogChange(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{Name: "app.users"}); err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	server := NewServer()
+	server.Collections = manager
+
+	first, err := server.openCollection("app.users")
+	if err != nil {
+		t.Fatalf("open first users handle: %v", err)
+	}
+	second, err := server.openCollection("app.users")
+	if err != nil {
+		t.Fatalf("open cached users handle: %v", err)
+	}
+	if second != first {
+		t.Fatal("server did not reuse current cached collection handle")
+	}
+
+	mutator, err := manager.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open mutator users handle: %v", err)
+	}
+	if _, err := mutator.CreateIndex(collections.IndexDefinition{Name: "email", Field: "email", ValueType: collections.IndexValueString}); err != nil {
+		t.Fatalf("create email index: %v", err)
+	}
+	if first.CachedCatalogIsCurrent() {
+		t.Fatal("server cached handle stayed current after external schema change")
+	}
+
+	afterSchemaChange, err := server.openCollection("app.users")
+	if err != nil {
+		t.Fatalf("open users after schema change: %v", err)
+	}
+	if afterSchemaChange == first {
+		t.Fatal("server reused stale collection handle after schema change")
+	}
+	if !afterSchemaChange.CachedCatalogIsCurrent() {
+		t.Fatal("server cached replacement handle is not current")
+	}
+	again, err := server.openCollection("app.users")
+	if err != nil {
+		t.Fatalf("open cached replacement users handle: %v", err)
+	}
+	if again != afterSchemaChange {
+		t.Fatal("server did not reuse replacement cached collection handle")
+	}
+}
+
 func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
 	server := NewServer()
 	coalescer := server.mongoUpdateCoalescer("app.users")

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2918,6 +2918,41 @@ func TestServerFindRawBSONOPMsgResponse(t *testing.T) {
 	}
 }
 
+func TestSinglePrimaryIDDocumentDoesNotTreatPresentEmptyStoredDocumentAsMissing(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{Name: "app.users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	id := bson.Raw(mustDocument(t, bson.D{{Key: "_id", Value: "empty"}})).Lookup("_id")
+	key, err := encodePrimaryKey(id)
+	if err != nil {
+		t.Fatalf("encode id: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{key}, [][]byte{[]byte{}}); err != nil {
+		t.Fatalf("insert present empty stored document: %v", err)
+	}
+
+	if _, found, err := singlePrimaryIDDocument(col, id); err == nil || found {
+		t.Fatalf("singlePrimaryIDDocument empty stored doc found=%v err=%v, want conversion error", found, err)
+	}
+
+	missing := bson.Raw(mustDocument(t, bson.D{{Key: "_id", Value: "missing"}})).Lookup("_id")
+	if doc, found, err := singlePrimaryIDDocument(col, missing); err != nil || found || doc != nil {
+		t.Fatalf("singlePrimaryIDDocument missing doc=%v found=%v err=%v, want nil false nil", doc, found, err)
+	}
+}
+
 func TestServerFindRawBSONOPMsgResponseHonorsMaxMessageLength(t *testing.T) {
 	rawDoc := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "payload", Value: strings.Repeat("x", 256)}})
 	if _, err := marshalCursorDocumentsMsgResponseWithIDInto(nil, 1, 250, "app.users", 0, "firstBatch", []wire.Document{rawDoc}, wire.DefaultMaxMessageLength); err != nil {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -3274,7 +3274,13 @@ func clientModeLabel(target, config string) string {
 	}
 	config = strings.TrimPrefix(config, target+"_")
 	config = strings.TrimPrefix(config, "bson_")
-	config = strings.TrimSuffix(config, "_range_index")
+	withoutRangeIndex := strings.TrimSuffix(config, "_range_index")
+	if withoutRangeIndex != "" {
+		config = withoutRangeIndex
+	}
+	if config == "range_index" {
+		config = "driver"
+	}
 	return "BSON " + config
 }
 

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -147,6 +147,17 @@ type loadModeRow struct {
 	RawJSON       string
 }
 
+type readModeRow struct {
+	Indexes          int
+	Target           string
+	Config           string
+	Phase            string
+	OpsPerSec        float64
+	SampledOpsPerSec float64
+	P95US            float64
+	RawJSON          string
+}
+
 type gitIdentity struct {
 	Label string
 	Hash  string
@@ -161,6 +172,7 @@ type reportData struct {
 	CollectionComparisons []collectionComparison
 	MongoFullSweep        []mongoSummaryRow
 	MongoLoadModes        []loadModeRow
+	MongoReadModes        []readModeRow
 	MongoScaling          map[int][]mongoSummaryRow
 	Profiles              profileReportData
 	Warnings              []string
@@ -334,6 +346,12 @@ func loadReportData(cfg config) (reportData, error) {
 	}
 	if rows, warnings, err := loadMongoLoadModes(filepath.Join(cfg.RunRoot, "mongo_client_mode_load_matrix_1m")); err == nil {
 		data.MongoLoadModes = rows
+		data.Warnings = append(data.Warnings, warnings...)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		data.Warnings = append(data.Warnings, err.Error())
+	}
+	if rows, warnings, err := loadMongoReadModes(filepath.Join(cfg.RunRoot, "mongo_client_mode_read_matrix_1m")); err == nil {
+		data.MongoReadModes = rows
 		data.Warnings = append(data.Warnings, warnings...)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		data.Warnings = append(data.Warnings, err.Error())
@@ -771,6 +789,59 @@ func loadMongoLoadModes(dir string) ([]loadModeRow, []string, error) {
 	return out, warnings, nil
 }
 
+func loadMongoReadModes(dir string) ([]readModeRow, []string, error) {
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	rows, err := readMatrix(matrixPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	var out []readModeRow
+	var warnings []string
+	for _, row := range rows {
+		rawPath, err := resolveRunArtifactPath(dir, row.RawJSON)
+		if err != nil {
+			warnings = append(warnings, err.Error())
+			continue
+		}
+		result, err := readBenchmarkResult(rawPath)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", rawPath, err))
+			continue
+		}
+		for _, phase := range result.Phases {
+			if !isReadModePhase(phase.Name) {
+				continue
+			}
+			if readModeIsRawWire(row) && readModePhaseKind(phase.Name) == "id" {
+				continue
+			}
+			out = append(out, readModeRow{
+				Indexes:          row.SecondaryIndexes,
+				Target:           row.Target,
+				Config:           row.Config,
+				Phase:            phase.Name,
+				OpsPerSec:        phase.OpsPerSecond,
+				SampledOpsPerSec: phase.SampledOpsPerSecond,
+				P95US:            phase.LatencyMicros.P95,
+				RawJSON:          row.RawJSON,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Indexes != out[j].Indexes {
+			return out[i].Indexes < out[j].Indexes
+		}
+		if readModePhaseOrder(out[i].Phase) != readModePhaseOrder(out[j].Phase) {
+			return readModePhaseOrder(out[i].Phase) < readModePhaseOrder(out[j].Phase)
+		}
+		if out[i].Target != out[j].Target {
+			return out[i].Target < out[j].Target
+		}
+		return out[i].Config < out[j].Config
+	})
+	return out, warnings, nil
+}
+
 func resolveRunArtifactPath(baseDir, relPath string) (string, error) {
 	if strings.TrimSpace(relPath) == "" {
 		return "", fmt.Errorf("empty artifact path under %s", baseDir)
@@ -858,6 +929,7 @@ func loadProfiles(runRoot string) (profileReportData, []string) {
 	for _, root := range []string{
 		filepath.Join(runRoot, "mongo_gateway_full_sweep_1m_expanded", "profiles"),
 		filepath.Join(runRoot, "mongo_client_mode_load_matrix_1m", "profiles"),
+		filepath.Join(runRoot, "mongo_client_mode_read_matrix_1m", "profiles"),
 	} {
 		for _, path := range walkProfileFiles(root, "profile_manifest.json", &warnings) {
 			item, err := readMongoProfileSummary(runRoot, path)
@@ -1173,6 +1245,7 @@ func renderHTML(data reportData) string {
 	}
 	renderMongoFullSweep(&b, data.MongoFullSweep)
 	renderMongoLoadModes(&b, data.MongoLoadModes)
+	renderMongoReadModes(&b, data.MongoReadModes)
 	renderMongoScaling(&b, data.MongoScaling)
 	renderCollections(&b, data.Collections, data.CollectionComparisons)
 	renderRawEngine(&b, data.RawEngine)
@@ -1192,6 +1265,9 @@ func reportNav(data reportData) string {
 	}
 	if len(data.MongoLoadModes) > 0 {
 		items = append(items, navItem{Href: "#mongo-load", Label: "Load modes"})
+	}
+	if len(data.MongoReadModes) > 0 {
+		items = append(items, navItem{Href: "#mongo-read-modes", Label: "Read modes"})
 	}
 	if len(data.MongoScaling) > 0 {
 		items = append(items, navItem{Href: "#scaling", Label: "Scaling"})
@@ -2296,7 +2372,7 @@ func renderMongoFullSweep(b *strings.Builder, rows []mongoSummaryRow) {
 	b.WriteString("<section id=\"mongo-full\"><h2>Mongo API Full Sweep</h2>")
 	b.WriteString("<p class=\"subtle\">Full BSON `driver-command-raw` TreeDB-vs-MongoDB phase comparison. Headline charts and summaries are shown first; raw `summary.tsv` rows are collapsed below.</p>")
 	b.WriteString("<div class=\"chart-group\"><h3>Index-count overview</h3>")
-	b.WriteString("<p class=\"subtle\">These two charts show the headline insert throughput and physical disk footprint as secondary indexes are added.</p>")
+	b.WriteString("<p class=\"subtle\">These two charts show the headline insert throughput and storage footprint as secondary indexes are added.</p>")
 	b.WriteString(fullSweepLoadNote(rows))
 	b.WriteString("<div class=\"chart-grid\">")
 	indexes := sortedMongoIndexes(rows)
@@ -2307,7 +2383,7 @@ func renderMongoFullSweep(b *strings.Builder, rows []mongoSummaryRow) {
 			{Name: "TreeDB", Values: mongoRowOps(loadRows, "tree"), Color: "#2867c7"},
 			{Name: "MongoDB", Values: mongoRowOps(loadRows, "mongo"), Color: "#1f8a5b"},
 		}, "docs/sec"))
-		b.WriteString(lineChart("Storage footprint vs secondary indexes", indexLabels, "secondary indexes", "storage bytes", []chartSeries{
+		b.WriteString(lineChart("Storage footprint vs secondary indexes (Mongo dbStats.totalSize)", indexLabels, "secondary indexes", "storage bytes", []chartSeries{
 			{Name: "TreeDB", Values: mongoRowDisk(loadRows, "tree"), Color: "#2867c7"},
 			{Name: "MongoDB", Values: mongoRowDisk(loadRows, "mongo"), Color: "#1f8a5b"},
 		}, "bytes"))
@@ -2379,13 +2455,51 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 		}
 	}
 	b.WriteString("</div>")
-	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the collection API directly in the selected TreeDB document format. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
+	b.WriteString("<p class=\"subtle\"><strong>* TreeDB-only modes:</strong> <code>direct</code> calls the collection API directly in the selected TreeDB document format. <code>raw-wire-tcp</code> still sends Mongo OP_MSG bytes over loopback TCP to the TreeDB gateway while bypassing the MongoDB Go driver. <code>raw-wire-tcp-pipeline</code> pipelines those raw TCP requests. <code>raw-wire</code> removes the socket too and drives the same raw command/gateway path in process. These modes are TreeDB-only ceiling probes, so each renders as one centered TreeDB bar instead of a paired MongoDB bar.</p>")
 	var body [][]string
 	for _, row := range rows {
 		body = append(body, []string{strconv.Itoa(row.Indexes), row.Target, row.Config, fmtOps(row.OpsPerSec), loadModePhysicalBytesCell(row), row.RawJSON})
 	}
 	b.WriteString("<details><summary>Raw load-mode rows</summary>")
 	writeTable(b, []string{"indexes", "target", "config", "load docs/sec", "physical bytes", "raw JSON"}, body, numericColumns(0, 3, 4))
+	b.WriteString("</details>")
+	b.WriteString("</section>\n")
+}
+
+func renderMongoReadModes(b *strings.Builder, rows []readModeRow) {
+	if len(rows) == 0 {
+		return
+	}
+	b.WriteString("<section id=\"mongo-read-modes\"><h2>Read Client-Mode Ceiling Matrix</h2>")
+	b.WriteString("<p class=\"subtle\">Concurrent read matrix using raw validation paths. Mongo-compatible client modes render as paired TreeDB/MongoDB bars; TreeDB-only direct/raw-wire modes are marked with <strong>*</strong> and show storage/gateway ceilings beside the compatible panels.</p>")
+	b.WriteString("<p class=\"subtle\">Raw-wire modes are rendered for range phases only. Point lookup rows for those modes are intentionally omitted because the current harness would otherwise use the normal driver lookup path while only the range phase exercises raw OP_MSG bytes.</p>")
+	b.WriteString("<div class=\"chart-grid\">")
+	for _, idx := range sortedReadModeIndexes(rows) {
+		for _, phase := range sortedReadModePhasesForIndex(rows, idx) {
+			cats, tree, mongo := readModeChartRows(rows, idx, phase)
+			if len(cats) == 0 {
+				continue
+			}
+			b.WriteString(loadModeBarChart(readModeChartTitle(phase, idx), cats, tree, mongo, "ops/sec", "Ops/Sec"))
+		}
+	}
+	b.WriteString("</div>")
+	var body [][]string
+	for _, row := range rows {
+		body = append(body, []string{
+			strconv.Itoa(row.Indexes),
+			row.Phase,
+			readModeReaderCountCell(row.Phase),
+			row.Target,
+			row.Config,
+			fmtOps(row.OpsPerSec),
+			fmtOps(row.SampledOpsPerSec),
+			fmtFloat(row.P95US, 1),
+			row.RawJSON,
+		})
+	}
+	b.WriteString("<details><summary>Raw read-mode rows</summary>")
+	writeTable(b, []string{"indexes", "phase", "readers", "target", "config", "ops/sec", "sampled ops/sec", "p95 us", "raw JSON"}, body, numericColumns(0, 2, 5, 6, 7))
 	b.WriteString("</details>")
 	b.WriteString("</section>\n")
 }
@@ -2752,11 +2866,7 @@ func mongoRowDisk(rows []mongoSummaryRow, side string) []float64 {
 	out := make([]float64, 0, len(rows))
 	for _, row := range rows {
 		if side == "mongo" {
-			if row.MongoPhysicalBytes > 0 {
-				out = append(out, row.MongoPhysicalBytes)
-			} else {
-				out = append(out, row.MongoDBStatsTotalSize)
-			}
+			out = append(out, row.MongoDBStatsTotalSize)
 		} else {
 			out = append(out, row.TreeDBPhysicalBytes)
 		}
@@ -2783,25 +2893,7 @@ func mongoStorageBasisText(rows []mongoSummaryRow) string {
 			}
 		}
 	}
-	mongoPhysical := 0
-	mongoDBStats := 0
-	for _, row := range rows {
-		if row.MongoPhysicalBytes > 0 {
-			mongoPhysical++
-		} else if row.MongoDBStatsTotalSize > 0 {
-			mongoDBStats++
-		}
-	}
-	mongoBasis := "MongoDB storage bytes from summary.tsv"
-	switch {
-	case mongoPhysical > 0 && mongoDBStats == 0:
-		mongoBasis = "MongoDB measured data-directory bytes"
-	case mongoPhysical == 0 && mongoDBStats > 0:
-		mongoBasis = "MongoDB dbStats.totalSize from this run"
-	case mongoPhysical > 0 && mongoDBStats > 0:
-		mongoBasis = "MongoDB mixed measured data-directory bytes and dbStats.totalSize; see raw rows"
-	}
-	return treeBasis + "; " + mongoBasis + "."
+	return treeBasis + "; MongoDB dbStats.totalSize from this run."
 }
 
 func mongoRow(rows []mongoSummaryRow, idx int, phase string) (mongoSummaryRow, bool) {
@@ -3047,6 +3139,36 @@ func sortedLoadModeIndexes(rows []loadModeRow) []int {
 	return out
 }
 
+func sortedReadModeIndexes(rows []readModeRow) []int {
+	seen := make(map[int]bool)
+	for _, row := range rows {
+		seen[row.Indexes] = true
+	}
+	var out []int
+	for idx := range seen {
+		out = append(out, idx)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func sortedReadModePhasesForIndex(rows []readModeRow, idx int) []string {
+	seen := make(map[string]bool)
+	for _, row := range rows {
+		if row.Indexes == idx {
+			seen[row.Phase] = true
+		}
+	}
+	var out []string
+	for phase := range seen {
+		out = append(out, phase)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return readModePhaseOrder(out[i]) < readModePhaseOrder(out[j])
+	})
+	return out
+}
+
 func loadModeChartRows(rows []loadModeRow, idx int) ([]string, []float64, []float64) {
 	return loadModeValueRows(rows, idx, func(row loadModeRow) float64 { return row.OpsPerSec })
 }
@@ -3139,24 +3261,33 @@ func loadModeDisplayLabel(mode string) string {
 }
 
 func loadModeLabel(row loadModeRow) string {
-	config := row.Config
-	if config == row.Target {
-		config = row.Target + "_driver"
+	return clientModeLabel(row.Target, row.Config)
+}
+
+func readModeLabel(row readModeRow) string {
+	return clientModeLabel(row.Target, row.Config)
+}
+
+func clientModeLabel(target, config string) string {
+	if config == target {
+		config = target + "_driver"
 	}
-	config = strings.TrimPrefix(config, row.Target+"_")
+	config = strings.TrimPrefix(config, target+"_")
 	config = strings.TrimPrefix(config, "bson_")
+	config = strings.TrimSuffix(config, "_range_index")
 	return "BSON " + config
 }
 
 func loadModeOrder(mode string) string {
 	order := map[string]int{
-		"BSON driver":             0,
-		"BSON driver_command":     1,
-		"BSON driver_command_raw": 2,
-		"BSON driver_unack":       3,
-		"BSON direct":             4,
-		"BSON raw_wire_tcp":       5,
-		"BSON raw_wire":           6,
+		"BSON driver":                0,
+		"BSON driver_command":        1,
+		"BSON driver_command_raw":    2,
+		"BSON driver_unack":          3,
+		"BSON direct":                4,
+		"BSON raw_wire_tcp":          5,
+		"BSON raw_wire_tcp_pipeline": 6,
+		"BSON raw_wire":              7,
 	}
 	if idx, ok := order[mode]; ok {
 		return fmt.Sprintf("%02d_%s", idx, mode)
@@ -3166,8 +3297,10 @@ func loadModeOrder(mode string) string {
 		return "04_" + mode
 	case "raw_wire_tcp":
 		return "05_" + mode
-	case "raw_wire":
+	case "raw_wire_tcp_pipeline":
 		return "06_" + mode
+	case "raw_wire":
+		return "07_" + mode
 	}
 	return "99_" + mode
 }
@@ -3180,11 +3313,127 @@ func loadModeKind(mode string) string {
 		return "direct"
 	case normalized == "raw_wire_tcp" || strings.HasSuffix(normalized, "_raw_wire_tcp"):
 		return "raw_wire_tcp"
+	case normalized == "raw_wire_tcp_pipeline" || strings.HasSuffix(normalized, "_raw_wire_tcp_pipeline"):
+		return "raw_wire_tcp_pipeline"
 	case normalized == "raw_wire" || strings.HasSuffix(normalized, "_raw_wire"):
 		return "raw_wire"
 	default:
 		return ""
 	}
+}
+
+func readModeChartRows(rows []readModeRow, idx int, phase string) ([]string, []float64, []float64) {
+	type pair struct {
+		TreeDB float64
+		Mongo  float64
+	}
+	pairs := make(map[string]pair)
+	for _, row := range rows {
+		if row.Indexes != idx || row.Phase != phase {
+			continue
+		}
+		mode := readModeLabel(row)
+		pair := pairs[mode]
+		switch row.Target {
+		case "treedb":
+			pair.TreeDB = row.OpsPerSec
+		case "mongo":
+			pair.Mongo = row.OpsPerSec
+		}
+		pairs[mode] = pair
+	}
+	var labels []string
+	for mode := range pairs {
+		labels = append(labels, mode)
+	}
+	sort.Slice(labels, func(i, j int) bool {
+		return loadModeOrder(labels[i]) < loadModeOrder(labels[j])
+	})
+	tree := make([]float64, 0, len(labels))
+	mongo := make([]float64, 0, len(labels))
+	for _, mode := range labels {
+		pair := pairs[mode]
+		tree = append(tree, pair.TreeDB)
+		mongo = append(mongo, pair.Mongo)
+	}
+	return labels, tree, mongo
+}
+
+func isReadModePhase(phase string) bool {
+	return strings.HasPrefix(phase, "concurrent_id_find_one_r") ||
+		strings.HasPrefix(phase, "concurrent_age_range_indexed_limit_10_r") ||
+		strings.HasPrefix(phase, "concurrent_age_range_scan_limit_10_r")
+}
+
+func readModePhaseKind(phase string) string {
+	switch {
+	case strings.HasPrefix(phase, "concurrent_id_find_one_r"):
+		return "id"
+	case strings.HasPrefix(phase, "concurrent_age_range_indexed_limit_10_r"),
+		strings.HasPrefix(phase, "concurrent_age_range_scan_limit_10_r"):
+		return "range"
+	default:
+		return ""
+	}
+}
+
+func readModePhaseOrder(phase string) string {
+	return fmt.Sprintf("%02d_%04d_%s", readModeKindOrder(readModePhaseKind(phase)), readModeReaderCount(phase), phase)
+}
+
+func readModeKindOrder(kind string) int {
+	switch kind {
+	case "id":
+		return 0
+	case "range":
+		return 1
+	default:
+		return 9
+	}
+}
+
+func readModeReaderCountCell(phase string) string {
+	count := readModeReaderCount(phase)
+	if count == 0 {
+		return "-"
+	}
+	return strconv.Itoa(count)
+}
+
+func readModeReaderCount(phase string) int {
+	idx := strings.LastIndex(phase, "_r")
+	if idx < 0 || idx+2 >= len(phase) {
+		return 0
+	}
+	count, _ := strconv.Atoi(phase[idx+2:])
+	return count
+}
+
+func readModeChartTitle(phase string, idx int) string {
+	label := phase
+	switch {
+	case strings.HasPrefix(phase, "concurrent_id_find_one_r"):
+		label = "ID find one"
+	case strings.HasPrefix(phase, "concurrent_age_range_indexed_limit_10_r"):
+		label = "Age range indexed limit 10"
+	case strings.HasPrefix(phase, "concurrent_age_range_scan_limit_10_r"):
+		label = "Age range scan limit 10"
+	}
+	if readers := readModeReaderCount(phase); readers > 0 {
+		unit := "readers"
+		if readers == 1 {
+			unit = "reader"
+		}
+		label += fmt.Sprintf(", %d %s", readers, unit)
+	}
+	return fmt.Sprintf("%s by client mode, %d indexes", label, idx)
+}
+
+func readModeIsRawWire(row matrixRow) bool {
+	mode := clientModeLabel(row.Target, row.Config)
+	return loadModeKind(mode) == "raw_wire" ||
+		loadModeKind(mode) == "raw_wire_tcp" ||
+		loadModeKind(mode) == "raw_wire_tcp_pipeline"
 }
 
 func indexCountLabel(indexes int) string {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -295,6 +295,12 @@ func TestLoadModeLabelNormalizesSingleMongoConfig(t *testing.T) {
 	if got, want := loadModeLabel(loadModeRow{Target: "mongo", Config: "mongo"}), "BSON driver"; got != want {
 		t.Fatalf("label = %q, want %q", got, want)
 	}
+	if got, want := loadModeLabel(loadModeRow{Target: "mongo", Config: "mongo_range_index"}), "BSON driver"; got != want {
+		t.Fatalf("legacy range-index label = %q, want %q", got, want)
+	}
+	if got, want := readModeLabel(readModeRow{Target: "treedb", Config: "treedb_bson_raw_wire_range_index"}), "BSON raw_wire"; got != want {
+		t.Fatalf("range-index mode label = %q, want %q", got, want)
+	}
 }
 
 func TestTreeDBOnlyLoadModeIncludesNonBSONDirectFormats(t *testing.T) {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -117,6 +117,15 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire_tcp.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1500}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":1800}]}`)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "raw", "mongo.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"load_insert_many","ops_per_sec":500}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_read_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw\t100\t0\traw/treedb_driver_command_raw.json\t2800\n"+
+		"treedb\ttreedb_bson_direct\t100\t0\traw/treedb_direct.json\t2800\n"+
+		"treedb\ttreedb_bson_raw_wire\t100\t0\traw/treedb_raw_wire.json\t2800\n"+
+		"mongo\tmongo_driver_command_raw\t100\t0\traw/mongo_driver_command_raw.json\t5000\n")
+	writeFile(t, filepath.Join(root, "mongo_client_mode_read_matrix_1m", "raw", "treedb_driver_command_raw.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":2000,"sampled_ops_per_sec":2100,"latency_micros":{"p95":12}},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":1000,"latency_micros":{"p95":24}}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_read_matrix_1m", "raw", "treedb_direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"direct","phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":3000,"latency_micros":{"p95":8}},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":1800,"latency_micros":{"p95":18}}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_read_matrix_1m", "raw", "treedb_raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"client_mode":"raw-wire","phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":9999},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":2200,"latency_micros":{"p95":11}}]}`)
+	writeFile(t, filepath.Join(root, "mongo_client_mode_read_matrix_1m", "raw", "mongo_driver_command_raw.json"), `{"target":"mongo","documents":100,"secondary_indexes":0,"phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":1200,"latency_micros":{"p95":16}},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":900,"latency_micros":{"p95":30}}]}`)
 
 	out := filepath.Join(root, "deep_report.html")
 	if err := run([]string{"-run-root", root, "-out", out, "-title", "test report"}); err != nil {
@@ -129,6 +138,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"origin/main=999888777666",
 		"Mongo API Full Sweep",
 		"Load-Only Client-Mode Matrix",
+		"Read Client-Mode Ceiling Matrix",
 		"Mongo API Reader/Writer Scaling",
 		"Collections vs SQLite",
 		"Raw TreeDB Engine",
@@ -181,6 +191,9 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"same raw command/gateway path in process",
 		"one centered TreeDB bar",
 		"Physical Storage By Client Mode",
+		"Raw read-mode rows",
+		"ID Find One, 8 Readers By Client Mode",
+		"Age Range Indexed Limit 10",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("report missing %q\n%s", want, html)
@@ -291,6 +304,8 @@ func TestTreeDBOnlyLoadModeIncludesNonBSONDirectFormats(t *testing.T) {
 		"BSON template_v1_direct",
 		"BSON raw_wire_tcp",
 		"BSON json_raw_wire_tcp",
+		"BSON raw_wire_tcp_pipeline",
+		"BSON json_raw_wire_tcp_pipeline",
 		"BSON raw_wire",
 		"BSON json_raw_wire",
 	} {
@@ -328,14 +343,14 @@ func TestRawEngineChartOmitsMissingVariants(t *testing.T) {
 	}
 }
 
-func TestMongoRowDiskFallsBackToDBStatsTotalSize(t *testing.T) {
+func TestMongoRowDiskUsesDBStatsTotalSize(t *testing.T) {
 	rows := []mongoSummaryRow{
 		{TreeDBPhysicalBytes: 2048, MongoPhysicalBytes: 0, MongoDBStatsTotalSize: 4096},
 		{TreeDBPhysicalBytes: 3072, MongoPhysicalBytes: 8192, MongoDBStatsTotalSize: 16384},
 	}
 
-	if got, want := mongoRowDisk(rows, "mongo"), []float64{4096, 8192}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("mongoRowDisk fallback = %v, want %v", got, want)
+	if got, want := mongoRowDisk(rows, "mongo"), []float64{4096, 16384}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mongoRowDisk = %v, want %v", got, want)
 	}
 }
 
@@ -725,6 +740,31 @@ func TestLoadMongoLoadModesBestEffort(t *testing.T) {
 	}
 	if !strings.Contains(warnings[0], "raw/missing.json") {
 		t.Fatalf("warning %q does not name missing raw JSON", warnings[0])
+	}
+}
+
+func TestLoadMongoReadModesFiltersRawWireIDRows(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_raw_wire_range_index\t100\t0\traw/raw_wire.json\t2000\n"+
+		"treedb\ttreedb_bson_direct\t100\t0\traw/direct.json\t2000\n")
+	writeFile(t, filepath.Join(root, "raw", "raw_wire.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":9999},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":1234}]}`)
+	writeFile(t, filepath.Join(root, "raw", "direct.json"), `{"target":"treedb","documents":100,"secondary_indexes":0,"phases":[{"name":"concurrent_id_find_one_r8","ops_per_sec":4321},{"name":"concurrent_age_range_indexed_limit_10_r8","ops_per_sec":2345}]}`)
+
+	rows, warnings, err := loadMongoReadModes(root)
+	if err != nil {
+		t.Fatalf("loadMongoReadModes failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if got, want := len(rows), 3; got != want {
+		t.Fatalf("rows = %d, want %d: %#v", got, want, rows)
+	}
+	for _, row := range rows {
+		if row.Config == "treedb_bson_raw_wire_range_index" && readModePhaseKind(row.Phase) == "id" {
+			t.Fatalf("raw-wire id row should be filtered: %#v", row)
+		}
 	}
 }
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -46,11 +46,10 @@ checkout, the temp directory itself, a home directory, or an immediate child of
 a home directory are rejected.
 
 The default `-client-mode driver` uses the official MongoDB Go driver
-`Collection.InsertMany` path for the load phase and app-style decoded read
-phases. `-client-mode driver-find-raw` still uses official-driver
-`Collection.Find` for range reads, but iterates `cursor.Current` as raw BSON
-instead of decoding documents into `bson.M`; use it to isolate official-driver
-find/cursor overhead from application decode overhead. `-client-mode
+`Collection.InsertMany` path for the load phase and validates read phases with
+raw BSON field lookups instead of `bson.M` materialization. `-client-mode
+driver-find-raw` keeps the same official-driver `Collection.Find` range-read
+behavior and remains available as an explicit raw range-read mode. `-client-mode
 driver-command` still uses the official driver but sends the load
 phase as a raw `insert` command through `Database.RunCommand`, avoiding the
 driver's `InsertMany` `_id` discovery and `InsertedIDs` bookkeeping. It is useful
@@ -61,8 +60,8 @@ when `-prebuild-documents` is enabled; its age range-read phase also uses a raw
 `find` command and parses `cursor.firstBatch` as raw BSON instead of decoding
 documents into `bson.M`. `-client-mode driver-unack` uses official-driver
 `InsertMany` with unacknowledged write concern; its sampled load metric is
-client enqueue cost, while the phase waits for the final inserted `_id` to
-become visible before reporting wall ops/sec. `-client-mode raw-wire` is
+client enqueue cost, while the phase waits for inserted `_id` values to become
+visible with raw BSON validation before reporting wall ops/sec. `-client-mode raw-wire` is
 TreeDB-only and calls the in-process gateway directly with raw OP_MSG document
 sequences. `-client-mode raw-wire-tcp` sends the same raw OP_MSG traffic over
 the gateway's loopback listener, isolating TreeDB gateway network/wire-server
@@ -444,7 +443,7 @@ is normalized by document count over the whole phase loop; `sampled_ops_sec` and
 sampled values when investigating gateway/client overhead with prebuilt
 fixtures, and wall `ops_sec` when measuring the full benchmark loop. Insert
 latency percentiles are per batch call. Range-query samples include cursor
-materialization with `cursor.All`.
+iteration and raw age-field validation, not `bson.M` decoding.
 
 `mongo_pool_stats_after_load` is reset immediately before the insert load phase,
 so its checkout counters describe the measured insert phase rather than setup or
@@ -668,8 +667,8 @@ The benchmark-only helpers accept these optional environment variables:
 focused indexed async-flush experiments.
 
 Use the official-driver row for user-visible Mongo compatibility throughput,
-`driver-find-raw` to remove range-read `bson.M` decode while keeping
-official-driver `Find`/cursor behavior, the driver-command rows to quantify the
+`driver-find-raw` when you want an explicit official-driver raw range-read row,
+the driver-command rows to quantify the
 driver's CRUD-helper overhead, the raw-wire rows to estimate the gateway/server
 ceiling, `raw-wire-tcp-pipeline` to measure how much single-connection TCP
 latency can be hidden by request pipelining, and the direct collection row to

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -3278,13 +3278,15 @@ func runDriverRawValidatedRangePhase(ctx context.Context, cfg config, target *be
 func runFindOneRawString(ctx context.Context, coll *mongo.Collection, filter any, field, want string, sample func(time.Duration), label string) error {
 	begin := time.Now()
 	raw, err := coll.FindOne(ctx, filter).Raw()
-	sample(time.Since(begin))
 	if err != nil {
+		sample(time.Since(begin))
 		return err
 	}
 	if got, ok := directBSONStringField(raw, field); !ok || got != want {
+		sample(time.Since(begin))
 		return fmt.Errorf("%s returned %s=%v ok=%t want %s", label, field, got, ok, want)
 	}
+	sample(time.Since(begin))
 	return nil
 }
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1547,15 +1547,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	idPhase, err := measureTreeDBProfiledPhase(target, profiler, "id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			id := benchmarkID(i % cfg.Documents)
-			var out bson.M
-			begin := time.Now()
-			err := coll.FindOne(ctx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
-			sample(time.Since(begin))
-			if err != nil {
+			if err := runFindOneRawString(ctx, coll, bson.D{{Key: "_id", Value: id}}, "_id", id, sample, "id lookup"); err != nil {
 				return err
-			}
-			if out["_id"] != id {
-				return fmt.Errorf("id lookup returned _id=%v want %s", out["_id"], id)
 			}
 		}
 		return nil
@@ -1569,15 +1562,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		emailPhase, err := measureTreeDBProfiledPhase(target, profiler, "email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Reads; i++ {
 				email := benchmarkEmail((i * 17) % cfg.Documents)
-				var out bson.M
-				begin := time.Now()
-				err := coll.FindOne(ctx, bson.D{{Key: "email", Value: email}}).Decode(&out)
-				sample(time.Since(begin))
-				if err != nil {
+				if err := runFindOneRawString(ctx, coll, bson.D{{Key: "email", Value: email}}, "email", email, sample, "email lookup"); err != nil {
 					return err
-				}
-				if out["email"] != email {
-					return fmt.Errorf("email lookup returned email=%v want %s", out["email"], email)
 				}
 			}
 			return nil
@@ -2666,6 +2652,10 @@ func directBSONInt64Field(raw []byte, key string) (int64, bool) {
 	return 0, false
 }
 
+func directBSONStringField(raw []byte, key string) (string, bool) {
+	return bson.Raw(raw).Lookup(key).StringValueOK()
+}
+
 func applyDirectBSONSetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, error) {
 	updateElements, err := update.Elements()
 	if err != nil {
@@ -2905,53 +2895,12 @@ func runConcurrentReadOperation(ctx context.Context, coll *mongo.Collection, cfg
 	switch kind {
 	case concurrentReadKindID:
 		id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
-		var out bson.M
-		begin := time.Now()
-		err := coll.FindOne(ctx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
-		sample(time.Since(begin))
-		if err != nil {
-			return err
-		}
-		if out["_id"] != id {
-			return fmt.Errorf("concurrent id lookup returned _id=%v want %s", out["_id"], id)
-		}
-		return nil
+		return runFindOneRawString(ctx, coll, bson.D{{Key: "_id", Value: id}}, "_id", id, sample, "concurrent id lookup")
 	case concurrentReadKindEmail:
 		email := benchmarkEmail(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
-		var out bson.M
-		begin := time.Now()
-		err := coll.FindOne(ctx, bson.D{{Key: "email", Value: email}}).Decode(&out)
-		sample(time.Since(begin))
-		if err != nil {
-			return err
-		}
-		if out["email"] != email {
-			return fmt.Errorf("concurrent email lookup returned email=%v want %s", out["email"], email)
-		}
-		return nil
+		return runFindOneRawString(ctx, coll, bson.D{{Key: "email", Value: email}}, "email", email, sample, "concurrent email lookup")
 	case concurrentReadKindRange:
-		minAge := rangeReadMinAge(op, cfg.Documents)
-		begin := time.Now()
-		cursor, err := coll.Find(ctx,
-			bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
-			options.Find().SetLimit(10))
-		if err != nil {
-			sample(time.Since(begin))
-			return err
-		}
-		var docs []bson.M
-		if err := cursor.All(ctx, &docs); err != nil {
-			sample(time.Since(begin))
-			return err
-		}
-		sample(time.Since(begin))
-		for _, doc := range docs {
-			age, ok := int64Value(doc["age"])
-			if !ok || age < minAge {
-				return fmt.Errorf("concurrent range returned age=%v below %d", doc["age"], minAge)
-			}
-		}
-		return nil
+		return runDriverRawValidatedRangeOperation(ctx, coll, rangeReadMinAge(op, cfg.Documents), sample)
 	default:
 		return fmt.Errorf("unknown concurrent read kind %q", kind)
 	}
@@ -3259,11 +3208,10 @@ func waitForLoadVisible(ctx context.Context, cfg config, coll *mongo.Collection)
 			}
 			checked++
 			id := ids[i]
-			var out bson.M
-			err := coll.FindOne(waitCtx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
+			raw, err := coll.FindOne(waitCtx, bson.D{{Key: "_id", Value: id}}).Raw()
 			if err == nil {
-				if out["_id"] != id {
-					return fmt.Errorf("post-unack visibility lookup returned _id=%v want %s", out["_id"], id)
+				if got, ok := directBSONStringField(raw, "_id"); !ok || got != id {
+					return fmt.Errorf("post-unack visibility lookup returned _id=%v ok=%t want %s", got, ok, id)
 				}
 				visible[i] = true
 				remaining--
@@ -3313,13 +3261,13 @@ func runRangePhase(ctx context.Context, cfg config, target *benchTarget, profile
 	if cfg.ClientMode == clientModeDriverFindRaw {
 		return runDriverFindRawRangePhase(ctx, cfg, target, profiler, coll)
 	}
-	return runDriverDecodedRangePhase(ctx, cfg, target, profiler, coll)
+	return runDriverRawValidatedRangePhase(ctx, cfg, target, profiler, coll)
 }
 
-func runDriverDecodedRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
+func runDriverRawValidatedRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder, coll *mongo.Collection) (phaseResult, error) {
 	return measureTreeDBProfiledPhase(target, profiler, rangePhaseName(cfg), cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
-			if err := runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
+			if err := runDriverRawValidatedRangeOperation(ctx, coll, rangeReadMinAge(i, cfg.Documents), sample); err != nil {
 				return err
 			}
 		}
@@ -3327,32 +3275,16 @@ func runDriverDecodedRangePhase(ctx context.Context, cfg config, target *benchTa
 	})
 }
 
-func runDriverDecodedRangeOperation(ctx context.Context, coll *mongo.Collection, minAge int64, sample func(time.Duration)) error {
+func runFindOneRawString(ctx context.Context, coll *mongo.Collection, filter any, field, want string, sample func(time.Duration), label string) error {
 	begin := time.Now()
-	cursor, err := coll.Find(ctx,
-		bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
-		options.Find().SetLimit(10))
-	if err != nil {
-		sample(time.Since(begin))
-		return err
-	}
-	var docs []bson.M
-	if err := cursor.All(ctx, &docs); err != nil {
-		sample(time.Since(begin))
-		return err
-	}
-	if len(docs) == 0 {
-		sample(time.Since(begin))
-		return errors.New("range returned no documents")
-	}
-	for _, doc := range docs {
-		age, ok := int64Value(doc["age"])
-		if !ok || age < minAge {
-			sample(time.Since(begin))
-			return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
-		}
-	}
+	raw, err := coll.FindOne(ctx, filter).Raw()
 	sample(time.Since(begin))
+	if err != nil {
+		return err
+	}
+	if got, ok := directBSONStringField(raw, field); !ok || got != want {
+		return fmt.Errorf("%s returned %s=%v ok=%t want %s", label, field, got, ok, want)
+	}
 	return nil
 }
 
@@ -3371,6 +3303,10 @@ func runDriverFindRawRangePhase(ctx context.Context, cfg config, target *benchTa
 }
 
 func runDriverFindRawRangeOperation(ctx context.Context, coll *mongo.Collection, minAge int64, sample func(time.Duration)) error {
+	return runDriverRawValidatedRangeOperation(ctx, coll, minAge, sample)
+}
+
+func runDriverRawValidatedRangeOperation(ctx context.Context, coll *mongo.Collection, minAge int64, sample func(time.Duration)) error {
 	begin := time.Now()
 	cursor, err := coll.Find(ctx,
 		bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
@@ -3438,11 +3374,7 @@ func runDriverCommandRawRangeOperation(ctx context.Context, cfg config, db *mong
 	if err != nil {
 		return err
 	}
-	batch, err := parseFindFirstBatch(raw)
-	if err != nil {
-		return err
-	}
-	return validateRawAgeBatch(batch, minAge)
+	return validateFindFirstBatchAge(raw, minAge)
 }
 
 func runTreeDBRawWireRangePhase(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (phaseResult, error) {
@@ -3903,7 +3835,7 @@ func runConcurrentRangePhaseWithOps(ctx context.Context, cfg config, target *ben
 	}
 	return measureTreeDBProfiledPhase(target, profiler, phaseName, operations, func(sample func(time.Duration)) error {
 		return runConcurrentOperations(ctx, readers, operations, func(op int) error {
-			return runDriverDecodedRangeOperation(ctx, coll, rangeReadMinAge(op, cfg.Documents), sample)
+			return runDriverRawValidatedRangeOperation(ctx, coll, rangeReadMinAge(op, cfg.Documents), sample)
 		})
 	})
 }
@@ -4067,6 +3999,58 @@ func rawDocumentsFromArrayInto(batch bson.RawArray, dst []bson.Raw) ([]bson.Raw,
 		rem = next
 	}
 	return docs, nil
+}
+
+func validateFindFirstBatchAge(raw bson.Raw, minAge int64) error {
+	if !rawCommandOK(raw) {
+		return fmt.Errorf("find failed: %s", rawCommandErrorMessage(raw))
+	}
+	cursor, ok := raw.Lookup("cursor").DocumentOK()
+	if !ok {
+		return errors.New("find response missing cursor")
+	}
+	batch, ok := cursor.Lookup("firstBatch").ArrayOK()
+	if !ok {
+		return errors.New("find response missing cursor.firstBatch")
+	}
+	return validateRawAgeArray(batch, minAge)
+}
+
+func validateRawAgeArray(batch bson.RawArray, minAge int64) error {
+	length, rem, ok := bsoncore.ReadLength(bsoncore.Array(batch))
+	if !ok || length < 5 || int(length) > len(batch) {
+		return errors.New("malformed find cursor.firstBatch")
+	}
+	rem = rem[:int(length)-4]
+	if len(rem) == 0 || rem[len(rem)-1] != 0x00 {
+		return errors.New("malformed find cursor.firstBatch")
+	}
+	rem = rem[:len(rem)-1]
+
+	seen := false
+	for len(rem) > 0 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return errors.New("malformed find cursor.firstBatch")
+		}
+		value, err := elem.ValueErr()
+		if err != nil {
+			return err
+		}
+		doc, ok := value.DocumentOK()
+		if !ok {
+			return errors.New("find firstBatch entry is not a document")
+		}
+		if err := validateRawAgeDocument(bson.Raw(doc), minAge); err != nil {
+			return err
+		}
+		seen = true
+		rem = next
+	}
+	if !seen {
+		return errors.New("raw range returned no documents")
+	}
+	return nil
 }
 
 func rawArrayDocumentCapacityHint(payloadBytes int) int {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -673,8 +673,8 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- TreeDB disk bytes prefer `treedb_disk_after_maintenance.total_bytes`, then fall back to `treedb_disk_after_checkpoint.total_bytes` and `treedb_disk_after_load.total_bytes` for older runs.\n")
 	b.WriteString("- TreeDB physical bytes come from the matrix runner's `du` measurement of the isolated TreeDB directory.\n")
 	b.WriteString("- MongoDB `dbStats.dataSize` is uncompressed logical document size, not disk usage.\n")
-	b.WriteString("- MongoDB `dbStats.totalSize` is reported separately because it can diverge sharply from the isolated data-directory `du` measurement on small WiredTiger workloads.\n")
-	b.WriteString("- MongoDB physical bytes are the preferred local disk comparison when the matrix runner has an isolated data directory, such as Docker mode.\n")
+	b.WriteString("- MongoDB `dbStats.totalSize` is the storage-footprint comparison basis for MongoDB in this report.\n")
+	b.WriteString("- MongoDB physical bytes are retained only as a diagnostic data-directory `du` measurement when the matrix runner has an isolated data directory, such as Docker mode.\n")
 	b.WriteString("- Wall ops/sec values include the full benchmark phase loop. Sampled ops/sec values isolate the timed driver/gateway call inside each phase and are useful when prebuilt fixtures are enabled.\n")
 	b.WriteString("- `concurrent_id_find_one_rN` phases are an `_id` read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Read Sweep section when present.\n")
 	b.WriteString("- `concurrent_email_find_one_rN` phases are an email read throughput sweep over `N` concurrent readers, and are also grouped in the Concurrent Read Sweep section when present.\n")
@@ -923,9 +923,7 @@ func cellDiskScore(cell cellComparison) int64 {
 		}
 	}
 	if cell.Mongo != nil {
-		if cell.Mongo.Row.PhysicalBytes > 0 {
-			score += cell.Mongo.Row.PhysicalBytes
-		} else if mongoTotal, ok := mongoDBStatsTotalBytes(cell.Mongo.Result); ok {
+		if mongoTotal, ok := mongoDBStatsTotalBytes(cell.Mongo.Result); ok {
 			score += mongoTotal
 		}
 	}

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -32,6 +32,7 @@ SKIP_RAW="${SKIP_RAW:-false}"
 SKIP_COLLECTIONS="${SKIP_COLLECTIONS:-false}"
 SKIP_MONGO="${SKIP_MONGO:-false}"
 SKIP_LOAD_MODES="${SKIP_LOAD_MODES:-false}"
+SKIP_READ_MODES="${SKIP_READ_MODES:-false}"
 SKIP_SCALING="${SKIP_SCALING:-false}"
 ORIGINAL_ARGS=("$@")
 FAILURES=0
@@ -47,6 +48,7 @@ The output layout intentionally matches cmd/benchmark_run_report:
   <run-root>/collections_sqlite_canonical_1m/
   <run-root>/mongo_gateway_full_sweep_1m_expanded/
   <run-root>/mongo_client_mode_load_matrix_1m/
+  <run-root>/mongo_client_mode_read_matrix_1m/
   <run-root>/mongo_gateway_reader_writer_scaling_1m/
   <run-root>/deep_report.html
 
@@ -72,13 +74,14 @@ Options:
                           Skip pprof capture for TreeDB collections vs SQLite.
   --skip-mongo           Skip all Mongo-compatible sections.
   --skip-load-modes      Skip Mongo client-mode load matrix.
+  --skip-read-modes      Skip Mongo client-mode read matrix.
   --skip-scaling         Skip Mongo reader/writer scaling.
   --help                 Show this help.
 
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
-MONGO_MODE, MONGO_URI, MONGO_IMAGE (default: mongo:8), MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
+MONGO_MODE, MONGO_URI, MONGO_IMAGE (default: mongo:8), MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, SKIP_READ_MODES, and TITLE.
 EOF
 }
 
@@ -200,6 +203,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-load-modes)
       SKIP_LOAD_MODES=true
+      shift
+      ;;
+    --skip-read-modes)
+      SKIP_READ_MODES=true
       shift
       ;;
     --skip-scaling)
@@ -356,6 +363,7 @@ write_metadata() {
     echo "- skip_collections: $SKIP_COLLECTIONS"
     echo "- skip_mongo: $SKIP_MONGO"
     echo "- skip_load_modes: $SKIP_LOAD_MODES"
+    echo "- skip_read_modes: $SKIP_READ_MODES"
     echo "- skip_scaling: $SKIP_SCALING"
     echo "- go: $(go version)"
     echo "- uname: $(uname -a)"
@@ -512,6 +520,47 @@ run_mongo_load_modes() {
       --title "Mongo API Client-Mode Load Matrix"
 }
 
+run_mongo_read_modes() {
+  bool_true "$SKIP_MONGO" && return 0
+  bool_true "$SKIP_READ_MODES" && return 0
+  local root="$RUN_ROOT/mongo_client_mode_read_matrix_1m"
+  run_logged mongo_read_modes env \
+    TREEDB_DOCUMENT_FORMATS=bson \
+    TREEDB_CLIENT_MODES="driver-command-raw direct raw-wire-tcp raw-wire-tcp-pipeline raw-wire" \
+    MONGO_CLIENT_MODES="driver-command-raw" \
+    BATCH_SIZE="$MONGO_BATCH_SIZE" \
+    INSERT_PRODUCERS="$INSERT_PRODUCERS" \
+    MONGO_MAX_POOL_SIZE="$MONGO_MAX_POOL_SIZE" \
+    MONGO_MAX_CONNECTING="$MONGO_MAX_CONNECTING" \
+    PREBUILD_DOCUMENTS=true \
+    READS=0 \
+    RANGE_READS=0 \
+    UPDATES=0 \
+    DELETES=0 \
+    CONCURRENT_READ_KINDS=id,range \
+    CONCURRENT_READERS=0 \
+    CONCURRENT_READER_SWEEP="$MONGO_READERS" \
+    CONCURRENT_READS="$MONGO_CONCURRENT_READS" \
+    CONCURRENT_RANGE_READERS=0 \
+    CONCURRENT_RANGE_READER_SWEEP= \
+    CONCURRENT_RANGE_READS=0 \
+    CONCURRENT_WRITERS=0 \
+    CONCURRENT_WRITER_SWEEP= \
+    CONCURRENT_WRITES=0 \
+    PROFILE_TREEDB=true \
+    ./scripts/mongo_gateway_compare.sh \
+      --out "$root" \
+      --docs "$MONGO_DOCS" \
+      --indexes "$INDEXES_LIST" \
+      --range-index \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-uri "$MONGO_URI" \
+      --timeout "$TIMEOUT" \
+      --title "Mongo API Client-Mode Read Matrix"
+}
+
 run_mongo_scaling() {
   bool_true "$SKIP_MONGO" && return 0
   bool_true "$SKIP_SCALING" && return 0
@@ -554,6 +603,7 @@ run_raw_engine
 run_collections
 run_mongo_full_sweep
 run_mongo_load_modes
+run_mongo_read_modes
 run_mongo_scaling
 render_report
 


### PR DESCRIPTION
## Summary

Adds the TreeDB read bottleneck work as a focused PR:

- adds a clean-domain fast path for `flushBufferedNoIndex()` using an atomic pending count so read-only paths avoid taking the write-domain lock when there is nothing to flush
- caches Mongo gateway collection handles and adds a direct single `_id` raw BSON response path
- changes mongo gateway benchmark validation to raw BSON field lookup instead of `bson.M` decode for read paths
- adds a first-class Read Client-Mode Ceiling Matrix to the deep benchmark HTML report, including raw/direct ceiling panels beside Mongo-compatible panels
- changes MongoDB storage-footprint scoring/reporting to use only `dbStats.totalSize`

No Mongo compression flag is added.

## Validation

- `GOWORK=off go test -count=1 ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./cmd/benchmark_run_report ./cmd/mongo_gateway_compare_report`
- `git diff --check`
- smoke rerender: `/tmp/gomap_read_modes_smoke_TelNcf/deep_report.html`
- smoke assertion: report includes `Read Client-Mode Ceiling Matrix` and filters raw-wire `_id` rows that are not meaningful for that mode
