### PR TITLE
experiments/colgranule: reset q4 bitset by touched words

### DIFF
--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -48,7 +48,7 @@ type jsonBenchPartQueryScratch struct {
 	q2Counts    []uint64
 	q2Seen      []uint64
 	q3Counts    []uint64
-	q4Seen      []uint64
+	q4Seen      touchedBitset
 	q5Seen      []uint64
 	q5Min       []int64
 	q5Max       []int64
@@ -502,7 +502,7 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 			if user >= didHeader.cardinality || user >= didCardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: did code %d outside cardinality %d", user, didCardinality)
 			}
-			if bitsetTestAndSet(seen, user) {
+			if bitsetTestAndSetTouched(seen, &scratch.q4Seen.touched, user) {
 				continue
 			}
 			top = insertQ4Top(top, jsonBenchPartTimePair{user: int64(user), t: timestamp})
@@ -708,14 +708,9 @@ func (s *jsonBenchPartQueryScratch) resetQ4Seen(didCardinality uint32) ([]uint64
 	if words <= 0 || words > maxAggregateCells {
 		return nil, fmt.Errorf("colgranule: q4 seen words=%d exceeds cap %d", words, maxAggregateCells)
 	}
-	if cap(s.q4Seen) < words {
-		s.q4Seen = make([]uint64, words)
-	} else {
-		s.q4Seen = s.q4Seen[:words]
-	}
-	clear(s.q4Seen)
+	seen := s.q4Seen.reset(words)
 	s.q4Pairs = s.q4Pairs[:0]
-	return s.q4Seen, nil
+	return seen, nil
 }
 
 func (s *jsonBenchPartQueryScratch) resetQ5Dense(didCardinality uint32) ([]uint64, []int64, []int64, []uint32, error) {
@@ -790,6 +785,37 @@ func (s *jsonBenchPartQueryScratch) resetQ3Dense(eventCardinality uint32) ([]uin
 	}
 	clear(s.q3Counts)
 	return s.q3Counts, nil
+}
+
+type touchedBitset struct {
+	words   []uint64
+	touched []int
+}
+
+func (b *touchedBitset) reset(words int) []uint64 {
+	for _, word := range b.touched {
+		b.words[word] = 0
+	}
+	b.touched = b.touched[:0]
+	if cap(b.words) < words {
+		b.words = make([]uint64, words)
+	} else {
+		b.words = b.words[:words]
+	}
+	return b.words
+}
+
+func bitsetTestAndSetTouched(words []uint64, touched *[]int, code uint32) bool {
+	word := int(code / 64)
+	bit := uint(code % 64)
+	mask := uint64(1) << bit
+	existing := words[word]
+	if existing == 0 {
+		*touched = append(*touched, word)
+	}
+	seen := existing&mask != 0
+	words[word] = existing | mask
+	return seen
 }
 
 func bitsetTestAndSet(words []uint64, code uint32) bool {

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -170,6 +170,33 @@ func TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix(t *testing.T) {
 	}
 }
 
+func TestTouchedBitsetResetClearsOnlyTouchedWords(t *testing.T) {
+	var bitset touchedBitset
+	words := bitset.reset(4)
+	if bitsetTestAndSetTouched(words, &bitset.touched, 3) {
+		t.Fatal("first code was already set")
+	}
+	if bitsetTestAndSetTouched(words, &bitset.touched, 3) == false {
+		t.Fatal("second code was not reported as already set")
+	}
+	bitsetTestAndSetTouched(words, &bitset.touched, 135)
+	if len(bitset.touched) != 2 {
+		t.Fatalf("touched words=%v want 2 unique words", bitset.touched)
+	}
+	words = bitset.reset(4)
+	for i, word := range words {
+		if word != 0 {
+			t.Fatalf("word %d=%d after reset, want 0", i, word)
+		}
+	}
+	if len(bitset.touched) != 0 {
+		t.Fatalf("touched after reset=%v want empty", bitset.touched)
+	}
+	if bitsetTestAndSetTouched(words, &bitset.touched, 3) {
+		t.Fatal("code remained set after reset")
+	}
+}
+
 func TestLoadJSONBenchColumnsLocal1MIfPresent(t *testing.T) {
 	path := os.Getenv("JSONBENCH_DATA")
 	if path == "" {


### PR DESCRIPTION
## Summary

- Add a touched-word bitset reset helper for sparse reuse cases.
- Use touched-word reset for q4 `did_code` seen state, where sort-key early-stop touches only a few words.
- Keep q2/q5 on full clears after benchmarking showed the per-row touched branch is slower for their dense scan shapes.

Part of #1534 M1 hot-kernel polish. Stacks on #1554.

## Benchmark Results

Synthetic encoded-kernel benchmark:

| Query | Time | Notes |
|---|---:|---|
| q2 group count distinct | 3.79 ms | dense full-clear path retained |
| q4 min by user | 32.9 us | touched-word reset |
| q5 span by user | 6.29 ms | dense full-clear path retained |

1m encoded-part comparison against local ClickHouse:

| Query | Encoded part best | Local ClickHouse | Kernel |
|---|---:|---:|---|
| q1 | 0.002326s | 0.014000s | `grouped_count_codes` |
| q2 | 0.005490s | 0.027000s | `fused_dense_group_count_distinct_codes` |
| q3 | 0.008092s | 0.014000s | `fused_dense_group_count_hour_codes` |
| q4 | 0.000013s | 0.013000s | `sort_key_early_stop_min_by_user` |
| q5 | 0.010083s | 0.013000s | `fused_dense_span_by_user` |

## Validation

- `go test ./experiments/colgranule -run 'TestTouchedBitsetResetClearsOnlyTouchedWords|TestRunJSONBenchPartQueriesSampleMatchesRawReference|TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries/(Q2_group_count_distinct|Q4_min_by_user|Q5_span_by_user)' -benchmem -benchtime=20x`
- `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_m1_touched_bitsets_1m_raw.json -out-md tmp/colgranule_m1_touched_bitsets_1m_report.md`
