### PR TITLE
TreeDB command WAL PR6.5: collection/catalog performance polish

### DIFF
--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -960,7 +960,8 @@ Deliverables:
   artifacts before matrix hardening and public raw KV default cutover;
 - apply the strict default-ready throughput gate to collection/catalog lanes:
   command-WAL throughput divided by the relevant WAL-off baseline throughput
-  must be greater than `1.01x`; `1.01x` or lower fails;
+  must be greater than `1.01x`; anything not strictly greater than `1.01x`
+  fails;
 - explicitly prevent PR9 public raw KV performance evidence from being reused as
   a collection command-WAL default-readiness claim;
 - convert any below-gate collection overhead into a follow-up issue with exact
@@ -973,8 +974,8 @@ Acceptance:
 - collection insert/delete/update command-WAL lanes remain supported command
   kinds but are not default-ready performance lanes until the follow-up issue
   clears strict `>1.01x` throughput for every supported lane;
-- PR9 may only claim public raw KV default-readiness unless it adds new
-  collection/catalog performance artifacts that clear the same strict gate.
+- PR9 must restrict default-readiness claims to public raw KV unless it adds
+  new collection/catalog performance artifacts that clear the same strict gate.
 
 PR6.5 evidence:
 

--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -952,6 +952,39 @@ PR6 evidence:
 - performance artifact:
   `artifacts/command-wal/pr6/bench.txt`.
 
+### PR 6.5: Collection/catalog command-WAL performance polish
+
+Deliverables:
+
+- consolidate the PR4, PR5, and PR6 collection/catalog command-WAL performance
+  artifacts before matrix hardening and public raw KV default cutover;
+- apply the strict default-ready throughput gate to collection/catalog lanes:
+  command-WAL throughput divided by the relevant WAL-off baseline throughput
+  must be greater than `1.01x`; `1.01x` or lower fails;
+- explicitly prevent PR9 public raw KV performance evidence from being reused as
+  a collection command-WAL default-readiness claim;
+- convert any below-gate collection overhead into a follow-up issue with exact
+  lane thresholds.
+
+Acceptance:
+
+- catalog create remains default-ready on performance evidence because the PR6
+  artifact shows command-WAL create throughput above the WAL-off baseline;
+- collection insert/delete/update command-WAL lanes remain supported command
+  kinds but are not default-ready performance lanes until the follow-up issue
+  clears strict `>1.01x` throughput for every supported lane;
+- PR9 may only claim public raw KV default-readiness unless it adds new
+  collection/catalog performance artifacts that clear the same strict gate.
+
+PR6.5 evidence:
+
+- consolidated performance summary:
+  `artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md`;
+- acceptance artifact:
+  `artifacts/command-wal/pr6_5/acceptance.json`;
+- follow-up issue for the below-gate collection lanes:
+  `https://github.com/snissn/gomap/issues/1584`.
+
 ### PR 7: Matrix enforcement and future-command guardrails
 
 Deliverables:

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -414,6 +414,18 @@ PR 6: catalog mutation commands:
 - acceptance artifact:
   `artifacts/command-wal/pr6/acceptance.json`.
 
+PR 6.5: collection/catalog command-WAL performance polish:
+
+- consolidated benchmark evidence:
+  `artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md`;
+- acceptance artifact:
+  `artifacts/command-wal/pr6_5/acceptance.json`;
+- default-ready collection throughput follow-up:
+  `https://github.com/snissn/gomap/issues/1584`;
+- PR9 raw KV default cutover evidence must not be used to claim collection
+  command-WAL default readiness until every supported collection lane clears
+  strict `>1.01x` command-WAL/WAL-off throughput.
+
 PR 7: matrix enforcement and drift tests:
 
 - `TestCommandWALSupportMatrixCoversMutatingCollectionRegistry`;

