### PR TITLE
[comparison draft] unsafe update-combiner throughput ceiling PoC

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1534,9 +1534,9 @@ func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
 
 // SetUpdateCombineLaneWorkersForProfiling switches sharded update-combiner
 // ingress between the production global-combiner path and a profiling-only
-// lane-worker path. Lane workers are intended for throughput experiments that
-// validate sharded document-id execution before the correctness protocol is
-// finalized.
+// lane-worker path. Lane workers are comparison-branch instrumentation for
+// throughput experiments that validate sharded document-id execution before the
+// correctness protocol is finalized; they are not a production merge contract.
 func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool) {
 	if m == nil {
 		return
@@ -1557,8 +1557,9 @@ func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool
 // SetUpdateCombineUnsafeStaleDirectPlansForProfiling allows lane-worker
 // profiling runs to stage non-overlapping direct buffered update plans that were
 // built before another lane advanced the buffered generation. This is not a
-// production correctness contract; callers must restrict it to benchmark shapes
-// with non-overlapping document IDs and unchanged unique secondary indexes.
+// production correctness contract or merge-to-main behavior; callers must
+// restrict it to benchmark shapes with non-overlapping document IDs and
+// unchanged unique secondary indexes.
 func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
 	if m == nil {
 		return
@@ -1580,7 +1581,8 @@ func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(e
 // runs acknowledge after request admission instead of waiting for the lane
 // worker and prepared-batch merger to stage the update. This intentionally does
 // not define a production durability or visibility contract; it exists only to
-// measure the foreground admission ceiling against a separately timed drain.
+// measure the foreground admission ceiling against a separately timed drain on
+// comparison branches.
 func (m *CollectionManager) SetUpdateCombineUnsafeAsyncAckForProfiling(enabled bool) {
 	if m == nil {
 		return

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -71,6 +71,7 @@ const (
 	// and visibility lag.
 	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits = 4
 	defaultCollectionUpdateCombineMaxBatch              = 256
+	defaultCollectionUpdateCombineShards                = 1
 	defaultCollectionUpdateCombineDrainYields           = 1
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
 	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
@@ -924,6 +925,7 @@ type collectionWriteDomain struct {
 	updateDraining         *collectionUpdateCombiner
 	updateCombineDone      bool
 	updateCombineTTL       time.Duration
+	updateCombineShards    int
 	closingWrites          atomic.Bool
 	loaded                 bool
 	meta                   CollectionMeta
@@ -1486,6 +1488,30 @@ func (m *CollectionManager) ResetUpdateCombinersForProfiling() {
 	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.resetUpdateCombinerForProfiling()
+	}
+}
+
+// SetUpdateCombineShardsForProfiling sets the update-combiner ingress shard
+// count for already-opened collection write domains managed by m. It is intended
+// for benchmark/profiling experiments and resets active combiners so subsequent
+// updates use the new lane count.
+func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
+	if m == nil {
+		return
+	}
+	if shards < 1 {
+		shards = defaultCollectionUpdateCombineShards
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineShardsForProfiling(shards)
 	}
 }
 
@@ -2316,10 +2342,27 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 	if domain := m.domains[name]; domain != nil {
 		return domain
 	}
-	domain := &collectionWriteDomain{}
+	domain := &collectionWriteDomain{updateCombineShards: defaultCollectionUpdateCombineShards}
 	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
 	m.domains[name] = domain
 	return domain
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineShardsForProfiling(shards int) {
+	if domain == nil {
+		return
+	}
+	if shards < 1 {
+		shards = defaultCollectionUpdateCombineShards
+	}
+	domain.updateCombineMu.Lock()
+	if domain.updateCombineShards == shards {
+		domain.updateCombineMu.Unlock()
+		return
+	}
+	domain.updateCombineShards = shards
+	domain.updateCombineMu.Unlock()
+	domain.resetUpdateCombinerForProfiling()
 }
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
@@ -8797,6 +8840,12 @@ type collectionUpdateCombiner struct {
 	mu       sync.RWMutex
 	stopped  bool
 
+	shardedRequests []chan collectionUpdateCombineRequest
+	readyShards     chan int
+	nextShard       int
+	deferred        []collectionUpdateCombineRequest
+	deferredCount   atomic.Int64
+
 	batchScratch []collectionUpdateCombineRequest
 	itemsScratch []updateBatchItem
 	waiters      sync.Pool
@@ -8847,7 +8896,7 @@ func (c *Collection) updateFastPathWithoutCreatingCombiner() (*collectionUpdateC
 			if domain.updateCombiner == combiner {
 				domain.updateCombiner = nil
 			}
-		} else if combiner.running.Load() || len(combiner.requests) > 0 {
+		} else if combiner.hasQueuedOrRunning() {
 			return combiner, nil
 		}
 	}
@@ -8991,18 +9040,39 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 			domain.updateCombineMu.Unlock()
 			continue
 		}
-		combiner := &collectionUpdateCombiner{
-			maxBatch: defaultCollectionUpdateCombineMaxBatch,
-			idleTTL:  domain.updateCombineIdleTTL(),
-			requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
-			done:     make(chan struct{}),
-			domain:   domain,
-		}
+		combiner := domain.newUpdateCombinerLocked()
 		domain.updateCombiner = combiner
 		domain.updateCombineMu.Unlock()
-		go combiner.run()
+		combiner.start()
 		return combiner
 	}
+}
+
+func (domain *collectionWriteDomain) newUpdateCombinerLocked() *collectionUpdateCombiner {
+	shards := domain.updateCombineShardCountLocked()
+	combiner := &collectionUpdateCombiner{
+		maxBatch: defaultCollectionUpdateCombineMaxBatch,
+		idleTTL:  domain.updateCombineIdleTTL(),
+		done:     make(chan struct{}),
+		domain:   domain,
+	}
+	if shards <= 1 {
+		combiner.requests = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+		return combiner
+	}
+	combiner.shardedRequests = make([]chan collectionUpdateCombineRequest, shards)
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+	}
+	combiner.readyShards = make(chan int, shards*4)
+	return combiner
+}
+
+func (domain *collectionWriteDomain) updateCombineShardCountLocked() int {
+	if domain == nil || domain.updateCombineShards < 1 {
+		return defaultCollectionUpdateCombineShards
+	}
+	return domain.updateCombineShards
 }
 
 func (domain *collectionWriteDomain) stopUpdateCombiner() {
@@ -9113,6 +9183,38 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	return result.matched, result.modified, result.err
 }
 
+func hashCollectionUpdateDocumentID(documentID []byte) uint64 {
+	return xxhash.Sum64(documentID)
+}
+
+func (combiner *collectionUpdateCombiner) hasShardedIngress() bool {
+	return combiner != nil && len(combiner.shardedRequests) > 0
+}
+
+func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
+	if combiner == nil {
+		return false
+	}
+	if combiner.running.Load() || combiner.deferredCount.Load() > 0 {
+		return true
+	}
+	if combiner.hasShardedIngress() {
+		for _, requests := range combiner.shardedRequests {
+			if len(requests) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	return len(combiner.requests) > 0
+}
+
+func (combiner *collectionUpdateCombiner) start() {
+	if combiner != nil {
+		go combiner.run()
+	}
+}
+
 func newCollectionUpdateCombineRequest(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error), bsonSet bsonSetUpdate, hasBSONSet bool, done chan collectionUpdateCombineResult) collectionUpdateCombineRequest {
 	req := collectionUpdateCombineRequest{
 		collection: c,
@@ -9124,11 +9226,11 @@ func newCollectionUpdateCombineRequest(c *Collection, documentID []byte, update 
 	if len(documentID) <= collectionUpdateCombineInlineDocumentIDMax {
 		req.documentIDInlineLen = len(documentID)
 		copy(req.documentIDInline[:], documentID)
-		req.documentHash = xxhash.Sum64(req.documentIDInline[:req.documentIDInlineLen])
+		req.documentHash = hashCollectionUpdateDocumentID(req.documentIDInline[:req.documentIDInlineLen])
 		return req
 	}
 	req.documentID = bytes.Clone(documentID)
-	req.documentHash = xxhash.Sum64(req.documentID)
+	req.documentHash = hashCollectionUpdateDocumentID(req.documentID)
 	return req
 }
 
@@ -9203,6 +9305,23 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	if combiner.stopped {
 		return false
 	}
+	if combiner.hasShardedIngress() {
+		shard := int(req.documentHash % uint64(len(combiner.shardedRequests)))
+		requests := combiner.shardedRequests[shard]
+		select {
+		case requests <- req:
+			select {
+			case combiner.readyShards <- shard:
+			default:
+			}
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineRequest(len(requests))
+			}
+			return true
+		default:
+			return false
+		}
+	}
 	select {
 	case combiner.requests <- req:
 		if combiner.domain != nil {
@@ -9236,6 +9355,15 @@ func (combiner *collectionUpdateCombiner) closeRequests() bool {
 		return false
 	}
 	combiner.stopped = true
+	if combiner.hasShardedIngress() {
+		for _, requests := range combiner.shardedRequests {
+			close(requests)
+		}
+		if combiner.readyShards != nil {
+			close(combiner.readyShards)
+		}
+		return true
+	}
 	if combiner.requests != nil {
 		close(combiner.requests)
 	}
@@ -9255,19 +9383,75 @@ func (combiner *collectionUpdateCombiner) run() {
 			close(combiner.done)
 		}
 	}()
+	if combiner.hasShardedIngress() {
+		combiner.runSharded()
+		return
+	}
 	if combiner.idleTTL <= 0 {
-		for first := range combiner.requests {
+		for {
+			first, ok := combiner.waitForNextRequest()
+			if !ok {
+				return
+			}
 			combiner.runBatchStartingWith(first)
 		}
-		return
 	}
 	idle := time.NewTimer(combiner.idleTTL)
 	defer idle.Stop()
 	for {
+		if first, ok := combiner.popDeferredRequest(); ok {
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+			continue
+		}
 		select {
 		case first, ok := <-combiner.requests:
 			if !ok {
 				return
+			}
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+		case <-idle.C:
+			if combiner.retireIdle() {
+				return
+			}
+			idle.Reset(combiner.idleTTL)
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) runSharded() {
+	if combiner.idleTTL <= 0 {
+		for {
+			first, ok := combiner.waitForNextRequest()
+			if !ok {
+				return
+			}
+			combiner.runBatchStartingWith(first)
+		}
+	}
+	idle := time.NewTimer(combiner.idleTTL)
+	defer idle.Stop()
+	for {
+		if first, ok := combiner.popDeferredRequest(); ok {
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+			continue
+		}
+		select {
+		case _, ok := <-combiner.readyShards:
+			if !ok {
+				return
+			}
+			first, got, closed := combiner.tryDequeueShardedRequest()
+			if !got {
+				if closed {
+					return
+				}
+				continue
 			}
 			stopAndDrainTimer(idle)
 			combiner.runBatchStartingWith(first)
@@ -9288,6 +9472,87 @@ func stopAndDrainTimer(timer *time.Timer) {
 		default:
 		}
 	}
+}
+
+func (combiner *collectionUpdateCombiner) waitForNextRequest() (collectionUpdateCombineRequest, bool) {
+	if combiner == nil {
+		return collectionUpdateCombineRequest{}, false
+	}
+	if req, ok := combiner.popDeferredRequest(); ok {
+		return req, true
+	}
+	if combiner.hasShardedIngress() {
+		return combiner.waitForShardedRequest()
+	}
+	req, ok := <-combiner.requests
+	return req, ok
+}
+
+func (combiner *collectionUpdateCombiner) popDeferredRequest() (collectionUpdateCombineRequest, bool) {
+	if combiner == nil || len(combiner.deferred) == 0 {
+		return collectionUpdateCombineRequest{}, false
+	}
+	req := combiner.deferred[0]
+	copy(combiner.deferred, combiner.deferred[1:])
+	combiner.deferred[len(combiner.deferred)-1] = collectionUpdateCombineRequest{}
+	combiner.deferred = combiner.deferred[:len(combiner.deferred)-1]
+	combiner.deferredCount.Add(-1)
+	return req, true
+}
+
+func (combiner *collectionUpdateCombiner) deferUpdateCombineRequest(req collectionUpdateCombineRequest) {
+	if combiner == nil {
+		return
+	}
+	combiner.deferred = append(combiner.deferred, req)
+	combiner.deferredCount.Add(1)
+}
+
+func (combiner *collectionUpdateCombiner) waitForShardedRequest() (collectionUpdateCombineRequest, bool) {
+	for {
+		if req, ok, closed := combiner.tryDequeueShardedRequest(); ok || closed {
+			return req, ok
+		}
+		_, ok := <-combiner.readyShards
+		if !ok {
+			if req, got, _ := combiner.tryDequeueShardedRequest(); got {
+				return req, true
+			}
+			return collectionUpdateCombineRequest{}, false
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) tryDequeueRequest() (collectionUpdateCombineRequest, bool, bool) {
+	if combiner.hasShardedIngress() {
+		return combiner.tryDequeueShardedRequest()
+	}
+	select {
+	case req, ok := <-combiner.requests:
+		return req, ok, !ok
+	default:
+		return collectionUpdateCombineRequest{}, false, false
+	}
+}
+
+func (combiner *collectionUpdateCombiner) tryDequeueShardedRequest() (collectionUpdateCombineRequest, bool, bool) {
+	if combiner == nil || len(combiner.shardedRequests) == 0 {
+		return collectionUpdateCombineRequest{}, false, true
+	}
+	allClosed := true
+	for offset := 0; offset < len(combiner.shardedRequests); offset++ {
+		idx := (combiner.nextShard + offset) % len(combiner.shardedRequests)
+		select {
+		case req, ok := <-combiner.shardedRequests[idx]:
+			if ok {
+				combiner.nextShard = (idx + 1) % len(combiner.shardedRequests)
+				return req, true, false
+			}
+		default:
+			allClosed = false
+		}
+	}
+	return collectionUpdateCombineRequest{}, false, allClosed
 }
 
 func (combiner *collectionUpdateCombiner) retireIdle() bool {
@@ -9311,9 +9576,7 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 	if !stopped {
 		return false
 	}
-	for req := range combiner.requests {
-		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
-	}
+	combiner.drainClosedRequestsDirect()
 	if combiner.domain != nil {
 		combiner.domain.updateCombineMu.Lock()
 		if combiner.domain.updateDraining == combiner {
@@ -9322,6 +9585,35 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 		combiner.domain.updateCombineMu.Unlock()
 	}
 	return true
+}
+
+func (combiner *collectionUpdateCombiner) drainClosedRequestsDirect() {
+	if combiner == nil {
+		return
+	}
+	for {
+		req, ok := combiner.popDeferredRequest()
+		if !ok {
+			break
+		}
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+	if combiner.hasShardedIngress() {
+		for {
+			req, ok, closed := combiner.tryDequeueShardedRequest()
+			if ok {
+				completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+				continue
+			}
+			if closed {
+				return
+			}
+			return
+		}
+	}
+	for req := range combiner.requests {
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
 }
 
 func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionUpdateCombineRequest) {
@@ -9338,6 +9630,14 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	drainYields := 0
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
 	combiner.observeUpdateCombineDequeued(first, detailedStats)
+	deferredCount := len(combiner.deferred)
+	for i := 0; i < deferredCount && len(batch) < batchCap; i++ {
+		req, ok := combiner.popDeferredRequest()
+		if !ok {
+			break
+		}
+		batch = combiner.appendUpdateCombineRequestToBatch(batch, req)
+	}
 	var drainStart time.Time
 	if detailedStats {
 		drainStart = time.Now()
@@ -9348,18 +9648,21 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 		}
 	}
 	for len(batch) < batchCap {
-		select {
-		case req, ok := <-combiner.requests:
-			if !ok {
-				finishDrain()
-				combiner.runBatch(batch)
-				clear(batch)
-				combiner.batchScratch = batch[:0]
-				return
-			}
-			batch = append(batch, req)
+		req, ok, closed := combiner.tryDequeueRequest()
+		if ok {
 			combiner.observeUpdateCombineDequeued(req, detailedStats)
-		default:
+			req.queuedAt = time.Time{}
+			batch = combiner.appendUpdateCombineRequestToBatch(batch, req)
+			continue
+		}
+		if closed {
+			finishDrain()
+			combiner.runBatch(batch)
+			clear(batch)
+			combiner.batchScratch = batch[:0]
+			return
+		}
+		{
 			if drainYields < defaultCollectionUpdateCombineDrainYields {
 				drainYields++
 				if combiner.drainYield != nil {
@@ -9380,6 +9683,34 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	combiner.runBatch(batch)
 	clear(batch)
 	combiner.batchScratch = batch[:0]
+}
+
+func (combiner *collectionUpdateCombiner) appendUpdateCombineRequestToBatch(batch []collectionUpdateCombineRequest, req collectionUpdateCombineRequest) []collectionUpdateCombineRequest {
+	if collectionUpdateCombineBatchHasID(batch, req) {
+		combiner.deferUpdateCombineRequest(req)
+		return batch
+	}
+	return append(batch, req)
+}
+
+func collectionUpdateCombineBatchHasID(batch []collectionUpdateCombineRequest, req collectionUpdateCombineRequest) bool {
+	reqDocumentID := (&req).documentIDBytes()
+	hash := req.documentHash
+	if hash == 0 && len(reqDocumentID) > 0 {
+		hash = hashCollectionUpdateDocumentID(reqDocumentID)
+	}
+	for i := range batch {
+		prev := &batch[i]
+		prevDocumentID := prev.documentIDBytes()
+		prevHash := prev.documentHash
+		if prevHash == 0 && len(prevDocumentID) > 0 {
+			prevHash = hashCollectionUpdateDocumentID(prevDocumentID)
+		}
+		if prevHash == hash && bytes.Equal(prevDocumentID, reqDocumentID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (combiner *collectionUpdateCombiner) observeUpdateCombineDequeued(req collectionUpdateCombineRequest, detailedStats bool) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -73,6 +73,7 @@ const (
 	defaultCollectionUpdateCombineMaxBatch              = 256
 	defaultCollectionUpdateCombineShards                = 1
 	defaultCollectionUpdateCombineDrainYields           = 1
+	defaultCollectionUpdateCombineLaneDrainYields       = 4
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
 	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
 	collectionPprofComponentKey                         = "gomap_component"
@@ -9628,7 +9629,7 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 				}
 				batch = append(batch, req)
 			default:
-				if drainYields < defaultCollectionUpdateCombineDrainYields {
+				if drainYields < defaultCollectionUpdateCombineLaneDrainYields {
 					drainYields++
 					runtime.Gosched()
 					continue
@@ -9745,7 +9746,7 @@ func (combiner *collectionUpdateCombiner) runPreparedBatchMerger() {
 				pending = append(pending, prepared)
 				pendingRequests += len(prepared.batch)
 			default:
-				if drainYields < defaultCollectionUpdateCombineDrainYields {
+				if drainYields < defaultCollectionUpdateCombineLaneDrainYields {
 					drainYields++
 					runtime.Gosched()
 					continue

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -69,17 +69,18 @@ const (
 	// background indexed flush work. When the queue reaches this many immutable
 	// flush units, the triggering writer publishes synchronously to cap memory
 	// and visibility lag.
-	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits = 4
-	defaultCollectionUpdateCombineMaxBatch              = 256
-	defaultCollectionUpdateCombineShards                = 1
-	defaultCollectionUpdateCombineDrainYields           = 1
-	defaultCollectionUpdateCombineLaneDrainYields       = 4
-	collectionUpdateCombineIdleTTL                      = 30 * time.Second
-	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
-	collectionPprofComponentKey                         = "gomap_component"
-	collectionPprofOperationKey                         = "gomap_operation"
-	collectionPprofIndexedAsyncFlush                    = "collections_indexed_async_flush"
-	collectionPprofIndexedAsyncFlushRun                 = "publish_buffered_indexed_flush"
+	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits  = 4
+	defaultCollectionUpdateCombineMaxBatch               = 256
+	defaultCollectionUpdateCombineShards                 = 1
+	defaultCollectionUpdateCombineDrainYields            = 1
+	defaultCollectionUpdateCombineLaneDrainYields        = 4
+	defaultCollectionUpdateCombineUnsafeAsyncAckQueueCap = 65536
+	collectionUpdateCombineIdleTTL                       = 30 * time.Second
+	collectionUpdateCombineInlineQuietPeriod             = time.Millisecond
+	collectionPprofComponentKey                          = "gomap_component"
+	collectionPprofOperationKey                          = "gomap_operation"
+	collectionPprofIndexedAsyncFlush                     = "collections_indexed_async_flush"
+	collectionPprofIndexedAsyncFlushRun                  = "publish_buffered_indexed_flush"
 )
 
 var (
@@ -603,6 +604,7 @@ type CollectionManagerStats struct {
 	UpdateCombineFallbackRequests  uint64
 	UpdateCombineQueueDepthMax     uint64
 	UpdateCombineInlineRequests    uint64
+	UpdateCombineUnsafeAsyncAcks   uint64
 	UpdateCombineEnqueue           time.Duration
 	UpdateCombineWait              time.Duration
 	UpdateCombineQueueWait         time.Duration
@@ -929,6 +931,7 @@ type collectionWriteDomain struct {
 	updateCombineShards                 int
 	updateCombineLaneWorkers            bool
 	updateCombineUnsafeStaleDirectPlans atomic.Bool
+	updateCombineUnsafeAsyncAck         atomic.Bool
 	closingWrites                       atomic.Bool
 	loaded                              bool
 	meta                                CollectionMeta
@@ -1010,6 +1013,7 @@ type collectionWriteDomain struct {
 	updateCombineFallbackRequests      atomic.Uint64
 	updateCombineQueueDepthMax         atomic.Uint64
 	updateCombineInlineRequests        atomic.Uint64
+	updateCombineUnsafeAsyncAcks       atomic.Uint64
 	updateInlineInFlight               atomic.Uint64
 	updateCombineLastRequestUnixNano   atomic.Int64
 	updateInlineDocumentID             [collectionUpdateCombineInlineDocumentIDMax]byte
@@ -1306,6 +1310,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_combine.fallback_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineFallbackRequests)
 	out["treedb.collections.write_domain.update_combine.queue_depth_max"] = fmt.Sprintf("%d", stats.UpdateCombineQueueDepthMax)
 	out["treedb.collections.write_domain.update_combine.inline_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineInlineRequests)
+	out["treedb.collections.write_domain.update_combine.unsafe_async_acks_total"] = fmt.Sprintf("%d", stats.UpdateCombineUnsafeAsyncAcks)
 	out["treedb.collections.write_domain.update_combine.enqueue_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineEnqueue.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineWait.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.queue_wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateCombineQueueWait.Nanoseconds())
@@ -1494,6 +1499,15 @@ func (m *CollectionManager) ResetUpdateCombinersForProfiling() {
 	}
 }
 
+// DrainUpdateCombinersForProfiling stops and drains active update combiners
+// without flushing the collection write domains. It is intended for benchmark
+// windows that intentionally acknowledge before background combine/stage work
+// has completed, so the benchmark can time foreground admission separately from
+// the background drain.
+func (m *CollectionManager) DrainUpdateCombinersForProfiling() {
+	m.ResetUpdateCombinersForProfiling()
+}
+
 // SetUpdateCombineShardsForProfiling sets the update-combiner ingress shard
 // count for already-opened collection write domains managed by m. It is intended
 // for benchmark/profiling experiments and resets active combiners so subsequent
@@ -1562,6 +1576,28 @@ func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(e
 	}
 }
 
+// SetUpdateCombineUnsafeAsyncAckForProfiling makes update-combiner profiling
+// runs acknowledge after request admission instead of waiting for the lane
+// worker and prepared-batch merger to stage the update. This intentionally does
+// not define a production durability or visibility contract; it exists only to
+// measure the foreground admission ceiling against a separately timed drain.
+func (m *CollectionManager) SetUpdateCombineUnsafeAsyncAckForProfiling(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineUnsafeAsyncAckForProfiling(enabled)
+	}
+}
+
 func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if s == nil {
 		return
@@ -1627,6 +1663,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 		s.UpdateCombineQueueDepthMax = other.UpdateCombineQueueDepthMax
 	}
 	s.UpdateCombineInlineRequests += other.UpdateCombineInlineRequests
+	s.UpdateCombineUnsafeAsyncAcks += other.UpdateCombineUnsafeAsyncAcks
 	s.UpdateCombineEnqueue += other.UpdateCombineEnqueue
 	s.UpdateCombineWait += other.UpdateCombineWait
 	s.UpdateCombineQueueWait += other.UpdateCombineQueueWait
@@ -1764,6 +1801,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateCombineFallbackRequests = domain.updateCombineFallbackRequests.Load()
 	stats.UpdateCombineQueueDepthMax = domain.updateCombineQueueDepthMax.Load()
 	stats.UpdateCombineInlineRequests = domain.updateCombineInlineRequests.Load()
+	stats.UpdateCombineUnsafeAsyncAcks = domain.updateCombineUnsafeAsyncAcks.Load()
 	stats.UpdateCombineEnqueue = durationFromAtomicNs(domain.updateCombineEnqueueNs.Load())
 	stats.UpdateCombineWait = durationFromAtomicNs(domain.updateCombineWaitNs.Load())
 	stats.UpdateCombineQueueWait = durationFromAtomicNs(domain.updateCombineQueueWaitNs.Load())
@@ -2315,6 +2353,13 @@ func (domain *collectionWriteDomain) observeUpdateCombineInline() {
 	domain.updateCombineInlineRequests.Add(1)
 }
 
+func (domain *collectionWriteDomain) observeUpdateCombineUnsafeAsyncAck() {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineUnsafeAsyncAcks.Add(1)
+}
+
 func (domain *collectionWriteDomain) observeUpdateCombineEnqueue(d time.Duration) {
 	if domain == nil || d <= 0 {
 		return
@@ -2431,6 +2476,17 @@ func (domain *collectionWriteDomain) setUpdateCombineUnsafeStaleDirectPlansForPr
 		return
 	}
 	domain.updateCombineUnsafeStaleDirectPlans.Store(enabled)
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineUnsafeAsyncAckForProfiling(enabled bool) {
+	if domain == nil {
+		return
+	}
+	if domain.updateCombineUnsafeAsyncAck.Load() == enabled {
+		return
+	}
+	domain.updateCombineUnsafeAsyncAck.Store(enabled)
+	domain.resetUpdateCombinerForProfiling()
 }
 
 func (domain *collectionWriteDomain) allowUnsafeStaleDirectUpdatePlanForProfiling(plan *updateBatchPlan) bool {
@@ -8907,15 +8963,16 @@ func updateBatchItemError(index int, err error) error {
 }
 
 type collectionUpdateCombiner struct {
-	maxBatch     int
-	idleTTL      time.Duration
-	requests     chan collectionUpdateCombineRequest
-	done         chan struct{}
-	domain       *collectionWriteDomain
-	running      atomic.Bool
-	runningCount atomic.Int64
-	mu           sync.RWMutex
-	stopped      bool
+	maxBatch       int
+	idleTTL        time.Duration
+	requests       chan collectionUpdateCombineRequest
+	done           chan struct{}
+	domain         *collectionWriteDomain
+	unsafeAsyncAck bool
+	running        atomic.Bool
+	runningCount   atomic.Int64
+	mu             sync.RWMutex
+	stopped        bool
 
 	shardedRequests []chan collectionUpdateCombineRequest
 	readyShards     chan int
@@ -8985,6 +9042,9 @@ func (c *Collection) updateFastPathWithoutCreatingCombiner() (*collectionUpdateC
 		} else if combiner.hasQueuedOrRunning() {
 			return combiner, nil
 		}
+	}
+	if domain.updateCombineUnsafeAsyncAck.Load() {
+		return nil, nil
 	}
 	if !domain.updateInlineQuietAfterCombinerActivity() {
 		return nil, nil
@@ -9136,19 +9196,25 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 
 func (domain *collectionWriteDomain) newUpdateCombinerLocked() *collectionUpdateCombiner {
 	shards := domain.updateCombineShardCountLocked()
+	unsafeAsyncAck := domain.updateCombineUnsafeAsyncAck.Load()
+	queueCap := defaultCollectionUpdateCombineMaxBatch * 4
+	if unsafeAsyncAck {
+		queueCap = defaultCollectionUpdateCombineUnsafeAsyncAckQueueCap
+	}
 	combiner := &collectionUpdateCombiner{
-		maxBatch: defaultCollectionUpdateCombineMaxBatch,
-		idleTTL:  domain.updateCombineIdleTTL(),
-		done:     make(chan struct{}),
-		domain:   domain,
+		maxBatch:       defaultCollectionUpdateCombineMaxBatch,
+		idleTTL:        domain.updateCombineIdleTTL(),
+		done:           make(chan struct{}),
+		domain:         domain,
+		unsafeAsyncAck: unsafeAsyncAck,
 	}
 	if shards <= 1 {
-		combiner.requests = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+		combiner.requests = make(chan collectionUpdateCombineRequest, queueCap)
 		return combiner
 	}
 	combiner.shardedRequests = make([]chan collectionUpdateCombineRequest, shards)
 	for i := range combiner.shardedRequests {
-		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, queueCap)
 	}
 	combiner.readyShards = make(chan int, shards*4)
 	combiner.laneWorkers = domain.updateCombineLaneWorkers
@@ -9222,6 +9288,40 @@ func (domain *collectionWriteDomain) drainUpdateCombiner(mode updateCombinerDrai
 
 func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error), bsonSet bsonSetUpdate, hasBSONSet bool) (bool, bool, error) {
 	if combiner == nil || combiner.maxBatch <= 1 {
+		if err := c.ensureWriteDomainOpen(); err != nil {
+			return false, false, err
+		}
+		if hasBSONSet {
+			return c.updateBSONSetDirect(documentID, bsonSet)
+		}
+		return c.updateDirect(documentID, update)
+	}
+	if combiner.unsafeAsyncAck {
+		req := newCollectionUpdateCombineRequest(c, documentID, update, bsonSet, hasBSONSet, nil)
+		detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+		var enqueueStart time.Time
+		if detailedStats {
+			enqueueStart = time.Now()
+			req.queuedAt = enqueueStart
+		}
+		if combiner.enqueue(req) {
+			if detailedStats {
+				combiner.domain.observeUpdateCombineEnqueue(time.Since(enqueueStart))
+			}
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineUnsafeAsyncAck()
+			}
+			return true, true, nil
+		}
+		if detailedStats {
+			combiner.domain.observeUpdateCombineEnqueue(time.Since(enqueueStart))
+		}
+		// This profiling-only mode is best-effort. If the foreground admission
+		// queue saturates, fall back to the existing safe direct path so the
+		// caller gets a real result instead of dropping the update.
+		if combiner.isStopped() {
+			combiner.waitDone()
+		}
 		if err := c.ensureWriteDomainOpen(); err != nil {
 			return false, false, err
 		}
@@ -9398,7 +9498,11 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	if validateCollectionUpdateCombineRequest(req) != nil {
 		return false
 	}
-	if req.done == nil || cap(req.done) == 0 || len(req.done) > 0 {
+	if req.done == nil {
+		if !combiner.unsafeAsyncAck {
+			return false
+		}
+	} else if cap(req.done) == 0 || len(req.done) > 0 {
 		return false
 	}
 	combiner.mu.RLock()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -912,37 +912,39 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu             sync.Mutex
-	mu                     sync.RWMutex
-	indexedAsyncMu         sync.Mutex
-	indexedAsyncCond       *sync.Cond
-	indexedAsyncRun        bool
-	indexedAsyncErr        error
-	indexedPrepareCond     *sync.Cond
-	indexedPrepareFreezes  int
-	updateCombineMu        sync.Mutex
-	updateCombiner         *collectionUpdateCombiner
-	updateDraining         *collectionUpdateCombiner
-	updateCombineDone      bool
-	updateCombineTTL       time.Duration
-	updateCombineShards    int
-	closingWrites          atomic.Bool
-	loaded                 bool
-	meta                   CollectionMeta
-	catalog                *collectionCatalog
-	baseCommitSeq          uint64
-	baseSystemRoot         uint64
-	primaryRoot            uint64
-	storagePolicy          backenddb.OrderedRootStoragePolicy
-	table                  memtable.Table
-	indexedPublishingUnits []indexedFlushUnit
-	indexedFlushUnits      []indexedFlushUnit
-	rootRuns               map[string][]memtable.Table
-	rootMutableRuns        map[string]memtable.Table
-	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs            map[string]uint64
-	rootValueArenas        [][]byte
-	primaryIDIndex         *bufferedUniqueValueIndex
+	mutationMu                          sync.Mutex
+	mu                                  sync.RWMutex
+	indexedAsyncMu                      sync.Mutex
+	indexedAsyncCond                    *sync.Cond
+	indexedAsyncRun                     bool
+	indexedAsyncErr                     error
+	indexedPrepareCond                  *sync.Cond
+	indexedPrepareFreezes               int
+	updateCombineMu                     sync.Mutex
+	updateCombiner                      *collectionUpdateCombiner
+	updateDraining                      *collectionUpdateCombiner
+	updateCombineDone                   bool
+	updateCombineTTL                    time.Duration
+	updateCombineShards                 int
+	updateCombineLaneWorkers            bool
+	updateCombineUnsafeStaleDirectPlans atomic.Bool
+	closingWrites                       atomic.Bool
+	loaded                              bool
+	meta                                CollectionMeta
+	catalog                             *collectionCatalog
+	baseCommitSeq                       uint64
+	baseSystemRoot                      uint64
+	primaryRoot                         uint64
+	storagePolicy                       backenddb.OrderedRootStoragePolicy
+	table                               memtable.Table
+	indexedPublishingUnits              []indexedFlushUnit
+	indexedFlushUnits                   []indexedFlushUnit
+	rootRuns                            map[string][]memtable.Table
+	rootMutableRuns                     map[string]memtable.Table
+	rootPolicies                        map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs                         map[string]uint64
+	rootValueArenas                     [][]byte
+	primaryIDIndex                      *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
 	primaryRunIndex        *bufferedPrimaryRunIndex
@@ -1512,6 +1514,50 @@ func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
 	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.setUpdateCombineShardsForProfiling(shards)
+	}
+}
+
+// SetUpdateCombineLaneWorkersForProfiling switches sharded update-combiner
+// ingress between the production global-combiner path and a profiling-only
+// lane-worker path. Lane workers are intended for throughput experiments that
+// validate sharded document-id execution before the correctness protocol is
+// finalized.
+func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineLaneWorkersForProfiling(enabled)
+	}
+}
+
+// SetUpdateCombineUnsafeStaleDirectPlansForProfiling allows lane-worker
+// profiling runs to stage non-overlapping direct buffered update plans that were
+// built before another lane advanced the buffered generation. This is not a
+// production correctness contract; callers must restrict it to benchmark shapes
+// with non-overlapping document IDs and unchanged unique secondary indexes.
+func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled)
 	}
 }
 
@@ -2363,6 +2409,35 @@ func (domain *collectionWriteDomain) setUpdateCombineShardsForProfiling(shards i
 	domain.updateCombineShards = shards
 	domain.updateCombineMu.Unlock()
 	domain.resetUpdateCombinerForProfiling()
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineLaneWorkersForProfiling(enabled bool) {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineMu.Lock()
+	if domain.updateCombineLaneWorkers == enabled {
+		domain.updateCombineMu.Unlock()
+		return
+	}
+	domain.updateCombineLaneWorkers = enabled
+	domain.updateCombineMu.Unlock()
+	domain.resetUpdateCombinerForProfiling()
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineUnsafeStaleDirectPlans.Store(enabled)
+}
+
+func (domain *collectionWriteDomain) allowUnsafeStaleDirectUpdatePlanForProfiling(plan *updateBatchPlan) bool {
+	return domain != nil &&
+		domain.updateCombineUnsafeStaleDirectPlans.Load() &&
+		plan != nil &&
+		plan.directBufferedUpdate != nil &&
+		plan.canBufferDirectUpdateBatch
 }
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
@@ -8831,17 +8906,20 @@ func updateBatchItemError(index int, err error) error {
 }
 
 type collectionUpdateCombiner struct {
-	maxBatch int
-	idleTTL  time.Duration
-	requests chan collectionUpdateCombineRequest
-	done     chan struct{}
-	domain   *collectionWriteDomain
-	running  atomic.Bool
-	mu       sync.RWMutex
-	stopped  bool
+	maxBatch     int
+	idleTTL      time.Duration
+	requests     chan collectionUpdateCombineRequest
+	done         chan struct{}
+	domain       *collectionWriteDomain
+	running      atomic.Bool
+	runningCount atomic.Int64
+	mu           sync.RWMutex
+	stopped      bool
 
 	shardedRequests []chan collectionUpdateCombineRequest
 	readyShards     chan int
+	preparedBatches chan collectionUpdateCombinePreparedBatch
+	laneWorkers     bool
 	nextShard       int
 	deferred        []collectionUpdateCombineRequest
 	deferredCount   atomic.Int64
@@ -8871,6 +8949,13 @@ type collectionUpdateCombineResult struct {
 	matched  bool
 	modified bool
 	err      error
+}
+
+type collectionUpdateCombinePreparedBatch struct {
+	batch          []collectionUpdateCombineRequest
+	plan           *updateBatchPlan
+	err            error
+	fallbackDirect bool
 }
 
 type collectionUpdateCombineWaiter struct {
@@ -9065,6 +9150,10 @@ func (domain *collectionWriteDomain) newUpdateCombinerLocked() *collectionUpdate
 		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
 	}
 	combiner.readyShards = make(chan int, shards*4)
+	combiner.laneWorkers = domain.updateCombineLaneWorkers
+	if combiner.laneWorkers {
+		combiner.preparedBatches = make(chan collectionUpdateCombinePreparedBatch, shards*4)
+	}
 	return combiner
 }
 
@@ -9191,9 +9280,16 @@ func (combiner *collectionUpdateCombiner) hasShardedIngress() bool {
 	return combiner != nil && len(combiner.shardedRequests) > 0
 }
 
+func (combiner *collectionUpdateCombiner) hasShardWorkers() bool {
+	return combiner != nil && combiner.laneWorkers && len(combiner.shardedRequests) > 0
+}
+
 func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
 	if combiner == nil {
 		return false
+	}
+	if combiner.hasShardWorkers() && !combiner.isStopped() {
+		return true
 	}
 	if combiner.running.Load() || combiner.deferredCount.Load() > 0 {
 		return true
@@ -9211,6 +9307,10 @@ func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
 
 func (combiner *collectionUpdateCombiner) start() {
 	if combiner != nil {
+		if combiner.hasShardWorkers() {
+			go combiner.runShardWorkers()
+			return
+		}
 		go combiner.run()
 	}
 }
@@ -9463,6 +9563,439 @@ func (combiner *collectionUpdateCombiner) runSharded() {
 			idle.Reset(combiner.idleTTL)
 		}
 	}
+}
+
+func (combiner *collectionUpdateCombiner) runShardWorkers() {
+	defer func() {
+		_ = combiner.closeRequests()
+		if combiner.done != nil {
+			close(combiner.done)
+		}
+	}()
+	var wg sync.WaitGroup
+	for shard := range combiner.shardedRequests {
+		wg.Add(1)
+		go func(shard int) {
+			defer wg.Done()
+			combiner.runShardWorker(shard)
+		}(shard)
+	}
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		if combiner.preparedBatches != nil {
+			close(combiner.preparedBatches)
+		}
+		close(workersDone)
+	}()
+	combiner.runPreparedBatchMerger()
+	<-workersDone
+}
+
+func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
+	if combiner == nil || shard < 0 || shard >= len(combiner.shardedRequests) {
+		return
+	}
+	requests := combiner.shardedRequests[shard]
+	batchCap := combiner.maxBatch
+	if batchCap < 1 {
+		batchCap = 1
+	}
+	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
+	itemsScratch := make([]updateBatchItem, 0, batchCap)
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	for first := range requests {
+		batch = append(batch[:0], first)
+		combiner.observeUpdateCombineDequeued(first, detailedStats)
+		drainYields := 0
+		var drainStart time.Time
+		if detailedStats {
+			drainStart = time.Now()
+		}
+		closed := false
+		for len(batch) < batchCap {
+			select {
+			case req, ok := <-requests:
+				if !ok {
+					closed = true
+					goto flush
+				}
+				combiner.observeUpdateCombineDequeued(req, detailedStats)
+				req.queuedAt = time.Time{}
+				if collectionUpdateCombineBatchHasID(batch, req) {
+					completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+					continue
+				}
+				batch = append(batch, req)
+			default:
+				if drainYields < defaultCollectionUpdateCombineDrainYields {
+					drainYields++
+					runtime.Gosched()
+					continue
+				}
+				goto flush
+			}
+		}
+	flush:
+		if detailedStats {
+			combiner.domain.observeUpdateCombineDrain(time.Since(drainStart))
+		}
+		prepared := combiner.prepareBatchWithScratch(batch, &itemsScratch)
+		if combiner.preparedBatches == nil {
+			combiner.completePreparedBatch(prepared)
+		} else {
+			combiner.preparedBatches <- prepared
+		}
+		clear(batch)
+		batch = batch[:0]
+		if closed {
+			return
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collectionUpdateCombineRequest, itemsScratch *[]updateBatchItem) collectionUpdateCombinePreparedBatch {
+	ownedBatch := make([]collectionUpdateCombineRequest, len(batch))
+	copy(ownedBatch, batch)
+	prepared := collectionUpdateCombinePreparedBatch{batch: ownedBatch}
+	combiner.beginUpdateCombineRun()
+	defer combiner.endUpdateCombineRun()
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	var runStart time.Time
+	if detailedStats {
+		runStart = time.Now()
+	}
+	defer func() {
+		if detailedStats {
+			combiner.domain.observeUpdateCombineRun(time.Since(runStart))
+		}
+	}()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			prepared.err = collectionUpdatePanicError("combiner_prepare", recovered)
+		}
+	}()
+	if combiner.domain == nil ||
+		combiner.domain.closingWrites.Load() ||
+		collectionUpdateCombineHasDuplicateIDs(ownedBatch) ||
+		!collectionUpdateCombineSameCollection(ownedBatch) {
+		prepared.fallbackDirect = true
+		return prepared
+	}
+	if itemsScratch == nil {
+		localScratch := make([]updateBatchItem, 0, len(ownedBatch))
+		itemsScratch = &localScratch
+	}
+	if cap(*itemsScratch) < len(ownedBatch) {
+		*itemsScratch = make([]updateBatchItem, len(ownedBatch))
+	}
+	clear(*itemsScratch)
+	items := (*itemsScratch)[:len(ownedBatch)]
+	for i := range ownedBatch {
+		req := &ownedBatch[i]
+		items[i] = updateBatchItem{
+			UpdateBatchItem: UpdateBatchItem{
+				DocumentID: req.documentIDBytes(),
+				Update:     req.update,
+			},
+			bsonSet:    req.bsonSet,
+			hasBSONSet: req.hasBSONSet,
+		}
+	}
+	plan, err := ownedBatch[0].collection.buildUpdateBatchPlan(items, updateBatchModeNoSecondaryUniqueIndexChanges, false)
+	clear(items)
+	*itemsScratch = items[:0]
+	if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) ||
+		errors.Is(err, errUpdateBatchChangesSecondaryUniqueIndex) {
+		prepared.fallbackDirect = true
+		return prepared
+	}
+	if err != nil {
+		prepared.err = err
+		return prepared
+	}
+	if plan == nil || plan.directBufferedUpdate == nil {
+		prepared.plan = plan
+		return prepared
+	}
+	prepared.plan = plan
+	return prepared
+}
+
+func (combiner *collectionUpdateCombiner) runPreparedBatchMerger() {
+	if combiner == nil || combiner.preparedBatches == nil {
+		return
+	}
+	batchCap := combiner.maxBatch
+	if batchCap < 1 {
+		batchCap = 1
+	}
+	pending := make([]collectionUpdateCombinePreparedBatch, 0, batchCap)
+	for first := range combiner.preparedBatches {
+		pending = append(pending[:0], first)
+		pendingRequests := len(first.batch)
+		drainYields := 0
+		for pendingRequests < batchCap {
+			select {
+			case prepared, ok := <-combiner.preparedBatches:
+				if !ok {
+					combiner.stagePreparedBatches(pending)
+					return
+				}
+				pending = append(pending, prepared)
+				pendingRequests += len(prepared.batch)
+			default:
+				if drainYields < defaultCollectionUpdateCombineDrainYields {
+					drainYields++
+					runtime.Gosched()
+					continue
+				}
+				goto stage
+			}
+		}
+	stage:
+		combiner.stagePreparedBatches(pending)
+		for i := range pending {
+			pending[i] = collectionUpdateCombinePreparedBatch{}
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collectionUpdateCombinePreparedBatch) {
+	if len(prepared) == 0 {
+		return
+	}
+	direct := make([]collectionUpdateCombinePreparedBatch, 0, len(prepared))
+	for _, p := range prepared {
+		if p.err != nil || p.fallbackDirect || p.plan == nil || p.plan.directBufferedUpdate == nil {
+			combiner.completePreparedBatch(p)
+			continue
+		}
+		direct = append(direct, p)
+	}
+	if len(direct) == 0 {
+		return
+	}
+	merged, collection, err := mergeDirectBufferedPreparedBatches(direct)
+	if err == nil {
+		err = collection.withMutationLock(func() error {
+			buffered, bufferErr := collection.bufferDirectUpdateBatchPlanLocked(merged)
+			if bufferErr != nil {
+				return bufferErr
+			}
+			if !buffered {
+				return ErrConcurrentMutation
+			}
+			if collection.writeDomain != nil {
+				collection.writeDomain.mu.Lock()
+				for _, p := range direct {
+					retainDirectBufferedDocumentArenaLocked(collection.writeDomain, p.plan)
+				}
+				collection.writeDomain.mu.Unlock()
+			}
+			collection.setLastUpdateStats(merged.stats)
+			return nil
+		})
+	}
+	if err != nil {
+		for _, p := range direct {
+			combiner.completePreparedBatchWithError(p, err)
+		}
+		return
+	}
+	for _, p := range direct {
+		combiner.completePreparedBatch(p)
+	}
+}
+
+func (combiner *collectionUpdateCombiner) completePreparedBatch(prepared collectionUpdateCombinePreparedBatch) {
+	defer func() {
+		if prepared.plan != nil {
+			prepared.plan.close()
+		}
+	}()
+	if prepared.err != nil {
+		if completeUpdateCombineBatchWithItemFallback(prepared.batch, prepared.err) {
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+			}
+			return
+		}
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+		}
+		completeUpdateCombineBatchWithError(prepared.batch, prepared.err)
+		return
+	}
+	if prepared.fallbackDirect {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+		}
+		for _, req := range prepared.batch {
+			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+		}
+		return
+	}
+	if prepared.plan == nil {
+		completeUpdateCombineBatchWithError(prepared.batch, errors.New("collections: update combiner prepared nil plan"))
+		return
+	}
+	results := prepared.plan.results
+	if len(results) != len(prepared.batch) {
+		completeUpdateCombineBatchWithError(prepared.batch, fmt.Errorf("collections: update combiner result count %d for prepared batch size %d", len(results), len(prepared.batch)))
+		return
+	}
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+	}
+	for i, req := range prepared.batch {
+		result := results[i]
+		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
+	}
+}
+
+func (combiner *collectionUpdateCombiner) completePreparedBatchWithError(prepared collectionUpdateCombinePreparedBatch, err error) {
+	defer func() {
+		if prepared.plan != nil {
+			prepared.plan.close()
+		}
+	}()
+	if completeUpdateCombineBatchWithItemFallback(prepared.batch, err) {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+		}
+		return
+	}
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+	}
+	completeUpdateCombineBatchWithError(prepared.batch, err)
+}
+
+func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePreparedBatch) (*updateBatchPlan, *Collection, error) {
+	if len(prepared) == 0 {
+		return nil, nil, errors.New("collections: no prepared update batches to merge")
+	}
+	firstPlan := prepared[0].plan
+	if firstPlan == nil || firstPlan.directBufferedUpdate == nil || len(prepared[0].batch) == 0 || prepared[0].batch[0].collection == nil {
+		return nil, nil, errors.New("collections: invalid prepared direct update batch")
+	}
+	collection := prepared[0].batch[0].collection
+	merged := &updateBatchPlan{
+		meta:                        firstPlan.meta,
+		catalog:                     firstPlan.catalog,
+		baseUserRoot:                firstPlan.baseUserRoot,
+		baseSystemRoot:              firstPlan.baseSystemRoot,
+		baseCommitSeq:               firstPlan.baseCommitSeq,
+		baseRootIDs:                 make(map[string]uint64, len(firstPlan.baseRootIDs)),
+		canBufferIndexedUpdateBatch: firstPlan.canBufferIndexedUpdateBatch,
+		canBufferDirectUpdateBatch:  true,
+		directBufferedUpdate: &directBufferedUpdatePlan{
+			templateRootName: firstPlan.directBufferedUpdate.templateRootName,
+			primaryRootName:  firstPlan.directBufferedUpdate.primaryRootName,
+		},
+	}
+	rootIndex := make(map[string]int, len(firstPlan.rootNames))
+	addRoot := func(plan *updateBatchPlan, idx int) error {
+		if idx < 0 || idx >= len(plan.rootNames) || idx >= len(plan.policies) || idx >= len(plan.uniqueSecondaryIndexByRoot) {
+			return errors.New("collections: invalid direct update root metadata")
+		}
+		rootName := plan.rootNames[idx]
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: direct update plan missing base root for %q", rootName)
+		}
+		if existingIdx, ok := rootIndex[rootName]; ok {
+			if merged.baseRootIDs[rootName] != baseRoot ||
+				merged.uniqueSecondaryIndexByRoot[existingIdx] != plan.uniqueSecondaryIndexByRoot[idx] {
+				return fmt.Errorf("collections: incompatible direct update root %q", rootName)
+			}
+			return nil
+		}
+		rootIndex[rootName] = len(merged.rootNames)
+		merged.rootNames = append(merged.rootNames, rootName)
+		merged.baseRootIDs[rootName] = baseRoot
+		merged.policies = append(merged.policies, plan.policies[idx])
+		merged.uniqueSecondaryIndexByRoot = append(merged.uniqueSecondaryIndexByRoot, plan.uniqueSecondaryIndexByRoot[idx])
+		return nil
+	}
+	for _, p := range prepared {
+		plan := p.plan
+		if plan == nil || plan.directBufferedUpdate == nil {
+			return nil, nil, errors.New("collections: cannot merge non-direct update plan")
+		}
+		if len(p.batch) == 0 || p.batch[0].collection != collection {
+			return nil, nil, errors.New("collections: cannot merge update plans across collections")
+		}
+		for i := range plan.rootNames {
+			if err := addRoot(plan, i); err != nil {
+				return nil, nil, err
+			}
+		}
+		merged.results = append(merged.results, plan.results...)
+		addCollectionUpdateStatsForMerge(&merged.stats, plan.stats)
+		merged.directBufferedUpdate.templateEntries = append(merged.directBufferedUpdate.templateEntries, plan.directBufferedUpdate.templateEntries...)
+		merged.directBufferedUpdate.primaryEntries = append(merged.directBufferedUpdate.primaryEntries, plan.directBufferedUpdate.primaryEntries...)
+		merged.directBufferedUpdate.secondaryRootPlans = append(merged.directBufferedUpdate.secondaryRootPlans, plan.directBufferedUpdate.secondaryRootPlans...)
+		merged.directBufferedUpdate.stagedBytes += plan.directBufferedUpdate.stagedBytes
+	}
+	return merged, collection, nil
+}
+
+func addCollectionUpdateStatsForMerge(dst *CollectionUpdateStats, src CollectionUpdateStats) {
+	if dst == nil {
+		return
+	}
+	if dst.Indexes == 0 {
+		dst.Indexes = src.Indexes
+	}
+	dst.Items += src.Items
+	dst.Matched += src.Matched
+	dst.Modified += src.Modified
+	dst.Runs += src.Runs
+	dst.BufferedBatches += src.BufferedBatches
+	dst.CurrentRead += src.CurrentRead
+	dst.Callback += src.Callback
+	dst.StructuredUpdateApply += src.StructuredUpdateApply
+	dst.StructuredUpdateApplications += src.StructuredUpdateApplications
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.OldIndexStateExtract += src.OldIndexStateExtract
+	dst.NewIndexStateExtract += src.NewIndexStateExtract
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.SecondaryDeleteEntries += src.SecondaryDeleteEntries
+	dst.SecondarySetEntries += src.SecondarySetEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.IndexValueChanges += src.IndexValueChanges
+	dst.IndexValueUnchanged += src.IndexValueUnchanged
+	dst.MaskFallbacks += src.MaskFallbacks
+	dst.UniqueIndexChecks += src.UniqueIndexChecks
+	dst.UniqueIndexCheckSkips += src.UniqueIndexCheckSkips
+	for _, secondaryRun := range src.SecondaryRuns {
+		mergeCollectionUpdateSecondaryRunStatsForMerge(&dst.SecondaryRuns, secondaryRun)
+	}
+	for i := 0; i < src.IndexStatsCount && i < len(src.IndexStats); i++ {
+		mergeCollectionUpdateIndexStat(&dst.IndexStats, &dst.IndexStatsCount, src.IndexStats[i])
+	}
+}
+
+func mergeCollectionUpdateSecondaryRunStatsForMerge(dst *[]CollectionUpdateSecondaryRunStats, src CollectionUpdateSecondaryRunStats) {
+	if dst == nil || src.IndexName == "" {
+		return
+	}
+	for i := range *dst {
+		if (*dst)[i].IndexName == src.IndexName {
+			(*dst)[i].Deletes = saturatingAddNonNegativeInt((*dst)[i].Deletes, src.Deletes)
+			(*dst)[i].Sets = saturatingAddNonNegativeInt((*dst)[i].Sets, src.Sets)
+			(*dst)[i].KeyBytes = saturatingAddNonNegativeInt((*dst)[i].KeyBytes, src.KeyBytes)
+			return
+		}
+	}
+	*dst = append(*dst, src)
 }
 
 func stopAndDrainTimer(timer *time.Timer) {
@@ -9720,9 +10253,31 @@ func (combiner *collectionUpdateCombiner) observeUpdateCombineDequeued(req colle
 	combiner.domain.observeUpdateCombineQueueWait(time.Since(req.queuedAt))
 }
 
+func (combiner *collectionUpdateCombiner) beginUpdateCombineRun() {
+	if combiner == nil {
+		return
+	}
+	if combiner.runningCount.Add(1) == 1 {
+		combiner.running.Store(true)
+	}
+}
+
+func (combiner *collectionUpdateCombiner) endUpdateCombineRun() {
+	if combiner == nil {
+		return
+	}
+	if combiner.runningCount.Add(-1) == 0 {
+		combiner.running.Store(false)
+	}
+}
+
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
-	combiner.running.Store(true)
-	defer combiner.running.Store(false)
+	combiner.runBatchWithScratch(batch, &combiner.itemsScratch)
+}
+
+func (combiner *collectionUpdateCombiner) runBatchWithScratch(batch []collectionUpdateCombineRequest, itemsScratch *[]updateBatchItem) {
+	combiner.beginUpdateCombineRun()
+	defer combiner.endUpdateCombineRun()
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
 	var runStart time.Time
 	if detailedStats {
@@ -9753,11 +10308,15 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 		}
 		return
 	}
-	if cap(combiner.itemsScratch) < len(batch) {
-		combiner.itemsScratch = make([]updateBatchItem, len(batch))
+	if itemsScratch == nil {
+		localScratch := make([]updateBatchItem, 0, len(batch))
+		itemsScratch = &localScratch
 	}
-	clear(combiner.itemsScratch)
-	items := combiner.itemsScratch[:len(batch)]
+	if cap(*itemsScratch) < len(batch) {
+		*itemsScratch = make([]updateBatchItem, len(batch))
+	}
+	clear(*itemsScratch)
+	items := (*itemsScratch)[:len(batch)]
 	for i := range batch {
 		req := &batch[i]
 		items[i] = updateBatchItem{
@@ -9771,7 +10330,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	results, batched, err := batch[0].collection.updateBatchOwnedItems(items, updateBatchModeNoSecondaryUniqueIndexChanges)
 	clear(items)
-	combiner.itemsScratch = items[:0]
+	*itemsScratch = items[:0]
 	if !batched && err == nil {
 		if combiner.domain != nil {
 			combiner.domain.observeUpdateCombineBatch(len(batch), true)
@@ -12277,7 +12836,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	if domain.count != 0 {
+	allowUnsafeStaleDirectPlan := domain.allowUnsafeStaleDirectUpdatePlanForProfiling(plan)
+	if domain.count != 0 && !allowUnsafeStaleDirectPlan {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9737,6 +9737,184 @@ func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerDefersDuplicateIDsAndBatchesDistinctPeers(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	first := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update:     setScore(1),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	duplicate := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update:     setScore(2),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	peer := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u2"),
+		update:     setScore(3),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	combiner := &collectionUpdateCombiner{
+		maxBatch: 8,
+		domain:   col.writeDomain,
+		requests: make(chan collectionUpdateCombineRequest, 2),
+	}
+	combiner.requests <- duplicate
+	combiner.requests <- peer
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+
+	combiner.runBatchStartingWith(first)
+	for name, done := range map[string]chan collectionUpdateCombineResult{
+		"first": first.done,
+		"peer":  peer.done,
+	} {
+		result := <-done
+		if result.err != nil || !result.matched || !result.modified {
+			t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+		}
+	}
+	select {
+	case result := <-duplicate.done:
+		t.Fatalf("duplicate completed in same batch: %+v", result)
+	default:
+	}
+	if got := len(combiner.deferred); got != 1 {
+		t.Fatalf("deferred duplicate count=%d want 1", got)
+	}
+	midState := d.State()
+	if midState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("first combined batch advanced commit seq by %d, want 1", midState.CommitSeq-beforeState.CommitSeq)
+	}
+	midStats := mgr.StatsSnapshot()
+	if got := midStats.UpdateCombineFallbackRequests - beforeStats.UpdateCombineFallbackRequests; got != 0 {
+		t.Fatalf("fallback requests after distinct-peer batch=%d want 0", got)
+	}
+
+	deferred, ok := combiner.popDeferredRequest()
+	if !ok {
+		t.Fatal("missing deferred duplicate")
+	}
+	combiner.runBatchStartingWith(deferred)
+	result := <-duplicate.done
+	if result.err != nil || !result.matched || !result.modified {
+		t.Fatalf("duplicate result=%+v want matched modified nil err", result)
+	}
+	afterState := d.State()
+	if afterState.CommitSeq != beforeState.CommitSeq+2 {
+		t.Fatalf("two serialized batches advanced commit seq by %d, want 2", afterState.CommitSeq-beforeState.CommitSeq)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("u1 document=%s want final score 2", got)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":3`)) {
+		t.Fatalf("u2 document=%s want score 3", got)
+	}
+}
+
+func TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+		readyShards:     make(chan int, 16),
+		done:            make(chan struct{}),
+	}
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 8)
+	}
+	firstDone := make(chan collectionUpdateCombineResult, 1)
+	secondDone := make(chan collectionUpdateCombineResult, 1)
+	if !combiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u1"), setScore(1), bsonSetUpdate{}, false, firstDone)) {
+		t.Fatal("enqueue first sharded update")
+	}
+	if !combiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u2"), setScore(2), bsonSetUpdate{}, false, secondDone)) {
+		t.Fatal("enqueue second sharded update")
+	}
+	before := d.State()
+	go combiner.run()
+	defer combiner.stop()
+	for name, done := range map[string]chan collectionUpdateCombineResult{
+		"first":  firstDone,
+		"second": secondDone,
+	} {
+		select {
+		case result := <-done:
+			if result.err != nil || !result.matched || !result.modified {
+				t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+			}
+		case <-time.After(collectionTestTimeout(t, time.Second)):
+			t.Fatalf("%s update did not complete", name)
+		}
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("sharded ingress batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateCombinerMixedCollectionsFallbackDirect(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1548,6 +1548,88 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateStatsForMergeKeepsPerIndexBreakdown(t *testing.T) {
+	left := CollectionUpdateStats{
+		Items:           3,
+		Matched:         3,
+		Modified:        3,
+		SecondaryRuns:   []CollectionUpdateSecondaryRunStats{{IndexName: "city", Deletes: 1, Sets: 2, KeyBytes: 64}},
+		IndexStatsCount: 2,
+		IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+			{
+				CollectionName:   "users",
+				IndexName:        "email",
+				IndexOrdinal:     0,
+				Unique:           true,
+				Unchanged:        3,
+				UniqueCheckSkips: 3,
+			},
+			{
+				CollectionName:    "users",
+				IndexName:         "city",
+				IndexOrdinal:      1,
+				Changed:           3,
+				SecondaryRuns:     1,
+				SecondaryDeletes:  1,
+				SecondarySets:     2,
+				SecondaryKeyBytes: 64,
+			},
+		},
+	}
+	right := CollectionUpdateStats{
+		Items:           4,
+		Matched:         4,
+		Modified:        4,
+		SecondaryRuns:   []CollectionUpdateSecondaryRunStats{{IndexName: "city", Deletes: 3, Sets: 4, KeyBytes: 96}},
+		IndexStatsCount: 2,
+		IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+			{
+				CollectionName:   "users",
+				IndexName:        "email",
+				IndexOrdinal:     0,
+				Unique:           true,
+				Unchanged:        4,
+				UniqueCheckSkips: 4,
+			},
+			{
+				CollectionName:    "users",
+				IndexName:         "city",
+				IndexOrdinal:      1,
+				Changed:           4,
+				SecondaryRuns:     1,
+				SecondaryDeletes:  3,
+				SecondarySets:     4,
+				SecondaryKeyBytes: 96,
+			},
+		},
+	}
+
+	var merged CollectionUpdateStats
+	addCollectionUpdateStatsForMerge(&merged, left)
+	addCollectionUpdateStatsForMerge(&merged, right)
+
+	if got, want := merged.Items, 7; got != want {
+		t.Fatalf("merged items=%d want %d", got, want)
+	}
+	if got, want := len(merged.SecondaryRuns), 1; got != want {
+		t.Fatalf("secondary runs=%d want %d: %+v", got, want, merged.SecondaryRuns)
+	}
+	if city := merged.SecondaryRuns[0]; city.IndexName != "city" || city.Deletes != 4 || city.Sets != 6 || city.KeyBytes != 160 {
+		t.Fatalf("merged secondary city=%+v want deletes/sets/key bytes 4/6/160", city)
+	}
+	if got, want := merged.IndexStatsCount, 2; got != want {
+		t.Fatalf("index stats count=%d want %d", got, want)
+	}
+	email := merged.IndexStats[0]
+	if email.IndexName != "email" || !email.Unique || email.Unchanged != 7 || email.UniqueCheckSkips != 7 {
+		t.Fatalf("merged email=%+v want unchanged/skips 7", email)
+	}
+	city := merged.IndexStats[1]
+	if city.IndexName != "city" || city.Changed != 7 || city.SecondaryRuns != 2 || city.SecondaryDeletes != 4 || city.SecondarySets != 6 || city.SecondaryKeyBytes != 160 {
+		t.Fatalf("merged city index=%+v want changed/runs/deletes/sets/key bytes 7/2/4/6/160", city)
+	}
+}
+
 func TestCollectionUpdateIndexStatsDoNotMergeOverlappingIndexNames(t *testing.T) {
 	newDomain := func(collection string, changed int) *collectionWriteDomain {
 		domain := &collectionWriteDomain{

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -188,6 +188,16 @@ the single-queue combiner. Values above `1` shard request ingress by document ID
 while preserving one global merged publish batch, and benchmark rows report
 `update_combine_shards` so shard-count runs are not mixed accidentally.
 
+For sharded-combiner proof-of-concept runs, add
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true` to let each
+document-ID shard prepare direct buffered update plans concurrently, then merge
+prepared plans back into one global buffer/publish path. Add
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true` only
+for controlled benchmark shapes with non-overlapping document IDs and unchanged
+unique secondary indexes. That stale-plan flag is intentionally profiling-only:
+it validates throughput headroom before the production conflict protocol is
+implemented.
+
 ## MongoDB Target
 
 ```sh

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -182,6 +182,12 @@ synchronous-threshold rows by accident. The concurrent update profile benchmark
 times a final `FlushAll()` drain before reporting docs/sec, so async rows include
 deferred indexed publish work rather than enqueue latency alone.
 
+For update-combiner ingress experiments, set
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=N`. The default `1` preserves
+the single-queue combiner. Values above `1` shard request ingress by document ID
+while preserving one global merged publish batch, and benchmark rows report
+`update_combine_shards` so shard-count runs are not mixed accidentally.
+
 ## MongoDB Target
 
 ```sh

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -198,6 +198,15 @@ unique secondary indexes. That stale-plan flag is intentionally profiling-only:
 it validates throughput headroom before the production conflict protocol is
 implemented.
 
+For unsafe foreground-admission ceiling runs, also set
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK=true`. This
+profiling-only mode acknowledges after request admission into the sharded
+combiner queue, then drains lane workers and `FlushAll()` inside the timed
+window. Rows report foreground metrics such as
+`update_combine_unsafe_async_ack_docs/sec` and final drain metrics such as
+`update_combine_unsafe_async_final_drain_ns/doc`; this mode is not a durability
+or visibility contract.
+
 ## MongoDB Target
 
 ```sh

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -198,6 +198,13 @@ unique secondary indexes. That stale-plan flag is intentionally profiling-only:
 it validates throughput headroom before the production conflict protocol is
 implemented.
 
+These lane-worker and unsafe-ack modes are comparison-branch instrumentation,
+not production behavior and not a merge-to-main contract. They exist to preserve
+a measured upper bound for future safe implementations. Production work should
+replace them with explicit conflict handling, read visibility, backpressure, and
+durability semantics before any similar behavior is enabled outside profiling
+runs.
+
 For unsafe foreground-admission ceiling runs, also set
 `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK=true`. This
 profiling-only mode acknowledges after request admission into the sharded

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -97,6 +97,7 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -123,6 +124,9 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 0 {
 		t.Fatalf("buffered max root runs default=%d want 0", got)
 	}
+	if got := profileBenchUpdateCombineShards(t); got != 1 {
+		t.Fatalf("update combine shards default=%d want 1", got)
+	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush env=true want true")
@@ -147,6 +151,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
 		t.Fatalf("buffered max root runs=%d want 789", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "4")
+	if got := profileBenchUpdateCombineShards(t); got != 4 {
+		t.Fatalf("update combine shards=%d want 4", got)
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -748,6 +756,8 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 
 	b.ReportAllocs()
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	updateCombineShards := profileBenchUpdateCombineShards(b)
+	manager.SetUpdateCombineShardsForProfiling(updateCombineShards)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
@@ -768,6 +778,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 		b.Fatalf("run concurrent updates: %v", err)
 	}
 	b.ReportMetric(float64(writers), "writers")
+	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
 	reportProfileBenchOverlayCompactionStats(b, "warmup", warmupCompactStats)
@@ -2632,6 +2643,10 @@ func profileBenchUpdateDocumentCount(tb testing.TB) int {
 
 func profileBenchConcurrentWriters(tb testing.TB) int {
 	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_WRITERS", 8)
+}
+
+func profileBenchUpdateCombineShards(tb testing.TB) int {
+	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", 1)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -100,6 +100,7 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -134,6 +135,9 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	}
 	if profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
 		t.Fatal("update combine unsafe stale direct plans default=true want false")
+	}
+	if profileBenchUpdateCombineUnsafeAsyncAck(t) {
+		t.Fatal("update combine unsafe async ack default=true want false")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
@@ -171,6 +175,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "true")
 	if !profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
 		t.Fatal("update combine unsafe stale direct plans env=true want true")
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK", "true")
+	if !profileBenchUpdateCombineUnsafeAsyncAck(t) {
+		t.Fatal("update combine unsafe async ack env=true want true")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -778,19 +786,34 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	manager.SetUpdateCombineLaneWorkersForProfiling(updateCombineLaneWorkers)
 	updateCombineUnsafeStaleDirectPlans := profileBenchUpdateCombineUnsafeStaleDirectPlans(b)
 	manager.SetUpdateCombineUnsafeStaleDirectPlansForProfiling(updateCombineUnsafeStaleDirectPlans)
+	updateCombineUnsafeAsyncAck := profileBenchUpdateCombineUnsafeAsyncAck(b)
+	manager.SetUpdateCombineUnsafeAsyncAckForProfiling(updateCombineUnsafeAsyncAck)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
 	backendStatsBefore := backend.Stats()
 	b.ResetTimer()
 	started := time.Now()
+	var foregroundElapsed time.Duration
+	var combinerDrainElapsed time.Duration
+	var flushElapsed time.Duration
 	err = runProfileBenchTimedUpdatePhase(context.Background(), func(ctx context.Context) error {
+		foregroundStart := time.Now()
 		if err := runProfileBenchDirectCollectionConcurrentUpdates(ctx, writers, b.N, documentCount, idStride, ids, updateDocs, collection); err != nil {
 			return err
 		}
+		foregroundElapsed = time.Since(foregroundStart)
+		if updateCombineUnsafeAsyncAck {
+			combinerDrainStart := time.Now()
+			manager.DrainUpdateCombinersForProfiling()
+			combinerDrainElapsed = time.Since(combinerDrainStart)
+		}
 		// Keep async indexed-flush rows comparable with synchronous rows: the
 		// timed update phase includes the final drain of deferred publish work.
-		return manager.FlushAll()
+		flushStart := time.Now()
+		err := manager.FlushAll()
+		flushElapsed = time.Since(flushStart)
+		return err
 	})
 	timedElapsed := time.Since(started)
 	b.StopTimer()
@@ -804,6 +827,10 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	}
 	if updateCombineUnsafeStaleDirectPlans {
 		b.ReportMetric(1, "update_combine_unsafe_stale_direct_plans")
+	}
+	if updateCombineUnsafeAsyncAck {
+		b.ReportMetric(1, "update_combine_unsafe_async_ack")
+		reportProfileBenchUnsafeAsyncAckTimings(b, b.N, foregroundElapsed, combinerDrainElapsed, flushElapsed)
 	}
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
@@ -1025,6 +1052,25 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.sample_mod")), "backend_outer_leaf_sample_mod")
 }
 
+func reportProfileBenchUnsafeAsyncAckTimings(b *testing.B, docs int, foreground, combinerDrain, flush time.Duration) {
+	b.Helper()
+	if docs <= 0 {
+		return
+	}
+	reportDuration := func(name string, d time.Duration) {
+		if d > 0 {
+			b.ReportMetric(float64(d.Nanoseconds())/float64(docs), name)
+		}
+	}
+	reportDuration("update_combine_unsafe_async_ack_ns/doc", foreground)
+	reportDuration("update_combine_unsafe_async_combiner_drain_ns/doc", combinerDrain)
+	reportDuration("update_combine_unsafe_async_flush_ns/doc", flush)
+	reportDuration("update_combine_unsafe_async_final_drain_ns/doc", combinerDrain+flush)
+	if foreground > 0 {
+		b.ReportMetric(float64(docs)/foreground.Seconds(), "update_combine_unsafe_async_ack_docs/sec")
+	}
+}
+
 func reportProfileBenchBackendReadPathRatios(b *testing.B, after, before map[string]string) {
 	b.Helper()
 	reportPerHit := func(metric, bytesKey, hitsKey string) {
@@ -1227,6 +1273,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatchedRequests:     after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:    after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 		UpdateCombineInlineRequests:      after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests,
+		UpdateCombineUnsafeAsyncAcks:     after.UpdateCombineUnsafeAsyncAcks - before.UpdateCombineUnsafeAsyncAcks,
 		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
 		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
 		UpdateCombineQueueWait:           after.UpdateCombineQueueWait - before.UpdateCombineQueueWait,
@@ -1326,6 +1373,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineFallbackRequests:    1,
 		UpdateCombineQueueDepthMax:       12,
 		UpdateCombineInlineRequests:      4,
+		UpdateCombineUnsafeAsyncAcks:     5,
 		UpdateCombineEnqueue:             100 * time.Nanosecond,
 		UpdateCombineWait:                200 * time.Nanosecond,
 		UpdateCombineQueueWait:           250 * time.Nanosecond,
@@ -1387,6 +1435,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineFallbackRequests:    2,
 		UpdateCombineQueueDepthMax:       31,
 		UpdateCombineInlineRequests:      15,
+		UpdateCombineUnsafeAsyncAcks:     19,
 		UpdateCombineEnqueue:             700 * time.Nanosecond,
 		UpdateCombineWait:                1400 * time.Nanosecond,
 		UpdateCombineQueueWait:           1750 * time.Nanosecond,
@@ -1467,6 +1516,9 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineInlineRequests != 11 {
 		t.Fatalf("UpdateCombineInlineRequests=%d want 11", got.UpdateCombineInlineRequests)
+	}
+	if got.UpdateCombineUnsafeAsyncAcks != 14 {
+		t.Fatalf("UpdateCombineUnsafeAsyncAcks=%d want 14", got.UpdateCombineUnsafeAsyncAcks)
 	}
 	if got.UpdateCombineEnqueue != 600*time.Nanosecond || got.UpdateCombineWait != 1200*time.Nanosecond || got.UpdateCombineQueueWait != 1500*time.Nanosecond || got.UpdateCombineDrain != 1800*time.Nanosecond || got.UpdateCombineRun != 2400*time.Nanosecond || got.UpdateCombineResultDelivery != 3000*time.Nanosecond {
 		t.Fatalf("update combine timing delta enqueue/wait/queue-wait/drain/run/result-delivery=%s/%s/%s/%s/%s/%s want 600ns/1200ns/1500ns/1800ns/2400ns/3000ns",
@@ -1690,6 +1742,7 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		UpdateCombineFallbackRequests: 6,
 		UpdateCombineQueueDepthMax:    31,
 		UpdateCombineInlineRequests:   300,
+		UpdateCombineUnsafeAsyncAcks:  240,
 		UpdateCombineEnqueue:          600 * time.Nanosecond,
 		UpdateCombineWait:             1200 * time.Nanosecond,
 		UpdateCombineQueueWait:        3000 * time.Nanosecond,
@@ -1724,6 +1777,8 @@ func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing
 		"update_combine_batch_size_bucket_le_32/batch":    0.8,
 		"update_combine_inline_requests":                  300,
 		"update_combine_inline_requests/doc":              0.5,
+		"update_combine_unsafe_async_acks":                240,
+		"update_combine_unsafe_async_acks/doc":            0.4,
 		"update_combine_enqueue_ns/doc":                   1,
 		"update_combine_wait_ns/doc":                      2,
 		"update_combine_queue_wait_ns/doc":                5,
@@ -1927,6 +1982,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	if stats.UpdateCombineInlineRequests > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineInlineRequests), "update_combine_inline_requests")
 		b.ReportMetric(float64(stats.UpdateCombineInlineRequests)/float64(docs), "update_combine_inline_requests/doc")
+	}
+	if stats.UpdateCombineUnsafeAsyncAcks > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineUnsafeAsyncAcks), "update_combine_unsafe_async_acks")
+		b.ReportMetric(float64(stats.UpdateCombineUnsafeAsyncAcks)/float64(docs), "update_combine_unsafe_async_acks/doc")
 	}
 	reportDuration := func(name string, d time.Duration) {
 		if d > 0 {
@@ -2681,6 +2740,10 @@ func profileBenchUpdateCombineLaneWorkers(tb testing.TB) bool {
 
 func profileBenchUpdateCombineUnsafeStaleDirectPlans(tb testing.TB) bool {
 	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", false)
+}
+
+func profileBenchUpdateCombineUnsafeAsyncAck(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK", false)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -98,6 +98,8 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -127,6 +129,12 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	if got := profileBenchUpdateCombineShards(t); got != 1 {
 		t.Fatalf("update combine shards default=%d want 1", got)
 	}
+	if profileBenchUpdateCombineLaneWorkers(t) {
+		t.Fatal("update combine lane workers default=true want false")
+	}
+	if profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
+		t.Fatal("update combine unsafe stale direct plans default=true want false")
+	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush env=true want true")
@@ -155,6 +163,14 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "4")
 	if got := profileBenchUpdateCombineShards(t); got != 4 {
 		t.Fatalf("update combine shards=%d want 4", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "true")
+	if !profileBenchUpdateCombineLaneWorkers(t) {
+		t.Fatal("update combine lane workers env=true want true")
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "true")
+	if !profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
+		t.Fatal("update combine unsafe stale direct plans env=true want true")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -758,6 +774,10 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
 	updateCombineShards := profileBenchUpdateCombineShards(b)
 	manager.SetUpdateCombineShardsForProfiling(updateCombineShards)
+	updateCombineLaneWorkers := profileBenchUpdateCombineLaneWorkers(b)
+	manager.SetUpdateCombineLaneWorkersForProfiling(updateCombineLaneWorkers)
+	updateCombineUnsafeStaleDirectPlans := profileBenchUpdateCombineUnsafeStaleDirectPlans(b)
+	manager.SetUpdateCombineUnsafeStaleDirectPlansForProfiling(updateCombineUnsafeStaleDirectPlans)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
@@ -779,6 +799,12 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	}
 	b.ReportMetric(float64(writers), "writers")
 	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
+	if updateCombineLaneWorkers {
+		b.ReportMetric(1, "update_combine_lane_workers")
+	}
+	if updateCombineUnsafeStaleDirectPlans {
+		b.ReportMetric(1, "update_combine_unsafe_stale_direct_plans")
+	}
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
 	reportProfileBenchOverlayCompactionStats(b, "warmup", warmupCompactStats)
@@ -2647,6 +2673,14 @@ func profileBenchConcurrentWriters(tb testing.TB) int {
 
 func profileBenchUpdateCombineShards(tb testing.TB) int {
 	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", 1)
+}
+
+func profileBenchUpdateCombineLaneWorkers(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", false)
+}
+
+func profileBenchUpdateCombineUnsafeStaleDirectPlans(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", false)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {


### PR DESCRIPTION
## Summary

Comparison-only draft throughput proof-of-concept for issue #1500: sharded update-combiner lane workers now prepare direct buffered update plans concurrently by document-ID shard, then merge compatible prepared plans back into one global buffered/publish path.

This intentionally validates throughput headroom first and is not a merge-to-main candidate as-is. It is stacked on `codex/update-combine-bsonset-id-fastpath` and should remain draft/profiling-only until the production conflict protocol is implemented.

## Comparison branch boundary

- Keep this PR as a draft comparison branch.
- Use its benchmark numbers as the unsafe upper-bound target for later safe implementations.
- Do not treat the lane-worker, stale-plan, or unsafe async-ack modes as production semantics.
- Before landing equivalent behavior on `main`, add explicit conflict handling, read visibility, backpressure, and durability semantics.

## What changed

- Added profiling-only update-combiner lane workers gated by `CollectionManager.SetUpdateCombineLaneWorkersForProfiling`.
- Added a prepared-plan merger that combines compatible direct buffered update plans and stages them as one global direct-buffer batch.
- Preserved final publish economics in the benchmark shape: post-run rows still report `indexed_flush_calls=1` and `indexed_flush_docs/batch=100000`.
- Added profiling env knobs in `cmd/mongo_gateway_bench`:
  - `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=N`
  - `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true`
  - `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true`
- Added docs and a stats regression test so merged prepared-plan batches retain per-index detail counters.

## Safety boundary

This is not a production correctness contract yet.

The `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true` flag allows controlled benchmark runs to stage direct buffered update plans that were built before another lane advanced the buffered generation. Use it only for shapes with non-overlapping document IDs and unchanged unique secondary indexes.

Before making this production, the next PR needs explicit conflict/hot-key handling: per-document serialization, duplicate-key fallback, unique-secondary-change fallback, and transaction/coordinator boundaries.

## Benchmark evidence

Command family used for the post-cleanup comparison:

```sh
GOWORK=off \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=<32|64> \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=<1|8> \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=<false|true> \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=<false|true> \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -count=3 \
  -benchmem
```

Artifacts:

- Full writer sweep: `/tmp/gomap_lane_merge_poc_sweep_20260513_100859/sweep.txt`
- Post-cleanup 32/64 comparison: `/tmp/gomap_lane_merge_poc_post_stats_compare_20260513_101424/compare.txt`

Post-cleanup 3-run averages:

| mode | writers | docs/sec | ns/op | update_combine_wait_ns/doc | queue_wait_ns/doc | run_ns/doc | buffer_lock_hold_ns/doc | buffer_stage_ns/doc | indexed_flush_calls | indexed_flush_docs/batch | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| base | 32 | 189,888 | 5,267 | 132,908 | 35,271 | 3,804 | 308.4 | 321.3 | 1.0 | 100,000 | 1.0 |
| lane-merge PoC | 32 | 334,393 | 2,997 | 55,764 | 5,017 | 5,562 | 162.4 | 187.4 | 1.0 | 100,000 | 7.0 |
| base | 64 | 192,928 | 5,188 | 254,441 | 42,863 | 3,614 | 264.5 | 270.6 | 1.0 | 100,000 | 1.0 |
| lane-merge PoC | 64 | 369,188 | 2,714 | 87,186 | 7,543 | 5,434 | 105.6 | 119.9 | 1.0 | 100,000 | 5.0 |

Relative throughput:

- 32 writers: `334,393 / 189,888 = +76.1%`
- 64 writers: `369,188 / 192,928 = +91.4%`

Earlier full writer sweep showed the same scaling shape across concurrency:

- w1: +2.5%
- w4: +12.9%
- w8: +41.3%
- w16: +67.4%
- w32: +80.1%
- w64: +113.6%

## Validation

```sh
GOWORK=off go test ./TreeDB/collections ./cmd/mongo_gateway_bench
git diff --check
```


## Profile pass: lane-batching tune

Additional commit: `fef3c11a tune sharded update combiner lane batching`.

I profiled the current PoC at 64 writers with CPU, heap/alloc, block, and mutex profiles.

Artifacts:

- CPU-only profiles: `/tmp/gomap_update_combiner_poc_cpuonly_20260513_103021`
- Heavy alloc/mutex/block profiles: `/tmp/gomap_update_combiner_poc_profiles_20260513_102904`
- Lane drain experiments:
  - `/tmp/gomap_lane_drain16_compare_20260513_103140`
  - `/tmp/gomap_lane_drain4_compare_20260513_103243`
  - `/tmp/gomap_lane_drain2_compare_20260513_103325`
  - `/tmp/gomap_lane_pool_drain4_compare_20260513_103510`

Profile summary:

- The current PoC is no longer primarily blocked on one global combiner/publish lane.
- CPU-only pprof for lane mode shows the largest timed-update cumulative stack under `runShardWorker -> prepareBatchWithScratch -> buildUpdateBatchPlan`.
- Residual CPU is mostly current-document read / leaf lookup / BSON `$set` replacement work, not publish lock contention.
- Mutex profile is dominated by value-log leaf append during root publish, which is final flush/root-apply work rather than the combiner ingress wall.
- Block profile is dominated by expected writer waits on per-update completion plus background writer/maintenance loops; it did not expose a new single hot lock in lane ingress.
- Allocation profile showed the lane path still pays for prepared-plan batch objects and direct buffered primary entries. I tested pooling the prepared-batch request slice, but it did not improve throughput and was not kept.

Tuning kept:

- Lane-worker drain patience increased from the global default `1` scheduler yield to a lane-only `4` yields.
- This is PoC-only tuning for sharded lane workers; the original single-combiner path still uses the old drain behavior.

Drain-tuning evidence, 100k docs, 3-run averages:

| mode | writers | docs/sec | ns/op | items/batch | wait ns/doc | queue wait ns/doc | drain ns/doc | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| lane drain=4 | 32 | 328,255 | 3,046 | 1.74 | 59,796 | 4,076 | 3,949 | 6.0 |
| lane drain=4 | 64 | 395,682 | 2,528 | 2.14 | 87,013 | 6,590 | 2,871 | 5.0 |

For comparison, the prior post-cleanup lane-merge run averaged 369,188 docs/sec at 64 writers. The drain=4 tune improved the high-concurrency average in this sample while keeping the same safety boundary and one final indexed flush.

Experiment rejected:

- `defaultCollectionUpdateCombineLaneDrainYields=16` increased batch size but added too much drain delay; 64-writer throughput fell to 317,384 docs/sec.
- Pooling prepared-batch request slices reduced some bytes/op but hurt throughput and did not reduce alloc count, so it was reverted.

Next obvious walls after this PoC:

- Reduce current-document read / leaf lookup cost inside `buildUpdateBatchPlan` for non-overlapping `$set` updates.
- Reduce direct buffered primary-entry allocation/copy cost.
- Consider a benchmark-only direct prepared replacement path only if we intentionally want an unsafe upper ceiling distinct from the current semantic `$set` path.


## Profile pass: unsafe async foreground-ack ceiling

Additional commit: `76c84849 add unsafe async update ack profiling mode`.

This adds a profiling-only `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK=true` mode. In that mode, the foreground update path returns after the request is admitted to the sharded combiner queue. Lane workers still drain the queued requests, prepare real BSON `$set` update plans, stage them, and the benchmark then times `DrainUpdateCombinersForProfiling()` plus `FlushAll()` separately inside the measured window.

This is intentionally not a durability or visibility contract. It exists to measure the gap between foreground admission throughput and background update/root-publish drain throughput.

Command shape:

```sh
GOWORK=off \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=<1|64> \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=8 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_ASYNC_ACK=<false|true> \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=256000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=256000 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=300000x \
  -count=1 \
  -benchmem
```

Artifacts:

- Low/high sync vs async comparison: `/tmp/gomap_update_async_ack_poc_20260513_115800`
- Async-ack CPU/alloc/mutex/block profiles: `/tmp/gomap_update_async_ack_profiles_20260513_115830`
- Rejected lockless enqueue experiment: `/tmp/gomap_update_async_ack_nolock_20260513_120032`

Representative results, 300k docs:

| mode | writers | total docs/sec | total ns/doc | foreground ack docs/sec | foreground ack ns/doc | combiner drain ns/doc | final drain ns/doc | items/batch | update current read ns/doc | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sync lane | 1 | 152,936 | 6,539 | n/a | n/a | n/a | n/a | 1.0 | 641 | 10 |
| unsafe async ack | 1 | 472,494 | 2,116 | 1,202,795 | 831 | 272 | 1,285 | 29.9 | 2,075 | 2 |
| sync lane | 64 | 411,679 | 2,429 | n/a | n/a | n/a | n/a | 26.8 | 2,202 | 5 |
| unsafe async ack | 64 | 552,016 | 1,812 | 2,132,248 | 469 | 559 | 1,343 | 255.5 | 2,056 | 1 |

Profile conclusion:

- The foreground admission ceiling is now above 2M updates/sec at 64 writers on this host.
- The drain-included end-to-end row is still around 0.5M updates/sec because the background workers still perform real `buildUpdateBatchPlan`, current-document read, BSON `$set` replacement, staging, and final root publish.
- CPU profile for async-ack mode still lands primarily in `runShardWorker -> prepareBatchWithScratch -> buildUpdateBatchPlan`, with `readUpdateBatchCurrentDocument` / `Tree.GetAppend` as the main storage-read component.
- Prepared merge/stage is small relative to lane planning. Root publish remains visible in mutex profiles through value-log leaf append, but it is not foreground admission work.
- A lockless enqueue experiment was rejected: it did not improve foreground admission in the sample and weakened the profiling mode more than necessary.

