### PR TITLE
experiments/colgranule: add aggregate metadata prototype

### DIFF
--- a/experiments/colgranule/aggregate_metadata.go
+++ b/experiments/colgranule/aggregate_metadata.go
@@ -1,0 +1,241 @@
+package colgranule
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+const aggregateMetadataGroupMinMaxEntryBytes = 24
+
+type AggregateMetadataKind string
+
+const (
+	AggregateMetadataGroupMinMax AggregateMetadataKind = "group_min_max"
+)
+
+type AggregateMetadataFilter struct {
+	Column string `json:"column"`
+	Equals int64  `json:"equals"`
+}
+
+type AggregateMetadataDefinition struct {
+	Name           string                    `json:"name"`
+	Kind           AggregateMetadataKind     `json:"kind"`
+	GroupColumn    string                    `json:"group_column"`
+	ValueColumn    string                    `json:"value_column"`
+	Filters        []AggregateMetadataFilter `json:"filters"`
+	MaxBytesPerRow float64                   `json:"max_bytes_per_row"`
+}
+
+type AggregateMetadata struct {
+	Definition AggregateMetadataDefinition `json:"definition"`
+	Granules   []AggregateMetadataGranule  `json:"granules,omitempty"`
+	Stats      AggregateMetadataStats      `json:"stats"`
+}
+
+type AggregateMetadataStats struct {
+	Admitted            bool          `json:"admitted"`
+	RejectedReason      string        `json:"rejected_reason,omitempty"`
+	BuildDuration       time.Duration `json:"build_duration"`
+	Granules            int           `json:"granules"`
+	GranulesWithRows    int           `json:"granules_with_rows"`
+	RowsMatched         int           `json:"rows_matched"`
+	Entries             int           `json:"entries"`
+	ValueBytes          int           `json:"value_bytes"`
+	DescriptorBytes     int           `json:"descriptor_bytes"`
+	TotalBytes          int           `json:"total_bytes"`
+	BytesPerPartRow     float64       `json:"bytes_per_part_row"`
+	BytesPerMatchedRow  float64       `json:"bytes_per_matched_row"`
+	Compression         string        `json:"compression"`
+	AdmissionMaxBytes   float64       `json:"admission_max_bytes_per_row"`
+	AdmissionMeasuredBy string        `json:"admission_measured_by"`
+}
+
+type AggregateMetadataGranule struct {
+	GranuleOrdinal int                      `json:"granule_ordinal"`
+	FirstRow       int                      `json:"first_row"`
+	RowCount       int                      `json:"row_count"`
+	MatchedRows    int                      `json:"matched_rows"`
+	Entries        []AggregateMetadataEntry `json:"entries,omitempty"`
+}
+
+type AggregateMetadataEntry struct {
+	Group uint32 `json:"group"`
+	Count uint32 `json:"count"`
+	Min   int64  `json:"min"`
+	Max   int64  `json:"max"`
+}
+
+func (p *ColumnPart) AggregateMetadataByName(name string) (AggregateMetadata, bool) {
+	if p == nil || p.AggregateMetadata == nil {
+		return AggregateMetadata{}, false
+	}
+	metadata, ok := p.AggregateMetadata[name]
+	return metadata, ok
+}
+
+func normalizeAggregateMetadataDefinition(def AggregateMetadataDefinition, columns map[string]ColumnDefinition) (AggregateMetadataDefinition, error) {
+	if def.Name == "" {
+		return AggregateMetadataDefinition{}, errors.New("colgranule: aggregate metadata name is empty")
+	}
+	if def.Kind == "" {
+		def.Kind = AggregateMetadataGroupMinMax
+	}
+	if def.Kind != AggregateMetadataGroupMinMax {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: unsupported aggregate metadata kind %s", def.Kind)
+	}
+	groupDef, ok := columns[def.GroupColumn]
+	if !ok {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s is not declared", def.Name, def.GroupColumn)
+	}
+	if groupDef.Type != ColumnTypeLowCardinalityCode {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s type=%s want %s", def.Name, def.GroupColumn, groupDef.Type, ColumnTypeLowCardinalityCode)
+	}
+	valueDef, ok := columns[def.ValueColumn]
+	if !ok {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s is not declared", def.Name, def.ValueColumn)
+	}
+	if valueDef.Type != ColumnTypeInt64 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s type=%s want %s", def.Name, def.ValueColumn, valueDef.Type, ColumnTypeInt64)
+	}
+	seenFilters := make(map[string]struct{}, len(def.Filters))
+	for i, filter := range def.Filters {
+		if filter.Column == "" {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s filter %d has empty column", def.Name, i)
+		}
+		if _, ok := columns[filter.Column]; !ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s filter column %s is not declared", def.Name, filter.Column)
+		}
+		if _, ok := seenFilters[filter.Column]; ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s duplicate filter column %s", def.Name, filter.Column)
+		}
+		seenFilters[filter.Column] = struct{}{}
+	}
+	if def.MaxBytesPerRow < 0 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s max bytes per row %.3f is negative", def.Name, def.MaxBytesPerRow)
+	}
+	def.Filters = append([]AggregateMetadataFilter(nil), def.Filters...)
+	return def, nil
+}
+
+func (b *ColumnPartBuilder) buildAggregateMetadata(part *ColumnPart, batch ColumnBatch) error {
+	if len(b.opts.AggregateMetadata) == 0 {
+		return nil
+	}
+	part.AggregateMetadata = make(map[string]AggregateMetadata, len(b.opts.AggregateMetadata))
+	for _, def := range b.opts.AggregateMetadata {
+		metadata, err := b.buildGroupMinMaxMetadata(part, batch, def)
+		if err != nil {
+			return err
+		}
+		part.AggregateMetadata[def.Name] = metadata
+	}
+	return nil
+}
+
+func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch ColumnBatch, def AggregateMetadataDefinition) (AggregateMetadata, error) {
+	start := time.Now()
+	groupValues := batch.Columns[def.GroupColumn]
+	valueValues := batch.Columns[def.ValueColumn]
+	filterValues := make([][]int64, len(def.Filters))
+	for i, filter := range def.Filters {
+		filterValues[i] = batch.Columns[filter.Column]
+	}
+
+	metadata := AggregateMetadata{
+		Definition: AggregateMetadataDefinition{
+			Name:           def.Name,
+			Kind:           def.Kind,
+			GroupColumn:    def.GroupColumn,
+			ValueColumn:    def.ValueColumn,
+			Filters:        append([]AggregateMetadataFilter(nil), def.Filters...),
+			MaxBytesPerRow: def.MaxBytesPerRow,
+		},
+		Granules: make([]AggregateMetadataGranule, 0, len(part.Descriptor.Granules)),
+	}
+	groupIndex := make(map[uint32]int)
+	for _, granule := range part.Descriptor.Granules {
+		clear(groupIndex)
+		outGranule := AggregateMetadataGranule{
+			GranuleOrdinal: granule.Ordinal,
+			FirstRow:       granule.FirstRow,
+			RowCount:       granule.RowCount,
+		}
+		for partRow := granule.FirstRow; partRow < granule.FirstRow+granule.RowCount; partRow++ {
+			sourceRow := b.order[partRow]
+			if !aggregateMetadataFiltersMatch(filterValues, def.Filters, sourceRow) {
+				continue
+			}
+			group64 := groupValues[sourceRow]
+			if group64 < 0 || group64 > math.MaxUint32 {
+				return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s group value %d outside uint32", def.Name, group64)
+			}
+			group := uint32(group64)
+			value := valueValues[sourceRow]
+			outGranule.MatchedRows++
+			if index, ok := groupIndex[group]; ok {
+				entry := &outGranule.Entries[index]
+				entry.Count++
+				if value < entry.Min {
+					entry.Min = value
+				}
+				if value > entry.Max {
+					entry.Max = value
+				}
+				continue
+			}
+			if outGranule.MatchedRows > math.MaxUint32 {
+				return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s granule %d matched rows exceed uint32", def.Name, granule.Ordinal)
+			}
+			groupIndex[group] = len(outGranule.Entries)
+			outGranule.Entries = append(outGranule.Entries, AggregateMetadataEntry{
+				Group: group,
+				Count: 1,
+				Min:   value,
+				Max:   value,
+			})
+		}
+		sort.Slice(outGranule.Entries, func(i, j int) bool {
+			return outGranule.Entries[i].Group < outGranule.Entries[j].Group
+		})
+		if outGranule.MatchedRows > 0 {
+			metadata.Stats.GranulesWithRows++
+		}
+		metadata.Stats.RowsMatched += outGranule.MatchedRows
+		metadata.Stats.Entries += len(outGranule.Entries)
+		metadata.Granules = append(metadata.Granules, outGranule)
+	}
+	metadata.Stats.BuildDuration = time.Since(start)
+	metadata.Stats.Granules = len(part.Descriptor.Granules)
+	metadata.Stats.ValueBytes = metadata.Stats.Entries * aggregateMetadataGroupMinMaxEntryBytes
+	metadata.Stats.DescriptorBytes = len(part.Descriptor.Granules)*32 + len(def.Filters)*16 + 64
+	metadata.Stats.TotalBytes = metadata.Stats.ValueBytes + metadata.Stats.DescriptorBytes
+	metadata.Stats.Compression = "none_prototype"
+	metadata.Stats.AdmissionMaxBytes = def.MaxBytesPerRow
+	metadata.Stats.AdmissionMeasuredBy = "total_metadata_bytes / part_rows"
+	if part.Descriptor.RowCount > 0 {
+		metadata.Stats.BytesPerPartRow = float64(metadata.Stats.TotalBytes) / float64(part.Descriptor.RowCount)
+	}
+	if metadata.Stats.RowsMatched > 0 {
+		metadata.Stats.BytesPerMatchedRow = float64(metadata.Stats.TotalBytes) / float64(metadata.Stats.RowsMatched)
+	}
+	metadata.Stats.Admitted = true
+	if def.MaxBytesPerRow > 0 && metadata.Stats.BytesPerPartRow > def.MaxBytesPerRow {
+		metadata.Stats.Admitted = false
+		metadata.Stats.RejectedReason = fmt.Sprintf("bytes_per_part_row %.6f exceeds max %.6f", metadata.Stats.BytesPerPartRow, def.MaxBytesPerRow)
+		metadata.Granules = nil
+	}
+	return metadata, nil
+}
+
+func aggregateMetadataFiltersMatch(filterValues [][]int64, filters []AggregateMetadataFilter, row int) bool {
+	for i, filter := range filters {
+		if filterValues[i][row] != filter.Equals {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/colgranule/aggregate_metadata.go
+++ b/experiments/colgranule/aggregate_metadata.go
@@ -16,18 +16,48 @@ const (
 	AggregateMetadataGroupMinMax AggregateMetadataKind = "group_min_max"
 )
 
-type AggregateMetadataFilter struct {
-	Column string `json:"column"`
-	Equals int64  `json:"equals"`
+const AggregateMetadataDefinitionVersion uint16 = 1
+
+type AggregateMetadataScope string
+
+const (
+	AggregateMetadataScopeGranule AggregateMetadataScope = "granule"
+)
+
+type AggregateMetadataMeasureOp string
+
+const (
+	AggregateMetadataMeasureCount AggregateMetadataMeasureOp = "count"
+	AggregateMetadataMeasureMin   AggregateMetadataMeasureOp = "min"
+	AggregateMetadataMeasureMax   AggregateMetadataMeasureOp = "max"
+)
+
+type AggregateMetadataPredicateOp string
+
+const (
+	AggregateMetadataPredicateEq AggregateMetadataPredicateOp = "eq"
+)
+
+type AggregateMetadataMeasure struct {
+	Op     AggregateMetadataMeasureOp `json:"op"`
+	Column string                     `json:"column,omitempty"`
+}
+
+type AggregateMetadataPredicate struct {
+	Column string                       `json:"column"`
+	Op     AggregateMetadataPredicateOp `json:"op"`
+	Value  int64                        `json:"value"`
 }
 
 type AggregateMetadataDefinition struct {
-	Name           string                    `json:"name"`
-	Kind           AggregateMetadataKind     `json:"kind"`
-	GroupColumn    string                    `json:"group_column"`
-	ValueColumn    string                    `json:"value_column"`
-	Filters        []AggregateMetadataFilter `json:"filters"`
-	MaxBytesPerRow float64                   `json:"max_bytes_per_row"`
+	Name           string                       `json:"name"`
+	Version        uint16                       `json:"version"`
+	Kind           AggregateMetadataKind        `json:"kind"`
+	Scope          AggregateMetadataScope       `json:"scope"`
+	GroupKeys      []string                     `json:"group_keys"`
+	Measures       []AggregateMetadataMeasure   `json:"measures"`
+	Predicates     []AggregateMetadataPredicate `json:"predicates,omitempty"`
+	MaxBytesPerRow float64                      `json:"max_bytes_per_row"`
 }
 
 type AggregateMetadata struct {
@@ -81,44 +111,114 @@ func normalizeAggregateMetadataDefinition(def AggregateMetadataDefinition, colum
 	if def.Name == "" {
 		return AggregateMetadataDefinition{}, errors.New("colgranule: aggregate metadata name is empty")
 	}
+	if def.Version == 0 {
+		def.Version = AggregateMetadataDefinitionVersion
+	}
+	if def.Version != AggregateMetadataDefinitionVersion {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: unsupported aggregate metadata %s version %d", def.Name, def.Version)
+	}
 	if def.Kind == "" {
 		def.Kind = AggregateMetadataGroupMinMax
 	}
 	if def.Kind != AggregateMetadataGroupMinMax {
 		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: unsupported aggregate metadata kind %s", def.Kind)
 	}
-	groupDef, ok := columns[def.GroupColumn]
+	if def.Scope == "" {
+		def.Scope = AggregateMetadataScopeGranule
+	}
+	if def.Scope != AggregateMetadataScopeGranule {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: unsupported aggregate metadata %s scope %s", def.Name, def.Scope)
+	}
+	if len(def.GroupKeys) != 1 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s supports exactly one group key, got %d", def.Name, len(def.GroupKeys))
+	}
+	groupColumn := def.GroupKeys[0]
+	if groupColumn == "" {
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s has empty group key", def.Name)
+	}
+	groupDef, ok := columns[groupColumn]
 	if !ok {
-		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s is not declared", def.Name, def.GroupColumn)
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s is not declared", def.Name, groupColumn)
 	}
 	if groupDef.Type != ColumnTypeLowCardinalityCode {
-		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s type=%s want %s", def.Name, def.GroupColumn, groupDef.Type, ColumnTypeLowCardinalityCode)
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s group column %s type=%s want %s", def.Name, groupColumn, groupDef.Type, ColumnTypeLowCardinalityCode)
 	}
-	valueDef, ok := columns[def.ValueColumn]
+
+	valueColumn, err := aggregateMetadataGroupMinMaxValueColumn(def)
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	valueDef, ok := columns[valueColumn]
 	if !ok {
-		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s is not declared", def.Name, def.ValueColumn)
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s is not declared", def.Name, valueColumn)
 	}
 	if valueDef.Type != ColumnTypeInt64 {
-		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s type=%s want %s", def.Name, def.ValueColumn, valueDef.Type, ColumnTypeInt64)
+		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s value column %s type=%s want %s", def.Name, valueColumn, valueDef.Type, ColumnTypeInt64)
 	}
-	seenFilters := make(map[string]struct{}, len(def.Filters))
-	for i, filter := range def.Filters {
-		if filter.Column == "" {
-			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s filter %d has empty column", def.Name, i)
+
+	seenPredicates := make(map[string]struct{}, len(def.Predicates))
+	for i, predicate := range def.Predicates {
+		if predicate.Column == "" {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s predicate %d has empty column", def.Name, i)
 		}
-		if _, ok := columns[filter.Column]; !ok {
-			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s filter column %s is not declared", def.Name, filter.Column)
+		if predicate.Op != AggregateMetadataPredicateEq {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s predicate %d op %s is unsupported", def.Name, i, predicate.Op)
 		}
-		if _, ok := seenFilters[filter.Column]; ok {
-			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s duplicate filter column %s", def.Name, filter.Column)
+		if _, ok := columns[predicate.Column]; !ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s predicate column %s is not declared", def.Name, predicate.Column)
 		}
-		seenFilters[filter.Column] = struct{}{}
+		if _, ok := seenPredicates[predicate.Column]; ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s duplicate predicate column %s", def.Name, predicate.Column)
+		}
+		seenPredicates[predicate.Column] = struct{}{}
 	}
 	if def.MaxBytesPerRow < 0 {
 		return AggregateMetadataDefinition{}, fmt.Errorf("colgranule: aggregate metadata %s max bytes per row %.3f is negative", def.Name, def.MaxBytesPerRow)
 	}
-	def.Filters = append([]AggregateMetadataFilter(nil), def.Filters...)
+	def.GroupKeys = append([]string(nil), def.GroupKeys...)
+	def.Measures = append([]AggregateMetadataMeasure(nil), def.Measures...)
+	def.Predicates = append([]AggregateMetadataPredicate(nil), def.Predicates...)
 	return def, nil
+}
+
+func aggregateMetadataGroupMinMaxValueColumn(def AggregateMetadataDefinition) (string, error) {
+	if len(def.Measures) != 3 {
+		return "", fmt.Errorf("colgranule: aggregate metadata %s supports exactly count/min/max measures, got %d", def.Name, len(def.Measures))
+	}
+	var hasCount bool
+	var minColumn string
+	var maxColumn string
+	for i, measure := range def.Measures {
+		switch measure.Op {
+		case AggregateMetadataMeasureCount:
+			if hasCount {
+				return "", fmt.Errorf("colgranule: aggregate metadata %s has duplicate count measure", def.Name)
+			}
+			if measure.Column != "" {
+				return "", fmt.Errorf("colgranule: aggregate metadata %s count measure must not bind column %s", def.Name, measure.Column)
+			}
+			hasCount = true
+		case AggregateMetadataMeasureMin:
+			if minColumn != "" {
+				return "", fmt.Errorf("colgranule: aggregate metadata %s has duplicate min measure", def.Name)
+			}
+			minColumn = measure.Column
+		case AggregateMetadataMeasureMax:
+			if maxColumn != "" {
+				return "", fmt.Errorf("colgranule: aggregate metadata %s has duplicate max measure", def.Name)
+			}
+			maxColumn = measure.Column
+		default:
+			return "", fmt.Errorf("colgranule: aggregate metadata %s measure %d op %s is unsupported", def.Name, i, measure.Op)
+		}
+	}
+	if !hasCount || minColumn == "" || maxColumn == "" {
+		return "", fmt.Errorf("colgranule: aggregate metadata %s requires count, min, and max measures", def.Name)
+	}
+	if minColumn != maxColumn {
+		return "", fmt.Errorf("colgranule: aggregate metadata %s min column %s differs from max column %s", def.Name, minColumn, maxColumn)
+	}
+	return minColumn, nil
 }
 
 func (b *ColumnPartBuilder) buildAggregateMetadata(part *ColumnPart, batch ColumnBatch) error {
@@ -138,23 +238,21 @@ func (b *ColumnPartBuilder) buildAggregateMetadata(part *ColumnPart, batch Colum
 
 func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch ColumnBatch, def AggregateMetadataDefinition) (AggregateMetadata, error) {
 	start := time.Now()
-	groupValues := batch.Columns[def.GroupColumn]
-	valueValues := batch.Columns[def.ValueColumn]
-	filterValues := make([][]int64, len(def.Filters))
-	for i, filter := range def.Filters {
-		filterValues[i] = batch.Columns[filter.Column]
+	groupColumn := def.GroupKeys[0]
+	valueColumn, err := aggregateMetadataGroupMinMaxValueColumn(def)
+	if err != nil {
+		return AggregateMetadata{}, err
+	}
+	groupValues := batch.Columns[groupColumn]
+	valueValues := batch.Columns[valueColumn]
+	predicateValues := make([][]int64, len(def.Predicates))
+	for i, predicate := range def.Predicates {
+		predicateValues[i] = batch.Columns[predicate.Column]
 	}
 
 	metadata := AggregateMetadata{
-		Definition: AggregateMetadataDefinition{
-			Name:           def.Name,
-			Kind:           def.Kind,
-			GroupColumn:    def.GroupColumn,
-			ValueColumn:    def.ValueColumn,
-			Filters:        append([]AggregateMetadataFilter(nil), def.Filters...),
-			MaxBytesPerRow: def.MaxBytesPerRow,
-		},
-		Granules: make([]AggregateMetadataGranule, 0, len(part.Descriptor.Granules)),
+		Definition: cloneAggregateMetadataDefinition(def),
+		Granules:   make([]AggregateMetadataGranule, 0, len(part.Descriptor.Granules)),
 	}
 	groupIndex := make(map[uint32]int)
 	for _, granule := range part.Descriptor.Granules {
@@ -166,7 +264,7 @@ func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch Col
 		}
 		for partRow := granule.FirstRow; partRow < granule.FirstRow+granule.RowCount; partRow++ {
 			sourceRow := b.order[partRow]
-			if !aggregateMetadataFiltersMatch(filterValues, def.Filters, sourceRow) {
+			if !aggregateMetadataPredicatesMatch(predicateValues, def.Predicates, sourceRow) {
 				continue
 			}
 			group64 := groupValues[sourceRow]
@@ -211,7 +309,7 @@ func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch Col
 	metadata.Stats.BuildDuration = time.Since(start)
 	metadata.Stats.Granules = len(part.Descriptor.Granules)
 	metadata.Stats.ValueBytes = metadata.Stats.Entries * aggregateMetadataGroupMinMaxEntryBytes
-	metadata.Stats.DescriptorBytes = len(part.Descriptor.Granules)*32 + len(def.Filters)*16 + 64
+	metadata.Stats.DescriptorBytes = len(part.Descriptor.Granules)*32 + len(def.Predicates)*24 + len(def.Measures)*16 + len(def.GroupKeys)*16 + 72
 	metadata.Stats.TotalBytes = metadata.Stats.ValueBytes + metadata.Stats.DescriptorBytes
 	metadata.Stats.Compression = "none_prototype"
 	metadata.Stats.AdmissionMaxBytes = def.MaxBytesPerRow
@@ -231,9 +329,16 @@ func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch Col
 	return metadata, nil
 }
 
-func aggregateMetadataFiltersMatch(filterValues [][]int64, filters []AggregateMetadataFilter, row int) bool {
-	for i, filter := range filters {
-		if filterValues[i][row] != filter.Equals {
+func cloneAggregateMetadataDefinition(def AggregateMetadataDefinition) AggregateMetadataDefinition {
+	def.GroupKeys = append([]string(nil), def.GroupKeys...)
+	def.Measures = append([]AggregateMetadataMeasure(nil), def.Measures...)
+	def.Predicates = append([]AggregateMetadataPredicate(nil), def.Predicates...)
+	return def
+}
+
+func aggregateMetadataPredicatesMatch(predicateValues [][]int64, predicates []AggregateMetadataPredicate, row int) bool {
+	for i, predicate := range predicates {
+		if predicateValues[i][row] != predicate.Value {
 			return false
 		}
 	}

--- a/experiments/colgranule/aggregate_metadata_test.go
+++ b/experiments/colgranule/aggregate_metadata_test.go
@@ -1,0 +1,161 @@
+package colgranule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAggregateMetadataDefinitionExplicitShape(t *testing.T) {
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.AggregateMetadata = []AggregateMetadataDefinition{aggregateMetadataTestDefinition()}
+	part, err := BuildColumnPart(17, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {1, 2, 3, 4, 5},
+		"time_us":   {10, 20, 30, 40, 50},
+		"value":     {100, 200, 300, 400, 500},
+		"kind_code": {0, 1, 1, 2, 0},
+		"has_reply": {1, 1, 0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	metadata, ok := part.AggregateMetadataByName("test_kind_time")
+	if !ok {
+		t.Fatal("missing aggregate metadata")
+	}
+	if !metadata.Stats.Admitted {
+		t.Fatalf("metadata rejected: %+v", metadata.Stats)
+	}
+	if metadata.Definition.Version != AggregateMetadataDefinitionVersion {
+		t.Fatalf("version=%d want %d", metadata.Definition.Version, AggregateMetadataDefinitionVersion)
+	}
+	if metadata.Definition.Scope != AggregateMetadataScopeGranule {
+		t.Fatalf("scope=%q want %q", metadata.Definition.Scope, AggregateMetadataScopeGranule)
+	}
+	if !aggregateMetadataSingleGroupKey(metadata.Definition, "kind_code") || !aggregateMetadataHasCountMinMax(metadata.Definition, "time_us") {
+		t.Fatalf("definition not normalized to explicit count/min/max shape: %+v", metadata.Definition)
+	}
+	if len(metadata.Definition.Predicates) != 1 || !aggregateMetadataPredicateEquals(metadata.Definition.Predicates, "has_reply", 1) {
+		t.Fatalf("predicates=%+v want has_reply eq 1", metadata.Definition.Predicates)
+	}
+	if metadata.Stats.RowsMatched != 3 || metadata.Stats.Entries == 0 || len(metadata.Granules) != 3 {
+		t.Fatalf("stats=%+v granules=%d want matched=3 entries>0 granules=3", metadata.Stats, len(metadata.Granules))
+	}
+}
+
+func TestAggregateMetadataDefinitionRejectsUnsupportedShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(*AggregateMetadataDefinition)
+		want string
+	}{
+		{
+			name: "version",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Version = AggregateMetadataDefinitionVersion + 1
+			},
+			want: "version",
+		},
+		{
+			name: "scope",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Scope = AggregateMetadataScope("part")
+			},
+			want: "scope part",
+		},
+		{
+			name: "multi_group",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.GroupKeys = []string{"kind_code", "has_reply"}
+			},
+			want: "exactly one group key",
+		},
+		{
+			name: "group_type",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.GroupKeys = []string{"time_us"}
+			},
+			want: "want low_cardinality_code",
+		},
+		{
+			name: "predicate_op",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Predicates = []AggregateMetadataPredicate{{Column: "has_reply", Op: AggregateMetadataPredicateOp("range"), Value: 1}}
+			},
+			want: "op range is unsupported",
+		},
+		{
+			name: "duplicate_predicate",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Predicates = append(def.Predicates, def.Predicates[0])
+			},
+			want: "duplicate predicate column",
+		},
+		{
+			name: "missing_measure",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Measures = def.Measures[:2]
+			},
+			want: "count/min/max",
+		},
+		{
+			name: "unsupported_measure",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Measures[0] = AggregateMetadataMeasure{Op: AggregateMetadataMeasureOp("sum"), Column: "time_us"}
+			},
+			want: "op sum is unsupported",
+		},
+		{
+			name: "count_column",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Measures[0].Column = "time_us"
+			},
+			want: "count measure must not bind column",
+		},
+		{
+			name: "mismatched_value_column",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Measures[2].Column = "value"
+			},
+			want: "differs from max column",
+		},
+		{
+			name: "value_type",
+			edit: func(def *AggregateMetadataDefinition) {
+				def.Measures[1].Column = "kind_code"
+				def.Measures[2].Column = "kind_code"
+			},
+			want: "want int64",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+			def := aggregateMetadataTestDefinition()
+			tc.edit(&def)
+			opts.AggregateMetadata = []AggregateMetadataDefinition{def}
+			_, err := NewColumnPartBuilder(opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NewColumnPartBuilder err=%v want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func aggregateMetadataTestDefinition() AggregateMetadataDefinition {
+	return AggregateMetadataDefinition{
+		Name:      "test_kind_time",
+		Version:   AggregateMetadataDefinitionVersion,
+		Kind:      AggregateMetadataGroupMinMax,
+		Scope:     AggregateMetadataScopeGranule,
+		GroupKeys: []string{"kind_code"},
+		Measures: []AggregateMetadataMeasure{
+			{Op: AggregateMetadataMeasureCount},
+			{Op: AggregateMetadataMeasureMin, Column: "time_us"},
+			{Op: AggregateMetadataMeasureMax, Column: "time_us"},
+		},
+		Predicates: []AggregateMetadataPredicate{
+			{Column: "has_reply", Op: AggregateMetadataPredicateEq, Value: 1},
+		},
+		MaxBytesPerRow: 256,
+	}
+}

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -50,27 +50,28 @@ type clickHouseQ4FairnessResult struct {
 }
 
 type comparisonRaw struct {
-	GeneratedAt             string                                `json:"generated_at"`
-	DataPath                string                                `json:"data_path"`
-	Limit                   int                                   `json:"limit"`
-	Rows                    int                                   `json:"rows"`
-	Files                   []string                              `json:"files"`
-	InputBytes              int64                                 `json:"input_bytes"`
-	RowsPerGranule          int                                   `json:"rows_per_granule"`
-	LoadDuration            time.Duration                         `json:"load_duration"`
-	ClickHouseLocal         clickHouseResult                      `json:"clickhouse_local"`
-	RemainingTreeDB         remainingTreeDBResult                 `json:"remaining_treedb"`
-	RemainingTreeDBJSON     remainingTreeDBResult                 `json:"remaining_treedb_json"`
-	RemainingTreeDBTpl      remainingTreeDBResult                 `json:"remaining_treedb_template_v1"`
-	ConservativeBSON        remainingTreeDBResult                 `json:"conservative_remaining_treedb_bson"`
-	ConservativeJSON        remainingTreeDBResult                 `json:"conservative_remaining_treedb_json"`
-	ConservativeTpl         remainingTreeDBResult                 `json:"conservative_remaining_treedb_template_v1"`
-	RawTreeDBJSON           remainingTreeDBResult                 `json:"raw_treedb_json"`
-	QueryTimings            []colgranule.JSONBenchQueryTiming     `json:"query_timings"`
-	EncodedPartQueryTimings []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_query_timings"`
-	EncodedPartQ4Fairness   []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_q4_fairness_timings"`
-	ColumnSummaries         []colgranule.ColumnCodecSummary       `json:"column_summaries"`
-	BestColumnStorage       []bestColumnStorage                   `json:"best_column_storage"`
+	GeneratedAt              string                                `json:"generated_at"`
+	DataPath                 string                                `json:"data_path"`
+	Limit                    int                                   `json:"limit"`
+	Rows                     int                                   `json:"rows"`
+	Files                    []string                              `json:"files"`
+	InputBytes               int64                                 `json:"input_bytes"`
+	RowsPerGranule           int                                   `json:"rows_per_granule"`
+	LoadDuration             time.Duration                         `json:"load_duration"`
+	ClickHouseLocal          clickHouseResult                      `json:"clickhouse_local"`
+	RemainingTreeDB          remainingTreeDBResult                 `json:"remaining_treedb"`
+	RemainingTreeDBJSON      remainingTreeDBResult                 `json:"remaining_treedb_json"`
+	RemainingTreeDBTpl       remainingTreeDBResult                 `json:"remaining_treedb_template_v1"`
+	ConservativeBSON         remainingTreeDBResult                 `json:"conservative_remaining_treedb_bson"`
+	ConservativeJSON         remainingTreeDBResult                 `json:"conservative_remaining_treedb_json"`
+	ConservativeTpl          remainingTreeDBResult                 `json:"conservative_remaining_treedb_template_v1"`
+	RawTreeDBJSON            remainingTreeDBResult                 `json:"raw_treedb_json"`
+	QueryTimings             []colgranule.JSONBenchQueryTiming     `json:"query_timings"`
+	EncodedPartQueryTimings  []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_query_timings"`
+	EncodedPartQ4Fairness    []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_q4_fairness_timings"`
+	AggregateMetadataTimings []colgranule.JSONBenchPartQueryTiming `json:"aggregate_metadata_timings"`
+	ColumnSummaries          []colgranule.ColumnCodecSummary       `json:"column_summaries"`
+	BestColumnStorage        []bestColumnStorage                   `json:"best_column_storage"`
 }
 
 type remainingTreeDBResult struct {
@@ -139,6 +140,8 @@ func main() {
 	must(err)
 	encodedPartQ4Fairness, err := colgranule.RunJSONBenchPartQ4FairnessQueries(ds, *rowsPerGranule, *attempts)
 	must(err)
+	aggregateMetadataTimings, err := colgranule.RunJSONBenchPartAggregateMetadataQueries(ds, *rowsPerGranule, *attempts)
+	must(err)
 	var remaining remainingTreeDBResult
 	var remainingJSON remainingTreeDBResult
 	var remainingTpl remainingTreeDBResult
@@ -164,27 +167,28 @@ func main() {
 	}
 
 	raw := comparisonRaw{
-		GeneratedAt:             time.Now().UTC().Format(time.RFC3339),
-		DataPath:                *data,
-		Limit:                   *limit,
-		Rows:                    ds.Rows,
-		Files:                   ds.Files,
-		InputBytes:              inputBytes(ds.Files),
-		RowsPerGranule:          *rowsPerGranule,
-		LoadDuration:            loadDuration,
-		ClickHouseLocal:         readClickHouseResult(*clickHouseLocalPath),
-		RemainingTreeDB:         remaining,
-		RemainingTreeDBJSON:     remainingJSON,
-		RemainingTreeDBTpl:      remainingTpl,
-		ConservativeBSON:        conservativeBSON,
-		ConservativeJSON:        conservativeJSON,
-		ConservativeTpl:         conservativeTpl,
-		RawTreeDBJSON:           rawTreeDBJSON,
-		QueryTimings:            timings,
-		EncodedPartQueryTimings: encodedPartTimings,
-		EncodedPartQ4Fairness:   encodedPartQ4Fairness,
-		ColumnSummaries:         summaries,
-		BestColumnStorage:       bestColumns(summaries),
+		GeneratedAt:              time.Now().UTC().Format(time.RFC3339),
+		DataPath:                 *data,
+		Limit:                    *limit,
+		Rows:                     ds.Rows,
+		Files:                    ds.Files,
+		InputBytes:               inputBytes(ds.Files),
+		RowsPerGranule:           *rowsPerGranule,
+		LoadDuration:             loadDuration,
+		ClickHouseLocal:          readClickHouseResult(*clickHouseLocalPath),
+		RemainingTreeDB:          remaining,
+		RemainingTreeDBJSON:      remainingJSON,
+		RemainingTreeDBTpl:       remainingTpl,
+		ConservativeBSON:         conservativeBSON,
+		ConservativeJSON:         conservativeJSON,
+		ConservativeTpl:          conservativeTpl,
+		RawTreeDBJSON:            rawTreeDBJSON,
+		QueryTimings:             timings,
+		EncodedPartQueryTimings:  encodedPartTimings,
+		EncodedPartQ4Fairness:    encodedPartQ4Fairness,
+		AggregateMetadataTimings: aggregateMetadataTimings,
+		ColumnSummaries:          summaries,
+		BestColumnStorage:        bestColumns(summaries),
 	}
 
 	writeJSON(*outJSON, raw)
@@ -919,6 +923,29 @@ func writeMarkdown(path string, raw comparisonRaw) {
 				localShape)
 		}
 	}
+	if len(raw.AggregateMetadataTimings) > 0 {
+		fmt.Fprintf(&b, "\n## Aggregate Metadata Prototype\n\n")
+		fmt.Fprintf(&b, "These M1B timings use exact per-granule `did_code -> min(time_us), max(time_us), count` metadata for declared post/create rows. The prototype stores metadata uncompressed in memory and reports build cost plus byte accounting so later file-backed work can decide admission and compression policies.\n\n")
+		fmt.Fprintf(&b, "| Query | Metadata best | Best cache | Baseline | Speedup | Kernel | Metadata rows | Entries | Bytes | B/part row | Build | Compression |\n")
+		fmt.Fprintf(&b, "|---|---:|---|---:|---:|---|---:|---:|---:|---:|---:|---|\n")
+		for _, timing := range raw.AggregateMetadataTimings {
+			d := timing.Diagnostics
+			baseline := aggregateMetadataBaselineSeconds(raw, timing.Query)
+			fmt.Fprintf(&b, "| %s | %.6fs | %s | %s | %s | `%s` | %d | %d | %d | %.3f | %.6fs | `%s` |\n",
+				timing.Query,
+				timing.Best.Seconds(),
+				timing.BestCache,
+				formatSeconds(baseline),
+				formatSpeedup(timing.Best.Seconds(), baseline),
+				d.AggregateKernel,
+				d.AggregateMetadataRows,
+				d.AggregateMetadataEntries,
+				d.AggregateMetadataBytes,
+				d.AggregateMetadataBytesPerRow,
+				d.AggregateMetadataBuildDuration.Seconds(),
+				d.AggregateMetadataCompression)
+		}
+	}
 	fmt.Fprintf(&b, "\n## Storage Footprint\n\n")
 	allBest := bestTotal(raw.BestColumnStorage, nil)
 	queryBest := bestTotal(raw.BestColumnStorage, queryPathColumns())
@@ -1087,6 +1114,24 @@ func clickHouseQ4FairnessBest(result clickHouseResult, query string) clickHouseQ
 		}
 	}
 	return out
+}
+
+func aggregateMetadataBaselineSeconds(raw comparisonRaw, query string) float64 {
+	switch query {
+	case "Q4b-meta":
+		for _, timing := range raw.EncodedPartQ4Fairness {
+			if timing.Query == "Q4b" {
+				return timing.Best.Seconds()
+			}
+		}
+	case "Q5-meta":
+		for _, timing := range raw.EncodedPartQueryTimings {
+			if timing.Query == "Q5" {
+				return timing.Best.Seconds()
+			}
+		}
+	}
+	return 0
 }
 
 func queryPathColumns() map[string]bool {

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -926,22 +926,25 @@ func writeMarkdown(path string, raw comparisonRaw) {
 	if len(raw.AggregateMetadataTimings) > 0 {
 		fmt.Fprintf(&b, "\n## Aggregate Metadata Prototype\n\n")
 		fmt.Fprintf(&b, "These M1B timings use exact per-granule `did_code -> min(time_us), max(time_us), count` metadata for declared post/create rows. The prototype stores metadata uncompressed in memory and reports build cost plus byte accounting so later file-backed work can decide admission and compression policies.\n\n")
-		fmt.Fprintf(&b, "| Query | Metadata best | Best cache | Baseline | Speedup | Kernel | Metadata rows | Entries | Bytes | B/part row | Build | Compression |\n")
-		fmt.Fprintf(&b, "|---|---:|---|---:|---:|---|---:|---:|---:|---:|---:|---|\n")
+		fmt.Fprintf(&b, "| Query | Metadata best | Best cache | Baseline | Speedup | Break-even | Kernel | Metadata rows | Entries | Entries/matched row | Bytes | B/part row | B/matched row | Build | Compression |\n")
+		fmt.Fprintf(&b, "|---|---:|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---|\n")
 		for _, timing := range raw.AggregateMetadataTimings {
 			d := timing.Diagnostics
 			baseline := aggregateMetadataBaselineSeconds(raw, timing.Query)
-			fmt.Fprintf(&b, "| %s | %.6fs | %s | %s | %s | `%s` | %d | %d | %d | %.3f | %.6fs | `%s` |\n",
+			fmt.Fprintf(&b, "| %s | %.6fs | %s | %s | %s | %s | `%s` | %d | %d | %.3f | %d | %.3f | %.3f | %.6fs | `%s` |\n",
 				timing.Query,
 				timing.Best.Seconds(),
 				timing.BestCache,
 				formatSeconds(baseline),
 				formatSpeedup(timing.Best.Seconds(), baseline),
+				formatBreakEvenQueries(d.AggregateMetadataBuildDuration.Seconds(), baseline, timing.Best.Seconds()),
 				d.AggregateKernel,
 				d.AggregateMetadataRows,
 				d.AggregateMetadataEntries,
+				ratio(float64(d.AggregateMetadataEntries), float64(d.AggregateMetadataRows)),
 				d.AggregateMetadataBytes,
 				d.AggregateMetadataBytesPerRow,
+				ratio(float64(d.AggregateMetadataBytes), float64(d.AggregateMetadataRows)),
 				d.AggregateMetadataBuildDuration.Seconds(),
 				d.AggregateMetadataCompression)
 		}
@@ -1177,6 +1180,14 @@ func formatSpeedup(numerator, denominator float64) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.2fx", ratio(denominator, numerator))
+}
+
+func formatBreakEvenQueries(buildSeconds, baselineSeconds, metadataSeconds float64) string {
+	saved := baselineSeconds - metadataSeconds
+	if buildSeconds <= 0 || saved <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f", buildSeconds/saved)
 }
 
 func mib(bytes int64) float64 {

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -152,6 +152,97 @@ func BenchmarkJSONBenchQ4SortOrderFairness(b *testing.B) {
 	}
 }
 
+func BenchmarkJSONBenchAggregateMetadataQueries(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	timePart, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		b.Fatalf("BuildJSONBenchColumnPartWithAggregateMetadataForLayout(time): %v", err)
+	}
+	clickHouseOrderPart, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		b.Fatalf("BuildJSONBenchColumnPartWithAggregateMetadataForLayout(clickhouse): %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		b.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	queries := []struct {
+		name string
+		part *ColumnPart
+		run  jsonBenchPartQueryRunner
+	}{
+		{"Q4b_metadata_min_by_user", clickHouseOrderPart, runJSONBenchPartQ4ClickHouseOrderAggregateMetadata},
+		{"Q5_metadata_span_by_user", timePart, runJSONBenchPartQ5AggregateMetadata},
+		{"Q4b_row_scan_min_by_user", clickHouseOrderPart, runJSONBenchPartQ4ClickHouseOrder},
+		{"Q5_row_scan_span_by_user", timePart, runJSONBenchPartQ5},
+	}
+	for _, q := range queries {
+		b.Run(q.name, func(b *testing.B) {
+			b.ReportAllocs()
+			scratch := &jsonBenchPartQueryScratch{
+				scanner:   q.part.NewScanner(),
+				projected: make(map[string][]int64, 6),
+			}
+			rows, digest, diagnostics, err := q.run(q.part, codes, scratch)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink += int64(rows) + int64(digest)
+			rowsMeasured := diagnostics.RowsScanned
+			if rowsMeasured == 0 {
+				rowsMeasured = diagnostics.AggregateMetadataEntries
+			}
+			if rowsMeasured == 0 {
+				rowsMeasured = ds.Rows
+			}
+			valueBytes := rowsMeasured * len(diagnostics.ColumnsProjected) * 8
+			if valueBytes == 0 {
+				valueBytes = rowsMeasured * 8
+			}
+			b.SetBytes(int64(valueBytes))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, digest, diagnostics, err = q.run(q.part, codes, scratch)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(rows) + int64(digest)
+			}
+			rowsMeasured = diagnostics.RowsScanned
+			storedBytes := diagnostics.BytesDecoded
+			if rowsMeasured == 0 {
+				rowsMeasured = diagnostics.AggregateMetadataEntries
+				storedBytes = diagnostics.AggregateMetadataBytes
+			}
+			reportGranuleBenchMetrics(b, rowsMeasured, valueBytes, storedBytes)
+		})
+	}
+}
+
+func BenchmarkJSONBenchAggregateMetadataBuild(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	for _, layout := range []JSONBenchColumnPartLayout{
+		JSONBenchColumnPartLayoutTimeUS,
+		JSONBenchColumnPartLayoutClickHouseFilterUserTime,
+	} {
+		b.Run(string(layout), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(ds.Rows * len(ds.Columns) * 8))
+			for i := 0; i < b.N; i++ {
+				part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, layout)
+				if err != nil {
+					b.Fatal(err)
+				}
+				metadata, ok := part.AggregateMetadataByName(jsonBenchPostCreateDidTimeMetadata)
+				if !ok || !metadata.Stats.Admitted {
+					b.Fatalf("metadata missing/rejected: %+v", metadata.Stats)
+				}
+				benchSink += int64(metadata.Stats.TotalBytes)
+			}
+		})
+	}
+}
+
 func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
 	columns := map[string][]int64{
 		"row_index":              make([]int64, rows),

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -27,17 +27,25 @@ type JSONBenchPartQueryAttempt struct {
 }
 
 type JSONBenchPartQueryDiagnostics struct {
-	RowsScanned        int      `json:"rows_scanned"`
-	GranulesConsidered int      `json:"granules_considered"`
-	GranulesSkipped    int      `json:"granules_skipped"`
-	GranulesDecoded    int      `json:"granules_decoded"`
-	BlocksDecoded      int      `json:"blocks_decoded"`
-	BytesDecoded       int      `json:"bytes_decoded"`
-	ColumnsProjected   []string `json:"columns_projected"`
-	AggregateKernel    string   `json:"aggregate_kernel"`
-	CacheState         string   `json:"cache_state"`
-	SortKey            []string `json:"sort_key"`
-	EarlyStopAvailable bool     `json:"early_stop_available"`
+	RowsScanned                    int           `json:"rows_scanned"`
+	GranulesConsidered             int           `json:"granules_considered"`
+	GranulesSkipped                int           `json:"granules_skipped"`
+	GranulesDecoded                int           `json:"granules_decoded"`
+	BlocksDecoded                  int           `json:"blocks_decoded"`
+	BytesDecoded                   int           `json:"bytes_decoded"`
+	ColumnsProjected               []string      `json:"columns_projected"`
+	AggregateKernel                string        `json:"aggregate_kernel"`
+	CacheState                     string        `json:"cache_state"`
+	SortKey                        []string      `json:"sort_key"`
+	EarlyStopAvailable             bool          `json:"early_stop_available"`
+	AggregateMetadataUsed          bool          `json:"aggregate_metadata_used"`
+	AggregateMetadataName          string        `json:"aggregate_metadata_name,omitempty"`
+	AggregateMetadataRows          int           `json:"aggregate_metadata_rows,omitempty"`
+	AggregateMetadataEntries       int           `json:"aggregate_metadata_entries,omitempty"`
+	AggregateMetadataBytes         int           `json:"aggregate_metadata_bytes,omitempty"`
+	AggregateMetadataBuildDuration time.Duration `json:"aggregate_metadata_build_duration,omitempty"`
+	AggregateMetadataBytesPerRow   float64       `json:"aggregate_metadata_bytes_per_row,omitempty"`
+	AggregateMetadataCompression   string        `json:"aggregate_metadata_compression,omitempty"`
 }
 
 type jsonBenchPartQueryScratch struct {
@@ -83,12 +91,22 @@ var (
 	jsonBenchPartQ5Columns = []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"}
 )
 
+const jsonBenchPostCreateDidTimeMetadata = "jsonbench_post_create_did_time"
+
 func BuildJSONBenchColumnPart(ds JSONBenchDataset, rowsPerGranule int) (*ColumnPart, error) {
 	return BuildJSONBenchColumnPartForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
 }
 
 func BuildJSONBenchColumnPartForLayout(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (*ColumnPart, error) {
 	opts, err := JSONBenchColumnPartOptionsForLayout(ds, rowsPerGranule, layout)
+	if err != nil {
+		return nil, err
+	}
+	return BuildColumnPart(1, opts, ColumnBatch{Rows: ds.Rows, Columns: ds.Columns})
+}
+
+func BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (*ColumnPart, error) {
+	opts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds, rowsPerGranule, layout)
 	if err != nil {
 		return nil, err
 	}
@@ -151,6 +169,38 @@ func JSONBenchColumnPartOptionsForLayout(ds JSONBenchDataset, rowsPerGranule int
 			RowsPerGranule:        rowsPerGranule,
 			DefaultCodecBlockRows: rowsPerGranule,
 		},
+	}, nil
+}
+
+func JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (ColumnStoreOptions, error) {
+	opts, err := JSONBenchColumnPartOptionsForLayout(ds, rowsPerGranule, layout)
+	if err != nil {
+		return ColumnStoreOptions{}, err
+	}
+	def, err := JSONBenchPostCreateDidTimeAggregateMetadataDefinition(ds)
+	if err != nil {
+		return ColumnStoreOptions{}, err
+	}
+	opts.AggregateMetadata = append(opts.AggregateMetadata, def)
+	return opts, nil
+}
+
+func JSONBenchPostCreateDidTimeAggregateMetadataDefinition(ds JSONBenchDataset) (AggregateMetadataDefinition, error) {
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	return AggregateMetadataDefinition{
+		Name:        jsonBenchPostCreateDidTimeMetadata,
+		Kind:        AggregateMetadataGroupMinMax,
+		GroupColumn: "did_code",
+		ValueColumn: "time_us",
+		Filters: []AggregateMetadataFilter{
+			{Column: "kind_code", Equals: codes.kindCommit},
+			{Column: "commit_operation_code", Equals: codes.operationCreate},
+			{Column: "commit_collection_code", Equals: codes.collectionPost},
+		},
+		MaxBytesPerRow: 64,
 	}, nil
 }
 
@@ -286,6 +336,77 @@ func RunJSONBenchPartQ4FairnessQueries(ds JSONBenchDataset, rowsPerGranule int, 
 			rows, digest, diagnostics, err := q.run(q.part, codes, scratch)
 			if err != nil {
 				return nil, fmt.Errorf("%s encoded part query: %w", q.name, err)
+			}
+			elapsed := time.Since(start)
+			diagnostics.CacheState = cache
+			attempt := JSONBenchPartQueryAttempt{
+				Cache:        cache,
+				Duration:     elapsed,
+				ResultRows:   rows,
+				ResultDigest: digest,
+				Diagnostics:  diagnostics,
+			}
+			timing.Attempts = append(timing.Attempts, attempt)
+			timing.ResultRows = rows
+			timing.ResultDigest = digest
+			if timing.Best == 0 || elapsed < timing.Best {
+				timing.Best = elapsed
+				timing.BestCache = cache
+				timing.Diagnostics = diagnostics
+			}
+		}
+		out = append(out, timing)
+	}
+	return out, nil
+}
+
+func RunJSONBenchPartAggregateMetadataQueries(ds JSONBenchDataset, rowsPerGranule int, attempts int) ([]JSONBenchPartQueryTiming, error) {
+	if attempts <= 0 {
+		attempts = 3
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		return nil, err
+	}
+	timePart, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		return nil, err
+	}
+	clickHouseOrderPart, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, rowsPerGranule, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		return nil, err
+	}
+	queries := []struct {
+		name        string
+		description string
+		engine      string
+		part        *ColumnPart
+		run         jsonBenchPartQueryRunner
+	}{
+		{"Q4b-meta", "Top 3 post veterans from exact post/create did/time metadata", "encoded_column_part_aggregate_metadata_q4b", clickHouseOrderPart, runJSONBenchPartQ4ClickHouseOrderAggregateMetadata},
+		{"Q5-meta", "Longest post activity spans from exact post/create did/time metadata", "encoded_column_part_aggregate_metadata_q5", timePart, runJSONBenchPartQ5AggregateMetadata},
+	}
+	out := make([]JSONBenchPartQueryTiming, 0, len(queries))
+	for _, q := range queries {
+		timing := JSONBenchPartQueryTiming{
+			Query:       q.name,
+			Description: q.description,
+			Engine:      q.engine,
+			Attempts:    make([]JSONBenchPartQueryAttempt, 0, attempts),
+		}
+		scratch := &jsonBenchPartQueryScratch{
+			scanner:   q.part.NewScanner(),
+			projected: make(map[string][]int64, 6),
+		}
+		for i := 0; i < attempts; i++ {
+			cache := "cold"
+			if i > 0 {
+				cache = "warm"
+			}
+			start := time.Now()
+			rows, digest, diagnostics, err := q.run(q.part, codes, scratch)
+			if err != nil {
+				return nil, fmt.Errorf("%s aggregate metadata query: %w", q.name, err)
 			}
 			elapsed := time.Since(start)
 			diagnostics.CacheState = cache
@@ -774,6 +895,44 @@ func runJSONBenchPartQ4ClickHouseOrder(part *ColumnPart, codes queryCodeSet, scr
 	return len(top), digestQ4Top(top), diagnostics, nil
 }
 
+func runJSONBenchPartQ4ClickHouseOrderAggregateMetadata(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	metadata, err := requireJSONBenchPostCreateDidTimeMetadata(part, codes)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	seen, minTime, users, err := scratch.resetQ4FullDense(didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	for _, granule := range metadata.Granules {
+		for _, entry := range granule.Entries {
+			if entry.Group >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: aggregate metadata did code %d outside cardinality %d", entry.Group, didCardinality)
+			}
+			if bitsetTestAndSet(seen, entry.Group) {
+				if entry.Min < minTime[entry.Group] {
+					minTime[entry.Group] = entry.Min
+				}
+				continue
+			}
+			minTime[entry.Group] = entry.Min
+			users = append(users, entry.Group)
+		}
+	}
+	scratch.q4Users = users
+	top := scratch.q4Pairs[:0]
+	for _, user := range users {
+		top = insertQ4Top(top, jsonBenchPartTimePair{user: int64(user), t: minTime[user]})
+	}
+	scratch.q4Pairs = top
+	diagnostics := queryDiagnosticsFromAggregateMetadata(part, metadata, jsonBenchPartQ4Columns, "aggregate_metadata_min_by_user")
+	return len(top), digestQ4Top(top), diagnostics, nil
+}
+
 func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
 	kindBlocks, err := lowCardinalityBlocks(part, "kind_code")
 	if err != nil {
@@ -879,6 +1038,48 @@ func runJSONBenchPartQ5(part *ColumnPart, codes queryCodeSet, scratch *jsonBench
 	}
 	scratch.q5Pairs = top
 	diagnostics := partColumnDiagnostics(part, jsonBenchPartQ5Columns, "fused_dense_span_by_user")
+	return len(top), digestQ5Top(top), diagnostics, nil
+}
+
+func runJSONBenchPartQ5AggregateMetadata(part *ColumnPart, codes queryCodeSet, scratch *jsonBenchPartQueryScratch) (int, uint64, JSONBenchPartQueryDiagnostics, error) {
+	metadata, err := requireJSONBenchPostCreateDidTimeMetadata(part, codes)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	didCardinality, err := partCodeCardinality(part, "did_code")
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	seen, minTime, maxTime, users, err := scratch.resetQ5Dense(didCardinality)
+	if err != nil {
+		return 0, 0, JSONBenchPartQueryDiagnostics{}, err
+	}
+	for _, granule := range metadata.Granules {
+		for _, entry := range granule.Entries {
+			if entry.Group >= didCardinality {
+				return 0, 0, JSONBenchPartQueryDiagnostics{}, fmt.Errorf("colgranule: aggregate metadata did code %d outside cardinality %d", entry.Group, didCardinality)
+			}
+			if bitsetTestAndSet(seen, entry.Group) {
+				if entry.Min < minTime[entry.Group] {
+					minTime[entry.Group] = entry.Min
+				}
+				if entry.Max > maxTime[entry.Group] {
+					maxTime[entry.Group] = entry.Max
+				}
+				continue
+			}
+			minTime[entry.Group] = entry.Min
+			maxTime[entry.Group] = entry.Max
+			users = append(users, entry.Group)
+		}
+	}
+	scratch.q5Users = users
+	top := scratch.q5Pairs[:0]
+	for _, user := range users {
+		top = insertQ5Top(top, jsonBenchPartSpanPair{user: int64(user), span: maxTime[user] - minTime[user]})
+	}
+	scratch.q5Pairs = top
+	diagnostics := queryDiagnosticsFromAggregateMetadata(part, metadata, jsonBenchPartQ5Columns, "aggregate_metadata_span_by_user")
 	return len(top), digestQ5Top(top), diagnostics, nil
 }
 
@@ -1176,6 +1377,38 @@ func q5PairLess(left jsonBenchPartSpanPair, right jsonBenchPartSpanPair) bool {
 	return left.span > right.span
 }
 
+func requireJSONBenchPostCreateDidTimeMetadata(part *ColumnPart, codes queryCodeSet) (AggregateMetadata, error) {
+	metadata, ok := part.AggregateMetadataByName(jsonBenchPostCreateDidTimeMetadata)
+	if !ok {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: missing aggregate metadata %s", jsonBenchPostCreateDidTimeMetadata)
+	}
+	if !metadata.Stats.Admitted {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s rejected by admission: %s", metadata.Definition.Name, metadata.Stats.RejectedReason)
+	}
+	if metadata.Definition.Kind != AggregateMetadataGroupMinMax || metadata.Definition.GroupColumn != "did_code" || metadata.Definition.ValueColumn != "time_us" {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s has incompatible definition %+v", metadata.Definition.Name, metadata.Definition)
+	}
+	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "kind_code", codes.kindCommit) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing kind_code=%d filter", metadata.Definition.Name, codes.kindCommit)
+	}
+	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "commit_operation_code", codes.operationCreate) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_operation_code=%d filter", metadata.Definition.Name, codes.operationCreate)
+	}
+	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "commit_collection_code", codes.collectionPost) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_collection_code=%d filter", metadata.Definition.Name, codes.collectionPost)
+	}
+	return metadata, nil
+}
+
+func aggregateMetadataFilterEquals(filters []AggregateMetadataFilter, column string, value int64) bool {
+	for _, filter := range filters {
+		if filter.Column == column {
+			return filter.Equals == value
+		}
+	}
+	return false
+}
+
 func digestQ4Top(top []jsonBenchPartTimePair) uint64 {
 	var digest uint64
 	for _, p := range top {
@@ -1206,6 +1439,27 @@ func queryDiagnosticsFromDecodedPrefix(part *ColumnPart, columns []string, kerne
 		ColumnsProjected:   append([]string(nil), columns...),
 		AggregateKernel:    kernel,
 		SortKey:            sortKeyColumns(part),
+	}
+}
+
+func queryDiagnosticsFromAggregateMetadata(part *ColumnPart, metadata AggregateMetadata, columns []string, kernel string) JSONBenchPartQueryDiagnostics {
+	return JSONBenchPartQueryDiagnostics{
+		RowsScanned:                    0,
+		GranulesConsidered:             metadata.Stats.Granules,
+		GranulesDecoded:                0,
+		BlocksDecoded:                  0,
+		BytesDecoded:                   0,
+		ColumnsProjected:               append([]string(nil), columns...),
+		AggregateKernel:                kernel,
+		SortKey:                        sortKeyColumns(part),
+		AggregateMetadataUsed:          true,
+		AggregateMetadataName:          metadata.Definition.Name,
+		AggregateMetadataRows:          metadata.Stats.RowsMatched,
+		AggregateMetadataEntries:       metadata.Stats.Entries,
+		AggregateMetadataBytes:         metadata.Stats.TotalBytes,
+		AggregateMetadataBuildDuration: metadata.Stats.BuildDuration,
+		AggregateMetadataBytesPerRow:   metadata.Stats.BytesPerPartRow,
+		AggregateMetadataCompression:   metadata.Stats.Compression,
 	}
 }
 

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -191,14 +191,20 @@ func JSONBenchPostCreateDidTimeAggregateMetadataDefinition(ds JSONBenchDataset) 
 		return AggregateMetadataDefinition{}, err
 	}
 	return AggregateMetadataDefinition{
-		Name:        jsonBenchPostCreateDidTimeMetadata,
-		Kind:        AggregateMetadataGroupMinMax,
-		GroupColumn: "did_code",
-		ValueColumn: "time_us",
-		Filters: []AggregateMetadataFilter{
-			{Column: "kind_code", Equals: codes.kindCommit},
-			{Column: "commit_operation_code", Equals: codes.operationCreate},
-			{Column: "commit_collection_code", Equals: codes.collectionPost},
+		Name:      jsonBenchPostCreateDidTimeMetadata,
+		Version:   AggregateMetadataDefinitionVersion,
+		Kind:      AggregateMetadataGroupMinMax,
+		Scope:     AggregateMetadataScopeGranule,
+		GroupKeys: []string{"did_code"},
+		Measures: []AggregateMetadataMeasure{
+			{Op: AggregateMetadataMeasureCount},
+			{Op: AggregateMetadataMeasureMin, Column: "time_us"},
+			{Op: AggregateMetadataMeasureMax, Column: "time_us"},
+		},
+		Predicates: []AggregateMetadataPredicate{
+			{Column: "kind_code", Op: AggregateMetadataPredicateEq, Value: codes.kindCommit},
+			{Column: "commit_operation_code", Op: AggregateMetadataPredicateEq, Value: codes.operationCreate},
+			{Column: "commit_collection_code", Op: AggregateMetadataPredicateEq, Value: codes.collectionPost},
 		},
 		MaxBytesPerRow: 64,
 	}, nil
@@ -1385,25 +1391,55 @@ func requireJSONBenchPostCreateDidTimeMetadata(part *ColumnPart, codes queryCode
 	if !metadata.Stats.Admitted {
 		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s rejected by admission: %s", metadata.Definition.Name, metadata.Stats.RejectedReason)
 	}
-	if metadata.Definition.Kind != AggregateMetadataGroupMinMax || metadata.Definition.GroupColumn != "did_code" || metadata.Definition.ValueColumn != "time_us" {
+	if metadata.Definition.Version != AggregateMetadataDefinitionVersion || metadata.Definition.Kind != AggregateMetadataGroupMinMax || metadata.Definition.Scope != AggregateMetadataScopeGranule {
 		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s has incompatible definition %+v", metadata.Definition.Name, metadata.Definition)
 	}
-	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "kind_code", codes.kindCommit) {
-		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing kind_code=%d filter", metadata.Definition.Name, codes.kindCommit)
+	if !aggregateMetadataSingleGroupKey(metadata.Definition, "did_code") || !aggregateMetadataHasCountMinMax(metadata.Definition, "time_us") {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s has incompatible definition %+v", metadata.Definition.Name, metadata.Definition)
 	}
-	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "commit_operation_code", codes.operationCreate) {
-		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_operation_code=%d filter", metadata.Definition.Name, codes.operationCreate)
+	if len(metadata.Definition.Predicates) != 3 {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s has incompatible predicates %+v", metadata.Definition.Name, metadata.Definition.Predicates)
 	}
-	if !aggregateMetadataFilterEquals(metadata.Definition.Filters, "commit_collection_code", codes.collectionPost) {
-		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_collection_code=%d filter", metadata.Definition.Name, codes.collectionPost)
+	if !aggregateMetadataPredicateEquals(metadata.Definition.Predicates, "kind_code", codes.kindCommit) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing kind_code=%d predicate", metadata.Definition.Name, codes.kindCommit)
+	}
+	if !aggregateMetadataPredicateEquals(metadata.Definition.Predicates, "commit_operation_code", codes.operationCreate) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_operation_code=%d predicate", metadata.Definition.Name, codes.operationCreate)
+	}
+	if !aggregateMetadataPredicateEquals(metadata.Definition.Predicates, "commit_collection_code", codes.collectionPost) {
+		return AggregateMetadata{}, fmt.Errorf("colgranule: aggregate metadata %s missing commit_collection_code=%d predicate", metadata.Definition.Name, codes.collectionPost)
 	}
 	return metadata, nil
 }
 
-func aggregateMetadataFilterEquals(filters []AggregateMetadataFilter, column string, value int64) bool {
-	for _, filter := range filters {
-		if filter.Column == column {
-			return filter.Equals == value
+func aggregateMetadataSingleGroupKey(def AggregateMetadataDefinition, column string) bool {
+	return len(def.GroupKeys) == 1 && def.GroupKeys[0] == column
+}
+
+func aggregateMetadataHasCountMinMax(def AggregateMetadataDefinition, valueColumn string) bool {
+	if len(def.Measures) != 3 {
+		return false
+	}
+	var hasCount bool
+	var hasMin bool
+	var hasMax bool
+	for _, measure := range def.Measures {
+		switch measure.Op {
+		case AggregateMetadataMeasureCount:
+			hasCount = hasCount || measure.Column == ""
+		case AggregateMetadataMeasureMin:
+			hasMin = hasMin || measure.Column == valueColumn
+		case AggregateMetadataMeasureMax:
+			hasMax = hasMax || measure.Column == valueColumn
+		}
+	}
+	return hasCount && hasMin && hasMax
+}
+
+func aggregateMetadataPredicateEquals(predicates []AggregateMetadataPredicate, column string, value int64) bool {
+	for _, predicate := range predicates {
+		if predicate.Column == column {
+			return predicate.Op == AggregateMetadataPredicateEq && predicate.Value == value
 		}
 	}
 	return false

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -202,6 +202,99 @@ func TestRunJSONBenchPartQ4FairnessQueries(t *testing.T) {
 	}
 }
 
+func TestRunJSONBenchPartAggregateMetadataQueries(t *testing.T) {
+	ds := syntheticJSONBenchDataset(256)
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	rawQ4Rows, rawQ4Digest := runJSONBenchQ4(ds, codes)
+	rawQ5Rows, rawQ5Digest := runJSONBenchQ5(ds, codes)
+	timings, err := RunJSONBenchPartAggregateMetadataQueries(ds, 32, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartAggregateMetadataQueries: %v", err)
+	}
+	if len(timings) != 2 {
+		t.Fatalf("aggregate metadata timings=%d want 2", len(timings))
+	}
+	seen := map[string]bool{}
+	for _, timing := range timings {
+		seen[timing.Query] = true
+		if len(timing.Attempts) != 2 || timing.Attempts[0].Cache != "cold" || timing.Attempts[1].Cache != "warm" {
+			t.Fatalf("%s attempts=%+v want cold,warm labels", timing.Query, timing.Attempts)
+		}
+		d := timing.Diagnostics
+		if !d.AggregateMetadataUsed {
+			t.Fatalf("%s did not report aggregate metadata: %+v", timing.Query, d)
+		}
+		if d.AggregateMetadataName != jsonBenchPostCreateDidTimeMetadata {
+			t.Fatalf("%s metadata=%q want %q", timing.Query, d.AggregateMetadataName, jsonBenchPostCreateDidTimeMetadata)
+		}
+		if d.RowsScanned != 0 || d.BlocksDecoded != 0 || d.BytesDecoded != 0 {
+			t.Fatalf("%s diagnostics scanned/decode rows=%d blocks=%d bytes=%d want metadata-only", timing.Query, d.RowsScanned, d.BlocksDecoded, d.BytesDecoded)
+		}
+		if d.AggregateMetadataRows == 0 || d.AggregateMetadataEntries == 0 || d.AggregateMetadataBytes == 0 || d.AggregateMetadataCompression == "" {
+			t.Fatalf("%s missing metadata accounting: %+v", timing.Query, d)
+		}
+		switch timing.Query {
+		case "Q4b-meta":
+			if timing.ResultRows != rawQ4Rows || timing.ResultDigest != rawQ4Digest {
+				t.Fatalf("Q4b-meta rows/digest=(%d,%d) raw=(%d,%d)", timing.ResultRows, timing.ResultDigest, rawQ4Rows, rawQ4Digest)
+			}
+			if d.AggregateKernel != "aggregate_metadata_min_by_user" {
+				t.Fatalf("Q4b-meta kernel=%q want metadata min", d.AggregateKernel)
+			}
+			assertStringSliceEqual(t, d.SortKey, []string{"kind_code", "commit_operation_code", "commit_collection_code", "did_code", "time_us"})
+		case "Q5-meta":
+			if timing.ResultRows != rawQ5Rows || timing.ResultDigest != rawQ5Digest {
+				t.Fatalf("Q5-meta rows/digest=(%d,%d) raw=(%d,%d)", timing.ResultRows, timing.ResultDigest, rawQ5Rows, rawQ5Digest)
+			}
+			if d.AggregateKernel != "aggregate_metadata_span_by_user" {
+				t.Fatalf("Q5-meta kernel=%q want metadata span", d.AggregateKernel)
+			}
+			assertStringSliceEqual(t, d.SortKey, []string{"time_us"})
+		default:
+			t.Fatalf("unexpected aggregate metadata query %s", timing.Query)
+		}
+	}
+	if !seen["Q4b-meta"] || !seen["Q5-meta"] {
+		t.Fatalf("aggregate metadata queries seen=%v want Q4b-meta and Q5-meta", seen)
+	}
+}
+
+func TestJSONBenchAggregateMetadataAdmissionRejectsOversizedMetadata(t *testing.T) {
+	ds := syntheticJSONBenchDataset(256)
+	opts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds, 32, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptionsWithAggregateMetadataForLayout: %v", err)
+	}
+	if len(opts.AggregateMetadata) != 1 {
+		t.Fatalf("aggregate metadata defs=%d want 1", len(opts.AggregateMetadata))
+	}
+	opts.AggregateMetadata[0].MaxBytesPerRow = 0.001
+	part, err := BuildColumnPart(1, opts, ColumnBatch{Rows: ds.Rows, Columns: ds.Columns})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	metadata, ok := part.AggregateMetadataByName(jsonBenchPostCreateDidTimeMetadata)
+	if !ok {
+		t.Fatalf("missing aggregate metadata %s", jsonBenchPostCreateDidTimeMetadata)
+	}
+	if metadata.Stats.Admitted {
+		t.Fatalf("metadata admitted with tiny budget: %+v", metadata.Stats)
+	}
+	if metadata.Stats.RejectedReason == "" || metadata.Stats.TotalBytes == 0 || metadata.Stats.Entries == 0 {
+		t.Fatalf("metadata rejection missing accounting: %+v", metadata.Stats)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	if _, _, _, err := runJSONBenchPartQ5AggregateMetadata(part, codes, &jsonBenchPartQueryScratch{}); err == nil {
+		t.Fatal("runJSONBenchPartQ5AggregateMetadata accepted metadata rejected by admission")
+	}
+}
+
 func TestRunJSONBenchPartQ4EarlyStopRejectsClickHouseOrder(t *testing.T) {
 	ds := syntheticJSONBenchDataset(128)
 	part, err := BuildJSONBenchColumnPartForLayout(ds, 32, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
@@ -364,6 +457,45 @@ func TestRunJSONBenchPartQueriesLocalIfPresent(t *testing.T) {
 		raw := rawByQuery[timing.Query]
 		if timing.ResultRows != raw.ResultRows || timing.ResultDigest != raw.ResultDigest {
 			t.Fatalf("%s local part rows/digest=(%d,%d) raw=(%d,%d)", timing.Query, timing.ResultRows, timing.ResultDigest, raw.ResultRows, raw.ResultDigest)
+		}
+	}
+}
+
+func TestRunJSONBenchPartAggregateMetadataQueriesLocalIfPresent(t *testing.T) {
+	path := os.Getenv("JSONBENCH_DATA")
+	if path == "" {
+		t.Skip("JSONBENCH_DATA not set")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("local JSONBench fixture not present at %s", path)
+	}
+	ds, err := LoadJSONBenchColumns(path, 1000)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns(local): %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	rawQ4Rows, rawQ4Digest := runJSONBenchQ4(ds, codes)
+	rawQ5Rows, rawQ5Digest := runJSONBenchQ5(ds, codes)
+	timings, err := RunJSONBenchPartAggregateMetadataQueries(ds, DefaultRowsPerGranule, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartAggregateMetadataQueries(local): %v", err)
+	}
+	for _, timing := range timings {
+		if !timing.Diagnostics.AggregateMetadataUsed {
+			t.Fatalf("%s local diagnostics did not use aggregate metadata: %+v", timing.Query, timing.Diagnostics)
+		}
+		switch timing.Query {
+		case "Q4b-meta":
+			if timing.ResultRows != rawQ4Rows || timing.ResultDigest != rawQ4Digest {
+				t.Fatalf("Q4b-meta local rows/digest=(%d,%d) raw=(%d,%d)", timing.ResultRows, timing.ResultDigest, rawQ4Rows, rawQ4Digest)
+			}
+		case "Q5-meta":
+			if timing.ResultRows != rawQ5Rows || timing.ResultDigest != rawQ5Digest {
+				t.Fatalf("Q5-meta local rows/digest=(%d,%d) raw=(%d,%d)", timing.ResultRows, timing.ResultDigest, rawQ5Rows, rawQ5Digest)
+			}
 		}
 	}
 }

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -60,6 +60,7 @@ type ColumnStoreOptions struct {
 	SortKey           SortKey
 	PartPolicy        ColumnPartPolicy
 	Compression       ColumnCompressionPolicy
+	AggregateMetadata []AggregateMetadataDefinition
 }
 
 type ColumnPartPolicy struct {
@@ -86,11 +87,12 @@ type ColumnBatch struct {
 }
 
 type ColumnPart struct {
-	Options    ColumnStoreOptions
-	Descriptor ColumnPartDescriptor
-	Columns    map[string]ColumnPartColumn
-	Marks      []SortKeyMark
-	Locators   map[int64]RowLocator
+	Options           ColumnStoreOptions
+	Descriptor        ColumnPartDescriptor
+	Columns           map[string]ColumnPartColumn
+	Marks             []SortKeyMark
+	Locators          map[int64]RowLocator
+	AggregateMetadata map[string]AggregateMetadata
 }
 
 type ColumnPartDescriptor struct {
@@ -214,6 +216,9 @@ func (b *ColumnPartBuilder) Build(partID uint64, batch ColumnBatch) (*ColumnPart
 		}
 		part.Columns[def.Name] = column
 		part.Descriptor.Columns = append(part.Descriptor.Columns, descriptor)
+	}
+	if err := b.buildAggregateMetadata(part, batch); err != nil {
+		return nil, err
 	}
 	return part, nil
 }
@@ -430,6 +435,7 @@ func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, e
 		return ColumnStoreOptions{}, errors.New("colgranule: no declared columns")
 	}
 	seen := make(map[string]struct{}, len(opts.Columns))
+	columnsByName := make(map[string]ColumnDefinition, len(opts.Columns))
 	for i := range opts.Columns {
 		def, err := normalizeColumnDefinition(opts.Columns[i], opts.Compression.Default)
 		if err != nil {
@@ -439,6 +445,7 @@ func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, e
 			return ColumnStoreOptions{}, fmt.Errorf("colgranule: duplicate column %s", def.Name)
 		}
 		seen[def.Name] = struct{}{}
+		columnsByName[def.Name] = def
 		opts.Columns[i] = def
 	}
 	if _, ok := seen[opts.LogicalPrimaryKey.Columns[0]]; !ok {
@@ -464,6 +471,18 @@ func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, e
 		if c.Nulls != SortKeyNullsDefault && c.Nulls != SortKeyNullsFirst && c.Nulls != SortKeyNullsLast {
 			return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported null order %s", c.Nulls)
 		}
+	}
+	seenMetadata := make(map[string]struct{}, len(opts.AggregateMetadata))
+	for i := range opts.AggregateMetadata {
+		def, err := normalizeAggregateMetadataDefinition(opts.AggregateMetadata[i], columnsByName)
+		if err != nil {
+			return ColumnStoreOptions{}, err
+		}
+		if _, ok := seenMetadata[def.Name]; ok {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: duplicate aggregate metadata %s", def.Name)
+		}
+		seenMetadata[def.Name] = struct{}{}
+		opts.AggregateMetadata[i] = def
 	}
 	return opts, nil
 }


### PR DESCRIPTION
Adds the M1B aggregate metadata prototype for `experiments/colgranule`.

This adds a declared `ColumnStoreOptions.AggregateMetadata` hook and an exact per-granule `did_code -> min(time_us), max(time_us), count` metadata implementation for JSONBench post/create rows. It adds metadata-backed q4b and q5 runners so q4b can avoid row-by-row timestamp decode and q5 can combine per-granule min/max summaries without scanning encoded blocks.

Follow-up definition polish keeps the executed aggregate shape narrow but makes the contract future-shaped: definitions now carry version, per-granule scope, explicit group keys, explicit measures, and structured equality predicates. Option normalization still rejects unsupported versions, scopes, multi-key groups, non-equality predicates, unsupported measures, or mismatched value columns.

Latest local 1m JSONBench report (`tmp/colgranule_m1b_definition_polish_1m_report.md`, generated locally and not committed):

| Query | Metadata best | Baseline | Speedup | Break-even | Metadata rows | Entries | Entries/matched row | Bytes | B/part row | B/matched row | Build | Compression |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| Q4b-meta | 0.000364s | 0.002326s | 6.39x | 20.7 | 86,812 | 50,467 | 0.581 | 1,215,352 | 1.215 | 14.000 | 0.040679s | none_prototype |
| Q5-meta | 0.000657s | 0.024653s | 37.52x | 1.3 | 86,812 | 78,937 | 0.909 | 1,898,632 | 1.899 | 21.871 | 0.030975s | none_prototype |

Synthetic benchmark highlights:

| Benchmark | Local result range |
|---|---:|
| Q4b metadata | 237-241 us/op, 160 B/op, 2 allocs/op |
| Q4b row scan | 3.28-4.48 ms/op, 160 B/op, 2 allocs/op |
| Q5 metadata | 818 us-1.48 ms/op, 96 B/op, 2 allocs/op |
| Q5 row scan | 7.01-7.71 ms/op, 2440 B/op, 5 allocs/op |

Validation:

- `go test ./experiments/colgranule -run 'TestAggregateMetadataDefinition|TestRunJSONBenchPartAggregateMetadataQueries|TestJSONBenchAggregateMetadataAdmissionRejectsOversizedMetadata' -count=1`
- `go test ./experiments/colgranule -run 'TestRunJSONBenchPartAggregateMetadataQueries|TestJSONBenchAggregateMetadataAdmissionRejectsOversizedMetadata|TestRunJSONBenchPartQ4FairnessQueries|TestRunJSONBenchPartQueriesSampleMatchesRawReference' -count=1`
- `go test ./experiments/colgranule/...`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run 'TestRunJSONBenchPartAggregateMetadataQueriesLocalIfPresent|TestRunJSONBenchPartAggregateMetadataQueries' -count=1`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchAggregateMetadataQueries' -benchmem -count=3`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchAggregateMetadataBuild' -benchmem -count=3`
- 1m local comparison report command with `--measure-remaining-treedb=false` and local ClickHouse result from JSONBench PR #2.
