### PR TITLE
[codex] Instrument update combiner wait breakdown

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -505,6 +505,36 @@ type CollectionUpdateIndexStats struct {
 	SecondaryKeyBytes int
 }
 
+// CollectionUpdateCombineBucketCount is the number of power-of-two buckets used
+// for update-combiner queue-depth and batch-size observations.
+const CollectionUpdateCombineBucketCount = 10
+
+var collectionUpdateCombineBucketUpperBounds = [CollectionUpdateCombineBucketCount]int{
+	1, 2, 4, 8, 16, 32, 64, 128, 256, 0,
+}
+
+// CollectionUpdateCombineBucketLabel returns the stable metric suffix for an
+// update-combiner bucket. The final bucket is an overflow bucket.
+func CollectionUpdateCombineBucketLabel(index int) string {
+	if index < 0 || index >= CollectionUpdateCombineBucketCount {
+		return ""
+	}
+	upper := collectionUpdateCombineBucketUpperBounds[index]
+	if upper > 0 {
+		return fmt.Sprintf("le_%d", upper)
+	}
+	return fmt.Sprintf("gt_%d", collectionUpdateCombineBucketUpperBounds[index-1])
+}
+
+func collectionUpdateCombineBucketIndex(value int) int {
+	for i, upper := range collectionUpdateCombineBucketUpperBounds {
+		if upper == 0 || value <= upper {
+			return i
+		}
+	}
+	return CollectionUpdateCombineBucketCount - 1
+}
+
 // CollectionManagerStats captures aggregate write-domain counters for a
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
@@ -573,8 +603,12 @@ type CollectionManagerStats struct {
 	UpdateCombineInlineRequests    uint64
 	UpdateCombineEnqueue           time.Duration
 	UpdateCombineWait              time.Duration
+	UpdateCombineQueueWait         time.Duration
 	UpdateCombineDrain             time.Duration
 	UpdateCombineRun               time.Duration
+	UpdateCombineResultDelivery    time.Duration
+	UpdateCombineQueueDepthBuckets [CollectionUpdateCombineBucketCount]uint64
+	UpdateCombineBatchSizeBuckets  [CollectionUpdateCombineBucketCount]uint64
 	UpdateBatchCalls               uint64
 	UpdateBatchItems               uint64
 	UpdateBatchMatched             uint64
@@ -978,8 +1012,12 @@ type collectionWriteDomain struct {
 	updateInlineItems                  [1]updateBatchItem
 	updateCombineEnqueueNs             atomic.Uint64
 	updateCombineWaitNs                atomic.Uint64
+	updateCombineQueueWaitNs           atomic.Uint64
 	updateCombineDrainNs               atomic.Uint64
 	updateCombineRunNs                 atomic.Uint64
+	updateCombineResultDeliveryNs      atomic.Uint64
+	updateCombineQueueDepthBuckets     [CollectionUpdateCombineBucketCount]atomic.Uint64
+	updateCombineBatchSizeBuckets      [CollectionUpdateCombineBucketCount]atomic.Uint64
 	updateBatchCalls                   atomic.Uint64
 	updateBatchItems                   atomic.Uint64
 	updateBatchMatched                 atomic.Uint64
@@ -1265,8 +1303,24 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_combine.inline_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineInlineRequests)
 	out["treedb.collections.write_domain.update_combine.enqueue_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineEnqueue.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineWait.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.queue_wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineQueueWait.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.drain_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineDrain.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.run_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineRun.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.result_delivery_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineResultDelivery.Nanoseconds())
+	for i, count := range stats.UpdateCombineQueueDepthBuckets {
+		label := CollectionUpdateCombineBucketLabel(i)
+		if label == "" {
+			continue
+		}
+		out["treedb.collections.write_domain.update_combine.queue_depth_bucket_"+label+"_total"] = fmt.Sprintf("%d", count)
+	}
+	for i, count := range stats.UpdateCombineBatchSizeBuckets {
+		label := CollectionUpdateCombineBucketLabel(i)
+		if label == "" {
+			continue
+		}
+		out["treedb.collections.write_domain.update_combine.batch_size_bucket_"+label+"_total"] = fmt.Sprintf("%d", count)
+	}
 	out["treedb.collections.write_domain.update_batch.calls_total"] = fmt.Sprintf("%d", stats.UpdateBatchCalls)
 	out["treedb.collections.write_domain.update_batch.items_total"] = fmt.Sprintf("%d", stats.UpdateBatchItems)
 	out["treedb.collections.write_domain.update_batch.matched_total"] = fmt.Sprintf("%d", stats.UpdateBatchMatched)
@@ -1502,8 +1556,14 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateCombineInlineRequests += other.UpdateCombineInlineRequests
 	s.UpdateCombineEnqueue += other.UpdateCombineEnqueue
 	s.UpdateCombineWait += other.UpdateCombineWait
+	s.UpdateCombineQueueWait += other.UpdateCombineQueueWait
 	s.UpdateCombineDrain += other.UpdateCombineDrain
 	s.UpdateCombineRun += other.UpdateCombineRun
+	s.UpdateCombineResultDelivery += other.UpdateCombineResultDelivery
+	for i := range s.UpdateCombineQueueDepthBuckets {
+		s.UpdateCombineQueueDepthBuckets[i] += other.UpdateCombineQueueDepthBuckets[i]
+		s.UpdateCombineBatchSizeBuckets[i] += other.UpdateCombineBatchSizeBuckets[i]
+	}
 	s.UpdateBatchCalls += other.UpdateBatchCalls
 	s.UpdateBatchItems += other.UpdateBatchItems
 	s.UpdateBatchMatched += other.UpdateBatchMatched
@@ -1633,8 +1693,14 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateCombineInlineRequests = domain.updateCombineInlineRequests.Load()
 	stats.UpdateCombineEnqueue = durationFromAtomicNs(domain.updateCombineEnqueueNs.Load())
 	stats.UpdateCombineWait = durationFromAtomicNs(domain.updateCombineWaitNs.Load())
+	stats.UpdateCombineQueueWait = durationFromAtomicNs(domain.updateCombineQueueWaitNs.Load())
 	stats.UpdateCombineDrain = durationFromAtomicNs(domain.updateCombineDrainNs.Load())
 	stats.UpdateCombineRun = durationFromAtomicNs(domain.updateCombineRunNs.Load())
+	stats.UpdateCombineResultDelivery = durationFromAtomicNs(domain.updateCombineResultDeliveryNs.Load())
+	for i := range stats.UpdateCombineQueueDepthBuckets {
+		stats.UpdateCombineQueueDepthBuckets[i] = domain.updateCombineQueueDepthBuckets[i].Load()
+		stats.UpdateCombineBatchSizeBuckets[i] = domain.updateCombineBatchSizeBuckets[i].Load()
+	}
 	stats.UpdateBatchCalls = domain.updateBatchCalls.Load()
 	stats.UpdateBatchItems = domain.updateBatchItems.Load()
 	stats.UpdateBatchMatched = domain.updateBatchMatched.Load()
@@ -2163,6 +2229,9 @@ func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int)
 	domain.updateCombineLastRequestUnixNano.Store(time.Now().UnixNano())
 	if queueDepth > 0 {
 		atomicMaxUint64(&domain.updateCombineQueueDepthMax, uint64(queueDepth))
+		if domain.updateBatchDetailedStats.Load() {
+			domain.updateCombineQueueDepthBuckets[collectionUpdateCombineBucketIndex(queueDepth)].Add(1)
+		}
 	}
 }
 
