### PR TITLE
experiments/colgranule: add in-memory parts

### DIFF
--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -9,8 +9,14 @@ It currently covers:
 - 8192-row default int64 granules;
 - raw int64 encoding;
 - delta + zigzag varint encoding;
+- double-delta-style int64 encoding;
+- nullable/default-heavy int64, bool bitpack/RLE, and low-cardinality code paths;
 - none, snappy, and lz4 compression;
 - min/max metadata and range-scan skip;
+- sort-key marks and predicate pruning diagnostics;
+- aggregate kernels over encoded granules;
+- non-durable in-memory column parts made from row-aligned granules and
+  independently split column codec blocks;
 - JSONBench Bluesky fixture loading into int64-derived columns.
 
 ## Local JSONBench Data

--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -404,6 +404,76 @@ func BenchmarkAggregateExactDistinctInt64(b *testing.B) {
 	reportGranuleBenchMetrics(b, totalRows, totalRows*8, totalStoredBytes(idGranules))
 }
 
+func BenchmarkColumnPartBuildAndProjectedScan(b *testing.B) {
+	const rows = DefaultRowsPerGranule * 100
+	batch := buildPartBenchmarkBatch(rows)
+	opts := partBenchmarkOptions()
+	part, err := BuildColumnPart(1, opts, batch)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("build_in_memory_part", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(rows * len(opts.Columns) * 8))
+		builder, err := NewColumnPartBuilder(opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		var built *ColumnPart
+		for i := 0; i < b.N; i++ {
+			built, err = builder.Build(uint64(i+1), batch)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(built.Descriptor.RowCount)
+		}
+		reportGranuleBenchMetrics(b, rows, rows*len(opts.Columns)*8, totalPartStoredBytes(built))
+	})
+	b.Run("projected_scan_one_column", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(rows * 8))
+		scanner := part.NewScanner()
+		projection := []string{"time_us"}
+		scanScratch := make(map[string][]int64, len(projection))
+		scan, err := scanner.ScanProjectedInto(scanScratch, projection)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += scan.Columns["time_us"][0]
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			scan, err = scanner.ScanProjectedInto(scanScratch, projection)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += scan.Columns["time_us"][0]
+		}
+		reportGranuleBenchMetrics(b, rows, rows*8, totalPartProjectedStoredBytes(part, []string{"time_us"}))
+	})
+	b.Run("projected_scan_three_columns", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(rows * 3 * 8))
+		scanner := part.NewScanner()
+		projection := []string{"time_us", "kind_code", "has_reply"}
+		scanScratch := make(map[string][]int64, len(projection))
+		scan, err := scanner.ScanProjectedInto(scanScratch, projection)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += scan.Columns["time_us"][0] + scan.Columns["kind_code"][0] + scan.Columns["has_reply"][0]
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			scan, err = scanner.ScanProjectedInto(scanScratch, projection)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += scan.Columns["time_us"][0] + scan.Columns["kind_code"][0] + scan.Columns["has_reply"][0]
+		}
+		reportGranuleBenchMetrics(b, rows, rows*3*8, totalPartProjectedStoredBytes(part, projection))
+	})
+}
+
 func TestCompressionRatios(t *testing.T) {
 	for _, fx := range benchmarkFixtures() {
 		t.Logf("fixture=%s rows=%d raw_values_bytes=%d", fx.name, len(fx.values), len(fx.values)*8)
@@ -521,7 +591,7 @@ func buildPredicateBenchmarkGranules(granulesN int, rowsPerGranule int) ([]Encod
 		}
 		owned := g
 		owned.Payload = append([]byte(nil), g.Payload...)
-		mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: values}})
+		mark, err := BuildSortKeyMark([]SortKeyColumnValues{{Name: "time_us", Values: values}})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -635,4 +705,66 @@ func countCodesMaterialized(reader *GranuleReader, granules []EncodedGranule, co
 		}
 	}
 	return nil
+}
+
+func buildPartBenchmarkBatch(rows int) ColumnBatch {
+	columns := map[string][]int64{
+		"id":        make([]int64, rows),
+		"time_us":   make([]int64, rows),
+		"value":     make([]int64, rows),
+		"kind_code": make([]int64, rows),
+		"has_reply": make([]int64, rows),
+	}
+	for i := 0; i < rows; i++ {
+		columns["id"][i] = int64(rows - i)
+		columns["time_us"][i] = int64(i * 1000)
+		columns["value"][i] = int64((i * 17) % 1_000_003)
+		columns["kind_code"][i] = int64((i / 97) % 16)
+		columns["has_reply"][i] = int64((i / 11) & 1)
+	}
+	return ColumnBatch{Rows: rows, Columns: columns}
+}
+
+func partBenchmarkOptions() ColumnStoreOptions {
+	return ColumnStoreOptions{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionLZ4},
+			{Name: "time_us", Type: ColumnTypeInt64, Encoding: EncodingDoubleDeltaVarint, Compression: CompressionLZ4},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionLZ4},
+			{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Compression: CompressionLZ4, Cardinality: 16},
+			{Name: "has_reply", Type: ColumnTypeBool, Compression: CompressionLZ4},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "time_us"}}},
+		PartPolicy: ColumnPartPolicy{
+			RowsPerGranule:        DefaultRowsPerGranule,
+			DefaultCodecBlockRows: DefaultRowsPerGranule,
+		},
+	}
+}
+
+func totalPartStoredBytes(part *ColumnPart) int {
+	if part == nil {
+		return 0
+	}
+	total := 0
+	for _, column := range part.Columns {
+		for _, block := range column.Blocks {
+			total += block.Granule.StoredBytes
+		}
+	}
+	return total
+}
+
+func totalPartProjectedStoredBytes(part *ColumnPart, projection []string) int {
+	total := 0
+	for _, name := range projection {
+		column := part.Columns[name]
+		for _, block := range column.Blocks {
+			total += block.Granule.StoredBytes
+		}
+	}
+	return total
 }

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -271,36 +271,61 @@ func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []
 	if s.part == nil {
 		return ProjectedScanResult{}, errors.New("colgranule: nil part scanner")
 	}
