### PR TITLE
experiments/colgranule: optimize jsonbench q4 q5

### DIFF
--- a/experiments/colgranule/granule_bench_test.go
+++ b/experiments/colgranule/granule_bench_test.go
@@ -492,6 +492,10 @@ func TestCompressionRatios(t *testing.T) {
 }
 
 func reportGranuleBenchMetrics(b *testing.B, rows int, valueBytes int, storedBytes int) {
+	reportGranuleBenchMetrics64(b, rows, int64(valueBytes), int64(storedBytes))
+}
+
+func reportGranuleBenchMetrics64(b *testing.B, rows int, valueBytes int64, storedBytes int64) {
 	b.Helper()
 	if b.N == 0 || rows == 0 {
 		return

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -77,11 +77,11 @@ func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
 			if rowsScanned == 0 {
 				rowsScanned = ds.Rows
 			}
-			valueBytes := rowsScanned * len(diagnostics.ColumnsProjected) * 8
+			valueBytes := int64(rowsScanned) * int64(len(diagnostics.ColumnsProjected)) * 8
 			if valueBytes == 0 {
-				valueBytes = rowsScanned * 8
+				valueBytes = int64(rowsScanned) * 8
 			}
-			b.SetBytes(int64(valueBytes))
+			b.SetBytes(valueBytes)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				rows, digest, diagnostics, err = q.run(part, codes, scratch)
@@ -94,7 +94,7 @@ func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
 			if rowsScanned == 0 {
 				rowsScanned = ds.Rows
 			}
-			reportGranuleBenchMetrics(b, rowsScanned, valueBytes, diagnostics.BytesDecoded)
+			reportGranuleBenchMetrics64(b, rowsScanned, valueBytes, int64(diagnostics.BytesDecoded))
 		})
 	}
 }

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -73,9 +73,13 @@ func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
 				b.Fatal(err)
 			}
 			benchSink += int64(rows) + int64(digest)
-			valueBytes := ds.Rows * len(diagnostics.ColumnsProjected) * 8
+			rowsScanned := diagnostics.RowsScanned
+			if rowsScanned == 0 {
+				rowsScanned = ds.Rows
+			}
+			valueBytes := rowsScanned * len(diagnostics.ColumnsProjected) * 8
 			if valueBytes == 0 {
-				valueBytes = ds.Rows * 8
+				valueBytes = rowsScanned * 8
 			}
 			b.SetBytes(int64(valueBytes))
 			b.ResetTimer()
@@ -86,7 +90,11 @@ func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
 				}
 				benchSink += int64(rows) + int64(digest)
 			}
-			reportGranuleBenchMetrics(b, ds.Rows, valueBytes, diagnostics.BytesDecoded)
+			rowsScanned = diagnostics.RowsScanned
+			if rowsScanned == 0 {
+				rowsScanned = ds.Rows
+			}
+			reportGranuleBenchMetrics(b, rowsScanned, valueBytes, diagnostics.BytesDecoded)
 		})
 	}
 }

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -3,7 +3,6 @@ package colgranule
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 )
 
@@ -49,6 +48,11 @@ type jsonBenchPartQueryScratch struct {
 	q2Counts    []uint64
 	q2Seen      []uint64
 	q3Counts    []uint64
+	q4Seen      []uint64
+	q5Seen      []uint64
+	q5Min       []int64
+	q5Max       []int64
+	q5Users     []uint32
 	counts      map[int64]int64
 	unique      map[int64]map[int64]struct{}
 	events      []int64
@@ -63,6 +67,8 @@ type jsonBenchPartQueryRunner func(*ColumnPart, queryCodeSet, *jsonBenchPartQuer
 var (
 	jsonBenchPartQ2Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
 	jsonBenchPartQ3Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "time_us"}
+	jsonBenchPartQ4Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
+	jsonBenchPartQ5Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
 )
 
 func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnPart, error) {
@@ -390,98 +396,229 @@ func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 }
 
 func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
