### PR TITLE
experiments/colgranule: add M2 TCS1 asset store

### DIFF
--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -1,8 +1,8 @@
 # Int64 Column Granule Experiment
 
 This package is a non-durable column-store smoke test. It does not publish
-TreeDB roots, write column files, use collection WAL, or expose public
-collection APIs.
+TreeDB roots, use production TreeDB value-log publication, use collection WAL,
+or expose public collection APIs.
 
 It currently covers:
 
@@ -20,6 +20,8 @@ It currently covers:
 - exact serialized in-memory column part images with a manifest, section
   directory, descriptor bytes, marks, locators, dictionaries, aggregate
   metadata, and column payload sections;
+- value-log-shaped `TCS1` column part assets that wrap serialized images,
+  persist/reopen through `ColumnAssetStore`, and reconstruct scan-capable parts;
 - JSONBench Bluesky fixture loading into int64-derived columns.
 
 ## Local JSONBench Data
@@ -127,10 +129,36 @@ The current canonical section kinds are:
 
 `ParseColumnPartImage` validates the manifest and section bounds.
 `ColumnPartFromImage` reconstructs a scan-capable read-only part from serialized
-bytes alone. JSONBench query timings use that parsed image-backed part so M1D
-can catch representation mistakes before M2 adds files, checksums, and recovery.
+bytes alone.
 
-## M1D Gates Before File-Backed M2
+## TCS1 Column Asset Layout
+
+`TCS1` is the M2 value-log-shaped wrapper for a serialized column part image. It
+is a logical column asset payload, not a separate production column-file
+lifecycle. The first M2 mode stores one complete `ColumnPartImage` as a single
+asset with:
+
+- `TCS1` magic and version;
+- payload kind for serialized part images;
+- format flags, currently strict-zero;
+- payload byte length;
+- part id, row count, and image version copied from the image;
+- payload checksum.
+
+`ColumnAssetStore` is the experiment seam that models future TreeDB `ValuePtr`
+storage without importing `TreeDB/internal` from this package. The memory store
+is useful for benchmarks, and the append-segment store proves reopen/readback
+through a value-log-shaped `file id + offset + length + checksum` ref. Query
+kernels still receive a reconstructed `ColumnPart`, so M2 validates storage
+plumbing without changing the encoded-block execution interface.
+
+JSONBench query timings now build the serialized image, wrap/store it as a
+`TCS1` asset, read it back, reconstruct the part, and run q1-q5 through the same
+encoded kernels. Split assets for individual blocks, dictionaries, marks,
+locators, or aggregate metadata should remain benchmark-driven follow-ups; the
+single-record mode is the baseline.
+
+## M1D Gates Before Value-Log-Backed M2
 
 Before moving this experiment into durable files, the in-memory representation
 must stay aligned with the future file format:
@@ -152,5 +180,5 @@ must stay aligned with the future file format:
   `BenchmarkJSONBenchLocalPartImageM1D` benchmark must keep measuring
   serialization of an existing part, parse/reconstruct from image bytes, and the
   full build/serialize/parse/reconstruct path;
-- M2 should add persistence, checksums, file/container layout, recovery, and
-  lifecycle behavior without changing the logical section model.
+- M2 should add `TCS1` value-log-shaped persistence, checksums, asset refs,
+  recovery, and lifecycle behavior without changing the logical section model.

--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -154,9 +154,13 @@ plumbing without changing the encoded-block execution interface.
 
 JSONBench query timings now build the serialized image, wrap/store it as a
 `TCS1` asset, read it back, reconstruct the part, and run q1-q5 through the same
-encoded kernels. Split assets for individual blocks, dictionaries, marks,
-locators, or aggregate metadata should remain benchmark-driven follow-ups; the
-single-record mode is the baseline.
+encoded kernels. The query hot path uses scan-only reconstruction so it does not
+decode the point-lookup row-locator map or aggregate metadata for scans that do
+not need them. Full reconstruction with locators and eager metadata remains
+available for point lookup, metadata kernels, and integrity tests. Split assets
+for individual blocks, dictionaries, marks, locators, or aggregate metadata
+should remain benchmark-driven follow-ups; the single-record mode is the
+baseline.
 
 ## M1D Gates Before Value-Log-Backed M2
 

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -177,6 +177,11 @@ func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte
 	if ref.FileID != s.fileID {
 		return nil, fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ref.Offset > s.size || ref.Length > s.size-ref.Offset {
+		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, s.size)
+	}
 	if ref.Length > int64(int(ref.Length)) {
 		return nil, fmt.Errorf("colgranule: asset length=%d exceeds host int", ref.Length)
 	}

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -25,6 +25,7 @@ type ColumnAssetRef struct {
 
 type ColumnAssetStore interface {
 	Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
+	// Read may return store-owned bytes. Callers must treat the returned bytes as read-only.
 	Read(ref ColumnAssetRef) ([]byte, error)
 	ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error)
 }
@@ -72,10 +73,6 @@ func (s *MemoryColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Colu
 }
 
 func (s *MemoryColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
-	return s.ReadTo(ref, nil)
-}
-
-func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
 	if s == nil {
 		return nil, fmt.Errorf("colgranule: nil memory asset store")
 	}
@@ -90,6 +87,14 @@ func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte,
 	}
 	if checksum := crc32.ChecksumIEEE(payload); checksum != ref.Checksum {
 		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	}
+	return payload, nil
+}
+
+func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	payload, err := s.Read(ref)
+	if err != nil {
+		return nil, err
 	}
 	out := append(dst[:0], payload...)
 	return out, nil
