### PR TITLE
experiments/colgranule: fuse dense jsonbench kernels

### DIFF
--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -39,20 +40,30 @@ type JSONBenchPartQueryDiagnostics struct {
 }
 
 type jsonBenchPartQueryScratch struct {
-	arena     AggregateArena
-	scanner   *ColumnPartScanner
-	projected map[string][]int64
-	granules  []EncodedGranule
-	counts    map[int64]int64
-	unique    map[int64]map[int64]struct{}
-	events    []int64
-	first     map[int64]int64
-	spans     map[int64]jsonBenchPartSpan
-	q4Pairs   []jsonBenchPartTimePair
-	q5Pairs   []jsonBenchPartSpanPair
+	arena       AggregateArena
+	scanner     *ColumnPartScanner
+	projected   map[string][]int64
+	granules    []EncodedGranule
+	codeReaders [4]GranuleReader
+	timeReader  GranuleReader
+	q2Counts    []uint64
+	q2Seen      []uint64
+	q3Counts    []uint64
+	counts      map[int64]int64
+	unique      map[int64]map[int64]struct{}
+	events      []int64
+	first       map[int64]int64
+	spans       map[int64]jsonBenchPartSpan
+	q4Pairs     []jsonBenchPartTimePair
+	q5Pairs     []jsonBenchPartSpanPair
 }
 
 type jsonBenchPartQueryRunner func(*ColumnPart, queryCodeSet, *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error)
+
+var (
+	jsonBenchPartQ2Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
+	jsonBenchPartQ3Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "time_us"}
+)
 
 func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnPart, error) {
 	opts, err := JSONBenchColumnPartOptions(ds, rowsPerGranule)
@@ -217,66 +228,165 @@ func (s *jsonBenchPartQueryScratch) columnGranules(part *ColumnPart, column stri
 }
 
 func runJSONBenchPartQ2(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
-	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
-	scan, err := scanPartProjection(part, scratch, projection)
+	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	kind := scan.Columns["kind_code"]
-	operation := scan.Columns["commit_operation_code"]
-	collection := scan.Columns["commit_collection_code"]
-	did := scan.Columns["did_code"]
-	counts := scratch.resetCounts()
-	unique, events := scratch.resetUnique()
-	for i := range collection {
-		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate {
-			continue
-		}
-		event := collection[i]
-		if counts[event] == 0 {
-			events = append(events, event)
-		}
-		counts[event]++
-		if unique[event] == nil {
-			unique[event] = make(map[int64]struct{})
-		}
-		unique[event][did[i]] = struct{}{}
+	operationBlocks, err := lowCardinalityBlocks(part, "commit_operation_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	scratch.events = events
-	digest := digestCounts(counts)
-	sort.Slice(events, func(i, j int) bool { return events[i] < events[j] })
-	for _, event := range events {
-		users := unique[event]
-		digest = digestMix(digest, uint64(event), uint64(len(users)))
+	collectionBlocks, err := lowCardinalityBlocks(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_group_count_distinct")
-	return len(counts), digest, diagnostics, nil
+	didBlocks, err := lowCardinalityBlocks(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, didBlocks); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	collectionCardinality, err := partCodeCardinality(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	counts, seen, didWords, err := scratch.resetQ2Dense(collectionCardinality, didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	for blockIndex := range kindBlocks {
+		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		didHeader, err := scratch.codeHeader(3, didBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		rows := kindBlocks[blockIndex].Descriptor.RowCount
+		for row := 0; row < rows; row++ {
+			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			if kind >= kindHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
+			}
+			if int64(kind) != codes.kindCommit {
+				continue
+			}
+			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			if operation >= operationHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
+			}
+			if int64(operation) != codes.operationCreate {
+				continue
+			}
+			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			if event >= collectionHeader.cardinality || event >= collectionCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionCardinality)
+			}
+			did := readUint32Code(didHeader.data, didHeader.width, row)
+			if did >= didHeader.cardinality || did >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: did code %d outside cardinality %d", did, didCardinality)
+			}
+			counts[event]++
+			seen[int(event)*didWords+int(did/64)] |= uint64(1) << uint(did%64)
+		}
+	}
+	rows, digest := digestDenseQ2(counts, seen, didWords)
+	diagnostics := partColumnDiagnostics(part, jsonBenchPartQ2Columns, "fused_dense_group_count_distinct_codes")
+	return rows, digest, diagnostics, nil
 }
 
 func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
-	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "time_us"}
-	scan, err := scanPartProjection(part, scratch, projection)
+	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	kind := scan.Columns["kind_code"]
-	operation := scan.Columns["commit_operation_code"]
-	collection := scan.Columns["commit_collection_code"]
-	timeUS := scan.Columns["time_us"]
-	counts := scratch.resetCounts()
-	for i := range collection {
-		event := collection[i]
-		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate {
-			continue
-		}
-		if event != codes.collectionPost && event != codes.collectionRepost && event != codes.collectionLike {
-			continue
-		}
-		hour := unixMicroHour(timeUS[i])
-		counts[event*100+hour]++
+	operationBlocks, err := lowCardinalityBlocks(part, "commit_operation_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_group_count_hour")
-	return len(counts), digestCounts(counts), diagnostics, nil
+	collectionBlocks, err := lowCardinalityBlocks(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	timeBlocks, err := int64Blocks(part, "time_us")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, timeBlocks); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	collectionCardinality, err := partCodeCardinality(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	counts, err := scratch.resetQ3Dense(collectionCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	for blockIndex := range kindBlocks {
+		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		timeValues, err := scratch.timeReader.DecodeInt64(timeBlocks[blockIndex].Granule)
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		rows := kindBlocks[blockIndex].Descriptor.RowCount
+		if len(timeValues) != rows {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q3 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
+		}
+		for row := 0; row < rows; row++ {
+			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			if kind >= kindHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
+			}
+			if int64(kind) != codes.kindCommit {
+				continue
+			}
+			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			if operation >= operationHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
+			}
+			if int64(operation) != codes.operationCreate {
+				continue
+			}
+			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			if event >= collectionHeader.cardinality || event >= collectionCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionCardinality)
+			}
+			if int64(event) != codes.collectionPost && int64(event) != codes.collectionRepost && int64(event) != codes.collectionLike {
+				continue
+			}
+			hour := unixMicroHour(timeValues[row])
+			counts[int(event)*24+int(hour)]++
+		}
+	}
+	rows, digest := digestDenseQ3(counts)
+	diagnostics := partColumnDiagnostics(part, jsonBenchPartQ3Columns, "fused_dense_group_count_hour_codes")
+	return rows, digest, diagnostics, nil
 }
 
 func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
