### PR TITLE
experiments/colgranule: plan lifecycle from binary manifest views

### DIFF
--- a/experiments/colgranule/DEFERRED_ISSUES.md
+++ b/experiments/colgranule/DEFERRED_ISSUES.md
@@ -1,0 +1,27 @@
+# Deferred Experiment Issues
+
+This log is for non-blocking `experiments/colgranule` issues found while
+making the stacked PRs mergeable. It exists to avoid spending production-track
+time polishing experiment-only code while still preserving review context.
+
+## Deferral Rule
+
+Defer only issues that are clearly limited to the experiment harness or its
+diagnostics. Do not defer:
+
+- Fail-closed correctness issues in manifest, lifecycle, reachability, or
+  recovery paths.
+- Storage-contract issues that would mislead production column-store design.
+- Bugs that can corrupt benchmark parity, asset refs, checksums, or GC inputs.
+- Issues that block CI, active AI review resolution, or clean propagation.
+
+## Deferred Items
+
+- Experiment-only byte-accounting integer widths still use `int` in several
+  reporting structs. This is acceptable for the current JSONBench-scale harness
+  and should be revisited only if the experiment report format is reused as a
+  production/public API.
+- Additional JSON/report polish for `jsonbench_compare` should stay deferred
+  unless it affects q1-q5 parity, benchmark gate interpretation, or PR evidence.
+- Local setup-allocation cleanup in experiment lifecycle/view benchmarks should
+  not get standalone work unless it changes a production-facing design decision.

--- a/experiments/colgranule/collection_manifest_test.go
+++ b/experiments/colgranule/collection_manifest_test.go
@@ -225,6 +225,32 @@ func BenchmarkColumnCollectionManifestDecode10K(b *testing.B) {
 	}
 }
 
+func BenchmarkColumnCollectionManifestViewDecode10K(b *testing.B) {
+	manifest := syntheticColumnCollectionManifestForBenchmark(10_000)
+	payload, err := EncodeColumnCollectionManifest(manifest)
+	if err != nil {
+		b.Fatalf("EncodeColumnCollectionManifest: %v", err)
+	}
+	view, err := DecodeColumnCollectionManifestView(payload)
+	if err != nil {
+		b.Fatalf("DecodeColumnCollectionManifestView: %v", err)
+	}
+	if view.BodyBytes() == 0 {
+		b.Fatalf("empty manifest view")
+	}
+	b.ReportMetric(float64(len(payload)), "manifest_bytes")
+	b.ReportMetric(float64(len(manifest.PartSet.BaseParts)), "parts")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		view, err := DecodeColumnCollectionManifestView(payload)
+		if err != nil {
+			b.Fatalf("DecodeColumnCollectionManifestView: %v", err)
+		}
+		benchSink += int64(view.BodyBytes())
+	}
+}
+
 func publishJSONBenchPartRows(t testing.TB, workspace *ColumnWorkspace, opts ColumnStoreOptions, ds JSONBenchDataset, partID uint64, start int, end int) ColumnWorkspacePartManifest {
 	t.Helper()
 	part, err := BuildColumnPart(partID, opts, ColumnBatch{Rows: end - start, Columns: sliceJSONBenchColumns(ds, start, end)})

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -1,6 +1,9 @@
 package colgranule
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
 	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
@@ -240,6 +243,35 @@ func TestColumnAssetReachabilityDeterministicChurnReclaimsAfterSnapshotDrain(t *
 	}
 }
 
