### PR TITLE
experiments/colgranule: add typed codec paths

### DIFF
--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -477,7 +477,6 @@ func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression
 	case CompressionNone:
 		report.ActualCompression = CompressionNone
 		report.CompressionKept = true
-		report.CompressionFallbackReason = "none_requested"
 		report.StoredBytes = len(raw)
 		return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
 	case CompressionSnappy:
@@ -657,8 +656,14 @@ func maxGranuleRawPayloadBytes(encoding Encoding, rows int) int {
 	switch encoding {
 	case EncodingRawInt64:
 		return rows * 8
-	case EncodingDeltaVarint:
+	case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
 		return rows * binary.MaxVarintLen64
+	case EncodingNullableInt64:
+		return nullableInt64HeaderBytes + 2*bitmapBytes(rows) + rows*binary.MaxVarintLen64
+	case EncodingBoolBitpackRLE:
+		return 2 + rows*binary.MaxVarintLen64
+	case EncodingLowCardinalityUint32:
+		return 1 + binary.MaxVarintLen64 + rows*4
 	default:
 		return -1
 	}

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/golang/snappy"
 	"github.com/pierrec/lz4/v4"
@@ -17,6 +18,10 @@ type Encoding uint8
 const (
 	EncodingRawInt64 Encoding = iota + 1
 	EncodingDeltaVarint
+	EncodingDoubleDeltaVarint
+	EncodingNullableInt64
+	EncodingBoolBitpackRLE
+	EncodingLowCardinalityUint32
 )
 
 func (e Encoding) String() string {
@@ -25,6 +30,14 @@ func (e Encoding) String() string {
 		return "raw_int64"
 	case EncodingDeltaVarint:
 		return "delta_varint"
+	case EncodingDoubleDeltaVarint:
+		return "double_delta_varint"
+	case EncodingNullableInt64:
+		return "nullable_int64"
+	case EncodingBoolBitpackRLE:
+		return "bool_bitpack_rle"
+	case EncodingLowCardinalityUint32:
+		return "low_cardinality_uint32"
 	default:
 		return fmt.Sprintf("encoding_%d", e)
 	}
@@ -36,6 +49,8 @@ const (
 	CompressionNone Compression = iota
 	CompressionSnappy
 	CompressionLZ4
+	CompressionZSTD
+	CompressionZSTDDict
 )
 
 func (c Compression) String() string {
@@ -46,6 +61,10 @@ func (c Compression) String() string {
 		return "snappy"
 	case CompressionLZ4:
 		return "lz4"
+	case CompressionZSTD:
+		return "zstd"
+	case CompressionZSTDDict:
+		return "zstd_dict"
 	default:
 		return fmt.Sprintf("compression_%d", c)
 	}
@@ -77,10 +96,23 @@ type PayloadRef struct {
 	Length int
 }
 
+type CodecReport struct {
+	Encoding                  Encoding
+	RequestedCompression      Compression
+	ActualCompression         Compression
+	CompressionAttempted      bool
+	CompressionKept           bool
+	CompressionFallbackReason string
+	RawBytes                  int
+	StoredBytes               int
+	CompressionNanos          int64
+}
+
 type EncodedGranule struct {
 	Rows         int
 	NullCount    int
 	DefaultCount int
+	HasMinMax    bool
 	Min          int64
 	Max          int64
 	Encoding     Encoding
@@ -88,13 +120,18 @@ type EncodedGranule struct {
 	RawBytes     int
 	StoredBytes  int
 	PayloadRef   PayloadRef
+	CodecReport  CodecReport
 	Payload      []byte
 }
 
 type GranuleBuilder struct {
 	cfg        Config
 	raw        []byte
+	encoded    []byte
 	compressed []byte
+	values64   []int64
+	bools      []bool
+	codes32    []uint32
 }
 
 func NewGranuleBuilder(cfg Config) *GranuleBuilder {
@@ -119,17 +156,22 @@ func (b *GranuleBuilder) BuildInt64(values []int64) (EncodedGranule, error) {
 		return EncodedGranule{}, err
 	}
 	b.raw = raw
-	payload, compression, compressed, err := compressPayloadInto(b.compressed[:0], raw, b.cfg.Compression)
+	selection, err := admitCompressionInto(b.compressed[:0], raw, b.cfg.Encoding, b.cfg.Compression)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
-	b.compressed = compressed
-	return newEncodedGranule(len(values), min, max, b.cfg.Encoding, compression, len(raw), payload), nil
+	b.compressed = selection.Scratch
+	return newEncodedGranule(len(values), min, max, true, b.cfg.Encoding, selection), nil
 }
 
 type GranuleReader struct {
-	raw    []byte
-	values []int64
+	raw      []byte
+	values   []int64
+	stored64 []int64
+	bools    []bool
+	nulls    []bool
+	defaults []bool
+	codes    []uint32
 }
 
 func (r *GranuleReader) DecodeInt64(g EncodedGranule) ([]int64, error) {
@@ -150,7 +192,7 @@ func (r *GranuleReader) DecodeInt64Into(dst []int64, g EncodedGranule) ([]int64,
 }
 
 func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
-	if low > high || high < g.Min || low > g.Max {
+	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
 		r.values = r.values[:0]
 		return 0, nil
 	}
@@ -176,11 +218,11 @@ func EncodeInt64(dst []byte, values []int64, cfg Config) (EncodedGranule, error)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
-	payload, compression, err := compressPayload(raw, cfg.Compression)
+	selection, err := compressPayload(raw, cfg.Encoding, cfg.Compression)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
-	return newEncodedGranule(len(values), min, max, cfg.Encoding, compression, len(raw), payload), nil
+	return newEncodedGranule(len(values), min, max, true, cfg.Encoding, selection), nil
 }
 
 func DecodeInt64(dst []int64, g EncodedGranule) ([]int64, error) {
@@ -209,6 +251,12 @@ func decodeInt64Payload(dst []int64, raw []byte, g EncodedGranule) ([]int64, err
 		if err != nil {
 			return nil, err
 		}
+	case EncodingDoubleDeltaVarint:
+		var err error
+		out, err = decodeDoubleDeltaVarint(out, raw, g.Rows)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("colgranule: unsupported encoding %d", g.Encoding)
 	}
@@ -216,7 +264,7 @@ func decodeInt64Payload(dst []int64, raw []byte, g EncodedGranule) ([]int64, err
 }
 
 func RangeScanCount(g EncodedGranule, low, high int64, scratch []int64) (int, []int64, error) {
-	if low > high || high < g.Min || low > g.Max {
+	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
 		return 0, scratch[:0], nil
 	}
 	var reader GranuleReader
@@ -233,20 +281,26 @@ func RangeScanCount(g EncodedGranule, low, high int64, scratch []int64) (int, []
 	return count, values, nil
 }
 
-func newEncodedGranule(rows int, min int64, max int64, encoding Encoding, compression Compression, rawBytes int, payload []byte) EncodedGranule {
+func newEncodedGranule(rows int, min int64, max int64, hasMinMax bool, encoding Encoding, selection CompressionSelection) EncodedGranule {
+	report := selection.Report
+	report.Encoding = encoding
+	report.ActualCompression = selection.Actual
+	report.StoredBytes = len(selection.Payload)
 	return EncodedGranule{
 		Rows:        rows,
+		HasMinMax:   hasMinMax,
 		Min:         min,
 		Max:         max,
 		Encoding:    encoding,
-		Compression: compression,
-		RawBytes:    rawBytes,
-		StoredBytes: len(payload),
+		Compression: selection.Actual,
+		RawBytes:    report.RawBytes,
+		StoredBytes: len(selection.Payload),
 		PayloadRef: PayloadRef{
 			Kind:   PayloadRefInline,
-			Length: len(payload),
+			Length: len(selection.Payload),
 		},
-		Payload: payload,
+		CodecReport: report,
+		Payload:     selection.Payload,
 	}
 }
 
@@ -275,6 +329,31 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 				delta = v - prev
 			}
 			n := binary.PutUvarint(buf[:], zigzag(delta))
+			dst = append(dst, buf[:n]...)
+			prev = v
+		}
+		return dst, nil
+	case EncodingDoubleDeltaVarint:
+		if cap(dst) < len(values)*2 {
+			dst = make([]byte, 0, len(values)*2)
+		}
+		var buf [binary.MaxVarintLen64]byte
+		prev := int64(0)
+		prevDelta := int64(0)
+		for i, v := range values {
+			var encoded int64
+			switch i {
+			case 0:
+				encoded = v
+			case 1:
+				encoded = v - prev
+				prevDelta = encoded
+			default:
+				delta := v - prev
+				encoded = delta - prevDelta
+				prevDelta = delta
+			}
+			n := binary.PutUvarint(buf[:], zigzag(encoded))
 			dst = append(dst, buf[:n]...)
 			prev = v
 		}
@@ -313,10 +392,65 @@ func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
 	return out, nil
 }
 
-func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byte, Compression, []byte, error) {
+func decodeDoubleDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	out := dst[:0]
+	if cap(out) < rows {
+		out = make([]int64, 0, rows)
+	}
+	prev := int64(0)
+	prevDelta := int64(0)
+	for len(raw) > 0 && len(out) < rows {
+		u, n := binary.Uvarint(raw)
+		if n <= 0 {
+			return nil, errors.New("colgranule: malformed double-delta varint")
+		}
+		encoded := unzigzag(u)
+		var v int64
+		switch len(out) {
+		case 0:
+			v = encoded
+		case 1:
+			prevDelta = encoded
+			v = prev + encoded
+		default:
+			delta := prevDelta + encoded
+			v = prev + delta
+			prevDelta = delta
+		}
+		out = append(out, v)
+		prev = v
+		raw = raw[n:]
+	}
+	if len(out) != rows {
+		return nil, fmt.Errorf("colgranule: decoded rows=%d want=%d", len(out), rows)
+	}
+	if len(raw) != 0 {
+		return nil, errors.New("colgranule: trailing double-delta bytes")
+	}
+	return out, nil
+}
+
+type CompressionSelection struct {
+	Payload []byte
+	Actual  Compression
+	Scratch []byte
+	Report  CodecReport
+}
+
+func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression Compression) (CompressionSelection, error) {
+	report := CodecReport{
+		Encoding:             encoding,
+		RequestedCompression: compression,
+		ActualCompression:    compression,
+		RawBytes:             len(raw),
+	}
 	switch compression {
 	case CompressionNone:
-		return raw, CompressionNone, dst[:0], nil
+		report.ActualCompression = CompressionNone
+		report.CompressionKept = true
+		report.CompressionFallbackReason = "none_requested"
+		report.StoredBytes = len(raw)
+		return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
 	case CompressionSnappy:
 		need := snappy.MaxEncodedLen(len(raw))
 		if cap(dst) < need {
@@ -324,8 +458,20 @@ func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byt
 		} else {
 			dst = dst[:need]
 		}
+		start := time.Now()
 		out := snappy.Encode(dst, raw)
-		return out, CompressionSnappy, out, nil
+		report.CompressionNanos = time.Since(start).Nanoseconds()
+		report.CompressionAttempted = true
+		if len(out) >= len(raw) {
+			report.ActualCompression = CompressionNone
+			report.CompressionFallbackReason = "not_smaller"
+			report.StoredBytes = len(raw)
+			return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
+		}
+		report.ActualCompression = CompressionSnappy
+		report.CompressionKept = true
+		report.StoredBytes = len(out)
+		return CompressionSelection{Payload: out, Actual: CompressionSnappy, Scratch: out, Report: report}, nil
 	case CompressionLZ4:
 		need := lz4.CompressBlockBound(len(raw))
 		if cap(dst) < need {
@@ -333,39 +479,38 @@ func compressPayloadInto(dst []byte, raw []byte, compression Compression) ([]byt
 		} else {
 			dst = dst[:need]
 		}
+		start := time.Now()
 		n, err := lz4.CompressBlock(raw, dst, nil)
+		report.CompressionNanos = time.Since(start).Nanoseconds()
 		if err != nil {
-			return nil, 0, nil, err
+			return CompressionSelection{}, err
 		}
+		report.CompressionAttempted = true
 		if n == 0 || n >= len(raw) {
-			return raw, CompressionNone, dst[:0], nil
+			report.ActualCompression = CompressionNone
+			report.CompressionFallbackReason = "not_smaller"
+			report.StoredBytes = len(raw)
+			return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
 		}
 		out := dst[:n]
-		return out, CompressionLZ4, out, nil
+		report.ActualCompression = CompressionLZ4
+		report.CompressionKept = true
+		report.StoredBytes = len(out)
+		return CompressionSelection{Payload: out, Actual: CompressionLZ4, Scratch: out, Report: report}, nil
 	default:
-		return nil, 0, nil, fmt.Errorf("colgranule: unsupported compression %d", compression)
+		return CompressionSelection{}, fmt.Errorf("colgranule: unsupported compression %d", compression)
 	}
 }
 
-func compressPayload(raw []byte, compression Compression) ([]byte, Compression, error) {
-	switch compression {
-	case CompressionNone:
-		return append([]byte(nil), raw...), CompressionNone, nil
-	case CompressionSnappy:
-		return snappy.Encode(nil, raw), CompressionSnappy, nil
-	case CompressionLZ4:
-		dst := make([]byte, lz4.CompressBlockBound(len(raw)))
-		n, err := lz4.CompressBlock(raw, dst, nil)
-		if err != nil {
-			return nil, 0, err
-		}
-		if n == 0 || n >= len(raw) {
-			return append([]byte(nil), raw...), CompressionNone, nil
-		}
-		return dst[:n], CompressionLZ4, nil
-	default:
-		return nil, 0, fmt.Errorf("colgranule: unsupported compression %d", compression)
+func compressPayload(raw []byte, encoding Encoding, compression Compression) (CompressionSelection, error) {
+	selection, err := admitCompressionInto(nil, raw, encoding, compression)
+	if err != nil {
+		return CompressionSelection{}, err
 	}
+	payload := append([]byte(nil), selection.Payload...)
+	selection.Payload = payload
+	selection.Report.StoredBytes = len(payload)
+	return selection, nil
 }
 
 func decompressPayload(g EncodedGranule) ([]byte, error) {

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -130,8 +130,6 @@ type GranuleBuilder struct {
 	encoded    []byte
 	compressed []byte
 	values64   []int64
-	bools      []bool
-	codes32    []uint32
 }
 
 func NewGranuleBuilder(cfg Config) *GranuleBuilder {
@@ -364,6 +362,12 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 }
 
 func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if rows > len(raw) {
+		return nil, fmt.Errorf("colgranule: delta rows=%d exceed payload bytes=%d", rows, len(raw))
+	}
 	out := dst[:0]
 	if cap(out) < rows {
 		out = make([]int64, 0, rows)
@@ -393,6 +397,12 @@ func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
 }
 
 func decodeDoubleDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if rows > len(raw) {
+		return nil, fmt.Errorf("colgranule: double-delta rows=%d exceed payload bytes=%d", rows, len(raw))
+	}
 	out := dst[:0]
 	if cap(out) < rows {
 		out = make([]int64, 0, rows)
@@ -456,7 +466,7 @@ func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression
 		if cap(dst) < need {
 			dst = make([]byte, need)
 		} else {
-			dst = dst[:need]
+			dst = dst[:0]
 		}
 		start := time.Now()
 		out := snappy.Encode(dst, raw)

--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -25,7 +25,7 @@ func benchmarkFixtures() []fixture {
 
 func benchmarkConfigs() []Config {
 	var configs []Config
-	for _, encoding := range []Encoding{EncodingRawInt64, EncodingDeltaVarint} {
+	for _, encoding := range []Encoding{EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
 		for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4} {
 			configs = append(configs, Config{Encoding: encoding, Compression: compression})
 		}
@@ -134,6 +134,118 @@ func BenchmarkRangeScanInt64Granule(b *testing.B) {
 	}
 }
 
+func BenchmarkDecodeNullableInt64Granule(b *testing.B) {
+	values := makeTimestampJitter(DefaultRowsPerGranule)
+	nulls := makeEveryNthBool(DefaultRowsPerGranule, 17)
+	defaults := makeEveryNthBool(DefaultRowsPerGranule, 29)
+	for i := range defaults {
+		if nulls[i] {
+			defaults[i] = false
+		}
+	}
+	for _, cfg := range []Config{
+		{Encoding: EncodingRawInt64, Compression: CompressionNone},
+		{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+		{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionLZ4},
+	} {
+		builder := NewGranuleBuilder(cfg)
+		g, err := builder.BuildNullableInt64(values, nulls, defaults, 1_700_000_000_000_000)
+		if err != nil {
+			b.Fatal(err)
+		}
+		name := fmt.Sprintf("%s/requested_%s/actual_%s/nulls_%d/defaults_%d/stored_%dB/raw_%dB", cfg.Encoding, cfg.Compression, g.Compression, g.NullCount, g.DefaultCount, g.StoredBytes, g.RawBytes)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(values) * 8))
+			var reader GranuleReader
+			decoded, _, _, err := reader.DecodeNullableInt64(g)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += decoded[len(decoded)-1]
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				decoded, _, _, err := reader.DecodeNullableInt64(g)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += decoded[len(decoded)-1]
+			}
+			reportGranuleBenchMetrics(b, len(values), len(values)*8, g.StoredBytes)
+		})
+	}
+}
+
+func BenchmarkCountBoolGranule(b *testing.B) {
+	fixtures := []struct {
+		name   string
+		values []bool
+	}{
+		{name: "alternating", values: makeAlternatingBool(DefaultRowsPerGranule)},
+		{name: "runs", values: makeBoolRuns(DefaultRowsPerGranule)},
+	}
+	for _, fx := range fixtures {
+		for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4} {
+			builder := NewGranuleBuilder(Config{Compression: compression})
+			g, err := builder.BuildBool(fx.values)
+			if err != nil {
+				b.Fatal(err)
+			}
+			name := fmt.Sprintf("%s/requested_%s/actual_%s/stored_%dB/raw_%dB", fx.name, compression, g.Compression, g.StoredBytes, g.RawBytes)
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(fx.values)))
+				var reader GranuleReader
+				count, err := reader.CountTrueBool(g)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(count)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					count, err := reader.CountTrueBool(g)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(count)
+				}
+				reportGranuleBenchMetrics(b, len(fx.values), len(fx.values), g.StoredBytes)
+			})
+		}
+	}
+}
+
+func BenchmarkCountUint32CodesGranule(b *testing.B) {
+	codes := makeUint32Codes(DefaultRowsPerGranule, 16)
+	for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4} {
+		builder := NewGranuleBuilder(Config{Compression: compression})
+		g, err := builder.BuildUint32Codes(codes, 16)
+		if err != nil {
+			b.Fatal(err)
+		}
+		name := fmt.Sprintf("cardinality_16/requested_%s/actual_%s/stored_%dB/raw_%dB", compression, g.Compression, g.StoredBytes, g.RawBytes)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(codes) * 4))
+			var reader GranuleReader
+			counts, err := reader.CountUint32Codes(g, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(counts[0])
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				counts, err = reader.CountUint32Codes(g, counts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(counts[0])
+			}
+			reportGranuleBenchMetrics(b, len(codes), len(codes)*4, g.StoredBytes)
+		})
+	}
+}
+
 func TestCompressionRatios(t *testing.T) {
 	for _, fx := range benchmarkFixtures() {
 		t.Logf("fixture=%s rows=%d raw_values_bytes=%d", fx.name, len(fx.values), len(fx.values)*8)
@@ -200,6 +312,38 @@ func makeRandom(n int) []int64 {
 	values := make([]int64, n)
 	for i := range values {
 		values[i] = r.Int63()
+	}
+	return values
+}
+
+func makeEveryNthBool(n int, step int) []bool {
+	values := make([]bool, n)
+	for i := range values {
+		values[i] = i%step == 0
+	}
+	return values
+}
+
+func makeAlternatingBool(n int) []bool {
+	values := make([]bool, n)
+	for i := range values {
+		values[i] = i%2 == 0
+	}
+	return values
+}
+
+func makeBoolRuns(n int) []bool {
+	values := make([]bool, n)
+	for i := range values {
+		values[i] = (i/256)%2 == 1
+	}
+	return values
+}
+
+func makeUint32Codes(n int, cardinality uint32) []uint32 {
+	values := make([]uint32, n)
+	for i := range values {
+		values[i] = uint32((i / 32) % int(cardinality))
 	}
 	return values
 }

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestEncodeDecodeInt64Granule(t *testing.T) {
 	values := []int64{-10, -9, -4, 0, 1, 99, 100, 101}
-	for _, encoding := range []Encoding{EncodingRawInt64, EncodingDeltaVarint} {
+	for _, encoding := range []Encoding{EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
 		for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4} {
 			g, err := EncodeInt64(nil, values, Config{Encoding: encoding, Compression: compression})
 			if err != nil {
@@ -23,6 +23,9 @@ func TestEncodeDecodeInt64Granule(t *testing.T) {
 			if g.Min != -10 || g.Max != 101 {
 				t.Fatalf("min/max=(%d,%d) want (-10,101)", g.Min, g.Max)
 			}
+			if !g.HasMinMax {
+				t.Fatalf("HasMinMax=false want true")
+			}
 			if g.Rows != len(values) || g.NullCount != 0 || g.DefaultCount != 0 {
 				t.Fatalf("metadata rows/null/default=(%d,%d,%d) want (%d,0,0)", g.Rows, g.NullCount, g.DefaultCount, len(values))
 			}
@@ -31,6 +34,9 @@ func TestEncodeDecodeInt64Granule(t *testing.T) {
 			}
 			if g.PayloadRef.Kind != PayloadRefInline || g.PayloadRef.Length != len(g.Payload) {
 				t.Fatalf("payload ref=(%s,%d) want (inline,%d)", g.PayloadRef.Kind, g.PayloadRef.Length, len(g.Payload))
+			}
+			if g.CodecReport.Encoding != encoding || g.CodecReport.ActualCompression != g.Compression || g.CodecReport.StoredBytes != g.StoredBytes {
+				t.Fatalf("codec report=%+v granule compression=%s stored=%d", g.CodecReport, g.Compression, g.StoredBytes)
 			}
 		}
 	}
@@ -62,6 +68,7 @@ func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
 			for _, cfg := range []Config{
 				{Encoding: EncodingRawInt64, Compression: CompressionNone},
 				{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
+				{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionSnappy},
 				{Encoding: EncodingDeltaVarint, Compression: CompressionLZ4},
 			} {
 				builder := NewGranuleBuilder(cfg)
@@ -80,6 +87,156 @@ func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBoolGranuleRoundTripAndCount(t *testing.T) {
+	runValues := make([]bool, 192)
+	for i := 64; i < 128; i++ {
+		runValues[i] = true
+	}
+	allTrue := make([]bool, 128)
+	for i := range allTrue {
+		allTrue[i] = true
+	}
+	tests := []struct {
+		name       string
+		values     []bool
+		wantMode   byte
+		wantTrues  int
+		wantMinMax [2]int64
+	}{
+		{name: "alternating", values: []bool{true, false, true, false, true, false, true, false, true}, wantMode: boolPayloadBitpack, wantTrues: 5, wantMinMax: [2]int64{0, 1}},
+		{name: "runs", values: runValues, wantMode: boolPayloadRLE, wantTrues: 64, wantMinMax: [2]int64{0, 1}},
+		{name: "all_true", values: allTrue, wantMode: boolPayloadRLE, wantTrues: len(allTrue), wantMinMax: [2]int64{1, 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewGranuleBuilder(Config{Compression: CompressionNone})
+			g, err := builder.BuildBool(tt.values)
+			if err != nil {
+				t.Fatalf("BuildBool: %v", err)
+			}
+			if g.Encoding != EncodingBoolBitpackRLE || g.Payload[0] != tt.wantMode {
+				t.Fatalf("encoding/mode=(%s,%d) want (%s,%d)", g.Encoding, g.Payload[0], EncodingBoolBitpackRLE, tt.wantMode)
+			}
+			if g.Min != tt.wantMinMax[0] || g.Max != tt.wantMinMax[1] {
+				t.Fatalf("min/max=(%d,%d) want %v", g.Min, g.Max, tt.wantMinMax)
+			}
+			var reader GranuleReader
+			got, err := reader.DecodeBool(g)
+			if err != nil {
+				t.Fatalf("DecodeBool: %v", err)
+			}
+			if !slices.Equal(got, tt.values) {
+				t.Fatalf("DecodeBool=%v want %v", got, tt.values)
+			}
+			count, err := reader.CountTrueBool(g)
+			if err != nil {
+				t.Fatalf("CountTrueBool: %v", err)
+			}
+			if count != tt.wantTrues {
+				t.Fatalf("CountTrueBool=%d want %d", count, tt.wantTrues)
+			}
+		})
+	}
+}
+
+func TestNullableInt64GranuleRoundTrip(t *testing.T) {
+	values := []int64{10, 20, 30, 40, 50, 60, 70}
+	nulls := []bool{false, true, false, false, false, true, false}
+	defaults := []bool{false, false, true, false, true, false, false}
+	defaultValue := int64(99)
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionSnappy})
+	g, err := builder.BuildNullableInt64(values, nulls, defaults, defaultValue)
+	if err != nil {
+		t.Fatalf("BuildNullableInt64: %v", err)
+	}
+	if g.Encoding != EncodingNullableInt64 || g.NullCount != 2 || g.DefaultCount != 2 {
+		t.Fatalf("encoding/null/default=(%s,%d,%d) want (%s,2,2)", g.Encoding, g.NullCount, g.DefaultCount, EncodingNullableInt64)
+	}
+	if !g.HasMinMax || g.Min != 10 || g.Max != 99 {
+		t.Fatalf("has/min/max=(%v,%d,%d) want (true,10,99)", g.HasMinMax, g.Min, g.Max)
+	}
+	var reader GranuleReader
+	gotValues, gotNulls, gotDefaults, err := reader.DecodeNullableInt64(g)
+	if err != nil {
+		t.Fatalf("DecodeNullableInt64: %v", err)
+	}
+	wantValues := []int64{10, 0, 99, 40, 99, 0, 70}
+	if !slices.Equal(gotValues, wantValues) {
+		t.Fatalf("values=%v want %v", gotValues, wantValues)
+	}
+	if !slices.Equal(gotNulls, nulls) {
+		t.Fatalf("nulls=%v want %v", gotNulls, nulls)
+	}
+	if !slices.Equal(gotDefaults, defaults) {
+		t.Fatalf("defaults=%v want %v", gotDefaults, defaults)
+	}
+}
+
+func TestLowCardinalityUint32RoundTripAndCounts(t *testing.T) {
+	codes := []uint32{0, 2, 1, 2, 2, 4, 4, 0, 3, 2}
+	builder := NewGranuleBuilder(Config{Compression: CompressionLZ4})
+	g, err := builder.BuildUint32Codes(codes, 5)
+	if err != nil {
+		t.Fatalf("BuildUint32Codes: %v", err)
+	}
+	if g.Encoding != EncodingLowCardinalityUint32 || g.Min != 0 || g.Max != 4 {
+		t.Fatalf("encoding/min/max=(%s,%d,%d) want (%s,0,4)", g.Encoding, g.Min, g.Max, EncodingLowCardinalityUint32)
+	}
+	var reader GranuleReader
+	got, err := reader.DecodeUint32Codes(g)
+	if err != nil {
+		t.Fatalf("DecodeUint32Codes: %v", err)
+	}
+	if !slices.Equal(got, codes) {
+		t.Fatalf("DecodeUint32Codes=%v want %v", got, codes)
+	}
+	counts, err := reader.CountUint32Codes(g, nil)
+	if err != nil {
+		t.Fatalf("CountUint32Codes: %v", err)
+	}
+	wantCounts := []int{2, 1, 4, 1, 2}
+	if !slices.Equal(counts, wantCounts) {
+		t.Fatalf("CountUint32Codes=%v want %v", counts, wantCounts)
+	}
+}
+
+func TestCompressionAdmissionReportsFallback(t *testing.T) {
+	values := makeRandom(8192)
+	g, err := EncodeInt64(nil, values, Config{Encoding: EncodingRawInt64, Compression: CompressionSnappy})
+	if err != nil {
+		t.Fatalf("EncodeInt64: %v", err)
+	}
+	if g.CodecReport.RequestedCompression != CompressionSnappy || !g.CodecReport.CompressionAttempted {
+		t.Fatalf("codec report did not record snappy attempt: %+v", g.CodecReport)
+	}
+	if g.StoredBytes > g.RawBytes {
+		t.Fatalf("stored bytes expanded silently: stored=%d raw=%d report=%+v", g.StoredBytes, g.RawBytes, g.CodecReport)
+	}
+	if g.Compression == CompressionNone && g.CodecReport.CompressionFallbackReason == "" {
+		t.Fatalf("fallback did not report reason: %+v", g.CodecReport)
+	}
+}
+
+func TestUnsupportedCodecIDsFailClosed(t *testing.T) {
+	g, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionNone})
+	if err != nil {
+		t.Fatalf("EncodeInt64: %v", err)
+	}
+	badEncoding := g
+	badEncoding.Encoding = Encoding(255)
+	if _, err := DecodeInt64(nil, badEncoding); err == nil {
+		t.Fatal("DecodeInt64 with bad encoding succeeded, want error")
+	}
+	badCompression := g
+	badCompression.Compression = Compression(255)
+	if _, err := DecodeInt64(nil, badCompression); err == nil {
+		t.Fatal("DecodeInt64 with bad compression succeeded, want error")
+	}
+	if _, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionZSTD}); err == nil {
+		t.Fatal("EncodeInt64 with unsupported zstd succeeded, want error")
 	}
 }
 
@@ -114,6 +271,51 @@ func TestGranuleReaderReusesBuffersWithoutStaleValues(t *testing.T) {
 	if !slices.Equal(got, shortValues) {
 		t.Fatalf("DecodeInt64Into(short)=%v want %v", got, shortValues)
 	}
+}
+
+func FuzzDecodeTypedGranuleCorruptPayloads(f *testing.F) {
+	boolGranule, err := NewGranuleBuilder(Config{Compression: CompressionNone}).BuildBool([]bool{true, false, true, true, false})
+	if err != nil {
+		f.Fatalf("BuildBool: %v", err)
+	}
+	nullableGranule, err := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone}).BuildNullableInt64(
+		[]int64{1, 2, 3, 4},
+		[]bool{false, true, false, false},
+		[]bool{false, false, true, false},
+		7,
+	)
+	if err != nil {
+		f.Fatalf("BuildNullableInt64: %v", err)
+	}
+	codeGranule, err := NewGranuleBuilder(Config{Compression: CompressionNone}).BuildUint32Codes([]uint32{0, 1, 1, 2}, 3)
+	if err != nil {
+		f.Fatalf("BuildUint32Codes: %v", err)
+	}
+	f.Add(byte(EncodingBoolBitpackRLE), boolGranule.Payload)
+	f.Add(byte(EncodingNullableInt64), nullableGranule.Payload)
+	f.Add(byte(EncodingLowCardinalityUint32), codeGranule.Payload)
+	f.Fuzz(func(t *testing.T, encoding byte, payload []byte) {
+		g := EncodedGranule{
+			Rows:        4,
+			Encoding:    Encoding(encoding),
+			Compression: CompressionNone,
+			RawBytes:    len(payload),
+			StoredBytes: len(payload),
+			PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(payload)},
+			Payload:     payload,
+		}
+		var reader GranuleReader
+		switch Encoding(encoding) {
+		case EncodingBoolBitpackRLE:
+			_, _ = reader.DecodeBool(g)
+			_, _ = reader.CountTrueBool(g)
+		case EncodingNullableInt64:
+			_, _, _, _ = reader.DecodeNullableInt64(g)
+		case EncodingLowCardinalityUint32:
+			_, _ = reader.DecodeUint32Codes(g)
+			_, _ = reader.CountUint32Codes(g, nil)
+		}
+	})
 }
 
 func TestCorruptPayloadsFailClosed(t *testing.T) {

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -61,6 +61,17 @@ func TestGranuleBuilderRejectsOversizedRows(t *testing.T) {
 	if _, err := EncodeInt64(nil, values, Config{Encoding: EncodingRawInt64, Compression: CompressionNone}); err == nil {
 		t.Fatal("EncodeInt64(oversized) succeeded, want error")
 	}
+	if _, err := builder.BuildNullableInt64(values, nil, nil, 0); err == nil {
+		t.Fatal("BuildNullableInt64(oversized) succeeded, want error")
+	}
+	bools := make([]bool, maxGranuleDecodeRows+1)
+	if _, err := builder.BuildBool(bools); err == nil {
+		t.Fatal("BuildBool(oversized) succeeded, want error")
+	}
+	codes := make([]uint32, maxGranuleDecodeRows+1)
+	if _, err := builder.BuildUint32Codes(codes, 1); err == nil {
+		t.Fatal("BuildUint32Codes(oversized) succeeded, want error")
+	}
 }
 
 func TestGranuleBuilderMinMaxMetadata(t *testing.T) {
@@ -208,6 +219,18 @@ func TestBoolCorruptPayloadsFailClosedBeforeDecodeAllocation(t *testing.T) {
 	}
 }
 
+func TestBoolAtTreatsShortOptionalBitmapAsFalse(t *testing.T) {
+	if !boolAt([]bool{true}, 0) {
+		t.Fatal("boolAt existing true row returned false")
+	}
+	if boolAt([]bool{true}, 1) {
+		t.Fatal("boolAt out-of-range row returned true")
+	}
+	if boolAt(nil, 0) {
+		t.Fatal("boolAt nil bitmap returned true")
+	}
+}
+
 func TestNullableInt64GranuleRoundTrip(t *testing.T) {
 	values := []int64{10, 20, 30, 40, 50, 60, 70}
 	nulls := []bool{false, true, false, false, false, true, false}
@@ -238,6 +261,24 @@ func TestNullableInt64GranuleRoundTrip(t *testing.T) {
 	}
 	if !slices.Equal(gotDefaults, defaults) {
 		t.Fatalf("defaults=%v want %v", gotDefaults, defaults)
+	}
+}
+
+func TestNullableInt64CorruptRowsFailClosedBeforeDecodeAllocation(t *testing.T) {
+	payload := make([]byte, nullableInt64HeaderBytes)
+	payload[0] = byte(EncodingDeltaVarint)
+	g := EncodedGranule{
+		Rows:        maxGranuleDecodeRows + 1,
+		Encoding:    EncodingNullableInt64,
+		Compression: CompressionNone,
+		RawBytes:    len(payload),
+		StoredBytes: len(payload),
+		PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(payload)},
+		Payload:     payload,
+	}
+	var reader GranuleReader
+	if _, _, _, err := reader.DecodeNullableInt64(g); err == nil {
+		t.Fatal("DecodeNullableInt64(corrupt) succeeded, want error")
 	}
 }
 
