### PR TITLE
[codex] reuse vector candidate distances

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1054,11 +1054,10 @@ func (idx *VectorIndex) selectLayerNeighborsLocked(vector []float32, vectorNormS
 		if idx.nodes[candidate.nodeID].level < layer {
 			continue
 		}
-		distance := idx.distanceToNodeWithPreparedQueryLocked(vector, vectorNormSquared, prepared, candidate.nodeID)
-		if math.IsInf(float64(distance), 1) {
+		if math.IsInf(float64(candidate.distance), 1) {
 			continue
 		}
-		scored = append(scored, vectorIndexCandidate{nodeID: candidate.nodeID, distance: distance})
+		scored = append(scored, candidate)
 	}
 	sortVectorIndexCandidates(scored)
 	if len(scored) > limit {

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -75,6 +75,43 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 }
 
+func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("slow"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("fast"), vector: []float32{0, 1}, level: 0},
+		{documentID: []byte("middle"), vector: []float32{0.5, 0.5}, level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+
+	got := index.selectLayerNeighborsLocked(
+		[]float32{1, 0},
+		1,
+		nil,
+		[]vectorIndexCandidate{
+			{nodeID: 1, distance: 0.9},
+			{nodeID: 2, distance: 0.1},
+			{nodeID: 3, distance: 0.2},
+		},
+		0,
+		2,
+		0,
+	)
+	if len(got) != 2 || got[0] != 2 || got[1] != 3 {
+		t.Fatalf("selected neighbors=%v want [2 3]", got)
+	}
+}
+
 func TestVectorIndexInsertCachesStoredNorm(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",


### PR DESCRIPTION
## Summary
- reuse distances already returned by searchLayerWithScratchLocked when selecting insert-layer neighbors
- avoid recomputing query-to-node cosine distance for every candidate in selectLayerNeighborsLocked
- add a regression test that makes selection follow the supplied candidate distances rather than node vectors

## Local benchmark evidence
Command:

TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorIndex(Build|IncrementalWrite)$' -benchtime=1x -count=3 -benchmem

Results on this branch:
- build: 1.304699088s, 1.327323916s, 1.309687977s
- incremental write: 1.371825545s, 1.353806112s, 1.344914819s

Previous Gonum branch #1523 local reference:
- build: 1.378421296s, 1.348152588s, 1.357748282s
- incremental write: 1.406273394s, 1.403311740s, 1.399822350s

## Validation
- go test ./TreeDB/collections -run 'TestVectorIndexSelectLayerNeighborsReusesCandidateDistances|TestCollectionVectorIndexSearchReranksCanonicalRows' -count=1
- go test ./TreeDB/collections -count=1
- git diff --check

Stacked on #1524.