### PR TITLE
[codex] Optimize BSON set update combiner validation

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11338,14 +11338,31 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			continue
 		}
 		results[i].Matched = true
-		currentID, err := captureBSONIDSnapshot(current.value, plannerOptions)
-		if err != nil {
-			_ = snap.Close()
-			return nil, updateBatchItemError(i, err)
-		}
 		prepared := preparedBatchUpdate{
 			itemIndex:  i,
 			documentID: item.DocumentID,
+		}
+		var currentID bsonIDSnapshot
+		var document []byte
+		var changedOne bool
+		if item.hasBSONSet {
+			phaseStart = updateBatchStatsNow(detailedStats)
+			scratch.bsonSetDocumentScratch, document, changedOne, err = callBSONSetUpdateAppendReplacement(item.bsonSet, scratch.bsonSetDocumentScratch[:0], current.value)
+			stats.StructuredUpdateApplications++
+			stats.StructuredUpdateApply += updateBatchStatsSince(detailedStats, phaseStart)
+			// When changedOne is true, document aliases bsonSetDocumentScratch
+			// until it is copied into the plan document arena below. No-op
+			// updates may return current.value and are discarded before staging.
+			if err != nil {
+				_ = snap.Close()
+				return nil, updateBatchItemError(i, fmt.Errorf("collections: current BSON document: %w", err))
+			}
+		} else {
+			currentID, err = captureBSONIDSnapshot(current.value, plannerOptions)
+			if err != nil {
+				_ = snap.Close()
+				return nil, updateBatchItemError(i, err)
+			}
 		}
 		if len(runtimes) > 0 {
 			if item.hasBSONSet {
@@ -11365,21 +11382,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 				return nil, updateBatchItemError(i, err)
 			}
 		}
-		var document []byte
-		var changedOne bool
-		if item.hasBSONSet {
-			phaseStart = updateBatchStatsNow(detailedStats)
-			scratch.bsonSetDocumentScratch, document, changedOne, err = callBSONSetUpdateAppendReplacement(item.bsonSet, scratch.bsonSetDocumentScratch[:0], current.value)
-			stats.StructuredUpdateApplications++
-			stats.StructuredUpdateApply += updateBatchStatsSince(detailedStats, phaseStart)
-			// When changedOne is true, document aliases bsonSetDocumentScratch
-			// until it is copied into the plan document arena below. No-op
-			// updates may return current.value and are discarded before staging.
-			if err != nil {
-				_ = snap.Close()
-				return nil, updateBatchItemError(i, err)
-			}
-		} else {
+		if !item.hasBSONSet {
 			phaseStart = updateBatchStatsNow(detailedStats)
 			document, changedOne, err = callCollectionUpdateCallback(item.Update, current.value)
 			stats.Callback += updateBatchStatsSince(detailedStats, phaseStart)
@@ -11398,10 +11401,12 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, errors.New("changed replacement document cannot be empty"))
 		}
