### PR TITLE
Add Mongo vector index metadata extension

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1491,6 +1491,9 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	if err := validateCreateIndexesCrossKindNames(meta, scalarDefs, vectorDefs); err != nil {
 		return commandError(commandCodeDuplicateKey, "DuplicateKey", err.Error())
 	}
+	if err := validateCreateIndexesExistingVectorDefinitions(meta, vectorDefs); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	for _, def := range scalarDefs {
 		if existing, ok := findIndexDefinition(meta.Indexes, def.Name); ok && sameIndexDefinition(existing, def) {
 			continue
@@ -3248,6 +3251,16 @@ func validateCreateIndexesCrossKindNames(meta collections.CollectionMeta, scalar
 	for _, def := range vectorDefs {
 		if _, ok := scalarNames[def.Name]; ok {
 			return fmt.Errorf("index name %q conflicts between scalar and vector indexes", def.Name)
+		}
+	}
+	return nil
+}
+
+func validateCreateIndexesExistingVectorDefinitions(meta collections.CollectionMeta, vectorDefs []collections.VectorIndexDefinition) error {
+	for _, def := range vectorDefs {
+		existing, ok := findVectorIndexDefinition(meta.VectorIndexes, def.Name)
+		if ok && !sameVectorIndexDefinition(existing, def) {
+			return fmt.Errorf("vector index %q already exists with a different definition", def.Name)
 		}
 	}
 	return nil

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1450,6 +1450,11 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		}
 		scalarDefs = append(scalarDefs, s.applyDefaultIndexOptions(def.scalarDef))
 	}
+	if err := validateCreateIndexesRequestDuplicates(scalarDefs, vectorDefs); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	scalarDefs = dedupeIdenticalIndexDefinitions(scalarDefs)
+	vectorDefs = dedupeIdenticalVectorIndexDefinitions(vectorDefs)
 	if err := validateCreateIndexesCrossKindNames(collections.CollectionMeta{}, scalarDefs, vectorDefs); err != nil {
 		return commandError(commandCodeDuplicateKey, "DuplicateKey", err.Error())
 	}
@@ -1461,8 +1466,8 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
 		meta := s.defaultCollectionMeta(name)
-		meta.Indexes = dedupeIdenticalIndexDefinitions(scalarDefs)
-		meta.VectorIndexes = dedupeIdenticalVectorIndexDefinitions(vectorDefs)
+		meta.Indexes = scalarDefs
+		meta.VectorIndexes = vectorDefs
 		created, err := s.Collections.CreateCollection(meta)
 		if err != nil {
 			// If another request created the collection after our miss, fall
@@ -3195,6 +3200,30 @@ func sameVectorIndexDefinition(left, right collections.VectorIndexDefinition) bo
 		left.EfConstruction == right.EfConstruction &&
 		left.EfSearch == right.EfSearch &&
 		left.Encoding == right.Encoding
+}
+
+func validateCreateIndexesRequestDuplicates(scalarDefs []collections.IndexDefinition, vectorDefs []collections.VectorIndexDefinition) error {
+	scalarSeen := make(map[string]collections.IndexDefinition, len(scalarDefs))
+	for _, def := range scalarDefs {
+		if existing, ok := scalarSeen[def.Name]; ok {
+			if !sameIndexDefinition(existing, def) {
+				return fmt.Errorf("duplicate index %q has conflicting definitions", def.Name)
+			}
+			continue
+		}
+		scalarSeen[def.Name] = def
+	}
+	vectorSeen := make(map[string]collections.VectorIndexDefinition, len(vectorDefs))
+	for _, def := range vectorDefs {
+		if existing, ok := vectorSeen[def.Name]; ok {
+			if !sameVectorIndexDefinition(existing, def) {
+				return fmt.Errorf("duplicate vector index %q has conflicting definitions", def.Name)
+			}
+			continue
+		}
+		vectorSeen[def.Name] = def
+	}
+	return nil
 }
 
 func validateCreateIndexesCrossKindNames(meta collections.CollectionMeta, scalarDefs []collections.IndexDefinition, vectorDefs []collections.VectorIndexDefinition) error {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -3033,6 +3033,12 @@ func optionalPositiveIntFieldWithPresence(doc wire.Document, key string) (int, b
 		out = int64(v)
 	} else if v, ok := value.Int64OK(); ok {
 		out = v
+	} else if v, ok := value.DoubleOK(); ok {
+		var integral bool
+		out, integral = exactInt64FromFloat64(v)
+		if !integral {
+			return 0, true, fmt.Errorf("Mongo command field %q must be an integer", key)
+		}
 	} else {
 		return 0, true, fmt.Errorf("Mongo command field %q must be an integer", key)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -3024,8 +3024,8 @@ func optionalPositiveIntFieldWithPresence(doc wire.Document, key string) (int, b
 	if out <= 0 {
 		return 0, true, fmt.Errorf("Mongo command field %q must be positive", key)
 	}
-	if out > int64(maxInt) {
-		return 0, true, fmt.Errorf("Mongo command field %q is out of int range", key)
+	if out > int64(^uint32(0)>>1) {
+		return 0, true, fmt.Errorf("Mongo command field %q is out of int32 range", key)
 	}
 	return int(out), true, nil
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -24,6 +24,14 @@ const (
 	commandCodeCursorNotFound      int32 = 43
 	commandCodeDuplicateKey        int32 = 11000
 	maxWireMessageLengthInt32Limit       = int64(1<<31 - 1)
+
+	treeDBIndexTypeField     = "treedbIndexType"
+	treeDBIndexTypeVector    = "vector"
+	treeDBVectorOptionsField = "treedbVector"
+
+	mongoDefaultVectorIndexM              = 16
+	mongoDefaultVectorIndexEfConstruction = 128
+	mongoDefaultVectorIndexEfSearch       = 64
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -1428,13 +1436,18 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	if len(indexDocs) == 0 {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway createIndexes requires at least one index")
 	}
-	defs := make([]collections.IndexDefinition, 0, len(indexDocs))
+	scalarDefs := make([]collections.IndexDefinition, 0, len(indexDocs))
+	var vectorDefs []collections.VectorIndexDefinition
 	for i, indexDoc := range indexDocs {
 		def, err := parseCreateIndexDefinition(indexDoc)
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("indexes[%d]: %v", i, err))
 		}
-		defs = append(defs, s.applyDefaultIndexOptions(def))
+		if def.vector {
+			vectorDefs = append(vectorDefs, def.vectorDef)
+			continue
+		}
+		scalarDefs = append(scalarDefs, s.applyDefaultIndexOptions(def.scalarDef))
 	}
 
 	createdAutomatically := false
@@ -1444,7 +1457,8 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
 		meta := s.defaultCollectionMeta(name)
-		meta.Indexes = dedupeIdenticalIndexDefinitions(defs)
+		meta.Indexes = dedupeIdenticalIndexDefinitions(scalarDefs)
+		meta.VectorIndexes = dedupeIdenticalVectorIndexDefinitions(vectorDefs)
 		created, err := s.Collections.CreateCollection(meta)
 		if err != nil {
 			// If another request created the collection after our miss, fall
@@ -1459,13 +1473,13 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 				{Key: "ok", Value: 1.0},
 				{Key: "createdCollectionAutomatically", Value: true},
 				{Key: "numIndexesBefore", Value: int32(1)},
-				{Key: "numIndexesAfter", Value: int32(1 + len(created.Indexes))},
+				{Key: "numIndexesAfter", Value: int32(1 + len(created.Indexes) + len(created.VectorIndexes))},
 			})
 		}
 	}
-	numBefore := int32(1 + len(col.Meta().Indexes))
+	numBefore := int32(1 + len(col.Meta().Indexes) + len(col.Meta().VectorIndexes))
 	meta := col.Meta()
-	for _, def := range defs {
+	for _, def := range scalarDefs {
 		if existing, ok := findIndexDefinition(meta.Indexes, def.Name); ok && sameIndexDefinition(existing, def) {
 			continue
 		}
@@ -1479,11 +1493,21 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		}
 		meta = *next
 	}
+	for _, def := range vectorDefs {
+		if existing, ok := findVectorIndexDefinition(meta.VectorIndexes, def.Name); ok && sameVectorIndexDefinition(existing, def) {
+			continue
+		}
+		next, err := col.CreateVectorIndex(def)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		meta = *next
+	}
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "createdCollectionAutomatically", Value: createdAutomatically},
 		{Key: "numIndexesBefore", Value: numBefore},
