### PR TITLE
[codex] add parallel vector graph search benchmark

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -274,6 +274,46 @@ func BenchmarkCollectionVectorIndexGraphOnlySearch(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectionVectorIndexGraphOnlySearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, col := openVectorBenchmarkCollection(b, docs, dims)
+	defer func() { _ = d.Close() }()
+	index, err := col.BuildVectorIndex(VectorIndexOptions{
+		Name:   "embedding_graph_only_parallel",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      16,
+	})
+	if err != nil {
+		b.Fatalf("build vector index: %v", err)
+	}
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+	if err != nil {
+		b.Fatalf("warm graph-only search: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatal("warm graph-only search returned no results")
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+			if err != nil {
+				b.Fatalf("graph-only vector search: %v", err)
+			}
+			if len(results) == 0 {
+				b.Fatal("graph-only vector search returned no results")
+			}
+		}
+	})
+}
+
 func BenchmarkCollectionVectorIndexSearchInt8(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -301,17 +302,31 @@ func BenchmarkCollectionVectorIndexGraphOnlySearchParallel(b *testing.B) {
 	b.ReportMetric(float64(dims), "dims")
 	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
 	b.ResetTimer()
+	var failureMu sync.Mutex
+	var firstFailure string
+	recordFailure := func(format string, args ...any) {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		if firstFailure == "" {
+			firstFailure = fmt.Sprintf(format, args...)
+		}
+	}
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
 			if err != nil {
-				b.Fatalf("graph-only vector search: %v", err)
+				recordFailure("graph-only vector search: %v", err)
+				return
 			}
 			if len(results) == 0 {
-				b.Fatal("graph-only vector search returned no results")
+				recordFailure("graph-only vector search returned no results")
+				return
 			}
 		}
 	})
+	if firstFailure != "" {
+		b.Fatal(firstFailure)
+	}
 }
 
 func BenchmarkCollectionVectorIndexSearchInt8(b *testing.B) {


### PR DESCRIPTION
## Summary
- add BenchmarkCollectionVectorIndexGraphOnlySearchParallel using b.RunParallel
- keeps the benchmark on the graph-only path so it directly exercises concurrent query traversal over the in-memory index
- records docs, dims, and index_bytes like the serial graph-only benchmark

## Local benchmark evidence
Command:

TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorIndexGraphOnlySearch(Parallel)?$' -benchtime=100x -count=3 -benchmem

Results:
- serial graph-only: 67.877, 64.827, 68.633 us/op
- parallel graph-only: 16.544, 16.675, 16.906 us/op

This confirms independent graph-only searches can run concurrently through the existing RLock plus scratch-pool path.

## Validation
- go test ./TreeDB/collections -count=1
- git diff --check

Stacked on #1523.