### PR TITLE
[codex] add TreeDB vector incremental write benchmark

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -98,6 +98,43 @@ func BenchmarkCollectionVectorIndexBuildInt8(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectionVectorIndexIncrementalWrite(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	ids, documents := vectorBenchmarkWriteBatch(docs, dims)
+
+	b.ReportMetric(float64(docs), "docs/write")
+	b.ReportMetric(float64(dims), "dims")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		d, col := openEmptyVectorBenchmarkCollection(b)
+		index, err := newVectorIndex(col, VectorIndexOptions{
+			Name:   "embedding_write",
+			Field:  "embedding",
+			Metric: VectorMetricCosine,
+			M:      16,
+		})
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("new vector index: %v", err)
+		}
+		col.RegisterVectorIndex(index)
+		b.StartTimer()
+		vectorBenchmarkInsertBatches(b, col, ids, documents, 512)
+		b.StopTimer()
+		stats := index.Stats()
+		if stats.LiveDocs != docs {
+			_ = d.Close()
+			b.Fatalf("incremental index live docs=%d want %d", stats.LiveDocs, docs)
+		}
+		b.ReportMetric(float64(stats.BytesMemory), "index_bytes")
+		if err := d.Close(); err != nil {
+			b.Fatalf("close db: %v", err)
+		}
+	}
+}
+
 func BenchmarkCollectionVectorIndexSearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
@@ -421,14 +458,14 @@ func openVectorBenchmarkCollection(tb testing.TB, docs, dims int) (*backenddb.DB
 	return openVectorBenchmarkCollectionWithIndexes(tb, docs, dims)
 }
 