-		{Key: "numIndexesAfter", Value: int32(1 + len(meta.Indexes))},
+		{Key: "numIndexesAfter", Value: int32(1 + len(meta.Indexes) + len(meta.VectorIndexes))},
 	})
 }
 
@@ -1539,7 +1563,8 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 		}
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	before := int32(1 + len(col.Meta().Indexes))
+	metaBefore := col.Meta()
+	before := int32(1 + len(metaBefore.Indexes) + len(metaBefore.VectorIndexes))
 	names, all, err := dropIndexNames(command)
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
@@ -1548,17 +1573,34 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 		if _, err := col.DropAllIndexes(); err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
-	} else {
-		for _, indexName := range names {
-			if indexName == "_id_" {
-				return commandError(commandCodeBadValue, "BadValue", "cannot drop _id index")
+		for _, index := range metaBefore.VectorIndexes {
+			if _, err := col.DropVectorIndex(index.Name); err != nil {
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
 			}
 		}
-		if _, err := col.DropIndexes(names); err != nil {
+	} else {
+		scalarNames, vectorNames, err := classifyDropIndexNames(metaBefore, names)
+		if err != nil {
 			if errors.Is(err, collections.ErrIndexNotFound) {
 				return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found")
 			}
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if len(scalarNames) > 0 {
+			if _, err := col.DropIndexes(scalarNames); err != nil {
+				if errors.Is(err, collections.ErrIndexNotFound) {
+					return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found")
+				}
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+		}
+		for _, indexName := range vectorNames {
+			if _, err := col.DropVectorIndex(indexName); err != nil {
+				if errors.Is(err, collections.ErrIndexNotFound) {
+					return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found")
+				}
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
 		}
 	}
 	return marshalDocument(bson.D{
@@ -2759,61 +2801,160 @@ func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, boo
 	return wire.Document(raw), changed, nil
 }
 
-func parseCreateIndexDefinition(doc wire.Document) (collections.IndexDefinition, error) {
+type createIndexDefinition struct {
+	scalarDef collections.IndexDefinition
+	vectorDef collections.VectorIndexDefinition
+	vector    bool
+}
+
+func parseCreateIndexDefinition(doc wire.Document) (createIndexDefinition, error) {
 	keyDoc, err := requiredDocumentField(doc, "key")
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	elements, err := bson.Raw(keyDoc).Elements()
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	if len(elements) != 1 {
-		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports single-field indexes only")
+		return createIndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports single-field indexes only")
 	}
 	field, err := elements[0].KeyErr()
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	if field == "_id" {
-		return collections.IndexDefinition{}, errors.New("Mongo gateway cannot create the built-in _id index")
-	}
-	if !isAscendingIndexKey(elements[0].Value()) {
-		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports ascending indexes only")
+		return createIndexDefinition{}, errors.New("Mongo gateway cannot create the built-in _id index")
 	}
 	name, namePresent, err := optionalStringFieldWithPresence(doc, "name")
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	if namePresent && name == "" {
-		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes index name cannot be empty")
+		return createIndexDefinition{}, errors.New("Mongo gateway createIndexes index name cannot be empty")
+	}
+	indexType, indexTypePresent, err := optionalStringFieldWithPresence(doc, treeDBIndexTypeField)
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	if indexTypePresent {
+		if indexType != treeDBIndexTypeVector {
+			return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes index %q on field %q has unsupported %s %q", indexNameOrDefault(name, namePresent, field, "_1"), field, treeDBIndexTypeField, indexType)
+		}
+		return parseCreateVectorIndexDefinition(doc, field, name, namePresent, elements[0].Value())
+	}
+
+	if isVectorIndexKey(elements[0].Value()) || !bson.Raw(doc).Lookup(treeDBVectorOptionsField).IsZero() {
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes vector index on field %q requires %s %q", field, treeDBIndexTypeField, treeDBIndexTypeVector)
+	}
+	if !isAscendingIndexKey(elements[0].Value()) {
+		return createIndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports ascending indexes only")
 	}
 	if !namePresent {
 		name = field + "_1"
 	}
 	unique, err := optionalBoolField(doc, "unique")
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	valueTypeRaw, valueTypePresent, err := optionalStringFieldWithPresence(doc, "treedbValueType")
 	if err != nil {
-		return collections.IndexDefinition{}, err
+		return createIndexDefinition{}, err
 	}
 	if !valueTypePresent {
-		return collections.IndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes index %q on field %q requires treedbValueType", name, field)
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes index %q on field %q requires treedbValueType", name, field)
 	}
 	valueType := collections.IndexValueType(valueTypeRaw)
 	switch valueType {
 	case collections.IndexValueString, collections.IndexValueBool, collections.IndexValueInt64, collections.IndexValueDouble:
 	default:
-		return collections.IndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes index %q on field %q has unsupported treedbValueType %q; supported values are string, bool, int64, double", name, field, valueTypeRaw)
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes index %q on field %q has unsupported treedbValueType %q; supported values are string, bool, int64, double", name, field, valueTypeRaw)
 	}
-	return collections.IndexDefinition{
+	return createIndexDefinition{scalarDef: collections.IndexDefinition{
 		Name:      name,
 		Field:     field,
 		ValueType: valueType,
 		Unique:    unique,
+	}}, nil
+}
+
+func parseCreateVectorIndexDefinition(doc wire.Document, field, name string, namePresent bool, keyValue bson.RawValue) (createIndexDefinition, error) {
+	if !isVectorIndexKey(keyValue) {
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes vector index on field %q requires key value %q", field, treeDBIndexTypeVector)
+	}
+	if !namePresent {
+		name = field + "_vector"
+	}
+	if unique, err := optionalBoolField(doc, "unique"); err != nil {
+		return createIndexDefinition{}, err
+	} else if unique {
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes vector index %q on field %q does not support unique", name, field)
+	}
+	if _, present, err := optionalStringFieldWithPresence(doc, "treedbValueType"); err != nil {
+		return createIndexDefinition{}, err
+	} else if present {
+		return createIndexDefinition{}, fmt.Errorf("Mongo gateway createIndexes vector index %q on field %q does not support treedbValueType", name, field)
+	}
+	options, err := requiredDocumentField(doc, treeDBVectorOptionsField)
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	dimensions, err := requiredPositiveIntField(options, "dimensions")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	metric, err := optionalVectorMetricField(options, "metric")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	m, err := optionalPositiveIntField(options, "m")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	efConstruction, err := optionalPositiveIntField(options, "efConstruction")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	efSearch, err := optionalPositiveIntField(options, "efSearch")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	encoding, err := optionalVectorEncodingField(options, "encoding")
+	if err != nil {
+		return createIndexDefinition{}, err
+	}
+	if m == 0 {
+		m = mongoDefaultVectorIndexM
+	}
+	if efConstruction == 0 {
+		efConstruction = mongoDefaultVectorIndexEfConstruction
+	}
+	if efConstruction < m {
+		efConstruction = m
+	}
+	if efSearch == 0 {
+		efSearch = mongoDefaultVectorIndexEfSearch
+	}
+	return createIndexDefinition{
+		vector: true,
+		vectorDef: collections.VectorIndexDefinition{
+			Name:           name,
+			Field:          field,
+			Metric:         metric,
+			Dimensions:     dimensions,
+			M:              m,
+			EfConstruction: efConstruction,
+			EfSearch:       efSearch,
+			Encoding:       encoding,
+		},
 	}, nil
+}
+
+func indexNameOrDefault(name string, present bool, field string, suffix string) string {
+	if present {
+		return name
+	}
+	return field + suffix
 }
 
 func optionalStringField(doc wire.Document, key string) (string, error) {
@@ -2844,6 +2985,83 @@ func isAscendingIndexKey(value bson.RawValue) bool {
 		return v == 1
 	}
 	return false
+}
+
+func isVectorIndexKey(value bson.RawValue) bool {
+	key, ok := value.StringValueOK()
+	return ok && key == treeDBIndexTypeVector
+}
+
+func requiredPositiveIntField(doc wire.Document, key string) (int, error) {
+	value, present, err := optionalPositiveIntFieldWithPresence(doc, key)
+	if err != nil {
+		return 0, err
+	}
+	if !present {
+		return 0, fmt.Errorf("Mongo command missing %q", key)
+	}
+	return value, nil
+}
+
+func optionalPositiveIntField(doc wire.Document, key string) (int, error) {
+	value, _, err := optionalPositiveIntFieldWithPresence(doc, key)
+	return value, err
+}
+
+func optionalPositiveIntFieldWithPresence(doc wire.Document, key string) (int, bool, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return 0, false, nil
+	}
+	var out int64
+	if v, ok := value.Int32OK(); ok {
+		out = int64(v)
+	} else if v, ok := value.Int64OK(); ok {
+		out = v
+	} else {
+		return 0, true, fmt.Errorf("Mongo command field %q must be an integer", key)
+	}
+	if out <= 0 {
+		return 0, true, fmt.Errorf("Mongo command field %q must be positive", key)
+	}
+	if out > int64(maxInt) {
+		return 0, true, fmt.Errorf("Mongo command field %q is out of int range", key)
+	}
+	return int(out), true, nil
+}
+
+func optionalVectorMetricField(doc wire.Document, key string) (collections.VectorMetric, error) {
+	value, present, err := optionalStringFieldWithPresence(doc, key)
+	if err != nil {
+		return 0, err
+	}
+	if !present || value == "" || value == collections.VectorMetricCosine.String() {
+		return collections.VectorMetricCosine, nil
+	}
+	switch value {
+	case collections.VectorMetricL2.String():
+		return collections.VectorMetricL2, nil
+	case collections.VectorMetricInnerProduct.String():
+		return collections.VectorMetricInnerProduct, nil
+	default:
+		return 0, fmt.Errorf("Mongo command field %q has unsupported vector metric %q; supported values are cosine, l2, inner_product", key, value)
+	}
+}
+
+func optionalVectorEncodingField(doc wire.Document, key string) (collections.VectorIndexEncoding, error) {
+	value, present, err := optionalStringFieldWithPresence(doc, key)
+	if err != nil {
+		return 0, err
+	}
+	if !present || value == "" || value == collections.VectorIndexEncodingFloat32.String() {
+		return collections.VectorIndexEncodingFloat32, nil
+	}
+	switch value {
+	case collections.VectorIndexEncodingInt8.String():
+		return collections.VectorIndexEncodingInt8, nil
+	default:
+		return 0, fmt.Errorf("Mongo command field %q has unsupported vector encoding %q; supported values are float32, int8", key, value)
+	}
 }
 
 func mongoCollectionDocument(name string, nameOnly bool) bson.D {
@@ -2883,6 +3101,23 @@ func mongoIndexDocuments(meta collections.CollectionMeta) bson.A {
 		}
 		out = append(out, doc)
 	}
+	for _, idx := range meta.VectorIndexes {
+		doc := bson.D{
+			{Key: "v", Value: int32(2)},
+			{Key: "key", Value: bson.D{{Key: idx.Field, Value: treeDBIndexTypeVector}}},
+			{Key: "name", Value: idx.Name},
+			{Key: treeDBIndexTypeField, Value: treeDBIndexTypeVector},
+			{Key: treeDBVectorOptionsField, Value: bson.D{
+				{Key: "dimensions", Value: int32(idx.Dimensions)},
+				{Key: "metric", Value: idx.Metric.String()},
+				{Key: "m", Value: int32(idx.M)},
+				{Key: "efConstruction", Value: int32(idx.EfConstruction)},
+				{Key: "efSearch", Value: int32(idx.EfSearch)},
+				{Key: "encoding", Value: idx.Encoding.String()},
+			}},
+		}
+		out = append(out, doc)
+	}
 	return out
 }
 
@@ -2906,6 +3141,26 @@ func dedupeIdenticalIndexDefinitions(defs []collections.IndexDefinition) []colle
 	return out
 }
 
+func findVectorIndexDefinition(indexes []collections.VectorIndexDefinition, name string) (collections.VectorIndexDefinition, bool) {
+	for _, index := range indexes {
+		if index.Name == name {
+			return index, true
+		}
+	}
+	return collections.VectorIndexDefinition{}, false
+}
+
+func dedupeIdenticalVectorIndexDefinitions(defs []collections.VectorIndexDefinition) []collections.VectorIndexDefinition {
+	out := make([]collections.VectorIndexDefinition, 0, len(defs))
+	for _, def := range defs {
+		if existing, ok := findVectorIndexDefinition(out, def.Name); ok && sameVectorIndexDefinition(existing, def) {
+			continue
+		}
+		out = append(out, def)
+	}
+	return out
+}
+
 func sameIndexDefinition(left, right collections.IndexDefinition) bool {
 	return left.Name == right.Name &&
 		left.Field == right.Field &&
@@ -2913,6 +3168,52 @@ func sameIndexDefinition(left, right collections.IndexDefinition) bool {
 		left.Unique == right.Unique &&
 		left.MultiKey == right.MultiKey &&
 		left.StoragePolicy == right.StoragePolicy
+}
+
+func sameVectorIndexDefinition(left, right collections.VectorIndexDefinition) bool {
+	return left.Name == right.Name &&
+		left.Field == right.Field &&
+		left.Metric == right.Metric &&
+		left.Dimensions == right.Dimensions &&
+		left.M == right.M &&
+		left.EfConstruction == right.EfConstruction &&
+		left.EfSearch == right.EfSearch &&
+		left.Encoding == right.Encoding
+}
+
+func classifyDropIndexNames(meta collections.CollectionMeta, names []string) ([]string, []string, error) {
+	hasVector := false
+	for _, indexName := range names {
+		if indexName == "_id_" {
+			return nil, nil, errors.New("cannot drop _id index")
+		}
+		if _, ok := findIndexDefinition(meta.Indexes, indexName); ok {
+			continue
+		}
+		if _, ok := findVectorIndexDefinition(meta.VectorIndexes, indexName); ok {
+			hasVector = true
+			continue
+		}
+		return nil, nil, collections.ErrIndexNotFound
+	}
+	if hasVector {
+		scalarNames, vectorNames := splitDropIndexNames(meta, names)
+		return scalarNames, vectorNames, nil
+	}
+	return names, nil, nil
+}
+
+func splitDropIndexNames(meta collections.CollectionMeta, names []string) ([]string, []string) {
+	scalarNames := make([]string, 0, len(names))
+	vectorNames := make([]string, 0, len(names))
+	for _, indexName := range names {
+		if _, ok := findIndexDefinition(meta.Indexes, indexName); ok {
+			scalarNames = append(scalarNames, indexName)
+			continue
+		}
+		vectorNames = append(vectorNames, indexName)
+	}
+	return scalarNames, vectorNames
 }
 
 func dropIndexNames(command wire.Document) ([]string, bool, error) {

--- a/TreeDB/mongo_gateway/index_metadata_bench_test.go
+++ b/TreeDB/mongo_gateway/index_metadata_bench_test.go
@@ -1,0 +1,98 @@
+package mongogateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func BenchmarkServerIndexMetadataScalarCycle(b *testing.B) {
+	db, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(b, serveCommand(b, server, 1, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	}))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		field := fmt.Sprintf("score_%d", i)
+		name := field + "_1"
+		assertOK(b, serveCommand(b, server, int32(10+i*3), bson.D{
+			{Key: "createIndexes", Value: "users"},
+			{Key: "indexes", Value: bson.A{bson.D{
+				{Key: "key", Value: bson.D{{Key: field, Value: int32(1)}}},
+				{Key: "name", Value: name},
+				{Key: "treedbValueType", Value: "double"},
+			}}},
+			{Key: "$db", Value: "app"},
+		}))
+		assertOK(b, serveCommand(b, server, int32(11+i*3), bson.D{
+			{Key: "listIndexes", Value: "users"},
+			{Key: "$db", Value: "app"},
+		}))
+		assertOK(b, serveCommand(b, server, int32(12+i*3), bson.D{
+			{Key: "dropIndexes", Value: "users"},
+			{Key: "index", Value: name},
+			{Key: "$db", Value: "app"},
+		}))
+	}
+}
+
+func BenchmarkServerIndexMetadataVectorCycle(b *testing.B) {
+	db, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(b, serveCommand(b, server, 1, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	}))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		field := fmt.Sprintf("embedding_%d", i)
+		name := field + "_vector"
+		assertOK(b, serveCommand(b, server, int32(10+i*3), bson.D{
+			{Key: "createIndexes", Value: "users"},
+			{Key: "indexes", Value: bson.A{bson.D{
+				{Key: "key", Value: bson.D{{Key: field, Value: "vector"}}},
+				{Key: "name", Value: name},
+				{Key: "treedbIndexType", Value: "vector"},
+				{Key: "treedbVector", Value: bson.D{
+					{Key: "dimensions", Value: int32(64)},
+					{Key: "metric", Value: "cosine"},
+					{Key: "m", Value: int32(16)},
+					{Key: "efConstruction", Value: int32(128)},
+					{Key: "efSearch", Value: int32(64)},
+					{Key: "encoding", Value: "float32"},
+				}},
+			}}},
+			{Key: "$db", Value: "app"},
+		}))
+		assertOK(b, serveCommand(b, server, int32(11+i*3), bson.D{
+			{Key: "listIndexes", Value: "users"},
+			{Key: "$db", Value: "app"},
+		}))
+		assertOK(b, serveCommand(b, server, int32(12+i*3), bson.D{
+			{Key: "dropIndexes", Value: "users"},
+			{Key: "index", Value: name},
+			{Key: "$db", Value: "app"},
+		}))
+	}
+}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2834,6 +2834,50 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 	})
 	assertCommandError(t, crossKindDuplicate, "DuplicateKey")
 
+	assertOK(t, serveCommand(t, server, 23330, bson.D{
+		{Key: "insert", Value: "vector_dup"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	}))
+	conflictingVectorDuplicate := serveCommand(t, server, 23331, bson.D{
+		{Key: "createIndexes", Value: "vector_dup"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+				{Key: "name", Value: "embedding_vector"},
+				{Key: "treedbIndexType", Value: "vector"},
+				{Key: "treedbVector", Value: bson.D{{Key: "dimensions", Value: int32(64)}}},
+			},
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+				{Key: "name", Value: "embedding_vector"},
+				{Key: "treedbIndexType", Value: "vector"},
+				{Key: "treedbVector", Value: bson.D{{Key: "dimensions", Value: int32(128)}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, conflictingVectorDuplicate, "BadValue")
+	errmsg, ok = bson.Raw(conflictingVectorDuplicate).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(errmsg, `duplicate vector index "embedding_vector"`) {
+		t.Fatalf("conflicting vector duplicate errmsg=%q ok=%v want duplicate vector index", errmsg, ok)
+	}
+	vectorDupCol, err := server.Collections.OpenCollection("app.vector_dup")
+	if err != nil {
+		t.Fatalf("open vector_dup collection: %v", err)
+	}
+	if got := len(vectorDupCol.Meta().VectorIndexes); got != 0 {
+		t.Fatalf("vector indexes after rejected duplicate=%d want 0", got)
+	}
+	vectorDupIndexes := cursorFirstBatch(t, serveCommand(t, server, 23332, bson.D{
+		{Key: "listIndexes", Value: "vector_dup"},
+		{Key: "$db", Value: "app"},
+	}))
+	if got, want := len(vectorDupIndexes), 1; got != want {
+		t.Fatalf("vector_dup indexes after rejected duplicate len=%d want %d", got, want)
+	}
+	assertIndexName(t, vectorDupIndexes[0], "_id_")
+
 	invalidListCollectionsDB := serveCommand(t, server, 234, bson.D{
 		{Key: "listCollections", Value: int32(1)},
 		{Key: "$db", Value: "bad/name"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2357,6 +2357,66 @@ func TestServerVectorIndexMetadataExtension(t *testing.T) {
 	assertIndexName(t, afterDropAll[0], "_id_")
 }
 
+func TestServerCreateIndexesConflictingExistingVectorDoesNotCreateScalar(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	vectorIndex := bson.D{
+		{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+		{Key: "name", Value: "embedding_vector"},
+		{Key: "treedbIndexType", Value: "vector"},
+		{Key: "treedbVector", Value: bson.D{
+			{Key: "dimensions", Value: int32(64)},
+			{Key: "metric", Value: "cosine"},
+		}},
+	}
+	assertOK(t, serveCommand(t, server, 23114, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{vectorIndex}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	conflictingVector := bson.D{
+		{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+		{Key: "name", Value: "embedding_vector"},
+		{Key: "treedbIndexType", Value: "vector"},
+		{Key: "treedbVector", Value: bson.D{
+			{Key: "dimensions", Value: int32(32)},
+			{Key: "metric", Value: "cosine"},
+		}},
+	}
+	response := serveCommand(t, server, 23115, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+				{Key: "name", Value: "city_1"},
+				{Key: "treedbValueType", Value: "string"},
+			},
+			conflictingVector,
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, ok := findIndexDefinition(col.Meta().Indexes, "city_1"); ok {
+		t.Fatalf("conflicting vector request created scalar index: %+v", col.Meta().Indexes)
+	}
+	stored, ok := findVectorIndexDefinition(col.Meta().VectorIndexes, "embedding_vector")
+	if !ok || stored.Dimensions != 64 {
+		t.Fatalf("vector index changed after conflicting request: %+v ok=%v", stored, ok)
+	}
+}
+
 func TestServerCreateCollectionCommand(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2251,6 +2251,30 @@ func TestServerVectorIndexMetadataExtension(t *testing.T) {
 		t.Fatalf("encoding=%q ok=%v want float32", got, ok)
 	}
 
+	doubleOptionsResponse := serveCommand(t, server, 231021, bson.D{
+		{Key: "createIndexes", Value: "users_double_vector_options"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbIndexType", Value: "vector"},
+			{Key: "treedbVector", Value: bson.D{
+				{Key: "dimensions", Value: float64(64)},
+				{Key: "m", Value: float64(16)},
+				{Key: "efConstruction", Value: float64(128)},
+				{Key: "efSearch", Value: float64(64)},
+			}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, doubleOptionsResponse)
+	doubleOptionsCol, err := server.Collections.OpenCollection("app.users_double_vector_options")
+	if err != nil {
+		t.Fatalf("open double-options collection: %v", err)
+	}
+	if got := doubleOptionsCol.Meta().VectorIndexes[0]; got.Dimensions != 64 || got.M != 16 || got.EfConstruction != 128 || got.EfSearch != 64 {
+		t.Fatalf("double vector options stored=%+v", got)
+	}
+
 	replayResponse := serveCommand(t, server, 23103, bson.D{
 		{Key: "createIndexes", Value: "users"},
 		{Key: "indexes", Value: bson.A{indexBatch[2]}},
@@ -2685,6 +2709,24 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 	errmsg, ok = bson.Raw(missingVectorOptions).Lookup("errmsg").StringValueOK()
 	if !ok || !strings.Contains(errmsg, "treedbVector") {
 		t.Fatalf("missing vector options errmsg=%q ok=%v want treedbVector", errmsg, ok)
+	}
+
+	fractionalVectorOption := serveCommand(t, server, 233221, bson.D{
+		{Key: "createIndexes", Value: "users_fractional_vector_option"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbIndexType", Value: "vector"},
+			{Key: "treedbVector", Value: bson.D{{Key: "dimensions", Value: float64(64.5)}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, fractionalVectorOption, "BadValue")
+	errmsg, ok = bson.Raw(fractionalVectorOption).Lookup("errmsg").StringValueOK()
+	for _, want := range []string{"dimensions", "integer"} {
+		if !ok || !strings.Contains(errmsg, want) {
+			t.Fatalf("fractional vector option errmsg=%q ok=%v want %q", errmsg, ok, want)
+		}
 	}
 
 	unsupportedVectorMetric := serveCommand(t, server, 23323, bson.D{

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2689,6 +2689,26 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 		}
 	}
 
+	oversizedVectorOption := serveCommand(t, server, 23324, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbIndexType", Value: "vector"},
+			{Key: "treedbVector", Value: bson.D{
+				{Key: "dimensions", Value: int64(1) << 40},
+			}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, oversizedVectorOption, "BadValue")
+	errmsg, ok = bson.Raw(oversizedVectorOption).Lookup("errmsg").StringValueOK()
+	for _, want := range []string{"dimensions", "int32"} {
+		if !ok || !strings.Contains(errmsg, want) {
+			t.Fatalf("oversized vector option errmsg=%q ok=%v want %q", errmsg, ok, want)
+		}
+	}
+
 	conflictingDuplicate := serveCommand(t, server, 2333, bson.D{
 		{Key: "createIndexes", Value: "conflicting_dup"},
 		{Key: "indexes", Value: bson.A{

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2166,6 +2166,154 @@ func TestServerIndexMetadataCommands(t *testing.T) {
 	assertIndexName(t, indexBatch[0], "_id_")
 }
 
+func TestServerVectorIndexMetadataExtension(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	vectorIndex := bson.D{
+		{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+		{Key: "name", Value: "embedding_vector"},
+		{Key: "treedbIndexType", Value: "vector"},
+		{Key: "treedbVector", Value: bson.D{
+			{Key: "dimensions", Value: int32(64)},
+			{Key: "metric", Value: "cosine"},
+			{Key: "m", Value: int32(16)},
+			{Key: "efConstruction", Value: int32(128)},
+			{Key: "efSearch", Value: int32(64)},
+			{Key: "encoding", Value: "float32"},
+		}},
+	}
+	createResponse := serveCommand(t, server, 23101, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+				{Key: "name", Value: "email_1"},
+				{Key: "treedbValueType", Value: "string"},
+			},
+			vectorIndex,
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, createResponse)
+	assertInt32(t, createResponse, "numIndexesBefore", 1)
+	assertInt32(t, createResponse, "numIndexesAfter", 3)
+
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if got := len(col.Meta().VectorIndexes); got != 1 {
+		t.Fatalf("vector indexes=%d want 1", got)
+	}
+	stored := col.Meta().VectorIndexes[0]
+	if stored.Name != "embedding_vector" || stored.Field != "embedding" || stored.Dimensions != 64 || stored.Metric != collections.VectorMetricCosine || stored.Encoding != collections.VectorIndexEncodingFloat32 {
+		t.Fatalf("stored vector index=%+v", stored)
+	}
+
+	indexesResponse := serveCommand(t, server, 23102, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch := cursorFirstBatch(t, indexesResponse)
+	if got, want := len(indexBatch), 3; got != want {
+		t.Fatalf("index batch len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+	assertIndexName(t, indexBatch[1], "email_1")
+	assertIndexName(t, indexBatch[2], "embedding_vector")
+	keyDoc, ok := indexBatch[2].Lookup("key").DocumentOK()
+	if !ok {
+		t.Fatalf("vector index key missing: %v", indexBatch[2])
+	}
+	if got, ok := keyDoc.Lookup("embedding").StringValueOK(); !ok || got != "vector" {
+		t.Fatalf("vector key embedding=%q ok=%v want vector", got, ok)
+	}
+	if got, ok := indexBatch[2].Lookup("treedbIndexType").StringValueOK(); !ok || got != "vector" {
+		t.Fatalf("treedbIndexType=%q ok=%v want vector", got, ok)
+	}
+	options, ok := indexBatch[2].Lookup("treedbVector").DocumentOK()
+	if !ok {
+		t.Fatalf("treedbVector missing: %v", indexBatch[2])
+	}
+	if got, ok := options.Lookup("dimensions").Int32OK(); !ok || got != 64 {
+		t.Fatalf("dimensions=%d ok=%v want 64", got, ok)
+	}
+	if got, ok := options.Lookup("metric").StringValueOK(); !ok || got != "cosine" {
+		t.Fatalf("metric=%q ok=%v want cosine", got, ok)
+	}
+	if got, ok := options.Lookup("encoding").StringValueOK(); !ok || got != "float32" {
+		t.Fatalf("encoding=%q ok=%v want float32", got, ok)
+	}
+
+	replayResponse := serveCommand(t, server, 23103, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{indexBatch[2]}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, replayResponse)
+	assertInt32(t, replayResponse, "numIndexesBefore", 3)
+	assertInt32(t, replayResponse, "numIndexesAfter", 3)
+
+	assertOK(t, serveCommand(t, server, 23104, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "ada@example.com"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "grace@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 23105, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "email", Value: "ada@example.com"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u1"})
+
+	dropResponse := serveCommand(t, server, 23106, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: "embedding_vector"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, dropResponse)
+	assertInt32(t, dropResponse, "nIndexesWas", 3)
+	afterDrop := cursorFirstBatch(t, serveCommand(t, server, 23107, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	}))
+	if got, want := len(afterDrop), 2; got != want {
+		t.Fatalf("index batch after vector drop len=%d want %d", got, want)
+	}
+	assertIndexName(t, afterDrop[0], "_id_")
+	assertIndexName(t, afterDrop[1], "email_1")
+
+	assertOK(t, serveCommand(t, server, 23108, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{vectorIndex}},
+		{Key: "$db", Value: "app"},
+	}))
+	dropAllResponse := serveCommand(t, server, 23109, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: "*"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, dropAllResponse)
+	assertInt32(t, dropAllResponse, "nIndexesWas", 3)
+	afterDropAll := cursorFirstBatch(t, serveCommand(t, server, 23110, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	}))
+	if got, want := len(afterDropAll), 1; got != want {
+		t.Fatalf("index batch after drop all len=%d want %d", got, want)
+	}
+	assertIndexName(t, afterDropAll[0], "_id_")
+}
+
 func TestServerCreateCollectionCommand(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2485,6 +2633,59 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 	for _, want := range []string{"email_1", "email", "decimal", "string", "bool", "int64", "double"} {
 		if !ok || !strings.Contains(errmsg, want) {
 			t.Fatalf("unsupported value type errmsg=%q ok=%v want %q", errmsg, ok, want)
+		}
+	}
+
+	missingVectorType := serveCommand(t, server, 23321, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbVector", Value: bson.D{{Key: "dimensions", Value: int32(64)}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, missingVectorType, "BadValue")
+	errmsg, ok = bson.Raw(missingVectorType).Lookup("errmsg").StringValueOK()
+	for _, want := range []string{"treedbIndexType", "vector", "embedding"} {
+		if !ok || !strings.Contains(errmsg, want) {
+			t.Fatalf("missing vector type errmsg=%q ok=%v want %q", errmsg, ok, want)
+		}
+	}
+
+	missingVectorOptions := serveCommand(t, server, 23322, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbIndexType", Value: "vector"},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, missingVectorOptions, "BadValue")
+	errmsg, ok = bson.Raw(missingVectorOptions).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(errmsg, "treedbVector") {
+		t.Fatalf("missing vector options errmsg=%q ok=%v want treedbVector", errmsg, ok)
+	}
+
+	unsupportedVectorMetric := serveCommand(t, server, 23323, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "embedding", Value: "vector"}}},
+			{Key: "name", Value: "embedding_vector"},
+			{Key: "treedbIndexType", Value: "vector"},
+			{Key: "treedbVector", Value: bson.D{
+				{Key: "dimensions", Value: int32(64)},
+				{Key: "metric", Value: "angular"},
+			}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, unsupportedVectorMetric, "BadValue")
+	errmsg, ok = bson.Raw(unsupportedVectorMetric).Lookup("errmsg").StringValueOK()
+	for _, want := range []string{"metric", "angular", "cosine", "l2", "inner_product"} {
+		if !ok || !strings.Contains(errmsg, want) {
+			t.Fatalf("unsupported vector metric errmsg=%q ok=%v want %q", errmsg, ok, want)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds the Mongo gateway metadata bridge for native TreeDB vector indexes. `createIndexes` now accepts an explicit TreeDB extension:

```js
{
  key: { embedding: "vector" },
  name: "embedding_vector",
  treedbIndexType: "vector",
  treedbVector: {
    dimensions: 64,
    metric: "cosine",
    m: 16,
    efConstruction: 128,
    efSearch: 64,
    encoding: "float32"
  }
}
```

The gateway stores this as `CollectionMeta.VectorIndexes`, lists it back through `listIndexes`, and drops it through `dropIndexes`. Scalar index behavior remains unchanged and still requires `treedbValueType`.

Mongo-native vector query/search syntax is intentionally out of scope for this PR. Unsupported vector-shaped `createIndexes` documents without the explicit TreeDB extension are rejected clearly.

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServer(VectorIndexMetadataExtension|IndexMetadataRejectsInvalidCommands|IndexMetadataCommands)$'`
- `GOWORK=off go test ./TreeDB/mongo_gateway`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench`
- `git diff --check`
- `GOWORK=off go test ./...`

## Benchmarks and Profiles

Artifacts: `/tmp/gomap_1540_pr5_perf`

Scalar cycle benchmark compared against #1548 with the same benchmark harness:

```text
ServerIndexMetadataScalarCycle-12  126.4us +/-12% -> 130.0us +/-7%, ~ p=0.143 n=10
B/op                             83.06Ki +/-1% -> 82.42Ki +/-1%, ~ p=0.123 n=10
allocs/op                         515.0 +/-0% -> 515.0 +/-0%, ~ p=1.000 n=10
```

Vector extension cycle on this PR:

```text
ServerIndexMetadataVectorCycle-12  104.9us +/-6%, 26.53KiB/op, 340 allocs/op
```

Profiles captured:

- `scalar_cpu.pprof`, `scalar_mem.pprof`, `scalar_cpu_top.txt`, `scalar_mem_top.txt`
- `vector_cpu.pprof`, `vector_mem.pprof`, `vector_cpu_top.txt`, `vector_mem_top.txt`

Profile read: scalar metadata remains dominated by TreeDB catalog/root publication and runtime allocation work; the vector parser/list/drop extension is not a new top allocation site for ordinary scalar metadata commands.

Refs #1540
