### PR TITLE
Keep HNSW backfill neighbors sorted

### DIFF
--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -659,6 +659,9 @@ func (idx *VectorIndex) newVectorIndexNode(documentID []byte, vector []float32, 
 		level:      level,
 		neighbors:  make([][]vectorIndexNeighbor, level+1),
 	}
+	for layer := range node.neighbors {
+		node.neighbors[layer] = make([]vectorIndexNeighbor, 0, idx.maxNeighborsForLayer(layer))
+	}
 	switch idx.encoding {
 	case VectorIndexEncodingInt8:
 		node.quantized, node.quantScale = quantizeVectorIndexInt8(vector)
@@ -1614,8 +1617,7 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 	}
 	for _, candidate := range candidates {
 		if len(selected) >= limit {
-			rejected = append(rejected, candidate)
-			continue
+			break
 		}
 		if idx.vectorIndexCandidateIsDiverseLocked(candidate, selected) {
 			selected = append(selected, candidate)
@@ -1633,7 +1635,7 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 
 func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
 	for _, existing := range selected {
-		distance := idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
+		distance := idx.distanceBetweenNodesFastLocked(candidate.nodeID, existing.nodeID)
 		if distance <= candidate.distance {
 			return false
 		}
@@ -1642,26 +1644,43 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 }
 
 func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
-	slices.SortFunc(candidates, func(left, right vectorIndexCandidate) int {
-		if left.distance < right.distance {
-			return -1
-		}
-		if left.distance > right.distance {
-			return 1
-		}
-		if left.nodeID >= 0 && left.nodeID < len(idx.nodes) && right.nodeID >= 0 && right.nodeID < len(idx.nodes) {
-			if cmp := bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID); cmp != 0 {
-				return cmp
+	for i := 1; i < len(candidates); i++ {
+		if idx.compareVectorIndexCandidatesByDistanceLocked(candidates[i-1], candidates[i]) > 0 {
+			if i == len(candidates)-1 {
+				candidate := candidates[i]
+				insert := i - 1
+				for insert >= 0 && idx.compareVectorIndexCandidatesByDistanceLocked(candidates[insert], candidate) > 0 {
+					candidates[insert+1] = candidates[insert]
+					insert--
+				}
+				candidates[insert+1] = candidate
+				return
 			}
+			slices.SortFunc(candidates, idx.compareVectorIndexCandidatesByDistanceLocked)
+			return
 		}
-		if left.nodeID < right.nodeID {
-			return -1
+	}
+}
+
+func (idx *VectorIndex) compareVectorIndexCandidatesByDistanceLocked(left, right vectorIndexCandidate) int {
+	if left.distance < right.distance {
+		return -1
+	}
+	if left.distance > right.distance {
+		return 1
+	}
+	if left.nodeID >= 0 && left.nodeID < len(idx.nodes) && right.nodeID >= 0 && right.nodeID < len(idx.nodes) {
+		if cmp := bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID); cmp != 0 {
+			return cmp
 		}
-		if left.nodeID > right.nodeID {
-			return 1
-		}
-		return 0
-	})
+	}
+	if left.nodeID < right.nodeID {
+		return -1
+	}
+	if left.nodeID > right.nodeID {
+		return 1
+	}
+	return 0
 }
 
 func (idx *VectorIndex) distanceToNodeLocked(query []float32, nodeID int) float32 {
@@ -1692,6 +1711,22 @@ func (idx *VectorIndex) distanceBetweenNodesLocked(leftNodeID, rightNodeID int) 
 		return float32(math.Inf(1))
 	}
 	distance, err := vectorDistanceBetweenStoredNodes(&idx.nodes[leftNodeID], &idx.nodes[rightNodeID], idx.metric)
+	if err != nil {
+		return float32(math.Inf(1))
+	}
+	return distance
+}
+
+func (idx *VectorIndex) distanceBetweenNodesFastLocked(leftNodeID, rightNodeID int) float32 {
+	if leftNodeID < 0 || leftNodeID >= len(idx.nodes) || rightNodeID < 0 || rightNodeID >= len(idx.nodes) {
+		return float32(math.Inf(1))
+	}
+	left := &idx.nodes[leftNodeID]
+	right := &idx.nodes[rightNodeID]
+	if idx.metric == VectorMetricCosine && len(left.vector) > 0 && len(left.vector) == len(right.vector) && left.cachedInvNorm != 0 && right.cachedInvNorm != 0 {
+		return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right)
+	}
+	distance, err := vectorDistanceBetweenStoredNodes(left, right, idx.metric)
 	if err != nil {
 		return float32(math.Inf(1))
 	}
@@ -1840,8 +1875,12 @@ func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (floa
 	if left.cachedInvNorm == 0 || right.cachedInvNorm == 0 {
 		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
 	}
+	return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right), nil
+}
+
+func vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right *vectorIndexNode) float32 {
 	dot := dotProductFloat32ForCosine(left.vector, right.vector, left.normSquared, right.normSquared)
-	return float32(1 - dot*float64(left.cachedInvNorm)*float64(right.cachedInvNorm)), nil
+	return float32(1 - dot*float64(left.cachedInvNorm)*float64(right.cachedInvNorm))
 }
 
 func dotProductFloat32ForCosine(left, right []float32, leftNormSquared, rightNormSquared float64) float64 {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1919,6 +1919,9 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 	if len(candidates) <= limit {
 		return candidates
 	}
+	if idx.metric == VectorMetricInnerProduct {
+		return candidates[:limit]
+	}
 	var selectedStack [128]vectorIndexCandidate
 	selected := selectedStack[:0]
 	if limit > len(selectedStack) {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1851,7 +1851,8 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 
 // sortVectorIndexCandidatesByDistanceLocked keeps the common already-sorted
 // case allocation-free and handles the exactly-one-candidate-appended-at-tail
-// case with insertion sort. Other unsorted shapes fall back to the full sort.
+// case with insertion sort. Broader near-sorted shapes intentionally fall back
+// to the full sort instead of carrying more repair logic in the hot path.
 func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
 	for i := 1; i < len(candidates); i++ {
 		if idx.compareVectorIndexCandidatesByDistanceLocked(candidates[i-1], candidates[i]) > 0 {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -751,10 +751,17 @@ func (idx *VectorIndex) levelForDocumentID(documentID []byte) int {
 	var seed [8]byte
 	binary.LittleEndian.PutUint64(seed[:], xxhash.Sum64(documentID)^xxhash.Sum64String(idx.name))
 	hash := xxhash.Sum64(seed[:])
-	level := 0
-	for level < 32 && hash&0x3 == 0 {
-		level++
-		hash >>= 2
+	promotionBase := idx.m
+	if promotionBase < 2 {
+		promotionBase = 2
+	}
+	if hash == 0 {
+		return 32
+	}
+	u := (float64(hash>>11) + 1) / (float64(uint64(1)<<53) + 1)
+	level := int(-math.Log(u) / math.Log(float64(promotionBase)))
+	if level > 32 {
+		return 32
 	}
 	return level
 }
@@ -879,18 +886,7 @@ func (idx *VectorIndex) pruneLayerNeighborsLocked(_ int, neighbors []vectorIndex
 		}
 		scored = append(scored, vectorIndexCandidate{nodeID: neighborID, distance: distance})
 	}
-	slices.SortFunc(scored, func(left, right vectorIndexCandidate) int {
-		if left.distance < right.distance {
-			return -1
-		}
-		if left.distance > right.distance {
-			return 1
-		}
-		return bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID)
-	})
-	if len(scored) > limit {
-		scored = scored[:limit]
-	}
+	scored = idx.selectDiverseCandidatesLocked(scored, limit)
 	out := neighbors[:0]
 	for _, candidate := range scored {
 		out = append(out, vectorIndexNeighbor{nodeID: candidate.nodeID, distance: candidate.distance})
@@ -1590,15 +1586,82 @@ func (idx *VectorIndex) selectLayerNeighborsLocked(vector []float32, vectorNormS
 		}
 		scored = append(scored, candidate)
 	}
-	sortVectorIndexCandidates(scored)
-	if len(scored) > limit {
-		scored = scored[:limit]
-	}
+	scored = idx.selectDiverseCandidatesLocked(scored, limit)
 	out := make([]int, len(scored))
 	for i := range scored {
 		out[i] = scored[i].nodeID
 	}
 	return out
+}
+
+func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCandidate, limit int) []vectorIndexCandidate {
+	if limit <= 0 || len(candidates) == 0 {
+		return nil
+	}
+	idx.sortVectorIndexCandidatesByDistanceLocked(candidates)
+	if len(candidates) <= limit {
+		return candidates
+	}
+	var selectedStack [128]vectorIndexCandidate
+	selected := selectedStack[:0]
+	if limit > len(selectedStack) {
+		selected = make([]vectorIndexCandidate, 0, limit)
+	}
+	var rejectedStack [128]vectorIndexCandidate
+	rejected := rejectedStack[:0]
+	if len(candidates) > len(rejectedStack) {
+		rejected = make([]vectorIndexCandidate, 0, len(candidates))
+	}
+	for _, candidate := range candidates {
+		if len(selected) >= limit {
+			rejected = append(rejected, candidate)
+			continue
+		}
+		if idx.vectorIndexCandidateIsDiverseLocked(candidate, selected) {
+			selected = append(selected, candidate)
+		} else {
+			rejected = append(rejected, candidate)
+		}
+	}
+	for i := 0; len(selected) < limit && i < len(rejected); i++ {
+		selected = append(selected, rejected[i])
+	}
+	out := candidates[:0]
+	out = append(out, selected...)
+	return out
+}
+
+func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
+	for _, existing := range selected {
+		distance := idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
+		if distance <= candidate.distance {
+			return false
+		}
+	}
+	return true
+}
+
+func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
+	slices.SortFunc(candidates, func(left, right vectorIndexCandidate) int {
+		if left.distance < right.distance {
+			return -1
+		}
+		if left.distance > right.distance {
+			return 1
+		}
+		if left.nodeID >= 0 && left.nodeID < len(idx.nodes) && right.nodeID >= 0 && right.nodeID < len(idx.nodes) {
+			if cmp := bytes.Compare(idx.nodes[left.nodeID].documentID, idx.nodes[right.nodeID].documentID); cmp != 0 {
+				return cmp
+			}
+		}
+		if left.nodeID < right.nodeID {
+			return -1
+		}
+		if left.nodeID > right.nodeID {
+			return 1
+		}
+		return 0
+	})
 }
 
 func (idx *VectorIndex) distanceToNodeLocked(query []float32, nodeID int) float32 {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1625,11 +1625,25 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 			rejected = append(rejected, candidate)
 		}
 	}
