### PR TITLE
experiments/colgranule: add M6 asset lifecycle shape

### DIFF
--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -170,16 +170,66 @@ baseline.
 ## Disk Workspace, Manifests, and Multipart Parts
 
 `ColumnWorkspace` is the M3 disk-backed experiment wrapper. It stores `TCS1`
-assets in append segments, writes a checksum-protected workspace manifest, and
-validates referenced assets on reopen. It is still not a TreeDB root publication
+assets in append segments, writes checksum-protected manifests, and validates
+referenced assets on reopen. Column-lane files live under an isolated namespace:
+`manifests/` for workspace and collection manifests, `assets/segments/` for
+append-segment assets, `assets/indexes/` for future secondary column metadata,
+`prepared/` for staged publish state, `quarantine/` for suspect assets, and
+`tmp/` for atomic manifest writes. It is still not a TreeDB root publication
 path and does not claim durable-at-ack collection semantics.
 
 `ColumnCollectionManifest` is the M4 collection-lane control-plane model used by
 the experiment. It records declared columns, logical primary key, sort key,
 base parts, delta parts, tombstones, retained-payload byte accounting metadata,
-and referenced `TCS1` asset records. `ColumnPartSetReader` opens those refs from
-the workspace, builds latest-visible row state, exposes `LatestLocator`, and
-runs JSONBench q1-q5 over visible rows.
+referenced `TCS1` asset records, and compact coverage descriptors for each part
+ref. Coverage descriptors carry role, generation, compaction level, source
+parts, optional replacement-delta source row/root generation ranges, primary-id
+range, sort-key range, row counts, deleted counts, asset refs, and checksums.
+`ColumnPartSetReader` opens those refs from the workspace, builds latest-visible
+row state, exposes `LatestLocator`, and runs JSONBench q1-q5 over visible rows.
+
+M6 treats declared JSONBench paths as column-owned state and the retained row
+payload as the non-column remainder. `JSONBenchRetainedDocument` removes the
+declared paths from row JSON, `JSONBenchDeclaredColumnValuesFromPart` reads
+those values back from an image-backed column part, and
+`RestoreJSONBenchDeclaredColumns` must reconstruct the original JSON document
+under canonical JSON comparison.
+
+Column asset lifecycle planning is manifest/ref based. `ColumnAssetRef`
+reachability is computed from active manifests, pending manifests,
+snapshot-pinned manifests, superseded manifests, prepared assets, and
+quarantined assets without decoding `TCS1` payload bytes or scanning rows. A
+typed `ColumnAssetManager` facade owns the experiment refs and models the
+production pin, zombie, rewrite-debt, quarantine, and deletion gate: reclaimable
+bytes are not ready to delete until reachability, zombie marking, and pin drain
+all agree. Compaction reports both pre-publish and post-publish reachability:
+before the new manifest is published, old active assets remain protected; after
+publish, old assets are directly reclaimable only when their whole segment has
+no live refs, otherwise they are rewrite debt. Prepared publish state is recorded
+in a checksum-protected registry under `prepared/`, and namespace inventory is a
+read-only reconciliation input that joins segment files and prepared refs against
+manifest/ref state before reporting orphan candidates. Publish bookkeeping can
+also use `PlanColumnAssetRefDelta` when the changed part refs are known, keeping
+the accounting path proportional to newly published, superseded, and prepared
+refs instead of rows or unchanged manifests.
+
+`PlanColumnPartSetCompaction` is the M6 policy-report seam for future background
+selection. It reports selected/skipped parts, live bytes, stale bytes, tombstone
+debt, expected reclaim ratio, sparse-visible-row pressure, read amplification,
+aggregate-metadata invalidation, and column-asset stale-byte pressure without
+publishing a new part. The explicit `CompactColumnPartSet` helper remains the
+only experiment path that writes the replacement base asset.
+
+Reopen validation has an explicit lazy boundary. The default experiment mode
+still validates full `TCS1` images for integrity tests, while
+`ColumnWorkspaceValidateTCS1Header` validates manifest/ref/header metadata
+without reading every full image payload. Loading the part still verifies the
+payload checksum and section structure before use.
+
+Adaptive mark sizing is explicit and opt-in through `ColumnAdaptiveMarkSizing`.
+When enabled, part build estimates uncompressed declared-column bytes per row
+and chooses rows per mark from a target byte budget with min/max row clamps.
+Fixed `RowsPerGranule` remains the default path for existing gates.
 
 The multipart query gate should preserve the M2 encoded-part execution shape:
 avoid projected-row materialization for hot q1-q5 kernels, report visible,

--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -185,6 +185,10 @@ referenced `TCS1` asset records, and compact coverage descriptors for each part
 ref. Coverage descriptors carry role, generation, compaction level, source
 parts, optional replacement-delta source row/root generation ranges, primary-id
 range, sort-key range, row counts, deleted counts, asset refs, and checksums.
+Collection manifest envelopes are written as compact JSON and checksum the
+canonical compact manifest payload; reopen can still validate earlier
+pretty-printed experiment payloads by compacting the raw manifest field before
+checksum comparison.
 `ColumnPartSetReader` opens those refs from the workspace, builds latest-visible
 row state, exposes `LatestLocator`, and runs JSONBench q1-q5 over visible rows.
 

--- a/experiments/colgranule/adaptive_mark.go
+++ b/experiments/colgranule/adaptive_mark.go
@@ -1,0 +1,124 @@
+package colgranule
+
+import "fmt"
+
+const (
+	DefaultAdaptiveMarkTargetBytes = 1 << 20
+	DefaultAdaptiveMarkMinRows     = 512
+)
+
+type ColumnAdaptiveMarkSizing struct {
+	Enabled     bool `json:"enabled,omitempty"`
+	TargetBytes int  `json:"target_bytes,omitempty"`
+	MinRows     int  `json:"min_rows,omitempty"`
+	MaxRows     int  `json:"max_rows,omitempty"`
+}
+
+type ColumnAdaptiveMarkEstimate struct {
+	Rows           int     `json:"rows"`
+	RawBytes       int     `json:"raw_bytes"`
+	RawBytesPerRow float64 `json:"raw_bytes_per_row"`
+	TargetBytes    int     `json:"target_bytes"`
+	MinRows        int     `json:"min_rows"`
+	MaxRows        int     `json:"max_rows"`
+	RowsPerMark    int     `json:"rows_per_mark"`
+	Marks          int     `json:"marks"`
+	ClampedByMin   bool    `json:"clamped_by_min,omitempty"`
+	ClampedByMax   bool    `json:"clamped_by_max,omitempty"`
+}
+
+func NormalizeColumnAdaptiveMarkSizing(cfg ColumnAdaptiveMarkSizing, rowsPerGranule int) (ColumnAdaptiveMarkSizing, error) {
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+	if cfg.TargetBytes == 0 {
+		cfg.TargetBytes = DefaultAdaptiveMarkTargetBytes
+	}
+	if cfg.TargetBytes < 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("colgranule: invalid adaptive mark target bytes %d", cfg.TargetBytes)
+	}
+	if cfg.MinRows == 0 {
+		cfg.MinRows = DefaultAdaptiveMarkMinRows
+	}
+	if cfg.MinRows <= 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("colgranule: invalid adaptive mark min rows %d", cfg.MinRows)
+	}
+	if cfg.MaxRows == 0 {
+		if rowsPerGranule > 0 {
+			cfg.MaxRows = rowsPerGranule
+		} else {
+			cfg.MaxRows = DefaultRowsPerGranule
+		}
+	}
+	if cfg.MaxRows <= 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("colgranule: invalid adaptive mark max rows %d", cfg.MaxRows)
+	}
+	if cfg.MinRows > cfg.MaxRows {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("colgranule: adaptive mark min rows %d exceeds max rows %d", cfg.MinRows, cfg.MaxRows)
+	}
+	return cfg, nil
+}
+
+func EstimateAdaptiveRowsPerMark(rows int, rawBytes int, cfg ColumnAdaptiveMarkSizing) (ColumnAdaptiveMarkEstimate, error) {
+	cfg, err := NormalizeColumnAdaptiveMarkSizing(cfg, 0)
+	if err != nil {
+		return ColumnAdaptiveMarkEstimate{}, err
+	}
+	if !cfg.Enabled {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("colgranule: adaptive mark sizing is disabled")
+	}
+	if rows <= 0 {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("colgranule: invalid adaptive mark rows %d", rows)
+	}
+	if rawBytes < 0 {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("colgranule: invalid adaptive mark raw bytes %d", rawBytes)
+	}
+	bytesPerRow := 1
+	if rawBytes > 0 {
+		bytesPerRow = (rawBytes + rows - 1) / rows
+	}
+	rowsPerMark := cfg.TargetBytes / bytesPerRow
+	if rowsPerMark == 0 {
+		rowsPerMark = 1
+	}
+	estimate := ColumnAdaptiveMarkEstimate{
+		Rows:           rows,
+		RawBytes:       rawBytes,
+		RawBytesPerRow: float64(rawBytes) / float64(rows),
+		TargetBytes:    cfg.TargetBytes,
+		MinRows:        cfg.MinRows,
+		MaxRows:        cfg.MaxRows,
+		RowsPerMark:    rowsPerMark,
+	}
+	if estimate.RowsPerMark < cfg.MinRows {
+		estimate.RowsPerMark = cfg.MinRows
+		estimate.ClampedByMin = true
+	}
+	if estimate.RowsPerMark > cfg.MaxRows {
+		estimate.RowsPerMark = cfg.MaxRows
+		estimate.ClampedByMax = true
+	}
+	estimate.Marks = (rows + estimate.RowsPerMark - 1) / estimate.RowsPerMark
+	return estimate, nil
+}
+
+func EstimateColumnBatchUncompressedBytes(batch ColumnBatch, defs []ColumnDefinition) (int, error) {
+	rows, err := validateColumnBatch(batch, defs)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, def := range defs {
+		switch def.Type {
+		case ColumnTypeInt64:
+			total += rows * 8
+		case ColumnTypeLowCardinalityCode:
+			total += rows * 4
+		case ColumnTypeBool:
+			total += rows
+		default:
+			return 0, fmt.Errorf("colgranule: unsupported column type %s for adaptive mark sizing", def.Type)
+		}
+	}
+	return total, nil
+}

--- a/experiments/colgranule/adaptive_mark_test.go
+++ b/experiments/colgranule/adaptive_mark_test.go
@@ -1,0 +1,138 @@
+package colgranule
+
+import "testing"
+
+func TestEstimateAdaptiveRowsPerMark(t *testing.T) {
+	tests := []struct {
+		name      string
+		rows      int
+		rawBytes  int
+		cfg       ColumnAdaptiveMarkSizing
+		wantRows  int
+		wantMin   bool
+		wantMax   bool
+		wantMarks int
+	}{
+		{
+			name:      "narrow rows clamp to max",
+			rows:      100_000,
+			rawBytes:  100_000 * 8,
+			cfg:       ColumnAdaptiveMarkSizing{Enabled: true, TargetBytes: 1 << 20, MinRows: 128, MaxRows: 8192},
+			wantRows:  8192,
+			wantMax:   true,
+			wantMarks: 13,
+		},
+		{
+			name:      "wide rows target bytes",
+			rows:      100_000,
+			rawBytes:  100_000 * 4096,
+			cfg:       ColumnAdaptiveMarkSizing{Enabled: true, TargetBytes: 1 << 20, MinRows: 128, MaxRows: 8192},
+			wantRows:  256,
+			wantMarks: 391,
+		},
+		{
+			name:      "very wide rows clamp to min",
+			rows:      100_000,
+			rawBytes:  100_000 * 65536,
+			cfg:       ColumnAdaptiveMarkSizing{Enabled: true, TargetBytes: 1 << 20, MinRows: 128, MaxRows: 8192},
+			wantRows:  128,
+			wantMin:   true,
+			wantMarks: 782,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EstimateAdaptiveRowsPerMark(tt.rows, tt.rawBytes, tt.cfg)
+			if err != nil {
+				t.Fatalf("EstimateAdaptiveRowsPerMark: %v", err)
+			}
+			if got.RowsPerMark != tt.wantRows || got.ClampedByMin != tt.wantMin || got.ClampedByMax != tt.wantMax || got.Marks != tt.wantMarks {
+				t.Fatalf("estimate=%+v want rows=%d min=%v max=%v marks=%d", got, tt.wantRows, tt.wantMin, tt.wantMax, tt.wantMarks)
+			}
+			if got.RawBytesPerRow <= 0 {
+				t.Fatalf("raw bytes per row=%f want >0", got.RawBytesPerRow)
+			}
+		})
+	}
+}
+
+func TestBuildColumnPartUsesAdaptiveMarkSizing(t *testing.T) {
+	rows := 20
+	batch := ColumnBatch{Rows: rows, Columns: map[string][]int64{
+		"id":        make([]int64, rows),
+		"time_us":   make([]int64, rows),
+		"value":     make([]int64, rows),
+		"kind_code": make([]int64, rows),
+		"has_reply": make([]int64, rows),
+	}}
+	for i := 0; i < rows; i++ {
+		batch.Columns["id"][i] = int64(i)
+		batch.Columns["time_us"][i] = int64(1000 + i)
+		batch.Columns["value"][i] = int64(i * 10)
+		batch.Columns["kind_code"][i] = int64(i % 3)
+		batch.Columns["has_reply"][i] = int64(i % 2)
+	}
+	opts := partTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.PartPolicy.RowsPerGranule = 0
+	opts.PartPolicy.DefaultCodecBlockRows = 0
+	opts.PartPolicy.AdaptiveMarkSizing = ColumnAdaptiveMarkSizing{
+		Enabled:     true,
+		TargetBytes: 100,
+		MinRows:     2,
+		MaxRows:     10,
+	}
+
+	part, err := BuildColumnPart(77, opts, batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	if got := part.Options.PartPolicy.RowsPerGranule; got != 3 {
+		t.Fatalf("adaptive rows per granule=%d want 3", got)
+	}
+	if got, want := len(part.Descriptor.Granules), 7; got != want {
+		t.Fatalf("granules=%d want %d", got, want)
+	}
+	for i, granule := range part.Descriptor.Granules[:len(part.Descriptor.Granules)-1] {
+		if granule.RowCount != 3 {
+			t.Fatalf("granule %d row count=%d want 3", i, granule.RowCount)
+		}
+	}
+}
+
+func TestNormalizeColumnAdaptiveMarkSizingRejectsInvalidClamp(t *testing.T) {
+	if _, err := NormalizeColumnAdaptiveMarkSizing(ColumnAdaptiveMarkSizing{Enabled: true, MinRows: 9, MaxRows: 8}, 0); err == nil {
+		t.Fatal("NormalizeColumnAdaptiveMarkSizing accepted min > max")
+	}
+}
+
+func BenchmarkAdaptiveMarkSizingWideRows(b *testing.B) {
+	const rows = 100_000
+	const rawBytes = rows * 4096
+	cfg := ColumnAdaptiveMarkSizing{
+		Enabled:     true,
+		TargetBytes: 1 << 20,
+		MinRows:     128,
+		MaxRows:     8192,
+	}
+	estimate, err := EstimateAdaptiveRowsPerMark(rows, rawBytes, cfg)
+	if err != nil {
+		b.Fatalf("EstimateAdaptiveRowsPerMark: %v", err)
+	}
+	fixedRowsPerMark := 8192
+	fixedMarks := (rows + fixedRowsPerMark - 1) / fixedRowsPerMark
+	b.ReportMetric(float64(fixedRowsPerMark), "fixed_rows_per_mark")
+	b.ReportMetric(float64(fixedMarks), "fixed_marks")
+	b.ReportMetric(float64(rawBytes/fixedMarks), "fixed_raw_bytes_per_mark")
+	b.ReportMetric(float64(estimate.RowsPerMark), "adaptive_rows_per_mark")
+	b.ReportMetric(float64(estimate.Marks), "adaptive_marks")
+	b.ReportMetric(float64(rawBytes/estimate.Marks), "adaptive_raw_bytes_per_mark")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := EstimateAdaptiveRowsPerMark(rows, rawBytes, cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(got.RowsPerMark + got.Marks)
+	}
+}

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -1,0 +1,256 @@
+package colgranule
+
+import (
+	"fmt"
+	"sync"
+)
+
+type ColumnAssetPin struct {
+	Ref    ColumnAssetRef `json:"ref"`
+	Reason string         `json:"reason,omitempty"`
+}
+
+type ColumnAssetManager struct {
+	mu          sync.Mutex
+	store       ColumnAssetStore
+	pins        map[ColumnAssetRef]int
+	zombies     map[ColumnAssetRef]string
+	quarantine  map[ColumnAssetRef]string
+	rewriteDebt map[ColumnAssetRef]string
+}
+
+type ColumnAssetManagerReclamationPlan struct {
+	Entries            []ColumnAssetManagerReclamationEntry `json:"entries"`
+	CandidateBytes     int                                  `json:"candidate_bytes"`
+	ReadyToDeleteBytes int                                  `json:"ready_to_delete_bytes"`
+	PinnedBytes        int                                  `json:"pinned_bytes"`
+	ZombieBytes        int                                  `json:"zombie_bytes"`
+	RewriteDebtBytes   int                                  `json:"rewrite_debt_bytes"`
+}
+
+type ColumnAssetManagerReclamationEntry struct {
+	Ref              ColumnAssetRef            `json:"ref"`
+	State            ColumnAssetLifecycleState `json:"state"`
+	Bytes            int                       `json:"bytes"`
+	Candidate        bool                      `json:"candidate,omitempty"`
+	Pinned           bool                      `json:"pinned,omitempty"`
+	Zombie           bool                      `json:"zombie,omitempty"`
+	Quarantined      bool                      `json:"quarantined,omitempty"`
+	RewriteRequired  bool                      `json:"rewrite_required,omitempty"`
+	ReadyToDelete    bool                      `json:"ready_to_delete,omitempty"`
+	ManagerReason    string                    `json:"manager_reason,omitempty"`
+	ReachableReasons []string                  `json:"reachable_reasons,omitempty"`
+}
+
+func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) {
+	if store == nil {
+		return nil, fmt.Errorf("colgranule: nil column asset manager store")
+	}
+	return &ColumnAssetManager{
+		store:       store,
+		pins:        make(map[ColumnAssetRef]int),
+		zombies:     make(map[ColumnAssetRef]string),
+		quarantine:  make(map[ColumnAssetRef]string),
+		rewriteDebt: make(map[ColumnAssetRef]string),
+	}, nil
+}
+
+func (m *ColumnAssetManager) Put(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if m == nil || m.store == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	return m.store.Put(kind, payload)
+}
+
+func (m *ColumnAssetManager) PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
+	if m == nil || m.store == nil {
+		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	if owned, ok := m.store.(columnAssetOwnedStore); ok {
+		return owned.PutOwned(kind, payload)
+	}
+	return m.store.Put(kind, payload)
+}
+
+func (m *ColumnAssetManager) Read(ref ColumnAssetRef) ([]byte, error) {
+	if m == nil || m.store == nil {
+		return nil, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	return m.store.Read(ref)
+}
+
+func (m *ColumnAssetManager) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	if m == nil || m.store == nil {
+		return nil, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	return m.store.ReadTo(ref, dst)
+}
+
+func (m *ColumnAssetManager) ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error) {
+	if m == nil || m.store == nil {
+		return nil, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	if ranged, ok := m.store.(ColumnAssetRangeReader); ok {
+		return ranged.ReadRange(ref, offset, length)
+	}
+	payload, err := m.store.Read(ref)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range offset %d", offset)
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range length %d", length)
+	}
+	if offset > int64(len(payload)) || int64(length) > int64(len(payload))-offset {
+		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside payload bytes=%d", offset, length, len(payload))
+	}
+	start := int(offset)
+	out := make([]byte, length)
+	copy(out, payload[start:start+length])
+	return out, nil
+}
+
+func (m *ColumnAssetManager) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.store == nil {
+		return nil
+	}
+	store := m.store
+	m.store = nil
+	if closer, ok := store.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func (m *ColumnAssetManager) Pin(ref ColumnAssetRef, reason string) (ColumnAssetPin, error) {
+	if err := validateColumnAssetRef(ref); err != nil {
+		return ColumnAssetPin{}, err
+	}
+	if m == nil {
+		return ColumnAssetPin{}, fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pins[ref]++
+	return ColumnAssetPin{Ref: ref, Reason: reason}, nil
+}
+
+func (m *ColumnAssetManager) Release(pin ColumnAssetPin) error {
+	if err := validateColumnAssetRef(pin.Ref); err != nil {
+		return err
+	}
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := m.pins[pin.Ref]
+	if count <= 0 {
+		return fmt.Errorf("colgranule: release unpinned column asset %+v", pin.Ref)
+	}
+	if count == 1 {
+		delete(m.pins, pin.Ref)
+	} else {
+		m.pins[pin.Ref] = count - 1
+	}
+	return nil
+}
+
+func (m *ColumnAssetManager) MarkZombie(ref ColumnAssetRef, reason string) error {
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.zombies[ref] = reason
+	return nil
+}
+
+func (m *ColumnAssetManager) MarkRewriteDebt(ref ColumnAssetRef, reason string) error {
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rewriteDebt[ref] = reason
+	return nil
+}
+
+func (m *ColumnAssetManager) Quarantine(ref ColumnAssetRef, reason string) error {
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.quarantine[ref] = reason
+	return nil
+}
+
+func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilityPlan) ColumnAssetManagerReclamationPlan {
+	var plan ColumnAssetManagerReclamationPlan
+	if m == nil {
+		return plan
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	plan.Entries = make([]ColumnAssetManagerReclamationEntry, 0, len(reachability.Entries))
+	for _, reachable := range reachability.Entries {
+		pinCount := m.pins[reachable.Ref]
+		zombieReason, zombie := m.zombies[reachable.Ref]
+		quarantineReason, quarantined := m.quarantine[reachable.Ref]
+		rewriteReason, rewrite := m.rewriteDebt[reachable.Ref]
+		entry := ColumnAssetManagerReclamationEntry{
+			Ref:              reachable.Ref,
+			State:            reachable.State,
+			Bytes:            reachable.Bytes,
+			Candidate:        reachable.DeleteEligible,
+			Pinned:           pinCount > 0,
+			Zombie:           zombie,
+			Quarantined:      quarantined,
+			RewriteRequired:  rewrite || (!reachable.DeleteEligible && reachable.State == ColumnAssetStateSuperseded),
+			ReachableReasons: reachable.Reasons,
+		}
+		switch {
+		case quarantined:
+			entry.ManagerReason = quarantineReason
+		case rewrite:
+			entry.ManagerReason = rewriteReason
+		case zombie:
+			entry.ManagerReason = zombieReason
+		}
+		if entry.Candidate {
+			plan.CandidateBytes += entry.Bytes
+		}
+		if entry.Pinned {
+			plan.PinnedBytes += entry.Bytes
+		}
+		if entry.Zombie {
+			plan.ZombieBytes += entry.Bytes
+		}
+		if entry.RewriteRequired {
+			plan.RewriteDebtBytes += entry.Bytes
+		}
+		entry.ReadyToDelete = entry.Candidate && entry.Zombie && !entry.Pinned && !entry.Quarantined
+		if entry.ReadyToDelete {
+			plan.ReadyToDeleteBytes += entry.Bytes
+		}
+		plan.Entries = append(plan.Entries, entry)
+	}
+	return plan
+}

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -1,0 +1,65 @@
+package colgranule
+
+import "testing"
+
+func TestColumnAssetManagerRequiresZombieAndPinDrainBeforeDelete(t *testing.T) {
+	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	manager, err := NewColumnAssetManager(NewMemoryColumnAssetStore())
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	reclaim := manager.PlanReclamation(reachability)
+	if reclaim.CandidateBytes != int(oldRef.Length) || reclaim.ReadyToDeleteBytes != 0 {
+		t.Fatalf("initial reclaim candidate/ready=(%d,%d) want (%d,0)", reclaim.CandidateBytes, reclaim.ReadyToDeleteBytes, oldRef.Length)
+	}
+	pin, err := manager.Pin(oldRef, "snapshot")
+	if err != nil {
+		t.Fatalf("Pin: %v", err)
+	}
+	if err := manager.MarkZombie(oldRef, "manifest superseded"); err != nil {
+		t.Fatalf("MarkZombie: %v", err)
+	}
+	reclaim = manager.PlanReclamation(reachability)
+	if reclaim.PinnedBytes != int(oldRef.Length) || reclaim.ZombieBytes != int(oldRef.Length) || reclaim.ReadyToDeleteBytes != 0 {
+		t.Fatalf("pinned reclaim pinned/zombie/ready=(%d,%d,%d) want (%d,%d,0)", reclaim.PinnedBytes, reclaim.ZombieBytes, reclaim.ReadyToDeleteBytes, oldRef.Length, oldRef.Length)
+	}
+	if err := manager.Release(pin); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	reclaim = manager.PlanReclamation(reachability)
+	if reclaim.ReadyToDeleteBytes != int(oldRef.Length) {
+		t.Fatalf("ready bytes=%d want %d", reclaim.ReadyToDeleteBytes, oldRef.Length)
+	}
+}
+
+func TestColumnAssetManagerReportsRewriteDebtForMixedSegment(t *testing.T) {
+	oldRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	activeRef := lifecycleAssetRef(t, 1, oldRef.Length, tcs1HeaderBytes+32)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	manager, err := NewColumnAssetManager(NewMemoryColumnAssetStore())
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	reclaim := manager.PlanReclamation(reachability)
+	if reclaim.CandidateBytes != 0 || reclaim.ReadyToDeleteBytes != 0 || reclaim.RewriteDebtBytes != int(oldRef.Length) {
+		t.Fatalf("mixed reclaim candidate/ready/rewrite=(%d,%d,%d) want (0,0,%d)", reclaim.CandidateBytes, reclaim.ReadyToDeleteBytes, reclaim.RewriteDebtBytes, oldRef.Length)
+	}
+}

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -35,6 +35,10 @@ type ColumnAssetStore interface {
 	ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error)
 }
 
