### PR TITLE
[codex] Trim single prepared update staging allocations

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10434,7 +10434,7 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 	if len(prepared) == 0 {
 		return
 	}
-	direct := make([]collectionUpdateCombinePreparedBatch, 0, len(prepared))
+	direct := prepared[:0]
 	for _, p := range prepared {
 		if p.err != nil || p.fallbackDirect || p.plan == nil || p.plan.directBufferedUpdate == nil {
 			combiner.completePreparedBatch(p)
@@ -10443,6 +10443,10 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 		direct = append(direct, p)
 	}
 	if len(direct) == 0 {
+		return
+	}
+	if len(direct) == 1 {
+		combiner.stageSingleDirectPreparedBatch(direct[0])
 		return
 	}
 	merged, collection, err := mergeDirectBufferedPreparedBatches(direct)
@@ -10479,6 +10483,34 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 	for _, p := range direct {
 		combiner.completePreparedBatch(p)
 	}
+}
+
+func (combiner *collectionUpdateCombiner) stageSingleDirectPreparedBatch(prepared collectionUpdateCombinePreparedBatch) {
+	if prepared.plan == nil || prepared.plan.directBufferedUpdate == nil || len(prepared.batch) == 0 || prepared.batch[0].collection == nil {
+		combiner.completePreparedBatchWithError(prepared, errors.New("collections: invalid prepared direct update batch"))
+		return
+	}
+	collection := prepared.batch[0].collection
+	err := collection.withMutationLock(func() error {
+		buffered, bufferErr := collection.bufferDirectUpdateBatchPlanLocked(prepared.plan)
+		if bufferErr != nil {
+			return bufferErr
+		}
+		if !buffered {
+			return ErrConcurrentMutation
+		}
+		collection.setLastUpdateStats(prepared.plan.stats)
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, ErrConcurrentMutation) {
+			combiner.completePreparedBatchWithDirectFallback(prepared)
+			return
+		}
+		combiner.completePreparedBatchWithError(prepared, err)
+		return
+	}
+	combiner.completePreparedBatch(prepared)
 }
 
 func (combiner *collectionUpdateCombiner) completePreparedBatch(prepared collectionUpdateCombinePreparedBatch) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10119,6 +10119,88 @@ func TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites(t *testing.T) 
 	assertCity("sfo")
 }
 
+func TestCollectionUpdateCombinerSinglePreparedLanePlanStagesBuffered(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1 << 20,
+			BufferedIndexedWriteMaxRootRuns:  1 << 20,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		laneWorkers:     true,
+		shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+	}
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 8)
+	}
+	spec, err := newBSONSetUpdate([]BSONSetField{{Key: "city", Value: mustBSONRawValue(t, "sea")}})
+	if err != nil {
+		t.Fatalf("prepare BSON set: %v", err)
+	}
+	req := newCollectionUpdateCombineRequest(col, []byte("u1"), nil, spec, true, make(chan collectionUpdateCombineResult, 1))
+	prepared := combiner.prepareBatchWithScratch([]collectionUpdateCombineRequest{req}, nil)
+	if prepared.err != nil {
+		t.Fatalf("prepare: %v", prepared.err)
+	}
+	if prepared.fallbackDirect || prepared.plan == nil || prepared.plan.directBufferedUpdate == nil {
+		t.Fatalf("prepare produced fallback/non-direct plan: %+v", prepared)
+	}
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{prepared})
+	result := <-req.done
+	if result.err != nil || !result.matched || !result.modified {
+		t.Fatalf("result=%+v want matched modified nil err", result)
+	}
+	afterState := d.State()
+	if afterState.CommitSeq != beforeState.CommitSeq {
+		t.Fatalf("single prepared stage advanced commit seq by %d before flush, want buffered", afterState.CommitSeq-beforeState.CommitSeq)
+	}
+	afterStats := mgr.StatsSnapshot()
+	if got := afterStats.UpdateCombineFallbackRequests - beforeStats.UpdateCombineFallbackRequests; got != 0 {
+		t.Fatalf("fallback requests=%d want 0", got)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
 func TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),


### PR DESCRIPTION
## Summary
- Reuse the prepared-batch slice as the direct-batch filter scratch in `stagePreparedBatches`.
- Fast-path a single prepared direct batch so it stages its existing plan directly instead of allocating/copying through `mergeDirectBufferedPreparedBatches`.
- Add coverage that a single lane-prepared direct update stages into the buffered layer without publishing or falling back.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateCombinerSinglePreparedLanePlanStagesBuffered|TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration|TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites|TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce|TestCollectionUpdateCombinerLaneWorkerEnqueueSkipsReadyShardSignal' -count=1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run '^TestTreeDBDirectBenchmarkSmoke/template-v1$' -count=3 -v`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -count=1`

## Benchmark Evidence
Command:

```sh
GOWORK=off GOMAXPROCS=6 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
  MONGO_GATEWAY_PROFILE_BENCH_WRITERS=64 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=8 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=256000 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=256000 \
  go test ./cmd/mongo_gateway_bench \
    -run '^$' \
    -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
    -benchtime=200000x \
    -count=3 \
    -benchmem
```

Baseline #1507 artifact: `/tmp/gomap_lane_signal_candidate_20260513_193545/bench.txt`
Candidate artifact: `/tmp/gomap_single_prepared_inplace_filter_candidate_20260513_201157/bench.txt`

Average of 3 runs:

| Metric | #1507 baseline | Candidate |
| --- | ---: | ---: |
| docs/sec | 252,117 | 254,147 |
| logical_update_docs/sec | 462,972 | 474,021 |
| update_combine_wait_ns/doc | 136,999 | 133,836 |
| update_combine_run_ns/doc | 3,280 | 3,234 |
| update_combine_drain_ns/doc | 1,211 | 1,167 |
| B/op | 1,821 | 1,782 |
| allocs/op | 2.00 | 1.00 |