@@ -153,7 +158,7 @@ func (s *SegmentColumnAssetStore) Path() string {
 
 func (s *SegmentColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
 	if s == nil {
-		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed segment asset store")
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: nil segment asset store")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -181,7 +186,7 @@ func (s *SegmentColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
 
 func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
 	if s == nil {
-		return nil, fmt.Errorf("colgranule: closed segment asset store")
+		return nil, fmt.Errorf("colgranule: nil segment asset store")
 	}
 	if err := validateColumnAssetRef(ref); err != nil {
 		return nil, err

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -30,10 +30,14 @@ type ColumnAssetStore interface {
 	ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error)
 }
 
+type columnAssetOwnedStore interface {
+	PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
+}
+
 type MemoryColumnAssetStore struct {
 	mu      sync.Mutex
 	nextOff int64
-	assets  map[columnAssetKey][]byte
+	assets  map[columnAssetKey]memoryColumnAsset
 }
 
 type columnAssetKey struct {
@@ -43,8 +47,13 @@ type columnAssetKey struct {
 	length int64
 }
 
+type memoryColumnAsset struct {
+	payload  []byte
+	checksum uint32
+}
+
 func NewMemoryColumnAssetStore() *MemoryColumnAssetStore {
-	return &MemoryColumnAssetStore{assets: make(map[columnAssetKey][]byte)}
+	return &MemoryColumnAssetStore{assets: make(map[columnAssetKey]memoryColumnAsset)}
 }
 
 func (s *MemoryColumnAssetStore) Reset() {
@@ -60,7 +69,17 @@ func (s *MemoryColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Colu
 	if s == nil {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: nil memory asset store")
 	}
-	value := append([]byte(nil), payload...)
+	return s.put(kind, append([]byte(nil), payload...))
+}
+
+func (s *MemoryColumnAssetStore) PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if s == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: nil memory asset store")
+	}
+	return s.put(kind, payload)
+}
+
+func (s *MemoryColumnAssetStore) put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	ref, err := newColumnAssetRef(kind, 1, s.nextOff, len(payload), payload)
@@ -68,7 +87,7 @@ func (s *MemoryColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Colu
 		return ColumnAssetRef{}, err
 	}
 	s.nextOff += ref.Length
-	s.assets[ref.key()] = value
+	s.assets[ref.key()] = memoryColumnAsset{payload: payload, checksum: ref.Checksum}
 	return ref, nil
 }
 
@@ -80,15 +99,15 @@ func (s *MemoryColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
 		return nil, err
 	}
 	s.mu.Lock()
-	payload, ok := s.assets[ref.key()]
+	asset, ok := s.assets[ref.key()]
 	s.mu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("colgranule: missing asset ref file=%d offset=%d length=%d kind=%s", ref.FileID, ref.Offset, ref.Length, ref.Kind)
 	}
-	if checksum := crc32.ChecksumIEEE(payload); checksum != ref.Checksum {
-		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	if asset.checksum != ref.Checksum {
+		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", asset.checksum, ref.Checksum)
 	}
-	return payload, nil
+	return asset.payload, nil
 }
 
 func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -152,8 +152,12 @@ func (s *SegmentColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Col
 	if err != nil {
 		return ColumnAssetRef{}, err
 	}
-	if _, err := s.file.WriteAt(payload, ref.Offset); err != nil {
+	n, err := s.file.WriteAt(payload, ref.Offset)
+	if err != nil {
 		return ColumnAssetRef{}, err
+	}
+	if n != len(payload) {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: short asset write bytes=%d want %d", n, len(payload))
 	}
 	s.size += ref.Length
 	return ref, nil

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,6 +14,8 @@ type ColumnAssetKind string
 
 const (
 	ColumnAssetKindTCS1PartImage ColumnAssetKind = "tcs1_part_image"
+
+	maxColumnAssetReadBytes int64 = 512 << 20
 )
 
 type ColumnAssetRef struct {
@@ -27,6 +30,8 @@ type ColumnAssetStore interface {
 	Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
 	// Read may return store-owned bytes. Callers must treat the returned bytes as read-only.
 	Read(ref ColumnAssetRef) ([]byte, error)
+	// ReadTo appends or writes the asset bytes into dst[:0] and returns caller-owned bytes.
+	// The returned slice may alias dst and remains valid until the caller mutates or reuses it.
 	ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error)
 }
 
@@ -41,13 +46,13 @@ type MemoryColumnAssetStore struct {
 }
 
 type columnAssetKey struct {
-	kind   ColumnAssetKind
 	fileID uint32
 	offset int64
-	length int64
 }
 
 type memoryColumnAsset struct {
+	kind     ColumnAssetKind
+	length   int64
 	payload  []byte
 	checksum uint32
 }
@@ -87,7 +92,12 @@ func (s *MemoryColumnAssetStore) put(kind ColumnAssetKind, payload []byte) (Colu
 		return ColumnAssetRef{}, err
 	}
 	s.nextOff += ref.Length
-	s.assets[ref.key()] = memoryColumnAsset{payload: payload, checksum: ref.Checksum}
+	s.assets[ref.key()] = memoryColumnAsset{
+		kind:     ref.Kind,
+		length:   ref.Length,
+		payload:  payload,
+		checksum: ref.Checksum,
+	}
 	return ref, nil
 }
 
@@ -102,7 +112,13 @@ func (s *MemoryColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
 	asset, ok := s.assets[ref.key()]
 	s.mu.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("colgranule: missing asset ref file=%d offset=%d length=%d kind=%s", ref.FileID, ref.Offset, ref.Length, ref.Kind)
+		return nil, fmt.Errorf("colgranule: missing asset ref file=%d offset=%d", ref.FileID, ref.Offset)
+	}
+	if asset.kind != ref.Kind {
+		return nil, fmt.Errorf("colgranule: asset kind=%s want %s", asset.kind, ref.Kind)
+	}
+	if asset.length != ref.Length {
+		return nil, fmt.Errorf("colgranule: asset length=%d want %d", asset.length, ref.Length)
 	}
 	if asset.checksum != ref.Checksum {
 		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", asset.checksum, ref.Checksum)
@@ -221,8 +237,11 @@ func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte
 	if ref.Offset > s.size || ref.Length > s.size-ref.Offset {
 		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, s.size)
 	}
-	if ref.Length > int64(int(ref.Length)) {
+	if ref.Length > int64(math.MaxInt) {
 		return nil, fmt.Errorf("colgranule: asset length=%d exceeds host int", ref.Length)
+	}
+	if ref.Length > maxColumnAssetReadBytes {
+		return nil, fmt.Errorf("colgranule: asset length=%d exceeds max read bytes=%d", ref.Length, maxColumnAssetReadBytes)
 	}
 	length := int(ref.Length)
 	if cap(dst) < length {
@@ -241,8 +260,8 @@ func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte
 }
 
 func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length int, payload []byte) (ColumnAssetRef, error) {
-	if kind == "" {
-		return ColumnAssetRef{}, fmt.Errorf("colgranule: empty column asset kind")
+	if err := validateColumnAssetKind(kind); err != nil {
+		return ColumnAssetRef{}, err
 	}
 	if fileID == 0 {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: zero column asset file id")
@@ -252,6 +271,9 @@ func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length
 	}
 	if length < 0 {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: negative column asset length %d", length)
+	}
+	if length == 0 {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: empty column asset payload")
 	}
 	if len(payload) != length {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: column asset payload bytes=%d want length=%d", len(payload), length)
@@ -266,8 +288,8 @@ func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length
 }
 
 func validateColumnAssetRef(ref ColumnAssetRef) error {
-	if ref.Kind == "" {
-		return fmt.Errorf("colgranule: empty column asset ref kind")
+	if err := validateColumnAssetKind(ref.Kind); err != nil {
+		return err
 	}
 	if ref.FileID == 0 {
 		return fmt.Errorf("colgranule: zero column asset ref file id")
@@ -278,14 +300,26 @@ func validateColumnAssetRef(ref ColumnAssetRef) error {
 	if ref.Length < 0 {
 		return fmt.Errorf("colgranule: negative column asset ref length %d", ref.Length)
 	}
+	if ref.Length == 0 {
+		return fmt.Errorf("colgranule: empty column asset ref payload")
+	}
 	return nil
 }
 
 func (ref ColumnAssetRef) key() columnAssetKey {
 	return columnAssetKey{
-		kind:   ref.Kind,
 		fileID: ref.FileID,
 		offset: ref.Offset,
-		length: ref.Length,
+	}
+}
+
+func validateColumnAssetKind(kind ColumnAssetKind) error {
+	switch kind {
+	case "":
+		return fmt.Errorf("colgranule: empty column asset kind")
+	case ColumnAssetKindTCS1PartImage:
+		return nil
+	default:
+		return fmt.Errorf("colgranule: unsupported column asset kind %s", kind)
 	}
 }

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -32,11 +32,18 @@ type ColumnAssetStore interface {
 type MemoryColumnAssetStore struct {
 	mu      sync.Mutex
 	nextOff int64
-	assets  map[ColumnAssetRef][]byte
+	assets  map[columnAssetKey][]byte
+}
+
+type columnAssetKey struct {
+	kind   ColumnAssetKind
+	fileID uint32
+	offset int64
+	length int64
 }
 
 func NewMemoryColumnAssetStore() *MemoryColumnAssetStore {
-	return &MemoryColumnAssetStore{assets: make(map[ColumnAssetRef][]byte)}
+	return &MemoryColumnAssetStore{assets: make(map[columnAssetKey][]byte)}
 }
 
 func (s *MemoryColumnAssetStore) Reset() {
@@ -60,7 +67,7 @@ func (s *MemoryColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Colu
 		return ColumnAssetRef{}, err
 	}
 	s.nextOff += ref.Length
-	s.assets[ref] = value
+	s.assets[ref.key()] = value
 	return ref, nil
 }
 
@@ -76,7 +83,7 @@ func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte,
 		return nil, err
 	}
 	s.mu.Lock()
-	payload, ok := s.assets[ref]
+	payload, ok := s.assets[ref.key()]
 	s.mu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("colgranule: missing asset ref file=%d offset=%d length=%d kind=%s", ref.FileID, ref.Offset, ref.Length, ref.Kind)
@@ -124,7 +131,12 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 }
 
 func (s *SegmentColumnAssetStore) Close() error {
-	if s == nil || s.file == nil {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
 		return nil
 	}
 	err := s.file.Close()
@@ -140,14 +152,14 @@ func (s *SegmentColumnAssetStore) Path() string {
 }
 
 func (s *SegmentColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
-	if s == nil || s.file == nil {
+	if s == nil {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed segment asset store")
-	}
-	if _, err := newColumnAssetRef(kind, s.fileID, 0, len(payload), payload); err != nil {
-		return ColumnAssetRef{}, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.file == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed segment asset store")
+	}
 	ref, err := newColumnAssetRef(kind, s.fileID, s.size, len(payload), payload)
 	if err != nil {
 		return ColumnAssetRef{}, err
@@ -168,17 +180,20 @@ func (s *SegmentColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
 }
 
 func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
-	if s == nil || s.file == nil {
+	if s == nil {
 		return nil, fmt.Errorf("colgranule: closed segment asset store")
 	}
 	if err := validateColumnAssetRef(ref); err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return nil, fmt.Errorf("colgranule: closed segment asset store")
+	}
 	if ref.FileID != s.fileID {
 		return nil, fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if ref.Offset > s.size || ref.Length > s.size-ref.Offset {
 		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, s.size)
 	}
@@ -240,4 +255,13 @@ func validateColumnAssetRef(ref ColumnAssetRef) error {
 		return fmt.Errorf("colgranule: negative column asset ref length %d", ref.Length)
 	}
 	return nil
+}
+
+func (ref ColumnAssetRef) key() columnAssetKey {
+	return columnAssetKey{
+		kind:   ref.Kind,
+		fileID: ref.FileID,
+		offset: ref.Offset,
+		length: ref.Length,
+	}
 }

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -1,0 +1,234 @@
+package colgranule
+
+import (
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type ColumnAssetKind string
+
+const (
+	ColumnAssetKindTCS1PartImage ColumnAssetKind = "tcs1_part_image"
+)
+
+type ColumnAssetRef struct {
+	Kind     ColumnAssetKind `json:"kind"`
+	FileID   uint32          `json:"file_id"`
+	Offset   int64           `json:"offset"`
+	Length   int64           `json:"length"`
+	Checksum uint32          `json:"checksum"`
+}
+
+type ColumnAssetStore interface {
+	Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
+	Read(ref ColumnAssetRef) ([]byte, error)
+	ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error)
+}
+
+type MemoryColumnAssetStore struct {
+	mu      sync.Mutex
+	nextOff int64
+	assets  map[ColumnAssetRef][]byte
+}
+
+func NewMemoryColumnAssetStore() *MemoryColumnAssetStore {
+	return &MemoryColumnAssetStore{assets: make(map[ColumnAssetRef][]byte)}
+}
+
+func (s *MemoryColumnAssetStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for ref := range s.assets {
+		delete(s.assets, ref)
+	}
+	s.nextOff = 0
+}
+
+func (s *MemoryColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if s == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: nil memory asset store")
+	}
+	value := append([]byte(nil), payload...)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ref, err := newColumnAssetRef(kind, 1, s.nextOff, len(payload), payload)
+	if err != nil {
+		return ColumnAssetRef{}, err
+	}
+	s.nextOff += ref.Length
+	s.assets[ref] = value
+	return ref, nil
+}
+
+func (s *MemoryColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
+	return s.ReadTo(ref, nil)
+}
+
+func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("colgranule: nil memory asset store")
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	payload, ok := s.assets[ref]
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("colgranule: missing asset ref file=%d offset=%d length=%d kind=%s", ref.FileID, ref.Offset, ref.Length, ref.Kind)
+	}
+	if checksum := crc32.ChecksumIEEE(payload); checksum != ref.Checksum {
+		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	}
+	out := append(dst[:0], payload...)
+	return out, nil
+}
+
+type SegmentColumnAssetStore struct {
+	mu     sync.Mutex
+	dir    string
+	path   string
+	file   *os.File
+	fileID uint32
+	size   int64
+}
+
+func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("colgranule: empty segment asset dir")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, "column-assets-000001.seg")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &SegmentColumnAssetStore{
+		dir:    dir,
+		path:   path,
+		file:   file,
+		fileID: 1,
+		size:   info.Size(),
+	}, nil
+}
+
+func (s *SegmentColumnAssetStore) Close() error {
+	if s == nil || s.file == nil {
+		return nil
+	}
+	err := s.file.Close()
+	s.file = nil
+	return err
+}
+
+func (s *SegmentColumnAssetStore) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+func (s *SegmentColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if s == nil || s.file == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed segment asset store")
+	}
+	if _, err := newColumnAssetRef(kind, s.fileID, 0, len(payload), payload); err != nil {
+		return ColumnAssetRef{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ref, err := newColumnAssetRef(kind, s.fileID, s.size, len(payload), payload)
+	if err != nil {
+		return ColumnAssetRef{}, err
+	}
+	if _, err := s.file.WriteAt(payload, ref.Offset); err != nil {
+		return ColumnAssetRef{}, err
+	}
+	s.size += ref.Length
+	return ref, nil
+}
+
+func (s *SegmentColumnAssetStore) Read(ref ColumnAssetRef) ([]byte, error) {
+	return s.ReadTo(ref, nil)
+}
+
+func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	if s == nil || s.file == nil {
+		return nil, fmt.Errorf("colgranule: closed segment asset store")
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return nil, err
+	}
+	if ref.FileID != s.fileID {
+		return nil, fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
+	}
+	if ref.Length > int64(int(ref.Length)) {
+		return nil, fmt.Errorf("colgranule: asset length=%d exceeds host int", ref.Length)
+	}
+	length := int(ref.Length)
+	if cap(dst) < length {
+		dst = make([]byte, length)
+	} else {
+		dst = dst[:length]
+	}
+	reader := io.NewSectionReader(s.file, ref.Offset, ref.Length)
+	if _, err := io.ReadFull(reader, dst); err != nil {
+		return nil, err
+	}
+	if checksum := crc32.ChecksumIEEE(dst); checksum != ref.Checksum {
+		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	}
+	return dst, nil
+}
+
+func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length int, payload []byte) (ColumnAssetRef, error) {
+	if kind == "" {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: empty column asset kind")
+	}
+	if fileID == 0 {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: zero column asset file id")
+	}
+	if offset < 0 {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: negative column asset offset %d", offset)
+	}
+	if length < 0 {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: negative column asset length %d", length)
+	}
+	if len(payload) != length {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: column asset payload bytes=%d want length=%d", len(payload), length)
+	}
+	return ColumnAssetRef{
+		Kind:     kind,
+		FileID:   fileID,
+		Offset:   offset,
+		Length:   int64(length),
+		Checksum: crc32.ChecksumIEEE(payload),
+	}, nil
+}
+
+func validateColumnAssetRef(ref ColumnAssetRef) error {
+	if ref.Kind == "" {
+		return fmt.Errorf("colgranule: empty column asset ref kind")
+	}
+	if ref.FileID == 0 {
+		return fmt.Errorf("colgranule: zero column asset ref file id")
+	}
+	if ref.Offset < 0 {
+		return fmt.Errorf("colgranule: negative column asset ref offset %d", ref.Offset)
+	}
+	if ref.Length < 0 {
+		return fmt.Errorf("colgranule: negative column asset ref length %d", ref.Length)
+	}
+	return nil
+}

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -449,11 +449,11 @@ func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					store.Reset()
-					ref, record, err := StoreTCS1ColumnPartImage(store, image)
+					ref, storedRecord, err := StoreTCS1ColumnPartImage(store, image)
 					if err != nil {
 						b.Fatal(err)
 					}
-					benchSink += int64(ref.Length + int64(record.PayloadBytes))
+					benchSink += int64(ref.Length + int64(storedRecord.PayloadBytes))
 				}
 				reportTCS1AssetThroughput(b, ds, record)
 			})
