### PR TITLE
experiments/colgranule: decode q4 time prefix

### DIFF
--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -191,6 +191,28 @@ func (r *GranuleReader) DecodeInt64Into(dst []int64, g EncodedGranule) ([]int64,
 	return decodeInt64Payload(dst, raw, g)
 }
 
+func (r *GranuleReader) int64Cursor(g EncodedGranule) (int64Cursor, error) {
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return int64Cursor{}, err
+	}
+	cursor := int64Cursor{
+		encoding: g.Encoding,
+		raw:      raw,
+		rows:     g.Rows,
+	}
+	switch g.Encoding {
+	case EncodingRawInt64:
+		if len(raw)%8 != 0 || len(raw)/8 != g.Rows {
+			return int64Cursor{}, fmt.Errorf("colgranule: raw int64 length=%d rows=%d", len(raw), g.Rows)
+		}
+	case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+	default:
+		return int64Cursor{}, fmt.Errorf("colgranule: unsupported encoding %d", g.Encoding)
+	}
+	return cursor, nil
+}
+
 func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
 	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
 		r.values = r.values[:0]
@@ -428,6 +450,81 @@ func decodeDoubleDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error)
 		return nil, errors.New("colgranule: trailing double-delta bytes")
 	}
 	return out, nil
+}
+
+type int64Cursor struct {
+	encoding  Encoding
+	raw       []byte
+	rows      int
+	row       int
+	offset    int
+	prev      int64
+	prevDelta int64
+}
+
+func (c *int64Cursor) Next() (int64, error) {
+	if c.row >= c.rows {
+		return 0, fmt.Errorf("colgranule: int64 cursor row=%d exceeds rows=%d", c.row, c.rows)
+	}
+	switch c.encoding {
+	case EncodingRawInt64:
+		v := int64(binary.LittleEndian.Uint64(c.raw[c.row*8:]))
+		c.row++
+		c.offset = c.row * 8
+		return v, nil
+	case EncodingDeltaVarint:
+		u, n := binary.Uvarint(c.raw[c.offset:])
+		if n <= 0 {
+			return 0, errors.New("colgranule: malformed delta varint")
+		}
+		delta := unzigzag(u)
+		v := delta
+		if c.row > 0 {
+			v = c.prev + delta
+		}
+		c.row++
+		c.offset += n
+		c.prev = v
+		return v, nil
+	case EncodingDoubleDeltaVarint:
+		u, n := binary.Uvarint(c.raw[c.offset:])
+		if n <= 0 {
+			return 0, errors.New("colgranule: malformed double-delta varint")
+		}
+		encoded := unzigzag(u)
+		var v int64
+		switch c.row {
+		case 0:
+			v = encoded
+		case 1:
+			c.prevDelta = encoded
+			v = c.prev + encoded
+		default:
+			delta := c.prevDelta + encoded
+			v = c.prev + delta
+			c.prevDelta = delta
+		}
+		c.row++
+		c.offset += n
+		c.prev = v
+		return v, nil
+	default:
+		return 0, fmt.Errorf("colgranule: unsupported encoding %d", c.encoding)
+	}
+}
+
+func (c *int64Cursor) Finish() error {
+	if c.row != c.rows {
+		return fmt.Errorf("colgranule: decoded rows=%d want=%d", c.row, c.rows)
+	}
+	if c.encoding != EncodingRawInt64 && c.offset != len(c.raw) {
+		return fmt.Errorf("colgranule: trailing %s bytes", c.encoding)
+	}
+	return nil
+}
+
+func (c *int64Cursor) RawBytesRead() int {
+	return c.offset
 }
 
 type CompressionSelection struct {

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -273,6 +273,58 @@ func TestGranuleReaderReusesBuffersWithoutStaleValues(t *testing.T) {
 	}
 }
 
