### PR TITLE
Improve TreeDB HNSW graph construction quality

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1919,6 +1919,9 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 	if len(candidates) <= limit {
 		return candidates
 	}
+	if idx.metric == VectorMetricInnerProduct {
+		return candidates[:limit]
+	}
 	var selectedStack [128]vectorIndexCandidate
 	selected := selectedStack[:0]
 	if limit > len(selectedStack) {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -751,10 +751,17 @@ func (idx *VectorIndex) levelForDocumentID(documentID []byte) int {
 	var seed [8]byte
 	binary.LittleEndian.PutUint64(seed[:], xxhash.Sum64(documentID)^xxhash.Sum64String(idx.name))
 	hash := xxhash.Sum64(seed[:])
-	level := 0
-	for level < 32 && hash&0x3 == 0 {
-		level++
-		hash >>= 2
+	promotionBase := idx.m
+	if promotionBase < 2 {
+		promotionBase = 2
+	}
+	if hash == 0 {
+		return 32
+	}
+	u := (float64(hash>>11) + 1) / (float64(uint64(1)<<53) + 1)
+	level := int(-math.Log(u) / math.Log(float64(promotionBase)))
+	if level > 32 {
+		return 32
 	}
 	return level
 }
@@ -879,18 +886,7 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndex
 		}
 		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: distance})
 	}
-	slices.SortFunc(scored, func(left, right vectorIndexCandidate) int {
-		if left.distance < right.distance {
-			return -1
-		}
-		if left.distance > right.distance {
-			return 1
-		}
-		return bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID)
-	})
-	if len(scored) > limit {
-		scored = scored[:limit]
-	}
+	scored = idx.selectDiverseCandidatesLocked(scored, limit)
 	out := neighbors[:0]
 	for _, candidate := range scored {
 		out = append(out, vectorIndexNeighbor{nodeID: candidate.nodeID, distance: candidate.distance})
@@ -1590,15 +1586,82 @@ func (idx *VectorIndex) selectLayerNeighborsLocked(vector []float32, vectorNormS
 		}
 		scored = append(scored, candidate)
 	}
-	sortVectorIndexCandidates(scored)
-	if len(scored) > limit {
-		scored = scored[:limit]
-	}
+	scored = idx.selectDiverseCandidatesLocked(scored, limit)
 	out := make([]int, len(scored))
 	for i := range scored {
 		out[i] = scored[i].nodeID
 	}
 	return out
+}
+
+func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCandidate, limit int) []vectorIndexCandidate {
+	if limit <= 0 || len(candidates) == 0 {
+		return nil
+	}
+	idx.sortVectorIndexCandidatesByDistanceLocked(candidates)
+	if len(candidates) <= limit {
+		return candidates
+	}
+	var selectedStack [128]vectorIndexCandidate
+	selected := selectedStack[:0]
+	if limit > len(selectedStack) {
+		selected = make([]vectorIndexCandidate, 0, limit)
+	}
+	var rejectedStack [128]vectorIndexCandidate
+	rejected := rejectedStack[:0]
+	if len(candidates) > len(rejectedStack) {
+		rejected = make([]vectorIndexCandidate, 0, len(candidates))
+	}
+	for _, candidate := range candidates {
+		if len(selected) >= limit {
+			rejected = append(rejected, candidate)
+			continue
+		}
+		if idx.vectorIndexCandidateIsDiverseLocked(candidate, selected) {
+			selected = append(selected, candidate)
+		} else {
+			rejected = append(rejected, candidate)
+		}
+	}
+	for i := 0; len(selected) < limit && i < len(rejected); i++ {
+		selected = append(selected, rejected[i])
+	}
+	out := candidates[:0]
+	out = append(out, selected...)
+	return out
+}
+
+func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
+	for _, existing := range selected {
+		distance := idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
+		if distance <= candidate.distance {
+			return false
+		}
+	}
+	return true
+}
+
+func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
+	slices.SortFunc(candidates, func(left, right vectorIndexCandidate) int {
+		if left.distance < right.distance {
+			return -1
+		}
+		if left.distance > right.distance {
+			return 1
+		}
+		if left.nodeID >= 0 && left.nodeID < len(idx.nodes) && right.nodeID >= 0 && right.nodeID < len(idx.nodes) {
+			if cmp := bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID); cmp != 0 {
+				return cmp
+			}
+		}
+		if left.nodeID < right.nodeID {
+			return -1
+		}
+		if left.nodeID > right.nodeID {
+			return 1
+		}
+		return 0
+	})
 }
 
 func (idx *VectorIndex) distanceToNodeLocked(query []float32, nodeID int) float32 {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1872,7 +1872,7 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
 	for _, existing := range selected {
 		distance := idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
-		if distance <= candidate.distance {
+		if distance < candidate.distance {
 			return false
 		}
 	}

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -345,6 +345,30 @@ func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	}
 }
 
