### PR TITLE
TreeDB: add native vector index metadata

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -782,17 +782,33 @@ type IndexDefinition struct {
 	StoragePolicy RootStoragePolicy `json:"storage_policy,omitempty"`
 }
 
+// VectorIndexDefinition declares a document vector field as an ANN-capable
+// collection index. PRs after the metadata/API step persist and maintain the
+// HNSW graph through collection index roots.
+type VectorIndexDefinition struct {
+	Name           string              `json:"name"`
+	Field          string              `json:"field"`
+	Metric         VectorMetric        `json:"metric"`
+	Dimensions     int                 `json:"dimensions"`
+	M              int                 `json:"m,omitempty"`
+	EfConstruction int                 `json:"ef_construction,omitempty"`
+	EfSearch       int                 `json:"ef_search,omitempty"`
+	Encoding       VectorIndexEncoding `json:"encoding,omitempty"`
+}
+
 type CollectionMeta struct {
-	Name    string            `json:"name"`
-	Options CollectionOptions `json:"options,omitempty"`
-	Indexes []IndexDefinition `json:"indexes,omitempty"`
+	Name          string                  `json:"name"`
+	Options       CollectionOptions       `json:"options,omitempty"`
+	Indexes       []IndexDefinition       `json:"indexes,omitempty"`
+	VectorIndexes []VectorIndexDefinition `json:"vector_indexes,omitempty"`
 }
 
 type collectionMetaDisk struct {
-	Version int               `json:"version"`
-	Name    string            `json:"name"`
-	Options CollectionOptions `json:"options,omitempty"`
-	Indexes []IndexDefinition `json:"indexes,omitempty"`
+	Version       int                     `json:"version"`
+	Name          string                  `json:"name"`
+	Options       CollectionOptions       `json:"options,omitempty"`
+	Indexes       []IndexDefinition       `json:"indexes,omitempty"`
+	VectorIndexes []VectorIndexDefinition `json:"vector_indexes,omitempty"`
 }
 
 type collectionCatalog struct {
@@ -2908,6 +2924,141 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	return newMeta.copy(), nil
 }
 
+// CreateVectorIndex adds vector index metadata to the collection schema.
+//
+// This metadata-only API makes vector fields declarable as document-store
+// indexes. Follow-on PRs persist and maintain the native HNSW graph under the
+// declared index.
+func (c *Collection) CreateVectorIndex(def VectorIndexDefinition) (*CollectionMeta, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errCollectionDBNil
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	baseMeta := catalog.meta
+	c.meta = baseMeta
+	_ = snap.Close()
+
+	newMeta, _, err := addVectorIndexToCollectionMeta(baseMeta, def)
+	if err != nil {
+		return nil, err
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), nil
+}
+
+func (c *Collection) DropVectorIndex(name string) (*CollectionMeta, error) {
+	if err := ValidateIndexName(name); err != nil {
+		return nil, err
+	}
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errCollectionDBNil
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	baseMeta := catalog.meta
+	c.meta = baseMeta
+	_ = snap.Close()
+
+	nextIndexes := make([]VectorIndexDefinition, 0, len(baseMeta.VectorIndexes))
+	dropped := false
+	for _, idx := range baseMeta.VectorIndexes {
+		if idx.Name == name {
+			dropped = true
+			continue
+		}
+		nextIndexes = append(nextIndexes, idx)
+	}
+	if !dropped {
+		return nil, ErrIndexNotFound
+	}
+	newMeta, err := normalizeCollectionMeta(CollectionMeta{
+		Name:          baseMeta.Name,
+		Options:       baseMeta.Options,
+		Indexes:       baseMeta.Indexes,
+		VectorIndexes: nextIndexes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), nil
+}
+
 func (c *Collection) DropIndex(name string) (*CollectionMeta, error) {
 	if err := ValidateIndexName(name); err != nil {
 		return nil, err
@@ -2994,9 +3145,10 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	}
 
 	newMeta, err := normalizeCollectionMeta(CollectionMeta{
-		Name:    baseMeta.Name,
-		Options: baseMeta.Options,
-		Indexes: nextIndexes,
+		Name:          baseMeta.Name,
+		Options:       baseMeta.Options,
+		Indexes:       nextIndexes,
+		VectorIndexes: baseMeta.VectorIndexes,
 	})
 	if err != nil {
 		return nil, err
@@ -17668,10 +17820,11 @@ func encodeCollectionMeta(meta CollectionMeta) ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(collectionMetaDisk{
-		Version: collectionMetaVersion,
-		Name:    normalized.Name,
-		Options: normalized.Options,
-		Indexes: normalized.Indexes,
+		Version:       collectionMetaVersion,
+		Name:          normalized.Name,
+		Options:       normalized.Options,
+		Indexes:       normalized.Indexes,
+		VectorIndexes: normalized.VectorIndexes,
 	})
 }
 
@@ -17684,9 +17837,10 @@ func decodeCollectionMeta(raw []byte) (CollectionMeta, error) {
 		return CollectionMeta{}, fmt.Errorf("collections: unsupported collection metadata version %d", disk.Version)
 	}
 	return normalizeCollectionMeta(CollectionMeta{
-		Name:    disk.Name,
-		Options: disk.Options,
-		Indexes: disk.Indexes,
+		Name:          disk.Name,
+		Options:       disk.Options,
+		Indexes:       disk.Indexes,
+		VectorIndexes: disk.VectorIndexes,
 	})
 }
 
@@ -17753,13 +17907,35 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		seen[indexes[i].Name] = struct{}{}
 	}
 	meta.Indexes = indexes
