### PR TITLE
experiments/colgranule: precompute jsonbench hour codes

### DIFF
--- a/experiments/colgranule/jsonbench.go
+++ b/experiments/colgranule/jsonbench.go
@@ -16,6 +16,8 @@ import (
 const DefaultJSONBenchPath = "experiments/colgranule/testdata/jsonbench_sample.jsonl"
 const DefaultJSONBenchDir = "experiments/colgranule/testdata"
 
+const jsonBenchHoursPerDay = 24
+
 type JSONBenchDataset struct {
 	Rows         int
 	Files        []string
@@ -34,6 +36,7 @@ func LoadJSONBenchColumns(path string, limit int) (JSONBenchDataset, error) {
 	ds := JSONBenchDataset{Columns: map[string][]int64{
 		"row_index":                   nil,
 		"time_us":                     nil,
+		"hour_of_day":                 nil,
 		"line_bytes":                  nil,
 		"did_code":                    nil,
 		"did_bytes":                   nil,
@@ -207,6 +210,7 @@ func appendJSONBenchRow(ds *JSONBenchDataset, dicts map[string]*stringDictionary
 	}
 	ds.Columns["row_index"] = append(ds.Columns["row_index"], row)
 	ds.Columns["time_us"] = append(ds.Columns["time_us"], ev.TimeUS)
+	ds.Columns["hour_of_day"] = append(ds.Columns["hour_of_day"], unixMicroHour(ev.TimeUS))
 	ds.Columns["line_bytes"] = append(ds.Columns["line_bytes"], int64(len(line)))
 	ds.Columns["did_code"] = append(ds.Columns["did_code"], dicts["did_code"].code(ev.Did))
 	ds.Columns["did_bytes"] = append(ds.Columns["did_bytes"], int64(len(ev.Did)))

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -103,6 +103,7 @@ func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
 	columns := map[string][]int64{
 		"row_index":              make([]int64, rows),
 		"time_us":                make([]int64, rows),
+		"hour_of_day":            make([]int64, rows),
 		"did_code":               make([]int64, rows),
 		"kind_code":              make([]int64, rows),
 		"commit_operation_code":  make([]int64, rows),
@@ -112,6 +113,7 @@ func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
 	for i := 0; i < rows; i++ {
 		columns["row_index"][i] = int64(i)
 		columns["time_us"][i] = 1_700_000_000_000_000 + int64(i)*1_000_000
+		columns["hour_of_day"][i] = unixMicroHour(columns["time_us"][i])
 		columns["did_code"][i] = int64((i % didCardinality) + 1)
 		columns["kind_code"][i] = 1
 		columns["commit_operation_code"][i] = 1

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -66,7 +66,7 @@ type jsonBenchPartQueryRunner func(*ColumnPart, queryCodeSet, *jsonBenchPartQuer
 
 var (
 	jsonBenchPartQ2Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
-	jsonBenchPartQ3Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "time_us"}
+	jsonBenchPartQ3Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "hour_of_day"}
 	jsonBenchPartQ4Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
 	jsonBenchPartQ5Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
 )
@@ -328,11 +328,11 @@ func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	timeBlocks, err := int64Blocks(part, "time_us")
+	hourBlocks, err := lowCardinalityBlocks(part, "hour_of_day")
 	if err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
-	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, timeBlocks); err != nil {
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, hourBlocks); err != nil {
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
 	collectionCardinality, err := partCodeCardinality(part, "commit_collection_code")
@@ -356,14 +356,11 @@ func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		timeValues, err := scratch.timeReader.DecodeInt64(timeBlocks[blockIndex].Granule)
+		hourHeader, err := scratch.codeHeader(3, hourBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
 		rows := kindBlocks[blockIndex].Descriptor.RowCount
-		if len(timeValues) != rows {
-			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q3 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
-		}
 		for row := 0; row < rows; row++ {
 			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
 			if kind >= kindHeader.cardinality {
@@ -386,8 +383,11 @@ func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 			if int64(event) != codes.collectionPost && int64(event) != codes.collectionRepost && int64(event) != codes.collectionLike {
 				continue
 			}
-			hour := unixMicroHour(timeValues[row])
-			counts[int(event)*24+int(hour)]++
+			hour := readUint32Code(hourHeader.data, hourHeader.width, row)
+			if hour >= hourHeader.cardinality || hour >= jsonBenchHoursPerDay {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: hour_of_day code %d outside cardinality %d", hour, hourHeader.cardinality)
+			}
+			counts[int(event)*jsonBenchHoursPerDay+int(hour)]++
 		}
 	}
 	rows, digest := digestDenseQ3(counts)
@@ -775,7 +775,7 @@ func (s *jsonBenchPartQueryScratch) resetQ3Dense(eventCardinality uint32) ([]uin
 	if eventCardinality == 0 {
 		return nil, errors.New("colgranule: invalid q3 event cardinality 0")
 	}
-	cells := int(eventCardinality) * 24
+	cells := int(eventCardinality) * jsonBenchHoursPerDay
 	if cells <= 0 || cells > maxAggregateCells {
 		return nil, fmt.Errorf("colgranule: q3 aggregate cells=%d exceeds cap %d", cells, maxAggregateCells)
 	}
@@ -905,8 +905,8 @@ func digestDenseQ3(counts []uint64) (int, uint64) {
 			continue
 		}
 		rows++
-		event := cell / 24
-		hour := cell % 24
+		event := cell / jsonBenchHoursPerDay
+		hour := cell % jsonBenchHoursPerDay
 		digest = digestMix(digest, uint64(event*100+hour), count)
 	}
 	return rows, digest
@@ -1031,6 +1031,9 @@ func partCodeCardinality(part *ColumnPart, column string) (uint32, error) {
 }
 
 func jsonBenchCodeCardinality(ds JSONBenchDataset, column string) (uint32, bool) {
+	if column == "hour_of_day" {
+		return jsonBenchHoursPerDay, true
+	}
 	dict := ds.Dictionaries[column]
 	if dict == nil {
 		return 0, false

--- a/experiments/colgranule/jsonbench_queries.go
+++ b/experiments/colgranule/jsonbench_queries.go
@@ -251,7 +251,7 @@ func runJSONBenchQ5(ds JSONBenchDataset, codes queryCodeSet) (int, uint64) {
 }
 
 func unixMicroHour(us int64) int64 {
-	return (us / 1_000_000 / 3600) % 24
+	return (us / 1_000_000 / 3600) % jsonBenchHoursPerDay
 }
 
 func digestCounts(counts map[int64]int64) uint64 {

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -13,10 +13,13 @@ func TestLoadJSONBenchColumnsSample(t *testing.T) {
 	if ds.Rows != 5 {
 		t.Fatalf("rows=%d want 5", ds.Rows)
 	}
-	for _, name := range []string{"time_us", "line_bytes", "did_code", "commit_collection_code", "record_created_at_unix_ms", "record_text_bytes"} {
+	for _, name := range []string{"time_us", "hour_of_day", "line_bytes", "did_code", "commit_collection_code", "record_created_at_unix_ms", "record_text_bytes"} {
 		if got := len(ds.Columns[name]); got != ds.Rows {
 			t.Fatalf("column %s len=%d want %d", name, got, ds.Rows)
 		}
+	}
+	if got, want := ds.Columns["hour_of_day"][0], unixMicroHour(ds.Columns["time_us"][0]); got != want {
+		t.Fatalf("hour_of_day[0]=%d want %d", got, want)
 	}
 	if got := ds.Columns["record_has_reply"][0]; got != 1 {
 		t.Fatalf("record_has_reply[0]=%d want 1", got)
@@ -82,6 +85,14 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunJSONBenchPartQueries: %v", err)
 	}
+	part, err := BuildJSONBenchColumnPart(ds, 2)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	hourColumn := part.Columns["hour_of_day"]
+	if hourColumn.Definition.Type != ColumnTypeLowCardinalityCode || hourColumn.Definition.Cardinality != jsonBenchHoursPerDay {
+		t.Fatalf("hour_of_day definition=%+v want low-cardinality/%d", hourColumn.Definition, jsonBenchHoursPerDay)
+	}
 	if len(partTimings) != len(rawTimings) {
 		t.Fatalf("part timings=%d raw timings=%d", len(partTimings), len(rawTimings))
 	}
@@ -119,6 +130,8 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 			if timing.Diagnostics.AggregateKernel != "fused_dense_group_count_hour_codes" {
 				t.Fatalf("Q3 kernel=%q want fused dense hour count", timing.Diagnostics.AggregateKernel)
 			}
+			assertContainsString(t, timing.Diagnostics.ColumnsProjected, "hour_of_day")
+			assertNotContainsString(t, timing.Diagnostics.ColumnsProjected, "time_us")
 		case "Q4":
 			if timing.Diagnostics.AggregateKernel != "sort_key_early_stop_min_by_user" {
 				t.Fatalf("Q4 kernel=%q want sort-key early stop", timing.Diagnostics.AggregateKernel)
@@ -152,6 +165,9 @@ func TestLoadJSONBenchColumnsLocal1MIfPresent(t *testing.T) {
 	}
 	if got := len(ds.Columns["time_us"]); got != 1000 {
 		t.Fatalf("time_us len=%d want 1000", got)
+	}
+	if got := len(ds.Columns["hour_of_day"]); got != 1000 {
+		t.Fatalf("hour_of_day len=%d want 1000", got)
 	}
 }
 
@@ -236,5 +252,24 @@ func assertJSONBenchPartDiagnostics(t *testing.T, query string, diagnostics JSON
 	}
 	if len(diagnostics.ColumnsProjected) == 0 {
 		t.Fatalf("%s diagnostics missing columns projected: %+v", query, diagnostics)
+	}
+}
+
+func assertContainsString(t *testing.T, values []string, want string) {
+	t.Helper()
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("%q not found in %v", want, values)
+}
+
+func assertNotContainsString(t *testing.T, values []string, unwanted string) {
+	t.Helper()
+	for _, value := range values {
+		if value == unwanted {
+			t.Fatalf("%q unexpectedly found in %v", unwanted, values)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add a derived `hour_of_day` JSONBench column.
- Encode `hour_of_day` as a 24-value low-cardinality code column.
- Switch encoded-part q3 to read `hour_of_day` codes instead of decoding `time_us` and dividing timestamps.
- Assert q3 diagnostics project `hour_of_day`, not `time_us`, while preserving q1-q5 raw-vector parity.

Part of #1534 M1 hot-kernel polish. Stacks on #1550.

## Benchmark Results

Synthetic q3 benchmark:

| Query | Time | ns/row | Rows/sec | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| q3 hourly grouped count | 5.22 ms | 6.375 | 156.9M | 2408 | 4 |

1m encoded-part comparison against local ClickHouse:

| Query | Encoded part best | Local ClickHouse | Kernel |
|---|---:|---:|---|
| q1 | 0.002331s | 0.014000s | `grouped_count_codes` |
| q2 | 0.005600s | 0.027000s | `fused_dense_group_count_distinct_codes` |
| q3 | 0.008092s | 0.014000s | `fused_dense_group_count_hour_codes` |
| q4 | 0.000042s | 0.013000s | `sort_key_early_stop_min_by_user` |
| q5 | 0.010174s | 0.013000s | `fused_dense_span_by_user` |

q3 projects `kind_code`, `commit_operation_code`, `commit_collection_code`, and `hour_of_day`, decoding `4,000,984` raw bytes.

## Validation

- `go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsSample|TestRunJSONBenchPartQueriesSampleMatchesRawReference' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries/Q3_hourly_grouped_count' -benchmem -benchtime=20x`
- `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_m1_hour_1m_raw.json -out-md tmp/colgranule_m1_hour_1m_report.md`
