### PR TITLE
experiments/colgranule: add q4 sort-order fairness

### DIFF
--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -26,16 +26,27 @@ import (
 )
 
 type clickHouseResult struct {
-	System             string      `json:"system"`
-	Version            string      `json:"version"`
-	OS                 string      `json:"os"`
-	Machine            string      `json:"machine"`
-	DatasetSize        int         `json:"dataset_size"`
-	NumLoadedDocuments int         `json:"num_loaded_documents"`
-	TotalSize          int64       `json:"total_size"`
-	DataSize           int64       `json:"data_size"`
-	IndexSize          int64       `json:"index_size"`
-	Result             [][]float64 `json:"result"`
+	System             string                       `json:"system"`
+	Version            string                       `json:"version"`
+	OS                 string                       `json:"os"`
+	Machine            string                       `json:"machine"`
+	DatasetSize        int                          `json:"dataset_size"`
+	NumLoadedDocuments int                          `json:"num_loaded_documents"`
+	TotalSize          int64                        `json:"total_size"`
+	DataSize           int64                        `json:"data_size"`
+	IndexSize          int64                        `json:"index_size"`
+	Result             [][]float64                  `json:"result"`
+	Q4Fairness         []clickHouseQ4FairnessResult `json:"q4_fairness"`
+}
+
+type clickHouseQ4FairnessResult struct {
+	Query       string    `json:"query"`
+	Description string    `json:"description"`
+	Table       string    `json:"table"`
+	SortKey     string    `json:"sort_key"`
+	QueryShape  string    `json:"query_shape"`
+	Attempts    []float64 `json:"attempts"`
+	Best        float64   `json:"best"`
 }
 
 type comparisonRaw struct {
@@ -57,6 +68,7 @@ type comparisonRaw struct {
 	RawTreeDBJSON           remainingTreeDBResult                 `json:"raw_treedb_json"`
 	QueryTimings            []colgranule.JSONBenchQueryTiming     `json:"query_timings"`
 	EncodedPartQueryTimings []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_query_timings"`
+	EncodedPartQ4Fairness   []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_q4_fairness_timings"`
 	ColumnSummaries         []colgranule.ColumnCodecSummary       `json:"column_summaries"`
 	BestColumnStorage       []bestColumnStorage                   `json:"best_column_storage"`
 }
@@ -125,6 +137,8 @@ func main() {
 	must(err)
 	encodedPartTimings, err := colgranule.RunJSONBenchPartQueries(ds, *rowsPerGranule, *attempts)
 	must(err)
+	encodedPartQ4Fairness, err := colgranule.RunJSONBenchPartQ4FairnessQueries(ds, *rowsPerGranule, *attempts)
+	must(err)
 	var remaining remainingTreeDBResult
 	var remainingJSON remainingTreeDBResult
 	var remainingTpl remainingTreeDBResult
@@ -168,6 +182,7 @@ func main() {
 		RawTreeDBJSON:           rawTreeDBJSON,
 		QueryTimings:            timings,
 		EncodedPartQueryTimings: encodedPartTimings,
+		EncodedPartQ4Fairness:   encodedPartQ4Fairness,
 		ColumnSummaries:         summaries,
 		BestColumnStorage:       bestColumns(summaries),
 	}
@@ -872,6 +887,38 @@ func writeMarkdown(path string, raw comparisonRaw) {
 				strings.Join(d.ColumnsProjected, ","))
 		}
 	}
