### PR TITLE
[codex] specialize TreeDB vector float32 cosine distance

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1052,6 +1052,9 @@ func vectorDistanceToStoredNodeWithQueryNorm(query []float32, queryNormSquared f
 	}
 	switch metric {
 	case VectorMetricCosine:
+		if len(node.vector) > 0 {
+			return vectorDistanceToFloat32NodeCosine(query, queryNormSquared, node)
+		}
 		var dot float64
 		for i, left := range query {
 			right := node.vectorValueAt(i)
@@ -1092,6 +1095,9 @@ func vectorDistanceBetweenStoredNodes(left, right *vectorIndexNode, metric Vecto
 	}
 	switch metric {
 	case VectorMetricCosine:
+		if len(left.vector) > 0 && len(right.vector) > 0 {
+			return vectorDistanceBetweenFloat32NodesCosine(left, right)
+		}
 		var dot float64
 		for i := 0; i < dims; i++ {
 			leftValue := left.vectorValueAt(i)
@@ -1120,6 +1126,41 @@ func vectorDistanceBetweenStoredNodes(left, right *vectorIndexNode, metric Vecto
 	default:
 		return 0, fmt.Errorf("collections: unsupported vector metric %d", metric)
 	}
+}
+
+func vectorDistanceToFloat32NodeCosine(query []float32, queryNormSquared float64, node *vectorIndexNode) (float32, error) {
+	if len(query) != len(node.vector) {
+		return 0, fmt.Errorf("collections: vector dimensions differ: %d vs %d", len(query), len(node.vector))
+	}
+	var dot float64
+	for i, left := range query {
+		dot += float64(left * node.vector[i])
+	}
+	leftNorm := queryNormSquared
+	if leftNorm < 0 {
+		leftNorm = vectorNormSquared(query)
+	}
+	rightNorm := node.cachedNormSquared()
+	if leftNorm == 0 || rightNorm == 0 {
+		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
+	}
+	return float32(1 - dot/(math.Sqrt(leftNorm)*math.Sqrt(rightNorm))), nil
+}
+
+func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (float32, error) {
+	if len(left.vector) != len(right.vector) {
+		return 0, fmt.Errorf("collections: vector dimensions differ: %d vs %d", len(left.vector), len(right.vector))
+	}
+	var dot float64
+	for i, leftValue := range left.vector {
+		dot += float64(leftValue * right.vector[i])
+	}
+	leftNorm := left.cachedNormSquared()
+	rightNorm := right.cachedNormSquared()
+	if leftNorm == 0 || rightNorm == 0 {
+		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
+	}
+	return float32(1 - dot/(math.Sqrt(leftNorm)*math.Sqrt(rightNorm))), nil
 }
 
 func (node *vectorIndexNode) vectorDimensions() int {

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -107,6 +108,39 @@ func TestVectorIndexInsertCachesInt8StoredNorm(t *testing.T) {
 	}
 	if got, want := node.normSquared, node.storedNormSquared(); got != want {
 		t.Fatalf("node cached norm=%v want dequantized norm %v", got, want)
+	}
+}
+
+func TestVectorIndexFloat32CosineSpecializationMatchesExactDistance(t *testing.T) {
+	query := []float32{0.25, -0.5, 1.25, 2}
+	node := vectorIndexNode{documentID: []byte("right"), vector: []float32{1.5, -0.25, 0.75, 3}}
+	node.normSquared = node.storedNormSquared()
+	queryNorm := vectorNormSquared(query)
+
+	gotQuery, err := vectorDistanceToFloat32NodeCosine(query, queryNorm, &node)
+	if err != nil {
+		t.Fatalf("specialized query distance: %v", err)
+	}
+	wantQuery, err := exactVectorDistance(query, node.vector, VectorMetricCosine)
+	if err != nil {
+		t.Fatalf("exact query distance: %v", err)
+	}
+	if math.Abs(float64(gotQuery-wantQuery)) > 1e-6 {
+		t.Fatalf("specialized query distance=%v want %v", gotQuery, wantQuery)
+	}
+
+	left := vectorIndexNode{documentID: []byte("left"), vector: query}
+	left.normSquared = left.storedNormSquared()
+	gotBetween, err := vectorDistanceBetweenFloat32NodesCosine(&left, &node)
+	if err != nil {
+		t.Fatalf("specialized node distance: %v", err)
+	}
+	wantBetween, err := exactVectorDistance(left.vector, node.vector, VectorMetricCosine)
+	if err != nil {
+		t.Fatalf("exact node distance: %v", err)
+	}
+	if math.Abs(float64(gotBetween-wantBetween)) > 1e-6 {
+		t.Fatalf("specialized node distance=%v want %v", gotBetween, wantBetween)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add direct float32-slice cosine distance helpers for the hot TreeDB vector index paths.
- Route cosine query-to-node and node-to-node distance calls through the specialized helpers only when stored nodes are float32 encoded.
- Keep int8 and non-cosine distance paths on the existing generic implementation.

## TDD

Added `TestVectorIndexFloat32CosineSpecializationMatchesExactDistance` first. Before implementation, it failed to compile because `vectorDistanceToFloat32NodeCosine` and `vectorDistanceBetweenFloat32NodesCosine` did not exist.

## Validation

- `go test ./TreeDB/collections -run '^TestVectorIndexFloat32CosineSpecializationMatchesExactDistance$' -count=1`
- `go test ./TreeDB/collections -run 'TestVectorIndex(Float32CosineSpecializationMatchesExactDistance|InsertCachesStoredNorm|InsertCachesInt8StoredNorm|PruneLayerNeighborsUsesDistanceThenDocumentID)$' -count=1`
- `go test ./TreeDB/collections -count=1`
- `git diff --check`

Benchmarks on this branch:

- 10k x 64 build: `2.548s`, `2.528s`, `2.520s`; prior #1516/#1515 reference was `2.870-2.907s`.
- 10k x 64 incremental write: `2.575s`, `2.584s`, `2.567s`; prior #1516 reference was `2.914-2.937s`.
- 3k x 64 build: `613.9ms`, `613.3ms`, `605.8ms`.
- 3k x 64 incremental write: `646.5ms`, `630.0ms`, `624.7ms`.
- 10k x 64 search smoke: Search `1.872ms/op`, graph-only `0.734ms/op`.
- 3k x 64 int8 build smoke: `840.7ms/op`.

## Profile Evidence

Artifacts:

- Build CPU: `/tmp/treedb_vector_priority3_profile/build/cpu.pprof`
- Build allocs: `/tmp/treedb_vector_priority3_profile/build/mem.pprof`
- Incremental write CPU: `/tmp/treedb_vector_priority3_profile/write/cpu.pprof`
- Incremental write allocs: `/tmp/treedb_vector_priority3_profile/write/mem.pprof`

10k x 64 build profile after this change:

- `vectorDistanceToStoredNodeWithQueryNorm`: cumulative `1.22s`, mostly dispatch into `vectorDistanceToFloat32NodeCosine`.
- `vectorDistanceToFloat32NodeCosine`: cumulative `1.16s`.
- `vectorDistanceBetweenStoredNodes`: cumulative `0.66s`, mostly dispatch into `vectorDistanceBetweenFloat32NodesCosine`.
- `vectorDistanceBetweenFloat32NodesCosine`: cumulative `0.65s`.

10k x 64 incremental-write profile after this change:

- `insertVectorLocked`: cumulative `2.61s`.
- `searchLayerLocked`: cumulative `1.58s`.
- `vectorDistanceToFloat32NodeCosine`: cumulative `1.21s`.
- `vectorDistanceBetweenFloat32NodesCosine`: cumulative `0.60s`.

The remaining allocation profile is still dominated by `searchLayerLocked`, which supports keeping Priority 4 as the next optimization target.

Follow-on to #1516. Part of #1513 Priority 3.