+	vectorIndexes := append([]VectorIndexDefinition(nil), meta.VectorIndexes...)
+	for i := range vectorIndexes {
+		normalized, err := normalizeVectorIndexDefinition(vectorIndexes[i])
+		if err != nil {
+			name := vectorIndexes[i].Name
+			if name == "" {
+				name = vectorIndexDefaultName(vectorIndexes[i].Field)
+			}
+			return CollectionMeta{}, fmt.Errorf("collections: invalid vector index %q: %w", name, err)
+		}
+		vectorIndexes[i] = normalized
+	}
+	sort.SliceStable(vectorIndexes, func(i, j int) bool {
+		return vectorIndexes[i].Name < vectorIndexes[j].Name
+	})
+	for i := range vectorIndexes {
+		if _, ok := seen[vectorIndexes[i].Name]; ok {
+			return CollectionMeta{}, fmt.Errorf("collections: duplicate index %q", vectorIndexes[i].Name)
+		}
+		seen[vectorIndexes[i].Name] = struct{}{}
+	}
+	meta.VectorIndexes = vectorIndexes
 	if meta.Options.DisableIndexedWriteMemtables {
 		meta.Options.BufferedIndexedWrites = false
 		meta.Options.BufferedIndexedWriteMaxDocuments = 0
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedOverlayRoots = false
-	} else if len(meta.Indexes) == 0 {
+	} else if len(meta.Indexes) == 0 && len(meta.VectorIndexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
 	} else {
 		meta.Options.BufferedIndexedWrites = true
@@ -17807,11 +17983,53 @@ func normalizeIndexValueType(valueType IndexValueType) (IndexValueType, error) {
 	}
 }
 
+func normalizeVectorIndexDefinition(def VectorIndexDefinition) (VectorIndexDefinition, error) {
+	if def.Name == "" {
+		def.Name = vectorIndexDefaultName(def.Field)
+	}
+	if err := ValidateIndexName(def.Name); err != nil {
+		return VectorIndexDefinition{}, err
+	}
+	if err := ValidateIndexPath(def.Field); err != nil {
+		return VectorIndexDefinition{}, fmt.Errorf("field: %w", err)
+	}
+	if _, err := parseVectorFieldPath(def.Field); err != nil {
+		return VectorIndexDefinition{}, err
+	}
+	if def.Dimensions <= 0 {
+		return VectorIndexDefinition{}, errors.New("dimensions must be positive")
+	}
+	metric, err := normalizeVectorMetric(def.Metric)
+	if err != nil {
+		return VectorIndexDefinition{}, err
+	}
+	encoding, err := normalizeVectorIndexEncoding(def.Encoding)
+	if err != nil {
+		return VectorIndexDefinition{}, err
+	}
+	def.Metric = metric
+	def.Encoding = encoding
+	if def.M <= 0 {
+		def.M = defaultVectorIndexM
+	}
+	if def.EfConstruction <= 0 {
+		def.EfConstruction = defaultVectorIndexEfConstruction
+	}
+	if def.EfConstruction < def.M {
+		def.EfConstruction = def.M
+	}
+	if def.EfSearch <= 0 {
+		def.EfSearch = defaultVectorIndexEfSearch
+	}
+	return def, nil
+}
+
 func (m CollectionMeta) copy() *CollectionMeta {
 	return &CollectionMeta{
-		Name:    m.Name,
-		Options: m.Options,
-		Indexes: append([]IndexDefinition(nil), m.Indexes...),
+		Name:          m.Name,
+		Options:       m.Options,
+		Indexes:       append([]IndexDefinition(nil), m.Indexes...),
+		VectorIndexes: append([]VectorIndexDefinition(nil), m.VectorIndexes...),
 	}
 }
 