+func TestVectorIndexCandidateDiversityAllowsEqualDistance(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("selected"), vector: []float32{1, 0}},
+		{documentID: []byte("candidate"), vector: []float32{0, 1}},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	if !index.vectorIndexCandidateIsDiverseLocked(
+		vectorIndexCandidate{nodeID: 1, distance: 1},
+		[]vectorIndexCandidate{{nodeID: 0, distance: 0.1}},
+	) {
+		t.Fatal("equal candidate-to-selected distance was treated as occluded")
+	}
+}
+
 func unitVectorAtDegrees(degrees float64) []float32 {
 	radians := degrees * math.Pi / 180
 	return []float32{float32(math.Cos(radians)), float32(math.Sin(radians))}

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -268,6 +268,38 @@ func TestVectorIndexSelectLayerNeighborsUsesHNSWDiversity(t *testing.T) {
 	}
 }
 
+func TestVectorIndexSelectLayerNeighborsSkipsDiversityForInnerProduct(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricInnerProduct,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("best"), vector: []float32{10, 0}, level: 0},
+		{documentID: []byte("next"), vector: []float32{9, 0}, level: 0},
+		{documentID: []byte("orthogonal"), vector: []float32{0, 1}, level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: -10},
+		{nodeID: 2, distance: -9},
+		{nodeID: 3, distance: 0},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 2, 0)
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("selected neighbors=%v want inner-product top candidates [1 2]", got)
+	}
+}
+
 func TestVectorIndexPruneLayerNeighborsUsesHNSWDiversity(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -171,7 +171,7 @@ func TestCollectionVectorIndexSearchKeepsExtraCandidatesThroughAttach(t *testing
 	}
 }
 
-func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) {
+func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentIDForDiverseNeighbors(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",
 		Field:  "embedding",
@@ -182,8 +182,8 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 	index.nodes = []vectorIndexNode{
 		{documentID: []byte("from"), vector: []float32{1, 0}},
-		{documentID: []byte("b"), vector: []float32{0.8, 0.2}},
-		{documentID: []byte("a"), vector: []float32{0.8, 0.2}},
+		{documentID: []byte("b"), vector: unitVectorAtDegrees(10)},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(-10)},
 		{documentID: []byte("far"), vector: []float32{0, 1}},
 	}
 	for i := range index.nodes {
@@ -191,9 +191,9 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 
 	got := index.pruneLayerNeighborsLocked(0, []vectorIndexNeighbor{
-		{nodeID: 3, distance: 1},
-		{nodeID: 1, distance: 0.03},
-		{nodeID: 2, distance: 0.03},
+		{nodeID: 3, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[3].vector)},
+		{nodeID: 1, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[2].vector)},
 	}, 2)
 	if len(got) != 2 || got[0].nodeID != 2 || got[1].nodeID != 1 {
 		t.Fatalf("pruned neighbors=%v want [2 1]", got)

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -149,6 +149,136 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 }
 
