### PR TITLE
[codex] Safe sharded update combiner buffered lanes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -71,6 +71,7 @@ const (
 	// and visibility lag.
 	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits = 4
 	defaultCollectionUpdateCombineMaxBatch              = 256
+	defaultCollectionUpdateCombineShards                = 1
 	defaultCollectionUpdateCombineDrainYields           = 1
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
 	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
@@ -924,6 +925,7 @@ type collectionWriteDomain struct {
 	updateDraining         *collectionUpdateCombiner
 	updateCombineDone      bool
 	updateCombineTTL       time.Duration
+	updateCombineShards    int
 	closingWrites          atomic.Bool
 	loaded                 bool
 	meta                   CollectionMeta
@@ -1486,6 +1488,30 @@ func (m *CollectionManager) ResetUpdateCombinersForProfiling() {
 	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.resetUpdateCombinerForProfiling()
+	}
+}
+
+// SetUpdateCombineShardsForProfiling sets the update-combiner ingress shard
+// count for already-opened collection write domains managed by m. It is intended
+// for benchmark/profiling experiments and resets active combiners so subsequent
+// updates use the new lane count.
+func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
+	if m == nil {
+		return
+	}
+	if shards < 1 {
+		shards = defaultCollectionUpdateCombineShards
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineShardsForProfiling(shards)
 	}
 }
 
@@ -2316,10 +2342,27 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 	if domain := m.domains[name]; domain != nil {
 		return domain
 	}
-	domain := &collectionWriteDomain{}
+	domain := &collectionWriteDomain{updateCombineShards: defaultCollectionUpdateCombineShards}
 	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
 	m.domains[name] = domain
 	return domain
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineShardsForProfiling(shards int) {
+	if domain == nil {
+		return
+	}
+	if shards < 1 {
+		shards = defaultCollectionUpdateCombineShards
+	}
+	domain.updateCombineMu.Lock()
+	if domain.updateCombineShards == shards {
+		domain.updateCombineMu.Unlock()
+		return
+	}
+	domain.updateCombineShards = shards
+	domain.updateCombineMu.Unlock()
+	domain.resetUpdateCombinerForProfiling()
 }
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
@@ -8797,6 +8840,12 @@ type collectionUpdateCombiner struct {
 	mu       sync.RWMutex
 	stopped  bool
 
+	shardedRequests []chan collectionUpdateCombineRequest
+	readyShards     chan int
+	nextShard       int
+	deferred        []collectionUpdateCombineRequest
+	deferredCount   atomic.Int64
+
 	batchScratch []collectionUpdateCombineRequest
 	itemsScratch []updateBatchItem
 	waiters      sync.Pool
@@ -8847,7 +8896,7 @@ func (c *Collection) updateFastPathWithoutCreatingCombiner() (*collectionUpdateC
 			if domain.updateCombiner == combiner {
 				domain.updateCombiner = nil
 			}
-		} else if combiner.running.Load() || len(combiner.requests) > 0 {
+		} else if combiner.hasQueuedOrRunning() {
 			return combiner, nil
 		}
 	}
@@ -8991,18 +9040,39 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 			domain.updateCombineMu.Unlock()
 			continue
 		}
-		combiner := &collectionUpdateCombiner{
-			maxBatch: defaultCollectionUpdateCombineMaxBatch,
-			idleTTL:  domain.updateCombineIdleTTL(),
-			requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
-			done:     make(chan struct{}),
-			domain:   domain,
-		}
+		combiner := domain.newUpdateCombinerLocked()
 		domain.updateCombiner = combiner
 		domain.updateCombineMu.Unlock()
-		go combiner.run()
+		combiner.start()
 		return combiner
 	}
+}
+
+func (domain *collectionWriteDomain) newUpdateCombinerLocked() *collectionUpdateCombiner {
+	shards := domain.updateCombineShardCountLocked()
+	combiner := &collectionUpdateCombiner{
+		maxBatch: defaultCollectionUpdateCombineMaxBatch,
+		idleTTL:  domain.updateCombineIdleTTL(),
+		done:     make(chan struct{}),
+		domain:   domain,
+	}
+	if shards <= 1 {
+		combiner.requests = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+		return combiner
+	}
+	combiner.shardedRequests = make([]chan collectionUpdateCombineRequest, shards)
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
+	}
+	combiner.readyShards = make(chan int, shards*4)
+	return combiner
+}
+
+func (domain *collectionWriteDomain) updateCombineShardCountLocked() int {
+	if domain == nil || domain.updateCombineShards < 1 {
+		return defaultCollectionUpdateCombineShards
+	}
+	return domain.updateCombineShards
 }
 
 func (domain *collectionWriteDomain) stopUpdateCombiner() {
@@ -9113,6 +9183,38 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	return result.matched, result.modified, result.err
 }
 
