### PR TITLE
[codex] prescore TreeDB vector neighbor pruning

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"sync"
 	"time"
 
@@ -583,19 +582,50 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 	neighbors = append(neighbors, toNodeID)
 	limit := idx.maxNeighborsForLayer(layer)
 	if len(neighbors) > limit {
-		sort.Slice(neighbors, func(i, j int) bool {
-			left := idx.nodes[neighbors[i]]
-			right := idx.nodes[neighbors[j]]
-			leftDistance := idx.distanceBetweenNodesLocked(fromNodeID, neighbors[i])
-			rightDistance := idx.distanceBetweenNodesLocked(fromNodeID, neighbors[j])
-			if leftDistance != rightDistance {
-				return leftDistance < rightDistance
-			}
-			return bytes.Compare(left.documentID, right.documentID) < 0
-		})
-		neighbors = neighbors[:limit]
+		neighbors = idx.pruneLayerNeighborsLocked(fromNodeID, neighbors, limit)
 	}
 	idx.nodes[fromNodeID].neighbors[layer] = neighbors
+}
+
+func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []int, limit int) []int {
+	if limit <= 0 || len(neighbors) == 0 {
+		return nil
+	}
+	if len(neighbors) <= limit {
+		return neighbors
+	}
+	var stack [128]vectorIndexCandidate
+	scored := stack[:0]
+	if len(neighbors) > len(stack) {
+		scored = make([]vectorIndexCandidate, 0, len(neighbors))
+	}
+	for _, neighborID := range neighbors {
+		if neighborID < 0 || neighborID >= len(idx.nodes) {
+			continue
+		}
+		distance := idx.distanceBetweenNodesLocked(fromNodeID, neighborID)
+		if math.IsInf(float64(distance), 1) {
+			continue
+		}
+		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: distance})
+	}
+	slices.SortFunc(scored, func(left, right vectorIndexCandidate) int {
+		if left.distance < right.distance {
+			return -1
+		}
+		if left.distance > right.distance {
+			return 1
+		}
+		return bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID)
+	})
+	if len(scored) > limit {
+		scored = scored[:limit]
+	}
+	out := neighbors[:0]
+	for _, candidate := range scored {
+		out = append(out, candidate.nodeID)
+	}
+	return out
 }
 
 // Search returns ANN candidates from the in-memory graph and exact-reranks the

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -49,6 +49,28 @@ func TestCollectionVectorIndexSearchReranksCanonicalRows(t *testing.T) {
 	}
 }
 
+func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("from"), vector: []float32{1, 0}},
+		{documentID: []byte("b"), vector: []float32{0.8, 0.2}},
+		{documentID: []byte("a"), vector: []float32{0.8, 0.2}},
+		{documentID: []byte("far"), vector: []float32{0, 1}},
+	}
+
+	got := index.pruneLayerNeighborsLocked(0, []int{3, 1, 2}, 2)
+	if len(got) != 2 || got[0] != 2 || got[1] != 1 {
+		t.Fatalf("pruned neighbors=%v want [2 1]", got)
+	}
+}
+
 func TestCollectionVectorIndexInt8EncodingReranksCanonicalRows(t *testing.T) {
 	const (
 		docs = 24


### PR DESCRIPTION
## Summary

Follow-up to #1512 for #1513 priority 1.

- adds a focused pruning test for distance-first, document-ID deterministic neighbor trimming
- changes `linkLayerLocked` to pre-score each overflowing neighbor once before sorting
- uses stack scratch for default neighbor-list sizes to avoid adding heap churn

## Results

Build-only benchmark, 3k docs x 64 dims:

- before: `15.83s` (`BenchmarkCollectionVectorIndexBuild`, profile `/tmp/treedb_vector_build_profile_20260514_094255`)
- after: `2.65s`, `2.72s`, `2.67s` (`TREEDB_VECTOR_BENCH_DOCS=3000 TREEDB_VECTOR_BENCH_DIMS=64 ... -count=3`)

Build-only benchmark, 10k docs x 64 dims:

- before: `54.6s`
- after: `10.8s`

Query smoke after change, 10k docs x 64 dims:

- integrated TreeDB ANN: `2.00ms/query`
- graph-only TreeDB ANN: `0.78ms/query`

Post-change profile:

- `/tmp/treedb_vector_build_prescore_stack_profile_20260514_095213`
- original sort-comparator hotspot is gone; remaining CPU is mostly distance kernels, which are tracked as later priorities in #1513.

## Validation

- `go test ./TreeDB/collections -run '^TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID$' -count=1`
- `go test ./TreeDB/collections -run 'TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID|TestCollectionVectorIndex|TestCollectionSearchVectorsExact|TestExactVectorDistance|TestVectorFromJSONField' -count=1`
- `go test ./TreeDB/collections -count=1`
- `git diff --check`
