### PR TITLE
Add TreeDB vector search demo benchmark

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -217,44 +218,8 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	dir := b.TempDir()
-	def := VectorIndexDefinition{
-		Name:       "embedding_graph_only",
-		Field:      "embedding",
-		Metric:     VectorMetricCosine,
-		Dimensions: dims,
-		M:          16,
-	}
-	d, col := openVectorBenchmarkCollectionWithVectorIndex(b, dir, docs, dims, def)
-	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("build native vector index: %v", err)
-	}
-	status, err := index.SaveSnapshot()
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("save native vector index: %v", err)
-	}
-	if err := d.Close(); err != nil {
-		b.Fatalf("close setup db: %v", err)
-	}
-	d, err = backenddb.Open(backenddb.Options{Dir: dir})
-	if err != nil {
-		b.Fatalf("reopen db: %v", err)
-	}
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
-	col, err = NewCollectionManager(d).OpenCollection("docs")
-	if err != nil {
-		b.Fatalf("open collection: %v", err)
-	}
-	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		b.Fatalf("load native vector index: %v", err)
-	}
-	if loaded == nil || !loadStatus.Loaded {
-		b.Fatalf("unexpected native load status loaded=%v status=%+v", loaded != nil, loadStatus)
-	}
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
 	if err != nil {
@@ -279,6 +244,121 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 			b.Fatal("native graph-only vector search returned no results")
 		}
 	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+	if err != nil {
+		b.Fatalf("warm native graph-only parallel search: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatal("warm native graph-only parallel search returned no results")
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("native graph-only vector search: %w", err)
+		}
+		if len(results) == 0 {
+			return errors.New("native graph-only vector search returned no results")
+		}
+		return nil
+	})
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			b.Fatalf("native vector search: %v", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			b.Fatalf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector parallel search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector parallel search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			return fmt.Errorf("native vector search: %w", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			return fmt.Errorf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+		return nil
+	})
 }
 
 func BenchmarkCollectionVectorIndexIncrementalWrite(b *testing.B) {
@@ -554,32 +634,18 @@ func BenchmarkCollectionVectorIndexGraphOnlySearchParallel(b *testing.B) {
 	b.ReportMetric(float64(docs), "docs/index")
 	b.ReportMetric(float64(dims), "dims")
 	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
 	b.ResetTimer()
-	var failureMu sync.Mutex
-	var firstFailure string
-	recordFailure := func(format string, args ...any) {
-		failureMu.Lock()
-		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = fmt.Sprintf(format, args...)
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("graph-only vector search: %w", err)
 		}
-	}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
-			if err != nil {
-				recordFailure("graph-only vector search: %v", err)
-				return
-			}
-			if len(results) == 0 {
-				recordFailure("graph-only vector search returned no results")
-				return
-			}
+		if len(results) == 0 {
+			return errors.New("graph-only vector search returned no results")
 		}
+		return nil
 	})
-	if firstFailure != "" {
-		b.Fatal(firstFailure)
-	}
 }
 
 func BenchmarkCollectionVectorIndexSearchInt8(b *testing.B) {
@@ -900,6 +966,75 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 		documents[i] = vectorBenchmarkDocument(i, dims)
 	}
 	return ids, documents
+}
+
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+	tb.Helper()
+	dir := tb.TempDir()
+	def := VectorIndexDefinition{
+		Name:       name,
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: dims,
+		M:          16,
+	}
+	d, col := openVectorBenchmarkCollectionWithVectorIndex(tb, dir, docs, dims, def)
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("build native vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("save native vector index: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("close setup db: %v", err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("reopen db: %v", err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("open collection: %v", err)
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("load native vector index: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID != saveStatus.RootID {
+		_ = d.Close()
+		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
+	}
+	return d, col, loaded, saveStatus
+}
+
+func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
+	b.Helper()
+	var failureMu sync.Mutex
+	var firstFailure string
+	recordFailure := func(err error) {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		if firstFailure == "" {
+			firstFailure = err.Error()
+		}
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := search(); err != nil {
+				recordFailure(err)
+				return
+			}
+		}
+	})
+	if firstFailure != "" {
+		b.Fatal(firstFailure)
+	}
 }
 
 func vectorBenchmarkInsertBatches(tb testing.TB, col *Collection, ids, documents [][]byte, batchSize int) {

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -220,7 +220,7 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -251,7 +251,7 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -283,15 +283,16 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.
 func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector search: %v", err)
 	}
@@ -306,12 +307,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			b.Fatalf("native vector search: %v", err)
 		}
@@ -324,15 +320,16 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector parallel search: %v", err)
 	}
@@ -347,12 +344,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	runParallelVectorSearchBenchmark(b, func() error {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			return fmt.Errorf("native vector search: %w", err)
 		}
@@ -994,7 +986,7 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 	return ids, documents
 }
 
-func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *VectorIndex, VectorIndexLoadStatus) {
 	tb.Helper()
 	dir := tb.TempDir()
 	def := VectorIndexDefinition{
@@ -1036,18 +1028,18 @@ func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name st
 		_ = d.Close()
 		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
 	}
-	return d, col, loaded, saveStatus
+	return d, loaded, loadStatus
 }
 
 func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 	b.Helper()
 	var failureMu sync.Mutex
-	var firstFailure string
+	var firstFailure error
 	recordFailure := func(err error) {
 		failureMu.Lock()
 		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = err.Error()
+		if firstFailure == nil {
+			firstFailure = err
 		}
 	}
 	b.RunParallel(func(pb *testing.PB) {
@@ -1058,7 +1050,7 @@ func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 			}
 		}
 	})
-	if firstFailure != "" {
+	if firstFailure != nil {
 		b.Fatal(firstFailure)
 	}
 }

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -24,7 +24,14 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -dims 64 \
   -queries 1000 \
   -validate-queries 32 \
+  -validate-docs 16 \
   -top-k 10 \
+  -m 16 \
+  -ef-construction 128 \
+  -ef-search 128 \
+  -min-recall 0.95 \
+  -compact=true \
+  -disable-exact-fallback=true \
   -json
 ```
 
@@ -34,3 +41,5 @@ The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
 `-require-value-log-bytes` or `-require-leaf-vlog-bytes` when a benchmark is
 meant to prove that the compacted datastore actually used those storage domains.
+Those flags are assertions, not format selectors; the demo fails if the selected
+TreeDB settings leave the asserted domain empty.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -43,3 +43,16 @@ bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
 meant to prove that the compacted datastore actually used those storage domains.
 Those flags are assertions, not format selectors; the demo fails if the selected
 TreeDB settings leave the asserted domain empty.
+
+Useful flags:
+
+- `-compact=false`: skip `CompactStorageFull` and report uncompacted reopen/load
+  behavior.
+- `-compact-sync-each-phase=true`: ask compaction to fsync each rewrite/pack
+  phase.
+- `-disable-exact-fallback=false`: allow exact fallback during benchmark
+  searches.
+- `-validate-queries N` and `-min-recall R`: run recall validation for `N`
+  queries; set `-min-recall=0` when disabling validation with
+  `-validate-queries=0`.
+- `-json`: emit the full result object for scripts.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -1,0 +1,31 @@
+# TreeDB Vector Search Demo
+
+`treedb_vector_search_demo` is a first-class harness for exercising native
+collection vector-index persistence end to end:
+
+1. create a TreeDB collection with a declared vector field index,
+2. load deterministic synthetic JSON documents,
+3. rebuild and persist the native HNSW graph,
+4. run `DB.CompactStorage(ctx, CompactStorageFull)`,
+5. close and reopen the compacted datastore,
+6. validate document reads and ANN recall against exact search,
+7. benchmark ANN search and report storage/memory usage.
+
+`CompactStorageFull` is intentionally used instead of manually chaining
+maintenance calls. It is TreeDB's canonical full storage compaction path:
+value-log rewrite/GC, leaf-generation pack/GC, index vacuum, settle passes,
+zero-byte value-log cleanup, and final debt audit.
+
+Example:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_search_demo \
+  -docs 10000 \
+  -dims 64 \
+  -queries 1000 \
+  -validate-queries 32 \
+  -top-k 10 \
+  -json
+```
+
+Use `-keep-dir` to inspect the generated datastore after the run.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -35,7 +35,9 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -json
 ```
 
-Use `-keep-dir` to inspect the generated datastore after the run.
+Use `-keep-dir` to inspect an automatically-created temporary datastore after
+the run. Passing an explicit `-dir` always keeps that directory, and it must be
+empty or absent before the run starts.
 
 The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
@@ -50,6 +52,8 @@ Useful flags:
   behavior.
 - `-compact-sync-each-phase=true`: ask compaction to fsync each rewrite/pack
   phase.
+- `-dir PATH`: write into a caller-chosen empty directory and keep it after the
+  run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -29,3 +29,8 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
 ```
 
 Use `-keep-dir` to inspect the generated datastore after the run.