+	if len(raw.EncodedPartQ4Fairness) > 0 {
+		fmt.Fprintf(&b, "\n## Q4 Sort-Order Fairness\n\n")
+		fmt.Fprintf(&b, "Q4a compares time-ordered TreeDB against a time-ordered ClickHouse table when the local ClickHouse result includes `q4_fairness`. Q4b compares a TreeDB part ordered by `kind`, `operation`, `collection`, `did`, and `time_us` against the standard ClickHouse table order, without TreeDB's global `time_us` early-stop shortcut.\n\n")
+		fmt.Fprintf(&b, "| Query | TreeDB best | Best cache | ClickHouse local | TreeDB / ClickHouse | Speedup | TreeDB sort key | Early stop | Kernel | Diagnostics | ClickHouse shape |\n")
+		fmt.Fprintf(&b, "|---|---:|---|---:|---:|---:|---|---|---|---|---|\n")
+		for _, timing := range raw.EncodedPartQ4Fairness {
+			d := timing.Diagnostics
+			local := clickHouseQ4FairnessBest(raw.ClickHouseLocal, timing.Query)
+			localSeconds := local.Best
+			localShape := local.QueryShape
+			if localShape == "" {
+				localShape = "not provided"
+			}
+			fmt.Fprintf(&b, "| %s | %.6fs | %s | %s | %s | %s | `%s` | %t | `%s` | rows=%d granules=%d skipped=%d decoded=%d blocks=%d bytes=%d | `%s` |\n",
+				timing.Query,
+				timing.Best.Seconds(),
+				timing.BestCache,
+				formatSeconds(localSeconds),
+				formatRatio(timing.Best.Seconds(), localSeconds),
+				formatSpeedup(timing.Best.Seconds(), localSeconds),
+				strings.Join(d.SortKey, ","),
+				d.EarlyStopAvailable,
+				d.AggregateKernel,
+				d.RowsScanned,
+				d.GranulesConsidered,
+				d.GranulesSkipped,
+				d.GranulesDecoded,
+				d.BlocksDecoded,
+				d.BytesDecoded,
+				localShape)
+		}
+	}
 	fmt.Fprintf(&b, "\n## Storage Footprint\n\n")
 	allBest := bestTotal(raw.BestColumnStorage, nil)
 	queryBest := bestTotal(raw.BestColumnStorage, queryPathColumns())
@@ -1018,6 +1065,30 @@ func clickHouseBest(result clickHouseResult, i int) float64 {
 	return best
 }
 
