### PR TITLE
Use TreeDB profiles in vector search demo

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -217,44 +218,8 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	dir := b.TempDir()
-	def := VectorIndexDefinition{
-		Name:       "embedding_graph_only",
-		Field:      "embedding",
-		Metric:     VectorMetricCosine,
-		Dimensions: dims,
-		M:          16,
-	}
-	d, col := openVectorBenchmarkCollectionWithVectorIndex(b, dir, docs, dims, def)
-	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("build native vector index: %v", err)
-	}
-	status, err := index.SaveSnapshot()
-	if err != nil {
-		_ = d.Close()
-		b.Fatalf("save native vector index: %v", err)
-	}
-	if err := d.Close(); err != nil {
-		b.Fatalf("close setup db: %v", err)
-	}
-	d, err = backenddb.Open(backenddb.Options{Dir: dir})
-	if err != nil {
-		b.Fatalf("reopen db: %v", err)
-	}
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
-	col, err = NewCollectionManager(d).OpenCollection("docs")
-	if err != nil {
-		b.Fatalf("open collection: %v", err)
-	}
-	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
-	if err != nil {
-		b.Fatalf("load native vector index: %v", err)
-	}
-	if loaded == nil || !loadStatus.Loaded {
-		b.Fatalf("unexpected native load status loaded=%v status=%+v", loaded != nil, loadStatus)
-	}
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
 	if err != nil {
@@ -279,6 +244,121 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 			b.Fatal("native graph-only vector search returned no results")
 		}
 	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+	if err != nil {
+		b.Fatalf("warm native graph-only parallel search: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatal("warm native graph-only parallel search returned no results")
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("native graph-only vector search: %w", err)
+		}
+		if len(results) == 0 {
+			return errors.New("native graph-only vector search returned no results")
+		}
+		return nil
+	})
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			b.Fatalf("native vector search: %v", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			b.Fatalf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+	}
+}
+
+func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	defer func() { _ = d.Close() }()
+	query := vectorBenchmarkEmbedding(docs/3, dims)
+	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		FetchMultiplier:      16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		b.Fatalf("warm native vector parallel search: %v", err)
+	}
+	if len(warm) == 0 || trace.RerankCount == 0 {
+		b.Fatalf("warm native vector parallel search results=%d rerank=%d", len(warm), trace.RerankCount)
+	}
+
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(status.BytesDisk), "native_root_bytes")
+	b.ReportMetric(float64(loaded.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+			TopK:                 vectorBenchmarkTopK,
+			EfSearch:             128,
+			FetchMultiplier:      16,
+			DisableExactFallback: true,
+		})
+		if err != nil {
+			return fmt.Errorf("native vector search: %w", err)
+		}
+		if len(results) == 0 || trace.RerankCount == 0 {
+			return fmt.Errorf("native vector search results=%d rerank=%d", len(results), trace.RerankCount)
+		}
+		return nil
+	})
 }
 
 func BenchmarkCollectionVectorIndexIncrementalWrite(b *testing.B) {
@@ -554,32 +634,18 @@ func BenchmarkCollectionVectorIndexGraphOnlySearchParallel(b *testing.B) {
 	b.ReportMetric(float64(docs), "docs/index")
 	b.ReportMetric(float64(dims), "dims")
 	b.ReportMetric(float64(index.Stats().BytesMemory), "index_bytes")
+	b.ReportAllocs()
 	b.ResetTimer()
-	var failureMu sync.Mutex
-	var firstFailure string
-	recordFailure := func(format string, args ...any) {
-		failureMu.Lock()
-		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = fmt.Sprintf(format, args...)
+	runParallelVectorSearchBenchmark(b, func() error {
+		results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
+		if err != nil {
+			return fmt.Errorf("graph-only vector search: %w", err)
 		}
-	}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			results, err := index.searchGraphOnly(query, vectorBenchmarkTopK, 128)
-			if err != nil {
-				recordFailure("graph-only vector search: %v", err)
-				return
-			}
-			if len(results) == 0 {
-				recordFailure("graph-only vector search returned no results")
-				return
-			}
+		if len(results) == 0 {
+			return errors.New("graph-only vector search returned no results")
 		}
+		return nil
 	})
-	if firstFailure != "" {
-		b.Fatal(firstFailure)
-	}
 }
 
 func BenchmarkCollectionVectorIndexSearchInt8(b *testing.B) {
@@ -900,6 +966,75 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 		documents[i] = vectorBenchmarkDocument(i, dims)
 	}
 	return ids, documents
+}
+
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+	tb.Helper()
+	dir := tb.TempDir()
+	def := VectorIndexDefinition{
+		Name:       name,
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: dims,
+		M:          16,
+	}
+	d, col := openVectorBenchmarkCollectionWithVectorIndex(tb, dir, docs, dims, def)
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("build native vector index: %v", err)
+	}
+	saveStatus, err := index.SaveSnapshot()
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("save native vector index: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("close setup db: %v", err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("reopen db: %v", err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("open collection: %v", err)
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("load native vector index: %v", err)
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID != saveStatus.RootID {
+		_ = d.Close()
+		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
+	}
+	return d, col, loaded, saveStatus
+}
+
+func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
+	b.Helper()
+	var failureMu sync.Mutex
+	var firstFailure string
+	recordFailure := func(err error) {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		if firstFailure == "" {
+			firstFailure = err.Error()
+		}
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := search(); err != nil {
+				recordFailure(err)
+				return
+			}
+		}
+	})
+	if firstFailure != "" {
+		b.Fatal(firstFailure)
+	}
 }
 
 func vectorBenchmarkInsertBatches(tb testing.TB, col *Collection, ids, documents [][]byte, batchSize int) {

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -220,7 +220,7 @@ func BenchmarkCollectionVectorIndexNativeRootLoad(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -251,7 +251,7 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_graph_only_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
 	warm, err := loaded.searchGraphOnly(query, vectorBenchmarkTopK, 128)
@@ -283,15 +283,16 @@ func BenchmarkCollectionVectorIndexNativeRootGraphOnlySearchParallel(b *testing.
 func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector search: %v", err)
 	}
@@ -306,12 +307,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			b.Fatalf("native vector search: %v", err)
 		}
@@ -324,15 +320,16 @@ func BenchmarkCollectionVectorIndexNativeRootSearch(b *testing.B) {
 func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
-	d, _, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
+	d, loaded, status := openLoadedNativeVectorBenchmarkIndex(b, docs, dims, "embedding_search_parallel")
 	defer func() { _ = d.Close() }()
 	query := vectorBenchmarkEmbedding(docs/3, dims)
-	warm, trace, err := loaded.Search(query, VectorIndexSearchOptions{
+	opts := VectorIndexSearchOptions{
 		TopK:                 vectorBenchmarkTopK,
 		EfSearch:             128,
 		FetchMultiplier:      16,
 		DisableExactFallback: true,
-	})
+	}
+	warm, trace, err := loaded.Search(query, opts)
 	if err != nil {
 		b.Fatalf("warm native vector parallel search: %v", err)
 	}
@@ -347,12 +344,7 @@ func BenchmarkCollectionVectorIndexNativeRootSearchParallel(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	runParallelVectorSearchBenchmark(b, func() error {
-		results, trace, err := loaded.Search(query, VectorIndexSearchOptions{
-			TopK:                 vectorBenchmarkTopK,
-			EfSearch:             128,
-			FetchMultiplier:      16,
-			DisableExactFallback: true,
-		})
+		results, trace, err := loaded.Search(query, opts)
 		if err != nil {
 			return fmt.Errorf("native vector search: %w", err)
 		}
@@ -994,7 +986,7 @@ func vectorBenchmarkWriteBatch(docs, dims int) ([][]byte, [][]byte) {
 	return ids, documents
 }
 
-func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *VectorIndex, VectorIndexLoadStatus) {
+func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *VectorIndex, VectorIndexLoadStatus) {
 	tb.Helper()
 	dir := tb.TempDir()
 	def := VectorIndexDefinition{
@@ -1036,18 +1028,18 @@ func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name st
 		_ = d.Close()
 		tb.Fatalf("unexpected native load status loaded=%v status=%+v save=%+v", loaded != nil, loadStatus, saveStatus)
 	}
-	return d, col, loaded, saveStatus
+	return d, loaded, loadStatus
 }
 
 func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 	b.Helper()
 	var failureMu sync.Mutex
-	var firstFailure string
+	var firstFailure error
 	recordFailure := func(err error) {
 		failureMu.Lock()
 		defer failureMu.Unlock()
-		if firstFailure == "" {
-			firstFailure = err.Error()
+		if firstFailure == nil {
+			firstFailure = err
 		}
 	}
 	b.RunParallel(func(pb *testing.PB) {
@@ -1058,7 +1050,7 @@ func runParallelVectorSearchBenchmark(b *testing.B, search func() error) {
 			}
 		}
 	})
-	if firstFailure != "" {
+	if firstFailure != nil {
 		b.Fatal(firstFailure)
 	}
 }

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -33,9 +33,14 @@ Use `-keep-dir` to inspect the generated datastore after the run.
 The demo defaults to TreeDB's `bench` profile because this is a benchmark
 harness. That profile uses the same index storage profile as `fast`: outer
 index leaves are stored in the leaf value log, leaf prefix compression is
-enabled, and value-log compression remains profile/default driven. Use
+enabled, and value-log compression remains profile/default driven. The demo
+also defaults to `-value-pointer-threshold 1024` and
+`-leaf-generation-segment-target 4194304` for this vector-search workload, so
+the compacted run keeps ordinary vector documents in outer leaves and gives
+`CompactStorageFull` sealed leaf generations to rewrite and GC. Use
 `-profile durable|fast|wal_on_fast|bench` to select a different first-class
-TreeDB profile.
+TreeDB profile, or pass `0` for either demo storage knob to use the selected
+profile default.
 
 The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -24,7 +24,14 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -dims 64 \
   -queries 1000 \
   -validate-queries 32 \
+  -validate-docs 16 \
   -top-k 10 \
+  -m 16 \
+  -ef-construction 128 \
+  -ef-search 128 \
+  -min-recall 0.95 \
+  -compact=true \
+  -disable-exact-fallback=true \
   -json
 ```
 
@@ -34,3 +41,5 @@ The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
 `-require-value-log-bytes` or `-require-leaf-vlog-bytes` when a benchmark is
 meant to prove that the compacted datastore actually used those storage domains.
+Those flags are assertions, not format selectors; the demo fails if the selected
+TreeDB settings leave the asserted domain empty.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -43,3 +43,16 @@ bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
 meant to prove that the compacted datastore actually used those storage domains.
 Those flags are assertions, not format selectors; the demo fails if the selected
 TreeDB settings leave the asserted domain empty.
+
+Useful flags:
+
+- `-compact=false`: skip `CompactStorageFull` and report uncompacted reopen/load
+  behavior.
+- `-compact-sync-each-phase=true`: ask compaction to fsync each rewrite/pack
+  phase.
+- `-disable-exact-fallback=false`: allow exact fallback during benchmark
+  searches.
+- `-validate-queries N` and `-min-recall R`: run recall validation for `N`
+  queries; set `-min-recall=0` when disabling validation with
+  `-validate-queries=0`.
+- `-json`: emit the full result object for scripts.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -1,0 +1,31 @@
+# TreeDB Vector Search Demo
+
+`treedb_vector_search_demo` is a first-class harness for exercising native
+collection vector-index persistence end to end:
+
+1. create a TreeDB collection with a declared vector field index,
+2. load deterministic synthetic JSON documents,
+3. rebuild and persist the native HNSW graph,
+4. run `DB.CompactStorage(ctx, CompactStorageFull)`,
+5. close and reopen the compacted datastore,
+6. validate document reads and ANN recall against exact search,
+7. benchmark ANN search and report storage/memory usage.
+
+`CompactStorageFull` is intentionally used instead of manually chaining
+maintenance calls. It is TreeDB's canonical full storage compaction path:
+value-log rewrite/GC, leaf-generation pack/GC, index vacuum, settle passes,
+zero-byte value-log cleanup, and final debt audit.
+
+Example:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_search_demo \
+  -docs 10000 \
+  -dims 64 \
+  -queries 1000 \
+  -validate-queries 32 \
+  -top-k 10 \
+  -json
+```
+
+Use `-keep-dir` to inspect the generated datastore after the run.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -2,7 +2,7 @@
 
 `treedb_vector_search_demo` is a first-class harness for exercising native
 collection vector-index persistence end to end. By default it runs a storage
-and read matrix with three cases:
+and search matrix with three cases:
 
 1. 1558-style outer B-tree leaves stored in `index.db`,
 2. 1560-style outer B-tree leaves stored in `leaf_vlog` before compaction, and
@@ -16,9 +16,8 @@ Each case:
 4. optionally run `DB.CompactStorage(ctx, CompactStorageFull)`,
 5. close and reopen the datastore,
 6. validate document reads and ANN recall against exact search,
-7. benchmark ANN search,
-8. benchmark serial document reads and parallel document reads, and
-9. report storage/memory usage.
+7. benchmark serial ANN search and parallel ANN search, and
+8. report storage/memory usage.
 
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:
@@ -31,17 +30,18 @@ Example:
 GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -docs 10000 \
   -dims 64 \
-  -queries 1000 \
+  -queries 10000 \
   -validate-queries 32 \
   -top-k 10 \
   -json
 ```
 
 Use `-keep-dir` to inspect the generated datastore after the run.
-Use `-matrix=false` to run only the single compacted 1560-style case.
-The matrix read stage defaults to 10,000 reads per lane and parallel
-concurrency levels `2,4,8,16,32,64,128`; override those with `-read-ops` and
-`-read-concurrency`.
+Use `-matrix=false` to run only the single 1560-style case; add
+`-compact=true` when that single case should run `CompactStorageFull`.
+The matrix search stage defaults to 10,000 ANN queries per lane and parallel
+concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
+`-search-concurrency`.
 
 The demo defaults to TreeDB's `bench` profile because this is a benchmark
 harness. That profile uses the same index storage profile as `fast`: outer
@@ -49,8 +49,9 @@ index leaves are stored in the leaf value log, leaf prefix compression is
 enabled, and value-log compression remains profile/default driven. The demo
 also defaults to `-value-pointer-threshold 1024` and
 `-leaf-generation-segment-target 4194304` for this vector-search workload, so
-the compacted run keeps ordinary vector documents in outer leaves and gives
-`CompactStorageFull` sealed leaf generations to rewrite and GC. Use
+the leaf-vlog layout keeps ordinary vector documents in outer leaves and gives
+the optional `CompactStorageFull` path sealed leaf generations to rewrite and
+GC. Use
 `-profile durable|fast|wal_on_fast|bench` to select a different first-class
 TreeDB profile, or pass `0` for either demo storage knob to use the selected
 profile default.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -35,7 +35,9 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -json
 ```
 
-Use `-keep-dir` to inspect the generated datastore after the run.
+Use `-keep-dir` to inspect an automatically-created temporary datastore after
+the run. Passing an explicit `-dir` always keeps that directory, and it must be
+empty or absent before the run starts.
 
 The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
@@ -50,6 +52,8 @@ Useful flags:
   behavior.
 - `-compact-sync-each-phase=true`: ask compaction to fsync each rewrite/pack
   phase.
+- `-dir PATH`: write into a caller-chosen empty directory and keep it after the
+  run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -1,15 +1,24 @@
 # TreeDB Vector Search Demo
 
 `treedb_vector_search_demo` is a first-class harness for exercising native
-collection vector-index persistence end to end:
+collection vector-index persistence end to end. By default it runs a storage
+and read matrix with three cases:
+
+1. 1558-style outer B-tree leaves stored in `index.db`,
+2. 1560-style outer B-tree leaves stored in `leaf_vlog` before compaction, and
+3. 1560-style outer B-tree leaves stored in `leaf_vlog` after compaction.
+
+Each case:
 
 1. create a TreeDB collection with a declared vector field index,
 2. load deterministic synthetic JSON documents,
 3. rebuild and persist the native HNSW graph,
-4. run `DB.CompactStorage(ctx, CompactStorageFull)`,
-5. close and reopen the compacted datastore,
+4. optionally run `DB.CompactStorage(ctx, CompactStorageFull)`,
+5. close and reopen the datastore,
 6. validate document reads and ANN recall against exact search,
-7. benchmark ANN search and report storage/memory usage.
+7. benchmark ANN search,
+8. benchmark serial document reads and parallel document reads, and
+9. report storage/memory usage.
 
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:
@@ -29,6 +38,10 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
 ```
 
 Use `-keep-dir` to inspect the generated datastore after the run.
+Use `-matrix=false` to run only the single compacted 1560-style case.
+The matrix read stage defaults to 10,000 reads per lane and parallel
+concurrency levels `2,4,8,16,32,64,128`; override those with `-read-ops` and
+`-read-concurrency`.
 
 The demo defaults to TreeDB's `bench` profile because this is a benchmark
 harness. That profile uses the same index storage profile as `fast`: outer

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -30,6 +30,13 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
 
 Use `-keep-dir` to inspect the generated datastore after the run.
 
+The demo defaults to TreeDB's `bench` profile because this is a benchmark
+harness. That profile uses the same index storage profile as `fast`: outer
+index leaves are stored in the leaf value log, leaf prefix compression is
+enabled, and value-log compression remains profile/default driven. Use
+`-profile durable|fast|wal_on_fast|bench` to select a different first-class
+TreeDB profile.
+
 The output includes the persisted TreeDB `format.json` knobs and storage-domain
 bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
 `-require-value-log-bytes` or `-require-leaf-vlog-bytes` when a benchmark is

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -29,3 +29,8 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
 ```
 
 Use `-keep-dir` to inspect the generated datastore after the run.
+
+The output includes the persisted TreeDB `format.json` knobs and storage-domain
+bytes for `index.db`, `value_vlog`, and `leaf_vlog`. Use
+`-require-value-log-bytes` or `-require-leaf-vlog-bytes` when a benchmark is
+meant to prove that the compacted datastore actually used those storage domains.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -65,7 +65,10 @@ type result struct {
 	M                    int                            `json:"m"`
 	EfConstruction       int                            `json:"ef_construction"`
 	EfSearch             int                            `json:"ef_search"`
+	MinRecall            float64                        `json:"min_recall"`
 	Compact              bool                           `json:"compact"`
+	CompactSyncEachPhase bool                           `json:"compact_sync_each_phase"`
+	DisableExactFallback bool                           `json:"disable_exact_fallback"`
 	Insert               phaseResult                    `json:"insert"`
 	Rebuild              phaseResult                    `json:"rebuild"`
 	CompactPhase         phaseResult                    `json:"compact_phase"`
@@ -157,7 +160,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return enc.Encode(res)
 	}
 	printText(stdout, res)
-	if !cfg.keepDir {
+	if !res.KeptDir {
 		fmt.Fprintf(stderr, "temporary db removed; rerun with -keep-dir to inspect files\n")
 	}
 	return nil
@@ -239,16 +242,17 @@ func parseConfig(args []string) (config, error) {
 		return config{}, errors.New("-validate-docs cannot be negative")
 	}
 	if cfg.validateQueries > cfg.docs {
-		cfg.validateQueries = cfg.docs
+		return config{}, errors.New("-validate-queries cannot exceed -docs")
 	}
 	if cfg.validateDocs > cfg.docs {
-		cfg.validateDocs = cfg.docs
+		return config{}, errors.New("-validate-docs cannot exceed -docs")
 	}
 	return cfg, nil
 }
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	dir := cfg.dir
+	explicitDir := dir != ""
 	cleanup := func() {}
 	if dir == "" {
 		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")
@@ -260,10 +264,23 @@ func execute(ctx context.Context, cfg config) (result, error) {
 			cleanup = func() { _ = os.RemoveAll(tmp) }
 		}
 	} else {
-		if err := os.RemoveAll(dir); err != nil {
-			return result{}, err
-		}
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		info, err := os.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				return result{}, fmt.Errorf("-dir %q exists and is not a directory", dir)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				return result{}, err
+			}
+			if len(entries) > 0 {
+				return result{}, fmt.Errorf("-dir %q already exists and is not empty; choose a new directory", dir)
+			}
+		} else if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return result{}, err
+			}
+		} else {
 			return result{}, err
 		}
 	}
