### PR TITLE
experiments/colgranule: run jsonbench over encoded parts

### DIFF
--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -125,6 +125,7 @@ func main() {
 	must(err)
 	encodedPartTimings, err := colgranule.RunJSONBenchPartQueries(ds, *rowsPerGranule, *attempts)
 	must(err)
+	must(validateEncodedPartParity(timings, encodedPartTimings))
 	var remaining remainingTreeDBResult
 	var remainingJSON remainingTreeDBResult
 	var remainingTpl remainingTreeDBResult
@@ -185,6 +186,30 @@ func readClickHouseResult(path string) clickHouseResult {
 	var result clickHouseResult
 	must(json.Unmarshal(data, &result))
 	return result
+}
+
+func validateEncodedPartParity(reference []colgranule.JSONBenchQueryTiming, encoded []colgranule.JSONBenchPartQueryTiming) error {
+	if len(encoded) == 0 {
+		return nil
+	}
+	if len(reference) != len(encoded) {
+		return fmt.Errorf("encoded part query count=%d want baseline count=%d", len(encoded), len(reference))
+	}
+	for i, got := range encoded {
+		want := reference[i]
+		if got.Query != want.Query {
+			return fmt.Errorf("encoded part query[%d]=%s want baseline query %s", i, got.Query, want.Query)
+		}
+		if got.ResultRows != want.ResultRows || got.ResultDigest != want.ResultDigest {
+			return fmt.Errorf("encoded part %s result rows/digest=(%d,%d) want baseline (%d,%d)", got.Query, got.ResultRows, got.ResultDigest, want.ResultRows, want.ResultDigest)
+		}
+		for attemptIndex, attempt := range got.Attempts {
+			if attempt.ResultRows != want.ResultRows || attempt.ResultDigest != want.ResultDigest {
+				return fmt.Errorf("encoded part %s attempt %d rows/digest=(%d,%d) want baseline (%d,%d)", got.Query, attemptIndex, attempt.ResultRows, attempt.ResultDigest, want.ResultRows, want.ResultDigest)
+			}
+		}
+	}
+	return nil
 }
 
 func measureRemainingTreeDB(ctx context.Context, files []string, rows int, dbDir string, format collections.DocumentFormat, shape remainingShape) (remainingTreeDBResult, error) {

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -39,25 +39,26 @@ type clickHouseResult struct {
 }
 
 type comparisonRaw struct {
-	GeneratedAt         string                            `json:"generated_at"`
-	DataPath            string                            `json:"data_path"`
-	Limit               int                               `json:"limit"`
-	Rows                int                               `json:"rows"`
-	Files               []string                          `json:"files"`
-	InputBytes          int64                             `json:"input_bytes"`
-	RowsPerGranule      int                               `json:"rows_per_granule"`
-	LoadDuration        time.Duration                     `json:"load_duration"`
-	ClickHouseLocal     clickHouseResult                  `json:"clickhouse_local"`
-	RemainingTreeDB     remainingTreeDBResult             `json:"remaining_treedb"`
-	RemainingTreeDBJSON remainingTreeDBResult             `json:"remaining_treedb_json"`
-	RemainingTreeDBTpl  remainingTreeDBResult             `json:"remaining_treedb_template_v1"`
-	ConservativeBSON    remainingTreeDBResult             `json:"conservative_remaining_treedb_bson"`
-	ConservativeJSON    remainingTreeDBResult             `json:"conservative_remaining_treedb_json"`
-	ConservativeTpl     remainingTreeDBResult             `json:"conservative_remaining_treedb_template_v1"`
-	RawTreeDBJSON       remainingTreeDBResult             `json:"raw_treedb_json"`
-	QueryTimings        []colgranule.JSONBenchQueryTiming `json:"query_timings"`
-	ColumnSummaries     []colgranule.ColumnCodecSummary   `json:"column_summaries"`
-	BestColumnStorage   []bestColumnStorage               `json:"best_column_storage"`
+	GeneratedAt             string                                `json:"generated_at"`
+	DataPath                string                                `json:"data_path"`
+	Limit                   int                                   `json:"limit"`
+	Rows                    int                                   `json:"rows"`
+	Files                   []string                              `json:"files"`
+	InputBytes              int64                                 `json:"input_bytes"`
+	RowsPerGranule          int                                   `json:"rows_per_granule"`
+	LoadDuration            time.Duration                         `json:"load_duration"`
+	ClickHouseLocal         clickHouseResult                      `json:"clickhouse_local"`
+	RemainingTreeDB         remainingTreeDBResult                 `json:"remaining_treedb"`
+	RemainingTreeDBJSON     remainingTreeDBResult                 `json:"remaining_treedb_json"`
+	RemainingTreeDBTpl      remainingTreeDBResult                 `json:"remaining_treedb_template_v1"`
+	ConservativeBSON        remainingTreeDBResult                 `json:"conservative_remaining_treedb_bson"`
+	ConservativeJSON        remainingTreeDBResult                 `json:"conservative_remaining_treedb_json"`
+	ConservativeTpl         remainingTreeDBResult                 `json:"conservative_remaining_treedb_template_v1"`
+	RawTreeDBJSON           remainingTreeDBResult                 `json:"raw_treedb_json"`
+	QueryTimings            []colgranule.JSONBenchQueryTiming     `json:"query_timings"`
+	EncodedPartQueryTimings []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_query_timings"`
+	ColumnSummaries         []colgranule.ColumnCodecSummary       `json:"column_summaries"`
+	BestColumnStorage       []bestColumnStorage                   `json:"best_column_storage"`
 }
 
 type remainingTreeDBResult struct {
@@ -122,6 +123,8 @@ func main() {
 	must(err)
 	timings, err := colgranule.RunJSONBenchQueries(ds, *attempts)
 	must(err)
+	encodedPartTimings, err := colgranule.RunJSONBenchPartQueries(ds, *rowsPerGranule, *attempts)
+	must(err)
 	var remaining remainingTreeDBResult
 	var remainingJSON remainingTreeDBResult
 	var remainingTpl remainingTreeDBResult
@@ -147,25 +150,26 @@ func main() {
 	}
 
 	raw := comparisonRaw{
-		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
-		DataPath:            *data,
-		Limit:               *limit,
-		Rows:                ds.Rows,
-		Files:               ds.Files,
-		InputBytes:          inputBytes(ds.Files),
-		RowsPerGranule:      *rowsPerGranule,
-		LoadDuration:        loadDuration,
-		ClickHouseLocal:     readClickHouseResult(*clickHouseLocalPath),
-		RemainingTreeDB:     remaining,
-		RemainingTreeDBJSON: remainingJSON,
-		RemainingTreeDBTpl:  remainingTpl,
-		ConservativeBSON:    conservativeBSON,
-		ConservativeJSON:    conservativeJSON,
-		ConservativeTpl:     conservativeTpl,
-		RawTreeDBJSON:       rawTreeDBJSON,
-		QueryTimings:        timings,
-		ColumnSummaries:     summaries,
-		BestColumnStorage:   bestColumns(summaries),
+		GeneratedAt:             time.Now().UTC().Format(time.RFC3339),
+		DataPath:                *data,
+		Limit:                   *limit,
+		Rows:                    ds.Rows,
+		Files:                   ds.Files,
+		InputBytes:              inputBytes(ds.Files),
+		RowsPerGranule:          *rowsPerGranule,
+		LoadDuration:            loadDuration,
+		ClickHouseLocal:         readClickHouseResult(*clickHouseLocalPath),
+		RemainingTreeDB:         remaining,
+		RemainingTreeDBJSON:     remainingJSON,
+		RemainingTreeDBTpl:      remainingTpl,
+		ConservativeBSON:        conservativeBSON,
+		ConservativeJSON:        conservativeJSON,
+		ConservativeTpl:         conservativeTpl,
+		RawTreeDBJSON:           rawTreeDBJSON,
+		QueryTimings:            timings,
+		EncodedPartQueryTimings: encodedPartTimings,
+		ColumnSummaries:         summaries,
+		BestColumnStorage:       bestColumns(summaries),
 	}
 
 	writeJSON(*outJSON, raw)
@@ -845,6 +849,28 @@ func writeMarkdown(path string, raw comparisonRaw) {
 	for i, timing := range raw.QueryTimings {
 		local := clickHouseBest(raw.ClickHouseLocal, i)
 		fmt.Fprintf(&b, "| %s | %.6fs | %.6fs | %.2fx | %s |\n", timing.Query, timing.Best.Seconds(), local, ratio(timing.Best.Seconds(), local), timing.Description)
+	}
+	if len(raw.EncodedPartQueryTimings) > 0 {
+		fmt.Fprintf(&b, "\n## Encoded Part Query Timing\n\n")
+		fmt.Fprintf(&b, "| Query | Best | Best cache | ClickHouse local | Part / ClickHouse | Kernel | Diagnostics |\n")
+		fmt.Fprintf(&b, "|---|---:|---|---:|---:|---|---|\n")
+		for i, timing := range raw.EncodedPartQueryTimings {
+			local := clickHouseBest(raw.ClickHouseLocal, i)
+			d := timing.Diagnostics
+			fmt.Fprintf(&b, "| %s | %.6fs | %s | %.6fs | %.2fx | `%s` | rows=%d granules=%d decoded=%d blocks=%d bytes=%d columns=`%s` |\n",
+				timing.Query,
+				timing.Best.Seconds(),
+				timing.BestCache,
+				local,
+				ratio(timing.Best.Seconds(), local),
+				d.AggregateKernel,
+				d.RowsScanned,
+				d.GranulesConsidered,
+				d.GranulesDecoded,
+				d.BlocksDecoded,
+				d.BytesDecoded,
+				strings.Join(d.ColumnsProjected, ","))
+		}
 	}
 	fmt.Fprintf(&b, "\n## Storage Footprint\n\n")
 	allBest := bestTotal(raw.BestColumnStorage, nil)

--- a/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/snissn/gomap/experiments/colgranule"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -167,5 +168,53 @@ func TestValidateRawJSONTreeDBDetectsMismatchedRows(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "validation mismatch") {
 		t.Fatalf("validation error %q does not mention mismatch", err)
+	}
+}
+
+func TestValidateEncodedPartParityRejectsMismatchedDigest(t *testing.T) {
+	reference := []colgranule.JSONBenchQueryTiming{{
+		Query:        "Q1",
+		ResultRows:   3,
+		ResultDigest: 10,
+	}}
+	encoded := []colgranule.JSONBenchPartQueryTiming{{
+		Query:        "Q1",
+		ResultRows:   3,
+		ResultDigest: 11,
+		Attempts: []colgranule.JSONBenchPartQueryAttempt{{
+			ResultRows:   3,
+			ResultDigest: 11,
+		}},
+	}}
+	err := validateEncodedPartParity(reference, encoded)
+	if err == nil {
+		t.Fatal("expected encoded part parity error")
+	}
+	if !strings.Contains(err.Error(), "rows/digest") {
+		t.Fatalf("parity error %q does not describe rows/digest mismatch", err)
+	}
+}
+
+func TestValidateEncodedPartParityRejectsMismatchedAttempt(t *testing.T) {
+	reference := []colgranule.JSONBenchQueryTiming{{
+		Query:        "Q2",
+		ResultRows:   4,
+		ResultDigest: 20,
+	}}
+	encoded := []colgranule.JSONBenchPartQueryTiming{{
+		Query:        "Q2",
+		ResultRows:   4,
+		ResultDigest: 20,
+		Attempts: []colgranule.JSONBenchPartQueryAttempt{{
+			ResultRows:   4,
+			ResultDigest: 21,
+		}},
+	}}
+	err := validateEncodedPartParity(reference, encoded)
+	if err == nil {
+		t.Fatal("expected encoded part attempt parity error")
+	}
+	if !strings.Contains(err.Error(), "attempt 0") {
+		t.Fatalf("parity error %q does not describe attempt mismatch", err)
 	}
 }

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -37,5 +38,97 @@ func BenchmarkJSONBenchLocalColumns(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	part, err := BuildJSONBenchColumnPart(ds, DefaultRowsPerGranule)
+	if err != nil {
+		b.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		b.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	queries := []struct {
+		name string
+		run  jsonBenchPartQueryRunner
+	}{
+		{"Q1_grouped_count", runJSONBenchPartQ1},
+		{"Q2_group_count_distinct", runJSONBenchPartQ2},
+		{"Q3_hourly_grouped_count", runJSONBenchPartQ3},
+		{"Q4_min_by_user", runJSONBenchPartQ4},
+		{"Q5_span_by_user", runJSONBenchPartQ5},
+	}
+	for _, q := range queries {
+		b.Run(q.name, func(b *testing.B) {
+			b.ReportAllocs()
+			scratch := &jsonBenchPartQueryScratch{
+				scanner:   part.NewScanner(),
+				projected: make(map[string][]int64, 6),
+			}
+			rows, digest, diagnostics, err := q.run(part, codes, scratch)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(rows) + int64(digest)
+			valueBytes := ds.Rows * len(diagnostics.ColumnsProjected) * 8
+			if valueBytes == 0 {
+				valueBytes = ds.Rows * 8
+			}
+			b.SetBytes(int64(valueBytes))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, digest, diagnostics, err = q.run(part, codes, scratch)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(rows) + int64(digest)
+			}
+			reportGranuleBenchMetrics(b, ds.Rows, valueBytes, diagnostics.BytesDecoded)
+		})
+	}
+}
+
+func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
+	columns := map[string][]int64{
+		"row_index":              make([]int64, rows),
+		"time_us":                make([]int64, rows),
+		"did_code":               make([]int64, rows),
+		"kind_code":              make([]int64, rows),
+		"commit_operation_code":  make([]int64, rows),
+		"commit_collection_code": make([]int64, rows),
+	}
+	const didCardinality = 65536
+	for i := 0; i < rows; i++ {
+		columns["row_index"][i] = int64(i)
+		columns["time_us"][i] = 1_700_000_000_000_000 + int64(i)*1_000_000
+		columns["did_code"][i] = int64((i % didCardinality) + 1)
+		columns["kind_code"][i] = 1
+		columns["commit_operation_code"][i] = 1
+		columns["commit_collection_code"][i] = int64((i % 3) + 1)
+	}
+	didDict := make(map[string]int64, didCardinality)
+	for i := 1; i <= didCardinality; i++ {
+		didDict[strconv.Itoa(i)] = int64(i)
+	}
+	return JSONBenchDataset{
+		Rows:    rows,
+		Columns: columns,
+		Dictionaries: map[string]map[string]int64{
+			"did_code": didDict,
+			"kind_code": {
+				"commit": 1,
+			},
+			"commit_operation_code": {
+				"create": 1,
+			},
+			"commit_collection_code": {
+				"app.bsky.feed.post":   1,
+				"app.bsky.feed.repost": 2,
+				"app.bsky.feed.like":   3,
+			},
+		},
 	}
 }

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -463,7 +463,7 @@ func queryDiagnosticsFromScan(scan PartScanDiagnostics, columns []string, kernel
 	return JSONBenchPartQueryDiagnostics{
 		RowsScanned:        scan.RowsScanned,
 		GranulesConsidered: scan.GranulesConsidered,
-		GranulesDecoded:    scan.GranulesConsidered,
+		GranulesDecoded:    scan.GranulesDecoded,
 		BlocksDecoded:      scan.BlocksDecoded,
 		BytesDecoded:       scan.BytesDecoded,
 		ColumnsProjected:   append([]string(nil), columns...),
@@ -474,21 +474,22 @@ func queryDiagnosticsFromScan(scan PartScanDiagnostics, columns []string, kernel
 func partColumnDiagnostics(part *ColumnPart, columns []string, kernel string) JSONBenchPartQueryDiagnostics {
 	var blocks int
 	var bytes int
-	covered := make(map[int]struct{}, len(part.Descriptor.Granules))
+	var granulesDecoded int
 	for _, name := range columns {
 		column := part.Columns[name]
+		columnGranules, err := countGranulesCoveredByBlocks(column.Blocks)
+		if err == nil && columnGranules > granulesDecoded {
+			granulesDecoded = columnGranules
+		}
 		for _, block := range column.Blocks {
 			blocks++
 			bytes += block.Granule.RawBytes
-			for granule := block.Descriptor.FirstGranule; granule <= block.Descriptor.LastGranule; granule++ {
-				covered[granule] = struct{}{}
-			}
 		}
 	}
 	return JSONBenchPartQueryDiagnostics{
 		RowsScanned:        part.Descriptor.RowCount,
 		GranulesConsidered: len(part.Descriptor.Granules),
-		GranulesDecoded:    len(covered),
+		GranulesDecoded:    granulesDecoded,
 		BlocksDecoded:      blocks,
 		BytesDecoded:       bytes,
 		ColumnsProjected:   append([]string(nil), columns...),

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -1,0 +1,543 @@
+package colgranule
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+type JSONBenchPartQueryTiming struct {
+	Query        string                        `json:"query"`
+	Description  string                        `json:"description"`
+	Engine       string                        `json:"engine"`
+	Attempts     []JSONBenchPartQueryAttempt   `json:"attempts"`
+	Best         time.Duration                 `json:"best"`
+	BestCache    string                        `json:"best_cache"`
+	ResultRows   int                           `json:"result_rows"`
+	ResultDigest uint64                        `json:"result_digest"`
+	Diagnostics  JSONBenchPartQueryDiagnostics `json:"diagnostics"`
+}
+
+type JSONBenchPartQueryAttempt struct {
+	Cache        string                        `json:"cache"`
+	Duration     time.Duration                 `json:"duration"`
+	ResultRows   int                           `json:"result_rows"`
+	ResultDigest uint64                        `json:"result_digest"`
+	Diagnostics  JSONBenchPartQueryDiagnostics `json:"diagnostics"`
+}
+
+type JSONBenchPartQueryDiagnostics struct {
+	RowsScanned        int      `json:"rows_scanned"`
+	GranulesConsidered int      `json:"granules_considered"`
+	GranulesSkipped    int      `json:"granules_skipped"`
+	GranulesDecoded    int      `json:"granules_decoded"`
+	BlocksDecoded      int      `json:"blocks_decoded"`
+	BytesDecoded       int      `json:"bytes_decoded"`
+	ColumnsProjected   []string `json:"columns_projected"`
+	AggregateKernel    string   `json:"aggregate_kernel"`
+	CacheState         string   `json:"cache_state"`
+}
+
+type jsonBenchPartQueryScratch struct {
+	arena     AggregateArena
+	scanner   *ColumnPartScanner
+	projected map[string][]int64
+	granules  []EncodedGranule
+	counts    map[int64]int64
+	unique    map[int64]map[int64]struct{}
+	events    []int64
+	first     map[int64]int64
+	spans     map[int64]jsonBenchPartSpan
+	q4Pairs   []jsonBenchPartTimePair
+	q5Pairs   []jsonBenchPartSpanPair
+}
+
+type jsonBenchPartQueryRunner func(*ColumnPart, queryCodeSet, *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error)
+
+func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnPart, error) {
+	opts, err := JSONBenchColumnPartOptions(ds, rowsPerGranule)
+	if err != nil {
+		return nil, err
+	}
+	return BuildColumnPart(1, opts, ColumnBatch{Rows: ds.Rows, Columns: ds.Columns})
+}
+
+func JSONBenchColumnPartOptions(ds JSONBenchDataset, rowsPerGranule int) (ColumnStoreOptions, error) {
+	if ds.Rows <= 0 {
+		return ColumnStoreOptions{}, fmt.Errorf("colgranule: JSONBench part requires positive rows, got %d", ds.Rows)
+	}
+	if rowsPerGranule <= 0 {
+		rowsPerGranule = DefaultRowsPerGranule
+	}
+	names := ds.ColumnNames()
+	defs := make([]ColumnDefinition, 0, len(names))
+	for _, name := range names {
+		values := ds.Columns[name]
+		if len(values) != ds.Rows {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: column %s rows=%d want=%d", name, len(values), ds.Rows)
+		}
+		def := ColumnDefinition{
+			Name:        name,
+			Type:        ColumnTypeInt64,
+			Encoding:    EncodingDeltaVarint,
+			Compression: CompressionLZ4,
+		}
+		if isJSONBenchMonotonicColumn(name) {
+			def.Encoding = EncodingDoubleDeltaVarint
+		}
+		if isJSONBenchBoolColumn(name) {
+			def.Type = ColumnTypeBool
+			def.Encoding = EncodingBoolBitpackRLE
+		}
+		if cardinality, ok := jsonBenchCodeCardinality(ds, name); ok && cardinality <= maxCodeCardinality {
+			def.Type = ColumnTypeLowCardinalityCode
+			def.Encoding = EncodingLowCardinalityUint32
+			def.Cardinality = cardinality
+		}
+		defs = append(defs, def)
+	}
+	return ColumnStoreOptions{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns:       defs,
+		LogicalPrimaryKey: LogicalPrimaryKey{
+			Columns: []string{"row_index"},
+		},
+		SortKey: SortKey{
+			Columns: []SortKeyColumn{{Column: "time_us"}},
+		},
+		PartPolicy: ColumnPartPolicy{
+			RowsPerGranule:        rowsPerGranule,
+			DefaultCodecBlockRows: rowsPerGranule,
+		},
+	}, nil
+}
+
+func RunJSONBenchPartQueries(ds JSONBenchDataset, rowsPerGranule int, attempts int) ([]JSONBenchPartQueryTiming, error) {
+	if attempts <= 0 {
+		attempts = 3
+	}
+	part, err := BuildJSONBenchColumnPart(ds, rowsPerGranule)
+	if err != nil {
+		return nil, err
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		return nil, err
+	}
+	queries := []struct {
+		name        string
+		description string
+		run         jsonBenchPartQueryRunner
+	}{
+		{"Q1", "Top event types", runJSONBenchPartQ1},
+		{"Q2", "Top event types with unique users", runJSONBenchPartQ2},
+		{"Q3", "Event counts by hour", runJSONBenchPartQ3},
+		{"Q4", "Top 3 post veterans", runJSONBenchPartQ4},
+		{"Q5", "Top 3 users with longest activity", runJSONBenchPartQ5},
+	}
+	out := make([]JSONBenchPartQueryTiming, 0, len(queries))
+	for _, q := range queries {
+		timing := JSONBenchPartQueryTiming{
+			Query:       q.name,
+			Description: q.description,
+			Engine:      "encoded_column_part",
+			Attempts:    make([]JSONBenchPartQueryAttempt, 0, attempts),
+		}
+		scratch := &jsonBenchPartQueryScratch{
+			scanner:   part.NewScanner(),
+			projected: make(map[string][]int64, 6),
+		}
+		for i := 0; i < attempts; i++ {
+			cache := "cold"
+			if i > 0 {
+				cache = "warm"
+			}
+			start := time.Now()
+			rows, digest, diagnostics, err := q.run(part, codes, scratch)
+			if err != nil {
+				return nil, fmt.Errorf("%s encoded part query: %w", q.name, err)
+			}
+			elapsed := time.Since(start)
+			diagnostics.CacheState = cache
+			attempt := JSONBenchPartQueryAttempt{
+				Cache:        cache,
+				Duration:     elapsed,
+				ResultRows:   rows,
+				ResultDigest: digest,
+				Diagnostics:  diagnostics,
+			}
+			timing.Attempts = append(timing.Attempts, attempt)
+			timing.ResultRows = rows
+			timing.ResultDigest = digest
+			if timing.Best == 0 || elapsed < timing.Best {
+				timing.Best = elapsed
+				timing.BestCache = cache
+				timing.Diagnostics = diagnostics
+			}
+		}
+		out = append(out, timing)
+	}
+	return out, nil
+}
+
+func runJSONBenchPartQ1(part *ColumnPart, _ queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	const column = "commit_collection_code"
+	blocks, err := scratch.columnGranules(part, column)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	cardinality, err := partCodeCardinality(part, column)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	counts, err := scratch.arena.GroupedCountCodes(blocks, cardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	rows, digest := digestUint64Counts(counts)
+	diagnostics := partColumnDiagnostics(part, []string{column}, "grouped_count_codes")
+	return rows, digest, diagnostics, nil
+}
+
+func (s *jsonBenchPartQueryScratch) columnGranules(part *ColumnPart, column string) ([]EncodedGranule, error) {
+	c, ok := part.Columns[column]
+	if !ok {
+		return nil, fmt.Errorf("colgranule: missing column %s", column)
+	}
+	if cap(s.granules) < len(c.Blocks) {
+		s.granules = make([]EncodedGranule, len(c.Blocks))
+	} else {
+		s.granules = s.granules[:len(c.Blocks)]
+	}
+	for i, block := range c.Blocks {
+		s.granules[i] = block.Granule
+	}
+	return s.granules, nil
+}
+
+func runJSONBenchPartQ2(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
+	scan, err := scanPartProjection(part, scratch, projection)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	kind := scan.Columns["kind_code"]
+	operation := scan.Columns["commit_operation_code"]
+	collection := scan.Columns["commit_collection_code"]
+	did := scan.Columns["did_code"]
+	counts := scratch.resetCounts()
+	unique, events := scratch.resetUnique()
+	for i := range collection {
+		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate {
+			continue
+		}
+		event := collection[i]
+		if counts[event] == 0 {
+			events = append(events, event)
+		}
+		counts[event]++
+		if unique[event] == nil {
+			unique[event] = make(map[int64]struct{})
+		}
+		unique[event][did[i]] = struct{}{}
+	}
+	scratch.events = events
+	digest := digestCounts(counts)
+	sort.Slice(events, func(i, j int) bool { return events[i] < events[j] })
+	for _, event := range events {
+		users := unique[event]
+		digest = digestMix(digest, uint64(event), uint64(len(users)))
+	}
+	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_group_count_distinct")
+	return len(counts), digest, diagnostics, nil
+}
+
+func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "time_us"}
+	scan, err := scanPartProjection(part, scratch, projection)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	kind := scan.Columns["kind_code"]
+	operation := scan.Columns["commit_operation_code"]
+	collection := scan.Columns["commit_collection_code"]
+	timeUS := scan.Columns["time_us"]
+	counts := scratch.resetCounts()
+	for i := range collection {
+		event := collection[i]
+		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate {
+			continue
+		}
+		if event != codes.collectionPost && event != codes.collectionRepost && event != codes.collectionLike {
+			continue
+		}
+		hour := unixMicroHour(timeUS[i])
+		counts[event*100+hour]++
+	}
+	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_group_count_hour")
+	return len(counts), digestCounts(counts), diagnostics, nil
+}
+
+func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
+	scan, err := scanPartProjection(part, scratch, projection)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	kind := scan.Columns["kind_code"]
+	operation := scan.Columns["commit_operation_code"]
+	collection := scan.Columns["commit_collection_code"]
+	did := scan.Columns["did_code"]
+	timeUS := scan.Columns["time_us"]
+	first := scratch.resetFirst()
+	for i := range collection {
+		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate || collection[i] != codes.collectionPost {
+			continue
+		}
+		user := did[i]
+		if prev, ok := first[user]; !ok || timeUS[i] < prev {
+			first[user] = timeUS[i]
+		}
+	}
+	top := scratch.q4Pairs[:0]
+	for user, t := range first {
+		top = append(top, jsonBenchPartTimePair{user: user, t: t})
+	}
+	scratch.q4Pairs = top
+	sort.Slice(top, func(i, j int) bool {
+		if top[i].t == top[j].t {
+			return top[i].user < top[j].user
+		}
+		return top[i].t < top[j].t
+	})
+	if len(top) > 3 {
+		top = top[:3]
+	}
+	var digest uint64
+	for _, p := range top {
+		digest = digestMix(digest, uint64(p.user), uint64(p.t))
+	}
+	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_min_by_user")
+	return len(top), digest, diagnostics, nil
+}
+
+func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
+	scan, err := scanPartProjection(part, scratch, projection)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	kind := scan.Columns["kind_code"]
+	operation := scan.Columns["commit_operation_code"]
+	collection := scan.Columns["commit_collection_code"]
+	did := scan.Columns["did_code"]
+	timeUS := scan.Columns["time_us"]
+	spans := scratch.resetSpans()
+	for i := range collection {
+		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate || collection[i] != codes.collectionPost {
+			continue
+		}
+		user := did[i]
+		s, ok := spans[user]
+		if !ok {
+			spans[user] = jsonBenchPartSpan{min: timeUS[i], max: timeUS[i]}
+			continue
+		}
+		if timeUS[i] < s.min {
+			s.min = timeUS[i]
+		}
+		if timeUS[i] > s.max {
+			s.max = timeUS[i]
+		}
+		spans[user] = s
+	}
+	top := scratch.q5Pairs[:0]
+	for user, s := range spans {
+		top = append(top, jsonBenchPartSpanPair{user: user, span: s.max - s.min})
+	}
+	scratch.q5Pairs = top
+	sort.Slice(top, func(i, j int) bool {
+		if top[i].span == top[j].span {
+			return top[i].user < top[j].user
+		}
+		return top[i].span > top[j].span
+	})
+	if len(top) > 3 {
+		top = top[:3]
+	}
+	var digest uint64
+	for _, p := range top {
+		digest = digestMix(digest, uint64(p.user), uint64(p.span))
+	}
+	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_span_by_user")
+	return len(top), digest, diagnostics, nil
+}
+
+type jsonBenchPartSpan struct {
+	min int64
+	max int64
+}
+
+type jsonBenchPartTimePair struct {
+	user int64
+	t    int64
+}
+
+type jsonBenchPartSpanPair struct {
+	user int64
+	span int64
+}
+
+func (s *jsonBenchPartQueryScratch) resetCounts() map[int64]int64 {
+	if s.counts == nil {
+		s.counts = make(map[int64]int64, 128)
+	} else {
+		for k := range s.counts {
+			delete(s.counts, k)
+		}
+	}
+	return s.counts
+}
+
+func (s *jsonBenchPartQueryScratch) resetUnique() (map[int64]map[int64]struct{}, []int64) {
+	if s.unique == nil {
+		s.unique = make(map[int64]map[int64]struct{}, 16)
+	} else {
+		for _, users := range s.unique {
+			for user := range users {
+				delete(users, user)
+			}
+		}
+	}
+	s.events = s.events[:0]
+	return s.unique, s.events
+}
+
+func (s *jsonBenchPartQueryScratch) resetFirst() map[int64]int64 {
+	if s.first == nil {
+		s.first = make(map[int64]int64, 128*1024)
+	} else {
+		for k := range s.first {
+			delete(s.first, k)
+		}
+	}
+	return s.first
+}
+
+func (s *jsonBenchPartQueryScratch) resetSpans() map[int64]jsonBenchPartSpan {
+	if s.spans == nil {
+		s.spans = make(map[int64]jsonBenchPartSpan, 128*1024)
+	} else {
+		for k := range s.spans {
+			delete(s.spans, k)
+		}
+	}
+	return s.spans
+}
+
+func digestUint64Counts(counts []uint64) (int, uint64) {
+	var digest uint64
+	rows := 0
+	for code, count := range counts {
+		if count == 0 {
+			continue
+		}
+		rows++
+		digest = digestMix(digest, uint64(code), count)
+	}
+	return rows, digest
+}
+
+func scanPartProjection(part *ColumnPart, scratch *jsonBenchPartQueryScratch, projection []string) (ProjectedScanResult, error) {
+	if scratch.scanner == nil {
+		scratch.scanner = part.NewScanner()
+	}
+	if scratch.projected == nil {
+		scratch.projected = make(map[string][]int64, len(projection))
+	}
+	return scratch.scanner.ScanProjectedInto(scratch.projected, projection)
+}
+
+func queryDiagnosticsFromScan(scan PartScanDiagnostics, columns []string, kernel string) JSONBenchPartQueryDiagnostics {
+	return JSONBenchPartQueryDiagnostics{
+		RowsScanned:        scan.RowsScanned,
+		GranulesConsidered: scan.GranulesConsidered,
+		GranulesDecoded:    scan.GranulesConsidered,
+		BlocksDecoded:      scan.BlocksDecoded,
+		BytesDecoded:       scan.BytesDecoded,
+		ColumnsProjected:   append([]string(nil), columns...),
+		AggregateKernel:    kernel,
+	}
+}
+
+func partColumnDiagnostics(part *ColumnPart, columns []string, kernel string) JSONBenchPartQueryDiagnostics {
+	var blocks int
+	var bytes int
+	covered := make(map[int]struct{}, len(part.Descriptor.Granules))
+	for _, name := range columns {
+		column := part.Columns[name]
+		for _, block := range column.Blocks {
+			blocks++
+			bytes += block.Granule.RawBytes
+			for granule := block.Descriptor.FirstGranule; granule <= block.Descriptor.LastGranule; granule++ {
+				covered[granule] = struct{}{}
+			}
+		}
+	}
+	return JSONBenchPartQueryDiagnostics{
+		RowsScanned:        part.Descriptor.RowCount,
+		GranulesConsidered: len(part.Descriptor.Granules),
+		GranulesDecoded:    len(covered),
+		BlocksDecoded:      blocks,
+		BytesDecoded:       bytes,
+		ColumnsProjected:   append([]string(nil), columns...),
+		AggregateKernel:    kernel,
+	}
+}
+
+func partCodeCardinality(part *ColumnPart, column string) (uint32, error) {
+	c, ok := part.Columns[column]
+	if !ok {
+		return 0, fmt.Errorf("colgranule: missing column %s", column)
+	}
+	if c.Definition.Type != ColumnTypeLowCardinalityCode {
+		return 0, fmt.Errorf("colgranule: column %s is %s, not low-cardinality code", column, c.Definition.Type)
+	}
+	return c.Definition.Cardinality, nil
+}
+
+func jsonBenchCodeCardinality(ds JSONBenchDataset, column string) (uint32, bool) {
+	dict := ds.Dictionaries[column]
+	if dict == nil {
+		return 0, false
+	}
+	maxCode := int64(0)
+	for _, code := range dict {
+		if code > maxCode {
+			maxCode = code
+		}
+	}
+	if maxCode < 0 || maxCode >= maxCodeCardinality {
+		return 0, false
+	}
+	return uint32(maxCode + 1), true
+}
+
+func isJSONBenchMonotonicColumn(name string) bool {
+	switch name {
+	case "row_index", "time_us", "record_created_at_unix_ms":
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONBenchBoolColumn(name string) bool {
+	switch name {
+	case "record_has_reply", "record_has_subject":
+		return true
+	default:
+		return false
+	}
+}

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -78,10 +78,12 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunJSONBenchQueries: %v", err)
 	}
-	partTimings, err := RunJSONBenchPartQueries(ds, 2, 2)
+	const rowsPerGranule = 2
+	partTimings, err := RunJSONBenchPartQueries(ds, rowsPerGranule, 2)
 	if err != nil {
 		t.Fatalf("RunJSONBenchPartQueries: %v", err)
 	}
+	granules := (ds.Rows + rowsPerGranule - 1) / rowsPerGranule
 	if len(partTimings) != len(rawTimings) {
 		t.Fatalf("part timings=%d raw timings=%d", len(partTimings), len(rawTimings))
 	}
@@ -107,9 +109,9 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 			if attempt.ResultRows != raw.ResultRows || attempt.ResultDigest != raw.ResultDigest {
 				t.Fatalf("%s/%s rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, attempt.Cache, attempt.ResultRows, attempt.ResultDigest, raw.ResultRows, raw.ResultDigest)
 			}
-			assertJSONBenchPartDiagnostics(t, timing.Query, attempt.Diagnostics, ds.Rows, 3)
+			assertJSONBenchPartDiagnostics(t, timing.Query, attempt.Diagnostics, ds.Rows, granules)
 		}
-		assertJSONBenchPartDiagnostics(t, timing.Query, timing.Diagnostics, ds.Rows, 3)
+		assertJSONBenchPartDiagnostics(t, timing.Query, timing.Diagnostics, ds.Rows, granules)
 	}
 }
 
@@ -186,7 +188,10 @@ func TestRunJSONBenchPartQueriesLocalIfPresent(t *testing.T) {
 		rawByQuery[timing.Query] = timing
 	}
 	for _, timing := range partTimings {
-		raw := rawByQuery[timing.Query]
+		raw, ok := rawByQuery[timing.Query]
+		if !ok {
+			t.Fatalf("unexpected local part query %s", timing.Query)
+		}
 		if timing.ResultRows != raw.ResultRows || timing.ResultDigest != raw.ResultDigest {
 			t.Fatalf("%s local part rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, timing.ResultRows, timing.ResultDigest, raw.ResultRows, raw.ResultDigest)
 		}
@@ -198,14 +203,14 @@ func assertJSONBenchPartDiagnostics(t *testing.T, query string, diagnostics JSON
 	if diagnostics.RowsScanned != rows {
 		t.Fatalf("%s diagnostics rows=%d want %d: %+v", query, diagnostics.RowsScanned, rows, diagnostics)
 	}
-	if diagnostics.GranulesConsidered != granules {
-		t.Fatalf("%s diagnostics granules=%d want %d: %+v", query, diagnostics.GranulesConsidered, granules, diagnostics)
+	if diagnostics.GranulesConsidered <= 0 || diagnostics.GranulesConsidered > granules {
+		t.Fatalf("%s diagnostics granules=%d want 1..%d: %+v", query, diagnostics.GranulesConsidered, granules, diagnostics)
 	}
-	if diagnostics.GranulesSkipped != 0 {
-		t.Fatalf("%s diagnostics skipped=%d want 0: %+v", query, diagnostics.GranulesSkipped, diagnostics)
+	if diagnostics.GranulesSkipped < 0 || diagnostics.GranulesSkipped > diagnostics.GranulesConsidered {
+		t.Fatalf("%s diagnostics skipped=%d want 0..%d: %+v", query, diagnostics.GranulesSkipped, diagnostics.GranulesConsidered, diagnostics)
 	}
-	if diagnostics.GranulesDecoded <= 0 || diagnostics.GranulesDecoded > granules {
-		t.Fatalf("%s diagnostics decoded granules=%d want 1..%d: %+v", query, diagnostics.GranulesDecoded, granules, diagnostics)
+	if diagnostics.GranulesDecoded <= 0 || diagnostics.GranulesDecoded > diagnostics.GranulesConsidered {
+		t.Fatalf("%s diagnostics decoded granules=%d want 1..%d: %+v", query, diagnostics.GranulesDecoded, diagnostics.GranulesConsidered, diagnostics)
 	}
 	if diagnostics.BlocksDecoded <= 0 || diagnostics.BytesDecoded <= 0 {
 		t.Fatalf("%s diagnostics missing decoded blocks/bytes: %+v", query, diagnostics)

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -69,6 +69,50 @@ func TestRunJSONBenchQueriesSample(t *testing.T) {
 	}
 }
 
+func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
+	ds, err := LoadJSONBenchColumns("testdata/jsonbench_sample.jsonl", 0)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns(sample): %v", err)
+	}
+	rawTimings, err := RunJSONBenchQueries(ds, 1)
+	if err != nil {
+		t.Fatalf("RunJSONBenchQueries: %v", err)
+	}
+	partTimings, err := RunJSONBenchPartQueries(ds, 2, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartQueries: %v", err)
+	}
+	if len(partTimings) != len(rawTimings) {
+		t.Fatalf("part timings=%d raw timings=%d", len(partTimings), len(rawTimings))
+	}
+	rawByQuery := make(map[string]JSONBenchQueryTiming, len(rawTimings))
+	for _, timing := range rawTimings {
+		rawByQuery[timing.Query] = timing
+	}
+	for _, timing := range partTimings {
+		raw, ok := rawByQuery[timing.Query]
+		if !ok {
+			t.Fatalf("unexpected part query %s", timing.Query)
+		}
+		if timing.ResultRows != raw.ResultRows || timing.ResultDigest != raw.ResultDigest {
+			t.Fatalf("%s part rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, timing.ResultRows, timing.ResultDigest, raw.ResultRows, raw.ResultDigest)
+		}
+		if timing.Engine != "encoded_column_part" {
+			t.Fatalf("%s engine=%q want encoded_column_part", timing.Query, timing.Engine)
+		}
+		if len(timing.Attempts) != 2 || timing.Attempts[0].Cache != "cold" || timing.Attempts[1].Cache != "warm" {
+			t.Fatalf("%s attempts=%+v want cold,warm labels", timing.Query, timing.Attempts)
+		}
+		for _, attempt := range timing.Attempts {
+			if attempt.ResultRows != raw.ResultRows || attempt.ResultDigest != raw.ResultDigest {
+				t.Fatalf("%s/%s rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, attempt.Cache, attempt.ResultRows, attempt.ResultDigest, raw.ResultRows, raw.ResultDigest)
+			}
+			assertJSONBenchPartDiagnostics(t, timing.Query, attempt.Diagnostics, ds.Rows, 3)
+		}
+		assertJSONBenchPartDiagnostics(t, timing.Query, timing.Diagnostics, ds.Rows, 3)
+	}
+}
+
 func TestLoadJSONBenchColumnsLocal1MIfPresent(t *testing.T) {
 	path := os.Getenv("JSONBENCH_DATA")
 	if path == "" {
@@ -114,5 +158,65 @@ func TestLoadJSONBenchColumnsLocalDirIfPresent(t *testing.T) {
 	}
 	if len(ds.Files) == 0 {
 		t.Fatalf("files=0 want nonzero")
+	}
+}
+
+func TestRunJSONBenchPartQueriesLocalIfPresent(t *testing.T) {
+	path := os.Getenv("JSONBENCH_DATA")
+	if path == "" {
+		t.Skip("JSONBENCH_DATA not set")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("local JSONBench fixture not present at %s", path)
+	}
+	ds, err := LoadJSONBenchColumns(path, 1000)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns(local): %v", err)
+	}
+	rawTimings, err := RunJSONBenchQueries(ds, 1)
+	if err != nil {
+		t.Fatalf("RunJSONBenchQueries(local): %v", err)
+	}
+	partTimings, err := RunJSONBenchPartQueries(ds, DefaultRowsPerGranule, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartQueries(local): %v", err)
+	}
+	rawByQuery := make(map[string]JSONBenchQueryTiming, len(rawTimings))
+	for _, timing := range rawTimings {
+		rawByQuery[timing.Query] = timing
+	}
+	for _, timing := range partTimings {
+		raw := rawByQuery[timing.Query]
+		if timing.ResultRows != raw.ResultRows || timing.ResultDigest != raw.ResultDigest {
+			t.Fatalf("%s local part rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, timing.ResultRows, timing.ResultDigest, raw.ResultRows, raw.ResultDigest)
+		}
+	}
+}
+
+func assertJSONBenchPartDiagnostics(t *testing.T, query string, diagnostics JSONBenchPartQueryDiagnostics, rows int, granules int) {
+	t.Helper()
+	if diagnostics.RowsScanned != rows {
+		t.Fatalf("%s diagnostics rows=%d want %d: %+v", query, diagnostics.RowsScanned, rows, diagnostics)
+	}
+	if diagnostics.GranulesConsidered != granules {
+		t.Fatalf("%s diagnostics granules=%d want %d: %+v", query, diagnostics.GranulesConsidered, granules, diagnostics)
+	}
+	if diagnostics.GranulesSkipped != 0 {
+		t.Fatalf("%s diagnostics skipped=%d want 0: %+v", query, diagnostics.GranulesSkipped, diagnostics)
+	}
+	if diagnostics.GranulesDecoded <= 0 || diagnostics.GranulesDecoded > granules {
+		t.Fatalf("%s diagnostics decoded granules=%d want 1..%d: %+v", query, diagnostics.GranulesDecoded, granules, diagnostics)
+	}
+	if diagnostics.BlocksDecoded <= 0 || diagnostics.BytesDecoded <= 0 {
+		t.Fatalf("%s diagnostics missing decoded blocks/bytes: %+v", query, diagnostics)
+	}
+	if diagnostics.AggregateKernel == "" {
+		t.Fatalf("%s diagnostics missing aggregate kernel: %+v", query, diagnostics)
+	}
+	if diagnostics.CacheState != "cold" && diagnostics.CacheState != "warm" {
+		t.Fatalf("%s diagnostics cache=%q want cold or warm", query, diagnostics.CacheState)
+	}
+	if len(diagnostics.ColumnsProjected) == 0 {
+		t.Fatalf("%s diagnostics missing columns projected: %+v", query, diagnostics)
 	}
 }

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -259,6 +259,7 @@ type PartScanDiagnostics struct {
 	RowsScanned        int
 	ColumnsProjected   int
 	GranulesConsidered int
+	GranulesDecoded    int
 	BlocksDecoded      int
 	BytesDecoded       int
 }
@@ -294,6 +295,9 @@ func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []
 			return ProjectedScanResult{}, err
 		}
 		next[name] = values
+		if diagnostics.GranulesDecoded > out.Diagnostics.GranulesDecoded {
+			out.Diagnostics.GranulesDecoded = diagnostics.GranulesDecoded
+		}
 		out.Diagnostics.BlocksDecoded += diagnostics.BlocksDecoded
 		out.Diagnostics.BytesDecoded += diagnostics.BytesDecoded
 	}
@@ -363,6 +367,11 @@ func (s *ColumnPartScanner) scanColumnInto(name string, dst []int64) ([]int64, P
 	}
 	out := ensureInt64Len(dst[:0], s.part.Descriptor.RowCount)
 	var diagnostics PartScanDiagnostics
+	granulesDecoded, err := countGranulesCoveredByBlocks(column.Blocks)
+	if err != nil {
+		return nil, diagnostics, fmt.Errorf("colgranule: column %s: %w", name, err)
+	}
+	diagnostics.GranulesDecoded = granulesDecoded
 	for _, block := range column.Blocks {
 		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
 		if err != nil {
@@ -376,6 +385,42 @@ func (s *ColumnPartScanner) scanColumnInto(name string, dst []int64) ([]int64, P
 		diagnostics.BytesDecoded += block.Granule.RawBytes
 	}
 	return out, diagnostics, nil
+}
+
+func countGranulesCoveredByBlocks(blocks []ColumnBlock) (int, error) {
+	total := 0
+	coveredStart := -1
+	coveredEnd := -1
+	prevFirst := -1
+	for _, block := range blocks {
+		first := block.Descriptor.FirstGranule
+		last := block.Descriptor.LastGranule
+		if first < 0 || last < first {
+			return 0, fmt.Errorf("invalid granule range %d..%d", first, last)
+		}
+		if prevFirst >= 0 && first < prevFirst {
+			return 0, fmt.Errorf("granule ranges out of order: %d after %d", first, prevFirst)
+		}
+		prevFirst = first
+		if coveredStart < 0 {
+			coveredStart = first
+			coveredEnd = last
+			continue
+		}
+		if first <= coveredEnd+1 {
+			if last > coveredEnd {
+				coveredEnd = last
+			}
+			continue
+		}
+		total += coveredEnd - coveredStart + 1
+		coveredStart = first
+		coveredEnd = last
+	}
+	if coveredStart >= 0 {
+		total += coveredEnd - coveredStart + 1
+	}
+	return total, nil
 }
 
 func (s *ColumnPartScanner) decodeBlock(columnType ColumnType, g EncodedGranule) ([]int64, error) {

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -276,6 +276,11 @@ func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []
 	if dst == nil {
 		dst = make(map[string][]int64, len(columns))
 	}
+	for existing := range dst {
+		if !containsString(columns, existing) {
+			delete(dst, existing)
+		}
+	}
 	out := ProjectedScanResult{
 		Rows:    s.part.Descriptor.RowCount,
 		Columns: dst,
@@ -295,6 +300,15 @@ func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []
 		out.Diagnostics.BytesDecoded += diagnostics.BytesDecoded
 	}
 	return out, nil
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *ColumnPartScanner) ValueAt(locator RowLocator, columnName string) (int64, error) {

--- a/experiments/colgranule/part_test.go
+++ b/experiments/colgranule/part_test.go
@@ -35,8 +35,8 @@ func TestColumnPartBuildPrimaryEqualsSortKey(t *testing.T) {
 	assertInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500})
 	assertInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{0, 1, 1, 0, 2})
 	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{0, 1, 1, 1, 0})
-	if scan.Diagnostics.RowsScanned != 5 || scan.Diagnostics.GranulesConsidered != 3 || scan.Diagnostics.BlocksDecoded != 12 {
-		t.Fatalf("diagnostics=%+v want rows=5 granules=3 blocks=12", scan.Diagnostics)
+	if scan.Diagnostics.RowsScanned != 5 || scan.Diagnostics.GranulesConsidered != 3 || scan.Diagnostics.GranulesDecoded != 3 || scan.Diagnostics.BlocksDecoded != 12 {
+		t.Fatalf("diagnostics=%+v want rows=5 granules=3 decoded=3 blocks=12", scan.Diagnostics)
 	}
 
 	scanner := part.NewScanner()
@@ -125,6 +125,9 @@ func TestColumnPartCodecBlocksCanSplitIndependently(t *testing.T) {
 	assertInt64s(t, "value", scan.Columns["value"], []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100})
 	assertInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{2, 0, 1, 2, 0, 1, 2, 1, 0, 1})
 	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{1, 0, 1, 0, 1, 0, 1, 0, 1, 0})
+	if scan.Diagnostics.GranulesDecoded != 4 || scan.Diagnostics.BlocksDecoded != 14 {
+		t.Fatalf("diagnostics=%+v want decoded=4 blocks=14", scan.Diagnostics)
+	}
 }
 
 func TestColumnPartPreservesExplicitCompressionNoneOverride(t *testing.T) {


### PR DESCRIPTION
## Objective

Implement Phase 2 / PR6 from #1534: execute JSONBench q1-q5 through encoded column parts, prove result digest parity against the existing raw-vector reference, and expose query diagnostics with cold/warm cache labels in the comparison JSON/Markdown output.

This is stacked on #1542 and targets `codex/colgranule-part-builder-scanner`.

## Context

PR5 added the in-memory column part builder/scanner. This PR uses that part layer for the JSONBench query path: q1 runs over encoded low-cardinality blocks with the grouped-count kernel, and q2-q5 run through the encoded part scanner plus query-local aggregate maps. The raw `ds.Columns` query runner remains only as the correctness reference.

The code remains experiment-only and non-durable. It does not publish TreeDB column roots or claim WAL-backed column-store writes.

## Non-goals

- No production TreeDB query API or planner.
- No durable file format/reopen support.
- No TreeDB row-store full-document benchmark integration inside this PR.
- No production ClickHouse import orchestration; this PR consumes existing local ClickHouse JSONBench result JSON for comparison only.

## Design

- Adds `BuildJSONBenchColumnPart` and `JSONBenchColumnPartOptions` to build an encoded in-memory part from loaded JSONBench columns.
- Uses `row_index` as the logical primary key and `time_us` as the physical sort key.
- Maps dictionary-code columns to `ColumnTypeLowCardinalityCode` when cardinality fits the experiment cap; bool columns use the bool bitpack/RLE path; monotonic timestamp/id columns use double-delta-style encoding.
- Adds `RunJSONBenchPartQueries` returning `JSONBenchPartQueryTiming` with per-attempt cold/warm labels.
- Adds diagnostics per attempt and per best result: rows scanned, granules considered/skipped/decoded, blocks decoded, bytes decoded, projected columns, aggregate kernel, and cache state.
- Wires `jsonbench_compare` raw JSON and Markdown reports to include `encoded_part_query_timings` and an “Encoded Part Query Timing” section.
- Adds a synthetic JSONBench-shaped encoded-part benchmark over 819,200 rows so q1-q5 can be measured without requiring external JSONBench data.

Invariants and fail-closed behavior:

- q1-q5 encoded-part results must match the raw-vector reference digests.
- scanner diagnostics must account for the part granules.
- missing columns, bad code cardinality, and invalid part shapes fail through the part builder/scanner instead of falling back to raw rows.
- JSONBench query execution does not read `ds.Columns` after part construction, except for dictionary constant lookup before query execution.

## Scope

- Includes (files/symbols):
  - `experiments/colgranule/jsonbench_part_queries.go`
  - `RunJSONBenchPartQueries`, `BuildJSONBenchColumnPart`, `JSONBenchPartQueryTiming`, `JSONBenchPartQueryDiagnostics`
  - `BenchmarkJSONBenchEncodedPartQueries`
  - JSONBench comparison JSON/Markdown fields for encoded part timings
  - `ScanProjectedInto` stale-projection cleanup in `part.go`
- Excludes (files/symbols):
  - TreeDB production storage/query paths
  - WAL/root publication
  - persistent part files
  - production benchmark harness orchestration outside `experiments/colgranule`

## Correctness

- Tests run (exact commands):
  - `go test ./experiments/colgranule/...`
  - `go test ./experiments/colgranule -run 'TestRunJSONBenchPartQueries' -count=1`
  - `go run ./experiments/colgranule/cmd/jsonbench_compare -data experiments/colgranule/testdata/jsonbench_sample.jsonl -limit 5 -rows-per-granule 2 -attempts 2 -measure-remaining-treedb=false -out-json tmp/colgranule_pr6_sample_raw.json -out-md tmp/colgranule_pr6_sample_report.md`
  - `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/dev/snissn/JSONBench/duckdb/local_results/run_20260508_075859_63706/chunks/chunk_000000_aa -limit 100000 -rows-per-granule 8192 -attempts 5 -measure-remaining-treedb=false -out-json tmp/colgranule_pr6_100k_raw.json -out-md tmp/colgranule_pr6_100k_report.md`
  - `(cd /Users/michaelseiler/dev/snissn/JSONBench && printf '\n' | ./download_data.sh)`
  - `gzip -t /Users/michaelseiler/data/bluesky/file_0001.json.gz`
  - `gzip -cd /Users/michaelseiler/data/bluesky/file_0001.json.gz | wc -l`
  - `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_pr6_1m_raw.json -out-md tmp/colgranule_pr6_1m_report.md`
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries' -benchmem -benchtime=20x`
  - `go test ./...`
  - `go test ./... -count=1`
- Corruption/edge cases covered:
  - q1-q5 encoded-part result rows and digests match raw-vector reference on checked-in sample data.
  - per-attempt cold/warm labels are present.
  - diagnostics include rows, granules, decoded blocks/bytes, projected columns, and aggregate kernel.
  - local `JSONBENCH_DATA` q1-q5 parity test is included and runs when the external fixture is present; it was skipped locally because `JSONBENCH_DATA` is not set in this environment.
  - sample `jsonbench_compare` command writes both JSON and Markdown with encoded-part timing fields.
- Concurrency/race coverage (if applicable): not applicable; this is single-threaded experiment query execution.

## Performance

- Benchmarks run (exact commands):
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries' -benchmem -benchtime=20x`
- Machine: Apple M3, `darwin/arm64`.
- Synthetic fixture: 819,200 JSONBench-shaped rows over encoded in-memory parts.
- Results table:

| Benchmark | ns/op | ns/row | rows/s | MiB/s | allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkJSONBenchEncodedPartQueries/Q1_grouped_count-8` | 1,957,465 | 2.389 | 418.5M | 3193 | 2360 B/op, 4 allocs/op |
| `BenchmarkJSONBenchEncodedPartQueries/Q2_group_count_distinct-8` | 33,724,327 | 41.17 | 24.3M | 741.3 | 200 B/op, 6 allocs/op |
| `BenchmarkJSONBenchEncodedPartQueries/Q3_hourly_grouped_count-8` | 12,578,417 | 15.35 | 65.1M | 1988 | 696 B/op, 4 allocs/op |
| `BenchmarkJSONBenchEncodedPartQueries/Q4_min_by_user-8` | 20,284,673 | 24.76 | 40.4M | 1541 | 168 B/op, 4 allocs/op |
| `BenchmarkJSONBenchEncodedPartQueries/Q5_span_by_user-8` | 21,948,677 | 26.79 | 37.3M | 1424 | 168 B/op, 4 allocs/op |

These benchmarks are allocation-light after warmup, with query memory scaling by projected columns/groups/users rather than by creating per-row heap objects.

- Real-data `1m` gate:
  - downloaded via `/Users/michaelseiler/dev/snissn/JSONBench/download_data.sh`.
  - data: `/Users/michaelseiler/data/bluesky/file_0001.json.gz`, gzip-valid, `1000000` rows, `129 MiB` compressed.
  - command: `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_pr6_1m_raw.json -out-md tmp/colgranule_pr6_1m_report.md`
  - ClickHouse baseline: `/Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json`.
  - TreeDB JSON full/projected baseline: `/Users/michaelseiler/dev/snissn/JSONBench/treedb/results/run_20260508_160154_compact_fix_1m/report.json`.
  - TreeDB template-v1 baseline: `/Users/michaelseiler/dev/snissn/JSONBench/treedb/results/run_20260508_104926_full1m_10943/report.json`.

| Query | Encoded part best | ClickHouse best | Throughput vs ClickHouse | Speedup vs TreeDB JSON full | Speedup vs TreeDB JSON projected | Speedup vs TreeDB template-v1 full |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `q1` | 0.002468s | 0.014000s | 5.67x | 483.8x | 60.9x | 1884.2x |
| `q2` | 0.049441s | 0.027000s | 0.55x | 37.9x | 13.4x | 129.3x |
| `q3` | 0.016246s | 0.014000s | 0.86x | 115.7x | 25.1x | 348.7x |
| `q4` | 0.021680s | 0.013000s | 0.60x | 70.6x | 24.0x | 254.0x |
| `q5` | 0.022215s | 0.013000s | 0.59x | 69.3x | 23.9x | 247.4x |

The `1m` run meets the Phase 2 gate: all q1-q5 queries beat TreeDB full-document baselines by more than `3x`; q1-q3 exceed the `5x+` TreeDB target; q1-q3 are at least `0.50x` local ClickHouse throughput; and q4-q5 exceed the `0.35x` local ClickHouse throughput target.

- Regressions (if any) and why acceptable: none known.

## Rollout / Toggle Plan

- Default setting: experiment-only code under `experiments/colgranule`; no production callers.
- How to disable quickly: do not call `RunJSONBenchPartQueries` or revert this PR.

## Follow-ups

- Use the encoded-part diagnostics to tune q2/q4/q5 aggregate kernels toward ClickHouse parity.
- Continue Phase 3 with minimal `TCS1` serialization after this in-memory part/query layer is reviewed.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope
- [x] Explicit exclude list (files/symbols NOT touched): see Scope
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: no durable paths touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe): part construction uses existing part/granule validation and code cardinality caps
- [x] CRC/checksum behavior is fail-closed (clean error, no panic): no CRC paths added; shape/type/cardinality errors fail closed
- [x] Any concurrency change has a defined state machine and invariants: no concurrency changes

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes: no persistent parser format added; added query parity/diagnostics tests
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see Correctness and Performance

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved: not applicable; no new compression codec is introduced

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable): not applicable; #1534 tracks this experiment stack
- [ ] Documented any new config knobs + defaults: no production knobs
- [x] Called out any format change in PR description (pre-alpha OK): no persistent format change in this PR

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold): experiment-only, not production-wired
- [x] Clear knobs to disable/revert behavior quickly: no production wiring; revert PR if needed
- [x] Observability: counters/logs to verify effectiveness: encoded-part query timings and diagnostics are now emitted in comparison JSON/Markdown