+func hashCollectionUpdateDocumentID(documentID []byte) uint64 {
+	return xxhash.Sum64(documentID)
+}
+
+func (combiner *collectionUpdateCombiner) hasShardedIngress() bool {
+	return combiner != nil && len(combiner.shardedRequests) > 0
+}
+
+func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
+	if combiner == nil {
+		return false
+	}
+	if combiner.running.Load() || combiner.deferredCount.Load() > 0 {
+		return true
+	}
+	if combiner.hasShardedIngress() {
+		for _, requests := range combiner.shardedRequests {
+			if len(requests) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	return len(combiner.requests) > 0
+}
+
+func (combiner *collectionUpdateCombiner) start() {
+	if combiner != nil {
+		go combiner.run()
+	}
+}
+
 func newCollectionUpdateCombineRequest(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error), bsonSet bsonSetUpdate, hasBSONSet bool, done chan collectionUpdateCombineResult) collectionUpdateCombineRequest {
 	req := collectionUpdateCombineRequest{
 		collection: c,
@@ -9124,11 +9226,11 @@ func newCollectionUpdateCombineRequest(c *Collection, documentID []byte, update 
 	if len(documentID) <= collectionUpdateCombineInlineDocumentIDMax {
 		req.documentIDInlineLen = len(documentID)
 		copy(req.documentIDInline[:], documentID)
-		req.documentHash = xxhash.Sum64(req.documentIDInline[:req.documentIDInlineLen])
+		req.documentHash = hashCollectionUpdateDocumentID(req.documentIDInline[:req.documentIDInlineLen])
 		return req
 	}
 	req.documentID = bytes.Clone(documentID)
-	req.documentHash = xxhash.Sum64(req.documentID)
+	req.documentHash = hashCollectionUpdateDocumentID(req.documentID)
 	return req
 }
 
@@ -9203,6 +9305,23 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	if combiner.stopped {
 		return false
 	}
+	if combiner.hasShardedIngress() {
+		shard := int(req.documentHash % uint64(len(combiner.shardedRequests)))
+		requests := combiner.shardedRequests[shard]
+		select {
+		case requests <- req:
+			select {
+			case combiner.readyShards <- shard:
+			default:
+			}
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineRequest(len(requests))
+			}
+			return true
+		default:
+			return false
+		}
+	}
 	select {
 	case combiner.requests <- req:
 		if combiner.domain != nil {
@@ -9236,6 +9355,15 @@ func (combiner *collectionUpdateCombiner) closeRequests() bool {
 		return false
 	}
 	combiner.stopped = true
+	if combiner.hasShardedIngress() {
+		for _, requests := range combiner.shardedRequests {
+			close(requests)
+		}
+		if combiner.readyShards != nil {
+			close(combiner.readyShards)
+		}
+		return true
+	}
 	if combiner.requests != nil {
 		close(combiner.requests)
 	}
@@ -9255,19 +9383,75 @@ func (combiner *collectionUpdateCombiner) run() {
 			close(combiner.done)
 		}
 	}()
+	if combiner.hasShardedIngress() {
+		combiner.runSharded()
+		return
+	}
 	if combiner.idleTTL <= 0 {
-		for first := range combiner.requests {
+		for {
+			first, ok := combiner.waitForNextRequest()
+			if !ok {
+				return
+			}
 			combiner.runBatchStartingWith(first)
 		}
-		return
 	}
 	idle := time.NewTimer(combiner.idleTTL)
 	defer idle.Stop()
 	for {
+		if first, ok := combiner.popDeferredRequest(); ok {
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+			continue
+		}
 		select {
 		case first, ok := <-combiner.requests:
 			if !ok {
 				return
+			}
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+		case <-idle.C:
+			if combiner.retireIdle() {
+				return
+			}
+			idle.Reset(combiner.idleTTL)
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) runSharded() {
+	if combiner.idleTTL <= 0 {
+		for {
+			first, ok := combiner.waitForNextRequest()
+			if !ok {
+				return
+			}
+			combiner.runBatchStartingWith(first)
+		}
+	}
+	idle := time.NewTimer(combiner.idleTTL)
+	defer idle.Stop()
+	for {
+		if first, ok := combiner.popDeferredRequest(); ok {
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+			continue
+		}
+		select {
+		case _, ok := <-combiner.readyShards:
+			if !ok {
+				return
+			}
+			first, got, closed := combiner.tryDequeueShardedRequest()
+			if !got {
+				if closed {
+					return
+				}
+				continue
 			}
 			stopAndDrainTimer(idle)
 			combiner.runBatchStartingWith(first)
@@ -9288,6 +9472,87 @@ func stopAndDrainTimer(timer *time.Timer) {
 		default:
 		}
 	}
+}
+
+func (combiner *collectionUpdateCombiner) waitForNextRequest() (collectionUpdateCombineRequest, bool) {
+	if combiner == nil {
+		return collectionUpdateCombineRequest{}, false
+	}
+	if req, ok := combiner.popDeferredRequest(); ok {
+		return req, true
+	}
+	if combiner.hasShardedIngress() {
+		return combiner.waitForShardedRequest()
+	}
+	req, ok := <-combiner.requests
+	return req, ok
+}
+
+func (combiner *collectionUpdateCombiner) popDeferredRequest() (collectionUpdateCombineRequest, bool) {
+	if combiner == nil || len(combiner.deferred) == 0 {
+		return collectionUpdateCombineRequest{}, false
+	}
+	req := combiner.deferred[0]
+	copy(combiner.deferred, combiner.deferred[1:])
+	combiner.deferred[len(combiner.deferred)-1] = collectionUpdateCombineRequest{}
+	combiner.deferred = combiner.deferred[:len(combiner.deferred)-1]
+	combiner.deferredCount.Add(-1)
+	return req, true
+}
+
+func (combiner *collectionUpdateCombiner) deferUpdateCombineRequest(req collectionUpdateCombineRequest) {
+	if combiner == nil {
+		return
+	}
+	combiner.deferred = append(combiner.deferred, req)
+	combiner.deferredCount.Add(1)
+}
+
+func (combiner *collectionUpdateCombiner) waitForShardedRequest() (collectionUpdateCombineRequest, bool) {
+	for {
+		if req, ok, closed := combiner.tryDequeueShardedRequest(); ok || closed {
+			return req, ok
+		}
+		_, ok := <-combiner.readyShards
+		if !ok {
+			if req, got, _ := combiner.tryDequeueShardedRequest(); got {
+				return req, true
+			}
+			return collectionUpdateCombineRequest{}, false
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) tryDequeueRequest() (collectionUpdateCombineRequest, bool, bool) {
+	if combiner.hasShardedIngress() {
+		return combiner.tryDequeueShardedRequest()
+	}
+	select {
+	case req, ok := <-combiner.requests:
+		return req, ok, !ok
+	default:
+		return collectionUpdateCombineRequest{}, false, false
+	}
+}
+
+func (combiner *collectionUpdateCombiner) tryDequeueShardedRequest() (collectionUpdateCombineRequest, bool, bool) {
+	if combiner == nil || len(combiner.shardedRequests) == 0 {
+		return collectionUpdateCombineRequest{}, false, true
+	}
+	allClosed := true
+	for offset := 0; offset < len(combiner.shardedRequests); offset++ {
+		idx := (combiner.nextShard + offset) % len(combiner.shardedRequests)
+		select {
+		case req, ok := <-combiner.shardedRequests[idx]:
+			if ok {
+				combiner.nextShard = (idx + 1) % len(combiner.shardedRequests)
+				return req, true, false
+			}
+		default:
+			allClosed = false
+		}
+	}
+	return collectionUpdateCombineRequest{}, false, allClosed
 }
 
 func (combiner *collectionUpdateCombiner) retireIdle() bool {
@@ -9311,9 +9576,7 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 	if !stopped {
 		return false
 	}
-	for req := range combiner.requests {
-		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
-	}
+	combiner.drainClosedRequestsDirect()
 	if combiner.domain != nil {
 		combiner.domain.updateCombineMu.Lock()
 		if combiner.domain.updateDraining == combiner {
@@ -9322,6 +9585,35 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 		combiner.domain.updateCombineMu.Unlock()
 	}
 	return true
+}
+
+func (combiner *collectionUpdateCombiner) drainClosedRequestsDirect() {
+	if combiner == nil {
+		return
+	}
+	for {
+		req, ok := combiner.popDeferredRequest()
+		if !ok {
+			break
+		}
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+	if combiner.hasShardedIngress() {
+		for {
+			req, ok, closed := combiner.tryDequeueShardedRequest()
+			if ok {
+				completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+				continue
+			}
+			if closed {
+				return
+			}
+			return
+		}
+	}
+	for req := range combiner.requests {
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
 }
 
 func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionUpdateCombineRequest) {
@@ -9338,6 +9630,14 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	drainYields := 0
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
 	combiner.observeUpdateCombineDequeued(first, detailedStats)
+	deferredCount := len(combiner.deferred)
+	for i := 0; i < deferredCount && len(batch) < batchCap; i++ {
+		req, ok := combiner.popDeferredRequest()
+		if !ok {
+			break
+		}
+		batch = combiner.appendUpdateCombineRequestToBatch(batch, req)
+	}
 	var drainStart time.Time
 	if detailedStats {
 		drainStart = time.Now()
@@ -9348,18 +9648,21 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 		}
 	}
 	for len(batch) < batchCap {
-		select {
-		case req, ok := <-combiner.requests:
-			if !ok {
-				finishDrain()
-				combiner.runBatch(batch)
-				clear(batch)
-				combiner.batchScratch = batch[:0]
-				return
-			}
-			batch = append(batch, req)
+		req, ok, closed := combiner.tryDequeueRequest()
+		if ok {
 			combiner.observeUpdateCombineDequeued(req, detailedStats)
-		default:
+			req.queuedAt = time.Time{}
+			batch = combiner.appendUpdateCombineRequestToBatch(batch, req)
+			continue
+		}
+		if closed {
+			finishDrain()
+			combiner.runBatch(batch)
+			clear(batch)
+			combiner.batchScratch = batch[:0]
+			return
+		}
+		{
 			if drainYields < defaultCollectionUpdateCombineDrainYields {
 				drainYields++
 				if combiner.drainYield != nil {
@@ -9380,6 +9683,34 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	combiner.runBatch(batch)
 	clear(batch)
 	combiner.batchScratch = batch[:0]
+}
+
+func (combiner *collectionUpdateCombiner) appendUpdateCombineRequestToBatch(batch []collectionUpdateCombineRequest, req collectionUpdateCombineRequest) []collectionUpdateCombineRequest {
+	if collectionUpdateCombineBatchHasID(batch, req) {
+		combiner.deferUpdateCombineRequest(req)
+		return batch
+	}
+	return append(batch, req)
+}
+
+func collectionUpdateCombineBatchHasID(batch []collectionUpdateCombineRequest, req collectionUpdateCombineRequest) bool {
+	reqDocumentID := (&req).documentIDBytes()
+	hash := req.documentHash
+	if hash == 0 && len(reqDocumentID) > 0 {
+		hash = hashCollectionUpdateDocumentID(reqDocumentID)
+	}
+	for i := range batch {
+		prev := &batch[i]
+		prevDocumentID := prev.documentIDBytes()
+		prevHash := prev.documentHash
+		if prevHash == 0 && len(prevDocumentID) > 0 {
+			prevHash = hashCollectionUpdateDocumentID(prevDocumentID)
+		}
+		if prevHash == hash && bytes.Equal(prevDocumentID, reqDocumentID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (combiner *collectionUpdateCombiner) observeUpdateCombineDequeued(req collectionUpdateCombineRequest, detailedStats bool) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -73,6 +73,7 @@ const (
 	defaultCollectionUpdateCombineMaxBatch              = 256
 	defaultCollectionUpdateCombineShards                = 1
 	defaultCollectionUpdateCombineDrainYields           = 1
+	defaultCollectionUpdateCombineLaneDrainYields       = 4
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
 	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
 	collectionPprofComponentKey                         = "gomap_component"
@@ -9628,7 +9629,7 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 				}
 				batch = append(batch, req)
 			default:
-				if drainYields < defaultCollectionUpdateCombineDrainYields {
+				if drainYields < defaultCollectionUpdateCombineLaneDrainYields {
 					drainYields++
 					runtime.Gosched()
 					continue
@@ -9745,7 +9746,7 @@ func (combiner *collectionUpdateCombiner) runPreparedBatchMerger() {
 				pending = append(pending, prepared)
 				pendingRequests += len(prepared.batch)
 			default:
-				if drainYields < defaultCollectionUpdateCombineDrainYields {
+				if drainYields < defaultCollectionUpdateCombineLaneDrainYields {
 					drainYields++
 					runtime.Gosched()
 					continue

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -74,6 +74,7 @@ const (
 	defaultCollectionUpdateCombineShards                = 1
 	defaultCollectionUpdateCombineDrainYields           = 1
 	defaultCollectionUpdateCombineLaneDrainYields       = 4
+	defaultCollectionUpdateCombinePreparedDrainYields   = 128
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
 	collectionUpdateCombineInlineQuietPeriod            = time.Millisecond
 	collectionPprofComponentKey                         = "gomap_component"
@@ -10193,7 +10194,7 @@ func (combiner *collectionUpdateCombiner) runPreparedBatchMerger() {
 				pending = append(pending, prepared)
 				pendingRequests += len(prepared.batch)
 			default:
-				if drainYields < defaultCollectionUpdateCombineLaneDrainYields {
+				if drainYields < defaultCollectionUpdateCombinePreparedDrainYields {
 					drainYields++
 					runtime.Gosched()
 					continue
@@ -11649,14 +11650,14 @@ func buildDirectBufferedTemplateRootEntries(records []templateV1Record) []direct
 	return entries
 }
 
-func buildDirectBufferedPrimaryRootEntries(changed []preparedBatchUpdate) []directBufferedRootEntry {
+func buildDirectBufferedPrimaryRootEntries(changed []preparedBatchUpdate, scratch *updateBatchPlanScratch) []directBufferedRootEntry {
 	if len(changed) == 0 {
 		return nil
 	}
 	entries := make([]directBufferedRootEntry, len(changed))
 	for i := range changed {
 		entries[i] = directBufferedRootEntry{
-			key:   bytes.Clone(changed[i].documentID),
+			key:   appendUpdateBatchPlanScratchKey(scratch, changed[i].documentID),
 			value: changed[i].document,
 			flags: node.FlagInline,
 		}
@@ -11673,15 +11674,27 @@ func detachUpdateBatchPlanDocumentArena(scratch *updateBatchPlanScratch) []byte 
 	return arena
 }
 
+func detachUpdateBatchPlanKeyArena(scratch *updateBatchPlanScratch) []byte {
+	if scratch == nil || len(scratch.keyArena) == 0 {
+		return nil
+	}
+	arena := scratch.keyArena
+	scratch.keyArena = nil
+	return arena
+}
+
 func retainDirectBufferedDocumentArenaLocked(domain *collectionWriteDomain, plan *updateBatchPlan) {
 	if domain == nil || plan == nil || plan.directBufferedUpdate == nil {
 		return
 	}
 	arena := detachUpdateBatchPlanDocumentArena(plan.scratch)
-	if len(arena) == 0 {
-		return
+	if len(arena) > 0 {
+		domain.rootValueArenas = append(domain.rootValueArenas, arena)
 	}
-	domain.rootValueArenas = append(domain.rootValueArenas, arena)
+	keyArena := detachUpdateBatchPlanKeyArena(plan.scratch)
+	if len(keyArena) > 0 {
+		domain.rootValueArenas = append(domain.rootValueArenas, keyArena)
+	}
 }
 
 func applyDirectBufferedRootEntries(table memtable.Table, entries []directBufferedRootEntry) error {
@@ -11789,6 +11802,7 @@ type updateBatchPlanScratch struct {
 	changed                []preparedBatchUpdate
 	changedDocuments       [][]byte
 	documentArena          []byte
+	keyArena               []byte
 	bsonSetDocumentScratch []byte
 	stateArena             indexEncodeArena
 	rootNames              []string
@@ -11847,6 +11861,11 @@ func getUpdateBatchPlanScratch(itemCount, runtimeCount int) *updateBatchPlanScra
 		scratch.documentArena = make([]byte, 0, documentArenaBytes)
 	} else {
 		scratch.documentArena = scratch.documentArena[:0]
+	}
+	if cap(scratch.keyArena) < itemCount*collectionUpdateCombineInlineDocumentIDMax {
+		scratch.keyArena = make([]byte, 0, itemCount*collectionUpdateCombineInlineDocumentIDMax)
+	} else {
+		scratch.keyArena = scratch.keyArena[:0]
 	}
 	scratch.bsonSetDocumentScratch = scratch.bsonSetDocumentScratch[:0]
 	arenaBytes := estimateIndexEncodeArenaBytesForCount(itemCount*2, runtimeCount)
@@ -11917,6 +11936,11 @@ func putUpdateBatchPlanScratch(scratch *updateBatchPlanScratch) {
 	} else {
 		scratch.documentArena = scratch.documentArena[:0]
 	}
+	if cap(scratch.keyArena) > updateBatchPlanScratchMaxDocumentArena {
+		scratch.keyArena = nil
+	} else {
+		scratch.keyArena = scratch.keyArena[:0]
+	}
 	if cap(scratch.bsonSetDocumentScratch) > updateBatchPlanScratchMaxBSONSetDocumentBytes {
 		scratch.bsonSetDocumentScratch = nil
 	} else {
@@ -11962,6 +11986,18 @@ func appendUpdateBatchPlanScratchDocument(scratch *updateBatchPlanScratch, docum
 	start := len(scratch.documentArena)
 	scratch.documentArena = append(scratch.documentArena, document...)
 	return scratch.documentArena[start:len(scratch.documentArena):len(scratch.documentArena)]
+}
+
+func appendUpdateBatchPlanScratchKey(scratch *updateBatchPlanScratch, key []byte) []byte {
+	if len(key) == 0 {
+		return nil
+	}
+	if scratch == nil {
+		return bytes.Clone(key)
+	}
+	start := len(scratch.keyArena)
+	scratch.keyArena = append(scratch.keyArena, key...)
+	return scratch.keyArena[start:len(scratch.keyArena):len(scratch.keyArena)]
 }
 
 type updateBatchBufferedRead struct {
@@ -12943,18 +12979,20 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			if item.hasBSONSet {
 				prepared.affectedIndexRuntimeMask, prepared.knownAffectedIndexes = item.bsonSet.affectedIndexMask(runtimes, plannerOptions)
 			}
-			phaseStart = updateBatchStatsNow(detailedStats)
-			if prepared.knownAffectedIndexes {
-				prepared.oldState, err = orderedIndexStateForKnownValidDocumentRuntimeMask(current.value, runtimes, prepared.affectedIndexRuntimeMask, plannerOptions, stateArena)
-			} else {
-				prepared.oldState, err = orderedIndexStateForDocumentWithArena(current.value, runtimes, plannerOptions, stateArena)
-			}
-			phaseDuration := updateBatchStatsSince(detailedStats, phaseStart)
-			stats.IndexStateExtraction += phaseDuration
-			stats.OldIndexStateExtract += phaseDuration
-			if err != nil {
-				_ = snap.Close()
-				return nil, updateBatchItemError(i, err)
+			if !prepared.knownAffectedIndexes || prepared.affectedIndexRuntimeMask != 0 {
+				phaseStart = updateBatchStatsNow(detailedStats)
+				if prepared.knownAffectedIndexes {
+					prepared.oldState, err = orderedIndexStateForKnownValidDocumentRuntimeMask(current.value, runtimes, prepared.affectedIndexRuntimeMask, plannerOptions, stateArena)
+				} else {
+					prepared.oldState, err = orderedIndexStateForDocumentWithArena(current.value, runtimes, plannerOptions, stateArena)
+				}
+				phaseDuration := updateBatchStatsSince(detailedStats, phaseStart)
+				stats.IndexStateExtraction += phaseDuration
+				stats.OldIndexStateExtract += phaseDuration
+				if err != nil {
+					_ = snap.Close()
+					return nil, updateBatchItemError(i, err)
+				}
 			}
 		}
 		if !item.hasBSONSet {
@@ -13047,6 +13085,10 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	for i := range changed {
 		changed[i].document = preparedDocuments[i]
 		if len(runtimes) > 0 {
+			if changed[i].knownAffectedIndexes && changed[i].affectedIndexRuntimeMask == 0 {
+				recordKnownUnaffectedIndexStats(runtimes, &stats)
+				continue
+			}
 			phaseStart = updateBatchStatsNow(detailedStats)
 			if changed[i].knownAffectedIndexes {
 				changed[i].newState, err = orderedIndexStateForKnownValidDocumentRuntimeMask(changed[i].document, runtimes, changed[i].affectedIndexRuntimeMask, plannerOptions, stateArena)
@@ -13149,7 +13191,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 		phaseStart = updateBatchStatsNow(detailedStats)
-		primaryEntries := buildDirectBufferedPrimaryRootEntries(changed)
+		primaryEntries := buildDirectBufferedPrimaryRootEntries(changed, scratch)
 		rootNames = append(rootNames, primaryRootName)
 		uniqueSecondary = append(uniqueSecondary, -1)
 		baseRootIDs[primaryRootName] = primaryRoot
@@ -14213,6 +14255,24 @@ func documentIndexRuntimeChanged(oldState, newState documentIndexState, runtime 
 
 func orderedDocumentIndexRuntimeChanged(oldState, newState orderedDocumentIndexState, runtimeIdx int) bool {
 	return !normalizedEncodedIndexValuesEqual(oldState.valuesAt(runtimeIdx), newState.valuesAt(runtimeIdx))
+}
+
+func recordKnownUnaffectedIndexStats(runtimes []indexRuntime, stats *CollectionUpdateStats) {
+	if stats == nil {
+		return
+	}
+	for runtimeIdx, runtime := range runtimes {
+		stats.IndexValueUnchanged++
+		if runtime.def.unique {
+			stats.UniqueIndexCheckSkips++
+		}
+		if runtimeIdx < stats.IndexStatsCount {
+			stats.IndexStats[runtimeIdx].Unchanged++
+			if runtime.def.unique {
+				stats.IndexStats[runtimeIdx].UniqueCheckSkips++
+			}
+		}
+	}
 }
 
 func updateIndexChangedMaskBit(runtimeIdx int) (uint64, bool) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10104,8 +10104,7 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 }
 
 func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collectionUpdateCombineRequest, itemsScratch *[]updateBatchItem) collectionUpdateCombinePreparedBatch {
-	ownedBatch := make([]collectionUpdateCombineRequest, len(batch))
-	copy(ownedBatch, batch)
+	ownedBatch := batch
 	prepared := collectionUpdateCombinePreparedBatch{batch: ownedBatch}
 	combiner.beginUpdateCombineRun()
 	defer combiner.endUpdateCombineRun()
@@ -10357,6 +10356,29 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		return nil, nil, errors.New("collections: invalid prepared direct update batch")
 	}
 	collection := prepared[0].batch[0].collection
+	commonBufferedBase := firstPlan.bufferedBase
+	commonBufferedReadGeneration := firstPlan.bufferedReadGeneration
+	sameBufferedRead := true
+	totalResults := 0
+	totalTemplateEntries := 0
+	totalPrimaryEntries := 0
+	totalSecondaryRootPlans := 0
+	for _, p := range prepared {
+		plan := p.plan
+		if plan == nil || plan.directBufferedUpdate == nil {
+			return nil, nil, errors.New("collections: cannot merge non-direct update plan")
+		}
+		if len(p.batch) == 0 || p.batch[0].collection != collection {
+			return nil, nil, errors.New("collections: cannot merge update plans across collections")
+		}
+		if plan.bufferedBase != commonBufferedBase || plan.bufferedReadGeneration != commonBufferedReadGeneration {
+			sameBufferedRead = false
+		}
+		totalResults += len(plan.results)
+		totalTemplateEntries += len(plan.directBufferedUpdate.templateEntries)
+		totalPrimaryEntries += len(plan.directBufferedUpdate.primaryEntries)
+		totalSecondaryRootPlans += len(plan.directBufferedUpdate.secondaryRootPlans)
+	}
 	merged := &updateBatchPlan{
 		meta:                        firstPlan.meta,
 		catalog:                     firstPlan.catalog,
@@ -10370,6 +10392,21 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 			templateRootName: firstPlan.directBufferedUpdate.templateRootName,
 			primaryRootName:  firstPlan.directBufferedUpdate.primaryRootName,
 		},
+	}
+	if totalResults > 0 {
+		merged.results = make([]UpdateBatchResult, 0, totalResults)
+	}
+	if totalTemplateEntries > 0 {
+		merged.directBufferedUpdate.templateEntries = make([]directBufferedRootEntry, 0, totalTemplateEntries)
+	}
+	if totalPrimaryEntries > 0 {
+		merged.directBufferedUpdate.primaryEntries = make([]directBufferedRootEntry, 0, totalPrimaryEntries)
+		if !sameBufferedRead {
+			merged.directBufferedUpdate.primaryEntryReadGenerations = make([]uint64, 0, totalPrimaryEntries)
+		}
+	}
+	if totalSecondaryRootPlans > 0 {
+		merged.directBufferedUpdate.secondaryRootPlans = make([]directBufferedSecondaryRootPlan, 0, totalSecondaryRootPlans)
 	}
 	rootIndex := make(map[string]int, len(firstPlan.rootNames))
 	addRoot := func(plan *updateBatchPlan, idx int) error {
@@ -10395,20 +10432,8 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		merged.uniqueSecondaryIndexByRoot = append(merged.uniqueSecondaryIndexByRoot, plan.uniqueSecondaryIndexByRoot[idx])
 		return nil
 	}
-	commonBufferedBase := firstPlan.bufferedBase
-	commonBufferedReadGeneration := firstPlan.bufferedReadGeneration
-	sameBufferedRead := true
 	for _, p := range prepared {
 		plan := p.plan
-		if plan == nil || plan.directBufferedUpdate == nil {
-			return nil, nil, errors.New("collections: cannot merge non-direct update plan")
-		}
-		if len(p.batch) == 0 || p.batch[0].collection != collection {
-			return nil, nil, errors.New("collections: cannot merge update plans across collections")
-		}
-		if plan.bufferedBase != commonBufferedBase || plan.bufferedReadGeneration != commonBufferedReadGeneration {
-			sameBufferedRead = false
-		}
 		for i := range plan.rootNames {
 			if err := addRoot(plan, i); err != nil {
 				return nil, nil, err
@@ -10422,8 +10447,10 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		if plan.bufferedBase {
 			readGeneration = plan.bufferedReadGeneration
 		}
-		for range plan.directBufferedUpdate.primaryEntries {
-			merged.directBufferedUpdate.primaryEntryReadGenerations = append(merged.directBufferedUpdate.primaryEntryReadGenerations, readGeneration)
+		if !sameBufferedRead {
+			for range plan.directBufferedUpdate.primaryEntries {
+				merged.directBufferedUpdate.primaryEntryReadGenerations = append(merged.directBufferedUpdate.primaryEntryReadGenerations, readGeneration)
+			}
 		}
 		merged.directBufferedUpdate.secondaryRootPlans = append(merged.directBufferedUpdate.secondaryRootPlans, plan.directBufferedUpdate.secondaryRootPlans...)
 		merged.directBufferedUpdate.stagedBytes += plan.directBufferedUpdate.stagedBytes

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -874,6 +874,7 @@ type bufferedIndexedCheckpoint struct {
 	mutableCount           int
 	mutableBytes           int64
 	writeGeneration        uint64
+	primaryWriteIndex      *bufferedPrimaryWriteIndex
 	rootRuns               map[string][]memtable.Table
 	rootMutableRuns        map[string]memtable.Table
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
@@ -901,6 +902,10 @@ type bufferedPrimaryRunIndex struct {
 	directEntries bool
 }
 
+type bufferedPrimaryWriteIndex struct {
+	generations map[uint64]uint64
+}
+
 type bufferedPrimaryRunRef struct {
 	key        []byte
 	table      memtable.Table
@@ -913,39 +918,38 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu                          sync.Mutex
-	mu                                  sync.RWMutex
-	indexedAsyncMu                      sync.Mutex
-	indexedAsyncCond                    *sync.Cond
-	indexedAsyncRun                     bool
-	indexedAsyncErr                     error
-	indexedPrepareCond                  *sync.Cond
-	indexedPrepareFreezes               int
-	updateCombineMu                     sync.Mutex
-	updateCombiner                      *collectionUpdateCombiner
-	updateDraining                      *collectionUpdateCombiner
-	updateCombineDone                   bool
-	updateCombineTTL                    time.Duration
-	updateCombineShards                 int
-	updateCombineLaneWorkers            bool
-	updateCombineUnsafeStaleDirectPlans atomic.Bool
-	closingWrites                       atomic.Bool
-	loaded                              bool
-	meta                                CollectionMeta
-	catalog                             *collectionCatalog
-	baseCommitSeq                       uint64
-	baseSystemRoot                      uint64
-	primaryRoot                         uint64
-	storagePolicy                       backenddb.OrderedRootStoragePolicy
-	table                               memtable.Table
-	indexedPublishingUnits              []indexedFlushUnit
-	indexedFlushUnits                   []indexedFlushUnit
-	rootRuns                            map[string][]memtable.Table
-	rootMutableRuns                     map[string]memtable.Table
-	rootPolicies                        map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs                         map[string]uint64
-	rootValueArenas                     [][]byte
-	primaryIDIndex                      *bufferedUniqueValueIndex
+	mutationMu               sync.Mutex
+	mu                       sync.RWMutex
+	indexedAsyncMu           sync.Mutex
+	indexedAsyncCond         *sync.Cond
+	indexedAsyncRun          bool
+	indexedAsyncErr          error
+	indexedPrepareCond       *sync.Cond
+	indexedPrepareFreezes    int
+	updateCombineMu          sync.Mutex
+	updateCombiner           *collectionUpdateCombiner
+	updateDraining           *collectionUpdateCombiner
+	updateCombineDone        bool
+	updateCombineTTL         time.Duration
+	updateCombineShards      int
+	updateCombineLaneWorkers bool
+	closingWrites            atomic.Bool
+	loaded                   bool
+	meta                     CollectionMeta
+	catalog                  *collectionCatalog
+	baseCommitSeq            uint64
+	baseSystemRoot           uint64
+	primaryRoot              uint64
+	storagePolicy            backenddb.OrderedRootStoragePolicy
+	table                    memtable.Table
+	indexedPublishingUnits   []indexedFlushUnit
+	indexedFlushUnits        []indexedFlushUnit
+	rootRuns                 map[string][]memtable.Table
+	rootMutableRuns          map[string]memtable.Table
+	rootPolicies             map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs              map[string]uint64
+	rootValueArenas          [][]byte
+	primaryIDIndex           *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
 	primaryRunIndex        *bufferedPrimaryRunIndex
@@ -958,6 +962,7 @@ type collectionWriteDomain struct {
 	mutableBytes           int64
 	rootRunCount           int
 	writeGeneration        uint64
+	primaryWriteIndex      *bufferedPrimaryWriteIndex
 	indexedDeletesOnly     bool
 
 	mutationLockCalls                  atomic.Uint64
@@ -1519,10 +1524,9 @@ func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
 }
 
 // SetUpdateCombineLaneWorkersForProfiling switches sharded update-combiner
-// ingress between the production global-combiner path and a profiling-only
-// lane-worker path. Lane workers are intended for throughput experiments that
-// validate sharded document-id execution before the correctness protocol is
-// finalized.
+// ingress between the global-combiner path and a lane-worker path. Lane workers
+// prepare direct buffered update plans concurrently by document-id shard, then
+// merge plans through the same buffered staging layer used by ordinary updates.
 func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool) {
 	if m == nil {
 		return
@@ -1537,28 +1541,6 @@ func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool
 	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.setUpdateCombineLaneWorkersForProfiling(enabled)
-	}
-}
-
-// SetUpdateCombineUnsafeStaleDirectPlansForProfiling allows lane-worker
-// profiling runs to stage non-overlapping direct buffered update plans that were
-// built before another lane advanced the buffered generation. This is not a
-// production correctness contract; callers must restrict it to benchmark shapes
-// with non-overlapping document IDs and unchanged unique secondary indexes.
-func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
-	if m == nil {
-		return
-	}
-	m.domainMu.RLock()
-	domains := make([]*collectionWriteDomain, 0, len(m.domains))
-	for _, domain := range m.domains {
-		if domain != nil {
-			domains = append(domains, domain)
-		}
-	}
-	m.domainMu.RUnlock()
-	for _, domain := range domains {
-		domain.setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled)
 	}
 }
 
@@ -2424,21 +2406,6 @@ func (domain *collectionWriteDomain) setUpdateCombineLaneWorkersForProfiling(ena
 	domain.updateCombineLaneWorkers = enabled
 	domain.updateCombineMu.Unlock()
 	domain.resetUpdateCombinerForProfiling()
-}
-
-func (domain *collectionWriteDomain) setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
-	if domain == nil {
-		return
-	}
-	domain.updateCombineUnsafeStaleDirectPlans.Store(enabled)
-}
-
-func (domain *collectionWriteDomain) allowUnsafeStaleDirectUpdatePlanForProfiling(plan *updateBatchPlan) bool {
-	return domain != nil &&
-		domain.updateCombineUnsafeStaleDirectPlans.Load() &&
-		plan != nil &&
-		plan.directBufferedUpdate != nil &&
-		plan.canBufferDirectUpdateBatch
 }
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
@@ -3691,6 +3658,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
+	domain.primaryWriteIndex = nil
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetCollectionRunTable(table)
@@ -3890,6 +3858,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
+	domain.notePrimaryWriteKeysLocked(plan.resultIDs, domain.writeGeneration)
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
 	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, catalog.meta.Options)
@@ -4074,6 +4043,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
 	domain.writeGeneration++
+	domain.notePrimaryWriteKeysLocked(plan.primaryKeys, domain.writeGeneration)
 	if rollbackOnError {
 		rollbackGeneration = domain.writeGeneration
 	}
@@ -5067,6 +5037,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
 		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
 		primaryRunIndexActive:  domain.primaryRunIndex != nil,
+		primaryWriteIndex:      cloneBufferedPrimaryWriteIndex(domain.primaryWriteIndex),
 		uniqueValueRuns:        cloneTableRunMap(domain.uniqueValueRuns),
 		uniqueValueMutableRuns: cloneMutableRunMap(domain.uniqueValueMutableRuns),
 		rootRunCount:           domain.rootRunCount,
@@ -5115,6 +5086,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	} else {
 		domain.primaryRunIndex = nil
 	}
+	domain.primaryWriteIndex = checkpoint.primaryWriteIndex
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
 	domain.uniqueValueMutableRuns = checkpoint.uniqueValueMutableRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.uniqueValueRuns))
@@ -5243,6 +5215,9 @@ func rebuildBufferedPendingIndexesLocked(domain *collectionWriteDomain, collecti
 		domain.primaryRunIndex = index
 	} else {
 		domain.primaryRunIndex = nil
+	}
+	if domain.primaryWriteIndex != nil {
+		domain.primaryWriteIndex = rebuildBufferedPrimaryWriteIndex(collectionName, pendingRuns, domain.writeGeneration)
 	}
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
 }
@@ -5564,6 +5539,156 @@ func addBufferedPrimaryIDKeys(index *bufferedUniqueValueIndex, keys [][]byte) {
 	if len(arena) > 0 {
 		index.arenas = append(index.arenas, arena)
 	}
+}
+
+func newBufferedPrimaryWriteIndex(capacity int) *bufferedPrimaryWriteIndex {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &bufferedPrimaryWriteIndex{generations: make(map[uint64]uint64, capacity)}
+}
+
+func (index *bufferedPrimaryWriteIndex) len() int {
+	if index == nil {
+		return 0
+	}
+	return len(index.generations)
+}
+
+func (index *bufferedPrimaryWriteIndex) addHash(hash uint64, generation uint64) {
+	if index == nil {
+		return
+	}
+	if index.generations == nil {
+		index.generations = make(map[uint64]uint64)
+	}
+	if existing := index.generations[hash]; generation > existing {
+		index.generations[hash] = generation
+	}
+}
+
+func (index *bufferedPrimaryWriteIndex) addKeys(keys [][]byte, generation uint64) {
+	if index == nil || len(keys) == 0 {
+		return
+	}
+	if index.generations == nil {
+		index.generations = make(map[uint64]uint64, len(keys))
+	}
+	for _, key := range keys {
+		if len(key) == 0 {
+			continue
+		}
+		index.addHash(xxhash.Sum64(key), generation)
+	}
+}
+
+func (index *bufferedPrimaryWriteIndex) addEntries(entries []directBufferedRootEntry, generation uint64) {
+	if index == nil || len(entries) == 0 {
+		return
+	}
+	if index.generations == nil {
+		index.generations = make(map[uint64]uint64, len(entries))
+	}
+	for _, entry := range entries {
+		if len(entry.key) == 0 {
+			continue
+		}
+		index.addHash(xxhash.Sum64(entry.key), generation)
+	}
+}
+
+func (index *bufferedPrimaryWriteIndex) addTable(table memtable.Table, generation uint64) error {
+	if index == nil || table == nil {
+		return nil
+	}
+	if index.generations == nil {
+		index.generations = make(map[uint64]uint64, table.Len())
+	}
+	it := table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if len(key) != 0 {
+			index.addHash(xxhash.Sum64(key), generation)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (index *bufferedPrimaryWriteIndex) generation(key []byte) (uint64, bool) {
+	if index == nil || len(index.generations) == 0 {
+		return 0, false
+	}
+	generation, ok := index.generations[xxhash.Sum64(key)]
+	return generation, ok
+}
+
+func cloneBufferedPrimaryWriteIndex(in *bufferedPrimaryWriteIndex) *bufferedPrimaryWriteIndex {
+	if in == nil {
+		return nil
+	}
+	out := newBufferedPrimaryWriteIndex(in.len())
+	for hash, generation := range in.generations {
+		out.generations[hash] = generation
+	}
+	if out.len() == 0 {
+		return nil
+	}
+	return out
+}
+
+func rebuildBufferedPrimaryWriteIndex(collectionName string, runs map[string][]memtable.Table, generation uint64) *bufferedPrimaryWriteIndex {
+	if collectionName == "" || len(runs) == 0 {
+		return nil
+	}
+	tables := runs[collectionPrimaryRootName(collectionName)]
+	if len(tables) == 0 {
+		return nil
+	}
+	index := newBufferedPrimaryWriteIndex(bufferedRunLenHint(tables))
+	for _, table := range tables {
+		if err := index.addTable(table, generation); err != nil {
+			return nil
+		}
+	}
+	if index.len() == 0 {
+		return nil
+	}
+	return index
+}
+
+func (domain *collectionWriteDomain) notePrimaryWriteKeysLocked(keys [][]byte, generation uint64) {
+	if domain == nil || len(keys) == 0 {
+		return
+	}
+	if domain.primaryWriteIndex == nil {
+		domain.primaryWriteIndex = newBufferedPrimaryWriteIndex(len(keys))
+	}
+	domain.primaryWriteIndex.addKeys(keys, generation)
+}
+
+func (domain *collectionWriteDomain) notePrimaryWriteEntriesLocked(entries []directBufferedRootEntry, generation uint64) {
+	if domain == nil || len(entries) == 0 {
+		return
+	}
+	if domain.primaryWriteIndex == nil {
+		domain.primaryWriteIndex = newBufferedPrimaryWriteIndex(len(entries))
+	}
+	domain.primaryWriteIndex.addEntries(entries, generation)
+}
+
+func (domain *collectionWriteDomain) notePrimaryWriteTableLocked(table memtable.Table, generation uint64) error {
+	if domain == nil || table == nil || table.Len() == 0 {
+		return nil
+	}
+	if domain.primaryWriteIndex == nil {
+		domain.primaryWriteIndex = newBufferedPrimaryWriteIndex(table.Len())
+	}
+	return domain.primaryWriteIndex.addTable(table, generation)
 }
 
 func applyDirectBufferedUniqueValuePrefixes(table memtable.Table, prefixes [][]byte) error {
@@ -6446,6 +6571,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
 		domain.mutableBytes = 0
+		domain.primaryWriteIndex = nil
 		return nil, nil
 	}
 	rootBaseIDs := make(map[string]uint64, len(rootNames))
@@ -7020,6 +7146,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
+	domain.primaryWriteIndex = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueMutableRuns = nil
@@ -8957,6 +9084,7 @@ type collectionUpdateCombinePreparedBatch struct {
 	plan           *updateBatchPlan
 	err            error
 	fallbackDirect bool
+	staged         chan struct{}
 }
 
 type collectionUpdateCombineWaiter struct {
@@ -9645,7 +9773,9 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 		if combiner.preparedBatches == nil {
 			combiner.completePreparedBatch(prepared)
 		} else {
+			prepared.staged = make(chan struct{})
 			combiner.preparedBatches <- prepared
+			<-prepared.staged
 		}
 		clear(batch)
 		batch = batch[:0]
@@ -9703,7 +9833,7 @@ func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collec
 			hasBSONSet: req.hasBSONSet,
 		}
 	}
-	plan, err := ownedBatch[0].collection.buildUpdateBatchPlan(items, updateBatchModeNoSecondaryUniqueIndexChanges, false)
+	plan, err := ownedBatch[0].collection.buildUpdateBatchPlan(items, updateBatchModeNoSecondaryUniqueIndexChanges, combiner.hasShardWorkers())
 	clear(items)
 	*itemsScratch = items[:0]
 	if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) ||
@@ -9800,7 +9930,11 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 	}
 	if err != nil {
 		for _, p := range direct {
-			combiner.completePreparedBatchWithError(p, err)
+			if errors.Is(err, ErrConcurrentMutation) {
+				combiner.completePreparedBatchWithDirectFallback(p)
+			} else {
+				combiner.completePreparedBatchWithError(p, err)
+			}
 		}
 		return
 	}
@@ -9810,6 +9944,7 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 }
 
 func (combiner *collectionUpdateCombiner) completePreparedBatch(prepared collectionUpdateCombinePreparedBatch) {
+	defer signalPreparedBatchStaged(prepared)
 	defer func() {
 		if prepared.plan != nil {
 			prepared.plan.close()
@@ -9856,6 +9991,7 @@ func (combiner *collectionUpdateCombiner) completePreparedBatch(prepared collect
 }
 
 func (combiner *collectionUpdateCombiner) completePreparedBatchWithError(prepared collectionUpdateCombinePreparedBatch, err error) {
+	defer signalPreparedBatchStaged(prepared)
 	defer func() {
 		if prepared.plan != nil {
 			prepared.plan.close()
@@ -9871,6 +10007,27 @@ func (combiner *collectionUpdateCombiner) completePreparedBatchWithError(prepare
 		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
 	}
 	completeUpdateCombineBatchWithError(prepared.batch, err)
+}
+
+func (combiner *collectionUpdateCombiner) completePreparedBatchWithDirectFallback(prepared collectionUpdateCombinePreparedBatch) {
+	defer signalPreparedBatchStaged(prepared)
+	defer func() {
+		if prepared.plan != nil {
+			prepared.plan.close()
+		}
+	}()
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+	}
+	for _, req := range prepared.batch {
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+}
+
+func signalPreparedBatchStaged(prepared collectionUpdateCombinePreparedBatch) {
+	if prepared.staged != nil {
+		close(prepared.staged)
+	}
 }
 
 func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePreparedBatch) (*updateBatchPlan, *Collection, error) {
@@ -9920,6 +10077,9 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		merged.uniqueSecondaryIndexByRoot = append(merged.uniqueSecondaryIndexByRoot, plan.uniqueSecondaryIndexByRoot[idx])
 		return nil
 	}
+	commonBufferedBase := firstPlan.bufferedBase
+	commonBufferedReadGeneration := firstPlan.bufferedReadGeneration
+	sameBufferedRead := true
 	for _, p := range prepared {
 		plan := p.plan
 		if plan == nil || plan.directBufferedUpdate == nil {
@@ -9927,6 +10087,9 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		}
 		if len(p.batch) == 0 || p.batch[0].collection != collection {
 			return nil, nil, errors.New("collections: cannot merge update plans across collections")
+		}
+		if plan.bufferedBase != commonBufferedBase || plan.bufferedReadGeneration != commonBufferedReadGeneration {
+			sameBufferedRead = false
 		}
 		for i := range plan.rootNames {
 			if err := addRoot(plan, i); err != nil {
@@ -9937,8 +10100,19 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		addCollectionUpdateStatsForMerge(&merged.stats, plan.stats)
 		merged.directBufferedUpdate.templateEntries = append(merged.directBufferedUpdate.templateEntries, plan.directBufferedUpdate.templateEntries...)
 		merged.directBufferedUpdate.primaryEntries = append(merged.directBufferedUpdate.primaryEntries, plan.directBufferedUpdate.primaryEntries...)
+		readGeneration := uint64(0)
+		if plan.bufferedBase {
+			readGeneration = plan.bufferedReadGeneration
+		}
+		for range plan.directBufferedUpdate.primaryEntries {
+			merged.directBufferedUpdate.primaryEntryReadGenerations = append(merged.directBufferedUpdate.primaryEntryReadGenerations, readGeneration)
+		}
 		merged.directBufferedUpdate.secondaryRootPlans = append(merged.directBufferedUpdate.secondaryRootPlans, plan.directBufferedUpdate.secondaryRootPlans...)
 		merged.directBufferedUpdate.stagedBytes += plan.directBufferedUpdate.stagedBytes
+	}
+	if sameBufferedRead {
+		merged.bufferedBase = commonBufferedBase
+		merged.bufferedReadGeneration = commonBufferedReadGeneration
 	}
 	return merged, collection, nil
 }
@@ -11064,12 +11238,13 @@ type updateBatchPlan struct {
 }
 
 type directBufferedUpdatePlan struct {
-	templateEntries    []directBufferedRootEntry
-	primaryEntries     []directBufferedRootEntry
-	secondaryRootPlans []directBufferedSecondaryRootPlan
-	templateRootName   string
-	primaryRootName    string
-	stagedBytes        int64
+	templateEntries             []directBufferedRootEntry
+	primaryEntries              []directBufferedRootEntry
+	primaryEntryReadGenerations []uint64
+	secondaryRootPlans          []directBufferedSecondaryRootPlan
+	templateRootName            string
+	primaryRootName             string
+	stagedBytes                 int64
 }
 
 type directBufferedRootEntry struct {
@@ -11854,6 +12029,35 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 		return true
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func (domain *collectionWriteDomain) directUpdatePlanHasPrimaryWriteConflictLocked(plan *updateBatchPlan) bool {
+	if domain == nil || plan == nil || plan.directBufferedUpdate == nil {
+		return true
+	}
+	baseGeneration := uint64(0)
+	if plan.bufferedBase {
+		baseGeneration = plan.bufferedReadGeneration
+	}
+	index := domain.primaryWriteIndex
+	if index == nil && domain.count > 0 {
+		collectionName := bufferedDomainCollectionName(domain, plan.meta.Name)
+		index = rebuildBufferedPrimaryWriteIndex(collectionName, pendingIndexedRootRunMapLocked(domain), domain.writeGeneration)
+		domain.primaryWriteIndex = index
+	}
+	if index == nil || index.len() == 0 {
+		return false
+	}
+	for i, entry := range plan.directBufferedUpdate.primaryEntries {
+		entryBaseGeneration := baseGeneration
+		if i < len(plan.directBufferedUpdate.primaryEntryReadGenerations) {
+			entryBaseGeneration = plan.directBufferedUpdate.primaryEntryReadGenerations[i]
+		}
+		if generation, ok := index.generation(entry.key); ok && generation > entryBaseGeneration {
+			return true
+		}
+	}
+	return false
 }
 
 func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
@@ -12837,13 +13041,14 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	allowUnsafeStaleDirectPlan := domain.allowUnsafeStaleDirectUpdatePlanForProfiling(plan)
-	if domain.count != 0 && !allowUnsafeStaleDirectPlan {
-		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
+	if domain.count != 0 {
+		canReadBuffered := updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot)
+		if !canReadBuffered {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
-		if plan.bufferedReadGeneration != domain.writeGeneration {
+		currentBufferedPlan := plan.bufferedBase && plan.bufferedReadGeneration == domain.writeGeneration
+		if !currentBufferedPlan && domain.directUpdatePlanHasPrimaryWriteConflictLocked(plan) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
@@ -13022,6 +13227,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
 	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
+	domain.notePrimaryWriteEntriesLocked(direct.primaryEntries, domain.writeGeneration)
 	if rollbackOnError {
 		rollbackGeneration = domain.writeGeneration
 	}
@@ -13210,6 +13416,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	rollbackGeneration := checkpoint.writeGeneration
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+	var primaryWriteTable memtable.Table
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]
 		table := plan.deltaTables[i]
@@ -13218,6 +13425,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
 			return false, errBufferedRootBaseMismatch(plan.meta.Name, rootName)
+		}
+		if rootName == primaryRootName {
+			primaryWriteTable = table
 		}
 		if _, ok := domain.rootBaseIDs[rootName]; !ok {
 			domain.rootBaseIDs[rootName] = baseRoot
@@ -13292,6 +13502,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
+	if err := domain.notePrimaryWriteTableLocked(primaryWriteTable, domain.writeGeneration); err != nil {
+		if rollbackOnError {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			c.meta = collectionMetaCheckpoint
+		}
+		return false, err
+	}
 	if rollbackOnError {
 		rollbackGeneration = domain.writeGeneration
 	}
@@ -13685,6 +13902,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.indexedDeletesOnly = false
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
+	domain.primaryWriteIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueMutableRuns = nil
 	domain.uniqueValueIndex = nil
@@ -13997,6 +14215,8 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 	domain.primaryRunIndex = nil
 	var stagedBytes int64
 	stagedRootRuns := 0
+	primaryRootName := collectionPrimaryRootName(meta.Name)
+	var primaryWriteTable memtable.Table
 	for i, rootName := range rootNames {
 		table := deltaTables[i]
 		if table == nil || table.Len() == 0 {
@@ -14016,6 +14236,9 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 		baseRoot := baseRootIDs[rootName]
 		if _, ok := domain.rootBaseIDs[rootName]; !ok {
 			domain.rootBaseIDs[rootName] = baseRoot
+		}
+		if rootName == primaryRootName {
+			primaryWriteTable = table
 		}
 		domain.rootPolicies[rootName] = policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
@@ -14040,6 +14263,10 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.indexedDeletesOnly = true
 	domain.writeGeneration++
+	if err := domain.notePrimaryWriteTableLocked(primaryWriteTable, domain.writeGeneration); err != nil {
+		rollback()
+		return false, err
+	}
 	domain.observeIndexedStage(deleted, stagedBytes, stagedRootRuns)
 	c.meta = meta
 	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, meta.Options)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -880,6 +880,11 @@ type bufferedIndexedCheckpoint struct {
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs            map[string]uint64
 	rootValueArenas        [][]byte
+	primaryOverlay         *bufferedPrimaryOverlay
+	primaryCache           *bufferedPrimaryOverlay
+	primaryCacheSystemRoot uint64
+	primaryCacheCollection string
+	primaryCacheDirty      bool
 	indexedPublishingUnits []indexedFlushUnit
 	indexedFlushUnits      []indexedFlushUnit
 	primaryRunIndexActive  bool
@@ -912,6 +917,18 @@ type bufferedPrimaryRunRef struct {
 	value      []byte
 	flags      byte
 	entryValid bool
+}
+
+type bufferedPrimaryOverlay struct {
+	values     map[uint64]bufferedPrimaryOverlayRef
+	collisions map[uint64][]bufferedPrimaryOverlayRef
+	count      int
+}
+
+type bufferedPrimaryOverlayRef struct {
+	key   []byte
+	value []byte
+	flags byte
 }
 
 type collectionWriteDomain struct {
@@ -949,6 +966,11 @@ type collectionWriteDomain struct {
 	rootPolicies             map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs              map[string]uint64
 	rootValueArenas          [][]byte
+	primaryOverlay           *bufferedPrimaryOverlay
+	primaryCache             *bufferedPrimaryOverlay
+	primaryCacheSystemRoot   uint64
+	primaryCacheCollection   string
+	primaryCacheDirty        bool
 	primaryIDIndex           *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
@@ -3534,7 +3556,7 @@ func (c *Collection) flushBufferedNoIndex() error {
 	}
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
-	if hasBufferedIndexedRootRuns(domain) {
+	if hasBufferedIndexedPendingWrites(domain) {
 		return nil
 	}
 	return c.flushBufferedNoIndexLocked(domain)
@@ -3565,6 +3587,7 @@ func (c *Collection) flushBufferedWritesLocked(domain *collectionWriteDomain) er
 	if domain == nil {
 		return nil
 	}
+	materializePrimaryOverlayLocked(domain)
 	if domain.count == 0 {
 		return domain.consumeIndexedAsyncFlushError()
 	}
@@ -4089,6 +4112,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
+	domain.primaryOverlay = nil
 	domain.rootRunCount = 0
 	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
@@ -4101,6 +4125,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.bufferedBytes = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
+	retainPrimaryDocumentCacheForCatalogLocked(domain, catalog.meta, baseSystemRoot)
 }
 
 func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts CollectionOptions) bool {
@@ -4509,6 +4534,49 @@ func mutableRootRunLocked(domain *collectionWriteDomain, rootName string) (memta
 	domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
 	domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 	return table, true
+}
+
+func materializePrimaryOverlayLocked(domain *collectionWriteDomain) bool {
+	if !hasBufferedPrimaryOverlay(domain) {
+		return false
+	}
+	collectionName := bufferedDomainCollectionName(domain, "")
+	if collectionName == "" {
+		return false
+	}
+	rootName := collectionPrimaryRootName(collectionName)
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, 1)
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, 1)
+	}
+	if _, ok := domain.rootPolicies[rootName]; !ok {
+		domain.rootPolicies[rootName] = domain.storagePolicy
+	}
+	if _, ok := domain.rootBaseIDs[rootName]; !ok {
+		domain.rootBaseIDs[rootName] = domain.primaryRoot
+	}
+	table, created := mutableRootRunLocked(domain, rootName)
+	if table == nil {
+		return false
+	}
+	entries := domain.primaryOverlay.appendEntries(make([]directBufferedRootEntry, 0, domain.primaryOverlay.len()))
+	stagePrimaryDocumentCacheEntriesLocked(domain, domain.meta, domain.baseSystemRoot, entries)
+	keys := make([][]byte, 0, len(entries))
+	for _, entry := range entries {
+		if entry.flags&node.FlagTombstone != 0 {
+			table.DeleteSteal(entry.key)
+		} else {
+			table.SetEntrySteal(entry.key, entry.value, page.ValuePtr{}, entry.flags)
+		}
+		keys = append(keys, entry.key)
+	}
+	if domain.primaryRunIndex != nil {
+		addBufferedPrimaryRunIndexKeys(domain.primaryRunIndex, keys, table)
+	}
+	domain.primaryOverlay = nil
+	return created
 }
 
 func mutableUniqueValueRunLocked(domain *collectionWriteDomain, indexName string) (memtable.Table, bool) {
@@ -5034,6 +5102,11 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		rootPolicies:           cloneRootPolicyMap(domain.rootPolicies),
 		rootBaseIDs:            cloneUint64Map(domain.rootBaseIDs),
 		rootValueArenas:        cloneArenaRefs(domain.rootValueArenas),
+		primaryOverlay:         cloneBufferedPrimaryOverlay(domain.primaryOverlay),
+		primaryCache:           cloneBufferedPrimaryOverlay(domain.primaryCache),
+		primaryCacheSystemRoot: domain.primaryCacheSystemRoot,
+		primaryCacheCollection: domain.primaryCacheCollection,
+		primaryCacheDirty:      domain.primaryCacheDirty,
 		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
 		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
 		primaryRunIndexActive:  domain.primaryRunIndex != nil,
@@ -5071,6 +5144,11 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.rootValueArenas = checkpoint.rootValueArenas
+	domain.primaryOverlay = checkpoint.primaryOverlay
+	domain.primaryCache = checkpoint.primaryCache
+	domain.primaryCacheSystemRoot = checkpoint.primaryCacheSystemRoot
+	domain.primaryCacheCollection = checkpoint.primaryCacheCollection
+	domain.primaryCacheDirty = checkpoint.primaryCacheDirty
 	domain.rootRunCount = checkpoint.rootRunCount
 	domain.indexedDeletesOnly = checkpoint.indexedDeletesOnly
 	pendingRuns := indexedFlushUnitPendingRootRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.rootRuns)
@@ -5218,6 +5296,10 @@ func rebuildBufferedPendingIndexesLocked(domain *collectionWriteDomain, collecti
 	}
 	if domain.primaryWriteIndex != nil {
 		domain.primaryWriteIndex = rebuildBufferedPrimaryWriteIndex(collectionName, pendingRuns, domain.writeGeneration)
+		if domain.primaryWriteIndex == nil && hasBufferedPrimaryOverlay(domain) {
+			domain.primaryWriteIndex = newBufferedPrimaryWriteIndex(domain.primaryOverlay.len())
+		}
+		domain.primaryWriteIndex.addOverlay(domain.primaryOverlay, domain.writeGeneration)
 	}
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
 }
@@ -5639,6 +5721,232 @@ func cloneBufferedPrimaryWriteIndex(in *bufferedPrimaryWriteIndex) *bufferedPrim
 		return nil
 	}
 	return out
+}
+
+func newBufferedPrimaryOverlay(capacity int) *bufferedPrimaryOverlay {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &bufferedPrimaryOverlay{values: make(map[uint64]bufferedPrimaryOverlayRef, capacity)}
+}
+
+func (overlay *bufferedPrimaryOverlay) len() int {
+	if overlay == nil {
+		return 0
+	}
+	return overlay.count
+}
+
+func (overlay *bufferedPrimaryOverlay) addEntry(entry directBufferedRootEntry) {
+	if overlay == nil || len(entry.key) == 0 {
+		return
+	}
+	if overlay.values == nil {
+		overlay.values = make(map[uint64]bufferedPrimaryOverlayRef)
+	}
+	ref := bufferedPrimaryOverlayRef{key: entry.key, value: entry.value, flags: entry.flags}
+	hash := xxhash.Sum64(entry.key)
+	if existing, ok := overlay.values[hash]; !ok {
+		overlay.values[hash] = ref
+		overlay.count++
+		return
+	} else if bytes.Equal(existing.key, entry.key) {
+		overlay.values[hash] = ref
+		return
+	}
+	if overlay.collisions == nil {
+		overlay.collisions = make(map[uint64][]bufferedPrimaryOverlayRef)
+	}
+	bucket := overlay.collisions[hash]
+	for i := len(bucket) - 1; i >= 0; i-- {
+		if bytes.Equal(bucket[i].key, entry.key) {
+			bucket[i] = ref
+			overlay.collisions[hash] = bucket
+			return
+		}
+	}
+	overlay.collisions[hash] = append(bucket, ref)
+	overlay.count++
+}
+
+func (overlay *bufferedPrimaryOverlay) addEntries(entries []directBufferedRootEntry) {
+	if overlay == nil || len(entries) == 0 {
+		return
+	}
+	for _, entry := range entries {
+		overlay.addEntry(entry)
+	}
+}
+
+func (overlay *bufferedPrimaryOverlay) lookupRef(key []byte) (bufferedPrimaryOverlayRef, bool) {
+	if overlay == nil || len(overlay.values) == 0 {
+		return bufferedPrimaryOverlayRef{}, false
+	}
+	hash := xxhash.Sum64(key)
+	if ref, ok := overlay.values[hash]; ok && bytes.Equal(ref.key, key) {
+		return ref, true
+	}
+	for _, ref := range overlay.collisions[hash] {
+		if bytes.Equal(ref.key, key) {
+			return ref, true
+		}
+	}
+	return bufferedPrimaryOverlayRef{}, false
+}
+
+func (overlay *bufferedPrimaryOverlay) appendEntries(dst []directBufferedRootEntry) []directBufferedRootEntry {
+	if overlay == nil || overlay.count == 0 {
+		return dst
+	}
+	for _, ref := range overlay.values {
+		dst = append(dst, directBufferedRootEntry{key: ref.key, value: ref.value, flags: ref.flags})
+	}
+	for _, bucket := range overlay.collisions {
+		for _, ref := range bucket {
+			dst = append(dst, directBufferedRootEntry{key: ref.key, value: ref.value, flags: ref.flags})
+		}
+	}
+	return dst
+}
+
+func cloneBufferedPrimaryOverlay(in *bufferedPrimaryOverlay) *bufferedPrimaryOverlay {
+	if in == nil || in.count == 0 {
+		return nil
+	}
+	out := newBufferedPrimaryOverlay(len(in.values))
+	out.count = in.count
+	for hash, ref := range in.values {
+		out.values[hash] = ref
+	}
+	if len(in.collisions) > 0 {
+		out.collisions = make(map[uint64][]bufferedPrimaryOverlayRef, len(in.collisions))
+		for hash, bucket := range in.collisions {
+			out.collisions[hash] = append([]bufferedPrimaryOverlayRef(nil), bucket...)
+		}
+	}
+	return out
+}
+
+func clearPrimaryDocumentCacheLocked(domain *collectionWriteDomain) {
+	if domain == nil {
+		return
+	}
+	domain.primaryCache = nil
+	domain.primaryCacheSystemRoot = 0
+	domain.primaryCacheCollection = ""
+	domain.primaryCacheDirty = false
+}
+
+func (c *Collection) clearWriteDomainPrimaryDocumentCache() {
+	if c == nil || c.writeDomain == nil {
+		return
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	clearPrimaryDocumentCacheLocked(domain)
+	domain.mu.Unlock()
+}
+
+func retainPrimaryDocumentCacheForCatalogLocked(domain *collectionWriteDomain, meta CollectionMeta, systemRoot uint64) {
+	if domain == nil || domain.primaryCache == nil || domain.primaryCache.len() == 0 {
+		clearPrimaryDocumentCacheLocked(domain)
+		return
+	}
+	if systemRoot == 0 ||
+		domain.primaryCacheCollection != meta.Name ||
+		!collectionMetaIndexSchemasEqual(domain.meta, meta) {
+		clearPrimaryDocumentCacheLocked(domain)
+		return
+	}
+	if domain.primaryCacheDirty || domain.primaryCacheSystemRoot == systemRoot {
+		domain.primaryCacheSystemRoot = systemRoot
+		domain.primaryCacheCollection = meta.Name
+		if domain.count == 0 {
+			domain.primaryCacheDirty = false
+		}
+		return
+	}
+	clearPrimaryDocumentCacheLocked(domain)
+}
+
+func stagePrimaryDocumentCacheEntriesLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, entries []directBufferedRootEntry) {
+	if domain == nil || len(entries) == 0 || baseSystemRoot == 0 || meta.Name == "" {
+		return
+	}
+	if domain.primaryCache != nil &&
+		(domain.primaryCacheSystemRoot != baseSystemRoot || domain.primaryCacheCollection != meta.Name) {
+		clearPrimaryDocumentCacheLocked(domain)
+	}
+	if domain.primaryCache == nil {
+		domain.primaryCache = newBufferedPrimaryOverlay(len(entries))
+		domain.primaryCacheSystemRoot = baseSystemRoot
+		domain.primaryCacheCollection = meta.Name
+	}
+	domain.primaryCache.addEntries(entries)
+	domain.primaryCacheDirty = true
+}
+
+func snapshotUpdateBatchPrimaryCache(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []updateBatchItem) updateBatchBufferedRead {
+	if domain == nil || baseSystemRoot == 0 || len(items) == 0 {
+		return updateBatchBufferedRead{}
+	}
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	cache := domain.primaryCache
+	if cache == nil || cache.len() == 0 ||
+		domain.primaryCacheSystemRoot != baseSystemRoot ||
+		domain.primaryCacheCollection != meta.Name {
+		return updateBatchBufferedRead{}
+	}
+	if domain.loaded && domain.catalog != nil && !sameCollectionMeta(domain.meta, meta) {
+		return updateBatchBufferedRead{}
+	}
+	entries, buffer := getUpdateBatchBufferedEntrySlots(len(items))
+	hits := 0
+	for i, item := range items {
+		ref, ok := cache.lookupRef(item.DocumentID)
+		if !ok {
+			continue
+		}
+		entries[i] = updateBatchBufferedEntry{
+			value: ref.value,
+			flags: ref.flags,
+			found: true,
+		}
+		hits++
+	}
+	if hits == 0 {
+		putUpdateBatchBufferedEntries(entries, buffer)
+		return updateBatchBufferedRead{}
+	}
+	return updateBatchBufferedRead{
+		enabled:        true,
+		primaryEntries: entries,
+		primaryBuffer:  buffer,
+	}
+}
+
+func hasBufferedPrimaryOverlay(domain *collectionWriteDomain) bool {
+	return domain != nil && domain.primaryOverlay != nil && domain.primaryOverlay.len() > 0
+}
+
+func hasBufferedIndexedPendingWrites(domain *collectionWriteDomain) bool {
+	return hasBufferedIndexedRootRuns(domain) || hasBufferedPrimaryOverlay(domain)
+}
+
+func (index *bufferedPrimaryWriteIndex) addOverlay(overlay *bufferedPrimaryOverlay, generation uint64) {
+	if index == nil || overlay == nil || overlay.len() == 0 {
+		return
+	}
+	if index.generations == nil {
+		index.generations = make(map[uint64]uint64, overlay.len())
+	}
+	for hash := range overlay.values {
+		index.addHash(hash, generation)
+	}
+	for hash := range overlay.collisions {
+		index.addHash(hash, generation)
+	}
 }
 
 func rebuildBufferedPrimaryWriteIndex(collectionName string, runs map[string][]memtable.Table, generation uint64) *bufferedPrimaryWriteIndex {
@@ -6503,6 +6811,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil, nil
 	}
 	domain.waitIndexedPrepareFreezeLocked()
+	materializePrimaryOverlayLocked(domain)
 	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil, nil
 	}
@@ -6566,6 +6875,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
+		domain.primaryOverlay = nil
 		domain.count = 0
 		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
@@ -6971,6 +7281,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(work.meta.Name))
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
+	retainPrimaryDocumentCacheForCatalogLocked(domain, work.meta, newSystemRoot)
 	domain.clearIndexedAsyncFlushError()
 	if !overlayPublish {
 		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
@@ -6989,6 +7300,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return nil
 	}
 	domain.waitIndexedPrepareFreezeLocked()
+	materializePrimaryOverlayLocked(domain)
 	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil
 	}
@@ -7038,6 +7350,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
+		domain.primaryOverlay = nil
 		domain.count = 0
 		domain.indexedDeletesOnly = false
 		domain.bufferedBytes = 0
@@ -7137,12 +7450,14 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(meta.Name))
+	retainPrimaryDocumentCacheForCatalogLocked(domain, meta, newSystemRoot)
 	domain.indexedFlushUnits = nil
 	domain.rootRuns = nil
 	domain.rootMutableRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
+	domain.primaryOverlay = nil
 	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
@@ -7169,6 +7484,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 }
 
 func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
+	materializePrimaryOverlayLocked(domain)
 	if domain == nil || len(domain.rootRuns) == 0 {
 		return false
 	}
@@ -8592,6 +8908,7 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte) (int, error) {
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	c.clearWriteDomainPrimaryDocumentCache()
 	if c.writeDomain != nil {
 		c.writeDomain.observeRootDeltaPlan(deltaStats)
 	}
@@ -8744,6 +9061,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	c.clearWriteDomainPrimaryDocumentCache()
 	if c.writeDomain != nil {
 		c.writeDomain.observeRootDeltaPlan(deltaStats)
 	}
@@ -11666,6 +11984,30 @@ func getUpdateBatchBufferedEntries(count int) ([]updateBatchBufferedEntry, *upda
 	return buffer.entries, buffer
 }
 
+func getUpdateBatchBufferedEntrySlots(count int) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer) {
+	if count <= 0 {
+		return nil, nil
+	}
+	if count > updateBatchBufferedEntryPoolMaxCap {
+		return make([]updateBatchBufferedEntry, count), nil
+	}
+	if v := updateBatchBufferedEntryPool.Get(); v != nil {
+		if buffer, ok := v.(*updateBatchBufferedEntryBuffer); ok && buffer != nil {
+			if cap(buffer.entries) >= count {
+				buffer.entries = buffer.entries[:count]
+				clear(buffer.entries)
+				buffer.arena = buffer.arena[:0]
+				return buffer.entries, buffer
+			}
+			putUpdateBatchBufferedEntries(buffer.entries, buffer)
+		}
+	}
+	buffer := &updateBatchBufferedEntryBuffer{
+		entries: make([]updateBatchBufferedEntry, count),
+	}
+	return buffer.entries, buffer
+}
+
 func putUpdateBatchBufferedEntries(entries []updateBatchBufferedEntry, buffer *updateBatchBufferedEntryBuffer) {
 	if entries == nil || buffer == nil || cap(entries) == 0 || cap(entries) > updateBatchBufferedEntryPoolMaxCap {
 		return
@@ -12005,11 +12347,11 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedIndexedRootRuns(domain)
+	return domain.count > 0 && hasBufferedIndexedPendingWrites(domain)
 }
 
 func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
-	if domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+	if domain == nil || domain.count == 0 || !hasBufferedIndexedPendingWrites(domain) {
 		return false
 	}
 	if !domain.loaded || domain.catalog == nil {
@@ -12022,7 +12364,7 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 		return false
 	}
 	collectionName := bufferedDomainCollectionName(domain, meta.Name)
-	if collectionName == "" || !hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
+	if collectionName == "" || !hasBufferedPrimaryWritesLocked(domain, collectionName) {
 		return false
 	}
 	if len(meta.Indexes) == 0 {
@@ -12043,6 +12385,10 @@ func (domain *collectionWriteDomain) directUpdatePlanHasPrimaryWriteConflictLock
 	if index == nil && domain.count > 0 {
 		collectionName := bufferedDomainCollectionName(domain, plan.meta.Name)
 		index = rebuildBufferedPrimaryWriteIndex(collectionName, pendingIndexedRootRunMapLocked(domain), domain.writeGeneration)
+		if index == nil && hasBufferedPrimaryOverlay(domain) {
+			index = newBufferedPrimaryWriteIndex(domain.primaryOverlay.len())
+		}
+		index.addOverlay(domain.primaryOverlay, domain.writeGeneration)
 		domain.primaryWriteIndex = index
 	}
 	if index == nil || index.len() == 0 {
@@ -12060,17 +12406,27 @@ func (domain *collectionWriteDomain) directUpdatePlanHasPrimaryWriteConflictLock
 	return false
 }
 
-func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+func readUpdateBatchCurrentDocumentFromBuffered(itemIndex int, buffered updateBatchBufferedRead) (updateBatchCurrentDocument, bool) {
 	if buffered.enabled {
 		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
 			entry := buffered.primaryEntries[itemIndex]
 			if entry.found {
 				if entry.flags&node.FlagTombstone != 0 {
-					return updateBatchCurrentDocument{buffered: true}, nil
+					return updateBatchCurrentDocument{buffered: true}, true
 				}
-				return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
+				return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, true
 			}
 		}
+	}
+	return updateBatchCurrentDocument{}, false
+}
+
+func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, cached updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+	if current, ok := readUpdateBatchCurrentDocumentFromBuffered(itemIndex, buffered); ok {
+		return current, nil
+	}
+	if current, ok := readUpdateBatchCurrentDocumentFromBuffered(itemIndex, cached); ok {
+		return current, nil
 	}
 	if !primaryReaderOK {
 		return updateBatchCurrentDocument{}, nil
@@ -12085,20 +12441,15 @@ func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader,
 	return updateBatchCurrentDocument{value: value, found: true}, nil
 }
 
-func readUpdateBatchCurrentDocumentAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, primaryRootName string, primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
-	if buffered.enabled {
-		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
-			entry := buffered.primaryEntries[itemIndex]
-			if entry.found {
-				if entry.flags&node.FlagTombstone != 0 {
-					return updateBatchCurrentDocument{buffered: true}, nil
-				}
-				return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
-			}
-		}
+func readUpdateBatchCurrentDocumentAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, primaryRootName string, primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, cached updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+	if current, ok := readUpdateBatchCurrentDocumentFromBuffered(itemIndex, buffered); ok {
+		return current, nil
+	}
+	if current, ok := readUpdateBatchCurrentDocumentFromBuffered(itemIndex, cached); ok {
+		return current, nil
 	}
 	if catalog == nil || len(catalog.overlayRootIDs(primaryRootName)) == 0 {
-		return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, dst)
+		return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, updateBatchBufferedRead{}, dst)
 	}
 	if catalog.rootID(primaryRootName) == 0 || catalog.anyOverlayRootMayContainKey(primaryRootName, documentID) {
 		value, overlayFound, documentFound, err := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, documentID, dst)
@@ -12109,7 +12460,7 @@ func readUpdateBatchCurrentDocumentAtCatalogRoot(snap *backenddb.Snapshot, catal
 			return updateBatchCurrentDocument{value: value, found: documentFound}, nil
 		}
 	}
-	return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, dst)
+	return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, updateBatchBufferedRead{}, dst)
 }
 
 const updateBatchBufferedPrimaryDirectProbeLimit = 1024
@@ -12193,6 +12544,111 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 	return entries, buffer, nil
 }
 
+func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDomain, collectionName string, items []updateBatchItem) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer, error) {
+	entries, buffer := getUpdateBatchBufferedEntries(len(items))
+	if domain == nil || len(items) == 0 {
+		return entries, buffer, nil
+	}
+	missing := len(items)
+	if overlay := domain.primaryOverlay; overlay != nil && overlay.len() > 0 {
+		for i, item := range items {
+			ref, ok := overlay.lookupRef(item.DocumentID)
+			if !ok {
+				continue
+			}
+			entries[i] = updateBatchBufferedEntry{
+				value: buffer.copyValue(ref.value),
+				flags: ref.flags,
+				found: true,
+			}
+			missing--
+		}
+	}
+	if missing <= 0 {
+		return entries, buffer, nil
+	}
+	if domain.primaryRunIndex != nil {
+		for i, item := range items {
+			if entries[i].found {
+				continue
+			}
+			ref, ok := domain.primaryRunIndex.lookupRef(item.DocumentID)
+			if !ok {
+				continue
+			}
+			value, flags, found := ref.value, ref.flags, ref.entryValid
+			if !found {
+				if ref.table == nil {
+					continue
+				}
+				value, _, flags, found = ref.table.GetEntry(item.DocumentID)
+			}
+			if !found {
+				continue
+			}
+			entries[i] = updateBatchBufferedEntry{
+				value: buffer.copyValue(value),
+				flags: flags,
+				found: true,
+			}
+			missing--
+		}
+		return entries, buffer, nil
+	}
+	runs := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(collectionName))
+	if len(runs) == 0 {
+		return entries, buffer, nil
+	}
+	if len(runs) <= 1 || len(runs)*len(items) <= updateBatchBufferedPrimaryDirectProbeLimit {
+		for i, item := range items {
+			if entries[i].found {
+				continue
+			}
+			if value, _, flags, found := getBufferedRunEntry(runs, item.DocumentID); found {
+				entries[i] = updateBatchBufferedEntry{
+					value: buffer.copyValue(value),
+					flags: flags,
+					found: true,
+				}
+			}
+		}
+		return entries, buffer, nil
+	}
+	targets := make(map[string]int, missing)
+	for i, item := range items {
+		if !entries[i].found {
+			targets[string(item.DocumentID)] = i
+		}
+	}
+	for i := len(runs) - 1; i >= 0 && len(targets) > 0; i-- {
+		run := runs[i]
+		if run == nil {
+			continue
+		}
+		it := run.NewIterator(nil, nil)
+		for it.Valid() && len(targets) > 0 {
+			key := string(it.UnsafeKey())
+			if itemIndex, ok := targets[key]; ok && !entries[itemIndex].found {
+				value, _, flags := it.UnsafeEntry()
+				entries[itemIndex] = updateBatchBufferedEntry{
+					value: buffer.copyValue(value),
+					flags: flags,
+					found: true,
+				}
+				delete(targets, key)
+			}
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			_ = it.Close()
+			putUpdateBatchBufferedEntries(entries, buffer)
+			return nil, nil, err
+		}
+		_ = it.Close()
+	}
+	return entries, buffer, nil
+}
+
 func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq uint64, baseSystemRoot uint64, items []updateBatchItem, documentFormat DocumentFormat) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
 	if domain == nil {
 		return updateBatchBufferedRead{}, nil, false, false, nil
@@ -12230,12 +12686,7 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 		var primaryEntries []updateBatchBufferedEntry
 		var primaryBuffer *updateBatchBufferedEntryBuffer
 		var err error
-		if domain.primaryRunIndex != nil {
-			primaryEntries, primaryBuffer, err = snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(domain.primaryRunIndex, items)
-		} else {
-			primaryRuns := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(bufferedCollectionName))
-			primaryEntries, primaryBuffer, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
-		}
+		primaryEntries, primaryBuffer, err = snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain, bufferedCollectionName, items)
 		if err != nil {
 			return updateBatchBufferedRead{}, nil, false, false, false, err
 		}
@@ -12253,7 +12704,7 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 			writeGeneration: domain.writeGeneration,
 		}, templateRuns, false, false, false, nil
 	}
-	if domain.count > 0 && hasBufferedIndexedRootRuns(domain) {
+	if domain.count > 0 && hasBufferedIndexedPendingWrites(domain) {
 		return updateBatchBufferedRead{}, nil, true, false, false, nil
 	}
 	if updateBatchBufferedSnapshotStaleLocked(domain, baseCommitSeq, baseSystemRoot) {
@@ -12330,6 +12781,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	baseUserRoot := snapshotUserRoot(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
+	cachedPrimaryRead := snapshotUpdateBatchPrimaryCache(c.writeDomain, meta, baseSystemRoot, items)
+	defer putUpdateBatchBufferedEntries(cachedPrimaryRead.primaryEntries, cachedPrimaryRead.primaryBuffer)
 	var bufferedRead updateBatchBufferedRead
 	var bufferedTemplateRuns []memtable.Table
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
@@ -12423,7 +12876,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
-		current, err := readUpdateBatchCurrentDocumentAtCatalogRoot(snap, catalog, primaryRootName, &primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		current, err := readUpdateBatchCurrentDocumentAtCatalogRoot(snap, catalog, primaryRootName, &primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, cachedPrimaryRead, currentScratch[:0])
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -12537,17 +12990,25 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	}
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	preparedDocuments, templateRecords, _, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
-	stats.PrepareDocuments += updateBatchStatsSince(detailedStats, phaseStart)
-	if err != nil {
-		for i, document := range changedDocuments {
-			if _, _, _, _, itemErr := prepareInsertDocuments([][]byte{document}, plannerOptions); itemErr != nil {
-				_ = snap.Close()
-				return nil, updateBatchItemError(changed[i].itemIndex, itemErr)
+	var preparedDocuments [][]byte
+	var templateRecords []templateV1Record
+	var templateResolver templateV1Resolver
+	if updateBatchItemsAllHaveBSONSet(items) && normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatBSON {
+		preparedDocuments = changedDocuments
+	} else {
+		var err error
+		preparedDocuments, templateRecords, _, templateResolver, err = prepareInsertDocuments(changedDocuments, plannerOptions)
+		stats.PrepareDocuments += updateBatchStatsSince(detailedStats, phaseStart)
+		if err != nil {
+			for i, document := range changedDocuments {
+				if _, _, _, _, itemErr := prepareInsertDocuments([][]byte{document}, plannerOptions); itemErr != nil {
+					_ = snap.Close()
+					return nil, updateBatchItemError(changed[i].itemIndex, itemErr)
+				}
 			}
+			_ = snap.Close()
+			return nil, fmt.Errorf("collections: update batch replacement prepare: %w", err)
 		}
-		_ = snap.Close()
-		return nil, fmt.Errorf("collections: update batch replacement prepare: %w", err)
 	}
 	if len(preparedDocuments) != len(changed) {
 		_ = snap.Close()
@@ -12994,6 +13455,84 @@ func updateBatchPlanUniqueSecondaryIndex(plan *updateBatchPlan, rootOffset int) 
 	return indexDef, true
 }
 
+func directUpdatePrimaryRootPolicy(plan *updateBatchPlan, primaryRootName string) (backenddb.OrderedRootStoragePolicy, bool) {
+	if plan == nil || primaryRootName == "" {
+		return 0, false
+	}
+	for i, rootName := range plan.rootNames {
+		if rootName == primaryRootName && i < len(plan.policies) {
+			return plan.policies[i], true
+		}
+	}
+	return 0, false
+}
+
+func canStageDirectPrimaryOverlay(plan *updateBatchPlan, direct *directBufferedUpdatePlan, primaryOnlyDirectUpdate bool, wouldFlush bool) bool {
+	return plan != nil &&
+		direct != nil &&
+		!primaryOnlyDirectUpdate &&
+		!wouldFlush &&
+		len(plan.meta.Indexes) > 0 &&
+		plan.meta.Options.BufferedIndexedWrites &&
+		len(direct.templateEntries) == 0 &&
+		len(direct.secondaryRootPlans) == 0 &&
+		direct.primaryRootName != "" &&
+		len(direct.primaryEntries) > 0
+}
+
+func (c *Collection) stageDirectPrimaryOverlayLocked(domain *collectionWriteDomain, plan *updateBatchPlan, modifiedCount int) (bool, error) {
+	if c == nil || domain == nil || plan == nil || plan.directBufferedUpdate == nil {
+		return false, nil
+	}
+	direct := plan.directBufferedUpdate
+	baseRoot, ok := plan.baseRootIDs[direct.primaryRootName]
+	if !ok {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q direct primary overlay missing base root for %q", plan.meta.Name, direct.primaryRootName)
+	}
+	if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, direct.primaryRootName); ok && pendingBaseRoot != baseRoot {
+		return false, errBufferedRootBaseMismatch(plan.meta.Name, direct.primaryRootName)
+	}
+	policy, ok := directUpdatePrimaryRootPolicy(plan, direct.primaryRootName)
+	if !ok {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q direct primary overlay missing policy for %q", plan.meta.Name, direct.primaryRootName)
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, 1)
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, 1)
+	}
+	if _, ok := domain.rootBaseIDs[direct.primaryRootName]; !ok {
+		domain.rootBaseIDs[direct.primaryRootName] = baseRoot
+	}
+	domain.rootPolicies[direct.primaryRootName] = policy
+	if domain.primaryOverlay == nil {
+		domain.primaryOverlay = newBufferedPrimaryOverlay(len(direct.primaryEntries))
+	}
+	domain.primaryOverlay.addEntries(direct.primaryEntries)
+	retainDirectBufferedDocumentArenaLocked(domain, plan)
+
+	domain.loaded = true
+	domain.meta = plan.meta
+	domain.catalog = plan.catalog
+	domain.baseCommitSeq = plan.baseCommitSeq
+	domain.baseSystemRoot = plan.baseSystemRoot
+	if plan.catalog != nil {
+		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+	}
+	domain.count += modifiedCount
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.indexedDeletesOnly = false
+	domain.writeGeneration++
+	domain.notePrimaryWriteEntriesLocked(direct.primaryEntries, domain.writeGeneration)
+	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, 0)
+	c.meta = plan.meta
+	plan.stats.BufferedBatches = 1
+	return true, nil
+}
+
 func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
 	if c == nil || plan == nil || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.primaryEntries) == 0 {
 		return false, nil
@@ -13137,6 +13676,20 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer freezePreAppendTables()
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 
+	overlayWouldFlush := false
+	if !primaryOnlyDirectUpdate {
+		overlayWouldFlush = shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, 0)
+	}
+	if canStageDirectPrimaryOverlay(plan, direct, primaryOnlyDirectUpdate, shouldAutoFlushAfterAdding || overlayWouldFlush) {
+		overlayAppendStart := updateBatchStatsNow(detailedStats)
+		buffered, err := c.stageDirectPrimaryOverlayLocked(domain, plan, modifiedCount)
+		overlayAppendDuration := updateBatchStatsSince(detailedStats, overlayAppendStart)
+		plan.stats.BufferStagePrimaryAppend += overlayAppendDuration
+		plan.stats.BufferStageRootAppend += overlayAppendDuration
+		return buffered, err
+	}
+	materializePrimaryOverlayLocked(domain)
+
 	phaseStart = updateBatchStatsNow(detailedStats)
 	rootTableStart := phaseStart
 	rootTables := make(map[string]memtable.Table, len(plan.rootNames))
@@ -13212,6 +13765,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
 	retainDirectBufferedDocumentArenaLocked(domain, plan)
+	stagePrimaryDocumentCacheEntriesLocked(domain, plan.meta, plan.baseSystemRoot, direct.primaryEntries)
 
 	domain.loaded = true
 	domain.meta = plan.meta
@@ -13416,6 +13970,8 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	rollbackGeneration := checkpoint.writeGeneration
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+	materializePrimaryOverlayLocked(domain)
+	clearPrimaryDocumentCacheLocked(domain)
 	var primaryWriteTable memtable.Table
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]
@@ -13898,6 +14454,8 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
+	domain.primaryOverlay = nil
+	retainPrimaryDocumentCacheForCatalogLocked(domain, catalog.meta, systemRoot)
 	domain.rootRunCount = 0
 	domain.indexedDeletesOnly = false
 	domain.primaryIDIndex = nil
@@ -14202,6 +14760,7 @@ func (c *Collection) bufferIndexedDeleteTablesLocked(
 	if domain.count == 0 {
 		c.initializeWriteDomainFromCatalogLocked(domain, catalog, baseCommitSeq, baseSystemRoot)
 	}
+	clearPrimaryDocumentCacheLocked(domain)
 	if domain.rootPolicies == nil {
 		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(rootNames))
 	}
@@ -15109,8 +15668,21 @@ func hasBufferedPrimaryRootRuns(domain *collectionWriteDomain, fallbackCollectio
 	return hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName))
 }
 
+func hasBufferedPrimaryWritesLocked(domain *collectionWriteDomain, fallbackCollectionName string) bool {
+	if hasBufferedPrimaryOverlay(domain) {
+		return true
+	}
+	return hasBufferedPrimaryRootRuns(domain, fallbackCollectionName)
+}
+
 func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain, documentID []byte, dst []byte) ([]byte, bool, bool) {
 	table := domain.table
+	if ref, ok := domain.primaryOverlay.lookupRef(documentID); ok {
+		if ref.flags&node.FlagTombstone != 0 {
+			return dst[:0], true, false
+		}
+		return append(dst[:0], ref.value...), true, true
+	}
 	if hasBufferedIndexedRootRuns(domain) {
 		name := collectionPrimaryRootName(c.meta.Name)
 		if domain.meta.Name != "" {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -912,37 +912,39 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu             sync.Mutex
-	mu                     sync.RWMutex
-	indexedAsyncMu         sync.Mutex
-	indexedAsyncCond       *sync.Cond
-	indexedAsyncRun        bool
-	indexedAsyncErr        error
-	indexedPrepareCond     *sync.Cond
-	indexedPrepareFreezes  int
-	updateCombineMu        sync.Mutex
-	updateCombiner         *collectionUpdateCombiner
-	updateDraining         *collectionUpdateCombiner
-	updateCombineDone      bool
-	updateCombineTTL       time.Duration
-	updateCombineShards    int
-	closingWrites          atomic.Bool
-	loaded                 bool
-	meta                   CollectionMeta
-	catalog                *collectionCatalog
-	baseCommitSeq          uint64
-	baseSystemRoot         uint64
-	primaryRoot            uint64
-	storagePolicy          backenddb.OrderedRootStoragePolicy
-	table                  memtable.Table
-	indexedPublishingUnits []indexedFlushUnit
-	indexedFlushUnits      []indexedFlushUnit
-	rootRuns               map[string][]memtable.Table
-	rootMutableRuns        map[string]memtable.Table
-	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs            map[string]uint64
-	rootValueArenas        [][]byte
-	primaryIDIndex         *bufferedUniqueValueIndex
+	mutationMu                          sync.Mutex
+	mu                                  sync.RWMutex
+	indexedAsyncMu                      sync.Mutex
+	indexedAsyncCond                    *sync.Cond
+	indexedAsyncRun                     bool
+	indexedAsyncErr                     error
+	indexedPrepareCond                  *sync.Cond
+	indexedPrepareFreezes               int
+	updateCombineMu                     sync.Mutex
+	updateCombiner                      *collectionUpdateCombiner
+	updateDraining                      *collectionUpdateCombiner
+	updateCombineDone                   bool
+	updateCombineTTL                    time.Duration
+	updateCombineShards                 int
+	updateCombineLaneWorkers            bool
+	updateCombineUnsafeStaleDirectPlans atomic.Bool
+	closingWrites                       atomic.Bool
+	loaded                              bool
+	meta                                CollectionMeta
+	catalog                             *collectionCatalog
+	baseCommitSeq                       uint64
+	baseSystemRoot                      uint64
+	primaryRoot                         uint64
+	storagePolicy                       backenddb.OrderedRootStoragePolicy
+	table                               memtable.Table
+	indexedPublishingUnits              []indexedFlushUnit
+	indexedFlushUnits                   []indexedFlushUnit
+	rootRuns                            map[string][]memtable.Table
+	rootMutableRuns                     map[string]memtable.Table
+	rootPolicies                        map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs                         map[string]uint64
+	rootValueArenas                     [][]byte
+	primaryIDIndex                      *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
 	primaryRunIndex        *bufferedPrimaryRunIndex
@@ -1512,6 +1514,50 @@ func (m *CollectionManager) SetUpdateCombineShardsForProfiling(shards int) {
 	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.setUpdateCombineShardsForProfiling(shards)
+	}
+}
+
+// SetUpdateCombineLaneWorkersForProfiling switches sharded update-combiner
+// ingress between the production global-combiner path and a profiling-only
+// lane-worker path. Lane workers are intended for throughput experiments that
+// validate sharded document-id execution before the correctness protocol is
+// finalized.
+func (m *CollectionManager) SetUpdateCombineLaneWorkersForProfiling(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineLaneWorkersForProfiling(enabled)
+	}
+}
+
+// SetUpdateCombineUnsafeStaleDirectPlansForProfiling allows lane-worker
+// profiling runs to stage non-overlapping direct buffered update plans that were
+// built before another lane advanced the buffered generation. This is not a
+// production correctness contract; callers must restrict it to benchmark shapes
+// with non-overlapping document IDs and unchanged unique secondary indexes.
+func (m *CollectionManager) SetUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled)
 	}
 }
 
@@ -2363,6 +2409,35 @@ func (domain *collectionWriteDomain) setUpdateCombineShardsForProfiling(shards i
 	domain.updateCombineShards = shards
 	domain.updateCombineMu.Unlock()
 	domain.resetUpdateCombinerForProfiling()
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineLaneWorkersForProfiling(enabled bool) {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineMu.Lock()
+	if domain.updateCombineLaneWorkers == enabled {
+		domain.updateCombineMu.Unlock()
+		return
+	}
+	domain.updateCombineLaneWorkers = enabled
+	domain.updateCombineMu.Unlock()
+	domain.resetUpdateCombinerForProfiling()
+}
+
+func (domain *collectionWriteDomain) setUpdateCombineUnsafeStaleDirectPlansForProfiling(enabled bool) {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineUnsafeStaleDirectPlans.Store(enabled)
+}
+
+func (domain *collectionWriteDomain) allowUnsafeStaleDirectUpdatePlanForProfiling(plan *updateBatchPlan) bool {
+	return domain != nil &&
+		domain.updateCombineUnsafeStaleDirectPlans.Load() &&
+		plan != nil &&
+		plan.directBufferedUpdate != nil &&
+		plan.canBufferDirectUpdateBatch
 }
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
@@ -8831,17 +8906,20 @@ func updateBatchItemError(index int, err error) error {
 }
 
 type collectionUpdateCombiner struct {
-	maxBatch int
-	idleTTL  time.Duration
-	requests chan collectionUpdateCombineRequest
-	done     chan struct{}
-	domain   *collectionWriteDomain
-	running  atomic.Bool
-	mu       sync.RWMutex
-	stopped  bool
+	maxBatch     int
+	idleTTL      time.Duration
+	requests     chan collectionUpdateCombineRequest
+	done         chan struct{}
+	domain       *collectionWriteDomain
+	running      atomic.Bool
+	runningCount atomic.Int64
+	mu           sync.RWMutex
+	stopped      bool
 
 	shardedRequests []chan collectionUpdateCombineRequest
 	readyShards     chan int
+	preparedBatches chan collectionUpdateCombinePreparedBatch
+	laneWorkers     bool
 	nextShard       int
 	deferred        []collectionUpdateCombineRequest
 	deferredCount   atomic.Int64
@@ -8871,6 +8949,13 @@ type collectionUpdateCombineResult struct {
 	matched  bool
 	modified bool
 	err      error
+}
+
+type collectionUpdateCombinePreparedBatch struct {
+	batch          []collectionUpdateCombineRequest
+	plan           *updateBatchPlan
+	err            error
+	fallbackDirect bool
 }
 
 type collectionUpdateCombineWaiter struct {
@@ -9065,6 +9150,10 @@ func (domain *collectionWriteDomain) newUpdateCombinerLocked() *collectionUpdate
 		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4)
 	}
 	combiner.readyShards = make(chan int, shards*4)
+	combiner.laneWorkers = domain.updateCombineLaneWorkers
+	if combiner.laneWorkers {
+		combiner.preparedBatches = make(chan collectionUpdateCombinePreparedBatch, shards*4)
+	}
 	return combiner
 }
 
@@ -9191,9 +9280,16 @@ func (combiner *collectionUpdateCombiner) hasShardedIngress() bool {
 	return combiner != nil && len(combiner.shardedRequests) > 0
 }
 
+func (combiner *collectionUpdateCombiner) hasShardWorkers() bool {
+	return combiner != nil && combiner.laneWorkers && len(combiner.shardedRequests) > 0
+}
+
 func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
 	if combiner == nil {
 		return false
+	}
+	if combiner.hasShardWorkers() && !combiner.isStopped() {
+		return true
 	}
 	if combiner.running.Load() || combiner.deferredCount.Load() > 0 {
 		return true
@@ -9211,6 +9307,10 @@ func (combiner *collectionUpdateCombiner) hasQueuedOrRunning() bool {
 
 func (combiner *collectionUpdateCombiner) start() {
 	if combiner != nil {
+		if combiner.hasShardWorkers() {
+			go combiner.runShardWorkers()
+			return
+		}
 		go combiner.run()
 	}
 }
@@ -9463,6 +9563,439 @@ func (combiner *collectionUpdateCombiner) runSharded() {
 			idle.Reset(combiner.idleTTL)
 		}
 	}
+}
+
+func (combiner *collectionUpdateCombiner) runShardWorkers() {
+	defer func() {
+		_ = combiner.closeRequests()
+		if combiner.done != nil {
+			close(combiner.done)
+		}
+	}()
+	var wg sync.WaitGroup
+	for shard := range combiner.shardedRequests {
+		wg.Add(1)
+		go func(shard int) {
+			defer wg.Done()
+			combiner.runShardWorker(shard)
+		}(shard)
+	}
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		if combiner.preparedBatches != nil {
+			close(combiner.preparedBatches)
+		}
+		close(workersDone)
+	}()
+	combiner.runPreparedBatchMerger()
+	<-workersDone
+}
+
+func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
+	if combiner == nil || shard < 0 || shard >= len(combiner.shardedRequests) {
+		return
+	}
+	requests := combiner.shardedRequests[shard]
+	batchCap := combiner.maxBatch
+	if batchCap < 1 {
+		batchCap = 1
+	}
+	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
+	itemsScratch := make([]updateBatchItem, 0, batchCap)
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	for first := range requests {
+		batch = append(batch[:0], first)
+		combiner.observeUpdateCombineDequeued(first, detailedStats)
+		drainYields := 0
+		var drainStart time.Time
+		if detailedStats {
+			drainStart = time.Now()
+		}
+		closed := false
+		for len(batch) < batchCap {
+			select {
+			case req, ok := <-requests:
+				if !ok {
+					closed = true
+					goto flush
+				}
+				combiner.observeUpdateCombineDequeued(req, detailedStats)
+				req.queuedAt = time.Time{}
+				if collectionUpdateCombineBatchHasID(batch, req) {
+					completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+					continue
+				}
+				batch = append(batch, req)
+			default:
+				if drainYields < defaultCollectionUpdateCombineDrainYields {
+					drainYields++
+					runtime.Gosched()
+					continue
+				}
+				goto flush
+			}
+		}
+	flush:
+		if detailedStats {
+			combiner.domain.observeUpdateCombineDrain(time.Since(drainStart))
+		}
+		prepared := combiner.prepareBatchWithScratch(batch, &itemsScratch)
+		if combiner.preparedBatches == nil {
+			combiner.completePreparedBatch(prepared)
+		} else {
+			combiner.preparedBatches <- prepared
+		}
+		clear(batch)
+		batch = batch[:0]
+		if closed {
+			return
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collectionUpdateCombineRequest, itemsScratch *[]updateBatchItem) collectionUpdateCombinePreparedBatch {
+	ownedBatch := make([]collectionUpdateCombineRequest, len(batch))
+	copy(ownedBatch, batch)
+	prepared := collectionUpdateCombinePreparedBatch{batch: ownedBatch}
+	combiner.beginUpdateCombineRun()
+	defer combiner.endUpdateCombineRun()
+	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
+	var runStart time.Time
+	if detailedStats {
+		runStart = time.Now()
+	}
+	defer func() {
+		if detailedStats {
+			combiner.domain.observeUpdateCombineRun(time.Since(runStart))
+		}
+	}()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			prepared.err = collectionUpdatePanicError("combiner_prepare", recovered)
+		}
+	}()
+	if combiner.domain == nil ||
+		combiner.domain.closingWrites.Load() ||
+		collectionUpdateCombineHasDuplicateIDs(ownedBatch) ||
+		!collectionUpdateCombineSameCollection(ownedBatch) {
+		prepared.fallbackDirect = true
+		return prepared
+	}
+	if itemsScratch == nil {
+		localScratch := make([]updateBatchItem, 0, len(ownedBatch))
+		itemsScratch = &localScratch
+	}
+	if cap(*itemsScratch) < len(ownedBatch) {
+		*itemsScratch = make([]updateBatchItem, len(ownedBatch))
+	}
+	clear(*itemsScratch)
+	items := (*itemsScratch)[:len(ownedBatch)]
+	for i := range ownedBatch {
+		req := &ownedBatch[i]
+		items[i] = updateBatchItem{
+			UpdateBatchItem: UpdateBatchItem{
+				DocumentID: req.documentIDBytes(),
+				Update:     req.update,
+			},
+			bsonSet:    req.bsonSet,
+			hasBSONSet: req.hasBSONSet,
+		}
+	}
+	plan, err := ownedBatch[0].collection.buildUpdateBatchPlan(items, updateBatchModeNoSecondaryUniqueIndexChanges, false)
+	clear(items)
+	*itemsScratch = items[:0]
+	if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) ||
+		errors.Is(err, errUpdateBatchChangesSecondaryUniqueIndex) {
+		prepared.fallbackDirect = true
+		return prepared
+	}
+	if err != nil {
+		prepared.err = err
+		return prepared
+	}
+	if plan == nil || plan.directBufferedUpdate == nil {
+		prepared.plan = plan
+		return prepared
+	}
+	prepared.plan = plan
+	return prepared
+}
+
+func (combiner *collectionUpdateCombiner) runPreparedBatchMerger() {
+	if combiner == nil || combiner.preparedBatches == nil {
+		return
+	}
+	batchCap := combiner.maxBatch
+	if batchCap < 1 {
+		batchCap = 1
+	}
+	pending := make([]collectionUpdateCombinePreparedBatch, 0, batchCap)
+	for first := range combiner.preparedBatches {
+		pending = append(pending[:0], first)
+		pendingRequests := len(first.batch)
+		drainYields := 0
+		for pendingRequests < batchCap {
+			select {
+			case prepared, ok := <-combiner.preparedBatches:
+				if !ok {
+					combiner.stagePreparedBatches(pending)
+					return
+				}
+				pending = append(pending, prepared)
+				pendingRequests += len(prepared.batch)
+			default:
+				if drainYields < defaultCollectionUpdateCombineDrainYields {
+					drainYields++
+					runtime.Gosched()
+					continue
+				}
+				goto stage
+			}
+		}
+	stage:
+		combiner.stagePreparedBatches(pending)
+		for i := range pending {
+			pending[i] = collectionUpdateCombinePreparedBatch{}
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collectionUpdateCombinePreparedBatch) {
+	if len(prepared) == 0 {
+		return
+	}
+	direct := make([]collectionUpdateCombinePreparedBatch, 0, len(prepared))
+	for _, p := range prepared {
+		if p.err != nil || p.fallbackDirect || p.plan == nil || p.plan.directBufferedUpdate == nil {
+			combiner.completePreparedBatch(p)
+			continue
+		}
+		direct = append(direct, p)
+	}
+	if len(direct) == 0 {
+		return
+	}
+	merged, collection, err := mergeDirectBufferedPreparedBatches(direct)
+	if err == nil {
+		err = collection.withMutationLock(func() error {
+			buffered, bufferErr := collection.bufferDirectUpdateBatchPlanLocked(merged)
+			if bufferErr != nil {
+				return bufferErr
+			}
+			if !buffered {
+				return ErrConcurrentMutation
+			}
+			if collection.writeDomain != nil {
+				collection.writeDomain.mu.Lock()
+				for _, p := range direct {
+					retainDirectBufferedDocumentArenaLocked(collection.writeDomain, p.plan)
+				}
+				collection.writeDomain.mu.Unlock()
+			}
+			collection.setLastUpdateStats(merged.stats)
+			return nil
+		})
+	}
+	if err != nil {
+		for _, p := range direct {
+			combiner.completePreparedBatchWithError(p, err)
+		}
+		return
+	}
+	for _, p := range direct {
+		combiner.completePreparedBatch(p)
+	}
+}
+
+func (combiner *collectionUpdateCombiner) completePreparedBatch(prepared collectionUpdateCombinePreparedBatch) {
+	defer func() {
+		if prepared.plan != nil {
+			prepared.plan.close()
+		}
+	}()
+	if prepared.err != nil {
+		if completeUpdateCombineBatchWithItemFallback(prepared.batch, prepared.err) {
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+			}
+			return
+		}
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+		}
+		completeUpdateCombineBatchWithError(prepared.batch, prepared.err)
+		return
+	}
+	if prepared.fallbackDirect {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+		}
+		for _, req := range prepared.batch {
+			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+		}
+		return
+	}
+	if prepared.plan == nil {
+		completeUpdateCombineBatchWithError(prepared.batch, errors.New("collections: update combiner prepared nil plan"))
+		return
+	}
+	results := prepared.plan.results
+	if len(results) != len(prepared.batch) {
+		completeUpdateCombineBatchWithError(prepared.batch, fmt.Errorf("collections: update combiner result count %d for prepared batch size %d", len(results), len(prepared.batch)))
+		return
+	}
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+	}
+	for i, req := range prepared.batch {
+		result := results[i]
+		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
+	}
+}
+
+func (combiner *collectionUpdateCombiner) completePreparedBatchWithError(prepared collectionUpdateCombinePreparedBatch, err error) {
+	defer func() {
+		if prepared.plan != nil {
+			prepared.plan.close()
+		}
+	}()
+	if completeUpdateCombineBatchWithItemFallback(prepared.batch, err) {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(prepared.batch), true)
+		}
+		return
+	}
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(prepared.batch), false)
+	}
+	completeUpdateCombineBatchWithError(prepared.batch, err)
+}
+
+func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePreparedBatch) (*updateBatchPlan, *Collection, error) {
+	if len(prepared) == 0 {
+		return nil, nil, errors.New("collections: no prepared update batches to merge")
+	}
+	firstPlan := prepared[0].plan
+	if firstPlan == nil || firstPlan.directBufferedUpdate == nil || len(prepared[0].batch) == 0 || prepared[0].batch[0].collection == nil {
+		return nil, nil, errors.New("collections: invalid prepared direct update batch")
+	}
+	collection := prepared[0].batch[0].collection
+	merged := &updateBatchPlan{
+		meta:                        firstPlan.meta,
+		catalog:                     firstPlan.catalog,
+		baseUserRoot:                firstPlan.baseUserRoot,
+		baseSystemRoot:              firstPlan.baseSystemRoot,
+		baseCommitSeq:               firstPlan.baseCommitSeq,
+		baseRootIDs:                 make(map[string]uint64, len(firstPlan.baseRootIDs)),
+		canBufferIndexedUpdateBatch: firstPlan.canBufferIndexedUpdateBatch,
+		canBufferDirectUpdateBatch:  true,
+		directBufferedUpdate: &directBufferedUpdatePlan{
+			templateRootName: firstPlan.directBufferedUpdate.templateRootName,
+			primaryRootName:  firstPlan.directBufferedUpdate.primaryRootName,
+		},
+	}
+	rootIndex := make(map[string]int, len(firstPlan.rootNames))
+	addRoot := func(plan *updateBatchPlan, idx int) error {
+		if idx < 0 || idx >= len(plan.rootNames) || idx >= len(plan.policies) || idx >= len(plan.uniqueSecondaryIndexByRoot) {
+			return errors.New("collections: invalid direct update root metadata")
+		}
+		rootName := plan.rootNames[idx]
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: direct update plan missing base root for %q", rootName)
+		}
+		if existingIdx, ok := rootIndex[rootName]; ok {
+			if merged.baseRootIDs[rootName] != baseRoot ||
+				merged.uniqueSecondaryIndexByRoot[existingIdx] != plan.uniqueSecondaryIndexByRoot[idx] {
+				return fmt.Errorf("collections: incompatible direct update root %q", rootName)
+			}
+			return nil
+		}
+		rootIndex[rootName] = len(merged.rootNames)
+		merged.rootNames = append(merged.rootNames, rootName)
+		merged.baseRootIDs[rootName] = baseRoot
+		merged.policies = append(merged.policies, plan.policies[idx])
+		merged.uniqueSecondaryIndexByRoot = append(merged.uniqueSecondaryIndexByRoot, plan.uniqueSecondaryIndexByRoot[idx])
+		return nil
+	}
+	for _, p := range prepared {
+		plan := p.plan
+		if plan == nil || plan.directBufferedUpdate == nil {
+			return nil, nil, errors.New("collections: cannot merge non-direct update plan")
+		}
+		if len(p.batch) == 0 || p.batch[0].collection != collection {
+			return nil, nil, errors.New("collections: cannot merge update plans across collections")
+		}
+		for i := range plan.rootNames {
+			if err := addRoot(plan, i); err != nil {
+				return nil, nil, err
+			}
+		}
+		merged.results = append(merged.results, plan.results...)
+		addCollectionUpdateStatsForMerge(&merged.stats, plan.stats)
+		merged.directBufferedUpdate.templateEntries = append(merged.directBufferedUpdate.templateEntries, plan.directBufferedUpdate.templateEntries...)
+		merged.directBufferedUpdate.primaryEntries = append(merged.directBufferedUpdate.primaryEntries, plan.directBufferedUpdate.primaryEntries...)
+		merged.directBufferedUpdate.secondaryRootPlans = append(merged.directBufferedUpdate.secondaryRootPlans, plan.directBufferedUpdate.secondaryRootPlans...)
+		merged.directBufferedUpdate.stagedBytes += plan.directBufferedUpdate.stagedBytes
+	}
+	return merged, collection, nil
+}
+
+func addCollectionUpdateStatsForMerge(dst *CollectionUpdateStats, src CollectionUpdateStats) {
+	if dst == nil {
+		return
+	}
+	if dst.Indexes == 0 {
+		dst.Indexes = src.Indexes
+	}
+	dst.Items += src.Items
+	dst.Matched += src.Matched
+	dst.Modified += src.Modified
+	dst.Runs += src.Runs
+	dst.BufferedBatches += src.BufferedBatches
+	dst.CurrentRead += src.CurrentRead
+	dst.Callback += src.Callback
+	dst.StructuredUpdateApply += src.StructuredUpdateApply
+	dst.StructuredUpdateApplications += src.StructuredUpdateApplications
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.OldIndexStateExtract += src.OldIndexStateExtract
+	dst.NewIndexStateExtract += src.NewIndexStateExtract
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.SecondaryDeleteEntries += src.SecondaryDeleteEntries
+	dst.SecondarySetEntries += src.SecondarySetEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.IndexValueChanges += src.IndexValueChanges
+	dst.IndexValueUnchanged += src.IndexValueUnchanged
+	dst.MaskFallbacks += src.MaskFallbacks
+	dst.UniqueIndexChecks += src.UniqueIndexChecks
+	dst.UniqueIndexCheckSkips += src.UniqueIndexCheckSkips
+	for _, secondaryRun := range src.SecondaryRuns {
+		mergeCollectionUpdateSecondaryRunStatsForMerge(&dst.SecondaryRuns, secondaryRun)
+	}
+	for i := 0; i < src.IndexStatsCount && i < len(src.IndexStats); i++ {
+		mergeCollectionUpdateIndexStat(&dst.IndexStats, &dst.IndexStatsCount, src.IndexStats[i])
+	}
+}
+
+func mergeCollectionUpdateSecondaryRunStatsForMerge(dst *[]CollectionUpdateSecondaryRunStats, src CollectionUpdateSecondaryRunStats) {
+	if dst == nil || src.IndexName == "" {
+		return
+	}
+	for i := range *dst {
+		if (*dst)[i].IndexName == src.IndexName {
+			(*dst)[i].Deletes = saturatingAddNonNegativeInt((*dst)[i].Deletes, src.Deletes)
+			(*dst)[i].Sets = saturatingAddNonNegativeInt((*dst)[i].Sets, src.Sets)
+			(*dst)[i].KeyBytes = saturatingAddNonNegativeInt((*dst)[i].KeyBytes, src.KeyBytes)
+			return
+		}
+	}
+	*dst = append(*dst, src)
 }
 
 func stopAndDrainTimer(timer *time.Timer) {
@@ -9720,9 +10253,31 @@ func (combiner *collectionUpdateCombiner) observeUpdateCombineDequeued(req colle
 	combiner.domain.observeUpdateCombineQueueWait(time.Since(req.queuedAt))
 }
 
+func (combiner *collectionUpdateCombiner) beginUpdateCombineRun() {
+	if combiner == nil {
+		return
+	}
+	if combiner.runningCount.Add(1) == 1 {
+		combiner.running.Store(true)
+	}
+}
+
+func (combiner *collectionUpdateCombiner) endUpdateCombineRun() {
+	if combiner == nil {
+		return
+	}
+	if combiner.runningCount.Add(-1) == 0 {
+		combiner.running.Store(false)
+	}
+}
+
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
-	combiner.running.Store(true)
-	defer combiner.running.Store(false)
+	combiner.runBatchWithScratch(batch, &combiner.itemsScratch)
+}
+
+func (combiner *collectionUpdateCombiner) runBatchWithScratch(batch []collectionUpdateCombineRequest, itemsScratch *[]updateBatchItem) {
+	combiner.beginUpdateCombineRun()
+	defer combiner.endUpdateCombineRun()
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
 	var runStart time.Time
 	if detailedStats {
@@ -9753,11 +10308,15 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 		}
 		return
 	}
