### PR TITLE
experiments/colgranule: harden replay profile contract

### DIFF
--- a/experiments/colgranule/collection_manifest.go
+++ b/experiments/colgranule/collection_manifest.go
@@ -222,7 +222,7 @@ func (w *ColumnWorkspace) SaveCollectionManifest(manifest ColumnCollectionManife
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	if err = tmp.Sync(); err != nil {
+	if err = w.syncManifestTempFile(tmp); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return err

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -61,7 +61,7 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	}
 	replayProfile := opts.ReplayProfile.normalized()
 	if workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
-		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q", replayProfile.Label(), replayProfile.workspaceManifestSyncMode())
+		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q", replayProfile.Label(), replayProfile.workspaceManifestSyncMode(), workspace.ManifestSyncMode())
 	}
 	collection := opts.Collection
 	if collection == "" {

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -60,7 +60,7 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 		return nil, err
 	}
 	replayProfile := opts.ReplayProfile.normalized()
-	if !replayProfile.ProductionSupported() && workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
+	if workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
 		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q", replayProfile.Label(), replayProfile.workspaceManifestSyncMode())
 	}
 	collection := opts.Collection

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -60,8 +60,12 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 		return nil, err
 	}
 	replayProfile := opts.ReplayProfile.normalized()
-	if workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
-		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q; open the workspace with columnWorkspaceOptionsForMutationReplayProfile or omit benchmark_no_sync for durable replay", replayProfile.Label(), replayProfile.workspaceManifestSyncMode(), workspace.ManifestSyncMode())
+	syncMode, err := replayProfile.workspaceManifestSyncMode()
+	if err != nil {
+		return nil, err
+	}
+	if workspace.ManifestSyncMode() != syncMode {
+		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires ColumnWorkspaceOptions.ManifestSyncMode=%q, got %q; use %q for durable replay and %q for benchmark-ceiling replay", replayProfile.Label(), syncMode, workspace.ManifestSyncMode(), ColumnWorkspaceManifestSyncDurable, ColumnWorkspaceManifestSyncDisabledForBenchmark)
 	}
 	collection := opts.Collection
 	if collection == "" {

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -65,7 +65,15 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 		return nil, err
 	}
 	if workspace.ManifestSyncMode() != syncMode {
-		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires ColumnWorkspaceOptions.ManifestSyncMode=%q, got %q; use %q for durable replay and %q for benchmark-ceiling replay", replayProfile.Label(), syncMode, workspace.ManifestSyncMode(), ColumnWorkspaceManifestSyncDurable, ColumnWorkspaceManifestSyncDisabledForBenchmark)
+		return nil, fmt.Errorf(
+			"colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q. "+
+				"Use %q for durable replay or %q for benchmark-ceiling replay",
+			replayProfile.Label(),
+			syncMode,
+			workspace.ManifestSyncMode(),
+			ColumnWorkspaceManifestSyncDurable,
+			ColumnWorkspaceManifestSyncDisabledForBenchmark,
+		)
 	}
 	collection := opts.Collection
 	if collection == "" {

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -59,6 +59,10 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	if err := opts.ReplayProfile.Validate(); err != nil {
 		return nil, err
 	}
+	replayProfile := opts.ReplayProfile.normalized()
+	if !replayProfile.ProductionSupported() && workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
+		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q", replayProfile.Label(), replayProfile.workspaceManifestSyncMode())
+	}
 	collection := opts.Collection
 	if collection == "" {
 		collection = workspace.Manifest().Collection
@@ -71,7 +75,7 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 		collection:    collection,
 		opts:          normalized,
 		dictionaries:  opts.Dictionaries,
-		replayProfile: opts.ReplayProfile.normalized(),
+		replayProfile: replayProfile,
 		nextPartID:    opts.InitialPartID,
 		nextGen:       opts.InitialGeneration,
 	}

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -61,7 +61,7 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	}
 	replayProfile := opts.ReplayProfile.normalized()
 	if workspace.ManifestSyncMode() != replayProfile.workspaceManifestSyncMode() {
-		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q", replayProfile.Label(), replayProfile.workspaceManifestSyncMode(), workspace.ManifestSyncMode())
+		return nil, fmt.Errorf("colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q; open the workspace with columnWorkspaceOptionsForMutationReplayProfile or omit benchmark_no_sync for durable replay", replayProfile.Label(), replayProfile.workspaceManifestSyncMode(), workspace.ManifestSyncMode())
 	}
 	collection := opts.Collection
 	if collection == "" {

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -1,11 +1,14 @@
 package colgranule
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"time"
 )
+
+var ErrColumnMutationReplayWorkspaceSyncMode = errors.New("colgranule: column mutation replay workspace sync mode mismatch")
 
 type ColumnMutationAdapterOptions struct {
 	Collection        string
@@ -66,8 +69,9 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	}
 	if workspace.ManifestSyncMode() != syncMode {
 		return nil, fmt.Errorf(
-			"colgranule: column mutation replay profile %q requires workspace manifest sync mode %q, got %q. "+
+			"%w: profile %q requires workspace manifest sync mode %q, got %q. "+
 				"Use %q for durable replay or %q for benchmark-ceiling replay",
+			ErrColumnMutationReplayWorkspaceSyncMode,
 			replayProfile.Label(),
 			syncMode,
 			workspace.ManifestSyncMode(),

--- a/experiments/colgranule/mutation_adapter.go
+++ b/experiments/colgranule/mutation_adapter.go
@@ -11,6 +11,7 @@ type ColumnMutationAdapterOptions struct {
 	Collection        string
 	StoreOptions      ColumnStoreOptions
 	Dictionaries      map[string]map[string]int64
+	ReplayProfile     ColumnMutationReplayProfile
 	InitialPartID     uint64
 	InitialGeneration uint64
 }
@@ -34,16 +35,17 @@ type ColumnMutationApplyResult struct {
 }
 
 type ColumnMutationAdapter struct {
-	workspace    *ColumnWorkspace
-	collection   string
-	opts         ColumnStoreOptions
-	dictionaries map[string]map[string]int64
-	baseParts    []ColumnManifestPartRef
-	deltaParts   []ColumnManifestPartRef
-	tombstones   []ColumnTombstone
-	manifest     ColumnCollectionManifest
-	nextPartID   uint64
-	nextGen      uint64
+	workspace     *ColumnWorkspace
+	collection    string
+	opts          ColumnStoreOptions
+	dictionaries  map[string]map[string]int64
+	replayProfile ColumnMutationReplayProfile
+	baseParts     []ColumnManifestPartRef
+	deltaParts    []ColumnManifestPartRef
+	tombstones    []ColumnTombstone
+	manifest      ColumnCollectionManifest
+	nextPartID    uint64
+	nextGen       uint64
 }
 
 func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAdapterOptions) (*ColumnMutationAdapter, error) {
@@ -54,6 +56,9 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	if err != nil {
 		return nil, err
 	}
+	if err := opts.ReplayProfile.Validate(); err != nil {
+		return nil, err
+	}
 	collection := opts.Collection
 	if collection == "" {
 		collection = workspace.Manifest().Collection
@@ -62,12 +67,13 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 		return nil, fmt.Errorf("colgranule: empty column mutation collection")
 	}
 	adapter := &ColumnMutationAdapter{
-		workspace:    workspace,
-		collection:   collection,
-		opts:         normalized,
-		dictionaries: opts.Dictionaries,
-		nextPartID:   opts.InitialPartID,
-		nextGen:      opts.InitialGeneration,
+		workspace:     workspace,
+		collection:    collection,
+		opts:          normalized,
+		dictionaries:  opts.Dictionaries,
+		replayProfile: opts.ReplayProfile.normalized(),
+		nextPartID:    opts.InitialPartID,
+		nextGen:       opts.InitialGeneration,
 	}
 	if adapter.nextPartID == 0 {
 		adapter.nextPartID = 1
@@ -97,6 +103,13 @@ func NewColumnMutationAdapter(workspace *ColumnWorkspace, opts ColumnMutationAda
 	}
 	adapter.manifest = manifest
 	return adapter, nil
+}
+
+func (a *ColumnMutationAdapter) ReplayProfile() ColumnMutationReplayProfile {
+	if a == nil {
+		return ColumnMutationReplayProfile{}
+	}
+	return a.replayProfile
 }
 
 func (a *ColumnMutationAdapter) Manifest() ColumnCollectionManifest {

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -2,7 +2,10 @@ package colgranule
 
 import (
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -71,7 +74,7 @@ func TestColumnMutationAdapterReplayAndJSONBenchParity(t *testing.T) {
 		t.Fatalf("delta coverage=%+v", coverage)
 	}
 
-	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{IncludeAggregateMetadata: true})
 	if err != nil {
 		t.Fatalf("Reader: %v", err)
 	}
@@ -115,6 +118,112 @@ func TestColumnMutationAdapterReplayAndJSONBenchParity(t *testing.T) {
 		t.Fatalf("replay Reader: %v", err)
 	}
 	assertJSONBenchPartSetQueriesMatchRaw(t, replayReader, expected)
+}
+
+func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) {
+	ds := syntheticJSONBenchDataset(256)
+	opts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds, 32, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(time): %v", err)
+	}
+	scenario := newJSONBenchMutationReplayScenario(t, ds)
+
+	original := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{}, false)
+	physicalReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{
+		InitialPartID:     1_000,
+		InitialGeneration: 50,
+	}, true)
+
+	assertJSONBenchPartSetQueriesMatchRaw(t, original.reader, scenario.expected)
+	assertJSONBenchPartSetQueriesMatchRaw(t, physicalReplay.reader, scenario.expected)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, original.reader, scenario.expected, JSONBenchColumnPartLayoutTimeUS)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, physicalReplay.reader, scenario.expected, JSONBenchColumnPartLayoutTimeUS)
+	assertColumnPartSetLogicalDigestMatchesDataset(t, original.reader, scenario.expected, ds.Dictionaries)
+	assertColumnPartSetLogicalDigestMatchesDataset(t, physicalReplay.reader, scenario.expected, ds.Dictionaries)
+	assertColumnReplayPhysicalDescriptorsDiffer(t, original, physicalReplay)
+	if original.manifest.ByteAccounting != physicalReplay.manifest.ByteAccounting {
+		t.Fatalf("byte accounting changed across physical replay\noriginal=%+v\nreplay=%+v", original.manifest.ByteAccounting, physicalReplay.manifest.ByteAccounting)
+	}
+	if original.reader.VisibilityStats() != physicalReplay.reader.VisibilityStats() {
+		t.Fatalf("visibility stats changed across physical replay\noriginal=%+v\nreplay=%+v", original.reader.VisibilityStats(), physicalReplay.reader.VisibilityStats())
+	}
+
+	remapped := remapJSONBenchDictionaryCodes(t, ds, 10_000)
+	remappedOpts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(remapped, 32, JSONBenchColumnPartLayoutTimeUS)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(remapped time): %v", err)
+	}
+	if ds.Dictionaries["commit_collection_code"]["app.bsky.feed.post"] == remapped.Dictionaries["commit_collection_code"]["app.bsky.feed.post"] {
+		t.Fatal("dictionary remap did not change commit_collection_code/app.bsky.feed.post")
+	}
+	remappedScenario := newJSONBenchMutationReplayScenario(t, remapped)
+	dictionaryReplay := testJSONBenchMutationReplayState(t, t.TempDir(), remapped, remappedOpts, remappedScenario, ColumnMutationAdapterOptions{
+		InitialPartID:     2_000,
+		InitialGeneration: 90,
+	}, true)
+	assertJSONBenchPartSetQueriesMatchRaw(t, dictionaryReplay.reader, remappedScenario.expected)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, dictionaryReplay.reader, remappedScenario.expected, JSONBenchColumnPartLayoutTimeUS)
+	assertColumnPartSetLogicalDigestMatchesDataset(t, dictionaryReplay.reader, remappedScenario.expected, ds.Dictionaries)
+	canonicalReplayExpected := canonicalizeJSONBenchDictionaryCodes(t, remappedScenario.expected, ds.Dictionaries)
+	assertJSONBenchQueryDigestsEqual(t, scenario.expected, canonicalReplayExpected)
+	if got, want := jsonBenchCanonicalDatasetDigest(t, remappedScenario.expected, ds.Dictionaries), jsonBenchCanonicalDatasetDigest(t, scenario.expected, ds.Dictionaries); got != want {
+		t.Fatalf("canonical declared-column digest=%d want %d", got, want)
+	}
+
+	clickHouseOpts, err := JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(ds, 32, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(clickhouse): %v", err)
+	}
+	clickHouseOriginal := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, ColumnMutationAdapterOptions{}, false)
+	clickHouseReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, ColumnMutationAdapterOptions{
+		InitialPartID:     3_000,
+		InitialGeneration: 130,
+	}, true)
+	assertJSONBenchPartSetQueriesMatchRaw(t, clickHouseOriginal.reader, scenario.expected)
+	assertJSONBenchPartSetQueriesMatchRaw(t, clickHouseReplay.reader, scenario.expected)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, clickHouseOriginal.reader, scenario.expected, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, clickHouseReplay.reader, scenario.expected, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
+	assertColumnReplayPhysicalDescriptorsDiffer(t, clickHouseOriginal, clickHouseReplay)
+	if clickHouseOriginal.manifest.ByteAccounting != clickHouseReplay.manifest.ByteAccounting {
+		t.Fatalf("clickhouse byte accounting changed across physical replay\noriginal=%+v\nreplay=%+v", clickHouseOriginal.manifest.ByteAccounting, clickHouseReplay.manifest.ByteAccounting)
+	}
+}
+
+func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile ColumnMutationReplayProfile
+		wantErr bool
+		want    string
+	}{
+		{name: "default durable", want: "durable"},
+		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
+		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true},
+		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true},
+		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},
+		{name: "fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast, BenchmarkOnly: true}, want: "fast_benchmark_ceiling"},
+		{name: "unknown rejected", profile: ColumnMutationReplayProfile{Durability: "unsafe"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.profile.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate(): %v", err)
+			}
+			if got := tt.profile.Label(); got != tt.want {
+				t.Fatalf("Label()=%q want %q", got, tt.want)
+			}
+			if production := tt.profile.ProductionSupported(); production != (tt.want == "durable") {
+				t.Fatalf("ProductionSupported()=%v label=%s", production, tt.want)
+			}
+		})
+	}
 }
 
 func TestColumnMutationAdapterDeleteOnlyBatch(t *testing.T) {
@@ -338,6 +447,64 @@ func BenchmarkColumnMutationAdapterApplyM8A(b *testing.B) {
 	}
 }
 
