### PR TITLE
[codex] reuse vector search scratch buffers

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -124,11 +124,13 @@ type VectorIndex struct {
 	efSearch            int
 	rebuildDeletedRatio float64
 
-	mu          sync.RWMutex
-	nodes       []vectorIndexNode
-	currentNode map[string]int
-	entry       int
-	maxLevel    int
+	mu            sync.RWMutex
+	nodes         []vectorIndexNode
+	currentNode   map[string]int
+	entry         int
+	maxLevel      int
+	insertScratch vectorIndexSearchScratch
+	searchScratch sync.Pool
 
 	mutationSeq            uint64
 	persistedEpoch         uint64
@@ -438,7 +440,7 @@ func (idx *VectorIndex) insertVectorLocked(documentID []byte, vector []float32) 
 		entryPoint = idx.greedyNearestAtLayerLocked(vector, vectorNorm, entryPoint, layer)
 	}
 	for layer := minInt(level, idx.maxLevel); layer >= 0; layer-- {
-		candidates := idx.searchLayerLocked(vector, vectorNorm, entryPoint, idx.efConstruction, layer)
+		candidates := idx.searchLayerWithScratchLocked(vector, vectorNorm, entryPoint, idx.efConstruction, layer, &idx.insertScratch)
 		neighbors := idx.selectLayerNeighborsLocked(vector, vectorNorm, candidates, layer, idx.maxNeighborsForLayer(layer), nodeID)
 		for _, neighborID := range neighbors {
 			idx.linkLayerLocked(nodeID, neighborID, layer)
@@ -726,7 +728,8 @@ func (idx *VectorIndex) Search(query []float32, opts VectorIndexSearchOptions) (
 		trace.Strategy = "ann_postfilter"
 	}
 	idx.mu.RLock()
-	candidates := idx.searchCandidatesLocked(query, queryNorm, candidateLimit)
+	scratch := idx.getSearchScratch()
+	candidates := idx.searchCandidatesLocked(query, queryNorm, candidateLimit, scratch)
 	trace.CandidatesExamined = len(candidates)
 	candidateIDs := make([][]byte, 0, len(candidates))
 	for _, candidate := range candidates {
@@ -743,6 +746,7 @@ func (idx *VectorIndex) Search(query []float32, opts VectorIndexSearchOptions) (
 		}
 		candidateIDs = append(candidateIDs, bytes.Clone(node.documentID))
 	}
+	idx.putSearchScratch(scratch)
 	idx.mu.RUnlock()
 	trace.CandidatesAfterTombstone = len(candidateIDs)
 
@@ -814,7 +818,8 @@ func (idx *VectorIndex) searchGraphOnly(query []float32, topK, efSearch int) ([]
 	if limit < topK {
 		limit = topK
 	}
-	candidates := idx.searchCandidatesLocked(query, queryNorm, limit)
+	scratch := idx.getSearchScratch()
+	candidates := idx.searchCandidatesLocked(query, queryNorm, limit, scratch)
 	results := make([]VectorSearchResult, 0, minInt(topK, len(candidates)))
 	for _, candidate := range candidates {
 		if len(results) >= topK {
@@ -836,6 +841,7 @@ func (idx *VectorIndex) searchGraphOnly(query []float32, topK, efSearch int) ([]
 			Distance:   candidate.distance,
 		})
 	}
+	idx.putSearchScratch(scratch)
 	return results, nil
 }
 
@@ -899,7 +905,7 @@ func (idx *VectorIndex) rerankCandidates(query []float32, candidateIDs [][]byte,
 	return results, nil
 }
 
-func (idx *VectorIndex) searchCandidatesLocked(query []float32, queryNormSquared float64, limit int) []vectorIndexCandidate {
+func (idx *VectorIndex) searchCandidatesLocked(query []float32, queryNormSquared float64, limit int, scratch *vectorIndexSearchScratch) []vectorIndexCandidate {
 	if idx.entry < 0 || len(idx.nodes) == 0 || limit <= 0 {
 		return nil
 	}
@@ -907,7 +913,7 @@ func (idx *VectorIndex) searchCandidatesLocked(query []float32, queryNormSquared
 	for layer := idx.maxLevel; layer > 0; layer-- {
 		entryPoint = idx.greedyNearestAtLayerLocked(query, queryNormSquared, entryPoint, layer)
 	}
-	return idx.searchLayerLocked(query, queryNormSquared, entryPoint, limit, 0)
+	return idx.searchLayerWithScratchLocked(query, queryNormSquared, entryPoint, limit, 0, scratch)
 }
 
 func (idx *VectorIndex) greedyNearestAtLayerLocked(query []float32, queryNormSquared float64, entryPoint int, layer int) int {
@@ -932,6 +938,24 @@ func (idx *VectorIndex) greedyNearestAtLayerLocked(query []float32, queryNormSqu
 }
 
 func (idx *VectorIndex) searchLayerLocked(query []float32, queryNormSquared float64, entryPoint int, limit int, layer int) []vectorIndexCandidate {
+	return idx.searchLayerWithScratchLocked(query, queryNormSquared, entryPoint, limit, layer, nil)
+}
+
+func (idx *VectorIndex) getSearchScratch() *vectorIndexSearchScratch {
+	if scratch, ok := idx.searchScratch.Get().(*vectorIndexSearchScratch); ok {
+		return scratch
+	}
+	return &vectorIndexSearchScratch{}
+}
+
+func (idx *VectorIndex) putSearchScratch(scratch *vectorIndexSearchScratch) {
+	if scratch == nil {
+		return
+	}
+	idx.searchScratch.Put(scratch)
+}
+
+func (idx *VectorIndex) searchLayerWithScratchLocked(query []float32, queryNormSquared float64, entryPoint int, limit int, layer int, scratch *vectorIndexSearchScratch) []vectorIndexCandidate {
 	if entryPoint < 0 || entryPoint >= len(idx.nodes) || limit <= 0 {
 		return nil
 	}
@@ -939,12 +963,15 @@ func (idx *VectorIndex) searchLayerLocked(query []float32, queryNormSquared floa
 	if math.IsInf(float64(entryDistance), 1) {
 		return nil
 	}
-	visited := make([]bool, len(idx.nodes))
-	visited[entryPoint] = true
+	if scratch == nil {
+		scratch = &vectorIndexSearchScratch{}
+	}
+	visited, mark := scratch.nextVisitedEpoch(len(idx.nodes))
+	visited[entryPoint] = mark
 	entry := vectorIndexCandidate{nodeID: entryPoint, distance: entryDistance}
-	queue := make(vectorIndexMinCandidateHeap, 0, minInt(limit, 64))
+	queue := scratch.queue[:0]
 	queue.push(entry)
-	best := make(vectorIndexMaxCandidateHeap, 0, limit)
+	best := scratch.best[:0]
 	best.pushBounded(entry, limit)
 	for len(queue) > 0 {
 		current := queue.pop()
@@ -955,10 +982,10 @@ func (idx *VectorIndex) searchLayerLocked(query []float32, queryNormSquared floa
 			continue
 		}
 		for _, neighborID := range idx.layerNeighborsLocked(current.nodeID, layer) {
-			if neighborID < 0 || neighborID >= len(idx.nodes) || visited[neighborID] {
+			if neighborID < 0 || neighborID >= len(idx.nodes) || visited[neighborID] == mark {
 				continue
 			}
-			visited[neighborID] = true
+			visited[neighborID] = mark
 			distance := idx.distanceToNodeWithQueryNormLocked(query, queryNormSquared, neighborID)
 			if math.IsInf(float64(distance), 1) {
 				continue
@@ -970,7 +997,10 @@ func (idx *VectorIndex) searchLayerLocked(query []float32, queryNormSquared floa
 			}
 		}
 	}
-	out := append([]vectorIndexCandidate(nil), best...)
+	scratch.queue = queue[:0]
+	scratch.best = best[:0]
+	out := append(scratch.out[:0], best...)
+	scratch.out = out
 	sortVectorIndexCandidates(out)
 	return out
 }
@@ -1204,6 +1234,39 @@ func (node *vectorIndexNode) vectorBytes() int {
 type vectorIndexCandidate struct {
 	nodeID   int
 	distance float32
+}
+
+type vectorIndexSearchScratch struct {
+	visitedEpochs []uint32
+	visitedEpoch  uint32
+	queue         vectorIndexMinCandidateHeap
+	best          vectorIndexMaxCandidateHeap
+	out           []vectorIndexCandidate
+}
+
+func (scratch *vectorIndexSearchScratch) nextVisitedEpoch(nodes int) ([]uint32, uint32) {
+	if cap(scratch.visitedEpochs) < nodes {
+		scratch.visitedEpochs = make([]uint32, nodes, growVectorIndexScratchCapacity(cap(scratch.visitedEpochs), nodes))
+	} else {
+		scratch.visitedEpochs = scratch.visitedEpochs[:nodes]
+	}
+	scratch.visitedEpoch++
+	if scratch.visitedEpoch == 0 {
+		clear(scratch.visitedEpochs)
+		scratch.visitedEpoch = 1
+	}
+	return scratch.visitedEpochs, scratch.visitedEpoch
+}
+
+func growVectorIndexScratchCapacity(current int, required int) int {
+	next := current
+	if next < 64 {
+		next = 64
+	}
+	for next < required {
+		next *= 2
+	}
+	return next
 }
 
 func sortVectorIndexCandidates(candidates []vectorIndexCandidate) {

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -144,6 +144,68 @@ func TestVectorIndexFloat32CosineSpecializationMatchesExactDistance(t *testing.T
 	}
 }
 
+func TestVectorIndexSearchLayerScratchReusesBuffers(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("a"), vector: []float32{1, 0}, neighbors: [][]int{{1, 2}}},
+		{documentID: []byte("b"), vector: []float32{0.9, 0.1}, neighbors: [][]int{{0, 2}}},
+		{documentID: []byte("c"), vector: []float32{0, 1}, neighbors: [][]int{{0, 1}}},
+	}
+	for i := range index.nodes {
+		index.nodes[i].normSquared = index.nodes[i].storedNormSquared()
+	}
+	var scratch vectorIndexSearchScratch
+	query := []float32{1, 0}
+	queryNorm := vectorNormSquared(query)
+
+	first := index.searchLayerWithScratchLocked(query, queryNorm, 0, 3, 0, &scratch)
+	if len(first) != 3 || first[0].nodeID != 0 || first[1].nodeID != 1 || first[2].nodeID != 2 {
+		t.Fatalf("first candidates=%v want node IDs [0 1 2]", first)
+	}
+	if len(scratch.visitedEpochs) != len(index.nodes) || cap(scratch.queue) == 0 || cap(scratch.best) == 0 || cap(scratch.out) == 0 {
+		t.Fatalf("scratch was not populated: visited=%d queue_cap=%d best_cap=%d out_cap=%d", len(scratch.visitedEpochs), cap(scratch.queue), cap(scratch.best), cap(scratch.out))
+	}
+	visited := &scratch.visitedEpochs[0]
+	queueCap := cap(scratch.queue)
+	bestCap := cap(scratch.best)
+	outCap := cap(scratch.out)
+
+	second := index.searchLayerWithScratchLocked(query, queryNorm, 0, 3, 0, &scratch)
+	if len(second) != len(first) {
+		t.Fatalf("second candidates=%v want len %d", second, len(first))
+	}
+	if &scratch.visitedEpochs[0] != visited || cap(scratch.queue) != queueCap || cap(scratch.best) != bestCap || cap(scratch.out) != outCap {
+		t.Fatal("scratch buffers were not reused")
+	}
+}
+
+func TestVectorIndexSearchScratchVisitedEpochsGrowGeometrically(t *testing.T) {
+	var scratch vectorIndexSearchScratch
+
+	scratch.nextVisitedEpoch(64)
+	if cap(scratch.visitedEpochs) != 64 {
+		t.Fatalf("initial visited cap=%d want 64", cap(scratch.visitedEpochs))
+	}
+	scratch.nextVisitedEpoch(65)
+	if cap(scratch.visitedEpochs) != 128 {
+		t.Fatalf("visited cap after one-node growth=%d want 128", cap(scratch.visitedEpochs))
+	}
+	visited := &scratch.visitedEpochs[0]
+	for nodes := 66; nodes <= 128; nodes++ {
+		scratch.nextVisitedEpoch(nodes)
+		if &scratch.visitedEpochs[0] != visited {
+			t.Fatalf("visited epochs reallocated at nodes=%d before capacity was exhausted", nodes)
+		}
+	}
+}
+
 func TestCollectionVectorIndexInt8EncodingReranksCanonicalRows(t *testing.T) {
 	const (
 		docs = 24


### PR DESCRIPTION
## Summary

Implements Priority 4 from #1513: reuse scratch buffers around TreeDB vector ANN layer search.

Changes:
- Reuses build-time `searchLayer` scratch on the insert path for visited marks, candidate heaps, and sorted output.
- Adds a per-index `sync.Pool` for query/search scratch so graph-only search also avoids the old per-search visited/output allocation pattern without sharing mutable buffers across concurrent searches.
- Grows visited scratch geometrically; the first attempt grew by one node at a time during builds and profiling caught that as a new allocation hotspot.
- Adds focused TDD coverage for buffer reuse and geometric scratch growth.

## Evidence

Focused tests:
- `go test ./TreeDB/collections -run 'TestVectorIndexSearch(LayerScratchReusesBuffers|ScratchVisitedEpochsGrowGeometrically)$' -count=1`
- `go test -race ./TreeDB/collections -run 'Test(CollectionVectorIndexSearchReranksCanonicalRows|VectorIndexSearchLayerScratchReusesBuffers|VectorIndexSearchScratchVisitedEpochsGrowGeometrically)$' -count=1`

Package validation:
- `go test ./TreeDB/collections -count=1`
- `git diff --check`

Priority 3 base comparison from detached worktree at `b120e358`:
- `BenchmarkCollectionVectorIndexBuild`: `2.623s`, `258,373,240 B/op`, `261,819 allocs/op`
- `BenchmarkCollectionVectorIndexIncrementalWrite`: `2.587s`, `268,847,256 B/op`, `273,290 allocs/op`
- `BenchmarkCollectionVectorIndexSearch`: `1.264ms/op`, `576,722 B/op`, `1,289 allocs/op`
- `BenchmarkCollectionVectorIndexGraphOnlySearch`: `145.397us/op`, `22,258 B/op`, `17 allocs/op`

This PR:
- `BenchmarkCollectionVectorIndexBuild`: `2.683s`, `42,398,152 B/op`, `183,294 allocs/op`
- `BenchmarkCollectionVectorIndexIncrementalWrite`: `2.616s`, `52,857,608 B/op`, `194,725 allocs/op`
- `BenchmarkCollectionVectorIndexSearch`: `1.265ms/op`, `556,563 B/op`, `1,284 allocs/op`
- `BenchmarkCollectionVectorIndexGraphOnlySearch`: `146.767us/op`, `754 B/op`, `11 allocs/op`

Repeated 10k x 64 timing samples:
- Build: `2.586s`, `2.576s`, `2.587s`
- Incremental write: `2.680s`, `2.587s`, `2.796s`
- Search: `1.225ms`, `1.235ms`, `1.159ms`
- Graph-only search: `149.832us`, `206.364us`, `147.497us`

Final profile artifacts:
- Build CPU/mem: `/tmp/treedb_vector_priority4_profile_final/build/cpu.pprof`, `/tmp/treedb_vector_priority4_profile_final/build/mem.pprof`
- Write CPU/mem: `/tmp/treedb_vector_priority4_profile_final/write/cpu.pprof`, `/tmp/treedb_vector_priority4_profile_final/write/mem.pprof`

Profile notes:
- Before fixing geometric growth, `nextVisitedEpoch` allocated ~189-199MB by growing the visited slice one node at a time.
- Final allocation profiles no longer show `searchLayerWithScratchLocked` as a material build allocator; build profile total allocation is ~93MB and write profile total allocation is ~93MB.
- CPU remains dominated by the intended distance kernels: `vectorDistanceToFloat32NodeCosine` and `vectorDistanceBetweenFloat32NodesCosine`. This PR is primarily an allocation/GC-pressure reduction, not a material CPU-throughput win.

Part of #1513.
