### PR TITLE
TreeDB: add M8A mutation adapter and locator profile

### DIFF
--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -1,0 +1,335 @@
+package colgranule
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+)
+
+type ColumnMutationAdapterOptions struct {
+	Collection        string
+	StoreOptions      ColumnStoreOptions
+	Dictionaries      map[string]map[string]int64
+	InitialPartID     uint64
+	InitialGeneration uint64
+}
+
+type ColumnMutationBatch struct {
+	Inserts                 ColumnBatch
+	Updates                 ColumnBatch
+	Deletes                 []int64
+	SourceRowRootGeneration uint64
+	SourceRowVersionLower   uint64
+	SourceRowVersionUpper   uint64
+}
+
+type ColumnMutationApplyResult struct {
+	Manifest     ColumnCollectionManifest
+	Part         ColumnWorkspacePartManifest
+	GenerationID uint64
+	InsertedRows int
+	UpdatedRows  int
+	DeletedRows  int
+}
+
+type ColumnMutationAdapter struct {
+	workspace    *ColumnWorkspace
+	collection   string
+	opts         ColumnStoreOptions
+	dictionaries map[string]map[string]int64
+	baseParts    []ColumnManifestPartRef
+	deltaParts   []ColumnManifestPartRef
+	tombstones   []ColumnTombstone
+	manifest     ColumnCollectionManifest
+	nextPartID   uint64
+	nextGen      uint64
+}
+
+func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAdapterOptions) (*ColumnMutationAdapter, error) {
+	if workspace == nil {
+		return nil, fmt.Errorf("colgranule: nil column workspace")
+	}
+	normalized, err := normalizeColumnStoreOptions(opts.StoreOptions)
+	if err != nil {
+		return nil, err
+	}
+	collection := opts.Collection
+	if collection == "" {
+		collection = workspace.Manifest().Collection
+	}
+	if collection == "" {
+		return nil, fmt.Errorf("colgranule: empty column mutation collection")
+	}
+	adapter := &ColumnMutationAdapter{
+		workspace:    workspace,
+		collection:   collection,
+		opts:         normalized,
+		dictionaries: opts.Dictionaries,
+		nextPartID:   opts.InitialPartID,
+		nextGen:      opts.InitialGeneration,
+	}
+	if adapter.nextPartID == 0 {
+		adapter.nextPartID = 1
+	}
+	if adapter.nextGen == 0 {
+		adapter.nextGen = 1
+	}
+	manifest, err := workspace.LoadCollectionManifest()
+	if err == nil {
+		adapter.baseParts = cloneColumnManifestPartRefs(manifest.PartSet.BaseParts)
+		adapter.deltaParts = cloneColumnManifestPartRefs(manifest.PartSet.DeltaParts)
+		adapter.tombstones = append([]ColumnTombstone(nil), manifest.PartSet.Tombstones...)
+		adapter.manifest = manifest
+		adapter.nextGen = max(adapter.nextGen, manifest.ActiveGeneration+1)
+		adapter.nextPartID = max(adapter.nextPartID, columnMutationNextPartID(workspace.Manifest()))
+		return adapter, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+	manifest, err = adapter.newManifest()
+	if err != nil {
+		return nil, err
+	}
+	if err := workspace.SaveCollectionManifest(manifest); err != nil {
+		return nil, err
+	}
+	adapter.manifest = manifest
+	return adapter, nil
+}
+
+func (a *ColumnMutationAdapter) Manifest() ColumnCollectionManifest {
+	if a == nil {
+		return ColumnCollectionManifest{}
+	}
+	return a.manifest
+}
+
+func (a *ColumnMutationAdapter) Reader(opts ColumnPartImageReadOptions) (*ColumnPartSetReader, error) {
+	if a == nil {
+		return nil, fmt.Errorf("colgranule: nil column mutation adapter")
+	}
+	return OpenColumnPartSetReader(a.workspace, a.Manifest(), opts)
+}
+
+func (a *ColumnMutationAdapter) PublishBaseBatch(batch ColumnBatch, coverage ColumnPartCoverageOptions) (ColumnMutationApplyResult, error) {
+	if a == nil {
+		return ColumnMutationApplyResult{}, fmt.Errorf("colgranule: nil column mutation adapter")
+	}
+	rows, err := validateColumnBatch(batch, a.opts.Columns)
+	if err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	if err := validateColumnMutationCoverageOptions(coverage); err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	partID := a.nextPartID
+	generationID := a.nextGen
+	part, err := BuildColumnPart(partID, a.opts, batch)
+	if err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	entry, err := a.workspace.PublishPart(part, a.dictionaries)
+	if err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	a.baseParts = append(a.baseParts, NewColumnManifestPartRefWithCoverageOptions(ColumnPartRoleBase, generationID, entry, coverage))
+	if err := a.publishManifest(); err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	a.nextPartID++
+	a.nextGen++
+	return ColumnMutationApplyResult{
+		Manifest:     a.manifest,
+		Part:         entry,
+		GenerationID: generationID,
+		InsertedRows: rows,
+	}, nil
+}
+
+func (a *ColumnMutationAdapter) Apply(batch ColumnMutationBatch) (ColumnMutationApplyResult, error) {
+	if a == nil {
+		return ColumnMutationApplyResult{}, fmt.Errorf("colgranule: nil column mutation adapter")
+	}
+	if err := validateColumnMutationCoverageOptions(ColumnPartCoverageOptions{
+		SourceRowRootGeneration: batch.SourceRowRootGeneration,
+		SourceRowVersionLower:   batch.SourceRowVersionLower,
+		SourceRowVersionUpper:   batch.SourceRowVersionUpper,
+	}); err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	rows, inserted, updated, err := a.mergeMutationRows(batch.Inserts, batch.Updates)
+	if err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	deletes := sortedUniqueInt64s(batch.Deletes)
+	if rows.Rows == 0 && len(deletes) == 0 {
+		return ColumnMutationApplyResult{Manifest: a.manifest}, nil
+	}
+	generationID := a.nextGen
+	result := ColumnMutationApplyResult{
+		GenerationID: generationID,
+		InsertedRows: inserted,
+		UpdatedRows:  updated,
+		DeletedRows:  len(deletes),
+	}
+	if rows.Rows != 0 {
+		partID := a.nextPartID
+		part, err := BuildColumnDeltaPart(partID, a.opts, rows)
+		if err != nil {
+			return ColumnMutationApplyResult{}, err
+		}
+		entry, err := a.workspace.PublishPart(part, a.dictionaries)
+		if err != nil {
+			return ColumnMutationApplyResult{}, err
+		}
+		ref := NewColumnManifestPartRefWithCoverageOptions(ColumnPartRoleDelta, generationID, entry, ColumnPartCoverageOptions{
+			SourceRowRootGeneration: batch.SourceRowRootGeneration,
+			SourceRowVersionLower:   batch.SourceRowVersionLower,
+			SourceRowVersionUpper:   batch.SourceRowVersionUpper,
+		})
+		a.deltaParts = append(a.deltaParts, ref)
+		a.nextPartID++
+		result.Part = entry
+	}
+	for _, primaryID := range deletes {
+		a.tombstones = append(a.tombstones, ColumnTombstone{
+			PrimaryID:     primaryID,
+			GenerationID:  generationID,
+			Reason:        "delete",
+			PreparedBytes: 0,
+		})
+	}
+	if len(deletes) != 0 {
+		sort.Slice(a.tombstones, func(i, j int) bool {
+			if a.tombstones[i].GenerationID != a.tombstones[j].GenerationID {
+				return a.tombstones[i].GenerationID < a.tombstones[j].GenerationID
+			}
+			return a.tombstones[i].PrimaryID < a.tombstones[j].PrimaryID
+		})
+	}
+	if err := a.publishManifest(); err != nil {
+		return ColumnMutationApplyResult{}, err
+	}
+	a.nextGen++
+	result.Manifest = a.manifest
+	return result, nil
+}
+
+func (a *ColumnMutationAdapter) mergeMutationRows(inserts ColumnBatch, updates ColumnBatch) (ColumnBatch, int, int, error) {
+	insertRows, err := validateOptionalColumnBatch(inserts, a.opts.Columns)
+	if err != nil {
+		return ColumnBatch{}, 0, 0, err
+	}
+	updateRows, err := validateOptionalColumnBatch(updates, a.opts.Columns)
+	if err != nil {
+		return ColumnBatch{}, 0, 0, err
+	}
+	total := insertRows + updateRows
+	if total == 0 {
+		return ColumnBatch{}, 0, 0, nil
+	}
+	columns := make(map[string][]int64, len(a.opts.Columns))
+	for _, def := range a.opts.Columns {
+		dst := make([]int64, 0, total)
+		if insertRows != 0 {
+			dst = append(dst, inserts.Columns[def.Name]...)
+		}
+		if updateRows != 0 {
+			dst = append(dst, updates.Columns[def.Name]...)
+		}
+		columns[def.Name] = dst
+	}
+	if err := validateDistinctPrimaryIDs(ColumnBatch{Rows: total, Columns: columns}, a.opts.LogicalPrimaryKey.Columns[0]); err != nil {
+		return ColumnBatch{}, 0, 0, err
+	}
+	return ColumnBatch{Rows: total, Columns: columns}, insertRows, updateRows, nil
+}
+
+func (a *ColumnMutationAdapter) publishManifest() error {
+	manifest, err := a.newManifest()
+	if err != nil {
+		return err
+	}
+	if err := a.workspace.SaveCollectionManifest(manifest); err != nil {
+		return err
+	}
+	a.manifest = manifest
+	return nil
+}
+
+func (a *ColumnMutationAdapter) newManifest() (ColumnCollectionManifest, error) {
+	manifest, err := NewColumnCollectionManifest(a.collection, a.opts, a.baseParts, a.deltaParts, a.tombstones)
+	if err != nil {
+		return ColumnCollectionManifest{}, err
+	}
+	if a.manifest.CreatedUnix != 0 {
+		manifest.CreatedUnix = a.manifest.CreatedUnix
+	}
+	if len(a.baseParts)+len(a.deltaParts)+len(a.tombstones) != 0 {
+		manifest.UpdatedUnix = time.Now().UnixNano()
+	}
+	return manifest, nil
+}
+
+func validateOptionalColumnBatch(batch ColumnBatch, defs []ColumnDefinition) (int, error) {
+	if batch.Rows == 0 && len(batch.Columns) == 0 {
+		return 0, nil
+	}
+	return validateColumnBatch(batch, defs)
+}
+
+func validateDistinctPrimaryIDs(batch ColumnBatch, primaryColumn string) error {
+	ids := batch.Columns[primaryColumn]
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("colgranule: duplicate mutation primary id %d", id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+func validateColumnMutationCoverageOptions(opts ColumnPartCoverageOptions) error {
+	if opts.SourceRowVersionLower != 0 && opts.SourceRowVersionUpper == 0 {
+		return fmt.Errorf("colgranule: source row version lower=%d without upper bound", opts.SourceRowVersionLower)
+	}
+	if opts.SourceRowVersionUpper != 0 && opts.SourceRowVersionLower >= opts.SourceRowVersionUpper {
+		return fmt.Errorf("colgranule: source row version lower=%d upper=%d", opts.SourceRowVersionLower, opts.SourceRowVersionUpper)
+	}
+	if opts.SourceRowRootGeneration == 0 && (opts.SourceRowVersionLower != 0 || opts.SourceRowVersionUpper != 0) {
+		return fmt.Errorf("colgranule: source row versions require source row root generation")
+	}
+	return nil
+}
+
+func columnMutationNextPartID(manifest ColumnWorkspaceManifest) uint64 {
+	var maxPartID uint64
+	for _, part := range manifest.Parts {
+		if part.PartID > maxPartID {
+			maxPartID = part.PartID
+		}
+	}
+	return maxPartID + 1
+}
+
+func sortedUniqueInt64s(values []int64) []int64 {
+	if len(values) == 0 {
+		return nil
+	}
+	out := append([]int64(nil), values...)
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	n := 0
+	var last int64
+	for i, value := range out {
+		if i != 0 && value == last {
+			continue
+		}
+		out[n] = value
+		n++
+		last = value
+	}
+	return out[:n]
+}

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -1,0 +1,416 @@
+package colgranule
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestColumnMutationAdapterReplayAndJSONBenchParity(t *testing.T) {
+	ds := syntheticJSONBenchDataset(256)
+	opts, err := JSONBenchColumnPartOptions(ds, 32)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	updates := map[int64]map[string]int64{
+		5: {
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][40],
+			"time_us":                ds.Columns["time_us"][5] - 10_000_000,
+		},
+		25: {
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][41],
+			"time_us":                ds.Columns["time_us"][25] + 20_000_000,
+		},
+	}
+	for _, update := range updates {
+		update["hour_of_day"] = unixMicroHour(update["time_us"])
+	}
+	deletes := []int64{10, 11}
+
+	dir := t.TempDir()
+	workspace, adapter := testColumnMutationAdapter(t, dir, opts, ds.Dictionaries)
+	defer workspace.Close()
+	baseResult, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{
+		SourceRowRootGeneration: 1,
+		SourceRowVersionUpper:   uint64(ds.Rows),
+	})
+	if err != nil {
+		t.Fatalf("PublishBaseBatch: %v", err)
+	}
+	if baseResult.GenerationID != 1 || baseResult.InsertedRows != ds.Rows {
+		t.Fatalf("base result=%+v want generation=1 inserted=%d", baseResult, ds.Rows)
+	}
+	result, err := adapter.Apply(ColumnMutationBatch{
+		Updates:                 jsonBenchDeltaBatch(ds, updates),
+		Deletes:                 deletes,
+		SourceRowRootGeneration: 2,
+		SourceRowVersionLower:   uint64(ds.Rows),
+		SourceRowVersionUpper:   uint64(ds.Rows + len(updates) + len(deletes)),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.GenerationID != 2 || result.UpdatedRows != len(updates) || result.DeletedRows != len(deletes) {
+		t.Fatalf("mutation result=%+v", result)
+	}
+	if len(result.Manifest.PartSet.BaseParts) != 1 || len(result.Manifest.PartSet.DeltaParts) != 1 || len(result.Manifest.PartSet.Tombstones) != len(deletes) {
+		t.Fatalf("manifest part set=%+v", result.Manifest.PartSet)
+	}
+	coverage := result.Manifest.PartSet.DeltaParts[0].Coverage
+	if coverage.SourceRowRootGeneration != 2 || coverage.SourceRowVersionLower != uint64(ds.Rows) || coverage.SourceRowVersionUpper != uint64(ds.Rows+len(updates)+len(deletes)) {
+		t.Fatalf("delta coverage=%+v", coverage)
+	}
+
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	expected := applyJSONBenchMutations(ds, updates, map[int64]bool{10: true, 11: true})
+	if stats := reader.VisibilityStats(); stats.VisibleRows != expected.Rows || stats.SupersededRows != len(updates) || stats.DeletedRows != len(deletes) {
+		t.Fatalf("visibility stats=%+v want visible=%d superseded=%d deleted=%d", stats, expected.Rows, len(updates), len(deletes))
+	}
+	assertJSONBenchPartSetQueriesMatchRaw(t, reader, expected)
+
+	reopened, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench", ValidationMode: ColumnWorkspaceValidateTCS1Header})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace(reopen): %v", err)
+	}
+	defer reopened.Close()
+	reopenedManifest, err := reopened.LoadCollectionManifest()
+	if err != nil {
+		t.Fatalf("LoadCollectionManifest(reopen): %v", err)
+	}
+	reopenedReader, err := OpenColumnPartSetReader(reopened, reopenedManifest, ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("OpenColumnPartSetReader(reopen): %v", err)
+	}
+	assertJSONBenchPartSetQueriesMatchRaw(t, reopenedReader, expected)
+
+	replayWorkspace, replayAdapter := testColumnMutationAdapter(t, t.TempDir(), opts, ds.Dictionaries)
+	defer replayWorkspace.Close()
+	if _, err := replayAdapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)}); err != nil {
+		t.Fatalf("replay PublishBaseBatch: %v", err)
+	}
+	if _, err := replayAdapter.Apply(ColumnMutationBatch{
+		Updates:                 jsonBenchDeltaBatch(ds, updates),
+		Deletes:                 deletes,
+		SourceRowRootGeneration: 2,
+		SourceRowVersionLower:   uint64(ds.Rows),
+		SourceRowVersionUpper:   uint64(ds.Rows + len(updates) + len(deletes)),
+	}); err != nil {
+		t.Fatalf("replay Apply: %v", err)
+	}
+	replayReader, err := replayAdapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("replay Reader: %v", err)
+	}
+	assertJSONBenchPartSetQueriesMatchRaw(t, replayReader, expected)
+}
+
+func TestColumnMutationAdapterDeleteOnlyBatch(t *testing.T) {
+	ds := syntheticJSONBenchDataset(96)
+	opts, err := JSONBenchColumnPartOptions(ds, 16)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	workspace, adapter := testColumnMutationAdapter(t, t.TempDir(), opts, ds.Dictionaries)
+	defer workspace.Close()
+	if _, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)}); err != nil {
+		t.Fatalf("PublishBaseBatch: %v", err)
+	}
+	result, err := adapter.Apply(ColumnMutationBatch{
+		Deletes:                 []int64{3, 5, 5, 7},
+		SourceRowRootGeneration: 2,
+		SourceRowVersionLower:   uint64(ds.Rows),
+		SourceRowVersionUpper:   uint64(ds.Rows + 1),
+	})
+	if err != nil {
+		t.Fatalf("Apply(delete-only): %v", err)
+	}
+	if result.GenerationID != 2 || result.DeletedRows != 3 || result.Part.PartID != 0 {
+		t.Fatalf("delete-only result=%+v", result)
+	}
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	if stats := reader.VisibilityStats(); stats.VisibleRows != ds.Rows-3 || stats.DeletedRows != 3 || stats.DeltaParts != 0 {
+		t.Fatalf("visibility stats=%+v", stats)
+	}
+	for _, id := range []int64{3, 5, 7} {
+		if _, ok := reader.LatestLocator(id); ok {
+			t.Fatalf("deleted id %d has latest locator", id)
+		}
+	}
+}
+
+func TestColumnPartSetLocatorDecisionPathsMatch(t *testing.T) {
+	ds := syntheticJSONBenchDataset(128)
+	opts, err := JSONBenchColumnPartOptions(ds, 16)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	workspace, adapter := testColumnMutationAdapter(t, t.TempDir(), opts, ds.Dictionaries)
+	defer workspace.Close()
+	if _, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)}); err != nil {
+		t.Fatalf("PublishBaseBatch: %v", err)
+	}
+	for i := 0; i < 12; i++ {
+		id := int64(i * 3)
+		row := int(id)
+		nextTime := ds.Columns["time_us"][row] + int64(i+1)*1_000_000
+		updates := jsonBenchDeltaBatch(ds, map[int64]map[string]int64{
+			id: {
+				"time_us":     nextTime,
+				"hour_of_day": unixMicroHour(nextTime),
+			},
+		})
+		if _, err := adapter.Apply(ColumnMutationBatch{
+			Updates:                 updates,
+			SourceRowRootGeneration: uint64(i + 2),
+			SourceRowVersionLower:   uint64(ds.Rows + i),
+			SourceRowVersionUpper:   uint64(ds.Rows + i + 1),
+		}); err != nil {
+			t.Fatalf("Apply update %d: %v", i, err)
+		}
+	}
+	if _, err := adapter.Apply(ColumnMutationBatch{
+		Deletes:                 []int64{9},
+		SourceRowRootGeneration: 20,
+		SourceRowVersionLower:   uint64(ds.Rows + 12),
+		SourceRowVersionUpper:   uint64(ds.Rows + 13),
+	}); err != nil {
+		t.Fatalf("Apply delete: %v", err)
+	}
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	for _, id := range []int64{0, 3, 12, 45, 127} {
+		side, sideOK := reader.LatestLocator(id)
+		scan, scanOK := reader.ScanLatestLocator(id)
+		if sideOK != scanOK || side != scan {
+			t.Fatalf("locator id=%d side=(%+v,%v) scan=(%+v,%v)", id, side, sideOK, scan, scanOK)
+		}
+		sideValue, sideValueOK, err := reader.ValueAtLatest(id, "time_us")
+		if err != nil {
+			t.Fatalf("ValueAtLatest(%d): %v", id, err)
+		}
+		scanValue, scanValueOK, err := reader.ScanValueAtLatest(id, "time_us")
+		if err != nil {
+			t.Fatalf("ScanValueAtLatest(%d): %v", id, err)
+		}
+		if sideValueOK != scanValueOK || sideValue != scanValue {
+			t.Fatalf("value id=%d side=(%d,%v) scan=(%d,%v)", id, sideValue, sideValueOK, scanValue, scanValueOK)
+		}
+	}
+	if _, ok := reader.LatestLocator(9); ok {
+		t.Fatal("deleted id 9 has side-index locator")
+	}
+	if _, ok := reader.ScanLatestLocator(9); ok {
+		t.Fatal("deleted id 9 has scan locator")
+	}
+}
+
+func BenchmarkColumnLocatorDecisionM8A(b *testing.B) {
+	for _, deltaParts := range []int{1, 8, 32, 128} {
+		b.Run(fmt.Sprintf("delta_parts_%03d", deltaParts), func(b *testing.B) {
+			reader, target := benchmarkColumnMutationLocatorReader(b, deltaParts)
+			b.ReportMetric(float64(deltaParts+1), "parts")
+			b.ReportMetric(float64(reader.VisibilityStats().VisibleRows), "visible_rows")
+			b.Run("side_index_locator", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					locator, ok := reader.LatestLocator(target)
+					if !ok {
+						b.Fatal("missing side-index locator")
+					}
+					benchSink += int64(locator.PartRow)
+				}
+			})
+			b.Run("part_local_scan_locator", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					locator, ok := reader.ScanLatestLocator(target)
+					if !ok {
+						b.Fatal("missing scan locator")
+					}
+					benchSink += int64(locator.PartRow)
+				}
+			})
+			b.Run("side_index_point_value", func(b *testing.B) {
+				var scratch ColumnPartSetPointLookupScratch
+				if _, _, err := reader.ValueAtLatestWithScratch(target, "time_us", &scratch); err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					value, ok, err := reader.ValueAtLatestWithScratch(target, "time_us", &scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if !ok {
+						b.Fatal("missing side-index value")
+					}
+					benchSink += value
+				}
+			})
+			b.Run("part_local_scan_point_value", func(b *testing.B) {
+				var scratch ColumnPartSetPointLookupScratch
+				if _, _, err := reader.ScanValueAtLatestWithScratch(target, "time_us", &scratch); err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					value, ok, err := reader.ScanValueAtLatestWithScratch(target, "time_us", &scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if !ok {
+						b.Fatal("missing scan value")
+					}
+					benchSink += value
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkColumnMutationAdapterApplyM8A(b *testing.B) {
+	ds := syntheticJSONBenchDataset(4096)
+	opts, err := JSONBenchColumnPartOptions(ds, 128)
+	if err != nil {
+		b.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	updates := make(map[int64]map[string]int64, 128)
+	for i := int64(0); i < 128; i++ {
+		id := i * 7
+		nextTime := ds.Columns["time_us"][int(id)] + 1_000_000
+		updates[id] = map[string]int64{
+			"time_us":     nextTime,
+			"hour_of_day": unixMicroHour(nextTime),
+		}
+	}
+	deletes := make([]int64, 0, 32)
+	for i := int64(0); i < 32; i++ {
+		deletes = append(deletes, 2048+i*3)
+	}
+	updateBatch := jsonBenchDeltaBatch(ds, updates)
+	root := b.TempDir()
+	b.ReportMetric(float64(updateBatch.Rows), "updated_rows")
+	b.ReportMetric(float64(len(deletes)), "deleted_rows")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		workspace, adapter := benchmarkColumnMutationAdapter(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries)
+		if _, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)}); err != nil {
+			_ = workspace.Close()
+			b.Fatalf("PublishBaseBatch: %v", err)
+		}
+		b.StartTimer()
+		_, err := adapter.Apply(ColumnMutationBatch{
+			Updates:                 updateBatch,
+			Deletes:                 deletes,
+			SourceRowRootGeneration: 2,
+			SourceRowVersionLower:   uint64(ds.Rows),
+			SourceRowVersionUpper:   uint64(ds.Rows + updateBatch.Rows + len(deletes)),
+		})
+		b.StopTimer()
+		if err != nil {
+			_ = workspace.Close()
+			b.Fatalf("Apply: %v", err)
+		}
+		_ = workspace.Close()
+	}
+}
+
+func testColumnMutationAdapter(t testing.TB, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64) (*ColumnWorkspace, *ColumnMutationAdapter) {
+	t.Helper()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
+		Collection:   "jsonbench",
+		StoreOptions: opts,
+		Dictionaries: dictionaries,
+	})
+	if err != nil {
+		_ = workspace.Close()
+		t.Fatalf("NewColumnMutationAdapter: %v", err)
+	}
+	return workspace, adapter
+}
+
+func benchmarkColumnMutationAdapter(b *testing.B, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64) (*ColumnWorkspace, *ColumnMutationAdapter) {
+	b.Helper()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		b.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
+		Collection:   "jsonbench",
+		StoreOptions: opts,
+		Dictionaries: dictionaries,
+	})
+	if err != nil {
+		_ = workspace.Close()
+		b.Fatalf("NewColumnMutationAdapter: %v", err)
+	}
+	return workspace, adapter
+}
+
+func benchmarkColumnMutationLocatorReader(b *testing.B, deltaParts int) (*ColumnPartSetReader, int64) {
+	b.Helper()
+	ds := syntheticJSONBenchDataset(8192)
+	opts, err := JSONBenchColumnPartOptions(ds, 128)
+	if err != nil {
+		b.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	workspace, adapter := benchmarkColumnMutationAdapter(b, b.TempDir(), opts, ds.Dictionaries)
+	b.Cleanup(func() { _ = workspace.Close() })
+	if _, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)}); err != nil {
+		b.Fatalf("PublishBaseBatch: %v", err)
+	}
+	target := int64(4096)
+	for i := 0; i < deltaParts; i++ {
+		id := target
+		if i%4 != 0 {
+			id = int64((i * 97) % ds.Rows)
+		}
+		nextTime := ds.Columns["time_us"][int(id)] + int64(i+1)*1_000_000
+		updates := jsonBenchDeltaBatch(ds, map[int64]map[string]int64{
+			id: {
+				"time_us":     nextTime,
+				"hour_of_day": unixMicroHour(nextTime),
+			},
+		})
+		if _, err := adapter.Apply(ColumnMutationBatch{
+			Updates:                 updates,
+			SourceRowRootGeneration: uint64(i + 2),
+			SourceRowVersionLower:   uint64(ds.Rows + i),
+			SourceRowVersionUpper:   uint64(ds.Rows + i + 1),
+		}); err != nil {
+			b.Fatalf("Apply(%d): %v", i, err)
+		}
+	}
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		b.Fatalf("Reader: %v", err)
+	}
+	return reader, target
+}

