### PR TITLE
experiments/colgranule: add predicate mark pruning

### DIFF
--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -246,6 +246,62 @@ func BenchmarkCountUint32CodesGranule(b *testing.B) {
 	}
 }
 
+func BenchmarkPredicatePruningInt64Granules(b *testing.B) {
+	const granulesN = 100
+	granules, marks, err := buildPredicateBenchmarkGranules(granulesN, DefaultRowsPerGranule)
+	if err != nil {
+		b.Fatal(err)
+	}
+	totalRows := granulesN * DefaultRowsPerGranule
+	low := int64(totalRows * 9 / 10)
+	high := int64(totalRows - 1)
+	plan := PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "time_us", Low: low, High: high},
+		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: low, High: high}},
+	}
+	b.Run("unpruned_projected_scan", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(totalRows * 8))
+		var reader GranuleReader
+		count, err := countInt64RangeUnpruned(&reader, granules, low, high)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(count)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			count, err = countInt64RangeUnpruned(&reader, granules, low, high)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(count)
+		}
+		reportGranuleBenchMetrics(b, totalRows, totalRows*8, totalStoredBytes(granules))
+	})
+	b.Run("pruned_by_sort_key_mark", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(totalRows * 8))
+		var reader GranuleReader
+		count, diagnostics, err := reader.CountInt64RangeWithDiagnostics(granules, marks, plan)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if diagnostics.SkippedByMark < granulesN*9/10 {
+			b.Fatalf("skipped_by_mark=%d want at least %d", diagnostics.SkippedByMark, granulesN*9/10)
+		}
+		benchSink += int64(count + diagnostics.SkippedByMark)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			count, diagnostics, err = reader.CountInt64RangeWithDiagnostics(granules, marks, plan)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(count + diagnostics.SkippedByMark)
+		}
+		reportGranuleBenchMetrics(b, totalRows, totalRows*8, totalStoredBytes(granules))
+	})
+}
+
 func TestCompressionRatios(t *testing.T) {
 	for _, fx := range benchmarkFixtures() {
 		t.Logf("fixture=%s rows=%d raw_values_bytes=%d", fx.name, len(fx.values), len(fx.values)*8)
@@ -346,4 +402,53 @@ func makeUint32Codes(n int, cardinality uint32) []uint32 {
 		values[i] = uint32((i / 32) % int(cardinality))
 	}
 	return values
+}
+
+func buildPredicateBenchmarkGranules(granulesN int, rowsPerGranule int) ([]EncodedGranule, []SortKeyMark, error) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionLZ4})
+	granules := make([]EncodedGranule, 0, granulesN)
+	marks := make([]SortKeyMark, 0, granulesN)
+	for granuleIndex := 0; granuleIndex < granulesN; granuleIndex++ {
+		values := make([]int64, rowsPerGranule)
+		for i := range values {
+			values[i] = int64(granuleIndex*rowsPerGranule + i)
+		}
+		g, err := builder.BuildInt64(values)
+		if err != nil {
+			return nil, nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: values}})
+		if err != nil {
+			return nil, nil, err
+		}
+		granules = append(granules, owned)
+		marks = append(marks, mark)
+	}
+	return granules, marks, nil
+}
+
+func countInt64RangeUnpruned(reader *GranuleReader, granules []EncodedGranule, low int64, high int64) (int, error) {
+	count := 0
+	for _, g := range granules {
+		values, err := reader.DecodeInt64(g)
+		if err != nil {
+			return 0, err
+		}
+		for _, v := range values {
+			if v >= low && v <= high {
+				count++
+			}
+		}
+	}
+	return count, nil
+}
+
+func totalStoredBytes(granules []EncodedGranule) int {
+	total := 0
+	for _, g := range granules {
+		total += g.StoredBytes
+	}
+	return total
 }

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -49,9 +49,10 @@ type SortKeyPrefixSummary struct {
 }
 
 type SortKeyMark struct {
-	Rows     int
-	Columns  []string
-	Prefixes []SortKeyPrefixSummary
+	Rows         int
+	Columns      []string
+	ColumnValues [][]int64
+	Prefixes     []SortKeyPrefixSummary
 }
 
 type sortKeyRangePlan struct {
@@ -74,9 +75,10 @@ func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
 		return SortKeyMark{}, errors.New("colgranule: empty sort-key mark")
 	}
 	mark := SortKeyMark{
-		Rows:     rows,
-		Columns:  make([]string, len(columns)),
-		Prefixes: make([]SortKeyPrefixSummary, len(columns)),
+		Rows:         rows,
+		Columns:      make([]string, len(columns)),
+		ColumnValues: make([][]int64, len(columns)),
+		Prefixes:     make([]SortKeyPrefixSummary, len(columns)),
 	}
 	lower := make([]int64, len(columns))
 	last := make([]int64, len(columns))
@@ -93,6 +95,7 @@ func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
 			return SortKeyMark{}, fmt.Errorf("colgranule: sort key column %s rows=%d want=%d", c.Name, len(c.Values), rows)
 		}
 		mark.Columns[i] = c.Name
+		mark.ColumnValues[i] = append([]int64(nil), c.Values...)
 		lower[i] = c.Values[0]
 		last[i] = c.Values[rows-1]
 	}
@@ -179,9 +182,16 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 		}
 		diagnostics.Decoded++
 		count := 0
