### PR TITLE
Add native vector search performance gates

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -217,44 +218,8 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	dir := b.TempDir()
-	def := VectorIndexDefinition{
-		Name:       "embedding_graph_only",
-		Field:      "embedding",
-		Metric:     VectorMetricCosine,
-		Dimensions: dims,
-		M:          16,
-	}
-	d, col := openVectorBenchmarkCollectionWithVectorIndex(b, dir, docs, dims, def)
-	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("build native vector index: %v", err)
-	}
-	status, err := index.SaveSnapshot()
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("save native vector index: %v", err)
-	}
-	if err := d.Close(); err != nil {
-		b.Fatalf("close setup db: %v", err)
-	}
-	d, err = backenddb.Open(backenddb.Options{Dir: dir})
-	if err != nil {
-		b.Fatalf("reopen db: %v", err)
-	}
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
-	col, err = NewCollectionManager(d).OpenCollection("docs")
-	if err != nil {
-		b.Fatalf("open collection: %v", err)
-	}
-	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		b.Fatalf("load native vector index: %v", err)
-	}
-	if loaded == nil || !loadStatus.Loaded {
-		b.Fatalf("unexpected native load status loaded=%v status=%+v", loaded != nil, loadStatus)
-	}
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
 	if err != nil {
@@ -279,6 +244,121 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 			b.Fatal("native graph-only vector search returned no results")
 		}
 	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+	if err != nil {
+		b.Fatalf("warm native graph-only parallel search: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatal("warm native graph-only parallel search returned no results")
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("native graph-only vector search: %w", err)
+		}
+		if len(results) == 0 {
+			return errors.New("native graph-only vector search returned no results")
+		}
+		return nil
+	})
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			b.Fatalf("native vector search: %v", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			b.Fatalf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector parallel search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector parallel search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			return fmt.Errorf("native vector search: %w", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			return fmt.Errorf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+		return nil
+	})
 }
 
 func BenchmarkCollectionVectorIndexIncrementalWrite(b *testing.B) {
@@ -554,32 +634,18 @@ func BenchmarkCollectionVectorIndexGraphOnlySearchParallel(b *testing.B) {
 	b.ReportMetric(float64(docs), "docs/index")
 	b.ReportMetric(float64(dims), "dims")
 	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
 	b.ResetTimer()
-	var failureMu sync.Mutex
-	var firstFailure string
-	recordFailure := func(format string, args ...any) {
-		failureMu.Lock()
-		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = fmt.Sprintf(format, args...)
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("graph-only vector search: %w", err)
 		}
-	}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
-			if err != nil {
-				recordFailure("graph-only vector search: %v", err)
-				return
-			}
-			if len(results) == 0 {
-				recordFailure("graph-only vector search returned no results")
-				return
-			}
+		if len(results) == 0 {
+			return errors.New("graph-only vector search returned no results")
 		}
+		return nil
 	})
-	if firstFailure != "" {
-		b.Fatal(firstFailure)
-	}
 }
 
 func BenchmarkCollectionVectorIndexSearchInt8(b *testing.B) {
@@ -900,6 +966,75 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 		documents[i] = vectorBenchmarkDocument(i, dims)
 	}
 	return ids, documents
+}
+
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+	tb.Helper()
+	dir := tb.TempDir()
+	def := VectorIndexDefinition{
+		Name:       name,
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: dims,
+		M:          16,
+	}
+	d, col := openVectorBenchmarkCollectionWithVectorIndex(tb, dir, docs, dims, def)
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("build native vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("save native vector index: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("close setup db: %v", err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("reopen db: %v", err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("open collection: %v", err)
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("load native vector index: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID != saveStatus.RootID {
+		_ = d.Close()
+		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
+	}
+	return d, col, loaded, saveStatus
+}
+
+func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
+	b.Helper()
+	var failureMu sync.Mutex
+	var firstFailure string
+	recordFailure := func(err error) {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		if firstFailure == "" {
+			firstFailure = err.Error()
+		}
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := search(); err != nil {
+				recordFailure(err)
+				return
+			}
+		}
+	})
+	if firstFailure != "" {
+		b.Fatal(firstFailure)
+	}
 }
 
 func vectorBenchmarkInsertBatches(tb testing.TB, col *Collection, ids, documents [][]byte, batchSize int) {

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -220,7 +220,7 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -251,7 +251,7 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -283,15 +283,16 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.
 func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector search: %v", err)
 	}
@@ -306,12 +307,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			b.Fatalf("native vector search: %v", err)
 		}