+
+The output includes the persisted TreeDB `format.json` knobs and storage-domain
+bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
+`-require-value-log-bytes` or `-require-leaf-vlog-bytes` when a benchmark is
+meant to prove that the compacted datastore actually used those storage domains.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -65,7 +65,10 @@ type result struct {
 	M                    int                            `json:"m"`
 	EfConstruction       int                            `json:"ef_construction"`
 	EfSearch             int                            `json:"ef_search"`
+	MinRecall            float64                        `json:"min_recall"`
 	Compact              bool                           `json:"compact"`
+	CompactSyncEachPhase bool                           `json:"compact_sync_each_phase"`
+	DisableExactFallback bool                           `json:"disable_exact_fallback"`
 	Insert               phaseResult                    `json:"insert"`
 	Rebuild              phaseResult                    `json:"rebuild"`
 	CompactPhase         phaseResult                    `json:"compact_phase"`
@@ -157,7 +160,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return enc.Encode(res)
 	}
 	printText(stdout, res)
-	if !cfg.keepDir {
+	if !res.KeptDir {
 		fmt.Fprintf(stderr, "temporary db removed; rerun with -keep-dir to inspect files\n")
 	}
 	return nil
@@ -239,16 +242,17 @@ func parseConfig(args []string) (config, error) {
 		return config{}, errors.New("-validate-docs cannot be negative")
 	}
 	if cfg.validateQueries > cfg.docs {
-		cfg.validateQueries = cfg.docs
+		return config{}, errors.New("-validate-queries cannot exceed -docs")
 	}
 	if cfg.validateDocs > cfg.docs {
-		cfg.validateDocs = cfg.docs
+		return config{}, errors.New("-validate-docs cannot exceed -docs")
 	}
 	return cfg, nil
 }
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	dir := cfg.dir
+	explicitDir := dir != ""
 	cleanup := func() {}
 	if dir == "" {
 		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")
@@ -260,10 +264,23 @@ func execute(ctx context.Context, cfg config) (result, error) {
 			cleanup = func() { _ = os.RemoveAll(tmp) }
 		}
 	} else {
-		if err := os.RemoveAll(dir); err != nil {
-			return result{}, err
-		}
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		info, err := os.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				return result{}, fmt.Errorf("-dir %q exists and is not a directory", dir)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				return result{}, err
+			}
+			if len(entries) > 0 {
+				return result{}, fmt.Errorf("-dir %q already exists and is not empty; choose a new directory", dir)
+			}
+		} else if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return result{}, err
+			}
+		} else {
 			return result{}, err
 		}
 	}
@@ -281,18 +298,21 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		EfSearch:       cfg.efSearch,
 	}
 	res := result{
-		Dir:             dir,
-		KeptDir:         cfg.keepDir,
-		Docs:            cfg.docs,
-		Dimensions:      cfg.dimensions,
-		Queries:         cfg.queries,
-		ValidateQueries: cfg.validateQueries,
-		ValidateDocs:    cfg.validateDocs,
-		TopK:            cfg.topK,
-		M:               cfg.m,
-		EfConstruction:  cfg.efConstruction,
-		EfSearch:        cfg.efSearch,
-		Compact:         cfg.compact,
+		Dir:                  dir,
+		KeptDir:              cfg.keepDir || explicitDir,
+		Docs:                 cfg.docs,
+		Dimensions:           cfg.dimensions,
+		Queries:              cfg.queries,
+		ValidateQueries:      cfg.validateQueries,
+		ValidateDocs:         cfg.validateDocs,
+		TopK:                 cfg.topK,
+		M:                    cfg.m,
+		EfConstruction:       cfg.efConstruction,
+		EfSearch:             cfg.efSearch,
+		MinRecall:            cfg.minRecall,
+		Compact:              cfg.compact,
+		CompactSyncEachPhase: cfg.compactSyncEachPhase,
+		DisableExactFallback: cfg.disableExactFallback,
 	}
 
 	d, err := backenddb.Open(backenddb.Options{
@@ -408,7 +428,12 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-	defer d.Close()
+	closeReopened := true
+	defer func() {
+		if closeReopened {
+			_ = d.Close()
+		}
+	}()
 	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		return result{}, err
@@ -423,6 +448,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res.ReopenLoad = phaseSince(reopenStart)
 	res.IndexStatsLoaded = loaded.Stats()
 	var afterLoad runtime.MemStats
+	runtime.GC()
 	runtime.ReadMemStats(&afterLoad)
 	res.Memory = memoryReport{
 		AllocBeforeLoadBytes: beforeLoad.Alloc,
@@ -442,6 +468,10 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	res.Search = search
+	closeReopened = false
+	if err := d.Close(); err != nil {
+		return result{}, err
+	}
 	return res, nil
 }
 
@@ -486,6 +516,8 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 		out.Recall = 1
 		return out, nil
 	}
+	// Recall validation disables exact fallback on the ANN side so it measures
+	// the graph result against the exact baseline computed inside CheckRecall.
 	recall, err := idx.CheckRecall(validationQueries(cfg.validateQueries, cfg.docs, cfg.dimensions), collections.VectorIndexSearchOptions{
 		TopK:                 cfg.topK,
 		EfSearch:             cfg.efSearch,
@@ -505,7 +537,7 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 }
 
 func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
-	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
+	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries+1)
 	latencies := make([]int64, len(queries))
 	var candidatesTotal int64
 	var rerankTotal int64
@@ -534,12 +566,16 @@ func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkR
 	total := time.Since(startAll)
 	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
 	avg := float64(total.Nanoseconds()) / float64(len(queries))
+	opsPerSecond := 0.0
+	if total > 0 {
+		opsPerSecond = float64(len(queries)) / total.Seconds()
+	}
 	return searchBenchmarkResult{
 		Queries:              len(queries),
 		TotalDurationNanos:   total.Nanoseconds(),
 		AvgNanos:             avg,
 		AvgMicros:            avg / 1000,
-		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
+		OpsPerSecond:         opsPerSecond,
 		P50Nanos:             percentile(latencies, 0.50),
 		P95Nanos:             percentile(latencies, 0.95),
 		P99Nanos:             percentile(latencies, 0.99),
@@ -564,9 +600,13 @@ func vectorIndexOptions(def collections.VectorIndexDefinition) collections.Vecto
 }
 
 func validationQueries(count, docs, dims int) [][]float32 {
+	return syntheticQueries(count, docs, dims, 0)
+}
+
+func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i, docs), dims)
+		queries[i] = embedding(queryDocIndex(i+offset, docs), dims)
 	}
 	return queries
 }
@@ -635,7 +675,7 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 			return err
 		}
 		group := strings.Split(rel, string(os.PathSeparator))[0]
-		if group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK" {
+		if rel == group && (group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK") {
 			group = rel
 		}
 		report.Domains[group] += size
