### PR TITLE
[codex] Resolve sharded combiner review cleanups

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10271,17 +10271,34 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 	}
 	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
 	deferred := make([]collectionUpdateCombineRequest, 0)
+	deferredHead := 0
 	itemsScratch := make([]updateBatchItem, 0, batchCap)
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
 	requestsClosed := false
+	hasDeferred := func() bool {
+		return deferredHead < len(deferred)
+	}
 	popDeferred := func() (collectionUpdateCombineRequest, bool) {
-		if len(deferred) == 0 {
+		if !hasDeferred() {
+			if len(deferred) > 0 {
+				clear(deferred)
+				deferred = deferred[:0]
+				deferredHead = 0
+			}
 			return collectionUpdateCombineRequest{}, false
 		}
-		req := deferred[0]
-		copy(deferred, deferred[1:])
-		deferred[len(deferred)-1] = collectionUpdateCombineRequest{}
-		deferred = deferred[:len(deferred)-1]
+		req := deferred[deferredHead]
+		deferred[deferredHead] = collectionUpdateCombineRequest{}
+		deferredHead++
+		if deferredHead == len(deferred) {
+			deferred = deferred[:0]
+			deferredHead = 0
+		} else if deferredHead >= 32 && deferredHead*2 >= len(deferred) {
+			remaining := copy(deferred, deferred[deferredHead:])
+			clear(deferred[remaining:])
+			deferred = deferred[:remaining]
+			deferredHead = 0
+		}
 		return req, true
 	}
 	for {
@@ -10344,7 +10361,7 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 		}
 		clear(batch)
 		batch = batch[:0]
-		if requestsClosed && len(deferred) == 0 {
+		if requestsClosed && !hasDeferred() {
 			return
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10270,28 +10270,54 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 		batchCap = 1
 	}
 	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
+	deferred := make([]collectionUpdateCombineRequest, 0)
 	itemsScratch := make([]updateBatchItem, 0, batchCap)
 	detailedStats := combiner.domain != nil && combiner.domain.updateBatchDetailedStats.Load()
-	for first := range requests {
+	requestsClosed := false
+	popDeferred := func() (collectionUpdateCombineRequest, bool) {
+		if len(deferred) == 0 {
+			return collectionUpdateCombineRequest{}, false
+		}
+		req := deferred[0]
+		copy(deferred, deferred[1:])
+		deferred[len(deferred)-1] = collectionUpdateCombineRequest{}
+		deferred = deferred[:len(deferred)-1]
+		return req, true
+	}
+	for {
+		first, fromDeferred := popDeferred()
+		if !fromDeferred {
+			if requestsClosed {
+				return
+			}
+			var ok bool
+			first, ok = <-requests
+			if !ok {
+				return
+			}
+			combiner.observeUpdateCombineDequeued(first, detailedStats)
+			first.queuedAt = time.Time{}
+		}
 		batch = append(batch[:0], first)
-		combiner.observeUpdateCombineDequeued(first, detailedStats)
 		drainYields := 0
 		var drainStart time.Time
 		if detailedStats {
 			drainStart = time.Now()
 		}
-		closed := false
 		for len(batch) < batchCap {
+			if requestsClosed {
+				goto flush
+			}
 			select {
 			case req, ok := <-requests:
 				if !ok {
-					closed = true
+					requestsClosed = true
 					goto flush
 				}
 				combiner.observeUpdateCombineDequeued(req, detailedStats)
 				req.queuedAt = time.Time{}
 				if collectionUpdateCombineBatchHasID(batch, req) {
-					completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+					deferred = append(deferred, req)
 					continue
 				}
 				batch = append(batch, req)
@@ -10318,7 +10344,7 @@ func (combiner *collectionUpdateCombiner) runShardWorker(shard int) {
 		}
 		clear(batch)
 		batch = batch[:0]
-		if closed {
+		if requestsClosed && len(deferred) == 0 {
 			return
 		}
 	}
@@ -10623,6 +10649,15 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		}
 		if len(p.batch) == 0 || p.batch[0].collection != collection {
 			return nil, nil, errors.New("collections: cannot merge update plans across collections")
+		}
+		if !sameCollectionMeta(plan.meta, firstPlan.meta) {
+			return nil, nil, fmt.Errorf("%w: cannot merge update plans across collection schemas", ErrConcurrentMutation)
+		}
+		if (plan.catalog == nil) != (firstPlan.catalog == nil) {
+			return nil, nil, fmt.Errorf("%w: cannot merge update plans across collection catalogs", ErrConcurrentMutation)
+		}
+		if plan.catalog != nil && !sameCollectionMeta(plan.catalog.meta, firstPlan.catalog.meta) {
+			return nil, nil, fmt.Errorf("%w: cannot merge update plans across collection catalog schemas", ErrConcurrentMutation)
 		}
 		if plan.bufferedBase != commonBufferedBase || plan.bufferedReadGeneration != commonBufferedReadGeneration {
 			sameBufferedRead = false
@@ -12891,12 +12926,22 @@ func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDoma
 	if missing <= 0 {
 		return entries, buffer, nil
 	}
+	primaryRuns := domain.rootRuns[collectionPrimaryRootName(collectionName)]
 	for i, item := range items {
 		if entries[i].found {
 			continue
 		}
 		ref, ok := lookupPendingPrimaryOverlayLocked(domain, item.DocumentID)
 		if !ok {
+			continue
+		}
+		if value, _, flags, found := getBufferedRunEntry(primaryRuns, item.DocumentID); found {
+			entries[i] = updateBatchBufferedEntry{
+				value: buffer.copyValue(value),
+				flags: flags,
+				found: true,
+			}
+			missing--
 			continue
 		}
 		entries[i] = updateBatchBufferedEntry{
@@ -16053,6 +16098,12 @@ func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain
 		return append(dst[:0], ref.value...), true, true
 	}
 	if ref, ok := lookupPendingPrimaryOverlayLocked(domain, documentID); ok {
+		if value, flags, found := c.getCurrentPrimaryRootRunEntryLocked(domain, documentID); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst[:0], true, false
+			}
+			return append(dst[:0], value...), true, true
+		}
 		if ref.flags&node.FlagTombstone != 0 {
 			return dst[:0], true, false
 		}
@@ -16092,6 +16143,18 @@ func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain
 		return dst[:0], true, false
 	}
 	return append(dst[:0], value...), true, true
+}
+
+func (c *Collection) getCurrentPrimaryRootRunEntryLocked(domain *collectionWriteDomain, documentID []byte) ([]byte, byte, bool) {
+	if c == nil || domain == nil {
+		return nil, 0, false
+	}
+	name := collectionPrimaryRootName(c.meta.Name)
+	if domain.meta.Name != "" {
+		name = collectionPrimaryRootName(domain.meta.Name)
+	}
+	value, _, flags, found := getBufferedRunEntry(domain.rootRuns[name], documentID)
+	return value, flags, found
 }
 
 func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9985,7 +9985,7 @@ func TestCollectionUpdateCombinerShardedIngressPublishesDistinctIDsOnce(t *testi
 		select {
 		case result := <-done:
 			if result.err != nil || !result.matched || !result.modified {
-				t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+				t.Fatalf("%s result matched=%v modified=%v err=%v want matched modified nil err", name, result.matched, result.modified, result.err)
 			}
 		case <-time.After(collectionTestTimeout(t, time.Second)):
 			t.Fatalf("%s update did not complete", name)
@@ -10117,6 +10117,97 @@ func TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites(t *testing.T) 
 		t.Fatalf("flush lane-worker updates: %v", err)
 	}
 	assertCity("sfo")
+}
+
+func TestCollectionUpdateCombinerLaneWorkersDeferDuplicateDocumentUntilAfterStage(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	setCity := func(city string) bsonSetUpdate {
+		t.Helper()
+		spec, err := newBSONSetUpdate([]BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, city),
+		}})
+		if err != nil {
+			t.Fatalf("prepare BSON set %q: %v", city, err)
+		}
+		return spec
+	}
+	done1 := make(chan collectionUpdateCombineResult, 1)
+	done2 := make(chan collectionUpdateCombineResult, 1)
+	req1 := newCollectionUpdateCombineRequest(col, []byte("u1"), nil, setCity("sea"), true, done1)
+	req2 := newCollectionUpdateCombineRequest(col, []byte("u1"), nil, setCity("sfo"), true, done2)
+
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		laneWorkers:     true,
+		shardedRequests: []chan collectionUpdateCombineRequest{make(chan collectionUpdateCombineRequest, 8)},
+		preparedBatches: make(chan collectionUpdateCombinePreparedBatch, 8),
+	}
+	mergerDone := make(chan struct{})
+	go func() {
+		combiner.runPreparedBatchMerger()
+		close(mergerDone)
+	}()
+	combiner.shardedRequests[0] <- req1
+	combiner.shardedRequests[0] <- req2
+	close(combiner.shardedRequests[0])
+	combiner.runShardWorker(0)
+	close(combiner.preparedBatches)
+	select {
+	case <-mergerDone:
+	case <-time.After(collectionTestTimeout(t, time.Second)):
+		t.Fatal("prepared batch merger did not exit")
+	}
+
+	for name, done := range map[string]chan collectionUpdateCombineResult{"first": done1, "second": done2} {
+		select {
+		case result := <-done:
+			if result.err != nil || !result.matched || !result.modified {
+				t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+			}
+		case <-time.After(collectionTestTimeout(t, time.Second)):
+			t.Fatalf("%s update did not complete", name)
+		}
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sfo" {
+		t.Fatalf("city=%q want sfo", got)
+	}
 }
 
 func TestCollectionUpdateCombinerSinglePreparedLanePlanStagesBuffered(t *testing.T) {
@@ -10293,11 +10384,19 @@ func TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration(t
 	beforeState := d.State()
 	beforeStats := mgr.StatsSnapshot()
 	first := prepareSetScore("u1", 1)
+	secondOtherDoc := prepareSetScore("u2", 10)
 	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{first})
 	requireResult(first, "first")
 
-	secondOtherDoc := prepareSetScore("u2", 10)
 	secondSameDoc := prepareSetScore("u1", 2)
+	merged, _, err := mergeDirectBufferedPreparedBatches([]collectionUpdateCombinePreparedBatch{secondOtherDoc, secondSameDoc})
+	if err != nil {
+		t.Fatalf("merge mixed-generation plans: %v", err)
+	}
+	if merged.directBufferedUpdate == nil || len(merged.directBufferedUpdate.primaryEntryReadGenerations) == 0 {
+		t.Fatalf("merged mixed-generation plan missing per-entry read generations: %+v", merged.directBufferedUpdate)
+	}
+	merged.close()
 	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{secondOtherDoc, secondSameDoc})
 	requireResult(secondOtherDoc, "second other doc")
 	requireResult(secondSameDoc, "second same doc")