@@ -387,6 +497,135 @@ type jsonBenchPartTimePair struct {
 type jsonBenchPartSpanPair struct {
 	user int64
 	span int64
+}
+
+func lowCardinalityBlocks(part *ColumnPart, column string) ([]ColumnBlock, error) {
+	return typedColumnBlocks(part, column, ColumnTypeLowCardinalityCode)
+}
+
+func int64Blocks(part *ColumnPart, column string) ([]ColumnBlock, error) {
+	return typedColumnBlocks(part, column, ColumnTypeInt64)
+}
+
+func typedColumnBlocks(part *ColumnPart, column string, columnType ColumnType) ([]ColumnBlock, error) {
+	c, ok := part.Columns[column]
+	if !ok {
+		return nil, fmt.Errorf("colgranule: missing column %s", column)
+	}
+	if c.Definition.Type != columnType {
+		return nil, fmt.Errorf("colgranule: column %s type=%s want %s", column, c.Definition.Type, columnType)
+	}
+	if len(c.Blocks) == 0 {
+		return nil, fmt.Errorf("colgranule: column %s has no blocks", column)
+	}
+	return c.Blocks, nil
+}
+
+func validateAlignedBlocks(reference []ColumnBlock, others ...[]ColumnBlock) error {
+	for _, blocks := range others {
+		if len(blocks) != len(reference) {
+			return fmt.Errorf("colgranule: aligned kernel block count=%d want %d", len(blocks), len(reference))
+		}
+		for i := range reference {
+			refDesc := reference[i].Descriptor
+			desc := blocks[i].Descriptor
+			if desc.FirstRow != refDesc.FirstRow || desc.RowCount != refDesc.RowCount {
+				return fmt.Errorf("colgranule: aligned kernel block %d rows=%d+%d want %d+%d", i, desc.FirstRow, desc.RowCount, refDesc.FirstRow, refDesc.RowCount)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *jsonBenchPartQueryScratch) codeHeader(reader int, block ColumnBlock) (uint32CodesHeader, error) {
+	if reader < 0 || reader >= len(s.codeReaders) {
+		return uint32CodesHeader{}, fmt.Errorf("colgranule: invalid code reader %d", reader)
+	}
+	raw, err := s.codeReaders[reader].decompressPayload(block.Granule)
+	if err != nil {
+		return uint32CodesHeader{}, err
+	}
+	return parseUint32CodesHeader(raw, block.Descriptor.RowCount)
+}
+
+func (s *jsonBenchPartQueryScratch) resetQ2Dense(eventCardinality uint32, didCardinality uint32) ([]uint64, []uint64, int, error) {
+	if eventCardinality == 0 || didCardinality == 0 {
+		return nil, nil, 0, fmt.Errorf("colgranule: invalid q2 cardinalities event=%d did=%d", eventCardinality, didCardinality)
+	}
+	didWords := (int(didCardinality) + 63) / 64
+	seenWords := int(eventCardinality) * didWords
+	if seenWords <= 0 || seenWords > maxAggregateCells {
+		return nil, nil, 0, fmt.Errorf("colgranule: q2 distinct bitset words=%d exceeds cap %d", seenWords, maxAggregateCells)
+	}
+	if cap(s.q2Counts) < int(eventCardinality) {
+		s.q2Counts = make([]uint64, eventCardinality)
+	} else {
+		s.q2Counts = s.q2Counts[:eventCardinality]
+	}
+	clear(s.q2Counts)
+	if cap(s.q2Seen) < seenWords {
+		s.q2Seen = make([]uint64, seenWords)
+	} else {
+		s.q2Seen = s.q2Seen[:seenWords]
+	}
+	clear(s.q2Seen)
+	return s.q2Counts, s.q2Seen, didWords, nil
+}
+
+func (s *jsonBenchPartQueryScratch) resetQ3Dense(eventCardinality uint32) ([]uint64, error) {
+	if eventCardinality == 0 {
+		return nil, errors.New("colgranule: invalid q3 event cardinality 0")
+	}
+	cells := int(eventCardinality) * 24
+	if cells <= 0 || cells > maxAggregateCells {
+		return nil, fmt.Errorf("colgranule: q3 aggregate cells=%d exceeds cap %d", cells, maxAggregateCells)
+	}
+	if cap(s.q3Counts) < cells {
+		s.q3Counts = make([]uint64, cells)
+	} else {
+		s.q3Counts = s.q3Counts[:cells]
+	}
+	clear(s.q3Counts)
+	return s.q3Counts, nil
+}
+
+func digestDenseQ2(counts []uint64, seen []uint64, didWords int) (int, uint64) {
+	var digest uint64
+	rows := 0
+	for event, count := range counts {
+		if count == 0 {
+			continue
+		}
+		rows++
+		digest = digestMix(digest, uint64(event), count)
+	}
+	for event, count := range counts {
+		if count == 0 {
+			continue
+		}
+		distinct := 0
+		eventSeen := seen[event*didWords : event*didWords+didWords]
+		for _, word := range eventSeen {
+			distinct += popcount64(word)
+		}
+		digest = digestMix(digest, uint64(event), uint64(distinct))
+	}
+	return rows, digest
+}
+
+func digestDenseQ3(counts []uint64) (int, uint64) {
+	var digest uint64
+	rows := 0
+	for cell, count := range counts {
+		if count == 0 {
+			continue
+		}
+		rows++
+		event := cell / 24
+		hour := cell % 24
+		digest = digestMix(digest, uint64(event*100+hour), count)
+	}
+	return rows, digest
 }
 
 func (s *jsonBenchPartQueryScratch) resetCounts() map[int64]int64 {

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -110,6 +110,16 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 			assertJSONBenchPartDiagnostics(t, timing.Query, attempt.Diagnostics, ds.Rows, 3)
 		}
 		assertJSONBenchPartDiagnostics(t, timing.Query, timing.Diagnostics, ds.Rows, 3)
+		switch timing.Query {
+		case "Q2":
+			if timing.Diagnostics.AggregateKernel != "fused_dense_group_count_distinct_codes" {
+				t.Fatalf("Q2 kernel=%q want fused dense distinct", timing.Diagnostics.AggregateKernel)
+			}
+		case "Q3":
+			if timing.Diagnostics.AggregateKernel != "fused_dense_group_count_hour_codes" {
+				t.Fatalf("Q3 kernel=%q want fused dense hour count", timing.Diagnostics.AggregateKernel)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Objective

Continue the post-#1544 ClickHouse-superiority push by replacing JSONBench q2/q3 projected-vector execution with fused dense kernels over encoded column blocks.

This is stacked on #1544 and targets `codex/colgranule-jsonbench-encoded-parts`.

## Context

#1544 moved q1-q5 onto encoded in-memory column parts. q2/q3 still decoded projected columns into full `[]int64` vectors and then aggregated through generic maps. That was correct but left obvious overhead: low-cardinality JSONBench codes are dense, block-local encoded streams, so q2/q3 can aggregate directly over decoded code headers without materializing projected code columns.

The code remains experiment-only and non-durable. It does not publish TreeDB column roots or claim WAL-backed column-store writes.

## Design

- q2 now uses a fused dense exact-distinct kernel:
  - reads `kind_code`, `commit_operation_code`, `commit_collection_code`, and `did_code` encoded blocks in aligned row ranges;
  - filters over low-cardinality codes in the row loop;
  - counts events in a dense `[]uint64`;
  - tracks exact distinct users with per-event bitsets over dense `did_code`;
  - avoids nested `map[event]map[did]struct{}`.
- q3 now uses a fused dense event/hour kernel:
  - reads `kind_code`, `commit_operation_code`, and `commit_collection_code` encoded blocks in aligned row ranges;
  - decodes only `time_us` into reusable scratch;
  - counts into dense `[event][hour]` cells instead of `map[int64]int64`.
- Both kernels validate aligned block row ranges and fail closed if the current JSONBench part shape is not suitable for fused execution.
- Sample tests now assert q2/q3 use the fused dense kernels while preserving raw-vector result parity.

## Scope

- Includes:
  - `experiments/colgranule/jsonbench_part_queries.go`
  - `experiments/colgranule/jsonbench_test.go`
- Excludes:
  - q4/q5 sort-key/min-max optimization
  - persistent file format changes
  - production TreeDB query/planner/WAL paths

## Correctness

- Tests run:
  - `go test ./experiments/colgranule -run 'TestRunJSONBenchPartQueriesSampleMatchesRawReference|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
  - `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
  - `go test ./experiments/colgranule/...`
  - `go test ./...`
- q1-q5 result digests still match the raw-vector reference on the checked-in sample.
- q2/q3 diagnostics now report:
  - `fused_dense_group_count_distinct_codes`
  - `fused_dense_group_count_hour_codes`

## Performance

- Synthetic benchmark command:
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries' -benchmem -benchtime=20x`
- Machine: Apple M3, `darwin/arm64`.
- Synthetic fixture: 819,200 JSONBench-shaped rows over encoded in-memory parts.

| Benchmark | ns/op | ns/row | rows/s | MiB/s | allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Q1_grouped_count` | 1,966,842 | 2.401 | 416.5M | 3178 | 2360 B/op, 4 allocs/op |
| `Q2_group_count_distinct` | 3,767,519 | 4.599 | 217.4M | 6636 | 2408 B/op, 4 allocs/op |
| `Q3_hourly_grouped_count` | 6,515,450 | 7.953 | 125.7M | 3837 | 2408 B/op, 4 allocs/op |
| `Q4_min_by_user` | 20,088,748 | 24.52 | 40.8M | 1556 | 168 B/op, 4 allocs/op |
| `Q5_span_by_user` | 21,643,708 | 26.42 | 37.8M | 1444 | 168 B/op, 4 allocs/op |

- Real-data `1m` command:
  - `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_dense_q2q3_1m_raw.json -out-md tmp/colgranule_dense_q2q3_1m_report.md`

| Query | Encoded best | ClickHouse best | Throughput vs ClickHouse | Previous #1544 best | Speedup vs #1544 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `q1` | 0.002311s | 0.014000s | 6.06x | 0.002468s | 1.07x |
| `q2` | 0.005526s | 0.027000s | 4.89x | 0.049441s | 8.95x |
| `q3` | 0.011528s | 0.014000s | 1.21x | 0.016246s | 1.41x |
| `q4` | 0.021693s | 0.013000s | 0.60x | 0.021680s | 1.00x |
| `q5` | 0.021748s | 0.013000s | 0.60x | 0.022215s | 1.02x |

After this PR, q1/q2/q3 are faster than the local ClickHouse `1m` result. q4/q5 remain the next optimization target.

## Follow-ups

- q4: exploit `time_us` sort order for early-stop `min(time_us) ORDER BY ASC LIMIT 3`.
- q5: replace `map[did]span` with dense `did_code -> min/max` arrays and top-3 selection, then consider per-granule aggregate metadata.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR
- [x] Explicit include list: see Scope
- [x] Explicit exclude list: see Scope
- [x] No production TreeDB behavior changed

### Safety / Correctness
- [x] No durable paths touched
- [x] No new mmap usage
- [x] New dense aggregate state is capped before allocation
- [x] Fused kernels fail closed on missing columns, bad types, or misaligned block row ranges
- [x] No concurrency changes

### Tests
- [x] Added deterministic regression checks for q2/q3 fused kernel selection
- [x] Preserved q1-q5 raw-vector digest parity
- [x] Ran local `JSONBENCH_DATA` parity smoke against the gzip `1m` fixture
- [x] Ran `go test ./...`

### Benchmarks / Measurements
- [x] Added/reused relevant benchmark coverage
- [x] Reported synthetic benchmark results
- [x] Reported real-data `1m` ClickHouse-relative results

### Rollout / Toggle Plan
- [x] Experiment-only code under `experiments/colgranule`
- [x] Revert this PR to disable