@@ -656,6 +696,7 @@ func phaseSince(start time.Time) phaseResult {
 }
 
 func percentile(sorted []int64, p float64) int64 {
+	// Nearest-rank percentile over an already sorted sample.
 	if len(sorted) == 0 {
 		return 0
 	}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -247,6 +248,12 @@ func parseConfig(args []string) (config, error) {
 	if cfg.validateDocs > cfg.docs {
 		return config{}, errors.New("-validate-docs cannot exceed -docs")
 	}
+	if cfg.validateQueries == 0 && cfg.minRecall > 0 {
+		return config{}, errors.New("-min-recall must be 0 when -validate-queries is 0")
+	}
+	if cfg.validateQueries+cfg.queries > cfg.docs {
+		return config{}, errors.New("-validate-queries plus -queries cannot exceed -docs")
+	}
 	return cfg, nil
 }
 
@@ -428,12 +435,15 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-	closeReopened := true
-	defer func() {
-		if closeReopened {
-			_ = d.Close()
+	closeReopened := func() error {
+		if d == nil {
+			return nil
 		}
-	}()
+		err := d.Close()
+		d = nil
+		return err
+	}
+	defer func() { _ = closeReopened() }()
 	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		return result{}, err
@@ -453,7 +463,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res.Memory = memoryReport{
 		AllocBeforeLoadBytes: beforeLoad.Alloc,
 		AllocAfterLoadBytes:  afterLoad.Alloc,
-		LoadAllocDeltaBytes:  int64(afterLoad.Alloc) - int64(beforeLoad.Alloc),
+		LoadAllocDeltaBytes:  allocDeltaBytes(afterLoad.Alloc, beforeLoad.Alloc),
 		IndexBytesMemory:     res.IndexStatsLoaded.BytesMemory,
 	}
 
@@ -468,11 +478,26 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	res.Search = search
-	closeReopened = false
-	if err := d.Close(); err != nil {
+	if err := closeReopened(); err != nil {
 		return result{}, err
 	}
 	return res, nil
+}
+
+func allocDeltaBytes(after, before uint64) int64 {
+	const maxInt64 = uint64(1<<63 - 1)
+	if after >= before {
+		delta := after - before
+		if delta > maxInt64 {
+			return int64(maxInt64)
+		}
+		return int64(delta)
+	}
+	delta := before - after
+	if delta > maxInt64 {
+		return -int64(maxInt64)
+	}
+	return -int64(delta)
 }
 
 func insertDocuments(col *collections.Collection, docs, dims, batchSize int) error {
@@ -513,7 +538,6 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 		}
 	}
 	if cfg.validateQueries == 0 {
-		out.Recall = 1
 		return out, nil
 	}
 	// Recall validation disables exact fallback on the ANN side so it measures
@@ -605,14 +629,42 @@ func validationQueries(count, docs, dims int) [][]float32 {
 
 func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
+	stride := queryDocStride(docs)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i+offset, docs), dims)
+		queries[i] = embedding(queryDocIndex(i+offset, docs, stride), dims)
 	}
 	return queries
 }
 