+func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testing.T) {
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2,
+		lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16),
+		lifecycleAssetRef(t, 1, int64(tcs1HeaderBytes+16), tcs1HeaderBytes+24),
+	)
+	superseded := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1,
+		lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+32),
+	)
+	materialized, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:      &active,
+		SupersededManifests: []ColumnCollectionManifest{superseded},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	activeView := mustColumnCollectionManifestView(t, active)
+	supersededView := mustColumnCollectionManifestView(t, superseded)
+	fromViews, err := PlanColumnAssetReachabilityFromViews(ColumnAssetReachabilityViewInput{
+		ActiveManifest:      &activeView,
+		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilityFromViews: %v", err)
+	}
+	if !reflect.DeepEqual(fromViews, materialized) {
+		t.Fatalf("view plan mismatch\nview=%+v\nmaterialized=%+v", fromViews, materialized)
+	}
+}
+
 func BenchmarkColumnAssetReachability10K(b *testing.B) {
 	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
 	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
@@ -260,6 +292,35 @@ func BenchmarkColumnAssetReachability10K(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		plan, err := PlanColumnAssetReachability(input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(plan.RetainedBytes + plan.ReclaimableBytes + plan.RewriteDebtBytes)
+	}
+}
+
+func BenchmarkColumnAssetReachabilityView10K(b *testing.B) {
+	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
+	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
+	activeView := mustColumnCollectionManifestView(b, active)
+	supersededView := mustColumnCollectionManifestView(b, superseded)
+	input := ColumnAssetReachabilityViewInput{
+		ActiveManifest:      &activeView,
+		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+	}
+	plan, err := PlanColumnAssetReachabilityFromViews(input)
+	if err != nil {
+		b.Fatalf("PlanColumnAssetReachabilityFromViews: %v", err)
+	}
+	b.ReportMetric(float64(plan.Stats.Manifests), "manifests")
+	b.ReportMetric(float64(plan.Stats.AssetRefs), "asset_refs")
+	b.ReportMetric(float64(plan.Stats.SegmentRefs), "segments")
+	b.ReportMetric(float64(plan.Stats.TCS1PayloadBytesDecoded), "payload_bytes_decoded")
+	b.ReportMetric(float64(plan.Stats.RowsScanned), "rows_scanned")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan, err := PlanColumnAssetReachabilityFromViews(input)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -428,4 +489,17 @@ func lifecycleSyntheticManifestForBenchmark(b *testing.B, collection string, par
 		b.Fatalf("NewColumnCollectionManifest: %v", err)
 	}
 	return manifest
+}
+
+func mustColumnCollectionManifestView(t testing.TB, manifest ColumnCollectionManifest) ColumnCollectionManifestView {
+	t.Helper()
+	payload, err := EncodeColumnCollectionManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeColumnCollectionManifest: %v", err)
+	}
+	view, err := DecodeColumnCollectionManifestView(payload)
+	if err != nil {
+		t.Fatalf("DecodeColumnCollectionManifestView: %v", err)
+	}
+	return view
 }

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -270,6 +270,62 @@ func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testin
 	if !reflect.DeepEqual(fromViews, materialized) {
 		t.Fatalf("view plan mismatch\nview=%+v\nmaterialized=%+v", fromViews, materialized)
 	}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(ColumnAssetReachabilityViewInput{
+		ActiveManifest:      &activeView,
+		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	if want := lifecycleSummaryFromPlan(materialized); !reflect.DeepEqual(summary, want) {
+		t.Fatalf("summary mismatch\nsummary=%+v\nmaterialized=%+v", summary, want)
+	}
+}
+
+func TestColumnAssetReachabilitySummaryScansPreparedRegistryView(t *testing.T) {
+	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	preparedRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	quarantinedRef := lifecycleAssetRef(t, 3, 0, tcs1HeaderBytes+32)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+	prepared := ColumnPreparedAsset{
+		Ref:          preparedRef,
+		GenerationID: 3,
+		Reason:       "publish staged",
+	}
+	quarantined := ColumnPreparedAsset{
+		Ref:    quarantinedRef,
+		Bytes:  int(quarantinedRef.Length),
+		Reason: "checksum mismatch",
+	}
+	materialized, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest:    &active,
+		PreparedAssets:    []ColumnPreparedAsset{prepared},
+		QuarantinedAssets: []ColumnPreparedAsset{quarantined},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	activeView := mustColumnCollectionManifestView(t, active)
+	registryView := mustColumnPreparedAssetRegistryView(t, ColumnPreparedAssetRegistry{
+		Magic:        columnWorkspacePreparedMagic,
+		Version:      columnWorkspacePreparedVersion,
+		Collection:   "jsonbench",
+		PublishID:    3,
+		GenerationID: 3,
+		UpdatedUnix:  1,
+		Assets:       []ColumnPreparedAsset{prepared},
+	})
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(ColumnAssetReachabilityViewInput{
+		ActiveManifest:    &activeView,
+		PreparedRegistry:  &registryView,
+		QuarantinedAssets: []ColumnPreparedAsset{quarantined},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	if want := lifecycleSummaryFromPlan(materialized); !reflect.DeepEqual(summary, want) {
+		t.Fatalf("summary mismatch\nsummary=%+v\nmaterialized=%+v", summary, want)
+	}
 }
 
 func BenchmarkColumnAssetReachability10K(b *testing.B) {
@@ -325,6 +381,65 @@ func BenchmarkColumnAssetReachabilityView10K(b *testing.B) {
 			b.Fatal(err)
 		}
 		benchSink += int64(plan.RetainedBytes + plan.ReclaimableBytes + plan.RewriteDebtBytes)
+	}
+}
+
+func BenchmarkColumnAssetReachabilitySummaryView10K(b *testing.B) {
+	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
+	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
+	activeView := mustColumnCollectionManifestView(b, active)
+	supersededView := mustColumnCollectionManifestView(b, superseded)
+	input := ColumnAssetReachabilityViewInput{
+		ActiveManifest:      &activeView,
+		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+	}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(input)
+	if err != nil {
+		b.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	b.ReportMetric(float64(summary.Stats.Manifests), "manifests")
+	b.ReportMetric(float64(summary.Stats.AssetRefs), "asset_refs")
+	b.ReportMetric(float64(summary.Stats.SegmentRefs), "segments")
+	b.ReportMetric(float64(summary.Stats.TCS1PayloadBytesDecoded), "payload_bytes_decoded")
+	b.ReportMetric(float64(summary.Stats.RowsScanned), "rows_scanned")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		summary, err := PlanColumnAssetReachabilitySummaryFromViews(input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(summary.RetainedBytes + summary.ReclaimableBytes + summary.RewriteDebtBytes)
+	}
+}
+
+func BenchmarkColumnAssetReachabilitySummaryView10KReuse(b *testing.B) {
+	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
+	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
+	activeView := mustColumnCollectionManifestView(b, active)
+	supersededView := mustColumnCollectionManifestView(b, superseded)
+	input := ColumnAssetReachabilityViewInput{
+		ActiveManifest:      &activeView,
+		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+	}
+	scratch := &ColumnAssetReachabilitySummaryScratch{}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input, scratch)
+	if err != nil {
+		b.Fatalf("PlanColumnAssetReachabilitySummaryFromViewsWithScratch: %v", err)
+	}
+	b.ReportMetric(float64(summary.Stats.Manifests), "manifests")
+	b.ReportMetric(float64(summary.Stats.AssetRefs), "asset_refs")
+	b.ReportMetric(float64(summary.Stats.SegmentRefs), "segments")
+	b.ReportMetric(float64(summary.Stats.TCS1PayloadBytesDecoded), "payload_bytes_decoded")
+	b.ReportMetric(float64(summary.Stats.RowsScanned), "rows_scanned")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		summary, err := PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input, scratch)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink += int64(summary.RetainedBytes + summary.ReclaimableBytes + summary.RewriteDebtBytes)
 	}
 }
 
@@ -481,6 +596,19 @@ func lifecycleFindEntry(t *testing.T, plan ColumnAssetReachabilityPlan, ref Colu
 	return ColumnAssetReachabilityEntry{}
 }
 
