### PR TITLE
[codex] Skip lane-worker ready shard signals

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10076,9 +10076,11 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 		requests := combiner.shardedRequests[shard]
 		select {
 		case requests <- req:
-			select {
-			case combiner.readyShards <- shard:
-			default:
+			if !combiner.hasShardWorkers() {
+				select {
+				case combiner.readyShards <- shard:
+				default:
+				}
 			}
 			if combiner.domain != nil {
 				combiner.domain.observeUpdateCombineRequest(len(requests))

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9997,6 +9997,38 @@ func TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce(t *testi
 	}
 }
 
+func TestCollectionUpdateCombinerLaneWorkerEnqueueSkipsReadyShardSignal(t *testing.T) {
+	col := &Collection{db: &backenddb.DB{}}
+	newCombiner := func(laneWorkers bool) *collectionUpdateCombiner {
+		combiner := &collectionUpdateCombiner{
+			laneWorkers:     laneWorkers,
+			shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+			readyShards:     make(chan int, 4),
+		}
+		for i := range combiner.shardedRequests {
+			combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 1)
+		}
+		return combiner
+	}
+	update := func([]byte) ([]byte, bool, error) { return nil, false, nil }
+
+	laneCombiner := newCombiner(true)
+	if !laneCombiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u1"), update, bsonSetUpdate{}, false, make(chan collectionUpdateCombineResult, 1))) {
+		t.Fatal("enqueue lane-worker request")
+	}
+	if got := len(laneCombiner.readyShards); got != 0 {
+		t.Fatalf("lane-worker ready shard signals=%d want 0", got)
+	}
+
+	mergerCombiner := newCombiner(false)
+	if !mergerCombiner.enqueue(newCollectionUpdateCombineRequest(col, []byte("u1"), update, bsonSetUpdate{}, false, make(chan collectionUpdateCombineResult, 1))) {
+		t.Fatal("enqueue sharded-merger request")
+	}
+	if got := len(mergerCombiner.readyShards); got != 1 {
+		t.Fatalf("sharded-merger ready shard signals=%d want 1", got)
+	}
+}
+
 func TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),


### PR DESCRIPTION
## Summary

PR-B in the update-combiner throughput stack.

This removes an unused coordination signal from the sharded update-combiner lane-worker path. When `laneWorkers` is enabled, each shard worker ranges its own shard request channel directly; only the older single-merger sharded path needs `readyShards` notifications. The patch keeps `readyShards` for that path and skips it for lane workers.

## Correctness

- Added `TestCollectionUpdateCombinerLaneWorkerEnqueueSkipsReadyShardSignal` to lock the split behavior:
  - lane-worker enqueue does not signal `readyShards`
  - sharded single-merger enqueue still signals `readyShards`

## Validation

```bash
GOWORK=off go test ./TreeDB/collections \
  -run 'TestCollectionUpdateCombinerLaneWorkerEnqueueSkipsReadyShardSignal|TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites|TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce' \
  -count=1
```

Result: pass.

```bash
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^TestTreeDBDirectBenchmarkSmoke$/template-v1$' \
  -count=1 -v
```

Result: pass.

Note: `GOWORK=off go test ./cmd/mongo_gateway_bench -run '^TestTreeDBDirectBenchmarkSmoke$/template-v1$' -count=5 -v` is flaky on both this branch and #1506 base with `collections: template-v1 template hash mismatch`; this patch does not touch that path.

## Benchmark Evidence

Compared against #1506 head `d7b754538a6f2b08db77b1de9e894ef9077b4262` using the 64-writer/8-shard lane-worker update benchmark:

```bash
GOWORK=off GOMAXPROCS=6 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=64 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=8 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=256000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=256000 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x -count=3 -benchmem
```

#1506 base artifact: `/tmp/gomap_lane_signal_base_20260513_193612/bench.txt`

- `docs/sec`: 245,626 / 248,035 / 239,494, avg 244,385
- `logical_update_docs/sec`: 465,977 / 442,355 / 455,086, avg 454,473
- `update_combine_wait_ns/doc`: 136,135 / 143,285 / 139,444, avg 139,621
- `update_combine_run_ns/doc`: 3,285 / 3,449 / 3,281, avg 3,338

Candidate artifact: `/tmp/gomap_lane_signal_candidate_20260513_193545/bench.txt`

- `docs/sec`: 248,113 / 258,152 / 250,087, avg 252,117 (+3.2%)
- `logical_update_docs/sec`: 454,787 / 466,919 / 467,211, avg 462,972 (+1.9%)
- `update_combine_wait_ns/doc`: 139,416 / 135,813 / 135,769, avg 136,999 (-1.9%)
- `update_combine_run_ns/doc`: 3,333 / 3,215 / 3,291, avg 3,280 (-1.8%)

This is a small coordination-path cleanup, not the main +90% throughput gap closer.
