### PR TITLE
experiments/colgranule: add M1C part size accounting

### DIFF
--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -79,3 +79,22 @@ removed, and a ClickHouse-aligned shape with the typed JSON paths removed:
 this part with `-measure-remaining-treedb=false`. The command also records a raw
 TreeDB key/value shape that stores `documentID(row) -> original JSON line bytes`
 without collection document encoding.
+
+To iterate on encoded-part build and query kernels without reloading the retained
+payload collections, reuse a previous raw comparison file:
+
+```sh
+go run ./experiments/colgranule/cmd/jsonbench_compare \
+  -data $JSONBENCH_DATA \
+  -limit 1000000 \
+  -rows-per-granule 8192 \
+  -attempts 5 \
+  -measure-remaining-treedb=false \
+  -retained-payload-from-json experiments/colgranule/JSONBENCH_COMPARISON_RAW.json
+```
+
+When retained-payload measurements are available, the Markdown report includes a
+full-dataset estimate that adds the current encoded column part to the measured
+TreeDB payload bytes. This is the M1C-era comparison point for ClickHouse
+`total_size`; the encoded part is still in memory, while the retained payload is
+measured from compacted TreeDB files.

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -955,12 +955,15 @@ func writeMarkdown(path string, raw comparisonRaw) {
 	}
 	if len(raw.EncodedPartBuildReports) > 0 {
 		fmt.Fprintf(&b, "\n## M1C Build and Size Accounting\n\n")
-		fmt.Fprintf(&b, "These reports build the actual encoded JSONBench column part layouts with aggregate metadata enabled. The current experiment stores declared columns, marks, descriptors, locators, aggregate metadata, and loader dictionary estimates; retained/original JSON payload is labeled separately and is absent from the encoded-part total.\n\n")
-		fmt.Fprintf(&b, "| Layout | Best build | ns/row | Rows/s | Encoded MiB/s | Stored MiB/s | Alloc B/op | Allocs/op | Temp B/op | Output B/row |\n")
-		fmt.Fprintf(&b, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+		fmt.Fprintf(&b, "These reports build the actual encoded JSONBench column part layouts with aggregate metadata enabled. The current experiment stores declared columns, marks, descriptors, locators, aggregate metadata, and loader dictionary estimates; retained/original JSON payload is labeled separately and is absent from the encoded-part total. Physical file count is `0` because M1C is still an in-memory part experiment; file-backed `TCS1` work should replace this with real file/container counts.\n\n")
+		fmt.Fprintf(&b, "| Layout | Files | Granules | Codec blocks | Best build | ns/row | Rows/s | Encoded MiB/s | Stored MiB/s | Alloc B/op | Allocs/op | Temp B/op | Output B/row |\n")
+		fmt.Fprintf(&b, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 		for _, report := range raw.EncodedPartBuildReports {
-			fmt.Fprintf(&b, "| `%s` | %.6fs | %.1f | %.0f | %.2f | %.2f | %d | %d | %d | %.3f |\n",
+			fmt.Fprintf(&b, "| `%s` | %d | %d | %d | %.6fs | %.1f | %.0f | %.2f | %.2f | %d | %d | %d | %.3f |\n",
 				report.Layout,
+				report.Accounting.PhysicalFiles,
+				report.Accounting.Granules,
+				report.Accounting.CodecBlocks,
 				report.Best.Duration.Seconds(),
 				report.NanosPerRow,
 				report.RowsPerSecond,

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -70,6 +70,7 @@ type comparisonRaw struct {
 	EncodedPartQueryTimings  []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_query_timings"`
 	EncodedPartQ4Fairness    []colgranule.JSONBenchPartQueryTiming `json:"encoded_part_q4_fairness_timings"`
 	AggregateMetadataTimings []colgranule.JSONBenchPartQueryTiming `json:"aggregate_metadata_timings"`
+	EncodedPartBuildReports  []colgranule.JSONBenchPartBuildReport `json:"encoded_part_build_reports"`
 	ColumnSummaries          []colgranule.ColumnCodecSummary       `json:"column_summaries"`
 	BestColumnStorage        []bestColumnStorage                   `json:"best_column_storage"`
 }
@@ -142,6 +143,8 @@ func main() {
 	must(err)
 	aggregateMetadataTimings, err := colgranule.RunJSONBenchPartAggregateMetadataQueries(ds, *rowsPerGranule, *attempts)
 	must(err)
+	encodedPartBuildReports, err := colgranule.RunJSONBenchPartBuildReports(ds, *rowsPerGranule, *attempts)
+	must(err)
 	var remaining remainingTreeDBResult
 	var remainingJSON remainingTreeDBResult
 	var remainingTpl remainingTreeDBResult
@@ -187,6 +190,7 @@ func main() {
 		EncodedPartQueryTimings:  encodedPartTimings,
 		EncodedPartQ4Fairness:    encodedPartQ4Fairness,
 		AggregateMetadataTimings: aggregateMetadataTimings,
+		EncodedPartBuildReports:  encodedPartBuildReports,
 		ColumnSummaries:          summaries,
 		BestColumnStorage:        bestColumns(summaries),
 	}
@@ -949,6 +953,70 @@ func writeMarkdown(path string, raw comparisonRaw) {
 				d.AggregateMetadataCompression)
 		}
 	}
+	if len(raw.EncodedPartBuildReports) > 0 {
+		fmt.Fprintf(&b, "\n## M1C Build and Size Accounting\n\n")
+		fmt.Fprintf(&b, "These reports build the actual encoded JSONBench column part layouts with aggregate metadata enabled. The current experiment stores declared columns, marks, descriptors, locators, aggregate metadata, and loader dictionary estimates; retained/original JSON payload is labeled separately and is absent from the encoded-part total.\n\n")
+		fmt.Fprintf(&b, "| Layout | Best build | ns/row | Rows/s | Encoded MiB/s | Stored MiB/s | Alloc B/op | Allocs/op | Temp B/op | Output B/row |\n")
+		fmt.Fprintf(&b, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+		for _, report := range raw.EncodedPartBuildReports {
+			fmt.Fprintf(&b, "| `%s` | %.6fs | %.1f | %.0f | %.2f | %.2f | %d | %d | %d | %.3f |\n",
+				report.Layout,
+				report.Best.Duration.Seconds(),
+				report.NanosPerRow,
+				report.RowsPerSecond,
+				report.EncodedMiBPerSecond,
+				report.StoredMiBPerSecond,
+				report.AllocatedBytesPerOp,
+				report.AllocsPerOp,
+				report.TemporaryBytes,
+				report.Accounting.BytesPerRow)
+		}
+		fmt.Fprintf(&b, "\n| Layout | Total bytes | vs raw JSON | vs source gzip | vs ClickHouse total | Declared columns | Dictionaries | Marks | Sort key | Aggregate metadata | Descriptors | Locators | Retained JSON |\n")
+		fmt.Fprintf(&b, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n")
+		for _, report := range raw.EncodedPartBuildReports {
+			accounting := report.Accounting
+			fmt.Fprintf(&b, "| `%s` | %d | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | `%s` |\n",
+				report.Layout,
+				accounting.TotalStoredBytes,
+				formatPercent(float64(accounting.TotalStoredBytes), float64(report.RawJSONBytes)),
+				formatPercent(float64(accounting.TotalStoredBytes), float64(raw.InputBytes)),
+				formatPercent(float64(accounting.TotalStoredBytes), float64(raw.ClickHouseLocal.TotalSize)),
+				accounting.DeclaredColumnStoredBytes,
+				accounting.DictionaryBytes,
+				accounting.MarkBytes,
+				accounting.SortKeyMetadataBytes,
+				accounting.AggregateMetadataBytes,
+				accounting.DescriptorBytes,
+				accounting.LocatorBytes,
+				accounting.RetainedJSONPayload)
+		}
+		fmt.Fprintf(&b, "\nCompression/admission by column/substream:\n\n")
+		fmt.Fprintf(&b, "| Layout | Column | Substream | Encoding | Requested | Actual | Blocks | Raw bytes | Stored bytes | Stored/raw | Attempts | Kept | Rejected | Fallback |\n")
+		fmt.Fprintf(&b, "|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|\n")
+		for _, report := range raw.EncodedPartBuildReports {
+			for _, detail := range report.Accounting.CompressionDetail {
+				fallback := detail.FallbackReason
+				if fallback == "" {
+					fallback = "kept"
+				}
+				fmt.Fprintf(&b, "| `%s` | `%s` | `%s` | `%s` | `%s` | `%s` | %d | %d | %d | %.3f | %d | %d | %d | `%s` |\n",
+					report.Layout,
+					detail.Column,
+					detail.Substream,
+					detail.Encoding,
+					detail.RequestedCompression,
+					detail.ActualCompression,
+					detail.Blocks,
+					detail.EncodedRawBytes,
+					detail.StoredBytes,
+					detail.StoredToEncodedRawRate,
+					detail.CompressionAttempted,
+					detail.CompressionKept,
+					detail.CompressionRejected,
+					fallback)
+			}
+		}
+	}
 	fmt.Fprintf(&b, "\n## Storage Footprint\n\n")
 	allBest := bestTotal(raw.BestColumnStorage, nil)
 	queryBest := bestTotal(raw.BestColumnStorage, queryPathColumns())
@@ -971,6 +1039,9 @@ func writeMarkdown(path string, raw comparisonRaw) {
 	fmt.Fprintf(&b, "| ClickHouse local total | %d | %.2f | `total_size` from local ClickHouse JSONBench result. |\n", raw.ClickHouseLocal.TotalSize, mib(raw.ClickHouseLocal.TotalSize))
 	fmt.Fprintf(&b, "| ClickHouse local data | %d | %.2f | `data_size` from local ClickHouse JSONBench result. |\n", raw.ClickHouseLocal.DataSize, mib(raw.ClickHouseLocal.DataSize))
 	fmt.Fprintf(&b, "| ClickHouse local index | %d | %.2f | `index_size` from local ClickHouse JSONBench result. |\n", raw.ClickHouseLocal.IndexSize, mib(raw.ClickHouseLocal.IndexSize))
+	for _, report := range raw.EncodedPartBuildReports {
+		fmt.Fprintf(&b, "| Encoded column part `%s` total | %d | %.2f | M1C actual part estimate including declared columns, loader dictionaries, marks, descriptors, locators, and admitted aggregate metadata; retained JSON is `%s`. |\n", report.Layout, report.Accounting.TotalStoredBytes, mib(int64(report.Accounting.TotalStoredBytes)), report.Accounting.RetainedJSONPayload)
+	}
 	fmt.Fprintf(&b, "| Granule best-codec all derived columns | %d | %.2f | %.2f%% of ClickHouse local total. |\n", allBest, mib(int64(allBest)), ratio(float64(allBest)*100, float64(raw.ClickHouseLocal.TotalSize)))
 	fmt.Fprintf(&b, "| Granule best-codec query/index paths | %d | %.2f | %.2f%% of ClickHouse local total. |\n", queryBest, mib(int64(queryBest)), ratio(float64(queryBest)*100, float64(raw.ClickHouseLocal.TotalSize)))
 	if raw.RemainingTreeDB.Enabled {
@@ -1180,6 +1251,13 @@ func formatSpeedup(numerator, denominator float64) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.2fx", ratio(denominator, numerator))
+}
+
+func formatPercent(numerator, denominator float64) string {
+	if denominator == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f%%", ratio(numerator*100, denominator))
 }
 
 func formatBreakEvenQueries(buildSeconds, baselineSeconds, metadataSeconds float64) string {

--- a/experiments/colgranule/cmd/jsonbench_compare/main.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/main.go
@@ -109,6 +109,11 @@ type bestColumnStorage struct {
 	ActualCompressionMix map[colgranule.Compression]int `json:"actual_compression_mix"`
 }
 
+type retainedPayloadOption struct {
+	Label  string
+	Result remainingTreeDBResult
+}
+
 type remainingShape string
 
 const (
@@ -124,9 +129,13 @@ func main() {
 	clickHouseLocalPath := flag.String("clickhouse-local", "", "optional local ClickHouse JSONBench result")
 	remainingDBDir := flag.String("remaining-db-dir", "artifacts/colgranule_remaining_treedb", "temporary TreeDB directory prefix for remaining payload measurement")
 	measureRemaining := flag.Bool("measure-remaining-treedb", true, "load remaining JSON shapes into JSON, BSON, and Template-v1 TreeDB collections, compact them, and include disk usage")
+	retainedPayloadFromJSON := flag.String("retained-payload-from-json", "", "optional jsonbench_compare raw JSON file whose retained-payload measurements should be reused when -measure-remaining-treedb=false")
 	outJSON := flag.String("out-json", "artifacts/colgranule/JSONBENCH_COMPARISON_RAW.json", "raw JSON output")
 	outMarkdown := flag.String("out-md", "artifacts/colgranule/JSONBENCH_COMPARISON_REPORT.md", "Markdown report output")
 	flag.Parse()
+	if *measureRemaining && *retainedPayloadFromJSON != "" {
+		must(errors.New("-retained-payload-from-json requires -measure-remaining-treedb=false"))
+	}
 
 	start := time.Now()
 	ds, err := colgranule.LoadJSONBenchColumns(*data, *limit)
@@ -167,6 +176,15 @@ func main() {
 		must(err)
 		rawTreeDBJSON, err = measureRawJSONTreeDB(context.Background(), ds.Files, ds.Rows, *remainingDBDir+"-raw-json")
 		must(err)
+	} else if *retainedPayloadFromJSON != "" {
+		retainedRaw := readComparisonRaw(*retainedPayloadFromJSON)
+		remaining = retainedRaw.RemainingTreeDB
+		remainingJSON = retainedRaw.RemainingTreeDBJSON
+		remainingTpl = retainedRaw.RemainingTreeDBTpl
+		conservativeBSON = retainedRaw.ConservativeBSON
+		conservativeJSON = retainedRaw.ConservativeJSON
+		conservativeTpl = retainedRaw.ConservativeTpl
+		rawTreeDBJSON = retainedRaw.RawTreeDBJSON
 	}
 
 	raw := comparisonRaw{
@@ -206,6 +224,14 @@ func readClickHouseResult(path string) clickHouseResult {
 	data, err := os.ReadFile(path)
 	must(err)
 	var result clickHouseResult
+	must(json.Unmarshal(data, &result))
+	return result
+}
+
+func readComparisonRaw(path string) comparisonRaw {
+	data, err := os.ReadFile(path)
+	must(err)
+	var result comparisonRaw
 	must(json.Unmarshal(data, &result))
 	return result
 }
@@ -993,6 +1019,33 @@ func writeMarkdown(path string, raw comparisonRaw) {
 				accounting.LocatorBytes,
 				accounting.RetainedJSONPayload)
 		}
+		retainedPayloads := retainedPayloadOptions(raw)
+		if len(retainedPayloads) > 0 {
+			fmt.Fprintf(&b, "\nFull-dataset retained-payload estimates add the current M1C encoded part total to a measured TreeDB payload collection containing the original JSON row with ClickHouse typed paths removed. This is the closest M1C-era comparison to ClickHouse `total_size`: the column part is still in memory, while the retained payload is an actual compacted TreeDB directory measurement.\n\n")
+			fmt.Fprintf(&b, "| Layout | Retained payload | Part bytes | Payload bytes | Total bytes | MiB | B/row | TreeDB / ClickHouse | Delta vs ClickHouse | Granules | Codec blocks | Part files | Payload files |\n")
+			fmt.Fprintf(&b, "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+			for _, report := range raw.EncodedPartBuildReports {
+				for _, payload := range retainedPayloads {
+					total := int64(report.Accounting.TotalStoredBytes) + payload.Result.AfterCompactBytes
+					fmt.Fprintf(&b, "| `%s` | `%s` | %d | %d | %d | %.2f | %.3f | %s | %s | %d | %d | %d | %d |\n",
+						report.Layout,
+						payload.Label,
+						report.Accounting.TotalStoredBytes,
+						payload.Result.AfterCompactBytes,
+						total,
+						mib(total),
+						ratio(float64(total), float64(report.Accounting.Rows)),
+						formatMultiplier(float64(total), float64(raw.ClickHouseLocal.TotalSize)),
+						formatSignedMiB(total-raw.ClickHouseLocal.TotalSize),
+						report.Accounting.Granules,
+						report.Accounting.CodecBlocks,
+						report.Accounting.PhysicalFiles,
+						payload.Result.AfterCompactFiles)
+				}
+			}
+		} else {
+			fmt.Fprintf(&b, "\nFull-dataset retained-payload estimate: not measured in this run. Re-run with `-measure-remaining-treedb=true`, or reuse a prior retained-payload run with `-measure-remaining-treedb=false -retained-payload-from-json <raw-json>`.\n")
+		}
 		fmt.Fprintf(&b, "\nCompression/admission by column/substream:\n\n")
 		fmt.Fprintf(&b, "| Layout | Column | Substream | Encoding | Requested | Actual | Blocks | Raw bytes | Stored bytes | Stored/raw | Attempts | Kept | Rejected | Fallback |\n")
 		fmt.Fprintf(&b, "|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|\n")
@@ -1044,6 +1097,12 @@ func writeMarkdown(path string, raw comparisonRaw) {
 	fmt.Fprintf(&b, "| ClickHouse local index | %d | %.2f | `index_size` from local ClickHouse JSONBench result. |\n", raw.ClickHouseLocal.IndexSize, mib(raw.ClickHouseLocal.IndexSize))
 	for _, report := range raw.EncodedPartBuildReports {
 		fmt.Fprintf(&b, "| Encoded column part `%s` total | %d | %.2f | M1C actual part estimate including declared columns, loader dictionaries, marks, descriptors, locators, and admitted aggregate metadata; retained JSON is `%s`. |\n", report.Layout, report.Accounting.TotalStoredBytes, mib(int64(report.Accounting.TotalStoredBytes)), report.Accounting.RetainedJSONPayload)
+	}
+	for _, report := range raw.EncodedPartBuildReports {
+		for _, payload := range retainedPayloadOptions(raw) {
+			total := int64(report.Accounting.TotalStoredBytes) + payload.Result.AfterCompactBytes
+			fmt.Fprintf(&b, "| M1C encoded part `%s` + `%s` retained payload | %d | %.2f | Full-dataset estimate: %.2f%% of ClickHouse local total, delta %s; part files `%d`, payload files `%d`, granules `%d`. |\n", report.Layout, payload.Label, total, mib(total), ratio(float64(total)*100, float64(raw.ClickHouseLocal.TotalSize)), formatSignedMiB(total-raw.ClickHouseLocal.TotalSize), report.Accounting.PhysicalFiles, payload.Result.AfterCompactFiles, report.Accounting.Granules)
+		}
 	}
 	fmt.Fprintf(&b, "| Granule best-codec all derived columns | %d | %.2f | %.2f%% of ClickHouse local total. |\n", allBest, mib(int64(allBest)), ratio(float64(allBest)*100, float64(raw.ClickHouseLocal.TotalSize)))
 	fmt.Fprintf(&b, "| Granule best-codec query/index paths | %d | %.2f | %.2f%% of ClickHouse local total. |\n", queryBest, mib(int64(queryBest)), ratio(float64(queryBest)*100, float64(raw.ClickHouseLocal.TotalSize)))
@@ -1228,6 +1287,20 @@ func bestTotal(cols []bestColumnStorage, include map[string]bool) int {
 	return total
 }
 
+func retainedPayloadOptions(raw comparisonRaw) []retainedPayloadOption {
+	options := make([]retainedPayloadOption, 0, 3)
+	if raw.RemainingTreeDB.Enabled {
+		options = append(options, retainedPayloadOption{Label: "BSON remaining", Result: raw.RemainingTreeDB})
+	}
+	if raw.RemainingTreeDBJSON.Enabled {
+		options = append(options, retainedPayloadOption{Label: "JSON remaining", Result: raw.RemainingTreeDBJSON})
+	}
+	if raw.RemainingTreeDBTpl.Enabled {
+		options = append(options, retainedPayloadOption{Label: "Template-v1 remaining", Result: raw.RemainingTreeDBTpl})
+	}
+	return options
+}
+
 func ratio(numerator, denominator float64) float64 {
 	if denominator == 0 {
 		return 0
@@ -1249,6 +1322,13 @@ func formatRatio(numerator, denominator float64) string {
 	return fmt.Sprintf("%.2fx", ratio(numerator, denominator))
 }
 
+func formatMultiplier(numerator, denominator float64) string {
+	if denominator == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.3fx", ratio(numerator, denominator))
+}
+
 func formatSpeedup(numerator, denominator float64) string {
 	if numerator == 0 || denominator == 0 {
 		return "n/a"
@@ -1261,6 +1341,15 @@ func formatPercent(numerator, denominator float64) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.2f%%", ratio(numerator*100, denominator))
+}
+
+func formatSignedMiB(bytes int64) string {
+	sign := "+"
+	if bytes < 0 {
+		sign = "-"
+		bytes = -bytes
+	}
+	return fmt.Sprintf("%s%.2f MiB", sign, mib(bytes))
 }
 
 func formatBreakEvenQueries(buildSeconds, baselineSeconds, metadataSeconds float64) string {

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -243,6 +243,63 @@ func BenchmarkJSONBenchAggregateMetadataBuild(b *testing.B) {
 	}
 }
 
+func BenchmarkJSONBenchPartBuildM1C(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	benchmarkJSONBenchPartBuildM1C(b, ds)
+}
+
+func BenchmarkJSONBenchLocalPartBuildM1C(b *testing.B) {
+	path := os.Getenv("JSONBENCH_DATA")
+	if path == "" {
+		path = DefaultJSONBenchDir
+	}
+	if _, err := os.Stat(path); err != nil {
+		b.Skipf("JSONBench data not present; set JSONBENCH_DATA or install %s", DefaultJSONBenchDir)
+	}
+	ds, err := LoadJSONBenchColumns(path, 1_000_000)
+	if err != nil {
+		b.Fatalf("LoadJSONBenchColumns: %v", err)
+	}
+	benchmarkJSONBenchPartBuildM1C(b, ds)
+}
+
+func benchmarkJSONBenchPartBuildM1C(b *testing.B, ds JSONBenchDataset) {
+	for _, layout := range []JSONBenchColumnPartLayout{
+		JSONBenchColumnPartLayoutTimeUS,
+		JSONBenchColumnPartLayoutClickHouseFilterUserTime,
+	} {
+		b.Run(string(layout), func(b *testing.B) {
+			part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, layout)
+			if err != nil {
+				b.Fatalf("BuildJSONBenchColumnPartWithAggregateMetadataForLayout: %v", err)
+			}
+			accounting := part.ByteAccounting()
+			accounting.DictionaryBytes = EstimateJSONBenchDictionaryBytes(ds)
+			accounting.RecomputeTotals()
+			b.ReportAllocs()
+			b.SetBytes(int64(accounting.EncodedRawBytes))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				part, err = BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, layout)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += int64(part.ByteAccounting().TotalStoredBytes)
+			}
+			seconds := b.Elapsed().Seconds()
+			if seconds > 0 {
+				b.ReportMetric(float64(ds.Rows*b.N)/seconds, "rows/s")
+				b.ReportMetric(float64(accounting.EncodedRawBytes*b.N)/seconds/(1024*1024), "encoded_MiB/s")
+				b.ReportMetric(float64(accounting.TotalStoredBytes*b.N)/seconds/(1024*1024), "stored_MiB/s")
+			}
+			if ds.Rows > 0 {
+				b.ReportMetric(float64(accounting.TotalStoredBytes)/float64(ds.Rows), "output_B/row")
+				b.ReportMetric(float64(accounting.EncodedRawBytes)/float64(ds.Rows), "encoded_B/row")
+			}
+		})
+	}
+}
+
 func syntheticJSONBenchDataset(rows int) JSONBenchDataset {
 	columns := map[string][]int64{
 		"row_index":              make([]int64, rows),

--- a/experiments/colgranule/jsonbench_part_build_report.go
+++ b/experiments/colgranule/jsonbench_part_build_report.go
@@ -1,0 +1,142 @@
+package colgranule
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+type JSONBenchPartBuildReport struct {
+	Layout               JSONBenchColumnPartLayout   `json:"layout"`
+	Rows                 int                         `json:"rows"`
+	RowsPerGranule       int                         `json:"rows_per_granule"`
+	Columns              int                         `json:"columns"`
+	Attempts             []JSONBenchPartBuildAttempt `json:"attempts"`
+	Best                 JSONBenchPartBuildAttempt   `json:"best"`
+	Accounting           ColumnPartByteAccounting    `json:"accounting"`
+	RawJSONBytes         int64                       `json:"raw_json_bytes"`
+	DictionaryBytes      int                         `json:"dictionary_bytes"`
+	RowsPerSecond        float64                     `json:"rows_per_second"`
+	EncodedMiBPerSecond  float64                     `json:"encoded_mib_per_second"`
+	StoredMiBPerSecond   float64                     `json:"stored_mib_per_second"`
+	NanosPerRow          float64                     `json:"nanos_per_row"`
+	AllocatedBytesPerOp  uint64                      `json:"allocated_bytes_per_op"`
+	AllocsPerOp          uint64                      `json:"allocs_per_op"`
+	AllocatedBytesPerRow float64                     `json:"allocated_bytes_per_row"`
+	TemporaryBytes       uint64                      `json:"temporary_bytes_estimate"`
+	TemporaryBytesPerRow float64                     `json:"temporary_bytes_per_row"`
+}
+
+type JSONBenchPartBuildAttempt struct {
+	Duration        time.Duration `json:"duration"`
+	AllocatedBytes  uint64        `json:"allocated_bytes"`
+	Mallocs         uint64        `json:"mallocs"`
+	TemporaryBytes  uint64        `json:"temporary_bytes_estimate"`
+	TotalBytes      int           `json:"total_bytes"`
+	EncodedRawBytes int           `json:"encoded_raw_bytes"`
+	StoredBytes     int           `json:"stored_bytes"`
+}
+
+func RunJSONBenchPartBuildReports(ds JSONBenchDataset, rowsPerGranule int, attempts int) ([]JSONBenchPartBuildReport, error) {
+	if attempts <= 0 {
+		attempts = 1
+	}
+	if rowsPerGranule <= 0 {
+		rowsPerGranule = DefaultRowsPerGranule
+	}
+	layouts := []JSONBenchColumnPartLayout{
+		JSONBenchColumnPartLayoutTimeUS,
+		JSONBenchColumnPartLayoutClickHouseFilterUserTime,
+	}
+	out := make([]JSONBenchPartBuildReport, 0, len(layouts))
+	for _, layout := range layouts {
+		report, err := runJSONBenchPartBuildReport(ds, rowsPerGranule, attempts, layout)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, report)
+	}
+	return out, nil
+}
+
+func runJSONBenchPartBuildReport(ds JSONBenchDataset, rowsPerGranule int, attempts int, layout JSONBenchColumnPartLayout) (JSONBenchPartBuildReport, error) {
+	var report JSONBenchPartBuildReport
+	report.Layout = layout
+	report.Rows = ds.Rows
+	report.RowsPerGranule = rowsPerGranule
+	report.Columns = len(ds.Columns)
+	report.RawJSONBytes = JSONBenchRawDocumentBytes(ds)
+	report.DictionaryBytes = EstimateJSONBenchDictionaryBytes(ds)
+	for i := 0; i < attempts; i++ {
+		part, attempt, accounting, err := measureJSONBenchPartBuild(ds, rowsPerGranule, layout)
+		if err != nil {
+			return JSONBenchPartBuildReport{}, fmt.Errorf("build layout=%s attempt=%d: %w", layout, i, err)
+		}
+		if part.Descriptor.RowCount != ds.Rows {
+			return JSONBenchPartBuildReport{}, fmt.Errorf("build layout=%s rows=%d want=%d", layout, part.Descriptor.RowCount, ds.Rows)
+		}
+		report.Attempts = append(report.Attempts, attempt)
+		if i == 0 || attempt.Duration < report.Best.Duration {
+			report.Best = attempt
+			report.Accounting = accounting
+		}
+	}
+	report.fillDerivedMetrics()
+	return report, nil
+}
+
+func measureJSONBenchPartBuild(ds JSONBenchDataset, rowsPerGranule int, layout JSONBenchColumnPartLayout) (*ColumnPart, JSONBenchPartBuildAttempt, ColumnPartByteAccounting, error) {
+	var before runtime.MemStats
+	var after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	start := time.Now()
+	part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, rowsPerGranule, layout)
+	duration := time.Since(start)
+	runtime.ReadMemStats(&after)
+	if err != nil {
+		return nil, JSONBenchPartBuildAttempt{}, ColumnPartByteAccounting{}, err
+	}
+	accounting := part.ByteAccounting()
+	accounting.DictionaryBytes = EstimateJSONBenchDictionaryBytes(ds)
+	accounting.RecomputeTotals()
+	allocated := after.TotalAlloc - before.TotalAlloc
+	temporary := uint64(0)
+	if allocated > uint64(accounting.TotalStoredBytes) {
+		temporary = allocated - uint64(accounting.TotalStoredBytes)
+	}
+	attempt := JSONBenchPartBuildAttempt{
+		Duration:        duration,
+		AllocatedBytes:  allocated,
+		Mallocs:         after.Mallocs - before.Mallocs,
+		TemporaryBytes:  temporary,
+		TotalBytes:      accounting.TotalStoredBytes,
+		EncodedRawBytes: accounting.EncodedRawBytes,
+		StoredBytes:     accounting.DeclaredColumnStoredBytes,
+	}
+	return part, attempt, accounting, nil
+}
+
+func (r *JSONBenchPartBuildReport) fillDerivedMetrics() {
+	seconds := r.Best.Duration.Seconds()
+	if seconds > 0 {
+		r.RowsPerSecond = float64(r.Rows) / seconds
+		r.EncodedMiBPerSecond = float64(r.Accounting.EncodedRawBytes) / seconds / 1024 / 1024
+		r.StoredMiBPerSecond = float64(r.Accounting.TotalStoredBytes) / seconds / 1024 / 1024
+		r.NanosPerRow = float64(r.Best.Duration.Nanoseconds()) / float64(r.Rows)
+	}
+	r.AllocatedBytesPerOp = r.Best.AllocatedBytes
+	r.AllocsPerOp = r.Best.Mallocs
+	r.TemporaryBytes = r.Best.TemporaryBytes
+	if r.Rows > 0 {
+		r.AllocatedBytesPerRow = float64(r.Best.AllocatedBytes) / float64(r.Rows)
+		r.TemporaryBytesPerRow = float64(r.Best.TemporaryBytes) / float64(r.Rows)
+	}
+}
+
+func JSONBenchRawDocumentBytes(ds JSONBenchDataset) int64 {
+	var total int64
+	for _, bytes := range ds.Columns["line_bytes"] {
+		total += bytes
+	}
+	return total
+}

--- a/experiments/colgranule/jsonbench_test.go
+++ b/experiments/colgranule/jsonbench_test.go
@@ -262,6 +262,40 @@ func TestRunJSONBenchPartAggregateMetadataQueries(t *testing.T) {
 	}
 }
 
+func TestRunJSONBenchPartBuildReports(t *testing.T) {
+	ds, err := LoadJSONBenchColumns("testdata/jsonbench_sample.jsonl", 0)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns(sample): %v", err)
+	}
+	reports, err := RunJSONBenchPartBuildReports(ds, 32, 2)
+	if err != nil {
+		t.Fatalf("RunJSONBenchPartBuildReports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("reports=%d want 2", len(reports))
+	}
+	for _, report := range reports {
+		if report.Rows != ds.Rows || report.RawJSONBytes == 0 || report.DictionaryBytes == 0 {
+			t.Fatalf("bad report input accounting: %+v", report)
+		}
+		if report.Best.Duration <= 0 || report.RowsPerSecond <= 0 || report.NanosPerRow <= 0 {
+			t.Fatalf("bad build timing: %+v", report)
+		}
+		if report.Accounting.TotalStoredBytes == 0 || report.Accounting.TotalStoredBytes != report.Accounting.CategoryBytes() {
+			t.Fatalf("bad byte accounting: %+v", report.Accounting)
+		}
+		if report.Accounting.DictionaryBytes != report.DictionaryBytes {
+			t.Fatalf("dictionary bytes accounting=%d report=%d", report.Accounting.DictionaryBytes, report.DictionaryBytes)
+		}
+		if report.Accounting.RetainedJSONPayload != "absent_declared_columns_only" {
+			t.Fatalf("retained JSON label=%q", report.Accounting.RetainedJSONPayload)
+		}
+		if len(report.Accounting.CompressionDetail) == 0 {
+			t.Fatalf("missing compression detail: %+v", report.Accounting)
+		}
+	}
+}
+
 func TestJSONBenchAggregateMetadataAdmissionRejectsOversizedMetadata(t *testing.T) {
 	ds := syntheticJSONBenchDataset(256)
 	opts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds, 32, JSONBenchColumnPartLayoutTimeUS)

--- a/experiments/colgranule/part_accounting.go
+++ b/experiments/colgranule/part_accounting.go
@@ -21,6 +21,7 @@ type ColumnPartByteAccounting struct {
 	Columns                   int                                   `json:"columns"`
 	Granules                  int                                   `json:"granules"`
 	CodecBlocks               int                                   `json:"codec_blocks"`
+	PhysicalFiles             int                                   `json:"physical_files"`
 	LogicalValueBytes         int                                   `json:"logical_value_bytes"`
 	EncodedRawBytes           int                                   `json:"encoded_raw_bytes"`
 	DeclaredColumnStoredBytes int                                   `json:"declared_column_stored_bytes"`
@@ -80,6 +81,7 @@ func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
 		Rows:                p.Descriptor.RowCount,
 		Columns:             len(p.Columns),
 		Granules:            len(p.Descriptor.Granules),
+		PhysicalFiles:       0,
 		RetainedJSONPayload: "absent_declared_columns_only",
 	}
 	compressionByKey := make(map[columnCompressionKey]*ColumnPartCompressionByteAccounting)

--- a/experiments/colgranule/part_accounting.go
+++ b/experiments/colgranule/part_accounting.go
@@ -1,0 +1,277 @@
+package colgranule
+
+import "sort"
+
+const (
+	columnPartDescriptorBaseBytes = 96
+	granuleDescriptorBytes        = 64
+	columnDescriptorBytes         = 32
+	columnBlockDescriptorBytes    = 64
+	sortKeyColumnDescriptorBytes  = 32
+	sortKeyMarkBaseBytes          = 16
+	sortKeyPrefixBaseBytes        = 16
+	sortKeyBoundInt64Bytes        = 8
+	rowLocatorBytes               = 32
+	dictionaryHeaderBytes         = 32
+	dictionaryEntryOverheadBytes  = 12
+)
+
+type ColumnPartByteAccounting struct {
+	Rows                      int                                   `json:"rows"`
+	Columns                   int                                   `json:"columns"`
+	Granules                  int                                   `json:"granules"`
+	CodecBlocks               int                                   `json:"codec_blocks"`
+	LogicalValueBytes         int                                   `json:"logical_value_bytes"`
+	EncodedRawBytes           int                                   `json:"encoded_raw_bytes"`
+	DeclaredColumnStoredBytes int                                   `json:"declared_column_stored_bytes"`
+	DictionaryBytes           int                                   `json:"dictionary_bytes"`
+	MarkBytes                 int                                   `json:"mark_bytes"`
+	SortKeyMetadataBytes      int                                   `json:"sort_key_metadata_bytes"`
+	AggregateMetadataBytes    int                                   `json:"aggregate_metadata_bytes"`
+	DescriptorBytes           int                                   `json:"descriptor_bytes"`
+	LocatorBytes              int                                   `json:"locator_bytes"`
+	TotalStoredBytes          int                                   `json:"total_stored_bytes"`
+	BytesPerRow               float64                               `json:"bytes_per_row"`
+	RetainedJSONPayload       string                                `json:"retained_json_payload"`
+	ColumnsDetail             []ColumnPartColumnByteAccounting      `json:"columns_detail"`
+	CompressionDetail         []ColumnPartCompressionByteAccounting `json:"compression_detail"`
+}
+
+type ColumnPartColumnByteAccounting struct {
+	Column               string         `json:"column"`
+	Type                 ColumnType     `json:"type"`
+	Rows                 int            `json:"rows"`
+	Blocks               int            `json:"blocks"`
+	LogicalValueBytes    int            `json:"logical_value_bytes"`
+	EncodedRawBytes      int            `json:"encoded_raw_bytes"`
+	StoredBytes          int            `json:"stored_bytes"`
+	Encoding             Encoding       `json:"encoding"`
+	RequestedCompression Compression    `json:"requested_compression"`
+	ActualCompressionMix map[string]int `json:"actual_compression_mix"`
+	CompressionAttempted int            `json:"compression_attempted"`
+	CompressionKept      int            `json:"compression_kept"`
+	CompressionRejected  int            `json:"compression_rejected"`
+	FallbackReasons      map[string]int `json:"fallback_reasons,omitempty"`
+	CompressionNanos     int64          `json:"compression_nanos"`
+}
+
+type ColumnPartCompressionByteAccounting struct {
+	Column                 string      `json:"column"`
+	Substream              string      `json:"substream"`
+	Encoding               Encoding    `json:"encoding"`
+	RequestedCompression   Compression `json:"requested_compression"`
+	ActualCompression      Compression `json:"actual_compression"`
+	Blocks                 int         `json:"blocks"`
+	CompressionAttempted   int         `json:"compression_attempted"`
+	CompressionKept        int         `json:"compression_kept"`
+	CompressionRejected    int         `json:"compression_rejected"`
+	FallbackReason         string      `json:"fallback_reason,omitempty"`
+	EncodedRawBytes        int         `json:"encoded_raw_bytes"`
+	StoredBytes            int         `json:"stored_bytes"`
+	CompressionNanos       int64       `json:"compression_nanos"`
+	StoredToEncodedRawRate float64     `json:"stored_to_encoded_raw_rate"`
+}
+
+func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
+	if p == nil {
+		return ColumnPartByteAccounting{}
+	}
+	out := ColumnPartByteAccounting{
+		Rows:                p.Descriptor.RowCount,
+		Columns:             len(p.Columns),
+		Granules:            len(p.Descriptor.Granules),
+		RetainedJSONPayload: "absent_declared_columns_only",
+	}
+	compressionByKey := make(map[columnCompressionKey]*ColumnPartCompressionByteAccounting)
+	for _, columnDescriptor := range p.Descriptor.Columns {
+		column, ok := p.Columns[columnDescriptor.Name]
+		if !ok {
+			continue
+		}
+		detail := ColumnPartColumnByteAccounting{
+			Column:               columnDescriptor.Name,
+			Type:                 column.Definition.Type,
+			Encoding:             column.Definition.Encoding,
+			RequestedCompression: column.Definition.Compression,
+			ActualCompressionMix: make(map[string]int),
+			FallbackReasons:      make(map[string]int),
+		}
+		for _, block := range column.Blocks {
+			report := block.Granule.CodecReport
+			out.CodecBlocks++
+			valueBytes := logicalColumnValueBytes(column.Definition.Type, block.Descriptor.RowCount)
+			detail.Rows += block.Descriptor.RowCount
+			detail.Blocks++
+			detail.LogicalValueBytes += valueBytes
+			detail.EncodedRawBytes += block.Descriptor.RawBytes
+			detail.StoredBytes += block.Descriptor.StoredBytes
+			detail.ActualCompressionMix[block.Descriptor.Compression.String()]++
+			if report.CompressionAttempted {
+				detail.CompressionAttempted++
+			}
+			if report.CompressionKept {
+				detail.CompressionKept++
+			}
+			if report.CompressionAttempted && !report.CompressionKept {
+				detail.CompressionRejected++
+			}
+			if report.CompressionFallbackReason != "" {
+				detail.FallbackReasons[report.CompressionFallbackReason]++
+			}
+			detail.CompressionNanos += report.CompressionNanos
+
+			key := columnCompressionKey{
+				column:               columnDescriptor.Name,
+				substream:            "values",
+				encoding:             block.Descriptor.Encoding,
+				requestedCompression: column.Definition.Compression,
+				actualCompression:    block.Descriptor.Compression,
+				fallbackReason:       report.CompressionFallbackReason,
+			}
+			compression := compressionByKey[key]
+			if compression == nil {
+				compression = &ColumnPartCompressionByteAccounting{
+					Column:               key.column,
+					Substream:            key.substream,
+					Encoding:             key.encoding,
+					RequestedCompression: key.requestedCompression,
+					ActualCompression:    key.actualCompression,
+					FallbackReason:       key.fallbackReason,
+				}
+				compressionByKey[key] = compression
+			}
+			compression.Blocks++
+			if report.CompressionAttempted {
+				compression.CompressionAttempted++
+			}
+			if report.CompressionKept {
+				compression.CompressionKept++
+			}
+			if report.CompressionAttempted && !report.CompressionKept {
+				compression.CompressionRejected++
+			}
+			compression.EncodedRawBytes += block.Descriptor.RawBytes
+			compression.StoredBytes += block.Descriptor.StoredBytes
+			compression.CompressionNanos += report.CompressionNanos
+		}
+		if len(detail.FallbackReasons) == 0 {
+			detail.FallbackReasons = nil
+		}
+		out.LogicalValueBytes += detail.LogicalValueBytes
+		out.EncodedRawBytes += detail.EncodedRawBytes
+		out.DeclaredColumnStoredBytes += detail.StoredBytes
+		out.ColumnsDetail = append(out.ColumnsDetail, detail)
+	}
+	out.MarkBytes = estimateSortKeyMarkBytes(p.Marks)
+	out.SortKeyMetadataBytes = estimateSortKeyMetadataBytes(p.Descriptor.SortKey)
+	out.AggregateMetadataBytes = aggregateMetadataStoredBytes(p.AggregateMetadata)
+	out.DescriptorBytes = estimateColumnPartDescriptorBytes(p.Descriptor)
+	out.LocatorBytes = len(p.Locators) * rowLocatorBytes
+	for _, compression := range compressionByKey {
+		if compression.EncodedRawBytes > 0 {
+			compression.StoredToEncodedRawRate = float64(compression.StoredBytes) / float64(compression.EncodedRawBytes)
+		}
+		out.CompressionDetail = append(out.CompressionDetail, *compression)
+	}
+	sort.Slice(out.CompressionDetail, func(i, j int) bool {
+		left := out.CompressionDetail[i]
+		right := out.CompressionDetail[j]
+		if left.Column != right.Column {
+			return left.Column < right.Column
+		}
+		if left.ActualCompression != right.ActualCompression {
+			return left.ActualCompression < right.ActualCompression
+		}
+		return left.FallbackReason < right.FallbackReason
+	})
+	out.RecomputeTotals()
+	return out
+}
+
+func (a *ColumnPartByteAccounting) RecomputeTotals() {
+	a.TotalStoredBytes = a.CategoryBytes()
+	if a.Rows > 0 {
+		a.BytesPerRow = float64(a.TotalStoredBytes) / float64(a.Rows)
+	}
+}
+
+func (a ColumnPartByteAccounting) CategoryBytes() int {
+	return a.DeclaredColumnStoredBytes +
+		a.DictionaryBytes +
+		a.MarkBytes +
+		a.SortKeyMetadataBytes +
+		a.AggregateMetadataBytes +
+		a.DescriptorBytes +
+		a.LocatorBytes
+}
+
+func EstimateJSONBenchDictionaryBytes(ds JSONBenchDataset) int {
+	total := 0
+	for _, dict := range ds.Dictionaries {
+		if len(dict) == 0 {
+			continue
+		}
+		total += dictionaryHeaderBytes
+		for value := range dict {
+			total += len(value) + dictionaryEntryOverheadBytes
+		}
+	}
+	return total
+}
+
+func logicalColumnValueBytes(columnType ColumnType, rows int) int {
+	switch columnType {
+	case ColumnTypeBool:
+		return rows
+	case ColumnTypeLowCardinalityCode:
+		return rows * 4
+	default:
+		return rows * 8
+	}
+}
+
+func estimateColumnPartDescriptorBytes(desc ColumnPartDescriptor) int {
+	total := columnPartDescriptorBaseBytes
+	total += len(desc.Granules) * granuleDescriptorBytes
+	for _, column := range desc.Columns {
+		total += columnDescriptorBytes
+		total += len(column.Blocks) * columnBlockDescriptorBytes
+	}
+	return total
+}
+
+func estimateSortKeyMetadataBytes(columns []SortKeyColumn) int {
+	return len(columns) * sortKeyColumnDescriptorBytes
+}
+
+func estimateSortKeyMarkBytes(marks []SortKeyMark) int {
+	total := 0
+	for _, mark := range marks {
+		total += sortKeyMarkBaseBytes
+		for _, prefix := range mark.Prefixes {
+			total += sortKeyPrefixBaseBytes
+			total += len(prefix.Lower.Values) * sortKeyBoundInt64Bytes
+			total += len(prefix.UpperExclusive.Values) * sortKeyBoundInt64Bytes
+		}
+	}
+	return total
+}
+
+func aggregateMetadataStoredBytes(metadata map[string]AggregateMetadata) int {
+	total := 0
+	for _, m := range metadata {
+		if m.Stats.Admitted {
+			total += m.Stats.TotalBytes
+		}
+	}
+	return total
+}
+
+type columnCompressionKey struct {
+	column               string
+	substream            string
+	encoding             Encoding
+	requestedCompression Compression
+	actualCompression    Compression
+	fallbackReason       string
+}

--- a/experiments/colgranule/part_accounting_test.go
+++ b/experiments/colgranule/part_accounting_test.go
@@ -1,0 +1,60 @@
+package colgranule
+
+import "testing"
+
+func TestColumnPartByteAccountingReconcilesCategories(t *testing.T) {
+	opts := partTestOptions([]SortKeyColumn{{Column: "time_us"}})
+	opts.AggregateMetadata = []AggregateMetadataDefinition{aggregateMetadataTestDefinition()}
+	part, err := BuildColumnPart(23, opts, ColumnBatch{Columns: map[string][]int64{
+		"id":        {5, 4, 3, 2, 1},
+		"time_us":   {50, 40, 30, 20, 10},
+		"value":     {500, 400, 300, 200, 100},
+		"kind_code": {0, 1, 1, 2, 0},
+		"has_reply": {1, 1, 0, 1, 0},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+
+	accounting := part.ByteAccounting()
+	if accounting.Rows != 5 || accounting.Columns != 5 || accounting.Granules != 3 {
+		t.Fatalf("shape=%+v want rows=5 columns=5 granules=3", accounting)
+	}
+	if accounting.DeclaredColumnStoredBytes == 0 || accounting.MarkBytes == 0 || accounting.SortKeyMetadataBytes == 0 || accounting.DescriptorBytes == 0 || accounting.LocatorBytes == 0 {
+		t.Fatalf("missing accounting categories: %+v", accounting)
+	}
+	if accounting.AggregateMetadataBytes == 0 {
+		t.Fatalf("aggregate metadata bytes were not counted: %+v", accounting)
+	}
+	if got, want := accounting.TotalStoredBytes, accounting.CategoryBytes(); got != want {
+		t.Fatalf("total bytes=%d category sum=%d accounting=%+v", got, want, accounting)
+	}
+	if accounting.BytesPerRow <= 0 {
+		t.Fatalf("bytes per row=%f want positive", accounting.BytesPerRow)
+	}
+	if accounting.RetainedJSONPayload != "absent_declared_columns_only" {
+		t.Fatalf("retained JSON label=%q", accounting.RetainedJSONPayload)
+	}
+	if len(accounting.ColumnsDetail) != 5 {
+		t.Fatalf("column detail count=%d want 5", len(accounting.ColumnsDetail))
+	}
+	for _, column := range accounting.ColumnsDetail {
+		if column.Rows != 5 || column.Blocks == 0 || column.LogicalValueBytes == 0 || column.StoredBytes == 0 {
+			t.Fatalf("bad column accounting: %+v", column)
+		}
+	}
+	if len(accounting.CompressionDetail) == 0 {
+		t.Fatal("missing compression detail")
+	}
+}
+
+func TestEstimateJSONBenchDictionaryBytes(t *testing.T) {
+	ds, err := LoadJSONBenchColumns("testdata/jsonbench_sample.jsonl", 0)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns: %v", err)
+	}
+	bytes := EstimateJSONBenchDictionaryBytes(ds)
+	if bytes <= 0 {
+		t.Fatalf("dictionary bytes=%d want positive", bytes)
+	}
+}

--- a/experiments/colgranule/part_accounting_test.go
+++ b/experiments/colgranule/part_accounting_test.go
@@ -20,6 +20,9 @@ func TestColumnPartByteAccountingReconcilesCategories(t *testing.T) {
 	if accounting.Rows != 5 || accounting.Columns != 5 || accounting.Granules != 3 {
 		t.Fatalf("shape=%+v want rows=5 columns=5 granules=3", accounting)
 	}
+	if accounting.PhysicalFiles != 0 {
+		t.Fatalf("physical files=%d want 0 for in-memory experiment", accounting.PhysicalFiles)
+	}
 	if accounting.DeclaredColumnStoredBytes == 0 || accounting.MarkBytes == 0 || accounting.SortKeyMetadataBytes == 0 || accounting.DescriptorBytes == 0 || accounting.LocatorBytes == 0 {
 		t.Fatalf("missing accounting categories: %+v", accounting)
 	}


### PR DESCRIPTION
Implements M1C for `experiments/colgranule` as a stacked follow-up on #1564.

This adds actual encoded-part byte accounting for the current in-memory part layout:

- declared column encoded bytes
- loader dictionary estimate
- sort-key mark bytes
- sort-key metadata bytes
- admitted aggregate metadata bytes
- descriptor bytes
- row-locator/index bytes
- reconciled total bytes and bytes/row
- retained/original JSON payload label
- per-column/substream compression admission details

The JSONBench comparison report now includes an M1C build/size section with physical file count, granules, codec blocks, build throughput, allocation measurements, category totals, raw JSON/source gzip/ClickHouse ratios, compression keep/reject summaries, and full-dataset retained-payload estimates. File count is currently `0` because M1C still builds in-memory parts; file-backed `TCS1` work should replace this with real file/container counts. The benchmark suite now has M1C part-build benchmarks for synthetic and local `1m` JSONBench fixtures.

Local `1m` M1C report (`tmp/colgranule_m1c_full_1m_report.md`, generated locally and not committed):

| Layout | Files | Granules | Codec blocks | Best build | Rows/s | Encoded MiB/s | Stored MiB/s | Alloc B/op | Allocs/op | Temp B/op | Output B/row |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `time_us` | 0 | 123 | 2,337 | 0.177139s | 5,645,269 | 126.29 | 290.78 | 153,631,256 | 9,404 | 99,613,053 | 54.018 |
| `clickhouse_filter_user_time` | 0 | 123 | 2,337 | 1.263336s | 791,553 | 18.91 | 38.96 | 183,937,496 | 10,143 | 132,328,214 | 51.609 |

| Layout | Total bytes | vs raw JSON | vs source gzip | vs ClickHouse total | Declared columns | Dictionaries | Marks | Sort key | Aggregate metadata | Descriptors | Locators | Retained JSON |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| `time_us` | 54,018,203 | 11.26% | 39.96% | 53.07% | 12,029,877 | 7,925,614 | 5,904 | 32 | 1,898,632 | 158,144 | 32,000,000 | `absent_declared_columns_only` |
| `clickhouse_filter_user_time` | 51,609,282 | 10.76% | 38.18% | 50.70% | 10,268,684 | 7,925,614 | 41,328 | 160 | 1,215,352 | 158,144 | 32,000,000 | `absent_declared_columns_only` |

Full-dataset estimates add the current M1C encoded part to the measured retained-payload TreeDB collections from `experiments/colgranule/JSONBENCH_COMPARISON_RAW.json`. These are the M1C-era comparison rows for local ClickHouse `total_size` `101,786,238` bytes:

| Layout | Retained payload | Part bytes | Payload bytes | Total bytes | MiB | B/row | TreeDB / ClickHouse | Delta vs ClickHouse | Granules | Codec blocks | Part files | Payload files |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `time_us` | `BSON remaining` | 54,018,203 | 54,670,992 | 108,689,195 | 103.65 | 108.689 | 1.068x | +6.58 MiB | 123 | 2,337 | 0 | 15 |
| `time_us` | `JSON remaining` | 54,018,203 | 52,170,488 | 106,188,691 | 101.27 | 106.189 | 1.043x | +4.20 MiB | 123 | 2,337 | 0 | 15 |
| `time_us` | `Template-v1 remaining` | 54,018,203 | 49,830,135 | 103,848,338 | 99.04 | 103.848 | 1.020x | +1.97 MiB | 123 | 2,337 | 0 | 15 |
| `clickhouse_filter_user_time` | `BSON remaining` | 51,609,282 | 54,670,992 | 106,280,274 | 101.36 | 106.280 | 1.044x | +4.29 MiB | 123 | 2,337 | 0 | 15 |
| `clickhouse_filter_user_time` | `JSON remaining` | 51,609,282 | 52,170,488 | 103,779,770 | 98.97 | 103.780 | 1.020x | +1.90 MiB | 123 | 2,337 | 0 | 15 |
| `clickhouse_filter_user_time` | `Template-v1 remaining` | 51,609,282 | 49,830,135 | 101,439,417 | 96.74 | 101.439 | 0.997x | -0.33 MiB | 123 | 2,337 | 0 | 15 |

Local `1m` build benchmark:

| Benchmark | Result |
|---|---:|
| `BenchmarkJSONBenchLocalPartBuildM1C/time_us` | 220.6 ms/op, 4.53M rows/s, 54.02 output B/row, 153,660,480 B/op, 9,505 allocs/op |
| `BenchmarkJSONBenchLocalPartBuildM1C/clickhouse_filter_user_time` | 1.400s/op, 714K rows/s, 51.61 output B/row, 183,968,320 B/op, 10,250 allocs/op |

Validation:

- `go test ./experiments/colgranule -run 'TestColumnPartByteAccounting|TestEstimateJSONBenchDictionaryBytes|TestRunJSONBenchPartBuildReports' -count=1`
- `go test ./experiments/colgranule/...`
- `go test ./...`
- `go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchPartBuildM1C' -benchmem -count=2`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run '^$' -bench '^BenchmarkJSONBenchLocalPartBuildM1C$' -benchmem -count=1 -benchtime=1x`
- `go run ./experiments/colgranule/cmd/jsonbench_compare -data /Users/michaelseiler/data/bluesky/file_0001.json.gz -limit 1000000 -rows-per-granule 8192 -attempts 3 -clickhouse-local /Users/michaelseiler/dev/snissn/JSONBench/clickhouse/local_results/run_20260515_184738_65766/result.json -measure-remaining-treedb=false -retained-payload-from-json experiments/colgranule/JSONBENCH_COMPARISON_RAW.json -out-json tmp/colgranule_m1c_full_1m_raw.json -out-md tmp/colgranule_m1c_full_1m_report.md`

Tracks #1534.