-	if len(columns) == 0 {
-		return ProjectedScanResult{}, errors.New("colgranule: empty projection")
+	projection, err := s.validateProjection(columns)
+	if err != nil {
+		return ProjectedScanResult{}, err
 	}
 	if dst == nil {
-		dst = make(map[string][]int64, len(columns))
-	}
-	for name := range dst {
-		if !containsString(columns, name) {
-			delete(dst, name)
-		}
+		dst = make(map[string][]int64, len(projection))
 	}
 	out := ProjectedScanResult{
 		Rows:    s.part.Descriptor.RowCount,
 		Columns: dst,
 		Diagnostics: PartScanDiagnostics{
 			RowsScanned:        s.part.Descriptor.RowCount,
-			ColumnsProjected:   len(columns),
+			ColumnsProjected:   len(projection),
 			GranulesConsidered: len(s.part.Descriptor.Granules),
 		},
 	}
-	for _, name := range columns {
+	next := make(map[string][]int64, len(projection))
+	for _, name := range projection {
 		values, diagnostics, err := s.scanColumnInto(name, dst[name])
 		if err != nil {
 			return ProjectedScanResult{}, err
 		}
-		out.Columns[name] = values
+		next[name] = values
 		out.Diagnostics.BlocksDecoded += diagnostics.BlocksDecoded
 		out.Diagnostics.BytesDecoded += diagnostics.BytesDecoded
 	}
+	for name := range dst {
+		if _, ok := next[name]; !ok {
+			delete(dst, name)
+		}
+	}
+	for name, values := range next {
+		dst[name] = values
+	}
 	return out, nil
+}
+
+func (s *ColumnPartScanner) validateProjection(columns []string) ([]string, error) {
+	if len(columns) == 0 {
+		return nil, errors.New("colgranule: empty projection")
+	}
+	seen := make(map[string]struct{}, len(columns))
+	for _, name := range columns {
+		if name == "" {
+			return nil, errors.New("colgranule: empty projection column")
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("colgranule: duplicate projection column %s", name)
+		}
+		if _, ok := s.part.Columns[name]; !ok {
+			return nil, fmt.Errorf("colgranule: missing column %s", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return columns, nil
 }
 
 func (s *ColumnPartScanner) ValueAt(locator RowLocator, columnName string) (int64, error) {
@@ -394,6 +419,9 @@ func (s *ColumnPartScanner) decodeBlock(columnType ColumnType, g EncodedGranule)
 }
 
 func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, error) {
+	opts.Columns = append([]ColumnDefinition(nil), opts.Columns...)
+	opts.LogicalPrimaryKey.Columns = append([]string(nil), opts.LogicalPrimaryKey.Columns...)
+	opts.SortKey.Columns = append([]SortKeyColumn(nil), opts.SortKey.Columns...)
 	if opts.SchemaVersion == 0 {
 		opts.SchemaVersion = 1
 	}
@@ -411,6 +439,9 @@ func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, e
 	}
 	if opts.PartPolicy.DefaultCodecBlockRows < 0 {
 		return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid default codec block rows %d", opts.PartPolicy.DefaultCodecBlockRows)
+	}
+	if err := validateCompression(opts.Compression.Default); err != nil {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported default compression %s", opts.Compression.Default)
 	}
 	if len(opts.LogicalPrimaryKey.Columns) != 1 {
 		return ColumnStoreOptions{}, fmt.Errorf("colgranule: experiment requires exactly one logical primary key column, got %d", len(opts.LogicalPrimaryKey.Columns))
@@ -473,6 +504,9 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 	if !def.CompressionSet && def.Compression == CompressionNone && defaultCompression != CompressionNone {
 		def.Compression = defaultCompression
 	}
+	if err := validateCompression(def.Compression); err != nil {
+		return ColumnDefinition{}, fmt.Errorf("colgranule: unsupported compression %s for %s", def.Compression, def.Name)
+	}
 	switch def.Type {
 	case ColumnTypeInt64:
 		if def.Encoding == 0 {
@@ -489,6 +523,15 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 		return ColumnDefinition{}, fmt.Errorf("colgranule: unsupported column type %s for %s", def.Type, def.Name)
 	}
 	return def, nil
+}
+
+func validateCompression(compression Compression) error {
+	switch compression {
+	case CompressionNone, CompressionSnappy, CompressionLZ4:
+		return nil
+	default:
+		return fmt.Errorf("colgranule: unsupported compression %s", compression)
+	}
 }
 
 func validateColumnBatch(batch ColumnBatch, defs []ColumnDefinition) (int, error) {
@@ -583,7 +626,7 @@ func (b *ColumnPartBuilder) buildGranulesAndLocators(part *ColumnPart, batch Col
 			}
 			markColumns[i] = SortKeyColumnValues{Name: sortColumn.Column, Values: values}
 		}
-		mark, err := BuildSortKeyMark(markColumns)
+		mark, err := buildOwnedSortKeyMark(markColumns)
 		if err != nil {
 			return err
 		}

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -76,6 +76,7 @@ type ColumnDefinition struct {
 	Type           ColumnType
 	Encoding       Encoding
 	Compression    Compression
+	CompressionSet bool
 	Cardinality    uint32
 	CodecBlockRows int
 }
@@ -276,6 +277,11 @@ func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []
 	if dst == nil {
 		dst = make(map[string][]int64, len(columns))
 	}
+	for name := range dst {
+		if !containsString(columns, name) {
+			delete(dst, name)
+		}
+	}
 	out := ProjectedScanResult{
 		Rows:    s.part.Descriptor.RowCount,
 		Columns: dst,
@@ -464,7 +470,7 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 	if def.CodecBlockRows < 0 {
 		return ColumnDefinition{}, fmt.Errorf("colgranule: invalid codec block rows %d for %s", def.CodecBlockRows, def.Name)
 	}
-	if def.Compression == CompressionNone && defaultCompression != CompressionNone {
+	if !def.CompressionSet && def.Compression == CompressionNone && defaultCompression != CompressionNone {
 		def.Compression = defaultCompression
 	}
 	switch def.Type {
@@ -548,6 +554,9 @@ func (b *ColumnPartBuilder) buildGranulesAndLocators(part *ColumnPart, batch Col
 		idLower, idUpper := int64(math.MaxInt64), int64(math.MinInt64)
 		for partRow := start; partRow < end; partRow++ {
 			primaryID := pkValues[b.order[partRow]]
+			if primaryID == math.MaxInt64 {
+				return fmt.Errorf("colgranule: primary id %d cannot form exclusive upper bound", primaryID)
+			}
 			if _, exists := part.Locators[primaryID]; exists {
 				return fmt.Errorf("colgranule: duplicate primary id %d", primaryID)
 			}

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -1,0 +1,669 @@
+package colgranule
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+)
+
+const columnPartDescriptorVersion = 1
+
+type ColumnSchemaMode string
+
+const (
+	ColumnSchemaFixed ColumnSchemaMode = "fixed"
+)
+
+type ColumnType string
+
+const (
+	ColumnTypeInt64              ColumnType = "int64"
+	ColumnTypeLowCardinalityCode ColumnType = "low_cardinality_code"
+	ColumnTypeBool               ColumnType = "bool"
+)
+
+type SortKeyDirection string
+
+const (
+	SortKeyAsc  SortKeyDirection = "asc"
+	SortKeyDesc SortKeyDirection = "desc"
+)
+
+type SortKeyNullOrder string
+
+const (
+	SortKeyNullsDefault SortKeyNullOrder = ""
+	SortKeyNullsFirst   SortKeyNullOrder = "first"
+	SortKeyNullsLast    SortKeyNullOrder = "last"
+)
+
+type LogicalPrimaryKey struct {
+	Columns []string
+}
+
+type SortKey struct {
+	Columns []SortKeyColumn
+}
+
+type SortKeyColumn struct {
+	Column    string
+	Direction SortKeyDirection
+	Nulls     SortKeyNullOrder
+}
+
+type ColumnStoreOptions struct {
+	SchemaVersion     uint32
+	SchemaMode        ColumnSchemaMode
+	Columns           []ColumnDefinition
+	LogicalPrimaryKey LogicalPrimaryKey
+	SortKey           SortKey
+	PartPolicy        ColumnPartPolicy
+	Compression       ColumnCompressionPolicy
+}
+
+type ColumnPartPolicy struct {
+	RowsPerGranule        int
+	DefaultCodecBlockRows int
+}
+
+type ColumnCompressionPolicy struct {
+	Default Compression
+}
+
+type ColumnDefinition struct {
+	Name           string
+	Type           ColumnType
+	Encoding       Encoding
+	Compression    Compression
+	Cardinality    uint32
+	CodecBlockRows int
+}
+
+type ColumnBatch struct {
+	Rows    int
+	Columns map[string][]int64
+}
+
+type ColumnPart struct {
+	Options    ColumnStoreOptions
+	Descriptor ColumnPartDescriptor
+	Columns    map[string]ColumnPartColumn
+	Marks      []SortKeyMark
+	Locators   map[int64]RowLocator
+}
+
+type ColumnPartDescriptor struct {
+	Version           uint8
+	PartID            uint64
+	SchemaVersion     uint32
+	RowCount          int
+	VisibleRowCount   int
+	LogicalPrimaryKey []string
+	SortKey           []SortKeyColumn
+	Granules          []GranuleDescriptor
+	Columns           []ColumnPartColumnDescriptor
+}
+
+type GranuleDescriptor struct {
+	Ordinal          int
+	FirstRow         int
+	RowCount         int
+	VisibleRows      int
+	DeletedRows      int
+	IDLower          int64
+	IDUpperExclusive int64
+	MarkOrdinal      int
+}
+
+type ColumnPartColumnDescriptor struct {
+	Name   string
+	Type   ColumnType
+	Blocks []ColumnBlockDescriptor
+}
+
+type ColumnBlockDescriptor struct {
+	FirstRow          int
+	RowCount          int
+	FirstGranule      int
+	LastGranule       int
+	Encoding          Encoding
+	Compression       Compression
+	RawBytes          int
+	StoredBytes       int
+	CodecBlockOrdinal int
+}
+
+type ColumnPartColumn struct {
+	Definition ColumnDefinition
+	Blocks     []ColumnBlock
+}
+
+type ColumnBlock struct {
+	Descriptor ColumnBlockDescriptor
+	Granule    EncodedGranule
+}
+
+type RowLocator struct {
+	PrimaryID      int64
+	PartID         uint64
+	PartRow        int
+	GranuleOrdinal int
+	RowInGranule   int
+}
+
+type ColumnPartBuilder struct {
+	opts     ColumnStoreOptions
+	order    []int
+	values64 []int64
+	codes32  []uint32
+	bools    []bool
+	builder  *GranuleBuilder
+}
+
+func NewColumnPartBuilder(opts ColumnStoreOptions) (*ColumnPartBuilder, error) {
+	normalized, err := normalizeColumnStoreOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &ColumnPartBuilder{opts: normalized, builder: NewGranuleBuilder(Config{})}, nil
+}
+
+func BuildColumnPart(partID uint64, opts ColumnStoreOptions, batch ColumnBatch) (*ColumnPart, error) {
+	builder, err := NewColumnPartBuilder(opts)
+	if err != nil {
+		return nil, err
+	}
+	return builder.Build(partID, batch)
+}
+
+func (b *ColumnPartBuilder) Build(partID uint64, batch ColumnBatch) (*ColumnPart, error) {
+	rows, err := validateColumnBatch(batch, b.opts.Columns)
+	if err != nil {
+		return nil, err
+	}
+	pkColumn := b.opts.LogicalPrimaryKey.Columns[0]
+	order, err := b.sortedOrder(batch, rows, pkColumn)
+	if err != nil {
+		return nil, err
+	}
+	b.order = order
+
+	part := &ColumnPart{
+		Options: b.opts,
+		Descriptor: ColumnPartDescriptor{
+			Version:           columnPartDescriptorVersion,
+			PartID:            partID,
+			SchemaVersion:     b.opts.SchemaVersion,
+			RowCount:          rows,
+			VisibleRowCount:   rows,
+			LogicalPrimaryKey: append([]string(nil), b.opts.LogicalPrimaryKey.Columns...),
+			SortKey:           append([]SortKeyColumn(nil), b.opts.SortKey.Columns...),
+		},
+		Columns:  make(map[string]ColumnPartColumn, len(b.opts.Columns)),
+		Locators: make(map[int64]RowLocator, rows),
+	}
+
+	if err := b.buildGranulesAndLocators(part, batch, pkColumn); err != nil {
+		return nil, err
+	}
+	for _, def := range b.opts.Columns {
+		column, descriptor, err := b.buildColumn(batch, def)
+		if err != nil {
+			return nil, err
+		}
+		part.Columns[def.Name] = column
+		part.Descriptor.Columns = append(part.Descriptor.Columns, descriptor)
+	}
+	return part, nil
+}
+
+func (p *ColumnPart) LocatePrimaryID(primaryID int64) (RowLocator, bool) {
+	locator, ok := p.Locators[primaryID]
+	return locator, ok
+}
+
+func (p *ColumnPart) EncodedColumnBlocks(name string) ([]EncodedGranule, error) {
+	column, ok := p.Columns[name]
+	if !ok {
+		return nil, fmt.Errorf("colgranule: missing column %s", name)
+	}
+	out := make([]EncodedGranule, len(column.Blocks))
+	for i, block := range column.Blocks {
+		out[i] = block.Granule
+	}
+	return out, nil
+}
+
+func (p *ColumnPart) NewScanner() *ColumnPartScanner {
+	return &ColumnPartScanner{part: p}
+}
+
+type ColumnPartScanner struct {
+	part    *ColumnPart
+	reader  GranuleReader
+	values  []int64
+	codes   []uint32
+	bools   []bool
+	scratch []int64
+}
+
+type ProjectedScanResult struct {
+	Rows        int
+	Columns     map[string][]int64
+	Diagnostics PartScanDiagnostics
+}
+
+type PartScanDiagnostics struct {
+	RowsScanned        int
+	ColumnsProjected   int
+	GranulesConsidered int
+	BlocksDecoded      int
+	BytesDecoded       int
+}
+
+func (s *ColumnPartScanner) ScanProjected(columns []string) (ProjectedScanResult, error) {
+	return s.ScanProjectedInto(make(map[string][]int64, len(columns)), columns)
+}
+
+func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []string) (ProjectedScanResult, error) {
+	if s.part == nil {
+		return ProjectedScanResult{}, errors.New("colgranule: nil part scanner")
+	}
+	if len(columns) == 0 {
+		return ProjectedScanResult{}, errors.New("colgranule: empty projection")
+	}
+	if dst == nil {
+		dst = make(map[string][]int64, len(columns))
+	}
+	out := ProjectedScanResult{
+		Rows:    s.part.Descriptor.RowCount,
+		Columns: dst,
+		Diagnostics: PartScanDiagnostics{
+			RowsScanned:        s.part.Descriptor.RowCount,
+			ColumnsProjected:   len(columns),
+			GranulesConsidered: len(s.part.Descriptor.Granules),
+		},
+	}
+	for _, name := range columns {
+		values, diagnostics, err := s.scanColumnInto(name, dst[name])
+		if err != nil {
+			return ProjectedScanResult{}, err
+		}
+		out.Columns[name] = values
+		out.Diagnostics.BlocksDecoded += diagnostics.BlocksDecoded
+		out.Diagnostics.BytesDecoded += diagnostics.BytesDecoded
+	}
+	return out, nil
+}
+
+func (s *ColumnPartScanner) ValueAt(locator RowLocator, columnName string) (int64, error) {
+	if s.part == nil {
+		return 0, errors.New("colgranule: nil part scanner")
+	}
+	if locator.PartID != s.part.Descriptor.PartID {
+		return 0, fmt.Errorf("colgranule: locator part=%d want %d", locator.PartID, s.part.Descriptor.PartID)
+	}
+	column, ok := s.part.Columns[columnName]
+	if !ok {
+		return 0, fmt.Errorf("colgranule: missing column %s", columnName)
+	}
+	for _, block := range column.Blocks {
+		if locator.PartRow < block.Descriptor.FirstRow || locator.PartRow >= block.Descriptor.FirstRow+block.Descriptor.RowCount {
+			continue
+		}
+		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
+		if err != nil {
+			return 0, err
+		}
+		return values[locator.PartRow-block.Descriptor.FirstRow], nil
+	}
+	return 0, fmt.Errorf("colgranule: locator row %d outside column %s", locator.PartRow, columnName)
+}
+
+func (s *ColumnPartScanner) scanColumn(name string) ([]int64, PartScanDiagnostics, error) {
+	return s.scanColumnInto(name, nil)
+}
+
+func (s *ColumnPartScanner) scanColumnInto(name string, dst []int64) ([]int64, PartScanDiagnostics, error) {
+	column, ok := s.part.Columns[name]
+	if !ok {
+		return nil, PartScanDiagnostics{}, fmt.Errorf("colgranule: missing column %s", name)
+	}
+	out := ensureInt64Len(dst[:0], s.part.Descriptor.RowCount)
+	var diagnostics PartScanDiagnostics
+	for _, block := range column.Blocks {
+		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		if len(values) != block.Descriptor.RowCount {
+			return nil, diagnostics, fmt.Errorf("colgranule: block rows=%d decoded=%d", block.Descriptor.RowCount, len(values))
+		}
+		copy(out[block.Descriptor.FirstRow:block.Descriptor.FirstRow+block.Descriptor.RowCount], values)
+		diagnostics.BlocksDecoded++
+		diagnostics.BytesDecoded += block.Granule.RawBytes
+	}
+	return out, diagnostics, nil
+}
+
+func (s *ColumnPartScanner) decodeBlock(columnType ColumnType, g EncodedGranule) ([]int64, error) {
+	switch columnType {
+	case ColumnTypeInt64:
+		values, err := s.reader.DecodeInt64Into(s.values[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.values = values
+		return values, nil
+	case ColumnTypeLowCardinalityCode:
+		codes, err := s.reader.DecodeUint32CodesInto(s.codes[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.codes = codes
+		s.scratch = ensureInt64Len(s.scratch[:0], len(codes))
+		for i, code := range codes {
+			s.scratch[i] = int64(code)
+		}
+		return s.scratch, nil
+	case ColumnTypeBool:
+		values, err := s.reader.DecodeBoolInto(s.bools[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.bools = values
+		s.scratch = ensureInt64Len(s.scratch[:0], len(values))
+		for i, v := range values {
+			if v {
+				s.scratch[i] = 1
+			} else {
+				s.scratch[i] = 0
+			}
+		}
+		return s.scratch, nil
+	default:
+		return nil, fmt.Errorf("colgranule: unsupported column type %s", columnType)
+	}
+}
+
+func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, error) {
+	if opts.SchemaVersion == 0 {
+		opts.SchemaVersion = 1
+	}
+	if opts.SchemaMode == "" {
+		opts.SchemaMode = ColumnSchemaFixed
+	}
+	if opts.SchemaMode != ColumnSchemaFixed {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported schema mode %s", opts.SchemaMode)
+	}
+	if opts.PartPolicy.RowsPerGranule == 0 {
+		opts.PartPolicy.RowsPerGranule = DefaultRowsPerGranule
+	}
+	if opts.PartPolicy.RowsPerGranule <= 0 {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid rows per granule %d", opts.PartPolicy.RowsPerGranule)
+	}
+	if opts.PartPolicy.DefaultCodecBlockRows < 0 {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid default codec block rows %d", opts.PartPolicy.DefaultCodecBlockRows)
+	}
+	if len(opts.LogicalPrimaryKey.Columns) != 1 {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: experiment requires exactly one logical primary key column, got %d", len(opts.LogicalPrimaryKey.Columns))
+	}
+	if len(opts.SortKey.Columns) == 0 {
+		opts.SortKey.Columns = []SortKeyColumn{{Column: opts.LogicalPrimaryKey.Columns[0]}}
+	}
+	if len(opts.Columns) == 0 {
+		return ColumnStoreOptions{}, errors.New("colgranule: no declared columns")
+	}
+	seen := make(map[string]struct{}, len(opts.Columns))
+	for i := range opts.Columns {
+		def, err := normalizeColumnDefinition(opts.Columns[i], opts.Compression.Default)
+		if err != nil {
+			return ColumnStoreOptions{}, err
+		}
+		if _, ok := seen[def.Name]; ok {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: duplicate column %s", def.Name)
+		}
+		seen[def.Name] = struct{}{}
+		opts.Columns[i] = def
+	}
+	if _, ok := seen[opts.LogicalPrimaryKey.Columns[0]]; !ok {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: logical primary key column %s is not declared", opts.LogicalPrimaryKey.Columns[0])
+	}
+	for i := range opts.SortKey.Columns {
+		c := &opts.SortKey.Columns[i]
+		if c.Column == "" {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: empty sort key column at %d", i)
+		}
+		if _, ok := seen[c.Column]; !ok {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: sort key column %s is not declared", c.Column)
+		}
+		if c.Direction == "" {
+			c.Direction = SortKeyAsc
+		}
+		if c.Direction != SortKeyAsc && c.Direction != SortKeyDesc {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported sort direction %s", c.Direction)
+		}
+		if c.Direction == SortKeyDesc {
+			return ColumnStoreOptions{}, errors.New("colgranule: descending sort keys are not supported by experiment marks yet")
+		}
+		if c.Nulls != SortKeyNullsDefault && c.Nulls != SortKeyNullsFirst && c.Nulls != SortKeyNullsLast {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported null order %s", c.Nulls)
+		}
+	}
+	return opts, nil
+}
+
+func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compression) (ColumnDefinition, error) {
+	if def.Name == "" {
+		return ColumnDefinition{}, errors.New("colgranule: empty column name")
+	}
+	if def.Type == "" {
+		def.Type = ColumnTypeInt64
+	}
+	if def.CodecBlockRows < 0 {
+		return ColumnDefinition{}, fmt.Errorf("colgranule: invalid codec block rows %d for %s", def.CodecBlockRows, def.Name)
+	}
+	if def.Compression == CompressionNone && defaultCompression != CompressionNone {
+		def.Compression = defaultCompression
+	}
+	switch def.Type {
+	case ColumnTypeInt64:
+		if def.Encoding == 0 {
+			def.Encoding = EncodingDeltaVarint
+		}
+		if def.Encoding != EncodingRawInt64 && def.Encoding != EncodingDeltaVarint && def.Encoding != EncodingDoubleDeltaVarint {
+			return ColumnDefinition{}, fmt.Errorf("colgranule: unsupported int64 encoding %s for %s", def.Encoding, def.Name)
+		}
+	case ColumnTypeLowCardinalityCode:
+		def.Encoding = EncodingLowCardinalityUint32
+	case ColumnTypeBool:
+		def.Encoding = EncodingBoolBitpackRLE
+	default:
+		return ColumnDefinition{}, fmt.Errorf("colgranule: unsupported column type %s for %s", def.Type, def.Name)
+	}
+	return def, nil
+}
+
+func validateColumnBatch(batch ColumnBatch, defs []ColumnDefinition) (int, error) {
+	if batch.Columns == nil {
+		return 0, errors.New("colgranule: nil column batch")
+	}
+	rows := batch.Rows
+	for _, def := range defs {
+		values, ok := batch.Columns[def.Name]
+		if !ok {
+			return 0, fmt.Errorf("colgranule: missing column %s", def.Name)
+		}
+		if rows == 0 {
+			rows = len(values)
+		}
+		if len(values) != rows {
+			return 0, fmt.Errorf("colgranule: column %s rows=%d want=%d", def.Name, len(values), rows)
+		}
+	}
+	if rows <= 0 {
+		return 0, fmt.Errorf("colgranule: invalid part rows %d", rows)
+	}
+	return rows, nil
+}
+
+func (b *ColumnPartBuilder) sortedOrder(batch ColumnBatch, rows int, pkColumn string) ([]int, error) {
+	if cap(b.order) < rows {
+		b.order = make([]int, rows)
+	} else {
+		b.order = b.order[:rows]
+	}
+	for i := range b.order {
+		b.order[i] = i
+	}
+	sort.Slice(b.order, func(i, j int) bool {
+		left := b.order[i]
+		right := b.order[j]
+		for _, c := range b.opts.SortKey.Columns {
+			values := batch.Columns[c.Column]
+			if values[left] == values[right] {
+				continue
+			}
+			if c.Direction == SortKeyDesc {
+				return values[left] > values[right]
+			}
+			return values[left] < values[right]
+		}
+		pk := batch.Columns[pkColumn]
+		if pk[left] != pk[right] {
+			return pk[left] < pk[right]
+		}
+		return left < right
+	})
+	return b.order, nil
+}
+
+func (b *ColumnPartBuilder) buildGranulesAndLocators(part *ColumnPart, batch ColumnBatch, pkColumn string) error {
+	rowsPerGranule := b.opts.PartPolicy.RowsPerGranule
+	pkValues := batch.Columns[pkColumn]
+	for start := 0; start < len(b.order); start += rowsPerGranule {
+		end := min(start+rowsPerGranule, len(b.order))
+		ordinal := len(part.Descriptor.Granules)
+		idLower, idUpper := int64(math.MaxInt64), int64(math.MinInt64)
+		for partRow := start; partRow < end; partRow++ {
+			primaryID := pkValues[b.order[partRow]]
+			if _, exists := part.Locators[primaryID]; exists {
+				return fmt.Errorf("colgranule: duplicate primary id %d", primaryID)
+			}
+			if primaryID < idLower {
+				idLower = primaryID
+			}
+			if primaryID > idUpper {
+				idUpper = primaryID
+			}
+			part.Locators[primaryID] = RowLocator{
+				PrimaryID:      primaryID,
+				PartID:         part.Descriptor.PartID,
+				PartRow:        partRow,
+				GranuleOrdinal: ordinal,
+				RowInGranule:   partRow - start,
+			}
+		}
+		markColumns := make([]SortKeyColumnValues, len(b.opts.SortKey.Columns))
+		for i, sortColumn := range b.opts.SortKey.Columns {
+			values := make([]int64, end-start)
+			sourceValues := batch.Columns[sortColumn.Column]
+			for row := start; row < end; row++ {
+				values[row-start] = sourceValues[b.order[row]]
+			}
+			markColumns[i] = SortKeyColumnValues{Name: sortColumn.Column, Values: values}
+		}
+		mark, err := BuildSortKeyMark(markColumns)
+		if err != nil {
+			return err
+		}
+		part.Marks = append(part.Marks, mark)
+		part.Descriptor.Granules = append(part.Descriptor.Granules, GranuleDescriptor{
+			Ordinal:          ordinal,
+			FirstRow:         start,
+			RowCount:         end - start,
+			VisibleRows:      end - start,
+			IDLower:          idLower,
+			IDUpperExclusive: exclusiveInt64Upper(idUpper),
+			MarkOrdinal:      len(part.Marks) - 1,
+		})
+	}
+	return nil
+}
+
+func (b *ColumnPartBuilder) buildColumn(batch ColumnBatch, def ColumnDefinition) (ColumnPartColumn, ColumnPartColumnDescriptor, error) {
+	blockRows := def.CodecBlockRows
+	if blockRows == 0 {
+		blockRows = b.opts.PartPolicy.DefaultCodecBlockRows
+	}
+	if blockRows == 0 {
+		blockRows = b.opts.PartPolicy.RowsPerGranule
+	}
+	column := ColumnPartColumn{Definition: def}
+	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type}
+	sourceValues := batch.Columns[def.Name]
+	for start := 0; start < len(b.order); start += blockRows {
+		end := min(start+blockRows, len(b.order))
+		g, err := b.buildColumnBlockGranule(sourceValues, def, start, end)
+		if err != nil {
+			return ColumnPartColumn{}, ColumnPartColumnDescriptor{}, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		desc := ColumnBlockDescriptor{
+			FirstRow:          start,
+			RowCount:          end - start,
+			FirstGranule:      start / b.opts.PartPolicy.RowsPerGranule,
+			LastGranule:       (end - 1) / b.opts.PartPolicy.RowsPerGranule,
+			Encoding:          owned.Encoding,
+			Compression:       owned.Compression,
+			RawBytes:          owned.RawBytes,
+			StoredBytes:       owned.StoredBytes,
+			CodecBlockOrdinal: len(column.Blocks),
+		}
+		column.Blocks = append(column.Blocks, ColumnBlock{Descriptor: desc, Granule: owned})
+		descriptor.Blocks = append(descriptor.Blocks, desc)
+	}
+	return column, descriptor, nil
+}
+
+func (b *ColumnPartBuilder) buildColumnBlockGranule(sourceValues []int64, def ColumnDefinition, start int, end int) (EncodedGranule, error) {
+	b.values64 = ensureInt64Len(b.values64[:0], end-start)
+	for row := start; row < end; row++ {
+		b.values64[row-start] = sourceValues[b.order[row]]
+	}
+	cfg := Config{Encoding: def.Encoding, Compression: def.Compression}
+	b.builder.Reset(cfg)
+	switch def.Type {
+	case ColumnTypeInt64:
+		return b.builder.BuildInt64(b.values64)
+	case ColumnTypeLowCardinalityCode:
+		b.codes32 = ensureUint32Len(b.codes32[:0], len(b.values64))
+		for i, v := range b.values64 {
+			if v < 0 || v > math.MaxUint32 {
+				return EncodedGranule{}, fmt.Errorf("colgranule: code value %d outside uint32 for %s", v, def.Name)
+			}
+			b.codes32[i] = uint32(v)
+		}
+		return b.builder.BuildUint32Codes(b.codes32, def.Cardinality)
+	case ColumnTypeBool:
+		b.bools = ensureBoolLen(b.bools[:0], len(b.values64))
+		for i, v := range b.values64 {
+			if v != 0 && v != 1 {
+				return EncodedGranule{}, fmt.Errorf("colgranule: bool value %d outside 0/1 for %s", v, def.Name)
+			}
+			b.bools[i] = v == 1
+		}
+		return b.builder.BuildBool(b.bools)
+	default:
+		return EncodedGranule{}, fmt.Errorf("colgranule: unsupported column type %s", def.Type)
+	}
+}
+
+func exclusiveInt64Upper(v int64) int64 {
+	if v == math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return v + 1
+}

--- a/experiments/colgranule/part_test.go
+++ b/experiments/colgranule/part_test.go
@@ -1,0 +1,224 @@
+package colgranule
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestColumnPartBuildPrimaryEqualsSortKey(t *testing.T) {
+	batch := ColumnBatch{Columns: map[string][]int64{
+		"id":        {3, 1, 2, 5, 4},
+		"time_us":   {30, 10, 20, 50, 40},
+		"value":     {300, 100, 200, 500, 400},
+		"kind_code": {1, 0, 1, 2, 0},
+		"has_reply": {1, 0, 1, 0, 1},
+	}}
+	part, err := BuildColumnPart(7, partTestOptions([]SortKeyColumn{{Column: "id"}}), batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	if part.Descriptor.RowCount != 5 || part.Descriptor.VisibleRowCount != 5 {
+		t.Fatalf("rows/visible=(%d,%d) want (5,5)", part.Descriptor.RowCount, part.Descriptor.VisibleRowCount)
+	}
+	if len(part.Descriptor.Granules) != 3 || len(part.Marks) != 3 {
+		t.Fatalf("granules/marks=(%d,%d) want (3,3)", len(part.Descriptor.Granules), len(part.Marks))
+	}
+	assertGranulesAligned(t, part, []int{2, 2, 1})
+
+	scan, err := part.NewScanner().ScanProjected([]string{"id", "value", "kind_code", "has_reply"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3, 4, 5})
+	assertInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500})
+	assertInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{0, 1, 1, 0, 2})
+	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{0, 1, 1, 1, 0})
+	if scan.Diagnostics.RowsScanned != 5 || scan.Diagnostics.GranulesConsidered != 3 || scan.Diagnostics.BlocksDecoded != 12 {
+		t.Fatalf("diagnostics=%+v want rows=5 granules=3 blocks=12", scan.Diagnostics)
+	}
+
+	scanner := part.NewScanner()
+	for id, wantValue := range map[int64]int64{1: 100, 2: 200, 3: 300, 4: 400, 5: 500} {
+		locator, ok := part.LocatePrimaryID(id)
+		if !ok {
+			t.Fatalf("missing locator for id %d", id)
+		}
+		got, err := scanner.ValueAt(locator, "value")
+		if err != nil {
+			t.Fatalf("ValueAt(id=%d): %v", id, err)
+		}
+		if got != wantValue {
+			t.Fatalf("ValueAt(id=%d)=%d want %d locator=%+v", id, got, wantValue, locator)
+		}
+	}
+}
+
+func TestColumnPartBuildPrimaryDiffersFromSortKey(t *testing.T) {
+	batch := ColumnBatch{Columns: map[string][]int64{
+		"id":        {100, 101, 102, 103, 104},
+		"time_us":   {50, 20, 20, 10, 50},
+		"value":     {5, 2, 3, 1, 4},
+		"kind_code": {0, 1, 2, 1, 0},
+		"has_reply": {0, 1, 0, 1, 0},
+	}}
+	part, err := BuildColumnPart(9, partTestOptions([]SortKeyColumn{{Column: "time_us"}}), batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	scan, err := part.NewScanner().ScanProjected([]string{"id", "time_us", "value"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertInt64s(t, "id", scan.Columns["id"], []int64{103, 101, 102, 100, 104})
+	assertInt64s(t, "time_us", scan.Columns["time_us"], []int64{10, 20, 20, 50, 50})
+	assertInt64s(t, "value", scan.Columns["value"], []int64{1, 2, 3, 5, 4})
+
+	locator, ok := part.LocatePrimaryID(100)
+	if !ok {
+		t.Fatal("missing locator for id 100")
+	}
+	if locator.PartRow != 3 || locator.GranuleOrdinal != 1 || locator.RowInGranule != 1 {
+		t.Fatalf("locator=%+v want part row 3 granule 1 row 1", locator)
+	}
+	mayContain, constrained, err := part.Marks[0].MayContainRanges([]Int64RangePredicate{{Column: "time_us", Low: 45, High: 55}})
+	if err != nil {
+		t.Fatalf("MayContainRanges: %v", err)
+	}
+	if !constrained || mayContain {
+		t.Fatalf("first mark constrained/mayContain=(%v,%v) want (true,false)", constrained, mayContain)
+	}
+}
+
+func TestColumnPartCodecBlocksCanSplitIndependently(t *testing.T) {
+	batch := ColumnBatch{Columns: map[string][]int64{
+		"id":        {10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		"time_us":   {10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		"value":     {100, 90, 80, 70, 60, 50, 40, 30, 20, 10},
+		"kind_code": {1, 0, 1, 2, 1, 0, 2, 1, 0, 2},
+		"has_reply": {0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+	}}
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.PartPolicy.RowsPerGranule = 3
+	opts.Columns[0].CodecBlockRows = 2
+	opts.Columns[1].CodecBlockRows = 4
+	opts.Columns[2].CodecBlockRows = 5
+	opts.Columns[3].CodecBlockRows = 6
+	opts.Columns[4].CodecBlockRows = 7
+	part, err := BuildColumnPart(11, opts, batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	assertColumnBlockRows(t, part, "id", []int{2, 2, 2, 2, 2})
+	assertColumnBlockRows(t, part, "time_us", []int{4, 4, 2})
+	assertColumnBlockRows(t, part, "value", []int{5, 5})
+	assertColumnBlockRows(t, part, "kind_code", []int{6, 4})
+	assertColumnBlockRows(t, part, "has_reply", []int{7, 3})
+
+	scan, err := part.NewScanner().ScanProjected([]string{"id", "time_us", "value", "kind_code", "has_reply"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	assertInt64s(t, "time_us", scan.Columns["time_us"], []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	assertInt64s(t, "value", scan.Columns["value"], []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100})
+	assertInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{2, 0, 1, 2, 0, 1, 2, 1, 0, 1})
+	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{1, 0, 1, 0, 1, 0, 1, 0, 1, 0})
+}
+
+func TestColumnPartBuilderFailsClosedOnInvalidShape(t *testing.T) {
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	_, err := BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 1},
+		"time_us":   {10, 20},
+		"value":     {100, 200},
+		"kind_code": {0, 1},
+		"has_reply": {0, 1},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "duplicate primary id") {
+		t.Fatalf("duplicate primary err=%v want duplicate primary id", err)
+	}
+	_, err = BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2},
+		"time_us":   {10},
+		"value":     {100, 200},
+		"kind_code": {0, 1},
+		"has_reply": {0, 1},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "rows=1 want=2") {
+		t.Fatalf("row mismatch err=%v want rows mismatch", err)
+	}
+	_, err = BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2},
+		"time_us":   {10, 20},
+		"value":     {100, 200},
+		"kind_code": {0, 9},
+		"has_reply": {0, 1},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "outside cardinality") {
+		t.Fatalf("cardinality err=%v want outside cardinality", err)
+	}
+	_, err = BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2},
+		"time_us":   {10, 20},
+		"value":     {100, 200},
+		"kind_code": {0, 1},
+		"has_reply": {0, 2},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "bool value") {
+		t.Fatalf("bool err=%v want bool value", err)
+	}
+}
+
+func partTestOptions(sortKey []SortKeyColumn) ColumnStoreOptions {
+	return ColumnStoreOptions{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+			{Name: "time_us", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Compression: CompressionNone, Cardinality: 3},
+			{Name: "has_reply", Type: ColumnTypeBool, Compression: CompressionNone},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: sortKey},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+	}
+}
+
+func assertGranulesAligned(t *testing.T, part *ColumnPart, rowCounts []int) {
+	t.Helper()
+	for i, wantRows := range rowCounts {
+		g := part.Descriptor.Granules[i]
+		if g.Ordinal != i || g.MarkOrdinal != i || g.RowCount != wantRows {
+			t.Fatalf("granule[%d]=%+v want ordinal=%d mark=%d rows=%d", i, g, i, i, wantRows)
+		}
+	}
+	for _, column := range part.Columns {
+		for _, block := range column.Blocks {
+			if block.Descriptor.FirstGranule < 0 || block.Descriptor.LastGranule >= len(rowCounts) || block.Descriptor.FirstGranule > block.Descriptor.LastGranule {
+				t.Fatalf("block descriptor=%+v has invalid granule range", block.Descriptor)
+			}
+		}
+	}
+}
+
+func assertColumnBlockRows(t *testing.T, part *ColumnPart, columnName string, want []int) {
+	t.Helper()
+	column := part.Columns[columnName]
+	got := make([]int, len(column.Blocks))
+	for i, block := range column.Blocks {
+		got[i] = block.Descriptor.RowCount
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s block rows=%v want %v", columnName, got, want)
+	}
+}
+
+func assertInt64s(t *testing.T, name string, got []int64, want []int64) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s=%v want %v", name, got, want)
+	}
+}

--- a/experiments/colgranule/part_test.go
+++ b/experiments/colgranule/part_test.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"math"
 	"slices"
 	"strings"
 	"testing"
@@ -126,6 +127,62 @@ func TestColumnPartCodecBlocksCanSplitIndependently(t *testing.T) {
 	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{1, 0, 1, 0, 1, 0, 1, 0, 1, 0})
 }
 
+func TestColumnPartPreservesExplicitCompressionNoneOverride(t *testing.T) {
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.Compression.Default = CompressionLZ4
+	opts.Columns[2].Compression = CompressionNone
+	opts.Columns[2].CompressionSet = true
+	part, err := BuildColumnPart(13, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2, 3},
+		"time_us":   {10, 20, 30},
+		"value":     {100, 200, 300},
+		"kind_code": {0, 1, 2},
+		"has_reply": {0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	if got := part.Columns["id"].Definition.Compression; got != CompressionLZ4 {
+		t.Fatalf("id compression=%s want default %s", got, CompressionLZ4)
+	}
+	if got := part.Columns["value"].Definition.Compression; got != CompressionNone {
+		t.Fatalf("value compression=%s want explicit %s", got, CompressionNone)
+	}
+}
+
+func TestScanProjectedIntoDropsStaleColumns(t *testing.T) {
+	part, err := BuildColumnPart(14, partTestOptions([]SortKeyColumn{{Column: "id"}}), ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2, 3},
+		"time_us":   {10, 20, 30},
+		"value":     {100, 200, 300},
+		"kind_code": {0, 1, 2},
+		"has_reply": {0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	scanner := part.NewScanner()
+	dst := map[string][]int64{"stale": {999}}
+	scan, err := scanner.ScanProjectedInto(dst, []string{"id", "value"})
+	if err != nil {
+		t.Fatalf("ScanProjectedInto(id,value): %v", err)
+	}
+	if _, ok := scan.Columns["stale"]; ok {
+		t.Fatalf("stale projection key remained after first scan: %v", scan.Columns)
+	}
+	if _, ok := scan.Columns["value"]; !ok {
+		t.Fatalf("value projection missing after first scan: %v", scan.Columns)
+	}
+	scan, err = scanner.ScanProjectedInto(dst, []string{"id"})
+	if err != nil {
+		t.Fatalf("ScanProjectedInto(id): %v", err)
+	}
+	if _, ok := scan.Columns["value"]; ok {
+		t.Fatalf("narrow projection retained stale value column: %v", scan.Columns)
+	}
+	assertInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3})
+}
+
 func TestColumnPartBuilderFailsClosedOnInvalidShape(t *testing.T) {
 	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
 	_, err := BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
@@ -167,6 +224,16 @@ func TestColumnPartBuilderFailsClosedOnInvalidShape(t *testing.T) {
 	}})
 	if err == nil || !strings.Contains(err.Error(), "bool value") {
 		t.Fatalf("bool err=%v want bool value", err)
+	}
+	_, err = BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {math.MaxInt64},
+		"time_us":   {10},
+		"value":     {100},
+		"kind_code": {0},
+		"has_reply": {0},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "cannot form exclusive upper bound") {
+		t.Fatalf("max primary id err=%v want exclusive upper bound failure", err)
 	}
 }
 

