### PR TITLE
experiments/colgranule: add aggregate kernels

### DIFF
--- a/experiments/colgranule/aggregate.go
+++ b/experiments/colgranule/aggregate.go
@@ -243,7 +243,11 @@ func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, t
 			if code >= header.cardinality || code >= cardinality {
 				return TimeBucketedCounts{}, fmt.Errorf("colgranule: code %d outside cardinality %d", code, cardinality)
 			}
-			bucketIndex := int(floorDiv(timestamp, bucketWidth) - minBucket)
+			bucketIndex64 := floorDiv(timestamp, bucketWidth) - minBucket
+			if bucketIndex64 < 0 || bucketIndex64 >= int64(buckets) {
+				return TimeBucketedCounts{}, fmt.Errorf("colgranule: timestamp %d outside bucket range [%d,%d]", timestamp, minBucket, maxBucket)
+			}
+			bucketIndex := int(bucketIndex64)
 			a.bucketCounts[bucketIndex*int(cardinality)+int(code)]++
 		}
 	}

--- a/experiments/colgranule/aggregate.go
+++ b/experiments/colgranule/aggregate.go
@@ -1,0 +1,342 @@
+package colgranule
+
+import (
+	"errors"
+	"fmt"
+)
+
+const maxAggregateCells = 1 << 20
+
+type AggregateArena struct {
+	reader       GranuleReader
+	counts       []uint64
+	bucketCounts []uint64
+	codeBits     []uint64
+	seenInt64    map[int64]struct{}
+}
+
+func (a *AggregateArena) Reset() {
+	a.counts = a.counts[:0]
+	a.bucketCounts = a.bucketCounts[:0]
+	a.codeBits = a.codeBits[:0]
+	for k := range a.seenInt64 {
+		delete(a.seenInt64, k)
+	}
+}
+
+func (a *AggregateArena) GroupedCountCodes(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
+	counts, err := a.prepareCounts(granules, cardinality)
+	if err != nil {
+		return nil, err
+	}
+	clear(counts)
+	for _, g := range granules {
+		if err := a.forEachCode(g, func(code uint32) error {
+			if int(code) >= len(counts) {
+				return fmt.Errorf("colgranule: code %d outside counts", code)
+			}
+			counts[code]++
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	a.counts = counts
+	return counts, nil
+}
+
+func (a *AggregateArena) FilteredGroupedCountCodes(codeGranules []EncodedGranule, filterGranules []EncodedGranule, filter Int64RangePredicate, cardinality uint32) ([]uint64, PredicateDiagnostics, error) {
+	var diagnostics PredicateDiagnostics
+	if len(codeGranules) != len(filterGranules) {
+		return nil, diagnostics, fmt.Errorf("colgranule: code granules=%d filter granules=%d", len(codeGranules), len(filterGranules))
+	}
+	counts, err := a.prepareCounts(codeGranules, cardinality)
+	if err != nil {
+		return nil, diagnostics, err
+	}
+	clear(counts)
+	if filter.Empty() {
+		a.counts = counts
+		return counts, diagnostics, nil
+	}
+	for i, codeGranule := range codeGranules {
+		filterGranule := filterGranules[i]
+		diagnostics.Considered++
+		if filterGranule.HasMinMax && (filter.High < filterGranule.Min || filter.Low > filterGranule.Max) {
+			diagnostics.SkippedByMinMax++
+			continue
+		}
+		filterValues, err := a.reader.DecodeInt64(filterGranule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		if len(filterValues) != codeGranule.Rows {
+			return nil, diagnostics, errors.New("colgranule: filter/code row mismatch")
+		}
+		codeRaw, err := a.reader.decompressPayload(codeGranule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		header, err := parseUint32CodesHeader(codeRaw, codeGranule.Rows)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		diagnostics.Decoded++
+		for row, value := range filterValues {
+			if value < filter.Low || value > filter.High {
+				continue
+			}
+			code := readUint32Code(header.data, header.width, row)
+			if code >= header.cardinality || int(code) >= len(counts) {
+				return nil, diagnostics, fmt.Errorf("colgranule: code %d outside counts", code)
+			}
+			counts[code]++
+			diagnostics.Matched++
+		}
+	}
+	a.counts = counts
+	return counts, diagnostics, nil
+}
+
+func (a *AggregateArena) MinMaxInt64(granules []EncodedGranule, filter *Int64RangePredicate) (int64, int64, bool, error) {
+	has := false
+	min, max := int64(0), int64(0)
+	for _, g := range granules {
+		if filter == nil && g.HasMinMax {
+			min, max, has = updateOptionalMinMax(min, max, has, g.Min)
+			min, max, has = updateOptionalMinMax(min, max, has, g.Max)
+			continue
+		}
+		values, err := a.reader.DecodeInt64(g)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		for _, v := range values {
+			if filter != nil && (v < filter.Low || v > filter.High) {
+				continue
+			}
+			min, max, has = updateOptionalMinMax(min, max, has, v)
+		}
+	}
+	return min, max, has, nil
+}
+
+func (a *AggregateArena) ExactDistinctCodes(granules []EncodedGranule, cardinality uint32) (int, error) {
+	cardinality, err := inferCodeCardinality(granules, cardinality)
+	if err != nil {
+		return 0, err
+	}
+	words := (int(cardinality) + 63) / 64
+	if words > maxAggregateCells {
+		return 0, fmt.Errorf("colgranule: code distinct words=%d exceeds cap %d", words, maxAggregateCells)
+	}
+	if cap(a.codeBits) < words {
+		a.codeBits = make([]uint64, words)
+	} else {
+		a.codeBits = a.codeBits[:words]
+	}
+	clear(a.codeBits)
+	for _, g := range granules {
+		if err := a.forEachCode(g, func(code uint32) error {
+			if code >= cardinality {
+				return fmt.Errorf("colgranule: code %d outside cardinality %d", code, cardinality)
+			}
+			if int(code/64) >= len(a.codeBits) {
+				return fmt.Errorf("colgranule: code %d outside cardinality %d", code, cardinality)
+			}
+			a.codeBits[code/64] |= 1 << uint(code%64)
+			return nil
+		}); err != nil {
+			return 0, err
+		}
+	}
+	distinct := 0
+	for _, word := range a.codeBits {
+		distinct += popcount64(word)
+	}
+	return distinct, nil
+}
+
+func (a *AggregateArena) ExactDistinctInt64(granules []EncodedGranule) (int, error) {
+	if a.seenInt64 == nil {
+		a.seenInt64 = make(map[int64]struct{})
+	} else {
+		for k := range a.seenInt64 {
+			delete(a.seenInt64, k)
+		}
+	}
+	for _, g := range granules {
+		values, err := a.reader.DecodeInt64(g)
+		if err != nil {
+			return 0, err
+		}
+		for _, v := range values {
+			a.seenInt64[v] = struct{}{}
+		}
+	}
+	return len(a.seenInt64), nil
+}
+
+type TimeBucketedCounts struct {
+	BucketWidth int64
+	MinBucket   int64
+	Buckets     int
+	Cardinality uint32
+	Counts      []uint64
+}
+
+func (c TimeBucketedCounts) Count(bucket int64, code uint32) uint64 {
+	if c.BucketWidth <= 0 || code >= c.Cardinality {
+		return 0
+	}
+	bucketIndex := int(bucket - c.MinBucket)
+	if bucketIndex < 0 || bucketIndex >= c.Buckets {
+		return 0
+	}
+	return c.Counts[bucketIndex*int(c.Cardinality)+int(code)]
+}
+
+func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, timeGranules []EncodedGranule, bucketWidth int64, cardinality uint32) (TimeBucketedCounts, error) {
+	if len(codeGranules) != len(timeGranules) {
+		return TimeBucketedCounts{}, fmt.Errorf("colgranule: code granules=%d time granules=%d", len(codeGranules), len(timeGranules))
+	}
+	if bucketWidth <= 0 {
+		return TimeBucketedCounts{}, fmt.Errorf("colgranule: invalid bucket width %d", bucketWidth)
+	}
+	cardinality, err := inferCodeCardinality(codeGranules, cardinality)
+	if err != nil {
+		return TimeBucketedCounts{}, err
+	}
+	minTime, maxTime, ok, err := a.MinMaxInt64(timeGranules, nil)
+	if err != nil {
+		return TimeBucketedCounts{}, err
+	}
+	if !ok {
+		return TimeBucketedCounts{BucketWidth: bucketWidth, Cardinality: cardinality}, nil
+	}
+	minBucket := floorDiv(minTime, bucketWidth)
+	maxBucket := floorDiv(maxTime, bucketWidth)
+	buckets := int(maxBucket - minBucket + 1)
+	cells := buckets * int(cardinality)
+	if cells < 0 || cells > maxAggregateCells {
+		return TimeBucketedCounts{}, fmt.Errorf("colgranule: aggregate cells=%d exceeds cap %d", cells, maxAggregateCells)
+	}
+	if cap(a.bucketCounts) < cells {
+		a.bucketCounts = make([]uint64, cells)
+	} else {
+		a.bucketCounts = a.bucketCounts[:cells]
+	}
+	clear(a.bucketCounts)
+	for i, codeGranule := range codeGranules {
+		times, err := a.reader.DecodeInt64(timeGranules[i])
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		codeRaw, err := a.reader.decompressPayload(codeGranule)
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		header, err := parseUint32CodesHeader(codeRaw, codeGranule.Rows)
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		if len(times) != codeGranule.Rows {
+			return TimeBucketedCounts{}, errors.New("colgranule: time/code row mismatch")
+		}
+		for row, timestamp := range times {
+			code := readUint32Code(header.data, header.width, row)
+			if code >= header.cardinality || code >= cardinality {
+				return TimeBucketedCounts{}, fmt.Errorf("colgranule: code %d outside cardinality %d", code, cardinality)
+			}
+			bucketIndex := int(floorDiv(timestamp, bucketWidth) - minBucket)
+			a.bucketCounts[bucketIndex*int(cardinality)+int(code)]++
+		}
+	}
+	return TimeBucketedCounts{
+		BucketWidth: bucketWidth,
+		MinBucket:   minBucket,
+		Buckets:     buckets,
+		Cardinality: cardinality,
+		Counts:      a.bucketCounts,
+	}, nil
+}
+
+func (a *AggregateArena) prepareCounts(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
+	cardinality, err := inferCodeCardinality(granules, cardinality)
+	if err != nil {
+		return nil, err
+	}
+	if cardinality > maxAggregateCells {
+		return nil, fmt.Errorf("colgranule: cardinality %d exceeds cap %d", cardinality, maxAggregateCells)
+	}
+	if cap(a.counts) < int(cardinality) {
+		a.counts = make([]uint64, cardinality)
+	} else {
+		a.counts = a.counts[:cardinality]
+	}
+	return a.counts, nil
+}
+
+func (a *AggregateArena) forEachCode(g EncodedGranule, fn func(uint32) error) error {
+	raw, err := a.reader.decompressPayload(g)
+	if err != nil {
+		return err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return err
+	}
+	for row := 0; row < g.Rows; row++ {
+		code := readUint32Code(header.data, header.width, row)
+		if code >= header.cardinality {
+			return fmt.Errorf("colgranule: code %d outside cardinality %d", code, header.cardinality)
+		}
+		if err := fn(code); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func inferCodeCardinality(granules []EncodedGranule, cardinality uint32) (uint32, error) {
+	if cardinality > maxCodeCardinality {
+		return 0, fmt.Errorf("colgranule: cardinality %d exceeds cap %d", cardinality, maxCodeCardinality)
+	}
+	if cardinality != 0 {
+		return cardinality, nil
+	}
+	maxCardinality := cardinality
+	var reader GranuleReader
+	for _, g := range granules {
+		raw, err := reader.decompressPayload(g)
+		if err != nil {
+			return 0, err
+		}
+		header, err := parseUint32CodesHeader(raw, g.Rows)
+		if err != nil {
+			return 0, err
+		}
+		if maxCardinality == 0 || header.cardinality > maxCardinality {
+			maxCardinality = header.cardinality
+		}
+	}
+	if maxCardinality == 0 {
+		return 0, errors.New("colgranule: empty code cardinality")
+	}
+	return maxCardinality, nil
+}
+
+func floorDiv(v int64, width int64) int64 {
+	q := v / width
+	r := v % width
+	if r != 0 && ((r < 0) != (width < 0)) {
+		q--
+	}
+	return q
+}
+
+func popcount64(v uint64) int {
+	v = v - ((v >> 1) & 0x5555555555555555)
+	v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
+	return int((((v + (v >> 4)) & 0x0f0f0f0f0f0f0f0f) * 0x0101010101010101) >> 56)
+}

--- a/experiments/colgranule/aggregate.go
+++ b/experiments/colgranule/aggregate.go
@@ -19,9 +19,7 @@ func (a *AggregateArena) Reset() {
 	a.counts = a.counts[:0]
 	a.bucketCounts = a.bucketCounts[:0]
 	a.codeBits = a.codeBits[:0]
-	for k := range a.seenInt64 {
-		delete(a.seenInt64, k)
-	}
+	clear(a.seenInt64)
 }
 
 func (a *AggregateArena) GroupedCountCodes(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
@@ -161,9 +159,7 @@ func (a *AggregateArena) ExactDistinctInt64(granules []EncodedGranule) (int, err
 	if a.seenInt64 == nil {
 		a.seenInt64 = make(map[int64]struct{})
 	} else {
-		for k := range a.seenInt64 {
-			delete(a.seenInt64, k)
-		}
+		clear(a.seenInt64)
 	}
 	for _, g := range granules {
 		values, err := a.reader.DecodeInt64(g)
@@ -216,10 +212,9 @@ func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, t
 	}
 	minBucket := floorDiv(minTime, bucketWidth)
 	maxBucket := floorDiv(maxTime, bucketWidth)
-	buckets := int(maxBucket - minBucket + 1)
-	cells := buckets * int(cardinality)
-	if cells < 0 || cells > maxAggregateCells {
-		return TimeBucketedCounts{}, fmt.Errorf("colgranule: aggregate cells=%d exceeds cap %d", cells, maxAggregateCells)
+	buckets, cells, err := boundedBucketCells(minBucket, maxBucket, cardinality)
+	if err != nil {
+		return TimeBucketedCounts{}, err
 	}
 	if cap(a.bucketCounts) < cells {
 		a.bucketCounts = make([]uint64, cells)
@@ -324,6 +319,27 @@ func inferCodeCardinality(granules []EncodedGranule, cardinality uint32) (uint32
 		return 0, errors.New("colgranule: empty code cardinality")
 	}
 	return maxCardinality, nil
+}
+
+func boundedBucketCells(minBucket int64, maxBucket int64, cardinality uint32) (int, int, error) {
+	if maxBucket < minBucket {
+		return 0, 0, fmt.Errorf("colgranule: invalid bucket range [%d,%d]", minBucket, maxBucket)
+	}
+	if cardinality == 0 {
+		return 0, 0, errors.New("colgranule: empty code cardinality")
+	}
+	maxBuckets := maxAggregateCells / int(cardinality)
+	if maxBuckets == 0 {
+		return 0, 0, fmt.Errorf("colgranule: aggregate cardinality=%d exceeds cell cap %d", cardinality, maxAggregateCells)
+	}
+	maxSpan := int64(maxBuckets - 1)
+	const minInt64 = -1 << 63
+	if maxBucket >= minInt64+maxSpan && maxBucket-maxSpan > minBucket {
+		return 0, 0, fmt.Errorf("colgranule: aggregate buckets exceed cap %d", maxBuckets)
+	}
+	buckets := int(maxBucket - minBucket + 1)
+	cells := buckets * int(cardinality)
+	return buckets, cells, nil
 }
 
 func floorDiv(v int64, width int64) int64 {

--- a/experiments/colgranule/aggregate.go
+++ b/experiments/colgranule/aggregate.go
@@ -22,6 +22,8 @@ func (a *AggregateArena) Reset() {
 	clear(a.seenInt64)
 }
 
+// GroupedCountCodes returns arena-owned count storage. The returned slice is
+// valid only until the next AggregateArena operation or Reset.
 func (a *AggregateArena) GroupedCountCodes(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
 	counts, err := a.prepareCounts(granules, cardinality)
 	if err != nil {
@@ -43,6 +45,8 @@ func (a *AggregateArena) GroupedCountCodes(granules []EncodedGranule, cardinalit
 	return counts, nil
 }
 
+// FilteredGroupedCountCodes returns arena-owned count storage. The returned
+// slice is valid only until the next AggregateArena operation or Reset.
 func (a *AggregateArena) FilteredGroupedCountCodes(codeGranules []EncodedGranule, filterGranules []EncodedGranule, filter Int64RangePredicate, cardinality uint32) ([]uint64, PredicateDiagnostics, error) {
 	var diagnostics PredicateDiagnostics
 	if len(codeGranules) != len(filterGranules) {
@@ -60,6 +64,9 @@ func (a *AggregateArena) FilteredGroupedCountCodes(codeGranules []EncodedGranule
 	for i, codeGranule := range codeGranules {
 		filterGranule := filterGranules[i]
 		diagnostics.Considered++
+		if filterGranule.Rows != codeGranule.Rows {
+			return nil, diagnostics, errors.New("colgranule: filter/code row mismatch")
+		}
 		if filterGranule.HasMinMax && (filter.High < filterGranule.Min || filter.Low > filterGranule.Max) {
 			diagnostics.SkippedByMinMax++
 			continue
@@ -185,13 +192,19 @@ func (c TimeBucketedCounts) Count(bucket int64, code uint32) uint64 {
 	if c.BucketWidth <= 0 || code >= c.Cardinality {
 		return 0
 	}
-	bucketIndex := int(bucket - c.MinBucket)
-	if bucketIndex < 0 || bucketIndex >= c.Buckets {
+	bucketOffset := bucket - c.MinBucket
+	if bucketOffset < 0 || bucketOffset >= int64(c.Buckets) {
 		return 0
 	}
-	return c.Counts[bucketIndex*int(c.Cardinality)+int(code)]
+	cell, err := bucketCellIndex(int(bucketOffset), c.Buckets, code, c.Cardinality, len(c.Counts))
+	if err != nil {
+		return 0
+	}
+	return c.Counts[cell]
 }
 
+// TimeBucketedCountCodes returns a result whose Counts slice is arena-owned.
+// Counts is valid only until the next AggregateArena operation or Reset.
 func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, timeGranules []EncodedGranule, bucketWidth int64, cardinality uint32) (TimeBucketedCounts, error) {
 	if len(codeGranules) != len(timeGranules) {
 		return TimeBucketedCounts{}, fmt.Errorf("colgranule: code granules=%d time granules=%d", len(codeGranules), len(timeGranules))
@@ -248,7 +261,11 @@ func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, t
 				return TimeBucketedCounts{}, fmt.Errorf("colgranule: timestamp %d outside bucket range [%d,%d]", timestamp, minBucket, maxBucket)
 			}
 			bucketIndex := int(bucketIndex64)
-			a.bucketCounts[bucketIndex*int(cardinality)+int(code)]++
+			cell, err := bucketCellIndex(bucketIndex, buckets, code, cardinality, len(a.bucketCounts))
+			if err != nil {
+				return TimeBucketedCounts{}, err
+			}
+			a.bucketCounts[cell]++
 		}
 	}
 	return TimeBucketedCounts{
@@ -344,6 +361,20 @@ func boundedBucketCells(minBucket int64, maxBucket int64, cardinality uint32) (i
 	buckets := int(maxBucket - minBucket + 1)
 	cells := buckets * int(cardinality)
 	return buckets, cells, nil
+}
+
+func bucketCellIndex(bucketIndex int, buckets int, code uint32, cardinality uint32, cells int) (int, error) {
+	if bucketIndex < 0 || bucketIndex >= buckets {
+		return 0, fmt.Errorf("colgranule: bucket index %d outside bucket count %d", bucketIndex, buckets)
+	}
+	if code >= cardinality {
+		return 0, fmt.Errorf("colgranule: code %d outside cardinality %d", code, cardinality)
+	}
+	cell := bucketIndex*int(cardinality) + int(code)
+	if cell < 0 || cell >= cells {
+		return 0, fmt.Errorf("colgranule: bucket cell %d outside counts length %d", cell, cells)
+	}
+	return cell, nil
 }
 
 func floorDiv(v int64, width int64) int64 {

--- a/experiments/colgranule/aggregate_test.go
+++ b/experiments/colgranule/aggregate_test.go
@@ -198,6 +198,25 @@ func TestTimeBucketedCountCodesRejectsHugeBucketSpan(t *testing.T) {
 	}
 }
 
+func TestTimeBucketedCountCodesRejectsStaleMinMaxMetadata(t *testing.T) {
+	codeGranules, err := buildCodeGranulesForTest([][]uint32{{0, 0}}, 1)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	timeBuilder := NewGranuleBuilder(Config{Encoding: EncodingRawInt64, Compression: CompressionNone})
+	timeGranule, err := timeBuilder.BuildInt64([]int64{0, 10})
+	if err != nil {
+		t.Fatalf("BuildInt64 times: %v", err)
+	}
+	timeGranule.Payload = append([]byte(nil), timeGranule.Payload...)
+	timeGranule.Max = 0
+	var arena AggregateArena
+	_, err = arena.TimeBucketedCountCodes(codeGranules, []EncodedGranule{timeGranule}, 10, 1)
+	if err == nil || !strings.Contains(err.Error(), "outside bucket range") {
+		t.Fatalf("TimeBucketedCountCodes stale min/max err=%v want outside bucket range", err)
+	}
+}
+
 func buildCodeGranulesForTest(codeSets [][]uint32, cardinality uint32) ([]EncodedGranule, error) {
 	builder := NewGranuleBuilder(Config{Compression: CompressionNone})
 	granules := make([]EncodedGranule, 0, len(codeSets))

--- a/experiments/colgranule/aggregate_test.go
+++ b/experiments/colgranule/aggregate_test.go
@@ -178,6 +178,26 @@ func TestTimeBucketedGroupedCountsMatchRaw(t *testing.T) {
 	}
 }
 
+func TestTimeBucketedCountCodesRejectsHugeBucketSpan(t *testing.T) {
+	codeGranules, err := buildCodeGranulesForTest([][]uint32{{0, 0}}, 1)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	const minInt64 = -1 << 63
+	const maxInt64 = 1<<63 - 1
+	timeBuilder := NewGranuleBuilder(Config{Encoding: EncodingRawInt64, Compression: CompressionNone})
+	timeGranule, err := timeBuilder.BuildInt64([]int64{minInt64, maxInt64})
+	if err != nil {
+		t.Fatalf("BuildInt64 times: %v", err)
+	}
+	timeGranule.Payload = append([]byte(nil), timeGranule.Payload...)
+	var arena AggregateArena
+	_, err = arena.TimeBucketedCountCodes(codeGranules, []EncodedGranule{timeGranule}, 1, 1)
+	if err == nil || !strings.Contains(err.Error(), "aggregate buckets exceed cap") {
+		t.Fatalf("TimeBucketedCountCodes huge span err=%v want aggregate bucket cap", err)
+	}
+}
+
 func buildCodeGranulesForTest(codeSets [][]uint32, cardinality uint32) ([]EncodedGranule, error) {
 	builder := NewGranuleBuilder(Config{Compression: CompressionNone})
 	granules := make([]EncodedGranule, 0, len(codeSets))

--- a/experiments/colgranule/aggregate_test.go
+++ b/experiments/colgranule/aggregate_test.go
@@ -1,0 +1,261 @@
+package colgranule
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGroupedCountCodesMatchesRawAndEmptyGroups(t *testing.T) {
+	codeSets := [][]uint32{
+		{0, 1, 1, 2, 4, 4},
+		{2, 2, 3, 4, 4, 4},
+	}
+	granules, err := buildCodeGranulesForTest(codeSets, 6)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	var arena AggregateArena
+	counts, err := arena.GroupedCountCodes(granules, 6)
+	if err != nil {
+		t.Fatalf("GroupedCountCodes: %v", err)
+	}
+	want := []uint64{1, 2, 3, 1, 5, 0}
+	if !slices.Equal(counts, want) {
+		t.Fatalf("counts=%v want %v", counts, want)
+	}
+}
+
+func TestFilteredGroupedCountCodesMatchesRaw(t *testing.T) {
+	codeSets := [][]uint32{
+		{0, 1, 1, 2, 3, 3, 0, 1, 2, 2},
+		{1, 2, 3, 3, 0, 0, 1, 2, 2, 3},
+	}
+	timeSets := [][]int64{
+		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+	}
+	codeGranules, err := buildCodeGranulesForTest(codeSets, 4)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	timeGranules, err := buildInt64GranulesFromSetsForTest(timeSets)
+	if err != nil {
+		t.Fatalf("build time granules: %v", err)
+	}
+	filter := Int64RangePredicate{Column: "time_us", Low: 5, High: 14}
+	var arena AggregateArena
+	counts, diagnostics, err := arena.FilteredGroupedCountCodes(codeGranules, timeGranules, filter, 4)
+	if err != nil {
+		t.Fatalf("FilteredGroupedCountCodes: %v", err)
+	}
+	want := rawFilteredCodeCounts(codeSets, timeSets, filter, 4)
+	if !slices.Equal(counts, want) {
+		t.Fatalf("counts=%v want %v", counts, want)
+	}
+	if diagnostics.Considered != 2 || diagnostics.Decoded != 2 || diagnostics.Matched != 10 {
+		t.Fatalf("diagnostics=%+v want considered=2 decoded=2 matched=10", diagnostics)
+	}
+}
+
+func TestAggregateKernelsFailClosedOnShapeMismatch(t *testing.T) {
+	codeGranules, err := buildCodeGranulesForTest([][]uint32{{0, 1, 2, 3}}, 4)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	var arena AggregateArena
+	if _, err := arena.GroupedCountCodes(codeGranules, 2); err == nil || !strings.Contains(err.Error(), "outside counts") {
+		t.Fatalf("GroupedCountCodes small cardinality err=%v want outside counts", err)
+	}
+	if _, err := arena.ExactDistinctCodes(codeGranules, 2); err == nil || !strings.Contains(err.Error(), "outside cardinality") {
+		t.Fatalf("ExactDistinctCodes small cardinality err=%v want outside cardinality", err)
+	}
+
+	filterGranules, err := buildInt64GranulesFromSetsForTest([][]int64{{0, 1, 2}})
+	if err != nil {
+		t.Fatalf("build filter granules: %v", err)
+	}
+	codeGranules, err = buildCodeGranulesForTest([][]uint32{{0, 1}}, 4)
+	if err != nil {
+		t.Fatalf("build shorter code granules: %v", err)
+	}
+	filter := Int64RangePredicate{Column: "time_us", Low: 0, High: 10}
+	if _, _, err := arena.FilteredGroupedCountCodes(codeGranules, filterGranules, filter, 4); err == nil || !strings.Contains(err.Error(), "row mismatch") {
+		t.Fatalf("FilteredGroupedCountCodes row mismatch err=%v want row mismatch", err)
+	}
+}
+
+func TestMinMaxInt64Kernels(t *testing.T) {
+	granules, err := buildInt64GranulesFromSetsForTest([][]int64{
+		{-5, -1, 0},
+		{7, 7, 7},
+	})
+	if err != nil {
+		t.Fatalf("build int64 granules: %v", err)
+	}
+	var arena AggregateArena
+	min, max, ok, err := arena.MinMaxInt64(granules, nil)
+	if err != nil {
+		t.Fatalf("MinMaxInt64: %v", err)
+	}
+	if !ok || min != -5 || max != 7 {
+		t.Fatalf("min/max/ok=(%d,%d,%v) want (-5,7,true)", min, max, ok)
+	}
+	filter := Int64RangePredicate{Column: "v", Low: 100, High: 200}
+	_, _, ok, err = arena.MinMaxInt64(granules, &filter)
+	if err != nil {
+		t.Fatalf("MinMaxInt64(empty filter): %v", err)
+	}
+	if ok {
+		t.Fatal("MinMaxInt64(empty filter) ok=true want false")
+	}
+	equalFilter := Int64RangePredicate{Column: "v", Low: 7, High: 7}
+	min, max, ok, err = arena.MinMaxInt64(granules, &equalFilter)
+	if err != nil {
+		t.Fatalf("MinMaxInt64(equal filter): %v", err)
+	}
+	if !ok || min != 7 || max != 7 {
+		t.Fatalf("equal min/max/ok=(%d,%d,%v) want (7,7,true)", min, max, ok)
+	}
+}
+
+func TestExactDistinctKernels(t *testing.T) {
+	codeSets := [][]uint32{
+		makeUint32CodeRange(512, 0),
+		makeUint32CodeRange(512, 512),
+	}
+	codeGranules, err := buildCodeGranulesForTest(codeSets, 1024)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	var arena AggregateArena
+	distinct, err := arena.ExactDistinctCodes(codeGranules, 1024)
+	if err != nil {
+		t.Fatalf("ExactDistinctCodes: %v", err)
+	}
+	if distinct != 1024 {
+		t.Fatalf("ExactDistinctCodes=%d want 1024", distinct)
+	}
+
+	idGranules, err := buildInt64GranulesFromSetsForTest([][]int64{
+		{10, 11, 10, 12},
+		{12, 13, 13, 10},
+	})
+	if err != nil {
+		t.Fatalf("build id granules: %v", err)
+	}
+	distinct, err = arena.ExactDistinctInt64(idGranules)
+	if err != nil {
+		t.Fatalf("ExactDistinctInt64: %v", err)
+	}
+	if distinct != 4 {
+		t.Fatalf("ExactDistinctInt64=%d want 4", distinct)
+	}
+}
+
+func TestTimeBucketedGroupedCountsMatchRaw(t *testing.T) {
+	codes := [][]uint32{{0, 1, 2, 0, 1, 2, 0, 1, 2, 0}, {1, 2, 0, 1, 2, 0, 1, 2, 0, 1}}
+	times := [][]int64{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19}}
+	codeGranules, err := buildCodeGranulesForTest(codes, 3)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	timeGranules, err := buildInt64GranulesFromSetsForTest(times)
+	if err != nil {
+		t.Fatalf("build time granules: %v", err)
+	}
+	var arena AggregateArena
+	got, err := arena.TimeBucketedCountCodes(codeGranules, timeGranules, 10, 3)
+	if err != nil {
+		t.Fatalf("TimeBucketedCountCodes: %v", err)
+	}
+	want := rawTimeBucketedCounts(codes, times, 10, 3)
+	if got.Buckets != want.Buckets || got.Cardinality != want.Cardinality || !slices.Equal(got.Counts, want.Counts) {
+		t.Fatalf("bucketed counts=%+v want %+v", got, want)
+	}
+	if got.Count(0, 0) != 4 || got.Count(1, 1) != 4 {
+		t.Fatalf("selected bucket counts got bucket0/code0=%d bucket1/code1=%d", got.Count(0, 0), got.Count(1, 1))
+	}
+}
+
+func buildCodeGranulesForTest(codeSets [][]uint32, cardinality uint32) ([]EncodedGranule, error) {
+	builder := NewGranuleBuilder(Config{Compression: CompressionNone})
+	granules := make([]EncodedGranule, 0, len(codeSets))
+	for _, codes := range codeSets {
+		g, err := builder.BuildUint32Codes(codes, cardinality)
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func buildInt64GranulesFromSetsForTest(sets [][]int64) ([]EncodedGranule, error) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	granules := make([]EncodedGranule, 0, len(sets))
+	for _, values := range sets {
+		g, err := builder.BuildInt64(values)
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func rawFilteredCodeCounts(codeSets [][]uint32, timeSets [][]int64, filter Int64RangePredicate, cardinality int) []uint64 {
+	counts := make([]uint64, cardinality)
+	for granuleIndex, codes := range codeSets {
+		for row, code := range codes {
+			timestamp := timeSets[granuleIndex][row]
+			if timestamp >= filter.Low && timestamp <= filter.High {
+				counts[code]++
+			}
+		}
+	}
+	return counts
+}
+
+func makeUint32CodeRange(n int, offset uint32) []uint32 {
+	values := make([]uint32, n)
+	for i := range values {
+		values[i] = offset + uint32(i)
+	}
+	return values
+}
+
+func rawTimeBucketedCounts(codeSets [][]uint32, timeSets [][]int64, bucketWidth int64, cardinality uint32) TimeBucketedCounts {
+	minTime, maxTime := timeSets[0][0], timeSets[0][0]
+	for _, times := range timeSets {
+		for _, timestamp := range times {
+			if timestamp < minTime {
+				minTime = timestamp
+			}
+			if timestamp > maxTime {
+				maxTime = timestamp
+			}
+		}
+	}
+	minBucket := floorDiv(minTime, bucketWidth)
+	maxBucket := floorDiv(maxTime, bucketWidth)
+	buckets := int(maxBucket - minBucket + 1)
+	counts := make([]uint64, buckets*int(cardinality))
+	for granuleIndex, codes := range codeSets {
+		for row, code := range codes {
+			bucket := floorDiv(timeSets[granuleIndex][row], bucketWidth)
+			counts[int(bucket-minBucket)*int(cardinality)+int(code)]++
+		}
+	}
+	return TimeBucketedCounts{
+		BucketWidth: bucketWidth,
+		MinBucket:   minBucket,
+		Buckets:     buckets,
+		Cardinality: cardinality,
+		Counts:      counts,
+	}
+}

--- a/experiments/colgranule/aggregate_test.go
+++ b/experiments/colgranule/aggregate_test.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -83,6 +84,14 @@ func TestAggregateKernelsFailClosedOnShapeMismatch(t *testing.T) {
 	if _, _, err := arena.FilteredGroupedCountCodes(codeGranules, filterGranules, filter, 4); err == nil || !strings.Contains(err.Error(), "row mismatch") {
 		t.Fatalf("FilteredGroupedCountCodes row mismatch err=%v want row mismatch", err)
 	}
+
+	filterGranules, err = buildInt64GranulesFromSetsForTest([][]int64{{100, 101, 102}})
+	if err != nil {
+		t.Fatalf("build pruned filter granules: %v", err)
+	}
+	if _, _, err := arena.FilteredGroupedCountCodes(codeGranules, filterGranules, filter, 4); err == nil || !strings.Contains(err.Error(), "row mismatch") {
+		t.Fatalf("FilteredGroupedCountCodes pruned row mismatch err=%v want row mismatch", err)
+	}
 }
 
 func TestMinMaxInt64Kernels(t *testing.T) {
@@ -150,6 +159,78 @@ func TestExactDistinctKernels(t *testing.T) {
 	}
 	if distinct != 4 {
 		t.Fatalf("ExactDistinctInt64=%d want 4", distinct)
+	}
+}
+
+func TestAggregateKernelsInferCardinalityFromHeaders(t *testing.T) {
+	codeGranules, err := buildCodeGranulesForTest([][]uint32{
+		{0, 1, 1},
+		{2, 4, 4},
+	}, 5)
+	if err != nil {
+		t.Fatalf("build code granules: %v", err)
+	}
+	var arena AggregateArena
+	counts, err := arena.GroupedCountCodes(codeGranules, 0)
+	if err != nil {
+		t.Fatalf("GroupedCountCodes inferred cardinality: %v", err)
+	}
+	want := []uint64{1, 2, 1, 0, 2}
+	if !slices.Equal(counts, want) {
+		t.Fatalf("inferred counts=%v want %v", counts, want)
+	}
+	distinct, err := arena.ExactDistinctCodes(codeGranules, 0)
+	if err != nil {
+		t.Fatalf("ExactDistinctCodes inferred cardinality: %v", err)
+	}
+	if distinct != 4 {
+		t.Fatalf("inferred distinct=%d want 4", distinct)
+	}
+}
+
+func TestAggregateKernelsInferMaxCardinalityFromMixedHeaders(t *testing.T) {
+	codeGranules, err := buildCodeGranulesWithCardinalitiesForTest(
+		[][]uint32{{0, 1}, {0, 2, 3}},
+		[]uint32{2, 4},
+	)
+	if err != nil {
+		t.Fatalf("build mixed-cardinality code granules: %v", err)
+	}
+	timeGranules, err := buildInt64GranulesFromSetsForTest([][]int64{{0, 1}, {10, 11, 12}})
+	if err != nil {
+		t.Fatalf("build time granules: %v", err)
+	}
+	var arena AggregateArena
+	counts, err := arena.GroupedCountCodes(codeGranules, 0)
+	if err != nil {
+		t.Fatalf("GroupedCountCodes mixed inferred cardinality: %v", err)
+	}
+	want := []uint64{2, 1, 1, 1}
+	if !slices.Equal(counts, want) {
+		t.Fatalf("mixed inferred counts=%v want %v", counts, want)
+	}
+	got, err := arena.TimeBucketedCountCodes(codeGranules, timeGranules, 10, 0)
+	if err != nil {
+		t.Fatalf("TimeBucketedCountCodes mixed inferred cardinality: %v", err)
+	}
+	if got.Cardinality != 4 || got.Buckets != 2 {
+		t.Fatalf("bucketed inferred cardinality/buckets=(%d,%d) want (4,2)", got.Cardinality, got.Buckets)
+	}
+	if got.Count(0, 0) != 1 || got.Count(0, 1) != 1 || got.Count(1, 0) != 1 || got.Count(1, 2) != 1 || got.Count(1, 3) != 1 {
+		t.Fatalf("bucketed inferred counts=%+v", got)
+	}
+}
+
+func TestAggregateKernelsInferCardinalityRejectsEmptyInputs(t *testing.T) {
+	var arena AggregateArena
+	if _, err := arena.GroupedCountCodes(nil, 0); err == nil || !strings.Contains(err.Error(), "empty code cardinality") {
+		t.Fatalf("GroupedCountCodes empty inferred cardinality err=%v want empty code cardinality", err)
+	}
+	if _, err := arena.ExactDistinctCodes(nil, 0); err == nil || !strings.Contains(err.Error(), "empty code cardinality") {
+		t.Fatalf("ExactDistinctCodes empty inferred cardinality err=%v want empty code cardinality", err)
+	}
+	if _, err := arena.TimeBucketedCountCodes(nil, nil, 10, 0); err == nil || !strings.Contains(err.Error(), "empty code cardinality") {
+		t.Fatalf("TimeBucketedCountCodes empty inferred cardinality err=%v want empty code cardinality", err)
 	}
 }
 
@@ -222,6 +303,24 @@ func buildCodeGranulesForTest(codeSets [][]uint32, cardinality uint32) ([]Encode
 	granules := make([]EncodedGranule, 0, len(codeSets))
 	for _, codes := range codeSets {
 		g, err := builder.BuildUint32Codes(codes, cardinality)
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func buildCodeGranulesWithCardinalitiesForTest(codeSets [][]uint32, cardinalities []uint32) ([]EncodedGranule, error) {
+	if len(codeSets) != len(cardinalities) {
+		return nil, errors.New("test: code/cardinality length mismatch")
+	}
+	builder := NewGranuleBuilder(Config{Compression: CompressionNone})
+	granules := make([]EncodedGranule, 0, len(codeSets))
+	for i, codes := range codeSets {
+		g, err := builder.BuildUint32Codes(codes, cardinalities[i])
 		if err != nil {
 			return nil, err
 		}

--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -302,6 +302,108 @@ func BenchmarkPredicatePruningInt64Granules(b *testing.B) {
 	})
 }
 
+func BenchmarkAggregateGroupedCountCodes(b *testing.B) {
+	const granulesN = 100
+	const cardinality = 16
+	codeGranules, err := buildAggregateCodeGranules(granulesN, DefaultRowsPerGranule, cardinality)
+	if err != nil {
+		b.Fatal(err)
+	}
+	totalRows := granulesN * DefaultRowsPerGranule
+	b.Run("encoded_kernel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(totalRows * 4))
+		var arena AggregateArena
+		counts, err := arena.GroupedCountCodes(codeGranules, cardinality)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(counts[0])
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			counts, err = arena.GroupedCountCodes(codeGranules, cardinality)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(counts[0])
+		}
+		reportGranuleBenchMetrics(b, totalRows, totalRows*4, totalStoredBytes(codeGranules))
+	})
+	b.Run("materialized_decode_loop", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(totalRows * 4))
+		var reader GranuleReader
+		counts := make([]uint64, cardinality)
+		if err := countCodesMaterialized(&reader, codeGranules, counts); err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(counts[0])
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := countCodesMaterialized(&reader, codeGranules, counts); err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(counts[0])
+		}
+		reportGranuleBenchMetrics(b, totalRows, totalRows*4, totalStoredBytes(codeGranules))
+	})
+}
+
+func BenchmarkAggregateFilteredGroupedCountCodes(b *testing.B) {
+	const granulesN = 100
+	const cardinality = 16
+	codeGranules, timeGranules, err := buildAggregateCodeTimeGranules(granulesN, DefaultRowsPerGranule, cardinality)
+	if err != nil {
+		b.Fatal(err)
+	}
+	totalRows := granulesN * DefaultRowsPerGranule
+	filter := Int64RangePredicate{Column: "time_us", Low: int64(totalRows * 9 / 10), High: int64(totalRows - 1)}
+	b.ReportAllocs()
+	b.SetBytes(int64(totalRows * 12))
+	var arena AggregateArena
+	counts, diagnostics, err := arena.FilteredGroupedCountCodes(codeGranules, timeGranules, filter, cardinality)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchSink += int64(counts[0] + uint64(diagnostics.SkippedByMinMax))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		counts, diagnostics, err = arena.FilteredGroupedCountCodes(codeGranules, timeGranules, filter, cardinality)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(counts[0] + uint64(diagnostics.SkippedByMinMax))
+	}
+	reportGranuleBenchMetrics(b, totalRows, totalRows*12, totalStoredBytes(codeGranules)+totalStoredBytes(timeGranules))
+}
+
+func BenchmarkAggregateExactDistinctInt64(b *testing.B) {
+	const granulesN = 16
+	const rowsPerGranule = DefaultRowsPerGranule
+	idGranules, err := buildDistinctIDGranules(granulesN, rowsPerGranule)
+	if err != nil {
+		b.Fatal(err)
+	}
+	totalRows := granulesN * rowsPerGranule
+	b.ReportAllocs()
+	b.SetBytes(int64(totalRows * 8))
+	var arena AggregateArena
+	distinct, err := arena.ExactDistinctInt64(idGranules)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchSink += int64(distinct)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		distinct, err = arena.ExactDistinctInt64(idGranules)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(distinct)
+	}
+	reportGranuleBenchMetrics(b, totalRows, totalRows*8, totalStoredBytes(idGranules))
+}
+
 func TestCompressionRatios(t *testing.T) {
 	for _, fx := range benchmarkFixtures() {
 		t.Logf("fixture=%s rows=%d raw_values_bytes=%d", fx.name, len(fx.values), len(fx.values)*8)
@@ -451,4 +553,86 @@ func totalStoredBytes(granules []EncodedGranule) int {
 		total += g.StoredBytes
 	}
 	return total
+}
+
+func buildAggregateCodeGranules(granulesN int, rowsPerGranule int, cardinality uint32) ([]EncodedGranule, error) {
+	builder := NewGranuleBuilder(Config{Compression: CompressionLZ4})
+	granules := make([]EncodedGranule, 0, granulesN)
+	for granuleIndex := 0; granuleIndex < granulesN; granuleIndex++ {
+		codes := makeUint32Codes(rowsPerGranule, cardinality)
+		for i := range codes {
+			codes[i] = (codes[i] + uint32(granuleIndex)) % cardinality
+		}
+		g, err := builder.BuildUint32Codes(codes, cardinality)
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func buildAggregateCodeTimeGranules(granulesN int, rowsPerGranule int, cardinality uint32) ([]EncodedGranule, []EncodedGranule, error) {
+	codeBuilder := NewGranuleBuilder(Config{Compression: CompressionLZ4})
+	timeBuilder := NewGranuleBuilder(Config{Encoding: EncodingDoubleDeltaVarint, Compression: CompressionLZ4})
+	codeGranules := make([]EncodedGranule, 0, granulesN)
+	timeGranules := make([]EncodedGranule, 0, granulesN)
+	for granuleIndex := 0; granuleIndex < granulesN; granuleIndex++ {
+		codes := makeUint32Codes(rowsPerGranule, cardinality)
+		times := make([]int64, rowsPerGranule)
+		for i := range times {
+			codes[i] = (codes[i] + uint32(granuleIndex)) % cardinality
+			times[i] = int64(granuleIndex*rowsPerGranule + i)
+		}
+		codeGranule, err := codeBuilder.BuildUint32Codes(codes, cardinality)
+		if err != nil {
+			return nil, nil, err
+		}
+		timeGranule, err := timeBuilder.BuildInt64(times)
+		if err != nil {
+			return nil, nil, err
+		}
+		codeOwned := codeGranule
+		timeOwned := timeGranule
+		codeOwned.Payload = append([]byte(nil), codeGranule.Payload...)
+		timeOwned.Payload = append([]byte(nil), timeGranule.Payload...)
+		codeGranules = append(codeGranules, codeOwned)
+		timeGranules = append(timeGranules, timeOwned)
+	}
+	return codeGranules, timeGranules, nil
+}
+
+func buildDistinctIDGranules(granulesN int, rowsPerGranule int) ([]EncodedGranule, error) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionLZ4})
+	granules := make([]EncodedGranule, 0, granulesN)
+	for granuleIndex := 0; granuleIndex < granulesN; granuleIndex++ {
+		values := make([]int64, rowsPerGranule)
+		for i := range values {
+			values[i] = int64(granuleIndex*rowsPerGranule + i)
+		}
+		g, err := builder.BuildInt64(values)
+		if err != nil {
+			return nil, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		granules = append(granules, owned)
+	}
+	return granules, nil
+}
+
+func countCodesMaterialized(reader *GranuleReader, granules []EncodedGranule, counts []uint64) error {
+	clear(counts)
+	for _, g := range granules {
+		codes, err := reader.DecodeUint32Codes(g)
+		if err != nil {
+			return err
+		}
+		for _, code := range codes {
+			counts[code]++
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Objective

Implement Phase 1 / PR4 from #1534: aggregate kernels over encoded column granules so the experiment can exercise grouped count, filtered grouped count, min/max, exact distinct, and time-bucketed grouped count without forcing every path through fully materialized row values.

This is stacked on #1539 and targets `codex/colgranule-predicate-marks`.

## Context

PR1 added reusable granule encode/read primitives, PR2 added typed codec paths, and PR3 added predicate marks. This PR adds the next inner-loop execution layer: reusable aggregate state over those encoded granules. It keeps the work WAL-independent and experiment-scoped while moving toward the column-store execution design in #1534.

## Non-goals

- No durable TreeDB integration or WAL coupling.
- No SQL/planner integration.
- No cube/materialized aggregate engine.
- No new on-disk format version beyond the experiment granule structures already introduced in the stack.

## Design

- Adds `AggregateArena` as a reusable execution scratch arena for low-allocation aggregate kernels.
- Adds grouped `count` over dictionary/code columns, including a direct encoded-code path and a materialized decode-loop benchmark baseline.
- Adds filtered grouped `count` that uses int64 min/max summaries to skip non-matching granules before decoding filter/code payloads.
- Adds `min`/`max` over int64 granules, exact distinct over low-cardinality codes and int64 ids, and time-bucketed grouped counts.
- Invariants:
  - code/filter/time granule sets must have matching lengths and row counts.
  - caller-declared cardinality must be large enough for observed codes.
  - aggregate cell counts are capped before allocation by `maxAggregateCells`.
- Fail-closed behavior:
  - mismatched granule lengths/rows return errors.
  - too-small cardinality returns errors instead of indexing past buffers.
  - invalid bucket widths and excessive cell counts return errors before allocation.

## Scope

- Includes (files/symbols):
  - `experiments/colgranule/aggregate.go`
  - `experiments/colgranule/aggregate_test.go`
  - aggregate benchmarks/helpers in `experiments/colgranule/granule_bench_test.go`
  - `AggregateArena`, `GroupedCountCodes`, `FilteredGroupedCountCodes`, `MinMaxInt64`, `ExactDistinctCodes`, `ExactDistinctInt64`, `TimeBucketedCountCodes`
- Excludes (files/symbols):
  - TreeDB production storage paths
  - WAL/recovery integration
  - JSONBench harness changes
  - planner/query API changes

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule/...`
  - `go test ./...`
  - `go test ./... -count=1`
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkAggregate' -benchmem -benchtime=100x`
- Corruption/edge cases covered:
  - empty low-cardinality groups are preserved.
  - filtered grouped counts match raw row-wise reference counts.
  - `min`/`max` handles metadata-only and filtered paths.
  - exact distinct over codes and int64 ids matches expected cardinality.
  - time-bucketed grouped counts match raw row-wise reference counts.
  - too-small declared cardinality fails closed for grouped count and exact distinct.
  - filter/code row-count mismatch fails closed.
- Concurrency/race coverage (if applicable): not applicable; these are single-threaded experiment kernels with caller-owned arenas.

## Performance

- Benchmarks run (exact commands):
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkAggregate' -benchmem -benchtime=100x`
- Machine: Apple M3, `darwin/arm64`.
- Results table:

| Benchmark | ns/op | ns/row | rows/s | MiB/s | allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkAggregateGroupedCountCodes/encoded_kernel-8` | 1,800,355 | 2.198 | 455.0M | 1736 | 0 B/op, 0 allocs/op |
| `BenchmarkAggregateGroupedCountCodes/materialized_decode_loop-8` | 2,178,464 | 2.659 | 376.0M | 1435 | 0 B/op, 0 allocs/op |
| `BenchmarkAggregateFilteredGroupedCountCodes-8` | 425,971 | 0.5200 | 1.923B | 22009 | 0 B/op, 0 allocs/op |
| `BenchmarkAggregateExactDistinctInt64-8` | 1,437,381 | 10.97 | 91.2M | 695.7 | 0 B/op, 0 allocs/op |

The encoded grouped-count kernel is about 1.21x faster than the materialized decode-loop baseline in this run. The filtered grouped-count benchmark skips by min/max and only decodes matching granules, sustaining about 1.92B rows/s with zero per-iteration allocations.

- Regressions (if any) and why acceptable: none known.

## Rollout / Toggle Plan

- Default setting: experiment-only code; no production path uses it by default.
- How to disable quickly: do not wire these kernels into production callers; reverting this PR removes the experiment API.

## Follow-ups

- Continue #1534 after the PR1-PR4 stack lands:
  - use these kernels from the JSONBench column-granule harness.
  - add on-disk part/granule side-file layout experiments.
  - add lifecycle/GC experiments for generated column assets.
  - later wire durable column assets to the user-command WAL once that work lands.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope
- [x] Explicit exclude list (files/symbols NOT touched): see Scope
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: no durable paths touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): no CRC/checksum paths added; shape/cap errors fail closed
- [x] Any concurrency change has a defined state machine and invariants: no concurrency changes

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes: added shape/cardinality edge tests; no format parser change in this PR
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see Correctness and Performance

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved: not applicable; this PR does not add compression codecs

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable): not applicable; #1534 tracks this experiment stack
- [ ] Documented any new config knobs + defaults: no config knobs added
- [x] Called out any format change in PR description (pre-alpha OK): no new format version in this PR

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold): experiment-only, not production-wired
- [x] Clear knobs to disable/revert behavior quickly: no production wiring; revert PR if needed
- [x] Observability: counters/logs to verify effectiveness: benchmark metrics and predicate diagnostics are exposed in the experiment path