@@ -2187,6 +2256,13 @@ func (domain *collectionWriteDomain) observeUpdateCombineWait(d time.Duration) {
 	domain.updateCombineWaitNs.Add(durationToAtomicNs(d))
 }
 
+func (domain *collectionWriteDomain) observeUpdateCombineQueueWait(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineQueueWaitNs.Add(durationToAtomicNs(d))
+}
+
 func (domain *collectionWriteDomain) observeUpdateCombineDrain(d time.Duration) {
 	if domain == nil || d <= 0 {
 		return
@@ -2201,12 +2277,22 @@ func (domain *collectionWriteDomain) observeUpdateCombineRun(d time.Duration) {
 	domain.updateCombineRunNs.Add(durationToAtomicNs(d))
 }
 
+func (domain *collectionWriteDomain) observeUpdateCombineResultDelivery(d time.Duration) {
+	if domain == nil || d <= 0 {
+		return
+	}
+	domain.updateCombineResultDeliveryNs.Add(durationToAtomicNs(d))
+}
+
 func (domain *collectionWriteDomain) observeUpdateCombineBatch(requests int, fallback bool) {
 	if domain == nil || requests <= 0 {
 		return
 	}
 	domain.updateCombineBatches.Add(1)
 	domain.updateCombineBatchedRequests.Add(uint64(requests))
+	if domain.updateBatchDetailedStats.Load() {
+		domain.updateCombineBatchSizeBuckets[collectionUpdateCombineBucketIndex(requests)].Add(1)
+	}
 	if fallback {
 		domain.updateCombineFallbackRequests.Add(uint64(requests))
 	}
@@ -8728,6 +8814,7 @@ type collectionUpdateCombineRequest struct {
 	update              func(current []byte) (replacement []byte, changed bool, err error)
 	bsonSet             bsonSetUpdate
 	hasBSONSet          bool
+	queuedAt            time.Time
 	done                chan collectionUpdateCombineResult
 }
 
@@ -8989,6 +9076,7 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	var enqueueStart time.Time
 	if detailedStats {
 		enqueueStart = time.Now()
+		req.queuedAt = enqueueStart
 	}
 	if !combiner.enqueue(req) {
 		if detailedStats {
@@ -9249,6 +9337,7 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	batch = append(batch, first)
 	drainYields := 0
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	combiner.observeUpdateCombineDequeued(first, detailedStats)
 	var drainStart time.Time
 	if detailedStats {
 		drainStart = time.Now()
@@ -9269,6 +9358,7 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 				return
 			}
 			batch = append(batch, req)
+			combiner.observeUpdateCombineDequeued(req, detailedStats)
 		default:
 			if drainYields < defaultCollectionUpdateCombineDrainYields {
 				drainYields++
@@ -9290,6 +9380,13 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	combiner.runBatch(batch)
 	clear(batch)
 	combiner.batchScratch = batch[:0]
+}
+
+func (combiner *collectionUpdateCombiner) observeUpdateCombineDequeued(req collectionUpdateCombineRequest, detailedStats bool) {
+	if !detailedStats || combiner == nil || combiner.domain == nil || req.queuedAt.IsZero() {
+		return
+	}
+	combiner.domain.observeUpdateCombineQueueWait(time.Since(req.queuedAt))
 }
 
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
@@ -9493,7 +9590,17 @@ func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result col
 	if req.done == nil {
 		return
 	}
+	domain := (*collectionWriteDomain)(nil)
+	if req.collection != nil {
+		domain = req.collection.writeDomain
+	}
+	if domain == nil || !domain.updateBatchDetailedStats.Load() {
+		req.done <- result
+		return
+	}
+	start := time.Now()
 	req.done <- result
+	domain.observeUpdateCombineResultDelivery(time.Since(start))
 }
 
 func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1383,15 +1383,34 @@ func TestUpdateBatchStatsSinceClampsSubResolutionDurations(t *testing.T) {
 
 func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
 	domain := &collectionWriteDomain{}
+	domain.updateBatchDetailedStats.Store(true)
+	domain.observeUpdateCombineRequest(1)
+	domain.observeUpdateCombineRequest(9)
 	domain.observeUpdateCombineInline()
+	domain.observeUpdateCombineBatch(2, false)
+	domain.observeUpdateCombineBatch(300, true)
 	domain.observeUpdateCombineEnqueue(3 * time.Nanosecond)
 	domain.observeUpdateCombineWait(5 * time.Nanosecond)
+	domain.observeUpdateCombineQueueWait(13 * time.Nanosecond)
 	domain.observeUpdateCombineDrain(7 * time.Nanosecond)
 	domain.observeUpdateCombineRun(11 * time.Nanosecond)
+	domain.observeUpdateCombineResultDelivery(17 * time.Nanosecond)
 	snapshot := domain.statsSnapshot()
 	var merged CollectionManagerStats
 	merged.add(snapshot)
 	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
+	if snapshot.UpdateCombineRequests != 2 {
+		t.Fatalf("snapshot requests=%d want 2", snapshot.UpdateCombineRequests)
+	}
+	if snapshot.UpdateCombineBatches != 2 {
+		t.Fatalf("snapshot batches=%d want 2", snapshot.UpdateCombineBatches)
+	}
+	if snapshot.UpdateCombineBatchedRequests != 302 {
+		t.Fatalf("snapshot batched requests=%d want 302", snapshot.UpdateCombineBatchedRequests)
+	}
+	if snapshot.UpdateCombineFallbackRequests != 300 {
+		t.Fatalf("snapshot fallback requests=%d want 300", snapshot.UpdateCombineFallbackRequests)
+	}
 	if snapshot.UpdateCombineInlineRequests != 1 {
 		t.Fatalf("snapshot inline requests=%d want 1", snapshot.UpdateCombineInlineRequests)
 	}
@@ -1409,8 +1428,10 @@ func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
 	}{
 		{"enqueue", "treedb.collections.write_domain.update_combine.enqueue_ns_total", 3 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineEnqueue }},
 		{"wait", "treedb.collections.write_domain.update_combine.wait_ns_total", 5 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineWait }},
+		{"queue wait", "treedb.collections.write_domain.update_combine.queue_wait_ns_total", 13 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineQueueWait }},
 		{"drain", "treedb.collections.write_domain.update_combine.drain_ns_total", 7 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineDrain }},
 		{"run", "treedb.collections.write_domain.update_combine.run_ns_total", 11 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineRun }},