+func BenchmarkColumnMutationReplayM9D(b *testing.B) {
+	fixtures := []struct {
+		name    string
+		rows    int
+		updates int
+		deletes int
+	}{
+		{name: "small_1k", rows: 1_024, updates: 64, deletes: 16},
+		{name: "medium_8k", rows: 8_192, updates: 256, deletes: 64},
+	}
+	profiles := []ColumnMutationReplayProfile{
+		{Durability: ColumnMutationReplayDurable},
+		{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true},
+	}
+	for _, fixture := range fixtures {
+		ds := syntheticJSONBenchDataset(fixture.rows)
+		opts, err := JSONBenchColumnPartOptions(ds, 128)
+		if err != nil {
+			b.Fatalf("JSONBenchColumnPartOptions(%s): %v", fixture.name, err)
+		}
+		scenario := benchmarkJSONBenchMutationReplayScenario(b, ds, fixture.updates, fixture.deletes)
+		commandBytes := estimateColumnMutationReplayCommandBytes(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, []ColumnMutationBatch{scenario.batch})
+		logicalRows := ds.Rows + scenario.batch.Updates.Rows + len(scenario.batch.Deletes)
+		for _, profile := range profiles {
+			if err := profile.Validate(); err != nil {
+				b.Fatalf("profile %q: %v", profile.Label(), err)
+			}
+			b.Run(fixture.name+"/"+profile.Label(), func(b *testing.B) {
+				root := b.TempDir()
+				var last ColumnCollectionManifest
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					workspace, adapter := benchmarkColumnMutationAdapter(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries)
+					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
+					if err == nil {
+						_, err = adapter.Apply(scenario.batch)
+					}
+					last = adapter.Manifest()
+					_ = workspace.Close()
+					if err != nil {
+						b.Fatalf("replay: %v", err)
+					}
+				}
+				b.StopTimer()
+				if b.N > 0 {
+					b.ReportMetric(float64(logicalRows*b.N)/b.Elapsed().Seconds(), "rows/sec")
+				}
+				b.ReportMetric(float64(logicalRows), "logical_rows/op")
+				b.ReportMetric(float64(commandBytes), "command_bytes/op")
+				b.ReportMetric(0, "row_remainder_bytes/op")
+				b.ReportMetric(float64(last.ByteAccounting.TotalAssetBytes), "column_asset_bytes/op")
+				b.ReportMetric(float64(last.ByteAccounting.DescriptorBytes), "manifest_control_bytes/op")
+			})
+		}
+	}
+}
+
 func testColumnMutationAdapter(t testing.TB, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64) (*ColumnWorkspace, *ColumnMutationAdapter) {
 	t.Helper()
 	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
@@ -413,4 +580,484 @@ func benchmarkColumnMutationLocatorReader(b *testing.B, deltaParts int) (*Column
 		b.Fatalf("Reader: %v", err)
 	}
 	return reader, target
+}
+
+type jsonBenchMutationReplayScenario struct {
+	batch    ColumnMutationBatch
+	expected JSONBenchDataset
+}
+
+type jsonBenchMutationReplayState struct {
+	reader   *ColumnPartSetReader
+	manifest ColumnCollectionManifest
+}
+
+func newJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset) jsonBenchMutationReplayScenario {
+	tb.Helper()
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		tb.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	updates := map[int64]map[string]int64{
+		5: {
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][40],
+			"time_us":                ds.Columns["time_us"][5] - 10_000_000,
+		},
+		25: {
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][41],
+			"time_us":                ds.Columns["time_us"][25] + 20_000_000,
+		},
+		97: {
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][42],
+			"time_us":                ds.Columns["time_us"][97] + 30_000_000,
+		},
+	}
+	for _, update := range updates {
+		update["hour_of_day"] = unixMicroHour(update["time_us"])
+	}
+	deletes := []int64{10, 11, 12}
+	deleteSet := map[int64]bool{10: true, 11: true, 12: true}
+	batch := ColumnMutationBatch{
+		Updates:                 jsonBenchDeltaBatch(ds, updates),
+		Deletes:                 deletes,
+		SourceRowRootGeneration: 2,
+		SourceRowVersionLower:   uint64(ds.Rows),
+		SourceRowVersionUpper:   uint64(ds.Rows + len(updates) + len(deletes)),
+	}
+	return jsonBenchMutationReplayScenario{
+		batch:    batch,
+		expected: applyJSONBenchMutations(ds, updates, deleteSet),
+	}
+}
+
+func benchmarkJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset, updates int, deletes int) jsonBenchMutationReplayScenario {
+	tb.Helper()
+	if updates <= 0 || deletes < 0 || updates+deletes >= ds.Rows {
+		tb.Fatalf("invalid replay scenario updates=%d deletes=%d rows=%d", updates, deletes, ds.Rows)
+	}
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		tb.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	updateMap := make(map[int64]map[string]int64, updates)
+	for i := 0; i < updates; i++ {
+		id := int64((i*17 + 5) % (ds.Rows / 2))
+		nextTime := ds.Columns["time_us"][int(id)] + int64(i+1)*1_000_000
+		updateMap[id] = map[string]int64{
+			"kind_code":              codes.kindCommit,
+			"commit_operation_code":  codes.operationCreate,
+			"commit_collection_code": codes.collectionPost,
+			"did_code":               ds.Columns["did_code"][(int(id)+41)%ds.Rows],
+			"time_us":                nextTime,
+			"hour_of_day":            unixMicroHour(nextTime),
+		}
+	}
+	deleteList := make([]int64, 0, deletes)
+	deleteSet := make(map[int64]bool, deletes)
+	for i := 0; i < deletes; i++ {
+		id := int64(ds.Rows - 1 - i*3)
+		deleteList = append(deleteList, id)
+		deleteSet[id] = true
+	}
+	batch := ColumnMutationBatch{
+		Updates:                 jsonBenchDeltaBatch(ds, updateMap),
+		Deletes:                 deleteList,
+		SourceRowRootGeneration: 2,
+		SourceRowVersionLower:   uint64(ds.Rows),
+		SourceRowVersionUpper:   uint64(ds.Rows + len(updateMap) + len(deleteSet)),
+	}
+	return jsonBenchMutationReplayScenario{
+		batch:    batch,
+		expected: applyJSONBenchMutations(ds, updateMap, deleteSet),
+	}
+}
+
+func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchDataset, opts ColumnStoreOptions, scenario jsonBenchMutationReplayScenario, adapterOpts ColumnMutationAdapterOptions, preseedAssetOffsets bool) jsonBenchMutationReplayState {
+	t.Helper()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	t.Cleanup(func() { _ = workspace.Close() })
+	if preseedAssetOffsets {
+		part, err := BuildColumnPart(777, opts, ColumnBatch{Rows: 1, Columns: sliceJSONBenchColumns(ds, 0, 1)})
+		if err != nil {
+			t.Fatalf("BuildColumnPart(preseed): %v", err)
+		}
+		entry, err := workspace.PublishPart(part, ds.Dictionaries)
+		if err != nil {
+			t.Fatalf("PublishPart(preseed): %v", err)
+		}
+		if entry.AssetRef.Offset != 0 {
+			t.Fatalf("preseed offset=%d want 0", entry.AssetRef.Offset)
+		}
+	}
+	adapterOpts.Collection = "jsonbench"
+	adapterOpts.StoreOptions = opts
+	adapterOpts.Dictionaries = ds.Dictionaries
+	adapter, err := NewColumnMutationAdapter(workspace, adapterOpts)
+	if err != nil {
+		t.Fatalf("NewColumnMutationAdapter: %v", err)
+	}
+	if _, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{
+		SourceRowRootGeneration: 1,
+		SourceRowVersionUpper:   uint64(ds.Rows),
+	}); err != nil {
+		t.Fatalf("PublishBaseBatch: %v", err)
+	}
+	if _, err := adapter.Apply(scenario.batch); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	return jsonBenchMutationReplayState{
+		reader:   reader,
+		manifest: adapter.Manifest(),
+	}
+}
+
+func assertColumnReplayPhysicalDescriptorsDiffer(t *testing.T, original jsonBenchMutationReplayState, replay jsonBenchMutationReplayState) {
+	t.Helper()
+	if original.manifest.ActiveGeneration == replay.manifest.ActiveGeneration {
+		t.Fatalf("active generation preserved: %d", original.manifest.ActiveGeneration)
+	}
+	if len(original.manifest.PartSet.BaseParts) != 1 || len(original.manifest.PartSet.DeltaParts) != 1 {
+		t.Fatalf("original part set=%+v", original.manifest.PartSet)
+	}
+	if len(replay.manifest.PartSet.BaseParts) != 1 || len(replay.manifest.PartSet.DeltaParts) != 1 {
+		t.Fatalf("replay part set=%+v", replay.manifest.PartSet)
+	}
+	originalBase := original.manifest.PartSet.BaseParts[0]
+	replayBase := replay.manifest.PartSet.BaseParts[0]
+	originalDelta := original.manifest.PartSet.DeltaParts[0]
+	replayDelta := replay.manifest.PartSet.DeltaParts[0]
+	if originalBase.GenerationID == replayBase.GenerationID || originalDelta.GenerationID == replayDelta.GenerationID {
+		t.Fatalf("generation ids preserved: original base/delta=%d/%d replay=%d/%d", originalBase.GenerationID, originalDelta.GenerationID, replayBase.GenerationID, replayDelta.GenerationID)
+	}
+	if originalBase.Part.PartID == replayBase.Part.PartID || originalDelta.Part.PartID == replayDelta.Part.PartID {
+		t.Fatalf("part ids preserved: original base/delta=%d/%d replay=%d/%d", originalBase.Part.PartID, originalDelta.Part.PartID, replayBase.Part.PartID, replayDelta.Part.PartID)
+	}
+	if originalBase.Part.AssetRef.Offset == replayBase.Part.AssetRef.Offset {
+		t.Fatalf("base asset offset preserved: %d", originalBase.Part.AssetRef.Offset)
+	}
+	originalLocator, ok := original.reader.LatestLocator(5)
+	if !ok {
+		t.Fatal("original missing locator for id 5")
+	}
+	replayLocator, ok := replay.reader.LatestLocator(5)
+	if !ok {
+		t.Fatal("replay missing locator for id 5")
+	}
+	if originalLocator.PartID == replayLocator.PartID {
+		t.Fatalf("locator part id preserved: %d", originalLocator.PartID)
+	}
+}
+
+func assertColumnPartSetLogicalDigestMatchesDataset(t *testing.T, reader *ColumnPartSetReader, ds JSONBenchDataset, canonicalDictionaries map[string]map[string]int64) {
+	t.Helper()
+	columns := sortedJSONBenchColumnNames(ds)
+	result, err := reader.ScanProjected(columns)
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	if result.Rows != ds.Rows {
+		t.Fatalf("ScanProjected rows=%d want %d", result.Rows, ds.Rows)
+	}
+	got := JSONBenchDataset{Rows: result.Rows, Columns: result.Columns, Dictionaries: ds.Dictionaries}
+	gotDigest := jsonBenchCanonicalDatasetDigest(t, got, canonicalDictionaries)
+	wantDigest := jsonBenchCanonicalDatasetDigest(t, ds, canonicalDictionaries)
+	if gotDigest != wantDigest {
+		t.Fatalf("projected declared-column digest=%d want %d", gotDigest, wantDigest)
+	}
+}
+
+func assertJSONBenchQueryDigestsEqual(t *testing.T, a JSONBenchDataset, b JSONBenchDataset) {
+	t.Helper()
+	aTimings, err := RunJSONBenchQueries(a, 1)
+	if err != nil {
+		t.Fatalf("RunJSONBenchQueries(a): %v", err)
+	}
+	bTimings, err := RunJSONBenchQueries(b, 1)
+	if err != nil {
+		t.Fatalf("RunJSONBenchQueries(b): %v", err)
+	}
+	if len(aTimings) != len(bTimings) {
+		t.Fatalf("query count=%d want %d", len(bTimings), len(aTimings))
+	}
+	for i := range aTimings {
+		if aTimings[i].Query != bTimings[i].Query || aTimings[i].ResultRows != bTimings[i].ResultRows || aTimings[i].ResultDigest != bTimings[i].ResultDigest {
+			t.Fatalf("%s rows/digest=(%d,%d) want %s (%d,%d)", bTimings[i].Query, bTimings[i].ResultRows, bTimings[i].ResultDigest, aTimings[i].Query, aTimings[i].ResultRows, aTimings[i].ResultDigest)
+		}
+	}
+}
+
+func assertJSONBenchReplaySpecializedQueriesMatchRaw(t *testing.T, reader *ColumnPartSetReader, ds JSONBenchDataset, layout JSONBenchColumnPartLayout) {
+	t.Helper()
+	codes, err := jsonBenchQueryCodes(ds)
+	if err != nil {
+		t.Fatalf("jsonBenchQueryCodes: %v", err)
+	}
+	switch layout {
+	case JSONBenchColumnPartLayoutTimeUS:
+		rawQ4Rows, rawQ4Digest := runJSONBenchQ4(ds, codes)
+		q4Rows, q4Digest, q4Diagnostics, err := runJSONBenchPartSetQ4TimeOrdered(reader, codes, &jsonBenchPartQueryScratch{})
+		if err != nil {
+			t.Fatalf("runJSONBenchPartSetQ4TimeOrdered: %v", err)
+		}
+		if q4Rows != rawQ4Rows || q4Digest != rawQ4Digest {
+			t.Fatalf("q4a rows/digest=(%d,%d) raw=(%d,%d)", q4Rows, q4Digest, rawQ4Rows, rawQ4Digest)
+		}
+		if q4Diagnostics.AggregateKernel == "" {
+			t.Fatalf("q4a diagnostics missing aggregate kernel: %+v", q4Diagnostics)
+		}
+
+		rawQ5Rows, rawQ5Digest := runJSONBenchQ5(ds, codes)
+		q5Rows, q5Digest, q5Diagnostics, err := runJSONBenchPartSetQ5AggregateMetadata(reader, codes, &jsonBenchPartQueryScratch{})
+		if err != nil {
+			if !strings.Contains(err.Error(), "requires all-visible") {
+				t.Fatalf("runJSONBenchPartSetQ5AggregateMetadata: %v", err)
+			}
+		} else {
+			if q5Rows != rawQ5Rows || q5Digest != rawQ5Digest {
+				t.Fatalf("q5 metadata rows/digest=(%d,%d) raw=(%d,%d)", q5Rows, q5Digest, rawQ5Rows, rawQ5Digest)
+			}
+			if !q5Diagnostics.AggregateMetadataUsed || q5Diagnostics.RowsScanned != 0 || q5Diagnostics.BlocksDecoded != 0 {
+				t.Fatalf("q5 metadata diagnostics=%+v want metadata-only", q5Diagnostics)
+			}
+		}
+	case JSONBenchColumnPartLayoutClickHouseFilterUserTime:
+		rawQ4Rows, rawQ4Digest := runJSONBenchQ4(ds, codes)
+		q4Rows, q4Digest, q4Diagnostics, err := runJSONBenchPartSetQ4ClickHouseOrder(reader, codes, &jsonBenchPartQueryScratch{})
+		if err != nil {
+			t.Fatalf("runJSONBenchPartSetQ4ClickHouseOrder: %v", err)
+		}
+		if q4Rows != rawQ4Rows || q4Digest != rawQ4Digest {
+			t.Fatalf("q4b rows/digest=(%d,%d) raw=(%d,%d)", q4Rows, q4Digest, rawQ4Rows, rawQ4Digest)
+		}
+		if q4Diagnostics.AggregateKernel != "multipart_clickhouse_order_prefix_scan_min_by_user" || q4Diagnostics.EarlyStopAvailable {
+			t.Fatalf("q4b diagnostics=%+v want ClickHouse-order prefix scan", q4Diagnostics)
+		}
+
+		q4MetaRows, q4MetaDigest, q4MetaDiagnostics, err := runJSONBenchPartSetQ4AggregateMetadata(reader, codes, &jsonBenchPartQueryScratch{})
+		if err != nil {
+			if !strings.Contains(err.Error(), "requires all-visible") {
+				t.Fatalf("runJSONBenchPartSetQ4AggregateMetadata: %v", err)
+			}
+		} else {
+			if q4MetaRows != rawQ4Rows || q4MetaDigest != rawQ4Digest {
+				t.Fatalf("q4 metadata rows/digest=(%d,%d) raw=(%d,%d)", q4MetaRows, q4MetaDigest, rawQ4Rows, rawQ4Digest)
+			}
+			if !q4MetaDiagnostics.AggregateMetadataUsed || q4MetaDiagnostics.RowsScanned != 0 || q4MetaDiagnostics.BlocksDecoded != 0 {
+				t.Fatalf("q4 metadata diagnostics=%+v want metadata-only", q4MetaDiagnostics)
+			}
+		}
+	default:
+		t.Fatalf("unsupported replay specialized layout %q", layout)
+	}
+}
+
+func remapJSONBenchDictionaryCodes(t *testing.T, ds JSONBenchDataset, offset int64) JSONBenchDataset {
+	t.Helper()
+	out := cloneJSONBenchDataset(ds)
+	out.Dictionaries = make(map[string]map[string]int64, len(ds.Dictionaries))
+	for name, dict := range ds.Dictionaries {
+		entries := sortedJSONBenchDictionaryEntries(dict)
+		shift := 1
+		if len(entries) > 1 {
+			shift = int(offset % int64(len(entries)))
+			if shift == 0 {
+				shift = 1
+			}
+		}
+		next := make(map[string]int64, len(entries))
+		oldToNew := make(map[int64]int64, len(entries))
+		for i, entry := range entries {
+			newCode := entries[(i+shift)%len(entries)].code
+			next[entry.label] = newCode
+			oldToNew[entry.code] = newCode
+		}
+		out.Dictionaries[name] = next
+		values := out.Columns[name]
+		for i, value := range values {
+			newValue, ok := oldToNew[value]
+			if !ok {
+				t.Fatalf("column %s row %d code=%d missing from dictionary", name, i, value)
+			}
+			values[i] = newValue
+		}
+	}
+	return out
+}
+
+func canonicalizeJSONBenchDictionaryCodes(t *testing.T, ds JSONBenchDataset, canonicalDictionaries map[string]map[string]int64) JSONBenchDataset {
+	t.Helper()
+	out := cloneJSONBenchDataset(ds)
+	out.Dictionaries = cloneJSONBenchDictionaries(canonicalDictionaries)
+	for name, canonical := range canonicalDictionaries {
+		source := ds.Dictionaries[name]
+		if source == nil {
+			continue
+		}
+		inverse := invertJSONBenchDictionary(t, name, source)
+		values := out.Columns[name]
+		for i, value := range values {
+			label, ok := inverse[value]
+			if !ok {
+				t.Fatalf("column %s row %d code=%d missing from source dictionary", name, i, value)
+			}
+			canonicalValue, ok := canonical[label]
+			if !ok {
+				t.Fatalf("column %s row %d label=%q missing from canonical dictionary", name, i, label)
+			}
+			values[i] = canonicalValue
+		}
+	}
+	return out
+}
+
+func jsonBenchCanonicalDatasetDigest(t *testing.T, ds JSONBenchDataset, canonicalDictionaries map[string]map[string]int64) uint64 {
+	t.Helper()
+	columns := sortedJSONBenchColumnNames(ds)
+	rowIndex := ds.Columns["row_index"]
+	if len(rowIndex) != ds.Rows {
+		t.Fatalf("row_index rows=%d want %d", len(rowIndex), ds.Rows)
+	}
+	order := make([]int, len(rowIndex))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return rowIndex[order[i]] < rowIndex[order[j]]
+	})
+	inverses := make(map[string]map[int64]string, len(ds.Dictionaries))
+	for name, dict := range ds.Dictionaries {
+		inverses[name] = invertJSONBenchDictionary(t, name, dict)
+	}
+	var digest uint64
+	digest = digestMix(digest, uint64(ds.Rows), uint64(len(columns)))
+	for _, row := range order {
+		digest = digestMix(digest, uint64(rowIndex[row]), 0)
+		for _, name := range columns {
+			values := ds.Columns[name]
+			if len(values) != ds.Rows {
+				t.Fatalf("column %s rows=%d want %d", name, len(values), ds.Rows)
+			}
+			value := values[row]
+			if canonical := canonicalDictionaries[name]; canonical != nil {
+				label, ok := inverses[name][value]
+				if !ok {
+					t.Fatalf("column %s row %d code=%d missing from source dictionary", name, row, value)
+				}
+				canonicalValue, ok := canonical[label]
+				if !ok {
+					t.Fatalf("column %s row %d label=%q missing from canonical dictionary", name, row, label)
+				}
+				value = canonicalValue
+			}
+			digest = digestMix(digest, hashString64(name), uint64(value))
+		}
+	}
+	return digest
+}
+
+func estimateColumnMutationReplayCommandBytes(base ColumnBatch, batches []ColumnMutationBatch) int {
+	total := estimateColumnBatchPayloadBytes(base)
+	for _, batch := range batches {
+		total += estimateColumnBatchPayloadBytes(batch.Inserts)
+		total += estimateColumnBatchPayloadBytes(batch.Updates)
+		total += len(batch.Deletes) * 8
+		total += 5 * 8
+	}
+	return total
+}
+
+func estimateColumnBatchPayloadBytes(batch ColumnBatch) int {
+	total := 8
+	for name, values := range batch.Columns {
+		total += len(name) + 8
+		total += len(values) * 8
+	}
+	return total
+}
+
+type jsonBenchDictionaryEntry struct {
+	label string
+	code  int64
+}
+
+func sortedJSONBenchDictionaryEntries(dict map[string]int64) []jsonBenchDictionaryEntry {
+	entries := make([]jsonBenchDictionaryEntry, 0, len(dict))
+	for label, code := range dict {
+		entries = append(entries, jsonBenchDictionaryEntry{label: label, code: code})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].code == entries[j].code {
+			return entries[i].label < entries[j].label
+		}
+		return entries[i].code < entries[j].code
+	})
+	return entries
+}
+
+func invertJSONBenchDictionary(t *testing.T, name string, dict map[string]int64) map[int64]string {
+	t.Helper()
+	inverse := make(map[int64]string, len(dict))
+	for label, code := range dict {
+		if prev, ok := inverse[code]; ok {
+			t.Fatalf("dictionary %s duplicate code=%d labels=%q,%q", name, code, prev, label)
+		}
+		inverse[code] = label
+	}
+	return inverse
+}
+
+func cloneJSONBenchDataset(ds JSONBenchDataset) JSONBenchDataset {
+	out := JSONBenchDataset{
+		Rows:         ds.Rows,
+		Files:        append([]string(nil), ds.Files...),
+		Columns:      make(map[string][]int64, len(ds.Columns)),
+		Dictionaries: cloneJSONBenchDictionaries(ds.Dictionaries),
+	}
+	for name, values := range ds.Columns {
+		out.Columns[name] = append([]int64(nil), values...)
+	}
+	return out
+}
+
+func cloneJSONBenchDictionaries(dicts map[string]map[string]int64) map[string]map[string]int64 {
+	out := make(map[string]map[string]int64, len(dicts))
+	for name, dict := range dicts {
+		next := make(map[string]int64, len(dict))
+		for label, code := range dict {
+			next[label] = code
+		}
+		out[name] = next
+	}
+	return out
+}
+
+func sortedJSONBenchColumnNames(ds JSONBenchDataset) []string {
+	columns := make([]string, 0, len(ds.Columns))
+	for name := range ds.Columns {
+		columns = append(columns, name)
+	}
+	sort.Strings(columns)
+	return columns
+}
+
+func hashString64(value string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(value))
+	return h.Sum64()
 }

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -653,8 +653,7 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
-					perOp := elapsed.Seconds() / float64(b.N)
-					b.ReportMetric(float64(logicalRows)/perOp, "rows/sec")
+					b.ReportMetric(float64(logicalRows)*float64(b.N)/elapsed.Seconds(), "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -238,7 +238,8 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 	if err != nil {
 		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
 	}
