### PR TITLE
experiments/colgranule: harden M9B lifecycle publish closure

### DIFF
--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -13,11 +13,14 @@ type ColumnAssetPin struct {
 }
 
 type ColumnAssetManager struct {
-	mu             sync.Mutex
-	store          ColumnAssetStore
-	pins           map[ColumnAssetRef]int
-	zombies        map[ColumnAssetRef]string
-	quarantine     map[ColumnAssetRef]string
+	mu         sync.Mutex
+	store      ColumnAssetStore
+	pins       map[ColumnAssetRef]int
+	zombies    map[ColumnAssetRef]string
+	quarantine map[ColumnAssetRef]string
+	// Direct quarantines are operator-owned and intentionally sticky until a
+	// future explicit unquarantine operation; publish-failure cleanup must not
+	// clear them just because a later publish retry succeeds.
 	operatorLocked map[ColumnAssetRef]struct{}
 	publishFailed  map[ColumnAssetRef]string
 	rewriteDebt    map[ColumnAssetRef]string
@@ -36,6 +39,10 @@ type ColumnAssetManagerReclamationPlan struct {
 	RewriteDebtBytes   int                                  `json:"rewrite_debt_bytes"`
 }
 
+// ColumnAssetPublishClosure is a single-process durability token returned by
+// PreparePublishClosure. JSON tags are for one-way diagnostics only: a
+// marshal/unmarshal round trip deliberately drops the private prepared identity
+// and is not accepted by SyncPublishClosure.
 type ColumnAssetPublishClosure struct {
 	PreparedAssets []ColumnPreparedAsset `json:"prepared_assets,omitempty"`
 	RequiredAssets int                   `json:"required_assets"`
@@ -247,6 +254,10 @@ func (m *ColumnAssetManager) PreparePublishClosure(prepared []ColumnPreparedAsse
 }
 
 func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnPreparedAsset) (ColumnAssetPublishClosure, error) {
+	return deriveColumnAssetPublishClosure(store, prepared, true)
+}
+
+func deriveColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnPreparedAsset, verifyRefs bool) (ColumnAssetPublishClosure, error) {
 	if store == nil {
 		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
@@ -258,6 +269,10 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 		// Keep a private copy so caller mutations to PreparedAssets are caught.
 		preparedIdentity: cloneColumnPreparedAssets(preparedClone),
 	}
+	if len(preparedClone) > maxColumnAssetInt {
+		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset count=%d exceeds host int", len(preparedClone))
+	}
+	closure.RequiredAssets = len(preparedClone)
 	// Sync is tied to the explicit publish closure: unreferenced buffered
 	// assets are not made durable until a root-visible prepared ref names them.
 	if _, ok := store.(columnAssetSyncer); ok && len(preparedClone) > 0 {
@@ -272,10 +287,11 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: duplicate prepared asset ref %+v", asset.Ref)
 		}
 		seen[asset.Ref] = struct{}{}
-		if err := verifyColumnAssetStoreRef(store, asset.Ref); err != nil {
-			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: missing required prepared asset %+v: %w", asset.Ref, err)
+		if verifyRefs {
+			if err := verifyColumnAssetStoreRef(store, asset.Ref); err != nil {
+				return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: missing required prepared asset %+v: %w", asset.Ref, err)
+			}
 		}
-		closure.RequiredAssets++
 		bytes := asset.Bytes
 		if bytes == 0 {
 			if asset.Ref.Length > int64(maxColumnAssetInt) {
@@ -301,7 +317,7 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	if store == nil {
 		return ColumnAssetSyncedPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
-	verified, err := prepareColumnAssetPublishClosure(store, closure.PreparedAssets)
+	verified, err := deriveColumnAssetPublishClosure(store, closure.preparedIdentity, false)
 	if err != nil {
 		return ColumnAssetSyncedPublishClosure{}, err
 	}
@@ -373,6 +389,7 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 			}
 			delete(m.publishFailed, asset.Ref)
 		}
+		delete(m.refFailedAt, asset.Ref)
 	}
 	return nil
 }
@@ -391,6 +408,9 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if len(prepared) == 0 {
+		return nil
+	}
 	m.publishEpoch++
 	if m.refFailedAt == nil {
 		m.refFailedAt = make(map[ColumnAssetRef]uint64)

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -272,6 +272,9 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 			}
 			bytes = int(asset.Ref.Length)
 		}
+		if bytes > int(^uint(0)>>1)-closure.RequiredBytes {
+			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset required bytes overflow")
+		}
 		closure.RequiredBytes += bytes
 	}
 	return closure, nil

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -11,13 +11,14 @@ type ColumnAssetPin struct {
 }
 
 type ColumnAssetManager struct {
-	mu          sync.Mutex
-	store       ColumnAssetStore
-	pins        map[ColumnAssetRef]int
-	zombies     map[ColumnAssetRef]string
-	quarantine  map[ColumnAssetRef]string
-	rewriteDebt map[ColumnAssetRef]string
-	published   map[ColumnAssetRef]string
+	mu            sync.Mutex
+	store         ColumnAssetStore
+	pins          map[ColumnAssetRef]int
+	zombies       map[ColumnAssetRef]string
+	quarantine    map[ColumnAssetRef]string
+	publishFailed map[ColumnAssetRef]struct{}
+	rewriteDebt   map[ColumnAssetRef]string
+	published     map[ColumnAssetRef]string
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -61,12 +62,13 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		return nil, fmt.Errorf("colgranule: nil column asset manager store")
 	}
 	return &ColumnAssetManager{
-		store:       store,
-		pins:        make(map[ColumnAssetRef]int),
-		zombies:     make(map[ColumnAssetRef]string),
-		quarantine:  make(map[ColumnAssetRef]string),
-		rewriteDebt: make(map[ColumnAssetRef]string),
-		published:   make(map[ColumnAssetRef]string),
+		store:         store,
+		pins:          make(map[ColumnAssetRef]int),
+		zombies:       make(map[ColumnAssetRef]string),
+		quarantine:    make(map[ColumnAssetRef]string),
+		publishFailed: make(map[ColumnAssetRef]struct{}),
+		rewriteDebt:   make(map[ColumnAssetRef]string),
+		published:     make(map[ColumnAssetRef]string),
 	}, nil
 }
 
@@ -282,6 +284,12 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	if err != nil {
 		return ColumnAssetSyncedPublishClosure{}, err
 	}
+	// Re-derive the closure from prepared refs so sync requirements cannot be
+	// cleared by caller mutation, but require the caller-visible accounting to
+	// still match the prepared asset set that was originally reviewed.
+	if err := validateColumnAssetPublishClosureMatches(closure, verified); err != nil {
+		return ColumnAssetSyncedPublishClosure{}, err
+	}
 	if verified.SyncRequired {
 		if syncer, ok := store.(columnAssetSyncer); ok {
 			if err := syncer.Sync(); err != nil {
@@ -313,9 +321,10 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, asset := range synced.closure.PreparedAssets {
-		delete(m.quarantine, asset.Ref)
-		delete(m.zombies, asset.Ref)
-		delete(m.rewriteDebt, asset.Ref)
+		if _, ok := m.publishFailed[asset.Ref]; ok {
+			delete(m.quarantine, asset.Ref)
+			delete(m.publishFailed, asset.Ref)
+		}
 		m.published[asset.Ref] = reason
 	}
 	return nil
@@ -337,6 +346,7 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	defer m.mu.Unlock()
 	for _, asset := range prepared {
 		m.quarantine[asset.Ref] = reason
+		m.publishFailed[asset.Ref] = struct{}{}
 	}
 	return nil
 }
@@ -406,6 +416,19 @@ func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
 	}
 	if asset.Bytes == 0 && asset.Ref.Length > int64(^uint(0)>>1) {
 		return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
+	}
+	return nil
+}
+
+func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, verified ColumnAssetPublishClosure) error {
+	if caller.RequiredAssets != verified.RequiredAssets {
+		return fmt.Errorf("colgranule: publish closure required assets=%d want %d", caller.RequiredAssets, verified.RequiredAssets)
+	}
+	if caller.RequiredBytes != verified.RequiredBytes {
+		return fmt.Errorf("colgranule: publish closure required bytes=%d want %d", caller.RequiredBytes, verified.RequiredBytes)
+	}
+	if caller.FlushRequired != verified.FlushRequired {
+		return fmt.Errorf("colgranule: publish closure flush required=%t want %t", caller.FlushRequired, verified.FlushRequired)
 	}
 	return nil
 }

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -414,10 +414,6 @@ func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error
 	if verifier, ok := store.(columnAssetVerifier); ok {
 		return verifier.Verify(ref)
 	}
-	if ranged, ok := store.(ColumnAssetRangeReader); ok {
-		_, err := ranged.ReadRange(ref, 0, 1)
-		return err
-	}
 	_, err := store.ReadTo(ref, nil)
 	return err
 }

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -27,6 +27,7 @@ type ColumnAssetManager struct {
 	publishEpoch   uint64
 	nextAttemptID  uint64
 	syncedAttempt  map[uint64]uint64
+	syncedRefs     map[uint64][]ColumnAssetRef
 	refFailedAt    map[ColumnAssetRef]uint64
 }
 
@@ -88,6 +89,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		publishFailed:  make(map[ColumnAssetRef]string),
 		rewriteDebt:    make(map[ColumnAssetRef]string),
 		syncedAttempt:  make(map[uint64]uint64),
+		syncedRefs:     make(map[uint64][]ColumnAssetRef),
 		refFailedAt:    make(map[ColumnAssetRef]uint64),
 	}, nil
 }
@@ -338,10 +340,14 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	if m.syncedAttempt == nil {
 		m.syncedAttempt = make(map[uint64]uint64)
 	}
+	if m.syncedRefs == nil {
+		m.syncedRefs = make(map[uint64][]ColumnAssetRef)
+	}
 	m.nextAttemptID++
 	attempt := m.nextAttemptID
 	epoch := m.publishEpoch
 	m.syncedAttempt[attempt] = epoch
+	m.syncedRefs[attempt] = columnPreparedAssetRefs(verified.PreparedAssets)
 	m.mu.Unlock()
 	return ColumnAssetSyncedPublishClosure{
 		closure: verified,
@@ -377,10 +383,13 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	}
 	for _, asset := range synced.closure.PreparedAssets {
 		if m.refFailedAt[asset.Ref] > epoch {
+			delete(m.syncedAttempt, synced.attempt)
+			delete(m.syncedRefs, synced.attempt)
 			return fmt.Errorf("colgranule: synced publish closure predates a later publish failure for ref %+v", asset.Ref)
 		}
 	}
 	delete(m.syncedAttempt, synced.attempt)
+	delete(m.syncedRefs, synced.attempt)
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
 			_, operatorLocked := m.operatorLocked[asset.Ref]
@@ -415,6 +424,12 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	if m.refFailedAt == nil {
 		m.refFailedAt = make(map[ColumnAssetRef]uint64)
 	}
+	for attempt, refs := range m.syncedRefs {
+		if columnAssetRefsOverlapPrepared(refs, prepared) {
+			delete(m.syncedAttempt, attempt)
+			delete(m.syncedRefs, attempt)
+		}
+	}
 	for _, asset := range prepared {
 		m.refFailedAt[asset.Ref] = m.publishEpoch
 		if _, publishOwned := m.publishFailed[asset.Ref]; publishOwned {
@@ -427,6 +442,28 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 		m.publishFailed[asset.Ref] = reason
 	}
 	return nil
+}
+
+func columnPreparedAssetRefs(prepared []ColumnPreparedAsset) []ColumnAssetRef {
+	if len(prepared) == 0 {
+		return nil
+	}
+	refs := make([]ColumnAssetRef, len(prepared))
+	for i, asset := range prepared {
+		refs[i] = asset.Ref
+	}
+	return refs
+}
+
+func columnAssetRefsOverlapPrepared(refs []ColumnAssetRef, prepared []ColumnPreparedAsset) bool {
+	for _, ref := range refs {
+		for _, asset := range prepared {
+			if ref == asset.Ref {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilityPlan) ColumnAssetManagerReclamationPlan {

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -36,6 +36,8 @@ type ColumnAssetPublishClosure struct {
 	RequiredBytes  int                   `json:"required_bytes"`
 	FlushRequired  bool                  `json:"flush_required,omitempty"`
 	SyncRequired   bool                  `json:"sync_required,omitempty"`
+
+	preparedIdentity []ColumnPreparedAsset
 }
 
 type ColumnAssetSyncedPublishClosure struct {
@@ -237,8 +239,9 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
 	closure := ColumnAssetPublishClosure{
-		PreparedAssets: cloneColumnPreparedAssets(prepared),
-		FlushRequired:  len(prepared) > 0,
+		PreparedAssets:   cloneColumnPreparedAssets(prepared),
+		FlushRequired:    len(prepared) > 0,
+		preparedIdentity: cloneColumnPreparedAssets(prepared),
 	}
 	// Sync is tied to the explicit publish closure: unreferenced buffered
 	// assets are not made durable until a root-visible prepared ref names them.
@@ -421,6 +424,12 @@ func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
 }
 
 func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, verified ColumnAssetPublishClosure) error {
+	if !columnPreparedAssetsEqual(caller.PreparedAssets, caller.preparedIdentity) {
+		return fmt.Errorf("colgranule: publish closure prepared assets changed after prepare")
+	}
+	if !columnPreparedAssetsEqual(verified.PreparedAssets, caller.preparedIdentity) {
+		return fmt.Errorf("colgranule: publish closure verified prepared assets changed after prepare")
+	}
 	if caller.RequiredAssets != verified.RequiredAssets {
 		return fmt.Errorf("colgranule: publish closure required assets=%d want %d", caller.RequiredAssets, verified.RequiredAssets)
 	}
@@ -431,6 +440,18 @@ func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, 
 		return fmt.Errorf("colgranule: publish closure flush required=%t want %t", caller.FlushRequired, verified.FlushRequired)
 	}
 	return nil
+}
+
+func columnPreparedAssetsEqual(left, right []ColumnPreparedAsset) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error {

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -17,6 +17,7 @@ type ColumnAssetManager struct {
 	zombies     map[ColumnAssetRef]string
 	quarantine  map[ColumnAssetRef]string
 	rewriteDebt map[ColumnAssetRef]string
+	published   map[ColumnAssetRef]string
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -65,6 +66,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		zombies:     make(map[ColumnAssetRef]string),
 		quarantine:  make(map[ColumnAssetRef]string),
 		rewriteDebt: make(map[ColumnAssetRef]string),
+		published:   make(map[ColumnAssetRef]string),
 	}, nil
 }
 
@@ -236,6 +238,8 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 		PreparedAssets: cloneColumnPreparedAssets(prepared),
 		FlushRequired:  len(prepared) > 0,
 	}
+	// Sync is tied to the explicit publish closure: unreferenced buffered
+	// assets are not made durable until a root-visible prepared ref names them.
 	if _, ok := store.(columnAssetSyncer); ok && len(prepared) > 0 {
 		closure.SyncRequired = true
 	}
@@ -291,15 +295,20 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	}, nil
 }
 
-func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, _ string) error {
+func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, reason string) error {
 	if m == nil {
 		return fmt.Errorf("colgranule: nil column asset manager")
 	}
 	if !synced.sealed {
 		return fmt.Errorf("colgranule: publish succeeded requires synced publish closure")
 	}
-	if _, err := m.PreparePublishClosure(synced.closure.PreparedAssets); err != nil {
-		return err
+	if reason == "" {
+		reason = "publish succeeded"
+	}
+	for _, asset := range synced.closure.PreparedAssets {
+		if err := validateColumnPreparedAsset(asset); err != nil {
+			return err
+		}
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -307,6 +316,7 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 		delete(m.quarantine, asset.Ref)
 		delete(m.zombies, asset.Ref)
 		delete(m.rewriteDebt, asset.Ref)
+		m.published[asset.Ref] = reason
 	}
 	return nil
 }
@@ -344,6 +354,7 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 		zombieReason, zombie := m.zombies[reachable.Ref]
 		quarantineReason, quarantined := m.quarantine[reachable.Ref]
 		rewriteReason, rewrite := m.rewriteDebt[reachable.Ref]
+		publishedReason, published := m.published[reachable.Ref]
 		entry := ColumnAssetManagerReclamationEntry{
 			Ref:              reachable.Ref,
 			State:            reachable.State,
@@ -362,6 +373,8 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 			entry.ManagerReason = rewriteReason
 		case zombie:
 			entry.ManagerReason = zombieReason
+		case published:
+			entry.ManagerReason = publishedReason
 		}
 		if entry.Candidate {
 			plan.CandidateBytes += entry.Bytes

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -266,6 +266,9 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 		if err := validateColumnPreparedAsset(asset); err != nil {
 			return err
 		}
+		if err := verifyColumnAssetStoreRef(store, asset.Ref); err != nil {
+			return fmt.Errorf("colgranule: missing required prepared asset %+v: %w", asset.Ref, err)
+		}
 	}
 	if !closure.SyncRequired {
 		return nil

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -36,6 +36,11 @@ type ColumnAssetPublishClosure struct {
 	SyncRequired   bool                  `json:"sync_required,omitempty"`
 }
 
+type ColumnAssetSyncedPublishClosure struct {
+	closure ColumnAssetPublishClosure
+	sealed  bool
+}
+
 type ColumnAssetManagerReclamationEntry struct {
 	Ref              ColumnAssetRef            `json:"ref"`
 	State            ColumnAssetLifecycleState `json:"state"`
@@ -220,6 +225,13 @@ func (m *ColumnAssetManager) PreparePublishClosure(prepared []ColumnPreparedAsse
 	if store == nil {
 		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
+	return prepareColumnAssetPublishClosure(store, prepared)
+}
+
+func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnPreparedAsset) (ColumnAssetPublishClosure, error) {
+	if store == nil {
+		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
+	}
 	closure := ColumnAssetPublishClosure{
 		PreparedAssets: cloneColumnPreparedAssets(prepared),
 		FlushRequired:  len(prepared) > 0,
@@ -252,43 +264,46 @@ func (m *ColumnAssetManager) PreparePublishClosure(prepared []ColumnPreparedAsse
 	return closure, nil
 }
 
-func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosure) error {
+func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosure) (ColumnAssetSyncedPublishClosure, error) {
 	if m == nil {
-		return fmt.Errorf("colgranule: nil column asset manager")
+		return ColumnAssetSyncedPublishClosure{}, fmt.Errorf("colgranule: nil column asset manager")
 	}
 	m.mu.Lock()
 	store := m.store
 	m.mu.Unlock()
 	if store == nil {
-		return fmt.Errorf("colgranule: closed column asset manager")
+		return ColumnAssetSyncedPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
-	for _, asset := range closure.PreparedAssets {
-		if err := validateColumnPreparedAsset(asset); err != nil {
-			return err
+	verified, err := prepareColumnAssetPublishClosure(store, closure.PreparedAssets)
+	if err != nil {
+		return ColumnAssetSyncedPublishClosure{}, err
+	}
+	if verified.SyncRequired {
+		if syncer, ok := store.(columnAssetSyncer); ok {
+			if err := syncer.Sync(); err != nil {
+				return ColumnAssetSyncedPublishClosure{}, err
+			}
 		}
-		if err := verifyColumnAssetStoreRef(store, asset.Ref); err != nil {
-			return fmt.Errorf("colgranule: missing required prepared asset %+v: %w", asset.Ref, err)
-		}
 	}
-	if !closure.SyncRequired {
-		return nil
-	}
-	if syncer, ok := store.(columnAssetSyncer); ok {
-		return syncer.Sync()
-	}
-	return nil
+	return ColumnAssetSyncedPublishClosure{
+		closure: verified,
+		sealed:  true,
+	}, nil
 }
 
-func (m *ColumnAssetManager) MarkPublishSucceeded(prepared []ColumnPreparedAsset, _ string) error {
+func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, _ string) error {
 	if m == nil {
 		return fmt.Errorf("colgranule: nil column asset manager")
 	}
-	if _, err := m.PreparePublishClosure(prepared); err != nil {
+	if !synced.sealed {
+		return fmt.Errorf("colgranule: publish succeeded requires synced publish closure")
+	}
+	if _, err := m.PreparePublishClosure(synced.closure.PreparedAssets); err != nil {
 		return err
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, asset := range prepared {
+	for _, asset := range synced.closure.PreparedAssets {
 		delete(m.quarantine, asset.Ref)
 		delete(m.zombies, asset.Ref)
 		delete(m.rewriteDebt, asset.Ref)

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -31,6 +31,16 @@ type ColumnAssetManager struct {
 	refFailedAt    map[ColumnAssetRef]uint64
 }
 
+type ColumnAssetManagerDebugState struct {
+	Quarantine     map[ColumnAssetRef]string
+	OperatorLocked map[ColumnAssetRef]struct{}
+	PublishFailed  map[ColumnAssetRef]string
+	PublishEpoch   uint64
+	RefFailedAt    map[ColumnAssetRef]uint64
+	SyncedAttempts int
+	SyncedRefs     int
+}
+
 type ColumnAssetManagerReclamationPlan struct {
 	Entries            []ColumnAssetManagerReclamationEntry `json:"entries"`
 	CandidateBytes     int                                  `json:"candidate_bytes"`
@@ -99,6 +109,23 @@ func (m *ColumnAssetManager) Put(kind ColumnAssetKind, payload []byte) (ColumnAs
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
 	return m.store.Put(kind, payload)
+}
+
+func (m *ColumnAssetManager) DebugState() ColumnAssetManagerDebugState {
+	if m == nil {
+		return ColumnAssetManagerDebugState{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return ColumnAssetManagerDebugState{
+		Quarantine:     cloneColumnAssetStringMap(m.quarantine),
+		OperatorLocked: cloneColumnAssetSet(m.operatorLocked),
+		PublishFailed:  cloneColumnAssetStringMap(m.publishFailed),
+		PublishEpoch:   m.publishEpoch,
+		RefFailedAt:    cloneColumnAssetEpochMap(m.refFailedAt),
+		SyncedAttempts: len(m.syncedAttempt),
+		SyncedRefs:     len(m.syncedRefs),
+	}
 }
 
 func (m *ColumnAssetManager) PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error) {
@@ -271,9 +298,6 @@ func deriveColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnPr
 		// Keep a private copy so caller mutations to PreparedAssets are caught.
 		preparedIdentity: cloneColumnPreparedAssets(preparedClone),
 	}
-	if len(preparedClone) > maxColumnAssetInt {
-		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset count=%d exceeds host int", len(preparedClone))
-	}
 	closure.RequiredAssets = len(preparedClone)
 	// Sync is tied to the explicit publish closure: unreferenced buffered
 	// assets are not made durable until a root-visible prepared ref names them.
@@ -315,6 +339,7 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	}
 	m.mu.Lock()
 	store := m.store
+	epoch := m.publishEpoch
 	m.mu.Unlock()
 	if store == nil {
 		return ColumnAssetSyncedPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
@@ -345,7 +370,6 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	}
 	m.nextAttemptID++
 	attempt := m.nextAttemptID
-	epoch := m.publishEpoch
 	m.syncedAttempt[attempt] = epoch
 	m.syncedRefs[attempt] = columnPreparedAssetRefs(verified.PreparedAssets)
 	m.mu.Unlock()
@@ -569,10 +593,39 @@ func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error
 	if verifier, ok := store.(columnAssetVerifier); ok {
 		return verifier.Verify(ref)
 	}
-	if ranged, ok := store.(ColumnAssetRangeReader); ok {
-		_, err := ranged.ReadRange(ref, 0, 1)
-		return err
-	}
 	_, err := store.ReadTo(ref, nil)
 	return err
+}
+
+func cloneColumnAssetStringMap(in map[ColumnAssetRef]string) map[ColumnAssetRef]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[ColumnAssetRef]string, len(in))
+	for ref, reason := range in {
+		out[ref] = reason
+	}
+	return out
+}
+
+func cloneColumnAssetSet(in map[ColumnAssetRef]struct{}) map[ColumnAssetRef]struct{} {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[ColumnAssetRef]struct{}, len(in))
+	for ref := range in {
+		out[ref] = struct{}{}
+	}
+	return out
+}
+
+func cloneColumnAssetEpochMap(in map[ColumnAssetRef]uint64) map[ColumnAssetRef]uint64 {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[ColumnAssetRef]uint64, len(in))
+	for ref, epoch := range in {
+		out[ref] = epoch
+	}
+	return out
 }

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -16,10 +16,8 @@ type ColumnAssetManager struct {
 	pins          map[ColumnAssetRef]int
 	zombies       map[ColumnAssetRef]string
 	quarantine    map[ColumnAssetRef]string
-	quarantineBy  map[ColumnAssetRef]string
 	publishFailed map[ColumnAssetRef]string
 	rewriteDebt   map[ColumnAssetRef]string
-	published     map[ColumnAssetRef]string
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -70,10 +68,8 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		pins:          make(map[ColumnAssetRef]int),
 		zombies:       make(map[ColumnAssetRef]string),
 		quarantine:    make(map[ColumnAssetRef]string),
-		quarantineBy:  make(map[ColumnAssetRef]string),
 		publishFailed: make(map[ColumnAssetRef]string),
 		rewriteDebt:   make(map[ColumnAssetRef]string),
-		published:     make(map[ColumnAssetRef]string),
 	}, nil
 }
 
@@ -221,7 +217,9 @@ func (m *ColumnAssetManager) Quarantine(ref ColumnAssetRef, reason string) error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.quarantine[ref] = reason
-	delete(m.quarantineBy, ref)
+	// A direct quarantine is an explicit safety decision, even when it reuses
+	// the publish-failure reason. A later successful retry must not clear it.
+	delete(m.publishFailed, ref)
 	return nil
 }
 
@@ -242,10 +240,12 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 	if store == nil {
 		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
 	}
+	preparedClone := cloneColumnPreparedAssets(prepared)
 	closure := ColumnAssetPublishClosure{
-		PreparedAssets:   cloneColumnPreparedAssets(prepared),
-		FlushRequired:    len(prepared) > 0,
-		preparedIdentity: cloneColumnPreparedAssets(prepared),
+		PreparedAssets: preparedClone,
+		FlushRequired:  len(preparedClone) > 0,
+		// Keep a private copy so caller mutations to PreparedAssets are caught.
+		preparedIdentity: cloneColumnPreparedAssets(preparedClone),
 	}
 	// Sync is tied to the explicit publish closure: unreferenced buffered
 	// assets are not made durable until a root-visible prepared ref names them.
@@ -311,7 +311,7 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	}, nil
 }
 
-func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, reason string) error {
+func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, _ string) error {
 	if m == nil {
 		return fmt.Errorf("colgranule: nil column asset manager")
 	}
@@ -320,9 +320,6 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	}
 	if synced.manager != m {
 		return fmt.Errorf("colgranule: synced publish closure belongs to another column asset manager")
-	}
-	if reason == "" {
-		reason = "publish succeeded"
 	}
 	for _, asset := range synced.closure.PreparedAssets {
 		if err := validateColumnPreparedAsset(asset); err != nil {
@@ -333,13 +330,11 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	defer m.mu.Unlock()
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
-			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason && m.quarantineBy[asset.Ref] == failedReason {
+			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason {
 				delete(m.quarantine, asset.Ref)
-				delete(m.quarantineBy, asset.Ref)
 			}
 			delete(m.publishFailed, asset.Ref)
 		}
-		m.published[asset.Ref] = reason
 	}
 	return nil
 }
@@ -359,8 +354,12 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, asset := range prepared {
+		if _, quarantined := m.quarantine[asset.Ref]; quarantined {
+			if _, publishOwned := m.publishFailed[asset.Ref]; !publishOwned {
+				continue
+			}
+		}
 		m.quarantine[asset.Ref] = reason
-		m.quarantineBy[asset.Ref] = reason
 		m.publishFailed[asset.Ref] = reason
 	}
 	return nil
@@ -379,7 +378,6 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 		zombieReason, zombie := m.zombies[reachable.Ref]
 		quarantineReason, quarantined := m.quarantine[reachable.Ref]
 		rewriteReason, rewrite := m.rewriteDebt[reachable.Ref]
-		publishedReason, published := m.published[reachable.Ref]
 		entry := ColumnAssetManagerReclamationEntry{
 			Ref:              reachable.Ref,
 			State:            reachable.State,
@@ -398,8 +396,6 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 			entry.ManagerReason = rewriteReason
 		case zombie:
 			entry.ManagerReason = zombieReason
-		case published:
-			entry.ManagerReason = publishedReason
 		}
 		if entry.Candidate {
 			plan.CandidateBytes += entry.Bytes
@@ -439,9 +435,6 @@ func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, 
 	if !columnPreparedAssetsEqual(caller.PreparedAssets, caller.preparedIdentity) {
 		return fmt.Errorf("colgranule: publish closure prepared assets changed after prepare")
 	}
-	if !columnPreparedAssetsEqual(verified.PreparedAssets, caller.preparedIdentity) {
-		return fmt.Errorf("colgranule: publish closure verified prepared assets changed after prepare")
-	}
 	if caller.RequiredAssets != verified.RequiredAssets {
 		return fmt.Errorf("colgranule: publish closure required assets=%d want %d", caller.RequiredAssets, verified.RequiredAssets)
 	}
@@ -451,6 +444,8 @@ func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, 
 	if caller.FlushRequired != verified.FlushRequired {
 		return fmt.Errorf("colgranule: publish closure flush required=%t want %t", caller.FlushRequired, verified.FlushRequired)
 	}
+	// SyncRequired is store-authoritative. SyncPublishClosure re-derives it so
+	// callers cannot clear required fsync work by mutating the closure.
 	return nil
 }
 

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -39,6 +39,7 @@ type ColumnAssetPublishClosure struct {
 	FlushRequired  bool                  `json:"flush_required,omitempty"`
 	SyncRequired   bool                  `json:"sync_required,omitempty"`
 
+	prepared         bool
 	preparedIdentity []ColumnPreparedAsset
 }
 
@@ -249,6 +250,7 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 	closure := ColumnAssetPublishClosure{
 		PreparedAssets: preparedClone,
 		FlushRequired:  len(preparedClone) > 0,
+		prepared:       true,
 		// Keep a private copy so caller mutations to PreparedAssets are caught.
 		preparedIdentity: cloneColumnPreparedAssets(preparedClone),
 	}
@@ -384,6 +386,9 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	defer m.mu.Unlock()
 	m.publishEpoch++
 	for _, asset := range prepared {
+		if _, publishOwned := m.publishFailed[asset.Ref]; publishOwned {
+			continue
+		}
 		if _, quarantined := m.quarantine[asset.Ref]; quarantined {
 			continue
 		}
@@ -460,7 +465,7 @@ func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
 }
 
 func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, verified ColumnAssetPublishClosure) error {
-	if len(caller.PreparedAssets) > 0 && len(caller.preparedIdentity) == 0 {
+	if !caller.prepared {
 		return fmt.Errorf("colgranule: publish closure was not prepared by this manager")
 	}
 	if !columnPreparedAssetsEqual(caller.PreparedAssets, caller.preparedIdentity) {

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -16,7 +16,7 @@ type ColumnAssetManager struct {
 	pins          map[ColumnAssetRef]int
 	zombies       map[ColumnAssetRef]string
 	quarantine    map[ColumnAssetRef]string
-	publishFailed map[ColumnAssetRef]struct{}
+	publishFailed map[ColumnAssetRef]string
 	rewriteDebt   map[ColumnAssetRef]string
 	published     map[ColumnAssetRef]string
 }
@@ -69,7 +69,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		pins:          make(map[ColumnAssetRef]int),
 		zombies:       make(map[ColumnAssetRef]string),
 		quarantine:    make(map[ColumnAssetRef]string),
-		publishFailed: make(map[ColumnAssetRef]struct{}),
+		publishFailed: make(map[ColumnAssetRef]string),
 		rewriteDebt:   make(map[ColumnAssetRef]string),
 		published:     make(map[ColumnAssetRef]string),
 	}, nil
@@ -329,8 +329,10 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, asset := range synced.closure.PreparedAssets {
-		if _, ok := m.publishFailed[asset.Ref]; ok {
-			delete(m.quarantine, asset.Ref)
+		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
+			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason {
+				delete(m.quarantine, asset.Ref)
+			}
 			delete(m.publishFailed, asset.Ref)
 		}
 		m.published[asset.Ref] = reason
@@ -354,7 +356,7 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	defer m.mu.Unlock()
 	for _, asset := range prepared {
 		m.quarantine[asset.Ref] = reason
-		m.publishFailed[asset.Ref] = struct{}{}
+		m.publishFailed[asset.Ref] = reason
 	}
 	return nil
 }

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -28,6 +28,14 @@ type ColumnAssetManagerReclamationPlan struct {
 	RewriteDebtBytes   int                                  `json:"rewrite_debt_bytes"`
 }
 
+type ColumnAssetPublishClosure struct {
+	PreparedAssets []ColumnPreparedAsset `json:"prepared_assets,omitempty"`
+	RequiredAssets int                   `json:"required_assets"`
+	RequiredBytes  int                   `json:"required_bytes"`
+	FlushRequired  bool                  `json:"flush_required,omitempty"`
+	SyncRequired   bool                  `json:"sync_required,omitempty"`
+}
+
 type ColumnAssetManagerReclamationEntry struct {
 	Ref              ColumnAssetRef            `json:"ref"`
 	State            ColumnAssetLifecycleState `json:"state"`
@@ -202,6 +210,104 @@ func (m *ColumnAssetManager) Quarantine(ref ColumnAssetRef, reason string) error
 	return nil
 }
 
+func (m *ColumnAssetManager) PreparePublishClosure(prepared []ColumnPreparedAsset) (ColumnAssetPublishClosure, error) {
+	if m == nil {
+		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	store := m.store
+	m.mu.Unlock()
+	if store == nil {
+		return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: closed column asset manager")
+	}
+	closure := ColumnAssetPublishClosure{
+		PreparedAssets: cloneColumnPreparedAssets(prepared),
+		FlushRequired:  len(prepared) > 0,
+	}
+	if _, ok := store.(columnAssetSyncer); ok && len(prepared) > 0 {
+		closure.SyncRequired = true
+	}
+	seen := make(map[ColumnAssetRef]struct{}, len(prepared))
+	for _, asset := range prepared {
+		if err := validateColumnPreparedAsset(asset); err != nil {
+			return ColumnAssetPublishClosure{}, err
+		}
+		if _, ok := seen[asset.Ref]; ok {
+			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: duplicate prepared asset ref %+v", asset.Ref)
+		}
+		seen[asset.Ref] = struct{}{}
+		if err := verifyColumnAssetStoreRef(store, asset.Ref); err != nil {
+			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: missing required prepared asset %+v: %w", asset.Ref, err)
+		}
+		closure.RequiredAssets++
+		bytes := asset.Bytes
+		if bytes == 0 {
+			if asset.Ref.Length > int64(^uint(0)>>1) {
+				return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
+			}
+			bytes = int(asset.Ref.Length)
+		}
+		closure.RequiredBytes += bytes
+	}
+	return closure, nil
+}
+
+func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosure) error {
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	m.mu.Lock()
+	store := m.store
+	m.mu.Unlock()
+	if store == nil {
+		return fmt.Errorf("colgranule: closed column asset manager")
+	}
+	for _, asset := range closure.PreparedAssets {
+		if err := validateColumnPreparedAsset(asset); err != nil {
+			return err
+		}
+	}
+	if syncer, ok := store.(columnAssetSyncer); ok {
+		return syncer.Sync()
+	}
+	return nil
+}
+
+func (m *ColumnAssetManager) MarkPublishSucceeded(prepared []ColumnPreparedAsset, _ string) error {
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	if _, err := m.PreparePublishClosure(prepared); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, asset := range prepared {
+		delete(m.quarantine, asset.Ref)
+		delete(m.zombies, asset.Ref)
+		delete(m.rewriteDebt, asset.Ref)
+	}
+	return nil
+}
+
+func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, reason string) error {
+	if m == nil {
+		return fmt.Errorf("colgranule: nil column asset manager")
+	}
+	if reason == "" {
+		reason = "publish failed"
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, asset := range prepared {
+		if err := validateColumnPreparedAsset(asset); err != nil {
+			return err
+		}
+		m.quarantine[asset.Ref] = reason
+	}
+	return nil
+}
+
 func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilityPlan) ColumnAssetManagerReclamationPlan {
 	var plan ColumnAssetManagerReclamationPlan
 	if m == nil {
@@ -223,7 +329,7 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 			Pinned:           pinCount > 0,
 			Zombie:           zombie,
 			Quarantined:      quarantined,
-			RewriteRequired:  rewrite || (!reachable.DeleteEligible && reachable.State == ColumnAssetStateSuperseded),
+			RewriteRequired:  rewrite || (!reachable.DeleteEligible && reachable.State == ColumnAssetStateCleanupSafe),
 			ReachableReasons: reachable.Reasons,
 		}
 		switch {
@@ -253,4 +359,29 @@ func (m *ColumnAssetManager) PlanReclamation(reachability ColumnAssetReachabilit
 		plan.Entries = append(plan.Entries, entry)
 	}
 	return plan
+}
+
+func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
+	if err := validateColumnAssetRef(asset.Ref); err != nil {
+		return err
+	}
+	if asset.Bytes < 0 {
+		return fmt.Errorf("colgranule: negative prepared asset bytes %d", asset.Bytes)
+	}
+	if asset.Bytes == 0 && asset.Ref.Length > int64(^uint(0)>>1) {
+		return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
+	}
+	return nil
+}
+
+func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error {
+	if verifier, ok := store.(columnAssetVerifier); ok {
+		return verifier.Verify(ref)
+	}
+	if ranged, ok := store.(ColumnAssetRangeReader); ok {
+		_, err := ranged.ReadRange(ref, 0, 0)
+		return err
+	}
+	_, err := store.ReadTo(ref, nil)
+	return err
 }

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -267,6 +267,9 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 			return err
 		}
 	}
+	if !closure.SyncRequired {
+		return nil
+	}
 	if syncer, ok := store.(columnAssetSyncer); ok {
 		return syncer.Sync()
 	}

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -18,6 +18,9 @@ type ColumnAssetManager struct {
 	quarantine    map[ColumnAssetRef]string
 	publishFailed map[ColumnAssetRef]string
 	rewriteDebt   map[ColumnAssetRef]string
+	publishEpoch  uint64
+	nextAttemptID uint64
+	syncedAttempt map[uint64]uint64
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -42,6 +45,7 @@ type ColumnAssetPublishClosure struct {
 type ColumnAssetSyncedPublishClosure struct {
 	closure ColumnAssetPublishClosure
 	manager *ColumnAssetManager
+	attempt uint64
 	sealed  bool
 }
 
@@ -70,6 +74,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		quarantine:    make(map[ColumnAssetRef]string),
 		publishFailed: make(map[ColumnAssetRef]string),
 		rewriteDebt:   make(map[ColumnAssetRef]string),
+		syncedAttempt: make(map[uint64]uint64),
 	}, nil
 }
 
@@ -307,14 +312,24 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 			}
 		}
 	}
