### PR TITLE
[codex] cache vector graph edge distances

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -615,7 +615,7 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 	idx.nodes[fromNodeID].neighbors[layer] = neighbors
 }
 
-func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []vectorIndexNeighbor, limit int) []vectorIndexNeighbor {
+func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndexNeighbor, limit int) []vectorIndexNeighbor {
 	if limit <= 0 || len(neighbors) == 0 {
 		return nil
 	}

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 	"gonum.org/v1/gonum/blas/blas32"
@@ -1506,7 +1507,9 @@ func (idx *VectorIndex) Stats() VectorIndexStats {
 		stats.DeletedRatio = float64(stats.DeletedDocs) / float64(stats.Nodes)
 		stats.AvgDegree = float64(edges) / float64(stats.Nodes)
 	}
-	stats.BytesMemory = vectorBytes + int64(edges*16) + int64(stats.Nodes*32)
+	// Approximate heap footprint; edge accounting tracks the neighbor struct
+	// size but excludes slice headers and spare capacity.
+	stats.BytesMemory = vectorBytes + int64(edges)*int64(unsafe.Sizeof(vectorIndexNeighbor{})) + int64(stats.Nodes*32)
 	stats.RebuildNeeded = stats.DeletedRatio >= idx.rebuildDeletedRatio && stats.DeletedDocs > 0
 	return stats
 }

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -148,8 +148,13 @@ type vectorIndexNode struct {
 	normSquared   float64
 	cachedInvNorm float32
 	level         int
-	neighbors     [][]int
+	neighbors     [][]vectorIndexNeighbor
 	deleted       bool
+}
+
+type vectorIndexNeighbor struct {
+	nodeID   int
+	distance float32
 }
 
 // BuildVectorIndex builds an in-memory vector secondary index from the current