-func queryDocIndex(i, docs int) int {
-	return (i*7919 + docs/3 + 17) % docs
+func queryDocStride(docs int) int {
+	stride := 7919
+	if docs > 0 {
+		stride %= docs
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	for gcd(stride, docs) != 1 {
+		stride++
+	}
+	return stride
+}
+
+func queryDocIndex(i, docs, stride int) int {
+	return (i*stride + docs/3 + 17) % docs
+}
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
 }
 
 func validationDocIndex(i, docs int) int {
@@ -626,12 +678,14 @@ func documentID(id int) []byte {
 func documentJSON(id, dims int) []byte {
 	vector := embedding(id, dims)
 	out := make([]byte, 0, 48+dims*10)
-	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	out = append(out, `{"group":`...)
+	out = strconv.AppendInt(out, int64(id%16), 10)
+	out = append(out, `,"embedding":[`...)
 	for i, value := range vector {
 		if i > 0 {
 			out = append(out, ',')
 		}
-		out = append(out, fmt.Sprintf("%.7g", value)...)
+		out = strconv.AppendFloat(out, float64(value), 'g', 7, 32)
 	}
 	out = append(out, ']', '}')
 	return out
@@ -646,6 +700,10 @@ func embedding(id, dims int) []float32 {
 		value := math.Sin(x*d*0.013) + math.Cos((x+17)*d*0.007) + math.Sin(float64((id%31)+1)*d*0.019)
 		out[i] = float32(value)
 		norm += value * value
+	}
+	if norm == 0 || math.IsNaN(norm) || math.IsInf(norm, 0) {
+		out[0] = 1
+		return out
 	}
 	scale := 1 / math.Sqrt(norm)
 	for i := range out {
@@ -674,10 +732,7 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 		if err != nil {
 			return err
 		}
-		group := strings.Split(rel, string(os.PathSeparator))[0]
-		if rel == group && (group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK") {
-			group = rel
-		}
+		group := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
 		report.Domains[group] += size
 		return nil
 	})
@@ -729,6 +784,8 @@ func printText(w io.Writer, res result) {
 			fully = res.CompactStorage.FullyCompacted
 		}
 		fmt.Fprintf(w, "compact_storage_full: %.3fs fully_compacted=%t\n", res.CompactPhase.Seconds, fully)
+	} else {
+		fmt.Fprintf(w, "compact_storage_full: skipped\n")
 	}
 	fmt.Fprintf(w, "reopen_and_load_native_index: %.3fs\n", res.ReopenLoad.Seconds)
 	fmt.Fprintf(w, "\nValidation\n")

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -1,0 +1,688 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs        = 10000
+	defaultDimensions  = 64
+	defaultQueries     = 1000
+	defaultTopK        = 10
+	defaultBatchSize   = 512
+	defaultM           = 16
+	defaultEfConstruct = 128
+	defaultEfSearch    = 128
+)
+
+type config struct {
+	dir                  string
+	keepDir              bool
+	docs                 int
+	dimensions           int
+	queries              int
+	validateQueries      int
+	validateDocs         int
+	topK                 int
+	batchSize            int
+	m                    int
+	efConstruction       int
+	efSearch             int
+	minRecall            float64
+	compact              bool
+	compactSyncEachPhase bool
+	disableExactFallback bool
+	jsonOut              bool
+}
+
+type result struct {
+	Dir                  string                         `json:"dir"`
+	KeptDir              bool                           `json:"kept_dir"`
+	Docs                 int                            `json:"docs"`
+	Dimensions           int                            `json:"dimensions"`
+	Queries              int                            `json:"queries"`
+	ValidateQueries      int                            `json:"validate_queries"`
+	ValidateDocs         int                            `json:"validate_docs"`
+	TopK                 int                            `json:"top_k"`
+	M                    int                            `json:"m"`
+	EfConstruction       int                            `json:"ef_construction"`
+	EfSearch             int                            `json:"ef_search"`
+	Compact              bool                           `json:"compact"`
+	Insert               phaseResult                    `json:"insert"`
+	Rebuild              phaseResult                    `json:"rebuild"`
+	CompactPhase         phaseResult                    `json:"compact_phase"`
+	ReopenLoad           phaseResult                    `json:"reopen_load"`
+	Validation           validationResult               `json:"validation"`
+	Search               searchBenchmarkResult          `json:"search"`
+	StorageBeforeCompact storageReport                  `json:"storage_before_compact"`
+	StorageAfterCompact  storageReport                  `json:"storage_after_compact"`
+	IndexStatsBefore     collections.VectorIndexStats   `json:"index_stats_before_compact"`
+	IndexStatsLoaded     collections.VectorIndexStats   `json:"index_stats_loaded"`
+	NativeRootBytes      int64                          `json:"native_root_bytes"`
+	CompactStorage       *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
+	Memory               memoryReport                   `json:"memory"`
+}
+
+type phaseResult struct {
+	DurationNanos int64   `json:"duration_nanos"`
+	Seconds       float64 `json:"seconds"`
+}
+
+type validationResult struct {
+	DocumentsChecked int     `json:"documents_checked"`
+	QueriesChecked   int     `json:"queries_checked"`
+	ExactTotal       int     `json:"exact_total"`
+	ANNTotal         int     `json:"ann_total"`
+	Overlap          int     `json:"overlap"`
+	Recall           float64 `json:"recall"`
+	MinRecall        float64 `json:"min_recall"`
+}
+
+type searchBenchmarkResult struct {
+	Queries              int     `json:"queries"`
+	TotalDurationNanos   int64   `json:"total_duration_nanos"`
+	AvgNanos             float64 `json:"avg_nanos"`
+	AvgMicros            float64 `json:"avg_micros"`
+	OpsPerSecond         float64 `json:"ops_per_second"`
+	P50Nanos             int64   `json:"p50_nanos"`
+	P95Nanos             int64   `json:"p95_nanos"`
+	P99Nanos             int64   `json:"p99_nanos"`
+	AvgCandidates        float64 `json:"avg_candidates"`
+	AvgRerank            float64 `json:"avg_rerank"`
+	ExactFallbacks       int     `json:"exact_fallbacks"`
+	DisableExactFallback bool    `json:"disable_exact_fallback"`
+}
+
+type storageReport struct {
+	TotalBytes  int64            `json:"total_bytes"`
+	BytesPerDoc float64          `json:"bytes_per_doc"`
+	Domains     map[string]int64 `json:"domains"`
+	Files       int              `json:"files"`
+}
+
+type memoryReport struct {
+	AllocBeforeLoadBytes uint64 `json:"alloc_before_load_bytes"`
+	AllocAfterLoadBytes  uint64 `json:"alloc_after_load_bytes"`
+	LoadAllocDeltaBytes  int64  `json:"load_alloc_delta_bytes"`
+	IndexBytesMemory     int64  `json:"index_bytes_memory"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb-vector-search-demo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	res, err := execute(context.Background(), cfg)
+	if err != nil {
+		return err
+	}
+	if cfg.jsonOut {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	printText(stdout, res)
+	if !cfg.keepDir {
+		fmt.Fprintf(stderr, "temporary db removed; rerun with -keep-dir to inspect files\n")
+	}
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{
+		docs:                 defaultDocs,
+		dimensions:           defaultDimensions,
+		queries:              defaultQueries,
+		validateQueries:      32,
+		validateDocs:         16,
+		topK:                 defaultTopK,
+		batchSize:            defaultBatchSize,
+		m:                    defaultM,
+		efConstruction:       defaultEfConstruct,
+		efSearch:             defaultEfSearch,
+		minRecall:            0.95,
+		compact:              true,
+		disableExactFallback: true,
+	}
+	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
+	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
+	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
+	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
+	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
+	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of ANN search queries to benchmark")
+	fs.IntVar(&cfg.validateQueries, "validate-queries", cfg.validateQueries, "Number of queries to validate against exact search")
+	fs.IntVar(&cfg.validateDocs, "validate-docs", cfg.validateDocs, "Number of documents to read and byte-validate after compaction/reopen")
+	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count")
+	fs.IntVar(&cfg.batchSize, "batch-size", cfg.batchSize, "Insert batch size")
+	fs.IntVar(&cfg.m, "m", cfg.m, "HNSW max neighbor parameter")
+	fs.IntVar(&cfg.efConstruction, "ef-construction", cfg.efConstruction, "HNSW efConstruction")
+	fs.IntVar(&cfg.efSearch, "ef-search", cfg.efSearch, "HNSW efSearch for ANN queries")
+	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
+	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
+	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
+	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
+	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.docs <= 0 {
+		return config{}, errors.New("-docs must be positive")
+	}
+	if cfg.dimensions <= 0 {
+		return config{}, errors.New("-dims must be positive")
+	}
+	if cfg.queries <= 0 {
+		return config{}, errors.New("-queries must be positive")
+	}
+	if cfg.topK <= 0 {
+		return config{}, errors.New("-top-k must be positive")
+	}
+	if cfg.topK > cfg.docs {
+		return config{}, errors.New("-top-k cannot exceed -docs")
+	}
+	if cfg.batchSize <= 0 {
+		return config{}, errors.New("-batch-size must be positive")
+	}
+	if cfg.m <= 0 {
+		return config{}, errors.New("-m must be positive")
+	}
+	if cfg.efConstruction <= 0 {
+		return config{}, errors.New("-ef-construction must be positive")
+	}
+	if cfg.efSearch <= 0 {
+		return config{}, errors.New("-ef-search must be positive")
+	}
+	if cfg.minRecall < 0 || cfg.minRecall > 1 {
+		return config{}, errors.New("-min-recall must be in [0,1]")
+	}
+	if cfg.validateQueries < 0 {
+		return config{}, errors.New("-validate-queries cannot be negative")
+	}
+	if cfg.validateDocs < 0 {
+		return config{}, errors.New("-validate-docs cannot be negative")
+	}
+	if cfg.validateQueries > cfg.docs {
+		cfg.validateQueries = cfg.docs
+	}
+	if cfg.validateDocs > cfg.docs {
+		cfg.validateDocs = cfg.docs
+	}
+	return cfg, nil
+}
+
+func execute(ctx context.Context, cfg config) (result, error) {
+	dir := cfg.dir
+	cleanup := func() {}
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")
+		if err != nil {
+			return result{}, err
+		}
+		dir = tmp
+		if !cfg.keepDir {
+			cleanup = func() { _ = os.RemoveAll(tmp) }
+		}
+	} else {
+		if err := os.RemoveAll(dir); err != nil {
+			return result{}, err
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return result{}, err
+		}
+	}
+	if !cfg.keepDir {
+		defer cleanup()
+	}
+
+	def := collections.VectorIndexDefinition{
+		Name:           "embedding",
+		Field:          "embedding",
+		Metric:         collections.VectorMetricCosine,
+		Dimensions:     cfg.dimensions,
+		M:              cfg.m,
+		EfConstruction: cfg.efConstruction,
+		EfSearch:       cfg.efSearch,
+	}
+	res := result{
+		Dir:             dir,
+		KeptDir:         cfg.keepDir,
+		Docs:            cfg.docs,
+		Dimensions:      cfg.dimensions,
+		Queries:         cfg.queries,
+		ValidateQueries: cfg.validateQueries,
+		ValidateDocs:    cfg.validateDocs,
+		TopK:            cfg.topK,
+		M:               cfg.m,
+		EfConstruction:  cfg.efConstruction,
+		EfSearch:        cfg.efSearch,
+		Compact:         cfg.compact,
+	}
+
+	d, err := backenddb.Open(backenddb.Options{
+		Dir: dir,
+		ValueLog: backenddb.ValueLogOptions{
+			Compression: backenddb.ValueLogCompressionAuto,
+		},
+	})
+	if err != nil {
+		return result{}, err
+	}
+	mgr := collections.NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name:          "docs",
+		VectorIndexes: []collections.VectorIndexDefinition{def},
+	}); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+
+	insertStart := time.Now()
+	if err := insertDocuments(col, cfg.docs, cfg.dimensions, cfg.batchSize); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	res.Insert = phaseSince(insertStart)
+
+	rebuildStart := time.Now()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if !status.NativeRootLoaded || status.RootID == 0 {
+		_ = d.Close()
+		return result{}, fmt.Errorf("unexpected native vector root status: %+v", status)
+	}
+	res.Rebuild = phaseSince(rebuildStart)
+	res.NativeRootBytes = status.NativeRootBytes
+	res.IndexStatsBefore = status.Stats
+
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	res.StorageBeforeCompact, err = storageUsage(dir, cfg.docs)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+
+	if cfg.compact {
+		compactStart := time.Now()
+		stats, err := d.CompactStorage(ctx, backenddb.CompactStorageOptions{
+			Mode:          backenddb.CompactStorageFull,
+			SyncEachPhase: cfg.compactSyncEachPhase,
+		})
+		if err != nil {
+			_ = d.Close()
+			return result{}, err
+		}
+		res.CompactPhase = phaseSince(compactStart)
+		res.CompactStorage = &stats
+		if err := d.Checkpoint(); err != nil {
+			_ = d.Close()
+			return result{}, err
+		}
+	}
+	res.StorageAfterCompact, err = storageUsage(dir, cfg.docs)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if err := d.Close(); err != nil {
+		return result{}, err
+	}
+
+	var beforeLoad runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&beforeLoad)
+	reopenStart := time.Now()
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		return result{}, err
+	}
+	defer d.Close()
+	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		return result{}, err
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptions(def))
+	if err != nil {
+		return result{}, err
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID == 0 {
+		return result{}, fmt.Errorf("failed to load compacted native vector root: %+v", loadStatus)
+	}
+	res.ReopenLoad = phaseSince(reopenStart)
+	res.IndexStatsLoaded = loaded.Stats()
+	var afterLoad runtime.MemStats
+	runtime.ReadMemStats(&afterLoad)
+	res.Memory = memoryReport{
+		AllocBeforeLoadBytes: beforeLoad.Alloc,
+		AllocAfterLoadBytes:  afterLoad.Alloc,
+		LoadAllocDeltaBytes:  int64(afterLoad.Alloc) - int64(beforeLoad.Alloc),
+		IndexBytesMemory:     res.IndexStatsLoaded.BytesMemory,
+	}
+
+	validation, err := validateCompactedData(col, loaded, cfg)
+	if err != nil {
+		return result{}, err
+	}
+	res.Validation = validation
+
+	search, err := benchmarkSearch(loaded, cfg)
+	if err != nil {
+		return result{}, err
+	}
+	res.Search = search
+	return res, nil
+}
+
+func insertDocuments(col *collections.Collection, docs, dims, batchSize int) error {
+	for start := 0; start < docs; start += batchSize {
+		end := start + batchSize
+		if end > docs {
+			end = docs
+		}
+		ids := make([][]byte, end-start)
+		documents := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			j := i - start
+			ids[j] = documentID(i)
+			documents[j] = documentJSON(i, dims)
+		}
+		if _, err := col.InsertBatch(ids, documents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCompactedData(col *collections.Collection, idx *collections.VectorIndex, cfg config) (validationResult, error) {
+	out := validationResult{
+		DocumentsChecked: cfg.validateDocs,
+		QueriesChecked:   cfg.validateQueries,
+		MinRecall:        cfg.minRecall,
+	}
+	for i := 0; i < cfg.validateDocs; i++ {
+		docIndex := validationDocIndex(i, cfg.docs)
+		got, err := col.Get(documentID(docIndex))
+		if err != nil {
+			return out, fmt.Errorf("get compacted doc %d: %w", docIndex, err)
+		}
+		want := documentJSON(docIndex, cfg.dimensions)
+		if !bytes.Equal(got, want) {
+			return out, fmt.Errorf("compacted doc %d mismatch", docIndex)
+		}
+	}
+	if cfg.validateQueries == 0 {
+		out.Recall = 1
+		return out, nil
+	}
+	recall, err := idx.CheckRecall(validationQueries(cfg.validateQueries, cfg.docs, cfg.dimensions), collections.VectorIndexSearchOptions{
+		TopK:                 cfg.topK,
+		EfSearch:             cfg.efSearch,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		return out, err
+	}
+	out.ExactTotal = recall.ExactTotal
+	out.ANNTotal = recall.ANNTotal
+	out.Overlap = recall.Overlap
+	out.Recall = recall.Recall
+	if out.Recall < cfg.minRecall {
+		return out, fmt.Errorf("recall %.4f below minimum %.4f", out.Recall, cfg.minRecall)
+	}
+	return out, nil
+}
+
+func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
+	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
+	latencies := make([]int64, len(queries))
+	var candidatesTotal int64
+	var rerankTotal int64
+	var exactFallbacks int
+	startAll := time.Now()
+	for i, query := range queries {
+		start := time.Now()
+		results, trace, err := idx.Search(query, collections.VectorIndexSearchOptions{
+			TopK:                 cfg.topK,
+			EfSearch:             cfg.efSearch,
+			DisableExactFallback: cfg.disableExactFallback,
+		})
+		latencies[i] = time.Since(start).Nanoseconds()
+		if err != nil {
+			return searchBenchmarkResult{}, err
+		}
+		if len(results) == 0 {
+			return searchBenchmarkResult{}, errors.New("vector search returned no results")
+		}
+		candidatesTotal += int64(trace.CandidatesExamined)
+		rerankTotal += int64(trace.RerankCount)
+		if trace.ExactFallbackReason != "" {
+			exactFallbacks++
+		}
+	}
+	total := time.Since(startAll)
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	avg := float64(total.Nanoseconds()) / float64(len(queries))
+	return searchBenchmarkResult{
+		Queries:              len(queries),
+		TotalDurationNanos:   total.Nanoseconds(),
+		AvgNanos:             avg,
+		AvgMicros:            avg / 1000,
+		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
+		P50Nanos:             percentile(latencies, 0.50),
+		P95Nanos:             percentile(latencies, 0.95),
+		P99Nanos:             percentile(latencies, 0.99),
+		AvgCandidates:        float64(candidatesTotal) / float64(len(queries)),
+		AvgRerank:            float64(rerankTotal) / float64(len(queries)),
+		ExactFallbacks:       exactFallbacks,
+		DisableExactFallback: cfg.disableExactFallback,
+	}, nil
+}
+
+func vectorIndexOptions(def collections.VectorIndexDefinition) collections.VectorIndexOptions {
+	return collections.VectorIndexOptions{
+		Name:           def.Name,
+		Field:          def.Field,
+		Metric:         def.Metric,
+		Dimensions:     def.Dimensions,
+		M:              def.M,
+		EfConstruction: def.EfConstruction,
+		EfSearch:       def.EfSearch,
+		Encoding:       def.Encoding,
+	}
+}
+
+func validationQueries(count, docs, dims int) [][]float32 {
+	queries := make([][]float32, count)
+	for i := 0; i < count; i++ {
+		queries[i] = embedding(queryDocIndex(i, docs), dims)
+	}
+	return queries
+}
+
+func queryDocIndex(i, docs int) int {
+	return (i*7919 + docs/3 + 17) % docs
+}
+
+func validationDocIndex(i, docs int) int {
+	return (i*1543 + docs/5 + 11) % docs
+}
+
+func documentID(id int) []byte {
+	return []byte(fmt.Sprintf("doc-%06d", id))
+}
+
+func documentJSON(id, dims int) []byte {
+	vector := embedding(id, dims)
+	out := make([]byte, 0, 48+dims*10)
+	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	for i, value := range vector {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, fmt.Sprintf("%.7g", value)...)
+	}
+	out = append(out, ']', '}')
+	return out
+}
+
+func embedding(id, dims int) []float32 {
+	out := make([]float32, dims)
+	var norm float64
+	x := float64(id + 1)
+	for i := range out {
+		d := float64(i + 1)
+		value := math.Sin(x*d*0.013) + math.Cos((x+17)*d*0.007) + math.Sin(float64((id%31)+1)*d*0.019)
+		out[i] = float32(value)
+		norm += value * value
+	}
+	scale := 1 / math.Sqrt(norm)
+	for i := range out {
+		out[i] = float32(float64(out[i]) * scale)
+	}
+	return out
+}
+
+func storageUsage(dir string, docs int) (storageReport, error) {
+	report := storageReport{Domains: make(map[string]int64)}
+	err := filepath.WalkDir(dir, func(path string, ent os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ent.IsDir() {
+			return nil
+		}
+		info, err := ent.Info()
+		if err != nil {
+			return err
+		}
+		size := info.Size()
+		report.TotalBytes += size
+		report.Files++
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		group := strings.Split(rel, string(os.PathSeparator))[0]
+		if group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK" {
+			group = rel
+		}
+		report.Domains[group] += size
+		return nil
+	})
+	if err != nil {
+		return storageReport{}, err
+	}
+	if docs > 0 {
+		report.BytesPerDoc = float64(report.TotalBytes) / float64(docs)
+	}
+	return report, nil
+}
+
+func phaseSince(start time.Time) phaseResult {
+	d := time.Since(start)
+	return phaseResult{DurationNanos: d.Nanoseconds(), Seconds: d.Seconds()}
+}
+
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func printText(w io.Writer, res result) {
+	fmt.Fprintf(w, "TreeDB vector search demo\n")
+	fmt.Fprintf(w, "dir=%s kept=%t docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d\n",
+		res.Dir, res.KeptDir, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch)
+	fmt.Fprintf(w, "\nPhases\n")
+	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
+	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)
+	if res.Compact {
+		fully := false
+		if res.CompactStorage != nil {
+			fully = res.CompactStorage.FullyCompacted
+		}
+		fmt.Fprintf(w, "compact_storage_full: %.3fs fully_compacted=%t\n", res.CompactPhase.Seconds, fully)
+	}
+	fmt.Fprintf(w, "reopen_and_load_native_index: %.3fs\n", res.ReopenLoad.Seconds)
+	fmt.Fprintf(w, "\nValidation\n")
+	fmt.Fprintf(w, "documents_checked=%d queries_checked=%d recall_at_%d=%.4f overlap=%d/%d\n",
+		res.Validation.DocumentsChecked, res.Validation.QueriesChecked, res.TopK, res.Validation.Recall, res.Validation.Overlap, res.Validation.ExactTotal)
+	fmt.Fprintf(w, "\nSearch Benchmark\n")
+	fmt.Fprintf(w, "avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d\n",
+		res.Search.AvgMicros,
+		float64(res.Search.P50Nanos)/1000,
+		float64(res.Search.P95Nanos)/1000,
+		float64(res.Search.P99Nanos)/1000,
+		res.Search.OpsPerSecond,
+		res.Search.ExactFallbacks)
+	fmt.Fprintf(w, "avg_candidates=%.1f avg_rerank=%.1f\n", res.Search.AvgCandidates, res.Search.AvgRerank)
+	fmt.Fprintf(w, "\nStorage\n")
+	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
+	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
+	printDomains(w, "after_compact", res.StorageAfterCompact.Domains)
+	fmt.Fprintf(w, "\nMemory\n")
+	fmt.Fprintf(w, "index_bytes_memory=%d load_alloc_delta=%d alloc_after_load=%d\n",
+		res.Memory.IndexBytesMemory, res.Memory.LoadAllocDeltaBytes, res.Memory.AllocAfterLoadBytes)
+}
+
+func printDomains(w io.Writer, label string, domains map[string]int64) {
+	keys := make([]string, 0, len(domains))
+	for key := range domains {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(w, "%s_domain name=%s bytes=%d\n", label, key, domains[key])
+	}
+}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -425,6 +425,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		_ = d.Close()
 		return result{}, errors.New("compacted storage has zero leaf_vlog bytes")
 	}
+	mgr = nil
+	col = nil
 	if err := d.Close(); err != nil {
 		return result{}, err
 	}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -184,7 +184,8 @@ func parseConfig(args []string) (config, error) {
 		disableExactFallback: true,
 	}
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
-	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory; explicit directories are kept")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
@@ -427,9 +428,6 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 
-	var beforeLoad runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
 	d, err = backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
@@ -448,12 +446,21 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
+	var beforeLoad runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&beforeLoad)
 	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptions(def))
 	if err != nil {
 		return result{}, err
 	}
-	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID == 0 {
-		return result{}, fmt.Errorf("failed to load compacted native vector root: %+v", loadStatus)
+	if loaded == nil {
+		return result{}, fmt.Errorf("native vector root load returned no runtime: %+v", loadStatus)
+	}
+	if !loadStatus.Loaded {
+		return result{}, fmt.Errorf("native vector root not marked loaded: %+v", loadStatus)
+	}
+	if loadStatus.RootID == 0 {
+		return result{}, fmt.Errorf("native vector root loaded with zero root id: %+v", loadStatus)
 	}
 	res.ReopenLoad = phaseSince(reopenStart)
 	res.IndexStatsLoaded = loaded.Stats()
@@ -561,7 +568,7 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 }
 
 func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
-	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries+1)
+	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries)
 	latencies := make([]int64, len(queries))
 	var candidatesTotal int64
 	var rerankTotal int64
@@ -574,10 +581,10 @@ func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkR
 			EfSearch:             cfg.efSearch,
 			DisableExactFallback: cfg.disableExactFallback,
 		})
-		latencies[i] = time.Since(start).Nanoseconds()
 		if err != nil {
 			return searchBenchmarkResult{}, err
 		}
+		latencies[i] = time.Since(start).Nanoseconds()
 		if len(results) == 0 {
 			return searchBenchmarkResult{}, errors.New("vector search returned no results")
 		}
@@ -668,7 +675,21 @@ func gcd(a, b int) int {
 }
 
 func validationDocIndex(i, docs int) int {
-	return (i*1543 + docs/5 + 11) % docs
+	return (i*validationDocStride(docs) + docs/5 + 11) % docs
+}
+
+func validationDocStride(docs int) int {
+	stride := 1543
+	if docs > 0 {
+		stride %= docs
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	for gcd(stride, docs) != 1 {
+		stride++
+	}
+	return stride
 }
 
 func documentID(id int) []byte {
@@ -677,7 +698,7 @@ func documentID(id int) []byte {
 
 func documentJSON(id, dims int) []byte {
 	vector := embedding(id, dims)
-	out := make([]byte, 0, 48+dims*10)
+	out := make([]byte, 0, 48+dims*16)
 	out = append(out, `{"group":`...)
 	out = strconv.AppendInt(out, int64(id%16), 10)
 	out = append(out, `,"embedding":[`...)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -48,6 +48,8 @@ type config struct {
 	compact              bool
 	compactSyncEachPhase bool
 	disableExactFallback bool
+	requireValueLogBytes bool
+	requireLeafVLogBytes bool
 	jsonOut              bool
 }
 
@@ -76,6 +78,8 @@ type result struct {
 	IndexStatsLoaded     collections.VectorIndexStats   `json:"index_stats_loaded"`
 	NativeRootBytes      int64                          `json:"native_root_bytes"`
 	CompactStorage       *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
+	FormatConfig         *backenddb.FormatConfig        `json:"format_config,omitempty"`
+	StorageExpectation   storageExpectationReport       `json:"storage_expectation"`
 	Memory               memoryReport                   `json:"memory"`
 }
 
@@ -114,6 +118,14 @@ type storageReport struct {
 	BytesPerDoc float64          `json:"bytes_per_doc"`
 	Domains     map[string]int64 `json:"domains"`
 	Files       int              `json:"files"`
+}
+
+type storageExpectationReport struct {
+	RequireValueLogBytes bool  `json:"require_value_log_bytes"`
+	RequireLeafVLogBytes bool  `json:"require_leaf_vlog_bytes"`
+	ValueLogBytes        int64 `json:"value_log_bytes"`
+	LeafVLogBytes        int64 `json:"leaf_vlog_bytes"`
+	IndexBytes           int64 `json:"index_bytes"`
 }
 
 type memoryReport struct {
@@ -184,6 +196,8 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
+	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
+	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -360,6 +374,27 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		_ = d.Close()
 		return result{}, err
+	}
+	if format, ok, err := backenddb.LoadFormatConfig(dir); err != nil {
+		_ = d.Close()
+		return result{}, err
+	} else if ok {
+		res.FormatConfig = &format
+	}
+	res.StorageExpectation = storageExpectationReport{
+		RequireValueLogBytes: cfg.requireValueLogBytes,
+		RequireLeafVLogBytes: cfg.requireLeafVLogBytes,
+		ValueLogBytes:        res.StorageAfterCompact.Domains["value_vlog"],
+		LeafVLogBytes:        res.StorageAfterCompact.Domains["leaf_vlog"],
+		IndexBytes:           res.StorageAfterCompact.Domains["index.db"],
+	}
+	if cfg.requireValueLogBytes && res.StorageExpectation.ValueLogBytes == 0 {
+		_ = d.Close()
+		return result{}, errors.New("compacted storage has zero value_vlog bytes")
+	}
+	if cfg.requireLeafVLogBytes && res.StorageExpectation.LeafVLogBytes == 0 {
+		_ = d.Close()
+		return result{}, errors.New("compacted storage has zero leaf_vlog bytes")
 	}
 	if err := d.Close(); err != nil {
 		return result{}, err
@@ -670,6 +705,16 @@ func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "\nStorage\n")
 	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
 	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
+	if res.FormatConfig != nil {
+		fmt.Fprintf(w, "format index_outer_leaves_in_vlog=%t leaf_prefix_compression=%t vlog_compression=%s\n",
+			res.FormatConfig.IndexOuterLeavesInValueLog,
+			res.FormatConfig.LeafPrefixCompression,
+			res.FormatConfig.ValueLogCompression)
+	}
+	fmt.Fprintf(w, "storage_domains index_db=%d value_vlog=%d leaf_vlog=%d\n",
+		res.StorageExpectation.IndexBytes,
+		res.StorageExpectation.ValueLogBytes,
+		res.StorageExpectation.LeafVLogBytes)
 	printDomains(w, "after_compact", res.StorageAfterCompact.Domains)
 	fmt.Fprintf(w, "\nMemory\n")
 	fmt.Fprintf(w, "index_bytes_memory=%d load_alloc_delta=%d alloc_after_load=%d\n",

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -430,6 +430,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err := d.Close(); err != nil {
 		return result{}, err
 	}
+	d = nil
+	runtime.GC()
 
 	reopenStart := time.Now()
 	d, err = backenddb.Open(backenddb.Options{Dir: dir})

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -333,10 +333,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	mgr := collections.NewCollectionManager(d)
-	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
-		Name:          "docs",
-		VectorIndexes: []collections.VectorIndexDefinition{def},
-	}); err != nil {
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{Name: "docs"}); err != nil {
 		_ = d.Close()
 		return result{}, err
 	}
@@ -357,6 +354,10 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	}
 	res.Insert = phaseSince(insertStart)
 
+	if _, err := col.CreateVectorIndex(def); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
 	rebuildStart := time.Now()
 	status, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
@@ -638,9 +639,17 @@ func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
 	stride := queryDocStride(docs)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i+offset, docs, stride), dims)
+		queries[i] = embedding(syntheticQueryID(i, docs, offset, stride), dims)
 	}
 	return queries
+}
+
+func syntheticQueryID(i, docs, offset, stride int) int {
+	id := i + offset
+	if docs <= 0 || id >= docs {
+		return id
+	}
+	return queryDocIndex(id, docs, stride)
 }
 
 func queryDocStride(docs int) int {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
+	res, err := execute(t.Context(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 128,
+		dimensions:           16,
+		queries:              8,
+		validateQueries:      4,
+		validateDocs:         4,
+		topK:                 5,
+		batchSize:            32,
+		m:                    8,
+		efConstruction:       64,
+		efSearch:             64,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.Validation.DocumentsChecked != 4 || res.Validation.QueriesChecked != 4 {
+		t.Fatalf("validation counts=%+v, want 4 docs and 4 queries", res.Validation)
+	}
+	if res.Validation.Recall < res.Validation.MinRecall {
+		t.Fatalf("recall=%f below min=%f", res.Validation.Recall, res.Validation.MinRecall)
+	}
+	if res.Search.Queries != 8 || res.Search.AvgNanos <= 0 || res.Search.ExactFallbacks != 0 {
+		t.Fatalf("unexpected search benchmark result: %+v", res.Search)
+	}
+	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
+		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
+	}
+	if res.Memory.IndexBytesMemory <= 0 {
+		t.Fatalf("missing index memory report: %+v", res.Memory)
+	}
+	if res.CompactStorage == nil || !res.CompactStorage.FullyCompacted {
+		t.Fatalf("compact storage stats=%+v, want fully compacted", res.CompactStorage)
+	}
+	if res.IndexStatsLoaded.LiveDocs != 128 {
+		t.Fatalf("loaded live docs=%d want 128", res.IndexStatsLoaded.LiveDocs)
+	}
+}
+
+func TestRunJSONOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-dir", t.TempDir(),
+		"-keep-dir",
+		"-docs", "64",
+		"-dims", "8",
+		"-queries", "4",
+		"-validate-queries", "2",
+		"-validate-docs", "2",
+		"-top-k", "3",
+		"-m", "4",
+		"-ef-construction", "32",
+		"-ef-search", "32",
+		"-min-recall", "0.5",
+		"-json",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v stderr=%s", err, stderr.String())
+	}
+	var res result
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, stdout.String())
+	}
+	if res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
+		t.Fatalf("unexpected JSON result: %+v", res)
+	}
+}
+
+func TestRunTextOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-dir", t.TempDir(),
+		"-keep-dir",
+		"-docs", "64",
+		"-dims", "8",
+		"-queries", "4",
+		"-validate-queries", "2",
+		"-validate-docs", "2",
+		"-top-k", "3",
+		"-m", "4",
+		"-ef-construction", "32",
+		"-ef-search", "32",
+		"-min-recall", "0.5",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"TreeDB vector search demo",
+		"compact_storage_full:",
+		"Storage",
+		"Memory",
+		"avg=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -86,6 +88,9 @@ func TestRunJSONOutput(t *testing.T) {
 	if res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
 		t.Fatalf("unexpected JSON result: %+v", res)
 	}
+	if res.MinRecall != 0.5 || !res.Compact || !res.DisableExactFallback {
+		t.Fatalf("missing reproducibility config in JSON result: %+v", res)
+	}
 }
 
 func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
@@ -112,6 +117,66 @@ func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
 		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
+	}
+}
+
+func TestExecuteRequireValueLogBytesFailsOnPagerBackedDefault(t *testing.T) {
+	_, err := execute(context.Background(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+		requireValueLogBytes: true,
+	})
+	if err == nil {
+		t.Fatal("execute succeeded, want value-log requirement failure")
+	}
+	if !strings.Contains(err.Error(), "zero value_vlog bytes") {
+		t.Fatalf("error=%v, want zero value_vlog bytes", err)
+	}
+}
+
+func TestExecuteRejectsNonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "unrelated"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write unrelated file: %v", err)
+	}
+	_, err := execute(context.Background(), config{
+		dir:                  dir,
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+	})
+	if err == nil {
+		t.Fatal("execute accepted non-empty -dir, want error")
+	}
+	if !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("error=%v, want not-empty directory error", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "unrelated")); err != nil {
+		t.Fatalf("unrelated file err=%v, want untouched", err)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 )
 
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
-	res, err := execute(t.Context(), config{
+	res, err := execute(context.Background(), config{
 		dir:                  t.TempDir(),
 		keepDir:              true,
 		docs:                 128,
@@ -88,7 +89,7 @@ func TestRunJSONOutput(t *testing.T) {
 }
 
 func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
-	_, err := execute(t.Context(), config{
+	_, err := execute(context.Background(), config{
 		dir:                  t.TempDir(),
 		keepDir:              true,
 		docs:                 64,

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -40,6 +40,12 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
 		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
 	}
+	if res.FormatConfig == nil {
+		t.Fatal("missing format config report")
+	}
+	if res.StorageExpectation.IndexBytes <= 0 {
+		t.Fatalf("missing storage expectation index bytes: %+v", res.StorageExpectation)
+	}
 	if res.Memory.IndexBytesMemory <= 0 {
 		t.Fatalf("missing index memory report: %+v", res.Memory)
 	}
@@ -81,6 +87,33 @@ func TestRunJSONOutput(t *testing.T) {
 	}
 }
 
+func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
+	_, err := execute(t.Context(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+		requireLeafVLogBytes: true,
+	})
+	if err == nil {
+		t.Fatal("execute succeeded, want leaf-vlog requirement failure")
+	}
+	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
+		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -106,6 +139,8 @@ func TestRunTextOutput(t *testing.T) {
 		"TreeDB vector search demo",
 		"compact_storage_full:",
 		"Storage",
+		"format index_outer_leaves_in_vlog=",
+		"storage_domains index_db=",
 		"Memory",
 		"avg=",
 	} {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -282,12 +282,22 @@ func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
 	stride := queryDocStride(docs)
 	seen := make(map[int]struct{}, validateCount)
 	for i := 0; i < validateCount; i++ {
-		seen[queryDocIndex(i, docs, stride)] = struct{}{}
+		seen[syntheticQueryID(i, docs, 0, stride)] = struct{}{}
 	}
 	for i := 0; i < benchmarkCount; i++ {
-		docIndex := queryDocIndex(i+validateCount, docs, stride)
+		docIndex := syntheticQueryID(i, docs, validateCount, stride)
 		if _, ok := seen[docIndex]; ok {
 			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
+		}
+	}
+}
+
+func TestSyntheticQueryIDSpillsPastCorpusAfterFullValidation(t *testing.T) {
+	docs := 17
+	stride := queryDocStride(docs)
+	for i := 0; i < 5; i++ {
+		if got := syntheticQueryID(i, docs, docs, stride); got != docs+i {
+			t.Fatalf("syntheticQueryID(%d)=%d want %d", i, got, docs+i)
 		}
 	}
 }

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -180,6 +180,84 @@ func TestExecuteRejectsNonEmptyDir(t *testing.T) {
 	}
 }
 
+func TestExecuteRemovesTemporaryDirWhenNotKept(t *testing.T) {
+	res, err := execute(context.Background(), config{
+		docs:                 64,
+		dimensions:           8,
+		queries:              4,
+		validateQueries:      2,
+		validateDocs:         2,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              false,
+		disableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.KeptDir {
+		t.Fatalf("KeptDir=%t want false", res.KeptDir)
+	}
+	if _, err := os.Stat(res.Dir); !os.IsNotExist(err) {
+		t.Fatalf("temporary dir stat err=%v, want not exist", err)
+	}
+}
+
+func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "recall gate without validation queries",
+			args: []string{"-validate-queries", "0"},
+			want: "-min-recall must be 0",
+		},
+		{
+			name: "overlapping validation and benchmark queries",
+			args: []string{"-docs", "10", "-queries", "8", "-validate-queries", "3", "-validate-docs", "0"},
+			want: "-validate-queries plus -queries cannot exceed -docs",
+		},
+		{
+			name: "topk exceeds docs",
+			args: []string{"-docs", "2", "-top-k", "3"},
+			want: "-top-k cannot exceed -docs",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseConfig(tc.args)
+			if err == nil {
+				t.Fatal("parseConfig succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
+	docs := 97
+	validateCount := 17
+	benchmarkCount := 53
+	stride := queryDocStride(docs)
+	seen := make(map[int]struct{}, validateCount)
+	for i := 0; i < validateCount; i++ {
+		seen[queryDocIndex(i, docs, stride)] = struct{}{}
+	}
+	for i := 0; i < benchmarkCount; i++ {
+		docIndex := queryDocIndex(i+validateCount, docs, stride)
+		if _, ok := seen[docIndex]; ok {
+			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
+		}
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -115,6 +115,8 @@ func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	if err == nil {
 		t.Fatal("execute succeeded, want leaf-vlog requirement failure")
 	}
+	// These assertions intentionally describe the current default backend
+	// profile, where this demo does not force leaf value-log storage.
 	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
 		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
 	}
@@ -142,6 +144,8 @@ func TestExecuteRequireValueLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	if err == nil {
 		t.Fatal("execute succeeded, want value-log requirement failure")
 	}
+	// These assertions intentionally describe the current default backend
+	// profile, where this demo does not force value-log storage.
 	if !strings.Contains(err.Error(), "zero value_vlog bytes") {
 		t.Fatalf("error=%v, want zero value_vlog bytes", err)
 	}
@@ -228,6 +232,11 @@ func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
 			args: []string{"-docs", "2", "-top-k", "3"},
 			want: "-top-k cannot exceed -docs",
 		},
+		{
+			name: "negative validate docs",
+			args: []string{"-validate-docs", "-1"},
+			want: "-validate-docs cannot be negative",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := parseConfig(tc.args)
@@ -238,6 +247,31 @@ func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
 				t.Fatalf("error=%v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseConfigDoesNotWriteFlagErrorsToProcessStderr(t *testing.T) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = writePipe
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = readPipe.Close()
+	})
+	_, err = parseConfig([]string{"-not-a-real-flag"})
+	_ = writePipe.Close()
+	if err == nil {
+		t.Fatal("parseConfig accepted unknown flag")
+	}
+	var stderr bytes.Buffer
+	if _, err := stderr.ReadFrom(readPipe); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("parseConfig wrote to stderr: %q", stderr.String())
 	}
 }
 
@@ -255,6 +289,18 @@ func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
 		if _, ok := seen[docIndex]; ok {
 			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
 		}
+	}
+}
+
+func TestValidationDocIndexSamplesDistinctDocsWhenStrideWouldCollapse(t *testing.T) {
+	docs := 1543
+	seen := make(map[int]struct{}, 16)
+	for i := 0; i < 16; i++ {
+		docIndex := validationDocIndex(i, docs)
+		if _, ok := seen[docIndex]; ok {
+			t.Fatalf("validation doc index repeated %d for docs=%d", docIndex, docs)
+		}
+		seen[docIndex] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `cmd/treedb_vector_search_demo`, a CLI harness for native TreeDB vector search
- load deterministic synthetic documents, rebuild/persist the native vector index, run `CompactStorageFull`, reopen, validate document bytes and recall, then benchmark ANN search
- report compacted storage by domain, bytes/doc, native root bytes, vector index memory, runtime allocation deltas, persisted format config, and storage expectation gates

## Validation
- `GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1`
- `GOWORK=off go run ./cmd/treedb_vector_search_demo -docs 10000 -dims 64 -queries 1000 -validate-queries 32 -validate-docs 32 -top-k 10 -json -keep-dir -dir /tmp/treedb_vector_search_demo_10k_64`

## 10k x 64 Results

Source: `/tmp/treedb_vector_search_demo_10k_64.json`

| Field | Result |
| --- | ---: |
| profile | none, raw backend options |
| docs x dims | 10,000 x 64 |
| queries | 1,000 |
| top_k | 10 |
| m / ef_construction / ef_search | 16 / 128 / 128 |
| recall@10 | 1.0000 |
| validation overlap | 320 / 320 |
| avg search | 0.998 ms |
| p50 search | 0.960 ms |
| p95 search | 1.259 ms |
| p99 search | 1.653 ms |
| ops/sec | 1,001.8 |
| avg candidates / rerank | 128 / 128 |
| exact fallbacks | 0 |
| insert phase | 0.134 s |
| rebuild native vector index | 1.382 s |
| full compaction phase | 0.996 s |
| reopen/load native index | 0.260 s |
| full compaction | `fully_compacted=true` |
| compacted storage | 24,904,055 bytes |
| compacted storage/doc | 2,490.4 bytes/doc |
| `index.db` bytes | 24,903,680 |
| `value_vlog` bytes | 0 |
| `leaf_vlog` bytes | 0 |
| native root bytes | 14,125,248 |
| vector index memory | 8,973,632 bytes |
| load alloc delta | 25,352,912 bytes |

Persisted format config from the same DB directory:

```json
{
  "index_outer_leaves_in_vlog": false,
  "leaf_prefix_compression": false,
  "index_columnar_leaves": false,
  "index_packed_valueptr": false,
  "index_internal_base_delta": false,
  "vlog_compression": "auto",
  "vlog_block_codec": "snappy",
  "vlog_auto_policy": "balanced"
}
```

Note: this PR intentionally reports the current raw-backend demo path. Follow-on #1560 switches the demo to first-class TreeDB profiles, where the default `bench` profile uses outer leaves in the leaf value log and makes `-require-leaf-vlog-bytes` pass.

Stacked on #1552.