--- a/experiments/colgranule/part_set.go
+++ b/experiments/colgranule/part_set.go
@@ -84,6 +84,10 @@ type ColumnPartSetScanResult struct {
 	Diagnostics ColumnPartSetScanDiagnostics
 }
 
+type ColumnPartSetPointLookupScratch struct {
+	scanner ColumnPartScanner
+}
+
 type ColumnPartSetScanDiagnostics struct {
 	RowsReturned       int                       `json:"rows_returned"`
 	RowsScanned        int                       `json:"rows_scanned"`
@@ -189,6 +193,49 @@ func (r *ColumnPartSetReader) LatestLocator(primaryID int64) (RowLocator, bool) 
 		return RowLocator{}, false
 	}
 	return ref.Locator, true
+}
+
+func (r *ColumnPartSetReader) ScanLatestLocator(primaryID int64) (RowLocator, bool) {
+	ref, ok := r.scanLatestRowRef(primaryID)
+	if !ok {
+		return RowLocator{}, false
+	}
+	return ref.Locator, true
+}
+
+func (r *ColumnPartSetReader) ValueAtLatest(primaryID int64, columnName string) (int64, bool, error) {
+	return r.ValueAtLatestWithScratch(primaryID, columnName, nil)
+}
+
+func (r *ColumnPartSetReader) ValueAtLatestWithScratch(primaryID int64, columnName string, scratch *ColumnPartSetPointLookupScratch) (int64, bool, error) {
+	if r == nil {
+		return 0, false, nil
+	}
+	ref, ok := r.latest[primaryID]
+	if !ok {
+		return 0, false, nil
+	}
+	value, err := r.valueAtRowRef(ref, columnName, scratch)
+	if err != nil {
+		return 0, false, err
+	}
+	return value, true, nil
+}
+
+func (r *ColumnPartSetReader) ScanValueAtLatest(primaryID int64, columnName string) (int64, bool, error) {
+	return r.ScanValueAtLatestWithScratch(primaryID, columnName, nil)
+}
+
+func (r *ColumnPartSetReader) ScanValueAtLatestWithScratch(primaryID int64, columnName string, scratch *ColumnPartSetPointLookupScratch) (int64, bool, error) {
+	ref, ok := r.scanLatestRowRef(primaryID)
+	if !ok {
+		return 0, false, nil
+	}
+	value, err := r.valueAtRowRef(ref, columnName, scratch)
+	if err != nil {
+		return 0, false, err
+	}
+	return value, true, nil
 }
 
 func (r *ColumnPartSetReader) ScanProjected(columns []string) (ColumnPartSetScanResult, error) {
@@ -326,6 +373,52 @@ func (r *ColumnPartSetReader) visibleRowsForPart(partIndex int) columnPartSetVis
 		return columnPartSetVisibleRows{}
 	}
 	return r.visibleRowList[partIndex]