+type ColumnAssetRangeReader interface {
+	ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error)
+}
+
 type columnAssetOwnedStore interface {
 	PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
 }
@@ -132,6 +136,26 @@ func (s *MemoryColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte,
 		return nil, err
 	}
 	out := append(dst[:0], payload...)
+	return out, nil
+}
+
+func (s *MemoryColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error) {
+	payload, err := s.Read(ref)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range offset %d", offset)
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range length %d", length)
+	}
+	if offset > int64(len(payload)) || int64(length) > int64(len(payload))-offset {
+		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside payload bytes=%d", offset, length, len(payload))
+	}
+	start := int(offset)
+	out := make([]byte, length)
+	copy(out, payload[start:start+length])
 	return out, nil
 }
 
@@ -257,6 +281,42 @@ func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte
 		return nil, fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
 	}
 	return dst, nil
+}
+
+func (s *SegmentColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("colgranule: nil segment asset store")
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range offset %d", offset)
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("colgranule: negative asset range length %d", length)
+	}
+	if offset > ref.Length || int64(length) > ref.Length-offset {
+		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside ref length=%d", offset, length, ref.Length)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return nil, fmt.Errorf("colgranule: closed segment asset store")
+	}
+	if ref.FileID != s.fileID {
+		return nil, fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
+	}
+	absolute := ref.Offset + offset
+	if absolute > s.size || int64(length) > s.size-absolute {
+		return nil, fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", absolute, length, s.size)
+	}
+	out := make([]byte, length)
+	reader := io.NewSectionReader(s.file, absolute, int64(length))
+	if _, err := io.ReadFull(reader, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length int, payload []byte) (ColumnAssetRef, error) {

--- a/experiments/colgranule/collection_manifest.go
+++ b/experiments/colgranule/collection_manifest.go
@@ -55,9 +55,44 @@ type ColumnPartSetManifest struct {
 }
 
 type ColumnManifestPartRef struct {
-	Role         ColumnPartRole              `json:"role"`
-	GenerationID uint64                      `json:"generation_id"`
-	Part         ColumnWorkspacePartManifest `json:"part"`
+	Role         ColumnPartRole               `json:"role"`
+	GenerationID uint64                       `json:"generation_id"`
+	Coverage     ColumnPartCoverageDescriptor `json:"coverage"`
+	Part         ColumnWorkspacePartManifest  `json:"part"`
+}
+
+type ColumnPartCoverageDescriptor struct {
+	Role                    ColumnPartRole               `json:"role"`
+	GenerationID            uint64                       `json:"generation_id"`
+	CompactionLevel         uint8                        `json:"compaction_level,omitempty"`
+	SourceParts             []ColumnSourcePartGeneration `json:"source_parts,omitempty"`
+	SourceRowRootGeneration uint64                       `json:"source_row_root_generation,omitempty"`
+	SourceRowVersionLower   uint64                       `json:"source_row_version_lower,omitempty"`
+	SourceRowVersionUpper   uint64                       `json:"source_row_version_upper_exclusive,omitempty"`
+	PrimaryIDLower          int64                        `json:"primary_id_lower"`
+	PrimaryIDUpperExclusive int64                        `json:"primary_id_upper_exclusive"`
+	SortKeyColumns          []string                     `json:"sort_key_columns,omitempty"`
+	SortKeyLower            []int64                      `json:"sort_key_lower,omitempty"`
+	SortKeyUpperExclusive   []int64                      `json:"sort_key_upper_exclusive,omitempty"`
+	SortKeyUpperUnbounded   bool                         `json:"sort_key_upper_unbounded,omitempty"`
+	Rows                    int                          `json:"rows"`
+	VisibleRows             int                          `json:"visible_rows"`
+	DeletedRows             int                          `json:"deleted_rows,omitempty"`
+	AssetRefs               []ColumnAssetRef             `json:"asset_refs"`
+	Checksums               []uint32                     `json:"checksums"`
+}
+
+type ColumnSourcePartGeneration struct {
+	PartID       uint64 `json:"part_id"`
+	GenerationID uint64 `json:"generation_id"`
+}
+
+type ColumnPartCoverageOptions struct {
+	SourceParts             []ColumnSourcePartGeneration
+	CompactionLevel         uint8
+	SourceRowRootGeneration uint64
+	SourceRowVersionLower   uint64
+	SourceRowVersionUpper   uint64
 }
 
 type ColumnTombstone struct {
@@ -90,7 +125,23 @@ type columnCollectionManifestEnvelope struct {
 }
 
 func NewColumnManifestPartRef(role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest) ColumnManifestPartRef {
-	return ColumnManifestPartRef{Role: role, GenerationID: generationID, Part: part}
+	return NewColumnManifestPartRefWithCoverage(role, generationID, part, nil, 0)
+}
+
+func NewColumnManifestPartRefWithCoverage(role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest, sourceParts []ColumnSourcePartGeneration, compactionLevel uint8) ColumnManifestPartRef {
+	return NewColumnManifestPartRefWithCoverageOptions(role, generationID, part, ColumnPartCoverageOptions{
+		SourceParts:     sourceParts,
+		CompactionLevel: compactionLevel,
+	})
+}
+
+func NewColumnManifestPartRefWithCoverageOptions(role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest, opts ColumnPartCoverageOptions) ColumnManifestPartRef {
+	return ColumnManifestPartRef{
+		Role:         role,
+		GenerationID: generationID,
+		Coverage:     columnPartCoverageDescriptor(role, generationID, part, opts),
+		Part:         part,
+	}
 }
 
 func NewColumnCollectionManifest(collection string, opts ColumnStoreOptions, baseParts []ColumnManifestPartRef, deltaParts []ColumnManifestPartRef, tombstones []ColumnTombstone) (ColumnCollectionManifest, error) {
@@ -153,7 +204,7 @@ func (w *ColumnWorkspace) SaveCollectionManifest(manifest ColumnCollectionManife
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(w.dir, ".column-collection-manifest-*.tmp")
+	tmp, err := os.CreateTemp(w.namespace.TempDir, ".column-collection-manifest-*.tmp")
 	if err != nil {
 		return err
 	}
@@ -242,7 +293,7 @@ func (w *ColumnWorkspace) collectionManifestPath() string {
 	if w == nil {
 		return ""
 	}
-	return filepath.Join(w.dir, columnCollectionManifestFile)
+	return filepath.Join(w.namespace.ManifestDir, columnCollectionManifestFile)
 }
 
 func (w *ColumnWorkspace) validateCollectionManifestPartRefs(manifest ColumnCollectionManifest) error {
@@ -339,6 +390,9 @@ func validateColumnCollectionManifest(manifest ColumnCollectionManifest) error {
 }
 
 func validateColumnManifestPartRef(ref ColumnManifestPartRef, role ColumnPartRole) error {
+	if err := validateColumnPartRole(role); err != nil {
+		return err
+	}
 	if ref.Role != role {
 		return fmt.Errorf("colgranule: collection manifest part %d role=%s want %s", ref.Part.PartID, ref.Role, role)
 	}
@@ -347,6 +401,89 @@ func validateColumnManifestPartRef(ref ColumnManifestPartRef, role ColumnPartRol
 	}
 	if err := validateColumnWorkspacePartManifest(ref.Part); err != nil {
 		return fmt.Errorf("colgranule: collection manifest part %d invalid: %w", ref.Part.PartID, err)
+	}
+	if err := validateColumnPartCoverageDescriptor(ref.Coverage, ref.Role, ref.GenerationID, ref.Part); err != nil {
+		return fmt.Errorf("colgranule: collection manifest part %d coverage invalid: %w", ref.Part.PartID, err)
+	}
+	return nil
+}
+
+func validateColumnPartRole(role ColumnPartRole) error {
+	switch role {
+	case ColumnPartRoleBase, ColumnPartRoleDelta:
+		return nil
+	default:
+		return fmt.Errorf("colgranule: unsupported collection manifest part role %s", role)
+	}
+}
+
+func columnPartCoverageDescriptor(role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest, opts ColumnPartCoverageOptions) ColumnPartCoverageDescriptor {
+	coverage := ColumnPartCoverageDescriptor{
+		Role:                    role,
+		GenerationID:            generationID,
+		CompactionLevel:         opts.CompactionLevel,
+		SourceParts:             append([]ColumnSourcePartGeneration(nil), opts.SourceParts...),
+		SourceRowRootGeneration: opts.SourceRowRootGeneration,
+		SourceRowVersionLower:   opts.SourceRowVersionLower,
+		SourceRowVersionUpper:   opts.SourceRowVersionUpper,
+		PrimaryIDLower:          part.Coverage.PrimaryIDLower,
+		PrimaryIDUpperExclusive: part.Coverage.PrimaryIDUpperExclusive,
+		SortKeyColumns:          append([]string(nil), part.Coverage.SortKeyColumns...),
+		SortKeyLower:            append([]int64(nil), part.Coverage.SortKeyLower...),
+		SortKeyUpperExclusive:   append([]int64(nil), part.Coverage.SortKeyUpperExclusive...),
+		SortKeyUpperUnbounded:   part.Coverage.SortKeyUpperUnbounded,
+		Rows:                    part.Rows,
+		VisibleRows:             part.VisibleRows,
+		DeletedRows:             part.Rows - part.VisibleRows,
+		AssetRefs:               []ColumnAssetRef{part.AssetRef},
+		Checksums:               []uint32{part.AssetRef.Checksum},
+	}
+	if len(coverage.SortKeyColumns) == 0 && len(part.SortKey) != 0 {
+		for _, sortKey := range part.SortKey {
+			coverage.SortKeyColumns = append(coverage.SortKeyColumns, sortKey.Column)
+		}
+	}
+	return coverage
+}
+
+func validateColumnPartCoverageDescriptor(coverage ColumnPartCoverageDescriptor, role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest) error {
+	if coverage.Role != role {
+		return fmt.Errorf("role=%s want %s", coverage.Role, role)
+	}
+	if coverage.GenerationID != generationID {
+		return fmt.Errorf("generation=%d want %d", coverage.GenerationID, generationID)
+	}
+	if coverage.SourceRowVersionUpper != 0 && coverage.SourceRowVersionLower >= coverage.SourceRowVersionUpper {
+		return fmt.Errorf("source row version lower=%d upper=%d", coverage.SourceRowVersionLower, coverage.SourceRowVersionUpper)
+	}
+	if coverage.SourceRowVersionLower != 0 && coverage.SourceRowVersionUpper == 0 {
+		return fmt.Errorf("source row version lower=%d without upper bound", coverage.SourceRowVersionLower)
+	}
+	if coverage.SourceRowRootGeneration == 0 && (coverage.SourceRowVersionLower != 0 || coverage.SourceRowVersionUpper != 0) {
+		return fmt.Errorf("source row versions require source row root generation")
+	}
+	if coverage.Rows != part.Rows || coverage.VisibleRows != part.VisibleRows || coverage.DeletedRows != part.Rows-part.VisibleRows {
+		return fmt.Errorf("rows/visible/deleted=(%d,%d,%d) want (%d,%d,%d)", coverage.Rows, coverage.VisibleRows, coverage.DeletedRows, part.Rows, part.VisibleRows, part.Rows-part.VisibleRows)
+	}
+	if len(coverage.SortKeyColumns) != len(part.SortKey) {
+		return fmt.Errorf("sort key columns=%d want %d", len(coverage.SortKeyColumns), len(part.SortKey))
+	}
+	for i, sortKey := range part.SortKey {
+		if coverage.SortKeyColumns[i] != sortKey.Column {
+			return fmt.Errorf("sort key column %d=%s want %s", i, coverage.SortKeyColumns[i], sortKey.Column)
+		}
+	}
+	if len(coverage.SortKeyLower) != 0 && len(coverage.SortKeyLower) != len(part.SortKey) {
+		return fmt.Errorf("sort key lower width=%d want %d", len(coverage.SortKeyLower), len(part.SortKey))
+	}
+	if len(coverage.SortKeyUpperExclusive) != 0 && len(coverage.SortKeyUpperExclusive) != len(part.SortKey) {
+		return fmt.Errorf("sort key upper width=%d want %d", len(coverage.SortKeyUpperExclusive), len(part.SortKey))
+	}
+	if len(coverage.AssetRefs) != 1 || coverage.AssetRefs[0] != part.AssetRef {
+		return fmt.Errorf("asset refs=%+v want [%+v]", coverage.AssetRefs, part.AssetRef)
+	}
+	if len(coverage.Checksums) != 1 || coverage.Checksums[0] != part.AssetRef.Checksum {
+		return fmt.Errorf("checksums=%+v want [%08x]", coverage.Checksums, part.AssetRef.Checksum)
 	}
 	return nil
 }
@@ -403,6 +540,18 @@ func cloneColumnManifestPartRefs(refs []ColumnManifestPartRef) []ColumnManifestP
 	out := append([]ColumnManifestPartRef(nil), refs...)
 	for i := range out {
 		out[i].Part.SortKey = append([]SortKeyColumn(nil), out[i].Part.SortKey...)
+		out[i].Part.Coverage = cloneColumnWorkspacePartCoverage(out[i].Part.Coverage)
+		out[i].Coverage = cloneColumnPartCoverageDescriptor(out[i].Coverage)
 	}
 	return out
+}
+
+func cloneColumnPartCoverageDescriptor(coverage ColumnPartCoverageDescriptor) ColumnPartCoverageDescriptor {
+	coverage.SourceParts = append([]ColumnSourcePartGeneration(nil), coverage.SourceParts...)
+	coverage.SortKeyColumns = append([]string(nil), coverage.SortKeyColumns...)
+	coverage.SortKeyLower = append([]int64(nil), coverage.SortKeyLower...)
+	coverage.SortKeyUpperExclusive = append([]int64(nil), coverage.SortKeyUpperExclusive...)
+	coverage.AssetRefs = append([]ColumnAssetRef(nil), coverage.AssetRefs...)
+	coverage.Checksums = append([]uint32(nil), coverage.Checksums...)
+	return coverage
 }

--- a/experiments/colgranule/collection_manifest.go
+++ b/experiments/colgranule/collection_manifest.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
@@ -122,6 +123,13 @@ type columnCollectionManifestEnvelope struct {
 	Version  uint16                   `json:"version"`
 	Checksum uint32                   `json:"checksum"`
 	Manifest ColumnCollectionManifest `json:"manifest"`
+}
+
+type columnCollectionManifestRawEnvelope struct {
+	Magic    string          `json:"magic"`
+	Version  uint16          `json:"version"`
+	Checksum uint32          `json:"checksum"`
+	Manifest json.RawMessage `json:"manifest"`
 }
 
 func NewColumnManifestPartRef(role ColumnPartRole, generationID uint64, part ColumnWorkspacePartManifest) ColumnManifestPartRef {
@@ -256,17 +264,17 @@ func EncodeColumnCollectionManifest(manifest ColumnCollectionManifest) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	env := columnCollectionManifestEnvelope{
+	env := columnCollectionManifestRawEnvelope{
 		Magic:    columnCollectionManifestMagic,
 		Version:  columnCollectionManifestVersion,
 		Checksum: crc32.ChecksumIEEE(manifestBytes),
-		Manifest: manifest,
+		Manifest: manifestBytes,
 	}
-	return json.MarshalIndent(env, "", "  ")
+	return json.Marshal(env)
 }
 
 func DecodeColumnCollectionManifest(data []byte) (ColumnCollectionManifest, error) {
-	var env columnCollectionManifestEnvelope
+	var env columnCollectionManifestRawEnvelope
 	if err := json.Unmarshal(data, &env); err != nil {
 		return ColumnCollectionManifest{}, err
 	}
@@ -276,17 +284,30 @@ func DecodeColumnCollectionManifest(data []byte) (ColumnCollectionManifest, erro
 	if env.Version != columnCollectionManifestVersion {
 		return ColumnCollectionManifest{}, fmt.Errorf("colgranule: unsupported collection manifest version %d", env.Version)
 	}
-	manifestBytes, err := json.Marshal(env.Manifest)
-	if err != nil {
-		return ColumnCollectionManifest{}, err
+	if len(env.Manifest) == 0 {
+		return ColumnCollectionManifest{}, fmt.Errorf("colgranule: collection manifest missing manifest payload")
 	}
-	if checksum := crc32.ChecksumIEEE(manifestBytes); checksum != env.Checksum {
+	checksum := crc32.ChecksumIEEE(env.Manifest)
+	if checksum != env.Checksum {
+		// Support earlier pretty-printed experiment payloads without paying this
+		// compaction cost on newly encoded compact manifests.
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, env.Manifest); err != nil {
+			return ColumnCollectionManifest{}, err
+		}
+		checksum = crc32.ChecksumIEEE(compact.Bytes())
+	}
+	if checksum != env.Checksum {
 		return ColumnCollectionManifest{}, fmt.Errorf("colgranule: collection manifest checksum=%08x want %08x", checksum, env.Checksum)
 	}
-	if err := validateColumnCollectionManifest(env.Manifest); err != nil {
+	var manifest ColumnCollectionManifest
+	if err := json.Unmarshal(env.Manifest, &manifest); err != nil {
 		return ColumnCollectionManifest{}, err
 	}
-	return env.Manifest, nil
+	if err := validateColumnCollectionManifest(manifest); err != nil {
+		return ColumnCollectionManifest{}, err
+	}
+	return manifest, nil
 }
 
 func (w *ColumnWorkspace) collectionManifestPath() string {
@@ -355,24 +376,37 @@ func validateColumnCollectionManifest(manifest ColumnCollectionManifest) error {
 			return fmt.Errorf("colgranule: collection manifest sort key column %s is not declared", c.Column)
 		}
 	}
-	seenParts := make(map[uint64]struct{}, len(manifest.PartSet.BaseParts)+len(manifest.PartSet.DeltaParts))
-	for _, ref := range manifest.PartSet.BaseParts {
-		if err := validateColumnManifestPartRef(ref, ColumnPartRoleBase); err != nil {
-			return err
+	if columnManifestPartIDsStrictlyIncreasing(manifest.PartSet) {
+		for _, ref := range manifest.PartSet.BaseParts {
+			if err := validateColumnManifestPartRef(ref, ColumnPartRoleBase); err != nil {
+				return err
+			}
 		}
-		if _, ok := seenParts[ref.Part.PartID]; ok {
-			return fmt.Errorf("colgranule: duplicate collection manifest part %d", ref.Part.PartID)
+		for _, ref := range manifest.PartSet.DeltaParts {
+			if err := validateColumnManifestPartRef(ref, ColumnPartRoleDelta); err != nil {
+				return err
+			}
 		}
-		seenParts[ref.Part.PartID] = struct{}{}
-	}
-	for _, ref := range manifest.PartSet.DeltaParts {
-		if err := validateColumnManifestPartRef(ref, ColumnPartRoleDelta); err != nil {
-			return err
+	} else {
+		seenParts := make(map[uint64]struct{}, len(manifest.PartSet.BaseParts)+len(manifest.PartSet.DeltaParts))
+		for _, ref := range manifest.PartSet.BaseParts {
+			if err := validateColumnManifestPartRef(ref, ColumnPartRoleBase); err != nil {
+				return err
+			}
+			if _, ok := seenParts[ref.Part.PartID]; ok {
+				return fmt.Errorf("colgranule: duplicate collection manifest part %d", ref.Part.PartID)
+			}
+			seenParts[ref.Part.PartID] = struct{}{}
 		}
-		if _, ok := seenParts[ref.Part.PartID]; ok {
-			return fmt.Errorf("colgranule: duplicate collection manifest part %d", ref.Part.PartID)
+		for _, ref := range manifest.PartSet.DeltaParts {
+			if err := validateColumnManifestPartRef(ref, ColumnPartRoleDelta); err != nil {
+				return err
+			}
+			if _, ok := seenParts[ref.Part.PartID]; ok {
+				return fmt.Errorf("colgranule: duplicate collection manifest part %d", ref.Part.PartID)
+			}
+			seenParts[ref.Part.PartID] = struct{}{}
 		}
-		seenParts[ref.Part.PartID] = struct{}{}
 	}
 	for _, tombstone := range manifest.PartSet.Tombstones {
 		if tombstone.GenerationID == 0 {
@@ -406,6 +440,26 @@ func validateColumnManifestPartRef(ref ColumnManifestPartRef, role ColumnPartRol
 		return fmt.Errorf("colgranule: collection manifest part %d coverage invalid: %w", ref.Part.PartID, err)
 	}
 	return nil
+}
+
+func columnManifestPartIDsStrictlyIncreasing(partSet ColumnPartSetManifest) bool {
+	var last uint64
+	var haveLast bool
+	for _, ref := range partSet.BaseParts {
+		if haveLast && ref.Part.PartID <= last {
+			return false
+		}
+		last = ref.Part.PartID
+		haveLast = true
+	}
+	for _, ref := range partSet.DeltaParts {
+		if haveLast && ref.Part.PartID <= last {
+			return false
+		}
+		last = ref.Part.PartID
+		haveLast = true
+	}
+	return true
 }
 
 func validateColumnPartRole(role ColumnPartRole) error {

--- a/experiments/colgranule/collection_manifest_test.go
+++ b/experiments/colgranule/collection_manifest_test.go
@@ -78,7 +78,7 @@ func TestColumnCollectionManifestRejectsUnknownVersionAndChecksumMismatch(t *tes
 	if err := workspace.SaveCollectionManifest(manifest); err != nil {
 		t.Fatalf("SaveCollectionManifest: %v", err)
 	}
-	path := filepath.Join(dir, columnCollectionManifestFile)
+	path := filepath.Join(ColumnWorkspaceNamespaceForDir(dir).ManifestDir, columnCollectionManifestFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
@@ -113,6 +113,60 @@ func TestColumnCollectionManifestRejectsUnknownVersionAndChecksumMismatch(t *tes
 	}
 }
 
+func TestColumnCollectionManifestPartCoverageDescriptor(t *testing.T) {
+	ds := syntheticJSONBenchDataset(64)
+	opts, err := JSONBenchColumnPartOptions(ds, 16)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	dir := t.TempDir()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	defer workspace.Close()
+	entry := publishJSONBenchPartRows(t, workspace, opts, ds, 301, 0, ds.Rows)
+	ref := NewColumnManifestPartRefWithCoverage(ColumnPartRoleBase, 7, entry, []ColumnSourcePartGeneration{{PartID: 11, GenerationID: 3}}, 2)
+	if ref.Coverage.Role != ColumnPartRoleBase || ref.Coverage.GenerationID != 7 || ref.Coverage.CompactionLevel != 2 {
+		t.Fatalf("bad coverage identity=%+v", ref.Coverage)
+	}
+	if len(ref.Coverage.SourceParts) != 1 || ref.Coverage.SourceParts[0].PartID != 11 || ref.Coverage.SourceParts[0].GenerationID != 3 {
+		t.Fatalf("bad coverage sources=%+v", ref.Coverage.SourceParts)
+	}
+	if got, want := ref.Coverage.AssetRefs[0], entry.AssetRef; got != want {
+		t.Fatalf("coverage asset ref=%+v want %+v", got, want)
+	}
+	if len(ref.Coverage.SortKeyColumns) == 0 || len(ref.Coverage.SortKeyLower) == 0 {
+		t.Fatalf("coverage missing sort key bounds=%+v", ref.Coverage)
+	}
+	if ref.Coverage.Rows != entry.Rows || ref.Coverage.VisibleRows != entry.VisibleRows || ref.Coverage.DeletedRows != entry.Rows-entry.VisibleRows {
+		t.Fatalf("coverage rows=%+v entry rows=%d visible=%d", ref.Coverage, entry.Rows, entry.VisibleRows)
+	}
+	deltaRef := NewColumnManifestPartRefWithCoverageOptions(ColumnPartRoleDelta, 8, entry, ColumnPartCoverageOptions{
+		SourceRowRootGeneration: 44,
+		SourceRowVersionLower:   120,
+		SourceRowVersionUpper:   121,
+	})
+	if deltaRef.Coverage.SourceRowRootGeneration != 44 || deltaRef.Coverage.SourceRowVersionLower != 120 || deltaRef.Coverage.SourceRowVersionUpper != 121 {
+		t.Fatalf("bad source row/root metadata=%+v", deltaRef.Coverage)
+	}
+	if _, err := NewColumnCollectionManifest("jsonbench", opts, nil, []ColumnManifestPartRef{deltaRef}, nil); err != nil {
+		t.Fatalf("NewColumnCollectionManifest with delta source metadata: %v", err)
+	}
+	badDelta := deltaRef
+	badDelta.Coverage.SourceRowVersionUpper = badDelta.Coverage.SourceRowVersionLower
+	if _, err := NewColumnCollectionManifest("jsonbench", opts, nil, []ColumnManifestPartRef{badDelta}, nil); err == nil || !strings.Contains(err.Error(), "source row version") {
+		t.Fatalf("NewColumnCollectionManifest err=%v want source row version rejection", err)
+	}
+	if _, err := NewColumnCollectionManifest("jsonbench", opts, []ColumnManifestPartRef{ref}, nil, nil); err != nil {
+		t.Fatalf("NewColumnCollectionManifest with coverage: %v", err)
+	}
+	ref.Coverage.Checksums[0]++
+	if _, err := NewColumnCollectionManifest("jsonbench", opts, []ColumnManifestPartRef{ref}, nil, nil); err == nil || !strings.Contains(err.Error(), "checksums") {
+		t.Fatalf("NewColumnCollectionManifest err=%v want coverage checksum rejection", err)
+	}
+}
+
 func BenchmarkColumnCollectionManifestDecode10K(b *testing.B) {
 	manifest := syntheticColumnCollectionManifestForBenchmark(10_000)
 	payload, err := EncodeColumnCollectionManifest(manifest)
@@ -129,7 +183,7 @@ func BenchmarkColumnCollectionManifestDecode10K(b *testing.B) {
 	}
 }
 
-func publishJSONBenchPartRows(t *testing.T, workspace *ColumnWorkspace, opts ColumnStoreOptions, ds JSONBenchDataset, partID uint64, start int, end int) ColumnWorkspacePartManifest {
+func publishJSONBenchPartRows(t testing.TB, workspace *ColumnWorkspace, opts ColumnStoreOptions, ds JSONBenchDataset, partID uint64, start int, end int) ColumnWorkspacePartManifest {
 	t.Helper()
 	part, err := BuildColumnPart(partID, opts, ColumnBatch{Rows: end - start, Columns: sliceJSONBenchColumns(ds, start, end)})
 	if err != nil {

--- a/experiments/colgranule/collection_manifest_test.go
+++ b/experiments/colgranule/collection_manifest_test.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -110,6 +111,40 @@ func TestColumnCollectionManifestRejectsUnknownVersionAndChecksumMismatch(t *tes
 	}
 	if _, err := workspace.LoadCollectionManifest(); err == nil || !strings.Contains(err.Error(), "collection manifest checksum") {
 		t.Fatalf("LoadCollectionManifest checksum err=%v want checksum mismatch", err)
+	}
+}
+
+func TestColumnCollectionManifestCompactEncodeAndPrettyFallback(t *testing.T) {
+	manifest := syntheticColumnCollectionManifestForBenchmark(2)
+	payload, err := EncodeColumnCollectionManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeColumnCollectionManifest: %v", err)
+	}
+	if bytes.Contains(payload, []byte("\n")) {
+		t.Fatalf("encoded manifest contains newlines, want compact envelope")
+	}
+	decoded, err := DecodeColumnCollectionManifest(payload)
+	if err != nil {
+		t.Fatalf("DecodeColumnCollectionManifest compact: %v", err)
+	}
+	if decoded.ActiveGeneration != manifest.ActiveGeneration || len(decoded.PartSet.BaseParts) != len(manifest.PartSet.BaseParts) {
+		t.Fatalf("decoded compact manifest generation/parts=(%d,%d) want (%d,%d)", decoded.ActiveGeneration, len(decoded.PartSet.BaseParts), manifest.ActiveGeneration, len(manifest.PartSet.BaseParts))
+	}
+
+	var env columnCollectionManifestEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		t.Fatalf("unmarshal compact envelope: %v", err)
+	}
+	pretty, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent envelope: %v", err)
+	}
+	decoded, err = DecodeColumnCollectionManifest(pretty)
+	if err != nil {
+		t.Fatalf("DecodeColumnCollectionManifest pretty fallback: %v", err)
+	}
+	if decoded.ActiveGeneration != manifest.ActiveGeneration || len(decoded.PartSet.BaseParts) != len(manifest.PartSet.BaseParts) {
+		t.Fatalf("decoded pretty manifest generation/parts=(%d,%d) want (%d,%d)", decoded.ActiveGeneration, len(decoded.PartSet.BaseParts), manifest.ActiveGeneration, len(manifest.PartSet.BaseParts))
 	}
 }
 

--- a/experiments/colgranule/jsonbench_split_document.go
+++ b/experiments/colgranule/jsonbench_split_document.go
@@ -1,0 +1,198 @@
+package colgranule
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+var jsonBenchDeclaredColumnPaths = []string{
+	"did",
+	"time_us",
+	"kind",
+	"commit.operation",
+	"commit.collection",
+}
+
+func JSONBenchDeclaredColumnPaths() []string {
+	return append([]string(nil), jsonBenchDeclaredColumnPaths...)
+}
+
+type JSONBenchDeclaredColumnValues struct {
+	TimeUS           int64  `json:"time_us"`
+	Did              string `json:"did"`
+	Kind             string `json:"kind"`
+	CommitOperation  string `json:"commit_operation,omitempty"`
+	CommitCollection string `json:"commit_collection,omitempty"`
+}
+
+func JSONBenchRetainedDocument(raw []byte) ([]byte, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("colgranule: decode JSONBench retained document: %w", err)
+	}
+	delete(doc, "did")
+	delete(doc, "time_us")
+	delete(doc, "kind")
+	rawCommit, ok := doc["commit"]
+	if ok {
+		var commit map[string]json.RawMessage
+		if err := json.Unmarshal(rawCommit, &commit); err != nil {
+			return nil, fmt.Errorf("colgranule: decode JSONBench retained commit object: %w", err)
+		}
+		delete(commit, "operation")
+		delete(commit, "collection")
+		encodedCommit, err := json.Marshal(commit)
+		if err != nil {
+			return nil, fmt.Errorf("colgranule: encode JSONBench retained commit object: %w", err)
+		}
+		doc["commit"] = encodedCommit
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("colgranule: encode JSONBench retained document: %w", err)
+	}
+	return encoded, nil
+}
+
+func RestoreJSONBenchDeclaredColumns(doc map[string]any, values JSONBenchDeclaredColumnValues) {
+	doc["did"] = values.Did
+	doc["time_us"] = values.TimeUS
+	doc["kind"] = values.Kind
+	if values.Kind != "commit" && values.CommitOperation == "" && values.CommitCollection == "" {
+		return
+	}
+	commit, ok := doc["commit"].(map[string]any)
+	if !ok {
+		commit = make(map[string]any, 2)
+	}
+	commit["operation"] = values.CommitOperation
+	commit["collection"] = values.CommitCollection
+	doc["commit"] = commit
+}
+
+func JSONBenchDeclaredColumnValuesFromPart(scanner *ColumnPartScanner, part *ColumnPart, dictionaries map[string]map[int64]string, primaryID int64) (JSONBenchDeclaredColumnValues, error) {
+	if scanner == nil {
+		return JSONBenchDeclaredColumnValues{}, fmt.Errorf("colgranule: nil column part scanner")
+	}
+	if part == nil {
+		return JSONBenchDeclaredColumnValues{}, fmt.Errorf("colgranule: nil column part")
+	}
+	locator, ok := part.LocatePrimaryID(primaryID)
+	if !ok {
+		return JSONBenchDeclaredColumnValues{}, os.ErrNotExist
+	}
+	timeUS, err := scanner.ValueAt(locator, "time_us")
+	if err != nil {
+		return JSONBenchDeclaredColumnValues{}, err
+	}
+	did, err := jsonBenchDictionaryStringFromPart(scanner, locator, dictionaries, "did_code")
+	if err != nil {
+		return JSONBenchDeclaredColumnValues{}, err
+	}
+	kind, err := jsonBenchDictionaryStringFromPart(scanner, locator, dictionaries, "kind_code")
+	if err != nil {
+		return JSONBenchDeclaredColumnValues{}, err
+	}
+	operation, err := jsonBenchDictionaryStringFromPart(scanner, locator, dictionaries, "commit_operation_code")
+	if err != nil {
+		return JSONBenchDeclaredColumnValues{}, err
+	}
+	collection, err := jsonBenchDictionaryStringFromPart(scanner, locator, dictionaries, "commit_collection_code")
+	if err != nil {
+		return JSONBenchDeclaredColumnValues{}, err
+	}
+	return JSONBenchDeclaredColumnValues{
+		TimeUS:           timeUS,
+		Did:              did,
+		Kind:             kind,
+		CommitOperation:  operation,
+		CommitCollection: collection,
+	}, nil
+}
+
+func ReverseJSONBenchDictionaries(dictionaries map[string]map[string]int64) map[string]map[int64]string {
+	out := make(map[string]map[int64]string, len(dictionaries))
+	for name, values := range dictionaries {
+		reversed := make(map[int64]string, len(values))
+		for value, code := range values {
+			reversed[code] = value
+		}
+		out[name] = reversed
+	}
+	return out
+}
+
+func DecodeJSONDocumentPreserveNumbers(raw []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	return normalizeJSONDocumentNumbers(v)
+}
+
+func jsonBenchDictionaryStringFromPart(scanner *ColumnPartScanner, locator RowLocator, dictionaries map[string]map[int64]string, column string) (string, error) {
+	code, err := scanner.ValueAt(locator, column)
+	if err != nil {
+		return "", err
+	}
+	values := dictionaries[column]
+	if values == nil {
+		return "", fmt.Errorf("colgranule: missing JSONBench dictionary %s", column)
+	}
+	value, ok := values[code]
+	if !ok {
+		return "", fmt.Errorf("colgranule: missing JSONBench dictionary %s code %d", column, code)
+	}
+	return value, nil
+}
+
+func normalizeJSONDocumentNumbers(v any) error {
+	switch x := v.(type) {
+	case map[string]any:
+		for key, value := range x {
+			normalized, err := normalizeJSONDocumentNumberValue(value)
+			if err != nil {
+				return err
+			}
+			x[key] = normalized
+		}
+	case []any:
+		for i, value := range x {
+			normalized, err := normalizeJSONDocumentNumberValue(value)
+			if err != nil {
+				return err
+			}
+			x[i] = normalized
+		}
+	}
+	return nil
+}
+
+func normalizeJSONDocumentNumberValue(value any) (any, error) {
+	switch x := value.(type) {
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return i, nil
+		}
+		f, err := x.Float64()
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case map[string]any:
+		if err := normalizeJSONDocumentNumbers(x); err != nil {
+			return nil, err
+		}
+		return x, nil
+	case []any:
+		if err := normalizeJSONDocumentNumbers(x); err != nil {
+			return nil, err
+		}
+		return x, nil
+	default:
+		return value, nil
+	}
+}

--- a/experiments/colgranule/jsonbench_split_document_test.go
+++ b/experiments/colgranule/jsonbench_split_document_test.go
@@ -1,0 +1,108 @@
+package colgranule
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestJSONBenchSplitDocumentParityWithColumnPartImage(t *testing.T) {
+	source := "testdata/jsonbench_sample.jsonl"
+	ds, err := LoadJSONBenchColumns(source, 0)
+	if err != nil {
+		t.Fatalf("LoadJSONBenchColumns: %v", err)
+	}
+	part, err := BuildJSONBenchColumnPartWithAggregateMetadataForLayout(ds, 2, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPartWithAggregateMetadataForLayout: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: ds.Dictionaries})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	imagePart, err := ColumnPartFromImage(parsed)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+
+	file, err := os.Open(source)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer file.Close()
+	reversed := ReverseJSONBenchDictionaries(ds.Dictionaries)
+	partScanner := imagePart.NewScanner()
+	rawScanner := bufio.NewScanner(file)
+	rawScanner.Buffer(make([]byte, 0, 256<<10), 8<<20)
+	row := int64(0)
+	for rawScanner.Scan() {
+		raw := bytes.TrimSpace(rawScanner.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		retainedBytes, err := JSONBenchRetainedDocument(raw)
+		if err != nil {
+			t.Fatalf("JSONBenchRetainedDocument(row=%d): %v", row, err)
+		}
+		var retained map[string]any
+		if err := DecodeJSONDocumentPreserveNumbers(retainedBytes, &retained); err != nil {
+			t.Fatalf("Decode retained row=%d: %v", row, err)
+		}
+		assertJSONBenchDeclaredPathsRemoved(t, row, retained)
+		values, err := JSONBenchDeclaredColumnValuesFromPart(partScanner, imagePart, reversed, row)
+		if err != nil {
+			t.Fatalf("JSONBenchDeclaredColumnValuesFromPart(row=%d): %v", row, err)
+		}
+		RestoreJSONBenchDeclaredColumns(retained, values)
+
+		var original map[string]any
+		if err := DecodeJSONDocumentPreserveNumbers(raw, &original); err != nil {
+			t.Fatalf("Decode original row=%d: %v", row, err)
+		}
+		got := mustCanonicalJSON(t, retained)
+		want := mustCanonicalJSON(t, original)
+		if string(got) != string(want) {
+			t.Fatalf("row %d split document parity mismatch\ngot  %s\nwant %s", row, got, want)
+		}
+		row++
+	}
+	if err := rawScanner.Err(); err != nil {
+		t.Fatalf("scan source: %v", err)
+	}
+	if row != int64(ds.Rows) {
+		t.Fatalf("validated rows=%d want %d", row, ds.Rows)
+	}
+}
+
+func assertJSONBenchDeclaredPathsRemoved(t *testing.T, row int64, doc map[string]any) {
+	t.Helper()
+	for _, key := range []string{"did", "time_us", "kind"} {
+		if _, ok := doc[key]; ok {
+			t.Fatalf("row %d retained document still has top-level declared column %q", row, key)
+		}
+	}
+	commit, ok := doc["commit"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, key := range []string{"operation", "collection"} {
+		if _, ok := commit[key]; ok {
+			t.Fatalf("row %d retained document still has commit declared column %q", row, key)
+		}
+	}
+}
+
+func mustCanonicalJSON(t *testing.T, doc map[string]any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -1,0 +1,459 @@
+package colgranule
+
+import (
+	"fmt"
+	"sort"
+)
+
+type ColumnAssetLifecycleState string
+
+const (
+	ColumnAssetStatePrepared       ColumnAssetLifecycleState = "prepared"
+	ColumnAssetStatePendingPublish ColumnAssetLifecycleState = "pending_publish"
+	ColumnAssetStateActive         ColumnAssetLifecycleState = "active"
+	ColumnAssetStateSuperseded     ColumnAssetLifecycleState = "superseded"
+	ColumnAssetStateSnapshotPinned ColumnAssetLifecycleState = "snapshot_pinned"
+	ColumnAssetStateReclaimable    ColumnAssetLifecycleState = "reclaimable"
+	ColumnAssetStateDeleting       ColumnAssetLifecycleState = "deleting"
+	ColumnAssetStateQuarantined    ColumnAssetLifecycleState = "quarantined"
+)
+
+type ColumnPreparedAsset struct {
+	Ref          ColumnAssetRef `json:"ref"`
+	Bytes        int            `json:"bytes"`
+	PublishID    uint64         `json:"publish_id,omitempty"`
+	GenerationID uint64         `json:"generation_id,omitempty"`
+	Reason       string         `json:"reason,omitempty"`
+}
+
+type ColumnAssetReachabilityInput struct {
+	ActiveManifest          *ColumnCollectionManifest  `json:"active_manifest,omitempty"`
+	PendingManifests        []ColumnCollectionManifest `json:"pending_manifests,omitempty"`
+	SnapshotPinnedManifests []ColumnCollectionManifest `json:"snapshot_pinned_manifests,omitempty"`
+	SupersededManifests     []ColumnCollectionManifest `json:"superseded_manifests,omitempty"`
+	PreparedAssets          []ColumnPreparedAsset      `json:"prepared_assets,omitempty"`
+	QuarantinedAssets       []ColumnPreparedAsset      `json:"quarantined_assets,omitempty"`
+}
+
+type ColumnAssetReachabilityPlan struct {
+	Entries                []ColumnAssetReachabilityEntry `json:"entries"`
+	Stats                  ColumnAssetReachabilityStats   `json:"stats"`
+	RetainedBytes          int                            `json:"retained_bytes"`
+	PreparedBytes          int                            `json:"prepared_bytes"`
+	QuarantinedBytes       int                            `json:"quarantined_bytes"`
+	SupersededBytes        int                            `json:"superseded_bytes"`
+	SnapshotProtectedBytes int                            `json:"snapshot_protected_bytes"`
+	RewriteDebtBytes       int                            `json:"rewrite_debt_bytes"`
+	ReclaimableBytes       int                            `json:"reclaimable_bytes"`
+}
+
+type ColumnAssetReachabilityStats struct {
+	Manifests                 int `json:"manifests"`
+	ActiveManifests           int `json:"active_manifests"`
+	PendingManifests          int `json:"pending_manifests"`
+	SnapshotPinnedManifests   int `json:"snapshot_pinned_manifests"`
+	SupersededManifests       int `json:"superseded_manifests"`
+	PreparedAssets            int `json:"prepared_assets"`
+	QuarantinedAssets         int `json:"quarantined_assets"`
+	AssetRefs                 int `json:"asset_refs"`
+	SegmentRefs               int `json:"segment_refs"`
+	MetadataBytesScanned      int `json:"metadata_bytes_scanned"`
+	TCS1PayloadBytesDecoded   int `json:"tcs1_payload_bytes_decoded"`
+	RowsScanned               int `json:"rows_scanned"`
+	ColumnPayloadBlocksRead   int `json:"column_payload_blocks_read"`
+	DirectlyDeletableSegments int `json:"directly_deletable_segments"`
+	MixedLiveDeadSegments     int `json:"mixed_live_dead_segments"`
+}
+
+type ColumnAssetReachabilityEntry struct {
+	Ref            ColumnAssetRef            `json:"ref"`
+	State          ColumnAssetLifecycleState `json:"state"`
+	Bytes          int                       `json:"bytes"`
+	PartID         uint64                    `json:"part_id,omitempty"`
+	GenerationID   uint64                    `json:"generation_id,omitempty"`
+	DeleteEligible bool                      `json:"delete_eligible,omitempty"`
+	Reasons        []string                  `json:"reasons,omitempty"`
+}
+
+type ColumnAssetRefDeltaKind string
+
+const (
+	ColumnAssetRefDeltaPublished  ColumnAssetRefDeltaKind = "published"
+	ColumnAssetRefDeltaSuperseded ColumnAssetRefDeltaKind = "superseded"
+	ColumnAssetRefDeltaPrepared   ColumnAssetRefDeltaKind = "prepared"
+)
+
+type ColumnAssetRefDeltaInput struct {
+	PublishedParts  []ColumnManifestPartRef `json:"published_parts,omitempty"`
+	SupersededParts []ColumnManifestPartRef `json:"superseded_parts,omitempty"`
+	PreparedAssets  []ColumnPreparedAsset   `json:"prepared_assets,omitempty"`
+}
+
+type ColumnAssetRefDeltaPlan struct {
+	Entries         []ColumnAssetRefDeltaEntry   `json:"entries"`
+	Stats           ColumnAssetReachabilityStats `json:"stats"`
+	PublishedBytes  int                          `json:"published_bytes"`
+	SupersededBytes int                          `json:"superseded_bytes"`
+	PreparedBytes   int                          `json:"prepared_bytes"`
+}
+
+type ColumnAssetRefDeltaEntry struct {
+	Kind         ColumnAssetRefDeltaKind `json:"kind"`
+	Ref          ColumnAssetRef          `json:"ref"`
+	Bytes        int                     `json:"bytes"`
+	PartID       uint64                  `json:"part_id,omitempty"`
+	GenerationID uint64                  `json:"generation_id,omitempty"`
+}
+
+type columnAssetReachabilityRecord struct {
+	entry       ColumnAssetReachabilityEntry
+	live        bool
+	candidate   bool
+	quarantined bool
+}
+
+func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAssetReachabilityPlan, error) {
+	records := make(map[ColumnAssetRef]*columnAssetReachabilityRecord)
+	segments := make(map[uint32]*columnAssetSegmentState)
+	plan := ColumnAssetReachabilityPlan{}
+
+	if input.ActiveManifest != nil {
+		plan.Stats.ActiveManifests = 1
+		if err := addManifestAssetRefs(records, segments, *input.ActiveManifest, ColumnAssetStateActive, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+	}
+	for _, manifest := range input.PendingManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStatePendingPublish, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.PendingManifests++
+	}
+	for _, manifest := range input.SnapshotPinnedManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateSnapshotPinned, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.SnapshotPinnedManifests++
+	}
+	for _, manifest := range input.SupersededManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, true, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.SupersededManifests++
+	}
+	for _, prepared := range input.PreparedAssets {
+		if err := addPreparedAsset(records, segments, prepared, ColumnAssetStatePrepared, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.PreparedAssets++
+	}
+	for _, quarantined := range input.QuarantinedAssets {
+		if err := addPreparedAsset(records, segments, quarantined, ColumnAssetStateQuarantined, false, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.QuarantinedAssets++
+	}
+
+	plan.Stats.Manifests = plan.Stats.ActiveManifests + plan.Stats.PendingManifests + plan.Stats.SnapshotPinnedManifests + plan.Stats.SupersededManifests
+	plan.Stats.AssetRefs = len(records)
+	for _, seg := range segments {
+		seg.liveRefs = 0
+		seg.candidateRefs = 0
+	}
+	for _, record := range records {
+		seg := segments[record.entry.Ref.FileID]
+		if seg == nil {
+			seg = &columnAssetSegmentState{}
+			segments[record.entry.Ref.FileID] = seg
+		}
+		if record.live {
+			seg.liveRefs++
+		}
+		if record.candidate && !record.live && !record.quarantined {
+			seg.candidateRefs++
+		}
+	}
+	plan.Stats.SegmentRefs = len(segments)
+	for _, seg := range segments {
+		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
+			plan.Stats.DirectlyDeletableSegments++
+		}
+		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
+			plan.Stats.MixedLiveDeadSegments++
+		}
+	}
+
+	plan.Entries = make([]ColumnAssetReachabilityEntry, 0, len(records))
+	for _, record := range records {
+		entry := record.entry
+		switch {
+		case record.quarantined:
+			plan.QuarantinedBytes += entry.Bytes
+		case record.live:
+			switch entry.State {
+			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
+				plan.PreparedBytes += entry.Bytes
+			case ColumnAssetStateSnapshotPinned:
+				plan.SnapshotProtectedBytes += entry.Bytes
+				plan.RetainedBytes += entry.Bytes
+			default:
+				plan.RetainedBytes += entry.Bytes
+			}
+		case record.candidate:
+			plan.SupersededBytes += entry.Bytes
+			seg := segments[entry.Ref.FileID]
+			if seg != nil && seg.liveRefs == 0 {
+				entry.DeleteEligible = true
+				entry.State = ColumnAssetStateReclaimable
+				plan.ReclaimableBytes += entry.Bytes
+			} else {
+				plan.RewriteDebtBytes += entry.Bytes
+			}
+		}
+		plan.Entries = append(plan.Entries, entry)
+	}
+	sort.Slice(plan.Entries, func(i, j int) bool {
+		a, b := plan.Entries[i].Ref, plan.Entries[j].Ref
+		if a.FileID != b.FileID {
+			return a.FileID < b.FileID
+		}
+		if a.Offset != b.Offset {
+			return a.Offset < b.Offset
+		}
+		if a.Length != b.Length {
+			return a.Length < b.Length
+		}
+		return a.Checksum < b.Checksum
+	})
+	return plan, nil
+}
+
+func PlanColumnAssetRefDelta(input ColumnAssetRefDeltaInput) (ColumnAssetRefDeltaPlan, error) {
+	plan := ColumnAssetRefDeltaPlan{}
+	plan.Entries = make([]ColumnAssetRefDeltaEntry, 0, len(input.PublishedParts)+len(input.SupersededParts)+len(input.PreparedAssets))
+	for _, ref := range input.PublishedParts {
+		entry, err := columnAssetRefDeltaEntry(ColumnAssetRefDeltaPublished, ref)
+		if err != nil {
+			return ColumnAssetRefDeltaPlan{}, err
+		}
+		plan.PublishedBytes += entry.Bytes
+		plan.Stats.AssetRefs++
+		plan.Stats.MetadataBytesScanned += ref.Part.ManifestBytes
+		plan.Entries = append(plan.Entries, entry)
+	}
+	for _, ref := range input.SupersededParts {
+		entry, err := columnAssetRefDeltaEntry(ColumnAssetRefDeltaSuperseded, ref)
+		if err != nil {
+			return ColumnAssetRefDeltaPlan{}, err
+		}
+		plan.SupersededBytes += entry.Bytes
+		plan.Stats.AssetRefs++
+		plan.Stats.MetadataBytesScanned += ref.Part.ManifestBytes
+		plan.Entries = append(plan.Entries, entry)
+	}
+	for _, prepared := range input.PreparedAssets {
+		if err := validateColumnAssetRef(prepared.Ref); err != nil {
+			return ColumnAssetRefDeltaPlan{}, err
+		}
+		bytes := prepared.Bytes
+		if bytes == 0 {
+			if prepared.Ref.Length > int64(^uint(0)>>1) {
+				return ColumnAssetRefDeltaPlan{}, fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", prepared.Ref.Length)
+			}
+			bytes = int(prepared.Ref.Length)
+		}
+		plan.PreparedBytes += bytes
+		plan.Stats.PreparedAssets++
+		plan.Stats.AssetRefs++
+		plan.Stats.MetadataBytesScanned++
+		plan.Entries = append(plan.Entries, ColumnAssetRefDeltaEntry{
+			Kind:         ColumnAssetRefDeltaPrepared,
+			Ref:          prepared.Ref,
+			Bytes:        bytes,
+			GenerationID: prepared.GenerationID,
+		})
+	}
+	sort.Slice(plan.Entries, func(i, j int) bool {
+		a, b := plan.Entries[i], plan.Entries[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Ref.FileID != b.Ref.FileID {
+			return a.Ref.FileID < b.Ref.FileID
+		}
+		if a.Ref.Offset != b.Ref.Offset {
+			return a.Ref.Offset < b.Ref.Offset
+		}
+		return a.Ref.Checksum < b.Ref.Checksum
+	})
+	return plan, nil
+}
+
+func ColumnCollectionManifestAssetRefs(manifest ColumnCollectionManifest) ([]ColumnAssetReachabilityEntry, error) {
+	stats := ColumnAssetReachabilityStats{}
+	records := make(map[ColumnAssetRef]*columnAssetReachabilityRecord)
+	segments := make(map[uint32]*columnAssetSegmentState)
+	if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateActive, true, false, &stats); err != nil {
+		return nil, err
+	}
+	out := make([]ColumnAssetReachabilityEntry, 0, len(records))
+	for _, record := range records {
+		out = append(out, record.entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].PartID != out[j].PartID {
+			return out[i].PartID < out[j].PartID
+		}
+		return out[i].Ref.Offset < out[j].Ref.Offset
+	})
+	return out, nil
+}
+
+func columnAssetRefDeltaEntry(kind ColumnAssetRefDeltaKind, ref ColumnManifestPartRef) (ColumnAssetRefDeltaEntry, error) {
+	if err := validateColumnManifestPartRef(ref, ref.Role); err != nil {
+		return ColumnAssetRefDeltaEntry{}, err
+	}
+	return ColumnAssetRefDeltaEntry{
+		Kind:         kind,
+		Ref:          ref.Part.AssetRef,
+		Bytes:        ref.Part.AssetBytes,
+		PartID:       ref.Part.PartID,
+		GenerationID: ref.GenerationID,
+	}, nil
+}
+
+type columnAssetSegmentState struct {
+	liveRefs      int
+	candidateRefs int
+}
+
+func addManifestAssetRefs(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, manifest ColumnCollectionManifest, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	if err := validateColumnCollectionManifest(manifest); err != nil {
+		return err
+	}
+	for i := range manifest.PartSet.BaseParts {
+		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.BaseParts[i], state, live, candidate, stats); err != nil {
+			return err
+		}
+	}
+	for i := range manifest.PartSet.DeltaParts {
+		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.DeltaParts[i], state, live, candidate, stats); err != nil {
+			return err
+		}
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned += len(manifest.PartSet.Tombstones)
+	}
+	return nil
+}
+
+func addManifestPartAssetRef(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, partRef ColumnManifestPartRef, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	entry := ColumnAssetReachabilityEntry{
+		Ref:          partRef.Part.AssetRef,
+		State:        state,
+		Bytes:        partRef.Part.AssetBytes,
+		PartID:       partRef.Part.PartID,
+		GenerationID: partRef.GenerationID,
+		Reasons:      []string{string(state)},
+	}
+	if err := addReachabilityEntry(records, segments, entry, live, candidate, false); err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned += partRef.Part.ManifestBytes
+	}
+	return nil
+}
+
+func addPreparedAsset(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, prepared ColumnPreparedAsset, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	if err := validateColumnAssetRef(prepared.Ref); err != nil {
+		return err
+	}
+	bytes := prepared.Bytes
+	if bytes == 0 {
+		if prepared.Ref.Length > int64(^uint(0)>>1) {
+			return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", prepared.Ref.Length)
+		}
+		bytes = int(prepared.Ref.Length)
+	}
+	entry := ColumnAssetReachabilityEntry{
+		Ref:          prepared.Ref,
+		State:        state,
+		Bytes:        bytes,
+		GenerationID: prepared.GenerationID,
+		Reasons:      []string{prepared.Reason},
+	}
+	if prepared.Reason == "" {
+		entry.Reasons = []string{string(state)}
+	}
+	if err := addReachabilityEntry(records, segments, entry, live, candidate, state == ColumnAssetStateQuarantined); err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned++
+	}
+	return nil
+}
+
+func addReachabilityEntry(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, entry ColumnAssetReachabilityEntry, live bool, candidate bool, quarantined bool) error {
+	if entry.Bytes < 0 {
+		return fmt.Errorf("colgranule: negative asset bytes %d", entry.Bytes)
+	}
+	if err := validateColumnAssetRef(entry.Ref); err != nil {
+		return err
+	}
+	record, ok := records[entry.Ref]
+	if !ok {
+		record = &columnAssetReachabilityRecord{entry: entry}
+		records[entry.Ref] = record
+	} else {
+		record.entry.State = strongestColumnAssetState(record.entry.State, entry.State)
+		if record.entry.Bytes == 0 {
+			record.entry.Bytes = entry.Bytes
+		}
+		if record.entry.PartID == 0 {
+			record.entry.PartID = entry.PartID
+		}
+		if record.entry.GenerationID == 0 || entry.GenerationID > record.entry.GenerationID {
+			record.entry.GenerationID = entry.GenerationID
+		}
+		record.entry.Reasons = append(record.entry.Reasons, entry.Reasons...)
+	}
+	record.live = record.live || live
+	record.candidate = record.candidate || candidate
+	record.quarantined = record.quarantined || quarantined
+	if segments[entry.Ref.FileID] == nil {
+		segments[entry.Ref.FileID] = &columnAssetSegmentState{}
+	}
+	return nil
+}
+
+func strongestColumnAssetState(a ColumnAssetLifecycleState, b ColumnAssetLifecycleState) ColumnAssetLifecycleState {
+	if columnAssetStateRank(b) > columnAssetStateRank(a) {
+		return b
+	}
+	return a
+}
+
+func columnAssetStateRank(state ColumnAssetLifecycleState) int {
+	switch state {
+	case ColumnAssetStateActive:
+		return 70
+	case ColumnAssetStatePendingPublish:
+		return 60
+	case ColumnAssetStateSnapshotPinned:
+		return 50
+	case ColumnAssetStatePrepared:
+		return 40
+	case ColumnAssetStateQuarantined:
+		return 30
+	case ColumnAssetStateReclaimable:
+		return 20
+	case ColumnAssetStateSuperseded:
+		return 10
+	case ColumnAssetStateDeleting:
+		return 0
+	default:
+		return -1
+	}
+}

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -112,8 +112,19 @@ type columnAssetReachabilityRecord struct {
 	quarantined bool
 }
 
+var (
+	columnAssetReasonPrepared       = []string{string(ColumnAssetStatePrepared)}
+	columnAssetReasonPendingPublish = []string{string(ColumnAssetStatePendingPublish)}
+	columnAssetReasonActive         = []string{string(ColumnAssetStateActive)}
+	columnAssetReasonSuperseded     = []string{string(ColumnAssetStateSuperseded)}
+	columnAssetReasonSnapshotPinned = []string{string(ColumnAssetStateSnapshotPinned)}
+	columnAssetReasonReclaimable    = []string{string(ColumnAssetStateReclaimable)}
+	columnAssetReasonDeleting       = []string{string(ColumnAssetStateDeleting)}
+	columnAssetReasonQuarantined    = []string{string(ColumnAssetStateQuarantined)}
+)
+
 func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAssetReachabilityPlan, error) {
-	records := make(map[ColumnAssetRef]*columnAssetReachabilityRecord)
+	records := make(map[ColumnAssetRef]columnAssetReachabilityRecord, estimateColumnAssetReachabilityRefs(input))
 	segments := make(map[uint32]*columnAssetSegmentState)
 	plan := ColumnAssetReachabilityPlan{}
 
@@ -291,7 +302,7 @@ func PlanColumnAssetRefDelta(input ColumnAssetRefDeltaInput) (ColumnAssetRefDelt
 
 func ColumnCollectionManifestAssetRefs(manifest ColumnCollectionManifest) ([]ColumnAssetReachabilityEntry, error) {
 	stats := ColumnAssetReachabilityStats{}
-	records := make(map[ColumnAssetRef]*columnAssetReachabilityRecord)
+	records := make(map[ColumnAssetRef]columnAssetReachabilityRecord, len(manifest.PartSet.BaseParts)+len(manifest.PartSet.DeltaParts))
 	segments := make(map[uint32]*columnAssetSegmentState)
 	if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateActive, true, false, &stats); err != nil {
 		return nil, err
@@ -327,7 +338,7 @@ type columnAssetSegmentState struct {
 	candidateRefs int
 }
 
-func addManifestAssetRefs(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, manifest ColumnCollectionManifest, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+func addManifestAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, manifest ColumnCollectionManifest, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
 	if err := validateColumnCollectionManifest(manifest); err != nil {
 		return err
 	}
@@ -347,14 +358,14 @@ func addManifestAssetRefs(records map[ColumnAssetRef]*columnAssetReachabilityRec
 	return nil
 }
 
-func addManifestPartAssetRef(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, partRef ColumnManifestPartRef, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+func addManifestPartAssetRef(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, partRef ColumnManifestPartRef, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
 	entry := ColumnAssetReachabilityEntry{
 		Ref:          partRef.Part.AssetRef,
 		State:        state,
 		Bytes:        partRef.Part.AssetBytes,
 		PartID:       partRef.Part.PartID,
 		GenerationID: partRef.GenerationID,
-		Reasons:      []string{string(state)},
+		Reasons:      columnAssetReachabilityDefaultReasons(state),
 	}
 	if err := addReachabilityEntry(records, segments, entry, live, candidate, false); err != nil {
 		return err
@@ -365,7 +376,7 @@ func addManifestPartAssetRef(records map[ColumnAssetRef]*columnAssetReachability
 	return nil
 }
 
-func addPreparedAsset(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, prepared ColumnPreparedAsset, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+func addPreparedAsset(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, prepared ColumnPreparedAsset, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
 	if err := validateColumnAssetRef(prepared.Ref); err != nil {
 		return err
 	}
@@ -384,7 +395,7 @@ func addPreparedAsset(records map[ColumnAssetRef]*columnAssetReachabilityRecord,
 		Reasons:      []string{prepared.Reason},
 	}
 	if prepared.Reason == "" {
-		entry.Reasons = []string{string(state)}
+		entry.Reasons = columnAssetReachabilityDefaultReasons(state)
 	}
 	if err := addReachabilityEntry(records, segments, entry, live, candidate, state == ColumnAssetStateQuarantined); err != nil {
 		return err
@@ -395,7 +406,7 @@ func addPreparedAsset(records map[ColumnAssetRef]*columnAssetReachabilityRecord,
 	return nil
 }
 
-func addReachabilityEntry(records map[ColumnAssetRef]*columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, entry ColumnAssetReachabilityEntry, live bool, candidate bool, quarantined bool) error {
+func addReachabilityEntry(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, entry ColumnAssetReachabilityEntry, live bool, candidate bool, quarantined bool) error {
 	if entry.Bytes < 0 {
 		return fmt.Errorf("colgranule: negative asset bytes %d", entry.Bytes)
 	}
@@ -404,8 +415,7 @@ func addReachabilityEntry(records map[ColumnAssetRef]*columnAssetReachabilityRec
 	}
 	record, ok := records[entry.Ref]
 	if !ok {
-		record = &columnAssetReachabilityRecord{entry: entry}
-		records[entry.Ref] = record
+		record = columnAssetReachabilityRecord{entry: entry}
 	} else {
 		record.entry.State = strongestColumnAssetState(record.entry.State, entry.State)
 		if record.entry.Bytes == 0 {
@@ -422,10 +432,51 @@ func addReachabilityEntry(records map[ColumnAssetRef]*columnAssetReachabilityRec
 	record.live = record.live || live
 	record.candidate = record.candidate || candidate
 	record.quarantined = record.quarantined || quarantined
+	records[entry.Ref] = record
 	if segments[entry.Ref.FileID] == nil {
 		segments[entry.Ref.FileID] = &columnAssetSegmentState{}
 	}
 	return nil
+}
+
+func estimateColumnAssetReachabilityRefs(input ColumnAssetReachabilityInput) int {
+	refs := len(input.PreparedAssets) + len(input.QuarantinedAssets)
+	if input.ActiveManifest != nil {
+		refs += len(input.ActiveManifest.PartSet.BaseParts) + len(input.ActiveManifest.PartSet.DeltaParts)
+	}
+	for i := range input.PendingManifests {
+		refs += len(input.PendingManifests[i].PartSet.BaseParts) + len(input.PendingManifests[i].PartSet.DeltaParts)
+	}
+	for i := range input.SnapshotPinnedManifests {
+		refs += len(input.SnapshotPinnedManifests[i].PartSet.BaseParts) + len(input.SnapshotPinnedManifests[i].PartSet.DeltaParts)
+	}
+	for i := range input.SupersededManifests {
+		refs += len(input.SupersededManifests[i].PartSet.BaseParts) + len(input.SupersededManifests[i].PartSet.DeltaParts)
+	}
+	return refs
+}
+
+func columnAssetReachabilityDefaultReasons(state ColumnAssetLifecycleState) []string {
+	switch state {
+	case ColumnAssetStatePrepared:
+		return columnAssetReasonPrepared
+	case ColumnAssetStatePendingPublish:
+		return columnAssetReasonPendingPublish
+	case ColumnAssetStateActive:
+		return columnAssetReasonActive
+	case ColumnAssetStateSuperseded:
+		return columnAssetReasonSuperseded
+	case ColumnAssetStateSnapshotPinned:
+		return columnAssetReasonSnapshotPinned
+	case ColumnAssetStateReclaimable:
+		return columnAssetReasonReclaimable
+	case ColumnAssetStateDeleting:
+		return columnAssetReasonDeleting
+	case ColumnAssetStateQuarantined:
+		return columnAssetReasonQuarantined
+	default:
+		return nil
+	}
 }
 
 func strongestColumnAssetState(a ColumnAssetLifecycleState, b ColumnAssetLifecycleState) ColumnAssetLifecycleState {

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -1,0 +1,431 @@
+package colgranule
+
+import "testing"
+
+func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
+	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.RetainedBytes != int(activeRef.Length) {
+		t.Fatalf("retained bytes=%d want %d", plan.RetainedBytes, activeRef.Length)
+	}
+	if plan.SupersededBytes != int(oldRef.Length) || plan.ReclaimableBytes != int(oldRef.Length) || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("superseded/reclaimable/rewrite=(%d,%d,%d) want (%d,%d,0)", plan.SupersededBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes, oldRef.Length, oldRef.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 1 || plan.Stats.MixedLiveDeadSegments != 0 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (1,0)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	oldEntry := lifecycleFindEntry(t, plan, oldRef)
+	if oldEntry.State != ColumnAssetStateReclaimable || !oldEntry.DeleteEligible {
+		t.Fatalf("old entry state/delete=(%s,%v) want reclaimable,true", oldEntry.State, oldEntry.DeleteEligible)
+	}
+	if plan.Stats.TCS1PayloadBytesDecoded != 0 || plan.Stats.RowsScanned != 0 || plan.Stats.ColumnPayloadBlocksRead != 0 {
+		t.Fatalf("planner decoded payload/rows/blocks=(%d,%d,%d), want all zero", plan.Stats.TCS1PayloadBytesDecoded, plan.Stats.RowsScanned, plan.Stats.ColumnPayloadBlocksRead)
+	}
+}
+
+func TestColumnAssetReachabilityTracksRewriteDebtForMixedSegments(t *testing.T) {
+	oldRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	activeRef := lifecycleAssetRef(t, 1, oldRef.Length, tcs1HeaderBytes+32)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != int(oldRef.Length) {
+		t.Fatalf("reclaimable/rewrite=(%d,%d) want (0,%d)", plan.ReclaimableBytes, plan.RewriteDebtBytes, oldRef.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 1 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,1)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	oldEntry := lifecycleFindEntry(t, plan, oldRef)
+	if oldEntry.State != ColumnAssetStateSuperseded || oldEntry.DeleteEligible {
+		t.Fatalf("old entry state/delete=(%s,%v) want superseded,false", oldEntry.State, oldEntry.DeleteEligible)
+	}
+}
+
+func TestColumnAssetReachabilityProtectsSnapshotPinnedManifest(t *testing.T) {
+	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:          &active,
+		SnapshotPinnedManifests: []ColumnCollectionManifest{old},
+		SupersededManifests:     []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("reclaimable/rewrite=(%d,%d) want (0,0)", plan.ReclaimableBytes, plan.RewriteDebtBytes)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 0 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,0)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	if plan.SnapshotProtectedBytes != int(oldRef.Length) {
+		t.Fatalf("snapshot protected bytes=%d want %d", plan.SnapshotProtectedBytes, oldRef.Length)
+	}
+	oldEntry := lifecycleFindEntry(t, plan, oldRef)
+	if oldEntry.State != ColumnAssetStateSnapshotPinned || oldEntry.DeleteEligible {
+		t.Fatalf("old entry state/delete=(%s,%v) want snapshot_pinned,false", oldEntry.State, oldEntry.DeleteEligible)
+	}
+}
+
+func TestColumnAssetReachabilityProtectsPendingAndPreparedAssets(t *testing.T) {
+	pendingRef := lifecycleAssetRef(t, 3, 0, tcs1HeaderBytes+16)
+	preparedRef := lifecycleAssetRef(t, 4, 0, tcs1HeaderBytes+24)
+	quarantinedRef := lifecycleAssetRef(t, 5, 0, tcs1HeaderBytes+32)
+	pending := lifecycleManifest(t, "jsonbench", ColumnPartRoleDelta, 3, pendingRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		PendingManifests: []ColumnCollectionManifest{pending},
+		PreparedAssets: []ColumnPreparedAsset{{
+			Ref:          preparedRef,
+			GenerationID: 3,
+			Reason:       "publish staged",
+		}},
+		QuarantinedAssets: []ColumnPreparedAsset{{
+			Ref:    quarantinedRef,
+			Bytes:  int(quarantinedRef.Length),
+			Reason: "checksum mismatch",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	wantPrepared := int(pendingRef.Length + preparedRef.Length)
+	if plan.PreparedBytes != wantPrepared {
+		t.Fatalf("prepared bytes=%d want %d", plan.PreparedBytes, wantPrepared)
+	}
+	if plan.QuarantinedBytes != int(quarantinedRef.Length) {
+		t.Fatalf("quarantined bytes=%d want %d", plan.QuarantinedBytes, quarantinedRef.Length)
+	}
+	if plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("reclaimable/rewrite=(%d,%d) want (0,0)", plan.ReclaimableBytes, plan.RewriteDebtBytes)
+	}
+	if got := lifecycleFindEntry(t, plan, pendingRef); got.State != ColumnAssetStatePendingPublish {
+		t.Fatalf("pending entry state=%s want pending_publish", got.State)
+	}
+	if got := lifecycleFindEntry(t, plan, preparedRef); got.State != ColumnAssetStatePrepared {
+		t.Fatalf("prepared entry state=%s want prepared", got.State)
+	}
+	if got := lifecycleFindEntry(t, plan, quarantinedRef); got.State != ColumnAssetStateQuarantined {
+		t.Fatalf("quarantined entry state=%s want quarantined", got.State)
+	}
+}
+
+func TestColumnCollectionManifestAssetRefsEnumeratesManifestMetadata(t *testing.T) {
+	baseRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	deltaRef := lifecycleAssetRef(t, 1, baseRef.Length, tcs1HeaderBytes+24)
+	basePart := NewColumnManifestPartRef(ColumnPartRoleBase, 1, lifecyclePartManifest(11, baseRef))
+	deltaPart := NewColumnManifestPartRef(ColumnPartRoleDelta, 2, lifecyclePartManifest(22, deltaRef))
+	manifest, err := NewColumnCollectionManifest("jsonbench", partTestOptions([]SortKeyColumn{{Column: "id"}}), []ColumnManifestPartRef{basePart}, []ColumnManifestPartRef{deltaPart}, nil)
+	if err != nil {
+		t.Fatalf("NewColumnCollectionManifest: %v", err)
+	}
+
+	entries, err := ColumnCollectionManifestAssetRefs(manifest)
+	if err != nil {
+		t.Fatalf("ColumnCollectionManifestAssetRefs: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entries=%d want 2", len(entries))
+	}
+	if entries[0].Ref != baseRef || entries[0].State != ColumnAssetStateActive || entries[0].PartID != 11 {
+		t.Fatalf("base entry=%+v want ref=%+v state=active part=11", entries[0], baseRef)
+	}
+	if entries[1].Ref != deltaRef || entries[1].State != ColumnAssetStateActive || entries[1].PartID != 22 {
+		t.Fatalf("delta entry=%+v want ref=%+v state=active part=22", entries[1], deltaRef)
+	}
+}
+
+func TestColumnAssetRefDeltaAccountingUsesChangedRefsOnly(t *testing.T) {
+	oldRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	newRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	preparedRef := lifecycleAssetRef(t, 3, 0, tcs1HeaderBytes+32)
+	oldPart := NewColumnManifestPartRef(ColumnPartRoleBase, 1, lifecyclePartManifest(11, oldRef))
+	newPart := NewColumnManifestPartRef(ColumnPartRoleBase, 2, lifecyclePartManifest(22, newRef))
+
+	plan, err := PlanColumnAssetRefDelta(ColumnAssetRefDeltaInput{
+		PublishedParts:  []ColumnManifestPartRef{newPart},
+		SupersededParts: []ColumnManifestPartRef{oldPart},
+		PreparedAssets: []ColumnPreparedAsset{{
+			Ref:          preparedRef,
+			GenerationID: 2,
+			Reason:       "publish staged",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetRefDelta: %v", err)
+	}
+	if plan.PublishedBytes != int(newRef.Length) || plan.SupersededBytes != int(oldRef.Length) || plan.PreparedBytes != int(preparedRef.Length) {
+		t.Fatalf("delta bytes published/superseded/prepared=(%d,%d,%d)", plan.PublishedBytes, plan.SupersededBytes, plan.PreparedBytes)
+	}
+	if plan.Stats.AssetRefs != 3 || plan.Stats.RowsScanned != 0 || plan.Stats.TCS1PayloadBytesDecoded != 0 || plan.Stats.ColumnPayloadBlocksRead != 0 {
+		t.Fatalf("delta stats=%+v want changed refs only without row/payload scans", plan.Stats)
+	}
+	if len(plan.Entries) != 3 {
+		t.Fatalf("entries=%d want 3", len(plan.Entries))
+	}
+}
+
+func TestColumnAssetReachabilityDeterministicChurnReclaimsAfterSnapshotDrain(t *testing.T) {
+	var activeRefs []ColumnAssetRef
+	var oldRefs []ColumnAssetRef
+	var oldBytes int
+	for i := 0; i < 8; i++ {
+		activeRefs = append(activeRefs, lifecycleAssetRef(t, 1, int64(i*(tcs1HeaderBytes+64)), tcs1HeaderBytes+64))
+		oldRef := lifecycleAssetRef(t, 2, int64(i*(tcs1HeaderBytes+96)), tcs1HeaderBytes+96)
+		oldRefs = append(oldRefs, oldRef)
+		oldBytes += int(oldRef.Length)
+	}
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 20, activeRefs...)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 10, oldRefs...)
+
+	pinned, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:          &active,
+		SnapshotPinnedManifests: []ColumnCollectionManifest{old},
+		SupersededManifests:     []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability pinned: %v", err)
+	}
+	if pinned.ReclaimableBytes != 0 || pinned.SnapshotProtectedBytes != oldBytes {
+		t.Fatalf("pinned reclaimable/snapshot=(%d,%d) want (0,%d)", pinned.ReclaimableBytes, pinned.SnapshotProtectedBytes, oldBytes)
+	}
+
+	drained, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability drained: %v", err)
+	}
+	if drained.ReclaimableBytes*100 < oldBytes*80 {
+		t.Fatalf("reclaimable bytes=%d old bytes=%d want at least 80%%", drained.ReclaimableBytes, oldBytes)
+	}
+	if drained.RewriteDebtBytes != 0 || drained.Stats.DirectlyDeletableSegments != 1 || drained.Stats.MixedLiveDeadSegments != 0 {
+		t.Fatalf("drained plan=%+v want closed superseded segment reclaimable", drained)
+	}
+	manager, err := NewColumnAssetManager(NewMemoryColumnAssetStore())
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	for _, entry := range drained.Entries {
+		if entry.DeleteEligible {
+			if err := manager.MarkZombie(entry.Ref, "snapshot drained"); err != nil {
+				t.Fatalf("MarkZombie: %v", err)
+			}
+		}
+	}
+	reclamation := manager.PlanReclamation(drained)
+	if reclamation.ReadyToDeleteBytes != drained.ReclaimableBytes {
+		t.Fatalf("ready delete bytes=%d want reclaimable=%d plan=%+v", reclamation.ReadyToDeleteBytes, drained.ReclaimableBytes, reclamation)
+	}
+}
+
+func BenchmarkColumnAssetReachability10K(b *testing.B) {
+	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
+	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
+	input := ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{superseded},
+	}
+	plan, err := PlanColumnAssetReachability(input)
+	if err != nil {
+		b.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	b.ReportMetric(float64(plan.Stats.Manifests), "manifests")
+	b.ReportMetric(float64(plan.Stats.AssetRefs), "asset_refs")
+	b.ReportMetric(float64(plan.Stats.SegmentRefs), "segments")
+	b.ReportMetric(float64(plan.Stats.TCS1PayloadBytesDecoded), "payload_bytes_decoded")
+	b.ReportMetric(float64(plan.Stats.RowsScanned), "rows_scanned")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan, err := PlanColumnAssetReachability(input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(plan.RetainedBytes + plan.ReclaimableBytes + plan.RewriteDebtBytes)
+	}
+}
+
+func BenchmarkColumnAssetRefDelta128(b *testing.B) {
+	published := lifecycleSyntheticPartRefsForBenchmark(64, 20_000, 3, 0)
+	superseded := lifecycleSyntheticPartRefsForBenchmark(64, 10_000, 2, 0)
+	input := ColumnAssetRefDeltaInput{
+		PublishedParts:  published,
+		SupersededParts: superseded,
+	}
+	plan, err := PlanColumnAssetRefDelta(input)
+	if err != nil {
+		b.Fatalf("PlanColumnAssetRefDelta: %v", err)
+	}
+	b.ReportMetric(float64(plan.Stats.AssetRefs), "changed_refs")
+	b.ReportMetric(float64(plan.Stats.RowsScanned), "rows_scanned")
+	b.ReportMetric(float64(plan.Stats.TCS1PayloadBytesDecoded), "payload_bytes_decoded")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan, err := PlanColumnAssetRefDelta(input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(plan.PublishedBytes + plan.SupersededBytes)
+	}
+}
+
+func BenchmarkColumnAssetManagerReclamation10K(b *testing.B) {
+	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
+	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
+	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{superseded},
+	})
+	if err != nil {
+		b.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	manager, err := NewColumnAssetManager(NewMemoryColumnAssetStore())
+	if err != nil {
+		b.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	for _, entry := range reachability.Entries {
+		if entry.DeleteEligible {
+			if err := manager.MarkZombie(entry.Ref, "benchmark superseded"); err != nil {
+				b.Fatalf("MarkZombie: %v", err)
+			}
+		}
+	}
+	plan := manager.PlanReclamation(reachability)
+	b.ReportMetric(float64(len(plan.Entries)), "asset_refs")
+	b.ReportMetric(float64(plan.CandidateBytes), "candidate_bytes")
+	b.ReportMetric(float64(plan.ReadyToDeleteBytes), "ready_delete_bytes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan := manager.PlanReclamation(reachability)
+		benchSink += int64(plan.ReadyToDeleteBytes + plan.RewriteDebtBytes)
+	}
+}
+
+func lifecycleAssetRef(t *testing.T, fileID uint32, offset int64, length int) ColumnAssetRef {
+	t.Helper()
+	payload := make([]byte, length)
+	for i := range payload {
+		payload[i] = byte(int(fileID) + int(offset) + i)
+	}
+	ref, err := newColumnAssetRef(ColumnAssetKindTCS1PartImage, fileID, offset, length, payload)
+	if err != nil {
+		t.Fatalf("newColumnAssetRef: %v", err)
+	}
+	return ref
+}
+
+func lifecycleManifest(t *testing.T, collection string, role ColumnPartRole, generationID uint64, refs ...ColumnAssetRef) ColumnCollectionManifest {
+	t.Helper()
+	baseParts := make([]ColumnManifestPartRef, 0, len(refs))
+	deltaParts := make([]ColumnManifestPartRef, 0, len(refs))
+	for i, ref := range refs {
+		partID := generationID*100 + uint64(i+1)
+		partRef := NewColumnManifestPartRef(role, generationID, lifecyclePartManifest(partID, ref))
+		switch role {
+		case ColumnPartRoleBase:
+			baseParts = append(baseParts, partRef)
+		case ColumnPartRoleDelta:
+			deltaParts = append(deltaParts, partRef)
+		default:
+			t.Fatalf("unsupported role %s", role)
+		}
+	}
+	manifest, err := NewColumnCollectionManifest(collection, partTestOptions([]SortKeyColumn{{Column: "id"}}), baseParts, deltaParts, nil)
+	if err != nil {
+		t.Fatalf("NewColumnCollectionManifest: %v", err)
+	}
+	return manifest
+}
+
+func lifecycleSyntheticPartRefsForBenchmark(parts int, firstPartID uint64, fileID uint32, baseOffset int64) []ColumnManifestPartRef {
+	partRefs := make([]ColumnManifestPartRef, parts)
+	offset := baseOffset
+	for i := range partRefs {
+		ref := ColumnAssetRef{
+			Kind:     ColumnAssetKindTCS1PartImage,
+			FileID:   fileID,
+			Offset:   offset,
+			Length:   int64(tcs1HeaderBytes + 512),
+			Checksum: uint32(i + 1),
+		}
+		partID := firstPartID + uint64(i)
+		partRefs[i] = NewColumnManifestPartRef(ColumnPartRoleBase, uint64(i+1), lifecyclePartManifest(partID, ref))
+		offset += ref.Length
+	}
+	return partRefs
+}
+
+func lifecyclePartManifest(partID uint64, ref ColumnAssetRef) ColumnWorkspacePartManifest {
+	imageBytes := int(ref.Length) - tcs1HeaderBytes
+	if imageBytes <= 0 {
+		imageBytes = int(ref.Length)
+	}
+	return ColumnWorkspacePartManifest{
+		PartID:        partID,
+		Rows:          1,
+		VisibleRows:   1,
+		SchemaVersion: 1,
+		SortKey:       []SortKeyColumn{{Column: "id"}},
+		AssetRef:      ref,
+		TCS1: TCS1PartRecord{
+			Version:      tcs1Version,
+			Kind:         tcs1PartImageKind,
+			PartID:       partID,
+			Rows:         1,
+			ImageVersion: columnPartImageVersion,
+			PayloadBytes: imageBytes,
+			TotalBytes:   int(ref.Length),
+			AssetRef:     ref,
+		},
+		ImageBytes:    imageBytes,
+		ManifestBytes: 4,
+		Sections:      1,
+		AssetBytes:    int(ref.Length),
+		PublishedUnix: int64(partID),
+	}
+}
+
+func lifecycleFindEntry(t *testing.T, plan ColumnAssetReachabilityPlan, ref ColumnAssetRef) ColumnAssetReachabilityEntry {
+	t.Helper()
+	for _, entry := range plan.Entries {
+		if entry.Ref == ref {
+			return entry
+		}
+	}
+	t.Fatalf("missing reachability entry for ref %+v in %+v", ref, plan.Entries)
+	return ColumnAssetReachabilityEntry{}
+}
+
+func lifecycleSyntheticManifestForBenchmark(b *testing.B, collection string, parts int, firstPartID uint64, fileID uint32, baseOffset int64) ColumnCollectionManifest {
+	b.Helper()
+	partRefs := lifecycleSyntheticPartRefsForBenchmark(parts, firstPartID, fileID, baseOffset)
+	manifest, err := NewColumnCollectionManifest(collection, partTestOptions([]SortKeyColumn{{Column: "id"}}), partRefs, nil, nil)
+	if err != nil {
+		b.Fatalf("NewColumnCollectionManifest: %v", err)
+	}
+	return manifest
+}

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -66,6 +66,7 @@ type ColumnStoreOptions struct {
 type ColumnPartPolicy struct {
 	RowsPerGranule        int
 	DefaultCodecBlockRows int
+	AdaptiveMarkSizing    ColumnAdaptiveMarkSizing
 }
 
 type ColumnCompressionPolicy struct {
@@ -183,6 +184,17 @@ func (b *ColumnPartBuilder) Build(partID uint64, batch ColumnBatch) (*ColumnPart
 	rows, err := validateColumnBatch(batch, b.opts.Columns)
 	if err != nil {
 		return nil, err
+	}
+	if b.opts.PartPolicy.AdaptiveMarkSizing.Enabled {
+		rawBytes, err := EstimateColumnBatchUncompressedBytes(batch, b.opts.Columns)
+		if err != nil {
+			return nil, err
+		}
+		estimate, err := EstimateAdaptiveRowsPerMark(rows, rawBytes, b.opts.PartPolicy.AdaptiveMarkSizing)
+		if err != nil {
+			return nil, err
+		}
+		b.opts.PartPolicy.RowsPerGranule = estimate.RowsPerMark
 	}
 	pkColumn := b.opts.LogicalPrimaryKey.Columns[0]
 	order, err := b.sortedOrder(batch, rows, pkColumn)
@@ -463,11 +475,20 @@ func normalizeColumnStoreOptions(opts ColumnStoreOptions) (ColumnStoreOptions, e
 	if opts.SchemaMode != ColumnSchemaFixed {
 		return ColumnStoreOptions{}, fmt.Errorf("colgranule: unsupported schema mode %s", opts.SchemaMode)
 	}
-	if opts.PartPolicy.RowsPerGranule == 0 {
-		opts.PartPolicy.RowsPerGranule = DefaultRowsPerGranule
-	}
-	if opts.PartPolicy.RowsPerGranule <= 0 {
-		return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid rows per granule %d", opts.PartPolicy.RowsPerGranule)
+	var err error
+	if opts.PartPolicy.AdaptiveMarkSizing.Enabled {
+		opts.PartPolicy.AdaptiveMarkSizing, err = NormalizeColumnAdaptiveMarkSizing(opts.PartPolicy.AdaptiveMarkSizing, opts.PartPolicy.RowsPerGranule)
+		if err != nil {
+			return ColumnStoreOptions{}, err
+		}
+		opts.PartPolicy.RowsPerGranule = opts.PartPolicy.AdaptiveMarkSizing.MaxRows
+	} else {
+		if opts.PartPolicy.RowsPerGranule == 0 {
+			opts.PartPolicy.RowsPerGranule = DefaultRowsPerGranule
+		}
+		if opts.PartPolicy.RowsPerGranule <= 0 {
+			return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid rows per granule %d", opts.PartPolicy.RowsPerGranule)
+		}
 	}
 	if opts.PartPolicy.DefaultCodecBlockRows < 0 {
 		return ColumnStoreOptions{}, fmt.Errorf("colgranule: invalid default codec block rows %d", opts.PartPolicy.DefaultCodecBlockRows)

--- a/experiments/colgranule/part_set.go
+++ b/experiments/colgranule/part_set.go
@@ -49,6 +49,35 @@ type ColumnPartSetVisibilityStats struct {
 	Tombstones     int `json:"tombstones"`
 }
 
+type ColumnPartSetCompactionPolicy struct {
+	MaxDeltaParts             int `json:"max_delta_parts,omitempty"`
+	MaxDeltaBytes             int `json:"max_delta_bytes,omitempty"`
+	MaxTombstones             int `json:"max_tombstones,omitempty"`
+	MaxReadAmplificationParts int `json:"max_read_amplification_parts,omitempty"`
+	MaxStaleBytes             int `json:"max_stale_bytes,omitempty"`
+	MinExpectedReclaimPPM     int `json:"min_expected_reclaim_ppm,omitempty"`
+	MinVisibleRowsPPM         int `json:"min_visible_rows_ppm,omitempty"`
+}
+
+type ColumnPartSetCompactionPlan struct {
+	ShouldCompact                bool     `json:"should_compact"`
+	Reasons                      []string `json:"reasons,omitempty"`
+	SelectedParts                int      `json:"selected_parts"`
+	SkippedParts                 int      `json:"skipped_parts"`
+	BaseParts                    int      `json:"base_parts"`
+	DeltaParts                   int      `json:"delta_parts"`
+	Tombstones                   int      `json:"tombstones"`
+	ReadAmplificationParts       int      `json:"read_amplification_parts"`
+	LiveBytes                    int      `json:"live_bytes"`
+	StaleBytes                   int      `json:"stale_bytes"`
+	TombstoneDebt                int      `json:"tombstone_debt"`
+	ExpectedReclaimPPM           int      `json:"expected_reclaim_ppm"`
+	VisibleRowsPPM               int      `json:"visible_rows_ppm"`
+	AggregateMetadataInvalid     bool     `json:"aggregate_metadata_invalid"`
+	AggregateMetadataRebuilds    bool     `json:"aggregate_metadata_rebuilds"`
+	ColumnAssetStaleBytePressure bool     `json:"column_asset_stale_byte_pressure"`
+}
+
 type ColumnPartSetScanResult struct {
 	Rows        int
 	Columns     map[string][]int64
@@ -72,18 +101,22 @@ type ColumnPartSetScanDiagnostics struct {
 }
 
 type ColumnPartSetCompactionResult struct {
-	Manifest         ColumnCollectionManifest    `json:"manifest"`
-	Part             ColumnWorkspacePartManifest `json:"part"`
-	InputRows        int                         `json:"input_rows"`
-	VisibleRows      int                         `json:"visible_rows"`
-	DroppedRows      int                         `json:"dropped_rows"`
-	SupersededRows   int                         `json:"superseded_rows"`
-	DeletedRows      int                         `json:"deleted_rows"`
-	OldAssetBytes    int                         `json:"old_asset_bytes"`
-	NewAssetBytes    int                         `json:"new_asset_bytes"`
-	ReclaimableBytes int                         `json:"reclaimable_bytes"`
-	NetBytesReduced  int                         `json:"net_bytes_reduced"`
-	CompactionUnix   int64                       `json:"compaction_unix_nano"`
+	Manifest                ColumnCollectionManifest    `json:"manifest"`
+	Part                    ColumnWorkspacePartManifest `json:"part"`
+	InputRows               int                         `json:"input_rows"`
+	VisibleRows             int                         `json:"visible_rows"`
+	DroppedRows             int                         `json:"dropped_rows"`
+	SupersededRows          int                         `json:"superseded_rows"`
+	DeletedRows             int                         `json:"deleted_rows"`
+	OldAssetBytes           int                         `json:"old_asset_bytes"`
+	NewAssetBytes           int                         `json:"new_asset_bytes"`
+	ReclaimableBytes        int                         `json:"reclaimable_bytes"`
+	RewriteDebtBytes        int                         `json:"rewrite_debt_bytes"`
+	NetBytesReduced         int                         `json:"net_bytes_reduced"`
+	SelectionPlan           ColumnPartSetCompactionPlan `json:"selection_plan"`
+	PrePublishReachability  ColumnAssetReachabilityPlan `json:"pre_publish_reachability"`
+	PostPublishReachability ColumnAssetReachabilityPlan `json:"post_publish_reachability"`
+	CompactionUnix          int64                       `json:"compaction_unix_nano"`
 }
 
 func OpenColumnPartSetReader(workspace *ColumnWorkspace, manifest ColumnCollectionManifest, opts ColumnPartImageReadOptions) (*ColumnPartSetReader, error) {
@@ -306,6 +339,73 @@ func BuildColumnDeltaPart(partID uint64, opts ColumnStoreOptions, replacements C
 	return BuildColumnPart(partID, opts, replacements)
 }
 
+func PlanColumnPartSetCompaction(manifest ColumnCollectionManifest, stats ColumnPartSetVisibilityStats, policy ColumnPartSetCompactionPolicy) (ColumnPartSetCompactionPlan, error) {
+	if err := validateColumnCollectionManifest(manifest); err != nil {
+		return ColumnPartSetCompactionPlan{}, err
+	}
+	totalParts := len(manifest.PartSet.BaseParts) + len(manifest.PartSet.DeltaParts)
+	if stats.Parts == 0 {
+		stats.Parts = totalParts
+		stats.BaseParts = len(manifest.PartSet.BaseParts)
+		stats.DeltaParts = len(manifest.PartSet.DeltaParts)
+		stats.InputRows = manifest.ByteAccounting.Rows
+		stats.VisibleRows = manifest.ByteAccounting.VisibleRows
+		stats.Tombstones = len(manifest.PartSet.Tombstones)
+	}
+	totalBytes := manifest.ByteAccounting.TotalAssetBytes
+	staleRows := stats.SupersededRows + stats.DeletedRows
+	staleBytes := proportionalBytes(totalBytes, staleRows, stats.InputRows)
+	if staleBytes > totalBytes {
+		staleBytes = totalBytes
+	}
+	deltaBytes := manifest.ByteAccounting.DeltaAssetBytes
+	plan := ColumnPartSetCompactionPlan{
+		BaseParts:                    len(manifest.PartSet.BaseParts),
+		DeltaParts:                   len(manifest.PartSet.DeltaParts),
+		Tombstones:                   len(manifest.PartSet.Tombstones),
+		ReadAmplificationParts:       totalParts,
+		LiveBytes:                    totalBytes - staleBytes,
+		StaleBytes:                   staleBytes,
+		TombstoneDebt:                len(manifest.PartSet.Tombstones),
+		ExpectedReclaimPPM:           ppm(staleBytes, totalBytes),
+		VisibleRowsPPM:               ppm(stats.VisibleRows, stats.InputRows),
+		AggregateMetadataInvalid:     stats.SupersededRows != 0 || stats.DeletedRows != 0 || len(manifest.PartSet.Tombstones) != 0,
+		AggregateMetadataRebuilds:    totalParts != 0,
+		ColumnAssetStaleBytePressure: policy.MaxStaleBytes > 0 && staleBytes >= policy.MaxStaleBytes,
+	}
+	if policy.MaxDeltaParts > 0 && len(manifest.PartSet.DeltaParts) >= policy.MaxDeltaParts {
+		plan.Reasons = append(plan.Reasons, "delta_part_count")
+	}
+	if policy.MaxDeltaBytes > 0 && deltaBytes >= policy.MaxDeltaBytes {
+		plan.Reasons = append(plan.Reasons, "delta_bytes")
+	}
+	if policy.MaxTombstones > 0 && len(manifest.PartSet.Tombstones) >= policy.MaxTombstones {
+		plan.Reasons = append(plan.Reasons, "tombstone_count")
+	}
+	if policy.MaxReadAmplificationParts > 0 && totalParts >= policy.MaxReadAmplificationParts {
+		plan.Reasons = append(plan.Reasons, "read_amplification")
+	}
+	if plan.ColumnAssetStaleBytePressure {
+		plan.Reasons = append(plan.Reasons, "column_asset_stale_bytes")
+	}
+	if policy.MinExpectedReclaimPPM > 0 && plan.ExpectedReclaimPPM >= policy.MinExpectedReclaimPPM {
+		plan.Reasons = append(plan.Reasons, "expected_reclaim_ratio")
+	}
+	if policy.MinVisibleRowsPPM > 0 && plan.VisibleRowsPPM <= policy.MinVisibleRowsPPM {
+		plan.Reasons = append(plan.Reasons, "sparse_visible_rows")
+	}
+	if plan.AggregateMetadataInvalid {
+		plan.Reasons = append(plan.Reasons, "aggregate_metadata_invalidation")
+	}
+	plan.ShouldCompact = len(plan.Reasons) != 0
+	if plan.ShouldCompact {
+		plan.SelectedParts = totalParts
+	} else {
+		plan.SkippedParts = totalParts
+	}
+	return plan, nil
+}
+
 func CompactColumnPartSet(workspace *ColumnWorkspace, reader *ColumnPartSetReader, opts ColumnStoreOptions, dictionaries map[string]map[string]int64, newPartID uint64) (ColumnPartSetCompactionResult, error) {
 	if workspace == nil {
 		return ColumnPartSetCompactionResult{}, fmt.Errorf("colgranule: nil column workspace")
@@ -314,6 +414,15 @@ func CompactColumnPartSet(workspace *ColumnWorkspace, reader *ColumnPartSetReade
 		return ColumnPartSetCompactionResult{}, fmt.Errorf("colgranule: nil part set reader")
 	}
 	normalized, err := normalizeColumnStoreOptions(opts)
+	if err != nil {
+		return ColumnPartSetCompactionResult{}, err
+	}
+	selectionPlan, err := PlanColumnPartSetCompaction(reader.manifest, reader.visibilityStat, ColumnPartSetCompactionPolicy{
+		MaxDeltaParts:             1,
+		MaxTombstones:             1,
+		MaxReadAmplificationParts: 2,
+		MinExpectedReclaimPPM:     1,
+	})
 	if err != nil {
 		return ColumnPartSetCompactionResult{}, err
 	}
@@ -341,7 +450,7 @@ func CompactColumnPartSet(workspace *ColumnWorkspace, reader *ColumnPartSetReade
 	manifest, err := NewColumnCollectionManifest(
 		reader.manifest.Collection,
 		normalized,
-		[]ColumnManifestPartRef{NewColumnManifestPartRef(ColumnPartRoleBase, newGeneration, entry)},
+		[]ColumnManifestPartRef{NewColumnManifestPartRefWithCoverage(ColumnPartRoleBase, newGeneration, entry, columnPartSetCompactionSourceParts(reader.manifest.PartSet), columnPartSetNextCompactionLevel(reader.manifest.PartSet))},
 		nil,
 		nil,
 	)
@@ -355,24 +464,97 @@ func CompactColumnPartSet(workspace *ColumnWorkspace, reader *ColumnPartSetReade
 	if err := validateColumnCollectionManifest(manifest); err != nil {
 		return ColumnPartSetCompactionResult{}, err
 	}
+	oldManifest := reader.manifest
+	prePublishPlan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:   &oldManifest,
+		PendingManifests: []ColumnCollectionManifest{manifest},
+	})
+	if err != nil {
+		return ColumnPartSetCompactionResult{}, err
+	}
+	postPublishPlan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &manifest,
+		SupersededManifests: []ColumnCollectionManifest{oldManifest},
+	})
+	if err != nil {
+		return ColumnPartSetCompactionResult{}, err
+	}
 	netReduced := oldAssetBytes - entry.AssetBytes
 	if netReduced < 0 {
 		netReduced = 0
 	}
 	return ColumnPartSetCompactionResult{
-		Manifest:         manifest,
-		Part:             entry,
-		InputRows:        reader.visibilityStat.InputRows,
-		VisibleRows:      scan.Rows,
-		DroppedRows:      reader.visibilityStat.InputRows - scan.Rows,
-		SupersededRows:   reader.visibilityStat.SupersededRows,
-		DeletedRows:      reader.visibilityStat.DeletedRows,
-		OldAssetBytes:    oldAssetBytes,
-		NewAssetBytes:    entry.AssetBytes,
-		ReclaimableBytes: oldAssetBytes,
-		NetBytesReduced:  netReduced,
-		CompactionUnix:   time.Now().UnixNano(),
+		Manifest:                manifest,
+		Part:                    entry,
+		InputRows:               reader.visibilityStat.InputRows,
+		VisibleRows:             scan.Rows,
+		DroppedRows:             reader.visibilityStat.InputRows - scan.Rows,
+		SupersededRows:          reader.visibilityStat.SupersededRows,
+		DeletedRows:             reader.visibilityStat.DeletedRows,
+		OldAssetBytes:           oldAssetBytes,
+		NewAssetBytes:           entry.AssetBytes,
+		ReclaimableBytes:        postPublishPlan.ReclaimableBytes,
+		RewriteDebtBytes:        postPublishPlan.RewriteDebtBytes,
+		NetBytesReduced:         netReduced,
+		SelectionPlan:           selectionPlan,
+		PrePublishReachability:  prePublishPlan,
+		PostPublishReachability: postPublishPlan,
+		CompactionUnix:          time.Now().UnixNano(),
 	}, nil
+}
+
+func proportionalBytes(totalBytes int, rows int, totalRows int) int {
+	if totalBytes <= 0 || rows <= 0 || totalRows <= 0 {
+		return 0
+	}
+	if rows >= totalRows {
+		return totalBytes
+	}
+	return int((int64(totalBytes) * int64(rows)) / int64(totalRows))
+}
+
+func ppm(numerator int, denominator int) int {
+	if numerator <= 0 || denominator <= 0 {
+		return 0
+	}
+	if numerator >= denominator {
+		return 1_000_000
+	}
+	return int((int64(numerator) * 1_000_000) / int64(denominator))
+}
+
+func columnPartSetCompactionSourceParts(partSet ColumnPartSetManifest) []ColumnSourcePartGeneration {
+	refs := append([]ColumnManifestPartRef(nil), partSet.BaseParts...)
+	refs = append(refs, partSet.DeltaParts...)
+	out := make([]ColumnSourcePartGeneration, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ColumnSourcePartGeneration{PartID: ref.Part.PartID, GenerationID: ref.GenerationID})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].GenerationID != out[j].GenerationID {
+			return out[i].GenerationID < out[j].GenerationID
+		}
+		return out[i].PartID < out[j].PartID
+	})
+	return out
+}
+
+func columnPartSetNextCompactionLevel(partSet ColumnPartSetManifest) uint8 {
+	var maxLevel uint8
+	for _, ref := range partSet.BaseParts {
+		if ref.Coverage.CompactionLevel > maxLevel {
+			maxLevel = ref.Coverage.CompactionLevel
+		}
+	}
+	for _, ref := range partSet.DeltaParts {
+		if ref.Coverage.CompactionLevel > maxLevel {
+			maxLevel = ref.Coverage.CompactionLevel
+		}
+	}
+	if maxLevel == ^uint8(0) {
+		return maxLevel
+	}
+	return maxLevel + 1
 }
 
 func RunJSONBenchColumnPartSetQueries(reader *ColumnPartSetReader, ds JSONBenchDataset, attempts int) ([]JSONBenchPartQueryTiming, error) {

--- a/experiments/colgranule/part_set_test.go
+++ b/experiments/colgranule/part_set_test.go
@@ -91,6 +91,25 @@ func TestColumnPartSetDeltaTombstoneVisibilityAndCompaction(t *testing.T) {
 		t.Fatal("deleted id 10 still has latest locator")
 	}
 	assertJSONBenchPartSetQueriesMatchRaw(t, reader, expected)
+	plan, err := PlanColumnPartSetCompaction(manifest, reader.VisibilityStats(), ColumnPartSetCompactionPolicy{
+		MaxDeltaParts:             1,
+		MaxTombstones:             1,
+		MaxReadAmplificationParts: 2,
+		MaxStaleBytes:             1,
+		MinExpectedReclaimPPM:     1,
+		MinVisibleRowsPPM:         990_000,
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnPartSetCompaction: %v", err)
+	}
+	for _, reason := range []string{"delta_part_count", "tombstone_count", "read_amplification", "column_asset_stale_bytes", "expected_reclaim_ratio", "sparse_visible_rows", "aggregate_metadata_invalidation"} {
+		if !containsString(plan.Reasons, reason) {
+			t.Fatalf("compaction reasons=%v missing %s", plan.Reasons, reason)
+		}
+	}
+	if !plan.ShouldCompact || plan.SelectedParts != 2 || plan.SkippedParts != 0 || plan.StaleBytes == 0 || plan.LiveBytes == 0 {
+		t.Fatalf("bad compaction plan=%+v", plan)
+	}
 
 	compacted, err := CompactColumnPartSet(workspace, reader, opts, ds.Dictionaries, 399)
 	if err != nil {
@@ -99,11 +118,27 @@ func TestColumnPartSetDeltaTombstoneVisibilityAndCompaction(t *testing.T) {
 	if compacted.VisibleRows != expected.Rows || compacted.DroppedRows != len(updates)+len(deletes) {
 		t.Fatalf("compaction rows visible=%d dropped=%d want visible=%d dropped=%d", compacted.VisibleRows, compacted.DroppedRows, expected.Rows, len(updates)+len(deletes))
 	}
-	if compacted.ReclaimableBytes != manifest.ByteAccounting.TotalAssetBytes || compacted.NewAssetBytes == 0 {
+	if compacted.OldAssetBytes != manifest.ByteAccounting.TotalAssetBytes || compacted.NewAssetBytes == 0 {
 		t.Fatalf("compaction bytes=%+v manifest bytes=%d", compacted, manifest.ByteAccounting.TotalAssetBytes)
+	}
+	if compacted.ReclaimableBytes != 0 || compacted.RewriteDebtBytes != manifest.ByteAccounting.TotalAssetBytes {
+		t.Fatalf("compaction reachability reclaimable/rewrite=(%d,%d) want (0,%d)", compacted.ReclaimableBytes, compacted.RewriteDebtBytes, manifest.ByteAccounting.TotalAssetBytes)
+	}
+	if compacted.PrePublishReachability.ReclaimableBytes != 0 || compacted.PrePublishReachability.RewriteDebtBytes != 0 {
+		t.Fatalf("pre-publish reachability should not expose old bytes to GC: %+v", compacted.PrePublishReachability)
+	}
+	if !compacted.SelectionPlan.ShouldCompact || compacted.SelectionPlan.SelectedParts != 2 {
+		t.Fatalf("bad compacted selection plan=%+v", compacted.SelectionPlan)
+	}
+	if compacted.PostPublishReachability.Stats.MixedLiveDeadSegments != 1 {
+		t.Fatalf("post-publish reachability mixed segments=%d want 1", compacted.PostPublishReachability.Stats.MixedLiveDeadSegments)
 	}
 	if len(compacted.Manifest.PartSet.BaseParts) != 1 || len(compacted.Manifest.PartSet.DeltaParts) != 0 || len(compacted.Manifest.PartSet.Tombstones) != 0 {
 		t.Fatalf("bad compacted manifest part set=%+v", compacted.Manifest.PartSet)
+	}
+	coverage := compacted.Manifest.PartSet.BaseParts[0].Coverage
+	if coverage.CompactionLevel != 1 || len(coverage.SourceParts) != 2 || coverage.SourceParts[0].PartID != baseEntry.PartID || coverage.SourceParts[1].PartID != deltaEntry.PartID {
+		t.Fatalf("bad compacted coverage=%+v base=%d delta=%d", coverage, baseEntry.PartID, deltaEntry.PartID)
 	}
 	if err := workspace.SaveCollectionManifest(compacted.Manifest); err != nil {
 		t.Fatalf("SaveCollectionManifest(compacted): %v", err)
@@ -558,6 +593,50 @@ func benchmarkJSONBenchColumnPartSetAggregateMetadataM4(b *testing.B, ds JSONBen
 			}
 			reportGranuleBenchMetrics(b, rowsMeasured, valueBytes, storedBytes)
 		})
+	}
+}
+
+func BenchmarkColumnPartSetCompactionPlan10K(b *testing.B) {
+	manifest := syntheticColumnCollectionManifestForBenchmark(10_000)
+	manifest.PartSet.Tombstones = make([]ColumnTombstone, 1000)
+	for i := range manifest.PartSet.Tombstones {
+		manifest.PartSet.Tombstones[i] = ColumnTombstone{
+			PrimaryID:    int64(i + 1),
+			GenerationID: manifest.ActiveGeneration,
+			Reason:       "benchmark delete",
+		}
+	}
+	manifest.ByteAccounting = columnManifestByteAccounting(manifest)
+	stats := ColumnPartSetVisibilityStats{
+		Parts:          len(manifest.PartSet.BaseParts),
+		BaseParts:      len(manifest.PartSet.BaseParts),
+		InputRows:      manifest.ByteAccounting.Rows,
+		VisibleRows:    manifest.ByteAccounting.Rows - 2000,
+		SupersededRows: 1000,
+		DeletedRows:    1000,
+		Tombstones:     len(manifest.PartSet.Tombstones),
+	}
+	policy := ColumnPartSetCompactionPolicy{
+		MaxTombstones:             1000,
+		MaxReadAmplificationParts: 1024,
+		MinExpectedReclaimPPM:     100_000,
+		MinVisibleRowsPPM:         900_000,
+	}
+	plan, err := PlanColumnPartSetCompaction(manifest, stats, policy)
+	if err != nil {
+		b.Fatalf("PlanColumnPartSetCompaction: %v", err)
+	}
+	b.ReportMetric(float64(len(manifest.PartSet.BaseParts)), "parts")
+	b.ReportMetric(float64(plan.StaleBytes), "stale_bytes")
+	b.ReportMetric(float64(plan.ExpectedReclaimPPM), "expected_reclaim_ppm")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan, err := PlanColumnPartSetCompaction(manifest, stats, policy)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(plan.SelectedParts + plan.StaleBytes)
 	}
 }
 

--- a/experiments/colgranule/tcs1.go
+++ b/experiments/colgranule/tcs1.go
@@ -143,6 +143,39 @@ func LoadTCS1ColumnPartImage(store ColumnAssetStore, ref ColumnAssetRef) (Column
 	return image, record, nil
 }
 
+func LoadTCS1ColumnPartHeader(store ColumnAssetStore, ref ColumnAssetRef) (TCS1PartRecord, error) {
+	if store == nil {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: nil column asset store")
+	}
+	if ref.Kind != ColumnAssetKindTCS1PartImage {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 asset kind=%s want %s", ref.Kind, ColumnAssetKindTCS1PartImage)
+	}
+	var header []byte
+	var err error
+	if ranged, ok := store.(ColumnAssetRangeReader); ok {
+		header, err = ranged.ReadRange(ref, 0, tcs1HeaderBytes)
+	} else {
+		var payload []byte
+		payload, err = store.Read(ref)
+		if err == nil {
+			if len(payload) < tcs1HeaderBytes {
+				err = fmt.Errorf("colgranule: truncated TCS1 header bytes=%d", len(payload))
+			} else {
+				header = payload[:tcs1HeaderBytes]
+			}
+		}
+	}
+	if err != nil {
+		return TCS1PartRecord{}, err
+	}
+	record, err := DecodeTCS1ColumnPartHeader(header, ref.Length)
+	if err != nil {
+		return TCS1PartRecord{}, err
+	}
+	record.AssetRef = ref
+	return record, nil
+}
+
 func ColumnPartFromTCS1Asset(store ColumnAssetStore, ref ColumnAssetRef) (*ColumnPart, TCS1PartRecord, error) {
 	return ColumnPartFromTCS1AssetWithOptions(store, ref, ColumnPartImageReadOptions{
 		IncludeRowLocators:       true,
@@ -199,6 +232,65 @@ func putColumnAssetPayload(store ColumnAssetStore, kind ColumnAssetKind, payload
 		return owned.PutOwned(kind, payload)
 	}
 	return store.Put(kind, payload)
+}
+
+func DecodeTCS1ColumnPartHeader(header []byte, totalBytes int64) (TCS1PartRecord, error) {
+	if len(header) < tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: truncated TCS1 header bytes=%d", len(header))
+	}
+	if totalBytes < tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 total bytes=%d below header bytes=%d", totalBytes, tcs1HeaderBytes)
+	}
+	if totalBytes > int64(^uint(0)>>1) {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 total bytes=%d exceeds host int", totalBytes)
+	}
+	magic := binary.LittleEndian.Uint32(header[tcs1MagicOffset:tcs1VersionOffset])
+	if magic != tcs1Magic {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: invalid TCS1 magic 0x%x", magic)
+	}
+	version := binary.LittleEndian.Uint16(header[tcs1VersionOffset:tcs1KindOffset])
+	if version != tcs1Version {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: unsupported TCS1 version %d", version)
+	}
+	kind := binary.LittleEndian.Uint16(header[tcs1KindOffset:tcs1FlagsOffset])
+	if kind != tcs1PartImageKind {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: unsupported TCS1 kind %d", kind)
+	}
+	flags := binary.LittleEndian.Uint32(header[tcs1FlagsOffset:tcs1HeaderBytesOffset])
+	if flags&^tcs1SupportedFlags != 0 {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: unsupported TCS1 flags 0x%x", flags)
+	}
+	headerBytes := binary.LittleEndian.Uint32(header[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset])
+	if headerBytes != tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 header bytes=%d want %d", headerBytes, tcs1HeaderBytes)
+	}
+	payloadBytes := binary.LittleEndian.Uint64(header[tcs1PayloadBytesOffset:tcs1PartIDOffset])
+	if payloadBytes > uint64(totalBytes-int64(tcs1PayloadOffset)) {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 payload bytes=%d exceed available=%d", payloadBytes, totalBytes-int64(tcs1PayloadOffset))
+	}
+	if payloadBytes != uint64(totalBytes-int64(tcs1PayloadOffset)) {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, totalBytes-int64(tcs1PayloadOffset))
+	}
+	partID := binary.LittleEndian.Uint64(header[tcs1PartIDOffset:tcs1RowsOffset])
+	rows64 := binary.LittleEndian.Uint64(header[tcs1RowsOffset:tcs1ImageVersionOffset])
+	if rows64 > uint64(^uint(0)>>1) {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 rows=%d exceeds host int", rows64)
+	}
+	imageVersion := binary.LittleEndian.Uint16(header[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if reserved := binary.LittleEndian.Uint16(header[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
+		return TCS1PartRecord{}, fmt.Errorf("colgranule: TCS1 reserved=%d want 0", reserved)
+	}
+	return TCS1PartRecord{
+		Version:      version,
+		Kind:         kind,
+		Flags:        flags,
+		PartID:       partID,
+		Rows:         int(rows64),
+		ImageVersion: imageVersion,
+		PayloadBytes: int(payloadBytes),
+		TotalBytes:   int(totalBytes),
+		PayloadCRC32: binary.LittleEndian.Uint32(header[tcs1PayloadCRC32Offset:tcs1PayloadOffset]),
+	}, nil
 }
 
 func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -15,19 +15,98 @@ const (
 	columnWorkspaceManifestFile    = "column-workspace-manifest.json"
 	columnWorkspaceManifestMagic   = "TCWS1"
 	columnWorkspaceManifestVersion = 1
+	columnWorkspacePreparedFile    = "column-prepared-assets.json"
+	columnWorkspacePreparedMagic   = "TCPR1"
+	columnWorkspacePreparedVersion = 1
+
+	columnWorkspaceManifestDirName   = "manifests"
+	columnWorkspaceAssetsDirName     = "assets"
+	columnWorkspaceSegmentsDirName   = "segments"
+	columnWorkspaceIndexesDirName    = "indexes"
+	columnWorkspacePreparedDirName   = "prepared"
+	columnWorkspaceQuarantineDirName = "quarantine"
+	columnWorkspaceTmpDirName        = "tmp"
 )
 
 type ColumnWorkspaceOptions struct {
-	Collection string
+	Collection     string
+	ValidationMode ColumnWorkspaceValidationMode
+}
+
+type ColumnWorkspaceValidationMode string
+
+const (
+	ColumnWorkspaceValidateFullImage  ColumnWorkspaceValidationMode = "full_image"
+	ColumnWorkspaceValidateTCS1Header ColumnWorkspaceValidationMode = "tcs1_header"
+)
+
+type ColumnWorkspaceNamespace struct {
+	RootDir       string `json:"root_dir"`
+	ManifestDir   string `json:"manifest_dir"`
+	AssetDir      string `json:"asset_dir"`
+	SegmentDir    string `json:"segment_dir"`
+	IndexDir      string `json:"index_dir"`
+	PreparedDir   string `json:"prepared_dir"`
+	QuarantineDir string `json:"quarantine_dir"`
+	TempDir       string `json:"temp_dir"`
+}
+
+func ColumnWorkspaceNamespaceForDir(dir string) ColumnWorkspaceNamespace {
+	assetDir := filepath.Join(dir, columnWorkspaceAssetsDirName)
+	return ColumnWorkspaceNamespace{
+		RootDir:       dir,
+		ManifestDir:   filepath.Join(dir, columnWorkspaceManifestDirName),
+		AssetDir:      assetDir,
+		SegmentDir:    filepath.Join(assetDir, columnWorkspaceSegmentsDirName),
+		IndexDir:      filepath.Join(assetDir, columnWorkspaceIndexesDirName),
+		PreparedDir:   filepath.Join(dir, columnWorkspacePreparedDirName),
+		QuarantineDir: filepath.Join(dir, columnWorkspaceQuarantineDirName),
+		TempDir:       filepath.Join(dir, columnWorkspaceTmpDirName),
+	}
+}
+
+func ensureColumnWorkspaceNamespace(namespace ColumnWorkspaceNamespace) error {
+	dirs := []string{
+		namespace.RootDir,
+		namespace.ManifestDir,
+		namespace.AssetDir,
+		namespace.SegmentDir,
+		namespace.IndexDir,
+		namespace.PreparedDir,
+		namespace.QuarantineDir,
+		namespace.TempDir,
+	}
+	for _, dir := range dirs {
+		if dir == "" {
+			return fmt.Errorf("colgranule: empty column workspace namespace dir")
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeColumnWorkspaceOptions(opts ColumnWorkspaceOptions) (ColumnWorkspaceOptions, error) {
+	switch opts.ValidationMode {
+	case "":
+		opts.ValidationMode = ColumnWorkspaceValidateFullImage
+	case ColumnWorkspaceValidateFullImage, ColumnWorkspaceValidateTCS1Header:
+	default:
+		return ColumnWorkspaceOptions{}, fmt.Errorf("colgranule: unsupported workspace validation mode %s", opts.ValidationMode)
+	}
+	return opts, nil
 }
 
 type ColumnWorkspace struct {
-	dir       string
-	assets    *SegmentColumnAssetStore
-	manifest  ColumnWorkspaceManifest
-	partByID  map[uint64]int
-	cacheSeen map[string]struct{}
-	cache     ColumnWorkspaceCacheStats
+	dir            string
+	namespace      ColumnWorkspaceNamespace
+	assets         *ColumnAssetManager
+	manifest       ColumnWorkspaceManifest
+	validationMode ColumnWorkspaceValidationMode
+	partByID       map[uint64]int
+	cacheSeen      map[string]struct{}
+	cache          ColumnWorkspaceCacheStats
 }
 
 type ColumnWorkspaceManifest struct {
@@ -41,19 +120,39 @@ type ColumnWorkspaceManifest struct {
 	Parts       []ColumnWorkspacePartManifest `json:"parts,omitempty"`
 }
 
+type ColumnPreparedAssetRegistry struct {
+	Magic        string                `json:"magic"`
+	Version      uint16                `json:"version"`
+	Collection   string                `json:"collection,omitempty"`
+	PublishID    uint64                `json:"publish_id"`
+	GenerationID uint64                `json:"generation_id"`
+	UpdatedUnix  int64                 `json:"updated_unix_nano"`
+	Assets       []ColumnPreparedAsset `json:"assets,omitempty"`
+}
+
 type ColumnWorkspacePartManifest struct {
-	PartID        uint64          `json:"part_id"`
-	Rows          int             `json:"rows"`
-	VisibleRows   int             `json:"visible_rows"`
-	SchemaVersion uint32          `json:"schema_version"`
-	SortKey       []SortKeyColumn `json:"sort_key,omitempty"`
-	AssetRef      ColumnAssetRef  `json:"asset_ref"`
-	TCS1          TCS1PartRecord  `json:"tcs1"`
-	ImageBytes    int             `json:"image_bytes"`
-	ManifestBytes int             `json:"manifest_bytes"`
-	Sections      int             `json:"sections"`
-	AssetBytes    int             `json:"asset_bytes"`
-	PublishedUnix int64           `json:"published_unix_nano"`
+	PartID        uint64                      `json:"part_id"`
+	Rows          int                         `json:"rows"`
+	VisibleRows   int                         `json:"visible_rows"`
+	SchemaVersion uint32                      `json:"schema_version"`
+	SortKey       []SortKeyColumn             `json:"sort_key,omitempty"`
+	Coverage      ColumnWorkspacePartCoverage `json:"coverage"`
+	AssetRef      ColumnAssetRef              `json:"asset_ref"`
+	TCS1          TCS1PartRecord              `json:"tcs1"`
+	ImageBytes    int                         `json:"image_bytes"`
+	ManifestBytes int                         `json:"manifest_bytes"`
+	Sections      int                         `json:"sections"`
+	AssetBytes    int                         `json:"asset_bytes"`
+	PublishedUnix int64                       `json:"published_unix_nano"`
+}
+
+type ColumnWorkspacePartCoverage struct {
+	PrimaryIDLower          int64    `json:"primary_id_lower"`
+	PrimaryIDUpperExclusive int64    `json:"primary_id_upper_exclusive"`
+	SortKeyColumns          []string `json:"sort_key_columns,omitempty"`
+	SortKeyLower            []int64  `json:"sort_key_lower,omitempty"`
+	SortKeyUpperExclusive   []int64  `json:"sort_key_upper_exclusive,omitempty"`
+	SortKeyUpperUnbounded   bool     `json:"sort_key_upper_unbounded,omitempty"`
 }
 
 type columnWorkspaceManifestEnvelope struct {
@@ -61,6 +160,27 @@ type columnWorkspaceManifestEnvelope struct {
 	Version  uint16                  `json:"version"`
 	Checksum uint32                  `json:"checksum"`
 	Manifest ColumnWorkspaceManifest `json:"manifest"`
+}
+
+type columnPreparedAssetRegistryEnvelope struct {
+	Magic    string                      `json:"magic"`
+	Version  uint16                      `json:"version"`
+	Checksum uint32                      `json:"checksum"`
+	Registry ColumnPreparedAssetRegistry `json:"registry"`
+}
+
+type ColumnWorkspaceNamespaceInventory struct {
+	SegmentFiles            []ColumnWorkspaceSegmentFile `json:"segment_files"`
+	PreparedRegistryPresent bool                         `json:"prepared_registry_present"`
+	PreparedAssets          []ColumnPreparedAsset        `json:"prepared_assets,omitempty"`
+	OrphanPreparedAssets    []ColumnPreparedAsset        `json:"orphan_prepared_assets,omitempty"`
+	ReferencedAssets        int                          `json:"referenced_assets"`
+}
+
+type ColumnWorkspaceSegmentFile struct {
+	FileID uint32 `json:"file_id"`
+	Path   string `json:"path"`
+	Bytes  int64  `json:"bytes"`
 }
 
 type ColumnWorkspaceLoadResult struct {
@@ -87,21 +207,36 @@ func OpenColumnWorkspace(dir string, opts ColumnWorkspaceOptions) (*ColumnWorksp
 	if dir == "" {
 		return nil, fmt.Errorf("colgranule: empty column workspace dir")
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, err
-	}
-	assets, err := OpenSegmentColumnAssetStore(filepath.Join(dir, "assets"))
+	normalized, err := normalizeColumnWorkspaceOptions(opts)
 	if err != nil {
 		return nil, err
 	}
-	w := &ColumnWorkspace{
-		dir:       dir,
-		assets:    assets,
-		partByID:  make(map[uint64]int),
-		cacheSeen: make(map[string]struct{}),
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
 	}
-	if err := w.loadOrInitManifest(opts); err != nil {
+	namespace := ColumnWorkspaceNamespaceForDir(dir)
+	if err := ensureColumnWorkspaceNamespace(namespace); err != nil {
+		return nil, err
+	}
+	assets, err := OpenSegmentColumnAssetStore(namespace.SegmentDir)
+	if err != nil {
+		return nil, err
+	}
+	assetManager, err := NewColumnAssetManager(assets)
+	if err != nil {
 		_ = assets.Close()
+		return nil, err
+	}
+	w := &ColumnWorkspace{
+		dir:            dir,
+		namespace:      namespace,
+		assets:         assetManager,
+		validationMode: normalized.ValidationMode,
+		partByID:       make(map[uint64]int),
+		cacheSeen:      make(map[string]struct{}),
+	}
+	if err := w.loadOrInitManifest(normalized); err != nil {
+		_ = assetManager.Close()
 		return nil, err
 	}
 	return w, nil
@@ -126,6 +261,13 @@ func (w *ColumnWorkspace) Dir() string {
 	return w.dir
 }
 
+func (w *ColumnWorkspace) Namespace() ColumnWorkspaceNamespace {
+	if w == nil {
+		return ColumnWorkspaceNamespace{}
+	}
+	return w.namespace
+}
+
 func (w *ColumnWorkspace) Manifest() ColumnWorkspaceManifest {
 	if w == nil {
 		return ColumnWorkspaceManifest{}
@@ -134,6 +276,7 @@ func (w *ColumnWorkspace) Manifest() ColumnWorkspaceManifest {
 	out.Parts = append([]ColumnWorkspacePartManifest(nil), w.manifest.Parts...)
 	for i := range out.Parts {
 		out.Parts[i].SortKey = append([]SortKeyColumn(nil), out.Parts[i].SortKey...)
+		out.Parts[i].Coverage = cloneColumnWorkspacePartCoverage(out.Parts[i].Coverage)
 	}
 	return out
 }
@@ -160,12 +303,17 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	if err != nil {
 		return ColumnWorkspacePartManifest{}, err
 	}
+	coverage, err := columnWorkspacePartCoverageFromPart(part)
+	if err != nil {
+		return ColumnWorkspacePartManifest{}, err
+	}
 	entry := ColumnWorkspacePartManifest{
 		PartID:        part.Descriptor.PartID,
 		Rows:          part.Descriptor.RowCount,
 		VisibleRows:   part.Descriptor.VisibleRowCount,
 		SchemaVersion: part.Descriptor.SchemaVersion,
 		SortKey:       append([]SortKeyColumn(nil), part.Descriptor.SortKey...),
+		Coverage:      coverage,
 		AssetRef:      ref,
 		TCS1:          record,
 		ImageBytes:    image.TotalBytes(),
@@ -273,7 +421,7 @@ func (w *ColumnWorkspace) saveManifest() error {
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(w.dir, ".column-workspace-manifest-*.tmp")
+	tmp, err := os.CreateTemp(w.namespace.TempDir, ".column-workspace-manifest-*.tmp")
 	if err != nil {
 		return err
 	}
@@ -299,11 +447,163 @@ func (w *ColumnWorkspace) saveManifest() error {
 	return nil
 }
 
+func (w *ColumnWorkspace) SavePreparedAssetRegistry(publishID uint64, generationID uint64, assets []ColumnPreparedAsset) error {
+	if w == nil {
+		return fmt.Errorf("colgranule: nil column workspace")
+	}
+	registry := ColumnPreparedAssetRegistry{
+		Magic:        columnWorkspacePreparedMagic,
+		Version:      columnWorkspacePreparedVersion,
+		Collection:   w.manifest.Collection,
+		PublishID:    publishID,
+		GenerationID: generationID,
+		UpdatedUnix:  time.Now().UnixNano(),
+		Assets:       cloneColumnPreparedAssets(assets),
+	}
+	if err := validateColumnPreparedAssetRegistry(registry); err != nil {
+		return err
+	}
+	payload, err := encodeColumnPreparedAssetRegistryEnvelope(registry)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(w.namespace.TempDir, ".column-prepared-assets-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err = tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = os.Rename(tmpPath, w.preparedRegistryPath()); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func (w *ColumnWorkspace) LoadPreparedAssetRegistry() (ColumnPreparedAssetRegistry, error) {
+	if w == nil {
+		return ColumnPreparedAssetRegistry{}, fmt.Errorf("colgranule: nil column workspace")
+	}
+	data, err := os.ReadFile(w.preparedRegistryPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ColumnPreparedAssetRegistry{
+				Magic:      columnWorkspacePreparedMagic,
+				Version:    columnWorkspacePreparedVersion,
+				Collection: w.manifest.Collection,
+			}, nil
+		}
+		return ColumnPreparedAssetRegistry{}, err
+	}
+	registry, err := decodeColumnPreparedAssetRegistryEnvelope(data)
+	if err != nil {
+		return ColumnPreparedAssetRegistry{}, err
+	}
+	if w.manifest.Collection != "" && registry.Collection != "" && registry.Collection != w.manifest.Collection {
+		return ColumnPreparedAssetRegistry{}, fmt.Errorf("colgranule: prepared registry collection=%q want %q", registry.Collection, w.manifest.Collection)
+	}
+	return registry, nil
+}
+
+func (w *ColumnWorkspace) ClearPreparedAssetRegistry() error {
+	if w == nil {
+		return fmt.Errorf("colgranule: nil column workspace")
+	}
+	err := os.Remove(w.preparedRegistryPath())
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (w *ColumnWorkspace) InventoryNamespace(manifests ...ColumnCollectionManifest) (ColumnWorkspaceNamespaceInventory, error) {
+	if w == nil {
+		return ColumnWorkspaceNamespaceInventory{}, fmt.Errorf("colgranule: nil column workspace")
+	}
+	inventory := ColumnWorkspaceNamespaceInventory{}
+	entries, err := os.ReadDir(w.namespace.SegmentDir)
+	if err != nil {
+		return ColumnWorkspaceNamespaceInventory{}, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		fileID, ok := columnWorkspaceSegmentFileID(entry.Name())
+		if !ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return ColumnWorkspaceNamespaceInventory{}, err
+		}
+		inventory.SegmentFiles = append(inventory.SegmentFiles, ColumnWorkspaceSegmentFile{
+			FileID: fileID,
+			Path:   filepath.Join(w.namespace.SegmentDir, entry.Name()),
+			Bytes:  info.Size(),
+		})
+	}
+	sort.Slice(inventory.SegmentFiles, func(i, j int) bool {
+		return inventory.SegmentFiles[i].FileID < inventory.SegmentFiles[j].FileID
+	})
+	registryPath := w.preparedRegistryPath()
+	if _, err := os.Stat(registryPath); err == nil {
+		inventory.PreparedRegistryPresent = true
+	} else if !os.IsNotExist(err) {
+		return ColumnWorkspaceNamespaceInventory{}, err
+	}
+	registry, err := w.LoadPreparedAssetRegistry()
+	if err != nil {
+		return ColumnWorkspaceNamespaceInventory{}, err
+	}
+	inventory.PreparedAssets = cloneColumnPreparedAssets(registry.Assets)
+	referenced := make(map[ColumnAssetRef]struct{})
+	for _, part := range w.manifest.Parts {
+		referenced[part.AssetRef] = struct{}{}
+	}
+	for _, manifest := range manifests {
+		refs, err := ColumnCollectionManifestAssetRefs(manifest)
+		if err != nil {
+			return ColumnWorkspaceNamespaceInventory{}, err
+		}
+		for _, ref := range refs {
+			referenced[ref.Ref] = struct{}{}
+		}
+	}
+	inventory.ReferencedAssets = len(referenced)
+	for _, prepared := range registry.Assets {
+		if _, ok := referenced[prepared.Ref]; !ok {
+			inventory.OrphanPreparedAssets = append(inventory.OrphanPreparedAssets, prepared)
+		}
+	}
+	return inventory, nil
+}
+
 func (w *ColumnWorkspace) manifestPath() string {
 	if w == nil {
 		return ""
 	}
-	return filepath.Join(w.dir, columnWorkspaceManifestFile)
+	return filepath.Join(w.namespace.ManifestDir, columnWorkspaceManifestFile)
+}
+
+func (w *ColumnWorkspace) preparedRegistryPath() string {
+	if w == nil {
+		return ""
+	}
+	return filepath.Join(w.namespace.PreparedDir, columnWorkspacePreparedFile)
 }
 
 func (w *ColumnWorkspace) rebuildPartIndex() {
@@ -315,12 +615,23 @@ func (w *ColumnWorkspace) rebuildPartIndex() {
 
 func (w *ColumnWorkspace) validateManifestAssets() error {
 	for _, entry := range w.manifest.Parts {
-		image, record, err := LoadTCS1ColumnPartImage(w.assets, entry.AssetRef)
-		if err != nil {
-			return fmt.Errorf("colgranule: validate workspace part %d asset: %w", entry.PartID, err)
-		}
-		if err := validateColumnWorkspacePartImage(entry, record, image); err != nil {
-			return err
+		switch w.validationMode {
+		case ColumnWorkspaceValidateTCS1Header:
+			record, err := LoadTCS1ColumnPartHeader(w.assets, entry.AssetRef)
+			if err != nil {
+				return fmt.Errorf("colgranule: validate workspace part %d asset header: %w", entry.PartID, err)
+			}
+			if err := validateColumnWorkspacePartHeader(entry, record); err != nil {
+				return err
+			}
+		default:
+			image, record, err := LoadTCS1ColumnPartImage(w.assets, entry.AssetRef)
+			if err != nil {
+				return fmt.Errorf("colgranule: validate workspace part %d asset: %w", entry.PartID, err)
+			}
+			if err := validateColumnWorkspacePartImage(entry, record, image); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -390,6 +701,92 @@ func decodeColumnWorkspaceManifestEnvelope(data []byte) (columnWorkspaceManifest
 	return env, nil
 }
 
+func encodeColumnPreparedAssetRegistryEnvelope(registry ColumnPreparedAssetRegistry) ([]byte, error) {
+	if err := validateColumnPreparedAssetRegistry(registry); err != nil {
+		return nil, err
+	}
+	registryBytes, err := json.Marshal(registry)
+	if err != nil {
+		return nil, err
+	}
+	env := columnPreparedAssetRegistryEnvelope{
+		Magic:    columnWorkspacePreparedMagic,
+		Version:  columnWorkspacePreparedVersion,
+		Checksum: crc32.ChecksumIEEE(registryBytes),
+		Registry: registry,
+	}
+	return json.MarshalIndent(env, "", "  ")
+}
+
+func decodeColumnPreparedAssetRegistryEnvelope(data []byte) (ColumnPreparedAssetRegistry, error) {
+	var env columnPreparedAssetRegistryEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return ColumnPreparedAssetRegistry{}, err
+	}
+	if env.Magic != columnWorkspacePreparedMagic {
+		return ColumnPreparedAssetRegistry{}, fmt.Errorf("colgranule: invalid prepared registry magic %q", env.Magic)
+	}
+	if env.Version != columnWorkspacePreparedVersion {
+		return ColumnPreparedAssetRegistry{}, fmt.Errorf("colgranule: unsupported prepared registry version %d", env.Version)
+	}
+	registryBytes, err := json.Marshal(env.Registry)
+	if err != nil {
+		return ColumnPreparedAssetRegistry{}, err
+	}
+	if checksum := crc32.ChecksumIEEE(registryBytes); checksum != env.Checksum {
+		return ColumnPreparedAssetRegistry{}, fmt.Errorf("colgranule: prepared registry checksum=%08x want %08x", checksum, env.Checksum)
+	}
+	if err := validateColumnPreparedAssetRegistry(env.Registry); err != nil {
+		return ColumnPreparedAssetRegistry{}, err
+	}
+	return env.Registry, nil
+}
+
+func validateColumnPreparedAssetRegistry(registry ColumnPreparedAssetRegistry) error {
+	if registry.Magic != columnWorkspacePreparedMagic {
+		return fmt.Errorf("colgranule: invalid prepared registry magic %q", registry.Magic)
+	}
+	if registry.Version != columnWorkspacePreparedVersion {
+		return fmt.Errorf("colgranule: unsupported prepared registry version %d", registry.Version)
+	}
+	if len(registry.Assets) == 0 {
+		return nil
+	}
+	seen := make(map[ColumnAssetRef]struct{}, len(registry.Assets))
+	for _, asset := range registry.Assets {
+		if err := validateColumnAssetRef(asset.Ref); err != nil {
+			return fmt.Errorf("colgranule: invalid prepared asset ref: %w", err)
+		}
+		if asset.Bytes < 0 {
+			return fmt.Errorf("colgranule: negative prepared asset bytes %d", asset.Bytes)
+		}
+		if asset.Bytes == 0 && asset.Ref.Length > int64(^uint(0)>>1) {
+			return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
+		}
+		if _, ok := seen[asset.Ref]; ok {
+			return fmt.Errorf("colgranule: duplicate prepared asset ref %+v", asset.Ref)
+		}
+		seen[asset.Ref] = struct{}{}
+	}
+	return nil
+}
+
+func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAsset {
+	return append([]ColumnPreparedAsset(nil), assets...)
+}
+
+func columnWorkspaceSegmentFileID(name string) (uint32, bool) {
+	var fileID uint32
+	var suffix string
+	if _, err := fmt.Sscanf(name, "column-assets-%06d%s", &fileID, &suffix); err != nil {
+		return 0, false
+	}
+	if suffix != ".seg" || fileID == 0 {
+		return 0, false
+	}
+	return fileID, true
+}
+
 func validateColumnWorkspaceManifest(manifest ColumnWorkspaceManifest) error {
 	if manifest.Magic != columnWorkspaceManifestMagic {
 		return fmt.Errorf("colgranule: invalid workspace manifest magic %q", manifest.Magic)
@@ -420,6 +817,9 @@ func validateColumnWorkspacePartManifest(part ColumnWorkspacePartManifest) error
 	if part.SchemaVersion == 0 {
 		return fmt.Errorf("colgranule: workspace part %d missing schema version", part.PartID)
 	}
+	if err := validateColumnWorkspacePartCoverage(part); err != nil {
+		return err
+	}
 	if err := validateColumnAssetRef(part.AssetRef); err != nil {
 		return fmt.Errorf("colgranule: workspace part %d invalid asset ref: %w", part.PartID, err)
 	}
@@ -444,6 +844,43 @@ func validateColumnWorkspacePartManifest(part ColumnWorkspacePartManifest) error
 	return nil
 }
 
+func validateColumnWorkspacePartCoverage(part ColumnWorkspacePartManifest) error {
+	if len(part.Coverage.SortKeyColumns) == 0 && len(part.Coverage.SortKeyLower) == 0 && len(part.Coverage.SortKeyUpperExclusive) == 0 && part.Coverage.PrimaryIDLower == 0 && part.Coverage.PrimaryIDUpperExclusive == 0 {
+		return nil
+	}
+	if len(part.Coverage.SortKeyColumns) != len(part.SortKey) {
+		return fmt.Errorf("colgranule: workspace part %d coverage sort key columns=%d want %d", part.PartID, len(part.Coverage.SortKeyColumns), len(part.SortKey))
+	}
+	for i, sortKey := range part.SortKey {
+		if part.Coverage.SortKeyColumns[i] != sortKey.Column {
+			return fmt.Errorf("colgranule: workspace part %d coverage sort key column %d=%s want %s", part.PartID, i, part.Coverage.SortKeyColumns[i], sortKey.Column)
+		}
+	}
+	if len(part.Coverage.SortKeyLower) != 0 && len(part.Coverage.SortKeyLower) != len(part.SortKey) {
+		return fmt.Errorf("colgranule: workspace part %d coverage lower sort key width=%d want %d", part.PartID, len(part.Coverage.SortKeyLower), len(part.SortKey))
+	}
+	if len(part.Coverage.SortKeyUpperExclusive) != 0 && len(part.Coverage.SortKeyUpperExclusive) != len(part.SortKey) {
+		return fmt.Errorf("colgranule: workspace part %d coverage upper sort key width=%d want %d", part.PartID, len(part.Coverage.SortKeyUpperExclusive), len(part.SortKey))
+	}
+	return nil
+}
+
+func validateColumnWorkspacePartHeader(entry ColumnWorkspacePartManifest, record TCS1PartRecord) error {
+	if record.AssetRef != entry.AssetRef {
+		return fmt.Errorf("colgranule: workspace part %d header ref=%+v want %+v", entry.PartID, record.AssetRef, entry.AssetRef)
+	}
+	if record.Version != entry.TCS1.Version || record.Kind != entry.TCS1.Kind || record.Flags != entry.TCS1.Flags {
+		return fmt.Errorf("colgranule: workspace part %d header version/kind/flags=(%d,%d,%d) want (%d,%d,%d)", entry.PartID, record.Version, record.Kind, record.Flags, entry.TCS1.Version, entry.TCS1.Kind, entry.TCS1.Flags)
+	}
+	if record.PartID != entry.PartID || record.Rows != entry.Rows || record.ImageVersion != entry.TCS1.ImageVersion {
+		return fmt.Errorf("colgranule: workspace part %d header part/rows/image=(%d,%d,%d) want (%d,%d,%d)", entry.PartID, record.PartID, record.Rows, record.ImageVersion, entry.PartID, entry.Rows, entry.TCS1.ImageVersion)
+	}
+	if record.PayloadBytes != entry.ImageBytes || record.TotalBytes != entry.AssetBytes || record.PayloadCRC32 != entry.TCS1.PayloadCRC32 {
+		return fmt.Errorf("colgranule: workspace part %d header payload/total/crc=(%d,%d,%08x) want (%d,%d,%08x)", entry.PartID, record.PayloadBytes, record.TotalBytes, record.PayloadCRC32, entry.ImageBytes, entry.AssetBytes, entry.TCS1.PayloadCRC32)
+	}
+	return nil
+}
+
 func validateColumnWorkspaceLoadedPart(entry ColumnWorkspacePartManifest, record TCS1PartRecord, part *ColumnPart) error {
 	if part == nil {
 		return fmt.Errorf("colgranule: workspace part %d loaded nil part", entry.PartID)
@@ -461,6 +898,9 @@ func validateColumnWorkspaceLoadedPart(entry ColumnWorkspacePartManifest, record
 }
 
 func validateColumnWorkspacePartImage(entry ColumnWorkspacePartManifest, record TCS1PartRecord, image ColumnPartImage) error {
+	if err := validateColumnWorkspacePartHeader(entry, record); err != nil {
+		return err
+	}
 	if record.AssetRef != entry.AssetRef {
 		return fmt.Errorf("colgranule: workspace part %d asset record ref=%+v want %+v", entry.PartID, record.AssetRef, entry.AssetRef)
 	}
@@ -477,4 +917,46 @@ func validateColumnWorkspacePartImage(entry ColumnWorkspacePartManifest, record 
 		return fmt.Errorf("colgranule: workspace image shape mismatch manifest bytes/sections=(%d,%d) image=(%d,%d)", entry.ManifestBytes, entry.Sections, image.ManifestBytes, len(image.Sections))
 	}
 	return nil
+}
+
+func columnWorkspacePartCoverageFromPart(part *ColumnPart) (ColumnWorkspacePartCoverage, error) {
+	if part == nil {
+		return ColumnWorkspacePartCoverage{}, fmt.Errorf("colgranule: nil part coverage")
+	}
+	if len(part.Descriptor.Granules) == 0 {
+		return ColumnWorkspacePartCoverage{}, fmt.Errorf("colgranule: part %d has no granules for coverage", part.Descriptor.PartID)
+	}
+	if len(part.Marks) == 0 {
+		return ColumnWorkspacePartCoverage{}, fmt.Errorf("colgranule: part %d has no sort-key marks for coverage", part.Descriptor.PartID)
+	}
+	coverage := ColumnWorkspacePartCoverage{
+		PrimaryIDLower:          part.Descriptor.Granules[0].IDLower,
+		PrimaryIDUpperExclusive: part.Descriptor.Granules[0].IDUpperExclusive,
+	}
+	for _, granule := range part.Descriptor.Granules[1:] {
+		if granule.IDLower < coverage.PrimaryIDLower {
+			coverage.PrimaryIDLower = granule.IDLower
+		}
+		if granule.IDUpperExclusive > coverage.PrimaryIDUpperExclusive {
+			coverage.PrimaryIDUpperExclusive = granule.IDUpperExclusive
+		}
+	}
+	fullPrefix := len(part.Marks[0].Prefixes) - 1
+	if fullPrefix < 0 {
+		return ColumnWorkspacePartCoverage{}, fmt.Errorf("colgranule: part %d has empty sort-key mark prefix", part.Descriptor.PartID)
+	}
+	first := part.Marks[0].Prefixes[fullPrefix]
+	last := part.Marks[len(part.Marks)-1].Prefixes[fullPrefix]
+	coverage.SortKeyColumns = append([]string(nil), first.Columns...)
+	coverage.SortKeyLower = append([]int64(nil), first.Lower.Values...)
+	coverage.SortKeyUpperExclusive = append([]int64(nil), last.UpperExclusive.Values...)
+	coverage.SortKeyUpperUnbounded = last.UpperExclusive.Unbounded
+	return coverage, nil
+}
+
+func cloneColumnWorkspacePartCoverage(coverage ColumnWorkspacePartCoverage) ColumnWorkspacePartCoverage {
+	coverage.SortKeyColumns = append([]string(nil), coverage.SortKeyColumns...)
+	coverage.SortKeyLower = append([]int64(nil), coverage.SortKeyLower...)
+	coverage.SortKeyUpperExclusive = append([]int64(nil), coverage.SortKeyUpperExclusive...)
+	return coverage
 }

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -89,9 +89,129 @@ func TestColumnWorkspacePublishesReopensAndRunsJSONBenchQueries(t *testing.T) {
 	}
 }
 
+func TestColumnWorkspaceCreatesIsolatedNamespace(t *testing.T) {
+	dir := t.TempDir()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	namespace := workspace.Namespace()
+	if err := workspace.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	for _, path := range []string{
+		namespace.ManifestDir,
+		namespace.AssetDir,
+		namespace.SegmentDir,
+		namespace.IndexDir,
+		namespace.PreparedDir,
+		namespace.QuarantineDir,
+		namespace.TempDir,
+	} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%s): %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", path)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(namespace.ManifestDir, columnWorkspaceManifestFile)); err != nil {
+		t.Fatalf("workspace manifest in isolated manifest dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(namespace.SegmentDir, "column-assets-000001.seg")); err != nil {
+		t.Fatalf("asset segment in isolated segment dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, columnWorkspaceManifestFile)); !os.IsNotExist(err) {
+		t.Fatalf("root workspace manifest err=%v want not exist", err)
+	}
+}
+
+func TestColumnWorkspacePreparedRegistryAndInventory(t *testing.T) {
+	ds := syntheticJSONBenchDataset(64)
+	opts, err := JSONBenchColumnPartOptions(ds, 16)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	dir := t.TempDir()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	entry := publishJSONBenchPartRows(t, workspace, opts, ds, 401, 0, ds.Rows)
+	preparedRef, err := workspace.assets.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+8))
+	if err != nil {
+		t.Fatalf("put prepared asset: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          preparedRef,
+		PublishID:    9,
+		GenerationID: 10,
+		Reason:       "prepare publish",
+	}
+	if err := workspace.SavePreparedAssetRegistry(9, 10, []ColumnPreparedAsset{prepared}); err != nil {
+		t.Fatalf("SavePreparedAssetRegistry: %v", err)
+	}
+	inventory, err := workspace.InventoryNamespace()
+	if err != nil {
+		t.Fatalf("InventoryNamespace: %v", err)
+	}
+	if !inventory.PreparedRegistryPresent || len(inventory.PreparedAssets) != 1 || len(inventory.OrphanPreparedAssets) != 1 {
+		t.Fatalf("inventory prepared=%+v", inventory)
+	}
+	if inventory.OrphanPreparedAssets[0].Ref != preparedRef {
+		t.Fatalf("orphan prepared ref=%+v want %+v", inventory.OrphanPreparedAssets[0].Ref, preparedRef)
+	}
+	if len(inventory.SegmentFiles) != 1 || inventory.SegmentFiles[0].FileID != preparedRef.FileID || inventory.SegmentFiles[0].Bytes == 0 {
+		t.Fatalf("segment inventory=%+v", inventory.SegmentFiles)
+	}
+	manifest, err := NewColumnCollectionManifest("jsonbench", opts, []ColumnManifestPartRef{
+		NewColumnManifestPartRef(ColumnPartRoleBase, 1, entry),
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewColumnCollectionManifest: %v", err)
+	}
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest: &manifest,
+		PreparedAssets: []ColumnPreparedAsset{prepared},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.PreparedBytes != int(preparedRef.Length) || plan.ReclaimableBytes != 0 {
+		t.Fatalf("prepared reachability=%+v want protected prepared bytes=%d", plan, preparedRef.Length)
+	}
+	if err := workspace.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("reopen workspace: %v", err)
+	}
+	defer reopened.Close()
+	registry, err := reopened.LoadPreparedAssetRegistry()
+	if err != nil {
+		t.Fatalf("LoadPreparedAssetRegistry: %v", err)
+	}
+	if registry.PublishID != 9 || registry.GenerationID != 10 || len(registry.Assets) != 1 || registry.Assets[0].Ref != preparedRef {
+		t.Fatalf("bad prepared registry=%+v", registry)
+	}
+	if err := reopened.ClearPreparedAssetRegistry(); err != nil {
+		t.Fatalf("ClearPreparedAssetRegistry: %v", err)
+	}
+	cleared, err := reopened.InventoryNamespace()
+	if err != nil {
+		t.Fatalf("InventoryNamespace after clear: %v", err)
+	}
+	if cleared.PreparedRegistryPresent || len(cleared.PreparedAssets) != 0 {
+		t.Fatalf("cleared inventory=%+v want no prepared registry", cleared)
+	}
+}
+
 func TestColumnWorkspaceRejectsUnknownManifestVersion(t *testing.T) {
 	dir, _ := testColumnWorkspaceWithPart(t)
-	path := filepath.Join(dir, columnWorkspaceManifestFile)
+	path := filepath.Join(ColumnWorkspaceNamespaceForDir(dir).ManifestDir, columnWorkspaceManifestFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
@@ -115,7 +235,7 @@ func TestColumnWorkspaceRejectsUnknownManifestVersion(t *testing.T) {
 
 func TestColumnWorkspaceRejectsManifestChecksumMismatch(t *testing.T) {
 	dir, _ := testColumnWorkspaceWithPart(t)
-	path := filepath.Join(dir, columnWorkspaceManifestFile)
+	path := filepath.Join(ColumnWorkspaceNamespaceForDir(dir).ManifestDir, columnWorkspaceManifestFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
@@ -139,7 +259,7 @@ func TestColumnWorkspaceRejectsManifestChecksumMismatch(t *testing.T) {
 
 func TestColumnWorkspaceRejectsCorruptTCS1AssetOnReopen(t *testing.T) {
 	dir, entry := testColumnWorkspaceWithPart(t)
-	path := filepath.Join(dir, "assets", "column-assets-000001.seg")
+	path := filepath.Join(ColumnWorkspaceNamespaceForDir(dir).SegmentDir, "column-assets-000001.seg")
 	file, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
@@ -153,6 +273,58 @@ func TestColumnWorkspaceRejectsCorruptTCS1AssetOnReopen(t *testing.T) {
 	}
 	if _, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"}); err == nil || !strings.Contains(err.Error(), "validate workspace part") {
 		t.Fatalf("OpenColumnWorkspace err=%v want corrupt asset validation", err)
+	}
+}
+
+func TestColumnWorkspaceCanValidateTCS1HeaderWithoutPayload(t *testing.T) {
+	dir, entry := testColumnWorkspaceWithPart(t)
+	path := filepath.Join(ColumnWorkspaceNamespaceForDir(dir).SegmentDir, "column-assets-000001.seg")
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := file.WriteAt([]byte{0}, entry.AssetRef.Offset+tcs1PayloadOffset+1); err != nil {
+		_ = file.Close()
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close corrupt file: %v", err)
+	}
+	reopened, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench", ValidationMode: ColumnWorkspaceValidateTCS1Header})
+	if err != nil {
+		t.Fatalf("metadata-only reopen should not read full payload: %v", err)
+	}
+	defer reopened.Close()
+	if _, err := reopened.LoadPart(entry.PartID); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("LoadPart err=%v want payload checksum failure", err)
+	}
+}
+
+func BenchmarkColumnWorkspaceReopenValidationModes(b *testing.B) {
+	dir, parts, assetBytes := benchmarkColumnWorkspaceDir(b, 128, 64)
+	modes := []struct {
+		name string
+		mode ColumnWorkspaceValidationMode
+	}{
+		{"full_image", ColumnWorkspaceValidateFullImage},
+		{"tcs1_header", ColumnWorkspaceValidateTCS1Header},
+	}
+	for _, mode := range modes {
+		b.Run(mode.name, func(b *testing.B) {
+			b.ReportMetric(float64(parts), "parts")
+			b.ReportMetric(float64(assetBytes), "asset_bytes")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench", ValidationMode: mode.mode})
+				if err != nil {
+					b.Fatalf("OpenColumnWorkspace: %v", err)
+				}
+				if err := workspace.Close(); err != nil {
+					b.Fatalf("Close: %v", err)
+				}
+			}
+		})
 	}
 }
 
@@ -176,4 +348,27 @@ func testColumnWorkspaceWithPart(t *testing.T) (string, ColumnWorkspacePartManif
 		t.Fatalf("Close: %v", err)
 	}
 	return dir, entry
+}
+
+func benchmarkColumnWorkspaceDir(b *testing.B, parts int, rowsPerPart int) (string, int, int) {
+	b.Helper()
+	ds := syntheticJSONBenchDataset(parts * rowsPerPart)
+	opts, err := JSONBenchColumnPartOptions(ds, rowsPerPart)
+	if err != nil {
+		b.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	dir := b.TempDir()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		b.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	assetBytes := 0
+	for part := 0; part < parts; part++ {
+		entry := publishJSONBenchPartRows(b, workspace, opts, ds, uint64(10_000+part), part*rowsPerPart, (part+1)*rowsPerPart)
+		assetBytes += entry.AssetBytes
+	}
+	if err := workspace.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+	return dir, parts, assetBytes
 }


### PR DESCRIPTION
## Objective

Add M6 as a chained PR on top of #1586. This keeps the M3 disk workspace, M4 collection manifest/multipart reader, and M5 delta/compaction path as the parent stack, then adds the M6 at-rest and lifecycle bridge for column-owned declared fields.

Stack:

- Parent: #1586 (`codex/colgranule-m3-disk-workspace`)
- This PR: M6 column asset-manager lifecycle shape
- Latest head: `cfde40e27` (`experiments/colgranule: optimize M6 control-plane planning`)

## Scope

This PR is intentionally experiment-only under `experiments/colgranule`:

- No production TreeDB root publication yet.
- No production command-WAL integration yet.
- No durable-at-ack collection JSON path changes yet.
- No production GC/rewrite execution changes yet.

The storage model is the split-document shape validated by JSONBench parity tests: declared column fields are stored in column assets, while the retained row payload stores the non-column remainder. Full-document reads reconstruct from retained row payload plus declared column values at one consistent generation. This avoids making the column lane a physically redundant full-document copy while still making column assets durable TreeDB-owned state once published.

## Design Summary

M6 adds the column asset/lifecycle machinery needed before durable integration:

- `ColumnAssetRef` and `ColumnAssetManager` make column data asset references typed and value-pointer-like, with segment/index/kind identity, byte ranges, checksums, row counts, and lifecycle state.
- Column workspace assets now live in isolated namespaces: manifests, assets/segments, assets/indexes, prepared publish state, quarantine, and tmp.
- TCS1 part assets support a persisted full-image asset with header validation and range-read friendly metadata.
- Prepared asset registry and namespace inventory APIs record publish-pending assets so future GC/rewrite planning can distinguish active, pending, reclaimable, zombie, and orphaned state.
- Collection manifest part coverage descriptors carry source row/root generation metadata so future publish and GC work can reason about which row root a column generation covers.
- Reachability planning is manifest/ref based. It scales with manifests, snapshots, pending publishes, and asset refs rather than scanning rows or decoding payloads.
- Ref-delta planning reports only changed asset refs across manifest generations, which is the accounting seam future publish/GC code needs.
- Compaction policy planning separates base/delta/tombstone state from the actual rewrite, with deterministic candidate reporting and metrics.
- Adaptive mark sizing estimates rows-per-mark from row width and target mark byte ranges so wide-row parts do not inherit a fixed row-count granule by accident.
- JSONBench split-document tests verify declared column fields can be removed from retained row JSON and reconstructed with parity.

## Correctness Coverage

Validated on the stacked branch with:

```sh
GOWORK=off go test ./experiments/colgranule/... -count=1
```

Result:

```text
ok  github.com/snissn/gomap/experiments/colgranule                         1.095s
?   github.com/snissn/gomap/experiments/colgranule/cmd/jsonbench_colgranule [no test files]
ok  github.com/snissn/gomap/experiments/colgranule/cmd/jsonbench_compare    1.059s
```

Also checked:

```sh
git diff --check
```

M6-specific coverage includes asset manager lifecycle transitions, corrupt/header-only asset reopen validation, prepared asset registry persistence, namespace inventory, coverage descriptor metadata, reachability/ref-delta planning, compaction-policy reporting, adaptive mark sizing, and split-document JSONBench reconstruction parity.

## Performance Gates

Artifacts from the follow-up local optimization run are under:

```text
/tmp/gomap_m6_opt_followup_GbbHg9/
```

Final M6 benchmark command:

```sh
GOWORK=off go test ./experiments/colgranule \
  -run '^$' \
  -bench 'BenchmarkColumnAssetReachability10K|BenchmarkColumnAssetRefDelta128|BenchmarkColumnAssetManagerReclamation10K|BenchmarkColumnWorkspaceReopenValidationModes|BenchmarkColumnPartSetCompactionPlan10K|BenchmarkAdaptiveMarkSizingWideRows|BenchmarkColumnCollectionManifestDecode10K' \
  -benchmem -benchtime=1x -count=5
```

M6 median/representative results:

| Benchmark | Result | Allocation profile | Notes |
|---|---:|---:|---|
| `BenchmarkAdaptiveMarkSizingWideRows` | ~125 ns/op | 0 B/op, 0 allocs/op | Pure sizing math; safe to use during part build planning. |
| `BenchmarkColumnAssetReachability10K` | ~9.18 ms/op | ~8.04 MiB/op, 71 allocs/op | Manifest/ref graph planning over 10K refs; scales with refs, not rows. |
| `BenchmarkColumnAssetRefDelta128` | ~11.8 us/op | 12,456 B/op, 4 allocs/op | Changed-ref-only accounting across manifest generations. |
| `BenchmarkColumnAssetManagerReclamation10K` | ~0.84 ms/op | 2.4 MB/op, 1 alloc/op | Reclamation candidate planning over 10K assets. |
| `BenchmarkColumnPartSetCompactionPlan10K` | ~0.99 ms/op | 240 B/op, 4 allocs/op | Compaction policy planning over 10K parts/entries. |
| `BenchmarkColumnWorkspaceReopenValidationModes/full_image` | ~43 ms/op | ~143.6 MB/op, ~3.6K allocs/op | Full image validation path. |
| `BenchmarkColumnWorkspaceReopenValidationModes/tcs1_header` | ~1.45 ms/op | ~702 KB/op, ~1.5K allocs/op | Header validation path for fast reopen. |
| `BenchmarkColumnCollectionManifestDecode10K` | ~145 ms/op | ~38.76 MiB/op, ~110K allocs/op | Control-plane manifest decode over 10K part refs. |

Existing query and compaction gates were also smoke-tested after M6:

```sh
GOWORK=off go test ./experiments/colgranule \
  -run '^$' \
  -bench 'BenchmarkJSONBenchEncodedPartQueries|BenchmarkJSONBenchColumnPartSetQueriesM4|BenchmarkJSONBenchColumnPartSetAggregateMetadataM4|BenchmarkColumnPartSetCompactionM5$|BenchmarkColumnCollectionManifestDecode10K' \
  -benchmem -benchtime=1x -count=1
```

Representative hot-path results:

| Gate | Result | Allocation profile |
|---|---:|---:|
| Encoded q1 | 2.04 ms/op | 2,568 B/op, 7 allocs/op |
| Encoded q2 | 3.51 ms/op | 2,616 B/op, 7 allocs/op |
| Encoded q3 | 4.26 ms/op | 2,616 B/op, 7 allocs/op |
| Encoded q4 | 28.6 us/op | 288 B/op, 4 allocs/op |
| Encoded q5 | 5.80 ms/op | 2,632 B/op, 7 allocs/op |
| M4 part-set q1 | 1.24 ms/op | 208 B/op, 3 allocs/op |
| M4 part-set q2 | 3.47 ms/op | 256 B/op, 3 allocs/op |
| M4 part-set q3 | 4.78 ms/op | 256 B/op, 3 allocs/op |
| M4 part-set q4 | 70.6 us/op | 480 B/op, 8 allocs/op |
| M4 part-set q5 | 6.56 ms/op | 272 B/op, 3 allocs/op |
| q4b aggregate metadata | 345 us/op | 352 B/op, 4 allocs/op |
| q5 aggregate metadata | 675 us/op | 288 B/op, 4 allocs/op |
| M5 compaction | 320.1 ms/op | 221.5 MB/op, 3,860 allocs/op |

Benchstat for the follow-up optimization against the initial M6 control-plane run:

- Manifest decode memory improved from `71.05 MiB/op` to `38.76 MiB/op` (`-45.44%`, `p=0.008`); runtime remains noisy/same at roughly `146.8 ms/op` to `145.1 ms/op`.
- Reachability over 10K refs improved from `9.601 MiB/op` to `8.041 MiB/op` (`-16.26%`) and from `40,216` to `71` allocs/op (`-99.82%`); runtime is same/slightly lower.
- Compaction-plan allocation dropped from `295,792 B/op` to `240 B/op` and from `37` to `4` allocs/op, with runtime unchanged around `0.98 ms/op`.
- Ref-delta over 128 changed refs improved from `13.67 us/op` to `11.79 us/op`; allocations are unchanged.
- Reopen header/full-image validation and existing q1-q5/M4/M5 smoke gates stayed in the same regime; hot query allocations are unchanged.

Manifest decode allocation count is still the residual watch item: JSON decode still materializes the 10K part descriptors/slices. A custom compact/binary descriptor decode would be a separate larger design, not a quick follow-up.

## Checklist

- [x] M6 typed column asset refs and manager added.
- [x] M6 isolated column workspace folders added.
- [x] M6 prepared publish registry and inventory added.
- [x] M6 manifest coverage/source-row metadata added.
- [x] M6 reachability/ref-delta planning added.
- [x] M6 adaptive mark sizing made explicit.
- [x] M6 JSONBench split-document parity added.
- [x] Focused package tests pass on the stacked branch.
- [x] Query/metadata/compaction perf gates smoke-tested.