+	m.mu.Lock()
+	if m.syncedAttempt == nil {
+		m.syncedAttempt = make(map[uint64]uint64)
+	}
+	m.nextAttemptID++
+	attempt := m.nextAttemptID
+	epoch := m.publishEpoch
+	m.syncedAttempt[attempt] = epoch
+	m.mu.Unlock()
 	return ColumnAssetSyncedPublishClosure{
 		closure: verified,
 		manager: m,
+		attempt: attempt,
 		sealed:  true,
 	}, nil
 }
 
-func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure, _ string) error {
+func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublishClosure) error {
 	if m == nil {
 		return fmt.Errorf("colgranule: nil column asset manager")
 	}
@@ -324,6 +339,9 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	if synced.manager != m {
 		return fmt.Errorf("colgranule: synced publish closure belongs to another column asset manager")
 	}
+	if synced.attempt == 0 {
+		return fmt.Errorf("colgranule: synced publish closure is missing attempt id")
+	}
 	for _, asset := range synced.closure.PreparedAssets {
 		if err := validateColumnPreparedAsset(asset); err != nil {
 			return err
@@ -331,6 +349,14 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	epoch, ok := m.syncedAttempt[synced.attempt]
+	if !ok {
+		return fmt.Errorf("colgranule: synced publish closure already consumed")
+	}
+	delete(m.syncedAttempt, synced.attempt)
+	if epoch != m.publishEpoch {
+		return fmt.Errorf("colgranule: synced publish closure predates a later publish failure")
+	}
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
 			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason {
@@ -356,11 +382,10 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.publishEpoch++
 	for _, asset := range prepared {
 		if _, quarantined := m.quarantine[asset.Ref]; quarantined {
-			if _, publishOwned := m.publishFailed[asset.Ref]; !publishOwned {
-				continue
-			}
+			continue
 		}
 		m.quarantine[asset.Ref] = reason
 		m.publishFailed[asset.Ref] = reason
@@ -435,6 +460,9 @@ func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
 }
 
 func validateColumnAssetPublishClosureMatches(caller ColumnAssetPublishClosure, verified ColumnAssetPublishClosure) error {
+	if len(caller.PreparedAssets) > 0 && len(caller.preparedIdentity) == 0 {
+		return fmt.Errorf("colgranule: publish closure was not prepared by this manager")
+	}
 	if !columnPreparedAssetsEqual(caller.PreparedAssets, caller.preparedIdentity) {
 		return fmt.Errorf("colgranule: publish closure prepared assets changed after prepare")
 	}

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -297,12 +297,14 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	if reason == "" {
 		reason = "publish failed"
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	for _, asset := range prepared {
 		if err := validateColumnPreparedAsset(asset); err != nil {
 			return err
 		}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, asset := range prepared {
 		m.quarantine[asset.Ref] = reason
 	}
 	return nil
@@ -379,7 +381,7 @@ func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error
 		return verifier.Verify(ref)
 	}
 	if ranged, ok := store.(ColumnAssetRangeReader); ok {
-		_, err := ranged.ReadRange(ref, 0, 0)
+		_, err := ranged.ReadRange(ref, 0, 1)
 		return err
 	}
 	_, err := store.ReadTo(ref, nil)

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -16,6 +16,7 @@ type ColumnAssetManager struct {
 	pins          map[ColumnAssetRef]int
 	zombies       map[ColumnAssetRef]string
 	quarantine    map[ColumnAssetRef]string
+	quarantineBy  map[ColumnAssetRef]string
 	publishFailed map[ColumnAssetRef]string
 	rewriteDebt   map[ColumnAssetRef]string
 	published     map[ColumnAssetRef]string
@@ -69,6 +70,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		pins:          make(map[ColumnAssetRef]int),
 		zombies:       make(map[ColumnAssetRef]string),
 		quarantine:    make(map[ColumnAssetRef]string),
+		quarantineBy:  make(map[ColumnAssetRef]string),
 		publishFailed: make(map[ColumnAssetRef]string),
 		rewriteDebt:   make(map[ColumnAssetRef]string),
 		published:     make(map[ColumnAssetRef]string),
@@ -219,6 +221,7 @@ func (m *ColumnAssetManager) Quarantine(ref ColumnAssetRef, reason string) error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.quarantine[ref] = reason
+	delete(m.quarantineBy, ref)
 	return nil
 }
 
@@ -330,8 +333,9 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	defer m.mu.Unlock()
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
-			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason {
+			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason && m.quarantineBy[asset.Ref] == failedReason {
 				delete(m.quarantine, asset.Ref)
+				delete(m.quarantineBy, asset.Ref)
 			}
 			delete(m.publishFailed, asset.Ref)
 		}
@@ -356,6 +360,7 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	defer m.mu.Unlock()
 	for _, asset := range prepared {
 		m.quarantine[asset.Ref] = reason
+		m.quarantineBy[asset.Ref] = reason
 		m.publishFailed[asset.Ref] = reason
 	}
 	return nil

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -21,6 +21,7 @@ type ColumnAssetManager struct {
 	publishEpoch  uint64
 	nextAttemptID uint64
 	syncedAttempt map[uint64]uint64
+	refFailedAt   map[ColumnAssetRef]uint64
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -76,6 +77,7 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		publishFailed: make(map[ColumnAssetRef]string),
 		rewriteDebt:   make(map[ColumnAssetRef]string),
 		syncedAttempt: make(map[uint64]uint64),
+		refFailedAt:   make(map[ColumnAssetRef]uint64),
 	}, nil
 }
 
@@ -356,8 +358,10 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 		return fmt.Errorf("colgranule: synced publish closure already consumed")
 	}
 	delete(m.syncedAttempt, synced.attempt)
-	if epoch != m.publishEpoch {
-		return fmt.Errorf("colgranule: synced publish closure predates a later publish failure")
+	for _, asset := range synced.closure.PreparedAssets {
+		if m.refFailedAt[asset.Ref] > epoch {
+			return fmt.Errorf("colgranule: synced publish closure predates a later publish failure for ref %+v", asset.Ref)
+		}
 	}
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
@@ -385,7 +389,11 @@ func (m *ColumnAssetManager) MarkPublishFailed(prepared []ColumnPreparedAsset, r
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.publishEpoch++
+	if m.refFailedAt == nil {
+		m.refFailedAt = make(map[ColumnAssetRef]uint64)
+	}
 	for _, asset := range prepared {
+		m.refFailedAt[asset.Ref] = m.publishEpoch
 		if _, publishOwned := m.publishFailed[asset.Ref]; publishOwned {
 			continue
 		}

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -42,6 +42,7 @@ type ColumnAssetPublishClosure struct {
 
 type ColumnAssetSyncedPublishClosure struct {
 	closure ColumnAssetPublishClosure
+	manager *ColumnAssetManager
 	sealed  bool
 }
 
@@ -302,6 +303,7 @@ func (m *ColumnAssetManager) SyncPublishClosure(closure ColumnAssetPublishClosur
 	}
 	return ColumnAssetSyncedPublishClosure{
 		closure: verified,
+		manager: m,
 		sealed:  true,
 	}, nil
 }
@@ -312,6 +314,9 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	}
 	if !synced.sealed {
 		return fmt.Errorf("colgranule: publish succeeded requires synced publish closure")
+	}
+	if synced.manager != m {
+		return fmt.Errorf("colgranule: synced publish closure belongs to another column asset manager")
 	}
 	if reason == "" {
 		reason = "publish succeeded"

--- a/experiments/colgranule/asset_manager.go
+++ b/experiments/colgranule/asset_manager.go
@@ -5,23 +5,26 @@ import (
 	"sync"
 )
 
+const maxColumnAssetInt = int(^uint(0) >> 1)
+
 type ColumnAssetPin struct {
 	Ref    ColumnAssetRef `json:"ref"`
 	Reason string         `json:"reason,omitempty"`
 }
 
 type ColumnAssetManager struct {
-	mu            sync.Mutex
-	store         ColumnAssetStore
-	pins          map[ColumnAssetRef]int
-	zombies       map[ColumnAssetRef]string
-	quarantine    map[ColumnAssetRef]string
-	publishFailed map[ColumnAssetRef]string
-	rewriteDebt   map[ColumnAssetRef]string
-	publishEpoch  uint64
-	nextAttemptID uint64
-	syncedAttempt map[uint64]uint64
-	refFailedAt   map[ColumnAssetRef]uint64
+	mu             sync.Mutex
+	store          ColumnAssetStore
+	pins           map[ColumnAssetRef]int
+	zombies        map[ColumnAssetRef]string
+	quarantine     map[ColumnAssetRef]string
+	operatorLocked map[ColumnAssetRef]struct{}
+	publishFailed  map[ColumnAssetRef]string
+	rewriteDebt    map[ColumnAssetRef]string
+	publishEpoch   uint64
+	nextAttemptID  uint64
+	syncedAttempt  map[uint64]uint64
+	refFailedAt    map[ColumnAssetRef]uint64
 }
 
 type ColumnAssetManagerReclamationPlan struct {
@@ -70,14 +73,15 @@ func NewColumnAssetManager(store ColumnAssetStore) (*ColumnAssetManager, error) 
 		return nil, fmt.Errorf("colgranule: nil column asset manager store")
 	}
 	return &ColumnAssetManager{
-		store:         store,
-		pins:          make(map[ColumnAssetRef]int),
-		zombies:       make(map[ColumnAssetRef]string),
-		quarantine:    make(map[ColumnAssetRef]string),
-		publishFailed: make(map[ColumnAssetRef]string),
-		rewriteDebt:   make(map[ColumnAssetRef]string),
-		syncedAttempt: make(map[uint64]uint64),
-		refFailedAt:   make(map[ColumnAssetRef]uint64),
+		store:          store,
+		pins:           make(map[ColumnAssetRef]int),
+		zombies:        make(map[ColumnAssetRef]string),
+		quarantine:     make(map[ColumnAssetRef]string),
+		operatorLocked: make(map[ColumnAssetRef]struct{}),
+		publishFailed:  make(map[ColumnAssetRef]string),
+		rewriteDebt:    make(map[ColumnAssetRef]string),
+		syncedAttempt:  make(map[uint64]uint64),
+		refFailedAt:    make(map[ColumnAssetRef]uint64),
 	}, nil
 }
 
@@ -225,9 +229,7 @@ func (m *ColumnAssetManager) Quarantine(ref ColumnAssetRef, reason string) error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.quarantine[ref] = reason
-	// A direct quarantine is an explicit safety decision, even when it reuses
-	// the publish-failure reason. A later successful retry must not clear it.
-	delete(m.publishFailed, ref)
+	m.operatorLocked[ref] = struct{}{}
 	return nil
 }
 
@@ -258,11 +260,11 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 	}
 	// Sync is tied to the explicit publish closure: unreferenced buffered
 	// assets are not made durable until a root-visible prepared ref names them.
-	if _, ok := store.(columnAssetSyncer); ok && len(prepared) > 0 {
+	if _, ok := store.(columnAssetSyncer); ok && len(preparedClone) > 0 {
 		closure.SyncRequired = true
 	}
-	seen := make(map[ColumnAssetRef]struct{}, len(prepared))
-	for _, asset := range prepared {
+	seen := make(map[ColumnAssetRef]struct{}, len(preparedClone))
+	for _, asset := range preparedClone {
 		if err := validateColumnPreparedAsset(asset); err != nil {
 			return ColumnAssetPublishClosure{}, err
 		}
@@ -276,12 +278,12 @@ func prepareColumnAssetPublishClosure(store ColumnAssetStore, prepared []ColumnP
 		closure.RequiredAssets++
 		bytes := asset.Bytes
 		if bytes == 0 {
-			if asset.Ref.Length > int64(^uint(0)>>1) {
+			if asset.Ref.Length > int64(maxColumnAssetInt) {
 				return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
 			}
 			bytes = int(asset.Ref.Length)
 		}
-		if bytes > int(^uint(0)>>1)-closure.RequiredBytes {
+		if bytes > maxColumnAssetInt-closure.RequiredBytes {
 			return ColumnAssetPublishClosure{}, fmt.Errorf("colgranule: prepared asset required bytes overflow")
 		}
 		closure.RequiredBytes += bytes
@@ -357,15 +359,16 @@ func (m *ColumnAssetManager) MarkPublishSucceeded(synced ColumnAssetSyncedPublis
 	if !ok {
 		return fmt.Errorf("colgranule: synced publish closure already consumed")
 	}
-	delete(m.syncedAttempt, synced.attempt)
 	for _, asset := range synced.closure.PreparedAssets {
 		if m.refFailedAt[asset.Ref] > epoch {
 			return fmt.Errorf("colgranule: synced publish closure predates a later publish failure for ref %+v", asset.Ref)
 		}
 	}
+	delete(m.syncedAttempt, synced.attempt)
 	for _, asset := range synced.closure.PreparedAssets {
 		if failedReason, ok := m.publishFailed[asset.Ref]; ok {
-			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason {
+			_, operatorLocked := m.operatorLocked[asset.Ref]
+			if quarantineReason, quarantined := m.quarantine[asset.Ref]; quarantined && quarantineReason == failedReason && !operatorLocked {
 				delete(m.quarantine, asset.Ref)
 			}
 			delete(m.publishFailed, asset.Ref)
@@ -466,7 +469,7 @@ func validateColumnPreparedAsset(asset ColumnPreparedAsset) error {
 	if asset.Bytes < 0 {
 		return fmt.Errorf("colgranule: negative prepared asset bytes %d", asset.Bytes)
 	}
-	if asset.Bytes == 0 && asset.Ref.Length > int64(^uint(0)>>1) {
+	if asset.Bytes == 0 && asset.Ref.Length > int64(maxColumnAssetInt) {
 		return fmt.Errorf("colgranule: prepared asset length=%d exceeds host int", asset.Ref.Length)
 	}
 	return nil
@@ -508,6 +511,10 @@ func columnPreparedAssetsEqual(left, right []ColumnPreparedAsset) bool {
 func verifyColumnAssetStoreRef(store ColumnAssetStore, ref ColumnAssetRef) error {
 	if verifier, ok := store.(columnAssetVerifier); ok {
 		return verifier.Verify(ref)
+	}
+	if ranged, ok := store.(ColumnAssetRangeReader); ok {
+		_, err := ranged.ReadRange(ref, 0, 1)
+		return err
 	}
 	_, err := store.ReadTo(ref, nil)
 	return err

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -408,18 +408,23 @@ func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testin
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
 		t.Fatalf("MarkPublishFailed: %v", err)
 	}
-	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
-		t.Fatalf("MarkPublishSucceeded after failure err=%v, want stale synced closure rejection", err)
+	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("MarkPublishSucceeded after failure err=%v, want consumed stale closure rejection", err)
 	}
-	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
-		t.Fatalf("second MarkPublishSucceeded after failure err=%v, want stale synced closure rejection", err)
+	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("second MarkPublishSucceeded after failure err=%v, want consumed stale closure rejection", err)
 	}
 	manager.mu.Lock()
 	gotReason, quarantined := manager.quarantine[ref]
 	gotFailedReason, publishFailed := manager.publishFailed[ref]
+	gotSyncedAttempts := len(manager.syncedAttempt)
+	gotSyncedRefs := len(manager.syncedRefs)
 	manager.mu.Unlock()
 	if !quarantined || gotReason != "root publish failed" || !publishFailed || gotFailedReason != "root publish failed" {
 		t.Fatalf("manager state quarantine=(%q,%v) publishFailed=(%q,%v), want root publish failed retained", gotReason, quarantined, gotFailedReason, publishFailed)
+	}
+	if gotSyncedAttempts != 0 || gotSyncedRefs != 0 {
+		t.Fatalf("synced attempts=%d refs=%d want failed publish to consume overlapping attempt", gotSyncedAttempts, gotSyncedRefs)
 	}
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -8,8 +8,8 @@ func TestColumnAssetManagerRequiresZombieAndPinDrainBeforeDelete(t *testing.T) {
 	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
 	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
 	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{old},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{old},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -48,8 +48,8 @@ func TestColumnAssetManagerReportsRewriteDebtForMixedSegment(t *testing.T) {
 	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
 	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
 	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{old},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{old},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -61,5 +61,68 @@ func TestColumnAssetManagerReportsRewriteDebtForMixedSegment(t *testing.T) {
 	reclaim := manager.PlanReclamation(reachability)
 	if reclaim.CandidateBytes != 0 || reclaim.ReadyToDeleteBytes != 0 || reclaim.RewriteDebtBytes != int(oldRef.Length) {
 		t.Fatalf("mixed reclaim candidate/ready/rewrite=(%d,%d,%d) want (0,0,%d)", reclaim.CandidateBytes, reclaim.ReadyToDeleteBytes, reclaim.RewriteDebtBytes, oldRef.Length)
+	}
+}
+
+func TestColumnAssetManagerValidatesPreparedPublishClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	if closure.RequiredAssets != 1 || closure.RequiredBytes != int(ref.Length) || !closure.FlushRequired {
+		t.Fatalf("closure=%+v want one required flushed asset", closure)
+	}
+
+	missing := prepared
+	missing.Ref.Offset += 4096
+	_, err = manager.PreparePublishClosure([]ColumnPreparedAsset{missing})
+	if err == nil {
+		t.Fatalf("PreparePublishClosure missing ref succeeded")
+	}
+}
+
+func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		QuarantinedAssets: []ColumnPreparedAsset{prepared},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	reclaim := manager.PlanReclamation(plan)
+	if len(reclaim.Entries) != 1 || !reclaim.Entries[0].Quarantined || reclaim.ReadyToDeleteBytes != 0 {
+		t.Fatalf("reclaim=%+v want quarantined and not ready", reclaim)
 	}
 }

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -296,6 +296,20 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	}
 }
 
+func TestColumnAssetManagerSyncPublishClosureRejectsUnpreparedNoopLiteral(t *testing.T) {
+	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	if _, err := manager.SyncPublishClosure(ColumnAssetPublishClosure{}); err == nil || !strings.Contains(err.Error(), "not prepared by this manager") {
+		t.Fatalf("SyncPublishClosure zero literal err=%v want not prepared by this manager", err)
+	}
+	if got := store.syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected zero literal closure", got)
+	}
+}
+
 func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -280,6 +280,20 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	if got := store.syncCalls.Load(); got != 0 {
 		t.Fatalf("sync calls=%d want 0 after rejected closure substitution", got)
 	}
+
+	literal := ColumnAssetPublishClosure{
+		PreparedAssets: []ColumnPreparedAsset{{Ref: refA, GenerationID: 7, PublishID: 11, Reason: "publish staged"}},
+		RequiredAssets: 1,
+		RequiredBytes:  int(refA.Length),
+		FlushRequired:  true,
+		SyncRequired:   true,
+	}
+	if _, err := manager.SyncPublishClosure(literal); err == nil || !strings.Contains(err.Error(), "not prepared by this manager") {
+		t.Fatalf("SyncPublishClosure literal err=%v, want not prepared by this manager", err)
+	}
+	if got := store.syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected literal closure", got)
+	}
 }
 
 func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
@@ -301,7 +315,7 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
 		t.Fatalf("MarkPublishFailed: %v", err)
 	}
-	if err := manager.MarkPublishSucceeded(ColumnAssetSyncedPublishClosure{}, "root published"); err == nil {
+	if err := manager.MarkPublishSucceeded(ColumnAssetSyncedPublishClosure{}); err == nil {
 		t.Fatal("MarkPublishSucceeded accepted an unsealed publish closure")
 	}
 	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
@@ -316,16 +330,80 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewColumnAssetManager other: %v", err)
 	}
-	if err := otherManager.MarkPublishSucceeded(synced, "root published"); err == nil {
+	if err := otherManager.MarkPublishSucceeded(synced); err == nil {
 		t.Fatal("MarkPublishSucceeded accepted a synced closure from another manager")
 	}
-	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
 		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
+	}
+}
+
+func TestColumnAssetManagerPublishSucceededConsumesSyncedClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("second MarkPublishSucceeded err=%v, want already consumed", err)
+	}
+}
+
+func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
+		t.Fatalf("MarkPublishSucceeded after failure err=%v, want stale synced closure rejection", err)
+	}
+	manager.mu.Lock()
+	gotReason, quarantined := manager.quarantine[ref]
+	gotFailedReason, publishFailed := manager.publishFailed[ref]
+	manager.mu.Unlock()
+	if !quarantined || gotReason != "root publish failed" || !publishFailed || gotFailedReason != "root publish failed" {
+		t.Fatalf("manager state quarantine=(%q,%v) publishFailed=(%q,%v), want root publish failed retained", gotReason, quarantined, gotFailedReason, publishFailed)
 	}
 }
 
@@ -356,7 +434,7 @@ func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testi
 	if err != nil {
 		t.Fatalf("SyncPublishClosure: %v", err)
 	}
-	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
 	manager.mu.Lock()
@@ -430,7 +508,7 @@ func TestColumnAssetManagerPublishSucceededPreservesQuarantineAfterPublishFailur
 	if err != nil {
 		t.Fatalf("SyncPublishClosure: %v", err)
 	}
-	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
 	manager.mu.Lock()
@@ -473,7 +551,7 @@ func TestColumnAssetManagerPublishSucceededPreservesSameReasonQuarantineAfterPub
 	if err != nil {
 		t.Fatalf("SyncPublishClosure: %v", err)
 	}
-	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
 	manager.mu.Lock()
@@ -524,6 +602,32 @@ func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T)
 	reclaim := manager.PlanReclamation(plan)
 	if len(reclaim.Entries) != 1 || !reclaim.Entries[0].Quarantined || reclaim.ReadyToDeleteBytes != 0 {
 		t.Fatalf("reclaim=%+v want quarantined and not ready", reclaim)
+	}
+}
+
+func TestColumnAssetManagerPublishFailurePreservesFirstReason(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "first failure"); err != nil {
+		t.Fatalf("MarkPublishFailed first: %v", err)
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "retry failure"); err != nil {
+		t.Fatalf("MarkPublishFailed retry: %v", err)
+	}
+	manager.mu.Lock()
+	gotReason := manager.quarantine[ref]
+	gotFailedReason := manager.publishFailed[ref]
+	manager.mu.Unlock()
+	if gotReason != "first failure" || gotFailedReason != "first failure" {
+		t.Fatalf("quarantine/publish failure reasons=(%q,%q) want first failure preserved", gotReason, gotFailedReason)
 	}
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -134,6 +134,36 @@ func TestColumnAssetManagerSyncPublishClosureHonorsSyncRequired(t *testing.T) {
 	}
 }
 
+func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testing.T) {
+	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	closure.SyncRequired = false
+	store.Reset()
+	if err := manager.SyncPublishClosure(closure); err == nil {
+		t.Fatal("SyncPublishClosure succeeded for missing no-op closure asset")
+	}
+	if store.syncCalls != 0 {
+		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", store.syncCalls)
+	}
+}
+
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -270,6 +270,13 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SyncPublishClosure: %v", err)
 	}
+	otherManager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager other: %v", err)
+	}
+	if err := otherManager.MarkPublishSucceeded(synced, "root published"); err == nil {
+		t.Fatal("MarkPublishSucceeded accepted a synced closure from another manager")
+	}
 	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -207,6 +207,10 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	if err != nil {
 		t.Fatalf("Put B: %v", err)
 	}