-	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
-	scan, err := scanPartProjection(part, scratch, projection)
+	if err := requireTimeUSAscendingSortKey(part); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	kind := scan.Columns["kind_code"]
-	operation := scan.Columns["commit_operation_code"]
-	collection := scan.Columns["commit_collection_code"]
-	did := scan.Columns["did_code"]
-	timeUS := scan.Columns["time_us"]
-	first := scratch.resetFirst()
-	for i := range collection {
-		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate || collection[i] != codes.collectionPost {
-			continue
-		}
-		user := did[i]
-		if prev, ok := first[user]; !ok || timeUS[i] < prev {
-			first[user] = timeUS[i]
-		}
+	operationBlocks, err := lowCardinalityBlocks(part, "commit_operation_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	collectionBlocks, err := lowCardinalityBlocks(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didBlocks, err := lowCardinalityBlocks(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	timeBlocks, err := int64Blocks(part, "time_us")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, didBlocks, timeBlocks); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	seen, err := scratch.resetQ4Seen(didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
 	top := scratch.q4Pairs[:0]
-	for user, t := range first {
-		top = append(top, jsonBenchPartTimePair{user: user, t: t})
+	rowsScanned := 0
+	blocksDecoded := 0
+	bytesDecoded := 0
+	lastGranule := -1
+	for blockIndex := range kindBlocks {
+		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		didHeader, err := scratch.codeHeader(3, didBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		timeValues, err := scratch.timeReader.DecodeInt64(timeBlocks[blockIndex].Granule)
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		blocksDecoded += 5
+		bytesDecoded += kindBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += operationBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += collectionBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += didBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += timeBlocks[blockIndex].Granule.RawBytes
+		if kindBlocks[blockIndex].Descriptor.LastGranule > lastGranule {
+			lastGranule = kindBlocks[blockIndex].Descriptor.LastGranule
+		}
+		rows := kindBlocks[blockIndex].Descriptor.RowCount
+		if len(timeValues) != rows {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q4 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
+		}
+		for row := 0; row < rows; row++ {
+			timestamp := timeValues[row]
+			if len(top) == 3 && timestamp > top[2].t {
+				scratch.q4Pairs = top
+				diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+				return len(top), digestQ4Top(top), diagnostics, nil
+			}
+			rowsScanned++
+			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			if kind >= kindHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
+			}
+			if int64(kind) != codes.kindCommit {
+				continue
+			}
+			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			if operation >= operationHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
+			}
+			if int64(operation) != codes.operationCreate {
+				continue
+			}
+			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			if event >= collectionHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionHeader.cardinality)
+			}
+			if int64(event) != codes.collectionPost {
+				continue
+			}
+			user := readUint32Code(didHeader.data, didHeader.width, row)
+			if user >= didHeader.cardinality || user >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: did code %d outside cardinality %d", user, didCardinality)
+			}
+			if bitsetTestAndSet(seen, user) {
+				continue
+			}
+			top = insertQ4Top(top, jsonBenchPartTimePair{user: int64(user), t: timestamp})
+		}
 	}
 	scratch.q4Pairs = top
-	sort.Slice(top, func(i, j int) bool {
-		if top[i].t == top[j].t {
-			return top[i].user < top[j].user
-		}
-		return top[i].t < top[j].t
-	})
-	if len(top) > 3 {
-		top = top[:3]
-	}
-	var digest uint64
-	for _, p := range top {
-		digest = digestMix(digest, uint64(p.user), uint64(p.t))
-	}
-	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_min_by_user")
-	return len(top), digest, diagnostics, nil
+	diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+	return len(top), digestQ4Top(top), diagnostics, nil
 }
 
 func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