-func openVectorBenchmarkCollectionWithIndexes(tb testing.TB, docs, dims int, indexes ...IndexDefinition) (*backenddb.DB, *Collection) {
+func openEmptyVectorBenchmarkCollection(tb testing.TB) (*backenddb.DB, *Collection) {
 	tb.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
 	if err != nil {
 		tb.Fatalf("open db: %v", err)
 	}
 	mgr := NewCollectionManager(d)
-	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", Indexes: indexes}); err != nil {
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
 		_ = d.Close()
 		tb.Fatalf("create collection: %v", err)
 	}
@@ -437,28 +474,62 @@ func openVectorBenchmarkCollectionWithIndexes(tb testing.TB, docs, dims int, ind
 		_ = d.Close()
 		tb.Fatalf("open collection: %v", err)
 	}
-	const batchSize = 512
-	for start := 0; start < docs; start += batchSize {
-		end := start + batchSize
-		if end > docs {
-			end = docs
+	return d, col
+}
+
+func openVectorBenchmarkCollectionWithIndexes(tb testing.TB, docs, dims int, indexes ...IndexDefinition) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	var d *backenddb.DB
+	var col *Collection
+	if len(indexes) == 0 {
+		d, col = openEmptyVectorBenchmarkCollection(tb)
+	} else {
+		var err error
+		d, err = backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
+		if err != nil {
+			tb.Fatalf("open db: %v", err)
 		}
-		ids := make([][]byte, 0, end-start)
-		documents := make([][]byte, 0, end-start)
-		for i := start; i < end; i++ {
-			ids = append(ids, []byte(fmt.Sprintf("doc-%06d", i)))
-			documents = append(documents, vectorBenchmarkDocument(i, dims))
-		}
-		if _, err := col.InsertBatch(ids, documents); err != nil {
+		mgr := NewCollectionManager(d)
+		if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", Indexes: indexes}); err != nil {
 			_ = d.Close()
-			tb.Fatalf("insert benchmark batch %d-%d: %v", start, end, err)
+			tb.Fatalf("create collection: %v", err)
+		}
+		col, err = mgr.OpenCollection("docs")
+		if err != nil {
+			_ = d.Close()
+			tb.Fatalf("open collection: %v", err)
 		}
 	}
+	ids, documents := vectorBenchmarkWriteBatch(docs, dims)
+	vectorBenchmarkInsertBatches(tb, col, ids, documents, 512)
 	if err := col.Flush(); err != nil {
 		_ = d.Close()
 		tb.Fatalf("flush benchmark collection: %v", err)
 	}
 	return d, col
+}
+
+func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
+	ids := make([][]byte, docs)
+	documents := make([][]byte, docs)
+	for i := 0; i < docs; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		documents[i] = vectorBenchmarkDocument(i, dims)
+	}
+	return ids, documents
+}
+
+func vectorBenchmarkInsertBatches(tb testing.TB, col *Collection, ids, documents [][]byte, batchSize int) {
+	tb.Helper()
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if _, err := col.InsertBatch(ids[start:end], documents[start:end]); err != nil {
+			tb.Fatalf("insert benchmark batch %d-%d: %v", start, end, err)
+		}
+	}
 }
 
 type vectorBenchmarkFixtureRecord struct {

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -37,6 +37,36 @@ func BenchmarkCollectionVectorUSearchBuild(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectionVectorUSearchIncrementalWrite(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	vectors := make([][]float32, docs)
+	for i := 0; i < docs; i++ {
+		vectors[i] = vectorBenchmarkEmbedding(i, dims)
+	}
+
+	b.ReportMetric(float64(docs), "docs/write")
+	b.ReportMetric(float64(dims), "dims")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		index := newVectorUSearchIndex(b, dims, docs, 16, 128, 128)
+		b.StartTimer()
+		for j, vector := range vectors {
+			if err := index.Add(usearch.Key(j), vector); err != nil {
+				_ = index.Destroy()
+				b.Fatalf("add usearch vector %d: %v", j, err)
+			}
+		}
+		b.StopTimer()
+		memory, _ := index.MemoryUsage()
+		b.ReportMetric(float64(memory), "index_bytes")
+		if err := index.Destroy(); err != nil {
+			b.Fatalf("destroy usearch index: %v", err)
+		}
+	}
+}
+
 func BenchmarkCollectionVectorUSearchBaseline(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -13,7 +13,9 @@ BENCHTIME="${BENCHTIME:-1x}"
 RUN_UNSAFE_USEARCH_FILTERED="${RUN_UNSAFE_USEARCH_FILTERED:-false}"
 BENCH_REGEX="${BENCH_REGEX:-BenchmarkCollectionVector(SearchExact|IndexSearch(Int8)?|IndexGraphOnlySearch(Int8)?|IndexFilteredSearch|USearchBaseline)$}"
 BUILD_BENCH_REGEX="${BUILD_BENCH_REGEX:-BenchmarkCollectionVector(IndexBuild(Int8)?|USearchBuild)$}"
+WRITE_BENCH_REGEX="${WRITE_BENCH_REGEX:-BenchmarkCollectionVector(IndexIncrementalWrite|USearchIncrementalWrite)$}"
 RUN_BUILD_BENCH="${RUN_BUILD_BENCH:-false}"
+RUN_WRITE_BENCH="${RUN_WRITE_BENCH:-false}"
 TREEDB_VECTOR_BENCH_DOCS="${TREEDB_VECTOR_BENCH_DOCS:-1000}"
 TREEDB_VECTOR_BENCH_DIMS="${TREEDB_VECTOR_BENCH_DIMS:-32}"
 
@@ -65,11 +67,19 @@ cat >"$RUN_DIR/README.md" <<EOF
 - count: \`$COUNT\`
 - benchmark regex: \`$BENCH_REGEX\`
 - build benchmark regex: \`$BUILD_BENCH_REGEX\`
+- write benchmark regex: \`$WRITE_BENCH_REGEX\`
 - run build benchmarks: \`$RUN_BUILD_BENCH\`
+- run write benchmarks: \`$RUN_WRITE_BENCH\`
 - unsafe USearch filtered benchmark: \`$RUN_UNSAFE_USEARCH_FILTERED\`
 
 The harness compares TreeDB exact scan, TreeDB in-memory ANN, TreeDB int8 ANN,
 and USearch cosine/f32 HNSW using the same synthetic vector generator.
+
+With \`RUN_WRITE_BENCH=true\`, it also compares TreeDB incremental
+\`InsertBatch\` with a registered in-memory vector index against USearch
+incremental \`Add\` on the same synthetic vector stream. The TreeDB benchmark
+includes collection document writes and vector-index update notifications; the
+USearch benchmark is in-memory index insertion only.
 EOF
 
 echo "USearch root: $USEARCH_ROOT"
@@ -87,5 +97,8 @@ echo "run dir: $RUN_DIR"
 	go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
 	if [[ "$RUN_BUILD_BENCH" == "true" ]]; then
 		go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BUILD_BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
+	fi
+	if [[ "$RUN_WRITE_BENCH" == "true" ]]; then
+		go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$WRITE_BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
 	fi
 ) 2>&1 | tee "$RUN_DIR/bench.txt"


### PR DESCRIPTION
## Summary

- Add `BenchmarkCollectionVectorIndexIncrementalWrite`, which times `InsertBatch` into an empty collection with a registered in-memory vector index.
- Add `BenchmarkCollectionVectorUSearchIncrementalWrite`, which times USearch incremental `Add` on the same generated vector stream.
- Add `RUN_WRITE_BENCH=true` support to `scripts/bench_vector_search_compare.sh` and document the comparison caveat in the generated run README.

## What This Compares

The TreeDB benchmark includes collection document writes and vector-index update notifications. The USearch benchmark is in-memory index insertion only. This is intentionally closer to the user-visible TreeDB write path than the existing build-only comparison, but it is still not a full storage-system apples-to-apples comparison.

## Validation

- `TREEDB_VECTOR_BENCH_DOCS=100 TREEDB_VECTOR_BENCH_DIMS=16 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorIndexIncrementalWrite$' -benchtime=1x -count=1`
- `USEARCH_ROOT=/tmp/usearch_2.25.2_amd64/root/usr/local CGO_CFLAGS='-I/tmp/usearch_2.25.2_amd64/root/usr/local/include' CGO_LDFLAGS='-L/tmp/usearch_2.25.2_amd64/root/usr/local/lib' LD_LIBRARY_PATH='/tmp/usearch_2.25.2_amd64/root/usr/local/lib' TREEDB_VECTOR_BENCH_DOCS=100 TREEDB_VECTOR_BENCH_DIMS=16 go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVector(IndexIncrementalWrite|USearchIncrementalWrite)$' -benchtime=1x -count=1`
- `go test ./TreeDB/collections -count=1`
- `RUN_DIR=/tmp/gomap_vector_write_compare_smoke RUN_WRITE_BENCH=true RUN_BUILD_BENCH=false COUNT=1 BENCHTIME=1x TREEDB_VECTOR_BENCH_DOCS=100 TREEDB_VECTOR_BENCH_DIMS=16 scripts/bench_vector_search_compare.sh`
- `git diff --check`

## Benchmark Results on This Branch

3k x 64, count=3:

- TreeDB incremental write: `725.2ms`, `718.2ms`, `736.1ms`; `1.79MB` index bytes.
- USearch incremental Add: `173.4ms`, `166.1ms`, `165.9ms`; `17.04MB` index bytes.

10k x 64, count=3:

- TreeDB incremental write: `2.914s`, `2.914s`, `2.937s`; `5.96MB` index bytes.
- USearch incremental Add: `764.3ms`, `755.6ms`, `762.0ms`; `17.30MB` index bytes.

Follow-on to #1515.