--- a/artifacts/command-wal/pr6_5/acceptance.json
+++ b/artifacts/command-wal/pr6_5/acceptance.json
@@ -28,9 +28,10 @@
   ],
   "performance_gate": {
     "required": true,
+    "throughput_gate_operator": ">",
     "threshold_operator": ">",
     "default_ready_min_ratio": 1.01,
-    "status": "excluded_with_follow_up",
+    "status": "fail_excluded_with_follow_up",
     "decision": "catalog create clears strict parity-plus; collection insert/delete/update lanes are measured below strict parity-plus and are explicitly excluded from PR9 default-ready scope until issue 1584 passes",
     "lanes": {
       "insert_unindexed": {

--- a/artifacts/command-wal/pr6_5/acceptance.json
+++ b/artifacts/command-wal/pr6_5/acceptance.json
@@ -3,7 +3,7 @@
   "milestone": "PR6.5 collection/catalog command-WAL performance polish",
   "branch": "codex/user-command-wal-pr6_5",
   "base_branch": "codex/user-command-wal-pr6",
-  "implementation_commit": "pr-head",
+  "implementation_commit": "ea9de049ee9f4f741f5dbeba55648cd8ee8357b2",
   "follow_up_issue": "https://github.com/snissn/gomap/issues/1584",
   "go_version": "go1.25.7",
   "platform": "linux/amd64",
@@ -30,52 +30,53 @@
     "required": true,
     "threshold_operator": ">",
     "default_ready_min_ratio": 1.01,
-    "status": "satisfied_for_pr6_5_scope_by_measured_exclusion_and_follow_up",
+    "status": "excluded_with_follow_up",
     "decision": "catalog create clears strict parity-plus; collection insert/delete/update lanes are measured below strict parity-plus and are explicitly excluded from PR9 default-ready scope until issue 1584 passes",
     "lanes": {
       "insert_unindexed": {
         "baseline_docs_per_sec": 1205000,
         "command_wal_docs_per_sec": 873200,
-        "ratio": 0.725,
+        "ratio": "0.725",
         "default_ready": false
       },
       "insert_indexed": {
         "baseline_docs_per_sec": 482100,
         "command_wal_docs_per_sec": 479800,
-        "ratio": 0.995,
+        "ratio": "0.995",
         "default_ready": false
       },
       "delete_unindexed": {
         "baseline_docs_per_sec": 866900,
         "command_wal_docs_per_sec": 807800,
-        "ratio": 0.932,
+        "ratio": "0.932",
         "default_ready": false
       },
       "delete_indexed": {
         "baseline_docs_per_sec": 407800,
         "command_wal_docs_per_sec": 383200,
-        "ratio": 0.94,
+        "ratio": "0.940",
         "default_ready": false
       },
       "update_unindexed": {
         "baseline_docs_per_sec": 793300,
         "command_wal_docs_per_sec": 649000,
-        "ratio": 0.818,
+        "ratio": "0.818",
         "default_ready": false
       },
       "update_indexed": {
         "baseline_docs_per_sec": 486800,
         "command_wal_docs_per_sec": 412000,
-        "ratio": 0.846,
+        "ratio": "0.846",
         "default_ready": false
       },
       "catalog_create": {
         "baseline_collections_per_sec": 18223,
         "command_wal_collections_per_sec": 51910,
-        "ratio": 2.848,
+        "ratio": "2.848",
         "default_ready": true
       }
-    }
+    },
+    "ratio_note": "ratio values are strings computed from the recorded throughput fields and rounded to three decimal places"
   },
   "default_cutover_scope": {
     "pr9_may_enable": [

--- a/artifacts/command-wal/pr6_5/acceptance.json
+++ b/artifacts/command-wal/pr6_5/acceptance.json
@@ -1,0 +1,98 @@
+{
+  "tracker": "https://github.com/snissn/gomap/issues/1529",
+  "milestone": "PR6.5 collection/catalog command-WAL performance polish",
+  "branch": "codex/user-command-wal-pr6_5",
+  "base_branch": "codex/user-command-wal-pr6",
+  "implementation_commit": "pr-head",
+  "follow_up_issue": "https://github.com/snissn/gomap/issues/1584",
+  "go_version": "go1.25.7",
+  "platform": "linux/amd64",
+  "features": [
+    "consolidates PR4 collection insert/delete command-WAL performance evidence",
+    "consolidates PR5 collection update command-WAL performance evidence",
+    "consolidates PR6 catalog create/rejected-DDL command-WAL performance evidence",
+    "applies the strict >1.01x default-ready throughput gate to collection/catalog lanes",
+    "keeps PR9 default cutover scoped to public raw KV because collection write lanes remain below strict parity-plus",
+    "opens explicit follow-up issue 1584 with thresholds for collection command-WAL optimization"
+  ],
+  "passed_tests": [
+    "GOWORK=off go test ./TreeDB/docs -run 'TestCommandWAL' -count=1",
+    "git diff --check",
+    "jq empty artifacts/command-wal/pr6_5/acceptance.json"
+  ],
+  "benchmark_artifacts": [
+    "artifacts/command-wal/pr4/collection-insert-delete-microbench-benchstat.txt",
+    "artifacts/command-wal/pr5/collection-update-microbench-benchstat.txt",
+    "artifacts/command-wal/pr6/bench.txt",
+    "artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md"
+  ],
+  "performance_gate": {
+    "required": true,
+    "threshold_operator": ">",
+    "default_ready_min_ratio": 1.01,
+    "status": "satisfied_for_pr6_5_scope_by_measured_exclusion_and_follow_up",
+    "decision": "catalog create clears strict parity-plus; collection insert/delete/update lanes are measured below strict parity-plus and are explicitly excluded from PR9 default-ready scope until issue 1584 passes",
+    "lanes": {
+      "insert_unindexed": {
+        "baseline_docs_per_sec": 1205000,
+        "command_wal_docs_per_sec": 873200,
+        "ratio": 0.725,
+        "default_ready": false
+      },
+      "insert_indexed": {
+        "baseline_docs_per_sec": 482100,
+        "command_wal_docs_per_sec": 479800,
+        "ratio": 0.995,
+        "default_ready": false
+      },
+      "delete_unindexed": {
+        "baseline_docs_per_sec": 866900,
+        "command_wal_docs_per_sec": 807800,
+        "ratio": 0.932,
+        "default_ready": false
+      },
+      "delete_indexed": {
+        "baseline_docs_per_sec": 407800,
+        "command_wal_docs_per_sec": 383200,
+        "ratio": 0.94,
+        "default_ready": false
+      },
+      "update_unindexed": {
+        "baseline_docs_per_sec": 793300,
+        "command_wal_docs_per_sec": 649000,
+        "ratio": 0.818,
+        "default_ready": false
+      },
+      "update_indexed": {
+        "baseline_docs_per_sec": 486800,
+        "command_wal_docs_per_sec": 412000,
+        "ratio": 0.846,
+        "default_ready": false
+      },
+      "catalog_create": {
+        "baseline_collections_per_sec": 18223,
+        "command_wal_collections_per_sec": 51910,
+        "ratio": 2.848,
+        "default_ready": true
+      }
+    }
+  },
+  "default_cutover_scope": {
+    "pr9_may_enable": [
+      "public raw KV Set/Delete/Batch.Write command-WAL cached path"
+    ],
+    "excluded_until_follow_up_passes": [
+      "collection insert/delete/update default-ready performance claims"
+    ],
+    "reason": "collection command-WAL lanes remain at or below 1.01x in existing PR4/PR5 benchmark artifacts"
+  },
+  "local_validation_commands": [
+    "GOWORK=off go test ./TreeDB/docs -run 'TestCommandWAL' -count=1",
+    "git diff --check",
+    "jq empty artifacts/command-wal/pr6_5/acceptance.json"
+  ],
+  "next_required_work": [
+    "issue 1584: optimize collection insert/delete/update command-WAL lanes until each supported lane is >1.01x its WAL-off baseline",
+    "do not use PR9 raw KV performance evidence to claim collection command-WAL default readiness"
+  ]
+}

--- a/artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md
+++ b/artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md
@@ -16,20 +16,20 @@ PR6.5 consolidates the collection/catalog command-WAL performance evidence from 
 The default-ready gate is strict parity-plus:
 
 - command-WAL throughput divided by the relevant WAL-off baseline throughput must be `>1.01x`;
-- `1.01x` or lower fails;
+- anything not strictly greater than `1.01x` fails;
 - sub-parity evidence is recorded as a blocker, not accepted as default-ready performance.
 
 ## Current Ratios
 
-| Lane | Baseline | Command WAL | Ratio | Default-ready decision |
-|---|---:|---:|---:|---|
-| insert unindexed | 1.205M docs/s | 873.2k docs/s | 0.725x | blocked by #1584 |
-| insert indexed | 482.1k docs/s | 479.8k docs/s | 0.995x | blocked by #1584 |
-| delete unindexed | 866.9k docs/s | 807.8k docs/s | 0.932x | blocked by #1584 |
-| delete indexed | 407.8k docs/s | 383.2k docs/s | 0.940x | blocked by #1584 |
-| update unindexed | 793.3k docs/s | 649.0k docs/s | 0.818x | blocked by #1584 |
-| update indexed | 486.8k docs/s | 412.0k docs/s | 0.846x | blocked by #1584 |
-| catalog create | 18.223k collections/s | 51.910k collections/s | 2.848x | passes strict gate |
+Lane | Baseline | Command WAL | Ratio | Default-ready decision
+---|---:|---:|---:|---
+insert unindexed | 1.205M docs/s | 873.2k docs/s | 0.725x | blocked by #1584
+insert indexed | 482.1k docs/s | 479.8k docs/s | 0.995x | blocked by #1584
+delete unindexed | 866.9k docs/s | 807.8k docs/s | 0.932x | blocked by #1584
+delete indexed | 407.8k docs/s | 383.2k docs/s | 0.940x | blocked by #1584
+update unindexed | 793.3k docs/s | 649.0k docs/s | 0.818x | blocked by #1584
+update indexed | 486.8k docs/s | 412.0k docs/s | 0.846x | blocked by #1584
+catalog create | 18.223k collections/s | 51.910k collections/s | 2.848x | passes strict gate
 
 ## Decision
 

--- a/artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md
+++ b/artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md
@@ -1,0 +1,38 @@
+# PR6.5 Collection/Catalog Command-WAL Performance Polish
+
+Tracker: https://github.com/snissn/gomap/issues/1529
+Follow-up blocker: https://github.com/snissn/gomap/issues/1584
+
+PR6.5 consolidates the collection/catalog command-WAL performance evidence from PR4, PR5, and PR6 before PR7 matrix hardening and PR9 public raw KV cutover.
+
+## Source Artifacts
+
+- `artifacts/command-wal/pr4/collection-insert-delete-microbench-benchstat.txt`
+- `artifacts/command-wal/pr5/collection-update-microbench-benchstat.txt`
+- `artifacts/command-wal/pr6/bench.txt`
+
+## Strict Throughput Gate
+
+The default-ready gate is strict parity-plus:
+
+- command-WAL throughput divided by the relevant WAL-off baseline throughput must be `>1.01x`;
+- `1.01x` or lower fails;
+- sub-parity evidence is recorded as a blocker, not accepted as default-ready performance.
+
+## Current Ratios
+
+| Lane | Baseline | Command WAL | Ratio | Default-ready decision |
+|---|---:|---:|---:|---|
+| insert unindexed | 1.205M docs/s | 873.2k docs/s | 0.725x | blocked by #1584 |
+| insert indexed | 482.1k docs/s | 479.8k docs/s | 0.995x | blocked by #1584 |
+| delete unindexed | 866.9k docs/s | 807.8k docs/s | 0.932x | blocked by #1584 |
+| delete indexed | 407.8k docs/s | 383.2k docs/s | 0.940x | blocked by #1584 |
+| update unindexed | 793.3k docs/s | 649.0k docs/s | 0.818x | blocked by #1584 |
+| update indexed | 486.8k docs/s | 412.0k docs/s | 0.846x | blocked by #1584 |
+| catalog create | 18.223k collections/s | 51.910k collections/s | 2.848x | passes strict gate |
+
+## Decision
+
+PR6.5 does not broaden the default command-WAL cutover to collection insert/delete/update lanes. Those lanes remain supported command kinds, but not default-ready performance lanes, until #1584 clears strict `>1.01x` evidence.
+
+PR9 may proceed as a public raw KV command-WAL cutover because its acceptance artifact and PR body scope the default performance gate to public raw KV `Set`, `Delete`, and `Batch.Write` lanes. Collection/catalog command families must not be cited as default-ready based on PR9 raw KV performance evidence.


### PR DESCRIPTION
## Summary

Adds the missing #1529 PR6.5 collection/catalog command-WAL performance polish slice.

This PR does not broaden command-WAL defaults. It consolidates the existing PR4/PR5/PR6 collection/catalog benchmark evidence, applies the strict `>1.01x` default-ready throughput gate, and records that collection insert/delete/update command-WAL lanes remain below the default-ready floor. Catalog create clears the strict gate. The below-gate collection lanes are tracked in #1584 and must not be treated as covered by PR9 public raw KV performance evidence.

## Evidence

Acceptance artifacts:

- `artifacts/command-wal/pr6_5/acceptance.json`
- `artifacts/command-wal/pr6_5/collection-catalog-performance-summary.md`

Local validation:

```sh
GOWORK=off go test ./TreeDB/docs -run 'TestCommandWAL' -count=1
git diff --check
jq empty artifacts/command-wal/pr6_5/acceptance.json
```

## Performance Gate

Strict default-ready threshold: command-WAL throughput / WAL-off baseline throughput must be `>1.01x`.

Current evidence:

- insert unindexed: `0.725x`, blocked by #1584
- insert indexed: `0.995x`, blocked by #1584
- delete unindexed: `0.932x`, blocked by #1584
- delete indexed: `0.940x`, blocked by #1584
- update unindexed: `0.818x`, blocked by #1584
- update indexed: `0.846x`, blocked by #1584
- catalog create: `2.848x`, passes strict gate

Decision: PR9 default readiness remains scoped to public raw KV. Collection insert/delete/update command families remain supported command kinds but are not default-ready performance lanes until #1584 clears the strict gate.

## Tracker

Part of #1529, PR6.5 milestone.


## Review / CI State

- Copilot reviewed latest head `381a6a1e` and reported the seven prior review items resolved.
- Codex reviewed latest head `381a6a1e` after the usage-limit reset and reported no major issues: #issuecomment-4468077187.
- Current review-thread query after `381a6a1e`: `active_unresolved=0`; only outdated unresolved threads remain.
- GitHub Actions checks for `381a6a1e` are green: `25/25`.


