### PR TITLE
experiments/colgranule: add reusable granule core

### DIFF
--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -322,7 +322,7 @@ func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byt
 		if cap(dst) < need {
 			dst = make([]byte, need)
 		} else {
-			dst = dst[:need]
+			dst = dst[:0]
 		}
 		out := snappy.Encode(dst, raw)
 		return out, CompressionSnappy, out, nil

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -10,7 +10,10 @@ import (
 	"github.com/pierrec/lz4/v4"
 )
 
-const DefaultRowsPerGranule = 8192
+const (
+	DefaultRowsPerGranule = 8192
+	maxGranuleDecodeRows  = 1 << 20
+)
 
 type Encoding uint8
 
@@ -285,6 +288,12 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 }
 
 func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if rows > len(raw) {
+		return nil, fmt.Errorf("colgranule: delta rows=%d exceed payload bytes=%d", rows, len(raw))
+	}
 	out := dst[:0]
 	if cap(out) < rows {
 		out = make([]int64, 0, rows)
@@ -311,6 +320,16 @@ func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
 		return nil, errors.New("colgranule: trailing delta bytes")
 	}
 	return out, nil
+}
+
+func validateGranuleDecodeRows(rows int) error {
+	if rows < 0 {
+		return fmt.Errorf("colgranule: negative rows=%d", rows)
+	}
+	if rows > maxGranuleDecodeRows {
+		return fmt.Errorf("colgranule: rows=%d exceed cap %d", rows, maxGranuleDecodeRows)
+	}
+	return nil
 }
 
 func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byte, Compression, []byte, error) {

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -56,14 +56,115 @@ type Config struct {
 	Compression Compression
 }
 
+type PayloadRefKind uint8
+
+const (
+	PayloadRefInline PayloadRefKind = iota + 1
+)
+
+func (k PayloadRefKind) String() string {
+	switch k {
+	case PayloadRefInline:
+		return "inline"
+	default:
+		return fmt.Sprintf("payload_ref_%d", k)
+	}
+}
+
+type PayloadRef struct {
+	Kind   PayloadRefKind
+	Offset int64
+	Length int
+}
+
 type EncodedGranule struct {
-	Rows        int
-	Min         int64
-	Max         int64
-	Encoding    Encoding
-	Compression Compression
-	RawBytes    int
-	Payload     []byte
+	Rows         int
+	NullCount    int
+	DefaultCount int
+	Min          int64
+	Max          int64
+	Encoding     Encoding
+	Compression  Compression
+	RawBytes     int
+	StoredBytes  int
+	PayloadRef   PayloadRef
+	Payload      []byte
+}
+
+type GranuleBuilder struct {
+	cfg        Config
+	raw        []byte
+	compressed []byte
+}
+
+func NewGranuleBuilder(cfg Config) *GranuleBuilder {
+	return &GranuleBuilder{cfg: cfg}
+}
+
+func (b *GranuleBuilder) Reset(cfg Config) {
+	b.cfg = cfg
+	b.raw = b.raw[:0]
+	b.compressed = b.compressed[:0]
+}
+
+// BuildInt64 returns a granule whose payload aliases builder-owned scratch until
+// the next BuildInt64 or Reset call.
+func (b *GranuleBuilder) BuildInt64(values []int64) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	min, max := minMax(values)
+	raw, err := encodeInt64Payload(b.raw[:0], values, b.cfg.Encoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.raw = raw
+	payload, compression, compressed, err := compressPayloadInto(b.compressed[:0], raw, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = compressed
+	return newEncodedGranule(len(values), min, max, b.cfg.Encoding, compression, len(raw), payload), nil
+}
+
+type GranuleReader struct {
+	raw    []byte
+	values []int64
+}
+
+func (r *GranuleReader) DecodeInt64(g EncodedGranule) ([]int64, error) {
+	values, err := r.DecodeInt64Into(r.values[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.values = values
+	return values, nil
+}
+
+func (r *GranuleReader) DecodeInt64Into(dst []int64, g EncodedGranule) ([]int64, error) {
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	return decodeInt64Payload(dst, raw, g)
+}
+
+func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
+	if low > high || high < g.Min || low > g.Max {
+		r.values = r.values[:0]
+		return 0, nil
+	}
+	values, err := r.DecodeInt64(g)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, v := range values {
+		if v >= low && v <= high {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func EncodeInt64(dst []byte, values []int64, cfg Config) (EncodedGranule, error) {
@@ -79,33 +180,31 @@ func EncodeInt64(dst []byte, values []int64, cfg Config) (EncodedGranule, error)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
-	return EncodedGranule{
-		Rows:        len(values),
-		Min:         min,
-		Max:         max,
-		Encoding:    cfg.Encoding,
-		Compression: compression,
-		RawBytes:    len(raw),
-		Payload:     payload,
-	}, nil
+	return newEncodedGranule(len(values), min, max, cfg.Encoding, compression, len(raw), payload), nil
 }
 
 func DecodeInt64(dst []int64, g EncodedGranule) ([]int64, error) {
-	raw, err := decompressPayload(g)
-	if err != nil {
-		return nil, err
-	}
+	var reader GranuleReader
+	return reader.DecodeInt64Into(dst, g)
+}
+
+func decodeInt64Payload(dst []int64, raw []byte, g EncodedGranule) ([]int64, error) {
 	out := dst[:0]
 	switch g.Encoding {
 	case EncodingRawInt64:
-		if len(raw) != g.Rows*8 {
+		if len(raw)%8 != 0 || len(raw)/8 != g.Rows {
 			return nil, fmt.Errorf("colgranule: raw int64 length=%d rows=%d", len(raw), g.Rows)
 		}
-		for len(raw) >= 8 {
-			out = append(out, int64(binary.LittleEndian.Uint64(raw[:8])))
-			raw = raw[8:]
+		if cap(out) < g.Rows {
+			out = make([]int64, g.Rows)
+		} else {
+			out = out[:g.Rows]
+		}
+		for i := range out {
+			out[i] = int64(binary.LittleEndian.Uint64(raw[i*8:]))
 		}
 	case EncodingDeltaVarint:
+		var err error
 		out, err = decodeDeltaVarint(out, raw, g.Rows)
 		if err != nil {
 			return nil, err
@@ -120,7 +219,8 @@ func RangeScanCount(g EncodedGranule, low, high int64, scratch []int64) (int, []
 	if low > high || high < g.Min || low > g.Max {
 		return 0, scratch[:0], nil
 	}
-	values, err := DecodeInt64(scratch, g)
+	var reader GranuleReader
+	values, err := reader.DecodeInt64Into(scratch, g)
 	if err != nil {
 		return 0, scratch, err
 	}
@@ -131,6 +231,23 @@ func RangeScanCount(g EncodedGranule, low, high int64, scratch []int64) (int, []
 		}
 	}
 	return count, values, nil
+}
+
+func newEncodedGranule(rows int, min int64, max int64, encoding Encoding, compression Compression, rawBytes int, payload []byte) EncodedGranule {
+	return EncodedGranule{
+		Rows:        rows,
+		Min:         min,
+		Max:         max,
+		Encoding:    encoding,
+		Compression: compression,
+		RawBytes:    rawBytes,
+		StoredBytes: len(payload),
+		PayloadRef: PayloadRef{
+			Kind:   PayloadRefInline,
+			Length: len(payload),
+		},
+		Payload: payload,
+	}
 }
 
 func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, error) {
@@ -169,6 +286,9 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 
 func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
 	out := dst[:0]
+	if cap(out) < rows {
+		out = make([]int64, 0, rows)
+	}
 	prev := int64(0)
 	for len(raw) > 0 && len(out) < rows {
 		u, n := binary.Uvarint(raw)
@@ -193,6 +313,40 @@ func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
 	return out, nil
 }
 
+func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byte, Compression, []byte, error) {
+	switch compression {
+	case CompressionNone:
+		return raw, CompressionNone, dst[:0], nil
+	case CompressionSnappy:
+		need := snappy.MaxEncodedLen(len(raw))
+		if cap(dst) < need {
+			dst = make([]byte, need)
+		} else {
+			dst = dst[:need]
+		}
+		out := snappy.Encode(dst, raw)
+		return out, CompressionSnappy, out, nil
+	case CompressionLZ4:
+		need := lz4.CompressBlockBound(len(raw))
+		if cap(dst) < need {
+			dst = make([]byte, need)
+		} else {
+			dst = dst[:need]
+		}
+		n, err := lz4.CompressBlock(raw, dst, nil)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		if n == 0 || n >= len(raw) {
+			return raw, CompressionNone, dst[:0], nil
+		}
+		out := dst[:n]
+		return out, CompressionLZ4, out, nil
+	default:
+		return nil, 0, nil, fmt.Errorf("colgranule: unsupported compression %d", compression)
+	}
+}
+
 func compressPayload(raw []byte, compression Compression) ([]byte, Compression, error) {
 	switch compression {
 	case CompressionNone:
@@ -215,8 +369,13 @@ func compressPayload(raw []byte, compression Compression) ([]byte, Compression, 
 }
 
 func decompressPayload(g EncodedGranule) ([]byte, error) {
-	if g.RawBytes < 0 {
-		return nil, fmt.Errorf("colgranule: negative raw payload length %d", g.RawBytes)
+	var reader GranuleReader
+	return reader.decompressPayload(g)
+}
+
+func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
+	if err := validateGranule(g); err != nil {
+		return nil, err
 	}
 	switch g.Compression {
 	case CompressionNone:
@@ -225,16 +384,34 @@ func decompressPayload(g EncodedGranule) ([]byte, error) {
 		}
 		return g.Payload, nil
 	case CompressionSnappy:
-		out, err := snappy.Decode(nil, g.Payload)
+		decodedLen, err := snappy.DecodedLen(g.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if decodedLen != g.RawBytes {
+			return nil, fmt.Errorf("colgranule: snappy decoded length=%d want=%d", decodedLen, g.RawBytes)
+		}
+		if cap(r.raw) < decodedLen {
+			r.raw = make([]byte, decodedLen)
+		} else {
+			r.raw = r.raw[:decodedLen]
+		}
+		out, err := snappy.Decode(r.raw, g.Payload)
 		if err != nil {
 			return nil, err
 		}
 		if len(out) != g.RawBytes {
 			return nil, fmt.Errorf("colgranule: snappy decoded length=%d want=%d", len(out), g.RawBytes)
 		}
+		r.raw = out
 		return out, nil
 	case CompressionLZ4:
-		out := make([]byte, g.RawBytes)
+		if cap(r.raw) < g.RawBytes {
+			r.raw = make([]byte, g.RawBytes)
+		} else {
+			r.raw = r.raw[:g.RawBytes]
+		}
+		out := r.raw
 		n, err := lz4.UncompressBlock(g.Payload, out)
 		if err != nil {
 			return nil, err
@@ -246,6 +423,34 @@ func decompressPayload(g EncodedGranule) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("colgranule: unsupported compression %d", g.Compression)
 	}
+}
+
+func validateGranule(g EncodedGranule) error {
+	if g.Rows <= 0 {
+		return fmt.Errorf("colgranule: invalid row count %d", g.Rows)
+	}
+	if g.NullCount < 0 {
+		return fmt.Errorf("colgranule: negative null count %d", g.NullCount)
+	}
+	if g.DefaultCount < 0 {
+		return fmt.Errorf("colgranule: negative default count %d", g.DefaultCount)
+	}
+	if g.NullCount > g.Rows || g.DefaultCount > g.Rows-g.NullCount {
+		return errors.New("colgranule: null/default count exceeds rows")
+	}
+	if g.RawBytes < 0 {
+		return fmt.Errorf("colgranule: negative raw payload length %d", g.RawBytes)
+	}
+	if g.StoredBytes < 0 {
+		return fmt.Errorf("colgranule: negative stored payload length %d", g.StoredBytes)
+	}
+	if g.StoredBytes != 0 && g.StoredBytes != len(g.Payload) {
+		return fmt.Errorf("colgranule: stored payload length=%d want=%d", len(g.Payload), g.StoredBytes)
+	}
+	if g.PayloadRef.Length != 0 && g.PayloadRef.Length != len(g.Payload) {
+		return fmt.Errorf("colgranule: payload ref length=%d want=%d", g.PayloadRef.Length, len(g.Payload))
+	}
+	return nil
 }
 
 func minMax(values []int64) (int64, int64) {

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -116,6 +116,9 @@ func (b *GranuleBuilder) BuildInt64(values []int64) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
 	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
 	min, max := minMax(values)
 	raw, err := encodeInt64Payload(b.raw[:0], values, b.cfg.Encoding)
 	if err != nil {
@@ -173,6 +176,9 @@ func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (
 func EncodeInt64(dst []byte, values []int64, cfg Config) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
 	}
 	min, max := minMax(values)
 	raw, err := encodeInt64Payload(dst[:0], values, cfg.Encoding)
@@ -339,7 +345,7 @@ func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byt
 	case CompressionSnappy:
 		need := snappy.MaxEncodedLen(len(raw))
 		if cap(dst) < need {
-			dst = make([]byte, need)
+			dst = make([]byte, 0, need)
 		} else {
 			dst = dst[:0]
 		}
@@ -448,6 +454,9 @@ func validateGranule(g EncodedGranule) error {
 	if g.Rows <= 0 {
 		return fmt.Errorf("colgranule: invalid row count %d", g.Rows)
 	}
+	if err := validateGranuleDecodeRows(g.Rows); err != nil {
+		return err
+	}
 	if g.NullCount < 0 {
 		return fmt.Errorf("colgranule: negative null count %d", g.NullCount)
 	}
@@ -463,13 +472,60 @@ func validateGranule(g EncodedGranule) error {
 	if g.StoredBytes < 0 {
 		return fmt.Errorf("colgranule: negative stored payload length %d", g.StoredBytes)
 	}
-	if g.StoredBytes != 0 && g.StoredBytes != len(g.Payload) {
+	maxRaw := maxGranuleRawPayloadBytes(g.Encoding, g.Rows)
+	if maxRaw < 0 {
+		return fmt.Errorf("colgranule: unsupported encoding %d", g.Encoding)
+	}
+	if g.RawBytes > maxRaw {
+		return fmt.Errorf("colgranule: raw payload length=%d exceeds max=%d", g.RawBytes, maxRaw)
+	}
+	maxStored, err := maxGranuleStoredPayloadBytes(g.Compression, maxRaw)
+	if err != nil {
+		return err
+	}
+	if g.StoredBytes > maxStored {
+		return fmt.Errorf("colgranule: stored payload length=%d exceeds max=%d", g.StoredBytes, maxStored)
+	}
+	if len(g.Payload) > maxStored {
+		return fmt.Errorf("colgranule: payload length=%d exceeds max=%d", len(g.Payload), maxStored)
+	}
+	if g.PayloadRef.Kind != PayloadRefInline {
+		return fmt.Errorf("colgranule: unsupported payload ref kind %d", g.PayloadRef.Kind)
+	}
+	if g.PayloadRef.Offset != 0 {
+		return fmt.Errorf("colgranule: inline payload offset=%d want=0", g.PayloadRef.Offset)
+	}
+	if g.StoredBytes != len(g.Payload) {
 		return fmt.Errorf("colgranule: stored payload length=%d want=%d", len(g.Payload), g.StoredBytes)
 	}
-	if g.PayloadRef.Length != 0 && g.PayloadRef.Length != len(g.Payload) {
+	if g.PayloadRef.Length != len(g.Payload) {
 		return fmt.Errorf("colgranule: payload ref length=%d want=%d", g.PayloadRef.Length, len(g.Payload))
 	}
 	return nil
+}
+
+func maxGranuleRawPayloadBytes(encoding Encoding, rows int) int {
+	switch encoding {
+	case EncodingRawInt64:
+		return rows * 8
+	case EncodingDeltaVarint:
+		return rows * binary.MaxVarintLen64
+	default:
+		return -1
+	}
+}
+
+func maxGranuleStoredPayloadBytes(compression Compression, maxRaw int) (int, error) {
+	switch compression {
+	case CompressionNone:
+		return maxRaw, nil
+	case CompressionSnappy:
+		return snappy.MaxEncodedLen(maxRaw), nil
+	case CompressionLZ4:
+		return lz4.CompressBlockBound(maxRaw), nil
+	default:
+		return 0, fmt.Errorf("colgranule: unsupported compression %d", compression)
+	}
 }
 
 func minMax(values []int64) (int64, int64) {

--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -40,13 +40,20 @@ func BenchmarkEncodeInt64Granule(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				b.ReportAllocs()
 				b.SetBytes(int64(len(fx.values) * 8))
+				builder := NewGranuleBuilder(cfg)
+				g, err := builder.BuildInt64(fx.values)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					g, err := EncodeInt64(nil, fx.values, cfg)
+					g, err = builder.BuildInt64(fx.values)
 					if err != nil {
 						b.Fatal(err)
 					}
-					benchSink += int64(len(g.Payload))
+					benchSink += int64(g.StoredBytes)
 				}
+				reportGranuleBenchMetrics(b, len(fx.values), len(fx.values)*8, g.StoredBytes)
 			})
 		}
 	}
@@ -59,19 +66,25 @@ func BenchmarkDecodeInt64Granule(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			name := fmt.Sprintf("%s/%s/%s/stored_%dB/raw_%dB", fx.name, cfg.Encoding, g.Compression, len(g.Payload), g.RawBytes)
+			name := fmt.Sprintf("%s/%s/requested_%s/actual_%s/stored_%dB/raw_%dB", fx.name, cfg.Encoding, cfg.Compression, g.Compression, g.StoredBytes, g.RawBytes)
 			b.Run(name, func(b *testing.B) {
 				b.ReportAllocs()
 				b.SetBytes(int64(len(fx.values) * 8))
-				scratch := make([]int64, 0, len(fx.values))
+				var reader GranuleReader
+				values, err := reader.DecodeInt64(g)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += values[len(values)-1]
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					values, err := DecodeInt64(scratch, g)
+					values, err := reader.DecodeInt64(g)
 					if err != nil {
 						b.Fatal(err)
 					}
 					benchSink += values[len(values)-1]
 				}
+				reportGranuleBenchMetrics(b, len(fx.values), len(fx.values)*8, g.StoredBytes)
 			})
 		}
 	}
@@ -86,25 +99,31 @@ func BenchmarkRangeScanInt64Granule(b *testing.B) {
 			}
 			low := fx.values[len(fx.values)/2]
 			high := low + 32
-			name := fmt.Sprintf("%s/%s/%s/hit/stored_%dB/raw_%dB", fx.name, cfg.Encoding, g.Compression, len(g.Payload), g.RawBytes)
+			name := fmt.Sprintf("%s/%s/requested_%s/actual_%s/hit/stored_%dB/raw_%dB", fx.name, cfg.Encoding, cfg.Compression, g.Compression, g.StoredBytes, g.RawBytes)
 			b.Run(name, func(b *testing.B) {
 				b.ReportAllocs()
 				b.SetBytes(int64(len(fx.values) * 8))
-				scratch := make([]int64, 0, len(fx.values))
+				var reader GranuleReader
+				count, err := reader.RangeScanCountInt64(g, low, high)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(count)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					count, out, err := RangeScanCount(g, low, high, scratch)
+					count, err := reader.RangeScanCountInt64(g, low, high)
 					if err != nil {
 						b.Fatal(err)
 					}
-					scratch = out
 					benchSink += int64(count)
 				}
+				reportGranuleBenchMetrics(b, len(fx.values), len(fx.values)*8, g.StoredBytes)
 			})
-			b.Run(fmt.Sprintf("%s/%s/%s/minmax_skip", fx.name, cfg.Encoding, g.Compression), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s/%s/requested_%s/actual_%s/minmax_skip", fx.name, cfg.Encoding, cfg.Compression, g.Compression), func(b *testing.B) {
 				b.ReportAllocs()
+				var reader GranuleReader
 				for i := 0; i < b.N; i++ {
-					count, _, err := RangeScanCount(g, g.Max+1, g.Max+100, nil)
+					count, err := reader.RangeScanCountInt64(g, g.Max+1, g.Max+100)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -124,12 +143,30 @@ func TestCompressionRatios(t *testing.T) {
 				t.Fatalf("EncodeInt64(%s,%s,%s): %v", fx.name, cfg.Encoding, cfg.Compression, err)
 			}
 			t.Logf("fixture=%s encoding=%s requested_compression=%s actual_compression=%s encoded_raw_bytes=%d stored_bytes=%d ratio_vs_values=%.4f ratio_vs_encoded=%.4f min=%d max=%d",
-				fx.name, cfg.Encoding, cfg.Compression, g.Compression, g.RawBytes, len(g.Payload),
-				float64(len(g.Payload))/float64(len(fx.values)*8),
-				float64(len(g.Payload))/float64(g.RawBytes),
+				fx.name, cfg.Encoding, cfg.Compression, g.Compression, g.RawBytes, g.StoredBytes,
+				float64(g.StoredBytes)/float64(len(fx.values)*8),
+				float64(g.StoredBytes)/float64(g.RawBytes),
 				g.Min, g.Max)
 		}
 	}
+}
+
+func reportGranuleBenchMetrics(b *testing.B, rows int, valueBytes int, storedBytes int) {
+	b.Helper()
+	if b.N == 0 || rows == 0 {
+		return
+	}
+	elapsed := b.Elapsed()
+	totalRows := float64(b.N) * float64(rows)
+	if elapsed > 0 {
+		seconds := elapsed.Seconds()
+		b.ReportMetric(totalRows/seconds, "rows/s")
+		b.ReportMetric(totalRows/seconds, "values/s")
+		b.ReportMetric(float64(b.N)*float64(valueBytes)/seconds/(1024*1024), "MiB/s")
+		b.ReportMetric(float64(elapsed.Nanoseconds())/totalRows, "ns/row")
+	}
+	b.ReportMetric(float64(valueBytes)/float64(rows), "value_B/row")
+	b.ReportMetric(float64(storedBytes)/float64(rows), "stored_B/row")
 }
 
 func makeMonotonic(n int) []int64 {

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -23,7 +23,167 @@ func TestEncodeDecodeInt64Granule(t *testing.T) {
 			if g.Min != -10 || g.Max != 101 {
 				t.Fatalf("min/max=(%d,%d) want (-10,101)", g.Min, g.Max)
 			}
+			if g.Rows != len(values) || g.NullCount != 0 || g.DefaultCount != 0 {
+				t.Fatalf("metadata rows/null/default=(%d,%d,%d) want (%d,0,0)", g.Rows, g.NullCount, g.DefaultCount, len(values))
+			}
+			if g.StoredBytes != len(g.Payload) {
+				t.Fatalf("stored_bytes=%d want payload len %d", g.StoredBytes, len(g.Payload))
+			}
+			if g.PayloadRef.Kind != PayloadRefInline || g.PayloadRef.Length != len(g.Payload) {
+				t.Fatalf("payload ref=(%s,%d) want (inline,%d)", g.PayloadRef.Kind, g.PayloadRef.Length, len(g.Payload))
+			}
 		}
+	}
+}
+
+func TestGranuleBuilderRejectsEmpty(t *testing.T) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingRawInt64, Compression: CompressionNone})
+	if _, err := builder.BuildInt64(nil); err == nil {
+		t.Fatal("BuildInt64(nil) succeeded, want error")
+	}
+	if _, err := EncodeInt64(nil, nil, Config{Encoding: EncodingRawInt64, Compression: CompressionNone}); err == nil {
+		t.Fatal("EncodeInt64(nil) succeeded, want error")
+	}
+}
+
+func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []int64
+		min    int64
+		max    int64
+	}{
+		{name: "negative_positive", values: []int64{-17, -1, 0, 9, 100}, min: -17, max: 100},
+		{name: "repeated", values: []int64{42, 42, 42, 42}, min: 42, max: 42},
+		{name: "monotonic", values: []int64{-3, -2, -1, 0, 1, 2, 3}, min: -3, max: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, cfg := range []Config{
+				{Encoding: EncodingRawInt64, Compression: CompressionNone},
+				{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+				{Encoding: EncodingDeltaVarint, Compression: CompressionLZ4},
+			} {
+				builder := NewGranuleBuilder(cfg)
+				g, err := builder.BuildInt64(tt.values)
+				if err != nil {
+					t.Fatalf("BuildInt64(%s,%s): %v", cfg.Encoding, cfg.Compression, err)
+				}
+				if g.Rows != len(tt.values) || g.Min != tt.min || g.Max != tt.max {
+					t.Fatalf("rows/min/max=(%d,%d,%d) want (%d,%d,%d)", g.Rows, g.Min, g.Max, len(tt.values), tt.min, tt.max)
+				}
+				if g.RawBytes <= 0 || g.StoredBytes != len(g.Payload) {
+					t.Fatalf("raw/stored/payload=(%d,%d,%d), want positive raw and stored payload length", g.RawBytes, g.StoredBytes, len(g.Payload))
+				}
+				if g.PayloadRef.Kind != PayloadRefInline || g.PayloadRef.Length != g.StoredBytes {
+					t.Fatalf("payload ref=(%s,%d) want (inline,%d)", g.PayloadRef.Kind, g.PayloadRef.Length, g.StoredBytes)
+				}
+			}
+		})
+	}
+}
+
+func TestGranuleReaderReusesBuffersWithoutStaleValues(t *testing.T) {
+	cfg := Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy}
+	long, err := EncodeInt64(nil, []int64{1, 2, 3, 4, 5}, cfg)
+	if err != nil {
+		t.Fatalf("EncodeInt64(long): %v", err)
+	}
+	shortValues := []int64{100, 101}
+	short, err := EncodeInt64(nil, shortValues, cfg)
+	if err != nil {
+		t.Fatalf("EncodeInt64(short): %v", err)
+	}
+	var reader GranuleReader
+	if _, err := reader.DecodeInt64(long); err != nil {
+		t.Fatalf("DecodeInt64(long): %v", err)
+	}
+	got, err := reader.DecodeInt64(short)
+	if err != nil {
+		t.Fatalf("DecodeInt64(short): %v", err)
+	}
+	if !slices.Equal(got, shortValues) {
+		t.Fatalf("DecodeInt64(short)=%v want %v", got, shortValues)
+	}
+
+	dst := []int64{-1, -1, -1, -1, -1}
+	got, err = reader.DecodeInt64Into(dst, short)
+	if err != nil {
+		t.Fatalf("DecodeInt64Into(short): %v", err)
+	}
+	if !slices.Equal(got, shortValues) {
+		t.Fatalf("DecodeInt64Into(short)=%v want %v", got, shortValues)
+	}
+}
+
+func TestCorruptPayloadsFailClosed(t *testing.T) {
+	values := []int64{-10, -5, 0, 5, 10}
+	tests := []struct {
+		name string
+		cfg  Config
+		edit func(EncodedGranule) EncodedGranule
+	}{
+		{
+			name: "raw_truncated",
+			cfg:  Config{Encoding: EncodingRawInt64, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = g.Payload[:len(g.Payload)-1]
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "delta_truncated",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = g.Payload[:len(g.Payload)-1]
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "delta_trailing",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = append(append([]byte(nil), g.Payload...), 0)
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				g.RawBytes = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "snappy_corrupt",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = append([]byte(nil), g.Payload...)
+				g.Payload = g.Payload[:len(g.Payload)-1]
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "metadata_bad_stored_bytes",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.StoredBytes++
+				return g
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, err := EncodeInt64(nil, values, tt.cfg)
+			if err != nil {
+				t.Fatalf("EncodeInt64: %v", err)
+			}
+			if _, err := DecodeInt64(nil, tt.edit(g)); err == nil {
+				t.Fatal("DecodeInt64(corrupt) succeeded, want error")
+			}
+		})
 	}
 }
 

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -46,6 +46,17 @@ func TestGranuleBuilderRejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestGranuleBuilderRejectsOversizedRows(t *testing.T) {
+	values := make([]int64, maxGranuleDecodeRows+1)
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	if _, err := builder.BuildInt64(values); err == nil {
+		t.Fatal("BuildInt64(oversized) succeeded, want error")
+	}
+	if _, err := EncodeInt64(nil, values, Config{Encoding: EncodingRawInt64, Compression: CompressionNone}); err == nil {
+		t.Fatal("EncodeInt64(oversized) succeeded, want error")
+	}
+}
+
 func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -198,6 +209,38 @@ func TestCorruptPayloadsFailClosed(t *testing.T) {
 			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
 			edit: func(g EncodedGranule) EncodedGranule {
 				g.StoredBytes++
+				return g
+			},
+		},
+		{
+			name: "metadata_bad_payload_ref_kind",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.PayloadRef.Kind = 0
+				return g
+			},
+		},
+		{
+			name: "metadata_bad_payload_ref_length_zero",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.PayloadRef.Length = 0
+				return g
+			},
+		},
+		{
+			name: "metadata_bad_payload_ref_offset",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.PayloadRef.Offset = 1
+				return g
+			},
+		},
+		{
+			name: "metadata_huge_raw_bytes",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.RawBytes = maxGranuleRawPayloadBytes(g.Encoding, g.Rows) + 1
 				return g
 			},
 		},

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -83,6 +83,22 @@ func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
 	}
 }
 