@@ -286,6 +327,22 @@ func TestLowCardinalityUint32CorruptRowsFailClosed(t *testing.T) {
 	}
 	if _, err := reader.CountUint32Codes(g, nil); err == nil {
 		t.Fatal("CountUint32Codes(corrupt) succeeded, want error")
+	}
+}
+
+func TestCompressionAdmissionReportsNoFallbackWhenNoneRequested(t *testing.T) {
+	g, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionNone})
+	if err != nil {
+		t.Fatalf("EncodeInt64: %v", err)
+	}
+	if g.CodecReport.RequestedCompression != CompressionNone || g.CodecReport.ActualCompression != CompressionNone {
+		t.Fatalf("codec report compression=(%s,%s), want none/none", g.CodecReport.RequestedCompression, g.CodecReport.ActualCompression)
+	}
+	if g.CodecReport.CompressionAttempted {
+		t.Fatalf("compression none unexpectedly attempted compression: %+v", g.CodecReport)
+	}
+	if g.CodecReport.CompressionFallbackReason != "" {
+		t.Fatalf("compression none fallback reason=%q, want empty", g.CodecReport.CompressionFallbackReason)
 	}
 }
 

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -142,6 +142,45 @@ func TestBoolGranuleRoundTripAndCount(t *testing.T) {
 	}
 }
 