-	for i := 0; len(selected) < limit && i < len(rejected); i++ {
-		selected = append(selected, rejected[i])
-	}
 	out := candidates[:0]
-	out = append(out, selected...)
+	backfill := minInt(limit-len(selected), len(rejected))
+	if backfill == 0 {
+		out = append(out, selected...)
+		return out
+	}
+	selectedPos := 0
+	rejectedPos := 0
+	for selectedPos < len(selected) && rejectedPos < backfill {
+		if idx.compareVectorIndexCandidatesByDistanceLocked(selected[selectedPos], rejected[rejectedPos]) <= 0 {
+			out = append(out, selected[selectedPos])
+			selectedPos++
+			continue
+		}
+		out = append(out, rejected[rejectedPos])
+		rejectedPos++
+	}
+	out = append(out, selected[selectedPos:]...)
+	out = append(out, rejected[rejectedPos:backfill]...)
 	return out
 }
 

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -490,7 +490,7 @@ func (c *Collection) ensureDeclaredNativeVectorIndexesLoaded() error {
 		if index != nil {
 			continue
 		}
-		if status.ExactFallbackReason == vectorIndexFallbackMissingGraphRoot {
+		if status.ExactFallbackReason != "" {
 			if _, err := c.BuildVectorIndex(vectorIndexOptionsFromDefinition(def)); err != nil {
 				return err
 			}

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -27,6 +27,7 @@ const (
 	defaultVectorIndexRebuildPPM     = 250_000
 	defaultVectorIndexExactFilterMax = 1024
 	defaultVectorRecallBatchCells    = 1 << 20
+	maxVectorIndexEagerNeighborCap   = 64
 )
 
 const (
@@ -867,7 +868,7 @@ func (idx *VectorIndex) newVectorIndexNodePrepared(documentID []byte, vector []f
 		neighbors:  make([][]vectorIndexNeighbor, level+1),
 	}
 	for layer := range node.neighbors {
-		node.neighbors[layer] = make([]vectorIndexNeighbor, 0, idx.maxNeighborsForLayer(layer))
+		node.neighbors[layer] = make([]vectorIndexNeighbor, 0, idx.initialNeighborCapacityForLayer(layer))
 	}
 	switch idx.encoding {
 	case VectorIndexEncodingInt8:
@@ -1064,6 +1065,10 @@ func (idx *VectorIndex) maxNeighborsForLayer(layer int) int {
 		return maxInt(idx.m*2, idx.m)
 	}
 	return idx.m
+}
+
+func (idx *VectorIndex) initialNeighborCapacityForLayer(layer int) int {
+	return minInt(idx.maxNeighborsForLayer(layer), maxVectorIndexEagerNeighborCap)
 }
 
 func normalizeVectorIndexEdgeDistance(distance float32) (float32, bool) {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1813,9 +1813,8 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 	}
 	for _, candidate := range candidates {
 		if len(selected) >= limit {
-			// Backfill only runs when diversity pruning leaves room below limit.
-			// Once full, avoid scanning the tail into rejected on construction hot paths.
-			break
+			rejected = append(rejected, candidate)
+			continue
 		}
 		if idx.vectorIndexCandidateIsDiverseLocked(candidate, selected) {
 			selected = append(selected, candidate)
@@ -1833,7 +1832,10 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 
 func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
 	for _, existing := range selected {
-		distance := idx.distanceBetweenNodesFastLocked(candidate.nodeID, existing.nodeID)
+		distance, ok := idx.distanceBetweenNodesFastLocked(candidate.nodeID, existing.nodeID)
+		if !ok {
+			return false
+		}
 		if distance <= candidate.distance {
 			return false
 		}
@@ -1842,8 +1844,8 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 }
 
 // sortVectorIndexCandidatesByDistanceLocked keeps the common already-sorted
-// case allocation-free and handles the append-one-candidate case with insertion
-// sort. Other unsorted shapes fall back to the standard full sort.
+// case allocation-free and handles the exactly-one-candidate-appended-at-tail
+// case with insertion sort. Other unsorted shapes fall back to the full sort.
 func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
 	for i := 1; i < len(candidates); i++ {
 		if idx.compareVectorIndexCandidatesByDistanceLocked(candidates[i-1], candidates[i]) > 0 {
@@ -1918,20 +1920,20 @@ func (idx *VectorIndex) distanceBetweenNodesLocked(leftNodeID, rightNodeID int) 
 	return distance
 }
 
-func (idx *VectorIndex) distanceBetweenNodesFastLocked(leftNodeID, rightNodeID int) float32 {
+func (idx *VectorIndex) distanceBetweenNodesFastLocked(leftNodeID, rightNodeID int) (float32, bool) {
 	if leftNodeID < 0 || leftNodeID >= len(idx.nodes) || rightNodeID < 0 || rightNodeID >= len(idx.nodes) {
-		return float32(math.Inf(1))
+		return 0, false
 	}
 	left := &idx.nodes[leftNodeID]
 	right := &idx.nodes[rightNodeID]
 	if idx.metric == VectorMetricCosine && canUseUncheckedFloat32NodeCosine(left, right) {
-		return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right)
+		return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right), true
 	}
 	distance, err := vectorDistanceBetweenStoredNodes(left, right, idx.metric)
 	if err != nil {
-		return float32(math.Inf(1))
+		return 0, false
 	}
-	return distance
+	return distance, true
 }
 
 func vectorDistanceToStoredNode(query []float32, node *vectorIndexNode, metric VectorMetric) (float32, error) {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1881,9 +1881,9 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 	for _, existing := range selected {
 		distance, ok := idx.distanceBetweenNodesFastLocked(candidate.nodeID, existing.nodeID)
 		if !ok {
-			return false
+			distance = idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
 		}
-		if distance <= candidate.distance {
+		if distance < candidate.distance {
 			return false
 		}
 	}
@@ -1895,22 +1895,38 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 // case with insertion sort. Broader near-sorted shapes intentionally fall back
 // to the full sort instead of carrying more repair logic in the hot path.
 func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
+	inversion := idx.firstVectorIndexCandidateInversionLocked(candidates)
+	switch {
+	case inversion == -1:
+		return
+	case inversion == len(candidates)-1:
+		idx.insertTailVectorIndexCandidateByDistanceLocked(candidates)
+	default:
+		slices.SortFunc(candidates, idx.compareVectorIndexCandidatesByDistanceLocked)
+	}
+}
+
+func (idx *VectorIndex) firstVectorIndexCandidateInversionLocked(candidates []vectorIndexCandidate) int {
 	for i := 1; i < len(candidates); i++ {
 		if idx.compareVectorIndexCandidatesByDistanceLocked(candidates[i-1], candidates[i]) > 0 {
-			if i == len(candidates)-1 {
-				candidate := candidates[i]
-				insert := i - 1
-				for insert >= 0 && idx.compareVectorIndexCandidatesByDistanceLocked(candidates[insert], candidate) > 0 {
-					candidates[insert+1] = candidates[insert]
-					insert--
-				}
-				candidates[insert+1] = candidate
-				return
-			}
-			slices.SortFunc(candidates, idx.compareVectorIndexCandidatesByDistanceLocked)
-			return
+			return i
 		}
 	}
+	return -1
+}
+
+func (idx *VectorIndex) insertTailVectorIndexCandidateByDistanceLocked(candidates []vectorIndexCandidate) {
+	tail := len(candidates) - 1
+	if tail <= 0 {
+		return
+	}
+	candidate := candidates[tail]
+	insert := tail - 1
+	for insert >= 0 && idx.compareVectorIndexCandidatesByDistanceLocked(candidates[insert], candidate) > 0 {
+		candidates[insert+1] = candidates[insert]
+		insert--
+	}
+	candidates[insert+1] = candidate
 }
 
 func (idx *VectorIndex) compareVectorIndexCandidatesByDistanceLocked(left, right vectorIndexCandidate) int {
@@ -1974,7 +1990,7 @@ func (idx *VectorIndex) distanceBetweenNodesFastLocked(leftNodeID, rightNodeID i
 	}
 	left := &idx.nodes[leftNodeID]
 	right := &idx.nodes[rightNodeID]
-	if idx.metric == VectorMetricCosine && canUseUncheckedFloat32NodeCosine(left, right) {
+	if idx.metric == VectorMetricCosine && canUseUncheckedFloat32NodeCosine(left, right, idx.dimensions) {
 		return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right), true
 	}
 	distance, err := vectorDistanceBetweenStoredNodes(left, right, idx.metric)
@@ -2123,15 +2139,16 @@ func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (floa
 	if len(left.vector) != len(right.vector) {
 		return 0, fmt.Errorf("collections: vector dimensions differ: %d vs %d", len(left.vector), len(right.vector))
 	}
-	if !canUseUncheckedFloat32NodeCosine(left, right) {
+	if !canUseUncheckedFloat32NodeCosine(left, right, 0) {
 		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
 	}
 	return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right), nil
 }
 
-func canUseUncheckedFloat32NodeCosine(left, right *vectorIndexNode) bool {
+func canUseUncheckedFloat32NodeCosine(left, right *vectorIndexNode, dimensions int) bool {
 	return len(left.vector) > 0 &&
 		len(left.vector) == len(right.vector) &&
+		(dimensions == 0 || len(left.vector) == dimensions) &&
 		left.cachedInvNorm != 0 &&
 		right.cachedInvNorm != 0
 }

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1813,6 +1813,8 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 	}
 	for _, candidate := range candidates {
 		if len(selected) >= limit {
+			// Backfill only runs when diversity pruning leaves room below limit.
+			// Once full, avoid scanning the tail into rejected on construction hot paths.
 			break
 		}
 		if idx.vectorIndexCandidateIsDiverseLocked(candidate, selected) {
@@ -1839,6 +1841,9 @@ func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorInde
 	return true
 }
 
+// sortVectorIndexCandidatesByDistanceLocked keeps the common already-sorted
+// case allocation-free and handles the append-one-candidate case with insertion
+// sort. Other unsorted shapes fall back to the standard full sort.
 func (idx *VectorIndex) sortVectorIndexCandidatesByDistanceLocked(candidates []vectorIndexCandidate) {
 	for i := 1; i < len(candidates); i++ {
 		if idx.compareVectorIndexCandidatesByDistanceLocked(candidates[i-1], candidates[i]) > 0 {
@@ -1919,7 +1924,7 @@ func (idx *VectorIndex) distanceBetweenNodesFastLocked(leftNodeID, rightNodeID i
 	}
 	left := &idx.nodes[leftNodeID]
 	right := &idx.nodes[rightNodeID]
-	if idx.metric == VectorMetricCosine && len(left.vector) > 0 && len(left.vector) == len(right.vector) && left.cachedInvNorm != 0 && right.cachedInvNorm != 0 {
+	if idx.metric == VectorMetricCosine && canUseUncheckedFloat32NodeCosine(left, right) {
 		return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right)
 	}
 	distance, err := vectorDistanceBetweenStoredNodes(left, right, idx.metric)
@@ -2068,10 +2073,17 @@ func vectorDistanceBetweenFloat32NodesCosine(left, right *vectorIndexNode) (floa
 	if len(left.vector) != len(right.vector) {
 		return 0, fmt.Errorf("collections: vector dimensions differ: %d vs %d", len(left.vector), len(right.vector))
 	}
-	if left.cachedInvNorm == 0 || right.cachedInvNorm == 0 {
+	if !canUseUncheckedFloat32NodeCosine(left, right) {
 		return 0, errors.New("collections: cosine vector cannot have zero magnitude")
 	}
 	return vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right), nil
+}
+
+func canUseUncheckedFloat32NodeCosine(left, right *vectorIndexNode) bool {
+	return len(left.vector) > 0 &&
+		len(left.vector) == len(right.vector) &&
+		left.cachedInvNorm != 0 &&
+		right.cachedInvNorm != 0
 }
 
 func vectorDistanceBetweenFloat32NodesCosineUnchecked(left, right *vectorIndexNode) float32 {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -1872,7 +1872,7 @@ func (idx *VectorIndex) selectDiverseCandidatesLocked(candidates []vectorIndexCa
 func (idx *VectorIndex) vectorIndexCandidateIsDiverseLocked(candidate vectorIndexCandidate, selected []vectorIndexCandidate) bool {
 	for _, existing := range selected {
 		distance := idx.distanceBetweenNodesLocked(candidate.nodeID, existing.nodeID)
-		if distance <= candidate.distance {
+		if distance < candidate.distance {
 			return false
 		}
 	}

--- a/TreeDB/collections/vector_index_persist_test.go
+++ b/TreeDB/collections/vector_index_persist_test.go
@@ -1721,6 +1721,113 @@ func TestCollectionVectorIndexNativeRootStatusReportsMissingRoot(t *testing.T) {
 	}
 }
 
+func TestCollectionVectorIndexNativeRootMutationRepairsSnapshotFallback(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	def := VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          4,
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert seed vectors: %v", err)
+	}
+	index, err := col.BuildVectorIndex(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("build vector index: %v", err)
+	}
+	if _, err := index.SaveSnapshot(); err != nil {
+		t.Fatalf("save vector index: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	newMeta, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:           "embedding",
+			Field:          "embedding",
+			Metric:         VectorMetricCosine,
+			Dimensions:     2,
+			M:              8,
+			EfConstruction: 16,
+			EfSearch:       32,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize collection meta: %v", err)
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		t.Fatalf("encode collection meta: %v", err)
+	}
+	_, _, err = d.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return col.buildSchemaOnlySystemDeltaIterator(catalog.meta, encodedMeta, nil)
+	})
+	if err != nil {
+		t.Fatalf("publish stale vector metadata: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	if got := len(reopenedCol.registeredVectorIndexes()); got != 0 {
+		t.Fatalf("reopened collection eagerly registered %d vector indexes want 0", got)
+	}
+	if _, err := reopenedCol.InsertBatch(
+		[][]byte{[]byte("c")},
+		[][]byte{[]byte(`{"embedding":[0.9,0.1]}`)},
+	); err != nil {
+		t.Fatalf("insert after snapshot fallback: %v", err)
+	}
+	if got := len(reopenedCol.registeredVectorIndexes()); got != 1 {
+		t.Fatalf("snapshot fallback did not repair vector index, got %d registered indexes", got)
+	}
+	loaded := reopenedCol.registeredVectorIndex("embedding")
+	if loaded == nil {
+		t.Fatal("snapshot fallback repair did not leave a registered vector index")
+	}
+	results, _, err := loaded.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 3, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search repaired vector index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "c", "b")
+}
+
 func TestCollectionVectorIndexNativeRootRebuildAPIAcceptsEmptyGraph(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -345,6 +345,30 @@ func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	}
 }
 
+func TestVectorIndexCandidateDiversityAllowsEqualDistance(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("selected"), vector: []float32{1, 0}},
+		{documentID: []byte("candidate"), vector: []float32{0, 1}},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	if !index.vectorIndexCandidateIsDiverseLocked(
+		vectorIndexCandidate{nodeID: 1, distance: 1},
+		[]vectorIndexCandidate{{nodeID: 0, distance: 0.1}},
+	) {
+		t.Fatal("equal candidate-to-selected distance was treated as occluded")
+	}
+}
+
 func unitVectorAtDegrees(degrees float64) []float32 {
 	radians := degrees * math.Pi / 180
 	return []float32{float32(math.Cos(radians)), float32(math.Sin(radians))}

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -268,6 +268,38 @@ func TestVectorIndexSelectLayerNeighborsUsesHNSWDiversity(t *testing.T) {
 	}
 }
 
+func TestVectorIndexSelectLayerNeighborsSkipsDiversityForInnerProduct(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricInnerProduct,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("best"), vector: []float32{10, 0}, level: 0},
+		{documentID: []byte("next"), vector: []float32{9, 0}, level: 0},
+		{documentID: []byte("orthogonal"), vector: []float32{0, 1}, level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: -10},
+		{nodeID: 2, distance: -9},
+		{nodeID: 3, distance: 0},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 2, 0)
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("selected neighbors=%v want inner-product top candidates [1 2]", got)
+	}
+}
+
 func TestVectorIndexPruneLayerNeighborsUsesHNSWDiversity(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -308,6 +308,29 @@ func TestVectorIndexInt8InsertUnchangedVectorNoops(t *testing.T) {
 	}
 }
 
+func TestVectorIndexCandidateDiversityRejectsInvalidPairDistance(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("candidate"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("invalid"), vector: []float32{1, 0, 0}, level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+
+	if index.vectorIndexCandidateIsDiverseLocked(vectorIndexCandidate{nodeID: 0, distance: 0.1}, []vectorIndexCandidate{{nodeID: 1}}) {
+		t.Fatal("candidate with invalid pair distance was treated as diverse")
+	}
+}
+
 func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -279,6 +279,45 @@ func TestVectorIndexSelectLayerNeighborsBackfillsPrunedCandidates(t *testing.T) 
 	}
 }
 
+func TestVectorIndexSelectDiverseCandidatesKeepsBackfillDistanceSorted(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      2,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("from"), vector: query, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(1), level: 0},
+		{documentID: []byte("backfill"), vector: unitVectorAtDegrees(2), level: 0},
+		{documentID: []byte("diverse"), vector: unitVectorAtDegrees(-20), level: 0},
+		{documentID: []byte("extra"), vector: unitVectorAtDegrees(-21), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: mustExactVectorDistance(t, query, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, query, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, query, index.nodes[3].vector)},
+		{nodeID: 4, distance: mustExactVectorDistance(t, query, index.nodes[4].vector)},
+	}
+
+	got := index.selectDiverseCandidatesLocked(candidates, 3)
+	if len(got) != 3 {
+		t.Fatalf("selected %d candidates=%v, want 3", len(got), got)
+	}
+	for i := 1; i < len(got); i++ {
+		if index.compareVectorIndexCandidatesByDistanceLocked(got[i-1], got[i]) > 0 {
+			t.Fatalf("selected candidates not distance sorted: %v", got)
+		}
+	}
+}
+
 func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -171,7 +171,7 @@ func TestCollectionVectorIndexSearchKeepsExtraCandidatesThroughAttach(t *testing
 	}
 }
 
-func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) {
+func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentIDForDiverseNeighbors(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",
 		Field:  "embedding",
@@ -182,8 +182,8 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 	index.nodes = []vectorIndexNode{
 		{documentID: []byte("from"), vector: []float32{1, 0}},
-		{documentID: []byte("b"), vector: []float32{0.8, 0.2}},
-		{documentID: []byte("a"), vector: []float32{0.8, 0.2}},
+		{documentID: []byte("b"), vector: unitVectorAtDegrees(10)},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(-10)},
 		{documentID: []byte("far"), vector: []float32{0, 1}},
 	}
 	for i := range index.nodes {
@@ -191,9 +191,9 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 
 	got := index.pruneLayerNeighborsLocked(0, []vectorIndexNeighbor{
-		{nodeID: 3, distance: 1},
-		{nodeID: 1, distance: 0.03},
-		{nodeID: 2, distance: 0.03},
+		{nodeID: 3, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[3].vector)},
+		{nodeID: 1, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[2].vector)},
 	}, 2)
 	if len(got) != 2 || got[0].nodeID != 2 || got[1].nodeID != 1 {
 		t.Fatalf("pruned neighbors=%v want [2 1]", got)

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -308,7 +308,7 @@ func TestVectorIndexInt8InsertUnchangedVectorNoops(t *testing.T) {
 	}
 }
 
-func TestVectorIndexCandidateDiversityRejectsInvalidPairDistance(t *testing.T) {
+func TestVectorIndexCandidateDiversitySkipsInvalidPairDistance(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",
 		Field:  "embedding",
@@ -326,8 +326,37 @@ func TestVectorIndexCandidateDiversityRejectsInvalidPairDistance(t *testing.T) {
 		index.nodes[i].cacheVectorNorms()
 	}
 
-	if index.vectorIndexCandidateIsDiverseLocked(vectorIndexCandidate{nodeID: 0, distance: 0.1}, []vectorIndexCandidate{{nodeID: 1}}) {
-		t.Fatal("candidate with invalid pair distance was treated as diverse")
+	if !index.vectorIndexCandidateIsDiverseLocked(vectorIndexCandidate{nodeID: 0, distance: 0.1}, []vectorIndexCandidate{{nodeID: 1}}) {
+		t.Fatal("invalid pair distance rejected the candidate instead of preserving sentinel fallback behavior")
+	}
+}
+
+func TestVectorIndexDistanceBetweenNodesFastMatchesStoredCosine(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("left"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("right"), vector: []float32{0.5, 0.5}, level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+
+	fast, ok := index.distanceBetweenNodesFastLocked(0, 1)
+	if !ok {
+		t.Fatal("fast pair distance path unavailable for valid cosine nodes")
+	}
+	slow := index.distanceBetweenNodesLocked(0, 1)
+	if math.Abs(float64(fast-slow)) > 1e-6 {
+		t.Fatalf("fast distance=%v slow=%v", fast, slow)
 	}
 }
 
@@ -386,6 +415,48 @@ func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	)
 	if len(got) != 2 || got[0] != 2 || got[1] != 3 {
 		t.Fatalf("selected neighbors=%v want [2 3]", got)
+	}
+}
+
+func TestSortVectorIndexCandidatesByDistanceTailInsert(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("a")},
+		{documentID: []byte("b")},
+		{documentID: []byte("c")},
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 0, distance: 0.1},
+		{nodeID: 2, distance: 0.3},
+		{nodeID: 1, distance: 0.2},
+	}
+	index.sortVectorIndexCandidatesByDistanceLocked(candidates)
+	if candidates[0].nodeID != 0 || candidates[1].nodeID != 1 || candidates[2].nodeID != 2 {
+		t.Fatalf("tail-insert sort candidates=%+v", candidates)
+	}
+}
+
+func TestSortVectorIndexCandidatesByDistanceFallbackSort(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{Name: "embedding", Field: "embedding", Metric: VectorMetricCosine})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("a")},
+		{documentID: []byte("b")},
+		{documentID: []byte("c")},
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 2, distance: 0.3},
+		{nodeID: 1, distance: 0.2},
+		{nodeID: 0, distance: 0.1},
+	}
+	index.sortVectorIndexCandidatesByDistanceLocked(candidates)
+	if candidates[0].nodeID != 0 || candidates[1].nodeID != 1 || candidates[2].nodeID != 2 {
+		t.Fatalf("fallback sort candidates=%+v", candidates)
 	}
 }
 

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -331,6 +331,27 @@ func TestVectorIndexCandidateDiversityRejectsInvalidPairDistance(t *testing.T) {
 	}
 }
 
