### PR TITLE
[codex] batch leaf log split appends

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12335,6 +12335,9 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 				k = maxKBySize
 			}
 		}
+		if l == &db.leafLog && l.id == leafLogLaneID && db.classifyVlogPayloadKindForRecords(records[i:end]) == vlogPayloadKindOuterLeaf {
+			k = 1
+		}
 		k = db.clampValueLogDictK(k)
 
 		plans = append(plans, vlogBatchPlan{
@@ -13401,6 +13404,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		// syscall pressure, and is typically safe for write-heavy workloads where
 		// random point reads are not the dominant cost.
 		k = valuelog.MaxFrameK
+	}
+	if l == &db.leafLog && l.id == leafLogLaneID && outerLeafPayloadsOnly {
+		// Leaf-generation planning accounts liveness at leaf-record granularity.
+		// Keep batched outer-leaf appends as one record per frame so one live leaf
+		// does not make unrelated leaves in a grouped frame look live too.
+		k = 1
 	}
 	if dictID != 0 && len(dict) > 0 {
 		k = db.clampValueLogDictK(k)

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"fmt"
 	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -14,6 +15,7 @@ type cachingLeafPageLog struct {
 }
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLog)(nil)
 
 var compactLeafLogPayloadScratchPool sync.Pool
 
@@ -58,6 +60,65 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	}
 	l.db.noteLeafGenerationRecordLength(ptr)
 	return leafPtr, nil
+}
+
+func (l *cachingLeafPageLog) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	if l == nil || l.db == nil || l.lane == nil {
+		return nil, errWALUnavailable
+	}
+	if len(leafPages) == 0 {
+		return nil, nil
+	}
+	if len(leafPages) == 1 {
+		ptr, err := l.AppendLeafPage(leafPages[0])
+		if err != nil {
+			return nil, err
+		}
+		return []page.LeafLogPtr{ptr}, nil
+	}
+
+	scratch := getCompactLeafLogPayloadScratch()
+	defer putCompactLeafLogPayloadScratch(scratch)
+
+	records := getValueLogRecordsCap(len(leafPages))
+	defer putValueLogRecordsNoClear(records)
+
+	var arena []byte
+	startRID := l.db.nextRID.Add(uint64(len(leafPages))) - uint64(len(leafPages)) + 1
+	for i, leafPage := range leafPages {
+		encodedLeafPage, compacted, err := valuelog.MaybeCompactLeafLogPayloadTo(scratch.buf[:0], leafPage)
+		if err != nil {
+			return nil, err
+		}
+		if compacted {
+			start := len(arena)
+			arena = append(arena, encodedLeafPage...)
+			encodedLeafPage = arena[start:len(arena):len(arena)]
+		}
+		records = append(records, valuelog.Record{
+			RID:   startRID + uint64(i),
+			Value: encodedLeafPage,
+		})
+	}
+
+	ptrs, err := l.db.appendValueLogForRecords(l.lane, records, journalDurabilityNone)
+	if err != nil {
+		return nil, err
+	}
+	defer putValueLogPtrsNoClear(ptrs)
+	if len(ptrs) != len(leafPages) {
+		return nil, fmt.Errorf("cachingdb: leaf page batch wrote %d ptrs for %d pages", len(ptrs), len(leafPages))
+	}
+	leafPtrs := make([]page.LeafLogPtr, len(ptrs))
+	for i, ptr := range ptrs {
+		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+		if convErr != nil {
+			return nil, convErr
+		}
+		leafPtrs[i] = leafPtr
+		l.db.noteLeafGenerationRecordLength(ptr)
+	}
+	return leafPtrs, nil
 }
 
 func getCompactLeafLogPayloadScratch() *compactLeafLogPayloadScratch {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -26,6 +26,10 @@ type LeafPageLog interface {
 	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 }
 
+type LeafPageBatchLog interface {
+	AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error)
+}
+
 type LeafPageReader interface {
 	ReadUnsafe(ptr page.ValuePtr) ([]byte, error)
 }
@@ -1294,6 +1298,68 @@ func (z *Zipper) persistLeafPage(b *node.Builder) (page.ChildRef, error) {
 	return page.LeafLogChildRef(ptr), nil
 }
 