+func lifecycleSummaryFromPlan(plan ColumnAssetReachabilityPlan) ColumnAssetReachabilitySummary {
+	return ColumnAssetReachabilitySummary{
+		Stats:                  plan.Stats,
+		RetainedBytes:          plan.RetainedBytes,
+		PreparedBytes:          plan.PreparedBytes,
+		QuarantinedBytes:       plan.QuarantinedBytes,
+		SupersededBytes:        plan.SupersededBytes,
+		SnapshotProtectedBytes: plan.SnapshotProtectedBytes,
+		RewriteDebtBytes:       plan.RewriteDebtBytes,
+		ReclaimableBytes:       plan.ReclaimableBytes,
+	}
+}
+
 func lifecycleSyntheticManifestForBenchmark(b *testing.B, collection string, parts int, firstPartID uint64, fileID uint32, baseOffset int64) ColumnCollectionManifest {
 	b.Helper()
 	partRefs := lifecycleSyntheticPartRefsForBenchmark(parts, firstPartID, fileID, baseOffset)
@@ -500,6 +628,19 @@ func mustColumnCollectionManifestView(t testing.TB, manifest ColumnCollectionMan
 	view, err := DecodeColumnCollectionManifestView(payload)
 	if err != nil {
 		t.Fatalf("DecodeColumnCollectionManifestView: %v", err)
+	}
+	return view
+}
+
+func mustColumnPreparedAssetRegistryView(t testing.TB, registry ColumnPreparedAssetRegistry) ColumnPreparedAssetRegistryView {
+	t.Helper()
+	payload, err := encodeColumnPreparedAssetRegistryEnvelope(registry)
+	if err != nil {
+		t.Fatalf("encodeColumnPreparedAssetRegistryEnvelope: %v", err)
+	}
+	view, err := DecodeColumnPreparedAssetRegistryView(payload)
+	if err != nil {
+		t.Fatalf("DecodeColumnPreparedAssetRegistryView: %v", err)
 	}
 	return view
 }

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -279,6 +280,19 @@ func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testin
 	}
 	if want := lifecycleSummaryFromPlan(materialized); !reflect.DeepEqual(summary, want) {
 		t.Fatalf("summary mismatch\nsummary=%+v\nmaterialized=%+v", summary, want)
+	}
+}
+
+func TestColumnCollectionManifestViewRejectsSemanticallyInvalidBinaryManifest(t *testing.T) {
+	ref := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	manifest := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, ref)
+	manifest.PartSet.BaseParts[0].Coverage.Checksums[0]++
+	manifest.ByteAccounting = columnManifestByteAccounting(manifest)
+	payload := encodeColumnCollectionManifestBinaryEnvelopeUnchecked(t, manifest)
+
+	_, err := DecodeColumnCollectionManifestView(payload)
+	if err == nil || !strings.Contains(err.Error(), "coverage invalid") {
+		t.Fatalf("DecodeColumnCollectionManifestView err=%v want coverage validation failure", err)
 	}
 }
 
@@ -630,6 +644,20 @@ func mustColumnCollectionManifestView(t testing.TB, manifest ColumnCollectionMan
 		t.Fatalf("DecodeColumnCollectionManifestView: %v", err)
 	}
 	return view