-	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	profile := ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile))
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace: %v", err)
 	}
@@ -247,13 +248,27 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		Collection:    "jsonbench",
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
-		ReplayProfile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true},
+		ReplayProfile: profile,
 	})
 	if err != nil {
 		t.Fatalf("NewColumnMutationAdapter benchmark profile: %v", err)
 	}
 	if got := adapter.ReplayProfile().Label(); got != "wal_on_fast_benchmark_ceiling" {
 		t.Fatalf("ReplayProfile label=%q want wal_on_fast_benchmark_ceiling", got)
+	}
+
+	durableWorkspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace durable: %v", err)
+	}
+	defer durableWorkspace.Close()
+	if _, err := NewColumnMutationAdapter(durableWorkspace, ColumnMutationAdapterOptions{
+		Collection:    "jsonbench",
+		StoreOptions:  opts,
+		Dictionaries:  ds.Dictionaries,
+		ReplayProfile: profile,
+	}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
+		t.Fatalf("NewColumnMutationAdapter relaxed profile on durable workspace err=%v want sync-mode rejection", err)
 	}
 
 	rejectedWorkspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
@@ -540,7 +555,8 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				if b.N > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
-					b.ReportMetric(float64(logicalRows*b.N)/b.Elapsed().Seconds(), "rows/sec")
+					perOpSeconds := b.Elapsed().Seconds() / float64(b.N)
+					b.ReportMetric(float64(logicalRows)/perOpSeconds, "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")
@@ -579,7 +595,7 @@ func benchmarkColumnMutationAdapter(b *testing.B, dir string, opts ColumnStoreOp
 
 func benchmarkColumnMutationAdapterWithProfile(b *testing.B, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64, profile ColumnMutationReplayProfile) (*ColumnWorkspace, *ColumnMutationAdapter) {
 	b.Helper()
-	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile))
 	if err != nil {
 		b.Fatalf("OpenColumnWorkspace: %v", err)
 	}
@@ -819,19 +835,21 @@ func assertColumnReplayPhysicalDescriptorsDiffer(t *testing.T, original jsonBenc
 	}
 }
 
-func assertColumnPartSetLogicalDigestMatchesDataset(t *testing.T, reader *ColumnPartSetReader, ds JSONBenchDataset, canonicalDictionaries map[string]map[string]int64) {
+func assertColumnPartSetLogicalDigestMatchesDataset(t *testing.T, reader *ColumnPartSetReader, expected JSONBenchDataset, canonicalDictionaries map[string]map[string]int64) {
 	t.Helper()
-	columns := sortedJSONBenchColumnNames(ds)
+	columns := sortedJSONBenchColumnNames(expected)
 	result, err := reader.ScanProjected(columns)
 	if err != nil {
 		t.Fatalf("ScanProjected: %v", err)
 	}
-	if result.Rows != ds.Rows {
-		t.Fatalf("ScanProjected rows=%d want %d", result.Rows, ds.Rows)
+	if result.Rows != expected.Rows {
+		t.Fatalf("ScanProjected rows=%d want %d", result.Rows, expected.Rows)
 	}
-	got := JSONBenchDataset{Rows: result.Rows, Columns: result.Columns, Dictionaries: ds.Dictionaries}
+	// The projected values use the expected dataset's physical dictionary codes;
+	// canonicalDictionaries is only the cross-replay comparison target.
+	got := JSONBenchDataset{Rows: result.Rows, Columns: result.Columns, Dictionaries: expected.Dictionaries}
 	gotDigest := jsonBenchCanonicalDatasetDigest(t, got, canonicalDictionaries)
-	wantDigest := jsonBenchCanonicalDatasetDigest(t, ds, canonicalDictionaries)
+	wantDigest := jsonBenchCanonicalDatasetDigest(t, expected, canonicalDictionaries)
 	if gotDigest != wantDigest {
 		t.Fatalf("projected declared-column digest=%d want %d", gotDigest, wantDigest)
 	}

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestColumnMutationAdapterReplayAndJSONBenchParity(t *testing.T) {
@@ -129,12 +128,17 @@ func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) 
 	}
 	scenario := newJSONBenchMutationReplayScenario(t, ds)
 
-	original := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{}, false)
-	physicalReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{
-		InitialPartID:     1_000,
-		InitialGeneration: 50,
-	}, true)
-	offsetReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{}, true)
+	original := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, testJSONBenchMutationReplayStateOptions{})
+	physicalReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, testJSONBenchMutationReplayStateOptions{
+		AdapterOptions: ColumnMutationAdapterOptions{
+			InitialPartID:     1_000,
+			InitialGeneration: 50,
+		},
+		PreseedAssetOffsets: true,
+	})
+	offsetReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, testJSONBenchMutationReplayStateOptions{
+		PreseedAssetOffsets: true,
+	})
 
 	assertJSONBenchPartSetQueriesMatchRaw(t, original.reader, scenario.expected)
 	assertJSONBenchPartSetQueriesMatchRaw(t, physicalReplay.reader, scenario.expected)
@@ -169,10 +173,13 @@ func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) 
 		t.Fatal("dictionary remap did not change commit_collection_code/app.bsky.feed.post")
 	}
 	remappedScenario := newJSONBenchMutationReplayScenario(t, remapped)
-	dictionaryReplay := testJSONBenchMutationReplayState(t, t.TempDir(), remapped, remappedOpts, remappedScenario, ColumnMutationAdapterOptions{
-		InitialPartID:     2_000,
-		InitialGeneration: 90,
-	}, true)
+	dictionaryReplay := testJSONBenchMutationReplayState(t, t.TempDir(), remapped, remappedOpts, remappedScenario, testJSONBenchMutationReplayStateOptions{
+		AdapterOptions: ColumnMutationAdapterOptions{
+			InitialPartID:     2_000,
+			InitialGeneration: 90,
+		},
+		PreseedAssetOffsets: true,
+	})
 	assertJSONBenchPartSetQueriesMatchRaw(t, dictionaryReplay.reader, remappedScenario.expected)
 	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, dictionaryReplay.reader, remappedScenario.expected, JSONBenchColumnPartLayoutTimeUS)
 	assertColumnPartSetLogicalDigestMatchesDataset(t, dictionaryReplay.reader, remappedScenario.expected, ds.Dictionaries)
@@ -186,11 +193,14 @@ func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) 
 	if err != nil {
 		t.Fatalf("JSONBenchColumnPartOptionsWithAggregateMetadataForLayout(clickhouse): %v", err)
 	}
-	clickHouseOriginal := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, ColumnMutationAdapterOptions{}, false)
-	clickHouseReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, ColumnMutationAdapterOptions{
-		InitialPartID:     3_000,
-		InitialGeneration: 130,
-	}, true)
+	clickHouseOriginal := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, testJSONBenchMutationReplayStateOptions{})
+	clickHouseReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, clickHouseOpts, scenario, testJSONBenchMutationReplayStateOptions{
+		AdapterOptions: ColumnMutationAdapterOptions{
+			InitialPartID:     3_000,
+			InitialGeneration: 130,
+		},
+		PreseedAssetOffsets: true,
+	})
 	assertJSONBenchPartSetQueriesMatchRaw(t, clickHouseOriginal.reader, scenario.expected)
 	assertJSONBenchPartSetQueriesMatchRaw(t, clickHouseReplay.reader, scenario.expected)
 	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, clickHouseOriginal.reader, scenario.expected, JSONBenchColumnPartLayoutClickHouseFilterUserTime)
@@ -575,7 +585,6 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				var last ColumnCollectionManifest
 				b.ReportAllocs()
 				b.ResetTimer()
-				start := time.Now()
 				for i := 0; i < b.N; i++ {
 					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
@@ -588,8 +597,8 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 						b.Fatalf("replay: %v", err)
 					}
 				}
-				elapsed := time.Since(start)
 				b.StopTimer()
+				elapsed := b.Elapsed()
 				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
@@ -789,14 +798,20 @@ func benchmarkJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset
 	}
 }
 
-func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchDataset, opts ColumnStoreOptions, scenario jsonBenchMutationReplayScenario, adapterOpts ColumnMutationAdapterOptions, preseedAssetOffsets bool) jsonBenchMutationReplayState {
+type testJSONBenchMutationReplayStateOptions struct {
+	AdapterOptions      ColumnMutationAdapterOptions
+	PreseedAssetOffsets bool
+}
+
+func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchDataset, opts ColumnStoreOptions, scenario jsonBenchMutationReplayScenario, stateOpts testJSONBenchMutationReplayStateOptions) jsonBenchMutationReplayState {
 	t.Helper()
-	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
+	adapterOpts := stateOpts.AdapterOptions
+	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", adapterOpts.ReplayProfile))
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace: %v", err)
 	}
 	t.Cleanup(func() { _ = workspace.Close() })
-	if preseedAssetOffsets {
+	if stateOpts.PreseedAssetOffsets {
 		part, err := BuildColumnPart(777, opts, ColumnBatch{Rows: 1, Columns: sliceJSONBenchColumns(ds, 0, 1)})
 		if err != nil {
 			t.Fatalf("BuildColumnPart(preseed): %v", err)

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestColumnMutationAdapterReplayAndJSONBenchParity(t *testing.T) {
@@ -133,19 +134,30 @@ func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) 
 		InitialPartID:     1_000,
 		InitialGeneration: 50,
 	}, true)
+	offsetReplay := testJSONBenchMutationReplayState(t, t.TempDir(), ds, opts, scenario, ColumnMutationAdapterOptions{}, true)
 
 	assertJSONBenchPartSetQueriesMatchRaw(t, original.reader, scenario.expected)
 	assertJSONBenchPartSetQueriesMatchRaw(t, physicalReplay.reader, scenario.expected)
+	assertJSONBenchPartSetQueriesMatchRaw(t, offsetReplay.reader, scenario.expected)
 	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, original.reader, scenario.expected, JSONBenchColumnPartLayoutTimeUS)
 	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, physicalReplay.reader, scenario.expected, JSONBenchColumnPartLayoutTimeUS)
+	assertJSONBenchReplaySpecializedQueriesMatchRaw(t, offsetReplay.reader, scenario.expected, JSONBenchColumnPartLayoutTimeUS)
 	assertColumnPartSetLogicalDigestMatchesDataset(t, original.reader, scenario.expected, ds.Dictionaries)
 	assertColumnPartSetLogicalDigestMatchesDataset(t, physicalReplay.reader, scenario.expected, ds.Dictionaries)
+	assertColumnPartSetLogicalDigestMatchesDataset(t, offsetReplay.reader, scenario.expected, ds.Dictionaries)
 	assertColumnReplayPhysicalDescriptorsDiffer(t, original, physicalReplay)
+	assertColumnReplayAssetOffsetsDifferOnly(t, original, offsetReplay)
 	if original.manifest.ByteAccounting != physicalReplay.manifest.ByteAccounting {
 		t.Fatalf("byte accounting changed across physical replay\noriginal=%+v\nreplay=%+v", original.manifest.ByteAccounting, physicalReplay.manifest.ByteAccounting)
 	}
+	if original.manifest.ByteAccounting != offsetReplay.manifest.ByteAccounting {
+		t.Fatalf("byte accounting changed across offset replay\noriginal=%+v\nreplay=%+v", original.manifest.ByteAccounting, offsetReplay.manifest.ByteAccounting)
+	}
 	if original.reader.VisibilityStats() != physicalReplay.reader.VisibilityStats() {
 		t.Fatalf("visibility stats changed across physical replay\noriginal=%+v\nreplay=%+v", original.reader.VisibilityStats(), physicalReplay.reader.VisibilityStats())
+	}
+	if original.reader.VisibilityStats() != offsetReplay.reader.VisibilityStats() {
+		t.Fatalf("visibility stats changed across offset replay\noriginal=%+v\nreplay=%+v", original.reader.VisibilityStats(), offsetReplay.reader.VisibilityStats())
 	}
 
 	remapped := remapJSONBenchDictionaryCodes(t, ds, 10_000)
@@ -196,11 +208,12 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 		wantErr         bool
 		wantErrContains string
 		want            string
+		wantLabel       string
 	}{
 		{name: "default durable", want: "durable"},
 		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
-		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true},
-		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true},
+		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true, wantLabel: "durable_benchmark_ceiling"},
+		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true, wantLabel: "durable_benchmark_ceiling"},
 		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},
@@ -216,6 +229,11 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 				}
 				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
 					t.Fatalf("Validate() err=%q want containing %q", err, tt.wantErrContains)
+				}
+				if tt.wantLabel != "" {
+					if got := tt.profile.Label(); got != tt.wantLabel {
+						t.Fatalf("Label()=%q want %q", got, tt.wantLabel)
+					}
 				}
 				return
 			}
@@ -557,6 +575,7 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				var last ColumnCollectionManifest
 				b.ReportAllocs()
 				b.ResetTimer()
+				start := time.Now()
 				for i := 0; i < b.N; i++ {
 					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
@@ -569,12 +588,12 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 						b.Fatalf("replay: %v", err)
 					}
 				}
+				elapsed := time.Since(start)
 				b.StopTimer()
