### PR TITLE
TreeDB: persist vector index snapshots in collection roots

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3046,14 +3046,15 @@ func (c *Collection) DropVectorIndex(name string) (*CollectionMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+	clearedRootNames := []string{collectionVectorIndexRootName(baseMeta.Name, name)}
 	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
-		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, nil)
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, clearedRootNames)
 	})
 	if err != nil {
 		return nil, err
 	}
 	c.meta = newMeta
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, clearedRootNames, []uint64{0})
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
@@ -17443,6 +17444,11 @@ func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, roo
 			return backendRootStoragePolicy(idx.StoragePolicy)
 		}
 	}
+	for _, idx := range meta.VectorIndexes {
+		if rootName == collectionVectorIndexRootName(meta.Name, idx.Name) {
+			return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+		}
+	}
 	return backenddb.OrderedRootStorageDefault, fmt.Errorf("collections: unknown collection root %q for %q", rootName, meta.Name)
 }
 
@@ -18225,6 +18231,9 @@ func collectionRootNames(meta CollectionMeta) []string {
 	for _, idx := range meta.Indexes {
 		out = append(out, collectionSecondaryRootName(meta.Name, idx.Name))
 	}
+	for _, idx := range meta.VectorIndexes {
+		out = append(out, collectionVectorIndexRootName(meta.Name, idx.Name))
+	}
 	return out
 }
 