+func TestBoolCorruptPayloadsFailClosedBeforeDecodeAllocation(t *testing.T) {
+	tests := []struct {
+		name string
+		rows int
+		raw  []byte
+	}{
+		{
+			name: "invalid_rle_start",
+			rows: 1,
+			raw:  []byte{boolPayloadRLE, 2, 1},
+		},
+		{
+			name: "huge_bitpack_rows",
+			rows: maxGranuleDecodeRows + 1,
+			raw:  []byte{boolPayloadBitpack},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := EncodedGranule{
+				Rows:        tt.rows,
+				Encoding:    EncodingBoolBitpackRLE,
+				Compression: CompressionNone,
+				RawBytes:    len(tt.raw),
+				StoredBytes: len(tt.raw),
+				PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(tt.raw)},
+				Payload:     tt.raw,
+			}
+			var reader GranuleReader
+			if _, err := reader.DecodeBool(g); err == nil {
+				t.Fatal("DecodeBool(corrupt) succeeded, want error")
+			}
+			if _, err := reader.CountTrueBool(g); err == nil {
+				t.Fatal("CountTrueBool(corrupt) succeeded, want error")
+			}
+		})
+	}
+}
+
 func TestNullableInt64GranuleRoundTrip(t *testing.T) {
 	values := []int64{10, 20, 30, 40, 50, 60, 70}
 	nulls := []bool{false, true, false, false, false, true, false}
@@ -203,6 +242,26 @@ func TestLowCardinalityUint32RoundTripAndCounts(t *testing.T) {
 	}
 }
 