@@ -10312,6 +10411,125 @@ func TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration(t
 	}
 	assertScore("u1", 2)
 	assertScore("u2", 10)
+}
+
+func TestMergeDirectBufferedPreparedBatchesRejectsSchemaMismatch(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1 << 20,
+			BufferedIndexedWriteMaxRootRuns:  1 << 20,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}, {Key: "score", Value: int32(0)}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}, {Key: "score", Value: int32(0)}}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		laneWorkers:     true,
+		shardedRequests: make([]chan collectionUpdateCombineRequest, 4),
+	}
+	for i := range combiner.shardedRequests {
+		combiner.shardedRequests[i] = make(chan collectionUpdateCombineRequest, 8)
+	}
+	prepareSetScore := func(id string, score int32) collectionUpdateCombinePreparedBatch {
+		t.Helper()
+		spec, err := newBSONSetUpdate([]BSONSetField{{
+			Key:   "score",
+			Value: mustBSONRawValue(t, score),
+		}})
+		if err != nil {
+			t.Fatalf("prepare BSON set score=%d: %v", score, err)
+		}
+		req := newCollectionUpdateCombineRequest(col, []byte(id), nil, spec, true, make(chan collectionUpdateCombineResult, 1))
+		prepared := combiner.prepareBatchWithScratch([]collectionUpdateCombineRequest{req}, nil)
+		if prepared.err != nil {
+			t.Fatalf("prepare %s score=%d: %v", id, score, prepared.err)
+		}
+		if prepared.fallbackDirect || prepared.plan == nil || prepared.plan.directBufferedUpdate == nil {
+			t.Fatalf("prepare %s score=%d produced fallback/non-direct plan: %+v", id, score, prepared)
+		}
+		return prepared
+	}
+
+	first := prepareSetScore("u1", 1)
+	defer first.plan.close()
+	second := prepareSetScore("u2", 2)
+	defer second.plan.close()
+	second.plan.meta.Indexes = append(second.plan.meta.Indexes, IndexDefinition{Name: "status", Field: "status", ValueType: IndexValueString})
+	if _, _, err := mergeDirectBufferedPreparedBatches([]collectionUpdateCombinePreparedBatch{first, second}); !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("merge schema mismatch err=%v want ErrConcurrentMutation", err)
+	}
+}
+
+func TestGetBufferedDocumentPrefersCurrentRootRunOverDetachedOverlay(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}
+	col := &Collection{meta: meta}
+	primaryRoot := collectionPrimaryRootName("users")
+
+	detachedOverlay := newBufferedPrimaryOverlay(1)
+	detachedOverlay.addEntries([]directBufferedRootEntry{{
+		key:   []byte("u1"),
+		value: mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "old"}}),
+		flags: node.FlagInline,
+	}})
+	currentPrimary := newCollectionRunTable(1)
+	setCollectionRunValue(currentPrimary, []byte("u1"), mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "new"}}))
+	defer resetCollectionRunTable(currentPrimary)
+
+	domain := &collectionWriteDomain{
+		count:  2,
+		loaded: true,
+		meta:   meta,
+		indexedFlushUnits: []indexedFlushUnit{{
+			primaryOverlay: detachedOverlay,
+		}},
+		rootRuns: map[string][]memtable.Table{
+			primaryRoot: {currentPrimary},
+		},
+	}
+	doc, buffered, found := col.getBufferedDocumentIntoLocked(domain, []byte("u1"), nil)
+	if !buffered || !found {
+		t.Fatalf("buffered=%v found=%v want true,true", buffered, found)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "new" {
+		t.Fatalf("city=%q want new", got)
+	}
 }
 
 func TestCollectionUpdateCombinerMixedCollectionsFallbackDirect(t *testing.T) {

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -191,10 +191,13 @@ while preserving one global merged publish batch, and benchmark rows report
 For sharded-combiner lane-worker runs, add
 `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true` to let each
 document-ID shard prepare direct buffered update plans concurrently, then merge
-prepared plans back into one global buffered staging path. Stale prepared plans
-are admitted only when their target document IDs have not changed in the
-buffered layer since the plan's read generation; conflicting plans fall back to
-the ordinary per-document update path and read buffered writes before returning.
+prepared plans back into one global buffered staging path. This flag is effective
+only when `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS` is greater than
+`1`; only effective lane-worker runs report `update_combine_lane_workers`.
+Stale prepared plans are admitted only when their target document IDs have not
+changed in the buffered layer since the plan's read generation; conflicting
+plans fall back to the ordinary per-document update path and read buffered
+writes before returning.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -174,6 +174,25 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	}
 }
 