+func (z *Zipper) persistLeafPages(builders ...*node.Builder) ([]page.ChildRef, error) {
+	if len(builders) == 0 {
+		return nil, nil
+	}
+	if !z.outerLeavesInValueLog {
+		refs := make([]page.ChildRef, len(builders))
+		for i, b := range builders {
+			if b == nil {
+				return nil, errors.New("zipper: nil leaf builder")
+			}
+			refs[i] = page.PageChildRef(b.PageID())
+		}
+		return refs, nil
+	}
+	if z.leafPageLog == nil {
+		return nil, errors.New("zipper: missing leaf page log")
+	}
+	if len(builders) == 1 {
+		ref, err := z.persistLeafPage(builders[0])
+		if err != nil {
+			return nil, err
+		}
+		return []page.ChildRef{ref}, nil
+	}
+	batchLog, ok := z.leafPageLog.(LeafPageBatchLog)
+	if !ok {
+		refs := make([]page.ChildRef, len(builders))
+		for i, b := range builders {
+			ref, err := z.persistLeafPage(b)
+			if err != nil {
+				return nil, err
+			}
+			refs[i] = ref
+		}
+		return refs, nil
+	}
+	leafPages := make([][]byte, len(builders))
+	for i, b := range builders {
+		if b == nil {
+			return nil, errors.New("zipper: nil leaf builder")
+		}
+		leafPages[i] = b.Data()
+	}
+	ptrs, err := batchLog.AppendLeafPages(leafPages)
+	if err != nil {
+		return nil, err
+	}
+	if len(ptrs) != len(builders) {
+		return nil, fmt.Errorf("zipper: leaf page batch returned %d ptrs for %d pages", len(ptrs), len(builders))
+	}
+	refs := make([]page.ChildRef, len(ptrs))
+	z.leafRefCacheMu.Lock()
+	for i, ptr := range ptrs {
+		if z.leafRefCache != nil {
+			z.leafRefCache[ptr] = builders[i].Data()
+		}
+		refs[i] = page.LeafLogChildRef(ptr)
+	}
+	z.leafRefCacheMu.Unlock()
+	return refs, nil
+}
+
 func (z *Zipper) ensureRootPage(key []byte, ref page.ChildRef, metrics *adaptive.Metrics) (uint64, error) {
 	if ref.Kind == page.ChildRefPage {
 		return ref.Page, nil
@@ -2524,21 +2590,22 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		metrics.LeafFill += float64(page.PageSize-rb.FreeSpace()) / float64(page.PageSize)
 		recordZipperLeafPageWrite(metrics, z.outerLeavesInValueLog)
 		recordZipperLeafPageWrite(metrics, z.outerLeavesInValueLog)
-		leftID, err = z.persistLeafPage(lb)
+		leafRefs, err := z.persistLeafPages(lb, rb)
 		if err != nil {
 			if !z.outerLeavesInValueLog {
 				retired = append(retired, lid, rid)
 			}
 			return page.ChildRef{}, page.ChildRef{}, nil, false, err
 		}
+		if len(leafRefs) != 2 {
+			if !z.outerLeavesInValueLog {
+				retired = append(retired, lid, rid)
+			}
+			return page.ChildRef{}, page.ChildRef{}, nil, false, fmt.Errorf("zipper: persisted split returned %d refs", len(leafRefs))
+		}
+		leftID = leafRefs[0]
 		recordZipperLeafLogPageRecordHintWrite(metrics, leftID)
-		rightID, err = z.persistLeafPage(rb)
-		if err != nil {
-			if !z.outerLeavesInValueLog {
-				retired = append(retired, lid, rid)
-			}
-			return page.ChildRef{}, page.ChildRef{}, nil, false, err
-		}
+		rightID = leafRefs[1]
 		recordZipperLeafLogPageRecordHintWrite(metrics, rightID)
 		return leftID, rightID, rightStart, true, nil
 	}


### PR DESCRIPTION
## Summary

Shortens the leaf-log append critical path for split sibling leaves without changing leaf-generation liveness semantics.

Changes:
- adds a `LeafPageBatchLog` path in the zipper
- implements `AppendLeafPages` for the caching leaf-page log so sibling leaf pages can be compacted before entering the value-log append path and persisted through one append call
- switches the two-leaf split path to persist both sibling leaves together
- forces outer-leaf value-log records to stay one leaf per frame, preserving record-granular leaf-generation accounting

## Correctness note

I intentionally did not batch bulk-build leaf generation in this PR. A broader batching attempt caused `TestLeafGenerationPack_RewritesCollectionInternalRootsBeforeGC` to fail because dead-byte accounting no longer saw the expected dead leaf records. This PR keeps the safe split-sibling batching only and keeps outer-leaf frames at one leaf record per frame.

## Performance evidence

Correctness guard that specifically protects leaf-generation accounting:

```sh
GOWORK=off go test ./TreeDB/db -run '^TestLeafGenerationPack_RewritesCollectionInternalRootsBeforeGC$'
```

Result:

```text
ok  github.com/snissn/gomap/TreeDB/db  (cached)
```

Focused package tests:

```sh
GOWORK=off go test ./TreeDB/caching ./TreeDB/zipper ./TreeDB/db \
  -run 'TestCachingLeafPageLog|TestZipper|TestLeafPageLog|TestLeafGenerationPack_RewritesCollectionInternalRootsBeforeGC'
```

Result:

```text
ok  github.com/snissn/gomap/TreeDB/caching 0.050s
ok  github.com/snissn/gomap/TreeDB/zipper 0.004s
ok  github.com/snissn/gomap/TreeDB/db 0.143s
```

Example update benchmark run on this branch:

```sh
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench 'BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchmem \
  -benchtime=1s \
  -count=1
```

Selected result line:

```text
BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2-12  167571  6299 ns/op  158747 docs/sec  1455 B/op  3 allocs/op
```

Leaf-log/root-apply metrics from the same run:

```text
publish_delta_group_root_apply_ns/doc=476.2
publish_delta_group_root_apply_leaf_log_pages_written/doc=0.09181
publish_delta_group_root_apply_leaf_log_record_hint_write_bytes/doc=61.12
publish_delta_group_lock_hold_ns/doc=3.792
update_buffer_lock_hold_ns/doc=525.1
```

Full local benchmark output was saved under `/tmp/gomap_leaflog_pr_validation_*` on the development host.