+	refC, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put C: %v", err)
+	}
 	prepared := []ColumnPreparedAsset{
 		{Ref: refA, GenerationID: 7, PublishID: 11, Reason: "publish staged"},
 		{Ref: refB, GenerationID: 7, PublishID: 11, Reason: "publish staged"},
@@ -221,6 +225,18 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	}
 	if store.syncCalls != 0 {
 		t.Fatalf("sync calls=%d want 0 after rejected closure mismatch", store.syncCalls)
+	}
+
+	closure, err = manager.PreparePublishClosure(prepared)
+	if err != nil {
+		t.Fatalf("PreparePublishClosure replacement case: %v", err)
+	}
+	closure.PreparedAssets[0].Ref = refC
+	if _, err := manager.SyncPublishClosure(closure); err == nil {
+		t.Fatal("SyncPublishClosure accepted closure with substituted prepared ref")
+	}
+	if store.syncCalls != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected closure substitution", store.syncCalls)
 	}
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -421,6 +421,38 @@ func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testin
 	}
 }
 
+func TestColumnAssetManagerPublishFailureDoesNotInvalidateDisjointSyncedClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	refA, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	refB, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+24))
+	if err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	preparedA := ColumnPreparedAsset{Ref: refA, GenerationID: 7, PublishID: 11, Reason: "publish staged A"}
+	preparedB := ColumnPreparedAsset{Ref: refB, GenerationID: 8, PublishID: 12, Reason: "publish staged B"}
+	closureA, err := manager.PreparePublishClosure([]ColumnPreparedAsset{preparedA})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure A: %v", err)
+	}
+	syncedA, err := manager.SyncPublishClosure(closureA)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure A: %v", err)
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{preparedB}, "root publish failed B"); err != nil {
+		t.Fatalf("MarkPublishFailed B: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(syncedA); err != nil {
+		t.Fatalf("MarkPublishSucceeded A after disjoint failure: %v", err)
+	}
+}
+
 func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -126,3 +126,78 @@ func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T)
 		t.Fatalf("reclaim=%+v want quarantined and not ready", reclaim)
 	}
 }
+
+func TestColumnAssetManagerPreparedPublishFailureIsAtomic(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	invalid := prepared
+	invalid.Ref.FileID = 0
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared, invalid}, "root publish failed"); err == nil {
+		t.Fatalf("MarkPublishFailed with invalid prepared asset succeeded")
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if len(manager.quarantine) != 0 {
+		t.Fatalf("quarantine entries=%d want 0 after failed publish-failure mark", len(manager.quarantine))
+	}
+}
+
+func TestColumnAssetStoreRangeProbeReadsNonZeroBytes(t *testing.T) {
+	ref := ColumnAssetRef{
+		Kind:     ColumnAssetKindTCS1PartImage,
+		FileID:   1,
+		Offset:   0,
+		Length:   int64(tcs1HeaderBytes),
+		Checksum: 1,
+	}
+	store := &rangeProbeOnlyStore{}
+	if err := verifyColumnAssetStoreRef(store, ref); err != nil {
+		t.Fatalf("verifyColumnAssetStoreRef: %v", err)
+	}
+	if store.readRangeCalls != 1 || store.lastLength != 1 {
+		t.Fatalf("ReadRange calls=%d length=%d want one non-zero byte probe", store.readRangeCalls, store.lastLength)
+	}
+}
+
+type rangeProbeOnlyStore struct {
+	readRangeCalls int
+	lastLength     int
+}
+
+func (s *rangeProbeOnlyStore) Put(ColumnAssetKind, []byte) (ColumnAssetRef, error) {
+	return ColumnAssetRef{}, nil
+}
+
+func (s *rangeProbeOnlyStore) Read(ColumnAssetRef) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *rangeProbeOnlyStore) ReadTo(ColumnAssetRef, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *rangeProbeOnlyStore) ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error) {
+	s.readRangeCalls++
+	s.lastLength = length
+	if err := validateColumnAssetRef(ref); err != nil {
+		return nil, err
+	}
+	if offset != 0 || length != 1 {
+		t := make([]byte, 0)
+		return t, nil
+	}
+	return []byte{0}, nil
+}

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 )
 
