### PR TITLE
[codex] Push command WAL batch writes past parity

### DIFF
--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -104,6 +104,43 @@ jobs:
           ci_list() {
             sed -e 's/\r$//' -e '/^#/d' -e '/^$/d' "$1"
           }
+          run_named_test_file() {
+            pkg="$1"
+            label="$2"
+            tests_file="$3"
+            output_file="$4"
+            max_regex_chars=6000
+            chunk=""
+            chunk_count=0
+            chunk_index=0
+            while IFS= read -r test_name || [ -n "$test_name" ]; do
+              if [ -z "$test_name" ]; then
+                continue
+              fi
+              if [ -n "$chunk" ]; then
+                candidate="${chunk}|${test_name}"
+              else
+                candidate="$test_name"
+              fi
+              if [ -n "$chunk" ] && [ "${#candidate}" -gt "$max_regex_chars" ]; then
+                chunk_index=$((chunk_index + 1))
+                regex="^(${chunk})$"
+                echo "${label} chunk=${chunk_index} tests=${chunk_count} regex_len=${#regex}"
+                go test -json -timeout 30m -p 1 "$pkg" -run "$regex" | tee -a "$output_file"
+                chunk="$test_name"
+                chunk_count=1
+              else
+                chunk="$candidate"
+                chunk_count=$((chunk_count + 1))
+              fi
+            done < "$tests_file"
+            if [ -n "$chunk" ]; then
+              chunk_index=$((chunk_index + 1))
+              regex="^(${chunk})$"
+              echo "${label} chunk=${chunk_index} tests=${chunk_count} regex_len=${#regex}"
+              go test -json -timeout 30m -p 1 "$pkg" -run "$regex" | tee -a "$output_file"
+            fi
+          }
           trap cleanup EXIT
           case "${{ matrix.shard_kind }}" in
             all)
@@ -156,15 +193,11 @@ jobs:
                 ran_tests=true
               fi
               if [ -s "$root_test_file" ]; then
-                root_regex="^($(paste -sd'|' "$root_test_file"))$"
-                echo "TreeDB root test shard=${package_shard_index}/${package_shard_count} regex=${root_regex}"
-                go test -json -timeout 30m -p 1 . -run "$root_regex" | tee -a treedb-test.jsonl
+                run_named_test_file . "TreeDB root test shard=${package_shard_index}/${package_shard_count}" "$root_test_file" treedb-test.jsonl
                 ran_tests=true
               fi
               if [ -s "$db_test_file" ]; then
-                db_regex="^($(paste -sd'|' "$db_test_file"))$"
-                echo "TreeDB/db test shard=${package_shard_index}/${package_shard_count} regex=${db_regex}"
-                go test -json -timeout 30m -p 1 ./db -run "$db_regex" | tee -a treedb-test.jsonl
+                run_named_test_file ./db "TreeDB/db test shard=${package_shard_index}/${package_shard_count}" "$db_test_file" treedb-test.jsonl
                 ran_tests=true
               fi
               if [ "$ran_tests" = false ]; then

--- a/TreeDB/caching/command_wal_checkpoint_publish_test.go
+++ b/TreeDB/caching/command_wal_checkpoint_publish_test.go
@@ -33,8 +33,8 @@ func TestCanPiggybackCommandWALCheckpointPublishSingleLaneCombinedQueue(t *testi
 
 	db.queueLaneIDs = []uint16{0, 0}
 	db.flushBackendMaxEntries = 1
-	if db.canPiggybackCommandWALCheckpointPublish(true) {
-		t.Fatal("expected chunked checkpoint queue to skip command WAL publish piggyback")
+	if !db.canPiggybackCommandWALCheckpointPublish(true) {
+		t.Fatal("expected chunked checkpoint queue to piggyback command WAL publish on the final sync batch")
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12214,6 +12214,7 @@ func (db *DB) flushWALRequests(l *lane, requests []walWriteRequest) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	beforeSize := w.Size()
 	for i := range requests {
 		req := &requests[i]
 		if len(req.records) == 1 {
@@ -12223,14 +12224,12 @@ func (db *DB) flushWALRequests(l *lane, requests []walWriteRequest) error {
 				l.walMu.Unlock()
 				return err
 			}
-			totalBytes += db.logRecordSize(rec.Key, rec.Value)
 		} else {
 			err := w.AppendBatch(req.records)
 			if err != nil {
 				l.walMu.Unlock()
 				return err
 			}
-			totalBytes += db.logBatchSize(req.records)
 		}
 		if req.sync {
 			needSync = true
@@ -12242,6 +12241,7 @@ func (db *DB) flushWALRequests(l *lane, requests []walWriteRequest) error {
 			return err
 		}
 	}
+	totalBytes = w.Size() - beforeSize
 	l.walMu.Unlock()
 
 	if totalBytes > 0 {
@@ -13048,7 +13048,10 @@ func (db *DB) appendWAL(l *lane, records []logRecord, durability journalDurabili
 	}
 
 	db.assignCommitSeq(records)
+	return db.appendWALPrepared(l, records, durability)
+}
 
+func (db *DB) appendWALPrepared(l *lane, records []logRecord, durability journalDurability) error {
 	switch durability {
 	case journalDurabilitySync:
 		return db.appendWALDirect(l, records, true)
@@ -13057,6 +13060,32 @@ func (db *DB) appendWAL(l *lane, records []logRecord, durability journalDurabili
 	default:
 		return db.appendWALInline(l, records, false)
 	}
+}
+
+func (db *DB) appendWALAssigned(l *lane, records []logRecord, durability journalDurability) error {
+	if db.disableJournal {
+		return nil
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	if l == nil {
+		return errWALUnavailable
+	}
+	select {
+	case <-db.closeCh:
+		return errWALClosed
+	default:
+	}
+	db.walAckMu.Lock()
+	if db.walErr != nil {
+		err := db.walErr
+		db.walAckMu.Unlock()
+		return err
+	}
+	db.walAckMu.Unlock()
+
+	return db.appendWALPrepared(l, records, durability)
 }
 
 func (db *DB) appendWALOne(l *lane, record logRecord, durability journalDurability) error {
@@ -14557,16 +14586,18 @@ func (db *DB) appendWALInline(l *lane, records []logRecord, flush bool) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	beforeSize := w.Size()
 	if len(records) == 1 {
 		rec := records[0]
 		err = w.Append(rec)
-		totalBytes = db.logRecordSize(rec.Key, rec.Value)
 	} else {
 		err = w.AppendBatch(records)
-		totalBytes = db.logBatchSize(records)
 	}
 	if err == nil && flush {
 		err = w.Flush()
+	}
+	if err == nil {
+		totalBytes = w.Size() - beforeSize
 	}
 	l.walMu.Unlock()
 
@@ -14596,10 +14627,14 @@ func (db *DB) appendWALInlineOne(l *lane, record logRecord, flush bool) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	beforeSize := w.Size()
 	err := w.Append(record)
-	totalBytes := db.logRecordSize(record.Key, record.Value)
 	if err == nil && flush {
 		err = w.Flush()
+	}
+	totalBytes := int64(0)
+	if err == nil {
+		totalBytes = w.Size() - beforeSize
 	}
 	l.walMu.Unlock()
 
@@ -19411,6 +19446,15 @@ func (db *DB) Checkpoint() error {
 	hasMutable := db.mutableBytes.Load() > 0
 	hasQueue := len(db.queue) > 0
 	hasDirtyVLog := db.hasDirtyValueLogLanes()
+	hasLiveWAL := false
+	if !db.disableJournal {
+		for i := range db.lanes {
+			if db.lanes[i].walLiveBytes.Load() > 0 {
+				hasLiveWAL = true
+				break
+			}
+		}
+	}
 	if hasMutable {
 		if err := db.rotateMutableShardsLocked(db.checkpointRotateCapacity(), false); err != nil {
 			db.mu.Unlock()
@@ -19418,6 +19462,17 @@ func (db *DB) Checkpoint() error {
 			return err
 		}
 		hasQueue = len(db.queue) > 0
+		hasLiveWAL = hasLiveWAL || !db.disableJournal
+	} else if !hasQueue && !hasDirtyVLog && !hasLiveWAL && db.commandWALCheckpointPublish == nil {
+		db.mu.Unlock()
+		releaseWriteMu()
+		db.checkpointNoopSkips.Add(1)
+		if err := db.maybeVacuumSparseIndexOnCheckpoint(); err != nil {
+			return err
+		}
+		db.checkValueLogRetention()
+		db.scheduleRetainedValueLogPrune()
+		return nil
 	} else if db.disableJournal && !hasQueue && !hasDirtyVLog {
 		// Checkpoint-kick retries may need to rotate current value-log segments
 		// even when there is no new foreground dirtiness, so observed-source GC
@@ -21850,7 +21905,7 @@ func (db *DB) rotateWALLockedWithOptions(l *lane, rotateValueLog bool) error {
 	if l.wal != nil {
 		oldPath := l.walPath
 		oldSize := l.wal.Size()
-		if err := l.wal.RotateTo(path); err != nil {
+		if err := l.wal.RotateToWithSync(path, !db.relaxedSync); err != nil {
 			return err
 		}
 		l.walSeq = nextSeq
@@ -28790,7 +28845,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		if durability == journalDurabilitySync {
 			defer b.db.releaseLaneSync(lane)
 		}
-		if !b.db.disableJournal {
+		if !b.db.disableJournal && allowPointers {
 			rids = make([]uint64, len(b.entries))
 		}
 	}
@@ -29002,21 +29057,22 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		if cap(records) < len(b.entries) {
 			records = make([]logRecord, 0, len(b.entries))
 		}
+		seq := b.db.nextCommitSeq.Add(1)
 		for i := range b.entries {
 			op := &b.entries[i]
 			switch op.Type {
 			case batch.OpDelete:
-				records = append(records, logRecord{Op: logOpDelete, Key: op.Key})
+				records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq})
 			case batch.OpPut:
 				if rids != nil && rids[i] != 0 {
-					records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i]})
+					records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i], Seq: seq})
 				} else {
-					records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value})
+					records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value, Seq: seq})
 				}
 			}
 		}
 		b.walBuf = records
-		if err := b.db.appendWAL(lane, records, durability); err != nil {
+		if err := b.db.appendWALAssigned(lane, records, durability); err != nil {
 			b.db.writeMu.RUnlock()
 			return err
 		}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10776,6 +10776,19 @@ func (db *DB) assignCommitSeq(records []logRecord) {
 	}
 }
 
+func allZeroBytes(p []byte) bool {
+	for _, b := range p {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func sameNonEmptyBytesData(a, b []byte) bool {
+	return len(a) > 0 && len(a) == len(b) && &a[0] == &b[0]
+}
+
 type domainIngressOp uint8
 
 const (
@@ -13086,6 +13099,80 @@ func (db *DB) appendWALAssigned(l *lane, records []logRecord, durability journal
 	db.walAckMu.Unlock()
 
 	return db.appendWALPrepared(l, records, durability)
+}
+
+type zeroInlineBatchCommitWriter interface {
+	AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error
+}
+
+func (db *DB) appendWALZeroInlineEntries(l *lane, entries []batch.Entry, seq uint64, valueLen int, durability journalDurability) (bool, error) {
+	if db.disableJournal {
+		return true, nil
+	}
+	if len(entries) == 0 {
+		return true, nil
+	}
+	if l == nil {
+		return true, errWALUnavailable
+	}
+	select {
+	case <-db.closeCh:
+		return true, errWALClosed
+	default:
+	}
+	db.walAckMu.Lock()
+	if db.walErr != nil {
+		err := db.walErr
+		db.walAckMu.Unlock()
+		return true, err
+	}
+	db.walAckMu.Unlock()
+
+	var (
+		totalBytes int64
+		err        error
+	)
+	l.walMu.Lock()
+	w := l.wal
+	if w == nil {
+		l.walMu.Unlock()
+		return true, errWALUnavailable
+	}
+	beforeSize := w.Size()
+	zw, ok := w.(zeroInlineBatchCommitWriter)
+	if !ok {
+		l.walMu.Unlock()
+		return false, nil
+	}
+	err = zw.AppendZeroInlineBatchFunc(len(entries), seq, valueLen, func(i int) []byte {
+		return entries[i].Key
+	})
+	if err == nil {
+		switch durability {
+		case journalDurabilitySync:
+			err = w.Sync()
+		case journalDurabilityFlush:
+			err = w.Flush()
+		}
+	}
+	if err == nil {
+		totalBytes = w.Size() - beforeSize
+	}
+	l.walMu.Unlock()
+
+	if err != nil {
+		db.walAckMu.Lock()
+		if db.walErr == nil {
+			db.walErr = err
+		}
+		db.walAckMu.Unlock()
+		return true, err
+	}
+
+	if totalBytes > 0 {
+		l.walLiveBytes.Add(totalBytes)
+	}
+	return true, nil
 }
 
 func (db *DB) appendWALOne(l *lane, record logRecord, durability journalDurability) error {
@@ -19658,7 +19745,7 @@ func (db *DB) Checkpoint() error {
 		db.mu.Unlock()
 		db.forgetValueLogRetain(path)
 	}
-	if removed {
+	if removed && !db.relaxedSync {
 		db.syncDirBestEffort(db.dir)
 	}
 	if err := db.maybeVacuumSparseIndexOnCheckpoint(); err != nil {
@@ -19750,11 +19837,10 @@ func (db *DB) canPiggybackCommandWALCheckpointPublish(sync bool) bool {
 	if len(units) != queueLen || totalLen <= 0 {
 		return false
 	}
-	// Only piggyback when the whole checkpoint queue will publish in one backend
-	// commit. Chunking would publish AppliedCommandLSN before later queued roots.
-	if totalLen > db.flushBackendEntriesCap(totalLen, sync) {
-		return false
-	}
+	// Chunked checkpoint flushes attach command-LSN publication to the final
+	// backend batch. Intermediate chunks publish roots without advancing
+	// AppliedCommandLSN, so crash recovery either replays the command frames or
+	// observes the final root/applied-LSN tuple together.
 	return true
 }
 
@@ -23002,6 +23088,7 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 	// to reduce peak allocator demand (and thus index.db high-watermark growth)
 	// under small KeepRecent windows.
 	chunkBackend := totalLen > backendEntriesCap
+	emittedChunk := false
 
 	// backendBatch := db.backend.NewBatch() // Original line, now replaced
 	if db.deferredValueLogEnabled() {
@@ -23037,6 +23124,7 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 				return nil
 			}
 
+			emittedChunk = true
 			db.backendWriteBatchesTotal.Add(1)
 			// If sync==true, we only need a single durability boundary at the end of
 			// the flush. Write the intermediate chunks without fsync to avoid
@@ -23199,6 +23287,31 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 		} else {
 			err = backendBatch.Write()
 		}
+		cerr := backendBatch.Close()
+		if err == nil {
+			err = cerr
+		}
+		if err != nil {
+			db.reportError(err)
+			return false
+		}
+		if commandPublishAttached {
+			commandPublish.consumed = true
+			db.commandWALCheckpointPublishPiggybacked.Add(1)
+		}
+	} else if sync && emittedChunk {
+		var attachErr error
+		commandPublishAttached, attachErr = commandPublish.attach(backendBatch)
+		if attachErr != nil {
+			db.reportError(attachErr)
+			_ = backendBatch.Close()
+			return false
+		}
+		// If the sequential path landed exactly on a chunk boundary, this empty
+		// final batch provides the single sync boundary for the prior chunks and
+		// can carry the command-WAL AppliedCommandLSN publication.
+		db.backendWriteBatchesTotal.Add(1)
+		err = backendBatch.WriteSync()
 		cerr := backendBatch.Close()
 		if err == nil {
 			err = cerr
@@ -28704,10 +28817,33 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	}
 	b.shardIdxs = shardIdxs
 	allDeletes := true
+	zeroInlineWALBatch := !b.db.disableJournal
+	zeroInlineValueLen := -1
+	var zeroInlineValueRef []byte
 	for i := range b.entries {
 		op := &b.entries[i]
 		if op.Type != batch.OpDelete {
 			allDeletes = false
+		}
+		if zeroInlineWALBatch {
+			if op.Type != batch.OpPut || op.IsPtr || len(op.Value) == 0 {
+				zeroInlineWALBatch = false
+			} else {
+				if zeroInlineValueLen < 0 {
+					zeroInlineValueLen = len(op.Value)
+				} else if zeroInlineValueLen != len(op.Value) {
+					zeroInlineWALBatch = false
+				}
+				if zeroInlineWALBatch {
+					if sameNonEmptyBytesData(op.Value, zeroInlineValueRef) {
+						// Same immutable value buffer as the first zero value in this batch.
+					} else if allZeroBytes(op.Value) {
+						zeroInlineValueRef = op.Value
+					} else {
+						zeroInlineWALBatch = false
+					}
+				}
+			}
 		}
 		idx := b.db.shardIndex(op.Key)
 		shardIdxs[i] = idx
@@ -29053,28 +29189,42 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	}
 
 	if !b.db.disableJournal {
-		records := b.walBuf[:0]
-		if cap(records) < len(b.entries) {
-			records = make([]logRecord, 0, len(b.entries))
-		}
 		seq := b.db.nextCommitSeq.Add(1)
-		for i := range b.entries {
-			op := &b.entries[i]
-			switch op.Type {
-			case batch.OpDelete:
-				records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq})
-			case batch.OpPut:
-				if rids != nil && rids[i] != 0 {
-					records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i], Seq: seq})
-				} else {
-					records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value, Seq: seq})
-				}
+		handledZeroInline := false
+		if zeroInlineWALBatch && rids == nil && zeroInlineValueLen > 0 {
+			var err error
+			handledZeroInline, err = b.db.appendWALZeroInlineEntries(lane, b.entries, seq, zeroInlineValueLen, durability)
+			if err != nil {
+				b.db.writeMu.RUnlock()
+				return err
+			}
+			if handledZeroInline {
+				b.walBuf = b.walBuf[:0]
 			}
 		}
-		b.walBuf = records
-		if err := b.db.appendWALAssigned(lane, records, durability); err != nil {
-			b.db.writeMu.RUnlock()
-			return err
+		if !handledZeroInline {
+			records := b.walBuf[:0]
+			if cap(records) < len(b.entries) {
+				records = make([]logRecord, 0, len(b.entries))
+			}
+			for i := range b.entries {
+				op := &b.entries[i]
+				switch op.Type {
+				case batch.OpDelete:
+					records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq})
+				case batch.OpPut:
+					if rids != nil && rids[i] != 0 {
+						records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i], Seq: seq})
+					} else {
+						records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value, Seq: seq})
+					}
+				}
+			}
+			b.walBuf = records
+			if err := b.db.appendWALAssigned(lane, records, durability); err != nil {
+				b.db.writeMu.RUnlock()
+				return err
+			}
 		}
 	}
 

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -26,7 +26,10 @@ func (w *countingLogWriter) AppendBatch(records []commitlog.Record) error {
 }
 
 func (w *countingLogWriter) RotateTo(_ string) error { return nil }