-				if b.N > 0 {
+				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
-					perOpSeconds := b.Elapsed().Seconds() / float64(b.N)
-					b.ReportMetric(float64(logicalRows)/perOpSeconds, "rows/sec")
+					b.ReportMetric(float64(logicalRows)*float64(b.N)/elapsed.Seconds(), "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")
@@ -850,6 +869,46 @@ func assertColumnReplayPhysicalDescriptorsDiffer(t *testing.T, original jsonBenc
 	}
 	if originalLocator.PartID == replayLocator.PartID {
 		t.Fatalf("locator part id preserved: %d", originalLocator.PartID)
+	}
+}
+
+func assertColumnReplayAssetOffsetsDifferOnly(t *testing.T, original jsonBenchMutationReplayState, replay jsonBenchMutationReplayState) {
+	t.Helper()
+	if original.manifest.ActiveGeneration != replay.manifest.ActiveGeneration {
+		t.Fatalf("active generation changed: original=%d replay=%d", original.manifest.ActiveGeneration, replay.manifest.ActiveGeneration)
+	}
+	if len(original.manifest.PartSet.BaseParts) != 1 || len(original.manifest.PartSet.DeltaParts) != 1 {
+		t.Fatalf("original part set=%+v", original.manifest.PartSet)
+	}
+	if len(replay.manifest.PartSet.BaseParts) != 1 || len(replay.manifest.PartSet.DeltaParts) != 1 {
+		t.Fatalf("replay part set=%+v", replay.manifest.PartSet)
+	}
+	originalBase := original.manifest.PartSet.BaseParts[0]
+	replayBase := replay.manifest.PartSet.BaseParts[0]
+	originalDelta := original.manifest.PartSet.DeltaParts[0]
+	replayDelta := replay.manifest.PartSet.DeltaParts[0]
+	if originalBase.GenerationID != replayBase.GenerationID || originalDelta.GenerationID != replayDelta.GenerationID {
+		t.Fatalf("generation ids changed: original base/delta=%d/%d replay=%d/%d", originalBase.GenerationID, originalDelta.GenerationID, replayBase.GenerationID, replayDelta.GenerationID)
+	}
+	if originalBase.Part.PartID != replayBase.Part.PartID || originalDelta.Part.PartID != replayDelta.Part.PartID {
+		t.Fatalf("part ids changed: original base/delta=%d/%d replay=%d/%d", originalBase.Part.PartID, originalDelta.Part.PartID, replayBase.Part.PartID, replayDelta.Part.PartID)
+	}
+	if originalBase.Part.AssetRef.Offset == replayBase.Part.AssetRef.Offset {
+		t.Fatalf("base asset offset preserved: %d", originalBase.Part.AssetRef.Offset)
+	}
+	if originalDelta.Part.AssetRef.Offset == replayDelta.Part.AssetRef.Offset {
+		t.Fatalf("delta asset offset preserved: %d", originalDelta.Part.AssetRef.Offset)
+	}
+	originalLocator, ok := original.reader.LatestLocator(5)
+	if !ok {
+		t.Fatal("original missing locator for id 5")
+	}
+	replayLocator, ok := replay.reader.LatestLocator(5)
+	if !ok {
+		t.Fatal("replay missing locator for id 5")
+	}
+	if originalLocator.PartID != replayLocator.PartID {
+		t.Fatalf("locator part id changed: original=%d replay=%d", originalLocator.PartID, replayLocator.PartID)
 	}
 }
 

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -191,17 +191,18 @@ func TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D(t *testing.T) 
 
 func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 	tests := []struct {
-		name    string
-		profile ColumnMutationReplayProfile
-		wantErr bool
-		want    string
+		name            string
+		profile         ColumnMutationReplayProfile
+		wantErr         bool
+		wantErrContains string
+		want            string
 	}{
 		{name: "default durable", want: "durable"},
 		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
 		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true},
 		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true},
-		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true},
-		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true},
+		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true, wantErrContains: "not supported for production"},
+		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},
 		{name: "fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast, BenchmarkOnly: true}, want: "fast_benchmark_ceiling"},
 		{name: "unknown rejected", profile: ColumnMutationReplayProfile{Durability: "unsafe"}, wantErr: true},
@@ -212,6 +213,9 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("Validate() nil error")
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("Validate() err=%q want containing %q", err, tt.wantErrContains)
 				}
 				return
 			}
@@ -225,6 +229,45 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 				t.Fatalf("ProductionSupported()=%v label=%s", production, tt.want)
 			}
 		})
+	}
+}
+
+func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
+	ds := syntheticJSONBenchDataset(32)
+	opts, err := JSONBenchColumnPartOptions(ds, 16)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	defer workspace.Close()
+	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
+		Collection:    "jsonbench",
+		StoreOptions:  opts,
+		Dictionaries:  ds.Dictionaries,
+		ReplayProfile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true},
+	})
+	if err != nil {
+		t.Fatalf("NewColumnMutationAdapter benchmark profile: %v", err)
+	}
+	if got := adapter.ReplayProfile().Label(); got != "wal_on_fast_benchmark_ceiling" {
+		t.Fatalf("ReplayProfile label=%q want wal_on_fast_benchmark_ceiling", got)
+	}
+
+	rejectedWorkspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace rejected: %v", err)
+	}
+	defer rejectedWorkspace.Close()
+	if _, err := NewColumnMutationAdapter(rejectedWorkspace, ColumnMutationAdapterOptions{
+		Collection:    "jsonbench",
+		StoreOptions:  opts,
+		Dictionaries:  ds.Dictionaries,
+		ReplayProfile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast},
+	}); err == nil || !strings.Contains(err.Error(), "not supported for production") {
+		t.Fatalf("NewColumnMutationAdapter production wal_on_fast err=%v want production rejection", err)
 	}
 }
 
@@ -482,7 +525,7 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					workspace, adapter := benchmarkColumnMutationAdapter(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries)
+					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
 					if err == nil {
 						_, err = adapter.Apply(scenario.batch)
@@ -495,6 +538,8 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				}
 				b.StopTimer()
 				if b.N > 0 {
+					// The replay gate deliberately includes per-iteration workspace
+					// open/publish/apply/close work in the timed loop.
 					b.ReportMetric(float64(logicalRows*b.N)/b.Elapsed().Seconds(), "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
@@ -502,6 +547,9 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				b.ReportMetric(0, "row_remainder_bytes/op")
 				b.ReportMetric(float64(last.ByteAccounting.TotalAssetBytes), "column_asset_bytes/op")
 				b.ReportMetric(float64(last.ByteAccounting.DescriptorBytes), "manifest_control_bytes/op")
+				if !profile.ProductionSupported() {
+					b.ReportMetric(1, "benchmark_ceiling")
+				}
 			})
 		}
 	}
@@ -526,15 +574,20 @@ func testColumnMutationAdapter(t testing.TB, dir string, opts ColumnStoreOptions
 }
 
 func benchmarkColumnMutationAdapter(b *testing.B, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64) (*ColumnWorkspace, *ColumnMutationAdapter) {
+	return benchmarkColumnMutationAdapterWithProfile(b, dir, opts, dictionaries, ColumnMutationReplayProfile{})
+}
+
+func benchmarkColumnMutationAdapterWithProfile(b *testing.B, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64, profile ColumnMutationReplayProfile) (*ColumnWorkspace, *ColumnMutationAdapter) {
 	b.Helper()
 	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "jsonbench"})
 	if err != nil {
 		b.Fatalf("OpenColumnWorkspace: %v", err)
 	}
 	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
-		Collection:   "jsonbench",
-		StoreOptions: opts,
-		Dictionaries: dictionaries,
+		Collection:    "jsonbench",
+		StoreOptions:  opts,
+		Dictionaries:  dictionaries,
+		ReplayProfile: profile,
 	})
 	if err != nil {
 		_ = workspace.Close()

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -622,12 +622,11 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				root := b.TempDir()
 				var last ColumnCollectionManifest
 				b.ReportAllocs()
+				b.StopTimer()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					if i > 0 {
-						b.StartTimer()
-					}
 					dir := filepath.Join(root, fmt.Sprintf("iter-%06d", i))
+					b.StartTimer()
 					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, dir, opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
 					if err == nil {

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -198,6 +198,8 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 	}{
 		{name: "default durable", want: "durable"},
 		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
+		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true},
+		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true},
 		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true},
 		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true},
 		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -3,6 +3,7 @@ package colgranule
 import (
 	"fmt"
 	"hash/fnv"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -222,8 +223,8 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 	}{
 		{name: "default durable", want: "durable"},
 		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
-		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true, wantLabel: "durable_benchmark_ceiling"},
-		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true, wantLabel: "durable_benchmark_ceiling"},
+		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true, wantErrContains: "durable (default)", wantLabel: "durable_benchmark_ceiling"},
+		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true, wantErrContains: "set BenchmarkOnly=true", wantLabel: "durable_benchmark_ceiling"},
 		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},
@@ -313,16 +314,11 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
 		ReplayProfile: profile,
-	}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
-		t.Fatalf("NewColumnMutationAdapter relaxed profile on durable workspace err=%v want sync-mode rejection", err)
+	}); err == nil || !strings.Contains(err.Error(), `requires workspace manifest sync mode "benchmark_no_sync", got "durable"`) {
+		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want exact sync-mode rejection", err)
 	}
 
-	rejectedWorkspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
-	if err != nil {
-		t.Fatalf("OpenColumnWorkspace rejected: %v", err)
-	}
-	defer rejectedWorkspace.Close()
-	if _, err := NewColumnMutationAdapter(rejectedWorkspace, ColumnMutationAdapterOptions{
+	if _, err := NewColumnMutationAdapter(durableWorkspace, ColumnMutationAdapterOptions{
 		Collection:    "jsonbench",
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
@@ -586,23 +582,32 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, filepath.Join(root, fmt.Sprintf("iter-%06d", i)), opts, ds.Dictionaries, profile)
+					dir := filepath.Join(root, fmt.Sprintf("iter-%06d", i))
+					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, dir, opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
 					if err == nil {
 						_, err = adapter.Apply(scenario.batch)
 					}
 					last = adapter.Manifest()
-					_ = workspace.Close()
+					if closeErr := workspace.Close(); err == nil {
+						err = closeErr
+					}
 					if err != nil {
 						b.Fatalf("replay: %v", err)
 					}
+					b.StopTimer()
+					if err := os.RemoveAll(dir); err != nil {
+						b.Fatalf("cleanup iteration dir: %v", err)
+					}
+					b.StartTimer()
 				}
 				b.StopTimer()
 				elapsed := b.Elapsed()
 				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
-					b.ReportMetric(float64(logicalRows)*float64(b.N)/elapsed.Seconds(), "rows/sec")
+					perOp := elapsed.Seconds() / float64(b.N)
+					b.ReportMetric(float64(logicalRows)/perOp, "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -256,6 +256,24 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 	if got := adapter.ReplayProfile().Label(); got != "wal_on_fast_benchmark_ceiling" {
 		t.Fatalf("ReplayProfile label=%q want wal_on_fast_benchmark_ceiling", got)
 	}
+	for _, tt := range []struct {
+		name    string
+		profile ColumnMutationReplayProfile
+	}{
+		{name: "default"},
+		{name: "explicit_durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}},
+	} {
+		t.Run("reject_durable_on_no_sync_"+tt.name, func(t *testing.T) {
+			if _, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
+				Collection:    "jsonbench",
+				StoreOptions:  opts,
+				Dictionaries:  ds.Dictionaries,
+				ReplayProfile: tt.profile,
+			}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
+				t.Fatalf("NewColumnMutationAdapter durable profile on no-sync workspace err=%v want sync-mode rejection", err)
+			}
+		})
+	}
 
 	durableWorkspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
 	if err != nil {

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -356,8 +356,11 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
 		ReplayProfile: profile,
-	}); err == nil || !strings.Contains(err.Error(), `requires ColumnWorkspaceOptions.ManifestSyncMode="benchmark_no_sync", got "durable"`) {
-		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want exact sync-mode rejection", err)
+	}); err == nil ||
+		!strings.Contains(err.Error(), "requires ColumnWorkspaceOptions.ManifestSyncMode=") ||
+		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDisabledForBenchmark)) ||
+		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDurable)) {
+		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want sync-mode rejection", err)
 	}
 
 	if _, err := NewColumnMutationAdapter(durableWorkspace, ColumnMutationAdapterOptions{

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -224,7 +224,7 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 		{name: "default durable", want: "durable"},
 		{name: "durable", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable}, want: "durable"},
 		{name: "default durable benchmark only rejected", profile: ColumnMutationReplayProfile{BenchmarkOnly: true}, wantErr: true, wantErrContains: "durable (default)", wantLabel: "durable_benchmark_ceiling"},
-		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true, wantErrContains: "set BenchmarkOnly=true", wantLabel: "durable_benchmark_ceiling"},
+		{name: "durable benchmark only rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: true, wantErrContains: "set Durability", wantLabel: "durable_benchmark_ceiling"},
 		{name: "wal on fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "fast production rejected", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast}, wantErr: true, wantErrContains: "not supported for production"},
 		{name: "wal on fast benchmark ceiling", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, want: "wal_on_fast_benchmark_ceiling"},
@@ -578,28 +578,30 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 			}
 			b.Run(fixture.name+"/"+profile.Label(), func(b *testing.B) {
 				root := b.TempDir()
+				cleanupDirs := make([]string, 0, b.N)
+				b.Cleanup(func() {
+					for _, dir := range cleanupDirs {
+						_ = os.RemoveAll(dir)
+					}
+				})
 				var last ColumnCollectionManifest
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					dir := filepath.Join(root, fmt.Sprintf("iter-%06d", i))
+					cleanupDirs = append(cleanupDirs, dir)
 					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, dir, opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
 					if err == nil {
 						_, err = adapter.Apply(scenario.batch)
 					}
-					last = adapter.Manifest()
 					if closeErr := workspace.Close(); err == nil {
 						err = closeErr
 					}
 					if err != nil {
 						b.Fatalf("replay: %v", err)
 					}
-					b.StopTimer()
-					if err := os.RemoveAll(dir); err != nil {
-						b.Fatalf("cleanup iteration dir: %v", err)
-					}
-					b.StartTimer()
+					last = adapter.Manifest()
 				}
 				b.StopTimer()
 				elapsed := b.Elapsed()
@@ -848,13 +850,38 @@ func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchData
 	if _, err := adapter.Apply(scenario.batch); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	reader, err := adapter.Reader(ColumnPartImageReadOptions{})
+	reader, err := adapter.Reader(ColumnPartImageReadOptions{IncludeAggregateMetadata: true})
 	if err != nil {
 		t.Fatalf("Reader: %v", err)
 	}
+	assertColumnPartSetReaderDecodedAggregateMetadata(t, reader, opts)
 	return jsonBenchMutationReplayState{
 		reader:   reader,
 		manifest: adapter.Manifest(),
+	}
+}
+
+func assertColumnPartSetReaderDecodedAggregateMetadata(t *testing.T, reader *ColumnPartSetReader, opts ColumnStoreOptions) {
+	t.Helper()
+	if len(opts.AggregateMetadata) == 0 {
+		return
+	}
+	if reader == nil {
+		t.Fatal("nil part set reader")
+	}
+	for _, loaded := range reader.parts {
+		if loaded.Part == nil {
+			t.Fatalf("reader loaded nil part for ref %+v", loaded.Ref)
+		}
+		for _, def := range opts.AggregateMetadata {
+			metadata, ok := loaded.Part.AggregateMetadataByName(def.Name)
+			if !ok {
+				t.Fatalf("part %d missing decoded aggregate metadata %s", loaded.Part.Descriptor.PartID, def.Name)
+			}
+			if metadata.Definition.Name != def.Name {
+				t.Fatalf("part %d aggregate metadata name=%q want %q", loaded.Part.Descriptor.PartID, metadata.Definition.Name, def.Name)
+			}
+		}
 	}
 }
 

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -340,7 +340,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 				StoreOptions:  opts,
 				Dictionaries:  ds.Dictionaries,
 				ReplayProfile: tt.profile,
-			}); err == nil || !strings.Contains(err.Error(), "requires ColumnWorkspaceOptions.ManifestSyncMode=") {
+			}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
 				t.Fatalf("NewColumnMutationAdapter durable profile on no-sync workspace err=%v want sync-mode rejection", err)
 			}
 		})
@@ -357,7 +357,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		Dictionaries:  ds.Dictionaries,
 		ReplayProfile: profile,
 	}); err == nil ||
-		!strings.Contains(err.Error(), "requires ColumnWorkspaceOptions.ManifestSyncMode=") ||
+		!strings.Contains(err.Error(), "requires workspace manifest sync mode") ||
 		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDisabledForBenchmark)) ||
 		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDurable)) {
 		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want sync-mode rejection", err)
@@ -653,8 +653,7 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
 					// open/publish/apply/close work in the timed loop.
-					perOp := elapsed.Seconds() / float64(b.N)
-					b.ReportMetric(float64(logicalRows)/perOp, "rows/sec")
+					b.ReportMetric(float64(logicalRows)*float64(b.N)/elapsed.Seconds(), "rows/sec")
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -261,6 +261,44 @@ func TestColumnMutationReplayProfileContractM9D(t *testing.T) {
 	}
 }
 
+func TestColumnWorkspaceOptionsForMutationReplayProfileValidatesM9D(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  ColumnMutationReplayProfile
+		wantMode ColumnWorkspaceManifestSyncMode
+		wantErr  string
+	}{
+		{name: "default durable", wantMode: ColumnWorkspaceManifestSyncDurable},
+		{name: "wal on fast benchmark", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}, wantMode: ColumnWorkspaceManifestSyncDisabledForBenchmark},
+		{name: "fast benchmark", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayFast, BenchmarkOnly: true}, wantMode: ColumnWorkspaceManifestSyncDisabledForBenchmark},
+		{name: "unknown rejected before open", profile: ColumnMutationReplayProfile{Durability: "unsafe"}, wantErr: "unsupported"},
+		{name: "durable benchmark rejected before open", profile: ColumnMutationReplayProfile{Durability: ColumnMutationReplayDurable, BenchmarkOnly: true}, wantErr: "cannot be benchmark-only"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := columnWorkspaceOptionsForMutationReplayProfile("jsonbench", tt.profile)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("columnWorkspaceOptionsForMutationReplayProfile() nil error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("columnWorkspaceOptionsForMutationReplayProfile() err=%q want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("columnWorkspaceOptionsForMutationReplayProfile(): %v", err)
+			}
+			if opts.Collection != "jsonbench" {
+				t.Fatalf("Collection=%q want jsonbench", opts.Collection)
+			}
+			if opts.ManifestSyncMode != tt.wantMode {
+				t.Fatalf("ManifestSyncMode=%q want %q", opts.ManifestSyncMode, tt.wantMode)
+			}
+		})
+	}
+}
+
 func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 	ds := syntheticJSONBenchDataset(32)
 	opts, err := JSONBenchColumnPartOptions(ds, 16)
@@ -268,7 +306,11 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
 	}
 	profile := ColumnMutationReplayProfile{Durability: ColumnMutationReplayWALOnFast, BenchmarkOnly: true}
-	workspace, err := OpenColumnWorkspace(t.TempDir(), columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile))
+	workspaceOpts, err := columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile)
+	if err != nil {
+		t.Fatalf("columnWorkspaceOptionsForMutationReplayProfile: %v", err)
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), workspaceOpts)
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace: %v", err)
 	}