@@ -129,8 +130,8 @@ func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {
 	if !synced.sealed || !synced.closure.SyncRequired {
 		t.Fatalf("synced closure=%+v want sealed sync-required token", synced)
 	}
-	if store.syncCalls != 1 {
-		t.Fatalf("sync calls=%d want 1", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 1 {
+		t.Fatalf("sync calls=%d want 1", got)
 	}
 	closure.SyncRequired = false
 	synced, err = manager.SyncPublishClosure(closure)
@@ -140,8 +141,8 @@ func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {
 	if !synced.closure.SyncRequired {
 		t.Fatalf("synced closure SyncRequired=false want derived true")
 	}
-	if store.syncCalls != 2 {
-		t.Fatalf("sync calls=%d want 2 after tampered sync flag", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 2 {
+		t.Fatalf("sync calls=%d want 2 after tampered sync flag", got)
 	}
 
 	empty, err := manager.PreparePublishClosure(nil)
@@ -155,8 +156,8 @@ func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {
 	if !synced.sealed || synced.closure.SyncRequired {
 		t.Fatalf("empty synced closure=%+v want sealed no-sync token", synced)
 	}
-	if store.syncCalls != 2 {
-		t.Fatalf("sync calls=%d want unchanged 2 after empty closure", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 2 {
+		t.Fatalf("sync calls=%d want unchanged 2 after empty closure", got)
 	}
 }
 
@@ -188,8 +189,8 @@ func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testin
 	if _, err := manager.SyncPublishClosure(closure); err == nil {
 		t.Fatal("SyncPublishClosure succeeded for missing no-op closure asset")
 	}
-	if store.syncCalls != 0 {
-		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", got)
 	}
 }
 
@@ -223,8 +224,8 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	if _, err := manager.SyncPublishClosure(closure); err == nil {
 		t.Fatal("SyncPublishClosure accepted closure with missing prepared ref")
 	}
-	if store.syncCalls != 0 {
-		t.Fatalf("sync calls=%d want 0 after rejected closure mismatch", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected closure mismatch", got)
 	}
 
 	closure, err = manager.PreparePublishClosure(prepared)
@@ -235,8 +236,8 @@ func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *tes
 	if _, err := manager.SyncPublishClosure(closure); err == nil {
 		t.Fatal("SyncPublishClosure accepted closure with substituted prepared ref")
 	}
-	if store.syncCalls != 0 {
-		t.Fatalf("sync calls=%d want 0 after rejected closure substitution", store.syncCalls)
+	if got := store.syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected closure substitution", got)
 	}
 }
 
@@ -285,9 +286,6 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
 		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
 	}
-	if got := manager.published[ref]; got != "root published" {
-		t.Fatalf("published reason=%q want root published", got)
-	}
 }
 
 func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testing.T) {
@@ -325,8 +323,39 @@ func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testi
 	if got := manager.quarantine[ref]; got != "checksum mismatch" {
 		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
 	}
-	if got := manager.published[ref]; got != "root published" {
-		t.Fatalf("published reason=%q want root published", got)
+}
+
+func TestColumnAssetManagerPublishFailurePreservesExistingQuarantine(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.Quarantine(ref, "checksum mismatch"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	manager.mu.Lock()
+	got := manager.quarantine[ref]
+	_, publishFailed := manager.publishFailed[ref]
+	manager.mu.Unlock()
+	if got != "checksum mismatch" {
+		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
+	}
+	if publishFailed {
+		t.Fatalf("publish-failed marker attached to an explicit quarantine")
 	}
 }
 
@@ -371,9 +400,6 @@ func TestColumnAssetManagerPublishSucceededPreservesQuarantineAfterPublishFailur
 	if _, ok := manager.publishFailed[ref]; ok {
 		t.Fatalf("publish-failed marker preserved after successful publish")
 	}
-	if got := manager.published[ref]; got != "root published" {
-		t.Fatalf("published reason=%q want root published", got)
-	}
 }
 
 func TestColumnAssetManagerPublishSucceededPreservesSameReasonQuarantineAfterPublishFailure(t *testing.T) {
@@ -417,9 +443,6 @@ func TestColumnAssetManagerPublishSucceededPreservesSameReasonQuarantineAfterPub
 	if _, ok := manager.publishFailed[ref]; ok {
 		t.Fatalf("publish-failed marker preserved after successful publish")
 	}
-	if got := manager.published[ref]; got != "root published" {
-		t.Fatalf("published reason=%q want root published", got)
-	}
 }
 
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
@@ -440,6 +463,16 @@ func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T)
 	}
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
 		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	manager.mu.Lock()
+	gotReason, quarantined := manager.quarantine[ref]
+	gotFailedReason, publishFailed := manager.publishFailed[ref]
+	manager.mu.Unlock()
+	if !quarantined || gotReason != "root publish failed" {
+		t.Fatalf("quarantine reason=%q present=%v want root publish failed,true", gotReason, quarantined)
+	}
+	if !publishFailed || gotFailedReason != "root publish failed" {
+		t.Fatalf("publish-failed reason=%q present=%v want root publish failed,true", gotFailedReason, publishFailed)
 	}
 	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
 		QuarantinedAssets: []ColumnPreparedAsset{prepared},
@@ -510,11 +543,11 @@ type rangeProbeOnlyStore struct {
 
 type syncProbeAssetStore struct {
 	*MemoryColumnAssetStore
-	syncCalls int
+	syncCalls atomic.Int64
 }
 
 func (s *syncProbeAssetStore) Sync() error {
-	s.syncCalls++
+	s.syncCalls.Add(1)
 	return nil
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -292,7 +292,7 @@ func TestColumnAssetManagerPreparedPublishFailureIsAtomic(t *testing.T) {
 	}
 }
 
-func TestColumnAssetStoreRangeProbeReadsNonZeroBytes(t *testing.T) {
+func TestColumnAssetStoreFallbackVerificationReadsFullRef(t *testing.T) {
 	ref := ColumnAssetRef{
 		Kind:     ColumnAssetKindTCS1PartImage,
 		FileID:   1,
@@ -304,14 +304,19 @@ func TestColumnAssetStoreRangeProbeReadsNonZeroBytes(t *testing.T) {
 	if err := verifyColumnAssetStoreRef(store, ref); err != nil {
 		t.Fatalf("verifyColumnAssetStoreRef: %v", err)
 	}
-	if store.readRangeCalls != 1 || store.lastLength != 1 {
-		t.Fatalf("ReadRange calls=%d length=%d want one non-zero byte probe", store.readRangeCalls, store.lastLength)
+	if store.readToCalls != 1 || store.readRangeCalls != 0 {
+		t.Fatalf("ReadTo/ReadRange calls=(%d,%d) want (1,0)", store.readToCalls, store.readRangeCalls)
+	}
+	badRef := ref
+	badRef.Checksum = 2
+	if err := verifyColumnAssetStoreRef(store, badRef); err == nil {
+		t.Fatal("verifyColumnAssetStoreRef accepted checksum-mismatched ref")
 	}
 }
 
 type rangeProbeOnlyStore struct {
+	readToCalls    int
 	readRangeCalls int
-	lastLength     int
 }
 
 type syncProbeAssetStore struct {
@@ -332,18 +337,22 @@ func (s *rangeProbeOnlyStore) Read(ColumnAssetRef) ([]byte, error) {
 	return nil, nil
 }
 
-func (s *rangeProbeOnlyStore) ReadTo(ColumnAssetRef, []byte) ([]byte, error) {
-	return nil, nil
+func (s *rangeProbeOnlyStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	s.readToCalls++
+	if err := validateColumnAssetRef(ref); err != nil {
+		return nil, err
+	}
+	if ref.Checksum != 1 {
+		return nil, fmt.Errorf("checksum mismatch")
+	}
+	payload := make([]byte, ref.Length)
+	return append(dst[:0], payload...), nil
 }
 
 func (s *rangeProbeOnlyStore) ReadRange(ref ColumnAssetRef, offset int64, length int) ([]byte, error) {
 	s.readRangeCalls++
-	s.lastLength = length
 	if err := validateColumnAssetRef(ref); err != nil {
 		return nil, err
 	}
-	if offset != 0 || length != 1 {
-		return nil, fmt.Errorf("unexpected range probe offset=%d length=%d", offset, length)
-	}
-	return []byte{0}, nil
+	return nil, fmt.Errorf("unexpected range probe offset=%d length=%d", offset, length)
 }

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -182,11 +182,45 @@ func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testin
 	}
 	closure.SyncRequired = false
 	store.Reset()
+	if _, err := store.Read(ref); err == nil {
+		t.Fatal("Reset left prepared asset readable")
+	}
 	if _, err := manager.SyncPublishClosure(closure); err == nil {
 		t.Fatal("SyncPublishClosure succeeded for missing no-op closure asset")
 	}
 	if store.syncCalls != 0 {
 		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", store.syncCalls)
+	}
+}
+
+func TestColumnAssetManagerSyncPublishClosureRejectsPreparedAssetMismatch(t *testing.T) {
+	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	refA, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	refB, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+24))
+	if err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	prepared := []ColumnPreparedAsset{
+		{Ref: refA, GenerationID: 7, PublishID: 11, Reason: "publish staged"},
+		{Ref: refB, GenerationID: 7, PublishID: 11, Reason: "publish staged"},
+	}
+	closure, err := manager.PreparePublishClosure(prepared)
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	closure.PreparedAssets = closure.PreparedAssets[:1]
+	if _, err := manager.SyncPublishClosure(closure); err == nil {
+		t.Fatal("SyncPublishClosure accepted closure with missing prepared ref")
+	}
+	if store.syncCalls != 0 {
+		t.Fatalf("sync calls=%d want 0 after rejected closure mismatch", store.syncCalls)
 	}
 }
 
@@ -227,6 +261,46 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	defer manager.mu.Unlock()
 	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
 		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
+	}
+	if got := manager.published[ref]; got != "root published" {
+		t.Fatalf("published reason=%q want root published", got)
+	}
+}
+
+func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.Quarantine(ref, "checksum mismatch"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if got := manager.quarantine[ref]; got != "checksum mismatch" {
+		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
 	}
 	if got := manager.published[ref]; got != "root published" {
 		t.Fatalf("published reason=%q want root published", got)

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -201,7 +201,7 @@ func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {
 	}
 }
 
-func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testing.T) {
+func TestColumnAssetManagerSyncPublishClosureUsesPreparedIdentityWithoutReverify(t *testing.T) {
 	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
 	manager, err := NewColumnAssetManager(store)
 	if err != nil {
@@ -226,11 +226,11 @@ func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testin
 	if _, err := store.Read(ref); err == nil {
 		t.Fatal("Reset left prepared asset readable")
 	}
-	if _, err := manager.SyncPublishClosure(closure); err == nil {
-		t.Fatal("SyncPublishClosure succeeded for missing no-op closure asset")
+	if _, err := manager.SyncPublishClosure(closure); err != nil {
+		t.Fatalf("SyncPublishClosure reverified prepared asset after prepare: %v", err)
 	}
-	if got := store.syncCalls.Load(); got != 0 {
-		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", got)
+	if got := store.syncCalls.Load(); got != 1 {
+		t.Fatalf("sync calls=%d want 1 after prepared closure sync", got)
 	}
 }
 
@@ -351,8 +351,8 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	}
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
-	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
-		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
+	if len(manager.quarantine) != 0 || len(manager.publishFailed) != 0 || len(manager.refFailedAt) != 0 {
+		t.Fatalf("manager state quarantine=%d publishFailed=%d refFailedAt=%d want publish failure state cleared", len(manager.quarantine), len(manager.publishFailed), len(manager.refFailedAt))
 	}
 }
 
@@ -420,6 +420,38 @@ func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testin
 	manager.mu.Unlock()
 	if !quarantined || gotReason != "root publish failed" || !publishFailed || gotFailedReason != "root publish failed" {
 		t.Fatalf("manager state quarantine=(%q,%v) publishFailed=(%q,%v), want root publish failed retained", gotReason, quarantined, gotFailedReason, publishFailed)
+	}
+}
+
+func TestColumnAssetManagerEmptyPublishFailureDoesNotInvalidateSyncedClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishFailed(nil, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed empty: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
+		t.Fatalf("MarkPublishSucceeded after empty publish failure: %v", err)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.publishEpoch != 0 || len(manager.refFailedAt) != 0 {
+		t.Fatalf("publishEpoch=%d refFailedAt=%d want unchanged after empty publish failure", manager.publishEpoch, len(manager.refFailedAt))
 	}
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -349,10 +349,9 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if len(manager.quarantine) != 0 || len(manager.publishFailed) != 0 || len(manager.refFailedAt) != 0 {
-		t.Fatalf("manager state quarantine=%d publishFailed=%d refFailedAt=%d want publish failure state cleared", len(manager.quarantine), len(manager.publishFailed), len(manager.refFailedAt))
+	state := manager.DebugState()
+	if len(state.Quarantine) != 0 || len(state.PublishFailed) != 0 || len(state.RefFailedAt) != 0 {
+		t.Fatalf("manager state quarantine=%d publishFailed=%d refFailedAt=%d want publish failure state cleared", len(state.Quarantine), len(state.PublishFailed), len(state.RefFailedAt))
 	}
 }
 
@@ -414,17 +413,58 @@ func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testin
 	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "already consumed") {
 		t.Fatalf("second MarkPublishSucceeded after failure err=%v, want consumed stale closure rejection", err)
 	}
-	manager.mu.Lock()
-	gotReason, quarantined := manager.quarantine[ref]
-	gotFailedReason, publishFailed := manager.publishFailed[ref]
-	gotSyncedAttempts := len(manager.syncedAttempt)
-	gotSyncedRefs := len(manager.syncedRefs)
-	manager.mu.Unlock()
+	state := manager.DebugState()
+	gotReason, quarantined := state.Quarantine[ref]
+	gotFailedReason, publishFailed := state.PublishFailed[ref]
 	if !quarantined || gotReason != "root publish failed" || !publishFailed || gotFailedReason != "root publish failed" {
 		t.Fatalf("manager state quarantine=(%q,%v) publishFailed=(%q,%v), want root publish failed retained", gotReason, quarantined, gotFailedReason, publishFailed)
 	}
-	if gotSyncedAttempts != 0 || gotSyncedRefs != 0 {
-		t.Fatalf("synced attempts=%d refs=%d want failed publish to consume overlapping attempt", gotSyncedAttempts, gotSyncedRefs)
+	if state.SyncedAttempts != 0 || state.SyncedRefs != 0 {
+		t.Fatalf("synced attempts=%d refs=%d want failed publish to consume overlapping attempt", state.SyncedAttempts, state.SyncedRefs)
+	}
+}
+
+func TestColumnAssetManagerPublishFailureDuringSyncInvalidatesLaterAttempt(t *testing.T) {
+	store := &blockingSyncAssetStore{
+		MemoryColumnAssetStore: NewMemoryColumnAssetStore(),
+		entered:                make(chan struct{}),
+		release:                make(chan struct{}),
+	}
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	result := make(chan struct {
+		synced ColumnAssetSyncedPublishClosure
+		err    error
+	}, 1)
+	go func() {
+		synced, err := manager.SyncPublishClosure(closure)
+		result <- struct {
+			synced ColumnAssetSyncedPublishClosure
+			err    error
+		}{synced: synced, err: err}
+	}()
+	<-store.entered
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	close(store.release)
+	got := <-result
+	if got.err != nil {
+		t.Fatalf("SyncPublishClosure: %v", got.err)
+	}
+	if err := manager.MarkPublishSucceeded(got.synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
+		t.Fatalf("MarkPublishSucceeded after in-flight failure err=%v, want later publish failure rejection", err)
 	}
 }
 
@@ -453,10 +493,9 @@ func TestColumnAssetManagerEmptyPublishFailureDoesNotInvalidateSyncedClosure(t *
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded after empty publish failure: %v", err)
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if manager.publishEpoch != 0 || len(manager.refFailedAt) != 0 {
-		t.Fatalf("publishEpoch=%d refFailedAt=%d want unchanged after empty publish failure", manager.publishEpoch, len(manager.refFailedAt))
+	state := manager.DebugState()
+	if state.PublishEpoch != 0 || len(state.RefFailedAt) != 0 {
+		t.Fatalf("publishEpoch=%d refFailedAt=%d want unchanged after empty publish failure", state.PublishEpoch, len(state.RefFailedAt))
 	}
 }
 
@@ -477,10 +516,9 @@ func TestColumnAssetManagerDirectQuarantinePreservesFailureProvenanceUntilRetry(
 	if err := manager.Quarantine(ref, "root publish failed"); err != nil {
 		t.Fatalf("Quarantine: %v", err)
 	}
-	manager.mu.Lock()
-	gotFailedReason, publishFailed := manager.publishFailed[ref]
-	_, operatorLocked := manager.operatorLocked[ref]
-	manager.mu.Unlock()
+	state := manager.DebugState()
+	gotFailedReason, publishFailed := state.PublishFailed[ref]
+	_, operatorLocked := state.OperatorLocked[ref]
 	if !publishFailed || gotFailedReason != "root publish failed" || !operatorLocked {
 		t.Fatalf("publishFailed=(%q,%v) operatorLocked=%v, want retained root publish failed and operator lock", gotFailedReason, publishFailed, operatorLocked)
 	}
@@ -495,11 +533,10 @@ func TestColumnAssetManagerDirectQuarantinePreservesFailureProvenanceUntilRetry(
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
-	manager.mu.Lock()
-	gotQuarantine := manager.quarantine[ref]
-	_, publishFailed = manager.publishFailed[ref]
-	_, operatorLocked = manager.operatorLocked[ref]
-	manager.mu.Unlock()
+	state = manager.DebugState()
+	gotQuarantine := state.Quarantine[ref]
+	_, publishFailed = state.PublishFailed[ref]
+	_, operatorLocked = state.OperatorLocked[ref]
 	if gotQuarantine != "root publish failed" || publishFailed || !operatorLocked {
 		t.Fatalf("quarantine=%q publishFailed=%v operatorLocked=%v, want operator quarantine retained and failure marker cleared", gotQuarantine, publishFailed, operatorLocked)
 	}
@@ -567,9 +604,8 @@ func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testi
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if got := manager.quarantine[ref]; got != "checksum mismatch" {
+	state := manager.DebugState()
+	if got := state.Quarantine[ref]; got != "checksum mismatch" {
 		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
 	}
 }
@@ -596,10 +632,9 @@ func TestColumnAssetManagerPublishFailurePreservesExistingQuarantine(t *testing.
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
 		t.Fatalf("MarkPublishFailed: %v", err)
 	}
-	manager.mu.Lock()
-	got := manager.quarantine[ref]
-	_, publishFailed := manager.publishFailed[ref]
-	manager.mu.Unlock()
+	state := manager.DebugState()
+	got := state.Quarantine[ref]
+	_, publishFailed := state.PublishFailed[ref]
 	if got != "checksum mismatch" {
 		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
 	}
@@ -641,12 +676,11 @@ func TestColumnAssetManagerPublishSucceededPreservesQuarantineAfterPublishFailur
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if got := manager.quarantine[ref]; got != "checksum mismatch" {
+	state := manager.DebugState()
+	if got := state.Quarantine[ref]; got != "checksum mismatch" {
 		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
 	}
-	if _, ok := manager.publishFailed[ref]; ok {
+	if _, ok := state.PublishFailed[ref]; ok {
 		t.Fatalf("publish-failed marker preserved after successful publish")
 	}
 }
@@ -684,12 +718,11 @@ func TestColumnAssetManagerPublishSucceededPreservesSameReasonQuarantineAfterPub
 	if err := manager.MarkPublishSucceeded(synced); err != nil {
 		t.Fatalf("MarkPublishSucceeded: %v", err)
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if got := manager.quarantine[ref]; got != "root publish failed" {
+	state := manager.DebugState()
+	if got := state.Quarantine[ref]; got != "root publish failed" {
 		t.Fatalf("quarantine reason=%q want root publish failed", got)
 	}
-	if _, ok := manager.publishFailed[ref]; ok {
+	if _, ok := state.PublishFailed[ref]; ok {
 		t.Fatalf("publish-failed marker preserved after successful publish")
 	}
 }
@@ -713,10 +746,9 @@ func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T)
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
 		t.Fatalf("MarkPublishFailed: %v", err)
 	}
-	manager.mu.Lock()
-	gotReason, quarantined := manager.quarantine[ref]
-	gotFailedReason, publishFailed := manager.publishFailed[ref]
-	manager.mu.Unlock()
+	state := manager.DebugState()
+	gotReason, quarantined := state.Quarantine[ref]
+	gotFailedReason, publishFailed := state.PublishFailed[ref]
 	if !quarantined || gotReason != "root publish failed" {
 		t.Fatalf("quarantine reason=%q present=%v want root publish failed,true", gotReason, quarantined)
 	}
@@ -752,10 +784,9 @@ func TestColumnAssetManagerPublishFailurePreservesFirstReason(t *testing.T) {
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "retry failure"); err != nil {
 		t.Fatalf("MarkPublishFailed retry: %v", err)
 	}
-	manager.mu.Lock()
-	gotReason := manager.quarantine[ref]
-	gotFailedReason := manager.publishFailed[ref]
-	manager.mu.Unlock()
+	state := manager.DebugState()
+	gotReason := state.Quarantine[ref]
+	gotFailedReason := state.PublishFailed[ref]
 	if gotReason != "first failure" || gotFailedReason != "first failure" {
 		t.Fatalf("quarantine/publish failure reasons=(%q,%q) want first failure preserved", gotReason, gotFailedReason)
 	}
@@ -782,14 +813,13 @@ func TestColumnAssetManagerPreparedPublishFailureIsAtomic(t *testing.T) {
 	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared, invalid}, "root publish failed"); err == nil {
 		t.Fatalf("MarkPublishFailed with invalid prepared asset succeeded")
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if len(manager.quarantine) != 0 {
-		t.Fatalf("quarantine entries=%d want 0 after failed publish-failure mark", len(manager.quarantine))
+	state := manager.DebugState()
+	if len(state.Quarantine) != 0 {
+		t.Fatalf("quarantine entries=%d want 0 after failed publish-failure mark", len(state.Quarantine))
 	}
 }
 
-func TestColumnAssetStoreFallbackVerificationUsesRangeProbe(t *testing.T) {
+func TestColumnAssetStoreFallbackVerificationReadsFullRef(t *testing.T) {
 	ref := ColumnAssetRef{
 		Kind:     ColumnAssetKindTCS1PartImage,
 		FileID:   1,
@@ -801,8 +831,8 @@ func TestColumnAssetStoreFallbackVerificationUsesRangeProbe(t *testing.T) {
 	if err := verifyColumnAssetStoreRef(store, ref); err != nil {
 		t.Fatalf("verifyColumnAssetStoreRef: %v", err)
 	}
-	if store.readToCalls != 0 || store.readRangeCalls != 1 {
-		t.Fatalf("ReadTo/ReadRange calls=(%d,%d) want (0,1)", store.readToCalls, store.readRangeCalls)
+	if store.readToCalls != 1 || store.readRangeCalls != 0 {
+		t.Fatalf("ReadTo/ReadRange calls=(%d,%d) want (1,0)", store.readToCalls, store.readRangeCalls)
 	}
 	badRef := ref
 	badRef.Checksum = 2
@@ -823,6 +853,18 @@ type syncProbeAssetStore struct {
 
 func (s *syncProbeAssetStore) Sync() error {
 	s.syncCalls.Add(1)
+	return nil
+}
+
+type blockingSyncAssetStore struct {
+	*MemoryColumnAssetStore
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingSyncAssetStore) Sync() error {
+	close(s.entered)
+	<-s.release
 	return nil
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -98,6 +99,46 @@ func TestColumnAssetManagerValidatesPreparedPublishClosure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("PreparePublishClosure missing ref succeeded")
 	}
+}
+
+func TestColumnAssetManagerRejectsPublishClosureRequiredBytesOverflow(t *testing.T) {
+	manager, err := NewColumnAssetManager(acceptingVerifierAssetStore{})
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	maxInt := int(^uint(0) >> 1)
+	prepared := []ColumnPreparedAsset{
+		{
+			Ref:   ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, FileID: 1, Offset: 0, Length: 1, Checksum: 1},
+			Bytes: maxInt,
+		},
+		{
+			Ref:   ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, FileID: 1, Offset: 1, Length: 1, Checksum: 1},
+			Bytes: 1,
+		},
+	}
+	_, err = manager.PreparePublishClosure(prepared)
+	if err == nil || !strings.Contains(err.Error(), "required bytes overflow") {
+		t.Fatalf("PreparePublishClosure overflow err=%v, want required bytes overflow", err)
+	}
+}
+
+type acceptingVerifierAssetStore struct{}
+
+func (acceptingVerifierAssetStore) Put(ColumnAssetKind, []byte) (ColumnAssetRef, error) {
+	return ColumnAssetRef{}, nil
+}
+
+func (acceptingVerifierAssetStore) Read(ColumnAssetRef) ([]byte, error) {
+	return nil, nil
+}
+
+func (acceptingVerifierAssetStore) ReadTo(ColumnAssetRef, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (acceptingVerifierAssetStore) Verify(ref ColumnAssetRef) error {
+	return validateColumnAssetRef(ref)
 }
 
 func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -96,6 +96,44 @@ func TestColumnAssetManagerValidatesPreparedPublishClosure(t *testing.T) {
 	}
 }
 
+func TestColumnAssetManagerSyncPublishClosureHonorsSyncRequired(t *testing.T) {
+	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	if !closure.SyncRequired {
+		t.Fatalf("SyncRequired=false want true for sync-capable store")
+	}
+	if err := manager.SyncPublishClosure(closure); err != nil {
+		t.Fatalf("SyncPublishClosure required: %v", err)
+	}
+	if store.syncCalls != 1 {
+		t.Fatalf("sync calls=%d want 1", store.syncCalls)
+	}
+	closure.SyncRequired = false
+	if err := manager.SyncPublishClosure(closure); err != nil {
+		t.Fatalf("SyncPublishClosure not required: %v", err)
+	}
+	if store.syncCalls != 1 {
+		t.Fatalf("sync calls=%d want unchanged 1", store.syncCalls)
+	}
+}
+
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)
@@ -175,6 +213,16 @@ func TestColumnAssetStoreRangeProbeReadsNonZeroBytes(t *testing.T) {
 type rangeProbeOnlyStore struct {
 	readRangeCalls int
 	lastLength     int
+}
+
+type syncProbeAssetStore struct {
+	*MemoryColumnAssetStore
+	syncCalls int
+}
+
+func (s *syncProbeAssetStore) Sync() error {
+	s.syncCalls++
+	return nil
 }
 
 func (s *rangeProbeOnlyStore) Put(ColumnAssetKind, []byte) (ColumnAssetRef, error) {

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -106,11 +106,10 @@ func TestColumnAssetManagerRejectsPublishClosureRequiredBytesOverflow(t *testing
 	if err != nil {
 		t.Fatalf("NewColumnAssetManager: %v", err)
 	}
-	maxInt := int(^uint(0) >> 1)
 	prepared := []ColumnPreparedAsset{
 		{
 			Ref:   ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, FileID: 1, Offset: 0, Length: 1, Checksum: 1},
-			Bytes: maxInt,
+			Bytes: maxColumnAssetInt,
 		},
 		{
 			Ref:   ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, FileID: 1, Offset: 1, Length: 1, Checksum: 1},
@@ -412,12 +411,60 @@ func TestColumnAssetManagerPublishFailureInvalidatesOlderSyncedClosure(t *testin
 	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
 		t.Fatalf("MarkPublishSucceeded after failure err=%v, want stale synced closure rejection", err)
 	}
+	if err := manager.MarkPublishSucceeded(synced); err == nil || !strings.Contains(err.Error(), "predates a later publish failure") {
+		t.Fatalf("second MarkPublishSucceeded after failure err=%v, want stale synced closure rejection", err)
+	}
 	manager.mu.Lock()
 	gotReason, quarantined := manager.quarantine[ref]
 	gotFailedReason, publishFailed := manager.publishFailed[ref]
 	manager.mu.Unlock()
 	if !quarantined || gotReason != "root publish failed" || !publishFailed || gotFailedReason != "root publish failed" {
 		t.Fatalf("manager state quarantine=(%q,%v) publishFailed=(%q,%v), want root publish failed retained", gotReason, quarantined, gotFailedReason, publishFailed)
+	}
+}
+
+func TestColumnAssetManagerDirectQuarantinePreservesFailureProvenanceUntilRetry(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{Ref: ref, GenerationID: 7, PublishID: 11, Reason: "publish staged"}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	if err := manager.Quarantine(ref, "root publish failed"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	manager.mu.Lock()
+	gotFailedReason, publishFailed := manager.publishFailed[ref]
+	_, operatorLocked := manager.operatorLocked[ref]
+	manager.mu.Unlock()
+	if !publishFailed || gotFailedReason != "root publish failed" || !operatorLocked {
+		t.Fatalf("publishFailed=(%q,%v) operatorLocked=%v, want retained root publish failed and operator lock", gotFailedReason, publishFailed, operatorLocked)
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	manager.mu.Lock()
+	gotQuarantine := manager.quarantine[ref]
+	_, publishFailed = manager.publishFailed[ref]
+	_, operatorLocked = manager.operatorLocked[ref]
+	manager.mu.Unlock()
+	if gotQuarantine != "root publish failed" || publishFailed || !operatorLocked {
+		t.Fatalf("quarantine=%q publishFailed=%v operatorLocked=%v, want operator quarantine retained and failure marker cleared", gotQuarantine, publishFailed, operatorLocked)
 	}
 }
 
@@ -705,7 +752,7 @@ func TestColumnAssetManagerPreparedPublishFailureIsAtomic(t *testing.T) {
 	}
 }
 
-func TestColumnAssetStoreFallbackVerificationReadsFullRef(t *testing.T) {
+func TestColumnAssetStoreFallbackVerificationUsesRangeProbe(t *testing.T) {
 	ref := ColumnAssetRef{
 		Kind:     ColumnAssetKindTCS1PartImage,
 		FileID:   1,
@@ -717,8 +764,8 @@ func TestColumnAssetStoreFallbackVerificationReadsFullRef(t *testing.T) {
 	if err := verifyColumnAssetStoreRef(store, ref); err != nil {
 		t.Fatalf("verifyColumnAssetStoreRef: %v", err)
 	}
-	if store.readToCalls != 1 || store.readRangeCalls != 0 {
-		t.Fatalf("ReadTo/ReadRange calls=(%d,%d) want (1,0)", store.readToCalls, store.readRangeCalls)
+	if store.readToCalls != 0 || store.readRangeCalls != 1 {
+		t.Fatalf("ReadTo/ReadRange calls=(%d,%d) want (0,1)", store.readToCalls, store.readRangeCalls)
 	}
 	badRef := ref
 	badRef.Checksum = 2
@@ -767,5 +814,11 @@ func (s *rangeProbeOnlyStore) ReadRange(ref ColumnAssetRef, offset int64, length
 	if err := validateColumnAssetRef(ref); err != nil {
 		return nil, err
 	}
-	return nil, fmt.Errorf("unexpected range probe offset=%d length=%d", offset, length)
+	if offset != 0 || length != 1 {
+		return nil, fmt.Errorf("unexpected range probe offset=%d length=%d", offset, length)
+	}
+	if ref.Checksum != 1 {
+		return nil, fmt.Errorf("checksum mismatch")
+	}
+	return []byte{0}, nil
 }

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -376,6 +376,52 @@ func TestColumnAssetManagerPublishSucceededPreservesQuarantineAfterPublishFailur
 	}
 }
 
+func TestColumnAssetManagerPublishSucceededPreservesSameReasonQuarantineAfterPublishFailure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	if err := manager.Quarantine(ref, "root publish failed"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if got := manager.quarantine[ref]; got != "root publish failed" {
+		t.Fatalf("quarantine reason=%q want root publish failed", got)
+	}
+	if _, ok := manager.publishFailed[ref]; ok {
+		t.Fatalf("publish-failed marker preserved after successful publish")
+	}
+	if got := manager.published[ref]; got != "root published" {
+		t.Fatalf("published reason=%q want root published", got)
+	}
+}
+
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -1,6 +1,9 @@
 package colgranule
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestColumnAssetManagerRequiresZombieAndPinDrainBeforeDelete(t *testing.T) {
 	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
@@ -225,6 +228,9 @@ func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
 	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
 		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
 	}
+	if got := manager.published[ref]; got != "root published" {
+		t.Fatalf("published reason=%q want root published", got)
+	}
 }
 
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
@@ -337,8 +343,7 @@ func (s *rangeProbeOnlyStore) ReadRange(ref ColumnAssetRef, offset int64, length
 		return nil, err
 	}
 	if offset != 0 || length != 1 {
-		t := make([]byte, 0)
-		return t, nil
+		return nil, fmt.Errorf("unexpected range probe offset=%d length=%d", offset, length)
 	}
 	return []byte{0}, nil
 }

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -96,7 +96,7 @@ func TestColumnAssetManagerValidatesPreparedPublishClosure(t *testing.T) {
 	}
 }
 
-func TestColumnAssetManagerSyncPublishClosureHonorsSyncRequired(t *testing.T) {
+func TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired(t *testing.T) {
 	store := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
 	manager, err := NewColumnAssetManager(store)
 	if err != nil {
@@ -119,18 +119,41 @@ func TestColumnAssetManagerSyncPublishClosureHonorsSyncRequired(t *testing.T) {
 	if !closure.SyncRequired {
 		t.Fatalf("SyncRequired=false want true for sync-capable store")
 	}
-	if err := manager.SyncPublishClosure(closure); err != nil {
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
 		t.Fatalf("SyncPublishClosure required: %v", err)
+	}
+	if !synced.sealed || !synced.closure.SyncRequired {
+		t.Fatalf("synced closure=%+v want sealed sync-required token", synced)
 	}
 	if store.syncCalls != 1 {
 		t.Fatalf("sync calls=%d want 1", store.syncCalls)
 	}
 	closure.SyncRequired = false
-	if err := manager.SyncPublishClosure(closure); err != nil {
-		t.Fatalf("SyncPublishClosure not required: %v", err)
+	synced, err = manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure tampered sync flag: %v", err)
 	}
-	if store.syncCalls != 1 {
-		t.Fatalf("sync calls=%d want unchanged 1", store.syncCalls)
+	if !synced.closure.SyncRequired {
+		t.Fatalf("synced closure SyncRequired=false want derived true")
+	}
+	if store.syncCalls != 2 {
+		t.Fatalf("sync calls=%d want 2 after tampered sync flag", store.syncCalls)
+	}
+
+	empty, err := manager.PreparePublishClosure(nil)
+	if err != nil {
+		t.Fatalf("PreparePublishClosure empty: %v", err)
+	}
+	synced, err = manager.SyncPublishClosure(empty)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure empty: %v", err)
+	}
+	if !synced.sealed || synced.closure.SyncRequired {
+		t.Fatalf("empty synced closure=%+v want sealed no-sync token", synced)
+	}
+	if store.syncCalls != 2 {
+		t.Fatalf("sync calls=%d want unchanged 2 after empty closure", store.syncCalls)
 	}
 }
 
@@ -156,11 +179,51 @@ func TestColumnAssetManagerSyncPublishClosureVerifiesNoopClosureAssets(t *testin
 	}
 	closure.SyncRequired = false
 	store.Reset()
-	if err := manager.SyncPublishClosure(closure); err == nil {
+	if _, err := manager.SyncPublishClosure(closure); err == nil {
 		t.Fatal("SyncPublishClosure succeeded for missing no-op closure asset")
 	}
 	if store.syncCalls != 0 {
 		t.Fatalf("sync calls=%d want 0 after failed no-op closure verification", store.syncCalls)
+	}
+}
+
+func TestColumnAssetManagerPublishSucceededRequiresSyncedClosure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(ColumnAssetSyncedPublishClosure{}, "root published"); err == nil {
+		t.Fatal("MarkPublishSucceeded accepted an unsealed publish closure")
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if len(manager.quarantine) != 0 || len(manager.zombies) != 0 || len(manager.rewriteDebt) != 0 {
+		t.Fatalf("manager state quarantine=%d zombies=%d rewrite=%d want all cleared", len(manager.quarantine), len(manager.zombies), len(manager.rewriteDebt))
 	}
 }
 

--- a/experiments/colgranule/asset_manager_test.go
+++ b/experiments/colgranule/asset_manager_test.go
@@ -330,6 +330,52 @@ func TestColumnAssetManagerPublishSucceededPreservesUnrelatedQuarantine(t *testi
 	}
 }
 
+func TestColumnAssetManagerPublishSucceededPreservesQuarantineAfterPublishFailure(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	manager, err := NewColumnAssetManager(store)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	ref, err := manager.Put(ColumnAssetKindTCS1PartImage, make([]byte, tcs1HeaderBytes+16))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	prepared := ColumnPreparedAsset{
+		Ref:          ref,
+		GenerationID: 7,
+		PublishID:    11,
+		Reason:       "publish staged",
+	}
+	if err := manager.MarkPublishFailed([]ColumnPreparedAsset{prepared}, "root publish failed"); err != nil {
+		t.Fatalf("MarkPublishFailed: %v", err)
+	}
+	if err := manager.Quarantine(ref, "checksum mismatch"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	closure, err := manager.PreparePublishClosure([]ColumnPreparedAsset{prepared})
+	if err != nil {
+		t.Fatalf("PreparePublishClosure: %v", err)
+	}
+	synced, err := manager.SyncPublishClosure(closure)
+	if err != nil {
+		t.Fatalf("SyncPublishClosure: %v", err)
+	}
+	if err := manager.MarkPublishSucceeded(synced, "root published"); err != nil {
+		t.Fatalf("MarkPublishSucceeded: %v", err)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if got := manager.quarantine[ref]; got != "checksum mismatch" {
+		t.Fatalf("quarantine reason=%q want checksum mismatch", got)
+	}
+	if _, ok := manager.publishFailed[ref]; ok {
+		t.Fatalf("publish-failed marker preserved after successful publish")
+	}
+	if got := manager.published[ref]; got != "root published" {
+		t.Fatalf("published reason=%q want root published", got)
+	}
+}
+
 func TestColumnAssetManagerPreparedPublishFailureQuarantinesAssets(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	manager, err := NewColumnAssetManager(store)

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -192,12 +192,11 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "column-assets-000001.seg")
-	_, statErr := os.Stat(path)
-	created := errors.Is(statErr, os.ErrNotExist)
-	if statErr != nil && !created {
-		return nil, statErr
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o644)
+	created := err == nil
+	if errors.Is(err, os.ErrExist) {
+		file, err = os.OpenFile(path, os.O_RDWR, 0o644)
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -385,18 +384,27 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return err
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.file == nil {
+		s.mu.Unlock()
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
-	if ref.FileID != s.fileID {
-		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
+	path := s.path
+	fileID := s.fileID
+	size := s.size
+	s.mu.Unlock()
+	if ref.FileID != fileID {
+		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}
-	if ref.Offset > s.size || ref.Length > s.size-ref.Offset {
-		return fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, s.size)
+	if ref.Offset > size || ref.Length > size-ref.Offset {
+		return fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, size)
 	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 	h := crc32.NewIEEE()
-	reader := io.NewSectionReader(s.file, ref.Offset, ref.Length)
+	reader := io.NewSectionReader(file, ref.Offset, ref.Length)
 	var buf [32 << 10]byte
 	if _, err := io.CopyBuffer(h, reader, buf[:]); err != nil {
 		return err

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -182,6 +182,9 @@ type SegmentColumnAssetStore struct {
 	fileID          uint32
 	size            int64
 	dirSyncRequired bool
+	closing         bool
+	activeFileIO    int
+	fileIOCond      *sync.Cond
 }
 
 func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
@@ -238,6 +241,11 @@ func (s *SegmentColumnAssetStore) Close() error {
 	if s.file == nil {
 		return nil
 	}
+	s.closing = true
+	cond := s.ensureFileIOCondLocked()
+	for s.activeFileIO > 0 {
+		cond.Wait()
+	}
 	err := s.file.Close()
 	s.file = nil
 	return err
@@ -249,9 +257,11 @@ func (s *SegmentColumnAssetStore) Sync() error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.file == nil {
+	if s.closing || s.file == nil {
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
+	// Hold the mutex across fsync as a publish barrier: Sync must seal all
+	// prior Put calls without allowing later writes to be mistaken as covered.
 	if err := s.file.Sync(); err != nil {
 		return err
 	}
@@ -259,6 +269,8 @@ func (s *SegmentColumnAssetStore) Sync() error {
 		if err := syncColumnAssetDirectory(s.dir); err != nil {
 			return err
 		}
+		// On Windows this records the strongest platform-supported sync attempt;
+		// reopen still conservatively requires another directory sync attempt.
 		s.dirSyncRequired = false
 	}
 	return nil
@@ -294,7 +306,7 @@ func (s *SegmentColumnAssetStore) Put(kind ColumnAssetKind, payload []byte) (Col
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.file == nil {
+	if s.closing || s.file == nil {
 		return ColumnAssetRef{}, fmt.Errorf("colgranule: closed segment asset store")
 	}
 	ref, err := newColumnAssetRef(kind, s.fileID, s.size, len(payload), payload)
@@ -325,7 +337,7 @@ func (s *SegmentColumnAssetStore) ReadTo(ref ColumnAssetRef, dst []byte) ([]byte
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.file == nil {
+	if s.closing || s.file == nil {
 		return nil, fmt.Errorf("colgranule: closed segment asset store")
 	}
 	if ref.FileID != s.fileID {
@@ -374,7 +386,7 @@ func (s *SegmentColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, le
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.file == nil {
+	if s.closing || s.file == nil {
 		return nil, fmt.Errorf("colgranule: closed segment asset store")
 	}
 	if ref.FileID != s.fileID {
@@ -399,14 +411,11 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 	if err := validateColumnAssetRef(ref); err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.file == nil {
-		return fmt.Errorf("colgranule: closed segment asset store")
+	file, fileID, size, err := s.beginFileIO()
+	if err != nil {
+		return err
 	}
-	file := s.file
-	fileID := s.fileID
-	size := s.size
+	defer s.endFileIO()
 	if ref.FileID != fileID {
 		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}
@@ -423,6 +432,32 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
 	}
 	return nil
+}
+
+func (s *SegmentColumnAssetStore) beginFileIO() (*os.File, uint32, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closing || s.file == nil {
+		return nil, 0, 0, fmt.Errorf("colgranule: closed segment asset store")
+	}
+	s.activeFileIO++
+	return s.file, s.fileID, s.size, nil
+}
+
+func (s *SegmentColumnAssetStore) endFileIO() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeFileIO--
+	if s.activeFileIO == 0 && s.fileIOCond != nil {
+		s.fileIOCond.Broadcast()
+	}
+}
+
+func (s *SegmentColumnAssetStore) ensureFileIOCondLocked() *sync.Cond {
+	if s.fileIOCond == nil {
+		s.fileIOCond = sync.NewCond(&s.mu)
+	}
+	return s.fileIOCond
 }
 
 func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length int, payload []byte) (ColumnAssetRef, error) {

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -43,6 +43,14 @@ type columnAssetOwnedStore interface {
 	PutOwned(kind ColumnAssetKind, payload []byte) (ColumnAssetRef, error)
 }
 
+type columnAssetVerifier interface {
+	Verify(ref ColumnAssetRef) error
+}
+
+type columnAssetSyncer interface {
+	Sync() error
+}
+
 type MemoryColumnAssetStore struct {
 	mu      sync.Mutex
 	nextOff int64
@@ -159,6 +167,11 @@ func (s *MemoryColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, len
 	return out, nil
 }
 
+func (s *MemoryColumnAssetStore) Verify(ref ColumnAssetRef) error {
+	_, err := s.Read(ref)
+	return err
+}
+
 type SegmentColumnAssetStore struct {
 	mu     sync.Mutex
 	dir    string
@@ -206,6 +219,18 @@ func (s *SegmentColumnAssetStore) Close() error {
 	err := s.file.Close()
 	s.file = nil
 	return err
+}
+
+func (s *SegmentColumnAssetStore) Sync() error {
+	if s == nil {
+		return fmt.Errorf("colgranule: nil segment asset store")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return fmt.Errorf("colgranule: closed segment asset store")
+	}
+	return s.file.Sync()
 }
 
 func (s *SegmentColumnAssetStore) Path() string {
@@ -317,6 +342,36 @@ func (s *SegmentColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, le
 		return nil, err
 	}
 	return out, nil
+}
+
+func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
+	if s == nil {
+		return fmt.Errorf("colgranule: nil segment asset store")
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return fmt.Errorf("colgranule: closed segment asset store")
+	}
+	if ref.FileID != s.fileID {
+		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, s.fileID)
+	}
+	if ref.Offset > s.size || ref.Length > s.size-ref.Offset {
+		return fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, s.size)
+	}
+	h := crc32.NewIEEE()
+	reader := io.NewSectionReader(s.file, ref.Offset, ref.Length)
+	var buf [32 << 10]byte
+	if _, err := io.CopyBuffer(h, reader, buf[:]); err != nil {
+		return err
+	}
+	if checksum := h.Sum32(); checksum != ref.Checksum {
+		return fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	}
+	return nil
 }
 
 func newColumnAssetRef(kind ColumnAssetKind, fileID uint32, offset int64, length int, payload []byte) (ColumnAssetRef, error) {

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -400,14 +400,13 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return err
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.file == nil {
-		s.mu.Unlock()
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
 	file := s.file
 	fileID := s.fileID
 	size := s.size
-	s.mu.Unlock()
 	if ref.FileID != fileID {
 		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -215,7 +215,7 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "column-assets-000001.seg")
-	file, _, err := openOrCreateColumnAssetSegment(path)
+	file, err := openOrCreateColumnAssetSegment(path)
 	if err != nil {
 		return nil, err
 	}
@@ -237,19 +237,19 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 	}, nil
 }
 
-func openOrCreateColumnAssetSegment(path string) (*os.File, bool, error) {
+func openOrCreateColumnAssetSegment(path string) (*os.File, error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o644)
 	if err == nil {
-		return file, true, nil
+		return file, nil
 	}
 	if !errors.Is(err, os.ErrExist) {
-		return nil, false, err
+		return nil, err
 	}
 	file, err = os.OpenFile(path, os.O_RDWR, 0o644)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return file, false, nil
+	return file, nil
 }
 
 func (s *SegmentColumnAssetStore) Close() error {
@@ -275,25 +275,23 @@ func (s *SegmentColumnAssetStore) Sync() error {
 	if s == nil {
 		return fmt.Errorf("colgranule: nil segment asset store")
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closing || s.file == nil {
-		return fmt.Errorf("colgranule: closed segment asset store")
-	}
-	// Hold the mutex across fsync as a publish barrier: Sync must seal all
-	// prior Put calls without allowing later writes to be mistaken as covered.
-	if err := s.file.Sync(); err != nil {
+	file, dir, dirSyncRequired, err := s.beginFileSync()
+	if err != nil {
 		return err
 	}
-	if s.dirSyncRequired {
-		if err := syncColumnAssetDirectory(s.dir); err != nil {
+	if err := file.Sync(); err != nil {
+		_ = s.endFileIO()
+		return err
+	}
+	clearDirSync := false
+	if dirSyncRequired {
+		if err := syncColumnAssetDirectory(dir); err != nil {
+			_ = s.endFileIO()
 			return err
 		}
-		// On Windows this records the strongest platform-supported sync attempt;
-		// reopen still conservatively requires another directory sync attempt.
-		s.dirSyncRequired = false
+		clearDirSync = true
 	}
-	return nil
+	return s.finishFileIO(clearDirSync)
 }
 
 func syncColumnAssetDirectory(dir string) error {
@@ -424,7 +422,7 @@ func (s *SegmentColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, le
 	return out, nil
 }
 
-func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
+func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) (err error) {
 	if s == nil {
 		return fmt.Errorf("colgranule: nil segment asset store")
 	}
@@ -435,7 +433,11 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 	if err != nil {
 		return err
 	}
-	defer s.endFileIO()
+	defer func() {
+		if endErr := s.endFileIO(); err == nil && endErr != nil {
+			err = endErr
+		}
+	}()
 	if ref.FileID != fileID {
 		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}
@@ -464,16 +466,38 @@ func (s *SegmentColumnAssetStore) beginFileIO() (*os.File, uint32, int64, error)
 	return s.file, s.fileID, s.size, nil
 }
 
-func (s *SegmentColumnAssetStore) endFileIO() {
+func (s *SegmentColumnAssetStore) beginFileSync() (*os.File, string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closing || s.file == nil {
+		return nil, "", false, fmt.Errorf("colgranule: closed segment asset store")
+	}
+	// Snapshot the file after all prior Put calls have released the mutex, then
+	// drop the mutex during fsync so reads are not blocked by slow storage.
+	s.activeFileIO++
+	return s.file, s.dir, s.dirSyncRequired, nil
+}
+
+func (s *SegmentColumnAssetStore) endFileIO() error {
+	return s.finishFileIO(false)
+}
+
+func (s *SegmentColumnAssetStore) finishFileIO(clearDirSync bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.activeFileIO <= 0 {
-		panic("colgranule: segment asset store file IO ended without matching begin")
+		return fmt.Errorf("colgranule: segment asset store file IO ended without matching begin")
+	}
+	if clearDirSync {
+		// On Windows this records the strongest platform-supported sync attempt;
+		// reopen still conservatively requires another directory sync attempt.
+		s.dirSyncRequired = false
 	}
 	s.activeFileIO--
 	if s.activeFileIO == 0 && s.fileIOCond != nil {
 		s.fileIOCond.Broadcast()
 	}
+	return nil
 }
 
 func (s *SegmentColumnAssetStore) ensureFileIOCondLocked() *sync.Cond {

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -192,11 +192,7 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "column-assets-000001.seg")
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o644)
-	created := err == nil
-	if errors.Is(err, os.ErrExist) {
-		file, err = os.OpenFile(path, os.O_RDWR, 0o644)
-	}
+	file, created, err := openOrCreateColumnAssetSegment(path)
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +209,21 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		size:            info.Size(),
 		dirSyncRequired: created,
 	}, nil
+}
+
+func openOrCreateColumnAssetSegment(path string) (*os.File, bool, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o644)
+	if err == nil {
+		return file, true, nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return nil, false, err
+	}
+	file, err = os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, false, err
+	}
+	return file, false, nil
 }
 
 func (s *SegmentColumnAssetStore) Close() error {
@@ -255,6 +266,8 @@ func syncColumnAssetDirectory(dir string) error {
 		return fmt.Errorf("colgranule: empty segment asset dir")
 	}
 	if runtime.GOOS == "windows" {
+		// Go does not expose portable directory fsync on Windows. File Sync is
+		// still required; POSIX directory-entry durability is best-effort here.
 		return nil
 	}
 	file, err := os.Open(dir)
@@ -384,27 +397,20 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return err
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.file == nil {
-		s.mu.Unlock()
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
-	path := s.path
 	fileID := s.fileID
 	size := s.size
-	s.mu.Unlock()
 	if ref.FileID != fileID {
 		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}
 	if ref.Offset > size || ref.Length > size-ref.Offset {
 		return fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, size)
 	}
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
 	h := crc32.NewIEEE()
-	reader := io.NewSectionReader(file, ref.Offset, ref.Length)
+	reader := io.NewSectionReader(s.file, ref.Offset, ref.Length)
 	var buf [32 << 10]byte
 	if _, err := io.CopyBuffer(h, reader, buf[:]); err != nil {
 		return err

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -207,8 +207,9 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		file:   file,
 		fileID: 1,
 		size:   info.Size(),
-		// Reopen cannot know whether a prior process synced the segment
-		// directory entry before publishing refs, so the next Sync seals it.
+		// Reopen deliberately treats the directory entry as unsealed: the store
+		// cannot prove a prior process synced it before publishing refs, so the
+		// next publish Sync seals the file and its directory entry together.
 		dirSyncRequired: true,
 	}, nil
 }
@@ -399,12 +400,14 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return err
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.file == nil {
+		s.mu.Unlock()
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
+	file := s.file
 	fileID := s.fileID
 	size := s.size
+	s.mu.Unlock()
 	if ref.FileID != fileID {
 		return fmt.Errorf("colgranule: asset file id=%d want %d", ref.FileID, fileID)
 	}
@@ -412,7 +415,7 @@ func (s *SegmentColumnAssetStore) Verify(ref ColumnAssetRef) error {
 		return fmt.Errorf("colgranule: asset range offset=%d length=%d outside segment bytes=%d", ref.Offset, ref.Length, size)
 	}
 	h := crc32.NewIEEE()
-	reader := io.NewSectionReader(s.file, ref.Offset, ref.Length)
+	reader := io.NewSectionReader(file, ref.Offset, ref.Length)
 	var buf [32 << 10]byte
 	if _, err := io.CopyBuffer(h, reader, buf[:]); err != nil {
 		return err

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -192,7 +192,7 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "column-assets-000001.seg")
-	file, created, err := openOrCreateColumnAssetSegment(path)
+	file, _, err := openOrCreateColumnAssetSegment(path)
 	if err != nil {
 		return nil, err
 	}
@@ -202,12 +202,14 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	return &SegmentColumnAssetStore{
-		dir:             dir,
-		path:            path,
-		file:            file,
-		fileID:          1,
-		size:            info.Size(),
-		dirSyncRequired: created,
+		dir:    dir,
+		path:   path,
+		file:   file,
+		fileID: 1,
+		size:   info.Size(),
+		// Reopen cannot know whether a prior process synced the segment
+		// directory entry before publishing refs, so the next Sync seals it.
+		dirSyncRequired: true,
 	}, nil
 }
 

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -280,13 +280,17 @@ func (s *SegmentColumnAssetStore) Sync() error {
 		return err
 	}
 	if err := file.Sync(); err != nil {
-		_ = s.endFileIO()
+		if endErr := s.endFileIO(); endErr != nil {
+			return errors.Join(err, endErr)
+		}
 		return err
 	}
 	clearDirSync := false
 	if dirSyncRequired {
 		if err := syncColumnAssetDirectory(dir); err != nil {
-			_ = s.endFileIO()
+			if endErr := s.endFileIO(); endErr != nil {
+				return errors.Join(err, endErr)
+			}
 			return err
 		}
 		clearDirSync = true

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -170,8 +170,28 @@ func (s *MemoryColumnAssetStore) ReadRange(ref ColumnAssetRef, offset int64, len
 }
 
 func (s *MemoryColumnAssetStore) Verify(ref ColumnAssetRef) error {
-	_, err := s.Read(ref)
-	return err
+	if s == nil {
+		return fmt.Errorf("colgranule: nil memory asset store")
+	}
+	if err := validateColumnAssetRef(ref); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	asset, ok := s.assets[ref.key()]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("colgranule: missing asset ref file=%d offset=%d", ref.FileID, ref.Offset)
+	}
+	if asset.kind != ref.Kind {
+		return fmt.Errorf("colgranule: asset kind=%s want %s", asset.kind, ref.Kind)
+	}
+	if asset.length != ref.Length {
+		return fmt.Errorf("colgranule: asset length=%d want %d", asset.length, ref.Length)
+	}
+	if checksum := crc32.ChecksumIEEE(asset.payload); checksum != ref.Checksum {
+		return fmt.Errorf("colgranule: asset ref checksum=%08x want %08x", checksum, ref.Checksum)
+	}
+	return nil
 }
 
 type SegmentColumnAssetStore struct {
@@ -447,6 +467,9 @@ func (s *SegmentColumnAssetStore) beginFileIO() (*os.File, uint32, int64, error)
 func (s *SegmentColumnAssetStore) endFileIO() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.activeFileIO <= 0 {
+		panic("colgranule: segment asset store file IO ended without matching begin")
+	}
 	s.activeFileIO--
 	if s.activeFileIO == 0 && s.fileIOCond != nil {
 		s.fileIOCond.Broadcast()

--- a/experiments/colgranule/asset_store.go
+++ b/experiments/colgranule/asset_store.go
@@ -1,12 +1,14 @@
 package colgranule
 
 import (
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 )
 
@@ -173,12 +175,13 @@ func (s *MemoryColumnAssetStore) Verify(ref ColumnAssetRef) error {
 }
 
 type SegmentColumnAssetStore struct {
-	mu     sync.Mutex
-	dir    string
-	path   string
-	file   *os.File
-	fileID uint32
-	size   int64
+	mu              sync.Mutex
+	dir             string
+	path            string
+	file            *os.File
+	fileID          uint32
+	size            int64
+	dirSyncRequired bool
 }
 
 func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
@@ -189,6 +192,11 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "column-assets-000001.seg")
+	_, statErr := os.Stat(path)
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return nil, statErr
+	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
@@ -199,11 +207,12 @@ func OpenSegmentColumnAssetStore(dir string) (*SegmentColumnAssetStore, error) {
 		return nil, err
 	}
 	return &SegmentColumnAssetStore{
-		dir:    dir,
-		path:   path,
-		file:   file,
-		fileID: 1,
-		size:   info.Size(),
+		dir:             dir,
+		path:            path,
+		file:            file,
+		fileID:          1,
+		size:            info.Size(),
+		dirSyncRequired: created,
 	}, nil
 }
 
@@ -230,7 +239,31 @@ func (s *SegmentColumnAssetStore) Sync() error {
 	if s.file == nil {
 		return fmt.Errorf("colgranule: closed segment asset store")
 	}
-	return s.file.Sync()
+	if err := s.file.Sync(); err != nil {
+		return err
+	}
+	if s.dirSyncRequired {
+		if err := syncColumnAssetDirectory(s.dir); err != nil {
+			return err
+		}
+		s.dirSyncRequired = false
+	}
+	return nil
+}
+
+func syncColumnAssetDirectory(dir string) error {
+	if dir == "" {
+		return fmt.Errorf("colgranule: empty segment asset dir")
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
 }
 
 func (s *SegmentColumnAssetStore) Path() string {

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -130,9 +130,8 @@ type columnAssetReachabilityRecord struct {
 }
 
 var (
-	// Shared one-element reason slices are immutable sentinels. Keep len == cap
-	// so any later append to a per-record copy reallocates instead of mutating
-	// package-level backing storage.
+	// Shared one-element reason slices are immutable sentinels. Clone before
+	// assigning them to any exported reachability entry.
 	columnAssetReasonPrepared              = []string{string(ColumnAssetStatePrepared)}
 	columnAssetReasonProcessVisible        = []string{string(ColumnAssetStateProcessVisible)}
 	columnAssetReasonPendingPublish        = []string{string(ColumnAssetStatePendingPublish)}
@@ -393,6 +392,7 @@ func addReachabilityEntry(records map[ColumnAssetRef]columnAssetReachabilityReco
 	if err := validateColumnAssetRef(entry.Ref); err != nil {
 		return err
 	}
+	entry.Reasons = cloneColumnAssetReachabilityReasons(entry.Reasons)
 	record, ok := records[entry.Ref]
 	if !ok {
 		record = columnAssetReachabilityRecord{entry: entry}
@@ -418,6 +418,15 @@ func addReachabilityEntry(records map[ColumnAssetRef]columnAssetReachabilityReco
 		segments[entry.Ref.FileID] = &columnAssetSegmentState{}
 	}
 	return nil
+}
+
+func cloneColumnAssetReachabilityReasons(reasons []string) []string {
+	if len(reasons) == 0 {
+		return nil
+	}
+	out := make([]string, len(reasons))
+	copy(out, reasons)
+	return out
 }
 
 func columnAssetRefBlocksSegmentDeletion(live bool, candidate bool, quarantined bool) bool {

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -125,6 +125,7 @@ type columnAssetReachabilityRecord struct {
 	entry       ColumnAssetReachabilityEntry
 	live        bool
 	candidate   bool
+	protected   bool
 	quarantined bool
 }
 
@@ -407,6 +408,7 @@ func addReachabilityEntry(records map[ColumnAssetRef]columnAssetReachabilityReco
 	}
 	record.live = record.live || live
 	record.candidate = record.candidate || candidate
+	record.protected = record.protected || (!live && (!candidate || quarantined))
 	record.quarantined = record.quarantined || quarantined
 	records[entry.Ref] = record
 	if segments[entry.Ref.FileID] == nil {

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -50,7 +50,7 @@ type ColumnAssetReachabilityPlan struct {
 	PreparedBytes          int                            `json:"prepared_bytes"`
 	ProcessVisibleBytes    int                            `json:"process_visible_bytes"`
 	PendingBytes           int                            `json:"pending_bytes"`
-	RecoveryPendingBytes   int                            `json:"recovery_pending_bytes"`
+	RootPublishedBytes     int                            `json:"root_published_bytes"`
 	QuarantinedBytes       int                            `json:"quarantined_bytes"`
 	SupersededBytes        int                            `json:"superseded_bytes"`
 	CleanupSafeBytes       int                            `json:"cleanup_safe_bytes"`
@@ -130,6 +130,9 @@ type columnAssetReachabilityRecord struct {
 }
 
 var (
+	// Shared one-element reason slices are immutable sentinels. Keep len == cap
+	// so any later append to a per-record copy reallocates instead of mutating
+	// package-level backing storage.
 	columnAssetReasonPrepared              = []string{string(ColumnAssetStatePrepared)}
 	columnAssetReasonProcessVisible        = []string{string(ColumnAssetStateProcessVisible)}
 	columnAssetReasonPendingPublish        = []string{string(ColumnAssetStatePendingPublish)}
@@ -408,13 +411,20 @@ func addReachabilityEntry(records map[ColumnAssetRef]columnAssetReachabilityReco
 	}
 	record.live = record.live || live
 	record.candidate = record.candidate || candidate
-	record.protected = record.protected || (!live && (!candidate || quarantined))
+	record.protected = record.protected || columnAssetRefBlocksSegmentDeletion(live, candidate, quarantined)
 	record.quarantined = record.quarantined || quarantined
 	records[entry.Ref] = record
 	if segments[entry.Ref.FileID] == nil {
 		segments[entry.Ref.FileID] = &columnAssetSegmentState{}
 	}
 	return nil
+}
+
+func columnAssetRefBlocksSegmentDeletion(live bool, candidate bool, quarantined bool) bool {
+	// Non-live refs still block whole-segment deletion unless they are purely
+	// cleanup-safe candidates. Quarantined refs deliberately block shared segment
+	// deletion until quarantine handling has made an explicit cleanup decision.
+	return !live && (!candidate || quarantined)
 }
 
 func estimateColumnAssetReachabilityRefs(input ColumnAssetReachabilityInput) int {
@@ -487,6 +497,8 @@ func strongestColumnAssetState(a ColumnAssetLifecycleState, b ColumnAssetLifecyc
 func columnAssetStateRank(state ColumnAssetLifecycleState) int {
 	switch state {
 	case ColumnAssetStateQuarantined:
+		// Quarantine is reported as the dominant state so unsafe/isolated refs
+		// remain visible even if another reachable manifest still names them.
 		return 100
 	case ColumnAssetStateRecoveryAuthoritative:
 		return 90

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -316,13 +316,14 @@ func addManifestAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityReco
 	if err := validateColumnCollectionManifest(manifest); err != nil {
 		return err
 	}
+	reasons := columnAssetReachabilityDefaultReasons(state)
 	for i := range manifest.PartSet.BaseParts {
-		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.BaseParts[i], state, live, candidate, stats); err != nil {
+		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.BaseParts[i], state, live, candidate, reasons, stats); err != nil {
 			return err
 		}
 	}
 	for i := range manifest.PartSet.DeltaParts {
-		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.DeltaParts[i], state, live, candidate, stats); err != nil {
+		if err := addManifestPartAssetRef(records, segments, manifest.PartSet.DeltaParts[i], state, live, candidate, reasons, stats); err != nil {
 			return err
 		}
 	}
@@ -332,14 +333,14 @@ func addManifestAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityReco
 	return nil
 }
 
-func addManifestPartAssetRef(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, partRef ColumnManifestPartRef, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+func addManifestPartAssetRef(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, partRef ColumnManifestPartRef, state ColumnAssetLifecycleState, live bool, candidate bool, reasons []string, stats *ColumnAssetReachabilityStats) error {
 	entry := ColumnAssetReachabilityEntry{
 		Ref:          partRef.Part.AssetRef,
 		State:        state,
 		Bytes:        partRef.Part.AssetBytes,
 		PartID:       partRef.Part.PartID,
 		GenerationID: partRef.GenerationID,
-		Reasons:      columnAssetReachabilityDefaultReasons(state),
+		Reasons:      reasons,
 	}
 	if err := addReachabilityEntry(records, segments, entry, live, candidate, false); err != nil {
 		return err

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -310,6 +310,7 @@ func columnAssetRefDeltaEntry(kind ColumnAssetRefDeltaKind, ref ColumnManifestPa
 type columnAssetSegmentState struct {
 	liveRefs      int
 	candidateRefs int
+	protectedRefs int
 }
 
 func addManifestAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, manifest ColumnCollectionManifest, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -130,8 +130,9 @@ type columnAssetReachabilityRecord struct {
 }
 
 var (
-	// Shared one-element reason slices are immutable sentinels. Clone before
-	// assigning them to any exported reachability entry.
+	// Shared one-element reason slices are immutable sentinels. Internal
+	// builders may carry them, but addReachabilityEntry must clone before any
+	// exported reachability entry observes them.
 	columnAssetReasonPrepared              = []string{string(ColumnAssetStatePrepared)}
 	columnAssetReasonProcessVisible        = []string{string(ColumnAssetStateProcessVisible)}
 	columnAssetReasonPendingPublish        = []string{string(ColumnAssetStatePendingPublish)}

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -433,7 +433,13 @@ func columnAssetRefBlocksSegmentDeletion(live bool, candidate bool, quarantined 
 	// Non-live refs still block whole-segment deletion unless they are purely
 	// cleanup-safe candidates. Quarantined refs deliberately block shared segment
 	// deletion until quarantine handling has made an explicit cleanup decision.
-	return !live && (!candidate || quarantined)
+	if live {
+		return false
+	}
+	if quarantined {
+		return true
+	}
+	return !candidate
 }
 
 func estimateColumnAssetReachabilityRefs(input ColumnAssetReachabilityInput) int {
@@ -528,6 +534,9 @@ func columnAssetStateRank(state ColumnAssetLifecycleState) int {
 	case ColumnAssetStateReclaimable:
 		return 20
 	case ColumnAssetStateSuperseded:
+		// Superseded refs are still protected from direct segment deletion, but
+		// cleanup-safe/reclaimable states win when a later lifecycle scan proves
+		// the containing segment can be reclaimed or rewritten safely.
 		return 10
 	case ColumnAssetStateDeleting:
 		return 0

--- a/experiments/colgranule/lifecycle.go
+++ b/experiments/colgranule/lifecycle.go
@@ -8,14 +8,18 @@ import (
 type ColumnAssetLifecycleState string
 
 const (
-	ColumnAssetStatePrepared       ColumnAssetLifecycleState = "prepared"
-	ColumnAssetStatePendingPublish ColumnAssetLifecycleState = "pending_publish"
-	ColumnAssetStateActive         ColumnAssetLifecycleState = "active"
-	ColumnAssetStateSuperseded     ColumnAssetLifecycleState = "superseded"
-	ColumnAssetStateSnapshotPinned ColumnAssetLifecycleState = "snapshot_pinned"
-	ColumnAssetStateReclaimable    ColumnAssetLifecycleState = "reclaimable"
-	ColumnAssetStateDeleting       ColumnAssetLifecycleState = "deleting"
-	ColumnAssetStateQuarantined    ColumnAssetLifecycleState = "quarantined"
+	ColumnAssetStatePrepared              ColumnAssetLifecycleState = "prepared"
+	ColumnAssetStateProcessVisible        ColumnAssetLifecycleState = "process_visible"
+	ColumnAssetStatePendingPublish        ColumnAssetLifecycleState = "pending_publish"
+	ColumnAssetStateRootPublished         ColumnAssetLifecycleState = "root_published"
+	ColumnAssetStateRecoveryAuthoritative ColumnAssetLifecycleState = "recovery_authoritative"
+	ColumnAssetStateActive                ColumnAssetLifecycleState = "active"
+	ColumnAssetStateSuperseded            ColumnAssetLifecycleState = "superseded"
+	ColumnAssetStateCleanupSafe           ColumnAssetLifecycleState = "cleanup_safe"
+	ColumnAssetStateSnapshotPinned        ColumnAssetLifecycleState = "snapshot_pinned"
+	ColumnAssetStateReclaimable           ColumnAssetLifecycleState = "reclaimable"
+	ColumnAssetStateDeleting              ColumnAssetLifecycleState = "deleting"
+	ColumnAssetStateQuarantined           ColumnAssetLifecycleState = "quarantined"
 )
 
 type ColumnPreparedAsset struct {
@@ -27,12 +31,16 @@ type ColumnPreparedAsset struct {
 }
 
 type ColumnAssetReachabilityInput struct {
-	ActiveManifest          *ColumnCollectionManifest  `json:"active_manifest,omitempty"`
-	PendingManifests        []ColumnCollectionManifest `json:"pending_manifests,omitempty"`
-	SnapshotPinnedManifests []ColumnCollectionManifest `json:"snapshot_pinned_manifests,omitempty"`
-	SupersededManifests     []ColumnCollectionManifest `json:"superseded_manifests,omitempty"`
-	PreparedAssets          []ColumnPreparedAsset      `json:"prepared_assets,omitempty"`
-	QuarantinedAssets       []ColumnPreparedAsset      `json:"quarantined_assets,omitempty"`
+	ActiveManifest                 *ColumnCollectionManifest  `json:"active_manifest,omitempty"`
+	ProcessVisibleManifests        []ColumnCollectionManifest `json:"process_visible_manifests,omitempty"`
+	PendingManifests               []ColumnCollectionManifest `json:"pending_manifests,omitempty"`
+	RootPublishedManifests         []ColumnCollectionManifest `json:"root_published_manifests,omitempty"`
+	RecoveryAuthoritativeManifests []ColumnCollectionManifest `json:"recovery_authoritative_manifests,omitempty"`
+	SnapshotPinnedManifests        []ColumnCollectionManifest `json:"snapshot_pinned_manifests,omitempty"`
+	SupersededManifests            []ColumnCollectionManifest `json:"superseded_manifests,omitempty"`
+	CleanupSafeManifests           []ColumnCollectionManifest `json:"cleanup_safe_manifests,omitempty"`
+	PreparedAssets                 []ColumnPreparedAsset      `json:"prepared_assets,omitempty"`
+	QuarantinedAssets              []ColumnPreparedAsset      `json:"quarantined_assets,omitempty"`
 }
 
 type ColumnAssetReachabilityPlan struct {
@@ -40,29 +48,37 @@ type ColumnAssetReachabilityPlan struct {
 	Stats                  ColumnAssetReachabilityStats   `json:"stats"`
 	RetainedBytes          int                            `json:"retained_bytes"`
 	PreparedBytes          int                            `json:"prepared_bytes"`
+	ProcessVisibleBytes    int                            `json:"process_visible_bytes"`
+	PendingBytes           int                            `json:"pending_bytes"`
+	RecoveryPendingBytes   int                            `json:"recovery_pending_bytes"`
 	QuarantinedBytes       int                            `json:"quarantined_bytes"`
 	SupersededBytes        int                            `json:"superseded_bytes"`
+	CleanupSafeBytes       int                            `json:"cleanup_safe_bytes"`
 	SnapshotProtectedBytes int                            `json:"snapshot_protected_bytes"`
 	RewriteDebtBytes       int                            `json:"rewrite_debt_bytes"`
 	ReclaimableBytes       int                            `json:"reclaimable_bytes"`
 }
 
 type ColumnAssetReachabilityStats struct {
-	Manifests                 int `json:"manifests"`
-	ActiveManifests           int `json:"active_manifests"`
-	PendingManifests          int `json:"pending_manifests"`
-	SnapshotPinnedManifests   int `json:"snapshot_pinned_manifests"`
-	SupersededManifests       int `json:"superseded_manifests"`
-	PreparedAssets            int `json:"prepared_assets"`
-	QuarantinedAssets         int `json:"quarantined_assets"`
-	AssetRefs                 int `json:"asset_refs"`
-	SegmentRefs               int `json:"segment_refs"`
-	MetadataBytesScanned      int `json:"metadata_bytes_scanned"`
-	TCS1PayloadBytesDecoded   int `json:"tcs1_payload_bytes_decoded"`
-	RowsScanned               int `json:"rows_scanned"`
-	ColumnPayloadBlocksRead   int `json:"column_payload_blocks_read"`
-	DirectlyDeletableSegments int `json:"directly_deletable_segments"`
-	MixedLiveDeadSegments     int `json:"mixed_live_dead_segments"`
+	Manifests                      int `json:"manifests"`
+	ActiveManifests                int `json:"active_manifests"`
+	ProcessVisibleManifests        int `json:"process_visible_manifests"`
+	PendingManifests               int `json:"pending_manifests"`
+	RootPublishedManifests         int `json:"root_published_manifests"`
+	RecoveryAuthoritativeManifests int `json:"recovery_authoritative_manifests"`
+	SnapshotPinnedManifests        int `json:"snapshot_pinned_manifests"`
+	SupersededManifests            int `json:"superseded_manifests"`
+	CleanupSafeManifests           int `json:"cleanup_safe_manifests"`
+	PreparedAssets                 int `json:"prepared_assets"`
+	QuarantinedAssets              int `json:"quarantined_assets"`
+	AssetRefs                      int `json:"asset_refs"`
+	SegmentRefs                    int `json:"segment_refs"`
+	MetadataBytesScanned           int `json:"metadata_bytes_scanned"`
+	TCS1PayloadBytesDecoded        int `json:"tcs1_payload_bytes_decoded"`
+	RowsScanned                    int `json:"rows_scanned"`
+	ColumnPayloadBlocksRead        int `json:"column_payload_blocks_read"`
+	DirectlyDeletableSegments      int `json:"directly_deletable_segments"`
+	MixedLiveDeadSegments          int `json:"mixed_live_dead_segments"`
 }
 
 type ColumnAssetReachabilityEntry struct {
@@ -113,14 +129,18 @@ type columnAssetReachabilityRecord struct {
 }
 
 var (
-	columnAssetReasonPrepared       = []string{string(ColumnAssetStatePrepared)}
-	columnAssetReasonPendingPublish = []string{string(ColumnAssetStatePendingPublish)}
-	columnAssetReasonActive         = []string{string(ColumnAssetStateActive)}
-	columnAssetReasonSuperseded     = []string{string(ColumnAssetStateSuperseded)}
-	columnAssetReasonSnapshotPinned = []string{string(ColumnAssetStateSnapshotPinned)}
-	columnAssetReasonReclaimable    = []string{string(ColumnAssetStateReclaimable)}
-	columnAssetReasonDeleting       = []string{string(ColumnAssetStateDeleting)}
-	columnAssetReasonQuarantined    = []string{string(ColumnAssetStateQuarantined)}
+	columnAssetReasonPrepared              = []string{string(ColumnAssetStatePrepared)}
+	columnAssetReasonProcessVisible        = []string{string(ColumnAssetStateProcessVisible)}
+	columnAssetReasonPendingPublish        = []string{string(ColumnAssetStatePendingPublish)}
+	columnAssetReasonRootPublished         = []string{string(ColumnAssetStateRootPublished)}
+	columnAssetReasonRecoveryAuthoritative = []string{string(ColumnAssetStateRecoveryAuthoritative)}
+	columnAssetReasonActive                = []string{string(ColumnAssetStateActive)}
+	columnAssetReasonSuperseded            = []string{string(ColumnAssetStateSuperseded)}
+	columnAssetReasonCleanupSafe           = []string{string(ColumnAssetStateCleanupSafe)}
+	columnAssetReasonSnapshotPinned        = []string{string(ColumnAssetStateSnapshotPinned)}
+	columnAssetReasonReclaimable           = []string{string(ColumnAssetStateReclaimable)}
+	columnAssetReasonDeleting              = []string{string(ColumnAssetStateDeleting)}
+	columnAssetReasonQuarantined           = []string{string(ColumnAssetStateQuarantined)}
 )
 
 func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAssetReachabilityPlan, error) {
@@ -134,11 +154,29 @@ func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAsse
 			return ColumnAssetReachabilityPlan{}, err
 		}
 	}
+	for _, manifest := range input.ProcessVisibleManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateProcessVisible, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.ProcessVisibleManifests++
+	}
 	for _, manifest := range input.PendingManifests {
 		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStatePendingPublish, true, false, &plan.Stats); err != nil {
 			return ColumnAssetReachabilityPlan{}, err
 		}
 		plan.Stats.PendingManifests++
+	}
+	for _, manifest := range input.RootPublishedManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateRootPublished, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.RootPublishedManifests++
+	}
+	for _, manifest := range input.RecoveryAuthoritativeManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateRecoveryAuthoritative, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.RecoveryAuthoritativeManifests++
 	}
 	for _, manifest := range input.SnapshotPinnedManifests {
 		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateSnapshotPinned, true, false, &plan.Stats); err != nil {
@@ -147,10 +185,16 @@ func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAsse
 		plan.Stats.SnapshotPinnedManifests++
 	}
 	for _, manifest := range input.SupersededManifests {
-		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, true, &plan.Stats); err != nil {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, false, &plan.Stats); err != nil {
 			return ColumnAssetReachabilityPlan{}, err
 		}
 		plan.Stats.SupersededManifests++
+	}
+	for _, manifest := range input.CleanupSafeManifests {
+		if err := addManifestAssetRefs(records, segments, manifest, ColumnAssetStateCleanupSafe, false, true, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.CleanupSafeManifests++
 	}
 	for _, prepared := range input.PreparedAssets {
 		if err := addPreparedAsset(records, segments, prepared, ColumnAssetStatePrepared, true, false, &plan.Stats); err != nil {
@@ -165,77 +209,7 @@ func PlanColumnAssetReachability(input ColumnAssetReachabilityInput) (ColumnAsse
 		plan.Stats.QuarantinedAssets++
 	}
 
-	plan.Stats.Manifests = plan.Stats.ActiveManifests + plan.Stats.PendingManifests + plan.Stats.SnapshotPinnedManifests + plan.Stats.SupersededManifests
-	plan.Stats.AssetRefs = len(records)
-	for _, seg := range segments {
-		seg.liveRefs = 0
-		seg.candidateRefs = 0
-	}
-	for _, record := range records {
-		seg := segments[record.entry.Ref.FileID]
-		if seg == nil {
-			seg = &columnAssetSegmentState{}
-			segments[record.entry.Ref.FileID] = seg
-		}
-		if record.live {
-			seg.liveRefs++
-		}
-		if record.candidate && !record.live && !record.quarantined {
-			seg.candidateRefs++
-		}
-	}
-	plan.Stats.SegmentRefs = len(segments)
-	for _, seg := range segments {
-		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
-			plan.Stats.DirectlyDeletableSegments++
-		}
-		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
-			plan.Stats.MixedLiveDeadSegments++
-		}
-	}
-
-	plan.Entries = make([]ColumnAssetReachabilityEntry, 0, len(records))
-	for _, record := range records {
-		entry := record.entry
-		switch {
-		case record.quarantined:
-			plan.QuarantinedBytes += entry.Bytes
-		case record.live:
-			switch entry.State {
-			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
-				plan.PreparedBytes += entry.Bytes
-			case ColumnAssetStateSnapshotPinned:
-				plan.SnapshotProtectedBytes += entry.Bytes
-				plan.RetainedBytes += entry.Bytes
-			default:
-				plan.RetainedBytes += entry.Bytes
-			}
-		case record.candidate:
-			plan.SupersededBytes += entry.Bytes
-			seg := segments[entry.Ref.FileID]
-			if seg != nil && seg.liveRefs == 0 {
-				entry.DeleteEligible = true
-				entry.State = ColumnAssetStateReclaimable
-				plan.ReclaimableBytes += entry.Bytes
-			} else {
-				plan.RewriteDebtBytes += entry.Bytes
-			}
-		}
-		plan.Entries = append(plan.Entries, entry)
-	}
-	sort.Slice(plan.Entries, func(i, j int) bool {
-		a, b := plan.Entries[i].Ref, plan.Entries[j].Ref
-		if a.FileID != b.FileID {
-			return a.FileID < b.FileID
-		}
-		if a.Offset != b.Offset {
-			return a.Offset < b.Offset
-		}
-		if a.Length != b.Length {
-			return a.Length < b.Length
-		}
-		return a.Checksum < b.Checksum
-	})
+	finalizeColumnAssetReachabilityRecords(records, segments, &plan)
 	return plan, nil
 }
 
@@ -444,14 +418,26 @@ func estimateColumnAssetReachabilityRefs(input ColumnAssetReachabilityInput) int
 	if input.ActiveManifest != nil {
 		refs += len(input.ActiveManifest.PartSet.BaseParts) + len(input.ActiveManifest.PartSet.DeltaParts)
 	}
+	for i := range input.ProcessVisibleManifests {
+		refs += len(input.ProcessVisibleManifests[i].PartSet.BaseParts) + len(input.ProcessVisibleManifests[i].PartSet.DeltaParts)
+	}
 	for i := range input.PendingManifests {
 		refs += len(input.PendingManifests[i].PartSet.BaseParts) + len(input.PendingManifests[i].PartSet.DeltaParts)
+	}
+	for i := range input.RootPublishedManifests {
+		refs += len(input.RootPublishedManifests[i].PartSet.BaseParts) + len(input.RootPublishedManifests[i].PartSet.DeltaParts)
+	}
+	for i := range input.RecoveryAuthoritativeManifests {
+		refs += len(input.RecoveryAuthoritativeManifests[i].PartSet.BaseParts) + len(input.RecoveryAuthoritativeManifests[i].PartSet.DeltaParts)
 	}
 	for i := range input.SnapshotPinnedManifests {
 		refs += len(input.SnapshotPinnedManifests[i].PartSet.BaseParts) + len(input.SnapshotPinnedManifests[i].PartSet.DeltaParts)
 	}
 	for i := range input.SupersededManifests {
 		refs += len(input.SupersededManifests[i].PartSet.BaseParts) + len(input.SupersededManifests[i].PartSet.DeltaParts)
+	}
+	for i := range input.CleanupSafeManifests {
+		refs += len(input.CleanupSafeManifests[i].PartSet.BaseParts) + len(input.CleanupSafeManifests[i].PartSet.DeltaParts)
 	}
 	return refs
 }
@@ -460,12 +446,20 @@ func columnAssetReachabilityDefaultReasons(state ColumnAssetLifecycleState) []st
 	switch state {
 	case ColumnAssetStatePrepared:
 		return columnAssetReasonPrepared
+	case ColumnAssetStateProcessVisible:
+		return columnAssetReasonProcessVisible
 	case ColumnAssetStatePendingPublish:
 		return columnAssetReasonPendingPublish
+	case ColumnAssetStateRootPublished:
+		return columnAssetReasonRootPublished
+	case ColumnAssetStateRecoveryAuthoritative:
+		return columnAssetReasonRecoveryAuthoritative
 	case ColumnAssetStateActive:
 		return columnAssetReasonActive
 	case ColumnAssetStateSuperseded:
 		return columnAssetReasonSuperseded
+	case ColumnAssetStateCleanupSafe:
+		return columnAssetReasonCleanupSafe
 	case ColumnAssetStateSnapshotPinned:
 		return columnAssetReasonSnapshotPinned
 	case ColumnAssetStateReclaimable:
@@ -488,15 +482,23 @@ func strongestColumnAssetState(a ColumnAssetLifecycleState, b ColumnAssetLifecyc
 
 func columnAssetStateRank(state ColumnAssetLifecycleState) int {
 	switch state {
+	case ColumnAssetStateQuarantined:
+		return 100
+	case ColumnAssetStateRecoveryAuthoritative:
+		return 90
 	case ColumnAssetStateActive:
-		return 70
-	case ColumnAssetStatePendingPublish:
-		return 60
+		return 80
 	case ColumnAssetStateSnapshotPinned:
+		return 70
+	case ColumnAssetStateRootPublished:
+		return 60
+	case ColumnAssetStateProcessVisible:
+		return 55
+	case ColumnAssetStatePendingPublish:
 		return 50
 	case ColumnAssetStatePrepared:
 		return 40
-	case ColumnAssetStateQuarantined:
+	case ColumnAssetStateCleanupSafe:
 		return 30
 	case ColumnAssetStateReclaimable:
 		return 20

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -12,8 +12,8 @@ func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
 	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
 
 	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{old},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{old},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -21,8 +21,8 @@ func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
 	if plan.RetainedBytes != int(activeRef.Length) {
 		t.Fatalf("retained bytes=%d want %d", plan.RetainedBytes, activeRef.Length)
 	}
-	if plan.SupersededBytes != int(oldRef.Length) || plan.ReclaimableBytes != int(oldRef.Length) || plan.RewriteDebtBytes != 0 {
-		t.Fatalf("superseded/reclaimable/rewrite=(%d,%d,%d) want (%d,%d,0)", plan.SupersededBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes, oldRef.Length, oldRef.Length)
+	if plan.CleanupSafeBytes != int(oldRef.Length) || plan.ReclaimableBytes != int(oldRef.Length) || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("cleanup-safe/reclaimable/rewrite=(%d,%d,%d) want (%d,%d,0)", plan.CleanupSafeBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes, oldRef.Length, oldRef.Length)
 	}
 	if plan.Stats.DirectlyDeletableSegments != 1 || plan.Stats.MixedLiveDeadSegments != 0 {
 		t.Fatalf("deletable/mixed segments=(%d,%d) want (1,0)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
@@ -43,8 +43,8 @@ func TestColumnAssetReachabilityTracksRewriteDebtForMixedSegments(t *testing.T) 
 	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
 
 	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{old},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{old},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -56,8 +56,41 @@ func TestColumnAssetReachabilityTracksRewriteDebtForMixedSegments(t *testing.T) 
 		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,1)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
 	}
 	oldEntry := lifecycleFindEntry(t, plan, oldRef)
+	if oldEntry.State != ColumnAssetStateCleanupSafe || oldEntry.DeleteEligible {
+		t.Fatalf("old entry state/delete=(%s,%v) want cleanup_safe,false", oldEntry.State, oldEntry.DeleteEligible)
+	}
+}
+
+func TestColumnAssetReachabilityProtectsSupersededUntilCleanupSafe(t *testing.T) {
+	rootPublishedRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	rootPublished := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, rootPublishedRef)
+	old := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, oldRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		RootPublishedManifests: []ColumnCollectionManifest{rootPublished},
+		SupersededManifests:    []ColumnCollectionManifest{old},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.RecoveryPendingBytes != int(rootPublishedRef.Length) {
+		t.Fatalf("recovery pending bytes=%d want %d", plan.RecoveryPendingBytes, rootPublishedRef.Length)
+	}
+	if plan.SupersededBytes != int(oldRef.Length) || plan.CleanupSafeBytes != 0 || plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("superseded/cleanup-safe/reclaimable/rewrite=(%d,%d,%d,%d) want (%d,0,0,0)",
+			plan.SupersededBytes, plan.CleanupSafeBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes, oldRef.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 0 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,0)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	oldEntry := lifecycleFindEntry(t, plan, oldRef)
 	if oldEntry.State != ColumnAssetStateSuperseded || oldEntry.DeleteEligible {
 		t.Fatalf("old entry state/delete=(%s,%v) want superseded,false", oldEntry.State, oldEntry.DeleteEligible)
+	}
+	rootEntry := lifecycleFindEntry(t, plan, rootPublishedRef)
+	if rootEntry.State != ColumnAssetStateRootPublished || rootEntry.DeleteEligible {
+		t.Fatalf("root entry state/delete=(%s,%v) want root_published,false", rootEntry.State, rootEntry.DeleteEligible)
 	}
 }
 
@@ -112,9 +145,11 @@ func TestColumnAssetReachabilityProtectsPendingAndPreparedAssets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
 	}
-	wantPrepared := int(pendingRef.Length + preparedRef.Length)
-	if plan.PreparedBytes != wantPrepared {
-		t.Fatalf("prepared bytes=%d want %d", plan.PreparedBytes, wantPrepared)
+	if plan.PendingBytes != int(pendingRef.Length) {
+		t.Fatalf("pending bytes=%d want %d", plan.PendingBytes, pendingRef.Length)
+	}
+	if plan.PreparedBytes != int(preparedRef.Length) {
+		t.Fatalf("prepared bytes=%d want %d", plan.PreparedBytes, preparedRef.Length)
 	}
 	if plan.QuarantinedBytes != int(quarantinedRef.Length) {
 		t.Fatalf("quarantined bytes=%d want %d", plan.QuarantinedBytes, quarantinedRef.Length)
@@ -214,8 +249,8 @@ func TestColumnAssetReachabilityDeterministicChurnReclaimsAfterSnapshotDrain(t *
 	}
 
 	drained, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{old},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{old},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability drained: %v", err)
@@ -252,8 +287,8 @@ func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testin
 		lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+32),
 	)
 	materialized, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{superseded},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{superseded},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -261,8 +296,8 @@ func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testin
 	activeView := mustColumnCollectionManifestView(t, active)
 	supersededView := mustColumnCollectionManifestView(t, superseded)
 	fromViews, err := PlanColumnAssetReachabilityFromViews(ColumnAssetReachabilityViewInput{
-		ActiveManifest:      &activeView,
-		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+		ActiveManifest:       &activeView,
+		CleanupSafeManifests: []ColumnCollectionManifestView{supersededView},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachabilityFromViews: %v", err)
@@ -271,8 +306,41 @@ func TestColumnAssetReachabilityFromBinaryViewsMatchesMaterializedPlan(t *testin
 		t.Fatalf("view plan mismatch\nview=%+v\nmaterialized=%+v", fromViews, materialized)
 	}
 	summary, err := PlanColumnAssetReachabilitySummaryFromViews(ColumnAssetReachabilityViewInput{
-		ActiveManifest:      &activeView,
-		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+		ActiveManifest:       &activeView,
+		CleanupSafeManifests: []ColumnCollectionManifestView{supersededView},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	if want := lifecycleSummaryFromPlan(materialized); !reflect.DeepEqual(summary, want) {
+		t.Fatalf("summary mismatch\nsummary=%+v\nmaterialized=%+v", summary, want)
+	}
+}
+
+func TestColumnAssetReachabilitySummaryTracksDurabilityStates(t *testing.T) {
+	recoveryRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	rootPublishedRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	cleanupSafeRef := lifecycleAssetRef(t, 3, 0, tcs1HeaderBytes+32)
+	recovery := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 3, recoveryRef)
+	rootPublished := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, rootPublishedRef)
+	cleanupSafe := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, cleanupSafeRef)
+
+	materialized, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		RecoveryAuthoritativeManifests: []ColumnCollectionManifest{recovery},
+		RootPublishedManifests:         []ColumnCollectionManifest{rootPublished},
+		CleanupSafeManifests:           []ColumnCollectionManifest{cleanupSafe},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if materialized.RetainedBytes != int(recoveryRef.Length) || materialized.RecoveryPendingBytes != int(rootPublishedRef.Length) || materialized.CleanupSafeBytes != int(cleanupSafeRef.Length) {
+		t.Fatalf("durability bytes retained/recovery-pending/cleanup-safe=(%d,%d,%d)",
+			materialized.RetainedBytes, materialized.RecoveryPendingBytes, materialized.CleanupSafeBytes)
+	}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(ColumnAssetReachabilityViewInput{
+		RecoveryAuthoritativeManifests: []ColumnCollectionManifestView{mustColumnCollectionManifestView(t, recovery)},
+		RootPublishedManifests:         []ColumnCollectionManifestView{mustColumnCollectionManifestView(t, rootPublished)},
+		CleanupSafeManifests:           []ColumnCollectionManifestView{mustColumnCollectionManifestView(t, cleanupSafe)},
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
@@ -332,8 +400,8 @@ func BenchmarkColumnAssetReachability10K(b *testing.B) {
 	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
 	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
 	input := ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{superseded},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{superseded},
 	}
 	plan, err := PlanColumnAssetReachability(input)
 	if err != nil {
@@ -361,8 +429,8 @@ func BenchmarkColumnAssetReachabilityView10K(b *testing.B) {
 	activeView := mustColumnCollectionManifestView(b, active)
 	supersededView := mustColumnCollectionManifestView(b, superseded)
 	input := ColumnAssetReachabilityViewInput{
-		ActiveManifest:      &activeView,
-		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+		ActiveManifest:       &activeView,
+		CleanupSafeManifests: []ColumnCollectionManifestView{supersededView},
 	}
 	plan, err := PlanColumnAssetReachabilityFromViews(input)
 	if err != nil {
@@ -390,8 +458,8 @@ func BenchmarkColumnAssetReachabilitySummaryView10K(b *testing.B) {
 	activeView := mustColumnCollectionManifestView(b, active)
 	supersededView := mustColumnCollectionManifestView(b, superseded)
 	input := ColumnAssetReachabilityViewInput{
-		ActiveManifest:      &activeView,
-		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+		ActiveManifest:       &activeView,
+		CleanupSafeManifests: []ColumnCollectionManifestView{supersededView},
 	}
 	summary, err := PlanColumnAssetReachabilitySummaryFromViews(input)
 	if err != nil {
@@ -419,8 +487,8 @@ func BenchmarkColumnAssetReachabilitySummaryView10KReuse(b *testing.B) {
 	activeView := mustColumnCollectionManifestView(b, active)
 	supersededView := mustColumnCollectionManifestView(b, superseded)
 	input := ColumnAssetReachabilityViewInput{
-		ActiveManifest:      &activeView,
-		SupersededManifests: []ColumnCollectionManifestView{supersededView},
+		ActiveManifest:       &activeView,
+		CleanupSafeManifests: []ColumnCollectionManifestView{supersededView},
 	}
 	scratch := &ColumnAssetReachabilitySummaryScratch{}
 	summary, err := PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input, scratch)
@@ -472,8 +540,8 @@ func BenchmarkColumnAssetManagerReclamation10K(b *testing.B) {
 	active := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 1, 1, 0)
 	superseded := lifecycleSyntheticManifestForBenchmark(b, "active", 10_000, 10_001, 2, 0)
 	reachability, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &active,
-		SupersededManifests: []ColumnCollectionManifest{superseded},
+		ActiveManifest:       &active,
+		CleanupSafeManifests: []ColumnCollectionManifest{superseded},
 	})
 	if err != nil {
 		b.Fatalf("PlanColumnAssetReachability: %v", err)
@@ -601,8 +669,12 @@ func lifecycleSummaryFromPlan(plan ColumnAssetReachabilityPlan) ColumnAssetReach
 		Stats:                  plan.Stats,
 		RetainedBytes:          plan.RetainedBytes,
 		PreparedBytes:          plan.PreparedBytes,
+		ProcessVisibleBytes:    plan.ProcessVisibleBytes,
 		QuarantinedBytes:       plan.QuarantinedBytes,
 		SupersededBytes:        plan.SupersededBytes,
+		PendingBytes:           plan.PendingBytes,
+		RecoveryPendingBytes:   plan.RecoveryPendingBytes,
+		CleanupSafeBytes:       plan.CleanupSafeBytes,
 		SnapshotProtectedBytes: plan.SnapshotProtectedBytes,
 		RewriteDebtBytes:       plan.RewriteDebtBytes,
 		ReclaimableBytes:       plan.ReclaimableBytes,

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -61,6 +61,59 @@ func TestColumnAssetReachabilityTracksRewriteDebtForMixedSegments(t *testing.T) 
 	}
 }
 
+func TestColumnAssetReachabilityProtectedSupersededBlocksSegmentDeletion(t *testing.T) {
+	cleanupSafeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	protectedRef := lifecycleAssetRef(t, 1, cleanupSafeRef.Length, tcs1HeaderBytes+24)
+	cleanupSafe := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, cleanupSafeRef)
+	protected := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, protectedRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		CleanupSafeManifests: []ColumnCollectionManifest{cleanupSafe},
+		SupersededManifests:  []ColumnCollectionManifest{protected},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != int(cleanupSafeRef.Length) {
+		t.Fatalf("reclaimable/rewrite=(%d,%d) want (0,%d)", plan.ReclaimableBytes, plan.RewriteDebtBytes, cleanupSafeRef.Length)
+	}
+	if plan.CleanupSafeBytes != int(cleanupSafeRef.Length) || plan.SupersededBytes != int(protectedRef.Length) {
+		t.Fatalf("cleanup-safe/superseded=(%d,%d) want (%d,%d)", plan.CleanupSafeBytes, plan.SupersededBytes, cleanupSafeRef.Length, protectedRef.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 1 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,1)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	cleanupEntry := lifecycleFindEntry(t, plan, cleanupSafeRef)
+	if cleanupEntry.State != ColumnAssetStateCleanupSafe || cleanupEntry.DeleteEligible {
+		t.Fatalf("cleanup entry state/delete=(%s,%v) want cleanup_safe,false", cleanupEntry.State, cleanupEntry.DeleteEligible)
+	}
+	protectedEntry := lifecycleFindEntry(t, plan, protectedRef)
+	if protectedEntry.State != ColumnAssetStateSuperseded || protectedEntry.DeleteEligible {
+		t.Fatalf("protected entry state/delete=(%s,%v) want superseded,false", protectedEntry.State, protectedEntry.DeleteEligible)
+	}
+
+	cleanupView := mustColumnCollectionManifestView(t, cleanupSafe)
+	protectedView := mustColumnCollectionManifestView(t, protected)
+	viewInput := ColumnAssetReachabilityViewInput{
+		CleanupSafeManifests: []ColumnCollectionManifestView{cleanupView},
+		SupersededManifests:  []ColumnCollectionManifestView{protectedView},
+	}
+	fromViews, err := PlanColumnAssetReachabilityFromViews(viewInput)
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilityFromViews: %v", err)
+	}
+	if got, want := lifecycleSummaryFromPlan(fromViews), lifecycleSummaryFromPlan(plan); !reflect.DeepEqual(got, want) {
+		t.Fatalf("view summary=%+v want %+v", got, want)
+	}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(viewInput)
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	if want := lifecycleSummaryFromPlan(plan); !reflect.DeepEqual(summary, want) {
+		t.Fatalf("summary=%+v want %+v", summary, want)
+	}
+}
+
 func TestColumnAssetReachabilityProtectsSupersededUntilCleanupSafe(t *testing.T) {
 	rootPublishedRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
 	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -114,6 +114,52 @@ func TestColumnAssetReachabilityProtectedSupersededBlocksSegmentDeletion(t *test
 	}
 }
 
+func TestColumnAssetReachabilitySameRefCleanupSafeAndSupersededIsProtected(t *testing.T) {
+	ref := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	cleanupSafe := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, ref)
+	protected := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 1, ref)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		CleanupSafeManifests: []ColumnCollectionManifest{cleanupSafe},
+		SupersededManifests:  []ColumnCollectionManifest{protected},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.CleanupSafeBytes != int(ref.Length) || plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != int(ref.Length) {
+		t.Fatalf("cleanup-safe/reclaimable/rewrite=(%d,%d,%d) want (%d,0,%d)",
+			plan.CleanupSafeBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes, ref.Length, ref.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 1 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,1)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	entry := lifecycleFindEntry(t, plan, ref)
+	if entry.State != ColumnAssetStateCleanupSafe || entry.DeleteEligible {
+		t.Fatalf("entry state/delete=(%s,%v) want cleanup_safe,false", entry.State, entry.DeleteEligible)
+	}
+
+	cleanupView := mustColumnCollectionManifestView(t, cleanupSafe)
+	protectedView := mustColumnCollectionManifestView(t, protected)
+	viewInput := ColumnAssetReachabilityViewInput{
+		CleanupSafeManifests: []ColumnCollectionManifestView{cleanupView},
+		SupersededManifests:  []ColumnCollectionManifestView{protectedView},
+	}
+	fromViews, err := PlanColumnAssetReachabilityFromViews(viewInput)
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilityFromViews: %v", err)
+	}
+	if got, want := lifecycleSummaryFromPlan(fromViews), lifecycleSummaryFromPlan(plan); !reflect.DeepEqual(got, want) {
+		t.Fatalf("view summary=%+v want %+v", got, want)
+	}
+	summary, err := PlanColumnAssetReachabilitySummaryFromViews(viewInput)
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachabilitySummaryFromViews: %v", err)
+	}
+	if want := lifecycleSummaryFromPlan(plan); !reflect.DeepEqual(summary, want) {
+		t.Fatalf("summary=%+v want %+v", summary, want)
+	}
+}
+
 func TestColumnAssetReachabilityProtectsSupersededUntilCleanupSafe(t *testing.T) {
 	rootPublishedRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
 	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -24,10 +24,10 @@ func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
 		if len(reason) != 1 || cap(reason) != len(reason) || reason[0] != name {
 			t.Fatalf("reason sentinel %q=%v len=%d cap=%d, want one append-safe reason", name, reason, len(reason), cap(reason))
 		}
-		extended := append(reason, "caller appended reason")
-		extended[0] = "caller rewrote reason"
-		if reason[0] != name {
-			t.Fatalf("reason sentinel %q was mutated through appended slice: %v", name, reason)
+		mutated := append(reason, "caller append")
+		mutated[0] = "corrupted"
+		if got := reasons[name]; !reflect.DeepEqual(got, []string{name}) {
+			t.Fatalf("reason sentinel %q after append mutation=%v want [%q]", name, got, name)
 		}
 	}
 }

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -27,6 +27,49 @@ func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
 	}
 }
 
+func TestColumnAssetReachabilityReasonsAreDetached(t *testing.T) {
+	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	preparedRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, activeRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest: &active,
+		PreparedAssets: []ColumnPreparedAsset{{Ref: preparedRef}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	lifecycleFindEntry(t, plan, activeRef).Reasons[0] = "corrupted active reason"
+	lifecycleFindEntry(t, plan, preparedRef).Reasons[0] = "corrupted prepared reason"
+
+	plan, err = PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest: &active,
+		PreparedAssets: []ColumnPreparedAsset{{Ref: preparedRef}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability after mutation: %v", err)
+	}
+	if got := lifecycleFindEntry(t, plan, activeRef).Reasons[0]; got != string(ColumnAssetStateActive) {
+		t.Fatalf("active reason after caller mutation=%q want %q", got, ColumnAssetStateActive)
+	}
+	if got := lifecycleFindEntry(t, plan, preparedRef).Reasons[0]; got != string(ColumnAssetStatePrepared) {
+		t.Fatalf("prepared reason after caller mutation=%q want %q", got, ColumnAssetStatePrepared)
+	}
+
+	entries, err := ColumnCollectionManifestAssetRefs(active)
+	if err != nil {
+		t.Fatalf("ColumnCollectionManifestAssetRefs: %v", err)
+	}
+	entries[0].Reasons[0] = "corrupted manifest reason"
+	entries, err = ColumnCollectionManifestAssetRefs(active)
+	if err != nil {
+		t.Fatalf("ColumnCollectionManifestAssetRefs after mutation: %v", err)
+	}
+	if got := entries[0].Reasons[0]; got != string(ColumnAssetStateActive) {
+		t.Fatalf("manifest reason after caller mutation=%q want %q", got, ColumnAssetStateActive)
+	}
+}
+
 func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
 	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
 	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -32,6 +32,37 @@ func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
 	}
 }
 
+func TestColumnAssetReasonSentinelsAreDetachedThroughMergedEntriesM9B(t *testing.T) {
+	ref := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	records := make(map[ColumnAssetRef]columnAssetReachabilityRecord)
+	segments := make(map[uint32]*columnAssetSegmentState)
+	if err := addReachabilityEntry(records, segments, ColumnAssetReachabilityEntry{
+		Ref:     ref,
+		State:   ColumnAssetStatePrepared,
+		Bytes:   int(ref.Length),
+		Reasons: columnAssetReachabilityDefaultReasons(ColumnAssetStatePrepared),
+	}, true, false, false); err != nil {
+		t.Fatalf("add prepared reachability: %v", err)
+	}
+	if err := addReachabilityEntry(records, segments, ColumnAssetReachabilityEntry{
+		Ref:     ref,
+		State:   ColumnAssetStateActive,
+		Bytes:   int(ref.Length),
+		Reasons: columnAssetReachabilityDefaultReasons(ColumnAssetStateActive),
+	}, true, false, false); err != nil {
+		t.Fatalf("add active reachability: %v", err)
+	}
+	record := records[ref]
+	record.entry.Reasons[0] = "corrupted"
+	record.entry.Reasons = append(record.entry.Reasons, "caller append")
+	if got := columnAssetReasonPrepared; !reflect.DeepEqual(got, []string{string(ColumnAssetStatePrepared)}) {
+		t.Fatalf("prepared sentinel mutated to %v", got)
+	}
+	if got := columnAssetReasonActive; !reflect.DeepEqual(got, []string{string(ColumnAssetStateActive)}) {
+		t.Fatalf("active sentinel mutated to %v", got)
+	}
+}
+
 func TestColumnAssetReachabilitySummaryRecordIsPointerFree(t *testing.T) {
 	typ := reflect.TypeOf(columnAssetReachabilitySummaryRecord{})
 	for i := 0; i < typ.NumField(); i++ {
@@ -360,6 +391,30 @@ func TestColumnAssetReachabilityProtectsPendingAndPreparedAssets(t *testing.T) {
 	}
 	if got := lifecycleFindEntry(t, plan, quarantinedRef); got.State != ColumnAssetStateQuarantined {
 		t.Fatalf("quarantined entry state=%s want quarantined", got.State)
+	}
+}
+
+func TestColumnAssetReachabilityQuarantineDominatesLiveEntryStateM9B(t *testing.T) {
+	ref := lifecycleAssetRef(t, 5, 0, tcs1HeaderBytes+32)
+	active := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, ref)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ActiveManifest: &active,
+		QuarantinedAssets: []ColumnPreparedAsset{{
+			Ref:    ref,
+			Bytes:  int(ref.Length),
+			Reason: "checksum mismatch",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	entry := lifecycleFindEntry(t, plan, ref)
+	if entry.State != ColumnAssetStateQuarantined {
+		t.Fatalf("entry state=%s want quarantined", entry.State)
+	}
+	if plan.QuarantinedBytes != int(ref.Length) || plan.RetainedBytes != 0 {
+		t.Fatalf("quarantined/retained bytes=(%d,%d) want (%d,0)", plan.QuarantinedBytes, plan.RetainedBytes, ref.Length)
 	}
 }
 

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -27,6 +27,32 @@ func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
 	}
 }
 
+func TestColumnAssetReachabilitySummaryRecordIsPointerFree(t *testing.T) {
+	typ := reflect.TypeOf(columnAssetReachabilitySummaryRecord{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if typeContainsPointers(field.Type) {
+			t.Fatalf("columnAssetReachabilitySummaryRecord.%s has pointer-bearing type %s", field.Name, field.Type)
+		}
+	}
+}
+
+func typeContainsPointers(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.String, reflect.UnsafePointer:
+		return true
+	case reflect.Array:
+		return typeContainsPointers(typ.Elem())
+	case reflect.Struct:
+		for i := 0; i < typ.NumField(); i++ {
+			if typeContainsPointers(typ.Field(i).Type) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestColumnAssetReachabilityReasonsAreDetached(t *testing.T) {
 	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
 	preparedRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
+	reasons := map[string][]string{
+		string(ColumnAssetStatePrepared):              columnAssetReasonPrepared,
+		string(ColumnAssetStateProcessVisible):        columnAssetReasonProcessVisible,
+		string(ColumnAssetStatePendingPublish):        columnAssetReasonPendingPublish,
+		string(ColumnAssetStateRootPublished):         columnAssetReasonRootPublished,
+		string(ColumnAssetStateRecoveryAuthoritative): columnAssetReasonRecoveryAuthoritative,
+		string(ColumnAssetStateActive):                columnAssetReasonActive,
+		string(ColumnAssetStateSuperseded):            columnAssetReasonSuperseded,
+		string(ColumnAssetStateCleanupSafe):           columnAssetReasonCleanupSafe,
+		string(ColumnAssetStateSnapshotPinned):        columnAssetReasonSnapshotPinned,
+		string(ColumnAssetStateReclaimable):           columnAssetReasonReclaimable,
+		string(ColumnAssetStateDeleting):              columnAssetReasonDeleting,
+		string(ColumnAssetStateQuarantined):           columnAssetReasonQuarantined,
+	}
+	for name, reason := range reasons {
+		if len(reason) != 1 || cap(reason) != len(reason) || reason[0] != name {
+			t.Fatalf("reason sentinel %q=%v len=%d cap=%d, want one append-safe reason", name, reason, len(reason), cap(reason))
+		}
+	}
+}
+
 func TestColumnAssetReachabilityDeletesClosedSupersededSegment(t *testing.T) {
 	activeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
 	oldRef := lifecycleAssetRef(t, 2, 0, tcs1HeaderBytes+24)

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -24,6 +24,11 @@ func TestColumnAssetReasonSentinelsAreAppendSafe(t *testing.T) {
 		if len(reason) != 1 || cap(reason) != len(reason) || reason[0] != name {
 			t.Fatalf("reason sentinel %q=%v len=%d cap=%d, want one append-safe reason", name, reason, len(reason), cap(reason))
 		}
+		extended := append(reason, "caller appended reason")
+		extended[0] = "caller rewrote reason"
+		if reason[0] != name {
+			t.Fatalf("reason sentinel %q was mutated through appended slice: %v", name, reason)
+		}
 	}
 }
 

--- a/experiments/colgranule/lifecycle_test.go
+++ b/experiments/colgranule/lifecycle_test.go
@@ -173,8 +173,8 @@ func TestColumnAssetReachabilityProtectsSupersededUntilCleanupSafe(t *testing.T)
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
 	}
-	if plan.RecoveryPendingBytes != int(rootPublishedRef.Length) {
-		t.Fatalf("recovery pending bytes=%d want %d", plan.RecoveryPendingBytes, rootPublishedRef.Length)
+	if plan.RootPublishedBytes != int(rootPublishedRef.Length) {
+		t.Fatalf("root published bytes=%d want %d", plan.RootPublishedBytes, rootPublishedRef.Length)
 	}
 	if plan.SupersededBytes != int(oldRef.Length) || plan.CleanupSafeBytes != 0 || plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != 0 {
 		t.Fatalf("superseded/cleanup-safe/reclaimable/rewrite=(%d,%d,%d,%d) want (%d,0,0,0)",
@@ -264,6 +264,59 @@ func TestColumnAssetReachabilityProtectsPendingAndPreparedAssets(t *testing.T) {
 	}
 	if got := lifecycleFindEntry(t, plan, quarantinedRef); got.State != ColumnAssetStateQuarantined {
 		t.Fatalf("quarantined entry state=%s want quarantined", got.State)
+	}
+}
+
+func TestColumnAssetReachabilityProcessVisibleIsLive(t *testing.T) {
+	processVisibleRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	processVisible := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, processVisibleRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		ProcessVisibleManifests: []ColumnCollectionManifest{processVisible},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.ProcessVisibleBytes != int(processVisibleRef.Length) {
+		t.Fatalf("process-visible bytes=%d want %d", plan.ProcessVisibleBytes, processVisibleRef.Length)
+	}
+	if plan.CleanupSafeBytes != 0 || plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != 0 {
+		t.Fatalf("cleanup-safe/reclaimable/rewrite=(%d,%d,%d) want all zero", plan.CleanupSafeBytes, plan.ReclaimableBytes, plan.RewriteDebtBytes)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 0 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,0)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
+	}
+	entry := lifecycleFindEntry(t, plan, processVisibleRef)
+	if entry.State != ColumnAssetStateProcessVisible || entry.DeleteEligible {
+		t.Fatalf("entry state/delete=(%s,%v) want process_visible,false", entry.State, entry.DeleteEligible)
+	}
+}
+
+func TestColumnAssetReachabilityQuarantineBlocksSharedSegmentDeletion(t *testing.T) {
+	cleanupSafeRef := lifecycleAssetRef(t, 1, 0, tcs1HeaderBytes+16)
+	quarantinedRef := lifecycleAssetRef(t, 1, cleanupSafeRef.Length, tcs1HeaderBytes+24)
+	cleanupSafe := lifecycleManifest(t, "jsonbench", ColumnPartRoleBase, 2, cleanupSafeRef)
+
+	plan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
+		CleanupSafeManifests: []ColumnCollectionManifest{cleanupSafe},
+		QuarantinedAssets: []ColumnPreparedAsset{{
+			Ref:    quarantinedRef,
+			Bytes:  int(quarantinedRef.Length),
+			Reason: "checksum mismatch",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	if plan.ReclaimableBytes != 0 || plan.RewriteDebtBytes != int(cleanupSafeRef.Length) {
+		t.Fatalf("reclaimable/rewrite=(%d,%d) want (0,%d)", plan.ReclaimableBytes, plan.RewriteDebtBytes, cleanupSafeRef.Length)
+	}
+	if plan.QuarantinedBytes != int(quarantinedRef.Length) || plan.CleanupSafeBytes != int(cleanupSafeRef.Length) {
+		t.Fatalf("quarantined/cleanup-safe=(%d,%d) want (%d,%d)",
+			plan.QuarantinedBytes, plan.CleanupSafeBytes, quarantinedRef.Length, cleanupSafeRef.Length)
+	}
+	if plan.Stats.DirectlyDeletableSegments != 0 || plan.Stats.MixedLiveDeadSegments != 1 {
+		t.Fatalf("deletable/mixed segments=(%d,%d) want (0,1)", plan.Stats.DirectlyDeletableSegments, plan.Stats.MixedLiveDeadSegments)
 	}
 }
 
@@ -432,9 +485,9 @@ func TestColumnAssetReachabilitySummaryTracksDurabilityStates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanColumnAssetReachability: %v", err)
 	}
-	if materialized.RetainedBytes != int(recoveryRef.Length) || materialized.RecoveryPendingBytes != int(rootPublishedRef.Length) || materialized.CleanupSafeBytes != int(cleanupSafeRef.Length) {
-		t.Fatalf("durability bytes retained/recovery-pending/cleanup-safe=(%d,%d,%d)",
-			materialized.RetainedBytes, materialized.RecoveryPendingBytes, materialized.CleanupSafeBytes)
+	if materialized.RetainedBytes != int(recoveryRef.Length) || materialized.RootPublishedBytes != int(rootPublishedRef.Length) || materialized.CleanupSafeBytes != int(cleanupSafeRef.Length) {
+		t.Fatalf("durability bytes retained/root-published/cleanup-safe=(%d,%d,%d)",
+			materialized.RetainedBytes, materialized.RootPublishedBytes, materialized.CleanupSafeBytes)
 	}
 	summary, err := PlanColumnAssetReachabilitySummaryFromViews(ColumnAssetReachabilityViewInput{
 		RecoveryAuthoritativeManifests: []ColumnCollectionManifestView{mustColumnCollectionManifestView(t, recovery)},
@@ -772,7 +825,7 @@ func lifecycleSummaryFromPlan(plan ColumnAssetReachabilityPlan) ColumnAssetReach
 		QuarantinedBytes:       plan.QuarantinedBytes,
 		SupersededBytes:        plan.SupersededBytes,
 		PendingBytes:           plan.PendingBytes,
-		RecoveryPendingBytes:   plan.RecoveryPendingBytes,
+		RootPublishedBytes:     plan.RootPublishedBytes,
 		CleanupSafeBytes:       plan.CleanupSafeBytes,
 		SnapshotProtectedBytes: plan.SnapshotProtectedBytes,
 		RewriteDebtBytes:       plan.RewriteDebtBytes,

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -620,6 +620,7 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		entry := record.entry
 		switch {
 		case record.quarantined:
+			entry.State = ColumnAssetStateQuarantined
 			plan.QuarantinedBytes += entry.Bytes
 		case record.live:
 			if entry.State == ColumnAssetStateActive || entry.State == ColumnAssetStateRecoveryAuthoritative {

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -64,6 +64,7 @@ type columnAssetReachabilitySummaryRecord struct {
 	bytes       int
 	live        bool
 	candidate   bool
+	protected   bool
 	quarantined bool
 }
 
@@ -431,13 +432,15 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 		}
 		record.live = record.live || live
 		record.candidate = record.candidate || candidate
+		record.protected = record.protected || (!live && (!candidate || quarantined))
 		record.quarantined = record.quarantined || quarantined
 	} else {
 		s.records = append(s.records, columnAssetReachabilitySummaryRecord{
-			ref:   ref,
-			state: state,
-			bytes: bytes,
-			live:  live,
+			ref:       ref,
+			state:     state,
+			bytes:     bytes,
+			live:      live,
+			protected: !live && (!candidate || quarantined),
 		})
 		record := &s.records[len(s.records)-1]
 		record.candidate = candidate
@@ -467,7 +470,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		if record.candidate && !record.live && !record.quarantined {
 			seg.candidateRefs++
 		}
-		if !record.live && (!record.candidate || record.quarantined) {
+		if record.protected {
 			seg.protectedRefs++
 		}
 		segments[record.ref.FileID] = seg
@@ -539,7 +542,7 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		if record.candidate && !record.live && !record.quarantined {
 			seg.candidateRefs++
 		}
-		if !record.live && (!record.candidate || record.quarantined) {
+		if record.protected {
 			seg.protectedRefs++
 		}
 	}

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -35,7 +35,7 @@ type ColumnAssetReachabilitySummary struct {
 	PreparedBytes          int                          `json:"prepared_bytes"`
 	ProcessVisibleBytes    int                          `json:"process_visible_bytes"`
 	PendingBytes           int                          `json:"pending_bytes"`
-	RecoveryPendingBytes   int                          `json:"recovery_pending_bytes"`
+	RootPublishedBytes     int                          `json:"root_published_bytes"`
 	QuarantinedBytes       int                          `json:"quarantined_bytes"`
 	SupersededBytes        int                          `json:"superseded_bytes"`
 	CleanupSafeBytes       int                          `json:"cleanup_safe_bytes"`
@@ -294,6 +294,8 @@ func (s *ColumnAssetReachabilitySummaryScratch) reset(recordCap int) {
 	if cap(s.records) < recordCap {
 		s.records = make([]columnAssetReachabilitySummaryRecord, 0, recordCap)
 	} else {
+		// Records are pointer-free scratch today; if pointer-bearing fields are
+		// added, reintroduce clear(s.records) before truncating to avoid retention.
 		s.records = s.records[:0]
 	}
 	if s.recordIndex == nil {
@@ -432,7 +434,7 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 		}
 		record.live = record.live || live
 		record.candidate = record.candidate || candidate
-		record.protected = record.protected || (!live && (!candidate || quarantined))
+		record.protected = record.protected || columnAssetRefBlocksSegmentDeletion(live, candidate, quarantined)
 		record.quarantined = record.quarantined || quarantined
 	} else {
 		s.records = append(s.records, columnAssetReachabilitySummaryRecord{
@@ -440,7 +442,7 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 			state:     state,
 			bytes:     bytes,
 			live:      live,
-			protected: !live && (!candidate || quarantined),
+			protected: columnAssetRefBlocksSegmentDeletion(live, candidate, quarantined),
 		})
 		record := &s.records[len(s.records)-1]
 		record.candidate = candidate
@@ -500,7 +502,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 				case ColumnAssetStatePendingPublish:
 					summary.PendingBytes += record.bytes
 				case ColumnAssetStateRootPublished:
-					summary.RecoveryPendingBytes += record.bytes
+					summary.RootPublishedBytes += record.bytes
 				case ColumnAssetStateSnapshotPinned:
 					summary.SnapshotProtectedBytes += record.bytes
 					summary.RetainedBytes += record.bytes
@@ -574,7 +576,7 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 				case ColumnAssetStatePendingPublish:
 					plan.PendingBytes += entry.Bytes
 				case ColumnAssetStateRootPublished:
-					plan.RecoveryPendingBytes += entry.Bytes
+					plan.RootPublishedBytes += entry.Bytes
 				case ColumnAssetStateSnapshotPinned:
 					plan.SnapshotProtectedBytes += entry.Bytes
 					plan.RetainedBytes += entry.Bytes

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -456,6 +456,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 	for fileID, seg := range segments {
 		seg.liveRefs = 0
 		seg.candidateRefs = 0
+		seg.protectedRefs = 0
 		segments[fileID] = seg
 	}
 	for _, record := range records {
@@ -466,14 +467,17 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		if record.candidate && !record.live && !record.quarantined {
 			seg.candidateRefs++
 		}
+		if !record.live && (!record.candidate || record.quarantined) {
+			seg.protectedRefs++
+		}
 		segments[record.ref.FileID] = seg
 	}
 	summary.Stats.SegmentRefs = len(segments)
 	for _, seg := range segments {
-		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
+		if seg.liveRefs == 0 && seg.protectedRefs == 0 && seg.candidateRefs > 0 {
 			summary.Stats.DirectlyDeletableSegments++
 		}
-		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
+		if (seg.liveRefs > 0 || seg.protectedRefs > 0) && seg.candidateRefs > 0 {
 			summary.Stats.MixedLiveDeadSegments++
 		}
 	}
@@ -504,7 +508,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		case record.candidate:
 			summary.CleanupSafeBytes += record.bytes
 			seg := segments[record.ref.FileID]
-			if seg.liveRefs == 0 {
+			if seg.liveRefs == 0 && seg.protectedRefs == 0 {
 				summary.ReclaimableBytes += record.bytes
 			} else {
 				summary.RewriteDebtBytes += record.bytes
@@ -521,6 +525,7 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 	for _, seg := range segments {
 		seg.liveRefs = 0
 		seg.candidateRefs = 0
+		seg.protectedRefs = 0
 	}
 	for _, record := range records {
 		seg := segments[record.entry.Ref.FileID]
@@ -534,13 +539,16 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		if record.candidate && !record.live && !record.quarantined {
 			seg.candidateRefs++
 		}
+		if !record.live && (!record.candidate || record.quarantined) {
+			seg.protectedRefs++
+		}
 	}
 	plan.Stats.SegmentRefs = len(segments)
 	for _, seg := range segments {
-		if seg.liveRefs == 0 && seg.candidateRefs > 0 {
+		if seg.liveRefs == 0 && seg.protectedRefs == 0 && seg.candidateRefs > 0 {
 			plan.Stats.DirectlyDeletableSegments++
 		}
-		if seg.liveRefs > 0 && seg.candidateRefs > 0 {
+		if (seg.liveRefs > 0 || seg.protectedRefs > 0) && seg.candidateRefs > 0 {
 			plan.Stats.MixedLiveDeadSegments++
 		}
 	}
@@ -574,7 +582,7 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		case record.candidate:
 			plan.CleanupSafeBytes += entry.Bytes
 			seg := segments[entry.Ref.FileID]
-			if seg != nil && seg.liveRefs == 0 {
+			if seg != nil && seg.liveRefs == 0 && seg.protectedRefs == 0 {
 				entry.DeleteEligible = true
 				entry.State = ColumnAssetStateReclaimable
 				plan.ReclaimableBytes += entry.Bytes

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -16,21 +16,29 @@ type ColumnPreparedAssetRegistryView struct {
 }
 
 type ColumnAssetReachabilityViewInput struct {
-	ActiveManifest          *ColumnCollectionManifestView
-	PendingManifests        []ColumnCollectionManifestView
-	SnapshotPinnedManifests []ColumnCollectionManifestView
-	SupersededManifests     []ColumnCollectionManifestView
-	PreparedRegistry        *ColumnPreparedAssetRegistryView
-	PreparedAssets          []ColumnPreparedAsset
-	QuarantinedAssets       []ColumnPreparedAsset
+	ActiveManifest                 *ColumnCollectionManifestView
+	ProcessVisibleManifests        []ColumnCollectionManifestView
+	PendingManifests               []ColumnCollectionManifestView
+	RootPublishedManifests         []ColumnCollectionManifestView
+	RecoveryAuthoritativeManifests []ColumnCollectionManifestView
+	SnapshotPinnedManifests        []ColumnCollectionManifestView
+	SupersededManifests            []ColumnCollectionManifestView
+	CleanupSafeManifests           []ColumnCollectionManifestView
+	PreparedRegistry               *ColumnPreparedAssetRegistryView
+	PreparedAssets                 []ColumnPreparedAsset
+	QuarantinedAssets              []ColumnPreparedAsset
 }
 
 type ColumnAssetReachabilitySummary struct {
 	Stats                  ColumnAssetReachabilityStats `json:"stats"`
 	RetainedBytes          int                          `json:"retained_bytes"`
 	PreparedBytes          int                          `json:"prepared_bytes"`
+	ProcessVisibleBytes    int                          `json:"process_visible_bytes"`
+	PendingBytes           int                          `json:"pending_bytes"`
+	RecoveryPendingBytes   int                          `json:"recovery_pending_bytes"`
 	QuarantinedBytes       int                          `json:"quarantined_bytes"`
 	SupersededBytes        int                          `json:"superseded_bytes"`
+	CleanupSafeBytes       int                          `json:"cleanup_safe_bytes"`
 	SnapshotProtectedBytes int                          `json:"snapshot_protected_bytes"`
 	RewriteDebtBytes       int                          `json:"rewrite_debt_bytes"`
 	ReclaimableBytes       int                          `json:"reclaimable_bytes"`
@@ -120,11 +128,29 @@ func PlanColumnAssetReachabilityFromViews(input ColumnAssetReachabilityViewInput
 			return ColumnAssetReachabilityPlan{}, err
 		}
 	}
+	for _, manifest := range input.ProcessVisibleManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateProcessVisible, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.ProcessVisibleManifests++
+	}
 	for _, manifest := range input.PendingManifests {
 		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStatePendingPublish, true, false, &plan.Stats); err != nil {
 			return ColumnAssetReachabilityPlan{}, err
 		}
 		plan.Stats.PendingManifests++
+	}
+	for _, manifest := range input.RootPublishedManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateRootPublished, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.RootPublishedManifests++
+	}
+	for _, manifest := range input.RecoveryAuthoritativeManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateRecoveryAuthoritative, true, false, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.RecoveryAuthoritativeManifests++
 	}
 	for _, manifest := range input.SnapshotPinnedManifests {
 		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateSnapshotPinned, true, false, &plan.Stats); err != nil {
@@ -133,10 +159,16 @@ func PlanColumnAssetReachabilityFromViews(input ColumnAssetReachabilityViewInput
 		plan.Stats.SnapshotPinnedManifests++
 	}
 	for _, manifest := range input.SupersededManifests {
-		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, true, &plan.Stats); err != nil {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateSuperseded, false, false, &plan.Stats); err != nil {
 			return ColumnAssetReachabilityPlan{}, err
 		}
 		plan.Stats.SupersededManifests++
+	}
+	for _, manifest := range input.CleanupSafeManifests {
+		if err := addManifestViewAssetRefs(records, segments, manifest, ColumnAssetStateCleanupSafe, false, true, &plan.Stats); err != nil {
+			return ColumnAssetReachabilityPlan{}, err
+		}
+		plan.Stats.CleanupSafeManifests++
 	}
 	if input.PreparedRegistry != nil {
 		prepared, err := scanColumnPreparedRegistryViewAssets(*input.PreparedRegistry)
@@ -188,11 +220,29 @@ func PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input ColumnAssetRea
 			return ColumnAssetReachabilitySummary{}, err
 		}
 	}
+	for _, manifest := range input.ProcessVisibleManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateProcessVisible, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.ProcessVisibleManifests++
+	}
 	for _, manifest := range input.PendingManifests {
 		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStatePendingPublish, true, false, &summary.Stats); err != nil {
 			return ColumnAssetReachabilitySummary{}, err
 		}
 		summary.Stats.PendingManifests++
+	}
+	for _, manifest := range input.RootPublishedManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateRootPublished, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.RootPublishedManifests++
+	}
+	for _, manifest := range input.RecoveryAuthoritativeManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateRecoveryAuthoritative, true, false, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.RecoveryAuthoritativeManifests++
 	}
 	for _, manifest := range input.SnapshotPinnedManifests {
 		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateSnapshotPinned, true, false, &summary.Stats); err != nil {
@@ -201,10 +251,16 @@ func PlanColumnAssetReachabilitySummaryFromViewsWithScratch(input ColumnAssetRea
 		summary.Stats.SnapshotPinnedManifests++
 	}
 	for _, manifest := range input.SupersededManifests {
-		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateSuperseded, false, true, &summary.Stats); err != nil {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateSuperseded, false, false, &summary.Stats); err != nil {
 			return ColumnAssetReachabilitySummary{}, err
 		}
 		summary.Stats.SupersededManifests++
+	}
+	for _, manifest := range input.CleanupSafeManifests {
+		if err := addManifestViewAssetRefsToSummary(scratch, manifest, ColumnAssetStateCleanupSafe, false, true, &summary.Stats); err != nil {
+			return ColumnAssetReachabilitySummary{}, err
+		}
+		summary.Stats.CleanupSafeManifests++
 	}
 	if input.PreparedRegistry != nil {
 		if err := scanColumnPreparedRegistryViewAssetSummaries(*input.PreparedRegistry, func(ref ColumnAssetRef, bytes int) error {
@@ -237,7 +293,6 @@ func (s *ColumnAssetReachabilitySummaryScratch) reset(recordCap int) {
 	if cap(s.records) < recordCap {
 		s.records = make([]columnAssetReachabilitySummaryRecord, 0, recordCap)
 	} else {
-		clear(s.records)
 		s.records = s.records[:0]
 	}
 	if s.recordIndex == nil {
@@ -257,14 +312,26 @@ func estimateColumnAssetReachabilityViewRefs(input ColumnAssetReachabilityViewIn
 	if input.ActiveManifest != nil {
 		refs += estimateColumnCollectionManifestViewAssetRefs(*input.ActiveManifest)
 	}
+	for i := range input.ProcessVisibleManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.ProcessVisibleManifests[i])
+	}
 	for i := range input.PendingManifests {
 		refs += estimateColumnCollectionManifestViewAssetRefs(input.PendingManifests[i])
+	}
+	for i := range input.RootPublishedManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.RootPublishedManifests[i])
+	}
+	for i := range input.RecoveryAuthoritativeManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.RecoveryAuthoritativeManifests[i])
 	}
 	for i := range input.SnapshotPinnedManifests {
 		refs += estimateColumnCollectionManifestViewAssetRefs(input.SnapshotPinnedManifests[i])
 	}
 	for i := range input.SupersededManifests {
 		refs += estimateColumnCollectionManifestViewAssetRefs(input.SupersededManifests[i])
+	}
+	for i := range input.CleanupSafeManifests {
+		refs += estimateColumnCollectionManifestViewAssetRefs(input.CleanupSafeManifests[i])
 	}
 	if input.PreparedRegistry != nil {
 		n, err := countColumnPreparedRegistryViewAssets(*input.PreparedRegistry)
@@ -383,7 +450,7 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 }
 
 func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySummaryRecord, segments map[uint32]columnAssetSegmentState, summary *ColumnAssetReachabilitySummary) {
-	summary.Stats.Manifests = summary.Stats.ActiveManifests + summary.Stats.PendingManifests + summary.Stats.SnapshotPinnedManifests + summary.Stats.SupersededManifests
+	summary.Stats.Manifests = columnAssetReachabilityManifestCount(summary.Stats)
 	summary.Stats.AssetRefs = len(records)
 	for fileID, seg := range segments {
 		seg.liveRefs = 0
@@ -414,29 +481,41 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		case record.quarantined:
 			summary.QuarantinedBytes += record.bytes
 		case record.live:
-			switch record.state {
-			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
-				summary.PreparedBytes += record.bytes
-			case ColumnAssetStateSnapshotPinned:
-				summary.SnapshotProtectedBytes += record.bytes
+			if record.state == ColumnAssetStateActive || record.state == ColumnAssetStateRecoveryAuthoritative {
 				summary.RetainedBytes += record.bytes
-			default:
-				summary.RetainedBytes += record.bytes
+			} else {
+				switch record.state {
+				case ColumnAssetStatePrepared:
+					summary.PreparedBytes += record.bytes
+				case ColumnAssetStateProcessVisible:
+					summary.ProcessVisibleBytes += record.bytes
+				case ColumnAssetStatePendingPublish:
+					summary.PendingBytes += record.bytes
+				case ColumnAssetStateRootPublished:
+					summary.RecoveryPendingBytes += record.bytes
+				case ColumnAssetStateSnapshotPinned:
+					summary.SnapshotProtectedBytes += record.bytes
+					summary.RetainedBytes += record.bytes
+				default:
+					summary.RetainedBytes += record.bytes
+				}
 			}
 		case record.candidate:
-			summary.SupersededBytes += record.bytes
+			summary.CleanupSafeBytes += record.bytes
 			seg := segments[record.ref.FileID]
 			if seg.liveRefs == 0 {
 				summary.ReclaimableBytes += record.bytes
 			} else {
 				summary.RewriteDebtBytes += record.bytes
 			}
+		case record.state == ColumnAssetStateSuperseded:
+			summary.SupersededBytes += record.bytes
 		}
 	}
 }
 
 func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, plan *ColumnAssetReachabilityPlan) {
-	plan.Stats.Manifests = plan.Stats.ActiveManifests + plan.Stats.PendingManifests + plan.Stats.SnapshotPinnedManifests + plan.Stats.SupersededManifests
+	plan.Stats.Manifests = columnAssetReachabilityManifestCount(plan.Stats)
 	plan.Stats.AssetRefs = len(records)
 	for _, seg := range segments {
 		seg.liveRefs = 0
@@ -472,17 +551,27 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		case record.quarantined:
 			plan.QuarantinedBytes += entry.Bytes
 		case record.live:
-			switch entry.State {
-			case ColumnAssetStatePrepared, ColumnAssetStatePendingPublish:
-				plan.PreparedBytes += entry.Bytes
-			case ColumnAssetStateSnapshotPinned:
-				plan.SnapshotProtectedBytes += entry.Bytes
+			if entry.State == ColumnAssetStateActive || entry.State == ColumnAssetStateRecoveryAuthoritative {
 				plan.RetainedBytes += entry.Bytes
-			default:
-				plan.RetainedBytes += entry.Bytes
+			} else {
+				switch entry.State {
+				case ColumnAssetStatePrepared:
+					plan.PreparedBytes += entry.Bytes
+				case ColumnAssetStateProcessVisible:
+					plan.ProcessVisibleBytes += entry.Bytes
+				case ColumnAssetStatePendingPublish:
+					plan.PendingBytes += entry.Bytes
+				case ColumnAssetStateRootPublished:
+					plan.RecoveryPendingBytes += entry.Bytes
+				case ColumnAssetStateSnapshotPinned:
+					plan.SnapshotProtectedBytes += entry.Bytes
+					plan.RetainedBytes += entry.Bytes
+				default:
+					plan.RetainedBytes += entry.Bytes
+				}
 			}
 		case record.candidate:
-			plan.SupersededBytes += entry.Bytes
+			plan.CleanupSafeBytes += entry.Bytes
 			seg := segments[entry.Ref.FileID]
 			if seg != nil && seg.liveRefs == 0 {
 				entry.DeleteEligible = true
@@ -491,6 +580,8 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 			} else {
 				plan.RewriteDebtBytes += entry.Bytes
 			}
+		case entry.State == ColumnAssetStateSuperseded:
+			plan.SupersededBytes += entry.Bytes
 		}
 		plan.Entries = append(plan.Entries, entry)
 	}
@@ -507,6 +598,17 @@ func finalizeColumnAssetReachabilityRecords(records map[ColumnAssetRef]columnAss
 		}
 		return a.Checksum < b.Checksum
 	})
+}
+
+func columnAssetReachabilityManifestCount(stats ColumnAssetReachabilityStats) int {
+	return stats.ActiveManifests +
+		stats.ProcessVisibleManifests +
+		stats.PendingManifests +
+		stats.RootPublishedManifests +
+		stats.RecoveryAuthoritativeManifests +
+		stats.SnapshotPinnedManifests +
+		stats.SupersededManifests +
+		stats.CleanupSafeManifests
 }
 
 func countColumnCollectionManifestViewAssetRefs(view ColumnCollectionManifestView) (int, error) {

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -354,6 +354,7 @@ func estimateColumnCollectionManifestViewAssetRefs(view ColumnCollectionManifest
 }
 
 func addManifestViewAssetRefs(records map[ColumnAssetRef]columnAssetReachabilityRecord, segments map[uint32]*columnAssetSegmentState, view ColumnCollectionManifestView, state ColumnAssetLifecycleState, live bool, candidate bool, stats *ColumnAssetReachabilityStats) error {
+	reasons := columnAssetReachabilityDefaultReasons(state)
 	tombstones, err := scanColumnCollectionManifestViewAssetRefs(view, func(ref columnManifestViewAssetRef) error {
 		entry := ColumnAssetReachabilityEntry{
 			Ref:          ref.ref,
@@ -361,7 +362,7 @@ func addManifestViewAssetRefs(records map[ColumnAssetRef]columnAssetReachability
 			Bytes:        ref.bytes,
 			PartID:       ref.partID,
 			GenerationID: ref.generationID,
-			Reasons:      columnAssetReachabilityDefaultReasons(state),
+			Reasons:      reasons,
 		}
 		if err := addReachabilityEntry(records, segments, entry, live, candidate, false); err != nil {
 			return err

--- a/experiments/colgranule/lifecycle_view.go
+++ b/experiments/colgranule/lifecycle_view.go
@@ -59,14 +59,32 @@ type columnManifestViewAssetRef struct {
 }
 
 type columnAssetReachabilitySummaryRecord struct {
-	ref         ColumnAssetRef
-	state       ColumnAssetLifecycleState
+	fileID      uint32
+	state       columnAssetReachabilitySummaryState
 	bytes       int
 	live        bool
 	candidate   bool
 	protected   bool
 	quarantined bool
 }
+
+type columnAssetReachabilitySummaryState uint8
+
+const (
+	columnAssetSummaryStateUnknown columnAssetReachabilitySummaryState = iota
+	columnAssetSummaryStateDeleting
+	columnAssetSummaryStateSuperseded
+	columnAssetSummaryStateReclaimable
+	columnAssetSummaryStateCleanupSafe
+	columnAssetSummaryStatePrepared
+	columnAssetSummaryStatePendingPublish
+	columnAssetSummaryStateProcessVisible
+	columnAssetSummaryStateRootPublished
+	columnAssetSummaryStateSnapshotPinned
+	columnAssetSummaryStateActive
+	columnAssetSummaryStateRecoveryAuthoritative
+	columnAssetSummaryStateQuarantined
+)
 
 func DecodeColumnCollectionManifestView(data []byte) (ColumnCollectionManifestView, error) {
 	if isColumnControlPlaneBinary(data, columnCollectionManifestBinaryMagic) {
@@ -294,8 +312,8 @@ func (s *ColumnAssetReachabilitySummaryScratch) reset(recordCap int) {
 	if cap(s.records) < recordCap {
 		s.records = make([]columnAssetReachabilitySummaryRecord, 0, recordCap)
 	} else {
-		// Records are pointer-free scratch today; if pointer-bearing fields are
-		// added, reintroduce clear(s.records) before truncating to avoid retention.
+		// Records are pointer-free scratch; keep them that way so reset remains
+		// a cheap truncate in the repeated GC summary path.
 		s.records = s.records[:0]
 	}
 	if s.recordIndex == nil {
@@ -428,7 +446,7 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 	}
 	if index := s.recordIndex[ref]; index > 0 {
 		record := &s.records[index-1]
-		record.state = strongestColumnAssetState(record.state, state)
+		record.state = strongestColumnAssetReachabilitySummaryState(record.state, state)
 		if record.bytes == 0 {
 			record.bytes = bytes
 		}
@@ -438,8 +456,8 @@ func (s *ColumnAssetReachabilitySummaryScratch) addAssetRefToReachabilitySummary
 		record.quarantined = record.quarantined || quarantined
 	} else {
 		s.records = append(s.records, columnAssetReachabilitySummaryRecord{
-			ref:       ref,
-			state:     state,
+			fileID:    ref.FileID,
+			state:     columnAssetReachabilitySummaryStateFromLifecycle(state),
 			bytes:     bytes,
 			live:      live,
 			protected: columnAssetRefBlocksSegmentDeletion(live, candidate, quarantined),
@@ -465,7 +483,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		segments[fileID] = seg
 	}
 	for _, record := range records {
-		seg := segments[record.ref.FileID]
+		seg := segments[record.fileID]
 		if record.live {
 			seg.liveRefs++
 		}
@@ -475,7 +493,7 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		if record.protected {
 			seg.protectedRefs++
 		}
-		segments[record.ref.FileID] = seg
+		segments[record.fileID] = seg
 	}
 	summary.Stats.SegmentRefs = len(segments)
 	for _, seg := range segments {
@@ -491,19 +509,19 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 		case record.quarantined:
 			summary.QuarantinedBytes += record.bytes
 		case record.live:
-			if record.state == ColumnAssetStateActive || record.state == ColumnAssetStateRecoveryAuthoritative {
+			if record.state == columnAssetSummaryStateActive || record.state == columnAssetSummaryStateRecoveryAuthoritative {
 				summary.RetainedBytes += record.bytes
 			} else {
 				switch record.state {
-				case ColumnAssetStatePrepared:
+				case columnAssetSummaryStatePrepared:
 					summary.PreparedBytes += record.bytes
-				case ColumnAssetStateProcessVisible:
+				case columnAssetSummaryStateProcessVisible:
 					summary.ProcessVisibleBytes += record.bytes
-				case ColumnAssetStatePendingPublish:
+				case columnAssetSummaryStatePendingPublish:
 					summary.PendingBytes += record.bytes
-				case ColumnAssetStateRootPublished:
+				case columnAssetSummaryStateRootPublished:
 					summary.RootPublishedBytes += record.bytes
-				case ColumnAssetStateSnapshotPinned:
+				case columnAssetSummaryStateSnapshotPinned:
 					summary.SnapshotProtectedBytes += record.bytes
 					summary.RetainedBytes += record.bytes
 				default:
@@ -512,15 +530,54 @@ func finalizeColumnAssetReachabilitySummary(records []columnAssetReachabilitySum
 			}
 		case record.candidate:
 			summary.CleanupSafeBytes += record.bytes
-			seg := segments[record.ref.FileID]
+			seg := segments[record.fileID]
 			if seg.liveRefs == 0 && seg.protectedRefs == 0 {
 				summary.ReclaimableBytes += record.bytes
 			} else {
 				summary.RewriteDebtBytes += record.bytes
 			}
-		case record.state == ColumnAssetStateSuperseded:
+		case record.state == columnAssetSummaryStateSuperseded:
 			summary.SupersededBytes += record.bytes
 		}
+	}
+}
+
+func strongestColumnAssetReachabilitySummaryState(current columnAssetReachabilitySummaryState, next ColumnAssetLifecycleState) columnAssetReachabilitySummaryState {
+	nextState := columnAssetReachabilitySummaryStateFromLifecycle(next)
+	if nextState > current {
+		return nextState
+	}
+	return current
+}
+
+func columnAssetReachabilitySummaryStateFromLifecycle(state ColumnAssetLifecycleState) columnAssetReachabilitySummaryState {
+	switch state {
+	case ColumnAssetStateQuarantined:
+		return columnAssetSummaryStateQuarantined
+	case ColumnAssetStateRecoveryAuthoritative:
+		return columnAssetSummaryStateRecoveryAuthoritative
+	case ColumnAssetStateActive:
+		return columnAssetSummaryStateActive
+	case ColumnAssetStateSnapshotPinned:
+		return columnAssetSummaryStateSnapshotPinned
+	case ColumnAssetStateRootPublished:
+		return columnAssetSummaryStateRootPublished
+	case ColumnAssetStateProcessVisible:
+		return columnAssetSummaryStateProcessVisible
+	case ColumnAssetStatePendingPublish:
+		return columnAssetSummaryStatePendingPublish
+	case ColumnAssetStatePrepared:
+		return columnAssetSummaryStatePrepared
+	case ColumnAssetStateCleanupSafe:
+		return columnAssetSummaryStateCleanupSafe
+	case ColumnAssetStateReclaimable:
+		return columnAssetSummaryStateReclaimable
+	case ColumnAssetStateSuperseded:
+		return columnAssetSummaryStateSuperseded
+	case ColumnAssetStateDeleting:
+		return columnAssetSummaryStateDeleting
+	default:
+		return columnAssetSummaryStateUnknown
 	}
 }
 

--- a/experiments/colgranule/part_set.go
+++ b/experiments/colgranule/part_set.go
@@ -566,8 +566,8 @@ func CompactColumnPartSet(workspace *ColumnWorkspace, reader *ColumnPartSetReade
 		return ColumnPartSetCompactionResult{}, err
 	}
 	postPublishPlan, err := PlanColumnAssetReachability(ColumnAssetReachabilityInput{
-		ActiveManifest:      &manifest,
-		SupersededManifests: []ColumnCollectionManifest{oldManifest},
+		RecoveryAuthoritativeManifests: []ColumnCollectionManifest{manifest},
+		CleanupSafeManifests:           []ColumnCollectionManifest{oldManifest},
 	})
 	if err != nil {
 		return ColumnPartSetCompactionResult{}, err

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -207,7 +207,9 @@ func TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO(t *testing.T) {
 	if _, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("late payload")); err == nil || !strings.Contains(err.Error(), "closed segment asset store") {
 		t.Fatalf("Put during pending Close err=%v want closed segment asset store", err)
 	}
-	store.endFileIO()
+	if err := store.endFileIO(); err != nil {
+		t.Fatalf("endFileIO: %v", err)
+	}
 	select {
 	case err := <-closeDone:
 		if err != nil {
@@ -221,18 +223,15 @@ func TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO(t *testing.T) {
 	}
 }
 
-func TestSegmentColumnAssetStoreEndFileIOPanicsWithoutBegin(t *testing.T) {
+func TestSegmentColumnAssetStoreEndFileIORejectsWithoutBegin(t *testing.T) {
 	store, err := OpenSegmentColumnAssetStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
 	}
 	defer store.Close()
-	defer func() {
-		if recovered := recover(); recovered == nil {
-			t.Fatal("endFileIO without beginFileIO did not panic")
-		}
-	}()
-	store.endFileIO()
+	if err := store.endFileIO(); err == nil || !strings.Contains(err.Error(), "without matching begin") {
+		t.Fatalf("endFileIO without beginFileIO err=%v want without matching begin", err)
+	}
 }
 
 func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -238,7 +238,7 @@ func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if store.testClosing() {
+		if segmentStoreClosing(store) {
 			return
 		}
 		time.Sleep(time.Millisecond)
@@ -246,10 +246,10 @@ func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {
 	t.Fatal("segment store Close did not enter closing state")
 }
 
-func (s *SegmentColumnAssetStore) testClosing() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.closing
+func segmentStoreClosing(store *SegmentColumnAssetStore) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return store.closing
 }
 
 func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.T) {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -157,8 +157,14 @@ func TestSegmentColumnAssetStoreSyncsNewSegmentDirectoryEntry(t *testing.T) {
 		t.Fatalf("reopen segment store: %v", err)
 	}
 	defer reopened.Close()
+	if !reopened.dirSyncRequired {
+		t.Fatal("reopened segment store did not conservatively require directory sync")
+	}
+	if err := reopened.Sync(); err != nil {
+		t.Fatalf("reopened Sync: %v", err)
+	}
 	if reopened.dirSyncRequired {
-		t.Fatal("existing segment file should not require directory sync on reopen")
+		t.Fatal("reopened segment store still requires directory sync after Sync")
 	}
 }
 

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -130,6 +130,38 @@ func TestTCS1ColumnPartAssetRoundTripsThroughSegmentStoreAfterReopen(t *testing.
 	}
 }
 
+func TestSegmentColumnAssetStoreSyncsNewSegmentDirectoryEntry(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	if !store.dirSyncRequired {
+		t.Fatal("new segment store did not require directory sync")
+	}
+	if _, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("payload")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if store.dirSyncRequired {
+		t.Fatal("segment store still requires directory sync after Sync")
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := OpenSegmentColumnAssetStore(dir)
+	if err != nil {
+		t.Fatalf("reopen segment store: %v", err)
+	}
+	defer reopened.Close()
+	if reopened.dirSyncRequired {
+		t.Fatal("existing segment file should not require directory sync on reopen")
+	}
+}
+
 func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.T) {
 	store, err := OpenSegmentColumnAssetStore(t.TempDir())
 	if err != nil {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -5,6 +5,7 @@ import (
 	"hash/crc32"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTCS1ColumnPartAssetRoundTripsThroughMemoryStore(t *testing.T) {
@@ -166,6 +167,60 @@ func TestSegmentColumnAssetStoreSyncsNewSegmentDirectoryEntry(t *testing.T) {
 	if reopened.dirSyncRequired {
 		t.Fatal("reopened segment store still requires directory sync after Sync")
 	}
+}
+
+func TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO(t *testing.T) {
+	store, err := OpenSegmentColumnAssetStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, _, _, err := store.beginFileIO(); err != nil {
+		t.Fatalf("beginFileIO: %v", err)
+	}
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- store.Close()
+	}()
+	waitForSegmentStoreClosing(t, store)
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before active file IO drained: %v", err)
+	default:
+	}
+	if _, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("late payload")); err == nil || !strings.Contains(err.Error(), "closed segment asset store") {
+		t.Fatalf("Put during pending Close err=%v want closed segment asset store", err)
+	}
+	store.endFileIO()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after active file IO drained")
+	}
+	if err := store.Verify(ref); err == nil || !strings.Contains(err.Error(), "closed segment asset store") {
+		t.Fatalf("Verify after Close err=%v want closed segment asset store", err)
+	}
+}
+
+func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		store.mu.Lock()
+		closing := store.closing
+		store.mu.Unlock()
+		if closing {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("segment store Close did not enter closing state")
 }
 
 func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.T) {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -51,6 +51,19 @@ func TestMemoryColumnAssetStoreValidatesChecksumAfterLookup(t *testing.T) {
 	}
 }
 
+func TestMemoryColumnAssetStoreVerifyRecomputesChecksum(t *testing.T) {
+	store := NewMemoryColumnAssetStore()
+	payload := []byte("payload")
+	ref, err := store.PutOwned(ColumnAssetKindTCS1PartImage, payload)
+	if err != nil {
+		t.Fatalf("PutOwned: %v", err)
+	}
+	payload[0] = 'P'
+	if err := store.Verify(ref); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("Verify err=%v want checksum mismatch", err)
+	}
+}
+
 func TestMemoryColumnAssetStoreValidatesLengthAfterAddressLookup(t *testing.T) {
 	store := NewMemoryColumnAssetStore()
 	ref, err := store.Put(ColumnAssetKindTCS1PartImage, []byte("payload"))
@@ -206,6 +219,20 @@ func TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO(t *testing.T) {
 	if err := store.Verify(ref); err == nil || !strings.Contains(err.Error(), "closed segment asset store") {
 		t.Fatalf("Verify after Close err=%v want closed segment asset store", err)
 	}
+}
+
+func TestSegmentColumnAssetStoreEndFileIOPanicsWithoutBegin(t *testing.T) {
+	store, err := OpenSegmentColumnAssetStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenSegmentColumnAssetStore: %v", err)
+	}
+	defer store.Close()
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("endFileIO without beginFileIO did not panic")
+		}
+	}()
+	store.endFileIO()
 }
 
 func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {

--- a/experiments/colgranule/tcs1_test.go
+++ b/experiments/colgranule/tcs1_test.go
@@ -239,15 +239,18 @@ func waitForSegmentStoreClosing(t *testing.T, store *SegmentColumnAssetStore) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		store.mu.Lock()
-		closing := store.closing
-		store.mu.Unlock()
-		if closing {
+		if store.testClosing() {
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("segment store Close did not enter closing state")
+}
+
+func (s *SegmentColumnAssetStore) testClosing() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closing
 }
 
 func TestSegmentColumnAssetStoreRejectsOutOfRangeRefBeforeAllocation(t *testing.T) {


### PR DESCRIPTION
## Summary

M9B hardens the column asset lifecycle contract before production column roots claim durable-at-ack behavior. The key change is making publish/recovery/cleanup states explicit instead of treating every superseded manifest as immediately GC-eligible.

Changes:

- Add explicit lifecycle states and accounting for `process_visible`, `root_published`, `recovery_authoritative`, and `cleanup_safe`; root-published bytes are now reported under an explicit `root_published_bytes` bucket.
- Keep `superseded` manifests protected until a caller marks them cleanup-safe; only cleanup-safe assets can become reclaimable or rewrite debt.
- Track protected non-candidate refs at segment scope so a cleanup-safe asset cannot make a whole segment delete-eligible while the same segment still contains protected superseded/quarantined refs.
- Add publish-closure validation on the column asset manager: prepared refs must validate, exist in the asset store, and be syncable before root publication proceeds.
- Derive publish-closure sync requirements inside the manager and return a sealed synced-closure token; `MarkPublishSucceeded` now requires that token so callers cannot clear a mutable sync flag or skip closure sync before finalizing prepared assets.
- Add asset-store `Verify`/`Sync` hooks, including streaming checksum verification for segment-backed assets.
- Sync newly-created segment directory entries during the publish-closure sync path so a durable root cannot point at a segment filename whose directory entry was never fsynced.
- Make failed-publish quarantine atomic with respect to prepared-asset validation, and ensure range-reader verification probes actually read a non-zero range.
- Update compaction reachability to publish the new manifest as recovery-authoritative and mark the old manifest cleanup-safe only after the new generation is in place.
- Hoist detailed reachability reason lookup per manifest/view so the expanded lifecycle state model does not add avoidable per-ref diagnostic planner cost.
- Add TDD coverage for superseded protection, protected-ref segment blockers, process-visible live accounting, quarantine shared-segment blockers, durability-state summary parity, prepared publish validation, no-op closure asset re-verification, tampered sync-flag derivation, sealed publish-token enforcement, failed-publish quarantine, failed-publish atomicity, non-zero range verification probes, `SyncRequired` behavior, and segment-directory sync requirements.

Refs #1534. Chained on #1596.

## Performance / Benchmark Evidence

Scope: these are lifecycle/maintenance benchmarks over synthetic 10K-manifest asset sets, not q1-q5 query kernels. The measured work is manifest/ref reachability, summary-only GC byte decisions, ref-delta accounting, and manager reclamation planning. The main benchmark shape has 10K active refs plus 10K cleanup-safe refs, so detailed/summary/reclamation throughput below is based on 20K refs or entries per op. The publish-closure verification and segment-directory fsync changes are on the durable publish path and are not in these GC planner hot loops.

Parent used for original comparison: `ea1d4bf66` (`codex/colgranule-m9-1594-integration-base`)
Head used for original comparison: `02c077f1b` (`codex/colgranule-m9b-lifecycle-durability-closure`)
Current pushed head after review-invariant fixes: `06d4f4c87` (`codex/colgranule-m9b-lifecycle-durability-closure`)
Machine: Apple M3, darwin/arm64

Command used on a detached parent worktree and current head:

```sh
GOWORK=off go test ./experiments/colgranule -run "^$" \
  -bench "BenchmarkColumnAsset(Reachability10K|ReachabilityView10K|ReachabilitySummaryView10K|ReachabilitySummaryView10KReuse|RefDelta128|ManagerReclamation10K)$" \
  -benchmem -benchtime=500ms -count=10
benchstat /tmp/gomap_m9b_parent_lifecycle_530fcc_compare.txt /tmp/gomap_m9b_head_lifecycle_token_compare.txt
```

Results:

- Detailed materialized reachability: `8.191 ms/op` parent -> `8.166 ms/op` head, no significant change; about `2.45M refs/sec` or `408 ns/ref`; `8.041 MiB/op`, `71 allocs/op` unchanged.
- Binary-view detailed reachability: `8.071 ms/op` -> `8.369 ms/op`, benchstat reports `+3.69%`; about `2.39M refs/sec` or `418 ns/ref`; `8.041 MiB/op`, `71 allocs/op` unchanged. This is a diagnostic full-entry materialization path, not the normal GC eligibility path.
- Summary-only view planning: `4.074 ms/op` -> `4.060 ms/op`, no significant change; about `4.93M refs/sec` or `203 ns/ref`; `4.080 MiB/op`, `69 allocs/op` unchanged.
- Reused-scratch summary planning: `4.085 ms/op` -> `4.364 ms/op`, no significant change; about `4.58M refs/sec` or `218 ns/ref`; exactly `0 B/op`, `0 allocs/op` unchanged. This remains the intended normal GC eligibility/byte-decision path.
- Ref-delta accounting for 128 changed refs: `11.27 us/op` -> `11.33 us/op`, no significant change; about `11.3M refs/sec` or `88.5 ns/ref`; `12.16 KiB/op`, `4 allocs/op` unchanged.
- Manager reclamation over the 20K-entry benchmark plan: `779.7 us/op` -> `766.4 us/op`, no significant change; about `26.1M entries/sec` or `38.3 ns/entry`; `2.289 MiB/op`, `1 alloc/op` unchanged.
- Geomean CPU across the lifecycle set: `+1.41%`; geomean allocation change: `0.00%`.

Current-head refresh after the protected-ref review fix at `b7f4aa961`:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' \
  -bench 'BenchmarkColumnAsset(Reachability10K|ReachabilityView10K|ReachabilitySummaryView10K|ReachabilitySummaryView10KReuse|RefDelta128|ManagerReclamation10K)$' \
  -benchmem -benchtime=500ms -count=5 -cpu=1
benchstat /tmp/gomap_m9b_head_b7f4_lifecycle_refresh_count5.txt
```

Current-head refresh results:

- Detailed reachability: `11.35 ms/op`, `8.041 MiB/op`, `71 allocs/op`.
- Binary-view detailed reachability: `10.63 ms/op`, `8.041 MiB/op`, `71 allocs/op`.
- Summary-only view planning: `4.333 ms/op`, `4.080 MiB/op`, `69 allocs/op`.
- Reused-scratch summary planning: `4.130 ms/op`, exactly `0 B/op`, `0 allocs/op`. This remains the normal GC eligibility/byte-decision path.
- Ref-delta accounting for 128 changed refs: `11.67 us/op`, `12.16 KiB/op`, `4 allocs/op`.
- Manager reclamation over the 20K-entry benchmark plan: `1.199 ms/op`, `2.289 MiB/op`, `1 alloc/op`.

Review-invariant refresh at `06d4f4c87` after the root-published byte bucket rename, quarantine blocker test, segment-store open/verify fixes, and sealed-token success-path cleanup:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAsset(Reachability|Manager)' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
GOWORK=off go test ./experiments/colgranule -run 'TestSegmentColumnAssetStore|TestColumnAssetManagerSyncPublishClosure|TestColumnAssetManagerPublishSucceeded' -count=1
GOWORK=off go test ./experiments/colgranule -run '^$' \
  -bench 'BenchmarkColumnAssetReachabilitySummaryView10KReuse|BenchmarkColumnAssetManagerReclamation10K' \
  -benchmem -benchtime=500ms -count=5 -cpu=1
benchstat /tmp/gomap_m9b_reviewfix_lifecycle_bench_count5.txt
```

Review-invariant benchmark results:

- Reused-scratch summary planning: `4.112 ms/op`, exactly `0 B/op`, `0 allocs/op`. This remains the normal GC eligibility/byte-decision path.
- Manager reclamation over the 20K-entry benchmark plan: `1.287 ms/op`, `2.289 MiB/op`, `1 alloc/op`.

### Current-head refresh after review-thread hardening

Current pushed head: `d96a7cdf7`.

Additional current-head validation:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager|TestSegmentColumnAssetStore|TestColumnAssetReason|TestColumnAssetStoreFallbackVerification' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./experiments/colgranule/... -count=1
git diff --check
GOWORK=off go test ./experiments/colgranule -run '^$'   -bench 'BenchmarkColumnAssetReachabilitySummaryView10KReuse|BenchmarkColumnAssetManagerReclamation10K'   -benchmem -benchtime=500ms -count=3 -cpu=1
benchstat /tmp/gomap_m9b_reviewthreads_bench_count3.txt
```

Current-head benchmark refresh:

- Reused-scratch summary planning: ~`4.231 ms/op`, exactly `0 B/op`, `0 allocs/op`.
- Manager reclamation over the 20K-entry benchmark plan: ~`1.240 ms/op`, `2.289 MiB/op`, `1 alloc/op`.

This refresh covers the review-thread hardening for publish-closure accounting mismatches, publish-failure-only quarantine cleanup, segment-store open/verify handling, and immutable reason-sentinel tests. It preserves the important M9B performance contract: normal GC eligibility/byte-decision planning stays allocation-free, while detailed manager reclamation remains manifest/ref-scale maintenance work rather than row-scale query work.

## Throughput Interpretation

M9B adds stricter durability-state accounting, segment-level protected-ref blockers, publish-closure validation/re-verification, sealed synced-closure publish tokens, and directory-entry sync coverage without increasing allocation counts or bytes on the measured lifecycle hot paths. The normal GC decision path remains the reused-scratch summary planner at zero allocations and flat throughput. The detailed-view CPU movement is accepted because it is diagnostic materialization, the geomean movement is small, allocation-neutral, and limited to maintenance/diagnostic benchmarks, and the lifecycle contract prevents unsafe whole-segment deletion when cleanup-safe and still-protected refs share a segment.

## Gate Status

- Pass: normal GC eligibility/byte-decision planning remains the reused-scratch summary path at `0 B/op`, `0 allocs/op`; latest current-head review-thread refresh is ~`4.231 ms/op`.
- Pass: detailed reachability and manager reclamation remain manifest/ref-scale, not row-scale.
- Pass: ref-delta accounting for 128 changed refs remains about `11.3M refs/sec` with `4 allocs/op`.
- Accepted watch item: binary-view detailed reachability moved `+3.69%` CPU with unchanged allocations; this is a diagnostic full-entry materialization path, not the normal GC decision path.
- Pass: durable publish-closure sync/verification adds safety checks outside the measured GC planner loops and is covered by targeted tests.
- Pass: current-head review-invariant tests cover process-visible live accounting, quarantine shared-segment blockers, root-published byte accounting, segment-store create/verify handling, sealed-token publish success without double streaming verification, publish-closure mismatch rejection, and immutable reason sentinels.

## Artifacts

Full local artifacts:

- `/tmp/gomap_m9b_parent_lifecycle_530fcc_compare.txt`
- `/tmp/gomap_m9b_head_lifecycle_token_compare.txt`
- `/tmp/gomap_m9b_lifecycle_benchstat_token_compare.txt`
- `/tmp/gomap_m9b_head_b7f4_lifecycle_refresh_count5.txt`
- `/tmp/gomap_m9b_head_b7f4_lifecycle_refresh_benchstat.txt`
- `/tmp/gomap_m9b_reviewfix_lifecycle_bench_count5.txt`
- `/tmp/gomap_m9b_reviewfix_lifecycle_benchstat_count5.txt`
- `/tmp/gomap_m9b_fullref_verify_bench_count3.txt`
- `/tmp/gomap_m9b_reviewthreads_bench_count3.txt`
- `/tmp/gomap_m9b_reviewthreads_benchstat_count3.txt`

## Validation

- `GOWORK=off go test ./experiments/colgranule/... -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./experiments/colgranule/... -count=1`
- `GOWORK=off go test ./experiments/colgranule -run "^$" -bench "BenchmarkColumnAsset(Reachability10K|ReachabilityView10K|ReachabilitySummaryView10KReuse|ReachabilitySummaryView10K|RefDelta128|ManagerReclamation10K)$" -benchmem -benchtime=500ms -count=10`
- `benchstat /tmp/gomap_m9b_parent_lifecycle_530fcc_compare.txt /tmp/gomap_m9b_head_lifecycle_token_compare.txt`
- `GOWORK=off go test ./experiments/colgranule -run 'TestColumnAsset(Reachability|Manager)' -count=1`
- `GOWORK=off go test ./experiments/colgranule -run 'TestSegmentColumnAssetStore|TestColumnAssetManagerSyncPublishClosure|TestColumnAssetManagerPublishSucceeded' -count=1`
- `GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager|TestSegmentColumnAssetStore|TestColumnAssetReason|TestColumnAssetStoreFallbackVerification' -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./experiments/colgranule/... -count=1`
- `benchstat /tmp/gomap_m9b_reviewthreads_bench_count3.txt`
- `git diff --check`


## Latest validation (2026-05-18, `274ba933f58e`)

Review-thread fix for quarantine provenance:

- `go test ./experiments/colgranule -run 'TestColumnAssetManagerPublishSucceeded|TestColumnAssetManagerPreparedPublishFailure|TestColumnAssetManagerPlan|TestColumnAssetReachability' -count=1`
- `GOWORK=off go test ./experiments/colgranule/... -count=1`
- `git diff --check`

The publish-success path now stores publish-failure provenance and only clears quarantine when the active quarantine reason still matches the publish-failure reason; unrelated integrity quarantine remains visible while the publish-failed marker is cleared.

## Notes

This remains experiment-layer lifecycle/durability closure. It does not publish production TreeDB column roots yet, and it does not add a column-specific WAL. M10 remains the milestone that joins column manifest publication to the production command-WAL/root boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added finer lifecycle states (process_visible, root_published, recovery_authoritative, cleanup_safe) with expanded reachability accounting, protected refs, and updated planning/reporting.
  * Added a publish workflow (prepare → verify → optional sync → sealed confirm) with atomic success/failure handling, per-ref failure tracking, quarantine semantics, and publish-reason provenance.
  * Added optional store verification and durable directory-sync support for segment-backed stores.

* **Tests**
  * Expanded coverage for publish lifecycle, sync/verification behavior, directory-sync semantics, fallback verification reads, and updated reachability tests/benchmarks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->










### Latest Current-Head Evidence (May 18, 2026, quarantine-provenance head `e80007fac9c4`)
Current head: `e80007fac9c45ec49878c0339d559eff2cc436b0`.

This refresh adds a same-reason quarantine provenance guard so a later manual/user quarantine cannot be cleared merely because it reused the publish-failure reason string. The M9B lifecycle hot-path benchmark envelope remains unchanged: summary GC eligibility stays zero-allocation, and detailed manager reclamation remains one allocation for the materialized plan.

Exact-head validation on Apple M3:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager' -count=1
go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnAsset(ReachabilitySummaryView10KReuse|ManagerReclamation10K)$' -benchmem -benchtime=500ms -count=3
```

Result: asset-manager tests passed in `0.486s`; lifecycle benchmark passed in `5.796s`.

Current-head benchmark refresh:

| benchmark | time range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `ReachabilitySummaryView10KReuse` | `4.055-4.064 ms/op` | `0` | `0` |
| `ManagerReclamation10K` | `0.919-0.935 ms/op` | `2.400 MiB` | `1` |

### Latest Current-Head Evidence (May 18, 2026, review-thread closure head `8d39a9d0b0d2`)

Current head: `8d39a9d0b0d2a5c5c0ac051cd4670ea0bf9a0bbf`.

This refresh closes the remaining #1598 review-thread issues by removing unbounded successful-publish retention, making explicit quarantine provenance independent from publish-failure auto-quarantine cleanup, keeping publish-closure sync requirements store-authoritative, avoiding long segment-store mutex holds during streaming verify, keeping the reused summary scratch record pointer-free, and hardening the tests around those contracts.

Validation:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestSegmentColumnAssetStore' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
GOWORK=off go test -race ./experiments/colgranule -run 'TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired|TestColumnAssetReachabilitySummaryRecordIsPointerFree' -count=1
git diff --check
```

Benchmark command:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$'   -bench 'BenchmarkColumnAsset(Reachability10K|ReachabilityView10K|ReachabilitySummaryView10K|ReachabilitySummaryView10KReuse|RefDelta128|ManagerReclamation10K)$'   -benchmem -count=5
```

Current-head benchmark refresh on Apple M3, darwin/arm64:

| benchmark | time range | B/op | allocs/op | interpretation |
| --- | ---: | ---: | ---: | --- |
| `Reachability10K` | `8.27-8.40 ms/op` | `8,751,099-8,751,105` | `20,071` | diagnostic full-entry materialization over 20K refs |
| `ReachabilityView10K` | `8.34-8.45 ms/op` | `8,751,103-8,751,112` | `20,071` | diagnostic binary-view full-entry materialization over 20K refs |
| `ReachabilitySummaryView10K` | `4.107-4.130 ms/op` | `2,754,179-2,754,183` | `69` | summary-only byte decision path without scratch reuse |
| `ReachabilitySummaryView10KReuse` | `4.116-4.125 ms/op` | `0` | `0` | intended normal repeated GC eligibility/byte-decision path |
| `RefDelta128` | `11.07-11.15 us/op` | `12,456` | `4` | 128-ref delta accounting |
| `ManagerReclamation10K` | `0.781-0.785 ms/op` | `2,400,264-2,400,266` | `1` | materialized manager reclamation over the 20K-entry plan |

Gate interpretation: the normal repeated GC eligibility path remains the reused-scratch summary planner at exactly `0 B/op`, `0 allocs/op`. The detailed reachability paths still allocate by materialized diagnostic entry/reason output and are not the hot GC decision path.

### Latest Current-Head Delta (May 18, 2026, overflow guard head `1628bd98256b`)

Current head: `1628bd98256ba65fc6310c2e9f33e408c55d89e2`.

This delta adds a checked sum for publish-closure `RequiredBytes` so a large prepared batch cannot wrap the host `int`, plus a direct overflow regression test using a verifier-only asset store.

Validation:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
git diff --check
```

The benchmark-sensitive lifecycle code from the prior current-head refresh is unchanged by this overflow guard except for the constant-time checked addition inside publish-closure preparation.



### Latest Current-Head Evidence (May 18, 2026, lifecycle-review hardening head `1628bd982cf6`)
Current head: `1628bd982cf6eba2432b8b660b3dfea8c54c2792`.

This refresh incorporates the review-hardening follow-up on top of the quarantine-provenance fix: publish-failure quarantine ownership is explicit, direct quarantines remain sticky, fallback sync counters are race-safe in tests, segment-store verification releases the manager mutex before streaming CRC work, and the reachability summary scratch path uses pointer-free compact state with a regression test.

Exact-head validation on Apple M3:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore' -count=1
go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnAsset(ReachabilitySummaryView10KReuse|ManagerReclamation10K)$' -benchmem -benchtime=500ms -count=3
git diff --check
```

Result: focused lifecycle tests passed in `0.445s`; benchmark passed in `6.148s`; `git diff --check` passed.

Current-head benchmark refresh:

| benchmark | time range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `ReachabilitySummaryView10KReuse` | `4.138-4.144 ms/op` | `0` | `0` |
| `ManagerReclamation10K` | `0.794-0.798 ms/op` | `2.400 MiB` | `1` |

## Current-head validation update (2026-05-18, stack head 15100fcd6d48)

Current pushed head for this PR: `1628bd982cf6eba2432b8b660b3dfea8c54c2792`. The M9+ chain was revalidated after the final M9B lifecycle/provenance fix was propagated through M11B. The ancestry audit passes for #1598 -> #1603 -> #1604 -> #1605 -> #1606 -> #1607 -> #1608 -> #1609, so the top-head validation includes this PR's code plus its descendants.

Focused validation:
- `go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1`: PASS on top head `15100fcd6d48`.
- `git diff --check`: PASS.

Performance evidence:
- M9B exact head `1628bd982cf6`: `BenchmarkColumnAssetReachabilitySummaryView10KReuse` = 4.135-4.159 ms/op, 0 B/op, 0 allocs/op; `BenchmarkColumnAssetManagerReclamation10K` = 0.799-0.807 ms/op, 2.400 MiB/op, 1 alloc/op.
- M11B top head `15100fcd6d48`: row baseline query suite = 59.7-60.3 ms/op, 108.8-109.9 MB/s, 70K rows/op; B-tree index baseline query suite = 70.8-70.9 ms/op, 92.5 MB/s, 70K rows/op.
- M11 reporting remains unified-bench/benchprof-compatible: JSON, Markdown, and HTML artifacts are required, while the PR text reports throughput directly for review without opening profile artifacts.

CI/review status at this refresh: latest-head GitHub checks were queued or in progress with no latest-head failures observed. AI reviews will be re-requested after this evidence refresh; stale-run cleanup is limited to M9+ branches and explicitly excludes #1615.

### Latest Current-Head Evidence (May 18, 2026, remaining lifecycle-review closure head `02eda548c073`)

Current head: `02eda548c07353354862cbdd4c65190f8c6483d9`.

This delta layers the remaining review closure work on top of the newer publish-closure binding commit: zero-value publish-closure literals are rejected, repeated publish failures preserve first-failure provenance, segment asset `Verify` cannot race a concurrent `Close`, publish-barrier `Sync` semantics are documented, and reason-sentinel append safety is asserted directly.

Validation:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestSegmentColumnAssetStore' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
GOWORK=off go test -race ./experiments/colgranule -run 'TestColumnAssetManagerSyncPublishClosureDerivesSyncRequired|TestColumnAssetManagerSyncPublishClosureRejectsUnpreparedNoopLiteral|TestColumnAssetManagerPublishFailurePreservesFirstReason|TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO|TestColumnAssetReasonSentinelsAreAppendSafe' -count=1
git diff --cached --check
```

Benchmark refresh on Apple M3, darwin/arm64:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnAsset(ReachabilitySummaryView10KReuse|ManagerReclamation10K)$' -benchmem -count=3
```

| benchmark | time range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `ReachabilitySummaryView10KReuse` | `4.115-4.136 ms/op` | `0` | `0` |
| `ManagerReclamation10K` | `0.791-0.804 ms/op` | `2,400,263-2,400,267` | `1` |

### Latest Current-Head Delta (May 18, 2026, scoped publish-failure invalidation head `2d67ed119032`)

Current head: `2d67ed1190322ca9b5b7955ab117b1fe2213216b`.

This delta scopes synced publish invalidation to refs touched by later publish failures. A failed publish for ref B no longer invalidates an already-synced, disjoint publish for ref A; same-ref failures still reject older synced closures. The change adds direct coverage for the disjoint interleaving and preserves the prior same-ref stale-closure test.

Validation:

```sh
GOWORK=off go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestSegmentColumnAssetStore' -count=1
GOWORK=off go test -race ./experiments/colgranule -run 'TestColumnAssetManager(PublishFailure|SyncPublishClosure)|TestSegmentColumnAssetStoreCloseWaitsForActiveVerifyIO|TestColumnAssetReasonSentinelsAreAppendSafe' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
git diff --cached --check
```

Benchmark refresh:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' -bench 'BenchmarkColumnAsset(ReachabilitySummaryView10KReuse|ManagerReclamation10K)$' -benchmem -count=3
```

| benchmark | time range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `ReachabilitySummaryView10KReuse` | `4.118-4.274 ms/op` | `0` | `0` |
| `ManagerReclamation10K` | `0.790-0.794 ms/op` | `2,400,265-2,400,267` | `1` |

### Lifecycle review note

Quarantined column assets intentionally report `quarantined` as the dominant lifecycle state, even when another manifest can still reach the ref. Reclamation still requires delete eligibility plus zombie and pin drain; the dominant state is a diagnostics/safety signal so planners, JSON summaries, and replay/debug tooling do not hide unsafe refs behind `active` labels.

<!-- m9plus-current-head-evidence-start -->
## Current-Head Evidence Refresh (2026-05-18)

Chunk: `M9B` (lifecycle/durability closure).
Current head: `3676deccefb5d959122cea306de24f5f0a02a462` on `codex/colgranule-m9b-lifecycle-durability-closure`; base `codex/colgranule-m9-1594-integration-base`.
GitHub Actions current-head rollup at refresh time: `26` successful, `0` pending, `0` failing/cancelled.

Local / current validation:
- Live GitHub Actions rollup on current head is expected to remain green; this chunk was not changed by the M10A-M11B propagation.
- Existing PR body retains the focused lifecycle publish-closure validation and performance evidence for this chunk.

Performance / benchmark evidence:
- No new code was propagated into this chunk during the latest M10A-M11B refresh.
<!-- m9plus-current-head-evidence-end -->

<!-- m9plus-current-head-closeout-start -->

## Current-head closeout evidence (2026-05-18 UTC)


This PR current head: `01a265dccf955baa0bd7a10e4e9c9fe321c928db` on `codex/colgranule-m9b-lifecycle-durability-closure`. Chunk: `M9B` (lifecycle/durability closure).

Current M9+ stack heads after M10C review-fix propagation:

| Chunk | PR | Current head | Branch |
|---|---:|---|---|
| M9B | #1598 | `01a265dccf95` | `codex/colgranule-m9b-lifecycle-durability-closure` |
| M9C | #1603 | `d358313f407e` | `codex/colgranule-m9c-control-plane-durability` |
| M9D | #1604 | `8d862dc70391` | `codex/colgranule-m9d-replay-profile-contract` |
| M10A | #1605 | `2453042140bc` | `codex/colgranule-m10a-publish-plan-api` |
| M10B | #1606 | `1c5f94e05423` | `codex/colgranule-m10b-root-publication` |
| M10C | #1607 | `338a38211123` | `codex/colgranule-m10c-recovery-parity` |
| M11A | #1608 | `eb0cf90d8d5b` | `codex/colgranule-m11a-native-column-bench` |
| M11B | #1609 | `81c0454810b8` | `codex/colgranule-m11b-planner-skipscan` |

Validation on the current #1609 top stack head `81c0454810b8`:
- `GOWORK=off go test ./experiments/colgranule/... -count=1`: PASS (`experiments/colgranule` 3.568s, `cmd/jsonbench_compare` 1.108s).
- `go test ./TreeDB/collections -run 'TestColumnManifest|TestColumnPublishPlan|TestColumnStore(ReplayIntentBypassesRelaxedDurabilityGateM10C|AssignedForegroundIntentDoesNotBypassRelaxedDurabilityGateM10C|RelaxedProfilesRejectForegroundWritesM10C|BenchmarkRelaxedAllowsDurableCommandWALWritesM10C|ReadOnlyOpenWithUnappliedCollectionFrameFailsM10C)|ColumnStore|ColumnPublish|M10A|M10B|M10C|M11A|M11B' -count=1`: PASS (`1.198s`).
- `go test ./TreeDB/db -run 'CommandWAL|OrderedRoot|M10C|Replay|ConcurrentModification|TestCommandWALReplayIntentRequiresActiveRecoveryFrameM10C' -count=1`: PASS (`2.027s`).
- `go test ./cmd/unified_bench -run 'TestInstallAllocsProfileRate|TestCanonicalDBName|TestResolveDBs|TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B|TestColumnStoreSuiteProfiledQueries|TestColumnStoreSuitePlanner|TestBenchprof|TestBenchConfigHasAnyProfileOutput|TestRunBenchmarkCPUProfileStartFailureRemovesArtifactM11A|TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1`: PASS (`1.223s`).
- `git diff --check`: PASS.

Performance / benchmark evidence refreshed on the current #1609 top stack head:
- M9D durable replay after the review-thread hardening and asset-before-manifest durability fix: `BenchmarkColumnMutationReplayM9D/small_1k/durable`, `-benchtime=1x -count=3`, Apple M3: `44.425-78.078 ms/op`, `14.140K-24.851K rows/sec`, `18.718-18.723 MiB/op`, `824-829 allocs/op`, `2,254,369 column_asset_bytes/op`, `61,398 command_bytes/op`, `1,728 manifest_control_bytes/op`, `0 row_remainder_bytes/op`.
- M10C command-WAL replay smoke after timer cleanup: `BenchmarkColumnStoreCommandWALReplayM10C`, `-benchtime=1x -count=1`, `column_store=false`: `1.340247375 s/op`, `12.225K replay_docs/s`, `95.50 replay_frames/s`, `123,094,440 B/op`, `179,355 allocs/op`; `column_store=true`: `1.224755625 s/op`, `13.377K replay_docs/s`, `104.5 replay_frames/s`, `120,537,256 B/op`, `199,956 allocs/op`.
- M11B top-head planner baseline smoke: row baseline `75.676750 ms/op`, `86.66 MB/s`, `70,000 rows/op`, `31,341,704 B/op`, `656,801 allocs/op`.
- M11B top-head planner baseline smoke: B-tree index baseline `70.437709 ms/op`, `93.10 MB/s`, `70,000 rows/op`, `23,500,296 B/op`, `516,780 allocs/op`.
- The review-thread fixes are outside the M11B planner/query hot path except for propagated M9D/M10C correctness and benchmark-accounting improvements. M9B, M9C, M10A, and M10B benchmark contracts remain unchanged by this propagation.

CI / review state at this refresh:
- Review fixes included in these heads: M9C removes the unused pre-M10A identity-default helper, M10A reintroduces it at the publish-plan boundary where it is actually called, M9D uses a typed sync-mode error and avoids full manifest/index clones on publish rollback, and M10C exports column manifest identity sentinel errors, rejects fabricated replay intents outside the active recovery frame, restores replay LSN without per-frame `defer`, preserves default profile support setup, and keeps the replay benchmark timer stopped before reset.
- At the evidence refresh, #1598 latest-head checks were green; #1603 had latest-head checks mostly green with a few in progress; #1604-#1609 latest-head checks were queued with no latest-head failure observed yet.
- Fresh AI review and latest-head CI still need to settle cleanly before the M9+ execution goal can be closed.
- No CI stale-run cleanup is part of this refresh. PR #1615 and branch `codex/column-vector-dynamic-overlay-publish-capacity`, including protected heads `41dcc85e4f434926e6b2ab61eb0b70b673f1a16a` and `7fe6891c1ef308e4cba473a5eb828cc0748f779c`, remain excluded from any cleanup.

Completion note: these PRs are not done until latest-head CI and fresh AI review feedback settle cleanly on the newly pushed heads.

<!-- m9plus-current-head-closeout-end -->