-	projection := []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
-	scan, err := scanPartProjection(part, scratch, projection)
+	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	kind := scan.Columns["kind_code"]
-	operation := scan.Columns["commit_operation_code"]
-	collection := scan.Columns["commit_collection_code"]
-	did := scan.Columns["did_code"]
-	timeUS := scan.Columns["time_us"]
-	spans := scratch.resetSpans()
-	for i := range collection {
-		if kind[i] != codes.kindCommit || operation[i] != codes.operationCreate || collection[i] != codes.collectionPost {
-			continue
-		}
-		user := did[i]
-		s, ok := spans[user]
-		if !ok {
-			spans[user] = jsonBenchPartSpan{min: timeUS[i], max: timeUS[i]}
-			continue
-		}
-		if timeUS[i] < s.min {
-			s.min = timeUS[i]
-		}
-		if timeUS[i] > s.max {
-			s.max = timeUS[i]
-		}
-		spans[user] = s
+	operationBlocks, err := lowCardinalityBlocks(part, "commit_operation_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
+	collectionBlocks, err := lowCardinalityBlocks(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didBlocks, err := lowCardinalityBlocks(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	timeBlocks, err := int64Blocks(part, "time_us")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, didBlocks, timeBlocks); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	seen, minTime, maxTime, users, err := scratch.resetQ5Dense(didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	for blockIndex := range kindBlocks {
+		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		didHeader, err := scratch.codeHeader(3, didBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		timeValues, err := scratch.timeReader.DecodeInt64(timeBlocks[blockIndex].Granule)
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		rows := kindBlocks[blockIndex].Descriptor.RowCount
+		if len(timeValues) != rows {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q5 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
+		}
+		for row := 0; row < rows; row++ {
+			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			if kind >= kindHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
+			}
+			if int64(kind) != codes.kindCommit {
+				continue
+			}
+			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			if operation >= operationHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
+			}
+			if int64(operation) != codes.operationCreate {
+				continue
+			}
+			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			if event >= collectionHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionHeader.cardinality)
+			}
+			if int64(event) != codes.collectionPost {
+				continue
+			}
+			user := readUint32Code(didHeader.data, didHeader.width, row)
+			if user >= didHeader.cardinality || user >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: did code %d outside cardinality %d", user, didCardinality)
+			}
+			timestamp := timeValues[row]
+			if bitsetTestAndSet(seen, user) {
+				if timestamp < minTime[user] {
+					minTime[user] = timestamp
+				}
+				if timestamp > maxTime[user] {
+					maxTime[user] = timestamp
+				}
+				continue
+			}
+			minTime[user] = timestamp
+			maxTime[user] = timestamp
+			users = append(users, user)
+		}
+	}
+	scratch.q5Users = users
 	top := scratch.q5Pairs[:0]
-	for user, s := range spans {
-		top = append(top, jsonBenchPartSpanPair{user: user, span: s.max - s.min})
+	for _, user := range users {
+		top = insertQ5Top(top, jsonBenchPartSpanPair{user: int64(user), span: maxTime[user] - minTime[user]})
 	}
 	scratch.q5Pairs = top
-	sort.Slice(top, func(i, j int) bool {
-		if top[i].span == top[j].span {
-			return top[i].user < top[j].user
-		}
-		return top[i].span > top[j].span
-	})
-	if len(top) > 3 {
-		top = top[:3]
-	}
-	var digest uint64
-	for _, p := range top {
-		digest = digestMix(digest, uint64(p.user), uint64(p.span))
-	}
-	diagnostics := queryDiagnosticsFromScan(scan.Diagnostics, projection, "projected_scan_span_by_user")
-	return len(top), digest, diagnostics, nil
+	diagnostics := partColumnDiagnostics(part, jsonBenchPartQ5Columns, "fused_dense_span_by_user")
+	return len(top), digestQ5Top(top), diagnostics, nil
 }
 
 type jsonBenchPartSpan struct {
@@ -537,6 +674,17 @@ func validateAlignedBlocks(reference []ColumnBlock, others ...[]ColumnBlock) err
 	return nil
 }
 