+}
+
+func encodeColumnCollectionManifestBinaryEnvelopeUnchecked(t testing.TB, manifest ColumnCollectionManifest) []byte {
+	t.Helper()
+	w := columnBinaryWriter{}
+	writeColumnCollectionManifestBinary(&w, manifest)
+	if w.err != nil {
+		t.Fatalf("writeColumnCollectionManifestBinary: %v", w.err)
+	}
+	payload, err := encodeColumnControlPlaneEnvelope(columnCollectionManifestBinaryMagic, columnCollectionManifestBinaryVersion, w.buf)
+	if err != nil {
+		t.Fatalf("encodeColumnControlPlaneEnvelope: %v", err)
+	}
+	return payload
 }
 
 func mustColumnPreparedAssetRegistryView(t testing.TB, registry ColumnPreparedAssetRegistry) ColumnPreparedAssetRegistryView {

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -25,12 +25,38 @@ type ColumnAssetReachabilityViewInput struct {
 	QuarantinedAssets       []ColumnPreparedAsset
 }
 
+type ColumnAssetReachabilitySummary struct {
+	Stats                  ColumnAssetReachabilityStats `json:"stats"`
+	RetainedBytes          int                          `json:"retained_bytes"`
+	PreparedBytes          int                          `json:"prepared_bytes"`
+	QuarantinedBytes       int                          `json:"quarantined_bytes"`
+	SupersededBytes        int                          `json:"superseded_bytes"`
+	SnapshotProtectedBytes int                          `json:"snapshot_protected_bytes"`
+	RewriteDebtBytes       int                          `json:"rewrite_debt_bytes"`
+	ReclaimableBytes       int                          `json:"reclaimable_bytes"`
+}
+
+type ColumnAssetReachabilitySummaryScratch struct {
+	records     []columnAssetReachabilitySummaryRecord
+	recordIndex map[ColumnAssetRef]int
+	segments    map[uint32]columnAssetSegmentState
+}
+
 type columnManifestViewAssetRef struct {
 	ref           ColumnAssetRef
 	bytes         int
 	partID        uint64
 	generationID  uint64
 	manifestBytes int
+}
+
+type columnAssetReachabilitySummaryRecord struct {
+	ref         ColumnAssetRef
+	state       ColumnAssetLifecycleState
+	bytes       int
+	live        bool
+	candidate   bool
+	quarantined bool
 }
 
 func DecodeColumnCollectionManifestView(data []byte) (ColumnCollectionManifestView, error) {
@@ -140,6 +166,92 @@ func PlanColumnAssetReachabilityFromViews(input ColumnAssetReachabilityViewInput
 	return plan, nil
 }
 
+func PlanColumnAssetReachabilitySummaryFromViews(input ColumnAssetReachabilityViewInput) (ColumnAssetReachabilitySummary, error) {
+	return PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input, nil)
+}
+
+func PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input ColumnAssetReachabilityViewInput, scratch *ColumnAssetReachabilitySummaryScratch) (ColumnAssetReachabilitySummary, error) {
+	estimatedRefs, err := estimateColumnAssetReachabilityViewRefs(input)
+	if err != nil {
+		return ColumnAssetReachabilitySummary{}, err
+	}
+	if scratch == nil {
+		scratch = &ColumnAssetReachabilitySummaryScratch{}
+	}
+	scratch.reset(estimatedRefs)
+
+	summary := ColumnAssetReachabilitySummary{}
+
+	if input.ActiveManifest != nil {
+		summary.Stats.ActiveManifests = 1
+		if err := addManifestViewAssetRefsToSummary(scratch, *input.ActiveManifest, ColumnAssetStateActive, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+	}
+	for _, manifest := range input.PendingManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStatePendingPublish, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.PendingManifests++
+	}
+	for _, manifest := range input.SnapshotPinnedManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateSnapshotPinned, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.SnapshotPinnedManifests++
+	}
+	for _, manifest := range input.SupersededManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateSuperseded, false, true, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.SupersededManifests++
+	}
+	if input.PreparedRegistry != nil {
+		if err := scanColumnPreparedRegistryViewAssetSummaries(*input.PreparedRegistry, func(ref ColumnAssetRef, bytes int) error {
+			if err := addPreparedAssetRefToSummary(scratch, ref, bytes, ColumnAssetStatePrepared, true, false, &summary.Stats); err != nil {
+				return err
+			}
+			summary.Stats.PreparedAssets++
+			return nil
+		}); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+	}
+	for _, prepared := range input.PreparedAssets {
+		if err := addPreparedAssetRefToSummary(scratch, prepared.Ref, prepared.Bytes, ColumnAssetStatePrepared, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.PreparedAssets++
+	}
+	for _, quarantined := range input.QuarantinedAssets {
+		if err := addPreparedAssetRefToSummary(scratch, quarantined.Ref, quarantined.Bytes, ColumnAssetStateQuarantined, false, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.QuarantinedAssets++
+	}
+	finalizeColumnAssetReachabilitySummary(scratch.records, scratch.segments, &summary)
+	return summary, nil
+}
+
+func (s *ColumnAssetReachabilitySummaryScratch) reset(recordCap int) {
+	if cap(s.records) < recordCap {
+		s.records = make([]columnAssetReachabilitySummaryRecord, 0, recordCap)
+	} else {
+		clear(s.records)
+		s.records = s.records[:0]
+	}
+	if s.recordIndex == nil {
+		s.recordIndex = make(map[ColumnAssetRef]int, recordCap)
+	} else {
+		clear(s.recordIndex)
+	}
+	if s.segments == nil {
+		s.segments = make(map[uint32]columnAssetSegmentState)
+	} else {
+		clear(s.segments)
+	}
+}
+
 func estimateColumnAssetReachabilityViewRefs(input ColumnAssetReachabilityViewInput) (int, error) {
 	refs := len(input.PreparedAssets) + len(input.QuarantinedAssets)
 	if input.ActiveManifest != nil {
@@ -199,6 +311,128 @@ func addManifestViewAssetRefs(records map[ColumnAssetRef]columnAssetReachability
 		stats.MetadataBytesScanned += tombstones
 	}
 	return nil
+}
+
+func addManifestViewAssetRefsToSummary(scratch *ColumnAssetReachabilitySummaryScratch, view ColumnCollectionManifestView, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	tombstones, err := scanColumnCollectionManifestViewAssetRefs(view, func(ref columnManifestViewAssetRef) error {
+		if err := scratch.addAssetRefToReachabilitySummary(ref.ref, ref.bytes, state, live, candidate, false); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.MetadataBytesScanned += ref.manifestBytes
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned += tombstones
+	}
+	return nil
+}
+
+func addPreparedAssetRefToSummary(scratch *ColumnAssetReachabilitySummaryScratch, ref ColumnAssetRef, bytes int, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	if bytes == 0 {
+		if ref.Length > int64(^uint(0)>>1) {
+			return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", ref.Length)
+		}
+		bytes = int(ref.Length)
+	}
+	if err := scratch.addAssetRefToReachabilitySummary(ref, bytes, state, live, candidate, state == ColumnAssetStateQuarantined); err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned++
+	}
+	return nil
+}
+
+func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary(ref ColumnAssetRef, bytes int, state ColumnAssetLifecycleState, live bool, candidate bool, quarantined bool) error {
+	if bytes < 0 {
+		return fmt.Errorf("colgranule: negative asset bytes %d", bytes)
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	if index := s.recordIndex[ref]; index > 0 {
+		record := &s.records[index-1]
+		record.state = strongestColumnAssetState(record.state, state)
+		if record.bytes == 0 {
+			record.bytes = bytes
+		}
+		record.live = record.live || live
+		record.candidate = record.candidate || candidate
+		record.quarantined = record.quarantined || quarantined
+	} else {
+		s.records = append(s.records, columnAssetReachabilitySummaryRecord{
+			ref:   ref,
+			state: state,
+			bytes: bytes,
+			live:  live,
+		})
+		record := &s.records[len(s.records)-1]
+		record.candidate = candidate
+		record.quarantined = quarantined
+		s.recordIndex[ref] = len(s.records)
+	}
+	if _, ok := s.segments[ref.FileID]; !ok {
+		s.segments[ref.FileID] = columnAssetSegmentState{}
+	}
+	return nil
+}
+
+func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySummaryRecord, segments map[uint32]columnAssetSegmentState, summary *ColumnAssetReachabilitySummary) {
+	summary.Stats.Manifests = summary.Stats.ActiveManifests + summary.Stats.PendingManifests + summary.Stats.SnapshotPinnedManifests + summary.Stats.SupersededManifests
+	summary.Stats.AssetRefs = len(records)
+	for fileID, seg := range segments {
+		seg.liveRefs = 0
+		seg.candidateRefs = 0
+		segments[fileID] = seg
+	}
+	for _, record := range records {
+		seg := segments[record.ref.FileID]
+		if record.live {
+			seg.liveRefs++
+		}
+		if record.candidate && !record.live && !record.quarantined {
+			seg.candidateRefs++
+		}
+		segments[record.ref.FileID] = seg
+	}
+	summary.Stats.SegmentRefs = len(segments)
+	for _, seg := range segments {
+		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
+			summary.Stats.DirectlyDeletableSegments++
+		}
+		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
+			summary.Stats.MixedLiveDeadSegments++
+		}
+	}
+	for _, record := range records {
+		switch {
+		case record.quarantined:
+			summary.QuarantinedBytes += record.bytes
+		case record.live:
+			switch record.state {
+			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
+				summary.PreparedBytes += record.bytes
+			case ColumnAssetStateSnapshotPinned:
+				summary.SnapshotProtectedBytes += record.bytes
+				summary.RetainedBytes += record.bytes
+			default:
+				summary.RetainedBytes += record.bytes
+			}
+		case record.candidate:
+			summary.SupersededBytes += record.bytes
+			seg := segments[record.ref.FileID]
+			if seg.liveRefs == 0 {
+				summary.ReclaimableBytes += record.bytes
+			} else {
+				summary.RewriteDebtBytes += record.bytes
+			}
+		}
+	}
 }
 
 func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, plan *ColumnAssetReachabilityPlan) {
@@ -387,6 +621,31 @@ func scanColumnPreparedRegistryViewAssets(view ColumnPreparedAssetRegistryView) 
 		return nil, err
 	}
 	return assets, nil