+func clickHouseQ4FairnessBest(result clickHouseResult, query string) clickHouseQ4FairnessResult {
+	prefix := strings.ToLower(query)
+	var out clickHouseQ4FairnessResult
+	for _, candidate := range result.Q4Fairness {
+		if !strings.HasPrefix(strings.ToLower(candidate.Query), prefix) {
+			continue
+		}
+		if candidate.Best == 0 {
+			for i, attempt := range candidate.Attempts {
+				if i == 0 || attempt < candidate.Best {
+					candidate.Best = attempt
+				}
+			}
+		}
+		if candidate.Best == 0 {
+			continue
+		}
+		if out.Best == 0 || candidate.Best < out.Best {
+			out = candidate
+		}
+	}
+	return out
+}
+
 func queryPathColumns() map[string]bool {
 	return map[string]bool{
 		"kind_code": true, "commit_operation_code": true, "commit_collection_code": true, "did_code": true, "time_us": true,
@@ -1040,6 +1111,27 @@ func ratio(numerator, denominator float64) float64 {
 		return 0
 	}
 	return numerator / denominator
+}
+
+func formatSeconds(seconds float64) string {
+	if seconds == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.6fs", seconds)
+}
+
+func formatRatio(numerator, denominator float64) string {
+	if denominator == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2fx", ratio(numerator, denominator))
+}
+
+func formatSpeedup(numerator, denominator float64) string {
+	if numerator == 0 || denominator == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2fx", ratio(denominator, numerator))
 }
 
 func mib(bytes int64) float64 {

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -99,6 +99,59 @@ func BenchmarkJSONBenchEncodedPartQueries(b *testing.B) {
 	}
 }
 
+func BenchmarkJSONBenchQ4SortOrderFairness(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	timePart, err := BuildJSONBenchColumnPartForLayout(ds, DefaultRowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		b.Fatalf("BuildJSONBenchColumnPartForLayout(time): %v", err)
+	}
+	clickHouseOrderPart, err := BuildJSONBenchColumnPartForLayout(ds, DefaultRowsPerGranule, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		b.Fatalf("BuildJSONBenchColumnPartForLayout(clickhouse): %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		b.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	queries := []struct {
+		name string
+		part *ColumnPart
+		run  jsonBenchPartQueryRunner
+	}{
+		{"Q4a_time_ordered", timePart, runJSONBenchPartQ4},
+		{"Q4b_clickhouse_order", clickHouseOrderPart, runJSONBenchPartQ4ClickHouseOrder},
+	}
+	for _, q := range queries {
+		b.Run(q.name, func(b *testing.B) {
+			b.ReportAllocs()
+			scratch := &jsonBenchPartQueryScratch{
+				scanner:   q.part.NewScanner(),
+				projected: make(map[string][]int64, 6),
+			}
+			rows, digest, diagnostics, err := q.run(q.part, codes, scratch)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(rows) + int64(digest)
+			rowsScanned := diagnostics.RowsScanned
+			valueBytes := rowsScanned * len(diagnostics.ColumnsProjected) * 8
+			if valueBytes == 0 {
+				valueBytes = rowsScanned * 8
+			}
+			b.SetBytes(int64(valueBytes))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, digest, diagnostics, err = q.run(q.part, codes, scratch)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(rows) + int64(digest)
+			}
+			reportGranuleBenchMetrics(b, diagnostics.RowsScanned, valueBytes, diagnostics.BytesDecoded)
+		})
+	}
+}
+
 func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
 	columns := map[string][]int64{
 		"row_index":              make([]int64, rows),

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -36,6 +36,8 @@ type JSONBenchPartQueryDiagnostics struct {
 	ColumnsProjected   []string `json:"columns_projected"`
 	AggregateKernel    string   `json:"aggregate_kernel"`
 	CacheState         string   `json:"cache_state"`
+	SortKey            []string `json:"sort_key"`
+	EarlyStopAvailable bool     `json:"early_stop_available"`
 }
 
 type jsonBenchPartQueryScratch struct {
@@ -49,6 +51,9 @@ type jsonBenchPartQueryScratch struct {
 	q2Seen      []uint64
 	q3Counts    []uint64
 	q4Seen      touchedBitset
+	q4FullSeen  []uint64
+	q4Min       []int64
+	q4Users     []uint32
 	q5Seen      []uint64
 	q5Min       []int64
 	q5Max       []int64
@@ -64,6 +69,13 @@ type jsonBenchPartQueryScratch struct {
 
 type jsonBenchPartQueryRunner func(*ColumnPart, queryCodeSet, *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error)
 
+type JSONBenchColumnPartLayout string
+
+const (
+	JSONBenchColumnPartLayoutTimeUS                   JSONBenchColumnPartLayout = "time_us"
+	JSONBenchColumnPartLayoutClickHouseFilterUserTime JSONBenchColumnPartLayout = "clickhouse_filter_user_time"
+)
+
 var (
 	jsonBenchPartQ2Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code"}
 	jsonBenchPartQ3Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "hour_of_day"}
@@ -72,7 +84,11 @@ var (
 )
 
 func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnPart, error) {
-	opts, err := JSONBenchColumnPartOptions(ds, rowsPerGranule)
+	return BuildJSONBenchColumnPartForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+}
+
+func BuildJSONBenchColumnPartForLayout(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (*ColumnPart, error) {
+	opts, err := JSONBenchColumnPartOptionsForLayout(ds, rowsPerGranule, layout)
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +96,10 @@ func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnP
 }
 
 func JSONBenchColumnPartOptions(ds JSONBenchDataset, rowsPerGranule int) (ColumnStoreOptions, error) {
+	return JSONBenchColumnPartOptionsForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+}
+
+func JSONBenchColumnPartOptionsForLayout(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (ColumnStoreOptions, error) {
 	if ds.Rows <= 0 {
 		return ColumnStoreOptions{}, fmt.Errorf("colgranule: JSONBench part requires positive rows, got %d", ds.Rows)
 	}
@@ -113,6 +133,10 @@ func JSONBenchColumnPartOptions(ds JSONBenchDataset, rowsPerGranule int) (Column
 		}
 		defs = append(defs, def)
 	}
+	sortKey, err := jsonBenchSortKeyForLayout(layout)
+	if err != nil {
+		return ColumnStoreOptions{}, err
+	}
 	return ColumnStoreOptions{
 		SchemaVersion: 1,
 		SchemaMode:    ColumnSchemaFixed,
@@ -121,13 +145,30 @@ func JSONBenchColumnPartOptions(ds JSONBenchDataset, rowsPerGranule int) (Column
 			Columns: []string{"row_index"},
 		},
 		SortKey: SortKey{
-			Columns: []SortKeyColumn{{Column: "time_us"}},
+			Columns: sortKey,
 		},
 		PartPolicy: ColumnPartPolicy{
 			RowsPerGranule:        rowsPerGranule,
 			DefaultCodecBlockRows: rowsPerGranule,
 		},
 	}, nil
+}
+
+func jsonBenchSortKeyForLayout(layout JSONBenchColumnPartLayout) ([]SortKeyColumn, error) {
+	switch layout {
+	case "", JSONBenchColumnPartLayoutTimeUS:
+		return []SortKeyColumn{{Column: "time_us"}}, nil
+	case JSONBenchColumnPartLayoutClickHouseFilterUserTime:
+		return []SortKeyColumn{
+			{Column: "kind_code"},
+			{Column: "commit_operation_code"},
+			{Column: "commit_collection_code"},
+			{Column: "did_code"},
+			{Column: "time_us"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("colgranule: unknown JSONBench column part layout %q", layout)
+	}
 }
 
 func RunJSONBenchPartQueries(ds JSONBenchDataset, rowsPerGranule int, attempts int) ([]JSONBenchPartQueryTiming, error) {
@@ -172,6 +213,77 @@ func RunJSONBenchPartQueries(ds JSONBenchDataset, rowsPerGranule int, attempts i
 			}
 			start := time.Now()
 			rows, digest, diagnostics, err := q.run(part, codes, scratch)
+			if err != nil {
+				return nil, fmt.Errorf("%s encoded part query: %w", q.name, err)
+			}
+			elapsed := time.Since(start)
+			diagnostics.CacheState = cache
+			attempt := JSONBenchPartQueryAttempt{
+				Cache:        cache,
+				Duration:     elapsed,
+				ResultRows:   rows,
+				ResultDigest: digest,
+				Diagnostics:  diagnostics,
+			}
+			timing.Attempts = append(timing.Attempts, attempt)
+			timing.ResultRows = rows
+			timing.ResultDigest = digest
+			if timing.Best == 0 || elapsed < timing.Best {
+				timing.Best = elapsed
+				timing.BestCache = cache
+				timing.Diagnostics = diagnostics
+			}
+		}
+		out = append(out, timing)
+	}
+	return out, nil
+}
+
+func RunJSONBenchPartQ4FairnessQueries(ds JSONBenchDataset, rowsPerGranule int, attempts int) ([]JSONBenchPartQueryTiming, error) {
+	if attempts <= 0 {
+		attempts = 3
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		return nil, err
+	}
+	timePart, err := BuildJSONBenchColumnPartForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		return nil, err
+	}
+	clickHouseOrderPart, err := BuildJSONBenchColumnPartForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		return nil, err
+	}
+	queries := []struct {
+		name        string
+		description string
+		engine      string
+		part        *ColumnPart
+		run         jsonBenchPartQueryRunner
+	}{
+		{"Q4a", "Top 3 post veterans, time-ordered part", "encoded_column_part_q4a_time_ordered", timePart, runJSONBenchPartQ4},
+		{"Q4b", "Top 3 post veterans, ClickHouse-order part", "encoded_column_part_q4b_clickhouse_order", clickHouseOrderPart, runJSONBenchPartQ4ClickHouseOrder},
+	}
+	out := make([]JSONBenchPartQueryTiming, 0, len(queries))
+	for _, q := range queries {
+		timing := JSONBenchPartQueryTiming{
+			Query:       q.name,
+			Description: q.description,
+			Engine:      q.engine,
+			Attempts:    make([]JSONBenchPartQueryAttempt, 0, attempts),
+		}
+		scratch := &jsonBenchPartQueryScratch{
+			scanner:   q.part.NewScanner(),
+			projected: make(map[string][]int64, 6),
+		}
+		for i := 0; i < attempts; i++ {
+			cache := "cold"
+			if i > 0 {
+				cache = "warm"
+			}
+			start := time.Now()
+			rows, digest, diagnostics, err := q.run(q.part, codes, scratch)
 			if err != nil {
 				return nil, fmt.Errorf("%s encoded part query: %w", q.name, err)
 			}
@@ -473,7 +585,8 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 			if len(top) == 3 && timestamp > top[2].t {
 				scratch.q4Pairs = top
 				bytesDecoded += timeCursor.RawBytesRead()
-				diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+				diagnostics := queryDiagnosticsFromDecodedPrefix(part, jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+				diagnostics.EarlyStopAvailable = true
 				return len(top), digestQ4Top(top), diagnostics, nil
 			}
 			rowsScanned++
@@ -513,7 +626,151 @@ func runJSONBenchPartQ4(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 		bytesDecoded += timeCursor.RawBytesRead()
 	}
 	scratch.q4Pairs = top
-	diagnostics := queryDiagnosticsFromDecodedPrefix(jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+	diagnostics := queryDiagnosticsFromDecodedPrefix(part, jsonBenchPartQ4Columns, "sort_key_early_stop_min_by_user", rowsScanned, lastGranule, blocksDecoded, bytesDecoded)
+	diagnostics.EarlyStopAvailable = true
+	return len(top), digestQ4Top(top), diagnostics, nil
+}
+
+func runJSONBenchPartQ4ClickHouseOrder(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	operationBlocks, err := lowCardinalityBlocks(part, "commit_operation_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	collectionBlocks, err := lowCardinalityBlocks(part, "commit_collection_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didBlocks, err := lowCardinalityBlocks(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	timeBlocks, err := int64Blocks(part, "time_us")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	if err := validateAlignedBlocks(kindBlocks, operationBlocks, collectionBlocks, didBlocks, timeBlocks); err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	seen, minTime, users, err := scratch.resetQ4FullDense(didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	sortKeyRanges := []Int64RangePredicate{
+		{Column: "kind_code", Low: codes.kindCommit, High: codes.kindCommit},
+		{Column: "commit_operation_code", Low: codes.operationCreate, High: codes.operationCreate},
+		{Column: "commit_collection_code", Low: codes.collectionPost, High: codes.collectionPost},
+	}
+	rowsScanned := 0
+	granulesSkipped := 0
+	granulesDecoded := 0
+	blocksDecoded := 0
+	bytesDecoded := 0
+	for blockIndex := range kindBlocks {
+		mayContain, skipped, err := blockMayContainSortKeyRanges(part, kindBlocks[blockIndex], sortKeyRanges)
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		if !mayContain {
+			granulesSkipped += skipped
+			continue
+		}
+		kindHeader, err := scratch.tinyCodeHeader(0, kindBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		operationHeader, err := scratch.tinyCodeHeader(1, operationBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		collectionHeader, err := scratch.tinyCodeHeader(2, collectionBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		didHeader, err := scratch.codeHeader(3, didBlocks[blockIndex])
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		timeCursor, err := scratch.timeReader.int64Cursor(timeBlocks[blockIndex].Granule)
+		if err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		blocksDecoded += 5
+		bytesDecoded += kindBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += operationBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += collectionBlocks[blockIndex].Granule.RawBytes
+		bytesDecoded += didBlocks[blockIndex].Granule.RawBytes
+		granulesDecoded += blockGranuleSpan(kindBlocks[blockIndex])
+		rows := kindBlocks[blockIndex].Descriptor.RowCount
+		rowsScanned += rows
+		for row := 0; row < rows; row++ {
+			timestamp, err := timeCursor.Next()
+			if err != nil {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+			}
+			kind := readTinyCode(kindHeader, row)
+			if kind >= kindHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: kind code %d outside cardinality %d", kind, kindHeader.cardinality)
+			}
+			if int64(kind) != codes.kindCommit {
+				continue
+			}
+			operation := readTinyCode(operationHeader, row)
+			if operation >= operationHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: operation code %d outside cardinality %d", operation, operationHeader.cardinality)
+			}
+			if int64(operation) != codes.operationCreate {
+				continue
+			}
+			event := readTinyCode(collectionHeader, row)
+			if event >= collectionHeader.cardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: collection code %d outside cardinality %d", event, collectionHeader.cardinality)
+			}
+			if int64(event) != codes.collectionPost {
+				continue
+			}
+			user := readUint32Code(didHeader.data, didHeader.width, row)
+			if user >= didHeader.cardinality || user >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: did code %d outside cardinality %d", user, didCardinality)
+			}
+			if bitsetTestAndSet(seen, user) {
+				if timestamp < minTime[user] {
+					minTime[user] = timestamp
+				}
+				continue
+			}
+			minTime[user] = timestamp
+			users = append(users, user)
+		}
+		if err := timeCursor.Finish(); err != nil {
+			return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+		}
+		bytesDecoded += timeCursor.RawBytesRead()
+	}
+	scratch.q4Users = users
+	top := scratch.q4Pairs[:0]
+	for _, user := range users {
+		top = insertQ4Top(top, jsonBenchPartTimePair{user: int64(user), t: minTime[user]})
+	}
+	scratch.q4Pairs = top
+	diagnostics := JSONBenchPartQueryDiagnostics{
+		RowsScanned:        rowsScanned,
+		GranulesConsidered: len(part.Descriptor.Granules),
+		GranulesSkipped:    granulesSkipped,
+		GranulesDecoded:    granulesDecoded,
+		BlocksDecoded:      blocksDecoded,
+		BytesDecoded:       bytesDecoded,
+		ColumnsProjected:   append([]string(nil), jsonBenchPartQ4Columns...),
+		AggregateKernel:    "clickhouse_order_prefix_scan_min_by_user",
+		SortKey:            sortKeyColumns(part),
+	}
 	return len(top), digestQ4Top(top), diagnostics, nil
 }
 
@@ -733,6 +990,34 @@ func (s *jsonBenchPartQueryScratch) resetQ4Seen(didCardinality uint32) ([]uint64
 	return seen, nil
 }
 
+func (s *jsonBenchPartQueryScratch) resetQ4FullDense(didCardinality uint32) ([]uint64, []int64, []uint32, error) {
+	if didCardinality == 0 {
+		return nil, nil, nil, errors.New("colgranule: invalid q4 did cardinality 0")
+	}
+	cardinality := int(didCardinality)
+	words := (cardinality + 63) / 64
+	if words <= 0 || words > maxAggregateCells {
+		return nil, nil, nil, fmt.Errorf("colgranule: q4 seen words=%d exceeds cap %d", words, maxAggregateCells)
+	}
+	if cardinality > maxAggregateCells {
+		return nil, nil, nil, fmt.Errorf("colgranule: q4 dense cardinality=%d exceeds cap %d", cardinality, maxAggregateCells)
+	}
+	if cap(s.q4FullSeen) < words {
+		s.q4FullSeen = make([]uint64, words)
+	} else {
+		s.q4FullSeen = s.q4FullSeen[:words]
+	}
+	clear(s.q4FullSeen)
+	if cap(s.q4Min) < cardinality {
+		s.q4Min = make([]int64, cardinality)
+	} else {
+		s.q4Min = s.q4Min[:cardinality]
+	}
+	s.q4Users = s.q4Users[:0]
+	s.q4Pairs = s.q4Pairs[:0]
+	return s.q4FullSeen, s.q4Min, s.q4Users, nil
+}
+
 func (s *jsonBenchPartQueryScratch) resetQ5Dense(didCardinality uint32) ([]uint64, []int64, []int64, []uint32, error) {
 	if didCardinality == 0 {
 		return nil, nil, nil, nil, errors.New("colgranule: invalid q5 did cardinality 0")
@@ -907,7 +1192,7 @@ func digestQ5Top(top []jsonBenchPartSpanPair) uint64 {
 	return digest
 }
 
-func queryDiagnosticsFromDecodedPrefix(columns []string, kernel string, rowsScanned int, lastGranule int, blocksDecoded int, bytesDecoded int) JSONBenchPartQueryDiagnostics {
+func queryDiagnosticsFromDecodedPrefix(part *ColumnPart, columns []string, kernel string, rowsScanned int, lastGranule int, blocksDecoded int, bytesDecoded int) JSONBenchPartQueryDiagnostics {
 	granulesDecoded := 0
 	if lastGranule >= 0 {
 		granulesDecoded = lastGranule + 1
@@ -920,6 +1205,7 @@ func queryDiagnosticsFromDecodedPrefix(columns []string, kernel string, rowsScan
 		BytesDecoded:       bytesDecoded,
 		ColumnsProjected:   append([]string(nil), columns...),
 		AggregateKernel:    kernel,
+		SortKey:            sortKeyColumns(part),
 	}
 }
 
@@ -1066,7 +1352,44 @@ func partColumnDiagnostics(part *ColumnPart, columns []string, kernel string) JS
 		BytesDecoded:       bytes,
 		ColumnsProjected:   append([]string(nil), columns...),
 		AggregateKernel:    kernel,
+		SortKey:            sortKeyColumns(part),
 	}
+}
+
+func blockMayContainSortKeyRanges(part *ColumnPart, block ColumnBlock, ranges []Int64RangePredicate) (bool, int, error) {
+	if len(part.Marks) == 0 {
+		return true, 0, nil
+	}
+	skipped := 0
+	for granule := block.Descriptor.FirstGranule; granule <= block.Descriptor.LastGranule; granule++ {
+		if granule < 0 || granule >= len(part.Marks) {
+			return false, skipped, fmt.Errorf("colgranule: block references granule %d outside marks=%d", granule, len(part.Marks))
+		}
+		mayContain, constrained, err := part.Marks[granule].MayContainRanges(ranges)
+		if err != nil {
+			return false, skipped, err
+		}
+		if !constrained || mayContain {
+			return true, 0, nil
+		}
+		skipped++
+	}
+	return false, skipped, nil
+}
+
+func blockGranuleSpan(block ColumnBlock) int {
+	return block.Descriptor.LastGranule - block.Descriptor.FirstGranule + 1
+}
+
+func sortKeyColumns(part *ColumnPart) []string {
+	if part == nil {
+		return nil
+	}
+	out := make([]string, 0, len(part.Descriptor.SortKey))
+	for _, column := range part.Descriptor.SortKey {
+		out = append(out, column.Column)
+	}
+	return out
 }
 
 func partCodeCardinality(part *ColumnPart, column string) (uint32, error) {

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -136,11 +136,84 @@ func TestRunJSONBenchPartQueriesSampleMatchesRawReference(t *testing.T) {
 			if timing.Diagnostics.AggregateKernel != "sort_key_early_stop_min_by_user" {
 				t.Fatalf("Q4 kernel=%q want sort-key early stop", timing.Diagnostics.AggregateKernel)
 			}
+			if !timing.Diagnostics.EarlyStopAvailable {
+				t.Fatalf("Q4 diagnostics missing early-stop label: %+v", timing.Diagnostics)
+			}
 		case "Q5":
 			if timing.Diagnostics.AggregateKernel != "fused_dense_span_by_user" {
 				t.Fatalf("Q5 kernel=%q want fused dense span", timing.Diagnostics.AggregateKernel)
 			}
 		}
+	}
+}
+
+func TestRunJSONBenchPartQ4FairnessQueries(t *testing.T) {
+	ds := syntheticJSONBenchDataset(256)
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	rawRows, rawDigest := runJSONBenchQ4(ds, codes)
+	timings, err := RunJSONBenchPartQ4FairnessQueries(ds, 32, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartQ4FairnessQueries: %v", err)
+	}
+	if len(timings) != 2 {
+		t.Fatalf("fairness timings=%d want 2", len(timings))
+	}
+	seen := map[string]bool{}
+	for _, timing := range timings {
+		seen[timing.Query] = true
+		if timing.ResultRows != rawRows || timing.ResultDigest != rawDigest {
+			t.Fatalf("%s rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, timing.ResultRows, timing.ResultDigest, rawRows, rawDigest)
+		}
+		if len(timing.Attempts) != 2 || timing.Attempts[0].Cache != "cold" || timing.Attempts[1].Cache != "warm" {
+			t.Fatalf("%s attempts=%+v want cold,warm labels", timing.Query, timing.Attempts)
+		}
+		switch timing.Query {
+		case "Q4a":
+			if timing.Diagnostics.AggregateKernel != "sort_key_early_stop_min_by_user" {
+				t.Fatalf("Q4a kernel=%q want early-stop kernel", timing.Diagnostics.AggregateKernel)
+			}
+			if !timing.Diagnostics.EarlyStopAvailable {
+				t.Fatalf("Q4a early_stop_available=false: %+v", timing.Diagnostics)
+			}
+			assertStringSliceEqual(t, timing.Diagnostics.SortKey, []string{"time_us"})
+		case "Q4b":
+			if timing.Diagnostics.AggregateKernel != "clickhouse_order_prefix_scan_min_by_user" {
+				t.Fatalf("Q4b kernel=%q want ClickHouse-order prefix scan", timing.Diagnostics.AggregateKernel)
+			}
+			if timing.Diagnostics.EarlyStopAvailable {
+				t.Fatalf("Q4b unexpectedly reported early-stop available: %+v", timing.Diagnostics)
+			}
+			if timing.Diagnostics.RowsScanned <= 3 {
+				t.Fatalf("Q4b rows scanned=%d want no top-3 global-time short-circuit", timing.Diagnostics.RowsScanned)
+			}
+			if timing.Diagnostics.GranulesSkipped == 0 {
+				t.Fatalf("Q4b skipped no granules; want ClickHouse-order prefix pruning diagnostics: %+v", timing.Diagnostics)
+			}
+			assertStringSliceEqual(t, timing.Diagnostics.SortKey, []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"})
+		default:
+			t.Fatalf("unexpected fairness query %s", timing.Query)
+		}
+	}
+	if !seen["Q4a"] || !seen["Q4b"] {
+		t.Fatalf("fairness queries seen=%v want Q4a and Q4b", seen)
+	}
+}
+
+func TestRunJSONBenchPartQ4EarlyStopRejectsClickHouseOrder(t *testing.T) {
+	ds := syntheticJSONBenchDataset(128)
+	part, err := BuildJSONBenchColumnPartForLayout(ds, 32, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPartForLayout: %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	if _, _, _, err := runJSONBenchPartQ4(part, codes, &jsonBenchPartQueryScratch{}); err == nil {
+		t.Fatal("runJSONBenchPartQ4 accepted ClickHouse-order part, want fail-closed early-stop precondition")
 	}
 }
 
@@ -338,6 +411,18 @@ func assertNotContainsString(t *testing.T, values []string, unwanted string) {
 	for _, value := range values {
 		if value == unwanted {
 			t.Fatalf("%q unexpectedly found in %v", unwanted, values)
+		}
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("slice=%v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("slice=%v want %v", got, want)
 		}
 	}
 }


### PR DESCRIPTION
Adds the M1A q4 sort-order fairness matrix for the column-granule experiment.

Summary:
- Keeps existing q4 as the time-ordered `Q4a` path with the fail-closed `time_us` early-stop precondition.
- Adds a ClickHouse-shaped TreeDB layout ordered by `kind_code`, `commit_operation_code`, `commit_collection_code`, `did_code`, `time_us`.
- Adds `Q4b`, which runs q4 on that ClickHouse-shaped layout without global `time_us` early-stop, while still using sort-prefix mark pruning.
- Extends q4 diagnostics with sort key and early-stop availability labels.
- Extends `jsonbench_compare` with a dedicated q4 fairness report section and optional ClickHouse `q4_fairness` input.

External harness:
- JSONBench PR: https://github.com/snissn/JSONBench/pull/2

1m local fairness result using `/Users/michaelseiler/data/bluesky/file_0001.json.gz` and ClickHouse result `clickhouse/local_results/run_20260515_184738_65766/result.json`:

| Query | TreeDB best | ClickHouse local | Speedup | TreeDB sort key | Early stop | Diagnostics | ClickHouse shape |
|---|---:|---:|---:|---|---|---|---|
| `Q4a` | 0.000015s | 0.017000s | 1159.06x | `time_us` | yes | rows=9 granules=1 skipped=0 decoded=1 blocks=5 bytes=40994 | `order_by_time_limit_1_by_user_limit_3` |
| `Q4b` | 0.001505s | 0.011000s | 7.31x | `kind_code,commit_operation_code,commit_collection_code,did_code,time_us` | no | rows=90112 granules=123 skipped=112 decoded=11 blocks=55 bytes=927825 | `aggregate_min_group_order_limit` |

Validation:
- `go test ./experiments/colgranule -run 'TestRunJSONBenchPartQ4FairnessQueries|TestRunJSONBenchPartQ4EarlyStopRejectsClickHouseOrder|TestRunJSONBenchPartQ4EarlyStopUsesTimePrefix|TestRunJSONBenchPartQueriesSampleMatchesRawReference' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestLoadJSONBenchColumnsLocal1MIfPresent|TestRunJSONBenchPartQueriesLocalIfPresent|TestRunJSONBenchPartQ4FairnessQueries' -count=1`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchQ4SortOrderFairness' -benchmem -count=3`
- `go test ./...`
- Generated `artifacts/colgranule_m1a_1m_report.md` with the augmented ClickHouse `q4_fairness` result.