-		for _, v := range values {
-			if v >= plan.Filter.Low && v <= plan.Filter.High {
-				count++
+		if len(marks) != 0 && len(plan.SortKeyRanges) != 0 {
+			count, err = marks[i].countMatchingRows(values, plan)
+			if err != nil {
+				return total, diagnostics, err
+			}
+		} else {
+			for _, v := range values {
+				if v >= plan.Filter.Low && v <= plan.Filter.High {
+					count++
+				}
 			}
 		}
 		diagnostics.Matched += count
@@ -242,6 +252,50 @@ func (m SortKeyMark) mayContainCompiled(plan sortKeyRangePlan) (bool, bool, erro
 	return true, true, nil
 }
 
+func (m SortKeyMark) countMatchingRows(values []int64, plan PredicatePlan) (int, error) {
+	if len(values) != m.Rows {
+		return 0, fmt.Errorf("colgranule: decoded rows=%d mark rows=%d", len(values), m.Rows)
+	}
+	if len(m.ColumnValues) != len(m.Columns) {
+		return 0, errors.New("colgranule: sort key mark row values missing")
+	}
+	count := 0
+	for row, v := range values {
+		if v < plan.Filter.Low || v > plan.Filter.High {
+			continue
+		}
+		matches, err := m.rowMatchesRanges(row, plan.SortKeyRanges)
+		if err != nil {
+			return 0, err
+		}
+		if matches {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m SortKeyMark) rowMatchesRanges(row int, ranges []Int64RangePredicate) (bool, error) {
+	for _, predicate := range ranges {
+		if predicate.Empty() {
+			return false, nil
+		}
+		columnIndex := indexString(m.Columns, predicate.Column)
+		if columnIndex < 0 {
+			return false, fmt.Errorf("colgranule: sort key range column %q not present in mark", predicate.Column)
+		}
+		values := m.ColumnValues[columnIndex]
+		if row < 0 || row >= len(values) {
+			return false, fmt.Errorf("colgranule: sort key column %q rows=%d want row %d", predicate.Column, len(values), row)
+		}
+		value := values[row]
+		if value < predicate.Low || value > predicate.High {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func findRangePredicate(ranges []Int64RangePredicate, column string) (Int64RangePredicate, bool) {
 	for _, p := range ranges {
 		if p.Column == column {
@@ -280,12 +334,16 @@ func compareSortKeyRows(columns []SortKeyColumn, left int, right int) int {
 }
 
 func containsString(values []string, want string) bool {
-	for _, value := range values {
+	return indexString(values, want) >= 0
+}
+
+func indexString(values []string, want string) int {
+	for i, value := range values {
 		if value == want {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
 func exclusiveUpperBound(values []int64) ([]int64, bool) {

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -1,0 +1,297 @@
+package colgranule
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+const maxSortKeyColumns = 8
+
+type Int64RangePredicate struct {
+	Column string
+	Low    int64
+	High   int64
+}
+
+func (p Int64RangePredicate) Empty() bool {
+	return p.Low > p.High
+}
+
+type PredicatePlan struct {
+	Filter        Int64RangePredicate
+	SortKeyRanges []Int64RangePredicate
+}
+
+type PredicateDiagnostics struct {
+	Considered      int
+	SkippedByMark   int
+	SkippedByMinMax int
+	Decoded         int
+	Matched         int
+}
+
+type SortKeyColumn struct {
+	Name   string
+	Values []int64
+}
+
+type SortKeyBound struct {
+	Values    []int64
+	Exclusive bool
+	Unbounded bool
+}
+
+type SortKeyPrefixSummary struct {
+	Columns        []string
+	Lower          SortKeyBound
+	UpperExclusive SortKeyBound
+}
+
+type SortKeyMark struct {
+	Rows     int
+	Columns  []string
+	Prefixes []SortKeyPrefixSummary
+}
+
+type sortKeyRangePlan struct {
+	prefixLen int
+	lower     [maxSortKeyColumns]int64
+	upper     [maxSortKeyColumns]int64
+	hasUpper  bool
+	empty     bool
+}
+
+func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
+	if len(columns) == 0 {
+		return SortKeyMark{}, errors.New("colgranule: empty sort key")
+	}
+	if len(columns) > maxSortKeyColumns {
+		return SortKeyMark{}, fmt.Errorf("colgranule: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
+	}
+	rows := len(columns[0].Values)
+	if rows == 0 {
+		return SortKeyMark{}, errors.New("colgranule: empty sort-key mark")
+	}
+	mark := SortKeyMark{
+		Rows:     rows,
+		Columns:  make([]string, len(columns)),
+		Prefixes: make([]SortKeyPrefixSummary, len(columns)),
+	}
+	lower := make([]int64, len(columns))
+	last := make([]int64, len(columns))
+	for i, c := range columns {
+		if c.Name == "" {
+			return SortKeyMark{}, fmt.Errorf("colgranule: empty sort key column name at %d", i)
+		}
+		if len(c.Values) != rows {
+			return SortKeyMark{}, fmt.Errorf("colgranule: sort key column %s rows=%d want=%d", c.Name, len(c.Values), rows)
+		}
+		mark.Columns[i] = c.Name
+		lower[i] = c.Values[0]
+		last[i] = c.Values[rows-1]
+	}
+	for prefixLen := 1; prefixLen <= len(columns); prefixLen++ {
+		prefixColumns := append([]string(nil), mark.Columns[:prefixLen]...)
+		prefixLower := append([]int64(nil), lower[:prefixLen]...)
+		upper, hasUpper := exclusiveUpperBound(last[:prefixLen])
+		mark.Prefixes[prefixLen-1] = SortKeyPrefixSummary{
+			Columns: prefixColumns,
+			Lower: SortKeyBound{
+				Values: prefixLower,
+			},
+			UpperExclusive: SortKeyBound{
+				Values:    upper,
+				Exclusive: true,
+				Unbounded: !hasUpper,
+			},
+		}
+	}
+	return mark, nil
+}
+
+func (m SortKeyMark) MayContainRanges(ranges []Int64RangePredicate) (bool, bool, error) {
+	plan, err := compileSortKeyRangePlan(m.Columns, ranges)
+	if err != nil {
+		return false, false, err
+	}
+	return m.mayContainCompiled(plan)
+}
+
+func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule, marks []SortKeyMark, plan PredicatePlan) (int, PredicateDiagnostics, error) {
+	var diagnostics PredicateDiagnostics
+	if plan.Filter.Empty() {
+		return 0, diagnostics, nil
+	}
+	if len(marks) != 0 && len(marks) != len(granules) {
+		return 0, diagnostics, fmt.Errorf("colgranule: marks=%d granules=%d", len(marks), len(granules))
+	}
+	var sortPlan sortKeyRangePlan
+	var err error
+	if len(marks) != 0 {
+		sortPlan, err = compileSortKeyRangePlan(marks[0].Columns, plan.SortKeyRanges)
+		if err != nil {
+			return 0, diagnostics, err
+		}
+	}
+	total := 0
+	for i, g := range granules {
+		diagnostics.Considered++
+		if len(marks) != 0 {
+			if !sameStringSlice(marks[0].Columns, marks[i].Columns) {
+				return total, diagnostics, errors.New("colgranule: inconsistent sort key mark columns")
+			}
+			mayContain, constrained, err := marks[i].mayContainCompiled(sortPlan)
+			if err != nil {
+				return total, diagnostics, err
+			}
+			if constrained && !mayContain {
+				diagnostics.SkippedByMark++
+				continue
+			}
+		}
+		if g.HasMinMax && (plan.Filter.High < g.Min || plan.Filter.Low > g.Max) {
+			diagnostics.SkippedByMinMax++
+			continue
+		}
+		values, err := r.DecodeInt64(g)
+		if err != nil {
+			return total, diagnostics, err
+		}
+		diagnostics.Decoded++
+		count := 0
+		for _, v := range values {
+			if v >= plan.Filter.Low && v <= plan.Filter.High {
+				count++
+			}
+		}
+		diagnostics.Matched += count
+		total += count
+	}
+	return total, diagnostics, nil
+}
+
+func compileSortKeyRangePlan(columns []string, ranges []Int64RangePredicate) (sortKeyRangePlan, error) {
+	var plan sortKeyRangePlan
+	if len(ranges) == 0 || len(columns) == 0 {
+		return plan, nil
+	}
+	if len(columns) > maxSortKeyColumns {
+		return plan, fmt.Errorf("colgranule: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
+	}
+	var upperInclusive [maxSortKeyColumns]int64
+	for _, column := range columns {
+		predicate, ok := findRangePredicate(ranges, column)
+		if !ok {
+			break
+		}
+		if predicate.Empty() {
+			plan.empty = true
+			return plan, nil
+		}
+		plan.lower[plan.prefixLen] = predicate.Low
+		upperInclusive[plan.prefixLen] = predicate.High
+		plan.prefixLen++
+	}
+	if plan.prefixLen == 0 {
+		return plan, nil
+	}
+	plan.hasUpper = exclusiveUpperBoundArray(upperInclusive[:plan.prefixLen], &plan.upper)
+	return plan, nil
+}
+
+func (m SortKeyMark) mayContainCompiled(plan sortKeyRangePlan) (bool, bool, error) {
+	if plan.prefixLen == 0 {
+		return !plan.empty, false, nil
+	}
+	if plan.empty {
+		return false, true, nil
+	}
+	if plan.prefixLen > len(m.Prefixes) {
+		return false, true, errors.New("colgranule: missing sort key prefix summary")
+	}
+	prefix := m.Prefixes[plan.prefixLen-1]
+	if plan.hasUpper && compareInt64Tuple(plan.upper[:plan.prefixLen], prefix.Lower.Values) <= 0 {
+		return false, true, nil
+	}
+	if !prefix.UpperExclusive.Unbounded && compareInt64Tuple(prefix.UpperExclusive.Values, plan.lower[:plan.prefixLen]) <= 0 {
+		return false, true, nil
+	}
+	return true, true, nil
+}
+
+func findRangePredicate(ranges []Int64RangePredicate, column string) (Int64RangePredicate, bool) {
+	for _, p := range ranges {
+		if p.Column == column {
+			return p, true
+		}
+	}
+	return Int64RangePredicate{}, false
+}
+
+func exclusiveUpperBound(values []int64) ([]int64, bool) {
+	out := append([]int64(nil), values...)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] == math.MaxInt64 {
+			continue
+		}
+		out[i]++
+		for j := i + 1; j < len(out); j++ {
+			out[j] = math.MinInt64
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func exclusiveUpperBoundArray(values []int64, out *[maxSortKeyColumns]int64) bool {
+	for i, v := range values {
+		out[i] = v
+	}
+	for i := len(values) - 1; i >= 0; i-- {
+		if out[i] == math.MaxInt64 {
+			continue
+		}
+		out[i]++
+		for j := i + 1; j < len(values); j++ {
+			out[j] = math.MinInt64
+		}
+		return true
+	}
+	return false
+}
+
+func compareInt64Tuple(a []int64, b []int64) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func sameStringSlice(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -63,6 +63,18 @@ type sortKeyRangePlan struct {
 	empty     bool
 }
 
+type compiledRowSortKeyRange struct {
+	Column string
+	Values []int64
+	Low    int64
+	High   int64
+}
+
+type compiledRowSortKeyRanges struct {
+	ranges [maxSortKeyColumns]compiledRowSortKeyRange
+	count  int
+}
+
 func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
 	if len(columns) == 0 {
 		return SortKeyMark{}, errors.New("colgranule: empty sort key")
@@ -148,9 +160,6 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 	var sortPlan sortKeyRangePlan
 	var err error
 	if len(marks) != 0 {
-		if !containsString(marks[0].Columns, plan.Filter.Column) {
-			return 0, diagnostics, fmt.Errorf("colgranule: filter column %q not present in sort key mark", plan.Filter.Column)
-		}
 		sortPlan, err = compileSortKeyRangePlan(marks[0].Columns, plan.SortKeyRanges)
 		if err != nil {
 			return 0, diagnostics, err
@@ -205,13 +214,19 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 
 func compileSortKeyRangePlan(columns []string, ranges []Int64RangePredicate) (sortKeyRangePlan, error) {
 	var plan sortKeyRangePlan
-	if len(ranges) == 0 || len(columns) == 0 {
+	if len(ranges) == 0 {
 		return plan, nil
+	}
+	if len(columns) == 0 {
+		return plan, errors.New("colgranule: sort key ranges require mark columns")
 	}
 	if len(columns) > maxSortKeyColumns {
 		return plan, fmt.Errorf("colgranule: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
 	}
 	if err := validateSortKeyColumnNames(columns); err != nil {
+		return plan, err
+	}
+	if err := validateRangePredicates(columns, ranges); err != nil {
 		return plan, err
 	}
 	var upperInclusive [maxSortKeyColumns]int64
@@ -259,44 +274,56 @@ func (m SortKeyMark) countMatchingRows(values []int64, plan PredicatePlan) (int,
 	if len(values) != m.Rows {
 		return 0, fmt.Errorf("colgranule: decoded rows=%d mark rows=%d", len(values), m.Rows)
 	}
-	if len(m.ColumnValues) != len(m.Columns) {
-		return 0, errors.New("colgranule: sort key mark row values missing")
+	compiledRanges, err := m.compileRowSortKeyRanges(plan.SortKeyRanges)
+	if err != nil {
+		return 0, err
 	}
 	count := 0
 	for row, v := range values {
 		if v < plan.Filter.Low || v > plan.Filter.High {
 			continue
 		}
-		matches, err := m.rowMatchesRanges(row, plan.SortKeyRanges)
-		if err != nil {
-			return 0, err
-		}
-		if matches {
+		if compiledRanges.rowMatches(row) {
 			count++
 		}
 	}
 	return count, nil
 }
 
-func (m SortKeyMark) rowMatchesRanges(row int, ranges []Int64RangePredicate) (bool, error) {
+func (m SortKeyMark) compileRowSortKeyRanges(ranges []Int64RangePredicate) (compiledRowSortKeyRanges, error) {
+	if len(m.ColumnValues) != len(m.Columns) {
+		return compiledRowSortKeyRanges{}, errors.New("colgranule: sort key mark row values missing")
+	}
+	if err := validateRangePredicates(m.Columns, ranges); err != nil {
+		return compiledRowSortKeyRanges{}, err
+	}
+	var compiled compiledRowSortKeyRanges
 	for _, predicate := range ranges {
-		if predicate.Empty() {
-			return false, nil
-		}
 		columnIndex := indexString(m.Columns, predicate.Column)
-		if columnIndex < 0 {
-			return false, fmt.Errorf("colgranule: sort key range column %q not present in mark", predicate.Column)
-		}
 		values := m.ColumnValues[columnIndex]
-		if row < 0 || row >= len(values) {
-			return false, fmt.Errorf("colgranule: sort key column %q rows=%d want row %d", predicate.Column, len(values), row)
+		if len(values) != m.Rows {
+			return compiledRowSortKeyRanges{}, fmt.Errorf("colgranule: sort key column %q rows=%d want=%d", predicate.Column, len(values), m.Rows)
 		}
-		value := values[row]
+		compiled.ranges[compiled.count] = compiledRowSortKeyRange{
+			Column: predicate.Column,
+			Values: values,
+			Low:    predicate.Low,
+			High:   predicate.High,
+		}
+		compiled.count++
+	}
+	return compiled, nil
+}
+
+func (r compiledRowSortKeyRanges) rowMatches(row int) bool {
+	for i := 0; i < r.count; i++ {
+		predicate := r.ranges[i]
+		value := predicate.Values[row]
 		if value < predicate.Low || value > predicate.High {
-			return false, nil
+			return false
 		}
 	}
-	return true, nil
+	return true
 }
 
 func findRangePredicate(ranges []Int64RangePredicate, column string) (Int64RangePredicate, bool) {
@@ -316,6 +343,26 @@ func validateSortKeyColumnNames(columns []string) error {
 		for j := 0; j < i; j++ {
 			if columns[j] == column {
 				return fmt.Errorf("colgranule: duplicate sort key column %q", column)
+			}
+		}
+	}
+	return nil
+}
+
+func validateRangePredicates(columns []string, ranges []Int64RangePredicate) error {
+	if len(ranges) > maxSortKeyColumns {
+		return fmt.Errorf("colgranule: sort key ranges=%d exceeds cap %d", len(ranges), maxSortKeyColumns)
+	}
+	for i, predicate := range ranges {
+		if predicate.Column == "" {
+			return fmt.Errorf("colgranule: empty sort key range column at %d", i)
+		}
+		if !containsString(columns, predicate.Column) {
+			return fmt.Errorf("colgranule: sort key range column %q not present in mark", predicate.Column)
+		}
+		for j := 0; j < i; j++ {
+			if ranges[j].Column == predicate.Column {
+				return fmt.Errorf("colgranule: duplicate sort key range column %q", predicate.Column)
 			}
 		}
 	}

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -142,6 +142,9 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 	if len(marks) != 0 && len(marks) != len(granules) {
 		return 0, diagnostics, fmt.Errorf("colgranule: marks=%d granules=%d", len(marks), len(granules))
 	}
+	if len(marks) == 0 && len(plan.SortKeyRanges) != 0 {
+		return 0, diagnostics, errors.New("colgranule: sort key ranges require marks")
+	}
 	var sortPlan sortKeyRangePlan
 	var err error
 	if len(marks) != 0 {

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -84,12 +84,22 @@ func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
 		if c.Name == "" {
 			return SortKeyMark{}, fmt.Errorf("colgranule: empty sort key column name at %d", i)
 		}
+		for j := 0; j < i; j++ {
+			if columns[j].Name == c.Name {
+				return SortKeyMark{}, fmt.Errorf("colgranule: duplicate sort key column %q", c.Name)
+			}
+		}
 		if len(c.Values) != rows {
 			return SortKeyMark{}, fmt.Errorf("colgranule: sort key column %s rows=%d want=%d", c.Name, len(c.Values), rows)
 		}
 		mark.Columns[i] = c.Name
 		lower[i] = c.Values[0]
 		last[i] = c.Values[rows-1]
+	}
+	for row := 1; row < rows; row++ {
+		if compareSortKeyRows(columns, row-1, row) > 0 {
+			return SortKeyMark{}, fmt.Errorf("colgranule: sort key rows out of order at row %d", row)
+		}
 	}
 	for prefixLen := 1; prefixLen <= len(columns); prefixLen++ {
 		prefixColumns := append([]string(nil), mark.Columns[:prefixLen]...)
@@ -123,12 +133,18 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 	if plan.Filter.Empty() {
 		return 0, diagnostics, nil
 	}
+	if plan.Filter.Column == "" {
+		return 0, diagnostics, errors.New("colgranule: empty filter column")
+	}
 	if len(marks) != 0 && len(marks) != len(granules) {
 		return 0, diagnostics, fmt.Errorf("colgranule: marks=%d granules=%d", len(marks), len(granules))
 	}
 	var sortPlan sortKeyRangePlan
 	var err error
 	if len(marks) != 0 {
+		if !containsString(marks[0].Columns, plan.Filter.Column) {
+			return 0, diagnostics, fmt.Errorf("colgranule: filter column %q not present in sort key mark", plan.Filter.Column)
+		}
 		sortPlan, err = compileSortKeyRangePlan(marks[0].Columns, plan.SortKeyRanges)
 		if err != nil {
 			return 0, diagnostics, err
@@ -140,6 +156,9 @@ func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule
 		if len(marks) != 0 {
 			if !sameStringSlice(marks[0].Columns, marks[i].Columns) {
 				return total, diagnostics, errors.New("colgranule: inconsistent sort key mark columns")
+			}
+			if marks[i].Rows != g.Rows {
+				return total, diagnostics, fmt.Errorf("colgranule: mark rows=%d granule rows=%d at granule %d", marks[i].Rows, g.Rows, i)
 			}
 			mayContain, constrained, err := marks[i].mayContainCompiled(sortPlan)
 			if err != nil {
@@ -179,6 +198,9 @@ func compileSortKeyRangePlan(columns []string, ranges []Int64RangePredicate) (so
 	if len(columns) > maxSortKeyColumns {
 		return plan, fmt.Errorf("colgranule: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
 	}
+	if err := validateSortKeyColumnNames(columns); err != nil {
+		return plan, err
+	}
 	var upperInclusive [maxSortKeyColumns]int64
 	for _, column := range columns {
 		predicate, ok := findRangePredicate(ranges, column)
@@ -201,11 +223,11 @@ func compileSortKeyRangePlan(columns []string, ranges []Int64RangePredicate) (so
 }
 
 func (m SortKeyMark) mayContainCompiled(plan sortKeyRangePlan) (bool, bool, error) {
-	if plan.prefixLen == 0 {
-		return !plan.empty, false, nil
-	}
 	if plan.empty {
 		return false, true, nil
+	}
+	if plan.prefixLen == 0 {
+		return true, false, nil
 	}
 	if plan.prefixLen > len(m.Prefixes) {
 		return false, true, errors.New("colgranule: missing sort key prefix summary")
@@ -227,6 +249,43 @@ func findRangePredicate(ranges []Int64RangePredicate, column string) (Int64Range
 		}
 	}
 	return Int64RangePredicate{}, false
+}
+
+func validateSortKeyColumnNames(columns []string) error {
+	for i, column := range columns {
+		if column == "" {
+			return fmt.Errorf("colgranule: empty sort key column name at %d", i)
+		}
+		for j := 0; j < i; j++ {
+			if columns[j] == column {
+				return fmt.Errorf("colgranule: duplicate sort key column %q", column)
+			}
+		}
+	}
+	return nil
+}
+
+func compareSortKeyRows(columns []SortKeyColumn, left int, right int) int {
+	for _, column := range columns {
+		lv := column.Values[left]
+		rv := column.Values[right]
+		if lv < rv {
+			return -1
+		}
+		if lv > rv {
+			return 1
+		}
+	}
+	return 0
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func exclusiveUpperBound(values []int64) ([]int64, bool) {

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -38,6 +38,35 @@ func TestSortKeyMarkPrefixSummaries(t *testing.T) {
 	}
 }
 
+func TestSortKeyMarkRejectsDuplicateOrUnsortedColumns(t *testing.T) {
+	if _, err := BuildSortKeyMark([]SortKeyColumn{
+		{Name: "collection", Values: []int64{1, 1, 1}},
+		{Name: "collection", Values: []int64{10, 20, 30}},
+	}); err == nil {
+		t.Fatal("BuildSortKeyMark duplicate columns succeeded, want error")
+	}
+	if _, err := BuildSortKeyMark([]SortKeyColumn{
+		{Name: "collection", Values: []int64{1, 1, 1}},
+		{Name: "time_us", Values: []int64{10, 9, 11}},
+	}); err == nil {
+		t.Fatal("BuildSortKeyMark unsorted rows succeeded, want error")
+	}
+}
+
+func TestEmptySortKeyPredicateIsConstrainedEmpty(t *testing.T) {
+	mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "collection", Values: []int64{1, 1, 1}}})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark: %v", err)
+	}
+	mayContain, constrained, err := mark.MayContainRanges([]Int64RangePredicate{{Column: "collection", Low: 2, High: 1}})
+	if err != nil {
+		t.Fatalf("MayContainRanges: %v", err)
+	}
+	if mayContain || !constrained {
+		t.Fatalf("empty predicate mayContain/constrained=(%v,%v), want (false,true)", mayContain, constrained)
+	}
+}
+
 func TestCountInt64RangeDiagnostics(t *testing.T) {
 	granules, err := buildInt64GranulesForTest(makeSequentialInt64(100), 10)
 	if err != nil {
@@ -74,6 +103,37 @@ func TestCountInt64RangeDiagnostics(t *testing.T) {
 	}
 	if count != 0 || diagnostics.SkippedByMinMax != 10 || diagnostics.Decoded != 0 {
 		t.Fatalf("full-prune count=%d diagnostics=%+v", count, diagnostics)
+	}
+}
+
+func TestCountInt64RangeRejectsMismatchedMarkMetadata(t *testing.T) {
+	granules, err := buildInt64GranulesForTest([]int64{1, 2, 3}, 3)
+	if err != nil {
+		t.Fatalf("build granules: %v", err)
+	}
+	mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: []int64{1, 2}}})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark: %v", err)
+	}
+	var reader GranuleReader
+	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{mark}, PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "time_us", Low: 1, High: 3},
+		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 1, High: 3}},
+	})
+	if err == nil {
+		t.Fatal("CountInt64RangeWithDiagnostics mismatched mark rows succeeded, want error")
+	}
+
+	matchingMark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: []int64{1, 2, 3}}})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark matching: %v", err)
+	}
+	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{matchingMark}, PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "other_column", Low: 1, High: 3},
+		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 1, High: 3}},
+	})
+	if err == nil {
+		t.Fatal("CountInt64RangeWithDiagnostics mismatched filter column succeeded, want error")
 	}
 }
 

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -111,11 +112,19 @@ func TestCountInt64RangeRejectsMismatchedMarkMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build granules: %v", err)
 	}
+	var reader GranuleReader
+	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, nil, PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "time_us", Low: 1, High: 3},
+		SortKeyRanges: []Int64RangePredicate{{Column: "collection", Low: 1, High: 1}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "sort key ranges require marks") {
+		t.Fatalf("missing marks err=%v want sort key ranges require marks", err)
+	}
+
 	mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: []int64{1, 2}}})
 	if err != nil {
 		t.Fatalf("BuildSortKeyMark: %v", err)
 	}
-	var reader GranuleReader
 	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{mark}, PredicatePlan{
 		Filter:        Int64RangePredicate{Column: "time_us", Low: 1, High: 3},
 		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 1, High: 3}},

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -163,6 +163,37 @@ func TestSortKeyMarkPruningMatchesRawReference(t *testing.T) {
 	}
 }
 
+func TestSortKeyRangeIsAppliedWithinMixedGranule(t *testing.T) {
+	collections := []int64{1, 1, 2, 2}
+	times := []int64{110, 111, 110, 111}
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	g, err := builder.BuildInt64(times)
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	mark, err := BuildSortKeyMark([]SortKeyColumn{
+		{Name: "collection", Values: collections},
+		{Name: "time_us", Values: times},
+	})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark: %v", err)
+	}
+	var reader GranuleReader
+	count, diagnostics, err := reader.CountInt64RangeWithDiagnostics([]EncodedGranule{g}, []SortKeyMark{mark}, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 110, High: 111},
+		SortKeyRanges: []Int64RangePredicate{
+			{Column: "collection", Low: 1, High: 1},
+			{Column: "time_us", Low: 110, High: 111},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics: %v", err)
+	}
+	if count != 2 || diagnostics.Decoded != 1 || diagnostics.Matched != 2 {
+		t.Fatalf("count=%d diagnostics=%+v want count=2 decoded=1 matched=2", count, diagnostics)
+	}
+}
+
 func TestTimeOnlyPredicateDoesNotSortKeyPruneWhenNotLeftPrefix(t *testing.T) {
 	granules, marks, _, _, err := buildCompositeSortFixtureForTest()
 	if err != nil {

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -1,0 +1,240 @@
+package colgranule
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSortKeyMarkPrefixSummaries(t *testing.T) {
+	mark, err := BuildSortKeyMark([]SortKeyColumn{
+		{Name: "collection", Values: []int64{1, 1, 1, 2, 2}},
+		{Name: "time_us", Values: []int64{10, 20, 30, 5, 15}},
+	})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark: %v", err)
+	}
+	if mark.Rows != 5 || !slices.Equal(mark.Columns, []string{"collection", "time_us"}) {
+		t.Fatalf("mark rows/columns=(%d,%v)", mark.Rows, mark.Columns)
+	}
+	if !slices.Equal(mark.Prefixes[0].Lower.Values, []int64{1}) || !slices.Equal(mark.Prefixes[0].UpperExclusive.Values, []int64{3}) {
+		t.Fatalf("prefix 1 bounds=%v/%v want [1]/[3]", mark.Prefixes[0].Lower.Values, mark.Prefixes[0].UpperExclusive.Values)
+	}
+	if !slices.Equal(mark.Prefixes[1].Lower.Values, []int64{1, 10}) || !slices.Equal(mark.Prefixes[1].UpperExclusive.Values, []int64{2, 16}) {
+		t.Fatalf("prefix 2 bounds=%v/%v want [1 10]/[2 16]", mark.Prefixes[1].Lower.Values, mark.Prefixes[1].UpperExclusive.Values)
+	}
+	mayContain, constrained, err := mark.MayContainRanges([]Int64RangePredicate{{Column: "collection", Low: 3, High: 3}})
+	if err != nil {
+		t.Fatalf("MayContainRanges: %v", err)
+	}
+	if mayContain || !constrained {
+		t.Fatalf("collection=3 mayContain/constrained=(%v,%v) want (false,true)", mayContain, constrained)
+	}
+	mayContain, constrained, err = mark.MayContainRanges([]Int64RangePredicate{{Column: "time_us", Low: 12, High: 14}})
+	if err != nil {
+		t.Fatalf("MayContainRanges(time only): %v", err)
+	}
+	if !mayContain || constrained {
+		t.Fatalf("time-only mayContain/constrained=(%v,%v) want (true,false)", mayContain, constrained)
+	}
+}
+
+func TestCountInt64RangeDiagnostics(t *testing.T) {
+	granules, err := buildInt64GranulesForTest(makeSequentialInt64(100), 10)
+	if err != nil {
+		t.Fatalf("build granules: %v", err)
+	}
+	var reader GranuleReader
+	count, diagnostics, err := reader.CountInt64RangeWithDiagnostics(granules, nil, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 20, High: 29},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics(partial): %v", err)
+	}
+	if count != 10 || diagnostics.Considered != 10 || diagnostics.SkippedByMinMax != 9 || diagnostics.Decoded != 1 || diagnostics.Matched != 10 {
+		t.Fatalf("partial count=%d diagnostics=%+v", count, diagnostics)
+	}
+
+	reader = GranuleReader{}
+	count, diagnostics, err = reader.CountInt64RangeWithDiagnostics(granules, nil, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: -10, High: 1000},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics(no prune): %v", err)
+	}
+	if count != 100 || diagnostics.SkippedByMinMax != 0 || diagnostics.Decoded != 10 {
+		t.Fatalf("no-prune count=%d diagnostics=%+v", count, diagnostics)
+	}
+
+	reader = GranuleReader{}
+	count, diagnostics, err = reader.CountInt64RangeWithDiagnostics(granules, nil, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 1000, High: 2000},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics(full prune): %v", err)
+	}
+	if count != 0 || diagnostics.SkippedByMinMax != 10 || diagnostics.Decoded != 0 {
+		t.Fatalf("full-prune count=%d diagnostics=%+v", count, diagnostics)
+	}
+}
+
+func TestSortKeyMarkPruningMatchesRawReference(t *testing.T) {
+	granules, marks, collections, times, err := buildCompositeSortFixtureForTest()
+	if err != nil {
+		t.Fatalf("build fixture: %v", err)
+	}
+	plan := PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 110, High: 120},
+		SortKeyRanges: []Int64RangePredicate{
+			{Column: "collection", Low: 1, High: 1},
+			{Column: "time_us", Low: 110, High: 120},
+		},
+	}
+	var reader GranuleReader
+	count, diagnostics, err := reader.CountInt64RangeWithDiagnostics(granules, marks, plan)
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics: %v", err)
+	}
+	want := rawCompositeCount(collections, times, 1, 110, 120)
+	if count != want {
+		t.Fatalf("count=%d want raw reference %d", count, want)
+	}
+	if diagnostics.SkippedByMark != 3 || diagnostics.Decoded != 1 || diagnostics.Matched != want {
+		t.Fatalf("diagnostics=%+v want skipped_by_mark=3 decoded=1 matched=%d", diagnostics, want)
+	}
+}
+
+func TestTimeOnlyPredicateDoesNotSortKeyPruneWhenNotLeftPrefix(t *testing.T) {
+	granules, marks, _, _, err := buildCompositeSortFixtureForTest()
+	if err != nil {
+		t.Fatalf("build fixture: %v", err)
+	}
+	var reader GranuleReader
+	_, diagnostics, err := reader.CountInt64RangeWithDiagnostics(granules, marks, PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "time_us", Low: 110, High: 120},
+		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 110, High: 120}},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics: %v", err)
+	}
+	if diagnostics.SkippedByMark != 0 {
+		t.Fatalf("time-only predicate skipped by mark=%d want 0", diagnostics.SkippedByMark)
+	}
+}
+
+func TestMarkAndMinMaxSkipsDoNotDecodeCorruptPayload(t *testing.T) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	g, err := builder.BuildInt64([]int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	g.Payload = []byte{0xff}
+	g.StoredBytes = len(g.Payload)
+	g.PayloadRef.Length = len(g.Payload)
+	g.RawBytes = len(g.Payload)
+	mark, err := BuildSortKeyMark([]SortKeyColumn{
+		{Name: "collection", Values: []int64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+		{Name: "time_us", Values: []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+	})
+	if err != nil {
+		t.Fatalf("BuildSortKeyMark: %v", err)
+	}
+	var reader GranuleReader
+	count, diagnostics, err := reader.CountInt64RangeWithDiagnostics([]EncodedGranule{g}, []SortKeyMark{mark}, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 0, High: 9},
+		SortKeyRanges: []Int64RangePredicate{
+			{Column: "collection", Low: 2, High: 2},
+			{Column: "time_us", Low: 0, High: 9},
+		},
+	})
+	if err != nil {
+		t.Fatalf("mark-pruned corrupt payload returned error: %v", err)
+	}
+	if count != 0 || diagnostics.SkippedByMark != 1 || diagnostics.Decoded != 0 {
+		t.Fatalf("mark-pruned count=%d diagnostics=%+v", count, diagnostics)
+	}
+
+	reader = GranuleReader{}
+	count, diagnostics, err = reader.CountInt64RangeWithDiagnostics([]EncodedGranule{g}, nil, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 100, High: 200},
+	})
+	if err != nil {
+		t.Fatalf("minmax-pruned corrupt payload returned error: %v", err)
+	}
+	if count != 0 || diagnostics.SkippedByMinMax != 1 || diagnostics.Decoded != 0 {
+		t.Fatalf("minmax-pruned count=%d diagnostics=%+v", count, diagnostics)
+	}
+}
+
+func buildInt64GranulesForTest(values []int64, rowsPerGranule int) ([]EncodedGranule, error) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	var granules []EncodedGranule
+	for start := 0; start < len(values); start += rowsPerGranule {
+		end := start + rowsPerGranule
+		if end > len(values) {
+			end = len(values)
+		}
+		g, err := builder.BuildInt64(values[start:end])
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func makeSequentialInt64(n int) []int64 {
+	values := make([]int64, n)
+	for i := range values {
+		values[i] = int64(i)
+	}
+	return values
+}
+
+func buildCompositeSortFixtureForTest() ([]EncodedGranule, []SortKeyMark, []int64, []int64, error) {
+	const rowsPerGranule = 100
+	var granules []EncodedGranule
+	var marks []SortKeyMark
+	var allCollections []int64
+	var allTimes []int64
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	for _, collection := range []int64{1, 2} {
+		for block := 0; block < 2; block++ {
+			collections := make([]int64, rowsPerGranule)
+			times := make([]int64, rowsPerGranule)
+			for i := 0; i < rowsPerGranule; i++ {
+				collections[i] = collection
+				times[i] = int64(block*rowsPerGranule + i)
+			}
+			g, err := builder.BuildInt64(times)
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
+			owned := g
+			owned.Payload = append([]byte(nil), g.Payload...)
+			mark, err := BuildSortKeyMark([]SortKeyColumn{
+				{Name: "collection", Values: collections},
+				{Name: "time_us", Values: times},
+			})
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
+			granules = append(granules, owned)
+			marks = append(marks, mark)
+			allCollections = append(allCollections, collections...)
+			allTimes = append(allTimes, times...)
+		}
+	}
+	return granules, marks, allCollections, allTimes, nil
+}
+
+func rawCompositeCount(collections []int64, times []int64, collection int64, low int64, high int64) int {
+	count := 0
+	for i, gotCollection := range collections {
+		if gotCollection == collection && times[i] >= low && times[i] <= high {
+			count++
+		}
+	}
+	return count
+}

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -15,7 +15,7 @@ func TestSortKeyMarkPrefixSummaries(t *testing.T) {
 		t.Fatalf("BuildSortKeyMark: %v", err)
 	}
 	if mark.Rows != 5 || !slices.Equal(mark.Columns, []string{"collection", "time_us"}) {
-		t.Fatalf("mark rows/columns=(%d,%v)", mark.Rows, mark.Columns)
+		t.Fatalf("mark rows/columns=(%d,%v) want (5,[collection time_us])", mark.Rows, mark.Columns)
 	}
 	if !slices.Equal(mark.Prefixes[0].Lower.Values, []int64{1}) || !slices.Equal(mark.Prefixes[0].UpperExclusive.Values, []int64{3}) {
 		t.Fatalf("prefix 1 bounds=%v/%v want [1]/[3]", mark.Prefixes[0].Lower.Values, mark.Prefixes[0].UpperExclusive.Values)
@@ -139,10 +139,32 @@ func TestCountInt64RangeRejectsMismatchedMarkMetadata(t *testing.T) {
 	}
 	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{matchingMark}, PredicatePlan{
 		Filter:        Int64RangePredicate{Column: "other_column", Low: 1, High: 3},
-		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 1, High: 3}},
+		SortKeyRanges: []Int64RangePredicate{{Column: "other_column", Low: 1, High: 3}},
 	})