--- a/experiments/colgranule/part_test.go
+++ b/experiments/colgranule/part_test.go
@@ -183,6 +183,57 @@ func TestScanProjectedIntoDropsStaleColumns(t *testing.T) {
 	assertInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3})
 }
 
+func TestScanProjectedIntoValidatesProjectionBeforeMutatingDestination(t *testing.T) {
+	part, err := BuildColumnPart(15, partTestOptions([]SortKeyColumn{{Column: "id"}}), ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2, 3},
+		"time_us":   {10, 20, 30},
+		"value":     {100, 200, 300},
+		"kind_code": {0, 1, 2},
+		"has_reply": {0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	scanner := part.NewScanner()
+	dst := map[string][]int64{"stale": {999}}
+	if _, err := scanner.ScanProjectedInto(dst, []string{"id", "missing"}); err == nil || !strings.Contains(err.Error(), "missing column") {
+		t.Fatalf("ScanProjectedInto missing column err=%v want missing column", err)
+	}
+	if got, ok := dst["stale"]; !ok || !slices.Equal(got, []int64{999}) || len(dst) != 1 {
+		t.Fatalf("dst mutated after missing projection: %v", dst)
+	}
+	if _, err := scanner.ScanProjectedInto(dst, []string{"id", "id"}); err == nil || !strings.Contains(err.Error(), "duplicate projection column") {
+		t.Fatalf("ScanProjectedInto duplicate column err=%v want duplicate projection column", err)
+	}
+	if got, ok := dst["stale"]; !ok || !slices.Equal(got, []int64{999}) || len(dst) != 1 {
+		t.Fatalf("dst mutated after duplicate projection: %v", dst)
+	}
+}
+
+func TestColumnPartOptionsAreNotMutatedByNormalization(t *testing.T) {
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.Compression.Default = CompressionLZ4
+	part, err := BuildColumnPart(16, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2, 3},
+		"time_us":   {10, 20, 30},
+		"value":     {100, 200, 300},
+		"kind_code": {0, 1, 2},
+		"has_reply": {0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	if got := part.Columns["id"].Definition.Compression; got != CompressionLZ4 {
+		t.Fatalf("normalized id compression=%s want %s", got, CompressionLZ4)
+	}
+	if opts.Columns[0].Compression != CompressionNone {
+		t.Fatalf("caller options column compression mutated to %s", opts.Columns[0].Compression)
+	}
+	if opts.SortKey.Columns[0].Direction != "" {
+		t.Fatalf("caller sort key direction mutated to %s", opts.SortKey.Columns[0].Direction)
+	}
+}
+
 func TestColumnPartBuilderFailsClosedOnInvalidShape(t *testing.T) {
 	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
 	_, err := BuildColumnPart(1, opts, ColumnBatch{Columns: map[string][]int64{
@@ -234,6 +285,19 @@ func TestColumnPartBuilderFailsClosedOnInvalidShape(t *testing.T) {
 	}})
 	if err == nil || !strings.Contains(err.Error(), "cannot form exclusive upper bound") {
 		t.Fatalf("max primary id err=%v want exclusive upper bound failure", err)
+	}
+
+	invalidDefault := opts
+	invalidDefault.Compression.Default = Compression(255)
+	if _, err := NewColumnPartBuilder(invalidDefault); err == nil || !strings.Contains(err.Error(), "unsupported default compression") {
+		t.Fatalf("invalid default compression err=%v want unsupported default compression", err)
+	}
+
+	invalidColumn := opts
+	invalidColumn.Columns[0].Compression = Compression(255)
+	invalidColumn.Columns[0].CompressionSet = true
+	if _, err := NewColumnPartBuilder(invalidColumn); err == nil || !strings.Contains(err.Error(), "unsupported compression") {
+		t.Fatalf("invalid column compression err=%v want unsupported compression", err)
 	}
 }
 

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -76,6 +76,14 @@ type compiledRowSortKeyRanges struct {
 }
 
 func BuildSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
+	return buildSortKeyMark(columns, true)
+}
+
+func buildOwnedSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
+	return buildSortKeyMark(columns, false)
+}
+
+func buildSortKeyMark(columns []SortKeyColumnValues, copyValues bool) (SortKeyMark, error) {
 	if len(columns) == 0 {
 		return SortKeyMark{}, errors.New("colgranule: empty sort key")
 	}
@@ -107,7 +115,11 @@ func BuildSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
 			return SortKeyMark{}, fmt.Errorf("colgranule: sort key column %s rows=%d want=%d", c.Name, len(c.Values), rows)
 		}
 		mark.Columns[i] = c.Name
-		mark.ColumnValues[i] = append([]int64(nil), c.Values...)
+		if copyValues {
+			mark.ColumnValues[i] = append([]int64(nil), c.Values...)
+		} else {
+			mark.ColumnValues[i] = c.Values
+		}
 		lower[i] = c.Values[0]
 		last[i] = c.Values[rows-1]
 	}

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -31,7 +31,7 @@ type PredicateDiagnostics struct {
 	Matched         int
 }
 