@@ -281,18 +298,21 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		EfSearch:       cfg.efSearch,
 	}
 	res := result{
-		Dir:             dir,
-		KeptDir:         cfg.keepDir,
-		Docs:            cfg.docs,
-		Dimensions:      cfg.dimensions,
-		Queries:         cfg.queries,
-		ValidateQueries: cfg.validateQueries,
-		ValidateDocs:    cfg.validateDocs,
-		TopK:            cfg.topK,
-		M:               cfg.m,
-		EfConstruction:  cfg.efConstruction,
-		EfSearch:        cfg.efSearch,
-		Compact:         cfg.compact,
+		Dir:                  dir,
+		KeptDir:              cfg.keepDir || explicitDir,
+		Docs:                 cfg.docs,
+		Dimensions:           cfg.dimensions,
+		Queries:              cfg.queries,
+		ValidateQueries:      cfg.validateQueries,
+		ValidateDocs:         cfg.validateDocs,
+		TopK:                 cfg.topK,
+		M:                    cfg.m,
+		EfConstruction:       cfg.efConstruction,
+		EfSearch:             cfg.efSearch,
+		MinRecall:            cfg.minRecall,
+		Compact:              cfg.compact,
+		CompactSyncEachPhase: cfg.compactSyncEachPhase,
+		DisableExactFallback: cfg.disableExactFallback,
 	}
 
 	d, err := backenddb.Open(backenddb.Options{
@@ -408,7 +428,12 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-	defer d.Close()
+	closeReopened := true
+	defer func() {
+		if closeReopened {
+			_ = d.Close()
+		}
+	}()
 	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		return result{}, err
@@ -423,6 +448,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res.ReopenLoad = phaseSince(reopenStart)
 	res.IndexStatsLoaded = loaded.Stats()
 	var afterLoad runtime.MemStats
+	runtime.GC()
 	runtime.ReadMemStats(&afterLoad)
 	res.Memory = memoryReport{
 		AllocBeforeLoadBytes: beforeLoad.Alloc,
@@ -442,6 +468,10 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	res.Search = search
+	closeReopened = false
+	if err := d.Close(); err != nil {
+		return result{}, err
+	}
 	return res, nil
 }
 
@@ -486,6 +516,8 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 		out.Recall = 1
 		return out, nil
 	}
+	// Recall validation disables exact fallback on the ANN side so it measures
+	// the graph result against the exact baseline computed inside CheckRecall.
 	recall, err := idx.CheckRecall(validationQueries(cfg.validateQueries, cfg.docs, cfg.dimensions), collections.VectorIndexSearchOptions{
 		TopK:                 cfg.topK,
 		EfSearch:             cfg.efSearch,
@@ -505,7 +537,7 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 }
 
 func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
-	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
+	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries+1)
 	latencies := make([]int64, len(queries))
 	var candidatesTotal int64
 	var rerankTotal int64
@@ -534,12 +566,16 @@ func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkR
 	total := time.Since(startAll)
 	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
 	avg := float64(total.Nanoseconds()) / float64(len(queries))
+	opsPerSecond := 0.0
+	if total > 0 {
+		opsPerSecond = float64(len(queries)) / total.Seconds()
+	}
 	return searchBenchmarkResult{
 		Queries:              len(queries),
 		TotalDurationNanos:   total.Nanoseconds(),
 		AvgNanos:             avg,
 		AvgMicros:            avg / 1000,
-		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
+		OpsPerSecond:         opsPerSecond,
 		P50Nanos:             percentile(latencies, 0.50),
 		P95Nanos:             percentile(latencies, 0.95),
 		P99Nanos:             percentile(latencies, 0.99),
@@ -564,9 +600,13 @@ func vectorIndexOptions(def collections.VectorIndexDefinition) collections.Vecto
 }
 
 func validationQueries(count, docs, dims int) [][]float32 {
+	return syntheticQueries(count, docs, dims, 0)
+}
+
+func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i, docs), dims)
+		queries[i] = embedding(queryDocIndex(i+offset, docs), dims)
 	}
 	return queries
 }
@@ -635,7 +675,7 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 			return err
 		}
 		group := strings.Split(rel, string(os.PathSeparator))[0]
-		if group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK" {
+		if rel == group && (group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK") {
 			group = rel
 		}
 		report.Domains[group] += size
@@ -656,6 +696,7 @@ func phaseSince(start time.Time) phaseResult {
 }
 
 func percentile(sorted []int64, p float64) int64 {
+	// Nearest-rank percentile over an already sorted sample.
 	if len(sorted) == 0 {
 		return 0
 	}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -247,6 +248,12 @@ func parseConfig(args []string) (config, error) {
 	if cfg.validateDocs > cfg.docs {
 		return config{}, errors.New("-validate-docs cannot exceed -docs")
 	}
+	if cfg.validateQueries == 0 && cfg.minRecall > 0 {
+		return config{}, errors.New("-min-recall must be 0 when -validate-queries is 0")
+	}
+	if cfg.validateQueries+cfg.queries > cfg.docs {
+		return config{}, errors.New("-validate-queries plus -queries cannot exceed -docs")
+	}
 	return cfg, nil
 }
 
@@ -428,12 +435,15 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-	closeReopened := true
-	defer func() {
-		if closeReopened {
-			_ = d.Close()
+	closeReopened := func() error {
+		if d == nil {
+			return nil
 		}
-	}()
+		err := d.Close()
+		d = nil
+		return err
+	}
+	defer func() { _ = closeReopened() }()
 	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		return result{}, err
@@ -453,7 +463,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res.Memory = memoryReport{
 		AllocBeforeLoadBytes: beforeLoad.Alloc,
 		AllocAfterLoadBytes:  afterLoad.Alloc,
-		LoadAllocDeltaBytes:  int64(afterLoad.Alloc) - int64(beforeLoad.Alloc),
+		LoadAllocDeltaBytes:  allocDeltaBytes(afterLoad.Alloc, beforeLoad.Alloc),
 		IndexBytesMemory:     res.IndexStatsLoaded.BytesMemory,
 	}
 
@@ -468,11 +478,26 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	res.Search = search
-	closeReopened = false
-	if err := d.Close(); err != nil {
+	if err := closeReopened(); err != nil {
 		return result{}, err
 	}
 	return res, nil
+}
+
+func allocDeltaBytes(after, before uint64) int64 {
+	const maxInt64 = uint64(1<<63 - 1)
+	if after >= before {
+		delta := after - before
+		if delta > maxInt64 {
+			return int64(maxInt64)
+		}
+		return int64(delta)
+	}
+	delta := before - after
+	if delta > maxInt64 {
+		return -int64(maxInt64)
+	}
+	return -int64(delta)
 }
 
 func insertDocuments(col *collections.Collection, docs, dims, batchSize int) error {
@@ -513,7 +538,6 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 		}
 	}
 	if cfg.validateQueries == 0 {
-		out.Recall = 1
 		return out, nil
 	}
 	// Recall validation disables exact fallback on the ANN side so it measures
@@ -605,14 +629,42 @@ func validationQueries(count, docs, dims int) [][]float32 {
 
 func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
+	stride := queryDocStride(docs)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i+offset, docs), dims)
+		queries[i] = embedding(queryDocIndex(i+offset, docs, stride), dims)
 	}
 	return queries
 }
 