+func TestVectorIndexNewNodeCapsEagerNeighborCapacity(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      10_000,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	node := index.newVectorIndexNode([]byte("a"), []float32{1, 0}, 2)
+	for layer, neighbors := range node.neighbors {
+		if cap(neighbors) > maxVectorIndexEagerNeighborCap {
+			t.Fatalf("layer %d eager cap=%d exceeds cap %d", layer, cap(neighbors), maxVectorIndexEagerNeighborCap)
+		}
+	}
+	if got := index.maxNeighborsForLayer(0); got <= maxVectorIndexEagerNeighborCap {
+		t.Fatalf("test did not exercise high-M logical limit: %d", got)
+	}
+}
+
 func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -149,6 +149,136 @@ func TestVectorIndexPruneLayerNeighborsUsesDistanceThenDocumentID(t *testing.T) 
 	}
 }
 
+func TestVectorIndexLevelForDocumentIDUsesMDependentHNSWDistribution(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      16,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+
+	const docs = 65536
+	var ge1, ge2, ge3 int
+	for i := 0; i < docs; i++ {
+		level := index.levelForDocumentID([]byte(fmt.Sprintf("doc-%06d", i)))
+		if level >= 1 {
+			ge1++
+		}
+		if level >= 2 {
+			ge2++
+		}
+		if level >= 3 {
+			ge3++
+		}
+	}
+	if ge1 < docs/20 || ge1 > docs/12 {
+		t.Fatalf("level>=1 count=%d, want roughly docs/M=%d", ge1, docs/16)
+	}
+	if ge2 < docs/400 || ge2 > docs/160 {
+		t.Fatalf("level>=2 count=%d, want roughly docs/M^2=%d", ge2, docs/(16*16))
+	}
+	if ge3 < 1 || ge3 > docs/2000 {
+		t.Fatalf("level>=3 count=%d, want roughly docs/M^3=%d", ge3, docs/(16*16*16))
+	}
+}
+
+func TestVectorIndexSelectLayerNeighborsUsesHNSWDiversity(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("redundant"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("diverse"), vector: unitVectorAtDegrees(-7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: mustExactVectorDistance(t, query, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, query, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, query, index.nodes[3].vector)},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 2, 0)
+	if len(got) != 2 || got[0] != 1 || got[1] != 3 {
+		t.Fatalf("selected neighbors=%v want diverse [1 3]", got)
+	}
+}
+
+func TestVectorIndexPruneLayerNeighborsUsesHNSWDiversity(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("from"), vector: []float32{1, 0}, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("redundant"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("diverse"), vector: unitVectorAtDegrees(-7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+
+	got := index.pruneLayerNeighborsLocked(0, []vectorIndexNeighbor{
+		{nodeID: 1, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, index.nodes[0].vector, index.nodes[3].vector)},
+	}, 2)
+	if len(got) != 2 || got[0].nodeID != 1 || got[1].nodeID != 3 {
+		t.Fatalf("pruned neighbors=%v want diverse [1 3]", got)
+	}
+}
+
+func TestVectorIndexSelectLayerNeighborsBackfillsPrunedCandidates(t *testing.T) {
+	index, err := newVectorIndex(nil, VectorIndexOptions{
+		Name:   "embedding",
+		Field:  "embedding",
+		Metric: VectorMetricCosine,
+		M:      4,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	query := []float32{1, 0}
+	index.nodes = []vectorIndexNode{
+		{documentID: []byte("query"), vector: query, level: 0},
+		{documentID: []byte("a"), vector: unitVectorAtDegrees(5), level: 0},
+		{documentID: []byte("b"), vector: unitVectorAtDegrees(6), level: 0},
+		{documentID: []byte("c"), vector: unitVectorAtDegrees(7), level: 0},
+	}
+	for i := range index.nodes {
+		index.nodes[i].cacheVectorNorms()
+	}
+	candidates := []vectorIndexCandidate{
+		{nodeID: 1, distance: mustExactVectorDistance(t, query, index.nodes[1].vector)},
+		{nodeID: 2, distance: mustExactVectorDistance(t, query, index.nodes[2].vector)},
+		{nodeID: 3, distance: mustExactVectorDistance(t, query, index.nodes[3].vector)},
+	}
+
+	got := index.selectLayerNeighborsLocked(query, vectorNormSquared(query), nil, candidates, 0, 3, 0)
+	if len(got) != 3 {
+		t.Fatalf("selected %d neighbors=%v, want backfilled degree 3", len(got), got)
+	}
+}
+
 func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	index, err := newVectorIndex(nil, VectorIndexOptions{
 		Name:   "embedding",
@@ -184,6 +314,20 @@ func TestVectorIndexSelectLayerNeighborsReusesCandidateDistances(t *testing.T) {
 	if len(got) != 2 || got[0] != 2 || got[1] != 3 {
 		t.Fatalf("selected neighbors=%v want [2 3]", got)
 	}
+}
+
+func unitVectorAtDegrees(degrees float64) []float32 {
+	radians := degrees * math.Pi / 180
+	return []float32{float32(math.Cos(radians)), float32(math.Sin(radians))}
+}
+
+func mustExactVectorDistance(t *testing.T, left, right []float32) float32 {
+	t.Helper()
+	distance, err := exactVectorDistance(left, right, VectorMetricCosine)
+	if err != nil {
+		t.Fatalf("exact vector distance: %v", err)
+	}
+	return distance
 }
 
 func TestVectorIndexInsertCachesStoredNorm(t *testing.T) {


### PR DESCRIPTION
## Summary
- Merge HNSW diversity-selected and backfilled candidates in distance order instead of appending rejected backfill candidates after selected candidates.
- Preserve the selected/backfilled candidate set while keeping neighbor output ordered for cheaper future construction pruning.
- Add focused coverage for the backfill ordering invariant.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestVectorIndex(SelectDiverseCandidatesKeepsBackfillDistanceSorted|SelectLayerNeighborsBackfillsPrunedCandidates|PruneLayerNeighborsUsesHNSWDiversity)' -count=1`\n- `GOWORK=off go test ./TreeDB/collections ./cmd/treedb_vector_search_demo -count=1`\n- `git diff --check`\n- Build benchmark, 10k docs x 64 dims: `/tmp/hnsw_build_merge_only_ujKsOg/current.txt` vs #1580 baseline `/tmp/hnsw_perf_compare_20260515_205921/current.txt`\n  - `BenchmarkCollectionVectorIndexBuild`: `2.120s/op` -> `1.900s/op`, `-10.38%`, `p=0.002`, index bytes unchanged.\n- CPU/alloc profile: `/tmp/hnsw_build_merge_only_profile_S6ZtGU/`\n  - `sortVectorIndexCandidatesByDistanceLocked` is no longer a top construction cost in the sample (`~0.02s` of `2.05s`).\n- 1M strict gate: `/tmp/gomap_hnsw_build_merge_1m_20260515_220723/treedb.json`\n  - rebuild/index creation: `299.614s`\n  - recall@10: `1.0000` (`640/640`)\n  - vector index memory: `827,014,528` bytes\n  - exact fallbacks: `0`\n