@@ -468,11 +468,11 @@ func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
 				b.SetBytes(int64(record.TotalBytes))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					reconstructed, record, err := ColumnPartFromTCS1Asset(store, ref)
+					reconstructed, loadedRecord, err := ColumnPartFromTCS1Asset(store, ref)
 					if err != nil {
 						b.Fatal(err)
 					}
-					benchSink += int64(reconstructed.Descriptor.RowCount + record.PayloadBytes)
+					benchSink += int64(reconstructed.Descriptor.RowCount + loadedRecord.PayloadBytes)
 				}
 				reportTCS1AssetThroughput(b, ds, record)
 			})
@@ -488,11 +488,11 @@ func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					reconstructed, ref, record, err := TCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
+					reconstructed, ref, rebuiltRecord, err := TCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
 					if err != nil {
 						b.Fatal(err)
 					}
-					benchSink += int64(reconstructed.Descriptor.RowCount) + ref.Length + int64(record.PayloadBytes)
+					benchSink += int64(reconstructed.Descriptor.RowCount) + ref.Length + int64(rebuiltRecord.PayloadBytes)
 				}
 				reportTCS1AssetThroughput(b, ds, record)
 			})

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -283,6 +283,26 @@ func BenchmarkJSONBenchLocalPartImageM1D(b *testing.B) {
 	benchmarkJSONBenchPartImageM1D(b, ds)
 }
 
+func BenchmarkJSONBenchPartAssetM2(b *testing.B) {
+	ds := syntheticJSONBenchDataset(DefaultRowsPerGranule * 100)
+	benchmarkJSONBenchPartAssetM2(b, ds)
+}
+
+func BenchmarkJSONBenchLocalPartAssetM2(b *testing.B) {
+	path := os.Getenv("JSONBENCH_DATA")
+	if path == "" {
+		path = DefaultJSONBenchDir
+	}
+	if _, err := os.Stat(path); err != nil {
+		b.Skipf("JSONBench data not present; set JSONBENCH_DATA or install %s", DefaultJSONBenchDir)
+	}
+	ds, err := LoadJSONBenchColumns(path, 1_000_000)
+	if err != nil {
+		b.Fatalf("LoadJSONBenchColumns: %v", err)
+	}
+	benchmarkJSONBenchPartAssetM2(b, ds)
+}
+
 func benchmarkJSONBenchPartBuildM1C(b *testing.B, ds JSONBenchDataset) {
 	for _, layout := range []JSONBenchColumnPartLayout{
 		JSONBenchColumnPartLayoutTimeUS,
@@ -402,6 +422,84 @@ func benchmarkJSONBenchPartImageM1D(b *testing.B, ds JSONBenchDataset) {
 	}
 }
 
+func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
+	for _, layout := range []JSONBenchColumnPartLayout{
+		JSONBenchColumnPartLayoutTimeUS,
+		JSONBenchColumnPartLayoutClickHouseFilterUserTime,
+	} {
+		b.Run(string(layout), func(b *testing.B) {
+			part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, layout)
+			if err != nil {
+				b.Fatalf("BuildJSONBenchColumnPartWithAggregateMetadataForLayout: %v", err)
+			}
+			image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: ds.Dictionaries})
+			if err != nil {
+				b.Fatalf("BuildColumnPartImage: %v", err)
+			}
+			assetBytes, record, err := EncodeTCS1ColumnPartImage(image)
+			if err != nil {
+				b.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+			}
+			reportTCS1AssetBenchmarkMetrics(b, ds, record)
+
+			b.Run("store_existing_image_asset", func(b *testing.B) {
+				store := NewMemoryColumnAssetStore()
+				b.ReportAllocs()
+				b.SetBytes(int64(record.TotalBytes))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					store.Reset()
+					ref, record, err := StoreTCS1ColumnPartImage(store, image)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(ref.Length + int64(record.PayloadBytes))
+				}
+				reportTCS1AssetThroughput(b, ds, record)
+			})
+
+			b.Run("load_parse_reconstruct", func(b *testing.B) {
+				store := NewMemoryColumnAssetStore()
+				ref, err := store.Put(ColumnAssetKindTCS1PartImage, assetBytes)
+				if err != nil {
+					b.Fatalf("Put: %v", err)
+				}
+				b.ReportAllocs()
+				b.SetBytes(int64(record.TotalBytes))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					reconstructed, record, err := ColumnPartFromTCS1Asset(store, ref)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(reconstructed.Descriptor.RowCount + record.PayloadBytes)
+				}
+				reportTCS1AssetThroughput(b, ds, record)
+			})
+
+			b.Run("build_serialize_store_load_parse_reconstruct", func(b *testing.B) {
+				store := NewMemoryColumnAssetStore()
+				b.ReportAllocs()
+				b.SetBytes(int64(record.TotalBytes))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					store.Reset()
+					part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, DefaultRowsPerGranule, layout)
+					if err != nil {
+						b.Fatal(err)
+					}
+					reconstructed, ref, record, err := TCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(reconstructed.Descriptor.RowCount) + ref.Length + int64(record.PayloadBytes)
+				}
+				reportTCS1AssetThroughput(b, ds, record)
+			})
+		})
+	}
+}
+
 func reportPartImageBenchmarkMetrics(b *testing.B, ds JSONBenchDataset, accounting ColumnPartByteAccounting) {
 	b.Helper()
 	if ds.Rows == 0 {
@@ -412,6 +510,29 @@ func reportPartImageBenchmarkMetrics(b *testing.B, ds JSONBenchDataset, accounti
 	b.ReportMetric(float64(accounting.DictionaryBytes)/float64(ds.Rows), "dict_B/row")
 	b.ReportMetric(float64(accounting.AggregateMetadataBytes)/float64(ds.Rows), "agg_B/row")
 	b.ReportMetric(float64(accounting.LocatorBytes)/float64(ds.Rows), "locator_B/row")
+}
+
+func reportTCS1AssetBenchmarkMetrics(b *testing.B, ds JSONBenchDataset, record TCS1PartRecord) {
+	b.Helper()
+	if ds.Rows == 0 {
+		return
+	}
+	b.ReportMetric(float64(record.TotalBytes)/float64(ds.Rows), "asset_B/row")
+	b.ReportMetric(float64(record.PayloadBytes)/float64(ds.Rows), "payload_B/row")
+	b.ReportMetric(float64(tcs1HeaderBytes), "wrapper_B/part")
+}
+
+func reportTCS1AssetThroughput(b *testing.B, ds JSONBenchDataset, record TCS1PartRecord) {
+	b.Helper()
+	seconds := b.Elapsed().Seconds()
+	if seconds <= 0 {
+		return
+	}
+	b.ReportMetric(float64(ds.Rows*b.N)/seconds, "rows/s")
+	b.ReportMetric(float64(record.TotalBytes*b.N)/seconds/(1024*1024), "asset_MiB/s")
+	if ds.Rows > 0 {
+		b.ReportMetric(float64(record.TotalBytes)/float64(ds.Rows), "asset_B/row")
+	}
 }
 
 func reportPartImageThroughput(b *testing.B, ds JSONBenchDataset, accounting ColumnPartByteAccounting) {

--- a/experiments/colgranule/jsonbench_bench_test.go
+++ b/experiments/colgranule/jsonbench_bench_test.go
@@ -468,11 +468,49 @@ func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
 				b.SetBytes(int64(record.TotalBytes))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					reconstructed, loadedRecord, err := ColumnPartFromTCS1Asset(store, ref)
+					reconstructed, loadedRecord, err := ColumnPartFromTCS1AssetWithOptions(store, ref, ColumnPartImageReadOptions{})
 					if err != nil {
 						b.Fatal(err)
 					}
 					benchSink += int64(reconstructed.Descriptor.RowCount + loadedRecord.PayloadBytes)
+				}
+				reportTCS1AssetThroughput(b, ds, record)
+			})
+
+			b.Run("load_parse_reconstruct_metadata", func(b *testing.B) {
+				store := NewMemoryColumnAssetStore()
+				ref, err := store.Put(ColumnAssetKindTCS1PartImage, assetBytes)
+				if err != nil {
+					b.Fatalf("Put: %v", err)
+				}
+				b.ReportAllocs()
+				b.SetBytes(int64(record.TotalBytes))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					reconstructed, loadedRecord, err := ColumnPartFromTCS1AssetWithOptions(store, ref, ColumnPartImageReadOptions{IncludeAggregateMetadata: true})
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(reconstructed.Descriptor.RowCount+len(reconstructed.AggregateMetadata)) + int64(loadedRecord.PayloadBytes)
+				}
+				reportTCS1AssetThroughput(b, ds, record)
+			})
+
+			b.Run("load_parse_reconstruct_full_locators", func(b *testing.B) {
+				store := NewMemoryColumnAssetStore()
+				ref, err := store.Put(ColumnAssetKindTCS1PartImage, assetBytes)
+				if err != nil {
+					b.Fatalf("Put: %v", err)
+				}
+				b.ReportAllocs()
+				b.SetBytes(int64(record.TotalBytes))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					reconstructed, loadedRecord, err := ColumnPartFromTCS1Asset(store, ref)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSink += int64(reconstructed.Descriptor.RowCount+len(reconstructed.Locators)) + int64(loadedRecord.PayloadBytes)
 				}
 				reportTCS1AssetThroughput(b, ds, record)
 			})
@@ -488,7 +526,7 @@ func benchmarkJSONBenchPartAssetM2(b *testing.B, ds JSONBenchDataset) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					reconstructed, ref, rebuiltRecord, err := TCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
+					reconstructed, ref, rebuiltRecord, err := ScanOnlyTCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -113,16 +113,10 @@ func BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds JSONBenchDataset,
 	return BuildColumnPart(1, opts, ColumnBatch{Rows: ds.Rows, Columns: ds.Columns})
 }
 