-	if err == nil {
-		t.Fatal("CountInt64RangeWithDiagnostics mismatched filter column succeeded, want error")
+	if err == nil || !strings.Contains(err.Error(), "not present in mark") {
+		t.Fatalf("unknown sort key range err=%v want not present in mark", err)
+	}
+
+	_, _, err = reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{matchingMark}, PredicatePlan{
+		Filter: Int64RangePredicate{Column: "time_us", Low: 1, High: 3},
+		SortKeyRanges: []Int64RangePredicate{
+			{Column: "time_us", Low: 1, High: 2},
+			{Column: "time_us", Low: 2, High: 3},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate sort key range column") {
+		t.Fatalf("duplicate sort key range err=%v want duplicate sort key range column", err)
+	}
+
+	count, _, err := reader.CountInt64RangeWithDiagnostics(granules, []SortKeyMark{matchingMark}, PredicatePlan{
+		Filter:        Int64RangePredicate{Column: "value", Low: 2, High: 3},
+		SortKeyRanges: []Int64RangePredicate{{Column: "time_us", Low: 2, High: 3}},
+	})
+	if err != nil {
+		t.Fatalf("CountInt64RangeWithDiagnostics non-sort filter: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("non-sort filter count=%d want 2", count)
 	}
 }
 


### PR DESCRIPTION
## Objective

Implement Phase 1 / PR3 from #1534: add predicate execution and sort-key mark primitives to the column granule experiment before disk layout.

## Context

This is stacked on #1538 and targets `codex/colgranule-typed-codecs`. It builds on the typed codec work by adding pruning diagnostics and reusable predicate primitives around encoded int64 granules.

Refs #1534.

## Non-goals

- No SQL planner.
- No durable on-disk part format.
- No production TreeDB column-store integration.
- No multi-column scanner beyond sort-key metadata and a projected int64 range-count path.

## Design

- Adds `Int64RangePredicate`, `PredicatePlan`, and `PredicateDiagnostics`.
- Adds `SortKeyMark` with per-prefix lower and upper-exclusive bounds.
- Adds `BuildSortKeyMark` for composite int64 sort-key summaries.
- Adds sort-key mark pruning that only uses constrained left prefixes, so predicates on non-left-prefix columns do not produce false pruning.
- Adds `GranuleReader.CountInt64RangeWithDiagnostics` with considered/skipped-by-mark/skipped-by-minmax/decoded/matched counters.
- Keeps mark evaluation before payload decode so skipped granules do not decompress projected columns.

## Scope

- Includes (files/symbols): `experiments/colgranule/predicate.go`, `predicate_test.go`, `granule_bench_test.go`, `SortKeyMark`, `SortKeyPrefixSummary`, `PredicateDiagnostics`, `CountInt64RangeWithDiagnostics`.
- Excludes (files/symbols): TreeDB production storage, WAL, durable part layout, part manifests, aggregate kernels.

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule`
  - `go test ./experiments/colgranule/...`
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkPredicatePruningInt64Granules' -benchmem -benchtime=100x`
  - `go test ./...`
- Corruption/edge cases covered: full-prune, partial-prune, no-prune, prefix summary bounds, raw-vector reference parity, time-only predicate with sort key `collection,time_us`, mark skip before corrupt payload decode, min/max skip before corrupt payload decode.
- Concurrency/race coverage (if applicable): not applicable; readers and marks are caller-owned.

## Performance

- Benchmarks run (exact commands): `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkPredicatePruningInt64Granules' -benchmem -benchtime=100x`
- Environment: `darwin/arm64`, Apple M3, 100 granules x 8192 rows.
- Allocation gate: both benchmark paths reported `0 B/op` and `0 allocs/op`.

Predicate pruning benchmark:

| Path | ns/op | ns/row | rows/s | MiB/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| unpruned projected scan | 1,891,945 | 2.309 | 433.0M | 3304 | 0 | 0 |
| pruned by sort-key mark | 280,178 | 0.3420 | 2.924B | 22309 | 0 | 0 |

Notes:

- The deterministic fixture prunes at least 90% of granules by sort-key mark.
- Measured speedup is about 6.75x over the unpruned projected scan, above the 5x PR3 target.
- Mark/predicate evaluation does not decompress skipped projected columns.

## Rollout / Toggle Plan

- Default setting: experiment-only API; no production behavior is enabled.
- How to disable quickly: revert this PR or avoid the `experiments/colgranule` predicate helpers.

## Follow-ups

- Issues/PRs to do next: continue #1534 Phase 1 with PR4 for aggregate kernels over encoded granules after PR3 lands.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `experiments/colgranule/predicate.go`, `predicate_test.go`, `granule_bench_test.go`
- [x] Explicit exclude list (files/symbols NOT touched): TreeDB production storage, WAL, durable part layout, GC
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: not applicable; no `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): not applicable to CRC, but predicate/mark validation paths are fail-closed
- [x] Any concurrency change has a defined state machine and invariants: not applicable; no concurrency change

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./...`
  - [x] Any targeted packages/benchmarks: commands listed above

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved: not applicable to this predicate-only PR; inherited codec benchmarks cover incompressible payloads in #1538

### Docs
- [x] No repo doc update needed for this experiment-only API
- [x] No new config knobs
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: predicate diagnostics are exposed by the experiment API