+func requireTimeUSAscendingSortKey(part *ColumnPart) error {
+	if len(part.Descriptor.SortKey) != 1 {
+		return fmt.Errorf("colgranule: q4 early-stop requires single-column sort key, got %d columns", len(part.Descriptor.SortKey))
+	}
+	key := part.Descriptor.SortKey[0]
+	if key.Column != "time_us" || key.Direction != SortKeyAsc {
+		return fmt.Errorf("colgranule: q4 early-stop requires ascending time_us sort key, got %+v", key)
+	}
+	return nil
+}
+
 func (s *jsonBenchPartQueryScratch) codeHeader(reader int, block ColumnBlock) (uint32CodesHeader, error) {
 	if reader < 0 || reader >= len(s.codeReaders) {
 		return uint32CodesHeader{}, fmt.Errorf("colgranule: invalid code reader %d", reader)
@@ -546,6 +694,57 @@ func (s *jsonBenchPartQueryScratch) codeHeader(reader int, block ColumnBlock) (u
 		return uint32CodesHeader{}, err
 	}
 	return parseUint32CodesHeader(raw, block.Descriptor.RowCount)
+}
+
+func (s *jsonBenchPartQueryScratch) resetQ4Seen(didCardinality uint32) ([]uint64, error) {
+	if didCardinality == 0 {
+		return nil, errors.New("colgranule: invalid q4 did cardinality 0")
+	}
+	words := (int(didCardinality) + 63) / 64
+	if words <= 0 || words > maxAggregateCells {
+		return nil, fmt.Errorf("colgranule: q4 seen words=%d exceeds cap %d", words, maxAggregateCells)
+	}
+	if cap(s.q4Seen) < words {
+		s.q4Seen = make([]uint64, words)
+	} else {
+		s.q4Seen = s.q4Seen[:words]
+	}
+	clear(s.q4Seen)
+	s.q4Pairs = s.q4Pairs[:0]
+	return s.q4Seen, nil
+}
+
+func (s *jsonBenchPartQueryScratch) resetQ5Dense(didCardinality uint32) ([]uint64, []int64, []int64, []uint32, error) {
+	if didCardinality == 0 {
+		return nil, nil, nil, nil, errors.New("colgranule: invalid q5 did cardinality 0")
+	}
+	cardinality := int(didCardinality)
+	words := (cardinality + 63) / 64
+	if words <= 0 || words > maxAggregateCells {
+		return nil, nil, nil, nil, fmt.Errorf("colgranule: q5 seen words=%d exceeds cap %d", words, maxAggregateCells)
+	}
+	if cardinality > maxAggregateCells {
+		return nil, nil, nil, nil, fmt.Errorf("colgranule: q5 dense cardinality=%d exceeds cap %d", cardinality, maxAggregateCells)
+	}
+	if cap(s.q5Seen) < words {
+		s.q5Seen = make([]uint64, words)
+	} else {
+		s.q5Seen = s.q5Seen[:words]
+	}
+	clear(s.q5Seen)
+	if cap(s.q5Min) < cardinality {
+		s.q5Min = make([]int64, cardinality)
+	} else {
+		s.q5Min = s.q5Min[:cardinality]
+	}
+	if cap(s.q5Max) < cardinality {
+		s.q5Max = make([]int64, cardinality)
+	} else {
+		s.q5Max = s.q5Max[:cardinality]
+	}
+	s.q5Users = s.q5Users[:0]
+	s.q5Pairs = s.q5Pairs[:0]
+	return s.q5Seen, s.q5Min, s.q5Max, s.q5Users, nil
 }
 
 func (s *jsonBenchPartQueryScratch) resetQ2Dense(eventCardinality uint32, didCardinality uint32) ([]uint64, []uint64, int, error) {
@@ -587,6 +786,91 @@ func (s *jsonBenchPartQueryScratch) resetQ3Dense(eventCardinality uint32) ([]uin
 	}
 	clear(s.q3Counts)
 	return s.q3Counts, nil
+}
+
+func bitsetTestAndSet(words []uint64, code uint32) bool {
+	word := int(code / 64)
+	bit := uint(code % 64)
+	mask := uint64(1) << bit
+	seen := words[word]&mask != 0
+	words[word] |= mask
+	return seen
+}
+
+func insertQ4Top(top []jsonBenchPartTimePair, candidate jsonBenchPartTimePair) []jsonBenchPartTimePair {
+	if len(top) == 3 && !q4PairLess(candidate, top[2]) {
+		return top
+	}
+	if len(top) < 3 {
+		top = append(top, candidate)
+	} else {
+		top[2] = candidate
+	}
+	for i := len(top) - 1; i > 0 && q4PairLess(top[i], top[i-1]); i-- {
+		top[i], top[i-1] = top[i-1], top[i]
+	}
+	return top
+}
+
+func q4PairLess(left jsonBenchPartTimePair, right jsonBenchPartTimePair) bool {
+	if left.t == right.t {
+		return left.user < right.user
+	}
+	return left.t < right.t
+}
+
+func insertQ5Top(top []jsonBenchPartSpanPair, candidate jsonBenchPartSpanPair) []jsonBenchPartSpanPair {
+	if len(top) == 3 && !q5PairLess(candidate, top[2]) {
+		return top
+	}
+	if len(top) < 3 {
+		top = append(top, candidate)
+	} else {
+		top[2] = candidate
+	}
+	for i := len(top) - 1; i > 0 && q5PairLess(top[i], top[i-1]); i-- {
+		top[i], top[i-1] = top[i-1], top[i]
+	}
+	return top
+}
+
+func q5PairLess(left jsonBenchPartSpanPair, right jsonBenchPartSpanPair) bool {
+	if left.span == right.span {
+		return left.user < right.user
+	}
+	return left.span > right.span
+}
+
+func digestQ4Top(top []jsonBenchPartTimePair) uint64 {
+	var digest uint64
+	for _, p := range top {
+		digest = digestMix(digest, uint64(p.user), uint64(p.t))
+	}
+	return digest
+}
+
+func digestQ5Top(top []jsonBenchPartSpanPair) uint64 {
+	var digest uint64
+	for _, p := range top {
+		digest = digestMix(digest, uint64(p.user), uint64(p.span))
+	}
+	return digest
+}
+
+func queryDiagnosticsFromDecodedPrefix(columns []string, kernel string, rowsScanned int, lastGranule int, blocksDecoded int, bytesDecoded int) JSONBenchPartQueryDiagnostics {
+	granulesDecoded := 0
+	if lastGranule >= 0 {
+		granulesDecoded = lastGranule + 1
+	}
+	return JSONBenchPartQueryDiagnostics{
+		RowsScanned:        rowsScanned,
+		GranulesConsidered: granulesDecoded,
+		GranulesDecoded:    granulesDecoded,
+		BlocksDecoded:      blocksDecoded,
+		BytesDecoded:       bytesDecoded,
+		ColumnsProjected:   append([]string(nil), columns...),
+		AggregateKernel:    kernel,
+	}
 }
 
 func digestDenseQ2(counts []uint64, seen []uint64, didWords int) (int, uint64) {

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -3,6 +3,7 @@ package colgranule
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -517,12 +518,12 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		}
 		for row := 0; row < rows; row++ {
 			timestamp := timeValues[row]
+			rowsScanned++
 			if len(top) == 3 && timestamp > top[2].t {
 				scratch.q4Pairs = top
 				diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
 				return len(top), digestQ4Top(top), diagnostics, nil
 			}
-			rowsScanned++
 			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
 			if kind >= kindHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
@@ -714,6 +715,9 @@ func validateAlignedBlocks(reference []ColumnBlock, others ...[]ColumnBlock) err
 			desc := blocks[i].Descriptor
 			if desc.FirstRow != refDesc.FirstRow || desc.RowCount != refDesc.RowCount {
 				return fmt.Errorf("colgranule: aligned kernel block %d rows=%d+%d want %d+%d", i, desc.FirstRow, desc.RowCount, refDesc.FirstRow, refDesc.RowCount)
+			}
+			if desc.FirstGranule != refDesc.FirstGranule || desc.LastGranule != refDesc.LastGranule {
+				return fmt.Errorf("colgranule: aligned kernel block %d granules=%d..%d want %d..%d", i, desc.FirstGranule, desc.LastGranule, refDesc.FirstGranule, refDesc.LastGranule)
 			}
 		}
 	}

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -137,35 +137,25 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 func TestRunJSONBenchPartQ2FallsBackForHighCardinalityDID(t *testing.T) {
 	ds := jsonBenchPartEdgeDataset()
 	ds.Dictionaries["did_code"] = map[string]int64{"outside-low-cardinality-cap": maxCodeCardinality + 1}
-	rawTimings, err := RunJSONBenchQueries(ds, 1)
+	codes, err := jsonBenchQueryCodes(ds)
 	if err != nil {
-		t.Fatalf("RunJSONBenchQueries: %v", err)
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
 	}
-	partTimings, err := RunJSONBenchPartQueries(ds, 2, 1)
+	rawRows, rawDigest := runJSONBenchQ2(ds, codes)
+	part, err := BuildJSONBenchColumnPart(ds, 2)
 	if err != nil {
-		t.Fatalf("RunJSONBenchPartQueries: %v", err)
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
 	}
-	rawByQuery := make(map[string]JSONBenchQueryTiming, len(rawTimings))
-	for _, timing := range rawTimings {
-		rawByQuery[timing.Query] = timing
+	rows, digest, diagnostics, err := runJSONBenchPartQ2(part, codes, &jsonBenchPartQueryScratch{})
+	if err != nil {
+		t.Fatalf("runJSONBenchPartQ2: %v", err)
 	}
-	for _, timing := range partTimings {
-		if timing.Query != "Q2" {
-			continue
-		}
-		raw, ok := rawByQuery[timing.Query]
-		if !ok {
-			t.Fatalf("missing raw timing for %s", timing.Query)
-		}
-		if timing.ResultRows != raw.ResultRows || timing.ResultDigest != raw.ResultDigest {
-			t.Fatalf("Q2 fallback rows/digest=(%d,%d) raw=(%d,%d)", timing.ResultRows, timing.ResultDigest, raw.ResultRows, raw.ResultDigest)
-		}
-		if timing.Diagnostics.AggregateKernel != "projected_scan_group_count_distinct" {
-			t.Fatalf("Q2 fallback kernel=%q want projected scan", timing.Diagnostics.AggregateKernel)
-		}
-		return
+	if rows != rawRows || digest != rawDigest {
+		t.Fatalf("Q2 fallback rows/digest=(%d,%d) raw=(%d,%d)", rows, digest, rawRows, rawDigest)
 	}
-	t.Fatal("missing Q2 part timing")
+	if diagnostics.AggregateKernel != "projected_scan_group_count_distinct" {
+		t.Fatalf("Q2 fallback kernel=%q want projected scan", diagnostics.AggregateKernel)
+	}
 }
 
 func TestRunJSONBenchPartQ3RejectsInvalidHour(t *testing.T) {
@@ -182,6 +172,35 @@ func TestRunJSONBenchPartQ3RejectsInvalidHour(t *testing.T) {
 	_, _, _, err = runJSONBenchPartQ3(part, codes, &jsonBenchPartQueryScratch{})
 	if err == nil || !strings.Contains(err.Error(), "q3 hour") {
 		t.Fatalf("runJSONBenchPartQ3 err=%v want q3 hour validation", err)
+	}
+}
+
+func TestRunJSONBenchPartQ4RejectsIncompatibleSortKey(t *testing.T) {
+	ds := jsonBenchPartEdgeDataset()
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	cases := []struct {
+		name    string
+		sortKey []SortKeyColumn
+	}{
+		{name: "missing"},
+		{name: "compound", sortKey: []SortKeyColumn{{Column: "time_us"}, {Column: "row_index"}}},
+		{name: "descending", sortKey: []SortKeyColumn{{Column: "time_us", Direction: SortKeyDesc}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			part, err := BuildJSONBenchColumnPart(ds, 2)
+			if err != nil {
+				t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+			}
+			part.Descriptor.SortKey = append([]SortKeyColumn(nil), tc.sortKey...)
+			_, _, _, err = runJSONBenchPartQ4(part, codes, &jsonBenchPartQueryScratch{})
+			if err == nil || !strings.Contains(err.Error(), "q4 early-stop requires") {
+				t.Fatalf("runJSONBenchPartQ4 err=%v want sort-key validation", err)
+			}
+		})
 	}
 }
 

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -119,6 +119,14 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 			if timing.Diagnostics.AggregateKernel != "fused_dense_group_count_hour_codes" {
 				t.Fatalf("Q3 kernel=%q want fused dense hour count", timing.Diagnostics.AggregateKernel)
 			}
+		case "Q4":
+			if timing.Diagnostics.AggregateKernel != "sort_key_early_stop_min_by_user" {
+				t.Fatalf("Q4 kernel=%q want sort-key early stop", timing.Diagnostics.AggregateKernel)
+			}
+		case "Q5":
+			if timing.Diagnostics.AggregateKernel != "fused_dense_span_by_user" {
+				t.Fatalf("Q5 kernel=%q want fused dense span", timing.Diagnostics.AggregateKernel)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Objective

Finish the JSONBench-shaped ClickHouse-superiority pass by optimizing q4/q5 on top of #1549.

This is stacked on #1549 and targets `codex/colgranule-dense-jsonbench-kernels`.

## Context

#1549 made q1/q2/q3 faster than the local ClickHouse `1m` result. q4/q5 were still below ClickHouse because they used projected-vector scans plus generic Go maps/sorts.

This PR keeps the code experiment-only and non-durable. It does not publish TreeDB column roots or claim WAL-backed column-store writes.

## Design

- q4 now uses `time_us` sort-key order:
  - requires a single ascending `time_us` sort key and fails closed otherwise;
  - scans encoded blocks in row order;
  - tracks seen users with a dense `did_code` bitset;
  - maintains a top-3 `(first_time, user)` set;
  - stops as soon as the next row's `time_us` is greater than the current third-best first time.
- q5 now uses dense per-user span state:
  - scans encoded code blocks directly;
  - tracks users with a dense `did_code` bitset;
  - updates dense `did_code -> min(time_us), max(time_us)` arrays;
  - selects top 3 spans without sorting all users.
- Sample tests now assert q4/q5 use the new kernels while preserving raw-vector result parity.

## Scope

- Includes:
  - `experiments/colgranule/jsonbench_part_queries.go`
  - `experiments/colgranule/jsonbench_test.go`
- Excludes:
  - persistent column files
  - production TreeDB query/planner/WAL paths
  - q1/q2/q3 logic beyond inherited #1549 changes

## Correctness

- Tests run:
  - `go test ./experiments/colgranule -run 'TestRunJSONBenchPartQueriesSampleMatchesRawReference|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
  - `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
  - `go test ./experiments/colgranule/...`
  - `go test ./...`
- The `1m` `jsonbench_compare` output has matching raw-vector and encoded-part digests for q1-q5.
- q4/q5 diagnostics now report:
  - `sort_key_early_stop_min_by_user`
  - `fused_dense_span_by_user`

## Performance

- Synthetic benchmark command:
  - `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries' -benchmem -benchtime=20x`
- Machine: Apple M3, `darwin/arm64`.
- Synthetic fixture: 819,200 JSONBench-shaped rows over encoded in-memory parts.

| Benchmark | ns/op | ns/row | rows/s | MiB/s | allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Q1_grouped_count` | 1,979,929 | 2.417 | 413.8M | 3157 | 2360 B/op, 4 allocs/op |
| `Q2_group_count_distinct` | 3,800,821 | 4.640 | 215.5M | 6578 | 2408 B/op, 4 allocs/op |
| `Q3_hourly_grouped_count` | 6,552,015 | 7.998 | 125.0M | 3816 | 2408 B/op, 4 allocs/op |
| `Q4_min_by_user` | 48,254 | 6892 | 145K scanned rows/s | 5.5 | 80 B/op, 1 alloc/op |
| `Q5_span_by_user` | 6,206,162 | 7.576 | 132.0M | 5035 | 2424 B/op, 4 allocs/op |

For q4, `ns/row`, rows/s, and MiB/s are over rows actually scanned before sort-key early-stop. The query answered over the full logical part.

- Real-data `1m` command:
  - `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_q4q5_1m_raw.json -out-md tmp/colgranule_q4q5_1m_report.md`

| Query | Encoded best | ClickHouse best | Throughput vs ClickHouse | Kernel |
| --- | ---: | ---: | ---: | --- |
| `q1` | 0.002324s | 0.014000s | 6.02x | `grouped_count_codes` |
| `q2` | 0.005430s | 0.027000s | 4.97x | `fused_dense_group_count_distinct_codes` |
| `q3` | 0.011519s | 0.014000s | 1.22x | `fused_dense_group_count_hour_codes` |
| `q4` | 0.000043s | 0.013000s | 300.29x | `sort_key_early_stop_min_by_user` |
| `q5` | 0.009977s | 0.013000s | 1.30x | `fused_dense_span_by_user` |

After this PR, q1-q5 are all faster than the local ClickHouse `1m` result for the encoded declared-column experiment path.

## Follow-ups

- Validate these wins again after the `TCS1` file-backed path lands.
- Add per-granule aggregate metadata for q5-style span queries if later workloads need faster-than-scan behavior.
- Keep the report explicit that this is declared-column experiment execution, not a production SQL/planner/storage benchmark.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR
- [x] Explicit include list: see Scope
- [x] Explicit exclude list: see Scope
- [x] No production TreeDB behavior changed

### Safety / Correctness
- [x] No durable paths touched
- [x] No new mmap usage
- [x] Dense q4/q5 state is capped before allocation
- [x] q4 fails closed if the part is not sorted by ascending `time_us`
- [x] Fused kernels fail closed on missing columns, bad types, or misaligned block row ranges
- [x] No concurrency changes

### Tests
- [x] Added deterministic regression checks for q4/q5 kernel selection
- [x] Preserved q1-q5 raw-vector digest parity
- [x] Ran local `JSONBENCH_DATA` parity smoke against the gzip `1m` fixture
- [x] Ran `go test ./...`

### Benchmarks / Measurements
- [x] Reused relevant benchmark coverage
- [x] Reported synthetic benchmark results
- [x] Reported real-data `1m` ClickHouse-relative results

### Rollout / Toggle Plan
- [x] Experiment-only code under `experiments/colgranule`
- [x] Revert this PR to disable