-func imageBackedJSONBenchPart(part *ColumnPart, dictionaries map[string]map[string]int64) (*ColumnPart, error) {
-	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: dictionaries})
-	if err != nil {
-		return nil, err
-	}
-	parsed, err := ParseColumnPartImage(image.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return ColumnPartFromImage(parsed)
+func assetBackedJSONBenchPart(part *ColumnPart, dictionaries map[string]map[string]int64) (*ColumnPart, error) {
+	store := NewMemoryColumnAssetStore()
+	reconstructed, _, _, err := TCS1AssetBackedColumnPart(part, dictionaries, store)
+	return reconstructed, err
 }
 
 func JSONBenchColumnPartOptions(ds JSONBenchDataset, rowsPerGranule int) (ColumnStoreOptions, error) {
@@ -247,7 +241,7 @@ func RunJSONBenchPartQueries(ds JSONBenchDataset, rowsPerGranule int, attempts i
 	if err != nil {
 		return nil, err
 	}
-	part, err = imageBackedJSONBenchPart(part, ds.Dictionaries)
+	part, err = assetBackedJSONBenchPart(part, ds.Dictionaries)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +317,7 @@ func RunJSONBenchPartQ4FairnessQueries(ds JSONBenchDataset, rowsPerGranule int, 
 	if err != nil {
 		return nil, err
 	}
-	timePart, err = imageBackedJSONBenchPart(timePart, ds.Dictionaries)
+	timePart, err = assetBackedJSONBenchPart(timePart, ds.Dictionaries)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +325,7 @@ func RunJSONBenchPartQ4FairnessQueries(ds JSONBenchDataset, rowsPerGranule int, 
 	if err != nil {
 		return nil, err
 	}
-	clickHouseOrderPart, err = imageBackedJSONBenchPart(clickHouseOrderPart, ds.Dictionaries)
+	clickHouseOrderPart, err = assetBackedJSONBenchPart(clickHouseOrderPart, ds.Dictionaries)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +396,7 @@ func RunJSONBenchPartAggregateMetadataQueries(ds JSONBenchDataset, rowsPerGranul
 	if err != nil {
 		return nil, err
 	}
-	timePart, err = imageBackedJSONBenchPart(timePart, ds.Dictionaries)
+	timePart, err = assetBackedJSONBenchPart(timePart, ds.Dictionaries)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +404,7 @@ func RunJSONBenchPartAggregateMetadataQueries(ds JSONBenchDataset, rowsPerGranul
 	if err != nil {
 		return nil, err
 	}
-	clickHouseOrderPart, err = imageBackedJSONBenchPart(clickHouseOrderPart, ds.Dictionaries)
+	clickHouseOrderPart, err = assetBackedJSONBenchPart(clickHouseOrderPart, ds.Dictionaries)
 	if err != nil {
 		return nil, err
 	}

--- a/experiments/colgranule/jsonbench_part_queries.go
+++ b/experiments/colgranule/jsonbench_part_queries.go
@@ -114,8 +114,12 @@ func BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds JSONBenchDataset,
 }
 
 func assetBackedJSONBenchPart(part *ColumnPart, dictionaries map[string]map[string]int64) (*ColumnPart, error) {
+	return assetBackedJSONBenchPartWithOptions(part, dictionaries, ColumnPartImageReadOptions{})
+}
+
+func assetBackedJSONBenchPartWithOptions(part *ColumnPart, dictionaries map[string]map[string]int64, opts ColumnPartImageReadOptions) (*ColumnPart, error) {
 	store := NewMemoryColumnAssetStore()
-	reconstructed, _, _, err := TCS1AssetBackedColumnPart(part, dictionaries, store)
+	reconstructed, _, _, err := TCS1AssetBackedColumnPartWithOptions(part, dictionaries, store, opts)
 	return reconstructed, err
 }
 
@@ -396,7 +400,7 @@ func RunJSONBenchPartAggregateMetadataQueries(ds JSONBenchDataset, rowsPerGranul
 	if err != nil {
 		return nil, err
 	}
-	timePart, err = assetBackedJSONBenchPart(timePart, ds.Dictionaries)
+	timePart, err = assetBackedJSONBenchPartWithOptions(timePart, ds.Dictionaries, ColumnPartImageReadOptions{IncludeAggregateMetadata: true})
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +408,7 @@ func RunJSONBenchPartAggregateMetadataQueries(ds JSONBenchDataset, rowsPerGranul
 	if err != nil {
 		return nil, err
 	}
-	clickHouseOrderPart, err = assetBackedJSONBenchPart(clickHouseOrderPart, ds.Dictionaries)
+	clickHouseOrderPart, err = assetBackedJSONBenchPartWithOptions(clickHouseOrderPart, ds.Dictionaries, ColumnPartImageReadOptions{IncludeAggregateMetadata: true})
 	if err != nil {
 		return nil, err
 	}

--- a/experiments/colgranule/part_image.go
+++ b/experiments/colgranule/part_image.go
@@ -478,12 +478,23 @@ func (b *columnPartImageBuilder) addSortKeyMarksSection() error {
 }
 
 func (b *columnPartImageBuilder) addRowLocatorsSection() error {
-	var enc columnPartImageEncoder
 	primaryIDs := make([]int64, 0, len(b.part.Locators))
 	for primaryID := range b.part.Locators {
 		primaryIDs = append(primaryIDs, primaryID)
 	}
 	sort.Slice(primaryIDs, func(i, j int) bool { return primaryIDs[i] < primaryIDs[j] })
+	if uint64(len(primaryIDs)) > uint64(^uint32(0)) {
+		return fmt.Errorf("colgranule: row locator count=%d exceeds uint32", len(primaryIDs))
+	}
+	recordBytes, err := checkedMulInt(len(primaryIDs), rowLocatorBytes, "row locator section bytes")
+	if err != nil {
+		return err
+	}
+	payloadBytes, err := checkedAddInt(4, recordBytes, "row locator section bytes")
+	if err != nil {
+		return err
+	}
+	enc := columnPartImageEncoder{buf: make([]byte, 0, payloadBytes)}
 	enc.u32(uint32(len(primaryIDs)))
 	for _, primaryID := range primaryIDs {
 		locator := b.part.Locators[primaryID]

--- a/experiments/colgranule/part_image_decode.go
+++ b/experiments/colgranule/part_image_decode.go
@@ -168,9 +168,26 @@ func ParseColumnPartImage(data []byte) (ColumnPartImage, error) {
 	}, nil
 }
 
+type ColumnPartImageReadOptions struct {
+	IncludeRowLocators       bool
+	ValidateRowLocators      bool
+	IncludeAggregateMetadata bool
+}
+
 func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
+	return ColumnPartFromImageWithOptions(image, ColumnPartImageReadOptions{
+		IncludeRowLocators:       true,
+		ValidateRowLocators:      true,
+		IncludeAggregateMetadata: true,
+	})
+}
+
+func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageReadOptions) (*ColumnPart, error) {
 	if image.TotalBytes() == 0 {
 		return nil, fmt.Errorf("colgranule: empty part image")
+	}
+	if opts.ValidateRowLocators {
+		opts.IncludeRowLocators = true
 	}
 	if err := image.validateForRead(); err != nil {
 		return nil, err
@@ -201,18 +218,25 @@ func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
 	if err := validateDecodedSortKeyMarks(desc, marks); err != nil {
 		return nil, err
 	}
-	locators, err := decodeRowLocatorsSection(image)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateDecodedRowLocators(desc, image.PartID, locators); err != nil {
-		return nil, err
+	var locators map[int64]RowLocator
+	if opts.IncludeRowLocators {
+		locators, err = decodeRowLocatorsSection(image)
+		if err != nil {
+			return nil, err
+		}
+		if opts.ValidateRowLocators {
+			if err := validateDecodedRowLocators(desc, image.PartID, locators); err != nil {
+				return nil, err
+			}
+		}
 	}
 	if err := attachColumnPayloadsFromImage(image, columns); err != nil {
 		return nil, err
 	}
-	if err := validateDecodedRowLocatorsPrimaryKey(desc, columns, locators); err != nil {
-		return nil, err
+	if opts.ValidateRowLocators {
+		if err := validateDecodedRowLocatorsPrimaryKey(desc, columns, locators); err != nil {
+			return nil, err
+		}
 	}
 	optionsColumns := make([]ColumnDefinition, 0, len(desc.Columns))
 	for _, columnDescriptor := range desc.Columns {
@@ -227,9 +251,12 @@ func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
 		}
 		optionsColumns = append(optionsColumns, def)
 	}
-	aggregateMetadata, err := decodeAggregateMetadataSections(image)
-	if err != nil {
-		return nil, err
+	var aggregateMetadata map[string]AggregateMetadata
+	if opts.IncludeAggregateMetadata {
+		aggregateMetadata, err = decodeAggregateMetadataSections(image)
+		if err != nil {
+			return nil, err
+		}
 	}
 	aggregateDefinitions := make([]AggregateMetadataDefinition, 0, len(aggregateMetadata))
 	for _, metadata := range aggregateMetadata {
@@ -588,6 +615,13 @@ func checkedAddInt(a int, b int, field string) (int, error) {
 		return 0, fmt.Errorf("%s overflow %d+%d", field, a, b)
 	}
 	return a + b, nil
+}
+
+func uint32ToInt(v uint32, field string) (int, error) {
+	if uint64(int(v)) != uint64(v) {
+		return 0, fmt.Errorf("colgranule: %s=%d exceeds host int", field, v)
+	}
+	return int(v), nil
 }
 
 func decodeGranuleDescriptor(dec *columnPartImageDecoder) (GranuleDescriptor, error) {
@@ -999,53 +1033,57 @@ func decodeRowLocatorsSection(image ColumnPartImage) (map[int64]RowLocator, erro
 	if err != nil {
 		return nil, err
 	}
-	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
-	count, err := dec.u32()
+	data := image.sectionBytes(section)
+	if len(data) < 4 {
+		return nil, fmt.Errorf("colgranule: truncated row locators section bytes=%d", len(data))
+	}
+	count := binary.LittleEndian.Uint32(data[:4])
+	maxLocators := (len(data) - 4) / rowLocatorBytes
+	if uint64(count) > uint64(maxLocators) {
+		return nil, fmt.Errorf("colgranule: row locators count=%d exceeds section capacity=%d", count, maxLocators)
+	}
+	total, err := uint32ToInt(count, "row locators count")
 	if err != nil {
 		return nil, err
 	}
-	total, err := dec.boundedCount(count, 32, "row locators")
+	recordBytes, err := checkedMulInt(total, rowLocatorBytes, "row locator section bytes")
 	if err != nil {
 		return nil, err
+	}
+	wantBytes, err := checkedAddInt(4, recordBytes, "row locator section bytes")
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != wantBytes {
+		return nil, fmt.Errorf("colgranule: row locators section bytes=%d want %d", len(data), wantBytes)
 	}
 	out := make(map[int64]RowLocator, total)
+	offset := 4
 	for i := 0; i < total; i++ {
-		primaryID, err := dec.i64()
-		if err != nil {
-			return nil, err
-		}
-		partID, err := dec.u64()
-		if err != nil {
-			return nil, err
-		}
-		partRow, err := dec.u32()
-		if err != nil {
-			return nil, err
-		}
-		granuleOrdinal, err := dec.u32()
-		if err != nil {
-			return nil, err
-		}
-		rowInGranule, err := dec.u32()
-		if err != nil {
-			return nil, err
-		}
-		reserved, err := dec.u32()
-		if err != nil {
-			return nil, err
-		}
+		primaryID := int64(binary.LittleEndian.Uint64(data[offset:]))
+		offset += 8
+		partID := binary.LittleEndian.Uint64(data[offset:])
+		offset += 8
+		partRow := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		granuleOrdinal := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		rowInGranule := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		reserved := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
 		if reserved != 0 {
 			return nil, fmt.Errorf("colgranule: row locator primary id %d reserved=%d want 0", primaryID, reserved)
 		}
-		partRowInt, err := dec.countToInt(partRow, "row locator part row")
+		partRowInt, err := uint32ToInt(partRow, "row locator part row")
 		if err != nil {
 			return nil, err
 		}
-		granuleOrdinalInt, err := dec.countToInt(granuleOrdinal, "row locator granule ordinal")
+		granuleOrdinalInt, err := uint32ToInt(granuleOrdinal, "row locator granule ordinal")
 		if err != nil {
 			return nil, err
 		}
-		rowInGranuleInt, err := dec.countToInt(rowInGranule, "row locator row in granule")
+		rowInGranuleInt, err := uint32ToInt(rowInGranule, "row locator row in granule")
 		if err != nil {
 			return nil, err
 		}
@@ -1059,9 +1097,6 @@ func decodeRowLocatorsSection(image ColumnPartImage) (map[int64]RowLocator, erro
 			GranuleOrdinal: granuleOrdinalInt,
 			RowInGranule:   rowInGranuleInt,
 		}
-	}
-	if err := dec.finish(); err != nil {
-		return nil, err
 	}
 	return out, nil
 }

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -1,0 +1,212 @@
+package colgranule
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+)
+
+const (
+	tcs1Magic          uint32 = 0x31534354 // "TCS1", little-endian on disk.
+	tcs1Version        uint16 = 1
+	tcs1PartImageKind  uint16 = 1
+	tcs1HeaderBytes           = 48
+	tcs1SupportedFlags uint32 = 0
+)
+
+type TCS1PartRecord struct {
+	Version      uint16         `json:"version"`
+	Kind         uint16         `json:"kind"`
+	Flags        uint32         `json:"flags"`
+	PartID       uint64         `json:"part_id"`
+	Rows         int            `json:"rows"`
+	ImageVersion uint16         `json:"image_version"`
+	PayloadBytes int            `json:"payload_bytes"`
+	TotalBytes   int            `json:"total_bytes"`
+	PayloadCRC32 uint32         `json:"payload_crc32"`
+	AssetRef     ColumnAssetRef `json:"asset_ref,omitempty"`
+}
+
+func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, error) {
+	if image.TotalBytes() == 0 {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: empty column part image")
+	}
+	if image.Rows < 0 {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: negative image rows %d", image.Rows)
+	}
+	if _, err := ParseColumnPartImage(image.Bytes); err != nil {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: validate image before TCS1 encode: %w", err)
+	}
+	payloadBytes := len(image.Bytes)
+	totalBytes := tcs1HeaderBytes + payloadBytes
+	out := make([]byte, totalBytes)
+	binary.LittleEndian.PutUint32(out[0:4], tcs1Magic)
+	binary.LittleEndian.PutUint16(out[4:6], tcs1Version)
+	binary.LittleEndian.PutUint16(out[6:8], tcs1PartImageKind)
+	binary.LittleEndian.PutUint32(out[8:12], 0)
+	binary.LittleEndian.PutUint32(out[12:16], tcs1HeaderBytes)
+	binary.LittleEndian.PutUint64(out[16:24], uint64(payloadBytes))
+	binary.LittleEndian.PutUint64(out[24:32], image.PartID)
+	binary.LittleEndian.PutUint64(out[32:40], uint64(image.Rows))
+	binary.LittleEndian.PutUint16(out[40:42], image.Version)
+	binary.LittleEndian.PutUint16(out[42:44], 0)
+	checksum := crc32.ChecksumIEEE(image.Bytes)
+	binary.LittleEndian.PutUint32(out[44:48], checksum)
+	copy(out[tcs1HeaderBytes:], image.Bytes)
+	return out, TCS1PartRecord{
+		Version:      tcs1Version,
+		Kind:         tcs1PartImageKind,
+		PartID:       image.PartID,
+		Rows:         image.Rows,
+		ImageVersion: image.Version,
+		PayloadBytes: payloadBytes,
+		TotalBytes:   totalBytes,
+		PayloadCRC32: checksum,
+	}, nil
+}
+
+func DecodeTCS1ColumnPartImage(data []byte) (ColumnPartImage, TCS1PartRecord, error) {
+	record, payload, err := decodeTCS1Header(data)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, err
+	}
+	image, err := ParseColumnPartImage(payload)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, err
+	}
+	if image.PartID != record.PartID {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 part id=%d image part id=%d", record.PartID, image.PartID)
+	}
+	if image.Rows != record.Rows {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 rows=%d image rows=%d", record.Rows, image.Rows)
+	}
+	if image.Version != record.ImageVersion {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 image version=%d parsed image version=%d", record.ImageVersion, image.Version)
+	}
+	return image, record, nil
+}
+
+func StoreTCS1ColumnPartImage(store ColumnAssetStore, image ColumnPartImage) (ColumnAssetRef, TCS1PartRecord, error) {
+	if store == nil {
+		return ColumnAssetRef{}, TCS1PartRecord{}, fmt.Errorf("colgranule: nil column asset store")
+	}
+	payload, record, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		return ColumnAssetRef{}, TCS1PartRecord{}, err
+	}
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, payload)
+	if err != nil {
+		return ColumnAssetRef{}, TCS1PartRecord{}, err
+	}
+	record.AssetRef = ref
+	return ref, record, nil
+}
+
+func LoadTCS1ColumnPartImage(store ColumnAssetStore, ref ColumnAssetRef) (ColumnPartImage, TCS1PartRecord, error) {
+	if store == nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: nil column asset store")
+	}
+	if ref.Kind != ColumnAssetKindTCS1PartImage {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 asset kind=%s want %s", ref.Kind, ColumnAssetKindTCS1PartImage)
+	}
+	payload, err := store.Read(ref)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, err
+	}
+	image, record, err := DecodeTCS1ColumnPartImage(payload)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, err
+	}
+	record.AssetRef = ref
+	return image, record, nil
+}
+
+func ColumnPartFromTCS1Asset(store ColumnAssetStore, ref ColumnAssetRef) (*ColumnPart, TCS1PartRecord, error) {
+	image, record, err := LoadTCS1ColumnPartImage(store, ref)
+	if err != nil {
+		return nil, TCS1PartRecord{}, err
+	}
+	part, err := ColumnPartFromImage(image)
+	if err != nil {
+		return nil, TCS1PartRecord{}, err
+	}
+	return part, record, nil
+}
+
+func TCS1AssetBackedColumnPart(part *ColumnPart, dictionaries map[string]map[string]int64, store ColumnAssetStore) (*ColumnPart, ColumnAssetRef, TCS1PartRecord, error) {
+	if part == nil {
+		return nil, ColumnAssetRef{}, TCS1PartRecord{}, fmt.Errorf("colgranule: nil part")
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: dictionaries})
+	if err != nil {
+		return nil, ColumnAssetRef{}, TCS1PartRecord{}, err
+	}
+	ref, record, err := StoreTCS1ColumnPartImage(store, image)
+	if err != nil {
+		return nil, ColumnAssetRef{}, TCS1PartRecord{}, err
+	}
+	reconstructed, record, err := ColumnPartFromTCS1Asset(store, ref)
+	if err != nil {
+		return nil, ColumnAssetRef{}, TCS1PartRecord{}, err
+	}
+	return reconstructed, ref, record, nil
+}
+
+func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
+	if len(data) < tcs1HeaderBytes {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: truncated TCS1 header bytes=%d", len(data))
+	}
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != tcs1Magic {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: invalid TCS1 magic 0x%x", magic)
+	}
+	version := binary.LittleEndian.Uint16(data[4:6])
+	if version != tcs1Version {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 version %d", version)
+	}
+	kind := binary.LittleEndian.Uint16(data[6:8])
+	if kind != tcs1PartImageKind {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 kind %d", kind)
+	}
+	flags := binary.LittleEndian.Uint32(data[8:12])
+	if flags&^tcs1SupportedFlags != 0 {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 flags 0x%x", flags)
+	}
+	headerBytes := binary.LittleEndian.Uint32(data[12:16])
+	if headerBytes != tcs1HeaderBytes {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 header bytes=%d want %d", headerBytes, tcs1HeaderBytes)
+	}
+	payloadBytes := binary.LittleEndian.Uint64(data[16:24])
+	if payloadBytes > uint64(len(data)-tcs1HeaderBytes) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d exceed available=%d", payloadBytes, len(data)-tcs1HeaderBytes)
+	}
+	if payloadBytes != uint64(len(data)-tcs1HeaderBytes) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d total payload bytes=%d", payloadBytes, len(data)-tcs1HeaderBytes)
+	}
+	partID := binary.LittleEndian.Uint64(data[24:32])
+	rows64 := binary.LittleEndian.Uint64(data[32:40])
+	if rows64 > uint64(^uint(0)>>1) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 rows=%d exceeds host int", rows64)
+	}
+	rows := int(rows64)
+	imageVersion := binary.LittleEndian.Uint16(data[40:42])
+	if reserved := binary.LittleEndian.Uint16(data[42:44]); reserved != 0 {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 reserved=%d want 0", reserved)
+	}
+	wantChecksum := binary.LittleEndian.Uint32(data[44:48])
+	payload := data[tcs1HeaderBytes:]
+	if checksum := crc32.ChecksumIEEE(payload); checksum != wantChecksum {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload checksum=%08x want %08x", checksum, wantChecksum)
+	}
+	return TCS1PartRecord{
+		Version:      version,
+		Kind:         kind,
+		Flags:        flags,
+		PartID:       partID,
+		Rows:         rows,
+		ImageVersion: imageVersion,
+		PayloadBytes: int(payloadBytes),
+		TotalBytes:   len(data),
+		PayloadCRC32: wantChecksum,
+	}, payload, nil
+}

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -34,8 +34,18 @@ func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, e
 	if image.Rows < 0 {
 		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: negative image rows %d", image.Rows)
 	}