+func TestLowCardinalityUint32CorruptRowsFailClosed(t *testing.T) {
+	payload := []byte{4, 1}
+	g := EncodedGranule{
+		Rows:        maxGranuleDecodeRows + 1,
+		Encoding:    EncodingLowCardinalityUint32,
+		Compression: CompressionNone,
+		RawBytes:    len(payload),
+		StoredBytes: len(payload),
+		PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(payload)},
+		Payload:     payload,
+	}
+	var reader GranuleReader
+	if _, err := reader.DecodeUint32Codes(g); err == nil {
+		t.Fatal("DecodeUint32Codes(corrupt) succeeded, want error")
+	}
+	if _, err := reader.CountUint32Codes(g, nil); err == nil {
+		t.Fatal("CountUint32Codes(corrupt) succeeded, want error")
+	}
+}
+
 func TestCompressionAdmissionReportsFallback(t *testing.T) {
 	values := makeRandom(8192)
 	g, err := EncodeInt64(nil, values, Config{Encoding: EncodingRawInt64, Compression: CompressionSnappy})
@@ -237,6 +296,9 @@ func TestUnsupportedCodecIDsFailClosed(t *testing.T) {
 	}
 	if _, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionZSTD}); err == nil {
 		t.Fatal("EncodeInt64 with unsupported zstd succeeded, want error")
+	}
+	if _, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionZSTDDict}); err == nil {
+		t.Fatal("EncodeInt64 with unsupported zstd_dict succeeded, want error")
 	}
 }
 
