### PR TITLE
experiments/colgranule: add tiny code readers

### DIFF
--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -266,15 +266,15 @@ func runJSONBenchPartQ2(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
 	for blockIndex := range kindBlocks {
-		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		kindHeader, err := scratch.tinyCodeHeader(0, kindBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		operationHeader, err := scratch.tinyCodeHeader(1, operationBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		collectionHeader, err := scratch.tinyCodeHeader(2, collectionBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
@@ -284,21 +284,21 @@ func runJSONBenchPartQ2(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		}
 		rows := kindBlocks[blockIndex].Descriptor.RowCount
 		for row := 0; row < rows; row++ {
-			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			kind := readTinyCode(kindHeader, row)
 			if kind >= kindHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
 			}
 			if int64(kind) != codes.kindCommit {
 				continue
 			}
-			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			operation := readTinyCode(operationHeader, row)
 			if operation >= operationHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
 			}
 			if int64(operation) != codes.operationCreate {
 				continue
 			}
-			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			event := readTinyCode(collectionHeader, row)
 			if event >= collectionHeader.cardinality || event >= collectionCardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionCardinality)
 			}
@@ -344,46 +344,46 @@ func runJSONBenchPartQ3(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
 	for blockIndex := range kindBlocks {
-		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		kindHeader, err := scratch.tinyCodeHeader(0, kindBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		operationHeader, err := scratch.tinyCodeHeader(1, operationBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		collectionHeader, err := scratch.tinyCodeHeader(2, collectionBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		hourHeader, err := scratch.codeHeader(3, hourBlocks[blockIndex])
+		hourHeader, err := scratch.tinyCodeHeader(3, hourBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
 		rows := kindBlocks[blockIndex].Descriptor.RowCount
 		for row := 0; row < rows; row++ {
-			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			kind := readTinyCode(kindHeader, row)
 			if kind >= kindHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
 			}
 			if int64(kind) != codes.kindCommit {
 				continue
 			}
-			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			operation := readTinyCode(operationHeader, row)
 			if operation >= operationHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
 			}
 			if int64(operation) != codes.operationCreate {
 				continue
 			}
-			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			event := readTinyCode(collectionHeader, row)
 			if event >= collectionHeader.cardinality || event >= collectionCardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionCardinality)
 			}
 			if int64(event) != codes.collectionPost && int64(event) != codes.collectionRepost && int64(event) != codes.collectionLike {
 				continue
 			}
-			hour := readUint32Code(hourHeader.data, hourHeader.width, row)
+			hour := readTinyCode(hourHeader, row)
 			if hour >= hourHeader.cardinality || hour >= jsonBenchHoursPerDay {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: hour_of_day code %d outside cardinality %d", hour, hourHeader.cardinality)
 			}
@@ -436,15 +436,15 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 	bytesDecoded := 0
 	lastGranule := -1
 	for blockIndex := range kindBlocks {
-		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		kindHeader, err := scratch.tinyCodeHeader(0, kindBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		operationHeader, err := scratch.tinyCodeHeader(1, operationBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		collectionHeader, err := scratch.tinyCodeHeader(2, collectionBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
@@ -477,21 +477,21 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 				return len(top), digestQ4Top(top), diagnostics, nil
 			}
 			rowsScanned++
-			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			kind := readTinyCode(kindHeader, row)
 			if kind >= kindHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
 			}
 			if int64(kind) != codes.kindCommit {
 				continue
 			}
-			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			operation := readTinyCode(operationHeader, row)
 			if operation >= operationHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
 			}
 			if int64(operation) != codes.operationCreate {
 				continue
 			}
-			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			event := readTinyCode(collectionHeader, row)
 			if event >= collectionHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionHeader.cardinality)
 			}
@@ -550,15 +550,15 @@ func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 	}
 	for blockIndex := range kindBlocks {
-		kindHeader, err := scratch.codeHeader(0, kindBlocks[blockIndex])
+		kindHeader, err := scratch.tinyCodeHeader(0, kindBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		operationHeader, err := scratch.codeHeader(1, operationBlocks[blockIndex])
+		operationHeader, err := scratch.tinyCodeHeader(1, operationBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
-		collectionHeader, err := scratch.codeHeader(2, collectionBlocks[blockIndex])
+		collectionHeader, err := scratch.tinyCodeHeader(2, collectionBlocks[blockIndex])
 		if err != nil {
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
 		}
@@ -575,21 +575,21 @@ func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 			return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: q5 time/code row mismatch time=%d codes=%d", len(timeValues), rows)
 		}
 		for row := 0; row < rows; row++ {
-			kind := readUint32Code(kindHeader.data, kindHeader.width, row)
+			kind := readTinyCode(kindHeader, row)
 			if kind >= kindHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
 			}
 			if int64(kind) != codes.kindCommit {
 				continue
 			}
-			operation := readUint32Code(operationHeader.data, operationHeader.width, row)
+			operation := readTinyCode(operationHeader, row)
 			if operation >= operationHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
 			}
 			if int64(operation) != codes.operationCreate {
 				continue
 			}
-			event := readUint32Code(collectionHeader.data, collectionHeader.width, row)
+			event := readTinyCode(collectionHeader, row)
 			if event >= collectionHeader.cardinality {
 				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionHeader.cardinality)
 			}
@@ -698,6 +698,26 @@ func (s *jsonBenchPartQueryScratch) codeHeader(reader int, block ColumnBlock) (u
 		return uint32CodesHeader{}, err
 	}
 	return parseUint32CodesHeader(raw, block.Descriptor.RowCount)
+}
+
+type tinyCodeHeader struct {
+	cardinality uint32
+	data        []byte
+}
+
+func (s *jsonBenchPartQueryScratch) tinyCodeHeader(reader int, block ColumnBlock) (tinyCodeHeader, error) {
+	header, err := s.codeHeader(reader, block)
+	if err != nil {
+		return tinyCodeHeader{}, err
+	}
+	if header.width != 1 {
+		return tinyCodeHeader{}, fmt.Errorf("colgranule: tiny-code reader width=%d want 1", header.width)
+	}
+	return tinyCodeHeader{cardinality: header.cardinality, data: header.data}, nil
+}
+
+func readTinyCode(header tinyCodeHeader, row int) uint32 {
+	return uint32(header.data[row])
 }
 
 func (s *jsonBenchPartQueryScratch) resetQ4Seen(didCardinality uint32) ([]uint64, error) {

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -197,6 +197,21 @@ func TestTouchedBitsetResetClearsOnlyTouchedWords(t *testing.T) {
 	}
 }
 
+func TestTinyCodeHeaderRejectsWideCodes(t *testing.T) {
+	g, err := NewGranuleBuilder(Config{Compression: CompressionNone}).BuildUint32Codes([]uint32{1, 255, 256}, 300)
+	if err != nil {
+		t.Fatalf("BuildUint32Codes: %v", err)
+	}
+	block := ColumnBlock{
+		Descriptor: ColumnBlockDescriptor{RowCount: 3},
+		Granule:    g,
+	}
+	var scratch jsonBenchPartQueryScratch
+	if _, err := scratch.tinyCodeHeader(0, block); err == nil {
+		t.Fatal("tinyCodeHeader accepted width > 1, want error")
+	}
+}
+
 func TestLoadJSONBenchColumnsLocal1MIfPresent(t *testing.T) {
 	path := os.Getenv("JSONBENCH_DATA")
 	if path == "" {


### PR DESCRIPTION
## Summary

- Add a one-byte tiny-code header/reader for known-small low-cardinality JSONBench fields.
- Use tiny-code reads for `kind_code`, `commit_operation_code`, `commit_collection_code`, and q3 `hour_of_day` in the fused encoded kernels.
- Keep high-cardinality `did_code` on the generic width-aware reader.
- Fail closed if a tiny-code field grows beyond one-byte codes.

Part of #1534 M1 hot-kernel polish. Stacks on #1555.

## Benchmark Results

Synthetic encoded-kernel benchmark:

| Query | Time | ns/row | Rows/sec | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| q1 grouped count | 1.97 ms | 2.401 | 416.4M | 2360 | 4 |
| q2 group count distinct | 3.40 ms | 4.155 | 240.7M | 2408 | 4 |
| q3 hourly grouped count | 4.21 ms | 5.141 | 194.5M | 2408 | 4 |
| q4 min by user | 33.5 us | 4779 scanned-row | 209K scanned | 80 | 1 |
| q5 span by user | 5.80 ms | 7.075 | 141.3M | 2424 | 4 |

1m encoded-part comparison against local ClickHouse:

| Query | Encoded part best | Local ClickHouse | Encoded / ClickHouse | Speedup vs ClickHouse | Rows scanned | Blocks decoded | Decoded bytes | Kernel |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| q1 | 2.325 ms | 14.000 ms | 0.166x | 6.02x | 1,000,000 | 123 | 1,000,246 | `grouped_count_codes` |
| q2 | 5.092 ms | 27.000 ms | 0.189x | 5.30x | 1,000,000 | 492 | 6,542,478 | `fused_dense_group_count_distinct_codes` |
| q3 | 7.130 ms | 14.000 ms | 0.509x | 1.96x | 1,000,000 | 492 | 4,000,984 | `fused_dense_group_count_hour_codes` |
| q4 | 0.013 ms | 13.000 ms | 0.001x | 1,003.1x | 9 | 5 | 40,994 | `sort_key_early_stop_min_by_user` |
| q5 | 9.418 ms | 13.000 ms | 0.725x | 1.38x | 1,000,000 | 615 | 8,225,804 | `fused_dense_span_by_user` |

Notes:

- Lower is better for `Encoded / ClickHouse`; higher is better for speedup.
- q1/q2/q3/q5 scan all 1m rows through fused encoded-block kernels without row materialization.
- q4 is not a full scan: it exploits ascending `time_us` sort order and stops after 9 rows once the top-3 earliest users are final.

## Validation

- `go test ./experiments/colgranule -run 'TestTinyCodeHeaderRejectsWideCodes|TestRunJSONBenchPartQueriesSampleMatchesRawReference|TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent' -count=1`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries' -benchmem -benchtime=20x`
- `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 5 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/fresh_1m_20260508_121356_clickhouse/result.json -measure-remaining-treedb=false -out-json tmp/colgranule_m1_tiny_codes_1m_raw.json -out-md tmp/colgranule_m1_tiny_codes_1m_report.md`