@@ -17838,11 +18056,16 @@ func sameCollectionMeta(a, b CollectionMeta) bool {
 }
 
 func collectionMetaValuesEqual(a, b CollectionMeta) bool {
-	if a.Name != b.Name || a.Options != b.Options || len(a.Indexes) != len(b.Indexes) {
+	if a.Name != b.Name || a.Options != b.Options || len(a.Indexes) != len(b.Indexes) || len(a.VectorIndexes) != len(b.VectorIndexes) {
 		return false
 	}
 	for i := range a.Indexes {
 		if a.Indexes[i] != b.Indexes[i] {
+			return false
+		}
+	}
+	for i := range a.VectorIndexes {
+		if a.VectorIndexes[i] != b.VectorIndexes[i] {
 			return false
 		}
 	}
@@ -17858,14 +18081,45 @@ func collectionMetaHasSecondaryUniqueIndex(meta CollectionMeta) bool {
 	return false
 }
 
+func addVectorIndexToCollectionMeta(meta CollectionMeta, def VectorIndexDefinition) (CollectionMeta, VectorIndexDefinition, error) {
+	if _, ok := findIndex(meta.Indexes, def.Name); ok {
+		return CollectionMeta{}, VectorIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, def.Name); ok {
+		return CollectionMeta{}, VectorIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	candidate := CollectionMeta{
+		Name:          meta.Name,
+		Options:       meta.Options,
+		Indexes:       append([]IndexDefinition(nil), meta.Indexes...),
+		VectorIndexes: append(append([]VectorIndexDefinition(nil), meta.VectorIndexes...), def),
+	}
+	normalized, err := normalizeCollectionMeta(candidate)
+	if err != nil {
+		return CollectionMeta{}, VectorIndexDefinition{}, err
+	}
+	normalizedDef, ok := findVectorIndex(normalized.VectorIndexes, def.Name)
+	if !ok && def.Name == "" {
+		normalizedDef, ok = findVectorIndex(normalized.VectorIndexes, vectorIndexDefaultName(def.Field))
+	}
+	if !ok {
+		return CollectionMeta{}, VectorIndexDefinition{}, fmt.Errorf("collections: normalized vector index %q not found", def.Name)
+	}
+	return normalized, normalizedDef, nil
+}
+
 func addIndexToCollectionMeta(meta CollectionMeta, def IndexDefinition) (CollectionMeta, IndexDefinition, error) {
 	if _, ok := findIndex(meta.Indexes, def.Name); ok {
 		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
 	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, def.Name); ok {
+		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
 	candidate := CollectionMeta{
-		Name:    meta.Name,
-		Options: meta.Options,
-		Indexes: append(append([]IndexDefinition(nil), meta.Indexes...), def),
+		Name:          meta.Name,
+		Options:       meta.Options,
+		Indexes:       append(append([]IndexDefinition(nil), meta.Indexes...), def),
+		VectorIndexes: append([]VectorIndexDefinition(nil), meta.VectorIndexes...),
 	}
 	normalized, err := normalizeCollectionMeta(candidate)
 	if err != nil {
@@ -17949,6 +18203,15 @@ func findIndex(indexes []IndexDefinition, name string) (IndexDefinition, bool) {
 		}
 	}
 	return IndexDefinition{}, false
+}
+
+func findVectorIndex(indexes []VectorIndexDefinition, name string) (VectorIndexDefinition, bool) {
+	for _, idx := range indexes {
+		if idx.Name == name {
+			return idx, true
+		}
+	}
+	return VectorIndexDefinition{}, false
 }
 
 func collectionRootNames(meta CollectionMeta) []string {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -15778,6 +15778,11 @@ func TestCollectionVectorIndexMetadataCreateDropReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	defer func() {
+		if d != nil {
+			_ = d.Close()
+		}
+	}()
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
 		t.Fatalf("create collection: %v", err)
@@ -15812,6 +15817,7 @@ func TestCollectionVectorIndexMetadataCreateDropReopen(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
+	d = nil
 
 	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
@@ -15835,6 +15841,52 @@ func TestCollectionVectorIndexMetadataCreateDropReopen(t *testing.T) {
 	}
 	if _, err := reopenedCol.DropVectorIndex("embedding"); !errors.Is(err, ErrIndexNotFound) {
 		t.Fatalf("drop missing vector index err=%v want ErrIndexNotFound", err)
+	}
+}
+
+func TestCollectionVectorIndexMetadataJSONUsesStableStrings(t *testing.T) {
+	meta, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     VectorMetricInnerProduct,
+			Dimensions: 64,
+			Encoding:   VectorIndexEncodingInt8,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize meta: %v", err)
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"metric":"inner_product"`)) || !bytes.Contains(raw, []byte(`"encoding":"int8"`)) {
+		t.Fatalf("vector metadata JSON=%s want string metric and encoding", raw)
+	}
+	var decoded CollectionMeta
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal string meta: %v", err)
+	}
+	decoded, err = normalizeCollectionMeta(decoded)
+	if err != nil {
+		t.Fatalf("normalize decoded meta: %v", err)
+	}
+	if !sameCollectionMeta(meta, decoded) {
+		t.Fatalf("decoded meta=%+v want %+v", decoded, meta)
+	}
+	var numericDecoded CollectionMeta
+	if err := json.Unmarshal([]byte(`{"name":"docs","vector_indexes":[{"name":"embedding","field":"embedding","metric":0,"dimensions":64,"encoding":1}]}`), &numericDecoded); err != nil {
+		t.Fatalf("unmarshal numeric compatibility meta: %v", err)
+	}
+	numericDecoded, err = normalizeCollectionMeta(numericDecoded)
+	if err != nil {
+		t.Fatalf("normalize numeric meta: %v", err)
+	}
+	got, ok := findVectorIndex(numericDecoded.VectorIndexes, "embedding")
+	if !ok || got.Metric != VectorMetricCosine || got.Encoding != VectorIndexEncodingInt8 {
+		t.Fatalf("numeric decoded vector index=%+v ok=%v", got, ok)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -15772,6 +15772,206 @@ func TestCollectionCreateIndexBackfill_BuildsSecondaryAndIndexState(t *testing.T
 	}
 }
 
+func TestCollectionVectorIndexMetadataCreateDropReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	meta, err := col.CreateVectorIndex(VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 64,
+	})
+	if err != nil {
+		t.Fatalf("create vector index: %v", err)
+	}
+	created, ok := findVectorIndex(meta.VectorIndexes, "embedding")
+	if !ok {
+		t.Fatalf("created meta missing vector index: %+v", meta.VectorIndexes)
+	}
+	if created.M != defaultVectorIndexM || created.EfConstruction != defaultVectorIndexEfConstruction || created.EfSearch != defaultVectorIndexEfSearch {
+		t.Fatalf("vector defaults=%+v", created)
+	}
+	if _, ok := findVectorIndex(col.Meta().VectorIndexes, "embedding"); !ok {
+		t.Fatalf("collection meta missing vector index: %+v", col.Meta().VectorIndexes)
+	}
+	if len(col.Meta().Indexes) != 0 {
+		t.Fatalf("vector create added scalar indexes: %+v", col.Meta().Indexes)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	if _, ok := findVectorIndex(reopenedCol.Meta().VectorIndexes, "embedding"); !ok {
+		t.Fatalf("reopened meta missing vector index: %+v", reopenedCol.Meta().VectorIndexes)
+	}
+
+	meta, err = reopenedCol.DropVectorIndex("embedding")
+	if err != nil {
+		t.Fatalf("drop vector index: %v", err)
+	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, "embedding"); ok {
+		t.Fatalf("dropped meta still has vector index: %+v", meta.VectorIndexes)
+	}
+	if _, err := reopenedCol.DropVectorIndex("embedding"); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("drop missing vector index err=%v want ErrIndexNotFound", err)
+	}
+}
+
+func TestCollectionVectorIndexMetadataValidation(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	_, err = mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Dimensions: 0,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "dimensions must be positive") {
+		t.Fatalf("zero dimensions err=%v want dimensions error", err)
+	}
+	_, err = mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Indexes: []IndexDefinition{{
+			Name:      "embedding",
+			Field:     "city",
+			ValueType: IndexValueString,
+		}},
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Dimensions: 64,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate index") {
+		t.Fatalf("duplicate scalar/vector err=%v want duplicate index", err)
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("create docs: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open docs: %v", err)
+	}
+	if _, err := col.CreateVectorIndex(VectorIndexDefinition{Field: "embedding", Dimensions: 64}); err != nil {
+		t.Fatalf("create default-named vector index: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "embedding", Field: "city", ValueType: IndexValueString}); err == nil || !strings.Contains(err.Error(), "duplicate index") {
+		t.Fatalf("duplicate scalar create err=%v want duplicate index", err)
+	}
+	if _, err := col.CreateVectorIndex(VectorIndexDefinition{Name: "other", Field: "embedding", Dimensions: -1}); err == nil || !strings.Contains(err.Error(), "dimensions must be positive") {
+		t.Fatalf("negative dimensions err=%v want dimensions error", err)
+	}
+	if _, err := col.CreateVectorIndex(VectorIndexDefinition{Name: "bad", Field: ".embedding", Dimensions: 64}); err == nil || !strings.Contains(err.Error(), "field") {
+		t.Fatalf("bad field err=%v want field error", err)
+	}
+}
+
+func TestCollectionDropScalarIndexPreservesVectorMetadata(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Indexes: []IndexDefinition{{
+			Name:      "city",
+			Field:     "city",
+			ValueType: IndexValueString,
+		}},
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Dimensions: 64,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	meta, err := col.DropIndex("city")
+	if err != nil {
+		t.Fatalf("drop scalar index: %v", err)
+	}
+	if _, ok := findIndex(meta.Indexes, "city"); ok {
+		t.Fatalf("dropped scalar index still present: %+v", meta.Indexes)
+	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, "embedding"); !ok {
+		t.Fatalf("drop scalar index lost vector metadata: %+v", meta.VectorIndexes)
+	}
+}
+
+func TestCollectionDropVectorIndexPreservesScalarMetadata(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Indexes: []IndexDefinition{{
+			Name:      "city",
+			Field:     "city",
+			ValueType: IndexValueString,
+		}},
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Dimensions: 64,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	meta, err := col.DropVectorIndex("embedding")
+	if err != nil {
+		t.Fatalf("drop vector index: %v", err)
+	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, "embedding"); ok {
+		t.Fatalf("dropped vector index still present: %+v", meta.VectorIndexes)
+	}
+	if _, ok := findIndex(meta.Indexes, "city"); !ok {
+		t.Fatalf("drop vector index lost scalar metadata: %+v", meta.Indexes)
+	}
+}
+
 func TestCollectionDropIndexUpdatesSchema(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -3,10 +3,12 @@ package collections
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -33,6 +35,50 @@ const (
 	VectorIndexEncodingFloat32 VectorIndexEncoding = iota
 	VectorIndexEncodingInt8
 )
+
+func (e VectorIndexEncoding) String() string {
+	switch e {
+	case VectorIndexEncodingFloat32:
+		return "float32"
+	case VectorIndexEncodingInt8:
+		return "int8"
+	default:
+		return fmt.Sprintf("unknown(%d)", e)
+	}
+}
+
+func (e VectorIndexEncoding) MarshalJSON() ([]byte, error) {
+	encoding, err := normalizeVectorIndexEncoding(e)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(encoding.String())
+}
+
+func (e *VectorIndexEncoding) UnmarshalJSON(raw []byte) error {
+	if e == nil {
+		return errors.New("collections: nil vector index encoding")
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		encoding, err := parseVectorIndexEncoding(s)
+		if err != nil {
+			return err
+		}
+		*e = encoding
+		return nil
+	}
+	var n uint8
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return err
+	}
+	encoding, err := normalizeVectorIndexEncoding(VectorIndexEncoding(n))
+	if err != nil {
+		return err
+	}
+	*e = encoding
+	return nil
+}
 
 // VectorIndexOptions configures an in-memory vector secondary index built from
 // collection rows. The index stores stable collection document IDs and vector
@@ -265,6 +311,17 @@ func normalizeVectorIndexEncoding(encoding VectorIndexEncoding) (VectorIndexEnco
 		return encoding, nil
 	default:
 		return VectorIndexEncodingFloat32, fmt.Errorf("collections: unsupported vector index encoding %d", encoding)
+	}
+}
+
+func parseVectorIndexEncoding(value string) (VectorIndexEncoding, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "float32":
+		return VectorIndexEncodingFloat32, nil
+	case "int8":
+		return VectorIndexEncodingInt8, nil
+	default:
+		return VectorIndexEncodingFloat32, fmt.Errorf("collections: unsupported vector index encoding %q", value)
 	}
 }
 

--- a/TreeDB/collections/vector_index_metadata_bench_test.go
+++ b/TreeDB/collections/vector_index_metadata_bench_test.go
@@ -40,6 +40,11 @@ func BenchmarkCollectionOpenVectorIndexMetadata(b *testing.B) {
 	if err != nil {
 		b.Fatalf("open db: %v", err)
 	}
+	defer func() {
+		if d != nil {
+			_ = d.Close()
+		}
+	}()
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "docs",
@@ -54,6 +59,7 @@ func BenchmarkCollectionOpenVectorIndexMetadata(b *testing.B) {
 	if err := d.Close(); err != nil {
 		b.Fatalf("close db: %v", err)
 	}
+	d = nil
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/TreeDB/collections/vector_index_metadata_bench_test.go
+++ b/TreeDB/collections/vector_index_metadata_bench_test.go
@@ -1,0 +1,78 @@
+package collections
+
+import (
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func BenchmarkCollectionVectorIndexMetadataCreateDrop(b *testing.B) {
+	d, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		const name = "embedding"
+		if _, err := col.CreateVectorIndex(VectorIndexDefinition{Name: name, Field: "embedding", Dimensions: 64}); err != nil {
+			b.Fatalf("create vector index: %v", err)
+		}
+		if _, err := col.DropVectorIndex(name); err != nil {
+			b.Fatalf("drop vector index: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionOpenVectorIndexMetadata(b *testing.B) {
+	dir := b.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Dimensions: 64,
+		}},
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		b.Fatalf("close db: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := backenddb.Open(backenddb.Options{Dir: dir})
+		if err != nil {
+			b.Fatalf("reopen db: %v", err)
+		}
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("open collection: %v", err)
+		}
+		if len(col.Meta().VectorIndexes) != 1 {
+			_ = d.Close()
+			b.Fatalf("vector indexes=%d want 1", len(col.Meta().VectorIndexes))
+		}
+		if err := d.Close(); err != nil {
+			b.Fatalf("close db: %v", err)
+		}
+	}
+}

--- a/TreeDB/collections/vector_search.go
+++ b/TreeDB/collections/vector_search.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -21,6 +22,52 @@ const (
 	VectorMetricL2
 	VectorMetricInnerProduct
 )
+
+func (m VectorMetric) String() string {
+	switch m {
+	case VectorMetricCosine:
+		return "cosine"
+	case VectorMetricL2:
+		return "l2"
+	case VectorMetricInnerProduct:
+		return "inner_product"
+	default:
+		return fmt.Sprintf("unknown(%d)", m)
+	}
+}
+
+func (m VectorMetric) MarshalJSON() ([]byte, error) {
+	metric, err := normalizeVectorMetric(m)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(metric.String())
+}
+
+func (m *VectorMetric) UnmarshalJSON(raw []byte) error {
+	if m == nil {
+		return errors.New("collections: nil vector metric")
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		metric, err := parseVectorMetric(s)
+		if err != nil {
+			return err
+		}
+		*m = metric
+		return nil
+	}
+	var n uint8
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return err
+	}
+	metric, err := normalizeVectorMetric(VectorMetric(n))
+	if err != nil {
+		return err
+	}
+	*m = metric
+	return nil
+}
 
 // VectorSearchOptions configures exact vector search over collection primary
 // documents.
@@ -201,6 +248,19 @@ func normalizeVectorMetric(metric VectorMetric) (VectorMetric, error) {
 		return metric, nil
 	default:
 		return 0, fmt.Errorf("collections: unsupported vector metric %d", metric)
+	}
+}
+
+func parseVectorMetric(value string) (VectorMetric, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "cosine":
+		return VectorMetricCosine, nil
+	case "l2":
+		return VectorMetricL2, nil
+	case "inner_product", "inner-product", "innerproduct":
+		return VectorMetricInnerProduct, nil
+	default:
+		return 0, fmt.Errorf("collections: unsupported vector metric %q", value)
 	}
 }
 

--- a/TreeDB/nativewire/metadata.go
+++ b/TreeDB/nativewire/metadata.go
@@ -13,10 +13,11 @@ import (
 type CollectionHandle uint64
 
 const (
-	maxCollectionMetaIndexDefinitions = 1 << 16
-	minEncodedIndexDefinitionLen      = 6
-	collectionRefTagName              = 1
-	collectionRefTagHandle            = 2
+	maxCollectionMetaIndexDefinitions  = 1 << 16
+	minEncodedIndexDefinitionLen       = 6
+	minEncodedVectorIndexDefinitionLen = 7
+	collectionRefTagName               = 1
+	collectionRefTagHandle             = 2
 )
 
 type metadataIdempotencyEntry struct {
@@ -48,7 +49,7 @@ func appendCollectionHandleRefPayload(dst []byte, handle CollectionHandle) []byt
 }
 
 func encodeCollectionMeta(meta collections.CollectionMeta) []byte {
-	dst := binary.AppendUvarint(nil, 1)
+	dst := binary.AppendUvarint(nil, 2)
 	dst = appendString(dst, meta.Name)
 	dst = binary.AppendUvarint(dst, uint64(encodeDocumentFormat(meta.Options.DocumentFormat)))
 	dst = binary.AppendUvarint(dst, uint64(encodeRootStorage(meta.Options.DataRootStoragePolicy)))
@@ -66,6 +67,10 @@ func encodeCollectionMeta(meta collections.CollectionMeta) []byte {
 	for _, def := range meta.Indexes {
 		dst = appendIndexDefinition(dst, def, false)
 	}
+	dst = binary.AppendUvarint(dst, uint64(len(meta.VectorIndexes)))
+	for _, def := range meta.VectorIndexes {
+		dst = appendVectorIndexDefinition(dst, def, false)
+	}
 	return dst
 }
 
@@ -74,7 +79,7 @@ func decodeCollectionMeta(src []byte) (collections.CollectionMeta, error) {
 	if err != nil {
 		return collections.CollectionMeta{}, err
 	}
-	if version != 1 {
+	if version != 1 && version != 2 {
 		return collections.CollectionMeta{}, protocolError(iwire.ErrUnsupportedVersion, "collection_meta version %d", version)
 	}
 	name, err := readString(src, &off)
@@ -192,6 +197,30 @@ func decodeCollectionMeta(src []byte) (collections.CollectionMeta, error) {
 		meta.Indexes = append(meta.Indexes, def)
 		off = next
 	}
+	if version >= 2 {
+		vectorIndexCount, err := readUvarintField(src, &off, "vector_index_count")
+		if err != nil {
+			return collections.CollectionMeta{}, err
+		}
+		if vectorIndexCount > uint64(maxInt) {
+			return collections.CollectionMeta{}, protocolError(iwire.ErrResourceExhausted, "vector index count exceeds int capacity")
+		}
+		if vectorIndexCount > maxCollectionMetaIndexDefinitions {
+			return collections.CollectionMeta{}, protocolError(iwire.ErrResourceExhausted, "vector index count %d exceeds limit %d", vectorIndexCount, maxCollectionMetaIndexDefinitions)
+		}
+		if vectorIndexCount > uint64((len(src)-off)/minEncodedVectorIndexDefinitionLen) {
+			return collections.CollectionMeta{}, protocolError(iwire.ErrMalformedFrame, "vector index count %d exceeds remaining collection_meta payload", vectorIndexCount)
+		}
+		meta.VectorIndexes = make([]collections.VectorIndexDefinition, 0, int(vectorIndexCount))
+		for i := uint64(0); i < vectorIndexCount; i++ {
+			def, next, err := decodeVectorIndexDefinitionAt(src, off, false)
+			if err != nil {
+				return collections.CollectionMeta{}, err
+			}
+			meta.VectorIndexes = append(meta.VectorIndexes, def)
+			off = next
+		}
+	}
 	if off != len(src) {
 		return collections.CollectionMeta{}, protocolError(iwire.ErrMalformedFrame, "collection_meta has %d trailing bytes", len(src)-off)
 	}
@@ -276,6 +305,96 @@ func decodeIndexDefinitionAt(src []byte, off int, withVersion bool) (collections
 		Unique:        unique,
 		MultiKey:      multiKey,
 		StoragePolicy: decodedStoragePolicy,
+	}, off, nil
+}
+
+func appendVectorIndexDefinition(dst []byte, def collections.VectorIndexDefinition, withVersion bool) []byte {
+	if withVersion && len(dst) == 0 {
+		dst = binary.AppendUvarint(dst, 1)
+	}
+	dst = appendString(dst, def.Name)
+	dst = appendString(dst, def.Field)
+	dst = binary.AppendUvarint(dst, encodeVectorMetric(def.Metric))
+	dst = binary.AppendVarint(dst, int64(def.Dimensions))
+	dst = binary.AppendVarint(dst, int64(def.M))
+	dst = binary.AppendVarint(dst, int64(def.EfConstruction))
+	dst = binary.AppendVarint(dst, int64(def.EfSearch))
+	dst = binary.AppendUvarint(dst, encodeVectorIndexEncoding(def.Encoding))
+	return dst
+}
+
+func decodeVectorIndexDefinitionAt(src []byte, off int, withVersion bool) (collections.VectorIndexDefinition, int, error) {
+	if withVersion {
+		version, n, err := readUvarint(src[off:])
+		if err != nil {
+			return collections.VectorIndexDefinition{}, 0, err
+		}
+		if version != 1 {
+			return collections.VectorIndexDefinition{}, 0, protocolError(iwire.ErrUnsupportedVersion, "vector_index_definition version %d", version)
+		}
+		off += n
+	}
+	name, err := readString(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	field, err := readString(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	metric, err := readEnum(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	dimensions, err := readVarint(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	m, err := readVarint(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	efConstruction, err := readVarint(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	efSearch, err := readVarint(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	encoding, err := readEnum(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if err := ensureNonNegativeIntCapacity("vector_index dimensions", dimensions); err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if err := ensureNonNegativeIntCapacity("vector_index m", m); err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if err := ensureNonNegativeIntCapacity("vector_index ef_construction", efConstruction); err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if err := ensureNonNegativeIntCapacity("vector_index ef_search", efSearch); err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	decodedMetric, err := decodeVectorMetricStrict(metric)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	decodedEncoding, err := decodeVectorIndexEncodingStrict(encoding)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	return collections.VectorIndexDefinition{
+		Name:           name,
+		Field:          field,
+		Metric:         decodedMetric,
+		Dimensions:     int(dimensions),
+		M:              int(m),
+		EfConstruction: int(efConstruction),
+		EfSearch:       int(efSearch),
+		Encoding:       decodedEncoding,
 	}, off, nil
 }
 
@@ -500,6 +619,54 @@ func decodeIndexValueTypeStrict(valueType uint64) (collections.IndexValueType, e
 		return collections.IndexValueDouble, nil
 	default:
 		return "", protocolError(iwire.ErrInvalidCommand, "unsupported index_value_type enum %d", valueType)
+	}
+}
+
+func encodeVectorMetric(metric collections.VectorMetric) uint64 {
+	switch metric {
+	case collections.VectorMetricCosine:
+		return 1
+	case collections.VectorMetricL2:
+		return 2
+	case collections.VectorMetricInnerProduct:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func decodeVectorMetricStrict(metric uint64) (collections.VectorMetric, error) {
+	switch metric {
+	case 1:
+		return collections.VectorMetricCosine, nil
+	case 2:
+		return collections.VectorMetricL2, nil
+	case 3:
+		return collections.VectorMetricInnerProduct, nil
+	default:
+		return 0, protocolError(iwire.ErrInvalidCommand, "unsupported vector_metric enum %d", metric)
+	}
+}
+
+func encodeVectorIndexEncoding(encoding collections.VectorIndexEncoding) uint64 {
+	switch encoding {
+	case collections.VectorIndexEncodingFloat32:
+		return 1
+	case collections.VectorIndexEncodingInt8:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func decodeVectorIndexEncodingStrict(encoding uint64) (collections.VectorIndexEncoding, error) {
+	switch encoding {
+	case 1:
+		return collections.VectorIndexEncodingFloat32, nil
+	case 2:
+		return collections.VectorIndexEncodingInt8, nil
+	default:
+		return collections.VectorIndexEncodingFloat32, protocolError(iwire.ErrInvalidCommand, "unsupported vector_index_encoding enum %d", encoding)
 	}
 }
 

--- a/TreeDB/nativewire/metadata_test.go
+++ b/TreeDB/nativewire/metadata_test.go
@@ -102,6 +102,50 @@ func TestMetadataCommandsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMetadataCommandsPreserveVectorIndexes(t *testing.T) {
+	client, _, _ := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	meta, err := client.CreateCollection(ctx, collections.CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:           "embedding",
+			Field:          "embedding",
+			Metric:         collections.VectorMetricL2,
+			Dimensions:     64,
+			M:              12,
+			EfConstruction: 96,
+			EfSearch:       48,
+			Encoding:       collections.VectorIndexEncodingInt8,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if len(meta.VectorIndexes) != 1 {
+		t.Fatalf("created vector indexes=%+v", meta.VectorIndexes)
+	}
+	got := meta.VectorIndexes[0]
+	if got.Name != "embedding" || got.Field != "embedding" || got.Metric != collections.VectorMetricL2 || got.Dimensions != 64 || got.Encoding != collections.VectorIndexEncodingInt8 {
+		t.Fatalf("created vector index=%+v", got)
+	}
+
+	metas, err := client.ListCollections(ctx)
+	if err != nil {
+		t.Fatalf("ListCollections: %v", err)
+	}
+	if len(metas) != 1 || len(metas[0].VectorIndexes) != 1 {
+		t.Fatalf("listed collections=%+v", metas)
+	}
+	if metas[0].VectorIndexes[0] != got {
+		t.Fatalf("listed vector index=%+v want %+v", metas[0].VectorIndexes[0], got)
+	}
+}
+
 func TestMetadataHandleRefWorksForListIndexes(t *testing.T) {
 	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)


### PR DESCRIPTION
## Summary

Implements PR 1 from #1540: native collection metadata/API shape for vector indexes.

- Adds `VectorIndexDefinition` and `CollectionMeta.VectorIndexes`.
- Persists vector index metadata through the existing collection metadata path.
- Adds metadata-only `CreateVectorIndex` / `DropVectorIndex` APIs.
- Validates vector index name, field path, dimensions, metric, HNSW params, encoding, and duplicate names across scalar/vector indexes.
- Preserves scalar index metadata when vector indexes are dropped, and preserves vector metadata when scalar indexes are dropped.
- Adds vector metadata tests and focused metadata benchmarks.

This intentionally does not persist or maintain the HNSW graph yet; that is the next stacked PR.

## Tests

- `GOWORK=off go test ./TreeDB/collections`
- `GOWORK=off go test ./TreeDB/mongo_gateway`
- `GOWORK=off go test ./...`
- `git diff --check`

## Performance gate

Artifacts: `/tmp/gomap_1540_pr1_perf_20260514_233840`

Base: `origin/main` at `e00cb3cb0249e9ef7c70603620986bbdb27521c5`
Candidate: `049546f2`

Scalar hot-path comparison:

- Command: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^(BenchmarkCollectionShapeInsertBatchSingleStringJSON/indexes_(0|1)|BenchmarkCollectionUpdate_CallbackVsUpdateBatchJSON_(NoIndex|OneIndex)_Size1|BenchmarkCollectionCreateIndexBackfillExistingDocs)$' -benchmem -benchtime=100ms -count=10`
- `benchstat`: no statistically significant scalar allocation regression; geomean allocs/op unchanged.
- One short-benchtime timing outlier on `OneIndex/UpdateBatchSize1` rerun at `-benchtime=300ms -count=10` reversed to candidate faster, so treated as noise.

Allocation gate:

- No-index update: `69 allocs/op` base, `69 allocs/op` candidate.
- No-index UpdateBatch size 1: `72 allocs/op` base, `72 allocs/op` candidate.
- One-index UpdateBatch size 1: `184 allocs/op` base, `184 allocs/op` candidate.
- Overall scalar benchstat geomean allocs/op: `+0.00%`.

Vector metadata benchmark:

- `BenchmarkCollectionVectorIndexMetadataCreateDrop`: profile run `54.2us/op`, `10.2KiB/op`, `162 allocs/op`.
- `BenchmarkCollectionOpenVectorIndexMetadata`: about `10.0-10.4ms/op`, `~3.24MiB/op`, `268-277 allocs/op` including DB reopen.

Profile notes:

- CPU top sites for create/drop are schema publication and catalog load paths: `CreateVectorIndex`, `DropVectorIndex`, `PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`, `loadCollectionCatalog`, `encoding/json` metadata encode/decode.
- Vector-specific validation/normalization is small: `normalizeVectorIndexDefinition` and `parseVectorFieldPath` are not top-level bottlenecks.
- Allocation top sites are metadata/catalog operations: `newCollectionCatalogWithOverlayMetadataOwned`, `bytes.Clone`, `decodeCollectionMeta`, `CollectionMeta.copy`, `normalizeCollectionMeta`, `json.Marshal/Unmarshal`, and system-delta construction.
- No scalar hot path gained allocs/op in the measured benches.