-	if cap(combiner.itemsScratch) < len(batch) {
-		combiner.itemsScratch = make([]updateBatchItem, len(batch))
+	if itemsScratch == nil {
+		localScratch := make([]updateBatchItem, 0, len(batch))
+		itemsScratch = &localScratch
 	}
-	clear(combiner.itemsScratch)
-	items := combiner.itemsScratch[:len(batch)]
+	if cap(*itemsScratch) < len(batch) {
+		*itemsScratch = make([]updateBatchItem, len(batch))
+	}
+	clear(*itemsScratch)
+	items := (*itemsScratch)[:len(batch)]
 	for i := range batch {
 		req := &batch[i]
 		items[i] = updateBatchItem{
@@ -9771,7 +10330,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	results, batched, err := batch[0].collection.updateBatchOwnedItems(items, updateBatchModeNoSecondaryUniqueIndexChanges)
 	clear(items)
-	combiner.itemsScratch = items[:0]
+	*itemsScratch = items[:0]
 	if !batched && err == nil {
 		if combiner.domain != nil {
 			combiner.domain.observeUpdateCombineBatch(len(batch), true)
@@ -12277,7 +12836,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}()
 
 	phaseStart := updateBatchStatsNow(detailedStats)
-	if domain.count != 0 {
+	allowUnsafeStaleDirectPlan := domain.allowUnsafeStaleDirectUpdatePlanForProfiling(plan)
+	if domain.count != 0 && !allowUnsafeStaleDirectPlan {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9997,6 +9997,209 @@ func TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce(t *testi
 	}
 }
 
+func TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	mgr.SetUpdateCombineShardsForProfiling(4)
+	mgr.SetUpdateCombineLaneWorkersForProfiling(true)
+	combiner := col.updateCombiner()
+	if combiner == nil {
+		t.Fatal("expected update combiner")
+	}
+	defer combiner.stop()
+
+	setCity := func(city string) bsonSetUpdate {
+		t.Helper()
+		spec, err := newBSONSetUpdate([]BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, city),
+		}})
+		if err != nil {
+			t.Fatalf("prepare BSON set %q: %v", city, err)
+		}
+		return spec
+	}
+	assertCity := func(city string) {
+		t.Helper()
+		doc, err := col.Get([]byte("u1"))
+		if err != nil {
+			t.Fatalf("get u1: %v", err)
+		}
+		if got := bson.Raw(doc).Lookup("city").StringValue(); got != city {
+			t.Fatalf("city=%q want %q", got, city)
+		}
+	}
+
+	before := d.State()
+	matched, modified, err := combiner.update(col, []byte("u1"), nil, setCity("sea"), true)
+	if err != nil {
+		t.Fatalf("first lane-worker update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("first matched=%v modified=%v want true/true", matched, modified)
+	}
+	assertCity("sea")
+	matched, modified, err = combiner.update(col, []byte("u1"), nil, setCity("sfo"), true)
+	if err != nil {
+		t.Fatalf("second lane-worker update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("second matched=%v modified=%v want true/true", matched, modified)
+	}
+	assertCity("sfo")
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("lane-worker updates advanced commit seq by %d before flush, want buffered", after.CommitSeq-before.CommitSeq)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush lane-worker updates: %v", err)
+	}
+	assertCity("sfo")
+}
+
+func TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1 << 20,
+			BufferedIndexedWriteMaxRootRuns:  1 << 20,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}, {Key: "city", Value: "hnl"}, {Key: "score", Value: int32(0)}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}, {Key: "city", Value: "hnl"}, {Key: "score", Value: int32(0)}}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		laneWorkers:     true,
+		shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+	}
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 8)
+	}
+	prepareSetScore := func(id string, score int32) collectionUpdateCombinePreparedBatch {
+		t.Helper()
+		spec, err := newBSONSetUpdate([]BSONSetField{{
+			Key:   "score",
+			Value: mustBSONRawValue(t, score),
+		}})
+		if err != nil {
+			t.Fatalf("prepare BSON set score=%d: %v", score, err)
+		}
+		req := newCollectionUpdateCombineRequest(col, []byte(id), nil, spec, true, make(chan collectionUpdateCombineResult, 1))
+		prepared := combiner.prepareBatchWithScratch([]collectionUpdateCombineRequest{req}, nil)
+		if prepared.err != nil {
+			t.Fatalf("prepare %s score=%d: %v", id, score, prepared.err)
+		}
+		if prepared.fallbackDirect || prepared.plan == nil || prepared.plan.directBufferedUpdate == nil {
+			t.Fatalf("prepare %s score=%d produced fallback/non-direct plan: %+v", id, score, prepared)
+		}
+		return prepared
+	}
+	requireResult := func(prepared collectionUpdateCombinePreparedBatch, name string) {
+		t.Helper()
+		result := <-prepared.batch[0].done
+		if result.err != nil || !result.matched || !result.modified {
+			t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+		}
+	}
+	assertScore := func(id string, score int32) {
+		t.Helper()
+		doc, err := col.Get([]byte(id))
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if got := bson.Raw(doc).Lookup("score").Int32(); got != score {
+			t.Fatalf("%s score=%d want %d", id, got, score)
+		}
+	}
+
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	first := prepareSetScore("u1", 1)
+	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{first})
+	requireResult(first, "first")
+
+	secondOtherDoc := prepareSetScore("u2", 10)
+	secondSameDoc := prepareSetScore("u1", 2)
+	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{secondOtherDoc, secondSameDoc})
+	requireResult(secondOtherDoc, "second other doc")
+	requireResult(secondSameDoc, "second same doc")
+
+	afterState := d.State()
+	if afterState.CommitSeq != beforeState.CommitSeq {
+		t.Fatalf("merged lane plans advanced commit seq by %d before flush, want buffered", afterState.CommitSeq-beforeState.CommitSeq)
+	}
+	afterStats := mgr.StatsSnapshot()
+	if got := afterStats.UpdateCombineFallbackRequests - beforeStats.UpdateCombineFallbackRequests; got != 0 {
+		t.Fatalf("fallback requests=%d want 0", got)
+	}
+	assertScore("u1", 2)
+	assertScore("u2", 10)
+}
+
 func TestCollectionUpdateCombinerMixedCollectionsFallbackDirect(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -12764,6 +12967,122 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStalePrimary
 	})
 	if !errors.Is(err, ErrConcurrentMutation) {
 		t.Fatalf("buffer stale primary-only plan err=%v want ErrConcurrentMutation", err)
+	}
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBuffersStaleNonOverlappingPrimaryOnlyDirectPlan(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	spec, err := newBSONSetUpdate([]BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sfo"),
+	}})
+	if err != nil {
+		t.Fatalf("prepare stale primary-only bson set spec: %v", err)
+	}
+	plan, err := col.buildUpdateBatchPlan([]updateBatchItem{
+		newBSONSetUpdateBatchItem([]byte("u2"), spec),
+	}, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build stale non-overlap plan: %v", err)
+	}
+	defer plan.close()
+	if plan.bufferedBase {
+		t.Fatalf("plan bufferedBase=%v want false when domain was empty", plan.bufferedBase)
+	}
+	if !plan.canBufferDirectUpdateBatch || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.primaryEntries) == 0 {
+		t.Fatalf("plan direct buffered path unavailable: canBuffer=%v directPlan=%v primaryEntries=%d", plan.canBufferDirectUpdateBatch, plan.directBufferedUpdate != nil, len(plan.directBufferedUpdate.primaryEntries))
+	}
+
+	if _, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet u1: %v", err)
+	}
+	err = col.withMutationLock(func() error {
+		buffered, err := col.bufferUpdateBatchPlanLocked(plan)
+		if err != nil {
+			return err
+		}
+		if !buffered {
+			t.Fatalf("stale non-overlap primary-only plan was not buffered")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("buffer stale non-overlap primary-only plan: %v", err)
+	}
+	afterStage := d.State()
+	if afterStage.CommitSeq != before.CommitSeq {
+		t.Fatalf("staged non-overlap updates advanced commit seq by %d before flush, want buffered", afterStage.CommitSeq-before.CommitSeq)
+	}
+	for _, tc := range []struct {
+		id   string
+		city string
+	}{
+		{"u1", "sea"},
+		{"u2", "sfo"},
+	} {
+		doc, err := col.Get([]byte(tc.id))
+		if err != nil {
+			t.Fatalf("get %s before flush: %v", tc.id, err)
+		}
+		if got := bson.Raw(doc).Lookup("city").StringValue(); got != tc.city {
+			t.Fatalf("%s city=%q want %q before flush", tc.id, got, tc.city)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged updates: %v", err)
+	}
+	for _, tc := range []struct {
+		id   string
+		city string
+	}{
+		{"u1", "sea"},
+		{"u2", "sfo"},
+	} {
+		doc, err := col.Get([]byte(tc.id))
+		if err != nil {
+			t.Fatalf("get %s after flush: %v", tc.id, err)
+		}
+		if got := bson.Raw(doc).Lookup("city").StringValue(); got != tc.city {
+			t.Fatalf("%s city=%q want %q after flush", tc.id, got, tc.city)
+		}
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9737,6 +9737,184 @@ func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerDefersDuplicateIDsAndBatchesDistinctPeers(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	first := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update:     setScore(1),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	duplicate := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update:     setScore(2),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	peer := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u2"),
+		update:     setScore(3),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	combiner := &collectionUpdateCombiner{
+		maxBatch: 8,
+		domain:   col.writeDomain,
+		requests: make(chan collectionUpdateCombineRequest, 2),
+	}
+	combiner.requests <- duplicate
+	combiner.requests <- peer
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+
+	combiner.runBatchStartingWith(first)
+	for name, done := range map[string]chan collectionUpdateCombineResult{
+		"first": first.done,
+		"peer":  peer.done,
+	} {
+		result := <-done
+		if result.err != nil || !result.matched || !result.modified {
+			t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+		}
+	}
+	select {
+	case result := <-duplicate.done:
+		t.Fatalf("duplicate completed in same batch: %+v", result)
+	default:
+	}
+	if got := len(combiner.deferred); got != 1 {
+		t.Fatalf("deferred duplicate count=%d want 1", got)
+	}
+	midState := d.State()
+	if midState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("first combined batch advanced commit seq by %d, want 1", midState.CommitSeq-beforeState.CommitSeq)
+	}
+	midStats := mgr.StatsSnapshot()
+	if got := midStats.UpdateCombineFallbackRequests - beforeStats.UpdateCombineFallbackRequests; got != 0 {
+		t.Fatalf("fallback requests after distinct-peer batch=%d want 0", got)
+	}
+
+	deferred, ok := combiner.popDeferredRequest()
+	if !ok {
+		t.Fatal("missing deferred duplicate")
+	}
+	combiner.runBatchStartingWith(deferred)
+	result := <-duplicate.done
+	if result.err != nil || !result.matched || !result.modified {
+		t.Fatalf("duplicate result=%+v want matched modified nil err", result)
+	}
+	afterState := d.State()
+	if afterState.CommitSeq != beforeState.CommitSeq+2 {
+		t.Fatalf("two serialized batches advanced commit seq by %d, want 2", afterState.CommitSeq-beforeState.CommitSeq)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("u1 document=%s want final score 2", got)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":3`)) {
+		t.Fatalf("u2 document=%s want score 3", got)
+	}
+}
+
+func TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+		readyShards:     make(chan int, 16),
+		done:            make(chan struct{}),
+	}
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 8)
+	}
+	firstDone := make(chan collectionUpdateCombineResult, 1)
+	secondDone := make(chan collectionUpdateCombineResult, 1)
+	if !combiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u1"), setScore(1), bsonSetUpdate{}, false, firstDone)) {
+		t.Fatal("enqueue first sharded update")
+	}
+	if !combiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u2"), setScore(2), bsonSetUpdate{}, false, secondDone)) {
+		t.Fatal("enqueue second sharded update")
+	}
+	before := d.State()
+	go combiner.run()
+	defer combiner.stop()
+	for name, done := range map[string]chan collectionUpdateCombineResult{
+		"first":  firstDone,
+		"second": secondDone,
+	} {
+		select {
+		case result := <-done:
+			if result.err != nil || !result.matched || !result.modified {
+				t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+			}
+		case <-time.After(collectionTestTimeout(t, time.Second)):
+			t.Fatalf("%s update did not complete", name)
+		}
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("sharded ingress batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateCombinerMixedCollectionsFallbackDirect(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12670,7 +12670,7 @@ func TestDirectBufferedRootEntriesOwnKeysAndRetainDocumentArena(t *testing.T) {
 	primaryEntries := buildDirectBufferedPrimaryRootEntries([]preparedBatchUpdate{{
 		documentID: documentID,
 		document:   document,
-	}})
+	}}, scratch)
 	if len(primaryEntries) != 1 {
 		t.Fatalf("primary entries=%d want 1", len(primaryEntries))
 	}