-		err = validateBSONReplacementPreservesIDSnapshot(currentID, document, plannerOptions)
-		if err != nil {
-			_ = snap.Close()
-			return nil, updateBatchItemError(i, err)
+		if !item.hasBSONSet {
+			err = validateBSONReplacementPreservesIDSnapshot(currentID, document, plannerOptions)
+			if err != nil {
+				_ = snap.Close()
+				return nil, updateBatchItemError(i, err)
+			}
 		}
 		changed = append(changed, prepared)
 		changedDocuments = append(changedDocuments, appendUpdateBatchPlanScratchDocument(scratch, document))

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -350,9 +350,6 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 		if !elemOK {
 			return resetDst(), nil, false, bsoncore.NewInsufficientBytesError(current, rem)
 		}
-		if err := elem.Validate(); err != nil {
-			return resetDst(), nil, false, err
-		}
 		replacementFieldIndex := u.fieldIndexBytes(elem.KeyBytes())
 		if replacementFieldIndex < 0 {
 			if changed {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -314,6 +314,12 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 	if !ok {
 		return resetDst(), nil, false, bsoncore.NewInsufficientBytesError(current, rem)
 	}
+	if int(length) > len(current) {
+		return resetDst(), nil, false, bsoncore.NewDocumentLengthError(int(length), len(current))
+	}
+	if length < 5 || current[length-1] != 0x00 {
+		return resetDst(), nil, false, bsoncore.ErrMissingNull
+	}
 	length -= 4
 	var usedInline [8]bool
 	used := usedInline[:]
@@ -343,6 +349,9 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 		length -= int32(len(elem))
 		if !elemOK {
 			return resetDst(), nil, false, bsoncore.NewInsufficientBytesError(current, rem)
+		}
+		if err := elem.Validate(); err != nil {
+			return resetDst(), nil, false, err
 		}
 		replacementFieldIndex := u.fieldIndexBytes(elem.KeyBytes())
 		if replacementFieldIndex < 0 {
@@ -381,6 +390,9 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 			Type: bsoncore.Type(value.Type),
 			Data: value.Value,
 		})
+	}
+	if len(rem) < 1 || rem[0] != 0x00 {
+		return resetDst(), nil, false, bsoncore.ErrMissingNull
 	}
 	if !changed {
 		return dst[:start], current, false, nil

--- a/TreeDB/collections/bson_set_update_test.go
+++ b/TreeDB/collections/bson_set_update_test.go
@@ -96,7 +96,10 @@ func TestBSONSetUpdateAppendReplacementErrorPreservesGrownDestination(t *testing
 	if !ok {
 		t.Fatal("read first BSON element")
 	}
-	malformed := doc[:4+len(elem)]
+	malformed := append([]byte(nil), doc[:4+len(elem)]...)
+	malformed = append(malformed, 0x02, 'x', 0x00)
+	malformed = append(malformed, 0x00)
+	bsoncore.UpdateLength(malformed, 0, int32(len(malformed)))
 	update, err := newBSONSetUpdate([]BSONSetField{{
 		Key:   "city",
 		Value: mustBSONRawValue(t, "sea"),
@@ -124,6 +127,31 @@ func TestBSONSetUpdateAppendReplacementErrorPreservesGrownDestination(t *testing
 	}
 	if cap(out) <= cap(arena) {
 		t.Fatalf("out cap=%d want preserved grown capacity > %d", cap(out), cap(arena))
+	}
+}
+
+func TestBSONSetUpdateAppendReplacementRejectsInvalidCurrentBSON(t *testing.T) {
+	update, err := newBSONSetUpdate([]BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("new BSON set update: %v", err)
+	}
+	arena := []byte("prefix")
+	arena = arena[:len(arena):len(arena)]
+	out, replacement, changed, err := update.appendReplacement(arena, []byte{0x05, 0x00, 0x00, 0x00})
+	if err == nil {
+		t.Fatal("append replacement err=nil want invalid current BSON")
+	}
+	if changed {
+		t.Fatal("changed=true want false on invalid current BSON")
+	}
+	if replacement != nil {
+		t.Fatalf("replacement=%x want nil", replacement)
+	}
+	if !bytes.Equal(out, arena) {
+		t.Fatalf("out=%q want restored arena %q", out, arena)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on #1498.

This narrows the structured BSON `$set` update path inside `buildUpdateBatchPlan`:

- validate/apply the structured `$set` replacement before index-state extraction
- rely on the structured `$set` contract that `_id` cannot be assigned, so the batch planner skips the generic replacement `_id` rescan for `$set` items
- make `bsonSetUpdate.appendReplacement` reject malformed current BSON itself before callers can rely on it as the validation point
- keep generic callback/replacement updates on the existing `_id` snapshot + replacement validation path

## Why

#1498's new breakdown showed writers=32 spending most end-to-end wait behind the single update combiner. One safe way to lower `update_combine_wait_ns/doc` is reducing the combiner batch service time without breaking batch coalescing. Structured `$set` already validates field names and rejects `_id`, so the generic replacement `_id` rescan was redundant for this path.

## Benchmark Evidence

Command:

```sh
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchmem \
  -benchtime=100000x \
  -count=3 \
  -timeout 20m
```

Artifact: `/tmp/gomap_update_combine_bsonset_id_fastpath_repeat_20260513_070417/bench.txt`

Averages over 3 runs, branch vs #1498 base:

| metric | #1498 base | this branch |
| --- | ---: | ---: |
| ns/op | 5927.3 | 5513.0 |
| docs/sec | 168762.7 | 181508.7 |
| update_combine_wait_ns/doc | 150291.3 | 136855.7 |
| update_combine_queue_wait_ns/doc | 48427.3 | 43554.3 |
| update_combine_run_ns/doc | 4411.3 | 3992.0 |
| update_current_read_ns/doc | 1465.0 | 1449.3 |
| update_structured_apply_ns/doc | 401.2 | 565.6 |
| update_combine_items/batch | 19.34 | 19.34 |
| B/op | 1630.3 | 1638.3 |
| allocs/op | 1.0 | 1.0 |

`update_structured_apply_ns/doc` increases because BSON current-document validation moved into the structured `$set` application step. Total combiner run time and end-to-end wait still drop because the separate replacement `_id` validation scan is removed.

Single-run low-concurrency smoke, writers=8, same command with `MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8`:

| metric | #1498 base | this branch |
| --- | ---: | ---: |
| docs/sec | 135593 | 141508 |
| update_combine_wait_ns/doc | 48976 | 44910 |
| update_combine_run_ns/doc | 5452 | 4948 |
| allocs/op | 3 | 3 |

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestBSONSetUpdateAppendReplacementRejectsInvalidCurrentBSON|TestBuildUpdateBatchPlanBSONSetRejectsInvalidCurrentBSON|TestCollectionUpdateBatchBSONRejectsIDMutation|TestCollectionUpdateBSONSetRejectsInvalidFieldNames'
GOWORK=off go test ./TreeDB/collections ./cmd/mongo_gateway_bench
GOWORK=off go test ./cmd/mongo_gateway_bench -run '^TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats$' -count=1
git diff --check
```