+func TestProfileBenchEffectiveUpdateCombineLaneWorkers(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		shards      int
+		laneWorkers bool
+		want        bool
+	}{
+		{name: "disabled", shards: 4, laneWorkers: false, want: false},
+		{name: "single shard", shards: 1, laneWorkers: true, want: false},
+		{name: "sharded", shards: 4, laneWorkers: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := profileBenchEffectiveUpdateCombineLaneWorkers(tc.shards, tc.laneWorkers); got != tc.want {
+				t.Fatalf("effective lane workers=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProfileBenchTimedUpdatePhaseLabels(t *testing.T) {
 	called := false
 	err := runProfileBenchTimedUpdatePhase(context.Background(), func(ctx context.Context) error {
@@ -796,7 +815,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	}
 	b.ReportMetric(float64(writers), "writers")
 	b.ReportMetric(float64(updateCombineShards), "update_combine_shards")
-	if updateCombineLaneWorkers {
+	if profileBenchEffectiveUpdateCombineLaneWorkers(updateCombineShards, updateCombineLaneWorkers) {
 		b.ReportMetric(1, "update_combine_lane_workers")
 	}
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
@@ -2677,6 +2696,10 @@ func profileBenchUpdateCombineShards(tb testing.TB) int {
 
 func profileBenchUpdateCombineLaneWorkers(tb testing.TB) bool {
 	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS", false)
+}
+
+func profileBenchEffectiveUpdateCombineLaneWorkers(shards int, laneWorkers bool) bool {
+	return laneWorkers && shards > 1
 }
 
 func profileBenchBufferedIndexedAsyncFlush(tb testing.TB) bool {


### PR DESCRIPTION
## Summary
- Defer duplicate same-document lane-worker requests until after the current prepared batch is staged, matching the single-combiner ordering contract instead of running the later request directly against stale state.
- Keep that deferred lane queue O(1) with a head-index queue so hot-key bursts do not pay per-pop slice shifting.
- Reject merged prepared direct batches when their collection metadata/catalog schema differs, so lane plans prepared across schema changes fall back instead of staging stale secondary-index deltas.
- Prefer current mutable root runs over older detached primary overlays for buffered document reads and update planning; keep detached overlays ahead of their own detached root runs.
- Report `update_combine_lane_workers` only when lane workers are actually effective (`shards > 1`) and document that benchmark labeling rule.

## Review threads addressed
- #1505 duplicate same-document lane-worker fallback ordering.
- #1505 mixed-schema prepared lane plan merge.
- #1505 misleading lane-worker benchmark metric when shard count is 1.
- #1505 mixed-generation prepared plan test coverage.
- #1506 stale detached overlay read before newer current root run.
- #1509 Copilot deferred queue O(n^2) hot-key concern.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateCombinerLaneWorkersDeferDuplicateDocumentUntilAfterStage|TestCollectionUpdateCombinerMergedLanePlansPreserveBufferedReadGeneration|TestMergeDirectBufferedPreparedBatchesRejectsSchemaMismatch|TestGetBufferedDocumentPrefersCurrentRootRunOverDetachedOverlay|TestCollectionUpdateCombinerLaneWorkersReadOwnBufferedWrites|TestCollectionUpdateCombinerSinglePreparedLanePlanStagesBuffered' -count=1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchEffectiveUpdateCombineLaneWorkers|TestTreeDBDirectBenchmarkSmoke/template-v1' -count=1 -v`
- `GOWORK=off go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1`

## Benchmark Evidence
Command:

```sh
GOWORK=off GOMAXPROCS=6 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
  MONGO_GATEWAY_PROFILE_BENCH_WRITERS=64 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_SHARDS=8 \
  MONGO_GATEWAY_PROFILE_BENCH_UPDATE_COMBINE_LANE_WORKERS=true \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=256000 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=256000 \
  go test ./cmd/mongo_gateway_bench \
    -run '^$' \
    -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
    -benchtime=200000x \
    -count=3 \
    -benchmem
```

Artifact: `/tmp/gomap_review_cleanup_queue_candidate_20260513_204440/bench.txt`

| Metric | Runs | Average | Median |
| --- | ---: | ---: | ---: |
| docs/sec | 254,927 / 260,251 / 253,259 | 256,146 | 254,927 |
| logical_update_docs/sec | 467,040 / 470,064 / 459,599 | 465,568 | 467,040 |
| update_combine_wait_ns/doc | 135,811 / 134,853 / 137,953 | 136,206 | 135,811 |
| update_combine_run_ns/doc | 3,191 / 3,208 / 3,325 | 3,241 | 3,208 |
| update_combine_drain_ns/doc | 1,240 / 1,144 / 1,133 | 1,172 | 1,144 |
| B/op | 1,978 / 1,684 / 1,683 | 1,782 | 1,684 |
| allocs/op | 1 / 1 / 1 | 1 | 1 |

This stays in the same performance band as #1508 while adding the correctness/review cleanups.