@@ -324,15 +320,16 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector parallel search: %v", err)
 	}
@@ -347,12 +344,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	runParallelVectorSearchBenchmark(b, func() error {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			return fmt.Errorf("native vector search: %w", err)
 		}
@@ -994,7 +986,7 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 	return ids, documents
 }
 
-func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *VectorIndex, VectorIndexLoadStatus) {
 	tb.Helper()
 	dir := tb.TempDir()
 	def := VectorIndexDefinition{
@@ -1036,18 +1028,18 @@ func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name st
 		_ = d.Close()
 		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
 	}
-	return d, col, loaded, saveStatus
+	return d, loaded, loadStatus
 }
 
 func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 	b.Helper()
 	var failureMu sync.Mutex
-	var firstFailure string
+	var firstFailure error
 	recordFailure := func(err error) {
 		failureMu.Lock()
 		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = err.Error()
+		if firstFailure == nil {
+			firstFailure = err
 		}
 	}
 	b.RunParallel(func(pb *testing.PB) {
@@ -1058,7 +1050,7 @@ func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 			}
 		}
 	})
-	if firstFailure != "" {
+	if firstFailure != nil {
 		b.Fatal(firstFailure)
 	}
 }


### PR DESCRIPTION
## Summary

Adds native persisted vector-search performance gates for the final issue #1540 hardening layer.

This PR does not change product search semantics. It adds benchmark coverage for the persisted native HNSW graph paths that were missing from the stack:

- loaded native graph-only search, factored through a shared loaded-index helper;
- loaded native graph-only parallel search with `b.RunParallel`;
- loaded native full ANN + canonical rerank search;
- loaded native full ANN + canonical rerank parallel search.

The profile read from this gate does not justify adding a speculative node/document cache in this PR. Full search cost is split between graph traversal/dot products and canonical document rerank/read work, so a cache or rerank-source change should be a separate design/benchmark PR because it changes the memory/correctness tradeoff.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionVectorIndexNativeRoot(GraphOnlySearch|GraphOnlySearchParallel|Search|SearchParallel)$' -benchtime=1x -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionVectorIndexNativeRoot(GraphOnlySearch|GraphOnlySearchParallel|Search|SearchParallel)$' -benchtime=100x -count=10 -benchmem`
- `GOWORK=off go test ./TreeDB/collections`
- `git diff --check`
- `GOWORK=off go test ./...`

## Benchmarks and Profiles

Artifacts: `/tmp/gomap_1540_pr6_perf`

The comparison uses the same benchmark harness copied onto the immediate base branch (`codex/native-vector-index-mongo-metadata`, head `330e64c2`) so the numbers measure current native vector behavior rather than unrelated harness availability.

```text
CollectionVectorIndexNativeRootGraphOnlySearch-12           71.60us +/-5% -> 71.26us +/-4%, ~ p=0.912 n=10, 11 allocs/op
CollectionVectorIndexNativeRootGraphOnlySearchParallel-12   19.30us +/-3% -> 20.30us +/-20%, +5.14% p=0.002 n=10, 13 allocs/op
CollectionVectorIndexNativeRootSearch-12                    1.130ms +/-2% -> 1.135ms +/-8%, ~ p=0.247 n=10, 1284 allocs/op
CollectionVectorIndexNativeRootSearchParallel-12            223.0us +/-4% -> 224.9us +/-17%, ~ p=0.393 n=10, 1289 allocs/op
```

This PR is benchmark-only; there is no production hot-path code change. The parallel graph-only variance is recorded as harness/run noise rather than a product regression because the compared source is identical apart from benchmark availability.

Profiles captured:

- `native_search_cpu.pprof`, `native_search_mem.pprof`, `native_search_cpu_top.txt`, `native_search_mem_top.txt`
- `native_search_parallel_cpu.pprof`, `native_search_parallel_mem.pprof`, `native_search_parallel_cpu_top.txt`, `native_search_parallel_mem_top.txt`

Profile read:

- CPU top sites are graph traversal and distance scoring: `searchLayerWithScratchLocked`, Gonum `f32.DotUnitary`, candidate heap/sort work, and rerank-related vector/document parsing.
- Allocation profile is contaminated by benchmark setup because Go's package CPU/mem profiles include setup before `b.ResetTimer`, but the benchmark alloc/op counters provide the steady gate. The profile still shows canonical rerank/document read work as the relevant full-search allocation domain.
- No cache is added here; a cache would need a dedicated PR proving throughput gain, memory cost, and correctness around document-as-source-of-truth semantics.

Refs #1540
