### PR TITLE
[codex] try gonum f32 dot

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -13997,6 +13997,12 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			return false, ErrConcurrentMutation
 		}
 		currentBufferedPlan := plan.bufferedBase && plan.bufferedReadGeneration == domain.writeGeneration
+		if len(direct.templateEntries) > 0 && !currentBufferedPlan {
+			// Template-v1 IDs are collection-global; stale direct plans can reuse
+			// an ID even when their primary document writes do not conflict.
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, ErrConcurrentMutation
+		}
 		if !currentBufferedPlan && domain.directUpdatePlanHasPrimaryWriteConflictLocked(plan) {
 			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12750,6 +12750,123 @@ func TestCollectionUpdateBatchDirectBufferedTemplateV1AccumulatesRootRuns(t *tes
 	}
 }
 
+func TestCollectionUpdateBatchDirectBufferedTemplateV1RejectsStaleTemplatePlan(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatTemplateV1,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustTemplateV1Document(t, []string{"email", "city"}, []any{"a@example.com", "hnl"}),
+			mustTemplateV1Document(t, []string{"email", "city"}, []any{"b@example.com", "hnl"}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	itemsA, err := prepareUpdateBatchItems([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setTemplateV1JSON(t, `{"email":"a@example.com","city":"hnl","shape_a":1}`)},
+	})
+	if err != nil {
+		t.Fatalf("prepare stale plan A items: %v", err)
+	}
+	itemsB, err := prepareUpdateBatchItems([]UpdateBatchItem{
+		{DocumentID: []byte("u2"), Update: setTemplateV1JSON(t, `{"email":"b@example.com","city":"hnl","shape_b":1}`)},
+	})
+	if err != nil {
+		t.Fatalf("prepare stale plan B items: %v", err)
+	}
+	planA, err := col.buildUpdateBatchPlan(itemsA, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build plan A: %v", err)
+	}
+	defer planA.close()
+	planB, err := col.buildUpdateBatchPlan(itemsB, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build plan B: %v", err)
+	}
+	defer planB.close()
+	if planA.directBufferedUpdate == nil || len(planA.directBufferedUpdate.templateEntries) == 0 {
+		t.Fatal("plan A did not create direct buffered template entries")
+	}
+	if planB.directBufferedUpdate == nil || len(planB.directBufferedUpdate.templateEntries) == 0 {
+		t.Fatal("plan B did not create direct buffered template entries")
+	}
+
+	if err := col.withMutationLock(func() error {
+		buffered, err := col.bufferUpdateBatchPlanLocked(planA)
+		if err != nil {
+			return err
+		}
+		if !buffered {
+			return errors.New("plan A was not buffered")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("stage plan A: %v", err)
+	}
+	if err := col.withMutationLock(func() error {
+		buffered, err := col.bufferUpdateBatchPlanLocked(planB)
+		if !errors.Is(err, ErrConcurrentMutation) {
+			return fmt.Errorf("stale plan B buffered=%t err=%v, want ErrConcurrentMutation", buffered, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("stage stale plan B: %v", err)
+	}
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u2"), Update: setTemplateV1JSON(t, `{"email":"b@example.com","city":"hnl","shape_b":1}`)},
+	}); err != nil {
+		t.Fatalf("replanned public update B: %v", err)
+	} else if !batched {
+		t.Fatal("replanned public update B was declined")
+	}
+	for _, tc := range []struct {
+		id   []byte
+		want []byte
+	}{
+		{[]byte("u1"), []byte(`"shape_a":1`)},
+		{[]byte("u2"), []byte(`"shape_b":1`)},
+	} {
+		got, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		gotJSON, err := col.StoredDocumentJSON(got)
+		if err != nil {
+			t.Fatalf("materialize %s: %v", tc.id, err)
+		}
+		if !bytes.Contains(gotJSON, tc.want) {
+			t.Fatalf("document %s=%s missing %s", tc.id, gotJSON, tc.want)
+		}
+	}
+}
+
 func TestCollectionUpdateBatchDirectBufferedTemplateV1TemplateOnlySkipsSecondaryRoots(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/template_v1.go
+++ b/TreeDB/collections/template_v1.go
@@ -678,7 +678,7 @@ func (r *templateV1SnapshotResolver) lookupTemplateV1ByHash(hash [32]byte) (*tem
 		return nil, err
 	}
 	if tpl.hash != hash {
-		return nil, errors.New("collections: template-v1 template hash mismatch")
+		return nil, fmt.Errorf("collections: template-v1 template hash mismatch snapshot id=%d want=%x got=%x", id, hash, tpl.hash)
 	}
 	return tpl, nil
 }
@@ -764,7 +764,7 @@ func (r *templateV1BufferedRunsResolver) lookupTemplateV1ByHash(hash [32]byte) (
 			return nil, err
 		}
 		if tpl.hash != hash {
-			return nil, errors.New("collections: template-v1 template hash mismatch")
+			return nil, fmt.Errorf("collections: template-v1 template hash mismatch buffered id=%d want=%x got=%x", id, hash, tpl.hash)
 		}
 		return tpl, nil
 	}

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"gonum.org/v1/gonum/blas/blas32"
 )
 
 const (
@@ -1229,21 +1230,10 @@ func vectorDistanceToFloat32NodeCosinePrepared(query preparedFloat32CosineQuery,
 }
 
 func vectorDistanceToFloat32NodeCosineUnchecked(query preparedFloat32CosineQuery, node *vectorIndexNode) float32 {
-	q := query.vector
-	v := node.vector
-	var s0, s1, s2, s3 float32
-	i := 0
-	n := len(q)
-	for ; i+4 <= n; i += 4 {
-		s0 += q[i] * v[i]
-		s1 += q[i+1] * v[i+1]
-		s2 += q[i+2] * v[i+2]
-		s3 += q[i+3] * v[i+3]
-	}
-	dot := s0 + s1 + s2 + s3
-	for ; i < n; i++ {
-		dot += q[i] * v[i]
-	}
+	dot := blas32.Dot(
+		blas32.Vector{N: len(query.vector), Inc: 1, Data: query.vector},
+		blas32.Vector{N: len(node.vector), Inc: 1, Data: node.vector},
+	)
 	return 1 - dot*query.invNorm*node.cachedInvNorm
 }
 
@@ -1254,19 +1244,10 @@ func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (floa
 	if left.cachedInvNorm == 0 || right.cachedInvNorm == 0 {
 		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
 	}
-	var s0, s1, s2, s3 float32
-	i := 0
-	n := len(left.vector)
-	for ; i+4 <= n; i += 4 {
-		s0 += left.vector[i] * right.vector[i]
-		s1 += left.vector[i+1] * right.vector[i+1]
-		s2 += left.vector[i+2] * right.vector[i+2]
-		s3 += left.vector[i+3] * right.vector[i+3]
-	}
-	dot := s0 + s1 + s2 + s3
-	for ; i < n; i++ {
-		dot += left.vector[i] * right.vector[i]
-	}
+	dot := blas32.Dot(
+		blas32.Vector{N: len(left.vector), Inc: 1, Data: left.vector},
+		blas32.Vector{N: len(right.vector), Inc: 1, Data: right.vector},
+	)
 	return 1 - dot*left.cachedInvNorm*right.cachedInvNorm, nil
 }
 

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1592,7 +1592,7 @@ func (idx *VectorIndex) Rebuild() error {
 	idx.entry = entry
 	idx.maxLevel = maxLevel
 	idx.dimensions = dimensions
-	idx.lastRebuildDuration = time.Since(start)
+	idx.lastRebuildDuration = collectionObservedElapsedSince(start)
 	idx.markGraphChangedLocked()
 	idx.mu.Unlock()
 	idx.collection.RegisterVectorIndex(idx)

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1230,9 +1230,13 @@ func vectorDistanceToFloat32NodeCosinePrepared(query preparedFloat32CosineQuery,
 }
 
 func vectorDistanceToFloat32NodeCosineUnchecked(query preparedFloat32CosineQuery, node *vectorIndexNode) float32 {
+	n := len(query.vector)
+	if n != len(node.vector) {
+		panic(fmt.Sprintf("collections: vector dimensions differ: %d vs %d", n, len(node.vector)))
+	}
 	dot := blas32.Dot(
-		blas32.Vector{N: len(query.vector), Inc: 1, Data: query.vector},
-		blas32.Vector{N: len(node.vector), Inc: 1, Data: node.vector},
+		blas32.Vector{N: n, Inc: 1, Data: query.vector},
+		blas32.Vector{N: n, Inc: 1, Data: node.vector},
 	)
 	return 1 - dot*query.invNorm*node.cachedInvNorm
 }
@@ -1244,9 +1248,10 @@ func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (floa
 	if left.cachedInvNorm == 0 || right.cachedInvNorm == 0 {
 		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
 	}
+	n := len(left.vector)
 	dot := blas32.Dot(
-		blas32.Vector{N: len(left.vector), Inc: 1, Data: left.vector},
-		blas32.Vector{N: len(right.vector), Inc: 1, Data: right.vector},
+		blas32.Vector{N: n, Inc: 1, Data: left.vector},
+		blas32.Vector{N: n, Inc: 1, Data: right.vector},
 	)
 	return 1 - dot*left.cachedInvNorm*right.cachedInvNorm, nil
 }

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -761,7 +762,11 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 }
 
 func fsyncFile(path string) error {
-	f, err := os.Open(path)
+	flag := os.O_RDONLY
+	if runtime.GOOS == "windows" {
+		flag = os.O_RDWR
+	}
+	f, err := os.OpenFile(path, flag, 0)
 	if err != nil {
 		return err
 	}
@@ -770,6 +775,9 @@ func fsyncFile(path string) error {
 }
 
 func fsyncDir(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return err

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -99,6 +99,13 @@ type leafPageReadCacheSlot struct {
 	readMissEpoch       atomic.Uint64
 }
 
+func (s *leafPageReadCacheSlot) ReleaseLeafLogPageView() {
+	if s == nil {
+		return
+	}
+	s.mu.RUnlock()
+}
+
 type leafPageReadCache struct {
 	slots []leafPageReadCacheSlot
 
@@ -369,6 +376,22 @@ func (c *leafPageReadCache) getTo(ptr page.LeafLogPtr, dst []byte) ([]byte, bool
 	slot.mu.RUnlock()
 	c.hits.Add(1)
 	return data, false, true
+}
+
+func (c *leafPageReadCache) getViewLocked(ptr page.LeafLogPtr) ([]byte, *leafPageReadCacheSlot, bool) {
+	if c == nil || len(c.slots) == 0 {
+		return nil, nil, false
+	}
+	key := newLeafPageReadCacheKey(ptr)
+	slot := &c.slots[c.slotIndex(key)]
+	slot.mu.RLock()
+	if !slot.valid || slot.key != key {
+		slot.mu.RUnlock()
+		return nil, nil, false
+	}
+	data := slot.data
+	c.hits.Add(1)
+	return data, slot, true
 }
 
 func (c *leafPageReadCache) stats() leafPageReadCacheStats {

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -318,6 +318,46 @@ func TestValueReaderLeafLogPageUnsafeToSmallDstBypassesCache(t *testing.T) {
 	}
 }
 
+func TestValueReaderLeafLogPageUnsafeViewLocksUntilRelease(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	ptrA := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	ptrB := page.LeafLogPtr{FileID: 9, Offset: 256, RecordLengthHint: 4096}
+	leafA := bytes.Repeat([]byte{0x33}, page.PageSize)
+	leafB := bytes.Repeat([]byte{0x55}, page.PageSize)
+	cache.store(ptrA, leafA)
+
+	reader := valueReader{
+		vlogs:         &leafPageCacheTestFallback{err: errors.New("fallback should not be used")},
+		leafPageCache: cache,
+	}
+	view, lease, ok, err := reader.ReadLeafLogPageUnsafeView(ptrA)
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeView: %v", err)
+	}
+	if !ok || lease == nil || !bytes.Equal(view, leafA) {
+		t.Fatalf("cache view mismatch ok=%v leaseNil=%v", ok, lease == nil)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cache.store(ptrB, leafB)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("cache store completed while view lease was held")
+	case <-time.After(10 * time.Millisecond):
+	}
+	lease.ReleaseLeafLogPageView()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache store did not complete after view release")
+	}
+}
+
 func TestValueReaderLeafLogPageUnsafeToAdmitsRepeatedReadMiss(t *testing.T) {
 	cache := newLeafPageReadCache(8)
 	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -106,6 +106,17 @@ func (r valueReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([
 	return val, usedDst, nil
 }
 
+func (r valueReader) ReadLeafLogPageUnsafeView(ptr page.LeafLogPtr) ([]byte, tree.LeafLogPageViewLease, bool, error) {
+	if r.vlogs == nil {
+		return nil, nil, false, errors.New("treedb: missing value-log reader")
+	}
+	if r.leafPageCache == nil {
+		return nil, nil, false, nil
+	}
+	data, release, ok := r.leafPageCache.getViewLocked(ptr)
+	return data, release, ok, nil
+}
+
 func (r valueReader) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error) {
 	if r.vlogs == nil {
 		return nil, errors.New("treedb: missing value-log reader")

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -135,6 +135,19 @@ func NewNodeView(data []byte) Node {
 	return n
 }
 
+// InitNodeView resets n to wrap the given page data without allocating.
+func InitNodeView(n *Node, data []byte) {
+	if n == nil {
+		return
+	}
+	*n = Node{data: data}
+	if len(data) >= NodeHeaderSize {
+		flags := getUint16At(data, 12)
+		n.ptype = page.PageType(flags & pageTypeMask)
+		n.count = getUint16At(data, 14)
+	}
+}
+
 // SetKeyScratch installs caller-owned key scratch for prefix key reconstruction.
 // The slice must not be mutated concurrently while the node is in use.
 func (n *Node) SetKeyScratch(buf []byte) {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -128,6 +128,17 @@ type leafLogPageUnsafeToReader interface {
 	ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([]byte, bool, error)
 }
 
+// LeafLogPageViewLease releases a read-only leaf-log page view.
+type LeafLogPageViewLease interface {
+	ReleaseLeafLogPageView()
+}
+
+// Optional fast path for read-only leaf-log page views. The lease must be
+// released before the caller lets the returned page slice escape.
+type leafLogPageUnsafeViewReader interface {
+	ReadLeafLogPageUnsafeView(ptr page.LeafLogPtr) ([]byte, LeafLogPageViewLease, bool, error)
+}
+
 // Optional capability gate for key-aware pointer read interfaces.
 type slabKeyAwareCapability interface {
 	KeyAwareEnabled() bool
@@ -165,6 +176,7 @@ type Tree struct {
 	slabKeyAppender slabUnsafeKeyAppender
 	slabKeyBatcher  slabUnsafeKeyBatchAppender
 	leafLogToReader leafLogPageUnsafeToReader
+	leafLogView     leafLogPageUnsafeViewReader
 	rootPageID      uint64
 }
 
@@ -186,6 +198,9 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 	}
 	if leafToReader, ok := sr.(leafLogPageUnsafeToReader); ok {
 		t.leafLogToReader = leafToReader
+	}
+	if leafView, ok := sr.(leafLogPageUnsafeViewReader); ok {
+		t.leafLogView = leafView
 	}
 	if keyAwareEnabled {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {
@@ -224,6 +239,11 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.leafLogToReader = leafToReader
 	} else {
 		t.leafLogToReader = nil
+	}
+	if leafView, ok := sr.(leafLogPageUnsafeViewReader); ok {
+		t.leafLogView = leafView
+	} else {
+		t.leafLogView = nil
 	}
 	if keyAwarePointerReadsEnabled(sr) {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {
@@ -266,8 +286,16 @@ func (t *Tree) loadNodeView(pageID uint64, verifyAlways bool) (node.Node, error)
 }
 
 func (t *Tree) loadLeafLogNodeView(ptr page.LogRecordRef, iterator bool) (node.Node, error) {
+	var n node.Node
+	if err := t.loadLeafLogNodeViewInto(&n, ptr, iterator); err != nil {
+		return node.Node{}, err
+	}
+	return n, nil
+}
+
+func (t *Tree) loadLeafLogNodeViewInto(dst *node.Node, ptr page.LogRecordRef, iterator bool) error {
 	if t.slabReader == nil {
-		return node.Node{}, errors.New("missing slab reader")
+		return errors.New("missing slab reader")
 	}
 	var (
 		data []byte
@@ -279,56 +307,80 @@ func (t *Tree) loadLeafLogNodeView(ptr page.LogRecordRef, iterator bool) (node.N
 		data, err = t.slabReader.ReadUnsafe(ptr.ValuePtr())
 	}
 	if err != nil {
-		return node.Node{}, err
+		return err
 	}
-	return validateLeafLogNode(data, ptr, t.shouldVerifyLeafRefChecksum(), iterator)
+	return validateLeafLogNodeInto(dst, data, ptr, t.shouldVerifyLeafRefChecksum(), iterator)
 }
 
 func validateLeafLogNode(data []byte, ptr page.LogRecordRef, verifyChecksum bool, iterator bool) (node.Node, error) {
-	if len(data) != page.PageSize {
-		return node.Node{}, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+	var n node.Node
+	if err := validateLeafLogNodeInto(&n, data, ptr, verifyChecksum, iterator); err != nil {
+		return node.Node{}, err
 	}
-	n := node.NewNodeView(data)
-	if verifyChecksum && !n.VerifyChecksum() {
-		return node.Node{}, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
-	}
-	if n.Type() != page.PageTypeLeaf {
-		return node.Node{}, fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
-	}
-	noteOuterLeafLoad(ptr.ValuePtr(), len(data), iterator)
 	return n, nil
 }
 
-func (t *Tree) loadChildRefView(ref page.ChildRef, verifyAlways bool, iterator bool) (node.Node, error) {
-	if ref.Kind == page.ChildRefLeafLog {
-		return t.loadLeafLogNodeView(ref.Log, iterator)
+func validateLeafLogNodeInto(dst *node.Node, data []byte, ptr page.LogRecordRef, verifyChecksum bool, iterator bool) error {
+	if len(data) != page.PageSize {
+		return fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
 	}
-	return t.loadNodeViewWithLoadKind(ref.Page, verifyAlways, iterator)
+	node.InitNodeView(dst, data)
+	if verifyChecksum && !dst.VerifyChecksum() {
+		return fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
+	}
+	if dst.Type() != page.PageTypeLeaf {
+		return fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", dst.Type(), ptr.FileID, ptr.Offset)
+	}
+	noteOuterLeafLoad(ptr.ValuePtr(), len(data), iterator)
+	return nil
+}
+
+func (t *Tree) loadChildRefView(ref page.ChildRef, verifyAlways bool, iterator bool) (node.Node, error) {
+	var n node.Node
+	if err := t.loadChildRefViewInto(&n, ref, verifyAlways, iterator); err != nil {
+		return node.Node{}, err
+	}
+	return n, nil
+}
+
+func (t *Tree) loadChildRefViewInto(dst *node.Node, ref page.ChildRef, verifyAlways bool, iterator bool) error {
+	if ref.Kind == page.ChildRefLeafLog {
+		return t.loadLeafLogNodeViewInto(dst, ref.Log, iterator)
+	}
+	return t.loadNodeViewWithLoadKindInto(dst, ref.Page, verifyAlways, iterator)
 }
 
 func (t *Tree) loadNodeViewWithLoadKind(pageID uint64, verifyAlways bool, iterator bool) (node.Node, error) {
+	var n node.Node
+	if err := t.loadNodeViewWithLoadKindInto(&n, pageID, verifyAlways, iterator); err != nil {
+		return node.Node{}, err
+	}
+	return n, nil
+}
+
+func (t *Tree) loadNodeViewWithLoadKindInto(dst *node.Node, pageID uint64, verifyAlways bool, iterator bool) error {
 	if t == nil {
-		return node.Node{}, errors.New("missing tree")
+		return errors.New("missing tree")
 	}
 	if t.pager == nil {
-		return node.Node{}, errors.New("missing pager")
+		return errors.New("missing pager")
 	}
 	// Use Get (mmap) instead of ReadPage (Copy).
 	data, err := t.pager.Get(pageID)
 	if err != nil {
-		return node.Node{}, err
+		return err
 	}
-	n := node.NewNodeView(data) // VerifyChecksum is fast (CRC32C hardware accelerated).
+	node.InitNodeView(dst, data) // VerifyChecksum is fast (CRC32C hardware accelerated).
 	// We use Verified Cache to skip it if already checked.
 	if verifyAlways || !t.pager.IsVerified(pageID) {
-		if !n.VerifyChecksum() {
-			return node.Node{}, fmt.Errorf("checksum mismatch on page %d", pageID)
+		if !dst.VerifyChecksum() {
+			return fmt.Errorf("checksum mismatch on page %d", pageID)
 		}
 		if !verifyAlways {
 			t.pager.MarkVerified(pageID)
 		}
 	}
-	return n, nil
+	return nil
 }
 
 // GetEntry returns the persisted leaf entry for key.
@@ -343,8 +395,8 @@ func (t *Tree) GetEntry(key []byte) (node.LeafEntry, error) {
 	}
 
 	for depth := 0; depth < 50; depth++ {
-		n, err := t.loadChildRefView(currRef, verifyAlways, false)
-		if err != nil {
+		var n node.Node
+		if err := t.loadChildRefViewInto(&n, currRef, verifyAlways, false); err != nil {
 			return node.LeafEntry{}, err
 		}
 
@@ -414,59 +466,73 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 			n                node.Node
 			leafScratch      *leafRefPageScratch
 			leafScratchOwned bool
+			leafViewLease    LeafLogPageViewLease
 			loadedLeafRef    bool
 		)
 
 		if appendMode {
 			if currRef.Kind == page.ChildRefLeafLog && t.slabReader != nil {
 				ptr := currRef.Log
-				leafScratch = getLeafRefPageScratch()
 				var (
 					data []byte
 					err  error
 				)
-				if t.leafLogToReader != nil {
-					var usedDst bool
-					data, usedDst, err = t.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, leafScratch.buf)
+				if t.leafLogView != nil {
+					var ok bool
+					data, leafViewLease, ok, err = t.leafLogView.ReadLeafLogPageUnsafeView(ptr)
 					if err != nil {
-						putLeafRefPageScratch(leafScratch)
 						return nil, page.ValuePtr{}, 0, false, err
 					}
-					loadedLeafRef = true
-					leafScratchOwned = usedDst
-					if !usedDst {
+					if ok {
+						loadedLeafRef = true
+					}
+				}
+				if !loadedLeafRef {
+					leafScratch = getLeafRefPageScratch()
+					if t.leafLogToReader != nil {
+						var usedDst bool
+						data, usedDst, err = t.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, leafScratch.buf)
+						if err != nil {
+							putLeafRefPageScratch(leafScratch)
+							return nil, page.ValuePtr{}, 0, false, err
+						}
+						loadedLeafRef = true
+						leafScratchOwned = usedDst
+						if !usedDst {
+							putLeafRefPageScratch(leafScratch)
+							leafScratch = nil
+						}
+					} else if t.slabToReader != nil {
+						var usedDst bool
+						data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr.ValuePtr(), leafScratch.buf)
+						if err != nil {
+							putLeafRefPageScratch(leafScratch)
+							return nil, page.ValuePtr{}, 0, false, err
+						}
+						loadedLeafRef = true
+						leafScratchOwned = usedDst
+						if !usedDst {
+							putLeafRefPageScratch(leafScratch)
+							leafScratch = nil
+						}
+					} else if t.slabAppender != nil {
+						data, err = t.slabAppender.ReadUnsafeAppend(ptr.ValuePtr(), leafScratch.buf[:0])
+						if err != nil {
+							putLeafRefPageScratch(leafScratch)
+							return nil, page.ValuePtr{}, 0, false, err
+						}
+						loadedLeafRef = true
+						leafScratchOwned = true
+					} else {
 						putLeafRefPageScratch(leafScratch)
 						leafScratch = nil
 					}
-				} else if t.slabToReader != nil {
-					var usedDst bool
-					data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr.ValuePtr(), leafScratch.buf)
-					if err != nil {
-						putLeafRefPageScratch(leafScratch)
-						return nil, page.ValuePtr{}, 0, false, err
-					}
-					loadedLeafRef = true
-					leafScratchOwned = usedDst
-					if !usedDst {
-						putLeafRefPageScratch(leafScratch)
-						leafScratch = nil
-					}
-				} else if t.slabAppender != nil {
-					data, err = t.slabAppender.ReadUnsafeAppend(ptr.ValuePtr(), leafScratch.buf[:0])
-					if err != nil {
-						putLeafRefPageScratch(leafScratch)
-						return nil, page.ValuePtr{}, 0, false, err
-					}
-					loadedLeafRef = true
-					leafScratchOwned = true
-				} else {
-					putLeafRefPageScratch(leafScratch)
-					leafScratch = nil
 				}
 				if loadedLeafRef {
-					var err error
-					n, err = validateLeafLogNode(data, ptr, t.shouldVerifyLeafRefChecksum(), false)
-					if err != nil {
+					if err := validateLeafLogNodeInto(&n, data, ptr, t.shouldVerifyLeafRefChecksum(), false); err != nil {
+						if leafViewLease != nil {
+							leafViewLease.ReleaseLeafLogPageView()
+						}
 						if leafScratchOwned {
 							putLeafRefPageScratch(leafScratch)
 						}
@@ -477,9 +543,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 		}
 
 		if !loadedLeafRef {
-			var err error
-			n, err = t.loadChildRefView(currRef, verifyAlways, false)
-			if err != nil {
+			if err := t.loadChildRefViewInto(&n, currRef, verifyAlways, false); err != nil {
 				return nil, page.ValuePtr{}, 0, false, err
 			}
 		}
@@ -507,12 +571,18 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 		case page.PageTypeLeaf:
 			idx, found, err := n.SearchLeaf(key)
 			if err != nil {
+				if leafViewLease != nil {
+					leafViewLease.ReleaseLeafLogPageView()
+				}
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
 				return nil, page.ValuePtr{}, 0, false, err
 			}
 			if !found {
+				if leafViewLease != nil {
+					leafViewLease.ReleaseLeafLogPageView()
+				}
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
@@ -521,6 +591,9 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 
 			val, ptr, flags, err := n.GetLeafValueView(idx)
 			if err != nil {
+				if leafViewLease != nil {
+					leafViewLease.ReleaseLeafLogPageView()
+				}
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
@@ -531,10 +604,16 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				if val != nil {
 					out = append(dst, val...)
 				}
+				if leafViewLease != nil {
+					leafViewLease.ReleaseLeafLogPageView()
+				}
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
 				return out, ptr, flags, true, nil
+			}
+			if leafViewLease != nil {
+				leafViewLease.ReleaseLeafLogPageView()
 			}
 			if leafScratchOwned {
 				putLeafRefPageScratch(leafScratch)
@@ -542,6 +621,9 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 			return val, ptr, flags, false, nil
 
 		default:
+			if leafViewLease != nil {
+				leafViewLease.ReleaseLeafLogPageView()
+			}
 			if leafScratchOwned {
 				putLeafRefPageScratch(leafScratch)
 			}
@@ -714,8 +796,8 @@ func (t *Tree) Has(key []byte) (bool, error) {
 	}
 
 	for depth := 0; depth < 50; depth++ {
-		n, err := t.loadChildRefView(currRef, verifyAlways, false)
-		if err != nil {
+		var n node.Node
+		if err := t.loadChildRefViewInto(&n, currRef, verifyAlways, false); err != nil {
 			return false, err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.etcd.io/bbolt v1.4.3
 	go.mongodb.org/mongo-driver/v2 v2.6.0
 	golang.org/x/sys v0.35.0
+	gonum.org/v1/gonum v0.16.0
 	gonum.org/v1/plot v0.16.0
 )
 


### PR DESCRIPTION
## Summary
- replace the TreeDB float32 cosine dot loops with gonum/blas32.Dot in query-to-node and node-to-node cosine distance paths
- keep the existing prepared inverse-norm structure from #1519
- use the repo's existing Gonum v0.16.0 module version, so this does not raise the go directive

## Benchmark evidence
Baseline is #1519 / codex/treedb-vector-prepared-cosine-query on the same host.

Distance microbench, 4096 candidates x 64 dims, benchtime=200ms, count=3:
- baseline prepared_unchecked: ~111-114 us/op
- this PR prepared_unchecked: 53.111, 54.735, 53.617 us/op

10k docs x 64 dims build/write, benchtime=1x, count=3:
- baseline build: 1.981, 2.004, 2.035 s/op
- this PR build: 1.378, 1.348, 1.358 s/op
- baseline incremental write: 2.032, 2.007, 1.993 s/op
- this PR incremental write: 1.406, 1.403, 1.400 s/op

10k docs x 64 dims search, benchtime=100x, count=3:
- baseline integrated search: 1.120, 1.103, 1.117 ms/op
- this PR integrated search: 1.092, 1.128, 1.102 ms/op
- baseline graph-only search: 104, 101, 106 us/op
- this PR graph-only search: 68.699, 64.455, 66.860 us/op

Profile evidence:
- /tmp/treedb_vector_gonum_profile/build_cpu.pprof
- /tmp/treedb_vector_gonum_profile/build_mem.pprof
- build profile shows gonum.org/v1/gonum/internal/asm/f32.DotUnitary as the dot kernel after replacing both query-node and node-node dot paths

## Validation
- go test ./TreeDB/collections -run 'Test(VectorIndexFloat32CosineSpecializationMatchesExactDistance|CollectionVectorIndexSearchReranksCanonicalRows)$' -count=1
- go test ./TreeDB/collections -count=1
- git diff --check