@@ -298,7 +340,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 				StoreOptions:  opts,
 				Dictionaries:  ds.Dictionaries,
 				ReplayProfile: tt.profile,
-			}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
+			}); err == nil || !strings.Contains(err.Error(), "requires ColumnWorkspaceOptions.ManifestSyncMode=") {
 				t.Fatalf("NewColumnMutationAdapter durable profile on no-sync workspace err=%v want sync-mode rejection", err)
 			}
 		})
@@ -314,7 +356,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
 		ReplayProfile: profile,
-	}); err == nil || !strings.Contains(err.Error(), `requires workspace manifest sync mode "benchmark_no_sync", got "durable"`) {
+	}); err == nil || !strings.Contains(err.Error(), `requires ColumnWorkspaceOptions.ManifestSyncMode="benchmark_no_sync", got "durable"`) {
 		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want exact sync-mode rejection", err)
 	}
 
@@ -578,18 +620,14 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 			}
 			b.Run(fixture.name+"/"+profile.Label(), func(b *testing.B) {
 				root := b.TempDir()
-				cleanupDirs := make([]string, 0, b.N)
-				b.Cleanup(func() {
-					for _, dir := range cleanupDirs {
-						_ = os.RemoveAll(dir)
-					}
-				})
 				var last ColumnCollectionManifest
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
+					if i > 0 {
+						b.StartTimer()
+					}
 					dir := filepath.Join(root, fmt.Sprintf("iter-%06d", i))
-					cleanupDirs = append(cleanupDirs, dir)
 					workspace, adapter := benchmarkColumnMutationAdapterWithProfile(b, dir, opts, ds.Dictionaries, profile)
 					_, err := adapter.PublishBaseBatch(ColumnBatch{Rows: ds.Rows, Columns: ds.Columns}, ColumnPartCoverageOptions{SourceRowRootGeneration: 1, SourceRowVersionUpper: uint64(ds.Rows)})
 					if err == nil {
@@ -602,8 +640,13 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 						b.Fatalf("replay: %v", err)
 					}
 					last = adapter.Manifest()
+					b.StopTimer()
+					if err := os.RemoveAll(dir); err != nil {
+						b.Fatalf("cleanup %s: %v", dir, err)
+					}
 				}
-				b.StopTimer()
+				// Cleanup is outside the measured replay window, so rows/sec is
+				// derived from the same timer window as the benchmark ns/op.
 				elapsed := b.Elapsed()
 				if b.N > 0 && elapsed > 0 {
 					// The replay gate deliberately includes per-iteration workspace
@@ -649,7 +692,11 @@ func benchmarkColumnMutationAdapter(b *testing.B, dir string, opts ColumnStoreOp
 
 func benchmarkColumnMutationAdapterWithProfile(b *testing.B, dir string, opts ColumnStoreOptions, dictionaries map[string]map[string]int64, profile ColumnMutationReplayProfile) (*ColumnWorkspace, *ColumnMutationAdapter) {
 	b.Helper()
-	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile))
+	workspaceOpts, err := columnWorkspaceOptionsForMutationReplayProfile("jsonbench", profile)
+	if err != nil {
+		b.Fatalf("columnWorkspaceOptionsForMutationReplayProfile: %v", err)
+	}
+	workspace, err := OpenColumnWorkspace(dir, workspaceOpts)
 	if err != nil {
 		b.Fatalf("OpenColumnWorkspace: %v", err)
 	}
@@ -816,7 +863,11 @@ func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchData
 	t.Helper()
 	adapterOpts := stateOpts.AdapterOptions
 	adapterOpts.ReplayProfile = stateOpts.ReplayProfile
-	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", stateOpts.ReplayProfile))
+	workspaceOpts, err := columnWorkspaceOptionsForMutationReplayProfile("jsonbench", stateOpts.ReplayProfile)
+	if err != nil {
+		t.Fatalf("columnWorkspaceOptionsForMutationReplayProfile: %v", err)
+	}
+	workspace, err := OpenColumnWorkspace(dir, workspaceOpts)
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace: %v", err)
 	}

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -606,6 +606,7 @@ func BenchmarkColumnMutationReplayM9D(b *testing.B) {
 				}
 				b.ReportMetric(float64(logicalRows), "logical_rows/op")
 				b.ReportMetric(float64(commandBytes), "command_bytes/op")
+				// Row remainder payloads are intentionally absent from M9D mutation replay.
 				b.ReportMetric(0, "row_remainder_bytes/op")
 				b.ReportMetric(float64(last.ByteAccounting.TotalAssetBytes), "column_asset_bytes/op")
 				b.ReportMetric(float64(last.ByteAccounting.DescriptorBytes), "manifest_control_bytes/op")
@@ -758,7 +759,7 @@ func newJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset) json
 
 func benchmarkJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset, updates int, deletes int) jsonBenchMutationReplayScenario {
 	tb.Helper()
-	if updates <= 0 || deletes < 0 || updates+deletes >= ds.Rows {
+	if updates <= 0 || deletes < 0 || updates >= ds.Rows/2 || updates+deletes >= ds.Rows {
 		tb.Fatalf("invalid replay scenario updates=%d deletes=%d rows=%d", updates, deletes, ds.Rows)
 	}
 	codes, err := jsonBenchQueryCodes(ds)
@@ -993,6 +994,7 @@ func assertJSONBenchReplaySpecializedQueriesMatchRaw(t *testing.T, reader *Colum
 			if !strings.Contains(err.Error(), "requires all-visible") {
 				t.Fatalf("runJSONBenchPartSetQ5AggregateMetadata: %v", err)
 			}
+			t.Logf("skipping q5 metadata replay parity: %v", err)
 		} else {
 			if q5Rows != rawQ5Rows || q5Digest != rawQ5Digest {
 				t.Fatalf("q5 metadata rows/digest=(%d,%d) raw=(%d,%d)", q5Rows, q5Digest, rawQ5Rows, rawQ5Digest)
@@ -1019,6 +1021,7 @@ func assertJSONBenchReplaySpecializedQueriesMatchRaw(t *testing.T, reader *Colum
 			if !strings.Contains(err.Error(), "requires all-visible") {
 				t.Fatalf("runJSONBenchPartSetQ4AggregateMetadata: %v", err)
 			}
+			t.Logf("skipping q4 metadata replay parity: %v", err)
 		} else {
 			if q4MetaRows != rawQ4Rows || q4MetaDigest != rawQ4Digest {
 				t.Fatalf("q4 metadata rows/digest=(%d,%d) raw=(%d,%d)", q4MetaRows, q4MetaDigest, rawQ4Rows, rawQ4Digest)
@@ -1148,6 +1151,9 @@ func estimateColumnMutationReplayCommandBytes(base ColumnBatch, batches []Column
 }
 
 func estimateColumnBatchPayloadBytes(batch ColumnBatch) int {
+	if batch.Rows == 0 && len(batch.Columns) == 0 {
+		return 0
+	}
 	total := 8
 	for name, values := range batch.Columns {
 		total += len(name) + 8

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -806,13 +806,15 @@ func benchmarkJSONBenchMutationReplayScenario(tb testing.TB, ds JSONBenchDataset
 
 type testJSONBenchMutationReplayStateOptions struct {
 	AdapterOptions      ColumnMutationAdapterOptions
+	ReplayProfile       ColumnMutationReplayProfile
 	PreseedAssetOffsets bool
 }
 
 func testJSONBenchMutationReplayState(t *testing.T, dir string, ds JSONBenchDataset, opts ColumnStoreOptions, scenario jsonBenchMutationReplayScenario, stateOpts testJSONBenchMutationReplayStateOptions) jsonBenchMutationReplayState {
 	t.Helper()
 	adapterOpts := stateOpts.AdapterOptions
-	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", adapterOpts.ReplayProfile))
+	adapterOpts.ReplayProfile = stateOpts.ReplayProfile
+	workspace, err := OpenColumnWorkspace(dir, columnWorkspaceOptionsForMutationReplayProfile("jsonbench", stateOpts.ReplayProfile))
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace: %v", err)
 	}

--- a/experiments/colgranule/mutation_adapter_test.go
+++ b/experiments/colgranule/mutation_adapter_test.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -340,7 +341,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 				StoreOptions:  opts,
 				Dictionaries:  ds.Dictionaries,
 				ReplayProfile: tt.profile,
-			}); err == nil || !strings.Contains(err.Error(), "requires workspace manifest sync mode") {
+			}); !errors.Is(err, ErrColumnMutationReplayWorkspaceSyncMode) {
 				t.Fatalf("NewColumnMutationAdapter durable profile on no-sync workspace err=%v want sync-mode rejection", err)
 			}
 		})
@@ -356,10 +357,7 @@ func TestColumnMutationAdapterAppliesReplayProfileOptionM9D(t *testing.T) {
 		StoreOptions:  opts,
 		Dictionaries:  ds.Dictionaries,
 		ReplayProfile: profile,
-	}); err == nil ||
-		!strings.Contains(err.Error(), "requires workspace manifest sync mode") ||
-		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDisabledForBenchmark)) ||
-		!strings.Contains(err.Error(), string(ColumnWorkspaceManifestSyncDurable)) {
+	}); !errors.Is(err, ErrColumnMutationReplayWorkspaceSyncMode) {
 		t.Fatalf("NewColumnMutationAdapter benchmark profile on durable workspace err=%v want sync-mode rejection", err)
 	}
 

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -20,14 +20,18 @@ func (p ColumnMutationReplayProfile) Validate() error {
 	switch durability {
 	case ColumnMutationReplayDurable:
 		if p.BenchmarkOnly {
-			return fmt.Errorf("colgranule: durable column mutation replay profile cannot be benchmark-only; choose %q or %q with BenchmarkOnly for benchmark-ceiling runs", ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
+			label := "durable"
+			if p.Durability == "" {
+				label = "durable (default)"
+			}
+			return fmt.Errorf("colgranule: %s column mutation replay profile cannot be benchmark-only; for benchmark-ceiling runs use Durability %q or %q and set BenchmarkOnly=true", label, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
 		}
 		return nil
 	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:
 		if p.BenchmarkOnly {
 			return nil
 		}
-		return fmt.Errorf("colgranule: column mutation replay profile %q is not supported for production; set BenchmarkOnly for benchmark-ceiling runs until safe-root publication is available", durability)
+		return fmt.Errorf("colgranule: column mutation replay profile %q is not supported for production; set BenchmarkOnly=true for benchmark-ceiling runs until safe-root publication is available", durability)
 	default:
 		return fmt.Errorf("colgranule: unsupported column mutation replay profile %q", durability)
 	}

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -56,3 +56,17 @@ func (p ColumnMutationReplayProfile) normalized() ColumnMutationReplayProfile {
 	p.Durability = p.normalizedDurability()
 	return p
 }
+
+func (p ColumnMutationReplayProfile) workspaceManifestSyncMode() ColumnWorkspaceManifestSyncMode {
+	if p.ProductionSupported() {
+		return ColumnWorkspaceManifestSyncDurable
+	}
+	return ColumnWorkspaceManifestSyncDisabledForBenchmark
+}
+
+func columnWorkspaceOptionsForMutationReplayProfile(collection string, profile ColumnMutationReplayProfile) ColumnWorkspaceOptions {
+	return ColumnWorkspaceOptions{
+		Collection:       collection,
+		ManifestSyncMode: profile.normalized().workspaceManifestSyncMode(),
+	}
+}

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -24,7 +24,7 @@ func (p ColumnMutationReplayProfile) Validate() error {
 			if p.Durability == "" {
 				label = "durable (default)"
 			}
-			return fmt.Errorf("colgranule: %s column mutation replay profile cannot be benchmark-only; for benchmark-ceiling runs use Durability %q or %q and set BenchmarkOnly=true", label, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
+			return fmt.Errorf("colgranule: %s column mutation replay profile cannot be benchmark-only; for benchmark-ceiling runs set Durability to %q or %q (BenchmarkOnly=true is already set)", label, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
 		}
 		return nil
 	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -39,7 +39,7 @@ func (p ColumnMutationReplayProfile) ProductionSupported() bool {
 
 func (p ColumnMutationReplayProfile) Label() string {
 	durability := p.normalizedDurability()
-	if p.BenchmarkOnly && durability != ColumnMutationReplayDurable {
+	if p.BenchmarkOnly {
 		return string(durability) + "_benchmark_ceiling"
 	}
 	return string(durability)

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -1,0 +1,50 @@
+package colgranule
+
+import "fmt"
+
+type ColumnMutationReplayDurability string
+
+const (
+	ColumnMutationReplayDurable   ColumnMutationReplayDurability = "durable"
+	ColumnMutationReplayWALOnFast ColumnMutationReplayDurability = "wal_on_fast"
+	ColumnMutationReplayFast      ColumnMutationReplayDurability = "fast"
+)
+
+type ColumnMutationReplayProfile struct {
+	Durability    ColumnMutationReplayDurability
+	BenchmarkOnly bool
+}
+
+func (p ColumnMutationReplayProfile) Validate() error {
+	durability := p.normalizedDurability()
+	switch durability {
+	case ColumnMutationReplayDurable:
+		return nil
+	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:
+		if p.BenchmarkOnly {
+			return nil
+		}
+		return fmt.Errorf("colgranule: column mutation replay profile %q is benchmark-only until safe-root publication is available", durability)
+	default:
+		return fmt.Errorf("colgranule: unsupported column mutation replay profile %q", durability)
+	}
+}
+
+func (p ColumnMutationReplayProfile) ProductionSupported() bool {
+	return p.normalizedDurability() == ColumnMutationReplayDurable && !p.BenchmarkOnly
+}
+
+func (p ColumnMutationReplayProfile) Label() string {
+	durability := p.normalizedDurability()
+	if p.BenchmarkOnly && durability != ColumnMutationReplayDurable {
+		return string(durability) + "_benchmark_ceiling"
+	}
+	return string(durability)
+}
+
+func (p ColumnMutationReplayProfile) normalizedDurability() ColumnMutationReplayDurability {
+	if p.Durability == "" {
+		return ColumnMutationReplayDurable
+	}
+	return p.Durability
+}

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -27,7 +27,7 @@ func (p ColumnMutationReplayProfile) Validate() error {
 		if p.BenchmarkOnly {
 			return nil
 		}
-		return fmt.Errorf("colgranule: column mutation replay profile %q is benchmark-only until safe-root publication is available", durability)
+		return fmt.Errorf("colgranule: column mutation replay profile %q is not supported for production; set BenchmarkOnly for benchmark-ceiling runs until safe-root publication is available", durability)
 	default:
 		return fmt.Errorf("colgranule: unsupported column mutation replay profile %q", durability)
 	}
@@ -50,4 +50,9 @@ func (p ColumnMutationReplayProfile) normalizedDurability() ColumnMutationReplay
 		return ColumnMutationReplayDurable
 	}
 	return p.Durability
+}
+
+func (p ColumnMutationReplayProfile) normalized() ColumnMutationReplayProfile {
+	p.Durability = p.normalizedDurability()
+	return p
 }

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -24,7 +24,7 @@ func (p ColumnMutationReplayProfile) Validate() error {
 			if p.Durability == "" {
 				label = "durable (default)"
 			}
-			return fmt.Errorf("colgranule: %s column mutation replay profile cannot be benchmark-only; for benchmark-ceiling runs set Durability to %q or %q (BenchmarkOnly=true is already set)", label, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
+			return fmt.Errorf("colgranule: %s column mutation replay profile cannot be benchmark-only; for benchmark-ceiling runs set Durability to %q or %q while keeping BenchmarkOnly=true", label, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
 		}
 		return nil
 	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -31,7 +31,7 @@ func (p ColumnMutationReplayProfile) Validate() error {
 		if p.BenchmarkOnly {
 			return nil
 		}
-		return fmt.Errorf("colgranule: column mutation replay profile %q is not supported for production; set BenchmarkOnly=true for benchmark-ceiling runs until safe-root publication is available", durability)
+		return fmt.Errorf("colgranule: column mutation replay profile %q is not supported for production; production replay must use %q, while %q/%q are benchmark-ceiling-only and require BenchmarkOnly=true with a benchmark no-sync workspace", durability, ColumnMutationReplayDurable, ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
 	default:
 		return fmt.Errorf("colgranule: unsupported column mutation replay profile %q", durability)
 	}

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -20,7 +20,7 @@ func (p ColumnMutationReplayProfile) Validate() error {
 	switch durability {
 	case ColumnMutationReplayDurable:
 		if p.BenchmarkOnly {
-			return fmt.Errorf("colgranule: durable column mutation replay profile cannot be benchmark-only")
+			return fmt.Errorf("colgranule: durable column mutation replay profile cannot be benchmark-only; choose %q or %q with BenchmarkOnly for benchmark-ceiling runs", ColumnMutationReplayWALOnFast, ColumnMutationReplayFast)
 		}
 		return nil
 	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -37,6 +37,7 @@ func (p ColumnMutationReplayProfile) ProductionSupported() bool {
 	return p.normalizedDurability() == ColumnMutationReplayDurable && !p.BenchmarkOnly
 }
 
+// Label returns the normalized profile label and is safe to call before Validate.
 func (p ColumnMutationReplayProfile) Label() string {
 	durability := p.normalizedDurability()
 	if p.BenchmarkOnly {

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -62,16 +62,23 @@ func (p ColumnMutationReplayProfile) normalized() ColumnMutationReplayProfile {
 	return p
 }
 
-func (p ColumnMutationReplayProfile) workspaceManifestSyncMode() ColumnWorkspaceManifestSyncMode {
-	if p.ProductionSupported() {
-		return ColumnWorkspaceManifestSyncDurable
+func (p ColumnMutationReplayProfile) workspaceManifestSyncMode() (ColumnWorkspaceManifestSyncMode, error) {
+	if err := p.Validate(); err != nil {
+		return "", err
 	}
-	return ColumnWorkspaceManifestSyncDisabledForBenchmark
+	if p.normalized().ProductionSupported() {
+		return ColumnWorkspaceManifestSyncDurable, nil
+	}
+	return ColumnWorkspaceManifestSyncDisabledForBenchmark, nil
 }
 
-func columnWorkspaceOptionsForMutationReplayProfile(collection string, profile ColumnMutationReplayProfile) ColumnWorkspaceOptions {
+func columnWorkspaceOptionsForMutationReplayProfile(collection string, profile ColumnMutationReplayProfile) (ColumnWorkspaceOptions, error) {
+	mode, err := profile.workspaceManifestSyncMode()
+	if err != nil {
+		return ColumnWorkspaceOptions{}, err
+	}
 	return ColumnWorkspaceOptions{
 		Collection:       collection,
-		ManifestSyncMode: profile.normalized().workspaceManifestSyncMode(),
-	}
+		ManifestSyncMode: mode,
+	}, nil
 }

--- a/experiments/colgranule/mutation_replay_profile.go
+++ b/experiments/colgranule/mutation_replay_profile.go
@@ -19,6 +19,9 @@ func (p ColumnMutationReplayProfile) Validate() error {
 	durability := p.normalizedDurability()
 	switch durability {
 	case ColumnMutationReplayDurable:
+		if p.BenchmarkOnly {
+			return fmt.Errorf("colgranule: durable column mutation replay profile cannot be benchmark-only")
+		}
 		return nil
 	case ColumnMutationReplayWALOnFast, ColumnMutationReplayFast:
 		if p.BenchmarkOnly {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"os"
@@ -303,13 +304,7 @@ func (w *ColumnWorkspace) Manifest() ColumnWorkspaceManifest {
 	if w == nil {
 		return ColumnWorkspaceManifest{}
 	}
-	out := w.manifest
-	out.Parts = append([]ColumnWorkspacePartManifest(nil), w.manifest.Parts...)
-	for i := range out.Parts {
-		out.Parts[i].SortKey = append([]SortKeyColumn(nil), out.Parts[i].SortKey...)
-		out.Parts[i].Coverage = cloneColumnWorkspacePartCoverage(out.Parts[i].Coverage)
-	}
-	return out
+	return cloneColumnWorkspaceManifest(w.manifest)
 }
 
 func (w *ColumnWorkspace) CacheStats() ColumnWorkspaceCacheStats {
@@ -356,6 +351,29 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	if err := validateColumnWorkspacePartManifest(entry); err != nil {
 		return ColumnWorkspacePartManifest{}, err
 	}
+	var synced ColumnAssetSyncedPublishClosure
+	preparedAssets := []ColumnPreparedAsset{{
+		Ref:          entry.AssetRef,
+		Bytes:        entry.AssetBytes,
+		PublishID:    w.manifest.PublishID + 1,
+		GenerationID: w.manifest.Generation + 1,
+		Reason:       "workspace part publish",
+	}}
+	if w.ManifestSyncMode() != ColumnWorkspaceManifestSyncDisabledForBenchmark {
+		closure, err := w.assets.PreparePublishClosure(preparedAssets)
+		if err != nil {
+			return ColumnWorkspacePartManifest{}, err
+		}
+		synced, err = w.assets.SyncPublishClosure(closure)
+		if err != nil {
+			if failErr := w.assets.MarkPublishFailed(preparedAssets, "workspace part asset sync failed"); failErr != nil {
+				return ColumnWorkspacePartManifest{}, errors.Join(err, failErr)
+			}
+			return ColumnWorkspacePartManifest{}, err
+		}
+	}
+	oldManifest := cloneColumnWorkspaceManifest(w.manifest)
+	oldPartByID := cloneColumnWorkspacePartIndex(w.partByID)
 	if idx, ok := w.partByID[entry.PartID]; ok {
 		w.manifest.Parts[idx] = entry
 	} else {
@@ -370,7 +388,19 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	})
 	w.rebuildPartIndex()
 	if err := w.saveManifest(); err != nil {
+		w.manifest = oldManifest
+		w.partByID = oldPartByID
+		if synced.sealed {
+			if failErr := w.assets.MarkPublishFailed(preparedAssets, "workspace part manifest publish failed"); failErr != nil {
+				return ColumnWorkspacePartManifest{}, errors.Join(err, failErr)
+			}
+		}
 		return ColumnWorkspacePartManifest{}, err
+	}
+	if synced.sealed {
+		if err := w.assets.MarkPublishSucceeded(synced); err != nil {
+			return ColumnWorkspacePartManifest{}, err
+		}
 	}
 	return entry, nil
 }
@@ -658,6 +688,14 @@ func (w *ColumnWorkspace) rebuildPartIndex() {
 	}
 }
 
+func cloneColumnWorkspacePartIndex(index map[uint64]int) map[uint64]int {
+	out := make(map[uint64]int, len(index))
+	for partID, idx := range index {
+		out[partID] = idx
+	}
+	return out
+}
+
 func (w *ColumnWorkspace) validateManifestAssets() error {
 	for _, entry := range w.manifest.Parts {
 		switch w.validationMode {
@@ -840,6 +878,16 @@ func validateColumnPreparedAssetRegistry(registry ColumnPreparedAssetRegistry) e
 
 func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAsset {
 	return append([]ColumnPreparedAsset(nil), assets...)
+}
+
+func cloneColumnWorkspaceManifest(manifest ColumnWorkspaceManifest) ColumnWorkspaceManifest {
+	out := manifest
+	out.Parts = append([]ColumnWorkspacePartManifest(nil), manifest.Parts...)
+	for i := range out.Parts {
+		out.Parts[i].SortKey = append([]SortKeyColumn(nil), out.Parts[i].SortKey...)
+		out.Parts[i].Coverage = cloneColumnWorkspacePartCoverage(out.Parts[i].Coverage)
+	}
+	return out
 }
 
 func columnWorkspaceSegmentFileID(name string) (uint32, bool) {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -2,6 +2,7 @@ package colgranule
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"os"
@@ -356,6 +357,18 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	if err := validateColumnWorkspacePartManifest(entry); err != nil {
 		return ColumnWorkspacePartManifest{}, err
 	}
+	prepared := []ColumnPreparedAsset{{
+		Ref:          entry.AssetRef,
+		Bytes:        entry.AssetBytes,
+		GenerationID: w.manifest.Generation + 1,
+		PublishID:    w.manifest.PublishID + 1,
+		Reason:       "workspace part publish",
+	}}
+	synced, tracked, err := w.syncPreparedAssetsForManifest(prepared)
+	if err != nil {
+		markErr := w.assets.MarkPublishFailed(prepared, "workspace part asset sync failed")
+		return ColumnWorkspacePartManifest{}, errors.Join(err, markErr)
+	}
 	if idx, ok := w.partByID[entry.PartID]; ok {
 		w.manifest.Parts[idx] = entry
 	} else {
@@ -370,9 +383,37 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	})
 	w.rebuildPartIndex()
 	if err := w.saveManifest(); err != nil {
+		if tracked {
+			if markErr := w.assets.MarkPublishFailed(prepared, "workspace part manifest publish failed"); markErr != nil {
+				return ColumnWorkspacePartManifest{}, errors.Join(err, markErr)
+			}
+		}
 		return ColumnWorkspacePartManifest{}, err
 	}
+	if tracked {
+		if err := w.assets.MarkPublishSucceeded(synced); err != nil {
+			return ColumnWorkspacePartManifest{}, err
+		}
+	}
 	return entry, nil
+}
+
+func (w *ColumnWorkspace) syncPreparedAssetsForManifest(prepared []ColumnPreparedAsset) (ColumnAssetSyncedPublishClosure, bool, error) {
+	if w == nil || w.assets == nil {
+		return ColumnAssetSyncedPublishClosure{}, false, fmt.Errorf("colgranule: closed column workspace")
+	}
+	if len(prepared) == 0 || w.ManifestSyncMode() == ColumnWorkspaceManifestSyncDisabledForBenchmark {
+		return ColumnAssetSyncedPublishClosure{}, false, nil
+	}
+	closure, err := w.assets.PreparePublishClosure(prepared)
+	if err != nil {
+		return ColumnAssetSyncedPublishClosure{}, true, err
+	}
+	synced, err := w.assets.SyncPublishClosure(closure)
+	if err != nil {
+		return ColumnAssetSyncedPublishClosure{}, true, err
+	}
+	return synced, true, nil
 }
 
 func (w *ColumnWorkspace) LoadPart(partID uint64) (ColumnWorkspaceLoadResult, error) {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -366,24 +366,49 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 		}
 		return ColumnWorkspacePartManifest{}, err
 	}
-	oldManifest := cloneColumnWorkspaceManifest(w.manifest)
-	oldPartByID := cloneColumnWorkspacePartIndex(w.partByID)
-	if idx, ok := w.partByID[entry.PartID]; ok {
+	oldGeneration := w.manifest.Generation
+	oldPublishID := w.manifest.PublishID
+	oldUpdatedUnix := w.manifest.UpdatedUnix
+	idx, existed := w.partByID[entry.PartID]
+	var oldEntry ColumnWorkspacePartManifest
+	insertIdx := -1
+	if existed {
+		oldEntry = w.manifest.Parts[idx]
 		w.manifest.Parts[idx] = entry
 	} else {
-		w.partByID[entry.PartID] = len(w.manifest.Parts)
-		w.manifest.Parts = append(w.manifest.Parts, entry)
+		insertIdx = sort.Search(len(w.manifest.Parts), func(i int) bool {
+			return w.manifest.Parts[i].PartID >= entry.PartID
+		})
+		w.manifest.Parts = append(w.manifest.Parts, ColumnWorkspacePartManifest{})
+		copy(w.manifest.Parts[insertIdx+1:], w.manifest.Parts[insertIdx:])
+		w.manifest.Parts[insertIdx] = entry
+		for partID, partIdx := range w.partByID {
+			if partIdx >= insertIdx {
+				w.partByID[partID] = partIdx + 1
+			}
+		}
+		w.partByID[entry.PartID] = insertIdx
 	}
 	w.manifest.Generation++
 	w.manifest.PublishID++
 	w.manifest.UpdatedUnix = time.Now().UnixNano()
-	sort.Slice(w.manifest.Parts, func(i, j int) bool {
-		return w.manifest.Parts[i].PartID < w.manifest.Parts[j].PartID
-	})
-	w.rebuildPartIndex()
 	if err := w.saveManifest(); err != nil {
-		w.manifest = oldManifest
-		w.partByID = oldPartByID
+		w.manifest.Generation = oldGeneration
+		w.manifest.PublishID = oldPublishID
+		w.manifest.UpdatedUnix = oldUpdatedUnix
+		if existed {
+			w.manifest.Parts[idx] = oldEntry
+		} else {
+			copy(w.manifest.Parts[insertIdx:], w.manifest.Parts[insertIdx+1:])
+			w.manifest.Parts[len(w.manifest.Parts)-1] = ColumnWorkspacePartManifest{}
+			w.manifest.Parts = w.manifest.Parts[:len(w.manifest.Parts)-1]
+			delete(w.partByID, entry.PartID)
+			for partID, partIdx := range w.partByID {
+				if partIdx > insertIdx {
+					w.partByID[partID] = partIdx - 1
+				}
+			}
+		}
 		if tracked {
 			if markErr := w.assets.MarkPublishFailed(prepared, "workspace part manifest publish failed"); markErr != nil {
 				return ColumnWorkspacePartManifest{}, errors.Join(err, markErr)
@@ -698,14 +723,6 @@ func (w *ColumnWorkspace) rebuildPartIndex() {
 	for i := range w.manifest.Parts {
 		w.partByID[w.manifest.Parts[i].PartID] = i
 	}
-}
-
-func cloneColumnWorkspacePartIndex(index map[uint64]int) map[uint64]int {
-	out := make(map[uint64]int, len(index))
-	for partID, idx := range index {
-		out[partID] = idx
-	}
-	return out
 }
 
 func (w *ColumnWorkspace) validateManifestAssets() error {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -32,6 +32,7 @@ type ColumnWorkspaceOptions struct {
 	Collection       string
 	ValidationMode   ColumnWorkspaceValidationMode
 	ManifestSyncMode ColumnWorkspaceManifestSyncMode
+	syncTempFile     func(*os.File) error
 }
 
 type ColumnWorkspaceValidationMode string
@@ -121,6 +122,7 @@ type ColumnWorkspace struct {
 	manifest       ColumnWorkspaceManifest
 	validationMode ColumnWorkspaceValidationMode
 	manifestSync   ColumnWorkspaceManifestSyncMode
+	syncTempFile   func(*os.File) error
 	partByID       map[uint64]int
 	cacheSeen      map[string]struct{}
 	cache          ColumnWorkspaceCacheStats
@@ -250,6 +252,7 @@ func OpenColumnWorkspace(dir string, opts ColumnWorkspaceOptions) (*ColumnWorksp
 		assets:         assetManager,
 		validationMode: normalized.ValidationMode,
 		manifestSync:   normalized.ManifestSyncMode,
+		syncTempFile:   normalized.syncTempFile,
 		partByID:       make(map[uint64]int),
 		cacheSeen:      make(map[string]struct{}),
 	}
@@ -525,7 +528,11 @@ func (w *ColumnWorkspace) syncManifestTempFile(file *os.File) error {
 	if w.ManifestSyncMode() == ColumnWorkspaceManifestSyncDisabledForBenchmark {
 		return nil
 	}
-	return columnWorkspaceSyncTempFile(file)
+	syncTempFile := w.syncTempFile
+	if syncTempFile == nil {
+		syncTempFile = columnWorkspaceSyncTempFile
+	}
+	return syncTempFile(file)
 }
 
 func (w *ColumnWorkspace) LoadPreparedAssetRegistry() (ColumnPreparedAssetRegistry, error) {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -29,16 +29,25 @@ const (
 )
 
 type ColumnWorkspaceOptions struct {
-	Collection     string
-	ValidationMode ColumnWorkspaceValidationMode
+	Collection       string
+	ValidationMode   ColumnWorkspaceValidationMode
+	ManifestSyncMode ColumnWorkspaceManifestSyncMode
 }
 
 type ColumnWorkspaceValidationMode string
+type ColumnWorkspaceManifestSyncMode string
 
 const (
 	ColumnWorkspaceValidateFullImage  ColumnWorkspaceValidationMode = "full_image"
 	ColumnWorkspaceValidateTCS1Header ColumnWorkspaceValidationMode = "tcs1_header"
+
+	ColumnWorkspaceManifestSyncDurable              ColumnWorkspaceManifestSyncMode = "durable"
+	ColumnWorkspaceManifestSyncDisabledForBenchmark ColumnWorkspaceManifestSyncMode = "benchmark_no_sync"
 )
+
+var columnWorkspaceSyncTempFile = func(file *os.File) error {
+	return file.Sync()
+}
 
 type ColumnWorkspaceNamespace struct {
 	RootDir       string `json:"root_dir"`
@@ -95,6 +104,13 @@ func normalizeColumnWorkspaceOptions(opts ColumnWorkspaceOptions) (ColumnWorkspa
 	default:
 		return ColumnWorkspaceOptions{}, fmt.Errorf("colgranule: unsupported workspace validation mode %s", opts.ValidationMode)
 	}
+	switch opts.ManifestSyncMode {
+	case "":
+		opts.ManifestSyncMode = ColumnWorkspaceManifestSyncDurable
+	case ColumnWorkspaceManifestSyncDurable, ColumnWorkspaceManifestSyncDisabledForBenchmark:
+	default:
+		return ColumnWorkspaceOptions{}, fmt.Errorf("colgranule: unsupported workspace manifest sync mode %s", opts.ManifestSyncMode)
+	}
 	return opts, nil
 }
 
@@ -104,6 +120,7 @@ type ColumnWorkspace struct {
 	assets         *ColumnAssetManager
 	manifest       ColumnWorkspaceManifest
 	validationMode ColumnWorkspaceValidationMode
+	manifestSync   ColumnWorkspaceManifestSyncMode
 	partByID       map[uint64]int
 	cacheSeen      map[string]struct{}
 	cache          ColumnWorkspaceCacheStats
@@ -232,6 +249,7 @@ func OpenColumnWorkspace(dir string, opts ColumnWorkspaceOptions) (*ColumnWorksp
 		namespace:      namespace,
 		assets:         assetManager,
 		validationMode: normalized.ValidationMode,
+		manifestSync:   normalized.ManifestSyncMode,
 		partByID:       make(map[uint64]int),
 		cacheSeen:      make(map[string]struct{}),
 	}
@@ -240,6 +258,13 @@ func OpenColumnWorkspace(dir string, opts ColumnWorkspaceOptions) (*ColumnWorksp
 		return nil, err
 	}
 	return w, nil
+}
+
+func (w *ColumnWorkspace) ManifestSyncMode() ColumnWorkspaceManifestSyncMode {
+	if w == nil || w.manifestSync == "" {
+		return ColumnWorkspaceManifestSyncDurable
+	}
+	return w.manifestSync
 }
 
 func (w *ColumnWorkspace) Close() error {
@@ -431,7 +456,7 @@ func (w *ColumnWorkspace) saveManifest() error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	if err = tmp.Sync(); err != nil {
+	if err = w.syncManifestTempFile(tmp); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return err
@@ -477,7 +502,7 @@ func (w *ColumnWorkspace) SavePreparedAssetRegistry(publishID uint64, generation
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	if err = tmp.Sync(); err != nil {
+	if err = w.syncManifestTempFile(tmp); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return err
@@ -491,6 +516,16 @@ func (w *ColumnWorkspace) SavePreparedAssetRegistry(publishID uint64, generation
 		return err
 	}
 	return nil
+}
+
+func (w *ColumnWorkspace) syncManifestTempFile(file *os.File) error {
+	if w == nil {
+		return fmt.Errorf("colgranule: nil column workspace")
+	}
+	if w.ManifestSyncMode() == ColumnWorkspaceManifestSyncDisabledForBenchmark {
+		return nil
+	}
+	return columnWorkspaceSyncTempFile(file)
 }
 
 func (w *ColumnWorkspace) LoadPreparedAssetRegistry() (ColumnPreparedAssetRegistry, error) {

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -264,7 +264,10 @@ func OpenColumnWorkspace(dir string, opts ColumnWorkspaceOptions) (*ColumnWorksp
 }
 
 func (w *ColumnWorkspace) ManifestSyncMode() ColumnWorkspaceManifestSyncMode {
-	if w == nil || w.manifestSync == "" {
+	if w == nil {
+		return ""
+	}
+	if w.manifestSync == "" {
 		return ColumnWorkspaceManifestSyncDurable
 	}
 	return w.manifestSync

--- a/experiments/colgranule/workspace.go
+++ b/experiments/colgranule/workspace.go
@@ -366,8 +366,11 @@ func (w *ColumnWorkspace) PublishPart(part *ColumnPart, dictionaries map[string]
 	}}
 	synced, tracked, err := w.syncPreparedAssetsForManifest(prepared)
 	if err != nil {
-		markErr := w.assets.MarkPublishFailed(prepared, "workspace part asset sync failed")
-		return ColumnWorkspacePartManifest{}, errors.Join(err, markErr)
+		if tracked {
+			markErr := w.assets.MarkPublishFailed(prepared, "workspace part asset sync failed")
+			return ColumnWorkspacePartManifest{}, errors.Join(err, markErr)
+		}
+		return ColumnWorkspacePartManifest{}, err
 	}
 	if idx, ok := w.partByID[entry.PartID]; ok {
 		w.manifest.Parts[idx] = entry
@@ -407,7 +410,7 @@ func (w *ColumnWorkspace) syncPreparedAssetsForManifest(prepared []ColumnPrepare
 	}
 	closure, err := w.assets.PreparePublishClosure(prepared)
 	if err != nil {
-		return ColumnAssetSyncedPublishClosure{}, true, err
+		return ColumnAssetSyncedPublishClosure{}, false, err
 	}
 	synced, err := w.assets.SyncPublishClosure(closure)
 	if err != nil {

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -157,11 +157,12 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	if syncs < 1 {
 		t.Fatalf("durable open syncs=%d want at least 1", syncs)
 	}
+	syncs = 0
 	if err := durable.SaveCollectionManifest(manifest); err != nil {
 		t.Fatalf("SaveCollectionManifest durable: %v", err)
 	}
-	if syncs != 2 {
-		t.Fatalf("durable collection manifest syncs=%d want 2", syncs)
+	if syncs != 1 {
+		t.Fatalf("durable collection manifest syncs=%d want 1", syncs)
 	}
 	if err := durable.Close(); err != nil {
 		t.Fatalf("Close durable: %v", err)

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -3,6 +3,7 @@ package colgranule
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -211,6 +212,159 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	}
 	if err := relaxed.Close(); err != nil {
 		t.Fatalf("Close relaxed: %v", err)
+	}
+}
+
+func TestColumnWorkspacePublishPartSyncsAssetsBeforeDurableManifestM9D(t *testing.T) {
+	ds := syntheticJSONBenchDataset(16)
+	opts, err := JSONBenchColumnPartOptions(ds, 8)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	part, err := BuildColumnPart(111, opts, ColumnBatch{Rows: ds.Rows, Columns: sliceJSONBenchColumns(ds, 0, ds.Rows)})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+
+	var assetStore *syncProbeAssetStore
+	manifestSyncsAfterAssetSwap := 0
+	syncHook := func(file *os.File) error {
+		if assetStore != nil {
+			manifestSyncsAfterAssetSwap++
+			if got := assetStore.syncCalls.Load(); got == 0 {
+				return fmt.Errorf("asset sync count=%d before durable manifest sync", got)
+			}
+		}
+		return nil
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:   "jsonbench",
+		syncTempFile: syncHook,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	defer workspace.Close()
+	if err := workspace.assets.Close(); err != nil {
+		t.Fatalf("Close original asset manager: %v", err)
+	}
+	assetStore = &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(assetStore)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	workspace.assets = manager
+
+	if _, err := workspace.PublishPart(part, ds.Dictionaries); err != nil {
+		t.Fatalf("PublishPart durable: %v", err)
+	}
+	if got := assetStore.syncCalls.Load(); got != 1 {
+		t.Fatalf("asset sync calls=%d want 1", got)
+	}
+	if manifestSyncsAfterAssetSwap != 1 {
+		t.Fatalf("durable manifest syncs after asset swap=%d want 1", manifestSyncsAfterAssetSwap)
+	}
+	if state := workspace.assets.DebugState(); state.SyncedAttempts != 0 || state.SyncedRefs != 0 || len(state.Quarantine) != 0 || len(state.PublishFailed) != 0 {
+		t.Fatalf("asset manager state after durable publish=%+v want clean synced publish closure", state)
+	}
+}
+
+func TestColumnWorkspacePublishPartBenchmarkSyncModeSkipsAssetSyncM9D(t *testing.T) {
+	ds := syntheticJSONBenchDataset(16)
+	opts, err := JSONBenchColumnPartOptions(ds, 8)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	part, err := BuildColumnPart(112, opts, ColumnBatch{Rows: ds.Rows, Columns: sliceJSONBenchColumns(ds, 0, ds.Rows)})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:       "jsonbench",
+		ManifestSyncMode: ColumnWorkspaceManifestSyncDisabledForBenchmark,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	defer workspace.Close()
+	if err := workspace.assets.Close(); err != nil {
+		t.Fatalf("Close original asset manager: %v", err)
+	}
+	assetStore := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(assetStore)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	workspace.assets = manager
+
+	if _, err := workspace.PublishPart(part, ds.Dictionaries); err != nil {
+		t.Fatalf("PublishPart benchmark sync mode: %v", err)
+	}
+	if got := assetStore.syncCalls.Load(); got != 0 {
+		t.Fatalf("asset sync calls=%d want 0 in benchmark sync mode", got)
+	}
+}
+
+func TestColumnWorkspacePublishPartMarksAssetFailedWhenDurableManifestFailsM9D(t *testing.T) {
+	ds := syntheticJSONBenchDataset(16)
+	opts, err := JSONBenchColumnPartOptions(ds, 8)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	part, err := BuildColumnPart(113, opts, ColumnBatch{Rows: ds.Rows, Columns: sliceJSONBenchColumns(ds, 0, ds.Rows)})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+
+	manifestErr := fmt.Errorf("injected durable manifest sync failure")
+	var assetStore *syncProbeAssetStore
+	manifestFailures := 1
+	syncHook := func(file *os.File) error {
+		if assetStore != nil && manifestFailures > 0 {
+			manifestFailures--
+			return manifestErr
+		}
+		return nil
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:   "jsonbench",
+		syncTempFile: syncHook,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	defer workspace.Close()
+	if err := workspace.assets.Close(); err != nil {
+		t.Fatalf("Close original asset manager: %v", err)
+	}
+	assetStore = &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	manager, err := NewColumnAssetManager(assetStore)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	workspace.assets = manager
+
+	if _, err := workspace.PublishPart(part, ds.Dictionaries); err == nil || !strings.Contains(err.Error(), manifestErr.Error()) {
+		t.Fatalf("PublishPart err=%v want injected manifest failure", err)
+	}
+	if got := assetStore.syncCalls.Load(); got != 1 {
+		t.Fatalf("asset sync calls=%d want 1 before failed durable manifest publish", got)
+	}
+	if manifest := workspace.Manifest(); len(manifest.Parts) != 0 || manifest.Generation != 0 || manifest.PublishID != 0 {
+		t.Fatalf("workspace manifest after failed publish=%+v want rollback to empty manifest", manifest)
+	}
+	state := workspace.assets.DebugState()
+	if len(state.Quarantine) != 1 || len(state.PublishFailed) != 1 || state.SyncedAttempts != 0 || state.SyncedRefs != 0 {
+		t.Fatalf("asset manager state after failed durable publish=%+v want quarantined publish failure", state)
+	}
+	if _, err := workspace.PublishPart(part, ds.Dictionaries); err != nil {
+		t.Fatalf("PublishPart retry after failed durable manifest publish: %v", err)
+	}
+	if got := assetStore.syncCalls.Load(); got != 2 {
+		t.Fatalf("asset sync calls after retry=%d want 2", got)
+	}
+	if manifest := workspace.Manifest(); len(manifest.Parts) != 1 || manifest.Generation != 1 || manifest.PublishID != 1 {
+		t.Fatalf("workspace manifest after retry=%+v want one published part", manifest)
 	}
 }
 

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -232,7 +232,7 @@ func TestColumnWorkspacePublishPartSyncsAssetsBeforeDurableManifestM9D(t *testin
 		if assetStore != nil {
 			manifestSyncsAfterAssetSwap++
 			if got := assetStore.syncCalls.Load(); got == 0 {
-				return fmt.Errorf("asset sync count=%d before durable manifest sync", got)
+				t.Errorf("asset sync count=%d before durable manifest sync", got)
 			}
 		}
 		return nil

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -154,8 +154,8 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace durable: %v", err)
 	}
-	if syncs != 1 {
-		t.Fatalf("durable open syncs=%d want 1", syncs)
+	if syncs < 1 {
+		t.Fatalf("durable open syncs=%d want at least 1", syncs)
 	}
 	if err := durable.SaveCollectionManifest(manifest); err != nil {
 		t.Fatalf("SaveCollectionManifest durable: %v", err)

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -214,6 +214,91 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	}
 }
 
+func TestColumnWorkspacePublishPartSyncsAssetsBeforeDurableManifestM9D(t *testing.T) {
+	probe := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	publishPhase := false
+	syncHook := func(file *os.File) error {
+		if publishPhase && probe.syncCalls.Load() == 0 {
+			t.Fatalf("durable workspace manifest sync ran before asset store sync")
+		}
+		return nil
+	}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:   "jsonbench",
+		syncTempFile: syncHook,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	if err := workspace.assets.Close(); err != nil {
+		t.Fatalf("close initial asset manager: %v", err)
+	}
+	manager, err := NewColumnAssetManager(probe)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	workspace.assets = manager
+
+	ds := syntheticJSONBenchDataset(16)
+	part, err := BuildJSONBenchColumnPart(ds, 4)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	publishPhase = true
+	entry, err := workspace.PublishPart(part, ds.Dictionaries)
+	publishPhase = false
+	if err != nil {
+		t.Fatalf("PublishPart: %v", err)
+	}
+	if entry.AssetBytes == 0 {
+		t.Fatalf("published entry missing asset bytes: %+v", entry)
+	}
+	if got := probe.syncCalls.Load(); got != 1 {
+		t.Fatalf("asset sync calls=%d want 1", got)
+	}
+	state := manager.DebugState()
+	if state.SyncedAttempts != 0 || len(state.PublishFailed) != 0 || len(state.Quarantine) != 0 {
+		t.Fatalf("asset manager retained publish state after success: %+v", state)
+	}
+	if err := workspace.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestColumnWorkspacePublishPartBenchmarkSyncModeSkipsAssetSyncM9D(t *testing.T) {
+	probe := &syncProbeAssetStore{MemoryColumnAssetStore: NewMemoryColumnAssetStore()}
+	workspace, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:       "jsonbench",
+		ManifestSyncMode: ColumnWorkspaceManifestSyncDisabledForBenchmark,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace: %v", err)
+	}
+	if err := workspace.assets.Close(); err != nil {
+		t.Fatalf("close initial asset manager: %v", err)
+	}
+	manager, err := NewColumnAssetManager(probe)
+	if err != nil {
+		t.Fatalf("NewColumnAssetManager: %v", err)
+	}
+	workspace.assets = manager
+
+	ds := syntheticJSONBenchDataset(16)
+	part, err := BuildJSONBenchColumnPart(ds, 4)
+	if err != nil {
+		t.Fatalf("BuildJSONBenchColumnPart: %v", err)
+	}
+	if _, err := workspace.PublishPart(part, ds.Dictionaries); err != nil {
+		t.Fatalf("PublishPart: %v", err)
+	}
+	if got := probe.syncCalls.Load(); got != 0 {
+		t.Fatalf("benchmark-no-sync asset sync calls=%d want 0", got)
+	}
+	if err := workspace.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestColumnWorkspacePreparedRegistryAndInventory(t *testing.T) {
 	ds := syntheticJSONBenchDataset(64)
 	opts, err := JSONBenchColumnPartOptions(ds, 16)

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -135,6 +135,67 @@ func TestColumnWorkspaceCreatesIsolatedNamespace(t *testing.T) {
 	}
 }
 
+func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
+	oldSync := columnWorkspaceSyncTempFile
+	syncs := 0
+	columnWorkspaceSyncTempFile = func(file *os.File) error {
+		syncs++
+		return nil
+	}
+	defer func() {
+		columnWorkspaceSyncTempFile = oldSync
+	}()
+
+	manifest, err := NewColumnCollectionManifest("jsonbench", partTestOptions([]SortKeyColumn{{Column: "id"}}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewColumnCollectionManifest: %v", err)
+	}
+
+	durable, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace durable: %v", err)
+	}
+	if syncs != 1 {
+		t.Fatalf("durable open syncs=%d want 1", syncs)
+	}
+	if err := durable.SaveCollectionManifest(manifest); err != nil {
+		t.Fatalf("SaveCollectionManifest durable: %v", err)
+	}
+	if syncs != 2 {
+		t.Fatalf("durable collection manifest syncs=%d want 2", syncs)
+	}
+	if err := durable.Close(); err != nil {
+		t.Fatalf("Close durable: %v", err)
+	}
+
+	syncs = 0
+	relaxed, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:       "jsonbench",
+		ManifestSyncMode: ColumnWorkspaceManifestSyncDisabledForBenchmark,
+	})
+	if err != nil {
+		t.Fatalf("OpenColumnWorkspace relaxed: %v", err)
+	}
+	if syncs != 0 {
+		t.Fatalf("relaxed open syncs=%d want 0", syncs)
+	}
+	if got := relaxed.ManifestSyncMode(); got != ColumnWorkspaceManifestSyncDisabledForBenchmark {
+		t.Fatalf("ManifestSyncMode=%q want %q", got, ColumnWorkspaceManifestSyncDisabledForBenchmark)
+	}
+	if err := relaxed.SaveCollectionManifest(manifest); err != nil {
+		t.Fatalf("SaveCollectionManifest relaxed: %v", err)
+	}
+	if err := relaxed.SavePreparedAssetRegistry(1, 1, nil); err != nil {
+		t.Fatalf("SavePreparedAssetRegistry relaxed: %v", err)
+	}
+	if syncs != 0 {
+		t.Fatalf("relaxed manifest syncs=%d want 0", syncs)
+	}
+	if err := relaxed.Close(); err != nil {
+		t.Fatalf("Close relaxed: %v", err)
+	}
+}
+
 func TestColumnWorkspacePreparedRegistryAndInventory(t *testing.T) {
 	ds := syntheticJSONBenchDataset(64)
 	opts, err := JSONBenchColumnPartOptions(ds, 16)

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -142,6 +142,11 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 		return nil
 	}
 
+	var nilWorkspace *ColumnWorkspace
+	if got := nilWorkspace.ManifestSyncMode(); got != "" {
+		t.Fatalf("nil ManifestSyncMode=%q want empty", got)
+	}
+
 	manifest, err := NewColumnCollectionManifest("jsonbench", partTestOptions([]SortKeyColumn{{Column: "id"}}), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewColumnCollectionManifest: %v", err)
@@ -154,8 +159,8 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace durable: %v", err)
 	}
-	if syncs < 1 {
-		t.Fatalf("durable open syncs=%d want at least 1", syncs)
+	if syncs != 1 {
+		t.Fatalf("durable open syncs=%d want 1", syncs)
 	}
 	syncs = 0
 	if err := durable.SaveCollectionManifest(manifest); err != nil {

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -188,6 +188,12 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	if err := relaxed.SavePreparedAssetRegistry(1, 1, nil); err != nil {
 		t.Fatalf("SavePreparedAssetRegistry relaxed: %v", err)
 	}
+	ds := syntheticJSONBenchDataset(8)
+	opts, err := JSONBenchColumnPartOptions(ds, 4)
+	if err != nil {
+		t.Fatalf("JSONBenchColumnPartOptions: %v", err)
+	}
+	_ = publishJSONBenchPartRows(t, relaxed, opts, ds, 91, 0, ds.Rows)
 	if syncs != 0 {
 		t.Fatalf("relaxed manifest syncs=%d want 0", syncs)
 	}

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -136,22 +136,21 @@ func TestColumnWorkspaceCreatesIsolatedNamespace(t *testing.T) {
 }
 
 func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
-	oldSync := columnWorkspaceSyncTempFile
 	syncs := 0
-	columnWorkspaceSyncTempFile = func(file *os.File) error {
+	syncHook := func(file *os.File) error {
 		syncs++
 		return nil
 	}
-	defer func() {
-		columnWorkspaceSyncTempFile = oldSync
-	}()
 
 	manifest, err := NewColumnCollectionManifest("jsonbench", partTestOptions([]SortKeyColumn{{Column: "id"}}), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewColumnCollectionManifest: %v", err)
 	}
 
-	durable, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{Collection: "jsonbench"})
+	durable, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
+		Collection:   "jsonbench",
+		syncTempFile: syncHook,
+	})
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace durable: %v", err)
 	}
@@ -172,6 +171,7 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	relaxed, err := OpenColumnWorkspace(t.TempDir(), ColumnWorkspaceOptions{
 		Collection:       "jsonbench",
 		ManifestSyncMode: ColumnWorkspaceManifestSyncDisabledForBenchmark,
+		syncTempFile:     syncHook,
 	})
 	if err != nil {
 		t.Fatalf("OpenColumnWorkspace relaxed: %v", err)

--- a/experiments/colgranule/workspace_test.go
+++ b/experiments/colgranule/workspace_test.go
@@ -185,8 +185,14 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	if err := relaxed.SaveCollectionManifest(manifest); err != nil {
 		t.Fatalf("SaveCollectionManifest relaxed: %v", err)
 	}
+	if syncs != 0 {
+		t.Fatalf("relaxed collection manifest syncs=%d want 0", syncs)
+	}
 	if err := relaxed.SavePreparedAssetRegistry(1, 1, nil); err != nil {
 		t.Fatalf("SavePreparedAssetRegistry relaxed: %v", err)
+	}
+	if syncs != 0 {
+		t.Fatalf("relaxed prepared asset registry syncs=%d want 0", syncs)
 	}
 	ds := syntheticJSONBenchDataset(8)
 	opts, err := JSONBenchColumnPartOptions(ds, 4)
@@ -195,7 +201,7 @@ func TestColumnWorkspaceManifestSyncModeControlsFsyncM9D(t *testing.T) {
 	}
 	_ = publishJSONBenchPartRows(t, relaxed, opts, ds, 91, 0, ds.Rows)
 	if syncs != 0 {
-		t.Fatalf("relaxed manifest syncs=%d want 0", syncs)
+		t.Fatalf("relaxed workspace manifest syncs=%d want 0", syncs)
 	}
 	if err := relaxed.Close(); err != nil {
 		t.Fatalf("Close relaxed: %v", err)


### PR DESCRIPTION
## Summary

- Add the M9D replay/profile contract: `durable` is the only production-supported column mutation replay profile; `fast` and `wal_on_fast` are rejected unless explicitly marked benchmark-only ceilings.
- Wire the replay profile into the adapter/workspace path: durable profiles require durable manifest temp-file fsync workspaces, while benchmark-only `wal_on_fast_benchmark_ceiling` profiles require an explicit benchmark no-sync workspace mode.
- Harden JSONBench mutation replay parity so logical replay does not depend on physical part IDs, manifest generation IDs, asset offsets, locator part IDs, or dictionary code assignments.
- Add a replay rebuild benchmark that reports durable throughput plus command bytes, row/remainder bytes, column asset bytes, manifest/control bytes, B/op, and allocs/op.

## Correctness / TDD

- Added the M9D profile contract test first; the initial failing state was the missing `ColumnMutationReplayProfile` contract.
- Added replay parity that shifts part IDs, generation IDs, base asset offsets, locator part IDs, and dictionary code assignments while preserving visible ids, declared column semantics, q1-q5/q4a/q4b hashes, byte accounting, and visibility stats.
- Added a white-box workspace sync-mode test proving durable manifest writes call the sync hook and benchmark no-sync workspaces do not call it for workspace manifest, collection manifest, or prepared asset registry saves.
- Added adapter coverage proving benchmark-ceiling replay profiles are accepted only on matching benchmark no-sync workspaces, relaxed profiles are rejected on durable workspaces, and default/explicit durable profiles are rejected on no-sync workspaces. The durable-on-no-sync assertion failed before the adapter guard was tightened.
- Fixed dictionary-code replay to permute within declared cardinality after validation correctly rejected out-of-cardinality synthetic codes.

## Performance / Benchmark Evidence

Benchmarked head: `e8aac5b26d9c0d3db4e30ff496903631f8c1d0f5`
Machine: `darwin/arm64`, Apple M3

Benchmark command:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' \
  -bench 'BenchmarkColumnMutationReplayM9D' \
  -benchmem -benchtime=300ms -count=3 -cpu=1 \
  | tee /tmp/gomap_m9d_sync_guard_bench_count3.txt
benchstat /tmp/gomap_m9d_sync_guard_bench_count3.txt \
  | tee /tmp/gomap_m9d_sync_guard_benchstat_count3.txt
```

Results:

| Benchmark | Throughput | Time | B/op | allocs/op | Command bytes/op | Row remainder bytes/op | Column asset bytes/op | Manifest/control bytes/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `small_1k/durable` | `22.87k rows/sec` | `48.28 ms/op` | `17.81 MiB` | `812` | `61.41k` | `0` | `2.254M` | `1.728k` |
| `small_1k/wal_on_fast_benchmark_ceiling` | `36.60k rows/sec` | `30.17 ms/op` | `17.79 MiB` | `812` | `61.41k` | `0` | `2.254M` | `1.728k` |
| `medium_8k/durable` | `181.9k rows/sec` | `46.80 ms/op` | `20.11 MiB` | `1.720k` | `473.9k` | `0` | `2.559M` | `1.728k` |
| `medium_8k/wal_on_fast_benchmark_ceiling` | `294.0k rows/sec` | `28.95 ms/op` | `20.11 MiB` | `1.720k` | `473.9k` | `0` | `2.559M` | `1.728k` |

## Throughput Interpretation

- `durable` is the required M9D gate and the only production-supported profile. It preserves manifest fsync on publication paths and remains the correctness baseline.
- `wal_on_fast_benchmark_ceiling` changes the measured path rather than just changing the label: the adapter requires a benchmark-only workspace manifest sync mode that skips manifest temp-file fsyncs. This is ceiling data only, not a production recommendation.
- The benchmark measures replay rebuild work: publish base column assets, apply one logical mutation batch, publish manifest/control descriptors, and close that iteration workspace. It does not time external fixture loading.
- The medium fixture is the representative gate because fixed workspace/open/manifest overhead dominates the 1k case. Current-head durable medium replay is about `181.9k logical rows/sec` and `5.50 us/logical row`; the benchmark-only no-sync ceiling is about `294.0k logical rows/sec` and `3.40 us/logical row`.
- `row_remainder_bytes/op` is `0` because this M9D colgranule fixture exercises declared numeric column payload only. Retained row/remainder byte accounting remains a production collection concern for M10/M11.
- `manifest_control_bytes/op` is stable at `1.728k` because this benchmark publishes one base descriptor and one delta descriptor per replay. Column asset bytes are stable across durability profiles because the profile changes publication sync semantics, not physical encoding.

## Gate Status

- Pass: replay is independent of physical column descriptors and dictionary code identities.
- Pass: relaxed profiles are rejected for production at adapter construction and allowed only under explicit benchmark-ceiling labels/metrics with matching workspace sync mode.
- Pass: durable/default profiles are rejected on benchmark no-sync workspaces, preventing a no-sync workspace from masquerading as durable replay.
- Pass: q1-q5/q4a/q4b/q5 result-hash parity is preserved for replayed mutation state.
- Pass: replay benchmark reports durable throughput, ns/logical row via interpretation, B/op, allocs/op, command bytes, row/remainder bytes, column asset bytes, and manifest/control bytes in the PR body.

## Validation

```sh
GOWORK=off go test ./experiments/colgranule \
  -run 'TestColumnMutationReplayProfileContractM9D|TestColumnMutationAdapterAppliesReplayProfileOptionM9D|TestColumnMutationAdapterReplayIgnoresPhysicalDescriptorsM9D|TestColumnWorkspaceManifestSyncModeControlsFsyncM9D' \
  -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
GOWORK=off go test ./TreeDB/collections ./experiments/colgranule/... -count=1
git diff --check
GOWORK=off go test ./experiments/colgranule -run '^$' \
  -bench 'BenchmarkColumnMutationReplayM9D' \
  -benchmem -benchtime=300ms -count=3 -cpu=1
benchstat /tmp/gomap_m9d_sync_guard_bench_count3.txt
```

All commands passed locally.

## Artifacts

- Bench capture: `/tmp/gomap_m9d_sync_guard_bench_count3.txt`
- Benchstat capture: `/tmp/gomap_m9d_sync_guard_benchstat_count3.txt`
- No HTML artifact is generated by this M9D Go benchmark. The tracker requires HTML outputs once the M11A native `unified-bench` column suite exists.

Tracker: #1534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mutation replay adapter testing with comprehensive regression tests and benchmark suite to measure replay performance across different dataset sizes and durability profiles.

* **Chores**
  * Added new durability profile configuration options supporting durable, WAL-on-fast, and fast replay modes with production support validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Latest Current-Head Evidence (May 18, 2026, final M9B propagation head `42d8a7fe91d7`)
Current head: `42d8a7fe91d765386c628c1418a242aa60f84448`.

This refresh merges the final M9B quarantine-provenance fix through M9D. The M9D replay-profile performance evidence above remains the milestone contract: durable/default replay is the production path, benchmark-relaxed no-sync remains labeled as ceiling-only, and the benchmark reports replay throughput plus command/asset/control bytes.

Post-propagation validation at the propagated stack head passed:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.947s`, unified-bench tests passed in `0.686s`, and `git diff --check` passed.


### Latest Current-Head Evidence (May 18, 2026, final lifecycle-hardening propagation head `d1efac8934d1`)
Current head: `d1efac8934d13d660d63ddb69f417ccf24f19be5`.

This refresh merges the final lower-stack lifecycle-review hardening through this chained PR. The chunk-specific benchmark/performance evidence above remains the milestone contract for this PR; this section records the current propagated head and stack-level validation after the lower-stack change.

Post-propagation validation at the final top stack head passed from a clean worktree:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.565s`, unified-bench tests passed in `0.866s`, and `git diff --check` passed.

## Current-head validation update (2026-05-18, stack head 15100fcd6d48)

Current pushed head for this PR: `d1efac8934d13d660d63ddb69f417ccf24f19be5`. The M9+ chain was revalidated after the final M9B lifecycle/provenance fix was propagated through M11B. The ancestry audit passes for #1598 -> #1603 -> #1604 -> #1605 -> #1606 -> #1607 -> #1608 -> #1609, so the top-head validation includes this PR's code plus its descendants.

Focused validation:
- `go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1`: PASS on top head `15100fcd6d48`.
- `git diff --check`: PASS.

Performance evidence:
- M9B exact head `1628bd982cf6`: `BenchmarkColumnAssetReachabilitySummaryView10KReuse` = 4.135-4.159 ms/op, 0 B/op, 0 allocs/op; `BenchmarkColumnAssetManagerReclamation10K` = 0.799-0.807 ms/op, 2.400 MiB/op, 1 alloc/op.
- M11B top head `15100fcd6d48`: row baseline query suite = 59.7-60.3 ms/op, 108.8-109.9 MB/s, 70K rows/op; B-tree index baseline query suite = 70.8-70.9 ms/op, 92.5 MB/s, 70K rows/op.
- M11 reporting remains unified-bench/benchprof-compatible: JSON, Markdown, and HTML artifacts are required, while the PR text reports throughput directly for review without opening profile artifacts.

CI/review status at this refresh: latest-head GitHub checks were queued or in progress with no latest-head failures observed. AI reviews will be re-requested after this evidence refresh; stale-run cleanup is limited to M9+ branches and explicitly excludes #1615.

<!-- m9plus-current-head-evidence-start -->
## Current-Head Evidence Refresh (2026-05-18)

Chunk: `M9D` (replay profile contract).
Current head: `8d90178a5347d12e7b24a9e351412d0725252dd4` on `codex/colgranule-m9d-replay-profile-contract`; base `codex/colgranule-m9c-control-plane-durability`.
GitHub Actions current-head rollup at refresh time: `26` successful, `0` pending, `0` failing/cancelled.

Local / current validation:
- Live GitHub Actions rollup on current head is expected to remain green; this chunk was not changed by the M10A-M11B propagation.
- Existing PR body retains the focused replay/profile contract validation and performance evidence for this chunk.

Performance / benchmark evidence:
- No new code was propagated into this chunk during the latest M10A-M11B refresh.
<!-- m9plus-current-head-evidence-end -->

<!-- m9plus-current-head-closeout-start -->

## Current-head closeout evidence (2026-05-18 UTC)


This PR current head: `8d862dc7039106f82121ef836ca194f2888c0661` on `codex/colgranule-m9d-replay-profile-contract`. Chunk: `M9D` (replay profile contract).

Current M9+ stack heads after M10C review-fix propagation:

| Chunk | PR | Current head | Branch |
|---|---:|---|---|
| M9B | #1598 | `01a265dccf95` | `codex/colgranule-m9b-lifecycle-durability-closure` |
| M9C | #1603 | `d358313f407e` | `codex/colgranule-m9c-control-plane-durability` |
| M9D | #1604 | `8d862dc70391` | `codex/colgranule-m9d-replay-profile-contract` |
| M10A | #1605 | `2453042140bc` | `codex/colgranule-m10a-publish-plan-api` |
| M10B | #1606 | `1c5f94e05423` | `codex/colgranule-m10b-root-publication` |
| M10C | #1607 | `338a38211123` | `codex/colgranule-m10c-recovery-parity` |
| M11A | #1608 | `eb0cf90d8d5b` | `codex/colgranule-m11a-native-column-bench` |
| M11B | #1609 | `81c0454810b8` | `codex/colgranule-m11b-planner-skipscan` |

Validation on the current #1609 top stack head `81c0454810b8`:
- `GOWORK=off go test ./experiments/colgranule/... -count=1`: PASS (`experiments/colgranule` 3.568s, `cmd/jsonbench_compare` 1.108s).
- `go test ./TreeDB/collections -run 'TestColumnManifest|TestColumnPublishPlan|TestColumnStore(ReplayIntentBypassesRelaxedDurabilityGateM10C|AssignedForegroundIntentDoesNotBypassRelaxedDurabilityGateM10C|RelaxedProfilesRejectForegroundWritesM10C|BenchmarkRelaxedAllowsDurableCommandWALWritesM10C|ReadOnlyOpenWithUnappliedCollectionFrameFailsM10C)|ColumnStore|ColumnPublish|M10A|M10B|M10C|M11A|M11B' -count=1`: PASS (`1.198s`).
- `go test ./TreeDB/db -run 'CommandWAL|OrderedRoot|M10C|Replay|ConcurrentModification|TestCommandWALReplayIntentRequiresActiveRecoveryFrameM10C' -count=1`: PASS (`2.027s`).
- `go test ./cmd/unified_bench -run 'TestInstallAllocsProfileRate|TestCanonicalDBName|TestResolveDBs|TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B|TestColumnStoreSuiteProfiledQueries|TestColumnStoreSuitePlanner|TestBenchprof|TestBenchConfigHasAnyProfileOutput|TestRunBenchmarkCPUProfileStartFailureRemovesArtifactM11A|TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1`: PASS (`1.223s`).
- `git diff --check`: PASS.

Performance / benchmark evidence refreshed on the current #1609 top stack head:
- M9D durable replay after the review-thread hardening and asset-before-manifest durability fix: `BenchmarkColumnMutationReplayM9D/small_1k/durable`, `-benchtime=1x -count=3`, Apple M3: `44.425-78.078 ms/op`, `14.140K-24.851K rows/sec`, `18.718-18.723 MiB/op`, `824-829 allocs/op`, `2,254,369 column_asset_bytes/op`, `61,398 command_bytes/op`, `1,728 manifest_control_bytes/op`, `0 row_remainder_bytes/op`.
- M10C command-WAL replay smoke after timer cleanup: `BenchmarkColumnStoreCommandWALReplayM10C`, `-benchtime=1x -count=1`, `column_store=false`: `1.340247375 s/op`, `12.225K replay_docs/s`, `95.50 replay_frames/s`, `123,094,440 B/op`, `179,355 allocs/op`; `column_store=true`: `1.224755625 s/op`, `13.377K replay_docs/s`, `104.5 replay_frames/s`, `120,537,256 B/op`, `199,956 allocs/op`.
- M11B top-head planner baseline smoke: row baseline `75.676750 ms/op`, `86.66 MB/s`, `70,000 rows/op`, `31,341,704 B/op`, `656,801 allocs/op`.
- M11B top-head planner baseline smoke: B-tree index baseline `70.437709 ms/op`, `93.10 MB/s`, `70,000 rows/op`, `23,500,296 B/op`, `516,780 allocs/op`.
- The review-thread fixes are outside the M11B planner/query hot path except for propagated M9D/M10C correctness and benchmark-accounting improvements. M9B, M9C, M10A, and M10B benchmark contracts remain unchanged by this propagation.

CI / review state at this refresh:
- Review fixes included in these heads: M9C removes the unused pre-M10A identity-default helper, M10A reintroduces it at the publish-plan boundary where it is actually called, M9D uses a typed sync-mode error and avoids full manifest/index clones on publish rollback, and M10C exports column manifest identity sentinel errors, rejects fabricated replay intents outside the active recovery frame, restores replay LSN without per-frame `defer`, preserves default profile support setup, and keeps the replay benchmark timer stopped before reset.
- At the evidence refresh, #1598 latest-head checks were green; #1603 had latest-head checks mostly green with a few in progress; #1604-#1609 latest-head checks were queued with no latest-head failure observed yet.
- Fresh AI review and latest-head CI still need to settle cleanly before the M9+ execution goal can be closed.
- No CI stale-run cleanup is part of this refresh. PR #1615 and branch `codex/column-vector-dynamic-overlay-publish-capacity`, including protected heads `41dcc85e4f434926e6b2ab61eb0b70b673f1a16a` and `7fe6891c1ef308e4cba473a5eb828cc0748f779c`, remain excluded from any cleanup.

Completion note: these PRs are not done until latest-head CI and fresh AI review feedback settle cleanly on the newly pushed heads.

<!-- m9plus-current-head-closeout-end -->