@@ -12691,12 +12691,13 @@ func TestDirectBufferedRootEntriesOwnKeysAndRetainDocumentArena(t *testing.T) {
 	plan.directBufferedUpdate = &directBufferedUpdatePlan{primaryEntries: primaryEntries}
 	var domain collectionWriteDomain
 	retainDirectBufferedDocumentArenaLocked(&domain, plan)
-	if got := len(domain.rootValueArenas); got != 1 {
-		t.Fatalf("retained document arenas=%d want 1", got)
+	if got := len(domain.rootValueArenas); got != 2 {
+		t.Fatalf("retained key/document arenas=%d want 2", got)
 	}
 	plan.close()
 	reused := getUpdateBatchPlanScratch(1, 0)
 	_ = appendUpdateBatchPlanScratchDocument(reused, []byte(`{"city":"koa"}`))
+	_ = appendUpdateBatchPlanScratchKey(reused, []byte("u9"))
 	putUpdateBatchPlanScratch(reused)
 	got, deleted, ok := table.Get([]byte("u1"))
 	if !ok || deleted || !bytes.Equal(got, []byte(`{"city":"hnl"}`)) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1548,6 +1548,88 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateStatsForMergeKeepsPerIndexBreakdown(t *testing.T) {
+	left := CollectionUpdateStats{
+		Items:           3,
+		Matched:         3,
+		Modified:        3,
+		SecondaryRuns:   []CollectionUpdateSecondaryRunStats{{IndexName: "city", Deletes: 1, Sets: 2, KeyBytes: 64}},
+		IndexStatsCount: 2,
+		IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+			{
+				CollectionName:   "users",
+				IndexName:        "email",
+				IndexOrdinal:     0,
+				Unique:           true,
+				Unchanged:        3,
+				UniqueCheckSkips: 3,
+			},
+			{
+				CollectionName:    "users",
+				IndexName:         "city",
+				IndexOrdinal:      1,
+				Changed:           3,
+				SecondaryRuns:     1,
+				SecondaryDeletes:  1,
+				SecondarySets:     2,
+				SecondaryKeyBytes: 64,
+			},
+		},
+	}
+	right := CollectionUpdateStats{
+		Items:           4,
+		Matched:         4,
+		Modified:        4,
+		SecondaryRuns:   []CollectionUpdateSecondaryRunStats{{IndexName: "city", Deletes: 3, Sets: 4, KeyBytes: 96}},
+		IndexStatsCount: 2,
+		IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+			{
+				CollectionName:   "users",
+				IndexName:        "email",
+				IndexOrdinal:     0,
+				Unique:           true,
+				Unchanged:        4,
+				UniqueCheckSkips: 4,
+			},
+			{
+				CollectionName:    "users",
+				IndexName:         "city",
+				IndexOrdinal:      1,
+				Changed:           4,
+				SecondaryRuns:     1,
+				SecondaryDeletes:  3,
+				SecondarySets:     4,
+				SecondaryKeyBytes: 96,
+			},
+		},
+	}
+
+	var merged CollectionUpdateStats
+	addCollectionUpdateStatsForMerge(&merged, left)
+	addCollectionUpdateStatsForMerge(&merged, right)
+
+	if got, want := merged.Items, 7; got != want {
+		t.Fatalf("merged items=%d want %d", got, want)
+	}
+	if got, want := len(merged.SecondaryRuns), 1; got != want {
+		t.Fatalf("secondary runs=%d want %d: %+v", got, want, merged.SecondaryRuns)
+	}
+	if city := merged.SecondaryRuns[0]; city.IndexName != "city" || city.Deletes != 4 || city.Sets != 6 || city.KeyBytes != 160 {
+		t.Fatalf("merged secondary city=%+v want deletes/sets/key bytes 4/6/160", city)
+	}
+	if got, want := merged.IndexStatsCount, 2; got != want {
+		t.Fatalf("index stats count=%d want %d", got, want)
+	}
+	email := merged.IndexStats[0]
+	if email.IndexName != "email" || !email.Unique || email.Unchanged != 7 || email.UniqueCheckSkips != 7 {
+		t.Fatalf("merged email=%+v want unchanged/skips 7", email)
+	}
+	city := merged.IndexStats[1]
+	if city.IndexName != "city" || city.Changed != 7 || city.SecondaryRuns != 2 || city.SecondaryDeletes != 4 || city.SecondarySets != 6 || city.SecondaryKeyBytes != 160 {
+		t.Fatalf("merged city index=%+v want changed/runs/deletes/sets/key bytes 7/2/4/6/160", city)
+	}
+}
+
 func TestCollectionUpdateIndexStatsDoNotMergeOverlappingIndexNames(t *testing.T) {
 	newDomain := func(collection string, changed int) *collectionWriteDomain {
 		domain := &collectionWriteDomain{

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -310,6 +310,9 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 	if len(u.fields) == 0 {
 		return dst, current, false, nil
 	}
+	if returned, replacement, changed, ok, fastErr := u.appendSameShapeReplacement(dst, current); ok || fastErr != nil {
+		return returned, replacement, changed, fastErr
+	}
 	length, rem, ok := bsoncore.ReadLength(current)
 	if !ok {
 		return resetDst(), nil, false, bsoncore.NewInsufficientBytesError(current, rem)
@@ -399,6 +402,76 @@ func (u bsonSetUpdate) appendReplacement(dst, current []byte) (returned []byte, 
 		return resetDst(), nil, false, err
 	}
 	return raw, raw[start:len(raw):len(raw)], true, nil
+}
+
+func (u bsonSetUpdate) appendSameShapeReplacement(dst, current []byte) (returned []byte, replacement []byte, changed bool, ok bool, err error) {
+	start := len(dst)
+	if len(u.fields) == 0 {
+		return dst, current, false, true, nil
+	}
+	length, _, lengthOK := bsoncore.ReadLength(current)
+	if !lengthOK {
+		return dst[:start], nil, false, false, nil
+	}
+	if int(length) > len(current) {
+		return dst[:start], nil, false, false, nil
+	}
+	if length < 5 || current[length-1] != 0x00 {
+		return dst[:start], nil, false, false, nil
+	}
+	docEnd := int(length)
+	var usedInline [8]bool
+	used := usedInline[:]
+	if len(u.fields) > len(usedInline) {
+		used = make([]bool, len(u.fields))
+	} else {
+		used = used[:len(u.fields)]
+	}
+	var out []byte
+	ensureOut := func() []byte {
+		if out != nil {
+			return out
+		}
+		out = append(dst, current[:docEnd]...)
+		return out
+	}
+	remaining := current[4:docEnd]
+	for len(remaining) > 1 {
+		elemStart := docEnd - len(remaining)
+		elem, next, elemOK := bsoncore.ReadElement(remaining)
+		if !elemOK {
+			return dst[:start], nil, false, false, nil
+		}
+		remaining = next
+		fieldIdx := u.fieldIndexBytes(elem.KeyBytes())
+		if fieldIdx < 0 {
+			continue
+		}
+		used[fieldIdx] = true
+		currentValue := elem.Value()
+		field := u.fields[fieldIdx]
+		if bsonCoreValueEqualRawValue(currentValue, field.Value) {
+			continue
+		}
+		if currentValue.Type != bsoncore.Type(field.Value.Type) || len(currentValue.Data) != len(field.Value.Value) {
+			return dst[:start], nil, false, false, nil
+		}
+		valueOffset := elemStart + len(elem) - len(currentValue.Data)
+		copy(ensureOut()[start+valueOffset:start+valueOffset+len(field.Value.Value)], field.Value.Value)
+		changed = true
+	}
+	if len(remaining) != 1 || remaining[0] != 0x00 {
+		return dst[:start], nil, false, false, nil
+	}
+	for _, fieldUsed := range used {
+		if !fieldUsed {
+			return dst[:start], nil, false, false, nil
+		}
+	}
+	if !changed {
+		return dst[:start], current, false, true, nil
+	}
+	return out, out[start:len(out):len(out)], true, true, nil
 }
 
 func callBSONSetUpdateApply(update bsonSetUpdate, current []byte) (replacement []byte, changed bool, err error) {

--- a/TreeDB/collections/update_minimization_direct_buffered_test.go
+++ b/TreeDB/collections/update_minimization_direct_buffered_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
 func TestCollectionUpdateBatchDirectBufferedBSONSkipsUnchangedSecondaryRoots(t *testing.T) {
@@ -155,6 +157,103 @@ func TestCollectionUpdateBatchDirectBufferedBSONSkipsUnchangedSecondaryRoots(t *
 	}
 	if got := bufferedPrimaryCacheCountForTest(t, col); got != 0 {
 		t.Fatalf("primary cache entries after delete=%d want 0", got)
+	}
+}
+
+func TestCollectionUpdateBSONSetDirectBufferedUnaffectedIndexesSkipStateExtractionAndRetainKeys(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatBSON,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	ids := [][]byte{[]byte("u1"), []byte("u2"), []byte("u3"), []byte("u4")}
+	docs := make([][]byte, len(ids))
+	for i, id := range ids {
+		docs[i] = mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: string(id)},
+			{Key: "email", Value: string(id) + "@example.com"},
+			{Key: "city", Value: "hnl"},
+			{Key: "score", Value: int32(i)},
+		})
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	updateScore := func(docID string, score int32) BSONSetUpdateBatchItem {
+		return BSONSetUpdateBatchItem{
+			DocumentID: []byte(docID),
+			Fields: []BSONSetField{{
+				Key:   "score",
+				Value: bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, score)},
+			}},
+		}
+	}
+	if results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		updateScore("u1", 11),
+		updateScore("u2", 12),
+	}); err != nil {
+		t.Fatalf("first UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched || len(results) != 2 || !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
+		t.Fatalf("first results=%+v batched=%v want two matched modified rows", results, batched)
+	}
+	if results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{
+		updateScore("u3", 13),
+		updateScore("u4", 14),
+	}); err != nil {
+		t.Fatalf("second UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched || len(results) != 2 || !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
+		t.Fatalf("second results=%+v batched=%v want two matched modified rows", results, batched)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.IndexStateExtraction, time.Duration(0); got != want {
+		t.Fatalf("index state extraction=%s want %s for BSON $set fields disjoint from indexes", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 4; got != want {
+		t.Fatalf("index unchanged=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexCheckSkips, 2; got != want {
+		t.Fatalf("unique skips=%d want %d", got, want)
+	}
+	for _, tc := range []struct {
+		id    string
+		score int32
+	}{
+		{id: "u1", score: 11},
+		{id: "u2", score: 12},
+		{id: "u3", score: 13},
+		{id: "u4", score: 14},
+	} {
+		got, err := col.Get([]byte(tc.id))
+		if err != nil {
+			t.Fatalf("get %s after buffered BSON updates: %v", tc.id, err)
+		}
+		if gotScore := bson.Raw(got).Lookup("score").Int32(); gotScore != tc.score {
+			t.Fatalf("%s score=%d want %d", tc.id, gotScore, tc.score)
+		}
 	}
 }
 

--- a/TreeDB/collections/update_minimization_direct_buffered_test.go
+++ b/TreeDB/collections/update_minimization_direct_buffered_test.go
@@ -72,11 +72,15 @@ func TestCollectionUpdateBatchDirectBufferedBSONSkipsUnchangedSecondaryRoots(t *
 		collectionSecondaryRootName("users", "email"),
 		collectionSecondaryRootName("users", "city"),
 	)
-	if got, want := rootRunCount, 1; got != want {
-		t.Fatalf("rootRunCount=%d want %d primary-only buffered update", got, want)
+	overlayCount := bufferedPrimaryOverlayCountForTest(t, col)
+	if got, want := rootRunCount, 0; got != want {
+		t.Fatalf("rootRunCount=%d want %d before flush for primary-only overlay update", got, want)
 	}
-	if got, want := rootCounts[collectionPrimaryRootName("users")], 1; got != want {
-		t.Fatalf("primary runs=%d want %d", got, want)
+	if got, want := rootCounts[collectionPrimaryRootName("users")], 0; got != want {
+		t.Fatalf("primary runs=%d want %d before flush for primary-only overlay update", got, want)
+	}
+	if got, want := overlayCount, 1; got != want {
+		t.Fatalf("primary overlay entries=%d want %d", got, want)
 	}
 	for _, rootName := range []string{
 		collectionSecondaryRootName("users", "email"),
@@ -103,6 +107,54 @@ func TestCollectionUpdateBatchDirectBufferedBSONSkipsUnchangedSecondaryRoots(t *
 	}
 	if gotScore := doc["score"]; gotScore != int32(2) {
 		t.Fatalf("buffered BSON score=%v want int32(2)", gotScore)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush primary-only overlay update: %v", err)
+	}
+	if got, want := bufferedPrimaryCacheCountForTest(t, col), 1; got != want {
+		t.Fatalf("primary cache entries after flush=%d want %d", got, want)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed BSON document: %v", err)
+	}
+	if gotScore := bson.Raw(got).Lookup("score").Int32(); gotScore != int32(2) {
+		t.Fatalf("flushed BSON score=%v want int32(2)", gotScore)
+	}
+	results, batched, err = col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setBSONField("score", int32(3))},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges after cache-retained flush: %v", err)
+	}
+	if !batched {
+		t.Fatal("cached BSON update was declined")
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("cached update results=%+v want one matched modified row", results)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get second buffered BSON document: %v", err)
+	}
+	if gotScore := bson.Raw(got).Lookup("score").Int32(); gotScore != int32(3) {
+		t.Fatalf("second buffered BSON score=%v want int32(3)", gotScore)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush second primary-only overlay update: %v", err)
+	}
+	if got, want := bufferedPrimaryCacheCountForTest(t, col), 1; got != want {
+		t.Fatalf("primary cache entries after second flush=%d want %d", got, want)
+	}
+	deleted, err := col.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete document: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete document deleted=false want true")
+	}
+	if got := bufferedPrimaryCacheCountForTest(t, col); got != 0 {
+		t.Fatalf("primary cache entries after delete=%d want 0", got)
 	}
 }
 
@@ -294,4 +346,24 @@ func bufferedRootRunCountsForTest(t *testing.T, col *Collection, rootNames ...st
 		out[rootName] = len(col.writeDomain.rootRuns[rootName])
 	}
 	return out, col.writeDomain.rootRunCount
+}
+
+func bufferedPrimaryOverlayCountForTest(t *testing.T, col *Collection) int {
+	t.Helper()
+	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
+	if col.writeDomain.primaryOverlay == nil {
+		return 0
+	}
+	return col.writeDomain.primaryOverlay.len()
+}
+
+func bufferedPrimaryCacheCountForTest(t *testing.T, col *Collection) int {
+	t.Helper()
+	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
+	if col.writeDomain.primaryCache == nil {
+		return 0
+	}
+	return col.writeDomain.primaryCache.len()
 }

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -188,6 +188,16 @@ the single-queue combiner. Values above `1` shard request ingress by document ID
 while preserving one global merged publish batch, and benchmark rows report
 `update_combine_shards` so shard-count runs are not mixed accidentally.
 
+For sharded-combiner proof-of-concept runs, add
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true` to let each
+document-ID shard prepare direct buffered update plans concurrently, then merge
+prepared plans back into one global buffer/publish path. Add
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true` only
+for controlled benchmark shapes with non-overlapping document IDs and unchanged
+unique secondary indexes. That stale-plan flag is intentionally profiling-only:
+it validates throughput headroom before the production conflict protocol is
+implemented.
+
 ## MongoDB Target
 
 ```sh

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -188,15 +188,13 @@ the single-queue combiner. Values above `1` shard request ingress by document ID
 while preserving one global merged publish batch, and benchmark rows report
 `update_combine_shards` so shard-count runs are not mixed accidentally.
 
-For sharded-combiner proof-of-concept runs, add
+For sharded-combiner lane-worker runs, add
 `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true` to let each
 document-ID shard prepare direct buffered update plans concurrently, then merge
-prepared plans back into one global buffer/publish path. Add
-`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS=true` only
-for controlled benchmark shapes with non-overlapping document IDs and unchanged
-unique secondary indexes. That stale-plan flag is intentionally profiling-only:
-it validates throughput headroom before the production conflict protocol is
-implemented.
+prepared plans back into one global buffered staging path. Stale prepared plans
+are admitted only when their target document IDs have not changed in the
+buffered layer since the plan's read generation; conflicting plans fall back to
+the ordinary per-document update path and read buffered writes before returning.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -182,6 +182,12 @@ synchronous-threshold rows by accident. The concurrent update profile benchmark
 times a final `FlushAll()` drain before reporting docs/sec, so async rows include
 deferred indexed publish work rather than enqueue latency alone.
 
+For update-combiner ingress experiments, set
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=N`. The default `1` preserves
+the single-queue combiner. Values above `1` shard request ingress by document ID
+while preserving one global merged publish batch, and benchmark rows report
+`update_combine_shards` so shard-count runs are not mixed accidentally.
+
 ## MongoDB Target
 
 ```sh

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -774,13 +774,20 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	backendStatsBefore := backend.Stats()
 	b.ResetTimer()
 	started := time.Now()
+	var logicalUpdateElapsed time.Duration
+	var finalFlushElapsed time.Duration
 	err = runProfileBenchTimedUpdatePhase(context.Background(), func(ctx context.Context) error {
+		updateStarted := time.Now()
 		if err := runProfileBenchDirectCollectionConcurrentUpdates(ctx, writers, b.N, documentCount, idStride, ids, updateDocs, collection); err != nil {
 			return err
 		}
+		logicalUpdateElapsed = time.Since(updateStarted)
 		// Keep async indexed-flush rows comparable with synchronous rows: the
 		// timed update phase includes the final drain of deferred publish work.
-		return manager.FlushAll()
+		flushStarted := time.Now()
+		err := manager.FlushAll()
+		finalFlushElapsed = time.Since(flushStarted)
+		return err
 	})
 	timedElapsed := time.Since(started)
 	b.StopTimer()
@@ -800,6 +807,12 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportProfileBenchBackendVlogMmapStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportDocsPerSecond(b, b.N, timedElapsed)
+	if logicalUpdateElapsed > 0 {
+		b.ReportMetric(float64(b.N)/logicalUpdateElapsed.Seconds(), "logical_update_docs/sec")
+	}
+	if finalFlushElapsed > 0 {
+		b.ReportMetric(float64(finalFlushElapsed.Nanoseconds())/float64(b.N), "final_flush_ns/doc")
+	}
 }
 
 func runProfileBenchTimedUpdatePhase(ctx context.Context, run func(context.Context) error) error {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -99,7 +99,6 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "")
-	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -131,9 +130,6 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	}
 	if profileBenchUpdateCombineLaneWorkers(t) {
 		t.Fatal("update combine lane workers default=true want false")
-	}
-	if profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
-		t.Fatal("update combine unsafe stale direct plans default=true want false")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
@@ -167,10 +163,6 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "true")
 	if !profileBenchUpdateCombineLaneWorkers(t) {
 		t.Fatal("update combine lane workers env=true want true")
-	}
-	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "true")
-	if !profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
-		t.Fatal("update combine unsafe stale direct plans env=true want true")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -776,8 +768,6 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	manager.SetUpdateCombineShardsForProfiling(updateCombineShards)
 	updateCombineLaneWorkers := profileBenchUpdateCombineLaneWorkers(b)
 	manager.SetUpdateCombineLaneWorkersForProfiling(updateCombineLaneWorkers)
-	updateCombineUnsafeStaleDirectPlans := profileBenchUpdateCombineUnsafeStaleDirectPlans(b)
-	manager.SetUpdateCombineUnsafeStaleDirectPlansForProfiling(updateCombineUnsafeStaleDirectPlans)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
@@ -801,9 +791,6 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
 	if updateCombineLaneWorkers {
 		b.ReportMetric(1, "update_combine_lane_workers")
-	}
-	if updateCombineUnsafeStaleDirectPlans {
-		b.ReportMetric(1, "update_combine_unsafe_stale_direct_plans")
 	}
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
@@ -2677,10 +2664,6 @@ func profileBenchUpdateCombineShards(tb testing.TB) int {
 
 func profileBenchUpdateCombineLaneWorkers(tb testing.TB) bool {
 	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", false)
-}
-
-func profileBenchUpdateCombineUnsafeStaleDirectPlans(tb testing.TB) bool {
-	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", false)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -97,6 +97,7 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -123,6 +124,9 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 0 {
 		t.Fatalf("buffered max root runs default=%d want 0", got)
 	}
+	if got := profileBenchUpdateCombineShards(t); got != 1 {
+		t.Fatalf("update combine shards default=%d want 1", got)
+	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush env=true want true")
@@ -147,6 +151,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
 		t.Fatalf("buffered max root runs=%d want 789", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "4")
+	if got := profileBenchUpdateCombineShards(t); got != 4 {
+		t.Fatalf("update combine shards=%d want 4", got)
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -748,6 +756,8 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 
 	b.ReportAllocs()
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	updateCombineShards := profileBenchUpdateCombineShards(b)
+	manager.SetUpdateCombineShardsForProfiling(updateCombineShards)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
@@ -768,6 +778,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 		b.Fatalf("run concurrent updates: %v", err)
 	}
 	b.ReportMetric(float64(writers), "writers")
+	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
 	reportProfileBenchOverlayCompactionStats(b, "warmup", warmupCompactStats)
@@ -2632,6 +2643,10 @@ func profileBenchUpdateDocumentCount(tb testing.TB) int {
 
 func profileBenchConcurrentWriters(tb testing.TB) int {
 	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_WRITERS", 8)
+}
+
+func profileBenchUpdateCombineShards(tb testing.TB) int {
+	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", 1)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -98,6 +98,8 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
@@ -127,6 +129,12 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	if got := profileBenchUpdateCombineShards(t); got != 1 {
 		t.Fatalf("update combine shards default=%d want 1", got)
 	}
+	if profileBenchUpdateCombineLaneWorkers(t) {
+		t.Fatal("update combine lane workers default=true want false")
+	}
+	if profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
+		t.Fatal("update combine unsafe stale direct plans default=true want false")
+	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush env=true want true")
@@ -155,6 +163,14 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", "4")
 	if got := profileBenchUpdateCombineShards(t); got != 4 {
 		t.Fatalf("update combine shards=%d want 4", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", "true")
+	if !profileBenchUpdateCombineLaneWorkers(t) {
+		t.Fatal("update combine lane workers env=true want true")
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", "true")
+	if !profileBenchUpdateCombineUnsafeStaleDirectPlans(t) {
+		t.Fatal("update combine unsafe stale direct plans env=true want true")
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
@@ -758,6 +774,10 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
 	updateCombineShards := profileBenchUpdateCombineShards(b)
 	manager.SetUpdateCombineShardsForProfiling(updateCombineShards)
+	updateCombineLaneWorkers := profileBenchUpdateCombineLaneWorkers(b)
+	manager.SetUpdateCombineLaneWorkersForProfiling(updateCombineLaneWorkers)
+	updateCombineUnsafeStaleDirectPlans := profileBenchUpdateCombineUnsafeStaleDirectPlans(b)
+	manager.SetUpdateCombineUnsafeStaleDirectPlansForProfiling(updateCombineUnsafeStaleDirectPlans)
 	manager.ResetUpdateCombinersForProfiling()
 	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
@@ -779,6 +799,12 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	}
 	b.ReportMetric(float64(writers), "writers")
 	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
+	if updateCombineLaneWorkers {
+		b.ReportMetric(1, "update_combine_lane_workers")
+	}
+	if updateCombineUnsafeStaleDirectPlans {
+		b.ReportMetric(1, "update_combine_unsafe_stale_direct_plans")
+	}
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
 	reportProfileBenchOverlayCompactionStats(b, "warmup", warmupCompactStats)
@@ -2647,6 +2673,14 @@ func profileBenchConcurrentWriters(tb testing.TB) int {
 
 func profileBenchUpdateCombineShards(tb testing.TB) int {
 	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS", 1)
+}
+
+func profileBenchUpdateCombineLaneWorkers(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", false)
+}
+
+func profileBenchUpdateCombineUnsafeStaleDirectPlans(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS", false)
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {


### PR DESCRIPTION
## Summary

- Makes sharded update-combiner lane workers use the normal buffered staging correctness contract instead of the profiling-only unsafe stale-plan override.
- Preserves per-primary-entry buffered read generations when merging lane-prepared direct update plans, so stale same-document plans are rejected while non-overlapping stale plans can stage safely.
- Adds a per-shard staging barrier before the next lane batch is planned, so same-shard/same-document updates read their own buffered writes before returning.
- Tracks primary write generations with a hash-only conservative conflict index; hash collisions can only cause fallback/retry, not incorrect staging.
- Removes `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_UNSAFE_STALE_DIRECT_PLANS` from the benchmark harness/docs.

## Correctness tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateCombiner(MergedLanePlansPreserveBufferedReadGeneration|LaneWorkersReadOwnBufferedWrites)|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges(RejectsStalePrimaryOnlyDirectPlan|BuffersStaleNonOverlappingPrimaryOnlyDirectPlan)' -count=1
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./cmd/mongo_gateway_bench -count=1
git diff --check
```

All passed locally.

## Performance evidence

Command:

```sh
GOWORK=off \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=64 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=8 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=256000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=256000 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x -count=3 -benchmem
```

Observed local runs:

| run | ns/op | docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 4142 | 241,458 | 1967 | 3 |
| 2 | 3975 | 251,586 | 1738 | 3 |
| 3 | 3924 | 254,817 | 1741 | 3 |

`update_combine_fallback_requests` was not emitted in these runs, which means the fallback count was zero.

## Target gap

This is a safe baseline, not the final 456k/s design. The measured safe root-run-staging path is around 241k-255k/s on this workload. The remaining jump likely requires a cheaper logical buffered overlay that returns after staging resolved primary updates into an in-memory layer, then drains that layer to root-run updates separately while reads and subsequent updates consult the overlay.