+}
+
+func (r *ColumnPartSetReader) scanLatestRowRef(primaryID int64) (columnPartSetRowRef, bool) {
+	if r == nil {
+		return columnPartSetRowRef{}, false
+	}
+	var best columnPartSetRowRef
+	var found bool
+	tombstoneGeneration, tombstoned := r.tombstoneByID[primaryID]
+	for partIndex, loaded := range r.parts {
+		locator, ok := loaded.Part.LocatePrimaryID(primaryID)
+		if !ok {
+			continue
+		}
+		row := columnPartSetRowRef{
+			PrimaryID:    primaryID,
+			PartIndex:    partIndex,
+			PartRow:      locator.PartRow,
+			GenerationID: loaded.Ref.GenerationID,
+			Ordinal:      loaded.Ordinal,
+			Locator:      locator,
+		}
+		if tombstoned && tombstoneGeneration >= row.GenerationID {
+			continue
+		}
+		if !found || row.newerThan(best) {
+			best = row
+			found = true
+		}
+	}
+	return best, found
+}
+
+func (r *ColumnPartSetReader) valueAtRowRef(ref columnPartSetRowRef, columnName string, scratch *ColumnPartSetPointLookupScratch) (int64, error) {
+	if r == nil {
+		return 0, fmt.Errorf("colgranule: nil part set reader")
+	}
+	if ref.PartIndex < 0 || ref.PartIndex >= len(r.parts) {
+		return 0, fmt.Errorf("colgranule: row ref part index %d outside %d parts", ref.PartIndex, len(r.parts))
+	}
+	if scratch == nil {
+		scanner := ColumnPartScanner{part: r.parts[ref.PartIndex].Part}
+		return scanner.ValueAt(ref.Locator, columnName)
+	}
+	scratch.scanner.part = r.parts[ref.PartIndex].Part
+	return scratch.scanner.ValueAt(ref.Locator, columnName)
 }
 
 func (r columnPartSetRowRef) newerThan(other columnPartSetRowRef) bool {


### PR DESCRIPTION
## Summary

This is the M8A child PR on top of #1591. It keeps the work in `experiments/colgranule` and adds the non-durable mutation adapter/profile layer needed before production command-WAL integration:

- adds `ColumnMutationAdapter` for publishing base batches, row-aligned update/insert delta parts, and delete tombstones through the existing disk-backed collection manifest path;
- adds restart/replay coverage for JSONBench-shaped insert/update/delete sequences, including visible-row and q1-q5 parity after reopen;
- adds explicit locator-decision APIs that compare the current manifest-load side index with a part-local scan path;
- adds a scratch-backed point lookup path so steady-state point reconstruction is zero-allocation without making `ColumnPartSetReader` mutable/concurrency-unsafe.

This PR does not add production command-WAL integration and does not add a root-backed locator. The locator profile is intended to decide whether that is needed immediately.

## Correctness validation

- `GOWORK=off go test ./experiments/colgranule -run 'TestColumnMutationAdapter|TestColumnPartSetLocatorDecision' -count=1`
- `GOWORK=off go test ./experiments/colgranule/... -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./experiments/colgranule/... ./TreeDB/collections -count=1`

The new tests cover:

- base publish plus update/delete delta manifest generation;
- reopen using `ColumnWorkspaceValidateTCS1Header`;
- replaying the same mutation sequence into a fresh workspace;
- JSONBench q1-q5 result-hash parity against the raw-vector reference after mutations;
- delete-only batches with duplicate delete ids collapsed;
- side-index locator and scan locator equivalence, including deleted rows.

## Performance validation

Locator decision benchmark:

`GOWORK=off go test ./experiments/colgranule -run '^$' -bench '^BenchmarkColumnLocatorDecisionM8A$' -benchmem -count=3`

Representative Apple M3 results:

- side-index locator stays flat at about `10.0-11.4 ns/op`, `0 B/op`, `0 allocs/op` from `1` to `128` delta parts.
- part-local scan locator grows with part count: about `63-65 ns/op` at `1` delta part, `237-247 ns/op` at `8`, `868-869 ns/op` at `32`, and `4.0-4.6 us/op` at `128`; still `0 B/op`, `0 allocs/op`.
- scratch-backed side-index point value stays about `58-69 ns/op`, `0 B/op`, `0 allocs/op` across the same part counts.
- scratch-backed scan point value grows with part count: about `114-117 ns/op` at `1`, `284-317 ns/op` at `8`, `912 ns/op` at `32`, and `4.1-4.2 us/op` at `128`; `0 B/op`, `0 allocs/op`.

Mutation apply benchmark:

`GOWORK=off go test ./experiments/colgranule -run '^$' -bench '^BenchmarkColumnMutationAdapterApplyM8A$' -benchmem -benchtime=20x -count=5`

- `128` updated rows plus `32` deletes over a `4096`-row base: about `15.9-17.1 ms/op`, `9.4 MiB/op`, `3587 allocs/op`.
- This benchmark includes delta part build, compression, value-log-shaped asset publish, and manifest rewrite. It is intentionally reported separately from locator lookup/reconstruction cost.

Existing hot-query and lifecycle smoke gates:

`GOWORK=off go test ./experiments/colgranule -run '^$' -bench 'Benchmark(JSONBenchColumnPartSetQueriesM4PerQuery|JSONBenchColumnPartSetQ4FairnessM4|JSONBenchColumnPartSetAggregateMetadataM4|ColumnAssetReachability|ColumnAssetReachabilitySummary)' -benchmem -benchtime=100x -count=1`

- Reachability summary reuse remains `0 B/op`, `0 allocs/op`.
- Existing q1/q2/q3/q4a/q4b/q5 and aggregate-metadata query allocation regimes are preserved.

## Locator decision

M8A does not justify implementing a root-backed locator immediately. The current manifest-load side index gives constant-time, zero-allocation locator lookup and scratch-backed point reconstruction. The no-side-index part-local scan path scales linearly with part count and is already several microseconds at `128` delta parts.

The practical next step is to defer a production root-backed locator until production integration has a real update/delete or point-reconstruction workload that needs a persistent locator root. The M8B follow-up should document this measured deferral and keep the V1 locator shape as one `primary id -> latest visible row locator` per manifest generation, not one locator per column.