@@ -350,6 +412,39 @@ func TestCorruptPayloadsFailClosed(t *testing.T) {
 			cfg:  Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone},
 			edit: func(g EncodedGranule) EncodedGranule {
 				g.Payload = append(append([]byte(nil), g.Payload...), 0)
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				g.RawBytes = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "double_delta_truncated",
+			cfg:  Config{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = g.Payload[:len(g.Payload)-1]
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "double_delta_trailing",
+			cfg:  Config{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Payload = append(append([]byte(nil), g.Payload...), 0)
+				g.StoredBytes = len(g.Payload)
+				g.PayloadRef.Length = len(g.Payload)
+				g.RawBytes = len(g.Payload)
+				return g
+			},
+		},
+		{
+			name: "double_delta_huge_rows_tiny_payload",
+			cfg:  Config{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionNone},
+			edit: func(g EncodedGranule) EncodedGranule {
+				g.Rows = maxGranuleDecodeRows + 1
+				g.Payload = []byte{0}
 				g.StoredBytes = len(g.Payload)
 				g.PayloadRef.Length = len(g.Payload)
 				g.RawBytes = len(g.Payload)

--- a/experiments/colgranule/jsonbench_report.go
+++ b/experiments/colgranule/jsonbench_report.go
@@ -92,6 +92,9 @@ func DefaultJSONBenchConfigs() []Config {
 		{Encoding: EncodingDeltaVarint, Compression: CompressionNone},
 		{Encoding: EncodingDeltaVarint, Compression: CompressionSnappy},
 		{Encoding: EncodingDeltaVarint, Compression: CompressionLZ4},
+		{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionNone},
+		{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionSnappy},
+		{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionLZ4},
 	}
 }
 

--- a/experiments/colgranule/typed.go
+++ b/experiments/colgranule/typed.go
@@ -1,0 +1,679 @@
+package colgranule
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+const (
+	boolPayloadBitpack byte = 1
+	boolPayloadRLE     byte = 2
+
+	nullableInt64HeaderBytes = 21
+	maxCodeCardinality       = 1 << 20
+)
+
+func (b *GranuleBuilder) BuildBool(values []bool) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	raw := encodeBoolPayload(b.raw[:0], values)
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingBoolBitpackRLE, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	min, max := boolMinMax(values)
+	return newEncodedGranule(len(values), min, max, true, EncodingBoolBitpackRLE, selection), nil
+}
+
+func (r *GranuleReader) DecodeBool(g EncodedGranule) ([]bool, error) {
+	values, err := r.DecodeBoolInto(r.bools[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.bools = values
+	return values, nil
+}
+
+func (r *GranuleReader) DecodeBoolInto(dst []bool, g EncodedGranule) ([]bool, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return nil, fmt.Errorf("colgranule: bool decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	return decodeBoolPayload(dst, raw, g.Rows)
+}
+
+func (r *GranuleReader) CountTrueBool(g EncodedGranule) (int, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return 0, fmt.Errorf("colgranule: bool count got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return 0, err
+	}
+	return countTrueBoolPayload(raw, g.Rows)
+}
+
+func (b *GranuleBuilder) BuildNullableInt64(values []int64, nulls []bool, defaults []bool, defaultValue int64) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	valueEncoding, err := nullableValueEncoding(b.cfg.Encoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	if err := validateOptionalBoolRows("nulls", len(values), nulls); err != nil {
+		return EncodedGranule{}, err
+	}
+	if err := validateOptionalBoolRows("defaults", len(values), defaults); err != nil {
+		return EncodedGranule{}, err
+	}
+
+	b.values64 = b.values64[:0]
+	nullCount := 0
+	defaultCount := 0
+	hasMinMax := false
+	min, max := int64(0), int64(0)
+	for i, v := range values {
+		isNull := boolAt(nulls, i)
+		isDefault := boolAt(defaults, i)
+		if isNull && isDefault {
+			return EncodedGranule{}, fmt.Errorf("colgranule: row %d is both null and default", i)
+		}
+		switch {
+		case isNull:
+			nullCount++
+		case isDefault:
+			defaultCount++
+			min, max, hasMinMax = updateOptionalMinMax(min, max, hasMinMax, defaultValue)
+		default:
+			b.values64 = append(b.values64, v)
+			min, max, hasMinMax = updateOptionalMinMax(min, max, hasMinMax, v)
+		}
+	}
+
+	encodedValues, err := encodeInt64Payload(b.encoded[:0], b.values64, valueEncoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.encoded = encodedValues
+
+	nullMaskLen := bitmapBytes(len(values))
+	defaultMaskLen := bitmapBytes(len(values))
+	raw := b.raw[:0]
+	raw = append(raw, make([]byte, nullableInt64HeaderBytes)...)
+	raw[0] = byte(valueEncoding)
+	binary.LittleEndian.PutUint64(raw[1:9], uint64(defaultValue))
+	binary.LittleEndian.PutUint32(raw[9:13], uint32(len(b.values64)))
+	binary.LittleEndian.PutUint32(raw[13:17], uint32(nullMaskLen))
+	binary.LittleEndian.PutUint32(raw[17:21], uint32(defaultMaskLen))
+	raw = appendBitmap(raw, len(values), nulls)
+	raw = appendBitmap(raw, len(values), defaults)
+	raw = append(raw, encodedValues...)
+	b.raw = raw
+
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingNullableInt64, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	g := newEncodedGranule(len(values), min, max, hasMinMax, EncodingNullableInt64, selection)
+	g.NullCount = nullCount
+	g.DefaultCount = defaultCount
+	return g, nil
+}
+
+func (r *GranuleReader) DecodeNullableInt64(g EncodedGranule) ([]int64, []bool, []bool, error) {
+	values, nulls, defaults, err := r.DecodeNullableInt64Into(r.values[:0], r.nulls[:0], r.defaults[:0], g)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	r.values = values
+	r.nulls = nulls
+	r.defaults = defaults
+	return values, nulls, defaults, nil
+}
+
+func (r *GranuleReader) DecodeNullableInt64Into(dst []int64, nulls []bool, defaults []bool, g EncodedGranule) ([]int64, []bool, []bool, error) {
+	if g.Encoding != EncodingNullableInt64 {
+		return nil, nil, nil, fmt.Errorf("colgranule: nullable int64 decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	header, err := parseNullableInt64Header(raw, g.Rows)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	storedGranule := EncodedGranule{
+		Rows:        header.storedRows,
+		HasMinMax:   false,
+		Encoding:    header.valueEncoding,
+		Compression: CompressionNone,
+		RawBytes:    len(header.encodedValues),
+		StoredBytes: len(header.encodedValues),
+		PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(header.encodedValues)},
+		Payload:     header.encodedValues,
+	}
+	stored, err := decodeInt64Payload(r.stored64[:0], header.encodedValues, storedGranule)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	r.stored64 = stored
+
+	out := ensureInt64Len(dst, g.Rows)
+	nullOut := ensureBoolLen(nulls, g.Rows)
+	defaultOut := ensureBoolLen(defaults, g.Rows)
+	storedIndex := 0
+	for i := 0; i < g.Rows; i++ {
+		isNull := bitmapBit(header.nullMask, i)
+		isDefault := bitmapBit(header.defaultMask, i)
+		if isNull && isDefault {
+			return nil, nil, nil, fmt.Errorf("colgranule: nullable int64 row %d is both null and default", i)
+		}
+		nullOut[i] = isNull
+		defaultOut[i] = isDefault
+		switch {
+		case isNull:
+			out[i] = 0
+		case isDefault:
+			out[i] = header.defaultValue
+		default:
+			if storedIndex >= len(stored) {
+				return nil, nil, nil, errors.New("colgranule: nullable int64 stored values underflow")
+			}
+			out[i] = stored[storedIndex]
+			storedIndex++
+		}
+	}
+	if storedIndex != len(stored) {
+		return nil, nil, nil, errors.New("colgranule: nullable int64 stored values overflow")
+	}
+	return out, nullOut, defaultOut, nil
+}
+
+func (b *GranuleBuilder) BuildUint32Codes(codes []uint32, cardinality uint32) (EncodedGranule, error) {
+	if len(codes) == 0 {
+		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	minCode, maxCode := minMaxUint32(codes)
+	if cardinality == 0 {
+		if maxCode == ^uint32(0) {
+			return EncodedGranule{}, errors.New("colgranule: inferred cardinality overflows uint32")
+		}
+		cardinality = maxCode + 1
+	}
+	if cardinality > maxCodeCardinality {
+		return EncodedGranule{}, fmt.Errorf("colgranule: cardinality %d exceeds cap %d", cardinality, maxCodeCardinality)
+	}
+	if maxCode >= cardinality {
+		return EncodedGranule{}, fmt.Errorf("colgranule: code %d outside cardinality %d", maxCode, cardinality)
+	}
+	raw := encodeUint32CodesPayload(b.raw[:0], codes, cardinality, maxCode)
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingLowCardinalityUint32, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(len(codes), int64(minCode), int64(maxCode), true, EncodingLowCardinalityUint32, selection), nil
+}
+
+func (r *GranuleReader) DecodeUint32Codes(g EncodedGranule) ([]uint32, error) {
+	codes, err := r.DecodeUint32CodesInto(r.codes[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.codes = codes
+	return codes, nil
+}
+
+func (r *GranuleReader) DecodeUint32CodesInto(dst []uint32, g EncodedGranule) ([]uint32, error) {
+	if g.Encoding != EncodingLowCardinalityUint32 {
+		return nil, fmt.Errorf("colgranule: code decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return nil, err
+	}
+	out := ensureUint32Len(dst, g.Rows)
+	for i := 0; i < g.Rows; i++ {
+		code := readUint32Code(header.data, header.width, i)
+		if code >= header.cardinality {
+			return nil, fmt.Errorf("colgranule: code %d outside cardinality %d", code, header.cardinality)
+		}
+		out[i] = code
+	}
+	return out, nil
+}
+
+func (r *GranuleReader) CountUint32Codes(g EncodedGranule, counts []int) ([]int, error) {
+	if g.Encoding != EncodingLowCardinalityUint32 {
+		return nil, fmt.Errorf("colgranule: code count got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return nil, err
+	}
+	out := ensureIntLen(counts, int(header.cardinality))
+	clear(out)
+	for i := 0; i < g.Rows; i++ {
+		code := readUint32Code(header.data, header.width, i)
+		if code >= header.cardinality {
+			return nil, fmt.Errorf("colgranule: code %d outside cardinality %d", code, header.cardinality)
+		}
+		out[code]++
+	}
+	return out, nil
+}
+
+func encodeBoolPayload(dst []byte, values []bool) []byte {
+	bitpackLen := 1 + bitmapBytes(len(values))
+	rleLen := boolRLEPayloadLen(values)
+	if rleLen < bitpackLen {
+		dst = appendBoolRLE(dst[:0], values)
+		return dst
+	}
+	dst = append(dst[:0], boolPayloadBitpack)
+	return appendBitmap(dst, len(values), values)
+}
+
+func decodeBoolPayload(dst []bool, raw []byte, rows int) ([]bool, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("colgranule: missing bool payload mode")
+	}
+	out := ensureBoolLen(dst, rows)
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		if len(mask) != bitmapBytes(rows) {
+			return nil, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), bitmapBytes(rows))
+		}
+		for i := 0; i < rows; i++ {
+			out[i] = bitmapBit(mask, i)
+		}
+	case boolPayloadRLE:
+		if len(raw) < 2 {
+			return nil, errors.New("colgranule: truncated bool rle header")
+		}
+		value := raw[1] != 0
+		data := raw[2:]
+		row := 0
+		for len(data) > 0 && row < rows {
+			run, n := binary.Uvarint(data)
+			if n <= 0 {
+				return nil, errors.New("colgranule: malformed bool rle run")
+			}
+			if run == 0 || run > uint64(rows-row) {
+				return nil, errors.New("colgranule: invalid bool rle run")
+			}
+			for i := 0; i < int(run); i++ {
+				out[row+i] = value
+			}
+			row += int(run)
+			value = !value
+			data = data[n:]
+		}
+		if row != rows {
+			return nil, fmt.Errorf("colgranule: bool rle rows=%d want=%d", row, rows)
+		}
+		if len(data) != 0 {
+			return nil, errors.New("colgranule: trailing bool rle bytes")
+		}
+	default:
+		return nil, fmt.Errorf("colgranule: unsupported bool payload mode %d", raw[0])
+	}
+	return out, nil
+}
+
+func countTrueBoolPayload(raw []byte, rows int) (int, error) {
+	if len(raw) == 0 {
+		return 0, errors.New("colgranule: missing bool payload mode")
+	}
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		if len(mask) != bitmapBytes(rows) {
+			return 0, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), bitmapBytes(rows))
+		}
+		count := 0
+		fullBytes := rows / 8
+		for _, b := range mask[:fullBytes] {
+			count += bits.OnesCount8(b)
+		}
+		if rows%8 != 0 {
+			last := mask[fullBytes] & byte((1<<uint(rows%8))-1)
+			count += bits.OnesCount8(last)
+		}
+		return count, nil
+	case boolPayloadRLE:
+		if len(raw) < 2 {
+			return 0, errors.New("colgranule: truncated bool rle header")
+		}
+		value := raw[1] != 0
+		data := raw[2:]
+		row := 0
+		count := 0
+		for len(data) > 0 && row < rows {
+			run, n := binary.Uvarint(data)
+			if n <= 0 {
+				return 0, errors.New("colgranule: malformed bool rle run")
+			}
+			if run == 0 || run > uint64(rows-row) {
+				return 0, errors.New("colgranule: invalid bool rle run")
+			}
+			if value {
+				count += int(run)
+			}
+			row += int(run)
+			value = !value
+			data = data[n:]
+		}
+		if row != rows {
+			return 0, fmt.Errorf("colgranule: bool rle rows=%d want=%d", row, rows)
+		}
+		if len(data) != 0 {
+			return 0, errors.New("colgranule: trailing bool rle bytes")
+		}
+		return count, nil
+	default:
+		return 0, fmt.Errorf("colgranule: unsupported bool payload mode %d", raw[0])
+	}
+}
+
+func boolRLEPayloadLen(values []bool) int {
+	if len(values) == 0 {
+		return 0
+	}
+	var buf [binary.MaxVarintLen64]byte
+	n := 2
+	run := uint64(1)
+	prev := values[0]
+	for _, v := range values[1:] {
+		if v == prev {
+			run++
+			continue
+		}
+		n += binary.PutUvarint(buf[:], run)
+		run = 1
+		prev = v
+	}
+	n += binary.PutUvarint(buf[:], run)
+	return n
+}
+
+func appendBoolRLE(dst []byte, values []bool) []byte {
+	dst = append(dst, boolPayloadRLE)
+	if values[0] {
+		dst = append(dst, 1)
+	} else {
+		dst = append(dst, 0)
+	}
+	var buf [binary.MaxVarintLen64]byte
+	run := uint64(1)
+	prev := values[0]
+	for _, v := range values[1:] {
+		if v == prev {
+			run++
+			continue
+		}
+		n := binary.PutUvarint(buf[:], run)
+		dst = append(dst, buf[:n]...)
+		run = 1
+		prev = v
+	}
+	n := binary.PutUvarint(buf[:], run)
+	return append(dst, buf[:n]...)
+}
+
+func encodeUint32CodesPayload(dst []byte, codes []uint32, cardinality uint32, maxCode uint32) []byte {
+	width := uint32CodeWidth(maxCode)
+	dst = append(dst[:0], width)
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], uint64(cardinality))
+	dst = append(dst, buf[:n]...)
+	switch width {
+	case 1:
+		for _, code := range codes {
+			dst = append(dst, byte(code))
+		}
+	case 2:
+		oldLen := len(dst)
+		dst = append(dst, make([]byte, len(codes)*2)...)
+		for i, code := range codes {
+			binary.LittleEndian.PutUint16(dst[oldLen+i*2:], uint16(code))
+		}
+	case 4:
+		oldLen := len(dst)
+		dst = append(dst, make([]byte, len(codes)*4)...)
+		for i, code := range codes {
+			binary.LittleEndian.PutUint32(dst[oldLen+i*4:], code)
+		}
+	}
+	return dst
+}
+
+type uint32CodesHeader struct {
+	width       byte
+	cardinality uint32
+	data        []byte
+}
+
+func parseUint32CodesHeader(raw []byte, rows int) (uint32CodesHeader, error) {
+	if len(raw) < 2 {
+		return uint32CodesHeader{}, errors.New("colgranule: truncated code header")
+	}
+	width := raw[0]
+	if width != 1 && width != 2 && width != 4 {
+		return uint32CodesHeader{}, fmt.Errorf("colgranule: unsupported code width %d", width)
+	}
+	cardinality64, n := binary.Uvarint(raw[1:])
+	if n <= 0 {
+		return uint32CodesHeader{}, errors.New("colgranule: malformed code cardinality")
+	}
+	if cardinality64 == 0 || cardinality64 > maxCodeCardinality {
+		return uint32CodesHeader{}, fmt.Errorf("colgranule: invalid code cardinality %d", cardinality64)
+	}
+	data := raw[1+n:]
+	need := rows * int(width)
+	if len(data) != need {
+		return uint32CodesHeader{}, fmt.Errorf("colgranule: code data bytes=%d want=%d", len(data), need)
+	}
+	return uint32CodesHeader{width: width, cardinality: uint32(cardinality64), data: data}, nil
+}
+
+func readUint32Code(data []byte, width byte, row int) uint32 {
+	switch width {
+	case 1:
+		return uint32(data[row])
+	case 2:
+		return uint32(binary.LittleEndian.Uint16(data[row*2:]))
+	default:
+		return binary.LittleEndian.Uint32(data[row*4:])
+	}
+}
+
+type nullableInt64Header struct {
+	valueEncoding Encoding
+	defaultValue  int64
+	storedRows    int
+	nullMask      []byte
+	defaultMask   []byte
+	encodedValues []byte
+}
+
+func parseNullableInt64Header(raw []byte, rows int) (nullableInt64Header, error) {
+	if len(raw) < nullableInt64HeaderBytes {
+		return nullableInt64Header{}, errors.New("colgranule: truncated nullable int64 header")
+	}
+	valueEncoding := Encoding(raw[0])
+	if _, err := nullableValueEncoding(valueEncoding); err != nil {
+		return nullableInt64Header{}, err
+	}
+	defaultValue := int64(binary.LittleEndian.Uint64(raw[1:9]))
+	storedRows := int(binary.LittleEndian.Uint32(raw[9:13]))
+	if storedRows > rows {
+		return nullableInt64Header{}, fmt.Errorf("colgranule: nullable stored rows=%d exceeds rows=%d", storedRows, rows)
+	}
+	nullMaskLen := int(binary.LittleEndian.Uint32(raw[13:17]))
+	defaultMaskLen := int(binary.LittleEndian.Uint32(raw[17:21]))
+	wantMaskLen := bitmapBytes(rows)
+	if nullMaskLen != wantMaskLen {
+		return nullableInt64Header{}, fmt.Errorf("colgranule: null mask bytes=%d want=%d", nullMaskLen, wantMaskLen)
+	}
+	if defaultMaskLen != wantMaskLen {
+		return nullableInt64Header{}, fmt.Errorf("colgranule: default mask bytes=%d want=%d", defaultMaskLen, wantMaskLen)
+	}
+	need := nullableInt64HeaderBytes + nullMaskLen + defaultMaskLen
+	if need > len(raw) {
+		return nullableInt64Header{}, errors.New("colgranule: truncated nullable int64 masks")
+	}
+	return nullableInt64Header{
+		valueEncoding: valueEncoding,
+		defaultValue:  defaultValue,
+		storedRows:    storedRows,
+		nullMask:      raw[nullableInt64HeaderBytes : nullableInt64HeaderBytes+nullMaskLen],
+		defaultMask:   raw[nullableInt64HeaderBytes+nullMaskLen : need],
+		encodedValues: raw[need:],
+	}, nil
+}
+
+func nullableValueEncoding(encoding Encoding) (Encoding, error) {
+	switch encoding {
+	case EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+		return encoding, nil
+	default:
+		return 0, fmt.Errorf("colgranule: unsupported nullable int64 value encoding %d", encoding)
+	}
+}
+
+func appendBitmap(dst []byte, rows int, values []bool) []byte {
+	start := len(dst)
+	dst = append(dst, make([]byte, bitmapBytes(rows))...)
+	for i := 0; i < rows; i++ {
+		if boolAt(values, i) {
+			dst[start+i/8] |= 1 << uint(i%8)
+		}
+	}
+	return dst
+}
+
+func bitmapBytes(rows int) int {
+	return (rows + 7) / 8
+}
+
+func bitmapBit(mask []byte, row int) bool {
+	return mask[row/8]&(1<<uint(row%8)) != 0
+}
+
+func boolAt(values []bool, i int) bool {
+	return len(values) != 0 && values[i]
+}
+
+func validateOptionalBoolRows(name string, rows int, values []bool) error {
+	if len(values) != 0 && len(values) != rows {
+		return fmt.Errorf("colgranule: %s rows=%d want 0 or %d", name, len(values), rows)
+	}
+	return nil
+}
+
+func updateOptionalMinMax(min int64, max int64, has bool, v int64) (int64, int64, bool) {
+	if !has {
+		return v, v, true
+	}
+	if v < min {
+		min = v
+	}
+	if v > max {
+		max = v
+	}
+	return min, max, true
+}
+
+func boolMinMax(values []bool) (int64, int64) {
+	seenFalse := false
+	seenTrue := false
+	for _, v := range values {
+		if v {
+			seenTrue = true
+		} else {
+			seenFalse = true
+		}
+	}
+	switch {
+	case seenFalse && seenTrue:
+		return 0, 1
+	case seenTrue:
+		return 1, 1
+	default:
+		return 0, 0
+	}
+}
+
+func minMaxUint32(values []uint32) (uint32, uint32) {
+	min, max := values[0], values[0]
+	for _, v := range values[1:] {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
+func uint32CodeWidth(maxCode uint32) byte {
+	switch {
+	case maxCode <= 0xff:
+		return 1
+	case maxCode <= 0xffff:
+		return 2
+	default:
+		return 4
+	}
+}
+
+func ensureInt64Len(dst []int64, n int) []int64 {
+	if cap(dst) < n {
+		return make([]int64, n)
+	}
+	return dst[:n]
+}
+
+func ensureBoolLen(dst []bool, n int) []bool {
+	if cap(dst) < n {
+		return make([]bool, n)
+	}
+	return dst[:n]
+}
+
+func ensureUint32Len(dst []uint32, n int) []uint32 {
+	if cap(dst) < n {
+		return make([]uint32, n)
+	}
+	return dst[:n]
+}
+
+func ensureIntLen(dst []int, n int) []int {
+	if cap(dst) < n {
+		return make([]int, n)
+	}
+	return dst[:n]
+}

--- a/experiments/colgranule/typed.go
+++ b/experiments/colgranule/typed.go
@@ -21,6 +21,9 @@ func (b *GranuleBuilder) BuildBool(values []bool) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
 	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
 	raw := encodeBoolPayload(b.raw[:0], values)
 	b.raw = raw
 	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingBoolBitpackRLE, b.cfg.Compression)
@@ -68,6 +71,9 @@ func (r *GranuleReader) CountTrueBool(g EncodedGranule) (int, error) {
 func (b *GranuleBuilder) BuildNullableInt64(values []int64, nulls []bool, defaults []bool, defaultValue int64) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
 	}
 	valueEncoding, err := nullableValueEncoding(b.cfg.Encoding)
 	if err != nil {
@@ -209,6 +215,9 @@ func (r *GranuleReader) DecodeNullableInt64Into(dst []int64, nulls []bool, defau
 func (b *GranuleBuilder) BuildUint32Codes(codes []uint32, cardinality uint32) (EncodedGranule, error) {
 	if len(codes) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(codes)); err != nil {
+		return EncodedGranule{}, err
 	}
 	minCode, maxCode := minMaxUint32(codes)
 	if cardinality == 0 {
@@ -536,6 +545,9 @@ type nullableInt64Header struct {
 }
 
 func parseNullableInt64Header(raw []byte, rows int) (nullableInt64Header, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nullableInt64Header{}, err
+	}
 	if len(raw) < nullableInt64HeaderBytes {
 		return nullableInt64Header{}, errors.New("colgranule: truncated nullable int64 header")
 	}
@@ -550,7 +562,10 @@ func parseNullableInt64Header(raw []byte, rows int) (nullableInt64Header, error)
 	}
 	nullMaskLen := int(binary.LittleEndian.Uint32(raw[13:17]))
 	defaultMaskLen := int(binary.LittleEndian.Uint32(raw[17:21]))
-	wantMaskLen := bitmapBytes(rows)
+	wantMaskLen, err := bitmapBytesChecked(rows)
+	if err != nil {
+		return nullableInt64Header{}, err
+	}
 	if nullMaskLen != wantMaskLen {
 		return nullableInt64Header{}, fmt.Errorf("colgranule: null mask bytes=%d want=%d", nullMaskLen, wantMaskLen)
 	}
@@ -643,7 +658,7 @@ func bitmapBit(mask []byte, row int) bool {
 }
 
 func boolAt(values []bool, i int) bool {
-	return len(values) != 0 && values[i]
+	return i >= 0 && i < len(values) && values[i]
 }
 
 func validateOptionalBoolRows(name string, rows int, values []bool) error {

--- a/experiments/colgranule/typed.go
+++ b/experiments/colgranule/typed.go
@@ -13,8 +13,11 @@ const (
 
 	nullableInt64HeaderBytes = 21
 	maxCodeCardinality       = 1 << 20
+	maxGranuleDecodeRows     = 1 << 20
 )
 
+// BuildBool returns a granule whose payload aliases builder-owned scratch until
+// the next builder Build* or Reset call.
 func (b *GranuleBuilder) BuildBool(values []bool) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
@@ -61,6 +64,8 @@ func (r *GranuleReader) CountTrueBool(g EncodedGranule) (int, error) {
 	return countTrueBoolPayload(raw, g.Rows)
 }
 
+// BuildNullableInt64 returns a granule whose payload aliases builder-owned
+// scratch until the next builder Build* or Reset call.
 func (b *GranuleBuilder) BuildNullableInt64(values []int64, nulls []bool, defaults []bool, defaultValue int64) (EncodedGranule, error) {
 	if len(values) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
@@ -200,6 +205,8 @@ func (r *GranuleReader) DecodeNullableInt64Into(dst []int64, nulls []bool, defau
 	return out, nullOut, defaultOut, nil
 }
 
+// BuildUint32Codes returns a granule whose payload aliases builder-owned
+// scratch until the next builder Build* or Reset call.
 func (b *GranuleBuilder) BuildUint32Codes(codes []uint32, cardinality uint32) (EncodedGranule, error) {
 	if len(codes) == 0 {
 		return EncodedGranule{}, errors.New("colgranule: empty granule")
@@ -295,34 +302,39 @@ func encodeBoolPayload(dst []byte, values []bool) []byte {
 }
 
 func decodeBoolPayload(dst []bool, raw []byte, rows int) ([]bool, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
 	if len(raw) == 0 {
 		return nil, errors.New("colgranule: missing bool payload mode")
 	}
-	out := ensureBoolLen(dst, rows)
 	switch raw[0] {
 	case boolPayloadBitpack:
 		mask := raw[1:]
-		if len(mask) != bitmapBytes(rows) {
-			return nil, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), bitmapBytes(rows))
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return nil, err
 		}
+		if len(mask) != need {
+			return nil, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), need)
+		}
+		out := ensureBoolLen(dst, rows)
 		for i := 0; i < rows; i++ {
 			out[i] = bitmapBit(mask, i)
 		}
+		return out, nil
 	case boolPayloadRLE:
-		if len(raw) < 2 {
-			return nil, errors.New("colgranule: truncated bool rle header")
+		value, data, err := parseBoolRLEHeader(raw)
+		if err != nil {
+			return nil, err
 		}
-		value := raw[1] != 0
-		data := raw[2:]
+		if err := validateBoolRLERuns(data, rows); err != nil {
+			return nil, err
+		}
+		out := ensureBoolLen(dst, rows)
 		row := 0
 		for len(data) > 0 && row < rows {
 			run, n := binary.Uvarint(data)
-			if n <= 0 {
-				return nil, errors.New("colgranule: malformed bool rle run")
-			}
-			if run == 0 || run > uint64(rows-row) {
-				return nil, errors.New("colgranule: invalid bool rle run")
-			}
 			for i := 0; i < int(run); i++ {
 				out[row+i] = value
 			}
@@ -330,27 +342,28 @@ func decodeBoolPayload(dst []bool, raw []byte, rows int) ([]bool, error) {
 			value = !value
 			data = data[n:]
 		}
-		if row != rows {
-			return nil, fmt.Errorf("colgranule: bool rle rows=%d want=%d", row, rows)
-		}
-		if len(data) != 0 {
-			return nil, errors.New("colgranule: trailing bool rle bytes")
-		}
+		return out, nil
 	default:
 		return nil, fmt.Errorf("colgranule: unsupported bool payload mode %d", raw[0])
 	}
-	return out, nil
 }
 
 func countTrueBoolPayload(raw []byte, rows int) (int, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return 0, err
+	}
 	if len(raw) == 0 {
 		return 0, errors.New("colgranule: missing bool payload mode")
 	}
 	switch raw[0] {
 	case boolPayloadBitpack:
 		mask := raw[1:]
-		if len(mask) != bitmapBytes(rows) {
-			return 0, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), bitmapBytes(rows))
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return 0, err
+		}
+		if len(mask) != need {
+			return 0, fmt.Errorf("colgranule: bool bitpack bytes=%d want=%d", len(mask), need)
 		}
 		count := 0
 		fullBytes := rows / 8
@@ -363,11 +376,10 @@ func countTrueBoolPayload(raw []byte, rows int) (int, error) {
 		}
 		return count, nil
 	case boolPayloadRLE:
-		if len(raw) < 2 {
-			return 0, errors.New("colgranule: truncated bool rle header")
+		value, data, err := parseBoolRLEHeader(raw)
+		if err != nil {
+			return 0, err
 		}
-		value := raw[1] != 0
-		data := raw[2:]
 		row := 0
 		count := 0
 		for len(data) > 0 && row < rows {
@@ -476,6 +488,9 @@ type uint32CodesHeader struct {
 }
 
 func parseUint32CodesHeader(raw []byte, rows int) (uint32CodesHeader, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return uint32CodesHeader{}, err
+	}
 	if len(raw) < 2 {
 		return uint32CodesHeader{}, errors.New("colgranule: truncated code header")
 	}
@@ -491,6 +506,9 @@ func parseUint32CodesHeader(raw []byte, rows int) (uint32CodesHeader, error) {
 		return uint32CodesHeader{}, fmt.Errorf("colgranule: invalid code cardinality %d", cardinality64)
 	}
 	data := raw[1+n:]
+	if rows > int(^uint(0)>>1)/int(width) {
+		return uint32CodesHeader{}, fmt.Errorf("colgranule: code rows=%d width=%d overflow", rows, width)
+	}
 	need := rows * int(width)
 	if len(data) != need {
 		return uint32CodesHeader{}, fmt.Errorf("colgranule: code data bytes=%d want=%d", len(data), need)
@@ -576,6 +594,59 @@ func appendBitmap(dst []byte, rows int, values []bool) []byte {
 
 func bitmapBytes(rows int) int {
 	return (rows + 7) / 8
+}
+
+func bitmapBytesChecked(rows int) (int, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return 0, err
+	}
+	return bitmapBytes(rows), nil
+}
+
+func validateGranuleDecodeRows(rows int) error {
+	if rows < 0 {
+		return fmt.Errorf("colgranule: negative rows=%d", rows)
+	}
+	if rows > maxGranuleDecodeRows {
+		return fmt.Errorf("colgranule: rows=%d exceed cap %d", rows, maxGranuleDecodeRows)
+	}
+	return nil
+}
+
+func parseBoolRLEHeader(raw []byte) (bool, []byte, error) {
+	if len(raw) < 2 {
+		return false, nil, errors.New("colgranule: truncated bool rle header")
+	}
+	switch raw[1] {
+	case 0:
+		return false, raw[2:], nil
+	case 1:
+		return true, raw[2:], nil
+	default:
+		return false, nil, fmt.Errorf("colgranule: invalid bool rle start value %d", raw[1])
+	}
+}
+
+func validateBoolRLERuns(data []byte, rows int) error {
+	row := 0
+	for len(data) > 0 && row < rows {
+		run, n := binary.Uvarint(data)
+		if n <= 0 {
+			return errors.New("colgranule: malformed bool rle run")
+		}
+		if run == 0 || run > uint64(rows-row) {
+			return errors.New("colgranule: invalid bool rle run")
+		}
+		row += int(run)
+		data = data[n:]
+	}
+	if row != rows {
+		return fmt.Errorf("colgranule: bool rle rows=%d want=%d", row, rows)
+	}
+	if len(data) != 0 {
+		return errors.New("colgranule: trailing bool rle bytes")
+	}
+	return nil
 }
 
 func bitmapBit(mask []byte, row int) bool {


### PR DESCRIPTION
## Objective

Implement Phase 1 / PR2 from #1534: expand the column granule experiment beyond int64-only encoding into typed codec paths and explicit compression admission reporting.

## Context

This is stacked on #1537 and targets `codex/colgranule-granule-core` while PR1 is still open. It keeps the hot inner-loop work moving without introducing durable TreeDB roots, WAL integration, or on-disk part assets.

Refs #1534.

## Non-goals

- No durable on-disk part format.
- No production TreeDB column-store integration.
- No global dictionaries.
- No query planner or aggregate engine beyond the low-cardinality grouped-code count helper needed to validate code-path scans.
- No zstd implementation yet; this PR reserves codec IDs for `zstd` and `zstd_dict` and fails closed if requested.

## Design

- Adds `EncodingDoubleDeltaVarint` for int64 timestamp-like paths.
- Adds `EncodingBoolBitpackRLE` with per-granule bitpack vs RLE admission.
- Adds `EncodingNullableInt64` with explicit null/default bitmaps and compact storage for non-null/non-default values.
- Adds `EncodingLowCardinalityUint32` for integer dictionary-code streams with 1/2/4-byte code widths.
- Adds `CodecReport` to `EncodedGranule` with requested vs actual compression, kept/fallback status, raw/stored bytes, and compression timing.
- Changes compression admission so `snappy` and `lz4` fall back to `none` when compression would not shrink the payload, and records the fallback reason.
- Extends default JSONBench codec configs to include double-delta int64.

## Scope

- Includes (files/symbols): `experiments/colgranule/granule.go`, `typed.go`, `granule_test.go`, `granule_bench_test.go`, `jsonbench_report.go`, `EncodingDoubleDeltaVarint`, `EncodingNullableInt64`, `EncodingBoolBitpackRLE`, `EncodingLowCardinalityUint32`, `CodecReport`.
- Excludes (files/symbols): TreeDB production storage, WAL, durable part layout, part-local string dictionaries, aggregate kernels beyond grouped code counts.

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule`
  - `go test ./experiments/colgranule/...`
  - `go test ./experiments/colgranule -run '^$' -bench 'Benchmark(Encode|Decode|RangeScan|Count).*Granule' -benchmem -benchtime=100x`
  - `go test ./...`
- Corruption/edge cases covered: double-delta round trips, bool bitpack and RLE round trips, bool count without materializing rows, nullable/default-heavy int64 round trips, low-cardinality code decode and grouped counts, unsupported encoding/compression IDs, unsupported zstd requests, compression fallback reporting, typed corrupt-payload fuzz entrypoint.
- Concurrency/race coverage (if applicable): not applicable; builders/readers remain caller-owned scratch structs with no shared package-global mutable state.

## Performance

- Benchmarks run (exact commands): `go test ./experiments/colgranule -run '^$' -bench 'Benchmark(Encode|Decode|RangeScan|Count).*Granule' -benchmem -benchtime=100x`
- Environment: `darwin/arm64`, Apple M3, 8192-row granules.
- Allocation gate: the warmed sweep reported `0 B/op` and `0 allocs/op` for the new encode/decode/range/count benchmark variants.

Representative results from the PR2 sweep:

| Operation | Fixture | Encoding / compression | ns/row | rows/s | MiB/s | stored B/row | B/op | allocs/op |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Encode | `timestamp_jitter` | `double_delta_varint` / `lz4` | 3.666 | 272.8M | 2081 | 0.008789 | 0 | 0 |
| Decode | `timestamp_jitter` | `double_delta_varint` / `snappy` | 2.050 | 487.8M | 3722 | 0.04980 | 0 | 0 |
| Decode nullable | `timestamp_jitter` | `double_delta_varint` / `lz4` | 4.428 | 225.9M | 1723 | 0.05396 | 0 | 0 |
| Count bool | `alternating` | bitpack / `snappy` | 0.06831 | 14.6B | 13961 | 0.006470 | 0 | 0 |
| Count bool | `runs` | RLE / `none` | 0.01155 | 86.6B | 82602 | 0.008057 | 0 | 0 |
| Count codes | cardinality 16 | uint32 code width 1 / `lz4` | 2.209 | 452.7M | 1727 | 0.01648 | 0 | 0 |

Additional notes:

- Random incompressible fixtures now report `actual_none` for `snappy`/`lz4` when compression would expand or fail to shrink the payload.
- Bool count scans packed/RLE payloads directly and does not allocate or materialize a `[]bool` in the measured path.
- Low-cardinality grouped counts operate on integer codes and allocate based on cardinality, not row count; the warmed measured path reuses the counts slice.
- Regressions (if any) and why acceptable: none known in the focused colgranule package.

## Rollout / Toggle Plan

- Default setting: experiment-only API; no production behavior is enabled.
- How to disable quickly: revert this PR or avoid the `experiments/colgranule` package.

## Follow-ups

- Issues/PRs to do next: continue #1534 Phase 1 with PR3 for predicate execution and sort-key mark primitives after PR2 lands.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `experiments/colgranule/granule.go`, `typed.go`, `granule_test.go`, `granule_bench_test.go`, `jsonbench_report.go`
- [x] Explicit exclude list (files/symbols NOT touched): TreeDB production storage, WAL, durable part layout, GC
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: not applicable; no `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): not applicable to CRC, but codec validation paths are fail-closed
- [x] Any concurrency change has a defined state machine and invariants: not applicable; no concurrency change

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./...`
  - [x] Any targeted packages/benchmarks: commands listed above

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [x] No repo doc update needed for this experiment-only API
- [x] No new config knobs
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: not applicable; no production behavior enabled