-	if _, err := ParseColumnPartImage(image.Bytes); err != nil {
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
 		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: validate image before TCS1 encode: %w", err)
+	}
+	if parsed.PartID != image.PartID {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 encode part id=%d parsed image part id=%d", image.PartID, parsed.PartID)
+	}
+	if parsed.Rows != image.Rows {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 encode rows=%d parsed image rows=%d", image.Rows, parsed.Rows)
+	}
+	if parsed.Version != image.Version {
+		return nil, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 encode image version=%d parsed image version=%d", image.Version, parsed.Version)
 	}
 	payloadBytes := len(image.Bytes)
 	totalBytes := tcs1HeaderBytes + payloadBytes

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -116,7 +116,7 @@ func StoreTCS1ColumnPartImage(store ColumnAssetStore, image ColumnPartImage) (Co
 	if err != nil {
 		return ColumnAssetRef{}, TCS1PartRecord{}, err
 	}
-	ref, err := store.Put(ColumnAssetKindTCS1PartImage, payload)
+	ref, err := putColumnAssetPayload(store, ColumnAssetKindTCS1PartImage, payload)
 	if err != nil {
 		return ColumnAssetRef{}, TCS1PartRecord{}, err
 	}
@@ -144,11 +144,19 @@ func LoadTCS1ColumnPartImage(store ColumnAssetStore, ref ColumnAssetRef) (Column
 }
 
 func ColumnPartFromTCS1Asset(store ColumnAssetStore, ref ColumnAssetRef) (*ColumnPart, TCS1PartRecord, error) {
+	return ColumnPartFromTCS1AssetWithOptions(store, ref, ColumnPartImageReadOptions{
+		IncludeRowLocators:       true,
+		ValidateRowLocators:      true,
+		IncludeAggregateMetadata: true,
+	})
+}
+
+func ColumnPartFromTCS1AssetWithOptions(store ColumnAssetStore, ref ColumnAssetRef, opts ColumnPartImageReadOptions) (*ColumnPart, TCS1PartRecord, error) {
 	image, record, err := LoadTCS1ColumnPartImage(store, ref)
 	if err != nil {
 		return nil, TCS1PartRecord{}, err
 	}
-	part, err := ColumnPartFromImage(image)
+	part, err := ColumnPartFromImageWithOptions(image, opts)
 	if err != nil {
 		return nil, TCS1PartRecord{}, err
 	}
@@ -156,6 +164,14 @@ func ColumnPartFromTCS1Asset(store ColumnAssetStore, ref ColumnAssetRef) (*Colum
 }
 
 func TCS1AssetBackedColumnPart(part *ColumnPart, dictionaries map[string]map[string]int64, store ColumnAssetStore) (*ColumnPart, ColumnAssetRef, TCS1PartRecord, error) {
+	return TCS1AssetBackedColumnPartWithOptions(part, dictionaries, store, ColumnPartImageReadOptions{
+		IncludeRowLocators:       true,
+		ValidateRowLocators:      true,
+		IncludeAggregateMetadata: true,
+	})
+}
+
+func TCS1AssetBackedColumnPartWithOptions(part *ColumnPart, dictionaries map[string]map[string]int64, store ColumnAssetStore, opts ColumnPartImageReadOptions) (*ColumnPart, ColumnAssetRef, TCS1PartRecord, error) {
 	if part == nil {
 		return nil, ColumnAssetRef{}, TCS1PartRecord{}, fmt.Errorf("colgranule: nil part")
 	}
@@ -167,11 +183,22 @@ func TCS1AssetBackedColumnPart(part *ColumnPart, dictionaries map[string]map[str
 	if err != nil {
 		return nil, ColumnAssetRef{}, TCS1PartRecord{}, err
 	}
-	reconstructed, record, err := ColumnPartFromTCS1Asset(store, ref)
+	reconstructed, record, err := ColumnPartFromTCS1AssetWithOptions(store, ref, opts)
 	if err != nil {
 		return nil, ColumnAssetRef{}, TCS1PartRecord{}, err
 	}
 	return reconstructed, ref, record, nil
+}
+
+func ScanOnlyTCS1AssetBackedColumnPart(part *ColumnPart, dictionaries map[string]map[string]int64, store ColumnAssetStore) (*ColumnPart, ColumnAssetRef, TCS1PartRecord, error) {
+	return TCS1AssetBackedColumnPartWithOptions(part, dictionaries, store, ColumnPartImageReadOptions{})
+}
+
+func putColumnAssetPayload(store ColumnAssetStore, kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if owned, ok := store.(columnAssetOwnedStore); ok {
+		return owned.PutOwned(kind, payload)
+	}
+	return store.Put(kind, payload)
 }
 
 func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -7,11 +7,23 @@ import (
 )
 
 const (
-	tcs1Magic          uint32 = 0x31534354 // "TCS1", little-endian on disk.
-	tcs1Version        uint16 = 1
-	tcs1PartImageKind  uint16 = 1
-	tcs1HeaderBytes           = 48
-	tcs1SupportedFlags uint32 = 0
+	tcs1Magic              uint32 = 0x31534354 // "TCS1", little-endian on disk.
+	tcs1Version            uint16 = 1
+	tcs1PartImageKind      uint16 = 1
+	tcs1SupportedFlags     uint32 = 0
+	tcs1MagicOffset               = 0
+	tcs1VersionOffset             = tcs1MagicOffset + 4
+	tcs1KindOffset                = tcs1VersionOffset + 2
+	tcs1FlagsOffset               = tcs1KindOffset + 2
+	tcs1HeaderBytesOffset         = tcs1FlagsOffset + 4
+	tcs1PayloadBytesOffset        = tcs1HeaderBytesOffset + 4
+	tcs1PartIDOffset              = tcs1PayloadBytesOffset + 8
+	tcs1RowsOffset                = tcs1PartIDOffset + 8
+	tcs1ImageVersionOffset        = tcs1RowsOffset + 8
+	tcs1ReservedOffset            = tcs1ImageVersionOffset + 2
+	tcs1PayloadCRC32Offset        = tcs1ReservedOffset + 2
+	tcs1HeaderBytes               = tcs1PayloadCRC32Offset + 4
+	tcs1PayloadOffset             = tcs1HeaderBytes
 )
 
 type TCS1PartRecord struct {
@@ -50,19 +62,19 @@ func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, e
 	payloadBytes := len(image.Bytes)
 	totalBytes := tcs1HeaderBytes + payloadBytes
 	out := make([]byte, totalBytes)
-	binary.LittleEndian.PutUint32(out[0:4], tcs1Magic)
-	binary.LittleEndian.PutUint16(out[4:6], tcs1Version)
-	binary.LittleEndian.PutUint16(out[6:8], tcs1PartImageKind)
-	binary.LittleEndian.PutUint32(out[8:12], 0)
-	binary.LittleEndian.PutUint32(out[12:16], tcs1HeaderBytes)
-	binary.LittleEndian.PutUint64(out[16:24], uint64(payloadBytes))
-	binary.LittleEndian.PutUint64(out[24:32], image.PartID)
-	binary.LittleEndian.PutUint64(out[32:40], uint64(image.Rows))
-	binary.LittleEndian.PutUint16(out[40:42], image.Version)
-	binary.LittleEndian.PutUint16(out[42:44], 0)
+	binary.LittleEndian.PutUint32(out[tcs1MagicOffset:tcs1VersionOffset], tcs1Magic)
+	binary.LittleEndian.PutUint16(out[tcs1VersionOffset:tcs1KindOffset], tcs1Version)
+	binary.LittleEndian.PutUint16(out[tcs1KindOffset:tcs1FlagsOffset], tcs1PartImageKind)
+	binary.LittleEndian.PutUint32(out[tcs1FlagsOffset:tcs1HeaderBytesOffset], 0)
+	binary.LittleEndian.PutUint32(out[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset], tcs1HeaderBytes)
+	binary.LittleEndian.PutUint64(out[tcs1PayloadBytesOffset:tcs1PartIDOffset], uint64(payloadBytes))
+	binary.LittleEndian.PutUint64(out[tcs1PartIDOffset:tcs1RowsOffset], image.PartID)
+	binary.LittleEndian.PutUint64(out[tcs1RowsOffset:tcs1ImageVersionOffset], uint64(image.Rows))
+	binary.LittleEndian.PutUint16(out[tcs1ImageVersionOffset:tcs1ReservedOffset], image.Version)
+	binary.LittleEndian.PutUint16(out[tcs1ReservedOffset:tcs1PayloadCRC32Offset], 0)
 	checksum := crc32.ChecksumIEEE(image.Bytes)
-	binary.LittleEndian.PutUint32(out[44:48], checksum)
-	copy(out[tcs1HeaderBytes:], image.Bytes)
+	binary.LittleEndian.PutUint32(out[tcs1PayloadCRC32Offset:tcs1PayloadOffset], checksum)
+	copy(out[tcs1PayloadOffset:], image.Bytes)
 	return out, TCS1PartRecord{
 		Version:      tcs1Version,
 		Kind:         tcs1PartImageKind,
@@ -166,45 +178,45 @@ func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
 	if len(data) < tcs1HeaderBytes {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: truncated TCS1 header bytes=%d", len(data))
 	}
-	magic := binary.LittleEndian.Uint32(data[0:4])
+	magic := binary.LittleEndian.Uint32(data[tcs1MagicOffset:tcs1VersionOffset])
 	if magic != tcs1Magic {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: invalid TCS1 magic 0x%x", magic)
 	}
-	version := binary.LittleEndian.Uint16(data[4:6])
+	version := binary.LittleEndian.Uint16(data[tcs1VersionOffset:tcs1KindOffset])
 	if version != tcs1Version {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 version %d", version)
 	}
-	kind := binary.LittleEndian.Uint16(data[6:8])
+	kind := binary.LittleEndian.Uint16(data[tcs1KindOffset:tcs1FlagsOffset])
 	if kind != tcs1PartImageKind {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 kind %d", kind)
 	}
-	flags := binary.LittleEndian.Uint32(data[8:12])
+	flags := binary.LittleEndian.Uint32(data[tcs1FlagsOffset:tcs1HeaderBytesOffset])
 	if flags&^tcs1SupportedFlags != 0 {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: unsupported TCS1 flags 0x%x", flags)
 	}
-	headerBytes := binary.LittleEndian.Uint32(data[12:16])
+	headerBytes := binary.LittleEndian.Uint32(data[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset])
 	if headerBytes != tcs1HeaderBytes {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 header bytes=%d want %d", headerBytes, tcs1HeaderBytes)
 	}
-	payloadBytes := binary.LittleEndian.Uint64(data[16:24])
-	if payloadBytes > uint64(len(data)-tcs1HeaderBytes) {
-		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d exceed available=%d", payloadBytes, len(data)-tcs1HeaderBytes)
+	payloadBytes := binary.LittleEndian.Uint64(data[tcs1PayloadBytesOffset:tcs1PartIDOffset])
+	if payloadBytes > uint64(len(data)-tcs1PayloadOffset) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d exceed available=%d", payloadBytes, len(data)-tcs1PayloadOffset)
 	}
-	if payloadBytes != uint64(len(data)-tcs1HeaderBytes) {
-		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, len(data)-tcs1HeaderBytes)
+	if payloadBytes != uint64(len(data)-tcs1PayloadOffset) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, len(data)-tcs1PayloadOffset)
 	}
-	partID := binary.LittleEndian.Uint64(data[24:32])
-	rows64 := binary.LittleEndian.Uint64(data[32:40])
+	partID := binary.LittleEndian.Uint64(data[tcs1PartIDOffset:tcs1RowsOffset])
+	rows64 := binary.LittleEndian.Uint64(data[tcs1RowsOffset:tcs1ImageVersionOffset])
 	if rows64 > uint64(^uint(0)>>1) {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 rows=%d exceeds host int", rows64)
 	}
 	rows := int(rows64)
-	imageVersion := binary.LittleEndian.Uint16(data[40:42])
-	if reserved := binary.LittleEndian.Uint16(data[42:44]); reserved != 0 {
+	imageVersion := binary.LittleEndian.Uint16(data[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if reserved := binary.LittleEndian.Uint16(data[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 reserved=%d want 0", reserved)
 	}
-	wantChecksum := binary.LittleEndian.Uint32(data[44:48])
-	payload := data[tcs1HeaderBytes:]
+	wantChecksum := binary.LittleEndian.Uint32(data[tcs1PayloadCRC32Offset:tcs1PayloadOffset])
+	payload := data[tcs1PayloadOffset:]
 	if checksum := crc32.ChecksumIEEE(payload); checksum != wantChecksum {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload checksum=%08x want %08x", checksum, wantChecksum)
 	}

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -82,7 +82,7 @@ func DecodeTCS1ColumnPartImage(data []byte) (ColumnPartImage, TCS1PartRecord, er
 	}
 	image, err := ParseColumnPartImage(payload)
 	if err != nil {
-		return ColumnPartImage{}, TCS1PartRecord{}, err
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: parse TCS1 column part image: %w", err)
 	}
 	if image.PartID != record.PartID {
 		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 part id=%d image part id=%d", record.PartID, image.PartID)
@@ -191,7 +191,7 @@ func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
 		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d exceed available=%d", payloadBytes, len(data)-tcs1HeaderBytes)
 	}
 	if payloadBytes != uint64(len(data)-tcs1HeaderBytes) {
-		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d total payload bytes=%d", payloadBytes, len(data)-tcs1HeaderBytes)
+		return TCS1PartRecord{}, nil, fmt.Errorf("colgranule: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, len(data)-tcs1HeaderBytes)
 	}
 	partID := binary.LittleEndian.Uint64(data[24:32])
 	rows64 := binary.LittleEndian.Uint64(data[32:40])

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -79,6 +79,22 @@ func TestTCS1ColumnPartAssetRoundTripsThroughSegmentStoreAfterReopen(t *testing.
 	}
 }
 
+func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.T) {
+	store, err := OpenSegmentColumnAssetStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	defer store.Close()
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("tiny"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ref.Length = 1 << 62
+	if _, err := store.ReadTo(ref, nil); err == nil || !strings.Contains(err.Error(), "outside segment") {
+		t.Fatalf("ReadTo err=%v want outside segment", err)
+	}
+}
+
 func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
 	_, image := testColumnPartImageFixture(t, false)
 	payload, _, err := EncodeTCS1ColumnPartImage(image)

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -160,6 +160,20 @@ func TestTCS1ColumnPartAssetRejectsImageHeaderMismatch(t *testing.T) {
 	}
 }
 
+func TestTCS1ColumnPartAssetEncodeRejectsImageStructMismatch(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, false)
+	mismatched := image
+	mismatched.PartID++
+	if _, _, err := EncodeTCS1ColumnPartImage(mismatched); err == nil || !strings.Contains(err.Error(), "part id") {
+		t.Fatalf("EncodeTCS1ColumnPartImage part id err=%v want mismatch", err)
+	}
+	mismatched = image
+	mismatched.Rows++
+	if _, _, err := EncodeTCS1ColumnPartImage(mismatched); err == nil || !strings.Contains(err.Error(), "rows") {
+		t.Fatalf("EncodeTCS1ColumnPartImage rows err=%v want mismatch", err)
+	}
+}
+
 func TestJSONBenchPartQueriesRunFromReopenedTCS1Asset(t *testing.T) {
 	ds, err := LoadJSONBenchColumns("testdata/jsonbench_sample.jsonl", 0)
 	if err != nil {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -50,6 +50,44 @@ func TestMemoryColumnAssetStoreValidatesChecksumAfterLookup(t *testing.T) {
 	}
 }
 
+func TestMemoryColumnAssetStoreValidatesLengthAfterAddressLookup(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ref.Length--
+	if _, err := store.Read(ref); err == nil || !strings.Contains(err.Error(), "asset length") {
+		t.Fatalf("Read err=%v want length mismatch", err)
+	}
+}
+
+func TestColumnAssetStoresRejectUnsupportedKind(t *testing.T) {
+	memory := NewMemoryColumnAssetStore()
+	ref, err := memory.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
+	if err != nil {
+		t.Fatalf("memory Put: %v", err)
+	}
+	ref.Kind = ColumnAssetKind("future_kind")
+	if _, err := memory.Read(ref); err == nil || !strings.Contains(err.Error(), "unsupported column asset kind") {
+		t.Fatalf("memory Read err=%v want unsupported kind", err)
+	}
+
+	segment, err := OpenSegmentColumnAssetStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	defer segment.Close()
+	ref, err = segment.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
+	if err != nil {
+		t.Fatalf("segment Put: %v", err)
+	}
+	ref.Kind = ColumnAssetKind("future_kind")
+	if _, err := segment.Read(ref); err == nil || !strings.Contains(err.Error(), "unsupported column asset kind") {
+		t.Fatalf("segment Read err=%v want unsupported kind", err)
+	}
+}
+
 func TestTCS1ColumnPartAssetRoundTripsThroughSegmentStoreAfterReopen(t *testing.T) {
 	_, image := testColumnPartImageFixture(t, true)
 	dir := t.TempDir()
@@ -105,6 +143,23 @@ func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.
 	ref.Length = 1 << 62
 	if _, err := store.ReadTo(ref, nil); err == nil || !strings.Contains(err.Error(), "outside segment") {
 		t.Fatalf("ReadTo err=%v want outside segment", err)
+	}
+}
+
+func TestSegmentColumnAssetStoreRejectsMaxReadBeforeAllocation(t *testing.T) {
+	store, err := OpenSegmentColumnAssetStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	defer store.Close()
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("tiny"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ref.Length = maxColumnAssetReadBytes + 1
+	store.size = ref.Length
+	if _, err := store.ReadTo(ref, nil); err == nil || !strings.Contains(err.Error(), "exceeds max read bytes") {
+		t.Fatalf("ReadTo err=%v want max read size", err)
 	}
 }
 

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"encoding/binary"
+	"hash/crc32"
 	"strings"
 	"testing"
 )
@@ -185,6 +186,30 @@ func TestTCS1ColumnPartAssetRejectsImageHeaderMismatch(t *testing.T) {
 	binary.LittleEndian.PutUint64(payload[24:32], image.PartID+1)
 	if _, _, err := DecodeTCS1ColumnPartImage(payload); err == nil || !strings.Contains(err.Error(), "part id") {
 		t.Fatalf("DecodeTCS1ColumnPartImage err=%v want part id mismatch", err)
+	}
+}
+
+func TestTCS1ColumnPartAssetRejectsUnknownInnerEncoding(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, false)
+	descriptor, dec := descriptorDecoderAtFirstColumnFirstBlock(t, image)
+	corruptImage := append([]byte(nil), image.Bytes...)
+	encodingOffset := descriptor.Offset + dec.offset + 4*8
+	binary.LittleEndian.PutUint16(corruptImage[encodingOffset:], 0xffff)
+
+	payload, _, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	copy(payload[tcs1HeaderBytes:], corruptImage)
+	binary.LittleEndian.PutUint32(payload[44:48], crc32.ChecksumIEEE(corruptImage))
+
+	store := NewMemoryColumnAssetStore()
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, payload)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, _, err := ColumnPartFromTCS1Asset(store, ref); err == nil || !strings.Contains(err.Error(), "unsupported int64 encoding") {
+		t.Fatalf("ColumnPartFromTCS1Asset err=%v want unsupported inner encoding", err)
 	}
 }
 

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -122,7 +122,7 @@ func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
 		{
 			name: "magic",
 			edit: func(in []byte) []byte {
-				binary.LittleEndian.PutUint32(in[0:4], 0)
+				binary.LittleEndian.PutUint32(in[tcs1MagicOffset:tcs1VersionOffset], 0)
 				return in
 			},
 			want: "magic",
@@ -130,7 +130,7 @@ func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
 		{
 			name: "version",
 			edit: func(in []byte) []byte {
-				binary.LittleEndian.PutUint16(in[4:6], 99)
+				binary.LittleEndian.PutUint16(in[tcs1VersionOffset:tcs1KindOffset], 99)
 				return in
 			},
 			want: "version",
@@ -138,7 +138,7 @@ func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
 		{
 			name: "flags",
 			edit: func(in []byte) []byte {
-				binary.LittleEndian.PutUint32(in[8:12], 1)
+				binary.LittleEndian.PutUint32(in[tcs1FlagsOffset:tcs1HeaderBytesOffset], 1)
 				return in
 			},
 			want: "flags",
@@ -146,7 +146,7 @@ func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
 		{
 			name: "reserved",
 			edit: func(in []byte) []byte {
-				binary.LittleEndian.PutUint16(in[42:44], 1)
+				binary.LittleEndian.PutUint16(in[tcs1ReservedOffset:tcs1PayloadCRC32Offset], 1)
 				return in
 			},
 			want: "reserved",
@@ -183,7 +183,7 @@ func TestTCS1ColumnPartAssetRejectsImageHeaderMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
 	}
-	binary.LittleEndian.PutUint64(payload[24:32], image.PartID+1)
+	binary.LittleEndian.PutUint64(payload[tcs1PartIDOffset:tcs1RowsOffset], image.PartID+1)
 	if _, _, err := DecodeTCS1ColumnPartImage(payload); err == nil || !strings.Contains(err.Error(), "part id") {
 		t.Fatalf("DecodeTCS1ColumnPartImage err=%v want part id mismatch", err)
 	}
@@ -200,8 +200,8 @@ func TestTCS1ColumnPartAssetRejectsUnknownInnerEncoding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
 	}
-	copy(payload[tcs1HeaderBytes:], corruptImage)
-	binary.LittleEndian.PutUint32(payload[44:48], crc32.ChecksumIEEE(corruptImage))
+	copy(payload[tcs1PayloadOffset:], corruptImage)
+	binary.LittleEndian.PutUint32(payload[tcs1PayloadCRC32Offset:tcs1PayloadOffset], crc32.ChecksumIEEE(corruptImage))
 
 	store := NewMemoryColumnAssetStore()
 	ref, err := store.Put(ColumnAssetKindTCS1PartImage, payload)

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -1,0 +1,233 @@
+package colgranule
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestTCS1ColumnPartAssetRoundTripsThroughMemoryStore(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, true)
+	store := NewMemoryColumnAssetStore()
+	ref, record, err := StoreTCS1ColumnPartImage(store, image)
+	if err != nil {
+		t.Fatalf("StoreTCS1ColumnPartImage: %v", err)
+	}
+	if record.PayloadBytes != image.TotalBytes() {
+		t.Fatalf("payload bytes=%d want image bytes=%d", record.PayloadBytes, image.TotalBytes())
+	}
+	if ref.Kind != ColumnAssetKindTCS1PartImage {
+		t.Fatalf("asset kind=%s want %s", ref.Kind, ColumnAssetKindTCS1PartImage)
+	}
+	imagePart, loaded, err := ColumnPartFromTCS1Asset(store, ref)
+	if err != nil {
+		t.Fatalf("ColumnPartFromTCS1Asset: %v", err)
+	}
+	if loaded.PartID != image.PartID || loaded.Rows != image.Rows || loaded.PayloadBytes != image.TotalBytes() {
+		t.Fatalf("loaded record=%+v image part/rows/bytes=(%d,%d,%d)", loaded, image.PartID, image.Rows, image.TotalBytes())
+	}
+	scan, err := imagePart.NewScanner().ScanProjected([]string{"id", "time_us", "value", "kind_code", "has_reply"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3, 4, 5})
+	assertInt64s(t, "time_us", scan.Columns["time_us"], []int64{10, 20, 30, 40, 50})
+	assertInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500})
+	assertInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{0, 1, 1, 0, 2})
+	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{0, 1, 1, 1, 0})
+}
+
+func TestTCS1ColumnPartAssetRoundTripsThroughSegmentStoreAfterReopen(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, true)
+	dir := t.TempDir()
+	store, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	ref, record, err := StoreTCS1ColumnPartImage(store, image)
+	if err != nil {
+		t.Fatalf("StoreTCS1ColumnPartImage: %v", err)
+	}
+	if record.AssetRef != ref {
+		t.Fatalf("record ref=%+v want %+v", record.AssetRef, ref)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("reopen segment store: %v", err)
+	}
+	defer reopened.Close()
+	imagePart, loaded, err := ColumnPartFromTCS1Asset(reopened, ref)
+	if err != nil {
+		t.Fatalf("ColumnPartFromTCS1Asset after reopen: %v", err)
+	}
+	if loaded.AssetRef != ref {
+		t.Fatalf("loaded ref=%+v want %+v", loaded.AssetRef, ref)
+	}
+	locator, ok := imagePart.LocatePrimaryID(4)
+	if !ok {
+		t.Fatal("missing locator for primary id 4")
+	}
+	value, err := imagePart.NewScanner().ValueAt(locator, "value")
+	if err != nil {
+		t.Fatalf("ValueAt: %v", err)
+	}
+	if value != 400 {
+		t.Fatalf("value at reopened asset row=%d want 400", value)
+	}
+}
+
+func TestTCS1ColumnPartAssetRejectsCorruption(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, false)
+	payload, _, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	tests := []struct {
+		name string
+		edit func([]byte) []byte
+		want string
+	}{
+		{
+			name: "magic",
+			edit: func(in []byte) []byte {
+				binary.LittleEndian.PutUint32(in[0:4], 0)
+				return in
+			},
+			want: "magic",
+		},
+		{
+			name: "version",
+			edit: func(in []byte) []byte {
+				binary.LittleEndian.PutUint16(in[4:6], 99)
+				return in
+			},
+			want: "version",
+		},
+		{
+			name: "flags",
+			edit: func(in []byte) []byte {
+				binary.LittleEndian.PutUint32(in[8:12], 1)
+				return in
+			},
+			want: "flags",
+		},
+		{
+			name: "reserved",
+			edit: func(in []byte) []byte {
+				binary.LittleEndian.PutUint16(in[42:44], 1)
+				return in
+			},
+			want: "reserved",
+		},
+		{
+			name: "checksum",
+			edit: func(in []byte) []byte {
+				in[len(in)-1] ^= 1
+				return in
+			},
+			want: "checksum",
+		},
+		{
+			name: "truncated",
+			edit: func(in []byte) []byte {
+				return in[:len(in)-1]
+			},
+			want: "payload bytes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			corrupt := tt.edit(append([]byte(nil), payload...))
+			if _, _, err := DecodeTCS1ColumnPartImage(corrupt); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("DecodeTCS1ColumnPartImage err=%v want contains %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestTCS1ColumnPartAssetRejectsImageHeaderMismatch(t *testing.T) {
+	_, image := testColumnPartImageFixture(t, false)
+	payload, _, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	binary.LittleEndian.PutUint64(payload[24:32], image.PartID+1)
+	if _, _, err := DecodeTCS1ColumnPartImage(payload); err == nil || !strings.Contains(err.Error(), "part id") {
+		t.Fatalf("DecodeTCS1ColumnPartImage err=%v want part id mismatch", err)
+	}
+}
+
+func TestJSONBenchPartQueriesRunFromReopenedTCS1Asset(t *testing.T) {
+	ds, err := LoadJSONBenchColumns("testdata/jsonbench_sample.jsonl", 0)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns(sample): %v", err)
+	}
+	rawTimings, err := RunJSONBenchQueries(ds, 1)
+	if err != nil {
+		t.Fatalf("RunJSONBenchQueries: %v", err)
+	}
+	rawByQuery := make(map[string]JSONBenchQueryTiming, len(rawTimings))
+	for _, timing := range rawTimings {
+		rawByQuery[timing.Query] = timing
+	}
+	part, err := BuildJSONBenchColumnPart(ds, 2)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	dir := t.TempDir()
+	store, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	_, assetRef, _, err := TCS1AssetBackedColumnPart(part, ds.Dictionaries, store)
+	if err != nil {
+		t.Fatalf("TCS1AssetBackedColumnPart: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopenedStore, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("reopen segment store: %v", err)
+	}
+	defer reopenedStore.Close()
+	reopenedPart, _, err := ColumnPartFromTCS1Asset(reopenedStore, assetRef)
+	if err != nil {
+		t.Fatalf("ColumnPartFromTCS1Asset after reopen: %v", err)
+	}
+
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	queries := []struct {
+		name string
+		run  jsonBenchPartQueryRunner
+	}{
+		{"Q1", runJSONBenchPartQ1},
+		{"Q2", runJSONBenchPartQ2},
+		{"Q3", runJSONBenchPartQ3},
+		{"Q4", runJSONBenchPartQ4},
+		{"Q5", runJSONBenchPartQ5},
+	}
+	for _, q := range queries {
+		scratch := &jsonBenchPartQueryScratch{
+			scanner:   reopenedPart.NewScanner(),
+			projected: make(map[string][]int64, 6),
+		}
+		rows, digest, diagnostics, err := q.run(reopenedPart, codes, scratch)
+		if err != nil {
+			t.Fatalf("%s asset-backed query: %v", q.name, err)
+		}
+		raw := rawByQuery[q.name]
+		if rows != raw.ResultRows || digest != raw.ResultDigest {
+			t.Fatalf("%s rows/digest=(%d,%d) raw=(%d,%d)", q.name, rows, digest, raw.ResultRows, raw.ResultDigest)
+		}
+		if diagnostics.AggregateKernel == "" {
+			t.Fatalf("%s missing aggregate kernel diagnostics: %+v", q.name, diagnostics)
+		}
+	}
+}

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -37,6 +37,18 @@ func TestTCS1ColumnPartAssetRoundTripsThroughMemoryStore(t *testing.T) {
 	assertInt64s(t, "has_reply", scan.Columns["has_reply"], []int64{0, 1, 1, 1, 0})
 }
 
+func TestMemoryColumnAssetStoreValidatesChecksumAfterLookup(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ref.Checksum++
+	if _, err := store.Read(ref); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("Read err=%v want checksum mismatch", err)
+	}
+}
+
 func TestTCS1ColumnPartAssetRoundTripsThroughSegmentStoreAfterReopen(t *testing.T) {
 	_, image := testColumnPartImageFixture(t, true)
 	dir := t.TempDir()

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -261,9 +261,12 @@ func TestJSONBenchPartQueriesRunFromReopenedTCS1Asset(t *testing.T) {
 		t.Fatalf("reopen segment store: %v", err)
 	}
 	defer reopenedStore.Close()
-	reopenedPart, _, err := ColumnPartFromTCS1Asset(reopenedStore, assetRef)
+	reopenedPart, _, err := ColumnPartFromTCS1AssetWithOptions(reopenedStore, assetRef, ColumnPartImageReadOptions{})
 	if err != nil {
 		t.Fatalf("ColumnPartFromTCS1Asset after reopen: %v", err)
+	}
+	if len(reopenedPart.Locators) != 0 {
+		t.Fatalf("scan-only asset load decoded %d locators", len(reopenedPart.Locators))
 	}
 
 	codes, err := jsonBenchQueryCodes(ds)


### PR DESCRIPTION
Implements the first M2 slice from #1534: a value-log-shaped `TCS1` column asset hot path around the serialized `ColumnPartImage` from M1D.

Changes:

- adds `ColumnAssetStore` with `Put`, `Read`, and `ReadTo`, plus memory and append-segment implementations
- adds `ColumnAssetRef` shaped like future `ValuePtr` usage: asset kind, file id, offset, length, checksum
- adds a strict `TCS1` wrapper for serialized part images with magic/version/kind/flags, payload length, part id, row count, image version, and payload checksum
- adds helpers to store/load/reconstruct `ColumnPart` from `TCS1` assets
- changes JSONBench part query setup to rebuild parts through `TCS1` assets before running the existing encoded-block q1-q5 kernels
- optimizes q1-q5 scan loads so they skip point-lookup row locator maps and aggregate metadata unless the query path asks for them
- keeps full locator/metadata reconstruction available and measured separately for point lookup and integrity coverage
- hardens malformed asset refs with supported-kind validation, explicit length validation after address lookup, a documented `ReadTo` ownership contract, and a max read-size guard before allocation
- adds corruption, header mismatch, unsupported inner-codec, memory-store, append-segment reopen, malformed-ref, and q1-q5 reopened-asset parity tests
- adds `BenchmarkJSONBenchPartAssetM2` and optional local `BenchmarkJSONBenchLocalPartAssetM2`
- documents `TCS1` as a value-log-shaped asset payload, not a separate column side-file lifecycle

Profiling notes:

- pre-optimization local `1m` `time_us` load/parse/reconstruct was `155.3 ms/op`, `6.44M rows/s`, `129.4 MB/op`, `5,232 allocs/op`
- optimized scan-only local `1m` `time_us` load/parse/reconstruct is `5.80 ms/op`, `172.4M rows/s`, `0.76 MB/op`, `979 allocs/op`
- full locator reconstruction remains measured separately at `98.0 ms/op` on the same local `1m` `time_us` layout
- post-optimization scan-load CPU profile is dominated by `crc32.ChecksumIEEE`; that checksum is retained for `TCS1` payload integrity

Local synthetic M2 benchmark:

| Layout | Phase | ns/op | Rows/s | Asset MiB/s | Asset B/row | B/op | allocs/op |
|---|---|---:|---:|---:|---:|---:|---:|
| `time_us` | store existing image asset | 8,718,622 | 93,959,923 | 3,919 | 43.73 | 35,834,030 | 18 |
| `time_us` | load/parse/reconstruct scan | 3,798,014 | 215,691,828 | 8,996 | 43.73 | 251,752 | 760 |
| `time_us` | load/parse/reconstruct scan + metadata | 6,314,506 | 129,733,149 | 5,411 | 43.73 | 7,361,529 | 885 |
| `time_us` | load/parse/reconstruct full locators | 67,965,542 | 12,053,176 | 502.7 | 43.73 | 73,587,472 | 2,940 |
| `time_us` | build/serialize/store/load/parse/reconstruct scan | 237,423,575 | 3,450,376 | 143.9 | 43.73 | 242,266,651 | 6,310 |
| `clickhouse_filter_user_time` | store existing image asset | 7,241,555 | 113,128,917 | 3,937 | 36.49 | 29,894,861 | 18 |
| `clickhouse_filter_user_time` | load/parse/reconstruct scan | 3,201,562 | 255,875,173 | 8,904 | 36.49 | 373,096 | 3,768 |
| `clickhouse_filter_user_time` | load/parse/reconstruct scan + metadata | 3,817,690 | 214,580,154 | 7,467 | 36.49 | 2,143,736 | 3,827 |
| `clickhouse_filter_user_time` | load/parse/reconstruct full locators | 65,104,255 | 12,582,900 | 437.8 | 36.49 | 68,430,632 | 5,885 |
| `clickhouse_filter_user_time` | build/serialize/store/load/parse/reconstruct scan | 946,483,958 | 865,520 | 30.12 | 36.49 | 215,255,248 | 9,980 |

Local 1M M2 benchmark (`JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz`, `-benchtime=3x`):

| Layout | Phase | ns/op | Rows/s | Asset MiB/s | Asset B/row | B/op | allocs/op |
|---|---|---:|---:|---:|---:|---:|---:|
| `time_us` | store existing image asset | 15,394,111 | 64,961,312 | 3,351 | 54.09 | 54,104,669 | 30 |
| `time_us` | load/parse/reconstruct scan | 5,799,570 | 172,431,958 | 8,895 | 54.09 | 755,488 | 979 |
| `time_us` | load/parse/reconstruct scan + metadata | 6,942,083 | 144,053,300 | 7,431 | 54.09 | 2,779,184 | 1,127 |
| `time_us` | load/parse/reconstruct full locators | 97,993,542 | 10,204,783 | 526.4 | 54.09 | 129,398,112 | 5,230 |
| `time_us` | build/serialize/store/load/parse/reconstruct scan | 413,071,458 | 2,420,890 | 124.9 | 54.09 | 372,611,072 | 10,613 |
| `clickhouse_filter_user_time` | store existing image asset | 13,299,000 | 75,194,174 | 3,710 | 51.73 | 51,737,181 | 30 |
| `clickhouse_filter_user_time` | load/parse/reconstruct scan | 5,659,375 | 176,704,462 | 8,717 | 51.73 | 904,616 | 4,677 |
| `clickhouse_filter_user_time` | load/parse/reconstruct scan + metadata | 6,133,208 | 163,052,340 | 8,044 | 51.73 | 2,166,072 | 4,713 |
| `clickhouse_filter_user_time` | load/parse/reconstruct full locators | 100,174,889 | 9,982,569 | 492.5 | 51.73 | 128,816,488 | 8,816 |
| `clickhouse_filter_user_time` | build/serialize/store/load/parse/reconstruct scan | 1,442,569,167 | 693,208 | 34.20 | 51.73 | 392,846,146 | 15,055 |

Validation:

- latest head: `1ef822127b8afdde74ef3b058fc48d54bb45025b`
- `go test ./experiments/colgranule -run 'TestTCS1|TestMemoryColumnAssetStore|TestColumnAssetStores|TestSegmentColumnAssetStore|TestJSONBenchPartQueriesRunFromReopenedTCS1Asset|TestRunJSONBenchPartQueriesSampleMatchesRawReference|TestRunJSONBenchPartQ4FairnessQueries|TestRunJSONBenchPartAggregateMetadataQueries' -count=1`
- `go test -race ./experiments/colgranule -run 'TestTCS1|TestMemoryColumnAssetStore|TestColumnAssetStores|TestSegmentColumnAssetStore|TestJSONBenchPartQueriesRunFromReopenedTCS1Asset|TestRunJSONBenchPartAggregateMetadataQueries' -count=1`
- `go test ./experiments/colgranule/... -count=1`
- `go vet ./experiments/colgranule/...`
- `go test ./... -count=1`
- `go test ./experiments/colgranule -run '^$' -bench '^BenchmarkJSONBenchPartAssetM2$' -benchmem -count=1`
- `JSONBENCH_DATA=/Users/michaelseiler/data/bluesky/file_0001.json.gz go test ./experiments/colgranule -run '^$' -bench '^BenchmarkJSONBenchLocalPartAssetM2$' -benchmem -count=1 -benchtime=3x`

Tracks #1534. Stacked on #1569.