+}
+
+func scanColumnPreparedRegistryViewAssetSummaries(view ColumnPreparedAssetRegistryView, fn func(ColumnAssetRef, int) error) error {
+	if len(view.body) == 0 {
+		return fmt.Errorf("colgranule: empty prepared registry view")
+	}
+	r := columnBinaryReader{data: view.body, label: "prepared registry view"}
+	r.skipString()
+	r.u64()
+	r.u64()
+	r.i64()
+	n := r.count("prepared assets")
+	for i := 0; i < n; i++ {
+		ref := readColumnAssetRefBinary(&r)
+		bytes := r.intValue("prepared bytes")
+		r.u64()
+		r.u64()
+		r.skipString()
+		if fn != nil && r.err == nil {
+			if err := fn(ref, bytes); err != nil {
+				r.err = err
+			}
+		}
+	}
+	return r.done()
 }
 
 func (r *columnBinaryReader) doneAfterSkippingPreparedAssets(count int) error {

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -65,6 +65,9 @@ func DecodeColumnCollectionManifestView(data []byte) (ColumnCollectionManifestVi
 		if err != nil {
 			return ColumnCollectionManifestView{}, err
 		}
+		if err := validateColumnCollectionManifestViewBody(body); err != nil {
+			return ColumnCollectionManifestView{}, err
+		}
 		return ColumnCollectionManifestView{data: data, body: body}, nil
 	}
 	manifest, err := DecodeColumnCollectionManifest(data)
@@ -82,6 +85,9 @@ func DecodeColumnPreparedAssetRegistryView(data []byte) (ColumnPreparedAssetRegi
 	if isColumnControlPlaneBinary(data, columnWorkspacePreparedBinaryMagic) {
 		body, err := decodeColumnControlPlaneEnvelope(data, columnWorkspacePreparedBinaryMagic, columnWorkspacePreparedBinaryVersion, "prepared registry")
 		if err != nil {
+			return ColumnPreparedAssetRegistryView{}, err
+		}
+		if err := validateColumnPreparedAssetRegistryViewBody(body); err != nil {
 			return ColumnPreparedAssetRegistryView{}, err
 		}
 		return ColumnPreparedAssetRegistryView{data: data, body: body}, nil
@@ -103,6 +109,24 @@ func (v ColumnCollectionManifestView) BodyBytes() int {
 
 func (v ColumnPreparedAssetRegistryView) BodyBytes() int {
 	return len(v.body)
+}
+
+func validateColumnCollectionManifestViewBody(body []byte) error {
+	r := columnBinaryReader{data: body, label: "collection manifest view"}
+	manifest := readColumnCollectionManifestBinary(&r)
+	if err := r.done(); err != nil {
+		return err
+	}
+	return validateColumnCollectionManifest(manifest)
+}
+
+func validateColumnPreparedAssetRegistryViewBody(body []byte) error {
+	r := columnBinaryReader{data: body, label: "prepared registry view"}
+	registry := readColumnPreparedAssetRegistryBinary(&r)
+	if err := r.done(); err != nil {
+		return err
+	}
+	return validateColumnPreparedAssetRegistry(registry)
 }
 
 func PlanColumnAssetReachabilityFromViews(input ColumnAssetReachabilityViewInput) (ColumnAssetReachabilityPlan, error) {

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -1,0 +1,528 @@
+package colgranule
+
+import (
+	"fmt"
+	"sort"
+)
+
+type ColumnCollectionManifestView struct {
+	data []byte
+	body []byte
+}
+
+type ColumnPreparedAssetRegistryView struct {
+	data []byte
+	body []byte
+}
+
+type ColumnAssetReachabilityViewInput struct {
+	ActiveManifest          *ColumnCollectionManifestView
+	PendingManifests        []ColumnCollectionManifestView
+	SnapshotPinnedManifests []ColumnCollectionManifestView
+	SupersededManifests     []ColumnCollectionManifestView
+	PreparedRegistry        *ColumnPreparedAssetRegistryView
+	PreparedAssets          []ColumnPreparedAsset
+	QuarantinedAssets       []ColumnPreparedAsset
+}
+
+type columnManifestViewAssetRef struct {
+	ref           ColumnAssetRef
+	bytes         int
+	partID        uint64
+	generationID  uint64
+	manifestBytes int
+}
+
+func DecodeColumnCollectionManifestView(data []byte) (ColumnCollectionManifestView, error) {
+	if isColumnControlPlaneBinary(data, columnCollectionManifestBinaryMagic) {
+		body, err := decodeColumnControlPlaneEnvelope(data, columnCollectionManifestBinaryMagic, columnCollectionManifestBinaryVersion, "collection manifest")
+		if err != nil {
+			return ColumnCollectionManifestView{}, err
+		}
+		return ColumnCollectionManifestView{data: data, body: body}, nil
+	}
+	manifest, err := DecodeColumnCollectionManifest(data)
+	if err != nil {
+		return ColumnCollectionManifestView{}, err
+	}
+	encoded, err := encodeColumnCollectionManifestBinaryEnvelope(manifest)
+	if err != nil {
+		return ColumnCollectionManifestView{}, err
+	}
+	return DecodeColumnCollectionManifestView(encoded)
+}
+
+func DecodeColumnPreparedAssetRegistryView(data []byte) (ColumnPreparedAssetRegistryView, error) {
+	if isColumnControlPlaneBinary(data, columnWorkspacePreparedBinaryMagic) {
+		body, err := decodeColumnControlPlaneEnvelope(data, columnWorkspacePreparedBinaryMagic, columnWorkspacePreparedBinaryVersion, "prepared registry")
+		if err != nil {
+			return ColumnPreparedAssetRegistryView{}, err
+		}
+		return ColumnPreparedAssetRegistryView{data: data, body: body}, nil
+	}
+	registry, err := decodeColumnPreparedAssetRegistryEnvelope(data)
+	if err != nil {
+		return ColumnPreparedAssetRegistryView{}, err
+	}
+	encoded, err := encodeColumnPreparedAssetRegistryBinaryEnvelope(registry)
+	if err != nil {
+		return ColumnPreparedAssetRegistryView{}, err
+	}
+	return DecodeColumnPreparedAssetRegistryView(encoded)
+}
+
+func (v ColumnCollectionManifestView) BodyBytes() int {
+	return len(v.body)
+}
+
+func (v ColumnPreparedAssetRegistryView) BodyBytes() int {
+	return len(v.body)
+}
+
+func PlanColumnAssetReachabilityFromViews(input ColumnAssetReachabilityViewInput) (ColumnAssetReachabilityPlan, error) {
+	estimatedRefs, err := estimateColumnAssetReachabilityViewRefs(input)
+	if err != nil {
+		return ColumnAssetReachabilityPlan{}, err
+	}
+	records := make(map[ColumnAssetRef]columnAssetReachabilityRecord, estimatedRefs)
+	segments := make(map[uint32]*columnAssetSegmentState)
+	plan := ColumnAssetReachabilityPlan{}
+
+	if input.ActiveManifest != nil {
+		plan.Stats.ActiveManifests = 1
+		if err := addManifestViewAssetRefs(records, segments, *input.ActiveManifest, ColumnAssetStateActive, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+	}
+	for _, manifest := range input.PendingManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStatePendingPublish, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.PendingManifests++
+	}
+	for _, manifest := range input.SnapshotPinnedManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateSnapshotPinned, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.SnapshotPinnedManifests++
+	}
+	for _, manifest := range input.SupersededManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, true, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.SupersededManifests++
+	}
+	if input.PreparedRegistry != nil {
+		prepared, err := scanColumnPreparedRegistryViewAssets(*input.PreparedRegistry)
+		if err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		for _, asset := range prepared {
+			if err := addPreparedAsset(records, segments, asset, ColumnAssetStatePrepared, true, false, &plan.Stats); err != nil {
+				return ColumnAssetReachabilityPlan{}, err
+			}
+			plan.Stats.PreparedAssets++
+		}
+	}
+	for _, prepared := range input.PreparedAssets {
+		if err := addPreparedAsset(records, segments, prepared, ColumnAssetStatePrepared, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.PreparedAssets++
+	}
+	for _, quarantined := range input.QuarantinedAssets {
+		if err := addPreparedAsset(records, segments, quarantined, ColumnAssetStateQuarantined, false, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.QuarantinedAssets++
+	}
+	finalizeColumnAssetReachabilityRecords(records, segments, &plan)
+	return plan, nil
+}
+
+func estimateColumnAssetReachabilityViewRefs(input ColumnAssetReachabilityViewInput) (int, error) {
+	refs := len(input.PreparedAssets) + len(input.QuarantinedAssets)
+	if input.ActiveManifest != nil {
+		refs += estimateColumnCollectionManifestViewAssetRefs(*input.ActiveManifest)
+	}
+	for i := range input.PendingManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.PendingManifests[i])
+	}
+	for i := range input.SnapshotPinnedManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.SnapshotPinnedManifests[i])
+	}
+	for i := range input.SupersededManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.SupersededManifests[i])
+	}
+	if input.PreparedRegistry != nil {
+		n, err := countColumnPreparedRegistryViewAssets(*input.PreparedRegistry)
+		if err != nil {
+			return 0, err
+		}
+		refs += n
+	}
+	return refs, nil
+}
+
+func estimateColumnCollectionManifestViewAssetRefs(view ColumnCollectionManifestView) int {
+	// The binary body is fixed-record heavy after the schema prefix. This keeps
+	// map growth bounded without adding a second full scan to every GC plan.
+	estimate := len(view.body) / 256
+	if estimate < 1 {
+		return 1
+	}
+	return estimate
+}
+
+func addManifestViewAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, view ColumnCollectionManifestView, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	tombstones, err := scanColumnCollectionManifestViewAssetRefs(view, func(ref columnManifestViewAssetRef) error {
+		entry := ColumnAssetReachabilityEntry{
+			Ref:          ref.ref,
+			State:        state,
+			Bytes:        ref.bytes,
+			PartID:       ref.partID,
+			GenerationID: ref.generationID,
+			Reasons:      columnAssetReachabilityDefaultReasons(state),
+		}
+		if err := addReachabilityEntry(records, segments, entry, live, candidate, false); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.MetadataBytesScanned += ref.manifestBytes
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.MetadataBytesScanned += tombstones
+	}
+	return nil
+}
+
+func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, plan *ColumnAssetReachabilityPlan) {
+	plan.Stats.Manifests = plan.Stats.ActiveManifests + plan.Stats.PendingManifests + plan.Stats.SnapshotPinnedManifests + plan.Stats.SupersededManifests
+	plan.Stats.AssetRefs = len(records)
+	for _, seg := range segments {
+		seg.liveRefs = 0
+		seg.candidateRefs = 0
+	}
+	for _, record := range records {
+		seg := segments[record.entry.Ref.FileID]
+		if seg == nil {
+			seg = &columnAssetSegmentState{}
+			segments[record.entry.Ref.FileID] = seg
+		}
+		if record.live {
+			seg.liveRefs++
+		}
+		if record.candidate && !record.live && !record.quarantined {
+			seg.candidateRefs++
+		}
+	}
+	plan.Stats.SegmentRefs = len(segments)
+	for _, seg := range segments {
+		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
+			plan.Stats.DirectlyDeletableSegments++
+		}
+		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
+			plan.Stats.MixedLiveDeadSegments++
+		}
+	}
+
+	plan.Entries = make([]ColumnAssetReachabilityEntry, 0, len(records))
+	for _, record := range records {
+		entry := record.entry
+		switch {
+		case record.quarantined:
+			plan.QuarantinedBytes += entry.Bytes
+		case record.live:
+			switch entry.State {
+			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
+				plan.PreparedBytes += entry.Bytes
+			case ColumnAssetStateSnapshotPinned:
+				plan.SnapshotProtectedBytes += entry.Bytes
+				plan.RetainedBytes += entry.Bytes
+			default:
+				plan.RetainedBytes += entry.Bytes
+			}
+		case record.candidate:
+			plan.SupersededBytes += entry.Bytes
+			seg := segments[entry.Ref.FileID]
+			if seg != nil && seg.liveRefs == 0 {
+				entry.DeleteEligible = true
+				entry.State = ColumnAssetStateReclaimable
+				plan.ReclaimableBytes += entry.Bytes
+			} else {
+				plan.RewriteDebtBytes += entry.Bytes
+			}
+		}
+		plan.Entries = append(plan.Entries, entry)
+	}
+	sort.Slice(plan.Entries, func(i, j int) bool {
+		a, b := plan.Entries[i].Ref, plan.Entries[j].Ref
+		if a.FileID != b.FileID {
+			return a.FileID < b.FileID
+		}
+		if a.Offset != b.Offset {
+			return a.Offset < b.Offset
+		}
+		if a.Length != b.Length {
+			return a.Length < b.Length
+		}
+		return a.Checksum < b.Checksum
+	})
+}
+
+func countColumnCollectionManifestViewAssetRefs(view ColumnCollectionManifestView) (int, error) {
+	var count int
+	_, err := scanColumnCollectionManifestViewAssetRefs(view, func(columnManifestViewAssetRef) error {
+		count++
+		return nil
+	})
+	return count, err
+}
+
+func scanColumnCollectionManifestViewAssetRefs(view ColumnCollectionManifestView, fn func(columnManifestViewAssetRef) error) (int, error) {
+	if len(view.body) == 0 {
+		return 0, fmt.Errorf("colgranule: empty collection manifest view")
+	}
+	r := columnBinaryReader{data: view.body, label: "collection manifest view"}
+	r.skipString()
+	r.u32()
+	r.u8()
+	r.skipStringSlice()
+	skipSortKeyColumnsBinary(&r)
+	skipColumnDefinitionsBinary(&r)
+	r.u64()
+	skipColumnCollectionAttachmentBinary(&r)
+	tombstones := scanColumnPartSetManifestBinaryView(&r, fn)
+	skipColumnCollectionByteAccountingBinary(&r)
+	r.i64()
+	r.i64()
+	if err := r.done(); err != nil {
+		return 0, err
+	}
+	return tombstones, nil
+}
+
+func scanColumnPartSetManifestBinaryView(r *columnBinaryReader, fn func(columnManifestViewAssetRef) error) int {
+	baseCount := r.count("base parts")
+	for i := 0; i < baseCount; i++ {
+		scanColumnManifestPartRefBinaryView(r, fn)
+	}
+	deltaCount := r.count("delta parts")
+	for i := 0; i < deltaCount; i++ {
+		scanColumnManifestPartRefBinaryView(r, fn)
+	}
+	tombstoneCount := r.count("tombstones")
+	for i := 0; i < tombstoneCount; i++ {
+		skipColumnTombstoneBinary(r)
+	}
+	return tombstoneCount
+}
+
+func scanColumnManifestPartRefBinaryView(r *columnBinaryReader, fn func(columnManifestViewAssetRef) error) {
+	r.u8()
+	generationID := r.u64()
+	skipColumnPartCoverageDescriptorBinary(r)
+	ref := scanColumnWorkspacePartManifestBinaryView(r)
+	ref.generationID = generationID
+	if fn != nil && r.err == nil {
+		if err := fn(ref); err != nil {
+			r.err = err
+		}
+	}
+}
+
+func scanColumnWorkspacePartManifestBinaryView(r *columnBinaryReader) columnManifestViewAssetRef {
+	ref := columnManifestViewAssetRef{partID: r.u64()}
+	r.intValue("part rows")
+	r.intValue("part visible rows")
+	r.u32()
+	skipSortKeyColumnsBinary(r)
+	skipColumnWorkspacePartCoverageBinary(r)
+	ref.ref = readColumnAssetRefBinary(r)
+	skipTCS1PartRecordBinary(r)
+	r.intValue("image bytes")
+	ref.manifestBytes = r.intValue("manifest bytes")
+	r.intValue("sections")
+	ref.bytes = r.intValue("asset bytes")
+	r.i64()
+	return ref
+}
+
+func countColumnPreparedRegistryViewAssets(view ColumnPreparedAssetRegistryView) (int, error) {
+	if len(view.body) == 0 {
+		return 0, fmt.Errorf("colgranule: empty prepared registry view")
+	}
+	r := columnBinaryReader{data: view.body, label: "prepared registry view"}
+	r.skipString()
+	r.u64()
+	r.u64()
+	r.i64()
+	count := r.count("prepared assets")
+	if err := r.doneAfterSkippingPreparedAssets(count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func scanColumnPreparedRegistryViewAssets(view ColumnPreparedAssetRegistryView) ([]ColumnPreparedAsset, error) {
+	if len(view.body) == 0 {
+		return nil, fmt.Errorf("colgranule: empty prepared registry view")
+	}
+	r := columnBinaryReader{data: view.body, label: "prepared registry view"}
+	r.skipString()
+	r.u64()
+	r.u64()
+	r.i64()
+	n := r.count("prepared assets")
+	assets := make([]ColumnPreparedAsset, n)
+	for i := range assets {
+		assets[i] = readColumnPreparedAssetBinary(&r)
+	}
+	if err := r.done(); err != nil {
+		return nil, err
+	}
+	return assets, nil
+}
+
+func (r *columnBinaryReader) doneAfterSkippingPreparedAssets(count int) error {
+	for i := 0; i < count; i++ {
+		skipColumnPreparedAssetBinary(r)
+	}
+	return r.done()
+}
+
+func skipColumnCollectionAttachmentBinary(r *columnBinaryReader) {
+	r.skipString()
+	r.skipString()
+	r.skipString()
+	r.skipString()
+	r.skipString()
+	r.skipStringSlice()
+}
+
+func skipColumnPartCoverageDescriptorBinary(r *columnBinaryReader) {
+	r.u8()
+	r.u64()
+	r.u8()
+	sourceCount := r.count("source parts")
+	for i := 0; i < sourceCount; i++ {
+		r.u64()
+		r.u64()
+	}
+	r.u64()
+	r.u64()
+	r.u64()
+	r.i64()
+	r.i64()
+	r.skipStringSlice()
+	r.skipI64Slice()
+	r.skipI64Slice()
+	r.bool()
+	r.intValue("coverage rows")
+	r.intValue("coverage visible rows")
+	r.intValue("coverage deleted rows")
+	assetCount := r.count("coverage asset refs")
+	for i := 0; i < assetCount; i++ {
+		readColumnAssetRefBinary(r)
+	}
+	r.skipU32Slice()
+}
+
+func skipColumnWorkspacePartCoverageBinary(r *columnBinaryReader) {
+	r.i64()
+	r.i64()
+	r.skipStringSlice()
+	r.skipI64Slice()
+	r.skipI64Slice()
+	r.bool()
+}
+
+func skipTCS1PartRecordBinary(r *columnBinaryReader) {
+	r.u16()
+	r.u16()
+	r.u32()
+	r.u64()
+	r.intValue("tcs1 rows")
+	r.u16()
+	r.intValue("payload bytes")
+	r.intValue("total bytes")
+	r.u32()
+	readColumnAssetRefBinary(r)
+}
+
+func skipColumnTombstoneBinary(r *columnBinaryReader) {
+	r.i64()
+	r.u64()
+	r.skipString()
+	r.intValue("prepared bytes")
+}
+
+func skipColumnPreparedAssetBinary(r *columnBinaryReader) {
+	readColumnAssetRefBinary(r)
+	r.intValue("prepared bytes")
+	r.u64()
+	r.u64()
+	r.skipString()
+}
+
+func skipSortKeyColumnsBinary(r *columnBinaryReader) {
+	n := r.count("sort keys")
+	for i := 0; i < n; i++ {
+		r.skipString()
+		r.u8()
+		r.u8()
+	}
+}
+
+func skipColumnDefinitionsBinary(r *columnBinaryReader) {
+	n := r.count("column definitions")
+	for i := 0; i < n; i++ {
+		r.skipString()
+		r.u8()
+		r.u8()
+		r.u8()
+		r.u32()
+		r.intValue("codec block rows")
+	}
+}
+
+func skipColumnCollectionByteAccountingBinary(r *columnBinaryReader) {
+	for i := 0; i < 12; i++ {
+		r.intValue("byte accounting")
+	}
+}
+
+func (r *columnBinaryReader) skipString() {
+	n := r.u32()
+	if uint64(n) > uint64(len(r.data)-r.off) {
+		r.fail("string length=%d exceeds remaining body bytes=%d", n, len(r.data)-r.off)
+		return
+	}
+	r.bytes(int(n))
+}
+
+func (r *columnBinaryReader) skipStringSlice() {
+	n := r.count("string slice")
+	for i := 0; i < n; i++ {
+		r.skipString()
+	}
+}
+
+func (r *columnBinaryReader) skipI64Slice() {
+	n := r.count("int64 slice")
+	for i := 0; i < n; i++ {
+		r.i64()
+	}
+}
+
+func (r *columnBinaryReader) skipU32Slice() {
+	n := r.count("uint32 slice")
+	for i := 0; i < n; i++ {
+		r.u32()
+	}
+}


### PR DESCRIPTION
## Objective

Add the second chained follow-on above the binary format PR. This PR moves the lifecycle/GC planning seam onto borrowed binary manifest views so the hot control-plane path no longer has to materialize 10K-part manifests just to enumerate column asset refs.

Stack:

- Parent: #1589 (`codex/colgranule-m6-binary-control-plane`)
- This PR: binary view decode and lifecycle planning

## Scope

- Adds `ColumnCollectionManifestView` over `TCC2` payloads.
- Adds `ColumnPreparedAssetRegistryView` over `TCP2` payloads.
- Adds `PlanColumnAssetReachabilityFromViews` for full diagnostic plans over active, pending, snapshot-pinned, superseded, prepared, and quarantined inputs.
- Adds `PlanColumnAssetReachabilitySummaryFromViews` for GC decision-mode planning of retained, prepared, quarantined, superseded, snapshot-protected, rewrite-debt, and reclaimable bytes without building a full `Entries` slice.
- Adds reusable `ColumnAssetReachabilitySummaryScratch` so repeated GC eligibility checks can reuse ref-index, record, and segment state storage.
- Scans binary part records directly to enumerate `ColumnAssetRef`, bytes, part ID, generation, and metadata-byte accounting.
- Keeps existing materialized planning API intact for compatibility and tests.
- Does not change TCS1 payloads, query kernels, part image encoding, or production TreeDB wiring.

## TDD Coverage

Added tests/benchmarks that require:

- Binary-view reachability produces the same detailed plan as materialized manifest reachability.
- Binary-view summary reachability produces the same byte totals and stats as the materialized detailed plan.
- Prepared-registry binary views feed summary planning without materializing registry assets.
- View decode exposes a non-empty body without materializing the manifest graph.
- 10K view decode is benchmarked separately from materialized decode.
- 10K detailed view reachability and 10K summary view reachability are benchmarked separately.
- Reusable summary scratch is benchmarked as the normal repeated-GC-decision mode.

## Validation

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetReachability.*View|TestColumnAssetReachabilitySummary|TestColumnCollectionManifest' -count=1
```

```text
ok  github.com/snissn/gomap/experiments/colgranule  0.628s
```

```sh
GOWORK=off go test ./experiments/colgranule/... -count=1
```

```text
ok  github.com/snissn/gomap/experiments/colgranule                         0.835s
?   github.com/snissn/gomap/experiments/colgranule/cmd/jsonbench_colgranule [no test files]
ok  github.com/snissn/gomap/experiments/colgranule/cmd/jsonbench_compare    0.888s
```

```sh
git diff --check
```

passed.

## Performance Gates

Command:

```sh
GOWORK=off go test ./experiments/colgranule \
  -run '^$' \
  -bench 'BenchmarkColumnAssetReachability(View|SummaryView).*10K|BenchmarkColumnCollectionManifestViewDecode10K' \
  -benchmem -benchtime=1x -count=5
```

Results:

| Benchmark | Representative result | Allocation profile |
|---|---:|---:|
| `BenchmarkColumnCollectionManifestViewDecode10K` | ~0.36-0.54 ms/op | 0 B/op, 0 allocs/op |
| `BenchmarkColumnAssetReachabilityView10K` | ~8.37-9.58 ms/op | 8.43 MiB/op, 71 allocs/op |
| `BenchmarkColumnAssetReachabilitySummaryView10K` | ~4.13-4.45 ms/op | 4.28 MiB/op, 69 allocs/op |
| `BenchmarkColumnAssetReachabilitySummaryView10KReuse` | ~3.93-4.14 ms/op | 0 B/op, 0 allocs/op |

Prior comparison points from the parent binary-format work:

| Benchmark | Representative result | Allocation profile |
|---|---:|---:|
| `BenchmarkColumnCollectionManifestDecode10K` | ~4.90-6.55 ms/op | 7.36 MiB/op, ~60.0K allocs/op |
| `BenchmarkColumnAssetReachability10K` | ~9.37-11.45 ms/op | 8.43 MiB/op, 71 allocs/op |
| `BenchmarkColumnAssetRefDelta128` | ~11.5-13.5 us/op | 12.2 KiB/op, 4 allocs/op |
| `BenchmarkColumnPartSetCompactionPlan10K` | ~0.95-0.97 ms/op | 240 B/op, 4 allocs/op |

Perf interpretation:

- The inner decode gate is zero-allocation for binary views.
- Detailed view planning remains available for diagnostics/tests and still owns full entries/reasons/sort output.
- Summary view planning is the GC decision path: it computes the retained/reclaimable/rewrite-debt byte decisions without allocating a detailed `Entries` slice.
- Reusable summary scratch removes steady-state heap allocation from repeated reachability decisions while still validating refs and preserving state precedence.
- The summary path uses a compact ref-to-index map, reusable record slice, and value-based segment grouping; it does not assume sorted refs are safe for correctness.