@@ -18242,6 +18251,10 @@ func collectionIndexStateRootName(collection string) string {
 
 func collectionSecondaryRootName(collection, indexName string) string {
 	return collection + "/index/" + indexName
+}
+
+func collectionVectorIndexRootName(collection, indexName string) string {
+	return collection + "/vector-index/" + indexName
 }
 
 func systemCollectionMetaKey(collection string) string {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -155,9 +155,10 @@ type VectorIndexRecall struct {
 	SearchTraces []VectorIndexTrace
 }
 
-// VectorIndex is an in-memory graph secondary index for collection vector
-// fields. It is intentionally not durable; callers can rebuild it from TreeDB
-// rows on startup and persisted HNSW snapshots can build on this API.
+// VectorIndex is the process-local runtime graph for collection vector fields.
+// Declared collection vector indexes can persist this runtime graph into a
+// TreeDB-managed collection root; ad hoc indexes can still be rebuilt from
+// primary collection rows.
 type VectorIndex struct {
 	collection *Collection
 

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -40,6 +40,8 @@ const (
 	vectorIndexNativeKeyEdgeLayerWidth = 3
 )
 
+var errVectorIndexNotDeclared = errors.New("collections: vector index is not declared in collection metadata")
+
 // VectorIndexLoadStatus reports whether a persisted vector index loaded or why
 // callers should use exact search as the safe fallback.
 type VectorIndexLoadStatus struct {
@@ -64,8 +66,9 @@ type VectorIndexPruneStatus struct {
 // vector indexes use a native TreeDB collection root; ad hoc in-memory indexes
 // keep using the legacy sidecar snapshot path.
 func (idx *VectorIndex) SaveSnapshot() (VectorIndexLoadStatus, error) {
-	if idx.usesNativeSnapshotRoot() {
-		return idx.SaveNativeSnapshot()
+	status, err := idx.SaveNativeSnapshot()
+	if err == nil || !errors.Is(err, errVectorIndexNotDeclared) {
+		return status, err
 	}
 	return idx.saveLegacySnapshot()
 }
@@ -105,7 +108,7 @@ func (idx *VectorIndex) SaveNativeSnapshot() (VectorIndexLoadStatus, error) {
 	}
 	def, ok := findVectorIndex(catalog.meta.VectorIndexes, idx.name)
 	if !ok {
-		return status, fmt.Errorf("collections: vector index %q is not declared in collection metadata", idx.name)
+		return status, fmt.Errorf("%w: %q", errVectorIndexNotDeclared, idx.name)
 	}
 	if reason := idx.validateNativeSnapshotDefinition(def); reason != "" {
 		return status, fmt.Errorf("collections: vector index %q does not match collection metadata: %s", idx.name, reason)
@@ -137,7 +140,9 @@ func (idx *VectorIndex) SaveNativeSnapshot() (VectorIndexLoadStatus, error) {
 	}
 	iter := publishTable.NewIterator(nil, nil)
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
-		BaseRoot:      baseRoot,
+		// Native vector snapshots are full graph images. Publish a replacement
+		// root so keys removed by rebuild/shrink do not survive from prior roots.
+		BaseRoot:      0,
 		Iter:          iter,
 		StoragePolicy: policy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -288,8 +293,12 @@ func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 // with ExactFallbackReason set and no error, so callers can safely use exact
 // search as the correctness fallback.
 func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
-	if c != nil && collectionMetaHasVectorIndex(c.meta, vectorIndexOptionName(opts)) {
-		return c.LoadNativeVectorIndexSnapshot(opts)
+	index, status, err := c.LoadNativeVectorIndexSnapshot(opts)
+	if err != nil {
+		return nil, status, err
+	}
+	if index != nil || status.Loaded || status.ExactFallbackReason != "missing_vector_index_metadata" {
+		return index, status, nil
 	}
 	return c.loadLegacyVectorIndexSnapshot(opts)
 }
@@ -771,15 +780,14 @@ func readVectorIndexNativeSnapshot(snap *backenddb.Snapshot, catalog *collection
 		if err := it.Error(); err != nil {
 			return snapshot, bytesDisk, "", err
 		}
-		keyString := string(key)
-		if keyString == vectorIndexNativeKeyMeta {
+		if bytes.Equal(key, []byte(vectorIndexNativeKeyMeta)) {
 			it.Next()
 			continue
 		}
 		bytesDisk += int64(len(value))
 		switch {
-		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixNode):
-			nodeID, ok := parseVectorIndexNativeOrdinal(keyString[len(vectorIndexNativeKeyPrefixNode):])
+		case bytes.HasPrefix(key, []byte(vectorIndexNativeKeyPrefixNode)):
+			nodeID, ok := parseVectorIndexNativeOrdinal(string(key[len(vectorIndexNativeKeyPrefixNode):]))
 			if !ok {
 				return snapshot, bytesDisk, "invalid_graph_root_key", nil
 			}
@@ -791,19 +799,19 @@ func readVectorIndexNativeSnapshot(snap *backenddb.Snapshot, catalog *collection
 			if nodeID > maxNodeID {
 				maxNodeID = nodeID
 			}
-		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixEdge):
+		case bytes.HasPrefix(key, []byte(vectorIndexNativeKeyPrefixEdge)):
 			var edge vectorIndexPersistEdges
 			if err := json.Unmarshal(value, &edge); err != nil {
 				return snapshot, bytesDisk, "invalid_graph_root_entry", nil
 			}
 			snapshot.Edges = append(snapshot.Edges, edge)
-		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixTomb):
-			nodeID, ok := parseVectorIndexNativeOrdinal(keyString[len(vectorIndexNativeKeyPrefixTomb):])
+		case bytes.HasPrefix(key, []byte(vectorIndexNativeKeyPrefixTomb)):
+			nodeID, ok := parseVectorIndexNativeOrdinal(string(key[len(vectorIndexNativeKeyPrefixTomb):]))
 			if !ok {
 				return snapshot, bytesDisk, "invalid_graph_root_key", nil
 			}
 			snapshot.Tombstones.NodeIDs = append(snapshot.Tombstones.NodeIDs, nodeID)
-		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixDoc):
+		case bytes.HasPrefix(key, []byte(vectorIndexNativeKeyPrefixDoc)):
 			var nodeID int
 			if err := json.Unmarshal(value, &nodeID); err != nil {
 				return snapshot, bytesDisk, "invalid_graph_root_entry", nil
@@ -868,21 +876,6 @@ func parseVectorIndexNativeOrdinal(value string) (int, bool) {
 		return 0, false
 	}
 	return parsed, true
-}
-
-func (idx *VectorIndex) usesNativeSnapshotRoot() bool {
-	if idx == nil || idx.collection == nil {
-		return false
-	}
-	return collectionMetaHasVectorIndex(idx.collection.meta, idx.name)
-}
-
-func collectionMetaHasVectorIndex(meta CollectionMeta, name string) bool {
-	if name == "" {
-		return false
-	}
-	_, ok := findVectorIndex(meta.VectorIndexes, name)
-	return ok
 }
 
 func vectorIndexOptionName(opts VectorIndexOptions) string {

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -12,8 +12,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 const (
@@ -25,6 +30,14 @@ const (
 	vectorIndexEdgesFile      = "edges.json"
 	vectorIndexTombstonesFile = "tombstones.json"
 	vectorIndexDocMapFile     = "docmap.json"
+
+	vectorIndexNativeKeyMeta           = "meta"
+	vectorIndexNativeKeyPrefixNode     = "node/"
+	vectorIndexNativeKeyPrefixEdge     = "edge/"
+	vectorIndexNativeKeyPrefixTomb     = "tomb/"
+	vectorIndexNativeKeyPrefixDoc      = "doc/"
+	vectorIndexNativeKeyOrdinalWidth   = 20
+	vectorIndexNativeKeyEdgeLayerWidth = 3
 )
 
 // VectorIndexLoadStatus reports whether a persisted vector index loaded or why
@@ -33,6 +46,8 @@ type VectorIndexLoadStatus struct {
 	Loaded              bool
 	ExactFallbackReason string
 	ManifestPath        string
+	RootName            string
+	RootID              uint64
 	Epoch               uint64
 	BytesDisk           int64
 }
@@ -45,9 +60,109 @@ type VectorIndexPruneStatus struct {
 	RemovedBytes  int64
 }
 
-// SaveSnapshot persists the current in-memory vector index as an immutable
-// epoch and atomically publishes a manifest that points at it.
+// SaveSnapshot persists the current in-memory vector index. Declared collection
+// vector indexes use a native TreeDB collection root; ad hoc in-memory indexes
+// keep using the legacy sidecar snapshot path.
 func (idx *VectorIndex) SaveSnapshot() (VectorIndexLoadStatus, error) {
+	if idx.usesNativeSnapshotRoot() {
+		return idx.SaveNativeSnapshot()
+	}
+	return idx.saveLegacySnapshot()
+}
+
+// SaveNativeSnapshot persists the current in-memory vector index as ordinary
+// TreeDB collection-root content and publishes that root through the collection
+// root descriptor system state.
+func (idx *VectorIndex) SaveNativeSnapshot() (VectorIndexLoadStatus, error) {
+	status := VectorIndexLoadStatus{}
+	if idx == nil {
+		return status, errors.New("collections: vector index is nil")
+	}
+	c := idx.collection
+	if c == nil {
+		return status, errCollectionNil
+	}
+	if c.db == nil {
+		return status, errCollectionDBNil
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
+		return status, err
+	}
+
+	pin := c.db.AcquireSnapshot()
+	if pin == nil {
+		return status, backenddb.ErrClosed
+	}
+	defer func() { _ = pin.Close() }()
+	catalog, err := loadCollectionCatalog(pin, c.meta.Name)
+	if err != nil {
+		return status, err
+	}
+	if catalog == nil {
+		return status, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, idx.name)
+	if !ok {
+		return status, fmt.Errorf("collections: vector index %q is not declared in collection metadata", idx.name)
+	}
+	if reason := idx.validateNativeSnapshotDefinition(def); reason != "" {
+		return status, fmt.Errorf("collections: vector index %q does not match collection metadata: %s", idx.name, reason)
+	}
+	rootName := collectionVectorIndexRootName(catalog.meta.Name, idx.name)
+	status.RootName = rootName
+	baseRoot := catalog.rootID(rootName)
+	baseRootIDs := map[string]uint64{rootName: baseRoot}
+	baseSystemRoot := snapshotSystemRoot(pin)
+	baseCommitSeq := snapshotCommitSeq(pin)
+	policy, err := collectionRootStoragePolicyForDB(c.db, catalog.meta, rootName)
+	if err != nil {
+		return status, err
+	}
+
+	snapshot, snapshotSeq := idx.persistSnapshot()
+	table, bytesDisk, err := buildVectorIndexNativeSnapshotTable(snapshot)
+	if err != nil {
+		return status, err
+	}
+	table.Freeze()
+	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	if err != nil {
+		resetCollectionRunTable(table)
+		return status, err
+	}
+	if pointerized {
+		defer resetCollectionRunTable(publishTable)
+	}
+	iter := publishTable.NewIterator(nil, nil)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRoot,
+		Iter:          iter,
+		StoragePolicy: policy,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIteratorForMeta(catalog.meta, baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+	})
+	_ = iter.Close()
+	resetCollectionRunTable(table)
+	if err != nil {
+		return status, err
+	}
+	if len(rootIDs) != 1 {
+		return status, unexpectedOrderedRootCountError(catalog.meta.Name, 1, len(rootIDs))
+	}
+	status.Loaded = true
+	status.RootID = rootIDs[0]
+	status.Epoch = rootIDs[0]
+	status.BytesDisk = bytesDisk
+	idx.recordPersistedSnapshot(status.Epoch, bytesDisk, snapshotSeq)
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, []string{rootName}, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return status, nil
+}
+
+func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 	status := VectorIndexLoadStatus{}
 	if idx == nil {
 		return status, errors.New("collections: vector index is nil")
@@ -173,6 +288,74 @@ func (idx *VectorIndex) SaveSnapshot() (VectorIndexLoadStatus, error) {
 // with ExactFallbackReason set and no error, so callers can safely use exact
 // search as the correctness fallback.
 func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
+	if c != nil && collectionMetaHasVectorIndex(c.meta, vectorIndexOptionName(opts)) {
+		return c.LoadNativeVectorIndexSnapshot(opts)
+	}
+	return c.loadLegacyVectorIndexSnapshot(opts)
+}
+
+// LoadNativeVectorIndexSnapshot loads a declared vector index from its TreeDB
+// collection root. Missing or invalid graph roots return a non-loaded status so
+// callers can safely fall back to exact search.
+func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
+	status := VectorIndexLoadStatus{}
+	if c == nil {
+		return nil, status, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, status, errCollectionDBNil
+	}
+	name := vectorIndexOptionName(opts)
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, status, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		return nil, status, err
+	}
+	if catalog == nil {
+		return nil, status, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
+	if !ok {
+		status.ExactFallbackReason = "missing_vector_index_metadata"
+		return nil, status, nil
+	}
+	rootName := collectionVectorIndexRootName(catalog.meta.Name, def.Name)
+	status.RootName = rootName
+	rootID := catalog.rootID(rootName)
+	if rootID == 0 && len(catalog.overlayRootIDs(rootName)) == 0 {
+		status.ExactFallbackReason = "missing_graph_root"
+		return nil, status, nil
+	}
+	snapshot, bytesDisk, reason, err := readVectorIndexNativeSnapshot(snap, catalog, rootName)
+	if err != nil {
+		return nil, status, err
+	}
+	if reason != "" {
+		status.ExactFallbackReason = reason
+		return nil, status, nil
+	}
+	index, err := newVectorIndex(c, vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		return nil, status, err
+	}
+	if reason := index.loadPersistSnapshot(snapshot); reason != "" {
+		status.ExactFallbackReason = reason
+		return nil, status, nil
+	}
+	status.Loaded = true
+	status.RootID = rootID
+	status.Epoch = rootID
+	status.BytesDisk = bytesDisk
+	index.recordLoadedSnapshot(status.Epoch, bytesDisk)
+	c.RegisterVectorIndex(index)
+	return index, status, nil
+}
+
+func (c *Collection) loadLegacyVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
 	status := VectorIndexLoadStatus{}
 	if c == nil {
 		return nil, status, errCollectionNil
@@ -513,6 +696,235 @@ func vectorIndexSnapshotBytes(manifestData []byte, entries []vectorIndexManifest
 		total += entry.Size
 	}
 	return total
+}
+
+func buildVectorIndexNativeSnapshotTable(snapshot vectorIndexPersistSnapshot) (memtable.Table, int64, error) {
+	entryCount := 1 + len(snapshot.Nodes) + len(snapshot.Edges) + len(snapshot.Tombstones.NodeIDs) + len(snapshot.DocMap.Current)
+	table := newCollectionRunTable(entryCount)
+	var bytesDisk int64
+	add := func(key []byte, payload any) error {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = append(data, '\n')
+		bytesDisk += int64(len(data))
+		table.SetSteal(key, data)
+		return nil
+	}
+	if err := add([]byte(vectorIndexNativeKeyMeta), snapshot.Meta); err != nil {
+		return nil, 0, err
+	}
+	for i := range snapshot.Nodes {
+		if err := add(vectorIndexNativeNodeKey(i), snapshot.Nodes[i]); err != nil {
+			return nil, 0, err
+		}
+	}
+	for i := range snapshot.Edges {
+		edge := snapshot.Edges[i]
+		if err := add(vectorIndexNativeEdgeKey(edge.NodeID, edge.Layer), edge); err != nil {
+			return nil, 0, err
+		}
+	}
+	for _, nodeID := range snapshot.Tombstones.NodeIDs {
+		if err := add(vectorIndexNativeTombstoneKey(nodeID), nodeID); err != nil {
+			return nil, 0, err
+		}
+	}
+	for docID, nodeID := range snapshot.DocMap.Current {
+		if err := add(vectorIndexNativeDocKey(docID), nodeID); err != nil {
+			return nil, 0, err
+		}
+	}
+	return table, bytesDisk, nil
+}
+
+func readVectorIndexNativeSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string) (vectorIndexPersistSnapshot, int64, string, error) {
+	var snapshot vectorIndexPersistSnapshot
+	var bytesDisk int64
+	rawMeta, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, []byte(vectorIndexNativeKeyMeta), nil)
+	if err != nil {
+		return snapshot, 0, "", err
+	}
+	if !ok {
+		return snapshot, 0, "missing_graph_root_entry", nil
+	}
+	bytesDisk += int64(len(rawMeta))
+	if err := json.Unmarshal(rawMeta, &snapshot.Meta); err != nil {
+		return snapshot, bytesDisk, "invalid_graph_root_entry", nil
+	}
+
+	nodes := make(map[int]vectorIndexPersistNode)
+	maxNodeID := -1
+	snapshot.DocMap.Current = make(map[string]int)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if err != nil {
+		return snapshot, bytesDisk, "", err
+	}
+	if it == nil {
+		return snapshot, bytesDisk, "missing_graph_root", nil
+	}
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		key := it.KeyCopy(nil)
+		value := it.ValueCopy(nil)
+		if err := it.Error(); err != nil {
+			return snapshot, bytesDisk, "", err
+		}
+		keyString := string(key)
+		if keyString == vectorIndexNativeKeyMeta {
+			it.Next()
+			continue
+		}
+		bytesDisk += int64(len(value))
+		switch {
+		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixNode):
+			nodeID, ok := parseVectorIndexNativeOrdinal(keyString[len(vectorIndexNativeKeyPrefixNode):])
+			if !ok {
+				return snapshot, bytesDisk, "invalid_graph_root_key", nil
+			}
+			var node vectorIndexPersistNode
+			if err := json.Unmarshal(value, &node); err != nil {
+				return snapshot, bytesDisk, "invalid_graph_root_entry", nil
+			}
+			nodes[nodeID] = node
+			if nodeID > maxNodeID {
+				maxNodeID = nodeID
+			}
+		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixEdge):
+			var edge vectorIndexPersistEdges
+			if err := json.Unmarshal(value, &edge); err != nil {
+				return snapshot, bytesDisk, "invalid_graph_root_entry", nil
+			}
+			snapshot.Edges = append(snapshot.Edges, edge)
+		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixTomb):
+			nodeID, ok := parseVectorIndexNativeOrdinal(keyString[len(vectorIndexNativeKeyPrefixTomb):])
+			if !ok {
+				return snapshot, bytesDisk, "invalid_graph_root_key", nil
+			}
+			snapshot.Tombstones.NodeIDs = append(snapshot.Tombstones.NodeIDs, nodeID)
+		case strings.HasPrefix(keyString, vectorIndexNativeKeyPrefixDoc):
+			var nodeID int
+			if err := json.Unmarshal(value, &nodeID); err != nil {
+				return snapshot, bytesDisk, "invalid_graph_root_entry", nil
+			}
+			snapshot.DocMap.Current[string(key[len(vectorIndexNativeKeyPrefixDoc):])] = nodeID
+		default:
+			return snapshot, bytesDisk, "invalid_graph_root_key", nil
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return snapshot, bytesDisk, "", err
+	}
+	if maxNodeID < 0 {
+		return snapshot, bytesDisk, "empty_index", nil
+	}
+	snapshot.Nodes = make([]vectorIndexPersistNode, maxNodeID+1)
+	for nodeID := 0; nodeID <= maxNodeID; nodeID++ {
+		node, ok := nodes[nodeID]
+		if !ok {
+			return snapshot, bytesDisk, "missing_graph_root_entry", nil
+		}
+		snapshot.Nodes[nodeID] = node
+	}
+	sort.Ints(snapshot.Tombstones.NodeIDs)
+	return snapshot, bytesDisk, "", nil
+}
+
+func vectorIndexNativeNodeKey(nodeID int) []byte {
+	return []byte(vectorIndexNativeKeyPrefixNode + formatVectorIndexNativeOrdinal(nodeID))
+}
+
+func vectorIndexNativeEdgeKey(nodeID, layer int) []byte {
+	return []byte(vectorIndexNativeKeyPrefixEdge + formatVectorIndexNativeOrdinal(nodeID) + "/" + formatVectorIndexNativeEdgeLayer(layer))
+}
+
+func vectorIndexNativeTombstoneKey(nodeID int) []byte {
+	return []byte(vectorIndexNativeKeyPrefixTomb + formatVectorIndexNativeOrdinal(nodeID))
+}
+
+func vectorIndexNativeDocKey(docID string) []byte {
+	key := make([]byte, 0, len(vectorIndexNativeKeyPrefixDoc)+len(docID))
+	key = append(key, vectorIndexNativeKeyPrefixDoc...)
+	key = append(key, docID...)
+	return key
+}
+
+func formatVectorIndexNativeOrdinal(value int) string {
+	return fmt.Sprintf("%0*d", vectorIndexNativeKeyOrdinalWidth, value)
+}
+
+func formatVectorIndexNativeEdgeLayer(value int) string {
+	return fmt.Sprintf("%0*d", vectorIndexNativeKeyEdgeLayerWidth, value)
+}
+
+func parseVectorIndexNativeOrdinal(value string) (int, bool) {
+	if len(value) != vectorIndexNativeKeyOrdinalWidth {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func (idx *VectorIndex) usesNativeSnapshotRoot() bool {
+	if idx == nil || idx.collection == nil {
+		return false
+	}
+	return collectionMetaHasVectorIndex(idx.collection.meta, idx.name)
+}
+
+func collectionMetaHasVectorIndex(meta CollectionMeta, name string) bool {
+	if name == "" {
+		return false
+	}
+	_, ok := findVectorIndex(meta.VectorIndexes, name)
+	return ok
+}
+
+func vectorIndexOptionName(opts VectorIndexOptions) string {
+	if opts.Name != "" {
+		return opts.Name
+	}
+	return vectorIndexDefaultName(opts.Field)
+}
+
+func vectorIndexOptionsFromDefinition(def VectorIndexDefinition) VectorIndexOptions {
+	return VectorIndexOptions{
+		Name:           def.Name,
+		Field:          def.Field,
+		Metric:         def.Metric,
+		Dimensions:     def.Dimensions,
+		M:              def.M,
+		EfConstruction: def.EfConstruction,
+		EfSearch:       def.EfSearch,
+		Encoding:       def.Encoding,
+	}
+}
+
+func (idx *VectorIndex) validateNativeSnapshotDefinition(def VectorIndexDefinition) string {
+	if idx == nil {
+		return "nil_index"
+	}
+	if def.Field != idx.field {
+		return "field_mismatch"
+	}
+	if def.Metric != idx.metric {
+		return "metric_mismatch"
+	}
+	if def.Encoding != idx.encoding {
+		return "encoding_mismatch"
+	}
+	if def.Dimensions != idx.dimensions {
+		return "dimension_mismatch"
+	}
+	if def.M != idx.m || def.EfConstruction != idx.efConstruction || def.EfSearch != idx.efSearch {
+		return "hnsw_param_mismatch"
+	}
+	return ""
 }
 
 func (idx *VectorIndex) recordPersistedSnapshot(epoch uint64, bytesDisk int64, snapshotSeq uint64) {

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
 func TestCollectionVectorIndexSnapshotReopenSearch(t *testing.T) {
@@ -96,6 +97,201 @@ func TestCollectionVectorIndexSnapshotReopenSearch(t *testing.T) {
 	}
 	if got, want := loaded.Stats().MaxLevel, index.Stats().MaxLevel; got != want {
 		t.Fatalf("loaded max level=%d want %d", got, want)
+	}
+}
+
+func TestCollectionVectorIndexNativeRootSnapshotReopenSearch(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     VectorMetricCosine,
+			Dimensions: 2,
+			M:          4,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+			[]byte(`{"embedding":[0.8,0.2]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, Dimensions: 2, M: 4})
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save native snapshot: %v", err)
+	}
+	if !saveStatus.Loaded || saveStatus.RootName != collectionVectorIndexRootName("docs", "embedding") || saveStatus.RootID == 0 || saveStatus.ManifestPath != "" {
+		t.Fatalf("unexpected native save status: %+v", saveStatus)
+	}
+	if saveStatus.BytesDisk <= 0 {
+		t.Fatalf("native save status missing bytes: %+v", saveStatus)
+	}
+	if _, err := os.Stat(filepath.Join(dir, vectorIndexDirName)); !os.IsNotExist(err) {
+		t.Fatalf("native snapshot created sidecar dir err=%v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection after reopen: %v", err)
+	}
+	loaded, loadStatus, err := reopenedCol.LoadVectorIndexSnapshot(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, Dimensions: 2})
+	if err != nil {
+		t.Fatalf("load native vector index snapshot: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.ExactFallbackReason != "" || loadStatus.RootID != saveStatus.RootID {
+		t.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
+	}
+	results, trace, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search native-loaded index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "c")
+	if trace.RerankCount == 0 {
+		t.Fatalf("native-loaded index did not rerank canonical rows: %+v", trace)
+	}
+	if _, err := os.Stat(filepath.Join(dir, vectorIndexDirName)); !os.IsNotExist(err) {
+		t.Fatalf("native load created sidecar dir err=%v", err)
+	}
+}
+
+func TestCollectionVectorIndexNativeRootMissingFallsBack(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     VectorMetricCosine,
+			Dimensions: 2,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	loaded, status, err := col.LoadVectorIndexSnapshot(VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine, Dimensions: 2})
+	if err != nil {
+		t.Fatalf("load missing native snapshot: %v", err)
+	}
+	if loaded != nil || status.Loaded || status.ExactFallbackReason != "missing_graph_root" || status.RootName != collectionVectorIndexRootName("docs", "embedding") {
+		t.Fatalf("missing native snapshot status loaded=%v status=%+v", loaded != nil, status)
+	}
+}
+
+func TestCollectionVectorIndexNativeRootIncompleteFallsBack(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	def := VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          4,
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save native snapshot: %v", err)
+	}
+	rootName := saveStatus.RootName
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("nil snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	baseRoot := catalog.rootID(rootName)
+	baseRootIDs := map[string]uint64{rootName: baseRoot}
+	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
+	table := newCollectionRunTable(1)
+	table.DeleteSteal(vectorIndexNativeNodeKey(0))
+	table.Freeze()
+	iter := table.NewIterator(nil, nil)
+	_, _, err = d.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRoot,
+		Iter:          iter,
+		StoragePolicy: backenddb.OrderedRootStorageDefault,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return col.buildRootDescriptorSystemDeltaIteratorForMeta(catalog.meta, baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+	})
+	_ = iter.Close()
+	resetCollectionRunTable(table)
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("publish incomplete graph root: %v", err)
+	}
+	loaded, status, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("load incomplete native snapshot: %v", err)
+	}
+	if loaded != nil || status.Loaded || status.ExactFallbackReason != "missing_graph_root_entry" {
+		t.Fatalf("incomplete native snapshot status loaded=%v status=%+v", loaded != nil, status)
 	}
 }
 

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -295,6 +295,139 @@ func TestCollectionVectorIndexNativeRootIncompleteFallsBack(t *testing.T) {
 	}
 }
 
+func TestCollectionVectorIndexNativeRootSaveReplacesPriorSnapshot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	def := VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          4,
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+			[]byte(`{"embedding":[0.7,0.3]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	if _, err := index.SaveSnapshot(); err != nil {
+		t.Fatalf("save first native snapshot: %v", err)
+	}
+	if err := col.Delete([]byte("c")); err != nil {
+		t.Fatalf("delete c: %v", err)
+	}
+	reduced, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("rebuild reduced vector index: %v", err)
+	}
+	secondStatus, err := reduced.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save replacement native snapshot: %v", err)
+	}
+	if !secondStatus.Loaded || secondStatus.RootID == 0 {
+		t.Fatalf("unexpected replacement save status: %+v", secondStatus)
+	}
+	loaded, status, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("load replacement native snapshot: %v", err)
+	}
+	if loaded == nil || !status.Loaded {
+		t.Fatalf("unexpected replacement load status loaded=%v status=%+v", loaded != nil, status)
+	}
+	if stats := loaded.Stats(); stats.LiveDocs != 2 || stats.Nodes != 2 {
+		t.Fatalf("replacement load retained stale graph entries: %+v", stats)
+	}
+	results, _, err := loaded.Search([]float32{0.7, 0.3}, VectorIndexSearchOptions{TopK: 3, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search replacement native snapshot: %v", err)
+	}
+	for _, result := range results {
+		if string(result.DocumentID) == "c" {
+			t.Fatalf("replacement search returned deleted document: %+v", results)
+		}
+	}
+}
+
+func TestCollectionVectorIndexNativeRootUsesCurrentCatalogForStaleHandles(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	staleCol, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open stale collection handle: %v", err)
+	}
+	freshCol, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open fresh collection handle: %v", err)
+	}
+	def := VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          4,
+	}
+	if _, err := freshCol.CreateVectorIndex(def); err != nil {
+		t.Fatalf("create vector index metadata: %v", err)
+	}
+	if len(staleCol.Meta().VectorIndexes) != 0 {
+		t.Fatalf("stale handle unexpectedly saw vector metadata: %+v", staleCol.Meta())
+	}
+	if _, err := staleCol.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert through stale handle: %v", err)
+	}
+	index, err := staleCol.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("build vector index through stale handle: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		t.Fatalf("save through stale handle: %v", err)
+	}
+	if !saveStatus.Loaded || saveStatus.ManifestPath != "" || saveStatus.RootID == 0 {
+		t.Fatalf("stale handle did not use native root save: %+v", saveStatus)
+	}
+	loaded, loadStatus, err := staleCol.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("load through stale handle: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID != saveStatus.RootID {
+		t.Fatalf("stale handle did not use native root load loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
+	}
+}
+
 func TestCollectionVectorIndexSnapshotLoadsLegacyEdgesWithoutDistances(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -149,6 +149,138 @@ func BenchmarkCollectionVectorIndexBuildInt8(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	dir := b.TempDir()
+	def := VectorIndexDefinition{
+		Name:       "embedding_native",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: dims,
+		M:          16,
+	}
+	d, col := openVectorBenchmarkCollectionWithVectorIndex(b, dir, docs, dims, def)
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		b.Fatalf("build native vector index: %v", err)
+	}
+	status, err := index.SaveSnapshot()
+	if err != nil {
+		_ = d.Close()
+		b.Fatalf("save native vector index: %v", err)
+	}
+	if !status.Loaded || status.RootID == 0 {
+		_ = d.Close()
+		b.Fatalf("unexpected native save status: %+v", status)
+	}
+	if err := d.Close(); err != nil {
+		b.Fatalf("close setup db: %v", err)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := backenddb.Open(backenddb.Options{Dir: dir})
+		if err != nil {
+			b.Fatalf("reopen db: %v", err)
+		}
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("open collection: %v", err)
+		}
+		loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("load native vector index: %v", err)
+		}
+		if loaded == nil || !loadStatus.Loaded || loadStatus.RootID != status.RootID {
+			_ = d.Close()
+			b.Fatalf("unexpected native load status loaded=%v status=%+v", loaded != nil, loadStatus)
+		}
+		if stats := loaded.Stats(); stats.LiveDocs != docs {
+			_ = d.Close()
+			b.Fatalf("loaded live docs=%d want %d", stats.LiveDocs, docs)
+		}
+		if err := d.Close(); err != nil {
+			b.Fatalf("close db: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	dir := b.TempDir()
+	def := VectorIndexDefinition{
+		Name:       "embedding_graph_only",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: dims,
+		M:          16,
+	}
+	d, col := openVectorBenchmarkCollectionWithVectorIndex(b, dir, docs, dims, def)
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		b.Fatalf("build native vector index: %v", err)
+	}
+	status, err := index.SaveSnapshot()
+	if err != nil {
+		_ = d.Close()
+		b.Fatalf("save native vector index: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		b.Fatalf("close setup db: %v", err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		b.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	col, err = NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		b.Fatalf("load native vector index: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded {
+		b.Fatalf("unexpected native load status loaded=%v status=%+v", loaded != nil, loadStatus)
+	}
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+	if err != nil {
+		b.Fatalf("warm native graph-only search: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatal("warm native graph-only search returned no results")
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			b.Fatalf("native graph-only vector search: %v", err)
+		}
+		if len(results) == 0 {
+			b.Fatal("native graph-only vector search returned no results")
+		}
+	}
+}
+
 func BenchmarkCollectionVectorIndexIncrementalWrite(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
@@ -604,6 +736,31 @@ func openVectorBenchmarkCollectionWithIndexes(tb testing.TB, docs, dims int, ind
 			_ = d.Close()
 			tb.Fatalf("open collection: %v", err)
 		}
+	}
+	ids, documents := vectorBenchmarkWriteBatch(docs, dims)
+	vectorBenchmarkInsertBatches(tb, col, ids, documents, 512)
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("flush benchmark collection: %v", err)
+	}
+	return d, col
+}
+
+func openVectorBenchmarkCollectionWithVectorIndex(tb testing.TB, dir string, docs, dims int, def VectorIndexDefinition) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("open collection: %v", err)
 	}
 	ids, documents := vectorBenchmarkWriteBatch(docs, dims)
 	vectorBenchmarkInsertBatches(tb, col, ids, documents, 512)


### PR DESCRIPTION
## Summary

PR 2 for #1540, stacked on #1543.

This moves declared collection vector indexes onto TreeDB-managed collection roots for persisted HNSW graph snapshots:

- declared `CollectionMeta.VectorIndexes` now get a `collection/vector-index/<name>` root descriptor;
- `VectorIndex.SaveSnapshot` uses native collection-root persistence when the index is declared in collection metadata;
- `Collection.LoadVectorIndexSnapshot` loads declared vector indexes from the native root and keeps the legacy sidecar path only for ad hoc non-declared indexes;
- native root layout stores ordinary per-meta, per-node, per-edge, per-tombstone, and per-docmap records to avoid large leaf values;
- missing/incomplete native graph roots return exact-fallback statuses instead of returning wrong ANN results;
- dropping vector index metadata clears the native vector root descriptor.

Base/head used for local validation:

- base: `cd381fd6095b72468784e23dccd0338e32a11741` (`codex/native-vector-index-metadata`)
- head: `ec0f6db5a2b2ba7811fa41d8a2eb008c62cf9030`

## Correctness validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionVectorIndexNativeRoot|TestCollectionVectorIndexSnapshotReopenSearch'
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench
GOWORK=off go test ./...
git diff --check
```

All passed locally.

Coverage added:

- native graph root save/load survives close/reopen and search uses the loaded ANN graph;
- declared vector index with no graph root falls back with `missing_graph_root`;
- incomplete graph root falls back with `missing_graph_root_entry`;
- legacy sidecar snapshot tests continue to pass for non-declared ad hoc indexes.

## Benchmarks and profiles

Artifacts are in:

```text
/tmp/gomap_1540_pr2_perf_20260515_003223
```

Commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionVectorIndexBuild|BenchmarkCollectionVectorIndexNativeRootLoad)$' \
  -benchmem -benchtime=1x -count=3

TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=64 GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionVectorIndexBuild|BenchmarkCollectionVectorIndexNativeRootLoad)$' \
  -benchmem -benchtime=1x -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionVectorIndexGraphOnlySearch|BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch|BenchmarkCollectionUpdate_CallbackVsUpdateBatchJSON_(NoIndex|OneIndex)_Size1)$' \
  -benchmem -benchtime=100x -count=5

TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=64 GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch$' \
  -benchmem -benchtime=100x -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionVectorIndexNativeRootLoad$' \
  -benchmem -benchtime=1x -count=1 \
  -cpuprofile native_root_load_cpu.pprof \
  -memprofile native_root_load_mem.pprof
```

Key results:

| Benchmark | Result |
| --- | ---: |
| 10k build | ~1.14-1.17s/op |
| 10k native load | ~253-257ms/op |
| 100k build | 20.402s/op |
| 100k native load | 2.524s/op |
| 100k load speedup vs rebuild | ~8.1x faster |
| 100k native loaded graph-only search | 120.7us/op, 754 B/op, 11 allocs/op |
| 10k loaded graph-only search | 754 B/op, 11 allocs/op |
| 10k in-memory graph-only search | 754 B/op, 11 allocs/op |

Profile interpretation:

- native load profile files: `native_root_load_cpu.pprof`, `native_root_load_mem.pprof`;
- load still spends visible allocation in TreeDB iterator value copies, JSON decode, and runtime graph materialization;
- graph build/setup dominates the one-shot pprof capture because Go benchmark CPU/alloc profiles include setup outside `ResetTimer`, so the timed benchmark numbers above are the source of truth for load-vs-build throughput;
- loaded graph-only search has the same measured steady allocs/op as the in-memory graph-only benchmark at 10k docs.

Performance gate statement:

- 100k persisted graph load is >5x faster than rebuild: pass (~8.1x).
- Loaded graph-only steady allocation delta vs in-memory graph-only: pass (same 11 allocs/op in this benchmark harness).
- Scalar update smoke did not show new alloc sites/counts from this PR; changed code is inactive for non-vector metadata.
- Remaining known optimization target: native load allocs are high because this PR uses JSON root records for straightforward correctness. This is acceptable for PR2 because load is still well over the required 100k speedup threshold; a later hardening PR can switch record values to compact binary if profiles justify it.