+		{"result delivery", "treedb.collections.write_domain.update_combine.result_delivery_ns_total", 17 * time.Nanosecond, func(s CollectionManagerStats) time.Duration { return s.UpdateCombineResultDelivery }},
 	}
 	for _, tc := range cases {
 		if got := tc.get(snapshot); got != tc.want {
@@ -1422,6 +1443,28 @@ func TestCollectionUpdateCombineTimingStatsSnapshotAndAdd(t *testing.T) {
 		if got, want := exported[tc.key], fmt.Sprintf("%d", tc.want.Nanoseconds()); got != want {
 			t.Fatalf("exported %s=%q want %q", tc.key, got, want)
 		}
+	}
+	queueDepthLe1 := collectionUpdateCombineBucketIndex(1)
+	queueDepthLe16 := collectionUpdateCombineBucketIndex(9)
+	batchSizeLe2 := collectionUpdateCombineBucketIndex(2)
+	batchSizeGt256 := collectionUpdateCombineBucketIndex(300)
+	if got := snapshot.UpdateCombineQueueDepthBuckets[queueDepthLe1]; got != 1 {
+		t.Fatalf("snapshot queue-depth le_1 bucket=%d want 1", got)
+	}
+	if got := merged.UpdateCombineQueueDepthBuckets[queueDepthLe16]; got != 1 {
+		t.Fatalf("merged queue-depth le_16 bucket=%d want 1", got)
+	}
+	if got := snapshot.UpdateCombineBatchSizeBuckets[batchSizeLe2]; got != 1 {
+		t.Fatalf("snapshot batch-size le_2 bucket=%d want 1", got)
+	}
+	if got := merged.UpdateCombineBatchSizeBuckets[batchSizeGt256]; got != 1 {
+		t.Fatalf("merged batch-size gt_256 bucket=%d want 1", got)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_combine.queue_depth_bucket_le_1_total"], "1"; got != want {
+		t.Fatalf("exported queue-depth le_1 bucket=%q want %q", got, want)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_combine.batch_size_bucket_gt_256_total"], "1"; got != want {
+		t.Fatalf("exported batch-size gt_256 bucket=%q want %q", got, want)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1192,8 +1192,10 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineInlineRequests:      after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests,
 		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
 		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
+		UpdateCombineQueueWait:           after.UpdateCombineQueueWait - before.UpdateCombineQueueWait,
 		UpdateCombineDrain:               after.UpdateCombineDrain - before.UpdateCombineDrain,
 		UpdateCombineRun:                 after.UpdateCombineRun - before.UpdateCombineRun,
+		UpdateCombineResultDelivery:      after.UpdateCombineResultDelivery - before.UpdateCombineResultDelivery,
 		IndexedFlushCalls:                after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:               after.IndexedFlushErrors - before.IndexedFlushErrors,
 		IndexedFlushForcedDrains:         after.IndexedFlushForcedDrains - before.IndexedFlushForcedDrains,
@@ -1230,6 +1232,10 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 	delta.OverlayVisibleDepth = after.OverlayVisibleDepth
 	if after.UpdateCombineQueueDepthMax > before.UpdateCombineQueueDepthMax {
 		delta.UpdateCombineQueueDepthMax = after.UpdateCombineQueueDepthMax
+	}
+	for i := range delta.UpdateCombineQueueDepthBuckets {
+		delta.UpdateCombineQueueDepthBuckets[i] = after.UpdateCombineQueueDepthBuckets[i] - before.UpdateCombineQueueDepthBuckets[i]
+		delta.UpdateCombineBatchSizeBuckets[i] = after.UpdateCombineBatchSizeBuckets[i] - before.UpdateCombineBatchSizeBuckets[i]
 	}
 	for i := 0; i < after.UpdateBatchIndexStatsCount && i < len(after.UpdateBatchIndexStats); i++ {
 		next := after.UpdateBatchIndexStats[i]
@@ -1285,8 +1291,10 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineInlineRequests:      4,
 		UpdateCombineEnqueue:             100 * time.Nanosecond,
 		UpdateCombineWait:                200 * time.Nanosecond,
+		UpdateCombineQueueWait:           250 * time.Nanosecond,
 		UpdateCombineDrain:               300 * time.Nanosecond,
 		UpdateCombineRun:                 400 * time.Nanosecond,
+		UpdateCombineResultDelivery:      500 * time.Nanosecond,
 		UpdateBatchStructuredApply:       50 * time.Nanosecond,
 		UpdateBatchIndexStateExtract:     70 * time.Nanosecond,
 		UpdateBatchOldIndexStateExtract:  30 * time.Nanosecond,
@@ -1344,8 +1352,10 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineInlineRequests:      15,
 		UpdateCombineEnqueue:             700 * time.Nanosecond,
 		UpdateCombineWait:                1400 * time.Nanosecond,
+		UpdateCombineQueueWait:           1750 * time.Nanosecond,
 		UpdateCombineDrain:               2100 * time.Nanosecond,
 		UpdateCombineRun:                 2800 * time.Nanosecond,
+		UpdateCombineResultDelivery:      3500 * time.Nanosecond,
 		UpdateBatchStructuredApply:       500 * time.Nanosecond,
 		UpdateBatchIndexStateExtract:     700 * time.Nanosecond,
 		UpdateBatchOldIndexStateExtract:  300 * time.Nanosecond,
@@ -1394,6 +1404,14 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			{CollectionName: "users", IndexName: "city", IndexOrdinal: 1, Changed: 17, SecondaryRuns: 17, SecondaryDeletes: 17, SecondarySets: 17, SecondaryKeyBytes: 1700},
 		},
 	}
+	before.UpdateCombineQueueDepthBuckets[0] = 1
+	before.UpdateCombineQueueDepthBuckets[3] = 2
+	before.UpdateCombineBatchSizeBuckets[1] = 3
+	before.UpdateCombineBatchSizeBuckets[4] = 4
+	after.UpdateCombineQueueDepthBuckets[0] = 3
+	after.UpdateCombineQueueDepthBuckets[3] = 7
+	after.UpdateCombineBatchSizeBuckets[1] = 11
+	after.UpdateCombineBatchSizeBuckets[4] = 13
 	got := deltaCollectionManagerUpdateStats(after, before)
 	if got.UpdateCombineRequests != 7 {
 		t.Fatalf("UpdateCombineRequests=%d want 7", got.UpdateCombineRequests)
@@ -1413,13 +1431,21 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateCombineInlineRequests != 11 {
 		t.Fatalf("UpdateCombineInlineRequests=%d want 11", got.UpdateCombineInlineRequests)
 	}
-	if got.UpdateCombineEnqueue != 600*time.Nanosecond || got.UpdateCombineWait != 1200*time.Nanosecond || got.UpdateCombineDrain != 1800*time.Nanosecond || got.UpdateCombineRun != 2400*time.Nanosecond {
-		t.Fatalf("update combine timing delta enqueue/wait/drain/run=%s/%s/%s/%s want 600ns/1200ns/1800ns/2400ns",
+	if got.UpdateCombineEnqueue != 600*time.Nanosecond || got.UpdateCombineWait != 1200*time.Nanosecond || got.UpdateCombineQueueWait != 1500*time.Nanosecond || got.UpdateCombineDrain != 1800*time.Nanosecond || got.UpdateCombineRun != 2400*time.Nanosecond || got.UpdateCombineResultDelivery != 3000*time.Nanosecond {
+		t.Fatalf("update combine timing delta enqueue/wait/queue-wait/drain/run/result-delivery=%s/%s/%s/%s/%s/%s want 600ns/1200ns/1500ns/1800ns/2400ns/3000ns",
 			got.UpdateCombineEnqueue,
 			got.UpdateCombineWait,
+			got.UpdateCombineQueueWait,
 			got.UpdateCombineDrain,
 			got.UpdateCombineRun,
+			got.UpdateCombineResultDelivery,
 		)
+	}
+	if got.UpdateCombineQueueDepthBuckets[0] != 2 || got.UpdateCombineQueueDepthBuckets[3] != 5 {
+		t.Fatalf("update combine queue-depth bucket deltas=%v want index 0=2 index 3=5", got.UpdateCombineQueueDepthBuckets)
+	}
+	if got.UpdateCombineBatchSizeBuckets[1] != 8 || got.UpdateCombineBatchSizeBuckets[4] != 9 {
+		t.Fatalf("update combine batch-size bucket deltas=%v want index 1=8 index 4=9", got.UpdateCombineBatchSizeBuckets)
 	}
 	if got.UpdateBatchStructuredApply != 450*time.Nanosecond {
 		t.Fatalf("UpdateBatchStructuredApply=%s want 450ns", got.UpdateBatchStructuredApply)
@@ -1629,28 +1655,44 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		UpdateCombineInlineRequests:   300,
 		UpdateCombineEnqueue:          600 * time.Nanosecond,
 		UpdateCombineWait:             1200 * time.Nanosecond,
+		UpdateCombineQueueWait:        3000 * time.Nanosecond,
 		UpdateCombineDrain:            1800 * time.Nanosecond,
 		UpdateCombineRun:              2400 * time.Nanosecond,
+		UpdateCombineResultDelivery:   3600 * time.Nanosecond,
 	}
+	stats.UpdateCombineQueueDepthBuckets[0] = 60
+	stats.UpdateCombineQueueDepthBuckets[4] = 540
+	stats.UpdateCombineBatchSizeBuckets[2] = 6
+	stats.UpdateCombineBatchSizeBuckets[5] = 24
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
 	})
 	want := map[string]float64{
-		"update_combine_requests":              600,
-		"update_combine_requests/doc":          1,
-		"update_combine_batches":               30,
-		"update_combine_items/batch":           20,
-		"update_combine_batched_requests":      600,
-		"update_combine_batched_requests/doc":  1,
-		"update_combine_fallback_requests":     6,
-		"update_combine_fallback_requests/doc": 0.01,
-		"update_combine_queue_depth_max":       31,
-		"update_combine_inline_requests":       300,
-		"update_combine_inline_requests/doc":   0.5,
-		"update_combine_enqueue_ns/doc":        1,
-		"update_combine_wait_ns/doc":           2,
-		"update_combine_drain_ns/doc":          3,
-		"update_combine_run_ns/doc":            4,
+		"update_combine_requests":                         600,
+		"update_combine_requests/doc":                     1,
+		"update_combine_batches":                          30,
+		"update_combine_items/batch":                      20,
+		"update_combine_batched_requests":                 600,
+		"update_combine_batched_requests/doc":             1,
+		"update_combine_fallback_requests":                6,
+		"update_combine_fallback_requests/doc":            0.01,
+		"update_combine_queue_depth_max":                  31,
+		"update_combine_queue_depth_bucket_le_1":          60,
+		"update_combine_queue_depth_bucket_le_1/request":  0.1,
+		"update_combine_queue_depth_bucket_le_16":         540,
+		"update_combine_queue_depth_bucket_le_16/request": 0.9,
+		"update_combine_batch_size_bucket_le_4":           6,
+		"update_combine_batch_size_bucket_le_4/batch":     0.2,
+		"update_combine_batch_size_bucket_le_32":          24,
+		"update_combine_batch_size_bucket_le_32/batch":    0.8,
+		"update_combine_inline_requests":                  300,
+		"update_combine_inline_requests/doc":              0.5,
+		"update_combine_enqueue_ns/doc":                   1,
+		"update_combine_wait_ns/doc":                      2,
+		"update_combine_queue_wait_ns/doc":                5,
+		"update_combine_drain_ns/doc":                     3,
+		"update_combine_run_ns/doc":                       4,
+		"update_combine_result_delivery_ns/doc":           6,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1821,6 +1863,30 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	if stats.UpdateCombineQueueDepthMax > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
 	}
+	for i, count := range stats.UpdateCombineQueueDepthBuckets {
+		if count == 0 || stats.UpdateCombineRequests == 0 {
+			continue
+		}
+		label := collections.CollectionUpdateCombineBucketLabel(i)
+		if label == "" {
+			continue
+		}
+		name := "update_combine_queue_depth_bucket_" + label
+		b.ReportMetric(float64(count), name)
+		b.ReportMetric(float64(count)/float64(stats.UpdateCombineRequests), name+"/request")
+	}
+	for i, count := range stats.UpdateCombineBatchSizeBuckets {
+		if count == 0 || stats.UpdateCombineBatches == 0 {
+			continue
+		}
+		label := collections.CollectionUpdateCombineBucketLabel(i)
+		if label == "" {
+			continue
+		}
+		name := "update_combine_batch_size_bucket_" + label
+		b.ReportMetric(float64(count), name)
+		b.ReportMetric(float64(count)/float64(stats.UpdateCombineBatches), name+"/batch")
+	}
 	if stats.UpdateCombineInlineRequests > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineInlineRequests), "update_combine_inline_requests")
 		b.ReportMetric(float64(stats.UpdateCombineInlineRequests)/float64(docs), "update_combine_inline_requests/doc")
@@ -1832,8 +1898,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	reportDuration("update_combine_enqueue_ns/doc", stats.UpdateCombineEnqueue)
 	reportDuration("update_combine_wait_ns/doc", stats.UpdateCombineWait)
+	reportDuration("update_combine_queue_wait_ns/doc", stats.UpdateCombineQueueWait)
 	reportDuration("update_combine_drain_ns/doc", stats.UpdateCombineDrain)
 	reportDuration("update_combine_run_ns/doc", stats.UpdateCombineRun)
+	reportDuration("update_combine_result_delivery_ns/doc", stats.UpdateCombineResultDelivery)
 	if stats.UpdateBatchSecondaryDeletes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")
 	}