+func TestVectorIndexLevelForDocumentIDUsesMDependentHNSWDistribution(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      16,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+
+	const docs = 65536
+	var ge1, ge2, ge3 int
+	for i := 0; i < docs; i++ {
+		level := index.levelForDocumentID([]byte(fmt.Sprintf("doc-%06d", i)))
+		if level >= 1 {
+			ge1++
+		}
+		if level >= 2 {
+			ge2++
+		}
+		if level >= 3 {
+			ge3++
+		}
+	}
+	if ge1 < docs/20 || ge1 > docs/12 {
+		t.Fatalf("level>=1 count=%d, want roughly docs/M=%d", ge1, docs/16)
+	}
+	if ge2 < docs/400 || ge2 > docs/160 {
+		t.Fatalf("level>=2 count=%d, want roughly docs/M^2=%d", ge2, docs/(16*16))
+	}
+	if ge3 < 1 || ge3 > docs/2000 {
+		t.Fatalf("level>=3 count=%d, want roughly docs/M^3=%d", ge3, docs/(16*16*16))
+	}
+}
+
+func TestVectorIndexSelectLayerNeighborsUsesHNSWDiversity(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("redundant"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("diverse"), vector: unitVectorAtDegrees(-7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: mustExactVectorDistance(t, query, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, query, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, query, index.nodes[3].vector)},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 2, 0)
+	if len(got) != 2 || got[0] != 1 || got[1] != 3 {
+		t.Fatalf("selected neighbors=%v want diverse [1 3]", got)
+	}
+}
+
+func TestVectorIndexPruneLayerNeighborsUsesHNSWDiversity(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("from"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("redundant"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("diverse"), vector: unitVectorAtDegrees(-7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+
+	got := index.pruneLayerNeighborsLocked(0, []vectorIndexNeighbor{
+		{nodeID: 1, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[3].vector)},
+	}, 2)
+	if len(got) != 2 || got[0].nodeID != 1 || got[1].nodeID != 3 {
+		t.Fatalf("pruned neighbors=%v want diverse [1 3]", got)
+	}
+}
+
+func TestVectorIndexSelectLayerNeighborsBackfillsPrunedCandidates(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("b"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("c"), vector: unitVectorAtDegrees(7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: mustExactVectorDistance(t, query, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, query, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, query, index.nodes[3].vector)},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 3, 0)
+	if len(got) != 3 {
+		t.Fatalf("selected %d neighbors=%v, want backfilled degree 3", len(got), got)
+	}
+}
+
 func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",
@@ -184,6 +314,20 @@ func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	if len(got) != 2 || got[0] != 2 || got[1] != 3 {
 		t.Fatalf("selected neighbors=%v want [2 3]", got)
 	}
+}
+
+func unitVectorAtDegrees(degrees float64) []float32 {
+	radians := degrees * math.Pi / 180
+	return []float32{float32(math.Cos(radians)), float32(math.Sin(radians))}
+}
+
+func mustExactVectorDistance(t *testing.T, left, right []float32) float32 {
+	t.Helper()
+	distance, err := exactVectorDistance(left, right, VectorMetricCosine)
+	if err != nil {
+		t.Fatalf("exact vector distance: %v", err)
+	}
+	return distance
 }
 
 func TestVectorIndexInsertCachesStoredNorm(t *testing.T) {


### PR DESCRIPTION
## Summary

- adds phase-1 HNSW construction invariants for level distribution, diverse neighbor selection, reciprocal pruning, and degree backfill
- changes TreeDB vector-index level generation from fixed 1/4 promotion to deterministic HNSW-style 1/M promotion
- changes insert neighbor selection and reciprocal pruning from nearest-only truncation to an Algorithm-4-style diversity heuristic with backfill

## Root Cause

The 1M vector DB comparison showed TreeDB returning full topK results but only `318/640` overlap with exact topK at `M=16`, `efConstruction=128`, `efSearch=128`, while pgvector returned `640/640` on the same exported vectors and query set.

A temporary graph probe showed TreeDB had the exact target node in memory and the target node had good local layer-0 neighbors, but greedy routing from the entry point landed far from the target cluster. This pointed at graph construction and routing-layer quality rather than persistence, query generation, or exact-recall validation.

pgvector's HNSW implementation uses `ml = 1 / log(m)` for level generation and Algorithm 4 neighbor selection/pruning. TreeDB previously promoted levels with probability 1/4 regardless of `M`, and selected/pruned neighbors by nearest distance only.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestVectorIndex(LevelForDocumentIDUsesMDependentHNSWDistribution|SelectLayerNeighborsUsesHNSWDiversity|PruneLayerNeighborsUsesHNSWDiversity|SelectLayerNeighborsBackfillsPrunedCandidates|PruneLayerNeighborsUsesDistanceThenDocumentID|SelectLayerNeighborsReusesCandidateDistances)' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections ./cmd/treedb_vector_search_demo -count=1`
- `git diff --check`

## 1M x 64 Strict Recall Validation

Dataset reused from the #1573 comparator run:

```text
/tmp/gomap_vector_db_compare_scale_1m_20260515_174552/dataset
```

Command shape:

```sh
GOWORK=off go run ./cmd/treedb_vector_search_demo \
  -matrix=false \
  -dataset-dir /tmp/gomap_vector_db_compare_scale_1m_20260515_174552/dataset \
  -dir /tmp/gomap_hnsw_quality_1m_20260515_202035/treedb \
  -keep-dir \
  -docs 1000000 \
  -dims 64 \
  -queries 10000 \
  -search-concurrency "4,16,64" \
  -validate-queries 64 \
  -validate-docs 16 \
  -top-k 10 \
  -m 16 \
  -ef-construction 128 \
  -ef-search 128 \
  -min-recall 0.95 \
  -json
```

Before/after at the same `M=16`, `efConstruction=128`, `efSearch=128`:

| Metric | Before | After |
| --- | ---: | ---: |
| Recall@10 | 0.4969 | 1.0000 |
| Overlap | 318/640 | 640/640 |
| Index build | 240.784s | 332.284s |
| Reopen/load | 32.619s | 30.667s |
| Storage/doc | 1883.0B | 1820.7B |
| Index memory | 895.37MB | 827.01MB |
| c1 avg search | 267us | 339us |
| c1 ops/sec | 3742.1 | 2951.0 |
| c64 ops/sec | 29614.3 | 22495.2 |

The recall regression is fixed at 1M, with a clear build/search cost tradeoff from more expensive construction and a different graph shape.

## Reference Source Study

- pgvector `HnswGetMl(m)` uses `1 / log(m)`: https://github.com/pgvector/pgvector/blob/master/src/hnsw.h
- pgvector uses layer limits `2m` at layer 0 and `m` above: https://github.com/pgvector/pgvector/blob/master/src/hnsw.h
- pgvector `SelectNeighbors` implements Algorithm 4 diversity pruning: https://github.com/pgvector/pgvector/blob/master/src/hnswutils.c