+func TestInt64CursorPrefixAndFinish(t *testing.T) {
+	values := []int64{1000, 1007, 1016, 1028, 1043, 1061}
+	for _, encoding := range []Encoding{EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
+		t.Run(encoding.String(), func(t *testing.T) {
+			g, err := EncodeInt64(nil, values, Config{Encoding: encoding, Compression: CompressionNone})
+			if err != nil {
+				t.Fatalf("EncodeInt64: %v", err)
+			}
+			var reader GranuleReader
+			cursor, err := reader.int64Cursor(g)
+			if err != nil {
+				t.Fatalf("int64Cursor: %v", err)
+			}
+			for i, want := range values[:3] {
+				got, err := cursor.Next()
+				if err != nil {
+					t.Fatalf("prefix Next(%d): %v", i, err)
+				}
+				if got != want {
+					t.Fatalf("prefix Next(%d)=%d want %d", i, got, want)
+				}
+			}
+			if cursor.RawBytesRead() <= 0 || cursor.RawBytesRead() >= g.RawBytes {
+				t.Fatalf("prefix raw bytes read=%d want between 1 and %d", cursor.RawBytesRead(), g.RawBytes-1)
+			}
+			if err := cursor.Finish(); err == nil {
+				t.Fatal("prefix Finish succeeded, want short-read error")
+			}
+
+			cursor, err = reader.int64Cursor(g)
+			if err != nil {
+				t.Fatalf("int64Cursor(full): %v", err)
+			}
+			for i, want := range values {
+				got, err := cursor.Next()
+				if err != nil {
+					t.Fatalf("full Next(%d): %v", i, err)
+				}
+				if got != want {
+					t.Fatalf("full Next(%d)=%d want %d", i, got, want)
+				}
+			}
+			if err := cursor.Finish(); err != nil {
+				t.Fatalf("full Finish: %v", err)
+			}
+			if cursor.RawBytesRead() != g.RawBytes {
+				t.Fatalf("full raw bytes read=%d want %d", cursor.RawBytesRead(), g.RawBytes)
+			}
+		})
+	}
+}
+
 func FuzzDecodeTypedGranuleCorruptPayloads(f *testing.F) {
 	boolGranule, err := NewGranuleBuilder(Config{Compression: CompressionNone}).BuildBool([]bool{true, false, true, true, false})
 	if err != nil {

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -452,7 +452,7 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		timeValues, err := scratch.timeReader.DecodeInt64(timeBlocks[blockIndex].Granule)
+		timeCursor, err := scratch.timeReader.int64Cursor(timeBlocks[blockIndex].Granule)
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
@@ -461,18 +461,18 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		bytesDecoded += operationBlocks[blockIndex].Granule.RawBytes
 		bytesDecoded += collectionBlocks[blockIndex].Granule.RawBytes
 		bytesDecoded += didBlocks[blockIndex].Granule.RawBytes
-		bytesDecoded += timeBlocks[blockIndex].Granule.RawBytes
 		if kindBlocks[blockIndex].Descriptor.LastGranule > lastGranule {
 			lastGranule = kindBlocks[blockIndex].Descriptor.LastGranule
 		}
 		rows := kindBlocks[blockIndex].Descriptor.RowCount
-		if len(timeValues) != rows {
-			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q4 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
-		}
 		for row := 0; row < rows; row++ {
-			timestamp := timeValues[row]
+			timestamp, err := timeCursor.Next()
+			if err != nil {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+			}
 			if len(top) == 3 && timestamp > top[2].t {
 				scratch.q4Pairs = top
+				bytesDecoded += timeCursor.RawBytesRead()
 				diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
 				return len(top), digestQ4Top(top), diagnostics, nil
 			}
@@ -507,6 +507,10 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 			}
 			top = insertQ4Top(top, jsonBenchPartTimePair{user: int64(user), t: timestamp})
 		}
+		if err := timeCursor.Finish(); err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		bytesDecoded += timeCursor.RawBytesRead()
 	}
 	scratch.q4Pairs = top
 	diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -144,6 +144,32 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 	}
 }
 
+func TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix(t *testing.T) {
+	ds := syntheticJSONBenchDataset(128)
+	part, err := BuildJSONBenchColumnPart(ds, 128)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	rows, digest, diagnostics, err := runJSONBenchPartQ4(part, codes, &jsonBenchPartQueryScratch{})
+	if err != nil {
+		t.Fatalf("runJSONBenchPartQ4: %v", err)
+	}
+	if rows != 3 || digest == 0 {
+		t.Fatalf("q4 rows/digest=(%d,%d), want non-empty top 3", rows, digest)
+	}
+	if diagnostics.RowsScanned >= ds.Rows {
+		t.Fatalf("q4 rows scanned=%d want early stop before %d", diagnostics.RowsScanned, ds.Rows)
+	}
+	fullDiagnostics := partColumnDiagnostics(part, jsonBenchPartQ4Columns, "full_decode_reference")
+	if diagnostics.BytesDecoded >= fullDiagnostics.BytesDecoded {
+		t.Fatalf("q4 decoded bytes=%d want less than full=%d", diagnostics.BytesDecoded, fullDiagnostics.BytesDecoded)
+	}
+}
+
 func TestLoadJSONBenchColumnsLocal1MIfPresent(t *testing.T) {
 	path := os.Getenv("JSONBENCH_DATA")
 	if path == "" {


### PR DESCRIPTION
## Summary

- Add an internal `int64Cursor` for prefix reads over raw, delta-varint, and double-delta-varint payloads.
- Switch q4 early-stop to read `time_us` through the cursor instead of materializing the full timestamp block.
- Keep full-block validation when q4 scans an entire block.
- Report only prefix-consumed timestamp bytes when q4 stops early.

Part of #1534 M1 hot-kernel polish. Stacks on #1553.

## Benchmark Results

Synthetic q4 benchmark:

| Query | Time | ns/scanned row | Rows/sec | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| q4 min by user | 32.9 us | 4696 | 213K | 80 | 1 |

1m encoded-part comparison against local ClickHouse:

| Query | Encoded part best | Local ClickHouse | Kernel |
|---|---:|---:|---|
| q1 | 0.002403s | 0.014000s | `grouped_count_codes` |
| q2 | 0.005560s | 0.027000s | `fused_dense_group_count_distinct_codes` |
| q3 | 0.008104s | 0.014000s | `fused_dense_group_count_hour_codes` |
| q4 | 0.000013s | 0.013000s | `sort_key_early_stop_min_by_user` |
| q5 | 0.009993s | 0.013000s | `fused_dense_span_by_user` |

q4 scans 9 rows, decodes 5 blocks, and reports `40,994` decoded bytes after prefix timestamp decoding.

## Validation

- `go test ./experiments/colgranule -run 'TestInt64CursorPrefixAndFinish|TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix|TestRunJSONBenchPartQueriesSampleMatchesRawReference' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries/Q4_min_by_user' -benchmem -benchtime=20x`
- `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_m1_q4_prefix_1m_raw.json -out-md tmp/colgranule_m1_q4_prefix_1m_report.md`