+func TestGranuleBuilderSnappyPayloadDoesNotPrefixScratch(t *testing.T) {
+	values := []int64{10, 11, 12, 13, 14, 15, 16, 17}
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy})
+	g, err := builder.BuildInt64(values)
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	got, err := DecodeInt64(nil, g)
+	if err != nil {
+		t.Fatalf("DecodeInt64: %v", err)
+	}
+	if !slices.Equal(got, values) {
+		t.Fatalf("DecodeInt64=%v want %v", got, values)
+	}
+}
+
 func TestGranuleReaderReusesBuffersWithoutStaleValues(t *testing.T) {
 	cfg := Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy}
 	long, err := EncodeInt64(nil, []int64{1, 2, 3, 4, 5}, cfg)

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -171,6 +171,18 @@ func TestCorruptPayloadsFailClosed(t *testing.T) {
 			},
 		},
 		{
+			name: "delta_huge_rows_tiny_payload",
+			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Rows = maxGranuleDecodeRows + 1
+				g.Payload = []byte{0}
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				g.RawBytes = len(g.Payload)
+				return g
+			},
+		},
+		{
 			name: "snappy_corrupt",
 			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
 			edit: func(g EncodedGranule) EncodedGranule {

--- a/experiments/colgranule/jsonbench_report.go
+++ b/experiments/colgranule/jsonbench_report.go
@@ -53,29 +53,29 @@ func SummarizeJSONBenchDataset(ds JSONBenchDataset, rowsPerGranule int, configs 
 				}
 				encoded = append(encoded, g)
 				summary.EncodedRawBytes += g.RawBytes
-				summary.StoredBytes += len(g.Payload)
+				summary.StoredBytes += g.StoredBytes
 				summary.ActualCompressionMix[g.Compression]++
 			}
 			summary.EncodeDuration = time.Since(start)
 			summary.Granules = len(encoded)
 
 			start = time.Now()
+			var reader GranuleReader
 			for _, g := range encoded {
-				if _, err := DecodeInt64(nil, g); err != nil {
+				if _, err := reader.DecodeInt64(g); err != nil {
 					return nil, fmt.Errorf("decode column=%s config=%s/%s: %w", name, cfg.Encoding, cfg.Compression, err)
 				}
 			}
 			summary.DecodeDuration = time.Since(start)
 
 			start = time.Now()
-			var scratch []int64
+			var scanReader GranuleReader
 			for _, g := range encoded {
-				count, out, err := RangeScanCount(g, low, high, scratch)
+				count, err := scanReader.RangeScanCountInt64(g, low, high)
 				if err != nil {
 					return nil, fmt.Errorf("range scan column=%s config=%s/%s: %w", name, cfg.Encoding, cfg.Compression, err)
 				}
 				summary.RangeScanMatches += count
-				scratch = out
 			}
 			summary.RangeScanDuration = time.Since(start)
 			out = append(out, summary)


### PR DESCRIPTION
## Objective

Implement Phase 1 / PR1 from #1534: a focused, high-performance column granule writer/reader core in `experiments/colgranule`.

## Context

This keeps column store work moving independently of WAL/durable TreeDB integration. The PR establishes the inner-loop API for writing int64 granules, decoding them through reusable scratch, validating metadata, and measuring encode/decode/scan throughput and allocation behavior.

Refs #1534.

## Non-goals

- No durable on-disk part format.
- No TreeDB root/WAL integration.
- No generational garbage collection.
- No multi-column execution engine.
- No generic typed-vector framework beyond the current int64 lane.

## Design

- Expands `EncodedGranule` with row/null/default counts, stored bytes, and inline payload refs.
- Adds `GranuleBuilder` for reusable-scratch int64 granule construction.
- Adds `GranuleReader` for reusable-scratch decode and range-count scan paths.
- Keeps existing `EncodeInt64`, `DecodeInt64`, and `RangeScanCount` entry points for current callers.
- Validates row counts, null/default counts, stored payload lengths, payload ref lengths, raw int64 length divisibility, and decompressed lengths before decoding.
- Keeps corrupt/truncated payloads fail-closed with returned errors.

## Scope

- Includes (files/symbols): `experiments/colgranule/granule.go`, `GranuleBuilder`, `GranuleReader`, `EncodedGranule`, int64 encode/decode/range count, JSONBench colgranule summary path, colgranule tests and benchmarks.
- Excludes (files/symbols): TreeDB production storage, WAL, disk part layout, GC, non-int64 column types.

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule`
  - `go test ./experiments/colgranule -run '^$' -bench 'Benchmark(Encode|Decode|RangeScan)Int64Granule' -benchmem -benchtime=100x`
  - `go test ./experiments/colgranule -run TestCompressionRatios -v`
  - `go test ./...` (one unrelated `TreeDB/caching` test failed once; targeted rerun passed)
  - `go test ./TreeDB/caching -run '^TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity$' -count=1`
- Corruption/edge cases covered: empty granules rejected, min/max exactness for negative/positive/repeated/monotonic values, truncated raw payloads, truncated/trailing delta payloads, truncated Snappy payloads, invalid stored-byte metadata, reused decode buffers returning the correct shorter result.
- Concurrency/race coverage (if applicable): not applicable; this PR adds per-builder/per-reader scratch structs with no shared package-global mutable state.

## Performance

- Benchmarks run (exact commands): `go test ./experiments/colgranule -run '^$' -bench 'Benchmark(Encode|Decode|RangeScan)Int64Granule' -benchmem -benchtime=100x`
- Environment: `darwin/arm64`, Apple M3, 8192-row granules.
- Allocation gate: the full warmed sweep reported `0 B/op` and `0 allocs/op` for encode, decode, range-hit, and min/max-skip benchmark variants.
- Before/after: median-of-5 before/after is not available because this is a new experiment API surface; this PR adds the benchmark coverage used below.

Representative results from the full sweep:

| Operation | Fixture | Encoding / compression | ns/row | rows/s | MiB/s | stored B/row | B/op | allocs/op |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Encode | `low_cardinality` | `raw_int64` / `none` | 1.242 | 805.3M | 6144 | 8.000 | 0 | 0 |
| Encode | `low_cardinality` | `delta_varint` / `lz4` | 3.218 | 310.8M | 2371 | 0.008667 | 0 | 0 |
| Encode | `random` | `delta_varint` / `snappy` | 7.092 | 141.0M | 1076 | 9.240 | 0 | 0 |
| Decode | `monotonic` | `raw_int64` / `none` | 0.5887 | 1.699B | 12959 | 8.000 | 0 | 0 |
| Decode | `low_cardinality` | `raw_int64` / `lz4` | 1.251 | 799.6M | 6101 | 0.1260 | 0 | 0 |
| Decode | `random` | `delta_varint` / `snappy` | 6.687 | 149.6M | 1141 | 9.240 | 0 | 0 |
| Range hit | `low_cardinality` | `delta_varint` / `snappy` | 1.939 | 515.7M | 3934 | 0.04785 | 0 | 0 |
| Range hit | `random` | `delta_varint` / `snappy` | 7.933 | 126.1M | 961.7 | 9.240 | 0 | 0 |

Additional notes:

- Min/max skip paths are metadata-only and measured around 4 to 5 ns/op with `0 B/op` and `0 allocs/op` in this run.
- Worst-case incompressible fixtures are included via `random`; LZ4 correctly falls back to `actual_none` for incompressible random payloads where compression would not shrink data.
- Regressions (if any) and why acceptable: none known in the focused colgranule package.

## Rollout / Toggle Plan

- Default setting: experiment-only API; no production behavior is enabled.
- How to disable quickly: revert this PR or avoid the `experiments/colgranule` package.

## Follow-ups

- Issues/PRs to do next: continue #1534 Phase 1 with PR2 for typed column batches and multi-column granule sets after PR1 lands.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `experiments/colgranule/granule.go`, `granule_test.go`, `granule_bench_test.go`, `jsonbench_report.go`
- [x] Explicit exclude list (files/symbols NOT touched): TreeDB production storage, WAL, durable part layout, GC
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: not applicable; no `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): not applicable to CRC, but validation paths are fail-closed
- [x] Any concurrency change has a defined state machine and invariants: not applicable; no concurrency change

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: commands listed above

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [x] No repo doc update needed for this experiment-only API
- [x] No new config knobs
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: not applicable; no production behavior enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved encode/decode pipeline for faster, more memory-efficient reads/writes and stronger integrity checks to detect corrupt or inconsistent data.

* **Benchmarks**
  * Updated benchmarks and reporting to measure stored-byte metrics and clarify subtest names, reflecting realistic compression and throughput.

* **Tests**
  * Expanded test coverage for empty/oversized inputs, metadata invariants, compression round-trips, buffer-reuse safety, and corruption rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->