-func (w *countingLogWriter) Size() int64             { return 0 }
+func (w *countingLogWriter) RotateToWithSync(_ string, _ bool) error {
+	return nil
+}
+func (w *countingLogWriter) Size() int64 { return 0 }
 func (w *countingLogWriter) Flush() error {
 	w.flushCalls++
 	return nil

--- a/TreeDB/caching/log_writer.go
+++ b/TreeDB/caching/log_writer.go
@@ -19,6 +19,7 @@ type commitWriter interface {
 	Append(record commitlog.Record) error
 	AppendBatch(records []commitlog.Record) error
 	RotateTo(path string) error
+	RotateToWithSync(path string, syncCurrent bool) error
 	Size() int64
 	Flush() error
 	Sync() error

--- a/TreeDB/caching/unified_wal_comprehensive_test.go
+++ b/TreeDB/caching/unified_wal_comprehensive_test.go
@@ -145,6 +145,52 @@ func TestUnifiedWAL_CrashRecoveryMissingPayloadSkipped(t *testing.T) {
 	}
 }
 
+func TestUnifiedWAL_CrashRecoveryCompactZeroInlineBatch(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	commitPath := filepath.Join(walDir, "commit-l0-000001.log")
+	writer, err := commitlog.NewWriter(commitPath)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	want := make([]byte, 64)
+	records := []commitlog.Record{
+		{Op: commitlog.OpSetInline, Key: []byte("zero-a"), Value: want, Seq: 1},
+		{Op: commitlog.OpSetInline, Key: []byte("zero-b"), Value: want, Seq: 1},
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("commitlog.AppendBatch: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		_ = writer.Close()
+		t.Fatalf("commitlog.Sync: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("commitlog.Close: %v", err)
+	}
+
+	opened, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer opened.Close()
+
+	for _, key := range [][]byte{[]byte("zero-a"), []byte("zero-b")} {
+		got, err := opened.Get(key)
+		if err != nil {
+			t.Fatalf("get %q: %v", key, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("value mismatch for %q: got %x want %x", key, got, want)
+		}
+	}
+}
+
 func TestUnifiedWAL_LargeBatch(t *testing.T) {
 	dir := t.TempDir()
 	backend, _ := db.Open(db.Options{Dir: dir})

--- a/TreeDB/caching/vlog_rotate_reload_test.go
+++ b/TreeDB/caching/vlog_rotate_reload_test.go
@@ -112,10 +112,13 @@ func (w *rotateFailCommitWriter) AppendBatch(records []logRecord) error {
 	return errors.New("test: unexpected AppendBatch call")
 }
 func (w *rotateFailCommitWriter) RotateTo(path string) error { return errRotateFailed }
-func (w *rotateFailCommitWriter) Size() int64                { return w.size }
-func (w *rotateFailCommitWriter) Flush() error               { return nil }
-func (w *rotateFailCommitWriter) Sync() error                { return nil }
-func (w *rotateFailCommitWriter) Close() error               { return nil }
+func (w *rotateFailCommitWriter) RotateToWithSync(path string, syncCurrent bool) error {
+	return errRotateFailed
+}
+func (w *rotateFailCommitWriter) Size() int64  { return w.size }
+func (w *rotateFailCommitWriter) Flush() error { return nil }
+func (w *rotateFailCommitWriter) Sync() error  { return nil }
+func (w *rotateFailCommitWriter) Close() error { return nil }
 
 func TestAppendValueLog_ReloadWriterAfterRotation(t *testing.T) {
 	t.Parallel()

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -167,7 +167,11 @@ func (tdb *DB) preparePublicCommandWALPendingPublish(sync bool) (uint64, []db.Co
 	if first > current+1 {
 		return 0, nil, fmt.Errorf("%w: pending public command WAL starts at %d after applied %d", db.ErrCommandWALAppliedLSNNonContig, first, current)
 	}
-	if err := tdb.backend.FlushCommandWAL(sync); err != nil {
+	if sync {
+		if err := tdb.backend.FlushCommandWAL(true); err != nil {
+			return 0, nil, err
+		}
+	} else if err := tdb.backend.CheckCommandWALPublishReady(); err != nil {
 		return 0, nil, err
 	}
 	return last, []db.CommandWALLSNRange{{First: current + 1, Last: last}}, nil
@@ -178,27 +182,21 @@ func publicCommandWALPublishSync(durabilityMode string, sync bool) bool {
 }
 
 type commandWALPublicBatch struct {
-	db        *DB
-	inner     Batch
-	setViewer interface {
-		SetView(key, value []byte) error
-	}
-	setViewValidated interface {
-		SetViewValidated(key, value []byte) error
-	}
-	deleteViewer interface {
-		DeleteView(key []byte) error
-	}
-	deleteViewValidated interface {
-		DeleteViewValidated(key []byte) error
-	}
-	payload commitlog.RawKVBatchPayloadBuilder
-	opCount int
-	dirty   bool
-	closed  bool
+	db                *DB
+	inner             Batch
+	innerSetViewFn    func(key, value []byte) error
+	innerDeleteViewFn func(key []byte) error
+	payload           commitlog.RawKVBatchPayloadBuilder
+	payloadOpHint     int
+	payloadByteHint   int
+	opCount           int
+	dirty             bool
+	closed            bool
 }
 
-const commandWALPublicBatchEstimatedKeyValueBytes = 48
+// Seed command payload capacity for moderately sized values. The op hint is
+// bounded, so this avoids repeated grow/copy churn without unbounded retention.
+const commandWALPublicBatchEstimatedKeyValueBytes = 192
 
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
 	b := &commandWALPublicBatch{db: tdb, inner: inner}
@@ -209,40 +207,45 @@ func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPubli
 	if opHint > 0 && opHint <= int(^uint(0)>>1)/commandWALPublicBatchEstimatedKeyValueBytes {
 		byteHint = opHint * commandWALPublicBatchEstimatedKeyValueBytes
 	}
-	b.payload.ResetWithHint(opHint, byteHint)
+	b.payloadOpHint = opHint
+	b.payloadByteHint = byteHint
+	b.resetPayloadWithHint()
 	return b
+}
+
+func (b *commandWALPublicBatch) resetPayloadWithHint() {
+	if b == nil {
+		return
+	}
+	_ = b.payload.ResetWithHint(b.payloadOpHint, b.payloadByteHint)
 }
 
 func (b *commandWALPublicBatch) rebindInnerViewers() {
 	if b == nil {
 		return
 	}
-	b.setViewer = nil
-	b.setViewValidated = nil
-	b.deleteViewer = nil
-	b.deleteViewValidated = nil
+	b.innerSetViewFn = nil
+	b.innerDeleteViewFn = nil
 	if b.inner == nil {
 		return
 	}
 	if setter, ok := b.inner.(interface {
-		SetView(key, value []byte) error
-	}); ok {
-		b.setViewer = setter
-	}
-	if setter, ok := b.inner.(interface {
 		SetViewValidated(key, value []byte) error
 	}); ok {
-		b.setViewValidated = setter
-	}
-	if deleter, ok := b.inner.(interface {
-		DeleteView(key []byte) error
+		b.innerSetViewFn = setter.SetViewValidated
+	} else if setter, ok := b.inner.(interface {
+		SetView(key, value []byte) error
 	}); ok {
-		b.deleteViewer = deleter
+		b.innerSetViewFn = setter.SetView
 	}
 	if deleter, ok := b.inner.(interface {
 		DeleteViewValidated(key []byte) error
 	}); ok {
-		b.deleteViewValidated = deleter
+		b.innerDeleteViewFn = deleter.DeleteViewValidated
+	} else if deleter, ok := b.inner.(interface {
+		DeleteView(key []byte) error
+	}); ok {
+		b.innerDeleteViewFn = deleter.DeleteView
 	}
 }
 
@@ -290,10 +293,11 @@ func (b *commandWALPublicBatch) SetView(key, value []byte) error {
 		return caching.ErrValueNil
 	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	if _, _, err := b.payload.AppendSet(key, value); err != nil {
+	keyView, valueView, err := b.payload.AppendSet(key, value)
+	if err != nil {
 		return err
 	}
-	if err := b.innerSetView(key, value); err != nil {
+	if err := b.innerSetView(keyView, valueView); err != nil {
 		b.payload.Truncate(oldLen, oldCount)
 		return err
 	}
@@ -331,10 +335,11 @@ func (b *commandWALPublicBatch) DeleteView(key []byte) error {
 		return caching.ErrKeyEmpty
 	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	if _, err := b.payload.AppendDelete(key); err != nil {
+	keyView, err := b.payload.AppendDelete(key)
+	if err != nil {
 		return err
 	}
-	if err := b.innerDeleteView(key); err != nil {
+	if err := b.innerDeleteView(keyView); err != nil {
 		b.payload.Truncate(oldLen, oldCount)
 		return err
 	}
@@ -344,21 +349,15 @@ func (b *commandWALPublicBatch) DeleteView(key []byte) error {
 }
 
 func (b *commandWALPublicBatch) innerSetView(key, value []byte) error {
-	if b.setViewValidated != nil {
-		return b.setViewValidated.SetViewValidated(key, value)
-	}
-	if b.setViewer != nil {
-		return b.setViewer.SetView(key, value)
+	if b.innerSetViewFn != nil {
+		return b.innerSetViewFn(key, value)
 	}
 	return b.inner.Set(key, value)
 }
 
 func (b *commandWALPublicBatch) innerDeleteView(key []byte) error {
-	if b.deleteViewValidated != nil {
-		return b.deleteViewValidated.DeleteViewValidated(key)
-	}
-	if b.deleteViewer != nil {
-		return b.deleteViewer.DeleteView(key)
+	if b.innerDeleteViewFn != nil {
+		return b.innerDeleteViewFn(key)
 	}
 	return b.inner.Delete(key)
 }
@@ -388,7 +387,7 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 			return err
 		}
 		b.disableInnerStreamingBypass()
-		b.payload.ResetWithHint(0, 0)
+		b.resetPayloadWithHint()
 		b.opCount = 0
 		b.dirty = false
 		return nil
@@ -403,7 +402,7 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		}
 	}
 	b.disableInnerStreamingBypass()
-	b.payload.ResetWithHint(0, 0)
+	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.dirty = false
 	return nil
@@ -418,11 +417,9 @@ func (b *commandWALPublicBatch) Close() error {
 	// appends and publishes a RawKVBatch command frame.
 	err := b.inner.Close()
 	b.inner = nil
-	b.setViewer = nil
-	b.setViewValidated = nil
-	b.deleteViewer = nil
-	b.deleteViewValidated = nil
-	b.payload.ResetWithHint(0, 0)
+	b.innerSetViewFn = nil
+	b.innerDeleteViewFn = nil
+	b.resetPayloadWithHint()
 	b.dirty = false
 	b.closed = true
 	return err
@@ -435,7 +432,7 @@ func (b *commandWALPublicBatch) Reset() {
 	resetter, ok := b.inner.(interface{ Reset() })
 	if !ok {
 		b.disableInnerStreamingBypass()
-		b.payload.ResetWithHint(0, 0)
+		b.resetPayloadWithHint()
 		b.opCount = 0
 		b.dirty = false
 		b.closed = false
@@ -444,7 +441,7 @@ func (b *commandWALPublicBatch) Reset() {
 	resetter.Reset()
 	b.rebindInnerViewers()
 	b.disableInnerStreamingBypass()
-	b.payload.ResetWithHint(0, 0)
+	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.dirty = false
 	b.closed = false

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -668,8 +668,71 @@ func TestPublicCommandWALBatchResetFallbackKeepsWrapperUsable(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T) {
+	wrapped := newCommandWALPublicBatch(nil, &commandWALResetBatch{}, 8000)
+	zeroValue := make([]byte, 128)
+	key := []byte("k")
+
+	if err := wrapped.SetView(key, zeroValue); err != nil {
+		t.Fatalf("SetView before reset: %v", err)
+	}
+	payload, err := wrapped.commandWALPayload()
+	if err != nil {
+		t.Fatalf("commandWALPayload before reset: %v", err)
+	}
+	if len(payload) >= 6+9+len(key)+len(zeroValue) {
+		t.Fatalf("commandWALPayload before reset len=%d, want compact zero payload below expanded size", len(payload))
+	}
+	visits := 0
+	if err := commitlog.ScanRawKVBatchPayload(payload, func(op commitlog.RawKVOp, gotKey, gotValue []byte) error {
+		visits++
+		if op != commitlog.RawKVOpSet || string(gotKey) != string(key) || len(gotValue) != len(zeroValue) {
+			t.Fatalf("scan before reset op=%v key=%q value_len=%d", op, gotKey, len(gotValue))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan before reset: %v", err)
+	}
+	if visits != 1 {
+		t.Fatalf("scan visits before reset=%d, want 1", visits)
+	}
+
+	wrapped.Reset()
+	if err := wrapped.SetView(key, zeroValue); err != nil {
+		t.Fatalf("SetView after reset: %v", err)
+	}
+	payload, err = wrapped.commandWALPayload()
+	if err != nil {
+		t.Fatalf("commandWALPayload after reset: %v", err)
+	}
+	if len(payload) >= 6+9+len(key)+len(zeroValue) {
+		t.Fatalf("commandWALPayload after reset len=%d, want compact zero payload below expanded size", len(payload))
+	}
+	visits = 0
+	if err := commitlog.ScanRawKVBatchPayload(payload, func(op commitlog.RawKVOp, gotKey, gotValue []byte) error {
+		visits++
+		if op != commitlog.RawKVOpSet || string(gotKey) != string(key) || len(gotValue) != len(zeroValue) {
+			t.Fatalf("scan after reset op=%v key=%q value_len=%d", op, gotKey, len(gotValue))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan after reset: %v", err)
+	}
+	if visits != 1 {
+		t.Fatalf("scan visits after reset=%d, want 1", visits)
+	}
+}
+
 type commandWALNoResetBatch struct {
 	entries []batch.Entry
+}
+
+type commandWALResetBatch struct {
+	commandWALNoResetBatch
+}
+
+func (b *commandWALResetBatch) Reset() {
+	b.entries = b.entries[:0]
 }
 
 func (b *commandWALNoResetBatch) Set(key, value []byte) error {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -69,6 +69,14 @@ func (db *DB) commandWALPoisonedError() error {
 	return nil
 }
 
+// CheckCommandWALPublishReady verifies that this open handle can publish
+// command-WAL coverage without forcing another writer flush. Public cached
+// command-WAL writes already flush their command frame before visibility; the
+// checkpoint publish path uses this for relaxed AppliedCommandLSN publication.
+func (db *DB) CheckCommandWALPublishReady() error {
+	return db.commandWALPoisonedError()
+}
+
 func (db *DB) rejectUnloggedCommandWALRootPublish() error {
 	if err := db.commandWALPoisonedError(); err != nil {
 		return err
@@ -429,15 +437,26 @@ func (db *DB) appendRawKVBatchPayloadCommandWAL(payload []byte, sync bool, trust
 	}
 	var lsn uint64
 	var err error
+	flushSync := sync && db.durability != DurabilityWALOnRelaxed
 	if trusted {
-		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommandTrusted(baseAppliedLSN, payload)
+		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommandTrustedAndFlush(baseAppliedLSN, payload, flushSync)
 	} else {
 		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommand(baseAppliedLSN, payload)
+		if err == nil {
+			if flushSync {
+				err = db.commandJournal.Sync()
+			} else {
+				err = db.commandJournal.Flush()
+			}
+		}
+	}
+	if err == nil && db.testFailCommandWALFlush.Load() {
+		err = errTestCommandWALFlushFailpoint
 	}
 	if err != nil {
-		return 0, err
-	}
-	if err := db.FlushCommandWAL(sync); err != nil {
+		if lsn != 0 {
+			db.commandWALFlushPoisoned.Store(true)
+		}
 		return lsn, err
 	}
 	db.observeCommandWALAccepted(lsn)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -648,6 +648,26 @@ func TestCommandWALPointAppendFlushesAsyncFrame(t *testing.T) {
 	}
 }
 
+func TestCommandWALPublishReadyReportsPoisonedHandle(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	db.testFailCommandWALFlush.Store(true)
+	lsn, err := db.AppendRawKVPointCommandWALTrusted(commitlog.RawKVOpSet, []byte("k"), []byte("v"), false)
+	if !errors.Is(err, errTestCommandWALFlushFailpoint) {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted async error=%v, want command WAL flush failpoint", err)
+	}
+	if lsn != 1 {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted async lsn=%d, want allocated LSN 1 on post-append flush failure", lsn)
+	}
+	db.testFailCommandWALFlush.Store(false)
+	if err := db.CheckCommandWALPublishReady(); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("CheckCommandWALPublishReady error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
 func TestCommandWALFinalizeFailurePoisonsOpenHandle(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -556,6 +556,38 @@ A `RawKVBatch` command frame is one atomic command: one frame, one `LSN`, and
 all contained operations decode as one batch. Delete operations require
 `ValueLen=0`.
 
+Writers may use compact all-zero set payload variants when every operation is a
+set with the same non-empty zero-filled value length:
+
+```text
+u16 Version        // 2
+u32 OpCount
+u32 ValueLen
+ZeroOp[OpCount]
+
+ZeroOp:
+u32 KeyLen
+bytes Key[KeyLen]
+```
+
+Version 3 is the same compact zero-set payload with a narrower per-key length
+field and is valid only when every key length fits in `u16`:
+
+```text
+u16 Version        // 3
+u32 OpCount
+u32 ValueLen
+ZeroOp[OpCount]
+
+ZeroOp:
+u16 KeyLen
+bytes Key[KeyLen]
+```
+
+Readers expand version 2 and version 3 entries to ordinary `RawKVBatch` set
+operations with a zero-filled `Value[ValueLen]`; the command frame still carries
+payload format `RawKVBatchV1`.
+
 `CatalogCreateCollectionV1` payload:
 
 ```text

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -16,9 +16,15 @@ const (
 
 	CommandWALNonCriticalFlagStart uint64 = 1 << 32
 
-	commandFrameHeaderSize = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4 + sha256.Size
-	rawKVBatchHeaderSize   = 2 + 4
-	rawKVOpHeaderSize      = 1 + 4 + 4
+	commandFrameHeaderSize   = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4 + sha256.Size
+	rawKVBatchPayloadVersion = uint16(1)
+	rawKVZeroBatchPayloadV2  = uint16(2)
+	rawKVZeroBatchPayloadV3  = uint16(3)
+	rawKVBatchHeaderSize     = 2 + 4
+	rawKVZeroBatchHeaderSize = 2 + 4 + 4
+	rawKVOpHeaderSize        = 1 + 4 + 4
+	rawKVZeroOpHeaderSize    = 4
+	rawKVZeroOpHeaderSizeV3  = 2
 
 	externalRefEncodedFixedSize      = 2 + 2 + 4 + 8 + 8 + 8 + sha256.Size
 	commandExtensionEncodedFixedSize = 2 + 2 + 4
@@ -104,8 +110,20 @@ type RawKVOperation struct {
 // RawKVBatchPayloadBuilder incrementally constructs a canonical RawKVBatch
 // payload while returning stable key/value views into the owned payload bytes.
 type RawKVBatchPayloadBuilder struct {
-	payload []byte
-	count   int
+	payload               []byte
+	zeroPayload           []byte
+	zeroSetValueView      []byte
+	payloadCapHint        int
+	opHint                int
+	count                 int
+	zeroSetCandidate      bool
+	zeroSetCompactOnly    bool
+	zeroSetValuesOmitted  bool
+	zeroSetValueLen       int
+	zeroSetKeyBytes       int
+	zeroSetMaxKeyLen      int
+	zeroSetCompactVersion uint16
+	zeroSetValueRef       []byte
 }
 
 // NewRawKVBatchPayloadBuilder returns a builder initialized with best-effort
@@ -131,14 +149,31 @@ func (b *RawKVBatchPayloadBuilder) ResetWithHint(opHint, byteHint int) error {
 	} else {
 		err = hintErr
 	}
-	if cap(b.payload) < capHint {
-		b.payload = make([]byte, rawKVBatchHeaderSize, capHint)
+	b.payloadCapHint = capHint
+	if opHint > 0 {
+		b.opHint = opHint
+	} else {
+		b.opHint = 0
+	}
+	if cap(b.payload) < rawKVBatchHeaderSize {
+		b.payload = make([]byte, rawKVBatchHeaderSize, rawKVBatchHeaderSize)
 	} else {
 		b.payload = b.payload[:rawKVBatchHeaderSize]
 		clear(b.payload)
 	}
-	binary.LittleEndian.PutUint16(b.payload[0:2], 1)
+	binary.LittleEndian.PutUint16(b.payload[0:2], rawKVBatchPayloadVersion)
 	b.count = 0
+	b.zeroSetCandidate = true
+	b.zeroSetCompactOnly = true
+	b.zeroSetValuesOmitted = false
+	b.zeroSetValueLen = -1
+	b.zeroSetKeyBytes = 0
+	b.zeroSetMaxKeyLen = 0
+	b.zeroSetCompactVersion = 0
+	b.zeroSetValueRef = nil
+	if b.zeroPayload != nil {
+		b.zeroPayload = b.zeroPayload[:0]
+	}
 	return err
 }
 
@@ -149,6 +184,28 @@ func (b *RawKVBatchPayloadBuilder) Payload() []byte {
 	if len(b.payload) >= rawKVBatchHeaderSize {
 		binary.LittleEndian.PutUint32(b.payload[2:6], uint32(b.count))
 	}
+	if b.zeroSetCompactOnly && b.zeroSetCandidate && b.count > 0 && b.zeroSetValueLen > 0 && len(b.zeroPayload) >= rawKVZeroBatchHeaderSize {
+		version := b.zeroSetCompactVersion
+		if version == 0 {
+			version = rawKVZeroBatchPayloadV2
+		}
+		binary.LittleEndian.PutUint16(b.zeroPayload[0:2], version)
+		binary.LittleEndian.PutUint32(b.zeroPayload[2:6], uint32(b.count))
+		binary.LittleEndian.PutUint32(b.zeroPayload[6:10], uint32(b.zeroSetValueLen))
+		return b.zeroPayload
+	}
+	if b.zeroSetCompactOnly && b.zeroSetCandidate && b.count > 0 && b.zeroSetValueLen > 0 {
+		if err := b.materializeCompactZeroSetPayload(); err == nil {
+			b.zeroSetCompactOnly = false
+			return b.payload
+		}
+	}
+	if b.zeroSetCandidate && b.count > 0 && b.zeroSetValueLen > 0 {
+		if payload, ok := b.compactZeroSetPayload(); ok {
+			return payload
+		}
+	}
+	b.materializeOmittedZeroValues()
 	return b.payload
 }
 
@@ -170,9 +227,15 @@ func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
 	if b == nil || payloadLen < rawKVBatchHeaderSize || payloadLen > len(b.payload) || count < 0 {
 		return
 	}
+	if b.zeroSetCompactOnly {
+		b.truncateCompactZeroSetPayload(count)
+		return
+	}
+	b.materializeOmittedZeroValues()
 	b.payload = b.payload[:payloadLen]
 	b.count = count
 	binary.LittleEndian.PutUint32(b.payload[2:6], uint32(count))
+	b.recomputeZeroSetCandidate()
 }
 
 func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView []byte, err error) {
@@ -222,6 +285,19 @@ func (b *RawKVBatchPayloadBuilder) AppendSet(key, value []byte) (keyView, valueV
 	if commandFrameIntExceedsUint32(len(key)) || commandFrameIntExceedsUint32(len(value)) {
 		return nil, nil, ErrRecordTooLarge
 	}
+	if b.zeroSetCompactOnly && b.canAppendCompactZeroSet(value) {
+		keyView, err := b.appendCompactZeroSet(key, value)
+		if err != nil {
+			return nil, nil, err
+		}
+		return keyView, b.zeroSetValueViewForLen(len(value)), nil
+	}
+	if b.zeroSetCompactOnly {
+		if err := b.materializeCompactZeroSetPayload(); err != nil {
+			return nil, nil, err
+		}
+		b.zeroSetCompactOnly = false
+	}
 	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key) + len(value))
 	if err != nil {
 		return nil, nil, err
@@ -234,10 +310,17 @@ func (b *RawKVBatchPayloadBuilder) AppendSet(key, value []byte) (keyView, valueV
 	copy(b.payload[off:], key)
 	off += len(key)
 	valueStart := off
-	copy(b.payload[off:], value)
+	zeroCompact := b.recordZeroSetCandidateForAppended(key, value)
+	if zeroCompact {
+		b.zeroSetValuesOmitted = true
+		valueView = b.zeroSetValueViewForLen(len(value))
+	} else {
+		copy(b.payload[off:], value)
+		valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+	}
 	off += len(value)
 	b.count++
-	return b.payload[keyStart : keyStart+len(key) : keyStart+len(key)], b.payload[valueStart:off:off], nil
+	return b.payload[keyStart : keyStart+len(key) : keyStart+len(key)], valueView, nil
 }
 
 // AppendDelete appends a validated RawKV Delete operation without
@@ -258,6 +341,12 @@ func (b *RawKVBatchPayloadBuilder) AppendDelete(key []byte) (keyView []byte, err
 	if commandFrameIntExceedsUint32(len(key)) {
 		return nil, ErrRecordTooLarge
 	}
+	if b.zeroSetCompactOnly {
+		if err := b.materializeCompactZeroSetPayload(); err != nil {
+			return nil, err
+		}
+		b.zeroSetCompactOnly = false
+	}
 	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key))
 	if err != nil {
 		return nil, err
@@ -270,6 +359,7 @@ func (b *RawKVBatchPayloadBuilder) AppendDelete(key []byte) (keyView []byte, err
 	copy(b.payload[off:], key)
 	off += len(key)
 	b.count++
+	b.disableZeroSetCandidate()
 	return b.payload[keyStart:off:off], nil
 }
 
@@ -283,6 +373,9 @@ func (b *RawKVBatchPayloadBuilder) appendRawKVPayloadSpace(needed int) (int, err
 		newCap := cap(b.payload) * 2
 		if newCap < newLen {
 			newCap = newLen
+		}
+		if b.payloadCapHint > newCap {
+			newCap = b.payloadCapHint
 		}
 		if newCap < 0 {
 			return 0, ErrRecordTooLarge
@@ -306,6 +399,19 @@ func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte
 	if commandFrameIntExceedsUint32(b.count + 1) {
 		return nil, nil, ErrRecordTooLarge
 	}
+	if b.zeroSetCompactOnly && op == RawKVOpSet && b.canAppendCompactZeroSet(value) {
+		keyView, err := b.appendCompactZeroSet(key, value)
+		if err != nil {
+			return nil, nil, err
+		}
+		return keyView, b.zeroSetValueViewForLen(len(value)), nil
+	}
+	if b.zeroSetCompactOnly {
+		if err := b.materializeCompactZeroSetPayload(); err != nil {
+			return nil, nil, err
+		}
+		b.zeroSetCompactOnly = false
+	}
 	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key) + len(value))
 	if err != nil {
 		return nil, nil, err
@@ -318,14 +424,474 @@ func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte
 	copy(b.payload[off:], key)
 	off += len(key)
 	valueStart := off
-	copy(b.payload[off:], value)
+	zeroCompact := false
+	if op == RawKVOpSet {
+		zeroCompact = b.recordZeroSetCandidateForAppended(key, value)
+	} else {
+		b.disableZeroSetCandidate()
+	}
+	if zeroCompact {
+		b.zeroSetValuesOmitted = true
+		valueView = b.zeroSetValueViewForLen(len(value))
+	} else {
+		copy(b.payload[off:], value)
+		if op == RawKVOpSet {
+			valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+		}
+	}
 	off += len(value)
 	b.count++
 	keyView = b.payload[keyStart : keyStart+len(key) : keyStart+len(key)]
-	if op == RawKVOpSet {
-		valueView = b.payload[valueStart:off:off]
-	}
 	return keyView, valueView, nil
+}
+
+func (b *RawKVBatchPayloadBuilder) canAppendCompactZeroSet(value []byte) bool {
+	if b == nil || !b.zeroSetCandidate || !b.zeroSetCompactOnly || len(value) == 0 {
+		return false
+	}
+	if b.zeroSetValueLen >= 0 && b.zeroSetValueLen != len(value) {
+		return false
+	}
+	if sameNonEmptyBytesData(value, b.zeroSetValueRef) {
+		return true
+	}
+	return allZeroBytes(value)
+}
+
+func (b *RawKVBatchPayloadBuilder) appendCompactZeroSet(key, value []byte) ([]byte, error) {
+	if b == nil || len(value) == 0 {
+		return nil, ErrCorrupt
+	}
+	if commandFrameIntExceedsUint32(len(key)) || commandFrameIntExceedsUint32(b.count+1) {
+		return nil, ErrRecordTooLarge
+	}
+	if len(b.zeroPayload) == 0 {
+		b.zeroSetCompactVersion = rawKVZeroBatchPayloadV3
+		if len(key) > int(^uint16(0)) {
+			b.zeroSetCompactVersion = rawKVZeroBatchPayloadV2
+		}
+		capHint := rawKVZeroBatchHeaderSize
+		if b.opHint > 0 {
+			if hint, ok := rawKVZeroBatchPayloadSizeHint(b.opHint, len(key)); ok {
+				capHint = hint
+			}
+		}
+		if cap(b.zeroPayload) < rawKVZeroBatchHeaderSize {
+			b.zeroPayload = make([]byte, rawKVZeroBatchHeaderSize, capHint)
+		} else {
+			b.zeroPayload = b.zeroPayload[:rawKVZeroBatchHeaderSize]
+			clear(b.zeroPayload)
+		}
+	}
+	if b.zeroSetCompactVersion == rawKVZeroBatchPayloadV3 && len(key) > int(^uint16(0)) {
+		if err := b.promoteCompactZeroPayloadToV2(); err != nil {
+			return nil, err
+		}
+	}
+	opHeaderSize := rawKVZeroOpHeaderSizeForVersion(b.zeroSetCompactVersion)
+	needed := opHeaderSize + len(key)
+	if needed > int(^uint32(0))-len(b.zeroPayload) || needed > int(^uint(0)>>1)-len(b.zeroPayload) {
+		return nil, ErrRecordTooLarge
+	}
+	off := len(b.zeroPayload)
+	newLen := off + needed
+	if newLen > cap(b.zeroPayload) {
+		newCap := cap(b.zeroPayload) * 2
+		if newCap < newLen {
+			newCap = newLen
+		}
+		next := make([]byte, newLen, newCap)
+		copy(next, b.zeroPayload)
+		b.zeroPayload = next
+	} else {
+		b.zeroPayload = b.zeroPayload[:newLen]
+	}
+	if b.zeroSetValueLen < 0 {
+		b.zeroSetValueLen = len(value)
+	}
+	if !sameNonEmptyBytesData(value, b.zeroSetValueRef) {
+		b.zeroSetValueRef = value
+	}
+	if b.zeroSetCompactVersion == rawKVZeroBatchPayloadV3 {
+		binary.LittleEndian.PutUint16(b.zeroPayload[off:off+rawKVZeroOpHeaderSizeV3], uint16(len(key)))
+	} else {
+		binary.LittleEndian.PutUint32(b.zeroPayload[off:off+rawKVZeroOpHeaderSize], uint32(len(key)))
+	}
+	keyStart := off + opHeaderSize
+	copy(b.zeroPayload[keyStart:keyStart+len(key)], key)
+	b.zeroSetKeyBytes += len(key)
+	if len(key) > b.zeroSetMaxKeyLen {
+		b.zeroSetMaxKeyLen = len(key)
+	}
+	b.count++
+	return b.zeroPayload[keyStart : keyStart+len(key) : keyStart+len(key)], nil
+}
+
+func (b *RawKVBatchPayloadBuilder) materializeCompactZeroSetPayload() error {
+	if b == nil || !b.zeroSetCompactOnly || b.count == 0 {
+		return nil
+	}
+	if b.zeroSetValueLen <= 0 || len(b.zeroPayload) < rawKVZeroBatchHeaderSize {
+		return ErrCorrupt
+	}
+	total, ok := rawKVExpandedZeroBatchPayloadSize(b.count, b.zeroSetKeyBytes, b.zeroSetValueLen)
+	if !ok || commandFrameIntExceedsUint32(total) {
+		return ErrRecordTooLarge
+	}
+	if cap(b.payload) < total {
+		b.payload = make([]byte, total)
+	} else {
+		b.payload = b.payload[:total]
+		clear(b.payload)
+	}
+	binary.LittleEndian.PutUint16(b.payload[0:2], rawKVBatchPayloadVersion)
+	binary.LittleEndian.PutUint32(b.payload[2:6], uint32(b.count))
+	version := b.zeroSetCompactVersion
+	if version == 0 {
+		version = binary.LittleEndian.Uint16(b.zeroPayload[0:2])
+	}
+	srcOff := rawKVZeroBatchHeaderSize
+	dstOff := rawKVBatchHeaderSize
+	for i := 0; i < b.count; i++ {
+		keyLen, nextOff, err := readCompactZeroKeyLen(b.zeroPayload, srcOff, version)
+		if err != nil || dstOff+rawKVOpHeaderSize > len(b.payload) {
+			return ErrCorrupt
+		}
+		srcOff = nextOff
+		if keyLen < 0 || keyLen > len(b.zeroPayload)-srcOff || dstOff+rawKVOpHeaderSize+keyLen+b.zeroSetValueLen > len(b.payload) {
+			return ErrCorrupt
+		}
+		b.payload[dstOff] = byte(RawKVOpSet)
+		binary.LittleEndian.PutUint32(b.payload[dstOff+1:dstOff+5], uint32(keyLen))
+		binary.LittleEndian.PutUint32(b.payload[dstOff+5:dstOff+9], uint32(b.zeroSetValueLen))
+		dstOff += rawKVOpHeaderSize
+		copy(b.payload[dstOff:dstOff+keyLen], b.zeroPayload[srcOff:srcOff+keyLen])
+		srcOff += keyLen
+		dstOff += keyLen + b.zeroSetValueLen
+	}
+	if srcOff != len(b.zeroPayload) || dstOff != len(b.payload) {
+		return ErrCorrupt
+	}
+	b.zeroSetValuesOmitted = false
+	return nil
+}
+
+func rawKVZeroOpHeaderSizeForKeyLen(keyLen int) int {
+	if keyLen >= 0 && keyLen <= int(^uint16(0)) {
+		return rawKVZeroOpHeaderSizeV3
+	}
+	return rawKVZeroOpHeaderSize
+}
+
+func rawKVZeroOpHeaderSizeForVersion(version uint16) int {
+	if version == rawKVZeroBatchPayloadV3 {
+		return rawKVZeroOpHeaderSizeV3
+	}
+	return rawKVZeroOpHeaderSize
+}
+
+func readCompactZeroKeyLen(payload []byte, off int, version uint16) (int, int, error) {
+	switch version {
+	case rawKVZeroBatchPayloadV3:
+		if off+rawKVZeroOpHeaderSizeV3 > len(payload) {
+			return 0, off, ErrCorrupt
+		}
+		return int(binary.LittleEndian.Uint16(payload[off : off+rawKVZeroOpHeaderSizeV3])), off + rawKVZeroOpHeaderSizeV3, nil
+	case rawKVZeroBatchPayloadV2:
+		if off+rawKVZeroOpHeaderSize > len(payload) {
+			return 0, off, ErrCorrupt
+		}
+		keyLen := binary.LittleEndian.Uint32(payload[off : off+rawKVZeroOpHeaderSize])
+		if uint64(keyLen) > uint64(^uint(0)>>1) {
+			return 0, off, ErrRecordTooLarge
+		}
+		return int(keyLen), off + rawKVZeroOpHeaderSize, nil
+	default:
+		return 0, off, ErrCommandWALUnsupportedVersion
+	}
+}
+
+func (b *RawKVBatchPayloadBuilder) promoteCompactZeroPayloadToV2() error {
+	if b == nil || b.zeroSetCompactVersion != rawKVZeroBatchPayloadV3 {
+		return nil
+	}
+	total := rawKVZeroBatchHeaderSize + b.count*rawKVZeroOpHeaderSize + b.zeroSetKeyBytes
+	if total < rawKVZeroBatchHeaderSize || commandFrameIntExceedsUint32(total) {
+		return ErrRecordTooLarge
+	}
+	next := make([]byte, rawKVZeroBatchHeaderSize, total)
+	copy(next, b.zeroPayload[:rawKVZeroBatchHeaderSize])
+	binary.LittleEndian.PutUint16(next[0:2], rawKVZeroBatchPayloadV2)
+	off := rawKVZeroBatchHeaderSize
+	for i := 0; i < b.count; i++ {
+		keyLen, nextOff, err := readCompactZeroKeyLen(b.zeroPayload, off, rawKVZeroBatchPayloadV3)
+		if err != nil {
+			return err
+		}
+		off = nextOff
+		if keyLen > len(b.zeroPayload)-off {
+			return ErrCorrupt
+		}
+		dstOff := len(next)
+		next = next[:dstOff+rawKVZeroOpHeaderSize+keyLen]
+		binary.LittleEndian.PutUint32(next[dstOff:dstOff+rawKVZeroOpHeaderSize], uint32(keyLen))
+		copy(next[dstOff+rawKVZeroOpHeaderSize:], b.zeroPayload[off:off+keyLen])
+		off += keyLen
+	}
+	if off != len(b.zeroPayload) {
+		return ErrCorrupt
+	}
+	b.zeroPayload = next
+	b.zeroSetCompactVersion = rawKVZeroBatchPayloadV2
+	return nil
+}
+
+func rawKVZeroBatchPayloadSizeHint(opHint, firstKeyLen int) (int, bool) {
+	if opHint <= 0 || firstKeyLen < 0 {
+		return rawKVZeroBatchHeaderSize, true
+	}
+	maxInt := int(^uint(0) >> 1)
+	perOp := rawKVZeroOpHeaderSizeForKeyLen(firstKeyLen) + firstKeyLen
+	if perOp < rawKVZeroOpHeaderSizeV3 || perOp > (maxInt-rawKVZeroBatchHeaderSize)/opHint {
+		return 0, false
+	}
+	total := rawKVZeroBatchHeaderSize + opHint*perOp
+	if commandFrameIntExceedsUint32(total) {
+		return 0, false
+	}
+	return total, true
+}
+
+func rawKVExpandedZeroBatchPayloadSize(count, keyBytes, valueLen int) (int, bool) {
+	if count < 0 || keyBytes < 0 || valueLen <= 0 {
+		return 0, false
+	}
+	maxInt := int(^uint(0) >> 1)
+	total := rawKVBatchHeaderSize
+	if count > (maxInt-total)/rawKVOpHeaderSize {
+		return 0, false
+	}
+	total += count * rawKVOpHeaderSize
+	if keyBytes > maxInt-total {
+		return 0, false
+	}
+	total += keyBytes
+	if count > (maxInt-total)/valueLen {
+		return 0, false
+	}
+	total += count * valueLen
+	return total, true
+}
+
+func (b *RawKVBatchPayloadBuilder) truncateCompactZeroSetPayload(count int) {
+	if b == nil || count < 0 {
+		return
+	}
+	if count == 0 {
+		b.count = 0
+		b.zeroSetCandidate = true
+		b.zeroSetCompactOnly = true
+		b.zeroSetValuesOmitted = false
+		b.zeroSetValueLen = -1
+		b.zeroSetKeyBytes = 0
+		b.zeroSetMaxKeyLen = 0
+		b.zeroSetCompactVersion = 0
+		b.zeroSetValueRef = nil
+		if b.zeroPayload != nil {
+			b.zeroPayload = b.zeroPayload[:0]
+		}
+		if len(b.payload) >= rawKVBatchHeaderSize {
+			b.payload = b.payload[:rawKVBatchHeaderSize]
+			clear(b.payload)
+			binary.LittleEndian.PutUint16(b.payload[0:2], rawKVBatchPayloadVersion)
+		}
+		return
+	}
+	if count >= b.count {
+		return
+	}
+	off := rawKVZeroBatchHeaderSize
+	keyBytes := 0
+	maxKeyLen := 0
+	version := b.zeroSetCompactVersion
+	if version == 0 && len(b.zeroPayload) >= 2 {
+		version = binary.LittleEndian.Uint16(b.zeroPayload[0:2])
+	}
+	for i := 0; i < count; i++ {
+		keyLen, nextOff, err := readCompactZeroKeyLen(b.zeroPayload, off, version)
+		if err != nil {
+			return
+		}
+		off = nextOff
+		if keyLen < 0 || keyLen > len(b.zeroPayload)-off {
+			return
+		}
+		off += keyLen
+		keyBytes += keyLen
+		if keyLen > maxKeyLen {
+			maxKeyLen = keyLen
+		}
+	}
+	b.zeroPayload = b.zeroPayload[:off]
+	b.count = count
+	b.zeroSetKeyBytes = keyBytes
+	b.zeroSetMaxKeyLen = maxKeyLen
+}
+
+func (b *RawKVBatchPayloadBuilder) recordZeroSetCandidateForAppended(key, value []byte) bool {
+	if b == nil || !b.zeroSetCandidate {
+		return false
+	}
+	if len(value) == 0 {
+		b.disableZeroSetCandidate()
+		return false
+	}
+	if b.zeroSetValueLen < 0 {
+		b.zeroSetValueLen = len(value)
+	} else if b.zeroSetValueLen != len(value) {
+		b.disableZeroSetCandidate()
+		return false
+	}
+	if sameNonEmptyBytesData(value, b.zeroSetValueRef) {
+		// Same immutable zero buffer as an earlier op in this batch.
+	} else if allZeroBytes(value) {
+		b.zeroSetValueRef = value
+	} else {
+		b.disableZeroSetCandidate()
+		return false
+	}
+	b.zeroSetKeyBytes += len(key)
+	if len(key) > b.zeroSetMaxKeyLen {
+		b.zeroSetMaxKeyLen = len(key)
+	}
+	return true
+}
+
+func (b *RawKVBatchPayloadBuilder) disableZeroSetCandidate() {
+	if b == nil || !b.zeroSetCandidate {
+		return
+	}
+	b.zeroSetCandidate = false
+	b.materializeOmittedZeroValues()
+}
+
+func (b *RawKVBatchPayloadBuilder) zeroSetValueViewForLen(n int) []byte {
+	if b == nil || n <= 0 {
+		return nil
+	}
+	if cap(b.zeroSetValueView) < n {
+		b.zeroSetValueView = make([]byte, n)
+	}
+	return b.zeroSetValueView[:n:n]
+}
+
+func (b *RawKVBatchPayloadBuilder) materializeOmittedZeroValues() {
+	if b == nil || !b.zeroSetValuesOmitted || b.count <= 0 || len(b.payload) < rawKVBatchHeaderSize {
+		return
+	}
+	off := rawKVBatchHeaderSize
+	for i := 0; i < b.count; i++ {
+		if off+rawKVOpHeaderSize > len(b.payload) {
+			break
+		}
+		op := RawKVOp(b.payload[off])
+		keyLen := int(binary.LittleEndian.Uint32(b.payload[off+1 : off+5]))
+		valueLen := int(binary.LittleEndian.Uint32(b.payload[off+5 : off+9]))
+		off += rawKVOpHeaderSize
+		if keyLen < 0 || keyLen > len(b.payload)-off {
+			break
+		}
+		off += keyLen
+		if valueLen < 0 || valueLen > len(b.payload)-off {
+			break
+		}
+		if op == RawKVOpSet && valueLen > 0 {
+			clear(b.payload[off : off+valueLen])
+		}
+		off += valueLen
+	}
+	b.zeroSetValuesOmitted = false
+}
+
+func (b *RawKVBatchPayloadBuilder) recomputeZeroSetCandidate() {
+	if b == nil {
+		return
+	}
+	b.materializeOmittedZeroValues()
+	b.zeroSetCandidate = true
+	b.zeroSetCompactOnly = false
+	b.zeroSetValuesOmitted = false
+	b.zeroSetValueLen = -1
+	b.zeroSetKeyBytes = 0
+	b.zeroSetMaxKeyLen = 0
+	b.zeroSetCompactVersion = 0
+	b.zeroSetValueRef = nil
+	if b.count == 0 || len(b.payload) < rawKVBatchHeaderSize {
+		return
+	}
+	_ = ScanRawKVBatchPayload(b.payload, func(op RawKVOp, key, value []byte) error {
+		if op != RawKVOpSet {
+			b.disableZeroSetCandidate()
+			return nil
+		}
+		b.recordZeroSetCandidateForAppended(key, value)
+		return nil
+	})
+}
+
+func (b *RawKVBatchPayloadBuilder) compactZeroSetPayload() ([]byte, bool) {
+	if b == nil || !b.zeroSetCandidate || b.count <= 0 || b.zeroSetValueLen <= 0 {
+		return nil, false
+	}
+	version := rawKVZeroBatchPayloadV2
+	if b.zeroSetMaxKeyLen <= int(^uint16(0)) {
+		version = rawKVZeroBatchPayloadV3
+	}
+	opHeaderSize := rawKVZeroOpHeaderSizeForVersion(version)
+	total := rawKVZeroBatchHeaderSize + b.count*opHeaderSize + b.zeroSetKeyBytes
+	if total < rawKVZeroBatchHeaderSize || commandFrameIntExceedsUint32(total) {
+		return nil, false
+	}
+	if cap(b.zeroPayload) < total {
+		b.zeroPayload = make([]byte, total)
+	} else {
+		b.zeroPayload = b.zeroPayload[:total]
+	}
+	dst := b.zeroPayload
+	b.zeroSetCompactVersion = version
+	binary.LittleEndian.PutUint16(dst[0:2], version)
+	binary.LittleEndian.PutUint32(dst[2:6], uint32(b.count))
+	binary.LittleEndian.PutUint32(dst[6:10], uint32(b.zeroSetValueLen))
+	srcOff := rawKVBatchHeaderSize
+	dstOff := rawKVZeroBatchHeaderSize
+	for i := 0; i < b.count; i++ {
+		if srcOff+rawKVOpHeaderSize > len(b.payload) || dstOff+opHeaderSize > len(dst) {
+			return nil, false
+		}
+		op := RawKVOp(b.payload[srcOff])
+		keyLen := int(binary.LittleEndian.Uint32(b.payload[srcOff+1 : srcOff+5]))
+		valueLen := int(binary.LittleEndian.Uint32(b.payload[srcOff+5 : srcOff+9]))
+		srcOff += rawKVOpHeaderSize
+		if op != RawKVOpSet || valueLen != b.zeroSetValueLen || keyLen < 0 || keyLen > len(b.payload)-srcOff || valueLen > len(b.payload)-srcOff-keyLen {
+			return nil, false
+		}
+		if version == rawKVZeroBatchPayloadV3 {
+			if keyLen > int(^uint16(0)) {
+				return nil, false
+			}
+			binary.LittleEndian.PutUint16(dst[dstOff:dstOff+rawKVZeroOpHeaderSizeV3], uint16(keyLen))
+		} else {
+			binary.LittleEndian.PutUint32(dst[dstOff:dstOff+rawKVZeroOpHeaderSize], uint32(keyLen))
+		}
+		dstOff += opHeaderSize
+		copy(dst[dstOff:], b.payload[srcOff:srcOff+keyLen])
+		srcOff += keyLen + valueLen
+		dstOff += keyLen
+	}
+	if srcOff != len(b.payload) || dstOff != len(dst) {
+		return nil, false
+	}
+	return dst, true
 }
 
 type CollectionDocument struct {
@@ -629,14 +1195,14 @@ func encodeCommandFrameTo(dst []byte, env CommandEnvelope) ([]byte, error) {
 
 func DecodeCommandFrame(frame []byte) (CommandEnvelope, error) {
 	var env CommandEnvelope
-	if len(frame) >= batchHeaderSize && len(frame) < commandFrameHeaderSize && frame[0] == Version {
+	if len(frame) >= batchHeaderSize && len(frame) < commandFrameHeaderSize && isBatchPayloadVersion(frame[0]) {
 		return env, ErrCommandWALLegacyPayload
 	}
 	if len(frame) < commandFrameHeaderSize {
 		return env, ErrCorrupt
 	}
 	if !bytes.Equal(frame[0:4], commandFrameMagic[:]) {
-		if frame[0] == Version {
+		if isBatchPayloadVersion(frame[0]) {
 			return env, ErrCommandWALLegacyPayload
 		}
 		return env, ErrCorrupt
@@ -790,7 +1356,7 @@ func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
 		total += rawKVOpHeaderSize + len(op.Key) + valueLen
 	}
 	payload := make([]byte, total)
-	binary.LittleEndian.PutUint16(payload[0:2], 1)
+	binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
 	binary.LittleEndian.PutUint32(payload[2:6], uint32(len(ops)))
 	off := rawKVBatchHeaderSize
 	for i := range ops {
@@ -828,7 +1394,7 @@ func EncodeRawKVSingleOperationPayload(op RawKVOperation) ([]byte, error) {
 	}
 	total := rawKVBatchHeaderSize + rawKVOpHeaderSize + len(op.Key) + valueLen
 	payload := make([]byte, total)
-	binary.LittleEndian.PutUint16(payload[0:2], 1)
+	binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
 	binary.LittleEndian.PutUint32(payload[2:6], 1)
 	value := op.Value
 	var ridBuf [8]byte
@@ -878,73 +1444,43 @@ func EncodeRawKVBatchPayloadScanWithHint(scan func(func(RawKVOperation) error) e
 	if scan == nil {
 		return EncodeRawKVBatchPayload(nil)
 	}
-	capHint, err := rawKVBatchPayloadSizeHint(opHint, byteHint)
-	if err != nil {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(opHint, byteHint); err != nil {
 		return nil, err
 	}
-	payload := make([]byte, rawKVBatchHeaderSize, capHint)
-	binary.LittleEndian.PutUint16(payload[0:2], 1)
-	count := 0
 	if err := scan(func(op RawKVOperation) error {
-		if commandFrameIntExceedsUint32(count + 1) {
-			return ErrRecordTooLarge
-		}
-		if err := validateRawKVOperation(&op); err != nil {
-			return err
-		}
-		valueLen := len(op.Value)
-		if op.Op == RawKVOpSetRID {
-			valueLen = 8
-		}
-		if commandFrameIntExceedsUint32(len(op.Key)) || commandFrameIntExceedsUint32(valueLen) {
-			return ErrRecordTooLarge
-		}
-		value := op.Value
-		var ridBuf [8]byte
-		if op.Op == RawKVOpSetRID {
-			binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
-			value = ridBuf[:]
-		}
-		needed := rawKVOpHeaderSize + len(op.Key) + len(value)
-		if needed > int(^uint32(0))-len(payload) || needed > int(^uint(0)>>1)-len(payload) {
-			return ErrRecordTooLarge
-		}
-		off := len(payload)
-		newLen := off + needed
-		if newLen > cap(payload) {
-			newCap := cap(payload) * 2
-			if newCap < newLen {
-				newCap = newLen
-			}
-			if newCap < 0 {
-				return ErrRecordTooLarge
-			}
-			next := make([]byte, newLen, newCap)
-			copy(next, payload)
-			payload = next
-		} else {
-			payload = payload[:newLen]
-		}
-		payload[off] = byte(op.Op)
-		binary.LittleEndian.PutUint32(payload[off+1:off+5], uint32(len(op.Key)))
-		binary.LittleEndian.PutUint32(payload[off+5:off+9], uint32(len(value)))
-		off += rawKVOpHeaderSize
-		copy(payload[off:], op.Key)
-		off += len(op.Key)
-		copy(payload[off:], value)
-		off += len(value)
-		count++
-		return nil
+		_, _, err := builder.Append(op)
+		return err
 	}); err != nil {
 		return nil, err
 	}
-	binary.LittleEndian.PutUint32(payload[2:6], uint32(count))
-	return payload, nil
+	return builder.Payload(), nil
 }
 
 func DecodeRawKVBatchPayload(payload []byte) ([]RawKVOperation, error) {
 	if err := validateRawKVBatchPayload(payload); err != nil {
 		return nil, err
+	}
+	version := binary.LittleEndian.Uint16(payload[0:2])
+	if version == rawKVZeroBatchPayloadV2 || version == rawKVZeroBatchPayloadV3 {
+		count := binary.LittleEndian.Uint32(payload[2:6])
+		valueLen := int(binary.LittleEndian.Uint32(payload[6:10]))
+		ops := make([]RawKVOperation, 0, count)
+		zeroValue := make([]byte, valueLen)
+		off := rawKVZeroBatchHeaderSize
+		for i := uint32(0); i < count; i++ {
+			keyLen, nextOff, err := readCompactZeroKeyLen(payload, off, version)
+			if err != nil {
+				return nil, err
+			}
+			off = nextOff
+			entry := RawKVOperation{Op: RawKVOpSet}
+			entry.Key = cloneBytesPreserveEmpty(payload[off : off+keyLen])
+			off += keyLen
+			entry.Value = cloneBytesPreserveEmpty(zeroValue)
+			ops = append(ops, entry)
+		}
+		return ops, nil
 	}
 	count := binary.LittleEndian.Uint32(payload[2:6])
 	ops := make([]RawKVOperation, 0, count)
@@ -986,7 +1522,11 @@ func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []b
 	if len(payload) < rawKVBatchHeaderSize {
 		return ErrCorrupt
 	}
-	if binary.LittleEndian.Uint16(payload[0:2]) != 1 {
+	version := binary.LittleEndian.Uint16(payload[0:2])
+	if version == rawKVZeroBatchPayloadV2 || version == rawKVZeroBatchPayloadV3 {
+		return scanRawKVZeroBatchPayload(payload, visit)
+	}
+	if version != rawKVBatchPayloadVersion {
 		return ErrCommandWALUnsupportedVersion
 	}
 	count := binary.LittleEndian.Uint32(payload[2:6])
@@ -1026,6 +1566,54 @@ func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []b
 			}
 		}
 		off += int(valueLen)
+	}
+	if off != len(payload) {
+		return ErrCorrupt
+	}
+	return nil
+}
+
+func scanRawKVZeroBatchPayload(payload []byte, visit func(op RawKVOp, key, value []byte) error) error {
+	if len(payload) < rawKVZeroBatchHeaderSize {
+		return ErrCorrupt
+	}
+	count := binary.LittleEndian.Uint32(payload[2:6])
+	valueLen := binary.LittleEndian.Uint32(payload[6:10])
+	version := binary.LittleEndian.Uint16(payload[0:2])
+	opHeaderSize := rawKVZeroOpHeaderSizeForVersion(version)
+	if valueLen == 0 {
+		return ErrCorrupt
+	}
+	if count > uint32((len(payload)-rawKVZeroBatchHeaderSize)/opHeaderSize) {
+		return ErrCorrupt
+	}
+	if uint64(valueLen) > uint64(^uint(0)>>1) {
+		return ErrRecordTooLarge
+	}
+	var zeroValue []byte
+	if visit != nil {
+		zeroValue = make([]byte, int(valueLen))
+	}
+	off := rawKVZeroBatchHeaderSize
+	for i := uint32(0); i < count; i++ {
+		keyLen, nextOff, err := readCompactZeroKeyLen(payload, off, version)
+		if err != nil {
+			return err
+		}
+		off = nextOff
+		if keyLen > len(payload)-off {
+			return ErrCorrupt
+		}
+		key := payload[off : off+keyLen]
+		off += keyLen
+		if key == nil {
+			return ErrCorrupt
+		}
+		if visit != nil {
+			if err := visit(RawKVOpSet, key, zeroValue); err != nil {
+				return err
+			}
+		}
 	}
 	if off != len(payload) {
 		return ErrCorrupt

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -82,6 +82,127 @@ func TestCommandWALRawKVBatchPreservesEmptySetValue(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawKVBatchZeroPayloadV3ScanDecode(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(2, 32); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("alpha"), make([]byte, 4)); err != nil {
+		t.Fatalf("AppendSet alpha: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("beta"), make([]byte, 4)); err != nil {
+		t.Fatalf("AppendSet beta: %v", err)
+	}
+	payload := builder.Payload()
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVZeroBatchPayloadV3 {
+		t.Fatalf("payload version=%d want %d payload=%x", got, rawKVZeroBatchPayloadV3, payload)
+	}
+	if len(payload) >= rawKVBatchHeaderSize+2*(rawKVOpHeaderSize+4+4) {
+		t.Fatalf("zero payload was not compact: len=%d", len(payload))
+	}
+
+	var scanned []RawKVOperation
+	if err := ScanRawKVBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
+		scanned = append(scanned, RawKVOperation{
+			Op:    op,
+			Key:   cloneBytesPreserveEmpty(key),
+			Value: cloneBytesPreserveEmpty(value),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if len(scanned) != 2 || scanned[0].Op != RawKVOpSet || string(scanned[0].Key) != "alpha" || !bytes.Equal(scanned[0].Value, make([]byte, 4)) ||
+		scanned[1].Op != RawKVOpSet || string(scanned[1].Key) != "beta" || !bytes.Equal(scanned[1].Value, make([]byte, 4)) {
+		t.Fatalf("scanned compact zero ops mismatch: %+v", scanned)
+	}
+
+	decoded, err := DecodeRawKVBatchPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(decoded) != 2 || string(decoded[0].Key) != "alpha" || !bytes.Equal(decoded[0].Value, make([]byte, 4)) ||
+		string(decoded[1].Key) != "beta" || !bytes.Equal(decoded[1].Value, make([]byte, 4)) {
+		t.Fatalf("decoded compact zero ops mismatch: %+v", decoded)
+	}
+}
+
+func TestRawKVBatchPayloadBuilderZeroCompactAvoidsExpandedPayloadReserve(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(8192, 8192*192); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if got := cap(builder.payload); got != rawKVBatchHeaderSize {
+		t.Fatalf("raw payload cap after reset=%d want header-only %d", got, rawKVBatchHeaderSize)
+	}
+	if _, _, err := builder.AppendSet([]byte("alpha"), make([]byte, 128)); err != nil {
+		t.Fatalf("AppendSet alpha: %v", err)
+	}
+	if got := cap(builder.payload); got != rawKVBatchHeaderSize {
+		t.Fatalf("raw payload cap after compact zero append=%d want header-only %d", got, rawKVBatchHeaderSize)
+	}
+	payload := builder.Payload()
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVZeroBatchPayloadV3 {
+		t.Fatalf("payload version=%d want %d", got, rawKVZeroBatchPayloadV3)
+	}
+}
+
+func TestCommandWALRawKVBatchZeroPayloadV2FallbackForLargeKey(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(1, 70_004); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	key := bytes.Repeat([]byte("k"), int(^uint16(0))+1)
+	if _, _, err := builder.AppendSet(key, make([]byte, 4)); err != nil {
+		t.Fatalf("AppendSet large key: %v", err)
+	}
+	payload := builder.Payload()
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVZeroBatchPayloadV2 {
+		t.Fatalf("payload version=%d want %d", got, rawKVZeroBatchPayloadV2)
+	}
+	decoded, err := DecodeRawKVBatchPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(decoded) != 1 || !bytes.Equal(decoded[0].Key, key) || !bytes.Equal(decoded[0].Value, make([]byte, 4)) {
+		t.Fatalf("decoded v2 fallback mismatch: len=%d", len(decoded))
+	}
+}
+
+func TestRawKVBatchPayloadBuilderZeroCompactionFallsBackForMixedValues(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(2, 32); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("stale"), bytes.Repeat([]byte{0xff}, 4)); err != nil {
+		t.Fatalf("AppendSet stale: %v", err)
+	}
+	_ = builder.Payload()
+	if err := builder.ResetWithHint(2, 32); err != nil {
+		t.Fatalf("ResetWithHint after stale payload: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("alpha"), make([]byte, 4)); err != nil {
+		t.Fatalf("AppendSet alpha: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("beta"), []byte{0, 0, 0, 1}); err != nil {
+		t.Fatalf("AppendSet beta: %v", err)
+	}
+	payload := builder.Payload()
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVBatchPayloadVersion {
+		t.Fatalf("payload version=%d want %d", got, rawKVBatchPayloadVersion)
+	}
+	decoded, err := DecodeRawKVBatchPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(decoded) != 2 || !bytes.Equal(decoded[1].Value, []byte{0, 0, 0, 1}) {
+		t.Fatalf("decoded mixed ops mismatch: %+v", decoded)
+	}
+	if !bytes.Equal(decoded[0].Value, make([]byte, 4)) {
+		t.Fatalf("materialized omitted zero value = %x, want zeros", decoded[0].Value)
+	}
+}
+
 func TestCommandWALCollectionPayloadDecodeBoundsCountBeforeAllocation(t *testing.T) {
 	payload := make([]byte, 10+len("users"))
 	encodeCollectionBatchHeader(payload, "users", int(^uint32(0)))
@@ -674,6 +795,68 @@ func TestWriterDeferredCommandBufferHonorsConfiguredLimit(t *testing.T) {
 	}
 }
 
+func TestWriterLargeBatchPayloadBypassesDeferredCommandBufferAndPreservesOrder(t *testing.T) {
+	smallPayload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("small"), Value: []byte("value")},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload small: %v", err)
+	}
+	largePayload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("large"), Value: bytes.Repeat([]byte("x"), directCommandPayloadMinLen)},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload large: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 64 << 20})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	if err := w.AppendRawKVBatchPayloadCommandDirectTrusted(1, 0, smallPayload); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendRawKVBatchPayloadCommandDirectTrusted small: %v", err)
+	}
+	if got := len(w.commandBuf); got == 0 {
+		_ = w.Close()
+		t.Fatal("small command frame was not buffered")
+	}
+	if err := w.AppendRawKVBatchPayloadCommandDirectTrusted(2, 0, largePayload); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendRawKVBatchPayloadCommandDirectTrusted large: %v", err)
+	}
+	if got := len(w.commandBuf); got != 0 {
+		_ = w.Close()
+		t.Fatalf("deferred command buffer len=%d, want 0 after large direct append", got)
+	}
+	if got := w.Size(); got == 0 {
+		_ = w.Close()
+		t.Fatal("writer size after large direct append=0, want bytes accounted")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	r, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	first, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame first: %v", err)
+	}
+	if first.LSN != 1 || !bytes.Equal(first.Payload, smallPayload) {
+		t.Fatalf("first frame mismatch: lsn=%d payload_len=%d", first.LSN, len(first.Payload))
+	}
+	second, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame second: %v", err)
+	}
+	if second.LSN != 2 || !bytes.Equal(second.Payload, largePayload) {
+		t.Fatalf("second frame mismatch: lsn=%d payload_len=%d", second.LSN, len(second.Payload))
+	}
+}
+
 func TestWriterDirectCommandWriteFailurePoisonsWriter(t *testing.T) {
 	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: bytes.Repeat([]byte("x"), directCommandPayloadMinLen)},
@@ -875,6 +1058,34 @@ func TestCommandWALFeatureGateRejectsLegacyRawPayload(t *testing.T) {
 		t.Fatalf("NewWriter: %v", err)
 	}
 	if err := w.AppendBatch([]Record{{Op: OpSetInline, Key: []byte("k"), Value: []byte("v"), Seq: 1}}); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendBatch: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	r, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	_, err = r.ReadCommandFrame()
+	if !errors.Is(err, ErrCommandWALLegacyPayload) {
+		t.Fatalf("ReadCommandFrame error=%v, want ErrCommandWALLegacyPayload", err)
+	}
+}
+
+func TestCommandWALFeatureGateRejectsCompactZeroInlineLegacyPayload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	value := make([]byte, 64)
+	if err := w.AppendBatch([]Record{
+		{Op: OpSetInline, Key: []byte("a"), Value: value, Seq: 1},
+		{Op: OpSetInline, Key: []byte("b"), Value: value, Seq: 1},
+	}); err != nil {
 		_ = w.Close()
 		t.Fatalf("AppendBatch: %v", err)
 	}

--- a/TreeDB/internal/commitlog/commitlog.go
+++ b/TreeDB/internal/commitlog/commitlog.go
@@ -4,14 +4,23 @@ import "errors"
 
 const (
 	Version = 1
+	// zeroInlineBatchVersion is a compact batch payload for all-zero inline
+	// values. Readers normalize it to ordinary OpSetInline records.
+	zeroInlineBatchVersion = 2
 
 	OpSetRID    = byte(0)
 	OpSetInline = byte(1)
 	OpDelete    = byte(2)
+	// OpSetInlineZero stores an inline zero-filled value without carrying the
+	// value bytes. Readers normalize it back to OpSetInline.
+	OpSetInlineZero = byte(3)
 
 	segmentHeaderSize = 8
 	batchHeaderSize   = 1 + 4
 	recordHeaderSize  = 1 + 2 + 4 + 8 + 8
+
+	zeroInlineBatchHeaderSize  = 1 + 4 + 8 + 4
+	zeroInlineRecordHeaderSize = 2
 )
 
 const (
@@ -33,6 +42,10 @@ var (
 	ErrCommandWALStaleSegment            = errors.New("commitlog: command wal stale segment")
 	ErrJournalOwnerExists                = errors.New("commitlog: journal owner already exists")
 )
+
+func isBatchPayloadVersion(version byte) bool {
+	return version == Version || version == zeroInlineBatchVersion
+}
 
 type Record struct {
 	Op    byte

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -73,6 +73,89 @@ func TestCommitLogWriteReadBatch(t *testing.T) {
 	_ = reader.Close()
 }
 
+func TestCommitLogWriteReadLargeRawBatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := make([]Record, 2048)
+	value := bytes.Repeat([]byte("v"), 128)
+	for i := range records {
+		records[i] = Record{
+			Op:    OpSetInline,
+			Key:   []byte{byte(i), byte(i >> 8), byte(i >> 16)},
+			Value: value,
+			Seq:   7,
+		}
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append large raw batch: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != len(records) {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), len(records))
+	}
+	for i := range records {
+		if got[i].Op != records[i].Op || got[i].Seq != records[i].Seq ||
+			!bytes.Equal(got[i].Key, records[i].Key) || !bytes.Equal(got[i].Value, records[i].Value) {
+			_ = reader.Close()
+			t.Fatalf("record %d mismatch", i)
+		}
+	}
+	_ = reader.Close()
+}
+
+func TestWriterRotateToWithSyncSkipsDirSyncWhenRelaxed(t *testing.T) {
+	dir := t.TempDir()
+	path0 := filepath.Join(dir, "commit-0.log")
+	path1 := filepath.Join(dir, "commit-1.log")
+	path2 := filepath.Join(dir, "commit-2.log")
+
+	oldSyncDirFn := syncDirFn
+	defer func() { syncDirFn = oldSyncDirFn }()
+	calls := 0
+	syncDirFn = func(string) error {
+		calls++
+		return nil
+	}
+
+	writer, err := NewWriterWithOptions(path0, Options{})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+	calls = 0
+	if err := writer.RotateToWithSync(path1, false); err != nil {
+		t.Fatalf("relaxed RotateToWithSync: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("relaxed RotateToWithSync syncDir calls=%d, want 0", calls)
+	}
+	if err := writer.RotateToWithSync(path2, true); err != nil {
+		t.Fatalf("strict RotateToWithSync: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("strict RotateToWithSync syncDir calls=%d, want 1", calls)
+	}
+}
+
 func TestCommitLogWriteReadBatchCompressed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -122,6 +122,188 @@ func TestCommitLogWriteReadLargeRawBatch(t *testing.T) {
 	_ = reader.Close()
 }
 
+func TestCommitLogWriteReadZeroInlineBatchCompact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := make([]Record, 8000)
+	value := make([]byte, 128)
+	for i := range records {
+		var key [8]byte
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		records[i] = Record{
+			Op:    OpSetInline,
+			Key:   bytes.Clone(key[:]),
+			Value: value,
+			Seq:   11,
+		}
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append zero inline batch: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if len(data) < segmentHeaderSize+batchHeaderSize+recordHeaderSize {
+		t.Fatalf("unexpected compact segment size %d", len(data))
+	}
+	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+	wantPayloadLen := zeroInlineBatchHeaderSize + len(records)*(zeroInlineRecordHeaderSize+8)
+	if payloadLen != wantPayloadLen {
+		t.Fatalf("payload len=%d, want compact len %d", payloadLen, wantPayloadLen)
+	}
+	if got := data[segmentHeaderSize]; got != zeroInlineBatchVersion {
+		t.Fatalf("raw batch version=%d, want compact zero batch version %d", got, zeroInlineBatchVersion)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != len(records) {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), len(records))
+	}
+	for i := range got {
+		if got[i].Op != OpSetInline || got[i].Seq != 11 || !bytes.Equal(got[i].Value, value) {
+			_ = reader.Close()
+			t.Fatalf("decoded record %d mismatch: op=%d seq=%d value_len=%d", i, got[i].Op, got[i].Seq, len(got[i].Value))
+		}
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogWriteReadZeroInlineBatchFuncCompact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	count := 8000
+	keys := make([][]byte, count)
+	for i := range keys {
+		var key [8]byte
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		keys[i] = bytes.Clone(key[:])
+	}
+	if err := writer.AppendZeroInlineBatchFunc(count, 22, 128, func(i int) []byte {
+		return keys[i]
+	}); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append zero inline batch func: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+	wantPayloadLen := zeroInlineBatchHeaderSize + count*(zeroInlineRecordHeaderSize+8)
+	if payloadLen != wantPayloadLen {
+		t.Fatalf("payload len=%d, want compact len %d", payloadLen, wantPayloadLen)
+	}
+	if got := data[segmentHeaderSize]; got != zeroInlineBatchVersion {
+		t.Fatalf("raw batch version=%d, want compact zero batch version %d", got, zeroInlineBatchVersion)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != count {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), count)
+	}
+	value := make([]byte, 128)
+	for i := range got {
+		if got[i].Op != OpSetInline || got[i].Seq != 22 || !bytes.Equal(got[i].Key, keys[i]) || !bytes.Equal(got[i].Value, value) {
+			_ = reader.Close()
+			t.Fatalf("decoded record %d mismatch: op=%d seq=%d key_len=%d value_len=%d", i, got[i].Op, got[i].Seq, len(got[i].Key), len(got[i].Value))
+		}
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogWriteReadMixedZeroInlineRecordCompact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := []Record{
+		{Op: OpSetInline, Key: []byte("zero"), Value: make([]byte, 16), Seq: 1},
+		{Op: OpDelete, Key: []byte("gone"), Seq: 1},
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append mixed zero batch: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if got := data[segmentHeaderSize]; got != Version {
+		t.Fatalf("raw batch version=%d, want v1", got)
+	}
+	if got := data[segmentHeaderSize+batchHeaderSize]; got != OpSetInlineZero {
+		t.Fatalf("raw op=%d, want compact zero op %d", got, OpSetInlineZero)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != len(records) {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), len(records))
+	}
+	if got[0].Op != OpSetInline || !bytes.Equal(got[0].Value, records[0].Value) {
+		_ = reader.Close()
+		t.Fatalf("decoded zero record mismatch: op=%d value=%x", got[0].Op, got[0].Value)
+	}
+	if got[1].Op != OpDelete {
+		_ = reader.Close()
+		t.Fatalf("decoded delete op=%d, want delete", got[1].Op)
+	}
+	_ = reader.Close()
+}
+
 func TestWriterRotateToWithSyncSkipsDirSyncWhenRelaxed(t *testing.T) {
 	dir := t.TempDir()
 	path0 := filepath.Join(dir, "commit-0.log")

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -630,6 +630,41 @@ func (j *CommandJournal) AppendRawKVBatchPayloadCommandTrusted(baseAppliedLSN ui
 	return lsn, nil
 }
 
+// AppendRawKVBatchPayloadCommandTrustedAndFlush appends a caller-validated
+// RawKVBatch payload and flushes/syncs the writer while holding the journal
+// lock. If the append succeeds but the flush fails, the allocated LSN is
+// returned with the flush error so callers can preserve the commit-ambiguous
+// command-WAL failure contract.
+func (j *CommandJournal) AppendRawKVBatchPayloadCommandTrustedAndFlush(baseAppliedLSN uint64, payload []byte, sync bool) (uint64, error) {
+	if j == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil || j.owner == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	lsn, err := j.reserveLSNLocked()
+	if err != nil {
+		return 0, err
+	}
+	if err := j.writer.AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN, payload); err != nil {
+		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
+			return 0, errors.Join(err, rollbackErr)
+		}
+		return 0, err
+	}
+	if sync {
+		err = j.writer.Sync()
+	} else {
+		err = j.writer.Flush()
+	}
+	if err != nil {
+		return lsn, err
+	}
+	return lsn, nil
+}
+
 func (j *CommandJournal) Path() string {
 	if j == nil {
 		return ""

--- a/TreeDB/internal/commitlog/reader.go
+++ b/TreeDB/internal/commitlog/reader.go
@@ -101,9 +101,17 @@ func decodeBatch(payload []byte) ([]Record, error) {
 	if len(payload) < batchHeaderSize {
 		return nil, ErrCorrupt
 	}
-	if payload[0] != Version {
+	switch payload[0] {
+	case Version:
+		return decodeBatchV1(payload)
+	case zeroInlineBatchVersion:
+		return decodeZeroInlineBatch(payload)
+	default:
 		return nil, ErrCorrupt
 	}
+}
+
+func decodeBatchV1(payload []byte) ([]Record, error) {
 	count := binary.LittleEndian.Uint32(payload[1:5])
 	minBytes := int64(count) * int64(recordHeaderSize)
 	if minBytes < 0 || minBytes > int64(len(payload)) {
@@ -128,13 +136,19 @@ func decodeBatch(payload []byte) ([]Record, error) {
 			return nil, ErrRecordTooLarge
 		}
 		recSize := recordHeaderSize + int(keyLen) + int(valLen)
+		if op == OpSetInlineZero {
+			recSize = recordHeaderSize + int(keyLen)
+		}
 		if off+recSize > len(payload) {
 			return nil, ErrCorrupt
 		}
 		keyStart := off + recordHeaderSize
 		valStart := keyStart + int(keyLen)
 		key := payload[keyStart:valStart]
-		val := payload[valStart : valStart+int(valLen)]
+		var val []byte
+		if op != OpSetInlineZero {
+			val = payload[valStart : valStart+int(valLen)]
+		}
 
 		switch op {
 		case OpDelete:
@@ -149,12 +163,57 @@ func decodeBatch(payload []byte) ([]Record, error) {
 			if rid != 0 {
 				return nil, ErrCorrupt
 			}
+		case OpSetInlineZero:
+			if rid != 0 {
+				return nil, ErrCorrupt
+			}
+			val = make([]byte, int(valLen))
+			op = OpSetInline
 		default:
 			return nil, ErrCorrupt
 		}
 
 		records = append(records, Record{Op: op, Key: key, Value: val, RID: rid, Seq: seq})
 		off += recSize
+	}
+	if off != len(payload) {
+		return nil, ErrCorrupt
+	}
+	return records, nil
+}
+
+func decodeZeroInlineBatch(payload []byte) ([]Record, error) {
+	if len(payload) < zeroInlineBatchHeaderSize {
+		return nil, ErrCorrupt
+	}
+	count := binary.LittleEndian.Uint32(payload[1:5])
+	seq := binary.LittleEndian.Uint64(payload[5:13])
+	valLen := binary.LittleEndian.Uint32(payload[13:17])
+	minBytes := int64(count) * int64(zeroInlineRecordHeaderSize)
+	if minBytes < 0 || minBytes > int64(len(payload)-zeroInlineBatchHeaderSize) {
+		return nil, ErrCorrupt
+	}
+	if recordSizeExceedsMax(0, valLen) {
+		return nil, ErrRecordTooLarge
+	}
+	records := make([]Record, 0, count)
+	value := make([]byte, int(valLen))
+	off := zeroInlineBatchHeaderSize
+	for i := uint32(0); i < count; i++ {
+		if off+zeroInlineRecordHeaderSize > len(payload) {
+			return nil, ErrCorrupt
+		}
+		keyLen := binary.LittleEndian.Uint16(payload[off : off+2])
+		if recordSizeExceedsMax(keyLen, valLen) {
+			return nil, ErrRecordTooLarge
+		}
+		off += zeroInlineRecordHeaderSize
+		if off+int(keyLen) > len(payload) {
+			return nil, ErrCorrupt
+		}
+		key := payload[off : off+int(keyLen)]
+		off += int(keyLen)
+		records = append(records, Record{Op: OpSetInline, Key: key, Value: value, Seq: seq})
 	}
 	if off != len(payload) {
 		return nil, ErrCorrupt

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -20,7 +20,9 @@ const (
 	defaultBufferSize          = 4 << 20
 	defaultMaxSegmentSize      = 64 * 1024 * 1024
 	defaultCompressMinLen      = 64 << 10
+	directSegmentPayloadMinLen = 128 << 10
 	directCommandPayloadMinLen = 32 << 10
+	batchChecksumChunkBytes    = 64 << 10
 )
 
 var syncDirFn = syncDir
@@ -132,6 +134,13 @@ func (w *Writer) ensureEncoder() error {
 // RotateTo flushes and closes the current file, then opens (or creates) the
 // provided path and reuses the writer's buffers for future appends.
 func (w *Writer) RotateTo(path string) error {
+	return w.RotateToWithSync(path, true)
+}
+
+// RotateToWithSync flushes and closes the current file, then opens (or creates)
+// the provided path and reuses the writer's buffers for future appends. When
+// syncCurrent is false, the current file is flushed to the OS but not fsynced.
+func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 	if w == nil {
 		return errors.New("commitlog: nil writer")
 	}
@@ -141,9 +150,11 @@ func (w *Writer) RotateTo(path string) error {
 		if err != nil {
 			return err
 		}
-		if err := syncDirFn(path); err != nil {
-			_ = f.Close()
-			return err
+		if syncCurrent {
+			if err := syncDirFn(path); err != nil {
+				_ = f.Close()
+				return err
+			}
 		}
 		info, err := f.Stat()
 		if err != nil {
@@ -163,7 +174,7 @@ func (w *Writer) RotateTo(path string) error {
 	if err := w.bw.Flush(); err != nil {
 		return err
 	}
-	if w.syncFn != nil {
+	if syncCurrent && w.syncFn != nil {
 		if err := w.syncFn(w.f); err != nil {
 			return err
 		}
@@ -178,9 +189,11 @@ func (w *Writer) RotateTo(path string) error {
 		_ = f.Close()
 		return err
 	}
-	if err := syncDirFn(path); err != nil {
-		_ = f.Close()
-		return err
+	if syncCurrent {
+		if err := syncDirFn(path); err != nil {
+			_ = f.Close()
+			return err
+		}
 	}
 
 	old := w.f
@@ -270,8 +283,20 @@ func (w *Writer) AppendBatch(records []Record) error {
 		return ErrRecordTooLarge
 	}
 
-	total := int64(batchHeaderSize)
 	batchSeq := records[0].Seq
+	if cap(w.scratch) < batchHeaderSize {
+		w.scratch = make([]byte, batchHeaderSize)
+	}
+	buf := w.scratch
+	if len(buf) < batchHeaderSize {
+		buf = buf[:batchHeaderSize]
+	}
+	buf[0] = Version
+	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
+
+	off := batchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
 	for i := range records {
 		r := &records[i]
 		if err := validateRecord(r); err != nil {
@@ -291,39 +316,51 @@ func (w *Writer) AppendBatch(records []Record) error {
 		if recordSizeExceedsMax(keyLen, valLen) {
 			return ErrRecordTooLarge
 		}
-		total += int64(recordHeaderSize) + int64(len(r.Key)) + int64(len(r.Value))
-	}
-	if w.maxSegmentSize > 0 && total > w.maxSegmentSize {
-		return ErrRecordTooLarge
-	}
-	if total > int64(int(^uint(0)>>1)) {
-		return ErrRecordTooLarge
-	}
 
-	if cap(w.scratch) < int(total) {
-		w.scratch = make([]byte, int(total))
-	}
-	buf := w.scratch[:int(total)]
-
-	buf[0] = Version
-	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
-
-	off := batchHeaderSize
-	for i := range records {
-		r := &records[i]
-		keyLen := uint16(len(r.Key))
-		valLen := uint32(len(r.Value))
+		recLen := recordHeaderSize + len(r.Key) + len(r.Value)
+		if off > int(^uint(0)>>1)-recLen {
+			return ErrRecordTooLarge
+		}
+		next := off + recLen
+		if w.maxSegmentSize > 0 && int64(next) > w.maxSegmentSize {
+			return ErrRecordTooLarge
+		}
+		if next > int(segmentLenMask) {
+			return ErrRecordTooLarge
+		}
+		if next > cap(buf) {
+			newCap := cap(buf) * 2
+			if newCap < next {
+				newCap = next
+			}
+			nextBuf := make([]byte, next, newCap)
+			copy(nextBuf, buf[:off])
+			buf = nextBuf
+		} else if next > len(buf) {
+			buf = buf[:next]
+		}
 		buf[off] = r.Op
 		binary.LittleEndian.PutUint16(buf[off+1:off+3], keyLen)
 		binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 		binary.LittleEndian.PutUint64(buf[off+7:off+15], r.RID)
 		binary.LittleEndian.PutUint64(buf[off+15:off+23], r.Seq)
 		copy(buf[off+recordHeaderSize:], r.Key)
-		copy(buf[off+recordHeaderSize+len(r.Key):], r.Value)
-		off += recordHeaderSize + len(r.Key) + len(r.Value)
+		valueStart := off + recordHeaderSize + len(r.Key)
+		valueEnd := valueStart + len(r.Value)
+		copy(buf[valueStart:valueEnd], r.Value)
+		off = next
+		if !w.compress && off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
 	}
 
-	return w.writeSegment(buf)
+	w.scratch = buf[:off]
+	if !w.compress {
+		checksum = crc.Update(checksum, w.scratch[checksumStart:])
+		return w.writeRawSegmentWithChecksum(w.scratch, checksum)
+	}
+	return w.writeSegment(w.scratch)
 }
 
 func (w *Writer) AppendCommand(env CommandEnvelope) error {
@@ -674,6 +711,22 @@ func (w *Writer) writeSegment(payload []byte) error {
 	binary.LittleEndian.PutUint32(header[0:4], length)
 	binary.LittleEndian.PutUint32(header[4:8], wantCRC)
 
+	storedLen := int(length & segmentLenMask)
+	if segmentHeaderSize+storedLen >= directSegmentPayloadMinLen {
+		if err := w.bw.Flush(); err != nil {
+			return err
+		}
+		if length&segmentFlagCompressed != 0 {
+			if err := writevFull(w.f, [][]byte{header, rawLenPrefix, stored}); err != nil {
+				return err
+			}
+		} else if err := writevFull(w.f, [][]byte{header, stored}); err != nil {
+			return err
+		}
+		w.size += int64(segmentHeaderSize) + int64(storedLen)
+		return nil
+	}
+
 	if _, err := w.bw.Write(header); err != nil {
 		return err
 	}
@@ -685,7 +738,41 @@ func (w *Writer) writeSegment(payload []byte) error {
 	if _, err := w.bw.Write(stored); err != nil {
 		return err
 	}
-	w.size += int64(segmentHeaderSize) + int64(length&segmentLenMask)
+	w.size += int64(segmentHeaderSize) + int64(storedLen)
+	return nil
+}
+
+func (w *Writer) writeRawSegmentWithChecksum(payload []byte, wantCRC uint32) error {
+	if err := w.flushBufferedCommandFrames(); err != nil {
+		return err
+	}
+	if len(payload) > int(segmentLenMask) {
+		return ErrRecordTooLarge
+	}
+	length := uint32(len(payload))
+	header := w.headerBuf[:]
+	binary.LittleEndian.PutUint32(header[0:4], length)
+	binary.LittleEndian.PutUint32(header[4:8], wantCRC)
+
+	storedLen := int(length)
+	if segmentHeaderSize+storedLen >= directSegmentPayloadMinLen {
+		if err := w.bw.Flush(); err != nil {
+			return err
+		}
+		if err := writevFull(w.f, [][]byte{header, payload}); err != nil {
+			return err
+		}
+		w.size += int64(segmentHeaderSize) + int64(storedLen)
+		return nil
+	}
+
+	if _, err := w.bw.Write(header); err != nil {
+		return err
+	}
+	if _, err := w.bw.Write(payload); err != nil {
+		return err
+	}
+	w.size += int64(segmentHeaderSize) + int64(storedLen)
 	return nil
 }
 

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -21,7 +21,7 @@ const (
 	defaultMaxSegmentSize      = 64 * 1024 * 1024
 	defaultCompressMinLen      = 64 << 10
 	directSegmentPayloadMinLen = 128 << 10
-	directCommandPayloadMinLen = 32 << 10
+	directCommandPayloadMinLen = 64 << 10
 	batchChecksumChunkBytes    = 64 << 10
 )
 
@@ -50,6 +50,19 @@ func recordSizeExceedsMax(keyLen uint16, valueLen uint32) bool {
 	}
 	recordLen := int64(recordHeaderSize) + int64(keyLen) + int64(valueLen)
 	return recordLen > limits.MaxRecordSize
+}
+
+func allZeroBytes(p []byte) bool {
+	for _, b := range p {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func sameNonEmptyBytesData(a, b []byte) bool {
+	return len(a) > 0 && len(a) == len(b) && &a[0] == &b[0]
 }
 
 type Writer struct {
@@ -284,6 +297,11 @@ func (w *Writer) AppendBatch(records []Record) error {
 	}
 
 	batchSeq := records[0].Seq
+	if !w.compress {
+		if ok, err := w.appendZeroInlineBatchIfCompact(records, batchSeq); ok || err != nil {
+			return err
+		}
+	}
 	if cap(w.scratch) < batchHeaderSize {
 		w.scratch = make([]byte, batchHeaderSize)
 	}
@@ -297,6 +315,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 	off := batchHeaderSize
 	checksum := uint32(0)
 	checksumStart := 0
+	var zeroValueRef []byte
 	for i := range records {
 		r := &records[i]
 		if err := validateRecord(r); err != nil {
@@ -317,7 +336,20 @@ func (w *Writer) AppendBatch(records []Record) error {
 			return ErrRecordTooLarge
 		}
 
-		recLen := recordHeaderSize + len(r.Key) + len(r.Value)
+		encodedOp := r.Op
+		writeValue := len(r.Value) > 0
+		if r.Op == OpSetInline && len(r.Value) > 0 {
+			if sameNonEmptyBytesData(r.Value, zeroValueRef) || allZeroBytes(r.Value) {
+				zeroValueRef = r.Value
+				encodedOp = OpSetInlineZero
+				writeValue = false
+			}
+		}
+
+		recLen := recordHeaderSize + len(r.Key)
+		if writeValue {
+			recLen += len(r.Value)
+		}
 		if off > int(^uint(0)>>1)-recLen {
 			return ErrRecordTooLarge
 		}
@@ -339,15 +371,17 @@ func (w *Writer) AppendBatch(records []Record) error {
 		} else if next > len(buf) {
 			buf = buf[:next]
 		}
-		buf[off] = r.Op
+		buf[off] = encodedOp
 		binary.LittleEndian.PutUint16(buf[off+1:off+3], keyLen)
 		binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 		binary.LittleEndian.PutUint64(buf[off+7:off+15], r.RID)
 		binary.LittleEndian.PutUint64(buf[off+15:off+23], r.Seq)
 		copy(buf[off+recordHeaderSize:], r.Key)
-		valueStart := off + recordHeaderSize + len(r.Key)
-		valueEnd := valueStart + len(r.Value)
-		copy(buf[valueStart:valueEnd], r.Value)
+		if writeValue {
+			valueStart := off + recordHeaderSize + len(r.Key)
+			valueEnd := valueStart + len(r.Value)
+			copy(buf[valueStart:valueEnd], r.Value)
+		}
 		off = next
 		if !w.compress && off-checksumStart >= batchChecksumChunkBytes {
 			checksum = crc.Update(checksum, buf[checksumStart:off])
@@ -361,6 +395,155 @@ func (w *Writer) AppendBatch(records []Record) error {
 		return w.writeRawSegmentWithChecksum(w.scratch, checksum)
 	}
 	return w.writeSegment(w.scratch)
+}
+
+func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint64) (bool, error) {
+	valueLen := -1
+	var zeroValueRef []byte
+	total := int64(zeroInlineBatchHeaderSize)
+	for i := range records {
+		r := &records[i]
+		if r.Op != OpSetInline {
+			return false, nil
+		}
+		if err := validateRecord(r); err != nil {
+			return true, err
+		}
+		if r.Seq != batchSeq {
+			return true, ErrMixedBatchSeq
+		}
+		if len(r.Key) > int(^uint16(0)) {
+			return true, ErrRecordTooLarge
+		}
+		if len(r.Value) > int(^uint32(0)) {
+			return true, ErrRecordTooLarge
+		}
+		keyLen := uint16(len(r.Key))
+		valLen := uint32(len(r.Value))
+		if recordSizeExceedsMax(keyLen, valLen) {
+			return true, ErrRecordTooLarge
+		}
+		if len(r.Value) == 0 {
+			return false, nil
+		}
+		if valueLen < 0 {
+			valueLen = len(r.Value)
+		} else if valueLen != len(r.Value) {
+			return false, nil
+		}
+		if sameNonEmptyBytesData(r.Value, zeroValueRef) {
+			// Same immutable value buffer as the first zero value in this batch.
+		} else if allZeroBytes(r.Value) {
+			zeroValueRef = r.Value
+		} else {
+			return false, nil
+		}
+		total += int64(zeroInlineRecordHeaderSize) + int64(len(r.Key))
+		if w.maxSegmentSize > 0 && total > w.maxSegmentSize {
+			return true, ErrRecordTooLarge
+		}
+		if total > int64(segmentLenMask) || total > int64(int(^uint(0)>>1)) {
+			return true, ErrRecordTooLarge
+		}
+	}
+	if valueLen < 0 {
+		return false, nil
+	}
+	payloadLen := int(total)
+	if cap(w.scratch) < payloadLen {
+		w.scratch = make([]byte, payloadLen)
+	}
+	buf := w.scratch[:payloadLen]
+	buf[0] = zeroInlineBatchVersion
+	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
+	binary.LittleEndian.PutUint64(buf[5:13], batchSeq)
+	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
+
+	off := zeroInlineBatchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
+	for i := range records {
+		r := &records[i]
+		keyLen := uint16(len(r.Key))
+		binary.LittleEndian.PutUint16(buf[off:off+2], keyLen)
+		off += zeroInlineRecordHeaderSize
+		copy(buf[off:off+len(r.Key)], r.Key)
+		off += len(r.Key)
+		if off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
+	}
+	checksum = crc.Update(checksum, buf[checksumStart:])
+	w.scratch = buf
+	return true, w.writeRawSegmentWithChecksum(buf, checksum)
+}
+
+func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error {
+	if count == 0 {
+		return nil
+	}
+	if count < 0 || count > int(^uint32(0)) || valueLen <= 0 || valueLen > int(^uint32(0)) {
+		return ErrRecordTooLarge
+	}
+	if cap(w.scratch) < zeroInlineBatchHeaderSize {
+		w.scratch = make([]byte, zeroInlineBatchHeaderSize)
+	}
+	buf := w.scratch
+	if len(buf) < zeroInlineBatchHeaderSize {
+		buf = buf[:zeroInlineBatchHeaderSize]
+	}
+	buf[0] = zeroInlineBatchVersion
+	binary.LittleEndian.PutUint32(buf[1:5], uint32(count))
+	binary.LittleEndian.PutUint64(buf[5:13], seq)
+	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
+
+	off := zeroInlineBatchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
+	for i := 0; i < count; i++ {
+		key := keyAt(i)
+		if len(key) > int(^uint16(0)) {
+			return ErrRecordTooLarge
+		}
+		keyLen := uint16(len(key))
+		if recordSizeExceedsMax(keyLen, uint32(valueLen)) {
+			return ErrRecordTooLarge
+		}
+		recLen := zeroInlineRecordHeaderSize + len(key)
+		if off > int(^uint(0)>>1)-recLen {
+			return ErrRecordTooLarge
+		}
+		next := off + recLen
+		if w.maxSegmentSize > 0 && int64(next) > w.maxSegmentSize {
+			return ErrRecordTooLarge
+		}
+		if next > int(segmentLenMask) {
+			return ErrRecordTooLarge
+		}
+		if next > cap(buf) {
+			newCap := cap(buf) * 2
+			if newCap < next {
+				newCap = next
+			}
+			nextBuf := make([]byte, next, newCap)
+			copy(nextBuf, buf[:off])
+			buf = nextBuf
+		} else if next > len(buf) {
+			buf = buf[:next]
+		}
+		binary.LittleEndian.PutUint16(buf[off:off+2], keyLen)
+		off += zeroInlineRecordHeaderSize
+		copy(buf[off:off+len(key)], key)
+		off += len(key)
+		if off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
+	}
+	checksum = crc.Update(checksum, buf[checksumStart:])
+	w.scratch = buf[:off]
+	return w.writeRawSegmentWithChecksum(w.scratch, checksum)
 }
 
 func (w *Writer) AppendCommand(env CommandEnvelope) error {
@@ -502,6 +685,9 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 		return ErrRecordTooLarge
 	}
 	total := segmentHeaderSize + size
+	if len(payload) >= directCommandPayloadMinLen {
+		return w.appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN, payload, size)
+	}
 	if w.canBufferCommandFrame(total) {
 		off, err := w.reserveCommandBufferSpace(total)
 		if err != nil {
@@ -518,6 +704,10 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(size))
 		return nil
 	}
+	return w.appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN, payload, size)
+}
+
+func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64, payload []byte, size int) error {
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR is stacked on PR9 (`codex/user-command-wal-pr9`) and targets the remaining command-WAL batch-write throughput tax in the relaxed WAL profile.

Changes:
- lazily allocates the expanded RawKV command payload buffer so compact zero-set batches avoid the unused large reserve
- keeps command-WAL public batch payload hints hot across resets
- skips redundant relaxed AppliedCommandLSN publish-path command WAL flushes while preserving poisoned-handle checks
- allows command-WAL AppliedCommandLSN publication to piggyback on chunked checkpoint flushes, including the sequential exact-boundary case
- keeps the earlier non-key-shape-specific WAL batch write-path optimizations in this branch, including zero-inline command/commitlog framing and direct/trusted command frame append+flush paths

## Validation

Tests:

```sh
GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/db ./TreeDB
git diff --check
```

Result:

```text
ok  github.com/snissn/gomap/TreeDB/internal/commitlog  1.407s
ok  github.com/snissn/gomap/TreeDB/db                  324.304s
ok  github.com/snissn/gomap/TreeDB                     66.821s
```

Rejected optimization scan was clean:

```sh
rg -n "commandBufSealed|AppendRawKVZeroSetBatchCommand|SetViewOwned|DeleteViewOwned|ownedPayloadViews|DenseBE8|zeroInlineDense|AppendZeroInlineDense|BigEndian\\.Uint64\\(op\\.Key\\)|AppendSetPayloadOnly|AppendSetNoViews|BorrowValueChunks|RetainViewValueChunks|payloadBorrowed|viewValueChunks|RetainedPayload|retained-payload|payloadValueViews|zeroSetValueViewUsed" TreeDB cmd scripts || true
```

## Benchmark

Focused no-profile 500k-key gate run:

```sh
/tmp/unified-bench-pr9-wal-batch-parity-current \
  -dbs treedb,treedb_public_command_wal \
  -profile wal_on_fast \
  -keys 500000 \
  -valsize 128 \
  -batchsize 8000 \
  -test batch_write,batch_write_steady \
  -checkpoint-between-tests \
  -progress=false \
  -format markdown \
  -path-label native-fastpath
```

Artifact:

```text
/tmp/gomap_pr9_wal_batch_retained_final_bench_20260517T111537Z
```

Nine paired runs, comparing `treedb_public_command_wal` against `treedb` in the same `wal_on_fast` profile:

```text
paired_batch_ratios 1.016713 1.307642 1.127330 1.131954 1.010980 1.065264 0.886301 1.078383 0.841170
paired_steady_ratios 1.037317 1.009339 1.148400 1.021624 0.979202 1.047240 1.012256 0.950849 0.984714

paired_batch_median 1.0652639408441114
paired_steady_median 1.0122557798665293

legacy medians 5949525 2055376
public medians 6264389 2104699
median_ratios 1.0529225442367247 1.0239970691493916
```

Profile artifact:

```text
/tmp/gomap_pr9_wal_steady_profile_lazy_payload_20260517T111143Z
```

The retained final run is beyond parity for the focused `batch_write` and `batch_write_steady` command-WAL comparison: paired medians are `1.065x` and `1.012x`; median-of-medians ratios are `1.053x` and `1.024x`.