### PR DESCRIPTION
## Summary

This is PR 1 for the `update_combine_wait_ns/doc` sprint. It adds observability before changing update-combiner behavior:

- splits pre-batch queue wait out as `update_combine_queue_wait_ns/doc`
- measures result-channel delivery as `update_combine_result_delivery_ns/doc`
- adds power-of-two queue-depth and batch-size histograms to `CollectionManagerStats`
- emits the new metrics from the Mongo gateway benchmark reporter
- covers snapshot/add/export/delta/report behavior with focused tests

The new queue-wait metric is measured when the combiner dequeues a request, so it separates time spent waiting behind the single combiner worker from drain time, batch run time, and caller result delivery.

## Benchmark Evidence

Command used for both branch and detached `origin/main` baseline:

```sh
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=<8|32> \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchmem \
  -benchtime=100000x \
  -count=1 \
  -timeout 20m
```

Artifacts:

- branch: `/tmp/gomap_update_combine_wait_breakdown_20260513_064431/bench.txt`
- actual detached `origin/main`: `/tmp/gomap_update_combine_wait_main_bench_actual_20260513_064507/bench.txt`

| writers | ref | ns/op | docs/sec | wait ns/doc | queue wait ns/doc | run ns/doc | result delivery ns/doc | allocs/op |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | origin/main | 7,078 | 141,289 | 46,918 | n/a | 5,312 | n/a | 3 |
| 8 | branch | 7,096 | 140,923 | 46,886 | 13,053 | 5,237 | 349 | 3 |
| 32 | origin/main | 5,879 | 170,100 | 151,027 | n/a | 4,456 | n/a | 1 |
| 32 | branch | 5,715 | 174,981 | 145,491 | 46,064 | 4,252 | 239 | 1 |

Quick interpretation:

- instrumentation is perf-neutral in this sweep: w8 is effectively identical and w32 is within noise/slightly faster
- at 32 writers, about 46us/doc of the existing 145us/doc end-to-end wait is pre-batch queue time
- result delivery is sub-microsecond/doc, so it is not the primary bottleneck
- batch-size histograms show high-concurrency combining mostly lands in `le_16`/`le_32` buckets, which gives the next PR concrete tuning targets

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateCombineTimingStatsSnapshotAndAdd|TestCollectionManagerResetUpdateCombineQueueDepthMax'
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth'
GOWORK=off go test ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```

All passed.