-type SortKeyColumn struct {
+type SortKeyColumnValues struct {
 	Name   string
 	Values []int64
 }
@@ -62,7 +62,7 @@ type sortKeyRangePlan struct {
 	empty     bool
 }
 
-func BuildSortKeyMark(columns []SortKeyColumn) (SortKeyMark, error) {
+func BuildSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
 	if len(columns) == 0 {
 		return SortKeyMark{}, errors.New("colgranule: empty sort key")
 	}

--- a/experiments/colgranule/predicate.go
+++ b/experiments/colgranule/predicate.go
@@ -265,7 +265,7 @@ func validateSortKeyColumnNames(columns []string) error {
 	return nil
 }
 
-func compareSortKeyRows(columns []SortKeyColumn, left int, right int) int {
+func compareSortKeyRows(columns []SortKeyColumnValues, left int, right int) int {
 	for _, column := range columns {
 		lv := column.Values[left]
 		rv := column.Values[right]

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSortKeyMarkPrefixSummaries(t *testing.T) {
-	mark, err := BuildSortKeyMark([]SortKeyColumn{
+	mark, err := BuildSortKeyMark([]SortKeyColumnValues{
 		{Name: "collection", Values: []int64{1, 1, 1, 2, 2}},
 		{Name: "time_us", Values: []int64{10, 20, 30, 5, 15}},
 	})
@@ -131,7 +131,7 @@ func TestMarkAndMinMaxSkipsDoNotDecodeCorruptPayload(t *testing.T) {
 	g.StoredBytes = len(g.Payload)
 	g.PayloadRef.Length = len(g.Payload)
 	g.RawBytes = len(g.Payload)
-	mark, err := BuildSortKeyMark([]SortKeyColumn{
+	mark, err := BuildSortKeyMark([]SortKeyColumnValues{
 		{Name: "collection", Values: []int64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
 		{Name: "time_us", Values: []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
 	})
@@ -213,7 +213,7 @@ func buildCompositeSortFixtureForTest() ([]EncodedGranule, []SortKeyMark, []int6
 			}
 			owned := g
 			owned.Payload = append([]byte(nil), g.Payload...)
-			mark, err := BuildSortKeyMark([]SortKeyColumn{
+			mark, err := BuildSortKeyMark([]SortKeyColumnValues{
 				{Name: "collection", Values: collections},
 				{Name: "time_us", Values: times},
 			})

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -39,13 +39,13 @@ func TestSortKeyMarkPrefixSummaries(t *testing.T) {
 }
 
 func TestSortKeyMarkRejectsDuplicateOrUnsortedColumns(t *testing.T) {
-	if _, err := BuildSortKeyMark([]SortKeyColumn{
+	if _, err := BuildSortKeyMark([]SortKeyColumnValues{
 		{Name: "collection", Values: []int64{1, 1, 1}},
 		{Name: "collection", Values: []int64{10, 20, 30}},
 	}); err == nil {
 		t.Fatal("BuildSortKeyMark duplicate columns succeeded, want error")
 	}
-	if _, err := BuildSortKeyMark([]SortKeyColumn{
+	if _, err := BuildSortKeyMark([]SortKeyColumnValues{
 		{Name: "collection", Values: []int64{1, 1, 1}},
 		{Name: "time_us", Values: []int64{10, 9, 11}},
 	}); err == nil {
@@ -54,7 +54,7 @@ func TestSortKeyMarkRejectsDuplicateOrUnsortedColumns(t *testing.T) {
 }
 
 func TestEmptySortKeyPredicateIsConstrainedEmpty(t *testing.T) {
-	mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "collection", Values: []int64{1, 1, 1}}})
+	mark, err := BuildSortKeyMark([]SortKeyColumnValues{{Name: "collection", Values: []int64{1, 1, 1}}})
 	if err != nil {
 		t.Fatalf("BuildSortKeyMark: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestCountInt64RangeRejectsMismatchedMarkMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build granules: %v", err)
 	}
-	mark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: []int64{1, 2}}})
+	mark, err := BuildSortKeyMark([]SortKeyColumnValues{{Name: "time_us", Values: []int64{1, 2}}})
 	if err != nil {
 		t.Fatalf("BuildSortKeyMark: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestCountInt64RangeRejectsMismatchedMarkMetadata(t *testing.T) {
 		t.Fatal("CountInt64RangeWithDiagnostics mismatched mark rows succeeded, want error")
 	}
 
-	matchingMark, err := BuildSortKeyMark([]SortKeyColumn{{Name: "time_us", Values: []int64{1, 2, 3}}})
+	matchingMark, err := BuildSortKeyMark([]SortKeyColumnValues{{Name: "time_us", Values: []int64{1, 2, 3}}})
 	if err != nil {
 		t.Fatalf("BuildSortKeyMark matching: %v", err)
 	}

--- a/experiments/colgranule/predicate_test.go
+++ b/experiments/colgranule/predicate_test.go
@@ -171,7 +171,7 @@ func TestSortKeyRangeIsAppliedWithinMixedGranule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildInt64: %v", err)
 	}
-	mark, err := BuildSortKeyMark([]SortKeyColumn{
+	mark, err := BuildSortKeyMark([]SortKeyColumnValues{
 		{Name: "collection", Values: collections},
 		{Name: "time_us", Values: times},
 	})


### PR DESCRIPTION
## Objective

Implement Phase 2 / PR5 from #1534: build in-memory column parts out of encoded granules, with RFC-aligned options for logical primary keys and sort keys, row-aligned part granules, independent per-column codec block ranges, row locators, marks, and a projected scanner over encoded part data.

This is stacked on #1541 and targets `codex/colgranule-aggregate-kernels`.

## Context

PR1-PR4 built the granule, typed codec, predicate mark, and aggregate-kernel layers. This PR adds the non-durable part layer above those primitives so PR6 can run JSONBench q1-q5 over encoded parts instead of raw `ds.Columns` vectors.

The code remains experiment-only and does not publish TreeDB column roots or claim durable column-store writes.

## Non-goals

- No durable `TCS1` file format or reopen behavior.
- No production TreeDB collection API or WAL/root publication.
- No JSONBench q1-q5 encoded-part query runner yet; that is PR6.
- No descending sort-key mark support yet. The option type includes `SortKeyDesc`, but PR5 fails closed because the current mark summaries are ascending-only.

## Design

- Adds `ColumnStoreOptions`, `LogicalPrimaryKey`, `SortKey`, `SortKeyColumn`, `ColumnDefinition`, and part policy structs aligned with the column-store RFC shape.
- Adds `ColumnPartBuilder` and `BuildColumnPart` over `ColumnBatch` input vectors.
- Sorts rows by configured `SortKey` with logical primary id as deterministic tie-breaker.
- Splits the physical part into row-aligned `GranuleDescriptor` ranges, defaulting to `8192` rows through `DefaultRowsPerGranule`.
- Emits per-granule `SortKeyMark` metadata and a primary-id `RowLocator` map.
- Encodes declared columns into independent `ColumnBlock` ranges, so codec block row counts can differ per column while projected scans still reconstruct row-aligned results.
- Adds `ColumnPartScanner.ScanProjected` and reuse-friendly `ScanProjectedInto` for steady-state scans with caller-owned output buffers.
- Renames the mark-builder vector input from `SortKeyColumn` to `SortKeyColumnValues` so `SortKeyColumn` can match the RFC schema meaning.

Invariants and fail-closed behavior:

- exactly one logical primary key column is required in the experiment layer;
- declared columns must all exist and have equal row counts;
- duplicate primary ids are rejected;
- sort-key columns must be declared;
- unsupported schema modes, descending marks, bad code cardinality, and non-0/1 bool values return errors;
- codec block descriptors always record part-row ranges and first/last granule coverage.

## Scope

- Includes (files/symbols):
  - `experiments/colgranule/part.go`
  - `experiments/colgranule/part_test.go`
  - `BenchmarkColumnPartBuildAndProjectedScan`
  - `ColumnPartBuilder`, `ColumnPart`, `ColumnPartDescriptor`, `GranuleDescriptor`, `ColumnBlockDescriptor`, `RowLocator`, `ColumnPartScanner`
  - `SortKeyColumnValues` rename for mark-building inputs
- Excludes (files/symbols):
  - TreeDB production storage paths
  - persistent side files/manifests
  - command-WAL integration
  - q1-q5 encoded-part execution, which is PR6

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule/...`
  - `go test ./...`
  - `go test ./... -count=1`
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnPartBuildAndProjectedScan' -benchmem -benchtime=20x`
- Corruption/edge cases covered:
  - primary-key-equals-sort-key part layout;
  - primary-key-differs-from-sort-key part layout;
  - primary id tie-break ordering when sort-key values tie;
  - granule row ranges aligned across columns;
  - independent codec block row ranges per column;
  - projected scans match sorted source vectors exactly;
  - row locators resolve primary ids back to the visible part row;
  - duplicate primary ids, row-count mismatches, bad low-cardinality codes, and invalid bool values fail closed.
- Concurrency/race coverage (if applicable): not applicable; this is single-threaded experiment part construction and scanning.

## Performance

- Benchmarks run (exact commands):
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnPartBuildAndProjectedScan' -benchmem -benchtime=20x`
- Machine: Apple M3, `darwin/arm64`.
- Results table:

| Benchmark | ns/op | ns/row | rows/s | MiB/s | allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkColumnPartBuildAndProjectedScan/build_in_memory_part-8` | 69,641,925 | 85.01 | 11.76M | 448.7 | 66,213,495 B/op, 3359 allocs/op |
| `BenchmarkColumnPartBuildAndProjectedScan/projected_scan_one_column-8` | 1,911,031 | 2.333 | 428.7M | 3271 | 0 B/op, 0 allocs/op |
| `BenchmarkColumnPartBuildAndProjectedScan/projected_scan_three_columns-8` | 4,055,800 | 4.951 | 202.0M | 4623 | 0 B/op, 0 allocs/op |

The projected scan benchmark uses `ScanProjectedInto` after warmup, so it measures the reusable steady-state scanner path. The PR5 synthetic benchmark does not claim the JSONBench `1m` TreeDB full-document baseline gate yet; PR6 will wire q1-q5 through encoded parts and compare against the JSONBench/TreeDB baselines from the same run.

- Regressions (if any) and why acceptable: none known.

## Rollout / Toggle Plan

- Default setting: experiment-only code under `experiments/colgranule`; no production callers.
- How to disable quickly: do not use the experiment part builder/scanner, or revert this PR.

## Follow-ups

- PR6: run JSONBench q1-q5 through encoded parts, compare result digests with raw-vector reference, and report scan/query diagnostics with warm/cold labels.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope
- [x] Explicit exclude list (files/symbols NOT touched): see Scope
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: no durable paths touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe): part/granule/block row counts are validated before encode/decode allocation
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): no CRC paths added; shape/type/cardinality errors fail closed
- [x] Any concurrency change has a defined state machine and invariants: no concurrency changes

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes: no file/parser format added; added shape/type/cardinality edge tests
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see Correctness and Performance

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved: not applicable; no new compression codec is introduced

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable): not applicable; #1534 tracks this experiment stack
- [ ] Documented any new config knobs + defaults: experiment-only API, no production knobs
- [x] Called out any format change in PR description (pre-alpha OK): no persistent format change in this PR

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold): experiment-only, not production-wired
- [x] Clear knobs to disable/revert behavior quickly: no production wiring; revert PR if needed
- [x] Observability: counters/logs to verify effectiveness: scanner diagnostics and benchmark metrics are exposed in the experiment path