-func queryDocIndex(i, docs int) int {
-	return (i*7919 + docs/3 + 17) % docs
+func queryDocStride(docs int) int {
+	stride := 7919
+	if docs > 0 {
+		stride %= docs
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	for gcd(stride, docs) != 1 {
+		stride++
+	}
+	return stride
+}
+
+func queryDocIndex(i, docs, stride int) int {
+	return (i*stride + docs/3 + 17) % docs
+}
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
 }
 
 func validationDocIndex(i, docs int) int {
@@ -626,12 +678,14 @@ func documentID(id int) []byte {
 func documentJSON(id, dims int) []byte {
 	vector := embedding(id, dims)
 	out := make([]byte, 0, 48+dims*10)
-	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	out = append(out, `{"group":`...)
+	out = strconv.AppendInt(out, int64(id%16), 10)
+	out = append(out, `,"embedding":[`...)
 	for i, value := range vector {
 		if i > 0 {
 			out = append(out, ',')
 		}
-		out = append(out, fmt.Sprintf("%.7g", value)...)
+		out = strconv.AppendFloat(out, float64(value), 'g', 7, 32)
 	}
 	out = append(out, ']', '}')
 	return out
@@ -646,6 +700,10 @@ func embedding(id, dims int) []float32 {
 		value := math.Sin(x*d*0.013) + math.Cos((x+17)*d*0.007) + math.Sin(float64((id%31)+1)*d*0.019)
 		out[i] = float32(value)
 		norm += value * value
+	}
+	if norm == 0 || math.IsNaN(norm) || math.IsInf(norm, 0) {
+		out[0] = 1
+		return out
 	}
 	scale := 1 / math.Sqrt(norm)
 	for i := range out {
@@ -674,10 +732,7 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 		if err != nil {
 			return err
 		}
-		group := strings.Split(rel, string(os.PathSeparator))[0]
-		if rel == group && (group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK") {
-			group = rel
-		}
+		group := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
 		report.Domains[group] += size
 		return nil
 	})
@@ -729,6 +784,8 @@ func printText(w io.Writer, res result) {
 			fully = res.CompactStorage.FullyCompacted
 		}
 		fmt.Fprintf(w, "compact_storage_full: %.3fs fully_compacted=%t\n", res.CompactPhase.Seconds, fully)
+	} else {
+		fmt.Fprintf(w, "compact_storage_full: skipped\n")
 	}
 	fmt.Fprintf(w, "reopen_and_load_native_index: %.3fs\n", res.ReopenLoad.Seconds)
 	fmt.Fprintf(w, "\nValidation\n")

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -1,0 +1,688 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs        = 10000
+	defaultDimensions  = 64
+	defaultQueries     = 1000
+	defaultTopK        = 10
+	defaultBatchSize   = 512
+	defaultM           = 16
+	defaultEfConstruct = 128
+	defaultEfSearch    = 128
+)
+
+type config struct {
+	dir                  string
+	keepDir              bool
+	docs                 int
+	dimensions           int
+	queries              int
+	validateQueries      int
+	validateDocs         int
+	topK                 int
+	batchSize            int
+	m                    int
+	efConstruction       int
+	efSearch             int
+	minRecall            float64
+	compact              bool
+	compactSyncEachPhase bool
+	disableExactFallback bool
+	jsonOut              bool
+}
+
+type result struct {
+	Dir                  string                         `json:"dir"`
+	KeptDir              bool                           `json:"kept_dir"`
+	Docs                 int                            `json:"docs"`
+	Dimensions           int                            `json:"dimensions"`
+	Queries              int                            `json:"queries"`
+	ValidateQueries      int                            `json:"validate_queries"`
+	ValidateDocs         int                            `json:"validate_docs"`
+	TopK                 int                            `json:"top_k"`
+	M                    int                            `json:"m"`
+	EfConstruction       int                            `json:"ef_construction"`
+	EfSearch             int                            `json:"ef_search"`
+	Compact              bool                           `json:"compact"`
+	Insert               phaseResult                    `json:"insert"`
+	Rebuild              phaseResult                    `json:"rebuild"`
+	CompactPhase         phaseResult                    `json:"compact_phase"`
+	ReopenLoad           phaseResult                    `json:"reopen_load"`
+	Validation           validationResult               `json:"validation"`
+	Search               searchBenchmarkResult          `json:"search"`
+	StorageBeforeCompact storageReport                  `json:"storage_before_compact"`
+	StorageAfterCompact  storageReport                  `json:"storage_after_compact"`
+	IndexStatsBefore     collections.VectorIndexStats   `json:"index_stats_before_compact"`
+	IndexStatsLoaded     collections.VectorIndexStats   `json:"index_stats_loaded"`
+	NativeRootBytes      int64                          `json:"native_root_bytes"`
+	CompactStorage       *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
+	Memory               memoryReport                   `json:"memory"`
+}
+
+type phaseResult struct {
+	DurationNanos int64   `json:"duration_nanos"`
+	Seconds       float64 `json:"seconds"`
+}
+
+type validationResult struct {
+	DocumentsChecked int     `json:"documents_checked"`
+	QueriesChecked   int     `json:"queries_checked"`
+	ExactTotal       int     `json:"exact_total"`
+	ANNTotal         int     `json:"ann_total"`
+	Overlap          int     `json:"overlap"`
+	Recall           float64 `json:"recall"`
+	MinRecall        float64 `json:"min_recall"`
+}
+
+type searchBenchmarkResult struct {
+	Queries              int     `json:"queries"`
+	TotalDurationNanos   int64   `json:"total_duration_nanos"`
+	AvgNanos             float64 `json:"avg_nanos"`
+	AvgMicros            float64 `json:"avg_micros"`
+	OpsPerSecond         float64 `json:"ops_per_second"`
+	P50Nanos             int64   `json:"p50_nanos"`
+	P95Nanos             int64   `json:"p95_nanos"`
+	P99Nanos             int64   `json:"p99_nanos"`
+	AvgCandidates        float64 `json:"avg_candidates"`
+	AvgRerank            float64 `json:"avg_rerank"`
+	ExactFallbacks       int     `json:"exact_fallbacks"`
+	DisableExactFallback bool    `json:"disable_exact_fallback"`
+}
+
+type storageReport struct {
+	TotalBytes  int64            `json:"total_bytes"`
+	BytesPerDoc float64          `json:"bytes_per_doc"`
+	Domains     map[string]int64 `json:"domains"`
+	Files       int              `json:"files"`
+}
+
+type memoryReport struct {
+	AllocBeforeLoadBytes uint64 `json:"alloc_before_load_bytes"`
+	AllocAfterLoadBytes  uint64 `json:"alloc_after_load_bytes"`
+	LoadAllocDeltaBytes  int64  `json:"load_alloc_delta_bytes"`
+	IndexBytesMemory     int64  `json:"index_bytes_memory"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb-vector-search-demo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	res, err := execute(context.Background(), cfg)
+	if err != nil {
+		return err
+	}
+	if cfg.jsonOut {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	printText(stdout, res)
+	if !cfg.keepDir {
+		fmt.Fprintf(stderr, "temporary db removed; rerun with -keep-dir to inspect files\n")
+	}
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{
+		docs:                 defaultDocs,
+		dimensions:           defaultDimensions,
+		queries:              defaultQueries,
+		validateQueries:      32,
+		validateDocs:         16,
+		topK:                 defaultTopK,
+		batchSize:            defaultBatchSize,
+		m:                    defaultM,
+		efConstruction:       defaultEfConstruct,
+		efSearch:             defaultEfSearch,
+		minRecall:            0.95,
+		compact:              true,
+		disableExactFallback: true,
+	}
+	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
+	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
+	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
+	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
+	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
+	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of ANN search queries to benchmark")
+	fs.IntVar(&cfg.validateQueries, "validate-queries", cfg.validateQueries, "Number of queries to validate against exact search")
+	fs.IntVar(&cfg.validateDocs, "validate-docs", cfg.validateDocs, "Number of documents to read and byte-validate after compaction/reopen")
+	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count")
+	fs.IntVar(&cfg.batchSize, "batch-size", cfg.batchSize, "Insert batch size")
+	fs.IntVar(&cfg.m, "m", cfg.m, "HNSW max neighbor parameter")
+	fs.IntVar(&cfg.efConstruction, "ef-construction", cfg.efConstruction, "HNSW efConstruction")
+	fs.IntVar(&cfg.efSearch, "ef-search", cfg.efSearch, "HNSW efSearch for ANN queries")
+	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
+	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
+	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
+	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
+	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.docs <= 0 {
+		return config{}, errors.New("-docs must be positive")
+	}
+	if cfg.dimensions <= 0 {
+		return config{}, errors.New("-dims must be positive")
+	}
+	if cfg.queries <= 0 {
+		return config{}, errors.New("-queries must be positive")
+	}
+	if cfg.topK <= 0 {
+		return config{}, errors.New("-top-k must be positive")
+	}
+	if cfg.topK > cfg.docs {
+		return config{}, errors.New("-top-k cannot exceed -docs")
+	}
+	if cfg.batchSize <= 0 {
+		return config{}, errors.New("-batch-size must be positive")
+	}
+	if cfg.m <= 0 {
+		return config{}, errors.New("-m must be positive")
+	}
+	if cfg.efConstruction <= 0 {
+		return config{}, errors.New("-ef-construction must be positive")
+	}
+	if cfg.efSearch <= 0 {
+		return config{}, errors.New("-ef-search must be positive")
+	}
+	if cfg.minRecall < 0 || cfg.minRecall > 1 {
+		return config{}, errors.New("-min-recall must be in [0,1]")
+	}
+	if cfg.validateQueries < 0 {
+		return config{}, errors.New("-validate-queries cannot be negative")
+	}
+	if cfg.validateDocs < 0 {
+		return config{}, errors.New("-validate-docs cannot be negative")
+	}
+	if cfg.validateQueries > cfg.docs {
+		cfg.validateQueries = cfg.docs
+	}
+	if cfg.validateDocs > cfg.docs {
+		cfg.validateDocs = cfg.docs
+	}
+	return cfg, nil
+}
+
+func execute(ctx context.Context, cfg config) (result, error) {
+	dir := cfg.dir
+	cleanup := func() {}
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")
+		if err != nil {
+			return result{}, err
+		}
+		dir = tmp
+		if !cfg.keepDir {
+			cleanup = func() { _ = os.RemoveAll(tmp) }
+		}
+	} else {
+		if err := os.RemoveAll(dir); err != nil {
+			return result{}, err
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return result{}, err
+		}
+	}
+	if !cfg.keepDir {
+		defer cleanup()
+	}
+
+	def := collections.VectorIndexDefinition{
+		Name:           "embedding",
+		Field:          "embedding",
+		Metric:         collections.VectorMetricCosine,
+		Dimensions:     cfg.dimensions,
+		M:              cfg.m,
+		EfConstruction: cfg.efConstruction,
+		EfSearch:       cfg.efSearch,
+	}
+	res := result{
+		Dir:             dir,
+		KeptDir:         cfg.keepDir,
+		Docs:            cfg.docs,
+		Dimensions:      cfg.dimensions,
+		Queries:         cfg.queries,
+		ValidateQueries: cfg.validateQueries,
+		ValidateDocs:    cfg.validateDocs,
+		TopK:            cfg.topK,
+		M:               cfg.m,
+		EfConstruction:  cfg.efConstruction,
+		EfSearch:        cfg.efSearch,
+		Compact:         cfg.compact,
+	}
+
+	d, err := backenddb.Open(backenddb.Options{
+		Dir: dir,
+		ValueLog: backenddb.ValueLogOptions{
+			Compression: backenddb.ValueLogCompressionAuto,
+		},
+	})
+	if err != nil {
+		return result{}, err
+	}
+	mgr := collections.NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name:          "docs",
+		VectorIndexes: []collections.VectorIndexDefinition{def},
+	}); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+
+	insertStart := time.Now()
+	if err := insertDocuments(col, cfg.docs, cfg.dimensions, cfg.batchSize); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	res.Insert = phaseSince(insertStart)
+
+	rebuildStart := time.Now()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if !status.NativeRootLoaded || status.RootID == 0 {
+		_ = d.Close()
+		return result{}, fmt.Errorf("unexpected native vector root status: %+v", status)
+	}
+	res.Rebuild = phaseSince(rebuildStart)
+	res.NativeRootBytes = status.NativeRootBytes
+	res.IndexStatsBefore = status.Stats
+
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	res.StorageBeforeCompact, err = storageUsage(dir, cfg.docs)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+
+	if cfg.compact {
+		compactStart := time.Now()
+		stats, err := d.CompactStorage(ctx, backenddb.CompactStorageOptions{
+			Mode:          backenddb.CompactStorageFull,
+			SyncEachPhase: cfg.compactSyncEachPhase,
+		})
+		if err != nil {
+			_ = d.Close()
+			return result{}, err
+		}
+		res.CompactPhase = phaseSince(compactStart)
+		res.CompactStorage = &stats
+		if err := d.Checkpoint(); err != nil {
+			_ = d.Close()
+			return result{}, err
+		}
+	}
+	res.StorageAfterCompact, err = storageUsage(dir, cfg.docs)
+	if err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
+	if err := d.Close(); err != nil {
+		return result{}, err
+	}
+
+	var beforeLoad runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&beforeLoad)
+	reopenStart := time.Now()
+	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		return result{}, err
+	}
+	defer d.Close()
+	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		return result{}, err
+	}
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptions(def))
+	if err != nil {
+		return result{}, err
+	}
+	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID == 0 {
+		return result{}, fmt.Errorf("failed to load compacted native vector root: %+v", loadStatus)
+	}
+	res.ReopenLoad = phaseSince(reopenStart)
+	res.IndexStatsLoaded = loaded.Stats()
+	var afterLoad runtime.MemStats
+	runtime.ReadMemStats(&afterLoad)
+	res.Memory = memoryReport{
+		AllocBeforeLoadBytes: beforeLoad.Alloc,
+		AllocAfterLoadBytes:  afterLoad.Alloc,
+		LoadAllocDeltaBytes:  int64(afterLoad.Alloc) - int64(beforeLoad.Alloc),
+		IndexBytesMemory:     res.IndexStatsLoaded.BytesMemory,
+	}
+
+	validation, err := validateCompactedData(col, loaded, cfg)
+	if err != nil {
+		return result{}, err
+	}
+	res.Validation = validation
+
+	search, err := benchmarkSearch(loaded, cfg)
+	if err != nil {
+		return result{}, err
+	}
+	res.Search = search
+	return res, nil
+}
+
+func insertDocuments(col *collections.Collection, docs, dims, batchSize int) error {
+	for start := 0; start < docs; start += batchSize {
+		end := start + batchSize
+		if end > docs {
+			end = docs
+		}
+		ids := make([][]byte, end-start)
+		documents := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			j := i - start
+			ids[j] = documentID(i)
+			documents[j] = documentJSON(i, dims)
+		}
+		if _, err := col.InsertBatch(ids, documents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCompactedData(col *collections.Collection, idx *collections.VectorIndex, cfg config) (validationResult, error) {
+	out := validationResult{
+		DocumentsChecked: cfg.validateDocs,
+		QueriesChecked:   cfg.validateQueries,
+		MinRecall:        cfg.minRecall,
+	}
+	for i := 0; i < cfg.validateDocs; i++ {
+		docIndex := validationDocIndex(i, cfg.docs)
+		got, err := col.Get(documentID(docIndex))
+		if err != nil {
+			return out, fmt.Errorf("get compacted doc %d: %w", docIndex, err)
+		}
+		want := documentJSON(docIndex, cfg.dimensions)
+		if !bytes.Equal(got, want) {
+			return out, fmt.Errorf("compacted doc %d mismatch", docIndex)
+		}
+	}
+	if cfg.validateQueries == 0 {
+		out.Recall = 1
+		return out, nil
+	}
+	recall, err := idx.CheckRecall(validationQueries(cfg.validateQueries, cfg.docs, cfg.dimensions), collections.VectorIndexSearchOptions{
+		TopK:                 cfg.topK,
+		EfSearch:             cfg.efSearch,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		return out, err
+	}
+	out.ExactTotal = recall.ExactTotal
+	out.ANNTotal = recall.ANNTotal
+	out.Overlap = recall.Overlap
+	out.Recall = recall.Recall
+	if out.Recall < cfg.minRecall {
+		return out, fmt.Errorf("recall %.4f below minimum %.4f", out.Recall, cfg.minRecall)
+	}
+	return out, nil
+}
+
+func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
+	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
+	latencies := make([]int64, len(queries))
+	var candidatesTotal int64
+	var rerankTotal int64
+	var exactFallbacks int
+	startAll := time.Now()
+	for i, query := range queries {
+		start := time.Now()
+		results, trace, err := idx.Search(query, collections.VectorIndexSearchOptions{
+			TopK:                 cfg.topK,
+			EfSearch:             cfg.efSearch,
+			DisableExactFallback: cfg.disableExactFallback,
+		})
+		latencies[i] = time.Since(start).Nanoseconds()
+		if err != nil {
+			return searchBenchmarkResult{}, err
+		}
+		if len(results) == 0 {
+			return searchBenchmarkResult{}, errors.New("vector search returned no results")
+		}
+		candidatesTotal += int64(trace.CandidatesExamined)
+		rerankTotal += int64(trace.RerankCount)
+		if trace.ExactFallbackReason != "" {
+			exactFallbacks++
+		}
+	}
+	total := time.Since(startAll)
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	avg := float64(total.Nanoseconds()) / float64(len(queries))
+	return searchBenchmarkResult{
+		Queries:              len(queries),
+		TotalDurationNanos:   total.Nanoseconds(),
+		AvgNanos:             avg,
+		AvgMicros:            avg / 1000,
+		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
+		P50Nanos:             percentile(latencies, 0.50),
+		P95Nanos:             percentile(latencies, 0.95),
+		P99Nanos:             percentile(latencies, 0.99),
+		AvgCandidates:        float64(candidatesTotal) / float64(len(queries)),
+		AvgRerank:            float64(rerankTotal) / float64(len(queries)),
+		ExactFallbacks:       exactFallbacks,
+		DisableExactFallback: cfg.disableExactFallback,
+	}, nil
+}
+
+func vectorIndexOptions(def collections.VectorIndexDefinition) collections.VectorIndexOptions {
+	return collections.VectorIndexOptions{
+		Name:           def.Name,
+		Field:          def.Field,
+		Metric:         def.Metric,
+		Dimensions:     def.Dimensions,
+		M:              def.M,
+		EfConstruction: def.EfConstruction,
+		EfSearch:       def.EfSearch,
+		Encoding:       def.Encoding,
+	}
+}
+
+func validationQueries(count, docs, dims int) [][]float32 {
+	queries := make([][]float32, count)
+	for i := 0; i < count; i++ {
+		queries[i] = embedding(queryDocIndex(i, docs), dims)
+	}
+	return queries
+}
+
+func queryDocIndex(i, docs int) int {
+	return (i*7919 + docs/3 + 17) % docs
+}
+
+func validationDocIndex(i, docs int) int {
+	return (i*1543 + docs/5 + 11) % docs
+}
+
+func documentID(id int) []byte {
+	return []byte(fmt.Sprintf("doc-%06d", id))
+}
+
+func documentJSON(id, dims int) []byte {
+	vector := embedding(id, dims)
+	out := make([]byte, 0, 48+dims*10)
+	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	for i, value := range vector {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, fmt.Sprintf("%.7g", value)...)
+	}
+	out = append(out, ']', '}')
+	return out
+}
+
+func embedding(id, dims int) []float32 {
+	out := make([]float32, dims)
+	var norm float64
+	x := float64(id + 1)
+	for i := range out {
+		d := float64(i + 1)
+		value := math.Sin(x*d*0.013) + math.Cos((x+17)*d*0.007) + math.Sin(float64((id%31)+1)*d*0.019)
+		out[i] = float32(value)
+		norm += value * value
+	}
+	scale := 1 / math.Sqrt(norm)
+	for i := range out {
+		out[i] = float32(float64(out[i]) * scale)
+	}
+	return out
+}
+
+func storageUsage(dir string, docs int) (storageReport, error) {
+	report := storageReport{Domains: make(map[string]int64)}
+	err := filepath.WalkDir(dir, func(path string, ent os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ent.IsDir() {
+			return nil
+		}
+		info, err := ent.Info()
+		if err != nil {
+			return err
+		}
+		size := info.Size()
+		report.TotalBytes += size
+		report.Files++
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		group := strings.Split(rel, string(os.PathSeparator))[0]
+		if group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK" {
+			group = rel
+		}
+		report.Domains[group] += size
+		return nil
+	})
+	if err != nil {
+		return storageReport{}, err
+	}
+	if docs > 0 {
+		report.BytesPerDoc = float64(report.TotalBytes) / float64(docs)
+	}
+	return report, nil
+}
+
+func phaseSince(start time.Time) phaseResult {
+	d := time.Since(start)
+	return phaseResult{DurationNanos: d.Nanoseconds(), Seconds: d.Seconds()}
+}
+
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func printText(w io.Writer, res result) {
+	fmt.Fprintf(w, "TreeDB vector search demo\n")
+	fmt.Fprintf(w, "dir=%s kept=%t docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d\n",
+		res.Dir, res.KeptDir, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch)
+	fmt.Fprintf(w, "\nPhases\n")
+	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
+	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)
+	if res.Compact {
+		fully := false
+		if res.CompactStorage != nil {
+			fully = res.CompactStorage.FullyCompacted
+		}
+		fmt.Fprintf(w, "compact_storage_full: %.3fs fully_compacted=%t\n", res.CompactPhase.Seconds, fully)
+	}
+	fmt.Fprintf(w, "reopen_and_load_native_index: %.3fs\n", res.ReopenLoad.Seconds)
+	fmt.Fprintf(w, "\nValidation\n")
+	fmt.Fprintf(w, "documents_checked=%d queries_checked=%d recall_at_%d=%.4f overlap=%d/%d\n",
+		res.Validation.DocumentsChecked, res.Validation.QueriesChecked, res.TopK, res.Validation.Recall, res.Validation.Overlap, res.Validation.ExactTotal)
+	fmt.Fprintf(w, "\nSearch Benchmark\n")
+	fmt.Fprintf(w, "avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d\n",
+		res.Search.AvgMicros,
+		float64(res.Search.P50Nanos)/1000,
+		float64(res.Search.P95Nanos)/1000,
+		float64(res.Search.P99Nanos)/1000,
+		res.Search.OpsPerSecond,
+		res.Search.ExactFallbacks)
+	fmt.Fprintf(w, "avg_candidates=%.1f avg_rerank=%.1f\n", res.Search.AvgCandidates, res.Search.AvgRerank)
+	fmt.Fprintf(w, "\nStorage\n")
+	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
+	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
+	printDomains(w, "after_compact", res.StorageAfterCompact.Domains)
+	fmt.Fprintf(w, "\nMemory\n")
+	fmt.Fprintf(w, "index_bytes_memory=%d load_alloc_delta=%d alloc_after_load=%d\n",
+		res.Memory.IndexBytesMemory, res.Memory.LoadAllocDeltaBytes, res.Memory.AllocAfterLoadBytes)
+}
+
+func printDomains(w io.Writer, label string, domains map[string]int64) {
+	keys := make([]string, 0, len(domains))
+	for key := range domains {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(w, "%s_domain name=%s bytes=%d\n", label, key, domains[key])
+	}
+}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -425,6 +425,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		_ = d.Close()
 		return result{}, errors.New("compacted storage has zero leaf_vlog bytes")
 	}
+	mgr = nil
+	col = nil
 	if err := d.Close(); err != nil {
 		return result{}, err
 	}

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -22,68 +22,71 @@ import (
 )
 
 const (
-	defaultDocs        = 10000
-	defaultDimensions  = 64
-	defaultQueries     = 1000
-	defaultTopK        = 10
-	defaultBatchSize   = 512
-	defaultM           = 16
-	defaultEfConstruct = 128
-	defaultEfSearch    = 128
+	defaultDocs                  = 10000
+	defaultDimensions            = 64
+	defaultQueries               = 1000
+	defaultTopK                  = 10
+	defaultBatchSize             = 512
+	defaultM                     = 16
+	defaultEfConstruct           = 128
+	defaultEfSearch              = 128
+	defaultValuePointerThreshold = 1024
 )
 
 type config struct {
-	dir                  string
-	keepDir              bool
-	profile              treedb.Profile
-	docs                 int
-	dimensions           int
-	queries              int
-	validateQueries      int
-	validateDocs         int
-	topK                 int
-	batchSize            int
-	m                    int
-	efConstruction       int
-	efSearch             int
-	minRecall            float64
-	compact              bool
-	compactSyncEachPhase bool
-	disableExactFallback bool
-	requireValueLogBytes bool
-	requireLeafVLogBytes bool
-	jsonOut              bool
+	dir                   string
+	keepDir               bool
+	profile               treedb.Profile
+	docs                  int
+	dimensions            int
+	queries               int
+	validateQueries       int
+	validateDocs          int
+	topK                  int
+	batchSize             int
+	m                     int
+	efConstruction        int
+	efSearch              int
+	valuePointerThreshold int
+	minRecall             float64
+	compact               bool
+	compactSyncEachPhase  bool
+	disableExactFallback  bool
+	requireValueLogBytes  bool
+	requireLeafVLogBytes  bool
+	jsonOut               bool
 }
 
 type result struct {
-	Dir                  string                         `json:"dir"`
-	KeptDir              bool                           `json:"kept_dir"`
-	Profile              string                         `json:"profile"`
-	Docs                 int                            `json:"docs"`
-	Dimensions           int                            `json:"dimensions"`
-	Queries              int                            `json:"queries"`
-	ValidateQueries      int                            `json:"validate_queries"`
-	ValidateDocs         int                            `json:"validate_docs"`
-	TopK                 int                            `json:"top_k"`
-	M                    int                            `json:"m"`
-	EfConstruction       int                            `json:"ef_construction"`
-	EfSearch             int                            `json:"ef_search"`
-	Compact              bool                           `json:"compact"`
-	Insert               phaseResult                    `json:"insert"`
-	Rebuild              phaseResult                    `json:"rebuild"`
-	CompactPhase         phaseResult                    `json:"compact_phase"`
-	ReopenLoad           phaseResult                    `json:"reopen_load"`
-	Validation           validationResult               `json:"validation"`
-	Search               searchBenchmarkResult          `json:"search"`
-	StorageBeforeCompact storageReport                  `json:"storage_before_compact"`
-	StorageAfterCompact  storageReport                  `json:"storage_after_compact"`
-	IndexStatsBefore     collections.VectorIndexStats   `json:"index_stats_before_compact"`
-	IndexStatsLoaded     collections.VectorIndexStats   `json:"index_stats_loaded"`
-	NativeRootBytes      int64                          `json:"native_root_bytes"`
-	CompactStorage       *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
-	FormatConfig         *backenddb.FormatConfig        `json:"format_config,omitempty"`
-	StorageExpectation   storageExpectationReport       `json:"storage_expectation"`
-	Memory               memoryReport                   `json:"memory"`
+	Dir                   string                         `json:"dir"`
+	KeptDir               bool                           `json:"kept_dir"`
+	Profile               string                         `json:"profile"`
+	Docs                  int                            `json:"docs"`
+	Dimensions            int                            `json:"dimensions"`
+	Queries               int                            `json:"queries"`
+	ValidateQueries       int                            `json:"validate_queries"`
+	ValidateDocs          int                            `json:"validate_docs"`
+	TopK                  int                            `json:"top_k"`
+	M                     int                            `json:"m"`
+	EfConstruction        int                            `json:"ef_construction"`
+	EfSearch              int                            `json:"ef_search"`
+	ValuePointerThreshold int                            `json:"value_pointer_threshold"`
+	Compact               bool                           `json:"compact"`
+	Insert                phaseResult                    `json:"insert"`
+	Rebuild               phaseResult                    `json:"rebuild"`
+	CompactPhase          phaseResult                    `json:"compact_phase"`
+	ReopenLoad            phaseResult                    `json:"reopen_load"`
+	Validation            validationResult               `json:"validation"`
+	Search                searchBenchmarkResult          `json:"search"`
+	StorageBeforeCompact  storageReport                  `json:"storage_before_compact"`
+	StorageAfterCompact   storageReport                  `json:"storage_after_compact"`
+	IndexStatsBefore      collections.VectorIndexStats   `json:"index_stats_before_compact"`
+	IndexStatsLoaded      collections.VectorIndexStats   `json:"index_stats_loaded"`
+	NativeRootBytes       int64                          `json:"native_root_bytes"`
+	CompactStorage        *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
+	FormatConfig          *backenddb.FormatConfig        `json:"format_config,omitempty"`
+	StorageExpectation    storageExpectationReport       `json:"storage_expectation"`
+	Memory                memoryReport                   `json:"memory"`
 }
 
 type phaseResult struct {
@@ -168,20 +171,21 @@ func run(args []string, stdout, stderr io.Writer) error {
 
 func parseConfig(args []string) (config, error) {
 	cfg := config{
-		docs:                 defaultDocs,
-		dimensions:           defaultDimensions,
-		queries:              defaultQueries,
-		validateQueries:      32,
-		validateDocs:         16,
-		topK:                 defaultTopK,
-		batchSize:            defaultBatchSize,
-		m:                    defaultM,
-		efConstruction:       defaultEfConstruct,
-		efSearch:             defaultEfSearch,
-		minRecall:            0.95,
-		compact:              true,
-		disableExactFallback: true,
-		profile:              treedb.ProfileBench,
+		docs:                  defaultDocs,
+		dimensions:            defaultDimensions,
+		queries:               defaultQueries,
+		validateQueries:       32,
+		validateDocs:          16,
+		topK:                  defaultTopK,
+		batchSize:             defaultBatchSize,
+		m:                     defaultM,
+		efConstruction:        defaultEfConstruct,
+		efSearch:              defaultEfSearch,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		minRecall:             0.95,
+		compact:               true,
+		disableExactFallback:  true,
+		profile:               treedb.ProfileBench,
 	}
 	profileRaw := string(cfg.profile)
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
@@ -198,6 +202,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.m, "m", cfg.m, "HNSW max neighbor parameter")
 	fs.IntVar(&cfg.efConstruction, "ef-construction", cfg.efConstruction, "HNSW efConstruction")
 	fs.IntVar(&cfg.efSearch, "ef-search", cfg.efSearch, "HNSW efSearch for ANN queries")
+	fs.IntVar(&cfg.valuePointerThreshold, "value-pointer-threshold", cfg.valuePointerThreshold, "Value-log pointer threshold for the demo DB in bytes; 0 uses the selected TreeDB profile default")
 	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
@@ -240,6 +245,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.efSearch <= 0 {
 		return config{}, errors.New("-ef-search must be positive")
 	}
+	if cfg.valuePointerThreshold < 0 {
+		return config{}, errors.New("-value-pointer-threshold cannot be negative")
+	}
 	if cfg.minRecall < 0 || cfg.minRecall > 1 {
 		return config{}, errors.New("-min-recall must be in [0,1]")
 	}
@@ -280,8 +288,11 @@ func defaultProfile(profile treedb.Profile) treedb.Profile {
 	return profile
 }
 
-func openDemoBackend(profile treedb.Profile, dir string) (*backenddb.DB, func() error, error) {
+func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int) (*backenddb.DB, func() error, error) {
 	opts := treedb.OptionsFor(defaultProfile(profile), dir)
+	if valuePointerThreshold > 0 {
+		opts.ValueLog.PointerThreshold = valuePointerThreshold
+	}
 	if opts.IndexOuterLeavesInValueLog {
 		return treedb.OpenBackendWithCachedLeafLog(opts)
 	}
@@ -323,22 +334,23 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		EfSearch:       cfg.efSearch,
 	}
 	res := result{
-		Dir:             dir,
-		KeptDir:         cfg.keepDir,
-		Profile:         string(cfg.profile),
-		Docs:            cfg.docs,
-		Dimensions:      cfg.dimensions,
-		Queries:         cfg.queries,
-		ValidateQueries: cfg.validateQueries,
-		ValidateDocs:    cfg.validateDocs,
-		TopK:            cfg.topK,
-		M:               cfg.m,
-		EfConstruction:  cfg.efConstruction,
-		EfSearch:        cfg.efSearch,
-		Compact:         cfg.compact,
+		Dir:                   dir,
+		KeptDir:               cfg.keepDir,
+		Profile:               string(cfg.profile),
+		Docs:                  cfg.docs,
+		Dimensions:            cfg.dimensions,
+		Queries:               cfg.queries,
+		ValidateQueries:       cfg.validateQueries,
+		ValidateDocs:          cfg.validateDocs,
+		TopK:                  cfg.topK,
+		M:                     cfg.m,
+		EfConstruction:        cfg.efConstruction,
+		EfSearch:              cfg.efSearch,
+		ValuePointerThreshold: cfg.valuePointerThreshold,
+		Compact:               cfg.compact,
 	}
 
-	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir)
+	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold)
 	if err != nil {
 		return result{}, err
 	}
@@ -442,7 +454,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	runtime.GC()
 	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
-	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir)
+	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold)
 	if err != nil {
 		return result{}, err
 	}
@@ -741,8 +753,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -184,7 +184,8 @@ func parseConfig(args []string) (config, error) {
 		disableExactFallback: true,
 	}
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
-	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory; explicit directories are kept")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
@@ -427,9 +428,6 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 
-	var beforeLoad runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
 	d, err = backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
@@ -448,12 +446,21 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
+	var beforeLoad runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&beforeLoad)
 	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptions(def))
 	if err != nil {
 		return result{}, err
 	}
-	if loaded == nil || !loadStatus.Loaded || loadStatus.RootID == 0 {
-		return result{}, fmt.Errorf("failed to load compacted native vector root: %+v", loadStatus)
+	if loaded == nil {
+		return result{}, fmt.Errorf("native vector root load returned no runtime: %+v", loadStatus)
+	}
+	if !loadStatus.Loaded {
+		return result{}, fmt.Errorf("native vector root not marked loaded: %+v", loadStatus)
+	}
+	if loadStatus.RootID == 0 {
+		return result{}, fmt.Errorf("native vector root loaded with zero root id: %+v", loadStatus)
 	}
 	res.ReopenLoad = phaseSince(reopenStart)
 	res.IndexStatsLoaded = loaded.Stats()
@@ -561,7 +568,7 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 }
 
 func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
-	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries+1)
+	queries := syntheticQueries(cfg.queries, cfg.docs, cfg.dimensions, cfg.validateQueries)
 	latencies := make([]int64, len(queries))
 	var candidatesTotal int64
 	var rerankTotal int64
@@ -574,10 +581,10 @@ func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkR
 			EfSearch:             cfg.efSearch,
 			DisableExactFallback: cfg.disableExactFallback,
 		})
-		latencies[i] = time.Since(start).Nanoseconds()
 		if err != nil {
 			return searchBenchmarkResult{}, err
 		}
+		latencies[i] = time.Since(start).Nanoseconds()
 		if len(results) == 0 {
 			return searchBenchmarkResult{}, errors.New("vector search returned no results")
 		}
@@ -668,7 +675,21 @@ func gcd(a, b int) int {
 }
 
 func validationDocIndex(i, docs int) int {
-	return (i*1543 + docs/5 + 11) % docs
+	return (i*validationDocStride(docs) + docs/5 + 11) % docs
+}
+
+func validationDocStride(docs int) int {
+	stride := 1543
+	if docs > 0 {
+		stride %= docs
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	for gcd(stride, docs) != 1 {
+		stride++
+	}
+	return stride
 }
 
 func documentID(id int) []byte {
@@ -677,7 +698,7 @@ func documentID(id int) []byte {
 
 func documentJSON(id, dims int) []byte {
 	vector := embedding(id, dims)
-	out := make([]byte, 0, 48+dims*10)
+	out := make([]byte, 0, 48+dims*16)
 	out = append(out, `{"group":`...)
 	out = strconv.AppendInt(out, int64(id%16), 10)
 	out = append(out, `,"embedding":[`...)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -48,6 +48,8 @@ type config struct {
 	compact              bool
 	compactSyncEachPhase bool
 	disableExactFallback bool
+	requireValueLogBytes bool
+	requireLeafVLogBytes bool
 	jsonOut              bool
 }
 
@@ -76,6 +78,8 @@ type result struct {
 	IndexStatsLoaded     collections.VectorIndexStats   `json:"index_stats_loaded"`
 	NativeRootBytes      int64                          `json:"native_root_bytes"`
 	CompactStorage       *backenddb.CompactStorageStats `json:"compact_storage,omitempty"`
+	FormatConfig         *backenddb.FormatConfig        `json:"format_config,omitempty"`
+	StorageExpectation   storageExpectationReport       `json:"storage_expectation"`
 	Memory               memoryReport                   `json:"memory"`
 }
 
@@ -114,6 +118,14 @@ type storageReport struct {
 	BytesPerDoc float64          `json:"bytes_per_doc"`
 	Domains     map[string]int64 `json:"domains"`
 	Files       int              `json:"files"`
+}
+
+type storageExpectationReport struct {
+	RequireValueLogBytes bool  `json:"require_value_log_bytes"`
+	RequireLeafVLogBytes bool  `json:"require_leaf_vlog_bytes"`
+	ValueLogBytes        int64 `json:"value_log_bytes"`
+	LeafVLogBytes        int64 `json:"leaf_vlog_bytes"`
+	IndexBytes           int64 `json:"index_bytes"`
 }
 
 type memoryReport struct {
@@ -184,6 +196,8 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
+	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
+	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -360,6 +374,27 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err != nil {
 		_ = d.Close()
 		return result{}, err
+	}
+	if format, ok, err := backenddb.LoadFormatConfig(dir); err != nil {
+		_ = d.Close()
+		return result{}, err
+	} else if ok {
+		res.FormatConfig = &format
+	}
+	res.StorageExpectation = storageExpectationReport{
+		RequireValueLogBytes: cfg.requireValueLogBytes,
+		RequireLeafVLogBytes: cfg.requireLeafVLogBytes,
+		ValueLogBytes:        res.StorageAfterCompact.Domains["value_vlog"],
+		LeafVLogBytes:        res.StorageAfterCompact.Domains["leaf_vlog"],
+		IndexBytes:           res.StorageAfterCompact.Domains["index.db"],
+	}
+	if cfg.requireValueLogBytes && res.StorageExpectation.ValueLogBytes == 0 {
+		_ = d.Close()
+		return result{}, errors.New("compacted storage has zero value_vlog bytes")
+	}
+	if cfg.requireLeafVLogBytes && res.StorageExpectation.LeafVLogBytes == 0 {
+		_ = d.Close()
+		return result{}, errors.New("compacted storage has zero leaf_vlog bytes")
 	}
 	if err := d.Close(); err != nil {
 		return result{}, err
@@ -670,6 +705,16 @@ func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "\nStorage\n")
 	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
 	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
+	if res.FormatConfig != nil {
+		fmt.Fprintf(w, "format index_outer_leaves_in_vlog=%t leaf_prefix_compression=%t vlog_compression=%s\n",
+			res.FormatConfig.IndexOuterLeavesInValueLog,
+			res.FormatConfig.LeafPrefixCompression,
+			res.FormatConfig.ValueLogCompression)
+	}
+	fmt.Fprintf(w, "storage_domains index_db=%d value_vlog=%d leaf_vlog=%d\n",
+		res.StorageExpectation.IndexBytes,
+		res.StorageExpectation.ValueLogBytes,
+		res.StorageExpectation.LeafVLogBytes)
 	printDomains(w, "after_compact", res.StorageAfterCompact.Domains)
 	fmt.Fprintf(w, "\nMemory\n")
 	fmt.Fprintf(w, "index_bytes_memory=%d load_alloc_delta=%d alloc_after_load=%d\n",

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -34,6 +35,7 @@ const (
 type config struct {
 	dir                  string
 	keepDir              bool
+	profile              treedb.Profile
 	docs                 int
 	dimensions           int
 	queries              int
@@ -56,6 +58,7 @@ type config struct {
 type result struct {
 	Dir                  string                         `json:"dir"`
 	KeptDir              bool                           `json:"kept_dir"`
+	Profile              string                         `json:"profile"`
 	Docs                 int                            `json:"docs"`
 	Dimensions           int                            `json:"dimensions"`
 	Queries              int                            `json:"queries"`
@@ -178,10 +181,13 @@ func parseConfig(args []string) (config, error) {
 		minRecall:            0.95,
 		compact:              true,
 		disableExactFallback: true,
+		profile:              treedb.ProfileBench,
 	}
+	profileRaw := string(cfg.profile)
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
 	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
+	fs.StringVar(&profileRaw, "profile", profileRaw, "TreeDB profile: durable, fast, wal_on_fast, or bench")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
 	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of ANN search queries to benchmark")
@@ -202,6 +208,11 @@ func parseConfig(args []string) (config, error) {
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
+	profile, err := parseProfile(profileRaw)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.profile = profile
 	if cfg.docs <= 0 {
 		return config{}, errors.New("-docs must be positive")
 	}
@@ -247,7 +258,38 @@ func parseConfig(args []string) (config, error) {
 	return cfg, nil
 }
 
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch treedb.Profile(strings.ToLower(strings.TrimSpace(raw))) {
+	case "", treedb.ProfileBench:
+		return treedb.ProfileBench, nil
+	case treedb.ProfileDurable:
+		return treedb.ProfileDurable, nil
+	case treedb.ProfileFast:
+		return treedb.ProfileFast, nil
+	case treedb.ProfileWALOnFast:
+		return treedb.ProfileWALOnFast, nil
+	default:
+		return "", fmt.Errorf("unsupported -profile %q", raw)
+	}
+}
+
+func defaultProfile(profile treedb.Profile) treedb.Profile {
+	if profile == "" {
+		return treedb.ProfileBench
+	}
+	return profile
+}
+
+func openDemoBackend(profile treedb.Profile, dir string) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(defaultProfile(profile), dir)
+	if opts.IndexOuterLeavesInValueLog {
+		return treedb.OpenBackendWithCachedLeafLog(opts)
+	}
+	return treedb.OpenBackend(opts)
+}
+
 func execute(ctx context.Context, cfg config) (result, error) {
+	cfg.profile = defaultProfile(cfg.profile)
 	dir := cfg.dir
 	cleanup := func() {}
 	if dir == "" {
@@ -283,6 +325,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res := result{
 		Dir:             dir,
 		KeptDir:         cfg.keepDir,
+		Profile:         string(cfg.profile),
 		Docs:            cfg.docs,
 		Dimensions:      cfg.dimensions,
 		Queries:         cfg.queries,
@@ -295,12 +338,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Compact:         cfg.compact,
 	}
 
-	d, err := backenddb.Open(backenddb.Options{
-		Dir: dir,
-		ValueLog: backenddb.ValueLogOptions{
-			Compression: backenddb.ValueLogCompressionAuto,
-		},
-	})
+	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir)
 	if err != nil {
 		return result{}, err
 	}
@@ -309,22 +347,22 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Name:          "docs",
 		VectorIndexes: []collections.VectorIndexDefinition{def},
 	}); err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 	col, err := mgr.OpenCollection("docs")
 	if err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 
 	insertStart := time.Now()
 	if err := insertDocuments(col, cfg.docs, cfg.dimensions, cfg.batchSize); err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 	if err := col.Flush(); err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 	res.Insert = phaseSince(insertStart)
@@ -332,11 +370,11 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	rebuildStart := time.Now()
 	status, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 	if !status.NativeRootLoaded || status.RootID == 0 {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, fmt.Errorf("unexpected native vector root status: %+v", status)
 	}
 	res.Rebuild = phaseSince(rebuildStart)
@@ -344,12 +382,12 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	res.IndexStatsBefore = status.Stats
 
 	if err := d.Checkpoint(); err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 	res.StorageBeforeCompact, err = storageUsage(dir, cfg.docs)
 	if err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
 
@@ -360,23 +398,23 @@ func execute(ctx context.Context, cfg config) (result, error) {
 			SyncEachPhase: cfg.compactSyncEachPhase,
 		})
 		if err != nil {
-			_ = d.Close()
+			_ = cleanupBackend()
 			return result{}, err
 		}
 		res.CompactPhase = phaseSince(compactStart)
 		res.CompactStorage = &stats
 		if err := d.Checkpoint(); err != nil {
-			_ = d.Close()
+			_ = cleanupBackend()
 			return result{}, err
 		}
 	}
 	res.StorageAfterCompact, err = storageUsage(dir, cfg.docs)
 	if err != nil {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, err
 	}
-	if format, ok, err := backenddb.LoadFormatConfig(dir); err != nil {
-		_ = d.Close()
+	if format, ok, err := loadFormatConfig(dir); err != nil {
+		_ = cleanupBackend()
 		return result{}, err
 	} else if ok {
 		res.FormatConfig = &format
@@ -389,14 +427,14 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		IndexBytes:           res.StorageAfterCompact.Domains["index.db"],
 	}
 	if cfg.requireValueLogBytes && res.StorageExpectation.ValueLogBytes == 0 {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, errors.New("compacted storage has zero value_vlog bytes")
 	}
 	if cfg.requireLeafVLogBytes && res.StorageExpectation.LeafVLogBytes == 0 {
-		_ = d.Close()
+		_ = cleanupBackend()
 		return result{}, errors.New("compacted storage has zero leaf_vlog bytes")
 	}
-	if err := d.Close(); err != nil {
+	if err := cleanupBackend(); err != nil {
 		return result{}, err
 	}
 
@@ -404,11 +442,11 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	runtime.GC()
 	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
-	d, err = backenddb.Open(backenddb.Options{Dir: dir})
+	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir)
 	if err != nil {
 		return result{}, err
 	}
-	defer d.Close()
+	defer cleanupBackend()
 	col, err = collections.NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		return result{}, err
@@ -634,11 +672,7 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 		if err != nil {
 			return err
 		}
-		group := strings.Split(rel, string(os.PathSeparator))[0]
-		if group == "index.db" || group == "journal.wal" || group == "format.json" || group == "LOCK" {
-			group = rel
-		}
-		report.Domains[group] += size
+		report.Domains[storageDomain(rel)] += size
 		return nil
 	})
 	if err != nil {
@@ -648,6 +682,36 @@ func storageUsage(dir string, docs int) (storageReport, error) {
 		report.BytesPerDoc = float64(report.TotalBytes) / float64(docs)
 	}
 	return report, nil
+}
+
+func storageDomain(rel string) string {
+	rel = filepath.ToSlash(rel)
+	parts := strings.Split(rel, "/")
+	if len(parts) == 0 {
+		return rel
+	}
+	if len(parts) > 1 && parts[0] == "maindb" {
+		return storageDomain(strings.Join(parts[1:], "/"))
+	}
+	if len(parts) > 1 && (parts[0] == "dictdb" || parts[0] == "templatedb") {
+		return parts[0]
+	}
+	switch parts[0] {
+	case "leaf_vlog", "value_vlog", "wal":
+		return parts[0]
+	case "index.db", "journal.wal", "format.json", "LOCK", "vlog_ref_counts.meta":
+		return parts[0]
+	default:
+		return parts[0]
+	}
+}
+
+func loadFormatConfig(dir string) (backenddb.FormatConfig, bool, error) {
+	format, ok, err := backenddb.LoadFormatConfig(dir)
+	if err != nil || ok {
+		return format, ok, err
+	}
+	return backenddb.LoadFormatConfig(filepath.Join(dir, "maindb"))
 }
 
 func phaseSince(start time.Time) phaseResult {
@@ -677,8 +741,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d\n",
-		res.Dir, res.KeptDir, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -296,15 +296,15 @@ func defaultProfile(profile treedb.Profile) treedb.Profile {
 	return profile
 }
 
-func normalizeDemoDir(dir string) string {
+func normalizeDemoDir(dir string) (string, error) {
 	if dir == "" {
-		return ""
+		return "", nil
 	}
 	clean := filepath.Clean(dir)
 	if filepath.Base(clean) == "maindb" {
-		return filepath.Dir(clean)
+		return "", fmt.Errorf("demo -dir must be a TreeDB root directory, not a maindb directory; pass %q instead", filepath.Dir(clean))
 	}
-	return clean
+	return clean, nil
 }
 
 func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int, leafGenerationTarget int64) (*backenddb.DB, func() error, error) {
@@ -326,7 +326,10 @@ func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold i
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	cfg.profile = defaultProfile(cfg.profile)
-	dir := normalizeDemoDir(cfg.dir)
+	dir, err := normalizeDemoDir(cfg.dir)
+	if err != nil {
+		return result{}, err
+	}
 	cleanup := func() {}
 	if dir == "" {
 		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -430,6 +430,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err := d.Close(); err != nil {
 		return result{}, err
 	}
+	d = nil
+	runtime.GC()
 
 	reopenStart := time.Now()
 	d, err = backenddb.Open(backenddb.Options{Dir: dir})

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -333,10 +333,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	mgr := collections.NewCollectionManager(d)
-	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
-		Name:          "docs",
-		VectorIndexes: []collections.VectorIndexDefinition{def},
-	}); err != nil {
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{Name: "docs"}); err != nil {
 		_ = d.Close()
 		return result{}, err
 	}
@@ -357,6 +354,10 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	}
 	res.Insert = phaseSince(insertStart)
 
+	if _, err := col.CreateVectorIndex(def); err != nil {
+		_ = d.Close()
+		return result{}, err
+	}
 	rebuildStart := time.Now()
 	status, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
@@ -638,9 +639,17 @@ func syntheticQueries(count, docs, dims, offset int) [][]float32 {
 	queries := make([][]float32, count)
 	stride := queryDocStride(docs)
 	for i := 0; i < count; i++ {
-		queries[i] = embedding(queryDocIndex(i+offset, docs, stride), dims)
+		queries[i] = embedding(syntheticQueryID(i, docs, offset, stride), dims)
 	}
 	return queries
+}
+
+func syntheticQueryID(i, docs, offset, stride int) int {
+	id := i + offset
+	if docs <= 0 || id >= docs {
+		return id
+	}
+	return queryDocIndex(id, docs, stride)
 }
 
 func queryDocStride(docs int) int {

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -273,7 +273,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.efConstruction, "ef-construction", cfg.efConstruction, "HNSW efConstruction")
 	fs.IntVar(&cfg.efSearch, "ef-search", cfg.efSearch, "HNSW efSearch for ANN queries")
 	fs.IntVar(&cfg.valuePointerThreshold, "value-pointer-threshold", cfg.valuePointerThreshold, "Value-log pointer threshold for the demo DB in bytes; 0 uses the selected TreeDB profile default")
-	fs.Int64Var(&cfg.leafGenerationTarget, "leaf-generation-segment-target", cfg.leafGenerationTarget, "Leaf value-log generation segment target for the demo DB in bytes; 0 uses the selected TreeDB profile default")
+	fs.Int64Var(&cfg.leafGenerationTarget, "leaf-generation-segment-target", cfg.leafGenerationTarget, "Leaf value-log generation segment target for the demo DB in bytes; a positive value opts the demo into leaf generation rolling, 0 uses the selected TreeDB profile default")
 	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
@@ -437,9 +437,9 @@ func openDemoBackend(cfg config, dir string) (*backenddb.DB, func() error, error
 		opts.ValueLog.PointerThreshold = cfg.valuePointerThreshold
 	}
 	if cfg.leafGenerationTarget > 0 {
-		if opts.ValueLog.Generational.Policy == treedb.ValueLogGenerationDefault {
-			opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
-		}
+		// A positive demo-local target is an explicit opt-in to sealed leaf
+		// generations, including under the deterministic bench profile.
+		opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
 		opts.ValueLog.Generational.LeafSegmentTargetBytes = cfg.leafGenerationTarget
 	}
 	if opts.IndexOuterLeavesInValueLog {

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -296,13 +296,26 @@ func defaultProfile(profile treedb.Profile) treedb.Profile {
 	return profile
 }
 
+func normalizeDemoDir(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	clean := filepath.Clean(dir)
+	if filepath.Base(clean) == "maindb" {
+		return filepath.Dir(clean)
+	}
+	return clean
+}
+
 func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int, leafGenerationTarget int64) (*backenddb.DB, func() error, error) {
 	opts := treedb.OptionsFor(defaultProfile(profile), dir)
 	if valuePointerThreshold > 0 {
 		opts.ValueLog.PointerThreshold = valuePointerThreshold
 	}
 	if leafGenerationTarget > 0 {
-		opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
+		if opts.ValueLog.Generational.Policy == treedb.ValueLogGenerationDefault {
+			opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
+		}
 		opts.ValueLog.Generational.LeafSegmentTargetBytes = leafGenerationTarget
 	}
 	if opts.IndexOuterLeavesInValueLog {
@@ -313,7 +326,7 @@ func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold i
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	cfg.profile = defaultProfile(cfg.profile)
-	dir := cfg.dir
+	dir := normalizeDemoDir(cfg.dir)
 	cleanup := func() {}
 	if dir == "" {
 		tmp, err := os.MkdirTemp("", "treedb-vector-search-demo-*")

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -742,6 +742,7 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		if err != nil {
 			return matrixResult{}, fmt.Errorf("%s: %w", testCase.name, err)
 		}
+		res.KeptDir = cfg.keepDir
 		out.Cases = append(out.Cases, matrixCaseResult{
 			Name:        testCase.name,
 			Description: testCase.description,

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -31,6 +31,7 @@ const (
 	defaultEfConstruct           = 128
 	defaultEfSearch              = 128
 	defaultValuePointerThreshold = 1024
+	defaultLeafGenerationTarget  = 4 << 20
 )
 
 type config struct {
@@ -48,6 +49,7 @@ type config struct {
 	efConstruction        int
 	efSearch              int
 	valuePointerThreshold int
+	leafGenerationTarget  int64
 	minRecall             float64
 	compact               bool
 	compactSyncEachPhase  bool
@@ -71,6 +73,7 @@ type result struct {
 	EfConstruction        int                            `json:"ef_construction"`
 	EfSearch              int                            `json:"ef_search"`
 	ValuePointerThreshold int                            `json:"value_pointer_threshold"`
+	LeafGenerationTarget  int64                          `json:"leaf_generation_segment_target"`
 	Compact               bool                           `json:"compact"`
 	Insert                phaseResult                    `json:"insert"`
 	Rebuild               phaseResult                    `json:"rebuild"`
@@ -182,6 +185,7 @@ func parseConfig(args []string) (config, error) {
 		efConstruction:        defaultEfConstruct,
 		efSearch:              defaultEfSearch,
 		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
 		minRecall:             0.95,
 		compact:               true,
 		disableExactFallback:  true,
@@ -203,6 +207,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.efConstruction, "ef-construction", cfg.efConstruction, "HNSW efConstruction")
 	fs.IntVar(&cfg.efSearch, "ef-search", cfg.efSearch, "HNSW efSearch for ANN queries")
 	fs.IntVar(&cfg.valuePointerThreshold, "value-pointer-threshold", cfg.valuePointerThreshold, "Value-log pointer threshold for the demo DB in bytes; 0 uses the selected TreeDB profile default")
+	fs.Int64Var(&cfg.leafGenerationTarget, "leaf-generation-segment-target", cfg.leafGenerationTarget, "Leaf value-log generation segment target for the demo DB in bytes; 0 uses the selected TreeDB profile default")
 	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
@@ -248,6 +253,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.valuePointerThreshold < 0 {
 		return config{}, errors.New("-value-pointer-threshold cannot be negative")
 	}
+	if cfg.leafGenerationTarget < 0 {
+		return config{}, errors.New("-leaf-generation-segment-target cannot be negative")
+	}
 	if cfg.minRecall < 0 || cfg.minRecall > 1 {
 		return config{}, errors.New("-min-recall must be in [0,1]")
 	}
@@ -288,10 +296,14 @@ func defaultProfile(profile treedb.Profile) treedb.Profile {
 	return profile
 }
 
-func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int) (*backenddb.DB, func() error, error) {
+func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int, leafGenerationTarget int64) (*backenddb.DB, func() error, error) {
 	opts := treedb.OptionsFor(defaultProfile(profile), dir)
 	if valuePointerThreshold > 0 {
 		opts.ValueLog.PointerThreshold = valuePointerThreshold
+	}
+	if leafGenerationTarget > 0 {
+		opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
+		opts.ValueLog.Generational.LeafSegmentTargetBytes = leafGenerationTarget
 	}
 	if opts.IndexOuterLeavesInValueLog {
 		return treedb.OpenBackendWithCachedLeafLog(opts)
@@ -347,10 +359,11 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		EfConstruction:        cfg.efConstruction,
 		EfSearch:              cfg.efSearch,
 		ValuePointerThreshold: cfg.valuePointerThreshold,
+		LeafGenerationTarget:  cfg.leafGenerationTarget,
 		Compact:               cfg.compact,
 	}
 
-	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold)
+	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold, cfg.leafGenerationTarget)
 	if err != nil {
 		return result{}, err
 	}
@@ -454,7 +467,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	runtime.GC()
 	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
-	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold)
+	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold, cfg.leafGenerationTarget)
 	if err != nil {
 		return result{}, err
 	}
@@ -753,8 +766,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -13,7 +13,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -25,6 +28,8 @@ const (
 	defaultDocs                  = 10000
 	defaultDimensions            = 64
 	defaultQueries               = 1000
+	defaultReadOps               = 10000
+	defaultReadConcurrency       = "2,4,8,16,32,64,128"
 	defaultTopK                  = 10
 	defaultBatchSize             = 512
 	defaultM                     = 16
@@ -37,10 +42,13 @@ const (
 type config struct {
 	dir                   string
 	keepDir               bool
+	matrix                bool
 	profile               treedb.Profile
 	docs                  int
 	dimensions            int
 	queries               int
+	readOps               int
+	readConcurrency       []int
 	validateQueries       int
 	validateDocs          int
 	topK                  int
@@ -57,6 +65,8 @@ type config struct {
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
 	jsonOut               bool
+
+	indexOuterLeavesInValueLog *bool
 }
 
 type result struct {
@@ -66,6 +76,8 @@ type result struct {
 	Docs                  int                            `json:"docs"`
 	Dimensions            int                            `json:"dimensions"`
 	Queries               int                            `json:"queries"`
+	ReadOps               int                            `json:"read_ops"`
+	ReadConcurrency       []int                          `json:"read_concurrency"`
 	ValidateQueries       int                            `json:"validate_queries"`
 	ValidateDocs          int                            `json:"validate_docs"`
 	TopK                  int                            `json:"top_k"`
@@ -81,6 +93,7 @@ type result struct {
 	ReopenLoad            phaseResult                    `json:"reopen_load"`
 	Validation            validationResult               `json:"validation"`
 	Search                searchBenchmarkResult          `json:"search"`
+	ReadBenchmarks        []documentReadBenchmarkResult  `json:"read_benchmarks"`
 	StorageBeforeCompact  storageReport                  `json:"storage_before_compact"`
 	StorageAfterCompact   storageReport                  `json:"storage_after_compact"`
 	IndexStatsBefore      collections.VectorIndexStats   `json:"index_stats_before_compact"`
@@ -90,6 +103,25 @@ type result struct {
 	FormatConfig          *backenddb.FormatConfig        `json:"format_config,omitempty"`
 	StorageExpectation    storageExpectationReport       `json:"storage_expectation"`
 	Memory                memoryReport                   `json:"memory"`
+}
+
+type matrixResult struct {
+	Dir             string             `json:"dir"`
+	KeptDir         bool               `json:"kept_dir"`
+	Profile         string             `json:"profile"`
+	Docs            int                `json:"docs"`
+	Dimensions      int                `json:"dimensions"`
+	Queries         int                `json:"queries"`
+	ReadOps         int                `json:"read_ops"`
+	ReadConcurrency []int              `json:"read_concurrency"`
+	TopK            int                `json:"top_k"`
+	Cases           []matrixCaseResult `json:"cases"`
+}
+
+type matrixCaseResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Result      result `json:"result"`
 }
 
 type phaseResult struct {
@@ -120,6 +152,18 @@ type searchBenchmarkResult struct {
 	AvgRerank            float64 `json:"avg_rerank"`
 	ExactFallbacks       int     `json:"exact_fallbacks"`
 	DisableExactFallback bool    `json:"disable_exact_fallback"`
+}
+
+type documentReadBenchmarkResult struct {
+	Concurrency        int     `json:"concurrency"`
+	Operations         int     `json:"operations"`
+	TotalDurationNanos int64   `json:"total_duration_nanos"`
+	AvgNanos           float64 `json:"avg_nanos"`
+	AvgMicros          float64 `json:"avg_micros"`
+	OpsPerSecond       float64 `json:"ops_per_second"`
+	P50Nanos           int64   `json:"p50_nanos"`
+	P95Nanos           int64   `json:"p95_nanos"`
+	P99Nanos           int64   `json:"p99_nanos"`
 }
 
 type storageReport struct {
@@ -156,6 +200,22 @@ func run(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if cfg.matrix {
+		res, err := executeMatrix(context.Background(), cfg)
+		if err != nil {
+			return err
+		}
+		if cfg.jsonOut {
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(res)
+		}
+		printMatrixText(stdout, res)
+		if !cfg.keepDir {
+			fmt.Fprintf(stderr, "temporary db removed; rerun with -keep-dir to inspect files\n")
+		}
+		return nil
+	}
 	res, err := execute(context.Background(), cfg)
 	if err != nil {
 		return err
@@ -177,6 +237,7 @@ func parseConfig(args []string) (config, error) {
 		docs:                  defaultDocs,
 		dimensions:            defaultDimensions,
 		queries:               defaultQueries,
+		readOps:               defaultReadOps,
 		validateQueries:       32,
 		validateDocs:          16,
 		topK:                  defaultTopK,
@@ -187,18 +248,23 @@ func parseConfig(args []string) (config, error) {
 		valuePointerThreshold: defaultValuePointerThreshold,
 		leafGenerationTarget:  defaultLeafGenerationTarget,
 		minRecall:             0.95,
+		matrix:                true,
 		compact:               true,
 		disableExactFallback:  true,
 		profile:               treedb.ProfileBench,
 	}
 	profileRaw := string(cfg.profile)
+	readConcurrencyRaw := defaultReadConcurrency
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
 	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
+	fs.BoolVar(&cfg.matrix, "matrix", cfg.matrix, "Run the storage/read benchmark matrix instead of a single storage case")
 	fs.StringVar(&profileRaw, "profile", profileRaw, "TreeDB profile: durable, fast, wal_on_fast, or bench")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
 	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of ANN search queries to benchmark")
+	fs.IntVar(&cfg.readOps, "read-ops", cfg.readOps, "Document reads per serial/concurrent read benchmark")
+	fs.StringVar(&readConcurrencyRaw, "read-concurrency", readConcurrencyRaw, "Comma-separated parallel document-read concurrency levels; serial concurrency=1 is always included")
 	fs.IntVar(&cfg.validateQueries, "validate-queries", cfg.validateQueries, "Number of queries to validate against exact search")
 	fs.IntVar(&cfg.validateDocs, "validate-docs", cfg.validateDocs, "Number of documents to read and byte-validate after compaction/reopen")
 	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count")
@@ -218,6 +284,11 @@ func parseConfig(args []string) (config, error) {
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
+	readConcurrency, err := parseReadConcurrency(readConcurrencyRaw)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.readConcurrency = readConcurrency
 	profile, err := parseProfile(profileRaw)
 	if err != nil {
 		return config{}, err
@@ -231,6 +302,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.queries <= 0 {
 		return config{}, errors.New("-queries must be positive")
+	}
+	if cfg.readOps <= 0 {
+		return config{}, errors.New("-read-ops must be positive")
 	}
 	if cfg.topK <= 0 {
 		return config{}, errors.New("-top-k must be positive")
@@ -289,6 +363,52 @@ func parseProfile(raw string) (treedb.Profile, error) {
 	}
 }
 
+func parseReadConcurrency(raw string) ([]int, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]int, 0, len(parts))
+	seen := make(map[int]struct{}, len(parts)+1)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid -read-concurrency value %q", part)
+		}
+		if value <= 1 {
+			return nil, fmt.Errorf("-read-concurrency values must be greater than 1: %d", value)
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Ints(out)
+	if len(out) == 0 {
+		return nil, errors.New("-read-concurrency must include at least one value greater than 1")
+	}
+	return out, nil
+}
+
+func applyReadBenchmarkDefaults(cfg *config) error {
+	if cfg.readOps == 0 {
+		cfg.readOps = defaultReadOps
+	}
+	if cfg.readOps < 0 {
+		return errors.New("-read-ops cannot be negative")
+	}
+	if len(cfg.readConcurrency) == 0 {
+		concurrency, err := parseReadConcurrency(defaultReadConcurrency)
+		if err != nil {
+			return err
+		}
+		cfg.readConcurrency = concurrency
+	}
+	return nil
+}
+
 func defaultProfile(profile treedb.Profile) treedb.Profile {
 	if profile == "" {
 		return treedb.ProfileBench
@@ -307,16 +427,20 @@ func normalizeDemoDir(dir string) (string, error) {
 	return clean, nil
 }
 
-func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold int, leafGenerationTarget int64) (*backenddb.DB, func() error, error) {
-	opts := treedb.OptionsFor(defaultProfile(profile), dir)
-	if valuePointerThreshold > 0 {
-		opts.ValueLog.PointerThreshold = valuePointerThreshold
+func openDemoBackend(cfg config, dir string) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(defaultProfile(cfg.profile), dir)
+	if cfg.indexOuterLeavesInValueLog != nil {
+		opts.IndexOuterLeavesInValueLog = *cfg.indexOuterLeavesInValueLog
+		opts.IndexInternalBaseDelta = !*cfg.indexOuterLeavesInValueLog
 	}
-	if leafGenerationTarget > 0 {
+	if cfg.valuePointerThreshold > 0 {
+		opts.ValueLog.PointerThreshold = cfg.valuePointerThreshold
+	}
+	if cfg.leafGenerationTarget > 0 {
 		if opts.ValueLog.Generational.Policy == treedb.ValueLogGenerationDefault {
 			opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
 		}
-		opts.ValueLog.Generational.LeafSegmentTargetBytes = leafGenerationTarget
+		opts.ValueLog.Generational.LeafSegmentTargetBytes = cfg.leafGenerationTarget
 	}
 	if opts.IndexOuterLeavesInValueLog {
 		return treedb.OpenBackendWithCachedLeafLog(opts)
@@ -326,6 +450,9 @@ func openDemoBackend(profile treedb.Profile, dir string, valuePointerThreshold i
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	cfg.profile = defaultProfile(cfg.profile)
+	if err := applyReadBenchmarkDefaults(&cfg); err != nil {
+		return result{}, err
+	}
 	dir, err := normalizeDemoDir(cfg.dir)
 	if err != nil {
 		return result{}, err
@@ -368,6 +495,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Docs:                  cfg.docs,
 		Dimensions:            cfg.dimensions,
 		Queries:               cfg.queries,
+		ReadOps:               cfg.readOps,
+		ReadConcurrency:       append([]int(nil), cfg.readConcurrency...),
 		ValidateQueries:       cfg.validateQueries,
 		ValidateDocs:          cfg.validateDocs,
 		TopK:                  cfg.topK,
@@ -379,7 +508,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Compact:               cfg.compact,
 	}
 
-	d, cleanupBackend, err := openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold, cfg.leafGenerationTarget)
+	d, cleanupBackend, err := openDemoBackend(cfg, dir)
 	if err != nil {
 		return result{}, err
 	}
@@ -483,7 +612,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	runtime.GC()
 	runtime.ReadMemStats(&beforeLoad)
 	reopenStart := time.Now()
-	d, cleanupBackend, err = openDemoBackend(cfg.profile, dir, cfg.valuePointerThreshold, cfg.leafGenerationTarget)
+	d, cleanupBackend, err = openDemoBackend(cfg, dir)
 	if err != nil {
 		return result{}, err
 	}
@@ -521,7 +650,105 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		return result{}, err
 	}
 	res.Search = search
+	readBenchmarks, err := benchmarkDocumentReadMatrix(col, cfg)
+	if err != nil {
+		return result{}, err
+	}
+	res.ReadBenchmarks = readBenchmarks
 	return res, nil
+}
+
+func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
+	cfg.profile = defaultProfile(cfg.profile)
+	if err := applyReadBenchmarkDefaults(&cfg); err != nil {
+		return matrixResult{}, err
+	}
+	root, err := normalizeDemoDir(cfg.dir)
+	if err != nil {
+		return matrixResult{}, err
+	}
+	cleanup := func() {}
+	if root == "" {
+		tmp, err := os.MkdirTemp("", "treedb-vector-search-matrix-*")
+		if err != nil {
+			return matrixResult{}, err
+		}
+		root = tmp
+		if !cfg.keepDir {
+			cleanup = func() { _ = os.RemoveAll(tmp) }
+		}
+	} else {
+		if err := os.RemoveAll(root); err != nil {
+			return matrixResult{}, err
+		}
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return matrixResult{}, err
+		}
+	}
+	if !cfg.keepDir {
+		defer cleanup()
+	}
+
+	inlineLeaves := false
+	leafVLog := true
+	cases := []struct {
+		name        string
+		description string
+		compact     bool
+		outerLeaves *bool
+	}{
+		{
+			name:        "index_db_outer_leaves",
+			description: "1558-style layout: outer B-tree leaves stay in index.db",
+			compact:     true,
+			outerLeaves: &inlineLeaves,
+		},
+		{
+			name:        "leaf_vlog_before_compact",
+			description: "1560 layout: outer B-tree leaves in leaf_vlog before CompactStorageFull",
+			compact:     false,
+			outerLeaves: &leafVLog,
+		},
+		{
+			name:        "leaf_vlog_after_compact",
+			description: "1560 layout: outer B-tree leaves in leaf_vlog after CompactStorageFull",
+			compact:     true,
+			outerLeaves: &leafVLog,
+		},
+	}
+	out := matrixResult{
+		Dir:             root,
+		KeptDir:         cfg.keepDir,
+		Profile:         string(cfg.profile),
+		Docs:            cfg.docs,
+		Dimensions:      cfg.dimensions,
+		Queries:         cfg.queries,
+		ReadOps:         cfg.readOps,
+		ReadConcurrency: append([]int(nil), cfg.readConcurrency...),
+		TopK:            cfg.topK,
+		Cases:           make([]matrixCaseResult, 0, len(cases)),
+	}
+	for _, testCase := range cases {
+		caseCfg := cfg
+		caseCfg.matrix = false
+		caseCfg.keepDir = true
+		caseCfg.compact = testCase.compact
+		caseCfg.dir = filepath.Join(root, testCase.name)
+		caseCfg.indexOuterLeavesInValueLog = testCase.outerLeaves
+		if testCase.name == "index_db_outer_leaves" {
+			caseCfg.requireLeafVLogBytes = false
+		}
+		res, err := execute(ctx, caseCfg)
+		if err != nil {
+			return matrixResult{}, fmt.Errorf("%s: %w", testCase.name, err)
+		}
+		out.Cases = append(out.Cases, matrixCaseResult{
+			Name:        testCase.name,
+			Description: testCase.description,
+			Result:      res,
+		})
+	}
+	return out, nil
 }
 
 func insertDocuments(col *collections.Collection, docs, dims, batchSize int) error {
@@ -626,6 +853,112 @@ func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkR
 		AvgRerank:            float64(rerankTotal) / float64(len(queries)),
 		ExactFallbacks:       exactFallbacks,
 		DisableExactFallback: cfg.disableExactFallback,
+	}, nil
+}
+
+func benchmarkDocumentReadMatrix(col *collections.Collection, cfg config) ([]documentReadBenchmarkResult, error) {
+	inputs := documentReadInputs(cfg.readOps, cfg.docs, cfg.dimensions)
+	levels := make([]int, 0, len(cfg.readConcurrency)+1)
+	levels = append(levels, 1)
+	levels = append(levels, cfg.readConcurrency...)
+	out := make([]documentReadBenchmarkResult, 0, len(levels))
+	for _, concurrency := range levels {
+		bench, err := benchmarkDocumentReads(col, inputs, concurrency)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, bench)
+	}
+	return out, nil
+}
+
+type documentReadInput struct {
+	id   []byte
+	want []byte
+}
+
+func documentReadInputs(operations, docs, dims int) []documentReadInput {
+	inputs := make([]documentReadInput, operations)
+	for i := range inputs {
+		docIndex := validationDocIndex(i, docs)
+		inputs[i] = documentReadInput{
+			id:   documentID(docIndex),
+			want: documentJSON(docIndex, dims),
+		}
+	}
+	return inputs
+}
+
+func benchmarkDocumentReads(col *collections.Collection, inputs []documentReadInput, concurrency int) (documentReadBenchmarkResult, error) {
+	if concurrency <= 0 {
+		return documentReadBenchmarkResult{}, errors.New("document read concurrency must be positive")
+	}
+	latencies := make([]int64, len(inputs))
+	var next atomic.Int64
+	var errMu sync.Mutex
+	var firstErr error
+	setErr := func(err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	worker := func() {
+		for {
+			i := int(next.Add(1) - 1)
+			if i >= len(inputs) {
+				return
+			}
+			input := inputs[i]
+			start := time.Now()
+			got, err := col.Get(input.id)
+			latencies[i] = time.Since(start).Nanoseconds()
+			if err != nil {
+				setErr(err)
+				return
+			}
+			if !bytes.Equal(got, input.want) {
+				setErr(fmt.Errorf("document read mismatch for %s", input.id))
+				return
+			}
+		}
+	}
+
+	startAll := time.Now()
+	if concurrency == 1 {
+		worker()
+	} else {
+		var wg sync.WaitGroup
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func() {
+				defer wg.Done()
+				worker()
+			}()
+		}
+		wg.Wait()
+	}
+	total := time.Since(startAll)
+	if firstErr != nil {
+		return documentReadBenchmarkResult{}, firstErr
+	}
+	var latencyTotal int64
+	for _, latency := range latencies {
+		latencyTotal += latency
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	avg := float64(latencyTotal) / float64(len(inputs))
+	return documentReadBenchmarkResult{
+		Concurrency:        concurrency,
+		Operations:         len(inputs),
+		TotalDurationNanos: total.Nanoseconds(),
+		AvgNanos:           avg,
+		AvgMicros:          avg / 1000,
+		OpsPerSecond:       float64(len(inputs)) / total.Seconds(),
+		P50Nanos:           percentile(latencies, 0.50),
+		P95Nanos:           percentile(latencies, 0.95),
+		P99Nanos:           percentile(latencies, 0.99),
 	}, nil
 }
 
@@ -782,8 +1115,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d read_ops=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.ReadOps, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)
@@ -807,6 +1140,8 @@ func printText(w io.Writer, res result) {
 		res.Search.OpsPerSecond,
 		res.Search.ExactFallbacks)
 	fmt.Fprintf(w, "avg_candidates=%.1f avg_rerank=%.1f\n", res.Search.AvgCandidates, res.Search.AvgRerank)
+	fmt.Fprintf(w, "\nDocument Read Benchmark\n")
+	printReadBenchmarks(w, res.ReadBenchmarks)
 	fmt.Fprintf(w, "\nStorage\n")
 	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
 	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
@@ -824,6 +1159,56 @@ func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "\nMemory\n")
 	fmt.Fprintf(w, "index_bytes_memory=%d load_alloc_delta=%d alloc_after_load=%d\n",
 		res.Memory.IndexBytesMemory, res.Memory.LoadAllocDeltaBytes, res.Memory.AllocAfterLoadBytes)
+}
+
+func printMatrixText(w io.Writer, res matrixResult) {
+	fmt.Fprintf(w, "TreeDB vector search matrix\n")
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d read_ops=%d top_k=%d read_concurrency=%s\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.ReadOps, res.TopK, joinInts(res.ReadConcurrency))
+	for _, testCase := range res.Cases {
+		fmt.Fprintf(w, "\nCase %s\n", testCase.Name)
+		fmt.Fprintf(w, "%s\n", testCase.Description)
+		fmt.Fprintf(w, "storage_after_compact_total=%d bytes (%.1f/doc)\n",
+			testCase.Result.StorageAfterCompact.TotalBytes,
+			testCase.Result.StorageAfterCompact.BytesPerDoc)
+		fmt.Fprintf(w, "storage_domains index_db=%d value_vlog=%d leaf_vlog=%d\n",
+			testCase.Result.StorageExpectation.IndexBytes,
+			testCase.Result.StorageExpectation.ValueLogBytes,
+			testCase.Result.StorageExpectation.LeafVLogBytes)
+		if testCase.Result.FormatConfig != nil {
+			fmt.Fprintf(w, "format index_outer_leaves_in_vlog=%t leaf_prefix_compression=%t vlog_compression=%s\n",
+				testCase.Result.FormatConfig.IndexOuterLeavesInValueLog,
+				testCase.Result.FormatConfig.LeafPrefixCompression,
+				testCase.Result.FormatConfig.ValueLogCompression)
+		}
+		fmt.Fprintf(w, "vector_search avg=%.2fus p95=%.2fus recall_at_%d=%.4f\n",
+			testCase.Result.Search.AvgMicros,
+			float64(testCase.Result.Search.P95Nanos)/1000,
+			testCase.Result.TopK,
+			testCase.Result.Validation.Recall)
+		printReadBenchmarks(w, testCase.Result.ReadBenchmarks)
+	}
+}
+
+func printReadBenchmarks(w io.Writer, benchmarks []documentReadBenchmarkResult) {
+	for _, bench := range benchmarks {
+		fmt.Fprintf(w, "read concurrency=%d ops=%d avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f\n",
+			bench.Concurrency,
+			bench.Operations,
+			bench.AvgMicros,
+			float64(bench.P50Nanos)/1000,
+			float64(bench.P95Nanos)/1000,
+			float64(bench.P99Nanos)/1000,
+			bench.OpsPerSecond)
+	}
+}
+
+func joinInts(values []int) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = strconv.Itoa(value)
+	}
+	return strings.Join(parts, ",")
 }
 
 func printDomains(w io.Writer, label string, domains map[string]int64) {

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -27,9 +27,8 @@ import (
 const (
 	defaultDocs                  = 10000
 	defaultDimensions            = 64
-	defaultQueries               = 1000
-	defaultReadOps               = 10000
-	defaultReadConcurrency       = "2,4,8,16,32,64,128"
+	defaultQueries               = 10000
+	defaultSearchConcurrency     = "2,4,8,16,32,64,128"
 	defaultTopK                  = 10
 	defaultBatchSize             = 512
 	defaultM                     = 16
@@ -47,8 +46,7 @@ type config struct {
 	docs                  int
 	dimensions            int
 	queries               int
-	readOps               int
-	readConcurrency       []int
+	searchConcurrency     []int
 	validateQueries       int
 	validateDocs          int
 	topK                  int
@@ -76,8 +74,7 @@ type result struct {
 	Docs                  int                            `json:"docs"`
 	Dimensions            int                            `json:"dimensions"`
 	Queries               int                            `json:"queries"`
-	ReadOps               int                            `json:"read_ops"`
-	ReadConcurrency       []int                          `json:"read_concurrency"`
+	SearchConcurrency     []int                          `json:"search_concurrency"`
 	ValidateQueries       int                            `json:"validate_queries"`
 	ValidateDocs          int                            `json:"validate_docs"`
 	TopK                  int                            `json:"top_k"`
@@ -93,7 +90,7 @@ type result struct {
 	ReopenLoad            phaseResult                    `json:"reopen_load"`
 	Validation            validationResult               `json:"validation"`
 	Search                searchBenchmarkResult          `json:"search"`
-	ReadBenchmarks        []documentReadBenchmarkResult  `json:"read_benchmarks"`
+	SearchBenchmarks      []searchBenchmarkResult        `json:"search_benchmarks"`
 	StorageBeforeCompact  storageReport                  `json:"storage_before_compact"`
 	StorageAfterCompact   storageReport                  `json:"storage_after_compact"`
 	IndexStatsBefore      collections.VectorIndexStats   `json:"index_stats_before_compact"`
@@ -106,16 +103,15 @@ type result struct {
 }
 
 type matrixResult struct {
-	Dir             string             `json:"dir"`
-	KeptDir         bool               `json:"kept_dir"`
-	Profile         string             `json:"profile"`
-	Docs            int                `json:"docs"`
-	Dimensions      int                `json:"dimensions"`
-	Queries         int                `json:"queries"`
-	ReadOps         int                `json:"read_ops"`
-	ReadConcurrency []int              `json:"read_concurrency"`
-	TopK            int                `json:"top_k"`
-	Cases           []matrixCaseResult `json:"cases"`
+	Dir               string             `json:"dir"`
+	KeptDir           bool               `json:"kept_dir"`
+	Profile           string             `json:"profile"`
+	Docs              int                `json:"docs"`
+	Dimensions        int                `json:"dimensions"`
+	Queries           int                `json:"queries"`
+	SearchConcurrency []int              `json:"search_concurrency"`
+	TopK              int                `json:"top_k"`
+	Cases             []matrixCaseResult `json:"cases"`
 }
 
 type matrixCaseResult struct {
@@ -140,6 +136,7 @@ type validationResult struct {
 }
 
 type searchBenchmarkResult struct {
+	Concurrency          int     `json:"concurrency"`
 	Queries              int     `json:"queries"`
 	TotalDurationNanos   int64   `json:"total_duration_nanos"`
 	AvgNanos             float64 `json:"avg_nanos"`
@@ -152,18 +149,6 @@ type searchBenchmarkResult struct {
 	AvgRerank            float64 `json:"avg_rerank"`
 	ExactFallbacks       int     `json:"exact_fallbacks"`
 	DisableExactFallback bool    `json:"disable_exact_fallback"`
-}
-
-type documentReadBenchmarkResult struct {
-	Concurrency        int     `json:"concurrency"`
-	Operations         int     `json:"operations"`
-	TotalDurationNanos int64   `json:"total_duration_nanos"`
-	AvgNanos           float64 `json:"avg_nanos"`
-	AvgMicros          float64 `json:"avg_micros"`
-	OpsPerSecond       float64 `json:"ops_per_second"`
-	P50Nanos           int64   `json:"p50_nanos"`
-	P95Nanos           int64   `json:"p95_nanos"`
-	P99Nanos           int64   `json:"p99_nanos"`
 }
 
 type storageReport struct {
@@ -237,7 +222,6 @@ func parseConfig(args []string) (config, error) {
 		docs:                  defaultDocs,
 		dimensions:            defaultDimensions,
 		queries:               defaultQueries,
-		readOps:               defaultReadOps,
 		validateQueries:       32,
 		validateDocs:          16,
 		topK:                  defaultTopK,
@@ -249,22 +233,21 @@ func parseConfig(args []string) (config, error) {
 		leafGenerationTarget:  defaultLeafGenerationTarget,
 		minRecall:             0.95,
 		matrix:                true,
-		compact:               true,
+		compact:               false,
 		disableExactFallback:  true,
 		profile:               treedb.ProfileBench,
 	}
 	profileRaw := string(cfg.profile)
-	readConcurrencyRaw := defaultReadConcurrency
+	searchConcurrencyRaw := defaultSearchConcurrency
 	fs := flag.NewFlagSet("treedb_vector_search_demo", flag.ContinueOnError)
 	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
-	fs.BoolVar(&cfg.matrix, "matrix", cfg.matrix, "Run the storage/read benchmark matrix instead of a single storage case")
+	fs.BoolVar(&cfg.matrix, "matrix", cfg.matrix, "Run the storage/search benchmark matrix instead of a single storage case")
 	fs.StringVar(&profileRaw, "profile", profileRaw, "TreeDB profile: durable, fast, wal_on_fast, or bench")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
 	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of ANN search queries to benchmark")
-	fs.IntVar(&cfg.readOps, "read-ops", cfg.readOps, "Document reads per serial/concurrent read benchmark")
-	fs.StringVar(&readConcurrencyRaw, "read-concurrency", readConcurrencyRaw, "Comma-separated parallel document-read concurrency levels; serial concurrency=1 is always included")
+	fs.StringVar(&searchConcurrencyRaw, "search-concurrency", searchConcurrencyRaw, "Comma-separated parallel ANN search concurrency levels; serial concurrency=1 is always included")
 	fs.IntVar(&cfg.validateQueries, "validate-queries", cfg.validateQueries, "Number of queries to validate against exact search")
 	fs.IntVar(&cfg.validateDocs, "validate-docs", cfg.validateDocs, "Number of documents to read and byte-validate after compaction/reopen")
 	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count")
@@ -275,7 +258,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.valuePointerThreshold, "value-pointer-threshold", cfg.valuePointerThreshold, "Value-log pointer threshold for the demo DB in bytes; 0 uses the selected TreeDB profile default")
 	fs.Int64Var(&cfg.leafGenerationTarget, "leaf-generation-segment-target", cfg.leafGenerationTarget, "Leaf value-log generation segment target for the demo DB in bytes; a positive value opts the demo into leaf generation rolling, 0 uses the selected TreeDB profile default")
 	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
-	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reads")
+	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reopen/validation/search")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
@@ -284,11 +267,11 @@ func parseConfig(args []string) (config, error) {
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
-	readConcurrency, err := parseReadConcurrency(readConcurrencyRaw)
+	searchConcurrency, err := parseSearchConcurrency(searchConcurrencyRaw)
 	if err != nil {
 		return config{}, err
 	}
-	cfg.readConcurrency = readConcurrency
+	cfg.searchConcurrency = searchConcurrency
 	profile, err := parseProfile(profileRaw)
 	if err != nil {
 		return config{}, err
@@ -302,9 +285,6 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.queries <= 0 {
 		return config{}, errors.New("-queries must be positive")
-	}
-	if cfg.readOps <= 0 {
-		return config{}, errors.New("-read-ops must be positive")
 	}
 	if cfg.topK <= 0 {
 		return config{}, errors.New("-top-k must be positive")
@@ -363,7 +343,7 @@ func parseProfile(raw string) (treedb.Profile, error) {
 	}
 }
 
-func parseReadConcurrency(raw string) ([]int, error) {
+func parseSearchConcurrency(raw string) ([]int, error) {
 	parts := strings.Split(raw, ",")
 	out := make([]int, 0, len(parts))
 	seen := make(map[int]struct{}, len(parts)+1)
@@ -374,10 +354,10 @@ func parseReadConcurrency(raw string) ([]int, error) {
 		}
 		value, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, fmt.Errorf("invalid -read-concurrency value %q", part)
+			return nil, fmt.Errorf("invalid -search-concurrency value %q", part)
 		}
 		if value <= 1 {
-			return nil, fmt.Errorf("-read-concurrency values must be greater than 1: %d", value)
+			return nil, fmt.Errorf("-search-concurrency values must be greater than 1: %d", value)
 		}
 		if _, ok := seen[value]; ok {
 			continue
@@ -387,24 +367,18 @@ func parseReadConcurrency(raw string) ([]int, error) {
 	}
 	sort.Ints(out)
 	if len(out) == 0 {
-		return nil, errors.New("-read-concurrency must include at least one value greater than 1")
+		return nil, errors.New("-search-concurrency must include at least one value greater than 1")
 	}
 	return out, nil
 }
 
-func applyReadBenchmarkDefaults(cfg *config) error {
-	if cfg.readOps == 0 {
-		cfg.readOps = defaultReadOps
-	}
-	if cfg.readOps < 0 {
-		return errors.New("-read-ops cannot be negative")
-	}
-	if len(cfg.readConcurrency) == 0 {
-		concurrency, err := parseReadConcurrency(defaultReadConcurrency)
+func applySearchBenchmarkDefaults(cfg *config) error {
+	if len(cfg.searchConcurrency) == 0 {
+		concurrency, err := parseSearchConcurrency(defaultSearchConcurrency)
 		if err != nil {
 			return err
 		}
-		cfg.readConcurrency = concurrency
+		cfg.searchConcurrency = concurrency
 	}
 	return nil
 }
@@ -450,7 +424,7 @@ func openDemoBackend(cfg config, dir string) (*backenddb.DB, func() error, error
 
 func execute(ctx context.Context, cfg config) (result, error) {
 	cfg.profile = defaultProfile(cfg.profile)
-	if err := applyReadBenchmarkDefaults(&cfg); err != nil {
+	if err := applySearchBenchmarkDefaults(&cfg); err != nil {
 		return result{}, err
 	}
 	dir, err := normalizeDemoDir(cfg.dir)
@@ -495,8 +469,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Docs:                  cfg.docs,
 		Dimensions:            cfg.dimensions,
 		Queries:               cfg.queries,
-		ReadOps:               cfg.readOps,
-		ReadConcurrency:       append([]int(nil), cfg.readConcurrency...),
+		SearchConcurrency:     append([]int(nil), cfg.searchConcurrency...),
 		ValidateQueries:       cfg.validateQueries,
 		ValidateDocs:          cfg.validateDocs,
 		TopK:                  cfg.topK,
@@ -645,22 +618,20 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	}
 	res.Validation = validation
 
-	search, err := benchmarkSearch(loaded, cfg)
+	searchBenchmarks, err := benchmarkSearchMatrix(loaded, cfg)
 	if err != nil {
 		return result{}, err
 	}
-	res.Search = search
-	readBenchmarks, err := benchmarkDocumentReadMatrix(col, cfg)
-	if err != nil {
-		return result{}, err
+	res.SearchBenchmarks = searchBenchmarks
+	if len(searchBenchmarks) > 0 {
+		res.Search = searchBenchmarks[0]
 	}
-	res.ReadBenchmarks = readBenchmarks
 	return res, nil
 }
 
 func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 	cfg.profile = defaultProfile(cfg.profile)
-	if err := applyReadBenchmarkDefaults(&cfg); err != nil {
+	if err := applySearchBenchmarkDefaults(&cfg); err != nil {
 		return matrixResult{}, err
 	}
 	root, err := normalizeDemoDir(cfg.dir)
@@ -700,7 +671,7 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		{
 			name:        "index_db_outer_leaves",
 			description: "1558-style layout: outer B-tree leaves stay in index.db",
-			compact:     true,
+			compact:     false,
 			outerLeaves: &inlineLeaves,
 		},
 		{
@@ -717,16 +688,15 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		},
 	}
 	out := matrixResult{
-		Dir:             root,
-		KeptDir:         cfg.keepDir,
-		Profile:         string(cfg.profile),
-		Docs:            cfg.docs,
-		Dimensions:      cfg.dimensions,
-		Queries:         cfg.queries,
-		ReadOps:         cfg.readOps,
-		ReadConcurrency: append([]int(nil), cfg.readConcurrency...),
-		TopK:            cfg.topK,
-		Cases:           make([]matrixCaseResult, 0, len(cases)),
+		Dir:               root,
+		KeptDir:           cfg.keepDir,
+		Profile:           string(cfg.profile),
+		Docs:              cfg.docs,
+		Dimensions:        cfg.dimensions,
+		Queries:           cfg.queries,
+		SearchConcurrency: append([]int(nil), cfg.searchConcurrency...),
+		TopK:              cfg.topK,
+		Cases:             make([]matrixCaseResult, 0, len(cases)),
 	}
 	for _, testCase := range cases {
 		caseCfg := cfg
@@ -812,59 +782,16 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 }
 
 func benchmarkSearch(idx *collections.VectorIndex, cfg config) (searchBenchmarkResult, error) {
-	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
-	latencies := make([]int64, len(queries))
-	var candidatesTotal int64
-	var rerankTotal int64
-	var exactFallbacks int
-	startAll := time.Now()
-	for i, query := range queries {
-		start := time.Now()
-		results, trace, err := idx.Search(query, collections.VectorIndexSearchOptions{
-			TopK:                 cfg.topK,
-			EfSearch:             cfg.efSearch,
-			DisableExactFallback: cfg.disableExactFallback,
-		})
-		latencies[i] = time.Since(start).Nanoseconds()
-		if err != nil {
-			return searchBenchmarkResult{}, err
-		}
-		if len(results) == 0 {
-			return searchBenchmarkResult{}, errors.New("vector search returned no results")
-		}
-		candidatesTotal += int64(trace.CandidatesExamined)
-		rerankTotal += int64(trace.RerankCount)
-		if trace.ExactFallbackReason != "" {
-			exactFallbacks++
-		}
-	}
-	total := time.Since(startAll)
-	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
-	avg := float64(total.Nanoseconds()) / float64(len(queries))
-	return searchBenchmarkResult{
-		Queries:              len(queries),
-		TotalDurationNanos:   total.Nanoseconds(),
-		AvgNanos:             avg,
-		AvgMicros:            avg / 1000,
-		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
-		P50Nanos:             percentile(latencies, 0.50),
-		P95Nanos:             percentile(latencies, 0.95),
-		P99Nanos:             percentile(latencies, 0.99),
-		AvgCandidates:        float64(candidatesTotal) / float64(len(queries)),
-		AvgRerank:            float64(rerankTotal) / float64(len(queries)),
-		ExactFallbacks:       exactFallbacks,
-		DisableExactFallback: cfg.disableExactFallback,
-	}, nil
+	return benchmarkSearchConcurrent(idx, cfg, 1)
 }
 
-func benchmarkDocumentReadMatrix(col *collections.Collection, cfg config) ([]documentReadBenchmarkResult, error) {
-	inputs := documentReadInputs(cfg.readOps, cfg.docs, cfg.dimensions)
-	levels := make([]int, 0, len(cfg.readConcurrency)+1)
+func benchmarkSearchMatrix(idx *collections.VectorIndex, cfg config) ([]searchBenchmarkResult, error) {
+	levels := make([]int, 0, len(cfg.searchConcurrency)+1)
 	levels = append(levels, 1)
-	levels = append(levels, cfg.readConcurrency...)
-	out := make([]documentReadBenchmarkResult, 0, len(levels))
+	levels = append(levels, cfg.searchConcurrency...)
+	out := make([]searchBenchmarkResult, 0, len(levels))
 	for _, concurrency := range levels {
-		bench, err := benchmarkDocumentReads(col, inputs, concurrency)
+		bench, err := benchmarkSearchConcurrent(idx, cfg, concurrency)
 		if err != nil {
 			return nil, err
 		}
@@ -873,29 +800,16 @@ func benchmarkDocumentReadMatrix(col *collections.Collection, cfg config) ([]doc
 	return out, nil
 }
 
-type documentReadInput struct {
-	id   []byte
-	want []byte
-}
-
-func documentReadInputs(operations, docs, dims int) []documentReadInput {
-	inputs := make([]documentReadInput, operations)
-	for i := range inputs {
-		docIndex := validationDocIndex(i, docs)
-		inputs[i] = documentReadInput{
-			id:   documentID(docIndex),
-			want: documentJSON(docIndex, dims),
-		}
-	}
-	return inputs
-}
-
-func benchmarkDocumentReads(col *collections.Collection, inputs []documentReadInput, concurrency int) (documentReadBenchmarkResult, error) {
+func benchmarkSearchConcurrent(idx *collections.VectorIndex, cfg config, concurrency int) (searchBenchmarkResult, error) {
 	if concurrency <= 0 {
-		return documentReadBenchmarkResult{}, errors.New("document read concurrency must be positive")
+		return searchBenchmarkResult{}, errors.New("search concurrency must be positive")
 	}
-	latencies := make([]int64, len(inputs))
+	queries := validationQueries(cfg.queries, cfg.docs, cfg.dimensions)
+	latencies := make([]int64, len(queries))
 	var next atomic.Int64
+	var candidatesTotal int64
+	var rerankTotal int64
+	var exactFallbacks int64
 	var errMu sync.Mutex
 	var firstErr error
 	setErr := func(err error) {
@@ -908,24 +822,31 @@ func benchmarkDocumentReads(col *collections.Collection, inputs []documentReadIn
 	worker := func() {
 		for {
 			i := int(next.Add(1) - 1)
-			if i >= len(inputs) {
+			if i >= len(queries) {
 				return
 			}
-			input := inputs[i]
 			start := time.Now()
-			got, err := col.Get(input.id)
+			results, trace, err := idx.Search(queries[i], collections.VectorIndexSearchOptions{
+				TopK:                 cfg.topK,
+				EfSearch:             cfg.efSearch,
+				DisableExactFallback: cfg.disableExactFallback,
+			})
 			latencies[i] = time.Since(start).Nanoseconds()
 			if err != nil {
 				setErr(err)
 				return
 			}
-			if !bytes.Equal(got, input.want) {
-				setErr(fmt.Errorf("document read mismatch for %s", input.id))
+			if len(results) == 0 {
+				setErr(errors.New("vector search returned no results"))
 				return
+			}
+			atomic.AddInt64(&candidatesTotal, int64(trace.CandidatesExamined))
+			atomic.AddInt64(&rerankTotal, int64(trace.RerankCount))
+			if trace.ExactFallbackReason != "" {
+				atomic.AddInt64(&exactFallbacks, 1)
 			}
 		}
 	}
-
 	startAll := time.Now()
 	if concurrency == 1 {
 		worker()
@@ -942,24 +863,28 @@ func benchmarkDocumentReads(col *collections.Collection, inputs []documentReadIn
 	}
 	total := time.Since(startAll)
 	if firstErr != nil {
-		return documentReadBenchmarkResult{}, firstErr
+		return searchBenchmarkResult{}, firstErr
 	}
 	var latencyTotal int64
 	for _, latency := range latencies {
 		latencyTotal += latency
 	}
 	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
-	avg := float64(latencyTotal) / float64(len(inputs))
-	return documentReadBenchmarkResult{
-		Concurrency:        concurrency,
-		Operations:         len(inputs),
-		TotalDurationNanos: total.Nanoseconds(),
-		AvgNanos:           avg,
-		AvgMicros:          avg / 1000,
-		OpsPerSecond:       float64(len(inputs)) / total.Seconds(),
-		P50Nanos:           percentile(latencies, 0.50),
-		P95Nanos:           percentile(latencies, 0.95),
-		P99Nanos:           percentile(latencies, 0.99),
+	avg := float64(latencyTotal) / float64(len(queries))
+	return searchBenchmarkResult{
+		Concurrency:          concurrency,
+		Queries:              len(queries),
+		TotalDurationNanos:   total.Nanoseconds(),
+		AvgNanos:             avg,
+		AvgMicros:            avg / 1000,
+		OpsPerSecond:         float64(len(queries)) / total.Seconds(),
+		P50Nanos:             percentile(latencies, 0.50),
+		P95Nanos:             percentile(latencies, 0.95),
+		P99Nanos:             percentile(latencies, 0.99),
+		AvgCandidates:        float64(candidatesTotal) / float64(len(queries)),
+		AvgRerank:            float64(rerankTotal) / float64(len(queries)),
+		ExactFallbacks:       int(exactFallbacks),
+		DisableExactFallback: cfg.disableExactFallback,
 	}, nil
 }
 
@@ -1116,8 +1041,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d read_ops=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.ReadOps, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_native_vector_index: %.3fs native_root_bytes=%d\n", res.Rebuild.Seconds, res.NativeRootBytes)
@@ -1141,8 +1066,8 @@ func printText(w io.Writer, res result) {
 		res.Search.OpsPerSecond,
 		res.Search.ExactFallbacks)
 	fmt.Fprintf(w, "avg_candidates=%.1f avg_rerank=%.1f\n", res.Search.AvgCandidates, res.Search.AvgRerank)
-	fmt.Fprintf(w, "\nDocument Read Benchmark\n")
-	printReadBenchmarks(w, res.ReadBenchmarks)
+	fmt.Fprintf(w, "\nParallel Search Benchmark\n")
+	printSearchBenchmarks(w, res.SearchBenchmarks)
 	fmt.Fprintf(w, "\nStorage\n")
 	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
 	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
@@ -1164,8 +1089,8 @@ func printText(w io.Writer, res result) {
 
 func printMatrixText(w io.Writer, res matrixResult) {
 	fmt.Fprintf(w, "TreeDB vector search matrix\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d read_ops=%d top_k=%d read_concurrency=%s\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.ReadOps, res.TopK, joinInts(res.ReadConcurrency))
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d search_concurrency=%s\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, joinInts(res.SearchConcurrency))
 	for _, testCase := range res.Cases {
 		fmt.Fprintf(w, "\nCase %s\n", testCase.Name)
 		fmt.Fprintf(w, "%s\n", testCase.Description)
@@ -1187,20 +1112,21 @@ func printMatrixText(w io.Writer, res matrixResult) {
 			float64(testCase.Result.Search.P95Nanos)/1000,
 			testCase.Result.TopK,
 			testCase.Result.Validation.Recall)
-		printReadBenchmarks(w, testCase.Result.ReadBenchmarks)
+		printSearchBenchmarks(w, testCase.Result.SearchBenchmarks)
 	}
 }
 
-func printReadBenchmarks(w io.Writer, benchmarks []documentReadBenchmarkResult) {
+func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 	for _, bench := range benchmarks {
-		fmt.Fprintf(w, "read concurrency=%d ops=%d avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f\n",
+		fmt.Fprintf(w, "search concurrency=%d queries=%d avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d\n",
 			bench.Concurrency,
-			bench.Operations,
+			bench.Queries,
 			bench.AvgMicros,
 			float64(bench.P50Nanos)/1000,
 			float64(bench.P95Nanos)/1000,
 			float64(bench.P99Nanos)/1000,
-			bench.OpsPerSecond)
+			bench.OpsPerSecond,
+			bench.ExactFallbacks)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -288,6 +288,42 @@ func TestRunMatrixJSONOutput(t *testing.T) {
 	}
 }
 
+func TestExecuteMatrixReportsNestedKeptDirFromRoot(t *testing.T) {
+	res, err := executeMatrix(context.Background(), config{
+		docs:                  24,
+		dimensions:            8,
+		queries:               1,
+		readOps:               4,
+		readConcurrency:       []int{2},
+		validateQueries:       1,
+		validateDocs:          1,
+		topK:                  3,
+		batchSize:             12,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0.5,
+		compact:               true,
+		disableExactFallback:  true,
+	})
+	if err != nil {
+		t.Fatalf("executeMatrix: %v", err)
+	}
+	if res.KeptDir {
+		t.Fatalf("matrix kept_dir=true, want false")
+	}
+	for _, testCase := range res.Cases {
+		if testCase.Result.KeptDir {
+			t.Fatalf("case %s kept_dir=true, want false inherited from matrix root", testCase.Name)
+		}
+	}
+	if _, err := os.Stat(res.Dir); !os.IsNotExist(err) {
+		t.Fatalf("matrix dir stat err=%v, want removed temp dir", err)
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
+	res, err := execute(t.Context(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 128,
+		dimensions:           16,
+		queries:              8,
+		validateQueries:      4,
+		validateDocs:         4,
+		topK:                 5,
+		batchSize:            32,
+		m:                    8,
+		efConstruction:       64,
+		efSearch:             64,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.Validation.DocumentsChecked != 4 || res.Validation.QueriesChecked != 4 {
+		t.Fatalf("validation counts=%+v, want 4 docs and 4 queries", res.Validation)
+	}
+	if res.Validation.Recall < res.Validation.MinRecall {
+		t.Fatalf("recall=%f below min=%f", res.Validation.Recall, res.Validation.MinRecall)
+	}
+	if res.Search.Queries != 8 || res.Search.AvgNanos <= 0 || res.Search.ExactFallbacks != 0 {
+		t.Fatalf("unexpected search benchmark result: %+v", res.Search)
+	}
+	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
+		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
+	}
+	if res.Memory.IndexBytesMemory <= 0 {
+		t.Fatalf("missing index memory report: %+v", res.Memory)
+	}
+	if res.CompactStorage == nil || !res.CompactStorage.FullyCompacted {
+		t.Fatalf("compact storage stats=%+v, want fully compacted", res.CompactStorage)
+	}
+	if res.IndexStatsLoaded.LiveDocs != 128 {
+		t.Fatalf("loaded live docs=%d want 128", res.IndexStatsLoaded.LiveDocs)
+	}
+}
+
+func TestRunJSONOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-dir", t.TempDir(),
+		"-keep-dir",
+		"-docs", "64",
+		"-dims", "8",
+		"-queries", "4",
+		"-validate-queries", "2",
+		"-validate-docs", "2",
+		"-top-k", "3",
+		"-m", "4",
+		"-ef-construction", "32",
+		"-ef-search", "32",
+		"-min-recall", "0.5",
+		"-json",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v stderr=%s", err, stderr.String())
+	}
+	var res result
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, stdout.String())
+	}
+	if res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
+		t.Fatalf("unexpected JSON result: %+v", res)
+	}
+}
+
+func TestRunTextOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-dir", t.TempDir(),
+		"-keep-dir",
+		"-docs", "64",
+		"-dims", "8",
+		"-queries", "4",
+		"-validate-queries", "2",
+		"-validate-docs", "2",
+		"-top-k", "3",
+		"-m", "4",
+		"-ef-construction", "32",
+		"-ef-search", "32",
+		"-min-recall", "0.5",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"TreeDB vector search demo",
+		"compact_storage_full:",
+		"Storage",
+		"Memory",
+		"avg=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
-	res, err := execute(t.Context(), config{
+	res, err := execute(context.Background(), config{
 		dir:                   t.TempDir(),
 		keepDir:               true,
 		docs:                  128,
@@ -117,7 +120,7 @@ func TestRunJSONOutput(t *testing.T) {
 }
 
 func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) {
-	res, err := execute(t.Context(), config{
+	res, err := execute(context.Background(), config{
 		dir:                   t.TempDir(),
 		keepDir:               true,
 		docs:                  64,
@@ -145,6 +148,49 @@ func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) 
 	}
 	if res.StorageExpectation.LeafVLogBytes <= 0 {
 		t.Fatalf("missing leaf value-log bytes: %+v", res.StorageExpectation)
+	}
+}
+
+func TestExecuteNormalizesMainDBDirToRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "demo-root")
+	maindb := filepath.Join(root, "maindb")
+	if err := os.MkdirAll(filepath.Join(root, "dictdb"), 0o755); err != nil {
+		t.Fatalf("mkdir stale dictdb: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "dictdb", "stale"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale side-store file: %v", err)
+	}
+
+	res, err := execute(context.Background(), config{
+		dir:                   maindb,
+		keepDir:               true,
+		docs:                  64,
+		dimensions:            8,
+		queries:               2,
+		validateQueries:       1,
+		validateDocs:          1,
+		topK:                  3,
+		batchSize:             32,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0.5,
+		compact:               true,
+		disableExactFallback:  true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.Dir != root {
+		t.Fatalf("dir=%q want normalized root %q", res.Dir, root)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dictdb", "stale")); !os.IsNotExist(err) {
+		t.Fatalf("stale side-store file err=%v, want removed with normalized root cleanup", err)
+	}
+	if res.StorageAfterCompact.Domains["index.db"] <= 0 {
+		t.Fatalf("storage after compact did not include normalized root maindb index: %+v", res.StorageAfterCompact)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -9,21 +9,22 @@ import (
 
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	res, err := execute(t.Context(), config{
-		dir:                  t.TempDir(),
-		keepDir:              true,
-		docs:                 128,
-		dimensions:           16,
-		queries:              8,
-		validateQueries:      4,
-		validateDocs:         4,
-		topK:                 5,
-		batchSize:            32,
-		m:                    8,
-		efConstruction:       64,
-		efSearch:             64,
-		minRecall:            0.5,
-		compact:              true,
-		disableExactFallback: true,
+		dir:                   t.TempDir(),
+		keepDir:               true,
+		docs:                  128,
+		dimensions:            16,
+		queries:               8,
+		validateQueries:       4,
+		validateDocs:          4,
+		topK:                  5,
+		batchSize:             32,
+		m:                     8,
+		efConstruction:        64,
+		efSearch:              64,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		minRecall:             0.5,
+		compact:               true,
+		disableExactFallback:  true,
 	})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
@@ -39,6 +40,9 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	}
 	if res.Profile != "bench" {
 		t.Fatalf("profile=%q want bench", res.Profile)
+	}
+	if res.ValuePointerThreshold != defaultValuePointerThreshold {
+		t.Fatalf("value pointer threshold=%d want %d", res.ValuePointerThreshold, defaultValuePointerThreshold)
 	}
 	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
 		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
@@ -97,6 +101,9 @@ func TestRunJSONOutput(t *testing.T) {
 	if res.Profile != "bench" || res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
 		t.Fatalf("unexpected JSON result: %+v", res)
 	}
+	if res.ValuePointerThreshold != defaultValuePointerThreshold {
+		t.Fatalf("JSON value pointer threshold=%d want %d", res.ValuePointerThreshold, defaultValuePointerThreshold)
+	}
 	if res.FormatConfig == nil || !res.FormatConfig.IndexOuterLeavesInValueLog || !res.FormatConfig.LeafPrefixCompression {
 		t.Fatalf("unexpected JSON format config: %+v", res.FormatConfig)
 	}
@@ -104,22 +111,23 @@ func TestRunJSONOutput(t *testing.T) {
 
 func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) {
 	res, err := execute(t.Context(), config{
-		dir:                  t.TempDir(),
-		keepDir:              true,
-		docs:                 64,
-		dimensions:           8,
-		queries:              2,
-		validateQueries:      1,
-		validateDocs:         1,
-		topK:                 3,
-		batchSize:            32,
-		m:                    4,
-		efConstruction:       32,
-		efSearch:             32,
-		minRecall:            0.5,
-		compact:              true,
-		disableExactFallback: true,
-		requireLeafVLogBytes: true,
+		dir:                   t.TempDir(),
+		keepDir:               true,
+		docs:                  64,
+		dimensions:            8,
+		queries:               2,
+		validateQueries:       1,
+		validateDocs:          1,
+		topK:                  3,
+		batchSize:             32,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		minRecall:             0.5,
+		compact:               true,
+		disableExactFallback:  true,
+		requireLeafVLogBytes:  true,
 	})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
@@ -139,6 +147,19 @@ func TestParseProfileRejectsUnsupportedProfile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported -profile") {
 		t.Fatalf("error=%v, want unsupported -profile", err)
+	}
+}
+
+func TestParseConfigValuePointerThreshold(t *testing.T) {
+	cfg, err := parseConfig([]string{"-value-pointer-threshold", "2048"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.valuePointerThreshold != 2048 {
+		t.Fatalf("value pointer threshold=%d want 2048", cfg.valuePointerThreshold)
+	}
+	if _, err := parseConfig([]string{"-value-pointer-threshold", "-1"}); err == nil {
+		t.Fatal("parseConfig accepted negative value pointer threshold")
 	}
 }
 
@@ -166,6 +187,7 @@ func TestRunTextOutput(t *testing.T) {
 	for _, want := range []string{
 		"TreeDB vector search demo",
 		"profile=bench",
+		"value_pointer_threshold=1024",
 		"compact_storage_full:",
 		"Storage",
 		"format index_outer_leaves_in_vlog=",

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -22,6 +22,7 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 		efConstruction:        64,
 		efSearch:              64,
 		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
 		minRecall:             0.5,
 		compact:               true,
 		disableExactFallback:  true,
@@ -43,6 +44,9 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	}
 	if res.ValuePointerThreshold != defaultValuePointerThreshold {
 		t.Fatalf("value pointer threshold=%d want %d", res.ValuePointerThreshold, defaultValuePointerThreshold)
+	}
+	if res.LeafGenerationTarget != defaultLeafGenerationTarget {
+		t.Fatalf("leaf generation target=%d want %d", res.LeafGenerationTarget, defaultLeafGenerationTarget)
 	}
 	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
 		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
@@ -104,6 +108,9 @@ func TestRunJSONOutput(t *testing.T) {
 	if res.ValuePointerThreshold != defaultValuePointerThreshold {
 		t.Fatalf("JSON value pointer threshold=%d want %d", res.ValuePointerThreshold, defaultValuePointerThreshold)
 	}
+	if res.LeafGenerationTarget != defaultLeafGenerationTarget {
+		t.Fatalf("JSON leaf generation target=%d want %d", res.LeafGenerationTarget, defaultLeafGenerationTarget)
+	}
 	if res.FormatConfig == nil || !res.FormatConfig.IndexOuterLeavesInValueLog || !res.FormatConfig.LeafPrefixCompression {
 		t.Fatalf("unexpected JSON format config: %+v", res.FormatConfig)
 	}
@@ -124,6 +131,7 @@ func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) 
 		efConstruction:        32,
 		efSearch:              32,
 		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
 		minRecall:             0.5,
 		compact:               true,
 		disableExactFallback:  true,
@@ -163,6 +171,19 @@ func TestParseConfigValuePointerThreshold(t *testing.T) {
 	}
 }
 
+func TestParseConfigLeafGenerationSegmentTarget(t *testing.T) {
+	cfg, err := parseConfig([]string{"-leaf-generation-segment-target", "8388608"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.leafGenerationTarget != 8388608 {
+		t.Fatalf("leaf generation target=%d want 8388608", cfg.leafGenerationTarget)
+	}
+	if _, err := parseConfig([]string{"-leaf-generation-segment-target", "-1"}); err == nil {
+		t.Fatal("parseConfig accepted negative leaf generation target")
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -188,6 +209,7 @@ func TestRunTextOutput(t *testing.T) {
 		"TreeDB vector search demo",
 		"profile=bench",
 		"value_pointer_threshold=1024",
+		"leaf_generation_segment_target=4194304",
 		"compact_storage_full:",
 		"Storage",
 		"format index_outer_leaves_in_vlog=",

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -86,6 +88,9 @@ func TestRunJSONOutput(t *testing.T) {
 	if res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
 		t.Fatalf("unexpected JSON result: %+v", res)
 	}
+	if res.MinRecall != 0.5 || !res.Compact || !res.DisableExactFallback {
+		t.Fatalf("missing reproducibility config in JSON result: %+v", res)
+	}
 }
 
 func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
@@ -112,6 +117,66 @@ func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
 		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
+	}
+}
+
+func TestExecuteRequireValueLogBytesFailsOnPagerBackedDefault(t *testing.T) {
+	_, err := execute(context.Background(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+		requireValueLogBytes: true,
+	})
+	if err == nil {
+		t.Fatal("execute succeeded, want value-log requirement failure")
+	}
+	if !strings.Contains(err.Error(), "zero value_vlog bytes") {
+		t.Fatalf("error=%v, want zero value_vlog bytes", err)
+	}
+}
+
+func TestExecuteRejectsNonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "unrelated"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write unrelated file: %v", err)
+	}
+	_, err := execute(context.Background(), config{
+		dir:                  dir,
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+	})
+	if err == nil {
+		t.Fatal("execute accepted non-empty -dir, want error")
+	}
+	if !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("error=%v, want not-empty directory error", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "unrelated")); err != nil {
+		t.Fatalf("unrelated file err=%v, want untouched", err)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 )
 
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
-	res, err := execute(t.Context(), config{
+	res, err := execute(context.Background(), config{
 		dir:                  t.TempDir(),
 		keepDir:              true,
 		docs:                 128,
@@ -88,7 +89,7 @@ func TestRunJSONOutput(t *testing.T) {
 }
 
 func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
-	_, err := execute(t.Context(), config{
+	_, err := execute(context.Background(), config{
 		dir:                  t.TempDir(),
 		keepDir:              true,
 		docs:                 64,

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -40,6 +40,12 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
 		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
 	}
+	if res.FormatConfig == nil {
+		t.Fatal("missing format config report")
+	}
+	if res.StorageExpectation.IndexBytes <= 0 {
+		t.Fatalf("missing storage expectation index bytes: %+v", res.StorageExpectation)
+	}
 	if res.Memory.IndexBytesMemory <= 0 {
 		t.Fatalf("missing index memory report: %+v", res.Memory)
 	}
@@ -81,6 +87,33 @@ func TestRunJSONOutput(t *testing.T) {
 	}
 }
 
+func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
+	_, err := execute(t.Context(), config{
+		dir:                  t.TempDir(),
+		keepDir:              true,
+		docs:                 64,
+		dimensions:           8,
+		queries:              2,
+		validateQueries:      1,
+		validateDocs:         1,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              true,
+		disableExactFallback: true,
+		requireLeafVLogBytes: true,
+	})
+	if err == nil {
+		t.Fatal("execute succeeded, want leaf-vlog requirement failure")
+	}
+	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
+		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -106,6 +139,8 @@ func TestRunTextOutput(t *testing.T) {
 		"TreeDB vector search demo",
 		"compact_storage_full:",
 		"Storage",
+		"format index_outer_leaves_in_vlog=",
+		"storage_domains index_db=",
 		"Memory",
 		"avg=",
 	} {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -282,12 +282,22 @@ func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
 	stride := queryDocStride(docs)
 	seen := make(map[int]struct{}, validateCount)
 	for i := 0; i < validateCount; i++ {
-		seen[queryDocIndex(i, docs, stride)] = struct{}{}
+		seen[syntheticQueryID(i, docs, 0, stride)] = struct{}{}
 	}
 	for i := 0; i < benchmarkCount; i++ {
-		docIndex := queryDocIndex(i+validateCount, docs, stride)
+		docIndex := syntheticQueryID(i, docs, validateCount, stride)
 		if _, ok := seen[docIndex]; ok {
 			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
+		}
+	}
+}
+
+func TestSyntheticQueryIDSpillsPastCorpusAfterFullValidation(t *testing.T) {
+	docs := 17
+	stride := queryDocStride(docs)
+	for i := 0; i < 5; i++ {
+		if got := syntheticQueryID(i, docs, docs, stride); got != docs+i {
+			t.Fatalf("syntheticQueryID(%d)=%d want %d", i, got, docs+i)
 		}
 	}
 }

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -180,6 +180,84 @@ func TestExecuteRejectsNonEmptyDir(t *testing.T) {
 	}
 }
 
+func TestExecuteRemovesTemporaryDirWhenNotKept(t *testing.T) {
+	res, err := execute(context.Background(), config{
+		docs:                 64,
+		dimensions:           8,
+		queries:              4,
+		validateQueries:      2,
+		validateDocs:         2,
+		topK:                 3,
+		batchSize:            32,
+		m:                    4,
+		efConstruction:       32,
+		efSearch:             32,
+		minRecall:            0.5,
+		compact:              false,
+		disableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.KeptDir {
+		t.Fatalf("KeptDir=%t want false", res.KeptDir)
+	}
+	if _, err := os.Stat(res.Dir); !os.IsNotExist(err) {
+		t.Fatalf("temporary dir stat err=%v, want not exist", err)
+	}
+}
+
+func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "recall gate without validation queries",
+			args: []string{"-validate-queries", "0"},
+			want: "-min-recall must be 0",
+		},
+		{
+			name: "overlapping validation and benchmark queries",
+			args: []string{"-docs", "10", "-queries", "8", "-validate-queries", "3", "-validate-docs", "0"},
+			want: "-validate-queries plus -queries cannot exceed -docs",
+		},
+		{
+			name: "topk exceeds docs",
+			args: []string{"-docs", "2", "-top-k", "3"},
+			want: "-top-k cannot exceed -docs",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseConfig(tc.args)
+			if err == nil {
+				t.Fatal("parseConfig succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
+	docs := 97
+	validateCount := 17
+	benchmarkCount := 53
+	stride := queryDocStride(docs)
+	seen := make(map[int]struct{}, validateCount)
+	for i := 0; i < validateCount; i++ {
+		seen[queryDocIndex(i, docs, stride)] = struct{}{}
+	}
+	for i := 0; i < benchmarkCount; i++ {
+		docIndex := queryDocIndex(i+validateCount, docs, stride)
+		if _, ok := seen[docIndex]; ok {
+			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
+		}
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -151,7 +151,7 @@ func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) 
 	}
 }
 
-func TestExecuteNormalizesMainDBDirToRoot(t *testing.T) {
+func TestExecuteRejectsMainDBDir(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "demo-root")
 	maindb := filepath.Join(root, "maindb")
 	if err := os.MkdirAll(filepath.Join(root, "dictdb"), 0o755); err != nil {
@@ -161,7 +161,7 @@ func TestExecuteNormalizesMainDBDirToRoot(t *testing.T) {
 		t.Fatalf("write stale side-store file: %v", err)
 	}
 
-	res, err := execute(context.Background(), config{
+	_, err := execute(context.Background(), config{
 		dir:                   maindb,
 		keepDir:               true,
 		docs:                  64,
@@ -180,17 +180,14 @@ func TestExecuteNormalizesMainDBDirToRoot(t *testing.T) {
 		compact:               true,
 		disableExactFallback:  true,
 	})
-	if err != nil {
-		t.Fatalf("execute: %v", err)
+	if err == nil {
+		t.Fatal("execute accepted maindb path, want error")
 	}
-	if res.Dir != root {
-		t.Fatalf("dir=%q want normalized root %q", res.Dir, root)
+	if !strings.Contains(err.Error(), "TreeDB root directory") {
+		t.Fatalf("error=%v, want TreeDB root directory guidance", err)
 	}
-	if _, err := os.Stat(filepath.Join(root, "dictdb", "stale")); !os.IsNotExist(err) {
-		t.Fatalf("stale side-store file err=%v, want removed with normalized root cleanup", err)
-	}
-	if res.StorageAfterCompact.Domains["index.db"] <= 0 {
-		t.Fatalf("storage after compact did not include normalized root maindb index: %+v", res.StorageAfterCompact)
+	if _, err := os.Stat(filepath.Join(root, "dictdb", "stale")); err != nil {
+		t.Fatalf("stale side-store file err=%v, want untouched after rejected maindb path", err)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -17,8 +17,7 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 		docs:                  128,
 		dimensions:            16,
 		queries:               8,
-		readOps:               16,
-		readConcurrency:       []int{2},
+		searchConcurrency:     []int{2},
 		validateQueries:       4,
 		validateDocs:          4,
 		topK:                  5,
@@ -44,8 +43,8 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	if res.Search.Queries != 8 || res.Search.AvgNanos <= 0 || res.Search.ExactFallbacks != 0 {
 		t.Fatalf("unexpected search benchmark result: %+v", res.Search)
 	}
-	if len(res.ReadBenchmarks) != 2 || res.ReadBenchmarks[0].Concurrency != 1 || res.ReadBenchmarks[1].Concurrency != 2 {
-		t.Fatalf("unexpected read benchmarks: %+v", res.ReadBenchmarks)
+	if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].Concurrency != 1 || res.SearchBenchmarks[1].Concurrency != 2 {
+		t.Fatalf("unexpected search benchmarks: %+v", res.SearchBenchmarks)
 	}
 	if res.Profile != "bench" {
 		t.Fatalf("profile=%q want bench", res.Profile)
@@ -132,8 +131,7 @@ func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) 
 		docs:                  64,
 		dimensions:            8,
 		queries:               2,
-		readOps:               8,
-		readConcurrency:       []int{2},
+		searchConcurrency:     []int{2},
 		validateQueries:       1,
 		validateDocs:          1,
 		topK:                  3,
@@ -175,8 +173,7 @@ func TestExecuteRejectsMainDBDir(t *testing.T) {
 		docs:                  64,
 		dimensions:            8,
 		queries:               2,
-		readOps:               8,
-		readConcurrency:       []int{2},
+		searchConcurrency:     []int{2},
 		validateQueries:       1,
 		validateDocs:          1,
 		topK:                  3,
@@ -246,8 +243,7 @@ func TestRunMatrixJSONOutput(t *testing.T) {
 		"-docs", "48",
 		"-dims", "8",
 		"-queries", "2",
-		"-read-ops", "12",
-		"-read-concurrency", "2,4",
+		"-search-concurrency", "2,4",
 		"-validate-queries", "1",
 		"-validate-docs", "1",
 		"-top-k", "3",
@@ -272,9 +268,9 @@ func TestRunMatrixJSONOutput(t *testing.T) {
 		if res.Cases[i].Name != want {
 			t.Fatalf("case %d name=%q want %q", i, res.Cases[i].Name, want)
 		}
-		reads := res.Cases[i].Result.ReadBenchmarks
-		if len(reads) != 3 || reads[0].Concurrency != 1 || reads[1].Concurrency != 2 || reads[2].Concurrency != 4 {
-			t.Fatalf("case %s read benchmarks=%+v", want, reads)
+		searches := res.Cases[i].Result.SearchBenchmarks
+		if len(searches) != 3 || searches[0].Concurrency != 1 || searches[1].Concurrency != 2 || searches[2].Concurrency != 4 {
+			t.Fatalf("case %s search benchmarks=%+v", want, searches)
 		}
 	}
 	if res.Cases[0].Result.FormatConfig == nil || res.Cases[0].Result.FormatConfig.IndexOuterLeavesInValueLog {
@@ -293,8 +289,7 @@ func TestExecuteMatrixReportsNestedKeptDirFromRoot(t *testing.T) {
 		docs:                  24,
 		dimensions:            8,
 		queries:               1,
-		readOps:               4,
-		readConcurrency:       []int{2},
+		searchConcurrency:     []int{2},
 		validateQueries:       1,
 		validateDocs:          1,
 		topK:                  3,
@@ -351,12 +346,12 @@ func TestRunTextOutput(t *testing.T) {
 		"profile=bench",
 		"value_pointer_threshold=1024",
 		"leaf_generation_segment_target=4194304",
-		"compact_storage_full:",
 		"Storage",
 		"format index_outer_leaves_in_vlog=",
 		"storage_domains index_db=",
 		"Memory",
 		"avg=",
+		"Parallel Search Benchmark",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("text output missing %q:\n%s", want, out)

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -17,6 +17,8 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 		docs:                  128,
 		dimensions:            16,
 		queries:               8,
+		readOps:               16,
+		readConcurrency:       []int{2},
 		validateQueries:       4,
 		validateDocs:          4,
 		topK:                  5,
@@ -41,6 +43,9 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	}
 	if res.Search.Queries != 8 || res.Search.AvgNanos <= 0 || res.Search.ExactFallbacks != 0 {
 		t.Fatalf("unexpected search benchmark result: %+v", res.Search)
+	}
+	if len(res.ReadBenchmarks) != 2 || res.ReadBenchmarks[0].Concurrency != 1 || res.ReadBenchmarks[1].Concurrency != 2 {
+		t.Fatalf("unexpected read benchmarks: %+v", res.ReadBenchmarks)
 	}
 	if res.Profile != "bench" {
 		t.Fatalf("profile=%q want bench", res.Profile)
@@ -84,6 +89,7 @@ func TestRunJSONOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	err := run([]string{
+		"-matrix=false",
 		"-dir", t.TempDir(),
 		"-keep-dir",
 		"-docs", "64",
@@ -126,6 +132,8 @@ func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) 
 		docs:                  64,
 		dimensions:            8,
 		queries:               2,
+		readOps:               8,
+		readConcurrency:       []int{2},
 		validateQueries:       1,
 		validateDocs:          1,
 		topK:                  3,
@@ -167,6 +175,8 @@ func TestExecuteRejectsMainDBDir(t *testing.T) {
 		docs:                  64,
 		dimensions:            8,
 		queries:               2,
+		readOps:               8,
+		readConcurrency:       []int{2},
 		validateQueries:       1,
 		validateDocs:          1,
 		topK:                  3,
@@ -227,10 +237,62 @@ func TestParseConfigLeafGenerationSegmentTarget(t *testing.T) {
 	}
 }
 
+func TestRunMatrixJSONOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-dir", t.TempDir(),
+		"-keep-dir",
+		"-docs", "48",
+		"-dims", "8",
+		"-queries", "2",
+		"-read-ops", "12",
+		"-read-concurrency", "2,4",
+		"-validate-queries", "1",
+		"-validate-docs", "1",
+		"-top-k", "3",
+		"-m", "4",
+		"-ef-construction", "32",
+		"-ef-search", "32",
+		"-min-recall", "0.5",
+		"-json",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run matrix: %v stderr=%s", err, stderr.String())
+	}
+	var res matrixResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("decode matrix JSON output: %v\n%s", err, stdout.String())
+	}
+	if len(res.Cases) != 3 {
+		t.Fatalf("matrix cases=%d want 3", len(res.Cases))
+	}
+	wantNames := []string{"index_db_outer_leaves", "leaf_vlog_before_compact", "leaf_vlog_after_compact"}
+	for i, want := range wantNames {
+		if res.Cases[i].Name != want {
+			t.Fatalf("case %d name=%q want %q", i, res.Cases[i].Name, want)
+		}
+		reads := res.Cases[i].Result.ReadBenchmarks
+		if len(reads) != 3 || reads[0].Concurrency != 1 || reads[1].Concurrency != 2 || reads[2].Concurrency != 4 {
+			t.Fatalf("case %s read benchmarks=%+v", want, reads)
+		}
+	}
+	if res.Cases[0].Result.FormatConfig == nil || res.Cases[0].Result.FormatConfig.IndexOuterLeavesInValueLog {
+		t.Fatalf("index_db_outer_leaves format=%+v, want outer leaves in index.db", res.Cases[0].Result.FormatConfig)
+	}
+	if res.Cases[1].Result.FormatConfig == nil || !res.Cases[1].Result.FormatConfig.IndexOuterLeavesInValueLog {
+		t.Fatalf("leaf_vlog_before_compact format=%+v, want outer leaves in leaf_vlog", res.Cases[1].Result.FormatConfig)
+	}
+	if res.Cases[2].Result.CompactStorage == nil || !res.Cases[2].Result.CompactStorage.FullyCompacted {
+		t.Fatalf("leaf_vlog_after_compact compact stats=%+v", res.Cases[2].Result.CompactStorage)
+	}
+}
+
 func TestRunTextOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	err := run([]string{
+		"-matrix=false",
 		"-dir", t.TempDir(),
 		"-keep-dir",
 		"-docs", "64",

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -115,6 +115,8 @@ func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	if err == nil {
 		t.Fatal("execute succeeded, want leaf-vlog requirement failure")
 	}
+	// These assertions intentionally describe the current default backend
+	// profile, where this demo does not force leaf value-log storage.
 	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
 		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
 	}
@@ -142,6 +144,8 @@ func TestExecuteRequireValueLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 	if err == nil {
 		t.Fatal("execute succeeded, want value-log requirement failure")
 	}
+	// These assertions intentionally describe the current default backend
+	// profile, where this demo does not force value-log storage.
 	if !strings.Contains(err.Error(), "zero value_vlog bytes") {
 		t.Fatalf("error=%v, want zero value_vlog bytes", err)
 	}
@@ -228,6 +232,11 @@ func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
 			args: []string{"-docs", "2", "-top-k", "3"},
 			want: "-top-k cannot exceed -docs",
 		},
+		{
+			name: "negative validate docs",
+			args: []string{"-validate-docs", "-1"},
+			want: "-validate-docs cannot be negative",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := parseConfig(tc.args)
@@ -238,6 +247,31 @@ func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
 				t.Fatalf("error=%v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseConfigDoesNotWriteFlagErrorsToProcessStderr(t *testing.T) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = writePipe
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = readPipe.Close()
+	})
+	_, err = parseConfig([]string{"-not-a-real-flag"})
+	_ = writePipe.Close()
+	if err == nil {
+		t.Fatal("parseConfig accepted unknown flag")
+	}
+	var stderr bytes.Buffer
+	if _, err := stderr.ReadFrom(readPipe); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("parseConfig wrote to stderr: %q", stderr.String())
 	}
 }
 
@@ -255,6 +289,18 @@ func TestSyntheticQueriesDoNotOverlapValidationQueries(t *testing.T) {
 		if _, ok := seen[docIndex]; ok {
 			t.Fatalf("benchmark query doc %d overlapped validation set", docIndex)
 		}
+	}
+}
+
+func TestValidationDocIndexSamplesDistinctDocsWhenStrideWouldCollapse(t *testing.T) {
+	docs := 1543
+	seen := make(map[int]struct{}, 16)
+	for i := 0; i < 16; i++ {
+		docIndex := validationDocIndex(i, docs)
+		if _, ok := seen[docIndex]; ok {
+			t.Fatalf("validation doc index repeated %d for docs=%d", docIndex, docs)
+		}
+		seen[docIndex] = struct{}{}
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -37,14 +37,26 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	if res.Search.Queries != 8 || res.Search.AvgNanos <= 0 || res.Search.ExactFallbacks != 0 {
 		t.Fatalf("unexpected search benchmark result: %+v", res.Search)
 	}
+	if res.Profile != "bench" {
+		t.Fatalf("profile=%q want bench", res.Profile)
+	}
 	if res.StorageAfterCompact.TotalBytes <= 0 || res.StorageAfterCompact.BytesPerDoc <= 0 {
 		t.Fatalf("missing compacted storage report: %+v", res.StorageAfterCompact)
 	}
 	if res.FormatConfig == nil {
 		t.Fatal("missing format config report")
 	}
+	if !res.FormatConfig.IndexOuterLeavesInValueLog {
+		t.Fatalf("index_outer_leaves_in_vlog=false, want true: %+v", res.FormatConfig)
+	}
+	if !res.FormatConfig.LeafPrefixCompression {
+		t.Fatalf("leaf_prefix_compression=false, want true: %+v", res.FormatConfig)
+	}
 	if res.StorageExpectation.IndexBytes <= 0 {
 		t.Fatalf("missing storage expectation index bytes: %+v", res.StorageExpectation)
+	}
+	if res.StorageExpectation.LeafVLogBytes <= 0 {
+		t.Fatalf("missing leaf value-log bytes: %+v", res.StorageExpectation)
 	}
 	if res.Memory.IndexBytesMemory <= 0 {
 		t.Fatalf("missing index memory report: %+v", res.Memory)
@@ -82,13 +94,16 @@ func TestRunJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
 		t.Fatalf("decode JSON output: %v\n%s", err, stdout.String())
 	}
-	if res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
+	if res.Profile != "bench" || res.Docs != 64 || res.Search.Queries != 4 || res.StorageAfterCompact.TotalBytes <= 0 {
 		t.Fatalf("unexpected JSON result: %+v", res)
+	}
+	if res.FormatConfig == nil || !res.FormatConfig.IndexOuterLeavesInValueLog || !res.FormatConfig.LeafPrefixCompression {
+		t.Fatalf("unexpected JSON format config: %+v", res.FormatConfig)
 	}
 }
 
-func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
-	_, err := execute(t.Context(), config{
+func TestExecuteRequireLeafVLogBytesPassesWithDefaultBenchProfile(t *testing.T) {
+	res, err := execute(t.Context(), config{
 		dir:                  t.TempDir(),
 		keepDir:              true,
 		docs:                 64,
@@ -106,11 +121,24 @@ func TestExecuteRequireLeafVLogBytesFailsOnPagerBackedDefault(t *testing.T) {
 		disableExactFallback: true,
 		requireLeafVLogBytes: true,
 	})
-	if err == nil {
-		t.Fatal("execute succeeded, want leaf-vlog requirement failure")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
 	}
-	if !strings.Contains(err.Error(), "zero leaf_vlog bytes") {
-		t.Fatalf("error=%v, want zero leaf_vlog bytes", err)
+	if res.Profile != "bench" {
+		t.Fatalf("profile=%q want bench", res.Profile)
+	}
+	if res.StorageExpectation.LeafVLogBytes <= 0 {
+		t.Fatalf("missing leaf value-log bytes: %+v", res.StorageExpectation)
+	}
+}
+
+func TestParseProfileRejectsUnsupportedProfile(t *testing.T) {
+	_, err := parseProfile("raw")
+	if err == nil {
+		t.Fatal("parseProfile succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "unsupported -profile") {
+		t.Fatalf("error=%v, want unsupported -profile", err)
 	}
 }
 
@@ -137,6 +165,7 @@ func TestRunTextOutput(t *testing.T) {
 	out := stdout.String()
 	for _, want := range []string{
 		"TreeDB vector search demo",
+		"profile=bench",
 		"compact_storage_full:",
 		"Storage",
 		"format index_outer_leaves_in_vlog=",


### PR DESCRIPTION
## Summary
- add `-profile durable|fast|wal_on_fast|bench` to `treedb_vector_search_demo`
- default the demo to TreeDB `bench` profile so benchmark runs use first-class profile storage defaults
- open through TreeDB profile-aware backend helpers, including cached leaf-log wiring for outer-leaf value-log formats
- normalize public TreeDB root layout storage reporting so `maindb/leaf_vlog`, `maindb/value_vlog`, and `maindb/index.db` are reported as first-class storage domains
- add demo-local storage knobs:
  - `-value-pointer-threshold`, default `1024`, so normal vector documents and native vector-index records stay inside outer leaves instead of spilling to `value_vlog`
  - `-leaf-generation-segment-target`, default `4194304`, so the vector demo creates sealed leaf generations that `CompactStorageFull` can pack/rewrite/GC when compaction is requested
- make the default `-require-leaf-vlog-bytes` path pass under the benchmark profile
- make the command entrypoint default to a three-case storage/search matrix: index.db outer leaves, leaf_vlog before compaction, and leaf_vlog after compaction
- make `-compact=false` the default; the matrix only compacts the explicit `leaf_vlog_after_compact` case
- replace the mistaken parallel document-read stage with parallel ANN search benchmarks via `-queries` and `-search-concurrency`

## Validation
- `GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1`
- `GOWORK=off go vet ./cmd/treedb_vector_search_demo`
- `git diff --check`
- `GOWORK=off go run ./cmd/treedb_vector_search_demo -dir /tmp/treedb_vector_search_matrix_search_smoke -keep-dir -docs 1000 -dims 32 -queries 200 -search-concurrency 2,4,8 -validate-queries 4 -validate-docs 4 -top-k 5 -m 8 -ef-construction 64 -ef-search 64 -min-recall 0.5 -json >/tmp/treedb_vector_search_matrix_search_smoke.json`
- `GOWORK=off go run ./cmd/treedb_vector_search_demo -dir /tmp/treedb_vector_search_matrix_search_10k -keep-dir -docs 10000 -dims 64 -queries 10000 -search-concurrency 2,4,8,16,32,64,128 -validate-queries 16 -validate-docs 16 -top-k 10 -m 16 -ef-construction 128 -ef-search 128 -min-recall 0.95 -json >/tmp/treedb_vector_search_matrix_search_10k.json`
- `GOWORK=off go run ./cmd/treedb_vector_search_demo -matrix=false -compact=true -dir /tmp/treedb_vector_search_demo_profile_10k_deep_compact -keep-dir -docs 10000 -dims 64 -queries 1000 -validate-queries 32 -validate-docs 16 -top-k 10 -m 16 -ef-construction 128 -ef-search 128 -require-leaf-vlog-bytes -json >/tmp/treedb_vector_search_demo_profile_10k_deep_compact.json`

## 10k x 64 Single-Case Result

Source: `/tmp/treedb_vector_search_demo_profile_10k_deep_compact.json`

| Field | Result |
| --- | ---: |
| profile | `bench` |
| value pointer threshold | 1,024 bytes |
| leaf generation segment target | 4,194,304 bytes |
| docs x dims | 10,000 x 64 |
| queries | 1,000 |
| top_k | 10 |
| m / ef_construction / ef_search | 16 / 128 / 128 |
| recall@10 | 1.0000 |
| validation overlap | 320 / 320 |
| avg search | 1.200 ms |
| p50 search | 1.153 ms |
| p95 search | 1.620 ms |
| p99 search | 1.966 ms |
| ops/sec | 833.4 |
| avg candidates / rerank | 128 / 128 |
| exact fallbacks | 0 |
| insert phase | 0.187 s |
| rebuild native vector index | 1.519 s |
| full compaction phase | 0.509 s |
| reopen/load native index | 0.368 s |
| full compaction | `fully_compacted=true` |
| completed leaf pack passes | 2 |
| compacted storage | 16,888,006 bytes |
| compacted storage/doc | 1,688.8 bytes/doc |
| `index.db` bytes | 4,194,304 |
| `value_vlog` bytes | 0 |
| `leaf_vlog` bytes | 12,594,608 |
| native root bytes | 14,125,248 |
| vector index memory | 8,973,632 bytes |
| load alloc delta | 42,144,368 bytes |

Persisted format config from the same run:

```json
{
  "index_outer_leaves_in_vlog": true,
  "leaf_prefix_compression": true,
  "index_columnar_leaves": true,
  "index_packed_valueptr": true,
  "index_internal_base_delta": false,
  "index_adaptive_leaf_encoding": false,
  "vlog_compression": "auto",
  "vlog_block_codec": "snappy",
  "vlog_auto_policy": "balanced"
}
```

## Storage/Search Matrix Run

Source: `/tmp/treedb_vector_search_matrix_search_10k.json`

`avg`/`p50`/`p95` are per-search latency. `ops/sec` is total benchmark throughput for the lane.

| Case | Compacted | Storage bytes | `index.db` | `value_vlog` | `leaf_vlog` | Recall@10 | 1-way avg / p95 / ops/sec | 8-way avg / p95 / ops/sec | 128-way avg / p95 / ops/sec |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `index_db_outer_leaves` | no | 29,360,499 | 29,360,128 | 0 | 0 | 1.0000 | 982us / 1340us / 1,017 | 1475us / 2049us / 5,420 | 23246us / 177143us / 5,434 |
| `leaf_vlog_before_compact` | no | 20,701,246 | 4,194,304 | 0 | 16,440,664 | 1.0000 | 985us / 1132us / 1,014 | 1474us / 1984us / 5,423 | 21955us / 115536us / 5,748 |
| `leaf_vlog_after_compact` | yes | 16,888,006 | 4,194,304 | 0 | 12,594,608 | 1.0000 | 1214us / 1682us / 823 | 1865us / 2900us / 4,285 | 26392us / 159340us / 4,704 |

The full default entrypoint now runs the same storage matrix with 10,000 ANN searches per serial/concurrency lane and concurrency levels `2,4,8,16,32,64,128`. Use `-matrix=false` to run the single-case demo path; add `-compact=true` there if the single case should compact before reopen/search.

## Compaction Finding

The earlier 1024-threshold run still used a single writable leaf generation. `CompactStorageFull` reported fully compacted, but `leaf-generation-pack-1` was skipped with `plan_admission:no_candidates` because the only generation was `writable_generation`; it had no sealed outer-leaf generation to rewrite.

Enabling leaf generation rolling for the demo fixes that API mismatch without changing global TreeDB defaults. With `-leaf-generation-segment-target 4194304`, the same full compaction run performs two leaf-generation pack passes, then leaf GC removes old generation files. Storage moves from the earlier `20,664,669` bytes / `16,404,087 leaf_vlog` result down to `16,888,006` bytes / `12,594,608 leaf_vlog`, still with `value_vlog=0`.

## Threshold Sizing Evidence

For this demo shape, measured logical values are below 1 KiB:

| Value group | Count | Avg | p50 | p95 | Max | Above 512 | Above 1024 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Primary JSON documents | 10,000 | 727 B | 728 B | 737 B | 753 B | 10,000 | 0 |
| Native vector-index values | 33,420 | 423 B | 551 B | 758 B | 778 B | 20,000 | 0 |
| Native vector-index keys | 33,420 | 23 B | 25 B | 29 B | 29 B | 0 | 0 |

A 512-byte threshold pointerizes many records and stores most bytes in `value_vlog`. The 1024-byte demo-local threshold keeps this benchmark's document and vector-index payloads inside the outer leaf log while preserving the underlying TreeDB global default for other contexts.

Stacked on #1558.