@@ -471,7 +476,7 @@ func (idx *VectorIndex) newVectorIndexNode(documentID []byte, vector []float32, 
 	node := vectorIndexNode{
 		documentID: bytes.Clone(documentID),
 		level:      level,
-		neighbors:  make([][]int, level+1),
+		neighbors:  make([][]vectorIndexNeighbor, level+1),
 	}
 	switch idx.encoding {
 	case VectorIndexEncodingInt8:
@@ -593,11 +598,15 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 	}
 	neighbors := idx.nodes[fromNodeID].neighbors[layer]
 	for _, existing := range neighbors {
-		if existing == toNodeID {
+		if existing.nodeID == toNodeID {
 			return
 		}
 	}
-	neighbors = append(neighbors, toNodeID)
+	distance := idx.distanceBetweenNodesLocked(fromNodeID, toNodeID)
+	if math.IsInf(float64(distance), 1) {
+		return
+	}
+	neighbors = append(neighbors, vectorIndexNeighbor{nodeID: toNodeID, distance: distance})
 	limit := idx.maxNeighborsForLayer(layer)
 	if len(neighbors) > limit {
 		neighbors = idx.pruneLayerNeighborsLocked(fromNodeID, neighbors, limit)
@@ -605,7 +614,7 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 	idx.nodes[fromNodeID].neighbors[layer] = neighbors
 }
 
-func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []int, limit int) []int {
+func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []vectorIndexNeighbor, limit int) []vectorIndexNeighbor {
 	if limit <= 0 || len(neighbors) == 0 {
 		return nil
 	}
@@ -617,15 +626,15 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []in
 	if len(neighbors) > len(stack) {
 		scored = make([]vectorIndexCandidate, 0, len(neighbors))
 	}
-	for _, neighborID := range neighbors {
+	for _, neighbor := range neighbors {
+		neighborID := neighbor.nodeID
 		if neighborID < 0 || neighborID >= len(idx.nodes) {
 			continue
 		}
-		distance := idx.distanceBetweenNodesLocked(fromNodeID, neighborID)
-		if math.IsInf(float64(distance), 1) {
+		if math.IsInf(float64(neighbor.distance), 1) {
 			continue
 		}
-		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: distance})
+		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: neighbor.distance})
 	}
 	slices.SortFunc(scored, func(left, right vectorIndexCandidate) int {
 		if left.distance < right.distance {
@@ -641,7 +650,7 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(fromNodeID int, neighbors []in
 	}
 	out := neighbors[:0]
 	for _, candidate := range scored {
-		out = append(out, candidate.nodeID)
+		out = append(out, vectorIndexNeighbor{nodeID: candidate.nodeID, distance: candidate.distance})
 	}
 	return out
 }
@@ -951,7 +960,8 @@ func (idx *VectorIndex) greedyNearestAtLayerLocked(query []float32, queryNormSqu
 	changed := true
 	for changed {
 		changed = false
-		for _, neighborID := range idx.layerNeighborsLocked(best, layer) {
+		for _, neighbor := range idx.layerNeighborsLocked(best, layer) {
+			neighborID := neighbor.nodeID
 			distance := idx.distanceToNodeWithPreparedQueryLocked(query, queryNormSquared, prepared, neighborID)
 			if distance < bestDistance {
 				best = neighborID
@@ -1007,7 +1017,8 @@ func (idx *VectorIndex) searchLayerWithScratchLocked(query []float32, queryNormS
 		if current.nodeID < 0 || current.nodeID >= len(idx.nodes) {
 			continue
 		}
-		for _, neighborID := range idx.layerNeighborsLocked(current.nodeID, layer) {
+		for _, neighbor := range idx.layerNeighborsLocked(current.nodeID, layer) {
+			neighborID := neighbor.nodeID
 			if neighborID < 0 || neighborID >= len(idx.nodes) || visited[neighborID] == mark {
 				continue
 			}
@@ -1031,7 +1042,7 @@ func (idx *VectorIndex) searchLayerWithScratchLocked(query []float32, queryNormS
 	return out
 }
 
-func (idx *VectorIndex) layerNeighborsLocked(nodeID int, layer int) []int {
+func (idx *VectorIndex) layerNeighborsLocked(nodeID int, layer int) []vectorIndexNeighbor {
 	if nodeID < 0 || nodeID >= len(idx.nodes) {
 		return nil
 	}
@@ -1495,7 +1506,7 @@ func (idx *VectorIndex) Stats() VectorIndexStats {
 		stats.DeletedRatio = float64(stats.DeletedDocs) / float64(stats.Nodes)
 		stats.AvgDegree = float64(edges) / float64(stats.Nodes)
 	}
-	stats.BytesMemory = vectorBytes + int64(edges*8) + int64(stats.Nodes*32)
+	stats.BytesMemory = vectorBytes + int64(edges*16) + int64(stats.Nodes*32)
 	stats.RebuildNeeded = stats.DeletedRatio >= idx.rebuildDeletedRatio && stats.DeletedDocs > 0
 	return stats
 }
@@ -1610,10 +1621,10 @@ func cloneVectorIndexNodes(in []vectorIndexNode) []vectorIndexNode {
 			cachedInvNorm: in[i].cachedInvNorm,
 			level:         in[i].level,
 			deleted:       in[i].deleted,
-			neighbors:     make([][]int, len(in[i].neighbors)),
+			neighbors:     make([][]vectorIndexNeighbor, len(in[i].neighbors)),
 		}
 		for layer := range in[i].neighbors {
-			out[i].neighbors[layer] = append([]int(nil), in[i].neighbors[layer]...)
+			out[i].neighbors[layer] = append([]vectorIndexNeighbor(nil), in[i].neighbors[layer]...)
 		}
 	}
 	return out

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -604,7 +604,7 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 		}
 	}
 	distance := idx.distanceBetweenNodesLocked(fromNodeID, toNodeID)
-	if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 0) {
+	if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 1) {
 		return
 	}
 	neighbors = append(neighbors, vectorIndexNeighbor{nodeID: toNodeID, distance: distance})
@@ -632,7 +632,7 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndex
 		if neighborID < 0 || neighborID >= len(idx.nodes) {
 			continue
 		}
-		if math.IsNaN(float64(neighbor.distance)) || math.IsInf(float64(neighbor.distance), 0) {
+		if math.IsNaN(float64(neighbor.distance)) || math.IsInf(float64(neighbor.distance), 1) {
 			continue
 		}
 		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: neighbor.distance})

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -590,6 +590,16 @@ func (idx *VectorIndex) maxNeighborsForLayer(layer int) int {
 	return idx.m
 }
 
+func normalizeVectorIndexEdgeDistance(distance float32) (float32, bool) {
+	if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 1) {
+		return 0, false
+	}
+	if math.IsInf(float64(distance), -1) {
+		return -math.MaxFloat32, true
+	}
+	return distance, true
+}
+
 func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 	if fromNodeID < 0 || fromNodeID >= len(idx.nodes) {
 		return
@@ -604,7 +614,9 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 		}
 	}
 	distance := idx.distanceBetweenNodesLocked(fromNodeID, toNodeID)
-	if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 1) {
+	var ok bool
+	distance, ok = normalizeVectorIndexEdgeDistance(distance)
+	if !ok {
 		return
 	}
 	neighbors = append(neighbors, vectorIndexNeighbor{nodeID: toNodeID, distance: distance})
@@ -632,10 +644,11 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndex
 		if neighborID < 0 || neighborID >= len(idx.nodes) {
 			continue
 		}
-		if math.IsNaN(float64(neighbor.distance)) || math.IsInf(float64(neighbor.distance), 1) {
+		distance, ok := normalizeVectorIndexEdgeDistance(neighbor.distance)
+		if !ok {
 			continue
 		}
-		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: neighbor.distance})
+		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: distance})
 	}
 	slices.SortFunc(scored, func(left, right vectorIndexCandidate) int {
 		if left.distance < right.distance {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -604,7 +604,7 @@ func (idx *VectorIndex) linkLayerLocked(fromNodeID, toNodeID, layer int) {
 		}
 	}
 	distance := idx.distanceBetweenNodesLocked(fromNodeID, toNodeID)
-	if math.IsInf(float64(distance), 1) {
+	if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 0) {
 		return
 	}
 	neighbors = append(neighbors, vectorIndexNeighbor{nodeID: toNodeID, distance: distance})
@@ -632,7 +632,7 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndex
 		if neighborID < 0 || neighborID >= len(idx.nodes) {
 			continue
 		}
-		if math.IsInf(float64(neighbor.distance), 1) {
+		if math.IsNaN(float64(neighbor.distance)) || math.IsInf(float64(neighbor.distance), 0) {
 			continue
 		}
 		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: neighbor.distance})

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -428,10 +428,10 @@ type vectorIndexPersistNode struct {
 }
 
 type vectorIndexPersistEdges struct {
-	NodeID   int       `json:"node_id"`
-	Layer    int       `json:"layer"`
-	Neighbor []int     `json:"neighbors"`
-	Distance []float32 `json:"distances,omitempty"`
+	NodeID    int       `json:"node_id"`
+	Layer     int       `json:"layer"`
+	Neighbor  []int     `json:"neighbors"`
+	Distances []float32 `json:"distances,omitempty"`
 }
 
 type vectorIndexPersistTombstones struct {
@@ -482,10 +482,10 @@ func (idx *VectorIndex) persistSnapshot() (vectorIndexPersistSnapshot, uint64) {
 				distances[j] = neighbor.distance
 			}
 			snapshot.Edges = append(snapshot.Edges, vectorIndexPersistEdges{
-				NodeID:   i,
-				Layer:    layer,
-				Neighbor: neighborIDs,
-				Distance: distances,
+				NodeID:    i,
+				Layer:     layer,
+				Neighbor:  neighborIDs,
+				Distances: distances,
 			})
 		}
 		if node.deleted {
@@ -725,11 +725,14 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 		}
 		neighbors := make([]vectorIndexNeighbor, len(edge.Neighbor))
 		for i, neighbor := range edge.Neighbor {
-			distance := float32(math.Inf(1))
-			if i < len(edge.Distance) {
-				distance = edge.Distance[i]
+			if neighbor < 0 || neighbor >= len(nodes) {
+				return "invalid_edge_neighbor"
 			}
-			if math.IsInf(float64(distance), 1) {
+			distance := float32(math.Inf(1))
+			if i < len(edge.Distances) {
+				distance = edge.Distances[i]
+			}
+			if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 0) {
 				var err error
 				distance, err = vectorDistanceBetweenStoredNodes(&nodes[edge.NodeID], &nodes[neighbor], snapshot.Meta.Metric)
 				if err != nil {

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -427,9 +427,10 @@ type vectorIndexPersistNode struct {
 }
 
 type vectorIndexPersistEdges struct {
-	NodeID   int   `json:"node_id"`
-	Layer    int   `json:"layer"`
-	Neighbor []int `json:"neighbors"`
+	NodeID   int       `json:"node_id"`
+	Layer    int       `json:"layer"`
+	Neighbor []int     `json:"neighbors"`
+	Distance []float32 `json:"distances,omitempty"`
 }
 
 type vectorIndexPersistTombstones struct {
@@ -473,10 +474,17 @@ func (idx *VectorIndex) persistSnapshot() (vectorIndexPersistSnapshot, uint64) {
 			Deleted:    node.deleted,
 		}
 		for layer, neighbors := range node.neighbors {
+			neighborIDs := make([]int, len(neighbors))
+			distances := make([]float32, len(neighbors))
+			for j, neighbor := range neighbors {
+				neighborIDs[j] = neighbor.nodeID
+				distances[j] = neighbor.distance
+			}
 			snapshot.Edges = append(snapshot.Edges, vectorIndexPersistEdges{
 				NodeID:   i,
 				Layer:    layer,
-				Neighbor: append([]int(nil), neighbors...),
+				Neighbor: neighborIDs,
+				Distance: distances,
 			})
 		}
 		if node.deleted {
@@ -694,7 +702,7 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 			quantized:  append([]int8(nil), node.Quantized...),
 			quantScale: node.QuantScale,
 			level:      node.Level,
-			neighbors:  make([][]int, node.Level+1),
+			neighbors:  make([][]vectorIndexNeighbor, node.Level+1),
 			deleted:    node.Deleted,
 		}
 		nodes[i].cacheVectorNorms()
@@ -714,7 +722,22 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 				return "edge_neighbor_missing_layer"
 			}
 		}
-		nodes[edge.NodeID].neighbors[edge.Layer] = append([]int(nil), edge.Neighbor...)
+		neighbors := make([]vectorIndexNeighbor, len(edge.Neighbor))
+		for i, neighbor := range edge.Neighbor {
+			distance := float32(math.Inf(1))
+			if i < len(edge.Distance) {
+				distance = edge.Distance[i]
+			}
+			if math.IsInf(float64(distance), 1) {
+				var err error
+				distance, err = vectorDistanceBetweenStoredNodes(&nodes[edge.NodeID], &nodes[neighbor], snapshot.Meta.Metric)
+				if err != nil {
+					return "invalid_edge_distance"
+				}
+			}
+			neighbors[i] = vectorIndexNeighbor{nodeID: neighbor, distance: distance}
+		}
+		nodes[edge.NodeID].neighbors[edge.Layer] = neighbors
 	}
 	current := make(map[string]int, len(snapshot.DocMap.Current))
 	for docID, nodeID := range snapshot.DocMap.Current {

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -479,7 +479,15 @@ func (idx *VectorIndex) persistSnapshot() (vectorIndexPersistSnapshot, uint64) {
 			distances := make([]float32, len(neighbors))
 			for j, neighbor := range neighbors {
 				neighborIDs[j] = neighbor.nodeID
-				distances[j] = neighbor.distance
+				distance, ok := normalizeVectorIndexEdgeDistance(neighbor.distance)
+				if !ok {
+					distance = idx.distanceBetweenNodesLocked(i, neighbor.nodeID)
+					distance, ok = normalizeVectorIndexEdgeDistance(distance)
+					if !ok {
+						distance = math.MaxFloat32
+					}
+				}
+				distances[j] = distance
 			}
 			snapshot.Edges = append(snapshot.Edges, vectorIndexPersistEdges{
 				NodeID:    i,
@@ -735,12 +743,19 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 			if i < len(edge.Distances) {
 				distance = edge.Distances[i]
 			}
-			if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 1) {
+			if normalized, ok := normalizeVectorIndexEdgeDistance(distance); ok {
+				distance = normalized
+			} else {
 				var err error
 				distance, err = vectorDistanceBetweenStoredNodes(&nodes[edge.NodeID], &nodes[neighbor], snapshot.Meta.Metric)
 				if err != nil {
 					return "invalid_edge_distance"
 				}
+				normalized, ok = normalizeVectorIndexEdgeDistance(distance)
+				if !ok {
+					return "invalid_edge_distance"
+				}
+				distance = normalized
 			}
 			neighbors[i] = vectorIndexNeighbor{nodeID: neighbor, distance: distance}
 		}

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -735,7 +735,7 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 			if i < len(edge.Distances) {
 				distance = edge.Distances[i]
 			}
-			if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 0) {
+			if math.IsNaN(float64(distance)) || math.IsInf(float64(distance), 1) {
 				var err error
 				distance, err = vectorDistanceBetweenStoredNodes(&nodes[edge.NodeID], &nodes[neighbor], snapshot.Meta.Metric)
 				if err != nil {

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -723,6 +723,9 @@ func (idx *VectorIndex) loadPersistSnapshot(snapshot vectorIndexPersistSnapshot)
 				return "edge_neighbor_missing_layer"
 			}
 		}
+		if len(edge.Distances) > len(edge.Neighbor) {
+			return "invalid_edge_distance_count"
+		}
 		neighbors := make([]vectorIndexNeighbor, len(edge.Neighbor))
 		for i, neighbor := range edge.Neighbor {
 			if neighbor < 0 || neighbor >= len(nodes) {

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -1,6 +1,8 @@
 package collections
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -94,6 +96,68 @@ func TestCollectionVectorIndexSnapshotReopenSearch(t *testing.T) {
 	if got, want := loaded.Stats().MaxLevel, index.Stats().MaxLevel; got != want {
 		t.Fatalf("loaded max level=%d want %d", got, want)
 	}
+}
+
+func TestCollectionVectorIndexSnapshotLoadsLegacyEdgesWithoutDistances(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	col := openVectorIndexTestCollection(t, d)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+			[]byte(`{"embedding":[0,1]}`),
+			[]byte(`{"embedding":[0.2,0.8]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+	rewriteVectorIndexSnapshotJSONFile(t, saveStatus.ManifestPath, vectorIndexEdgesFile, func(edges []vectorIndexPersistEdges) []vectorIndexPersistEdges {
+		for i := range edges {
+			edges[i].Distance = nil
+		}
+		return edges
+	})
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection after reopen: %v", err)
+	}
+	loaded, loadStatus, err := reopenedCol.LoadVectorIndexSnapshot(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("load legacy vector index snapshot: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.ExactFallbackReason != "" {
+		t.Fatalf("unexpected legacy load status loaded=%v status=%+v", loaded != nil, loadStatus)
+	}
+	results, _, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search legacy-loaded index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "b")
 }
 
 func TestCollectionVectorIndexSnapshotInt8Encoding(t *testing.T) {
@@ -429,6 +493,38 @@ func rewriteVectorIndexManifest(tb testing.TB, manifestPath string, rewrite func
 	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
 		tb.Fatalf("write manifest: %v", err)
 	}
+}
+
+func rewriteVectorIndexSnapshotJSONFile[T any](tb testing.TB, manifestPath, fileName string, rewrite func(T) T) {
+	tb.Helper()
+	path := vectorIndexSnapshotFilePath(tb, manifestPath, fileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("read snapshot file: %v", err)
+	}
+	var payload T
+	if err := json.Unmarshal(data, &payload); err != nil {
+		tb.Fatalf("decode snapshot file: %v", err)
+	}
+	data, err = json.MarshalIndent(rewrite(payload), "", "  ")
+	if err != nil {
+		tb.Fatalf("encode snapshot file: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		tb.Fatalf("write snapshot file: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	rewriteVectorIndexManifest(tb, manifestPath, func(manifest *vectorIndexManifest) {
+		for i := range manifest.Files {
+			if manifest.Files[i].Name == fileName {
+				manifest.Files[i].Size = int64(len(data))
+				manifest.Files[i].SHA256 = hex.EncodeToString(sum[:])
+				return
+			}
+		}
+		tb.Fatalf("manifest missing file entry %q", fileName)
+	})
 }
 
 func vectorIndexSnapshotFilePath(tb testing.TB, manifestPath, fileName string) string {

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -253,6 +253,43 @@ func TestVectorIndexLoadPersistSnapshotRecomputesNonFiniteEdgeDistances(t *testi
 	requireVectorResultIDs(t, results, "a", "b")
 }
 
+func TestVectorIndexLoadPersistSnapshotRejectsExtraEdgeDistances(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	col := openVectorIndexTestCollection(t, d)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	snapshot, _ := index.persistSnapshot()
+	for i := range snapshot.Edges {
+		if len(snapshot.Edges[i].Neighbor) > 0 {
+			snapshot.Edges[i].Distances = append(snapshot.Edges[i].Distances, 0)
+			break
+		}
+	}
+	loaded, err := newVectorIndex(col, VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	if reason := loaded.loadPersistSnapshot(snapshot); reason != "invalid_edge_distance_count" {
+		t.Fatalf("load snapshot reason=%q want invalid_edge_distance_count", reason)
+	}
+}
+
 func TestCollectionVectorIndexSnapshotInt8Encoding(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -167,6 +167,7 @@ func TestCollectionVectorIndexSnapshotRecomputesShortEdgeDistances(t *testing.T)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	defer func() { _ = d.Close() }()
 	col := openVectorIndexTestCollection(t, d)
 	if _, err := col.InsertBatch(
 		[][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d")},

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -290,6 +290,52 @@ func TestVectorIndexLoadPersistSnapshotRejectsExtraEdgeDistances(t *testing.T) {
 	}
 }
 
+func TestVectorIndexPersistSnapshotClampsNegativeInfiniteEdgeDistances(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	col := openVectorIndexTestCollection(t, d)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	index.mu.Lock()
+	for i := range index.nodes {
+		for layer := range index.nodes[i].neighbors {
+			if len(index.nodes[i].neighbors[layer]) > 0 {
+				index.nodes[i].neighbors[layer][0].distance = float32(math.Inf(-1))
+				index.mu.Unlock()
+				snapshot, _ := index.persistSnapshot()
+				for _, edge := range snapshot.Edges {
+					for _, distance := range edge.Distances {
+						if math.IsInf(float64(distance), 0) || math.IsNaN(float64(distance)) {
+							t.Fatalf("persisted non-finite edge distance: %v", distance)
+						}
+					}
+				}
+				if _, err := json.Marshal(snapshot.Edges); err != nil {
+					t.Fatalf("marshal snapshot edges: %v", err)
+				}
+				return
+			}
+		}
+	}
+	index.mu.Unlock()
+	t.Fatal("index has no edge distances to mutate")
+}
+
 func TestCollectionVectorIndexSnapshotInt8Encoding(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -235,7 +235,7 @@ func TestVectorIndexLoadPersistSnapshotRecomputesNonFiniteEdgeDistances(t *testi
 	snapshot, _ := index.persistSnapshot()
 	for i := range snapshot.Edges {
 		if len(snapshot.Edges[i].Distances) > 0 {
-			snapshot.Edges[i].Distances[0] = float32(math.Inf(-1))
+			snapshot.Edges[i].Distances[0] = float32(math.Inf(1))
 			break
 		}
 	}

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,7 +127,7 @@ func TestCollectionVectorIndexSnapshotLoadsLegacyEdgesWithoutDistances(t *testin
 	}
 	rewriteVectorIndexSnapshotJSONFile(t, saveStatus.ManifestPath, vectorIndexEdgesFile, func(edges []vectorIndexPersistEdges) []vectorIndexPersistEdges {
 		for i := range edges {
-			edges[i].Distance = nil
+			edges[i].Distances = nil
 		}
 		return edges
 	})
@@ -156,6 +157,97 @@ func TestCollectionVectorIndexSnapshotLoadsLegacyEdgesWithoutDistances(t *testin
 	results, _, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true})
 	if err != nil {
 		t.Fatalf("search legacy-loaded index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "b")
+}
+
+func TestCollectionVectorIndexSnapshotRecomputesShortEdgeDistances(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	col := openVectorIndexTestCollection(t, d)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+			[]byte(`{"embedding":[0,1]}`),
+			[]byte(`{"embedding":[0.2,0.8]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+	rewriteVectorIndexSnapshotJSONFile(t, saveStatus.ManifestPath, vectorIndexEdgesFile, func(edges []vectorIndexPersistEdges) []vectorIndexPersistEdges {
+		for i := range edges {
+			if len(edges[i].Distances) > 0 {
+				edges[i].Distances = edges[i].Distances[:len(edges[i].Distances)-1]
+				break
+			}
+		}
+		return edges
+	})
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("load short-distance snapshot: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.ExactFallbackReason != "" {
+		t.Fatalf("unexpected short-distance load status loaded=%v status=%+v", loaded != nil, loadStatus)
+	}
+	results, _, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search short-distance loaded index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "b")
+}
+
+func TestVectorIndexLoadPersistSnapshotRecomputesNonFiniteEdgeDistances(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	col := openVectorIndexTestCollection(t, d)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	snapshot, _ := index.persistSnapshot()
+	for i := range snapshot.Edges {
+		if len(snapshot.Edges[i].Distances) > 0 {
+			snapshot.Edges[i].Distances[0] = float32(math.Inf(-1))
+			break
+		}
+	}
+	loaded, err := newVectorIndex(col, VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	if reason := loaded.loadPersistSnapshot(snapshot); reason != "" {
+		t.Fatalf("load snapshot with non-finite distance reason=%q", reason)
+	}
+	results, _, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search non-finite-distance loaded index: %v", err)
 	}
 	requireVectorResultIDs(t, results, "a", "b")
 }

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -69,8 +69,12 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 		index.nodes[i].cacheVectorNorms()
 	}
 
-	got := index.pruneLayerNeighborsLocked(0, []int{3, 1, 2}, 2)
-	if len(got) != 2 || got[0] != 2 || got[1] != 1 {
+	got := index.pruneLayerNeighborsLocked(0, []vectorIndexNeighbor{
+		{nodeID: 3, distance: 1},
+		{nodeID: 1, distance: 0.03},
+		{nodeID: 2, distance: 0.03},
+	}, 2)
+	if len(got) != 2 || got[0].nodeID != 2 || got[1].nodeID != 1 {
 		t.Fatalf("pruned neighbors=%v want [2 1]", got)
 	}
 }
@@ -229,9 +233,9 @@ func TestVectorIndexSearchLayerScratchReusesBuffers(t *testing.T) {
 		t.Fatalf("new vector index: %v", err)
 	}
 	index.nodes = []vectorIndexNode{
-		{documentID: []byte("a"), vector: []float32{1, 0}, neighbors: [][]int{{1, 2}}},
-		{documentID: []byte("b"), vector: []float32{0.9, 0.1}, neighbors: [][]int{{0, 2}}},
-		{documentID: []byte("c"), vector: []float32{0, 1}, neighbors: [][]int{{0, 1}}},
+		{documentID: []byte("a"), vector: []float32{1, 0}, neighbors: [][]vectorIndexNeighbor{{{nodeID: 1}, {nodeID: 2}}}},
+		{documentID: []byte("b"), vector: []float32{0.9, 0.1}, neighbors: [][]vectorIndexNeighbor{{{nodeID: 0}, {nodeID: 2}}}},
+		{documentID: []byte("c"), vector: []float32{0, 1}, neighbors: [][]vectorIndexNeighbor{{{nodeID: 0}, {nodeID: 1}}}},
 	}
 	for i := range index.nodes {
 		index.nodes[i].cacheVectorNorms()


### PR DESCRIPTION
## Summary
- store cached distances alongside in-memory vector graph edges
- use cached edge distances during neighbor pruning instead of recomputing node-to-node distance for every existing neighbor
- persist edge distances in vector index snapshots, with load-time fallback to recompute distances for older snapshots that only have neighbor IDs
- update memory accounting for the larger edge representation

## Local benchmark evidence
Command:

TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorIndex(Build|IncrementalWrite)$' -benchtime=1x -count=3 -benchmem

Results on this branch:
- build: 1.127657031s, 1.138818371s, 1.127753008s
- incremental write: 1.171219140s, 1.175518032s, 1.153284655s
- index bytes: ~8.95MB, up from ~5.96MB before cached edge distances

Previous stacked branch #1525 local reference:
- build: 1.304699088s, 1.327323916s, 1.309687977s
- incremental write: 1.371825545s, 1.353806112s, 1.344914819s

Search check:
- integrated search: 1.098942ms, 1.095098ms, 1.094685ms
- graph-only search: 63.874us, 64.616us, 67.189us
- parallel graph-only search: 15.701us, 16.177us, 17.380us

Profile artifact:
- /tmp/treedb_vector_edge_distance_profile/build_cpu.pprof
- /tmp/treedb_vector_edge_distance_profile/build_mem.pprof

Profile note:
- pruneLayerNeighborsLocked dropped to ~0.12s cumulative in the build profile after removing repeated distance scoring from that path.

## Validation
- go test ./TreeDB/collections -run 'TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID|TestVectorIndexSearchLayerScratchReusesBuffers|TestVectorIndexSnapshot|TestVectorIndexPersist' -count=1
- go test ./TreeDB/collections -count=1
- git diff --check

Stacked on #1525.