### PR TITLE
TreeDB/collections: add column publish-plan API

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3908,6 +3908,7 @@ func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t 
 		Name: "users",
 		Options: CollectionOptions{
 			BufferedIndexedOverlayRoots:      true,
+			DisableBufferedIndexedAsyncFlush: true,
 			BufferedIndexedWriteMaxDocuments: 1,
 			BufferedIndexedWriteMaxRootRuns:  1,
 		},
@@ -3977,6 +3978,7 @@ func TestCollectionCompactRootOverlaysFoldsIntoBaseRoots(t *testing.T) {
 		Name: "users",
 		Options: CollectionOptions{
 			BufferedIndexedOverlayRoots:      true,
+			DisableBufferedIndexedAsyncFlush: true,
 			BufferedIndexedWriteMaxDocuments: 1,
 			BufferedIndexedWriteMaxRootRuns:  1,
 		},

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -12,8 +12,15 @@ import (
 
 const (
 	columnManifestRootSuffix = "/column/manifest"
+)
 
-	errColumnPublishPlanRequiresEnabledColumnStore = "collections: column publish plan requires enabled=true column_store"
+// ErrColumnPublishPlanRequiresEnabledColumnStore is returned when publish-plan
+// construction or publication sees non-empty column-store metadata that is not
+// enabled for column writes.
+var ErrColumnPublishPlanRequiresEnabledColumnStore = errors.New("collections: column publish plan requires enabled=true column_store")
+
+var (
+	errColumnPublishPlanRequiresEnabledColumnStore = ErrColumnPublishPlanRequiresEnabledColumnStore
 )
 
 type ColumnPublishOperation string
@@ -242,7 +249,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		if columnStoreConfigEmpty(*input.ColumnStore) {
 			return ColumnPublishPlan{}, nil
 		}
-		return ColumnPublishPlan{}, errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
+		return ColumnPublishPlan{}, errColumnPublishPlanRequiresEnabledColumnStore
 	}
 	if err := validateColumnPublishOperation(input.Operation); err != nil {
 		return ColumnPublishPlan{}, err
@@ -521,7 +528,7 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 
 	updatedMeta := copyCollectionMeta(input.BaseMeta)
 	if updatedMeta.Options.ColumnStore == nil || !updatedMeta.Options.ColumnStore.Enabled {
-		return nil, errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
+		return nil, errColumnPublishPlanRequiresEnabledColumnStore
 	}
 	cfg := updatedMeta.Options.ColumnStore.copy()
 	active := activeIdentity
@@ -628,7 +635,7 @@ func columnPublishHookConfig(cfg ColumnStoreConfig) ColumnStoreConfig {
 
 func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) error {
 	if cfg == nil || !cfg.Enabled {
-		return errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
+		return errColumnPublishPlanRequiresEnabledColumnStore
 	}
 	if cfg.ManifestRoot == nil {
 		return errors.New("collections: column publish plan requires column manifest root descriptor")

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -328,6 +329,11 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		return ColumnPublishPlan{}, fmt.Errorf("collections: invalid column publish root delta: %w", err)
 	}
 
+	preparedBytes, err := checkedSumColumnPreparedAssetBytes(manifestPrepared.Assets)
+	if err != nil {
+		return ColumnPublishPlan{}, err
+	}
+
 	plan := ColumnPublishPlan{
 		Enabled:                                true,
 		Collection:                             input.Collection,
@@ -353,7 +359,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 			PublishedRefs:  closure.RequiredAssets,
 			PublishedBytes: closure.RequiredBytes,
 			PreparedRefs:   len(manifestPrepared.Assets),
-			PreparedBytes:  sumColumnPreparedAssetBytes(manifestPrepared.Assets),
+			PreparedBytes:  preparedBytes,
 		},
 		StageMetrics: metrics,
 	}
@@ -555,7 +561,10 @@ func validateColumnPublishClosure(input ColumnPublishPlanInput, cfg ColumnStoreC
 			Manifest:          manifest,
 		})
 	}
-	requiredBytes := sumColumnPreparedAssetBytes(prepared.Assets)
+	requiredBytes, err := checkedSumColumnPreparedAssetBytes(prepared.Assets)
+	if err != nil {
+		return ColumnPublishDurabilityClosure{}, err
+	}
 	return ColumnPublishDurabilityClosure{
 		PreparedAssets: prepared.Assets,
 		RequiredAssets: len(prepared.Assets),
@@ -662,6 +671,9 @@ func validateColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) e
 			return err
 		}
 	}
+	if _, err := checkedSumColumnPreparedAssetBytes(prepared.Assets); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -672,7 +684,11 @@ func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosu
 	if closure.RequiredAssets != len(closure.PreparedAssets) {
 		return fmt.Errorf("collections: column publish closure required assets=%d prepared=%d", closure.RequiredAssets, len(closure.PreparedAssets))
 	}
-	if got := sumColumnPreparedAssetBytes(closure.PreparedAssets); got != closure.RequiredBytes {
+	got, err := checkedSumColumnPreparedAssetBytes(closure.PreparedAssets)
+	if err != nil {
+		return err
+	}
+	if got != closure.RequiredBytes {
 		return fmt.Errorf("collections: column publish closure required bytes=%d prepared bytes=%d", closure.RequiredBytes, got)
 	}
 	if closure.RequiredAssets != 0 && (!closure.FlushRequired || !closure.SyncRequired) {
@@ -733,11 +749,22 @@ func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 }
 
 func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int64 {
-	var total int64
-	for _, asset := range assets {
-		total += asset.Bytes
+	total, err := checkedSumColumnPreparedAssetBytes(assets)
+	if err != nil {
+		return -1
 	}
 	return total
+}
+
+func checkedSumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) (int64, error) {
+	var total int64
+	for _, asset := range assets {
+		if asset.Bytes > math.MaxInt64-total {
+			return 0, errors.New("collections: column publish prepared asset bytes overflow")
+		}
+		total += asset.Bytes
+	}
+	return total, nil
 }
 
 func cloneColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) ColumnPublishPreparedAssets {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -474,6 +474,9 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 		return nil, backenddb.ErrClosed
 	}
 	defer func() { _ = current.Close() }()
+	if err := validateColumnManifestPublishedRoot(current, input.BaseMeta.Name, rootIDs[0], plan.RootDelta.IdentityRecord); err != nil {
+		return nil, err
+	}
 	catalog, err := loadCollectionCatalog(current, input.BaseMeta.Name)
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -451,6 +451,12 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	if recoveryIdentity != rootIdentity {
 		return nil, errors.New("collections: column publish plan recovery-authoritative manifest identity does not match root delta identity")
 	}
+	if input.BaseMeta.Options.ColumnStore != nil {
+		baseRecoveryLSN := input.BaseMeta.Options.ColumnStore.RecoveryAuthoritativeAppliedCommandLSN
+		if baseRecoveryLSN != 0 && plan.RecoveryAuthoritativeAppliedCommandLSN < baseRecoveryLSN {
+			return nil, fmt.Errorf("collections: column publish recovery-authoritative AppliedCommandLSN regression for %q: plan %d < base %d", input.BaseMeta.Name, plan.RecoveryAuthoritativeAppliedCommandLSN, baseRecoveryLSN)
+		}
+	}
 	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
 		state := c.db.State()
 		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -268,7 +268,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		start := time.Now()
 		if err := input.Hooks.EncodeDeclaredColumns(ColumnPublishDeclaredColumnEncodeInput{
 			Collection:  input.Collection,
-			ColumnStore: *cfg,
+			ColumnStore: columnPublishHookConfig(*cfg),
 			Operation:   input.Operation,
 		}); err != nil {
 			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish declared-column encode failed: %w", err)
@@ -477,8 +477,8 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 		return nil, errors.New("collections: column manifest publish requires enabled column_store metadata")
 	}
 	cfg := updatedMeta.Options.ColumnStore.copy()
-	active := plan.UpdatedActiveManifest
-	recovery := plan.RecoveryAuthoritativeManifest
+	active := activeIdentity
+	recovery := recoveryIdentity
 	cfg.ActiveManifest = &active
 	cfg.RecoveryAuthoritativeManifest = &recovery
 	cfg.RecoveryAuthoritativeAppliedCommandLSN = plan.RecoveryAuthoritativeAppliedCommandLSN
@@ -508,7 +508,7 @@ func prepareColumnPublishAssets(input ColumnPublishPlanInput, cfg ColumnStoreCon
 	}
 	return input.Hooks.PrepareAssets(ColumnPublishAssetPrepareInput{
 		Collection:        input.Collection,
-		ColumnStore:       cfg,
+		ColumnStore:       columnPublishHookConfig(cfg),
 		Operation:         input.Operation,
 		AppliedCommandLSN: input.AppliedCommandLSN,
 		CurrentManifest:   input.CurrentManifest,
@@ -521,7 +521,7 @@ func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreCo
 	}
 	return input.Hooks.EncodeManifest(ColumnPublishManifestEncodeInput{
 		Collection:        input.Collection,
-		ColumnStore:       cfg,
+		ColumnStore:       columnPublishHookConfig(cfg),
 		Operation:         input.Operation,
 		AppliedCommandLSN: input.AppliedCommandLSN,
 		CurrentManifest:   input.CurrentManifest,
@@ -533,7 +533,7 @@ func validateColumnPublishClosure(input ColumnPublishPlanInput, cfg ColumnStoreC
 	if input.Hooks.ValidateClosure != nil {
 		return input.Hooks.ValidateClosure(ColumnPublishClosureValidationInput{
 			Collection:        input.Collection,
-			ColumnStore:       cfg,
+			ColumnStore:       columnPublishHookConfig(cfg),
 			Operation:         input.Operation,
 			AppliedCommandLSN: input.AppliedCommandLSN,
 			Prepared:          prepared,
@@ -554,7 +554,7 @@ func buildColumnPublishRootDelta(input ColumnPublishPlanInput, cfg ColumnStoreCo
 	if input.Hooks.BuildRootDelta != nil {
 		return input.Hooks.BuildRootDelta(ColumnPublishRootDeltaInput{
 			Collection:         input.Collection,
-			ColumnStore:        cfg,
+			ColumnStore:        columnPublishHookConfig(cfg),
 			BaseManifestRootID: input.BaseManifestRootID,
 			Manifest:           manifest,
 			Closure:            cloneColumnPublishDurabilityClosure(closure),
@@ -570,6 +570,10 @@ func buildColumnPublishRootDelta(input ColumnPublishPlanInput, cfg ColumnStoreCo
 		Identity:       manifest.Identity,
 		IdentityRecord: encodeColumnManifestIdentityRecordArray(manifest.Identity),
 	}, nil
+}
+
+func columnPublishHookConfig(cfg ColumnStoreConfig) ColumnStoreConfig {
+	return cfg.copy()
 }
 
 func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) error {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -1,0 +1,600 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+const columnManifestRootSuffix = "/column/manifest"
+
+type ColumnPublishOperation string
+
+const (
+	ColumnPublishOperationInsert ColumnPublishOperation = "insert"
+	ColumnPublishOperationUpdate ColumnPublishOperation = "update"
+	ColumnPublishOperationDelete ColumnPublishOperation = "delete"
+)
+
+type ColumnAssetKind string
+
+const (
+	ColumnAssetKindTCS1PartImage ColumnAssetKind = "tcs1_part_image"
+)
+
+type ColumnAssetRef struct {
+	Kind     ColumnAssetKind
+	FileID   uint32
+	Offset   int64
+	Length   int64
+	Checksum uint32
+}
+
+type ColumnPreparedAsset struct {
+	Ref          ColumnAssetRef
+	Bytes        int
+	PublishID    uint64
+	GenerationID uint64
+	Reason       string
+}
+
+type ColumnPublishPlanInput struct {
+	Collection            string
+	ColumnStore           *ColumnStoreConfig
+	ColumnStoreNormalized bool
+	Operation             ColumnPublishOperation
+	CurrentManifest       *ColumnManifestIdentity
+	AppliedCommandLSN     uint64
+	BaseManifestRootID    uint64
+	MeasureAllocations    bool
+	Hooks                 ColumnPublishPlanHooks
+}
+
+type ColumnPublishPlanHooks struct {
+	ExtractDocuments      func() error
+	EncodeDeclaredColumns func(ColumnPublishDeclaredColumnEncodeInput) error
+	PrepareAssets         func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error)
+	EncodeManifest        func(ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error)
+	ValidateClosure       func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error)
+	BuildRootDelta        func(ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error)
+	BuildSystemDelta      func(ColumnPublishSystemDeltaInput) error
+}
+
+type ColumnPublishDeclaredColumnEncodeInput struct {
+	Collection  string
+	ColumnStore ColumnStoreConfig
+	Operation   ColumnPublishOperation
+}
+
+type ColumnPublishAssetPrepareInput struct {
+	Collection        string
+	ColumnStore       ColumnStoreConfig
+	Operation         ColumnPublishOperation
+	AppliedCommandLSN uint64
+	CurrentManifest   *ColumnManifestIdentity
+}
+
+type ColumnPublishPreparedAssets struct {
+	Assets             []ColumnPreparedAsset
+	RowCount           int
+	CommandBytes       int
+	RowRemainderBytes  int
+	ColumnPayloadBytes int
+}
+
+type ColumnPublishManifestEncodeInput struct {
+	Collection        string
+	ColumnStore       ColumnStoreConfig
+	Operation         ColumnPublishOperation
+	AppliedCommandLSN uint64
+	CurrentManifest   *ColumnManifestIdentity
+	Prepared          ColumnPublishPreparedAssets
+}
+
+type ColumnPublishManifestEncodeResult struct {
+	Identity      ColumnManifestIdentity
+	ManifestBytes int
+}
+
+type ColumnPublishClosureValidationInput struct {
+	Collection        string
+	ColumnStore       ColumnStoreConfig
+	Operation         ColumnPublishOperation
+	AppliedCommandLSN uint64
+	Prepared          ColumnPublishPreparedAssets
+	Manifest          ColumnPublishManifestEncodeResult
+}
+
+type ColumnPublishDurabilityClosure struct {
+	// PreparedAssets is owned by the closure/plan boundary; BuildColumnPublishPlan
+	// does not defensively clone it on the hot path.
+	PreparedAssets []ColumnPreparedAsset
+	RequiredAssets int
+	RequiredBytes  int
+	FlushRequired  bool
+	SyncRequired   bool
+}
+
+type ColumnPublishRootDeltaInput struct {
+	Collection         string
+	ColumnStore        ColumnStoreConfig
+	BaseManifestRootID uint64
+	Manifest           ColumnPublishManifestEncodeResult
+	Closure            ColumnPublishDurabilityClosure
+}
+
+type ColumnPublishSystemDeltaInput struct {
+	Plan ColumnPublishPlan
+}
+
+type ColumnManifestPublishSystemDeltaInput struct {
+	BaseMeta           CollectionMeta
+	BaseCommitSeq      uint64
+	BaseSystemRoot     uint64
+	BaseManifestRootID uint64
+	Plan               ColumnPublishPlan
+}
+
+type ColumnPublishPlan struct {
+	Enabled                                bool
+	Collection                             string
+	Operation                              ColumnPublishOperation
+	AppliedCommandLSN                      uint64
+	ManifestRootName                       string
+	ManifestRootBaseID                     uint64
+	UpdatedActiveManifest                  ColumnManifestIdentity
+	RecoveryAuthoritativeManifest          ColumnManifestIdentity
+	RecoveryAuthoritativeAppliedCommandLSN uint64
+	RootDelta                              ColumnManifestRootDelta
+	PreparedAssets                         []ColumnPreparedAsset
+	RequiredAssetCount                     int
+	RequiredAssetBytes                     int
+	RequiredAssetFlush                     bool
+	RequiredAssetSync                      bool
+	Rows                                   int
+	CommandBytes                           int
+	RowRemainderBytes                      int
+	ColumnPayloadBytes                     int
+	ManifestBytes                          int
+	Lifecycle                              ColumnPublishLifecycleSummary
+	StageMetrics                           ColumnPublishStageMetrics
+}
+
+type ColumnManifestRootDelta struct {
+	RootName       string
+	BaseRootID     uint64
+	StoragePolicy  RootStoragePolicy
+	Identity       ColumnManifestIdentity
+	IdentityRecord [columnManifestIdentityRecordSize]byte
+}
+
+type ColumnPublishLifecycleSummary struct {
+	PublishedRefs         int
+	PublishedBytes        int
+	PreparedRefs          int
+	PreparedBytes         int
+	SupersededRefs        int
+	SupersededBytes       int
+	CleanupSafeGeneration uint64
+	CleanupSafeRefs       int
+	CleanupSafeBytes      int
+	RewriteDebtBytes      int
+}
+
+type ColumnPublishStageMetrics struct {
+	DocumentExtraction      time.Duration
+	DeclaredColumnEncoding  time.Duration
+	AssetPreparation        time.Duration
+	AssetFlushSync          time.Duration
+	ManifestEncode          time.Duration
+	RootDeltaConstruction   time.Duration
+	SystemDeltaConstruction time.Duration
+	AllocBytes              uint64
+	Allocs                  uint64
+}
+
+func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, error) {
+	if input.ColumnStore == nil || !input.ColumnStore.Enabled {
+		return ColumnPublishPlan{}, nil
+	}
+	if err := validateColumnPublishOperation(input.Operation); err != nil {
+		return ColumnPublishPlan{}, err
+	}
+	if input.AppliedCommandLSN == 0 {
+		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires AppliedCommandLSN")
+	}
+	cfg := input.ColumnStore
+	if !input.ColumnStoreNormalized {
+		normalized, err := normalizeColumnStoreConfig(input.Collection, input.ColumnStore)
+		if err != nil {
+			return ColumnPublishPlan{}, err
+		}
+		cfg = normalized
+	}
+	if err := validateColumnPublishPlanConfig(input.Collection, cfg); err != nil {
+		return ColumnPublishPlan{}, err
+	}
+	if cfg == nil || !cfg.Enabled {
+		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires enabled column_store")
+	}
+	if cfg.ProfileSupport != ColumnStoreProfileDurableOnly {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish plan requires durable profile support, got %q", cfg.ProfileSupport)
+	}
+
+	var metrics ColumnPublishStageMetrics
+	var allocStart runtime.MemStats
+	if input.MeasureAllocations {
+		runtime.ReadMemStats(&allocStart)
+	}
+	if input.Hooks.ExtractDocuments != nil {
+		start := time.Now()
+		if err := input.Hooks.ExtractDocuments(); err != nil {
+			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish document extraction failed: %w", err)
+		}
+		metrics.DocumentExtraction = time.Since(start)
+	}
+	if input.Hooks.EncodeDeclaredColumns != nil {
+		start := time.Now()
+		if err := input.Hooks.EncodeDeclaredColumns(ColumnPublishDeclaredColumnEncodeInput{
+			Collection:  input.Collection,
+			ColumnStore: *cfg,
+			Operation:   input.Operation,
+		}); err != nil {
+			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish declared-column encode failed: %w", err)
+		}
+		metrics.DeclaredColumnEncoding = time.Since(start)
+	}
+
+	start := time.Now()
+	prepared, err := prepareColumnPublishAssets(input, *cfg)
+	if err != nil {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset preparation failed: %w", err)
+	}
+	metrics.AssetPreparation = time.Since(start)
+	if err := validateColumnPublishPreparedAssets(prepared); err != nil {
+		return ColumnPublishPlan{}, err
+	}
+
+	start = time.Now()
+	manifest, err := encodeColumnPublishManifest(input, *cfg, prepared)
+	if err != nil {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish manifest encode failed: %w", err)
+	}
+	metrics.ManifestEncode = time.Since(start)
+	normalizeColumnManifestIdentityDefaults(&manifest.Identity)
+	if err := validateColumnManifestIdentity(manifest.Identity); err != nil {
+		return ColumnPublishPlan{}, err
+	}
+
+	start = time.Now()
+	closure, err := validateColumnPublishClosure(input, *cfg, prepared, manifest)
+	if err != nil {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset-closure validation failed: %w", err)
+	}
+	metrics.AssetFlushSync = time.Since(start)
+	if err := validateColumnPublishDurabilityClosure(closure); err != nil {
+		return ColumnPublishPlan{}, err
+	}
+
+	start = time.Now()
+	rootDelta, err := buildColumnPublishRootDelta(input, *cfg, manifest, closure)
+	if err != nil {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish root-delta construction failed: %w", err)
+	}
+	metrics.RootDeltaConstruction = time.Since(start)
+
+	plan := ColumnPublishPlan{
+		Enabled:                                true,
+		Collection:                             input.Collection,
+		Operation:                              input.Operation,
+		AppliedCommandLSN:                      input.AppliedCommandLSN,
+		ManifestRootName:                       rootDelta.RootName,
+		ManifestRootBaseID:                     rootDelta.BaseRootID,
+		UpdatedActiveManifest:                  manifest.Identity,
+		RecoveryAuthoritativeManifest:          manifest.Identity,
+		RecoveryAuthoritativeAppliedCommandLSN: input.AppliedCommandLSN,
+		RootDelta:                              rootDelta,
+		PreparedAssets:                         closure.PreparedAssets,
+		RequiredAssetCount:                     closure.RequiredAssets,
+		RequiredAssetBytes:                     closure.RequiredBytes,
+		RequiredAssetFlush:                     closure.FlushRequired,
+		RequiredAssetSync:                      closure.SyncRequired,
+		Rows:                                   prepared.RowCount,
+		CommandBytes:                           prepared.CommandBytes,
+		RowRemainderBytes:                      prepared.RowRemainderBytes,
+		ColumnPayloadBytes:                     prepared.ColumnPayloadBytes,
+		ManifestBytes:                          manifest.ManifestBytes,
+		Lifecycle: ColumnPublishLifecycleSummary{
+			PublishedRefs:  closure.RequiredAssets,
+			PublishedBytes: closure.RequiredBytes,
+			PreparedRefs:   len(prepared.Assets),
+			PreparedBytes:  sumColumnPreparedAssetBytes(prepared.Assets),
+		},
+		StageMetrics: metrics,
+	}
+
+	if input.Hooks.BuildSystemDelta != nil {
+		start = time.Now()
+		if err := input.Hooks.BuildSystemDelta(ColumnPublishSystemDeltaInput{Plan: plan}); err != nil {
+			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish system-delta construction failed: %w", err)
+		}
+		plan.StageMetrics.SystemDeltaConstruction = time.Since(start)
+	}
+	if input.MeasureAllocations {
+		var allocEnd runtime.MemStats
+		runtime.ReadMemStats(&allocEnd)
+		plan.StageMetrics.AllocBytes = allocEnd.TotalAlloc - allocStart.TotalAlloc
+		plan.StageMetrics.Allocs = allocEnd.Mallocs - allocStart.Mallocs
+	}
+	return plan, nil
+}
+
+func (delta ColumnManifestRootDelta) OrderedRootPublishInput() (backenddb.OrderedRootPublishInput, error) {
+	if delta.RootName == "" {
+		return backenddb.OrderedRootPublishInput{}, errors.New("collections: column manifest root delta missing root name")
+	}
+	identity := delta.Identity
+	normalizeColumnManifestIdentityDefaults(&identity)
+	if err := validateColumnManifestIdentity(identity); err != nil {
+		return backenddb.OrderedRootPublishInput{}, err
+	}
+	policy, err := backendRootStoragePolicy(delta.StoragePolicy)
+	if err != nil {
+		return backenddb.OrderedRootPublishInput{}, err
+	}
+	return backenddb.OrderedRootPublishInput{
+		BaseRoot:      delta.BaseRootID,
+		Iter:          columnManifestIdentityIterator(identity),
+		StoragePolicy: policy,
+	}, nil
+}
+
+func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnManifestPublishSystemDeltaInput, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	plan := input.Plan
+	if !plan.Enabled {
+		return nil, errors.New("collections: disabled column publish plan cannot build system delta")
+	}
+	if len(rootIDs) != 1 {
+		return nil, unexpectedOrderedRootCountError(plan.Collection, 1, len(rootIDs))
+	}
+	if rootIDs[0] == 0 {
+		return nil, errors.New("collections: column manifest root publish returned zero root")
+	}
+	rootName := plan.ManifestRootName
+	if rootName == "" {
+		rootName = plan.RootDelta.RootName
+	}
+	if rootName == "" {
+		return nil, errors.New("collections: column publish plan missing manifest root name")
+	}
+
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	catalog, err := loadCollectionCatalog(current, input.BaseMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, input.BaseMeta) {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
+	}
+	if got := catalog.rootID(rootName); got != input.BaseManifestRootID {
+		return nil, errConcurrentRootModification(input.BaseMeta.Name, rootName)
+	}
+
+	updatedMeta := copyCollectionMeta(input.BaseMeta)
+	if updatedMeta.Options.ColumnStore == nil || !updatedMeta.Options.ColumnStore.Enabled {
+		return nil, errors.New("collections: column manifest publish requires enabled column_store metadata")
+	}
+	cfg := updatedMeta.Options.ColumnStore.copy()
+	active := plan.UpdatedActiveManifest
+	recovery := plan.RecoveryAuthoritativeManifest
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &recovery
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = plan.RecoveryAuthoritativeAppliedCommandLSN
+	updatedMeta.Options.ColumnStore = &cfg
+	encodedMeta, err := encodeCollectionMeta(updatedMeta)
+	if err != nil {
+		return nil, err
+	}
+	return buildSystemTargetIterator(current, map[string][]byte{
+		systemCollectionMetaKey(updatedMeta.Name): encodedMeta,
+		systemCollectionRootKey(rootName):         encodeRootID(rootIDs[0]),
+	})
+}
+
+func validateColumnPublishOperation(op ColumnPublishOperation) error {
+	switch op {
+	case ColumnPublishOperationInsert, ColumnPublishOperationUpdate, ColumnPublishOperationDelete:
+		return nil
+	default:
+		return fmt.Errorf("collections: unsupported column publish operation %q", op)
+	}
+}
+
+func prepareColumnPublishAssets(input ColumnPublishPlanInput, cfg ColumnStoreConfig) (ColumnPublishPreparedAssets, error) {
+	if input.Hooks.PrepareAssets == nil {
+		return ColumnPublishPreparedAssets{}, nil
+	}
+	return input.Hooks.PrepareAssets(ColumnPublishAssetPrepareInput{
+		Collection:        input.Collection,
+		ColumnStore:       cfg,
+		Operation:         input.Operation,
+		AppliedCommandLSN: input.AppliedCommandLSN,
+		CurrentManifest:   input.CurrentManifest,
+	})
+}
+
+func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreConfig, prepared ColumnPublishPreparedAssets) (ColumnPublishManifestEncodeResult, error) {
+	if input.Hooks.EncodeManifest == nil {
+		return ColumnPublishManifestEncodeResult{}, errors.New("manifest encode hook is required")
+	}
+	return input.Hooks.EncodeManifest(ColumnPublishManifestEncodeInput{
+		Collection:        input.Collection,
+		ColumnStore:       cfg,
+		Operation:         input.Operation,
+		AppliedCommandLSN: input.AppliedCommandLSN,
+		CurrentManifest:   input.CurrentManifest,
+		Prepared:          prepared,
+	})
+}
+
+func validateColumnPublishClosure(input ColumnPublishPlanInput, cfg ColumnStoreConfig, prepared ColumnPublishPreparedAssets, manifest ColumnPublishManifestEncodeResult) (ColumnPublishDurabilityClosure, error) {
+	if input.Hooks.ValidateClosure != nil {
+		return input.Hooks.ValidateClosure(ColumnPublishClosureValidationInput{
+			Collection:        input.Collection,
+			ColumnStore:       cfg,
+			Operation:         input.Operation,
+			AppliedCommandLSN: input.AppliedCommandLSN,
+			Prepared:          prepared,
+			Manifest:          manifest,
+		})
+	}
+	requiredBytes := sumColumnPreparedAssetBytes(prepared.Assets)
+	return ColumnPublishDurabilityClosure{
+		PreparedAssets: prepared.Assets,
+		RequiredAssets: len(prepared.Assets),
+		RequiredBytes:  requiredBytes,
+		FlushRequired:  len(prepared.Assets) != 0,
+		SyncRequired:   len(prepared.Assets) != 0,
+	}, nil
+}
+
+func buildColumnPublishRootDelta(input ColumnPublishPlanInput, cfg ColumnStoreConfig, manifest ColumnPublishManifestEncodeResult, closure ColumnPublishDurabilityClosure) (ColumnManifestRootDelta, error) {
+	if input.Hooks.BuildRootDelta != nil {
+		return input.Hooks.BuildRootDelta(ColumnPublishRootDeltaInput{
+			Collection:         input.Collection,
+			ColumnStore:        cfg,
+			BaseManifestRootID: input.BaseManifestRootID,
+			Manifest:           manifest,
+			Closure:            closure,
+		})
+	}
+	if cfg.ManifestRoot == nil {
+		return ColumnManifestRootDelta{}, errors.New("missing column manifest root descriptor")
+	}
+	return ColumnManifestRootDelta{
+		RootName:       cfg.ManifestRoot.Name,
+		BaseRootID:     input.BaseManifestRootID,
+		StoragePolicy:  cfg.ManifestRoot.StoragePolicy,
+		Identity:       manifest.Identity,
+		IdentityRecord: encodeColumnManifestIdentityRecordArray(manifest.Identity),
+	}, nil
+}
+
+func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) error {
+	if cfg == nil || !cfg.Enabled {
+		return errors.New("collections: column publish plan requires enabled column_store")
+	}
+	if cfg.ManifestRoot == nil {
+		return errors.New("collections: column publish plan requires column manifest root descriptor")
+	}
+	if cfg.ManifestRoot.Name == "" {
+		return errors.New("collections: column publish plan requires column manifest root name")
+	}
+	if !columnManifestRootNameMatches(collection, cfg.ManifestRoot.Name) {
+		return fmt.Errorf("collections: column manifest root descriptor name %q does not match %q", cfg.ManifestRoot.Name, collectionColumnManifestRootName(collection))
+	}
+	if _, err := backendRootStoragePolicy(cfg.ManifestRoot.StoragePolicy); err != nil {
+		return err
+	}
+	if cfg.ProfileSupport == "" {
+		return errors.New("collections: column publish plan requires normalized profile support")
+	}
+	return nil
+}
+
+func columnManifestRootNameMatches(collection, rootName string) bool {
+	if len(rootName) != len(collection)+len(columnManifestRootSuffix) {
+		return false
+	}
+	return rootName[:len(collection)] == collection && rootName[len(collection):] == columnManifestRootSuffix
+}
+
+func validateColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) error {
+	if prepared.RowCount < 0 {
+		return errors.New("collections: column publish prepared row count cannot be negative")
+	}
+	if prepared.CommandBytes < 0 || prepared.RowRemainderBytes < 0 || prepared.ColumnPayloadBytes < 0 {
+		return errors.New("collections: column publish prepared byte counts cannot be negative")
+	}
+	for _, asset := range prepared.Assets {
+		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosure) error {
+	if closure.RequiredAssets < 0 || closure.RequiredBytes < 0 {
+		return errors.New("collections: column publish closure counts cannot be negative")
+	}
+	if closure.RequiredAssets != len(closure.PreparedAssets) {
+		return fmt.Errorf("collections: column publish closure required assets=%d prepared=%d", closure.RequiredAssets, len(closure.PreparedAssets))
+	}
+	if got := sumColumnPreparedAssetBytes(closure.PreparedAssets); got != closure.RequiredBytes {
+		return fmt.Errorf("collections: column publish closure required bytes=%d prepared bytes=%d", closure.RequiredBytes, got)
+	}
+	if closure.RequiredAssets != 0 && (!closure.FlushRequired || !closure.SyncRequired) {
+		return errors.New("collections: durable column publish closure requires asset flush and sync")
+	}
+	for _, asset := range closure.PreparedAssets {
+		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
+	if err := validateColumnAssetRefForPlan(asset.Ref); err != nil {
+		return err
+	}
+	if asset.Bytes <= 0 {
+		return fmt.Errorf("collections: column prepared asset bytes=%d must be positive", asset.Bytes)
+	}
+	if int64(asset.Bytes) != asset.Ref.Length {
+		return fmt.Errorf("collections: column prepared asset bytes=%d does not match ref length=%d", asset.Bytes, asset.Ref.Length)
+	}
+	return nil
+}
+
+func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
+	if ref.Kind == "" {
+		return errors.New("collections: column asset ref kind is required")
+	}
+	if ref.FileID == 0 {
+		return errors.New("collections: column asset ref file_id is required")
+	}
+	if ref.Offset < 0 {
+		return fmt.Errorf("collections: column asset ref offset=%d cannot be negative", ref.Offset)
+	}
+	if ref.Length <= 0 {
+		return fmt.Errorf("collections: column asset ref length=%d must be positive", ref.Length)
+	}
+	if ref.Checksum == 0 {
+		return errors.New("collections: column asset ref checksum is required")
+	}
+	return nil
+}
+
+func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int {
+	total := 0
+	for _, asset := range assets {
+		total += asset.Bytes
+	}
+	return total
+}

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -59,7 +58,6 @@ type ColumnPublishPlanInput struct {
 	CurrentManifest       *ColumnManifestIdentity
 	AppliedCommandLSN     uint64
 	BaseManifestRootID    uint64
-	MeasureAllocations    bool
 	Hooks                 ColumnPublishPlanHooks
 }
 
@@ -226,8 +224,6 @@ type ColumnPublishStageMetrics struct {
 	ManifestEncode          time.Duration
 	RootDeltaConstruction   time.Duration
 	SystemDeltaConstruction time.Duration
-	AllocBytes              uint64
-	Allocs                  uint64
 }
 
 // BuildColumnPublishPlan validates and stages an atomic column manifest publish
@@ -261,10 +257,6 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	}
 
 	var metrics ColumnPublishStageMetrics
-	var allocStart runtime.MemStats
-	if input.MeasureAllocations {
-		runtime.ReadMemStats(&allocStart)
-	}
 	if input.Hooks.ExtractDocuments != nil {
 		start := time.Now()
 		if err := input.Hooks.ExtractDocuments(); err != nil {
@@ -293,7 +285,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err := validateColumnPublishPreparedAssets(prepared); err != nil {
 		return ColumnPublishPlan{}, err
 	}
-	manifestPrepared := cloneColumnPublishPreparedAssets(prepared)
+	manifestPrepared := prepared
 
 	start = time.Now()
 	manifest, err := encodeColumnPublishManifest(input, *cfg, manifestPrepared)
@@ -369,12 +361,6 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish system-delta construction failed: %w", err)
 		}
 		plan.StageMetrics.SystemDeltaConstruction = time.Since(start)
-	}
-	if input.MeasureAllocations {
-		var allocEnd runtime.MemStats
-		runtime.ReadMemStats(&allocEnd)
-		plan.StageMetrics.AllocBytes = allocEnd.TotalAlloc - allocStart.TotalAlloc
-		plan.StageMetrics.Allocs = allocEnd.Mallocs - allocStart.Mallocs
 	}
 	return plan, nil
 }

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -475,6 +475,16 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 		if baseRecoveryLSN != 0 && plan.RecoveryAuthoritativeAppliedCommandLSN < baseRecoveryLSN {
 			return nil, fmt.Errorf("collections: column publish recovery-authoritative AppliedCommandLSN regression for %q: plan %d < base %d", input.BaseMeta.Name, plan.RecoveryAuthoritativeAppliedCommandLSN, baseRecoveryLSN)
 		}
+		if baseRecoveryLSN != 0 && plan.AppliedCommandLSN < baseRecoveryLSN {
+			return nil, fmt.Errorf("collections: column publish AppliedCommandLSN regression for %q: plan %d < base recovery %d", input.BaseMeta.Name, plan.AppliedCommandLSN, baseRecoveryLSN)
+		}
+		if baseActive := input.BaseMeta.Options.ColumnStore.ActiveManifest; baseActive != nil {
+			normalizedBaseActive := *baseActive
+			normalizeColumnManifestIdentityDefaults(&normalizedBaseActive)
+			if activeIdentity.Generation <= normalizedBaseActive.Generation {
+				return nil, fmt.Errorf("collections: column publish manifest generation regression for %q: plan %d <= base %d", input.BaseMeta.Name, activeIdentity.Generation, normalizedBaseActive.Generation)
+			}
+		}
 	}
 	// The root IDs passed here were just built by the ordered-root publish path.
 	// Do not read them through the pre-commit snapshot: compressed roots may

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -576,7 +576,7 @@ func buildColumnPublishRootDelta(input ColumnPublishPlanInput, cfg ColumnStoreCo
 			ColumnStore:        cfg,
 			BaseManifestRootID: input.BaseManifestRootID,
 			Manifest:           manifest,
-			Closure:            closure,
+			Closure:            cloneColumnPublishDurabilityClosure(closure),
 		})
 	}
 	if cfg.ManifestRoot == nil {
@@ -753,6 +753,11 @@ func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAss
 		return assets
 	}
 	return append([]ColumnPreparedAsset(nil), assets...)
+}
+
+func cloneColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosure) ColumnPublishDurabilityClosure {
+	closure.PreparedAssets = cloneColumnPreparedAssets(closure.PreparedAssets)
+	return closure
 }
 
 func cloneColumnPublishPlanForHook(plan ColumnPublishPlan) ColumnPublishPlan {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -370,7 +370,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 
 	if input.Hooks.BuildSystemDelta != nil {
 		start = time.Now()
-		if err := input.Hooks.BuildSystemDelta(ColumnPublishSystemDeltaInput{Plan: plan}); err != nil {
+		if err := input.Hooks.BuildSystemDelta(ColumnPublishSystemDeltaInput{Plan: cloneColumnPublishPlanForHook(plan)}); err != nil {
 			return ColumnPublishPlan{}, fmt.Errorf("collections: column publish system-delta construction failed: %w", err)
 		}
 		plan.StageMetrics.SystemDeltaConstruction = time.Since(start)
@@ -729,9 +729,6 @@ func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	if ref.Length <= 0 {
 		return fmt.Errorf("collections: column asset ref length=%d must be positive", ref.Length)
 	}
-	if ref.Checksum == 0 {
-		return errors.New("collections: column asset ref checksum is required")
-	}
 	return nil
 }
 
@@ -756,4 +753,9 @@ func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAss
 		return assets
 	}
 	return append([]ColumnPreparedAsset(nil), assets...)
+}
+
+func cloneColumnPublishPlanForHook(plan ColumnPublishPlan) ColumnPublishPlan {
+	plan.PreparedAssets = cloneColumnPreparedAssets(plan.PreparedAssets)
+	return plan
 }

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -286,6 +286,9 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish root-delta construction failed: %w", err)
 	}
 	metrics.RootDeltaConstruction = time.Since(start)
+	if err := validateColumnManifestRootDeltaForPlan(rootDelta, input.BaseManifestRootID, *cfg, manifest.Identity); err != nil {
+		return ColumnPublishPlan{}, fmt.Errorf("collections: invalid column publish root delta: %w", err)
+	}
 
 	plan := ColumnPublishPlan{
 		Enabled:                                true,
@@ -516,6 +519,31 @@ func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) 
 	return nil
 }
 
+func validateColumnManifestRootDeltaForPlan(delta ColumnManifestRootDelta, baseRootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity) error {
+	if cfg.ManifestRoot == nil {
+		return errors.New("missing column manifest root descriptor")
+	}
+	if delta.RootName == "" {
+		return errors.New("missing column manifest root name")
+	}
+	if delta.RootName != cfg.ManifestRoot.Name {
+		return fmt.Errorf("root name %q does not match configured manifest root %q", delta.RootName, cfg.ManifestRoot.Name)
+	}
+	if delta.BaseRootID != baseRootID {
+		return fmt.Errorf("base root id=%d does not match expected %d", delta.BaseRootID, baseRootID)
+	}
+	if delta.StoragePolicy != cfg.ManifestRoot.StoragePolicy {
+		return fmt.Errorf("storage policy %q does not match configured manifest root policy %q", delta.StoragePolicy, cfg.ManifestRoot.StoragePolicy)
+	}
+	if delta.Identity != identity {
+		return fmt.Errorf("identity %+v does not match manifest identity %+v", delta.Identity, identity)
+	}
+	if delta.IdentityRecord != encodeColumnManifestIdentityRecordArray(identity) {
+		return errors.New("identity record does not match manifest identity")
+	}
+	return nil
+}
+
 func columnManifestRootNameMatches(collection, rootName string) bool {
 	if len(rootName) != len(collection)+len(columnManifestRootSuffix) {
 		return false
@@ -573,8 +601,13 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 }
 
 func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
-	if ref.Kind == "" {
-		return errors.New("collections: column asset ref kind is required")
+	switch ref.Kind {
+	case ColumnAssetKindTCS1PartImage:
+	default:
+		if ref.Kind == "" {
+			return errors.New("collections: column asset ref kind is required")
+		}
+		return fmt.Errorf("collections: unsupported column asset ref kind %q", ref.Kind)
 	}
 	if ref.FileID == 0 {
 		return errors.New("collections: column asset ref file_id is required")

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -429,6 +429,9 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	if plan.RecoveryAuthoritativeAppliedCommandLSN == 0 {
 		return nil, errors.New("collections: column publish plan missing recovery-authoritative AppliedCommandLSN")
 	}
+	if plan.RecoveryAuthoritativeAppliedCommandLSN < plan.AppliedCommandLSN {
+		return nil, fmt.Errorf("collections: column publish recovery-authoritative AppliedCommandLSN regression for %q: plan recovery %d < applied %d", input.BaseMeta.Name, plan.RecoveryAuthoritativeAppliedCommandLSN, plan.AppliedCommandLSN)
+	}
 	rootName := plan.ManifestRootName
 	if rootName == "" {
 		rootName = plan.RootDelta.RootName

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -297,6 +297,9 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err := validateColumnManifestIdentity(manifest.Identity); err != nil {
 		return ColumnPublishPlan{}, err
 	}
+	if manifest.ManifestBytes < 0 {
+		return ColumnPublishPlan{}, errors.New("collections: column publish manifest byte count cannot be negative")
+	}
 
 	start = time.Now()
 	closurePrepared := manifestPrepared
@@ -403,6 +406,12 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	}
 	if rootIDs[0] == 0 {
 		return nil, errors.New("collections: column manifest root publish returned zero root")
+	}
+	if plan.AppliedCommandLSN == 0 {
+		return nil, errors.New("collections: column publish plan missing AppliedCommandLSN")
+	}
+	if plan.RecoveryAuthoritativeAppliedCommandLSN == 0 {
+		return nil, errors.New("collections: column publish plan missing recovery-authoritative AppliedCommandLSN")
 	}
 	rootName := plan.ManifestRootName
 	if rootName == "" {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -279,6 +279,9 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err := validateColumnPublishDurabilityClosure(closure); err != nil {
 		return ColumnPublishPlan{}, err
 	}
+	if err := validateColumnPublishClosureMatchesPrepared(prepared, closure); err != nil {
+		return ColumnPublishPlan{}, err
+	}
 
 	start = time.Now()
 	rootDelta, err := buildColumnPublishRootDelta(input, *cfg, manifest, closure)
@@ -582,6 +585,18 @@ func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosu
 	for _, asset := range closure.PreparedAssets {
 		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateColumnPublishClosureMatchesPrepared(prepared ColumnPublishPreparedAssets, closure ColumnPublishDurabilityClosure) error {
+	if len(closure.PreparedAssets) != len(prepared.Assets) {
+		return fmt.Errorf("collections: column publish closure prepared assets=%d manifest prepared assets=%d", len(closure.PreparedAssets), len(prepared.Assets))
+	}
+	for i := range prepared.Assets {
+		if closure.PreparedAssets[i] != prepared.Assets[i] {
+			return fmt.Errorf("collections: column publish closure prepared asset %d does not match manifest prepared asset", i)
 		}
 	}
 	return nil

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -489,17 +489,17 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	// The root IDs passed here were just built by the ordered-root publish path.
 	// Do not read them through the pre-commit snapshot: compressed roots may
 	// depend on value-log segment visibility published by the enclosing commit.
+	if input.BaseCommitSeq == 0 || input.BaseSystemRoot == 0 {
+		return nil, fmt.Errorf("collections: column publish system delta requires BaseCommitSeq and BaseSystemRoot for %q", input.BaseMeta.Name)
+	}
 	current := c.db.AcquireSnapshot()
 	if current == nil {
 		return nil, backenddb.ErrClosed
 	}
 	defer func() { _ = current.Close() }()
-	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
-		state := current.State()
-		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||
-			(input.BaseSystemRoot != 0 && state.SystemRootPageID != input.BaseSystemRoot) {
-			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
-		}
+	state := current.State()
+	if state.CommitSeq != input.BaseCommitSeq || state.SystemRootPageID != input.BaseSystemRoot {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
 	}
 	catalog, err := loadCollectionCatalog(current, input.BaseMeta.Name)
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -443,6 +443,24 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	if input.BaseManifestRootID != plan.ManifestRootBaseID || input.BaseManifestRootID != plan.RootDelta.BaseRootID {
 		return nil, errConcurrentRootModification(input.BaseMeta.Name, rootName)
 	}
+	rootIdentity := plan.RootDelta.Identity
+	normalizeColumnManifestIdentityDefaults(&rootIdentity)
+	if err := validateColumnManifestIdentity(rootIdentity); err != nil {
+		return nil, err
+	}
+	if plan.RootDelta.IdentityRecord != encodeColumnManifestIdentityRecordArray(rootIdentity) {
+		return nil, errors.New("collections: column publish plan root identity record does not match root identity")
+	}
+	activeIdentity := plan.UpdatedActiveManifest
+	normalizeColumnManifestIdentityDefaults(&activeIdentity)
+	if activeIdentity != rootIdentity {
+		return nil, errors.New("collections: column publish plan active manifest identity does not match root delta identity")
+	}
+	recoveryIdentity := plan.RecoveryAuthoritativeManifest
+	normalizeColumnManifestIdentityDefaults(&recoveryIdentity)
+	if recoveryIdentity != rootIdentity {
+		return nil, errors.New("collections: column publish plan recovery-authoritative manifest identity does not match root delta identity")
+	}
 	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
 		state := c.db.State()
 		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -349,7 +349,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		RecoveryAuthoritativeManifest:          manifest.Identity,
 		RecoveryAuthoritativeAppliedCommandLSN: input.AppliedCommandLSN,
 		RootDelta:                              rootDelta,
-		PreparedAssets:                         closure.PreparedAssets,
+		PreparedAssets:                         cloneColumnPreparedAssets(closure.PreparedAssets),
 		RequiredAssetCount:                     closure.RequiredAssets,
 		RequiredAssetBytes:                     closure.RequiredBytes,
 		RequiredAssetFlush:                     closure.FlushRequired,
@@ -747,6 +747,13 @@ func cloneColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) Colu
 	if len(prepared.Assets) == 0 {
 		return prepared
 	}
-	prepared.Assets = append([]ColumnPreparedAsset(nil), prepared.Assets...)
+	prepared.Assets = cloneColumnPreparedAssets(prepared.Assets)
 	return prepared
+}
+
+func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAsset {
+	if len(assets) == 0 {
+		return assets
+	}
+	return append([]ColumnPreparedAsset(nil), assets...)
 }

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -473,6 +473,9 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 			return nil, fmt.Errorf("collections: column publish recovery-authoritative AppliedCommandLSN regression for %q: plan %d < base %d", input.BaseMeta.Name, plan.RecoveryAuthoritativeAppliedCommandLSN, baseRecoveryLSN)
 		}
 	}
+	// The root IDs passed here were just built by the ordered-root publish path.
+	// Do not read them through the pre-commit snapshot: compressed roots may
+	// depend on value-log segment visibility published by the enclosing commit.
 	current := c.db.AcquireSnapshot()
 	if current == nil {
 		return nil, backenddb.ErrClosed
@@ -484,9 +487,6 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 			(input.BaseSystemRoot != 0 && state.SystemRootPageID != input.BaseSystemRoot) {
 			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
 		}
-	}
-	if err := validateColumnManifestPublishedRoot(current, input.BaseMeta.Name, rootIDs[0], plan.RootDelta.IdentityRecord); err != nil {
-		return nil, err
 	}
 	catalog, err := loadCollectionCatalog(current, input.BaseMeta.Name)
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -10,7 +10,11 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
-const columnManifestRootSuffix = "/column/manifest"
+const (
+	columnManifestRootSuffix = "/column/manifest"
+
+	errColumnPublishPlanRequiresEnabledColumnStore = "collections: column publish plan requires enabled=true column_store"
+)
 
 type ColumnPublishOperation string
 
@@ -238,7 +242,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		if columnStoreConfigEmpty(*input.ColumnStore) {
 			return ColumnPublishPlan{}, nil
 		}
-		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires enabled=true column_store")
+		return ColumnPublishPlan{}, errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
 	}
 	if err := validateColumnPublishOperation(input.Operation); err != nil {
 		return ColumnPublishPlan{}, err
@@ -624,7 +628,7 @@ func columnPublishHookConfig(cfg ColumnStoreConfig) ColumnStoreConfig {
 
 func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) error {
 	if cfg == nil || !cfg.Enabled {
-		return errors.New("collections: column publish plan requires enabled column_store")
+		return errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
 	}
 	if cfg.ManifestRoot == nil {
 		return errors.New("collections: column publish plan requires column manifest root descriptor")
@@ -741,18 +745,35 @@ func validateColumnPublishClosureMatchesPrepared(prepared ColumnPublishPreparedA
 	if matchesOrder {
 		return nil
 	}
-	preparedCounts := make(map[ColumnPreparedAsset]int, len(prepared.Assets))
+	preparedCounts := make(map[columnPreparedAssetMatchKey]int, len(prepared.Assets))
 	for _, asset := range prepared.Assets {
-		preparedCounts[asset]++
+		preparedCounts[columnPreparedAssetMatchKeyOf(asset)]++
 	}
 	for i, asset := range closure.PreparedAssets {
-		count := preparedCounts[asset]
+		key := columnPreparedAssetMatchKeyOf(asset)
+		count := preparedCounts[key]
 		if count == 0 {
 			return fmt.Errorf("collections: column publish closure prepared asset %d does not match manifest prepared assets", i)
 		}
-		preparedCounts[asset] = count - 1
+		preparedCounts[key] = count - 1
 	}
 	return nil
+}
+
+type columnPreparedAssetMatchKey struct {
+	Ref          ColumnAssetRef
+	Bytes        int64
+	PublishID    uint64
+	GenerationID uint64
+}
+
+func columnPreparedAssetMatchKeyOf(asset ColumnPreparedAsset) columnPreparedAssetMatchKey {
+	return columnPreparedAssetMatchKey{
+		Ref:          asset.Ref,
+		Bytes:        asset.Bytes,
+		PublishID:    asset.PublishID,
+		GenerationID: asset.GenerationID,
+	}
 }
 
 func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -131,7 +131,8 @@ type ColumnPublishClosureValidationInput struct {
 // synced before the manifest root can become authoritative.
 type ColumnPublishDurabilityClosure struct {
 	// PreparedAssets is owned by the closure/plan boundary. BuildColumnPublishPlan
-	// compares it against the manifest snapshot before publishing.
+	// compares it as an order-independent multiset against the manifest snapshot
+	// before publishing.
 	PreparedAssets []ColumnPreparedAsset
 	RequiredAssets int
 	RequiredBytes  int64
@@ -312,7 +313,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset-closure validation failed: %w", err)
 	}
 	metrics.AssetClosureValidation = time.Since(start)
-	if err := validateColumnPublishDurabilityClosure(closure); err != nil {
+	if err := validateColumnPublishDurabilityClosure(closure, *cfg); err != nil {
 		return ColumnPublishPlan{}, err
 	}
 	if err := validateColumnPublishClosureMatchesPrepared(manifestPrepared, closure); err != nil {
@@ -345,7 +346,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		RecoveryAuthoritativeManifest:          manifest.Identity,
 		RecoveryAuthoritativeAppliedCommandLSN: input.AppliedCommandLSN,
 		RootDelta:                              rootDelta,
-		PreparedAssets:                         cloneColumnPreparedAssets(closure.PreparedAssets),
+		PreparedAssets:                         cloneColumnPreparedAssets(manifestPrepared.Assets),
 		RequiredAssetCount:                     closure.RequiredAssets,
 		RequiredAssetBytes:                     closure.RequiredBytes,
 		RequiredAssetFlush:                     closure.FlushRequired,
@@ -412,6 +413,15 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	}
 	if rootIDs[0] == 0 {
 		return nil, errors.New("collections: column manifest root publish returned zero root")
+	}
+	if input.BaseMeta.Options.ColumnStore == nil || input.BaseMeta.Options.ColumnStore.ManifestRoot == nil {
+		return nil, errors.New("collections: column manifest publish requires column manifest root metadata")
+	}
+	if _, err := backendRootStoragePolicy(plan.RootDelta.StoragePolicy); err != nil {
+		return nil, err
+	}
+	if plan.RootDelta.StoragePolicy != input.BaseMeta.Options.ColumnStore.ManifestRoot.StoragePolicy {
+		return nil, fmt.Errorf("collections: column publish plan storage policy %q does not match collection manifest root policy %q", plan.RootDelta.StoragePolicy, input.BaseMeta.Options.ColumnStore.ManifestRoot.StoragePolicy)
 	}
 	if plan.AppliedCommandLSN == 0 {
 		return nil, errors.New("collections: column publish plan missing AppliedCommandLSN")
@@ -531,7 +541,7 @@ func prepareColumnPublishAssets(input ColumnPublishPlanInput, cfg ColumnStoreCon
 		ColumnStore:       columnPublishHookConfig(cfg),
 		Operation:         input.Operation,
 		AppliedCommandLSN: input.AppliedCommandLSN,
-		CurrentManifest:   input.CurrentManifest,
+		CurrentManifest:   cloneColumnManifestIdentityPtr(input.CurrentManifest),
 	})
 }
 
@@ -544,7 +554,7 @@ func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreCo
 		ColumnStore:       columnPublishHookConfig(cfg),
 		Operation:         input.Operation,
 		AppliedCommandLSN: input.AppliedCommandLSN,
-		CurrentManifest:   input.CurrentManifest,
+		CurrentManifest:   cloneColumnManifestIdentityPtr(input.CurrentManifest),
 		Prepared:          cloneColumnPublishPreparedAssets(prepared),
 	})
 }
@@ -642,6 +652,9 @@ func validateColumnManifestRootDeltaForPlan(delta ColumnManifestRootDelta, baseR
 	if delta.StoragePolicy != cfg.ManifestRoot.StoragePolicy {
 		return fmt.Errorf("storage policy %q does not match configured manifest root policy %q", delta.StoragePolicy, cfg.ManifestRoot.StoragePolicy)
 	}
+	if _, err := backendRootStoragePolicy(delta.StoragePolicy); err != nil {
+		return err
+	}
 	if delta.Identity != identity {
 		return fmt.Errorf("identity %+v does not match manifest identity %+v", delta.Identity, identity)
 	}
@@ -665,9 +678,9 @@ func validateColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) e
 	if prepared.CommandBytes < 0 || prepared.RowRemainderBytes < 0 || prepared.ColumnPayloadBytes < 0 {
 		return errors.New("collections: column publish prepared byte counts cannot be negative")
 	}
-	for _, asset := range prepared.Assets {
+	for i, asset := range prepared.Assets {
 		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
-			return err
+			return fmt.Errorf("collections: column publish prepared asset[%d]: %w", i, err)
 		}
 	}
 	if _, err := checkedSumColumnPreparedAssetBytes(prepared.Assets); err != nil {
@@ -676,7 +689,7 @@ func validateColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) e
 	return nil
 }
 
-func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosure) error {
+func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosure, cfg ColumnStoreConfig) error {
 	if closure.RequiredAssets < 0 || closure.RequiredBytes < 0 {
 		return errors.New("collections: column publish closure counts cannot be negative")
 	}
@@ -690,12 +703,12 @@ func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosu
 	if got != closure.RequiredBytes {
 		return fmt.Errorf("collections: column publish closure required bytes=%d prepared bytes=%d", closure.RequiredBytes, got)
 	}
-	if closure.RequiredAssets != 0 && (!closure.FlushRequired || !closure.SyncRequired) {
+	if cfg.ProfileSupport == ColumnStoreProfileDurableOnly && closure.RequiredAssets != 0 && (!closure.FlushRequired || !closure.SyncRequired) {
 		return errors.New("collections: durable column publish closure requires asset flush and sync")
 	}
-	for _, asset := range closure.PreparedAssets {
+	for i, asset := range closure.PreparedAssets {
 		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
-			return err
+			return fmt.Errorf("collections: column publish closure asset[%d]: %w", i, err)
 		}
 	}
 	return nil
@@ -705,10 +718,26 @@ func validateColumnPublishClosureMatchesPrepared(prepared ColumnPublishPreparedA
 	if len(closure.PreparedAssets) != len(prepared.Assets) {
 		return fmt.Errorf("collections: column publish closure prepared assets=%d manifest prepared assets=%d", len(closure.PreparedAssets), len(prepared.Assets))
 	}
+	matchesOrder := true
 	for i := range prepared.Assets {
 		if closure.PreparedAssets[i] != prepared.Assets[i] {
-			return fmt.Errorf("collections: column publish closure prepared asset %d does not match manifest prepared asset", i)
+			matchesOrder = false
+			break
 		}
+	}
+	if matchesOrder {
+		return nil
+	}
+	preparedCounts := make(map[ColumnPreparedAsset]int, len(prepared.Assets))
+	for _, asset := range prepared.Assets {
+		preparedCounts[asset]++
+	}
+	for i, asset := range closure.PreparedAssets {
+		count := preparedCounts[asset]
+		if count == 0 {
+			return fmt.Errorf("collections: column publish closure prepared asset %d does not match manifest prepared assets", i)
+		}
+		preparedCounts[asset] = count - 1
 	}
 	return nil
 }
@@ -747,19 +776,11 @@ func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	return nil
 }
 
-func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int64 {
-	total, err := checkedSumColumnPreparedAssetBytes(assets)
-	if err != nil {
-		return -1
-	}
-	return total
-}
-
 func checkedSumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) (int64, error) {
 	var total int64
-	for _, asset := range assets {
+	for i, asset := range assets {
 		if asset.Bytes > math.MaxInt64-total {
-			return 0, errors.New("collections: column publish prepared asset bytes overflow")
+			return 0, fmt.Errorf("collections: column publish prepared asset[%d] bytes overflow", i)
 		}
 		total += asset.Bytes
 	}
@@ -772,6 +793,14 @@ func cloneColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) Colu
 	}
 	prepared.Assets = cloneColumnPreparedAssets(prepared.Assets)
 	return prepared
+}
+
+func cloneColumnManifestIdentityPtr(identity *ColumnManifestIdentity) *ColumnManifestIdentity {
+	if identity == nil {
+		return nil
+	}
+	copied := *identity
+	return &copied
 }
 
 func cloneColumnPreparedAssets(assets []ColumnPreparedAsset) []ColumnPreparedAsset {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -463,19 +463,18 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 			return nil, fmt.Errorf("collections: column publish recovery-authoritative AppliedCommandLSN regression for %q: plan %d < base %d", input.BaseMeta.Name, plan.RecoveryAuthoritativeAppliedCommandLSN, baseRecoveryLSN)
 		}
 	}
-	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
-		state := c.db.State()
-		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||
-			(input.BaseSystemRoot != 0 && state.SystemRootPageID != input.BaseSystemRoot) {
-			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
-		}
-	}
-
 	current := c.db.AcquireSnapshot()
 	if current == nil {
 		return nil, backenddb.ErrClosed
 	}
 	defer func() { _ = current.Close() }()
+	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
+		state := current.State()
+		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||
+			(input.BaseSystemRoot != 0 && state.SystemRootPageID != input.BaseSystemRoot) {
+			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
+		}
+	}
 	if err := validateColumnManifestPublishedRoot(current, input.BaseMeta.Name, rootIDs[0], plan.RootDelta.IdentityRecord); err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -15,17 +15,23 @@ const columnManifestRootSuffix = "/column/manifest"
 type ColumnPublishOperation string
 
 const (
+	// ColumnPublishOperationInsert publishes column assets for inserted rows.
 	ColumnPublishOperationInsert ColumnPublishOperation = "insert"
+	// ColumnPublishOperationUpdate publishes column assets for updated rows.
 	ColumnPublishOperationUpdate ColumnPublishOperation = "update"
+	// ColumnPublishOperationDelete publishes column tombstone/delete metadata.
 	ColumnPublishOperationDelete ColumnPublishOperation = "delete"
 )
 
+// ColumnAssetKind identifies the storage format behind a column asset ref.
 type ColumnAssetKind string
 
 const (
+	// ColumnAssetKindTCS1PartImage references an immutable TCS1 part image.
 	ColumnAssetKindTCS1PartImage ColumnAssetKind = "tcs1_part_image"
 )
 
+// ColumnAssetRef is the durable value-log-owned address of a column asset.
 type ColumnAssetRef struct {
 	Kind     ColumnAssetKind
 	FileID   uint32
@@ -34,6 +40,7 @@ type ColumnAssetRef struct {
 	Checksum uint32
 }
 
+// ColumnPreparedAsset describes an immutable asset staged for manifest publish.
 type ColumnPreparedAsset struct {
 	Ref          ColumnAssetRef
 	Bytes        int
@@ -42,6 +49,8 @@ type ColumnPreparedAsset struct {
 	Reason       string
 }
 
+// ColumnPublishPlanInput contains the normalized collection state and stage
+// hooks required to build an atomic column manifest publish plan.
 type ColumnPublishPlanInput struct {
 	Collection            string
 	ColumnStore           *ColumnStoreConfig
@@ -54,6 +63,7 @@ type ColumnPublishPlanInput struct {
 	Hooks                 ColumnPublishPlanHooks
 }
 
+// ColumnPublishPlanHooks provide the engine-specific stages for a publish plan.
 type ColumnPublishPlanHooks struct {
 	ExtractDocuments      func() error
 	EncodeDeclaredColumns func(ColumnPublishDeclaredColumnEncodeInput) error
@@ -64,12 +74,15 @@ type ColumnPublishPlanHooks struct {
 	BuildSystemDelta      func(ColumnPublishSystemDeltaInput) error
 }
 
+// ColumnPublishDeclaredColumnEncodeInput is passed to the declared-column
+// encoding stage.
 type ColumnPublishDeclaredColumnEncodeInput struct {
 	Collection  string
 	ColumnStore ColumnStoreConfig
 	Operation   ColumnPublishOperation
 }
 
+// ColumnPublishAssetPrepareInput is passed to the asset preparation stage.
 type ColumnPublishAssetPrepareInput struct {
 	Collection        string
 	ColumnStore       ColumnStoreConfig
@@ -78,6 +91,8 @@ type ColumnPublishAssetPrepareInput struct {
 	CurrentManifest   *ColumnManifestIdentity
 }
 
+// ColumnPublishPreparedAssets is the row/byte/accounting summary for staged
+// column assets before they are referenced by a manifest generation.
 type ColumnPublishPreparedAssets struct {
 	Assets             []ColumnPreparedAsset
 	RowCount           int
@@ -86,6 +101,7 @@ type ColumnPublishPreparedAssets struct {
 	ColumnPayloadBytes int
 }
 
+// ColumnPublishManifestEncodeInput is passed to the manifest encoding stage.
 type ColumnPublishManifestEncodeInput struct {
 	Collection        string
 	ColumnStore       ColumnStoreConfig
@@ -95,11 +111,14 @@ type ColumnPublishManifestEncodeInput struct {
 	Prepared          ColumnPublishPreparedAssets
 }
 
+// ColumnPublishManifestEncodeResult identifies the encoded manifest generation.
 type ColumnPublishManifestEncodeResult struct {
 	Identity      ColumnManifestIdentity
 	ManifestBytes int
 }
 
+// ColumnPublishClosureValidationInput is passed to the durability-closure
+// validation stage.
 type ColumnPublishClosureValidationInput struct {
 	Collection        string
 	ColumnStore       ColumnStoreConfig
@@ -109,9 +128,11 @@ type ColumnPublishClosureValidationInput struct {
 	Manifest          ColumnPublishManifestEncodeResult
 }
 
+// ColumnPublishDurabilityClosure records the assets that must be flushed and
+// synced before the manifest root can become authoritative.
 type ColumnPublishDurabilityClosure struct {
-	// PreparedAssets is owned by the closure/plan boundary; BuildColumnPublishPlan
-	// does not defensively clone it on the hot path.
+	// PreparedAssets is owned by the closure/plan boundary. BuildColumnPublishPlan
+	// compares it against the manifest snapshot before publishing.
 	PreparedAssets []ColumnPreparedAsset
 	RequiredAssets int
 	RequiredBytes  int
@@ -119,6 +140,7 @@ type ColumnPublishDurabilityClosure struct {
 	SyncRequired   bool
 }
 
+// ColumnPublishRootDeltaInput is passed to the manifest-root delta stage.
 type ColumnPublishRootDeltaInput struct {
 	Collection         string
 	ColumnStore        ColumnStoreConfig
@@ -127,10 +149,13 @@ type ColumnPublishRootDeltaInput struct {
 	Closure            ColumnPublishDurabilityClosure
 }
 
+// ColumnPublishSystemDeltaInput is passed to the metadata/system-root stage.
 type ColumnPublishSystemDeltaInput struct {
 	Plan ColumnPublishPlan
 }
 
+// ColumnManifestPublishSystemDeltaInput contains the collection metadata base
+// and publish plan used to build the atomic system-root update.
 type ColumnManifestPublishSystemDeltaInput struct {
 	BaseMeta           CollectionMeta
 	BaseCommitSeq      uint64
@@ -139,6 +164,8 @@ type ColumnManifestPublishSystemDeltaInput struct {
 	Plan               ColumnPublishPlan
 }
 
+// ColumnPublishPlan is the complete, validated plan for publishing a column
+// manifest generation and making it recovery-authoritative.
 type ColumnPublishPlan struct {
 	Enabled                                bool
 	Collection                             string
@@ -164,6 +191,8 @@ type ColumnPublishPlan struct {
 	StageMetrics                           ColumnPublishStageMetrics
 }
 
+// ColumnManifestRootDelta is the ordered-root publish descriptor for the
+// collection column manifest root.
 type ColumnManifestRootDelta struct {
 	RootName       string
 	BaseRootID     uint64
@@ -172,6 +201,8 @@ type ColumnManifestRootDelta struct {
 	IdentityRecord [columnManifestIdentityRecordSize]byte
 }
 
+// ColumnPublishLifecycleSummary summarizes lifecycle/GC-relevant asset effects
+// of the publish.
 type ColumnPublishLifecycleSummary struct {
 	PublishedRefs         int
 	PublishedBytes        int
@@ -185,6 +216,8 @@ type ColumnPublishLifecycleSummary struct {
 	RewriteDebtBytes      int
 }
 
+// ColumnPublishStageMetrics records stage timings and optional allocation
+// counters for publish-plan construction.
 type ColumnPublishStageMetrics struct {
 	DocumentExtraction      time.Duration
 	DeclaredColumnEncoding  time.Duration
@@ -197,9 +230,22 @@ type ColumnPublishStageMetrics struct {
 	Allocs                  uint64
 }
 
+// BuildColumnPublishPlan validates and stages an atomic column manifest publish
+// plan. A nil or completely empty disabled column_store is a zero-work fast path.
 func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, error) {
-	if input.ColumnStore == nil || !input.ColumnStore.Enabled {
+	if input.ColumnStore == nil {
 		return ColumnPublishPlan{}, nil
+	}
+	if !input.ColumnStore.Enabled {
+		if columnStoreConfigEmpty(*input.ColumnStore) {
+			return ColumnPublishPlan{}, nil
+		}
+		if !input.ColumnStoreNormalized {
+			if _, err := normalizeColumnStoreConfig(input.Collection, input.ColumnStore); err != nil {
+				return ColumnPublishPlan{}, err
+			}
+		}
+		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires enabled=true column_store")
 	}
 	if err := validateColumnPublishOperation(input.Operation); err != nil {
 		return ColumnPublishPlan{}, err
@@ -217,12 +263,6 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	}
 	if err := validateColumnPublishPlanConfig(input.Collection, cfg); err != nil {
 		return ColumnPublishPlan{}, err
-	}
-	if cfg == nil || !cfg.Enabled {
-		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires enabled column_store")
-	}
-	if cfg.ProfileSupport != ColumnStoreProfileDurableOnly {
-		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish plan requires durable profile support, got %q", cfg.ProfileSupport)
 	}
 
 	var metrics ColumnPublishStageMetrics
@@ -258,9 +298,10 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err := validateColumnPublishPreparedAssets(prepared); err != nil {
 		return ColumnPublishPlan{}, err
 	}
+	manifestPrepared := cloneColumnPublishPreparedAssets(prepared)
 
 	start = time.Now()
-	manifest, err := encodeColumnPublishManifest(input, *cfg, prepared)
+	manifest, err := encodeColumnPublishManifest(input, *cfg, manifestPrepared)
 	if err != nil {
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish manifest encode failed: %w", err)
 	}
@@ -271,7 +312,11 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	}
 
 	start = time.Now()
-	closure, err := validateColumnPublishClosure(input, *cfg, prepared, manifest)
+	closurePrepared := manifestPrepared
+	if input.Hooks.ValidateClosure != nil {
+		closurePrepared = cloneColumnPublishPreparedAssets(manifestPrepared)
+	}
+	closure, err := validateColumnPublishClosure(input, *cfg, closurePrepared, manifest)
 	if err != nil {
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset-closure validation failed: %w", err)
 	}
@@ -279,7 +324,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err := validateColumnPublishDurabilityClosure(closure); err != nil {
 		return ColumnPublishPlan{}, err
 	}
-	if err := validateColumnPublishClosureMatchesPrepared(prepared, closure); err != nil {
+	if err := validateColumnPublishClosureMatchesPrepared(manifestPrepared, closure); err != nil {
 		return ColumnPublishPlan{}, err
 	}
 
@@ -309,16 +354,16 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		RequiredAssetBytes:                     closure.RequiredBytes,
 		RequiredAssetFlush:                     closure.FlushRequired,
 		RequiredAssetSync:                      closure.SyncRequired,
-		Rows:                                   prepared.RowCount,
-		CommandBytes:                           prepared.CommandBytes,
-		RowRemainderBytes:                      prepared.RowRemainderBytes,
-		ColumnPayloadBytes:                     prepared.ColumnPayloadBytes,
+		Rows:                                   manifestPrepared.RowCount,
+		CommandBytes:                           manifestPrepared.CommandBytes,
+		RowRemainderBytes:                      manifestPrepared.RowRemainderBytes,
+		ColumnPayloadBytes:                     manifestPrepared.ColumnPayloadBytes,
 		ManifestBytes:                          manifest.ManifestBytes,
 		Lifecycle: ColumnPublishLifecycleSummary{
 			PublishedRefs:  closure.RequiredAssets,
 			PublishedBytes: closure.RequiredBytes,
-			PreparedRefs:   len(prepared.Assets),
-			PreparedBytes:  sumColumnPreparedAssetBytes(prepared.Assets),
+			PreparedRefs:   len(manifestPrepared.Assets),
+			PreparedBytes:  sumColumnPreparedAssetBytes(manifestPrepared.Assets),
 		},
 		StageMetrics: metrics,
 	}
@@ -339,6 +384,8 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	return plan, nil
 }
 
+// OrderedRootPublishInput converts the root delta into a backend ordered-root
+// publish input while preserving the already-validated identity record bytes.
 func (delta ColumnManifestRootDelta) OrderedRootPublishInput() (backenddb.OrderedRootPublishInput, error) {
 	if delta.RootName == "" {
 		return backenddb.OrderedRootPublishInput{}, errors.New("collections: column manifest root delta missing root name")
@@ -348,13 +395,16 @@ func (delta ColumnManifestRootDelta) OrderedRootPublishInput() (backenddb.Ordere
 	if err := validateColumnManifestIdentity(identity); err != nil {
 		return backenddb.OrderedRootPublishInput{}, err
 	}
+	if delta.IdentityRecord != encodeColumnManifestIdentityRecordArray(identity) {
+		return backenddb.OrderedRootPublishInput{}, errors.New("collections: column manifest root delta identity record does not match identity")
+	}
 	policy, err := backendRootStoragePolicy(delta.StoragePolicy)
 	if err != nil {
 		return backenddb.OrderedRootPublishInput{}, err
 	}
 	return backenddb.OrderedRootPublishInput{
 		BaseRoot:      delta.BaseRootID,
-		Iter:          columnManifestIdentityIterator(identity),
+		Iter:          columnManifestIdentityRecordIterator(delta.IdentityRecord),
 		StoragePolicy: policy,
 	}, nil
 }
@@ -379,6 +429,26 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 	}
 	if rootName == "" {
 		return nil, errors.New("collections: column publish plan missing manifest root name")
+	}
+	if plan.Collection != input.BaseMeta.Name {
+		return nil, fmt.Errorf("collections: column publish plan collection %q does not match collection %q", plan.Collection, input.BaseMeta.Name)
+	}
+	expectedRootName := collectionColumnManifestRootName(input.BaseMeta.Name)
+	if rootName != expectedRootName {
+		return nil, fmt.Errorf("collections: column publish plan root %q does not match collection root %q", rootName, expectedRootName)
+	}
+	if plan.RootDelta.RootName != "" && plan.RootDelta.RootName != rootName {
+		return nil, fmt.Errorf("collections: column publish plan root %q does not match root delta %q", rootName, plan.RootDelta.RootName)
+	}
+	if input.BaseManifestRootID != plan.ManifestRootBaseID || input.BaseManifestRootID != plan.RootDelta.BaseRootID {
+		return nil, errConcurrentRootModification(input.BaseMeta.Name, rootName)
+	}
+	if input.BaseCommitSeq != 0 || input.BaseSystemRoot != 0 {
+		state := c.db.State()
+		if (input.BaseCommitSeq != 0 && state.CommitSeq != input.BaseCommitSeq) ||
+			(input.BaseSystemRoot != 0 && state.SystemRootPageID != input.BaseSystemRoot) {
+			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", input.BaseMeta.Name)
+		}
 	}
 
 	current := c.db.AcquireSnapshot()
@@ -445,7 +515,7 @@ func prepareColumnPublishAssets(input ColumnPublishPlanInput, cfg ColumnStoreCon
 
 func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreConfig, prepared ColumnPublishPreparedAssets) (ColumnPublishManifestEncodeResult, error) {
 	if input.Hooks.EncodeManifest == nil {
-		return ColumnPublishManifestEncodeResult{}, errors.New("manifest encode hook is required")
+		return ColumnPublishManifestEncodeResult{}, errors.New("collections: column publish manifest encode hook is required")
 	}
 	return input.Hooks.EncodeManifest(ColumnPublishManifestEncodeInput{
 		Collection:        input.Collection,
@@ -518,6 +588,11 @@ func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) 
 	}
 	if cfg.ProfileSupport == "" {
 		return errors.New("collections: column publish plan requires normalized profile support")
+	}
+	switch cfg.ProfileSupport {
+	case ColumnStoreProfileDurableOnly, ColumnStoreProfileBenchmarkRelaxed:
+	default:
+		return fmt.Errorf("collections: unsupported column profile support %q", cfg.ProfileSupport)
 	}
 	return nil
 }
@@ -645,4 +720,12 @@ func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int {
 		total += asset.Bytes
 	}
 	return total
+}
+
+func cloneColumnPublishPreparedAssets(prepared ColumnPublishPreparedAssets) ColumnPublishPreparedAssets {
+	if len(prepared.Assets) == 0 {
+		return prepared
+	}
+	prepared.Assets = append([]ColumnPreparedAsset(nil), prepared.Assets...)
+	return prepared
 }

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -43,7 +43,7 @@ type ColumnAssetRef struct {
 // ColumnPreparedAsset describes an immutable asset staged for manifest publish.
 type ColumnPreparedAsset struct {
 	Ref          ColumnAssetRef
-	Bytes        int
+	Bytes        int64
 	PublishID    uint64
 	GenerationID uint64
 	Reason       string
@@ -96,9 +96,9 @@ type ColumnPublishAssetPrepareInput struct {
 type ColumnPublishPreparedAssets struct {
 	Assets             []ColumnPreparedAsset
 	RowCount           int
-	CommandBytes       int
-	RowRemainderBytes  int
-	ColumnPayloadBytes int
+	CommandBytes       int64
+	RowRemainderBytes  int64
+	ColumnPayloadBytes int64
 }
 
 // ColumnPublishManifestEncodeInput is passed to the manifest encoding stage.
@@ -114,7 +114,7 @@ type ColumnPublishManifestEncodeInput struct {
 // ColumnPublishManifestEncodeResult identifies the encoded manifest generation.
 type ColumnPublishManifestEncodeResult struct {
 	Identity      ColumnManifestIdentity
-	ManifestBytes int
+	ManifestBytes int64
 }
 
 // ColumnPublishClosureValidationInput is passed to the durability-closure
@@ -135,7 +135,7 @@ type ColumnPublishDurabilityClosure struct {
 	// compares it against the manifest snapshot before publishing.
 	PreparedAssets []ColumnPreparedAsset
 	RequiredAssets int
-	RequiredBytes  int
+	RequiredBytes  int64
 	FlushRequired  bool
 	SyncRequired   bool
 }
@@ -179,14 +179,14 @@ type ColumnPublishPlan struct {
 	RootDelta                              ColumnManifestRootDelta
 	PreparedAssets                         []ColumnPreparedAsset
 	RequiredAssetCount                     int
-	RequiredAssetBytes                     int
+	RequiredAssetBytes                     int64
 	RequiredAssetFlush                     bool
 	RequiredAssetSync                      bool
 	Rows                                   int
-	CommandBytes                           int
-	RowRemainderBytes                      int
-	ColumnPayloadBytes                     int
-	ManifestBytes                          int
+	CommandBytes                           int64
+	RowRemainderBytes                      int64
+	ColumnPayloadBytes                     int64
+	ManifestBytes                          int64
 	Lifecycle                              ColumnPublishLifecycleSummary
 	StageMetrics                           ColumnPublishStageMetrics
 }
@@ -205,15 +205,15 @@ type ColumnManifestRootDelta struct {
 // of the publish.
 type ColumnPublishLifecycleSummary struct {
 	PublishedRefs         int
-	PublishedBytes        int
+	PublishedBytes        int64
 	PreparedRefs          int
-	PreparedBytes         int
+	PreparedBytes         int64
 	SupersededRefs        int
-	SupersededBytes       int
+	SupersededBytes       int64
 	CleanupSafeGeneration uint64
 	CleanupSafeRefs       int
-	CleanupSafeBytes      int
-	RewriteDebtBytes      int
+	CleanupSafeBytes      int64
+	RewriteDebtBytes      int64
 }
 
 // ColumnPublishStageMetrics records stage timings and optional allocation
@@ -705,7 +705,7 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 	if asset.Bytes <= 0 {
 		return fmt.Errorf("collections: column prepared asset bytes=%d must be positive", asset.Bytes)
 	}
-	if int64(asset.Bytes) != asset.Ref.Length {
+	if asset.Bytes != asset.Ref.Length {
 		return fmt.Errorf("collections: column prepared asset bytes=%d does not match ref length=%d", asset.Bytes, asset.Ref.Length)
 	}
 	return nil
@@ -735,8 +735,8 @@ func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	return nil
 }
 
-func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int {
-	total := 0
+func sumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) int64 {
+	var total int64
 	for _, asset := range assets {
 		total += asset.Bytes
 	}

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -539,7 +539,7 @@ func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreCo
 		Operation:         input.Operation,
 		AppliedCommandLSN: input.AppliedCommandLSN,
 		CurrentManifest:   input.CurrentManifest,
-		Prepared:          prepared,
+		Prepared:          cloneColumnPublishPreparedAssets(prepared),
 	})
 }
 

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -521,7 +521,7 @@ func (c *Collection) buildColumnManifestPublishSystemDeltaIterator(input ColumnM
 
 	updatedMeta := copyCollectionMeta(input.BaseMeta)
 	if updatedMeta.Options.ColumnStore == nil || !updatedMeta.Options.ColumnStore.Enabled {
-		return nil, errors.New("collections: column manifest publish requires enabled column_store metadata")
+		return nil, errors.New(errColumnPublishPlanRequiresEnabledColumnStore)
 	}
 	cfg := updatedMeta.Options.ColumnStore.copy()
 	active := activeIdentity

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -240,11 +240,6 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		if columnStoreConfigEmpty(*input.ColumnStore) {
 			return ColumnPublishPlan{}, nil
 		}
-		if !input.ColumnStoreNormalized {
-			if _, err := normalizeColumnStoreConfig(input.Collection, input.ColumnStore); err != nil {
-				return ColumnPublishPlan{}, err
-			}
-		}
 		return ColumnPublishPlan{}, errors.New("collections: column publish plan requires enabled=true column_store")
 	}
 	if err := validateColumnPublishOperation(input.Operation); err != nil {

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -720,6 +720,11 @@ func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosu
 	if closure.RequiredAssets != len(closure.PreparedAssets) {
 		return fmt.Errorf("collections: column publish closure required assets=%d prepared=%d", closure.RequiredAssets, len(closure.PreparedAssets))
 	}
+	for i, asset := range closure.PreparedAssets {
+		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
+			return fmt.Errorf("collections: column publish closure asset[%d]: %w", i, err)
+		}
+	}
 	got, err := checkedSumColumnPreparedAssetBytes(closure.PreparedAssets)
 	if err != nil {
 		return err
@@ -729,11 +734,6 @@ func validateColumnPublishDurabilityClosure(closure ColumnPublishDurabilityClosu
 	}
 	if cfg.ProfileSupport == ColumnStoreProfileDurableOnly && closure.RequiredAssets != 0 && (!closure.FlushRequired || !closure.SyncRequired) {
 		return errors.New("collections: durable column publish closure requires asset flush and sync")
-	}
-	for i, asset := range closure.PreparedAssets {
-		if err := validateColumnPreparedAssetForPlan(asset); err != nil {
-			return fmt.Errorf("collections: column publish closure asset[%d]: %w", i, err)
-		}
 	}
 	return nil
 }
@@ -821,7 +821,7 @@ func checkedSumColumnPreparedAssetBytes(assets []ColumnPreparedAsset) (int64, er
 	var total int64
 	for i, asset := range assets {
 		if asset.Bytes > math.MaxInt64-total {
-			return 0, fmt.Errorf("collections: column publish prepared asset[%d] bytes overflow", i)
+			return 0, fmt.Errorf("collections: column publish asset[%d] bytes overflow", i)
 		}
 		total += asset.Bytes
 	}

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -189,7 +189,7 @@ type ColumnPublishStageMetrics struct {
 	DocumentExtraction      time.Duration
 	DeclaredColumnEncoding  time.Duration
 	AssetPreparation        time.Duration
-	AssetFlushSync          time.Duration
+	AssetClosureValidation  time.Duration
 	ManifestEncode          time.Duration
 	RootDeltaConstruction   time.Duration
 	SystemDeltaConstruction time.Duration
@@ -275,7 +275,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 	if err != nil {
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset-closure validation failed: %w", err)
 	}
-	metrics.AssetFlushSync = time.Since(start)
+	metrics.AssetClosureValidation = time.Since(start)
 	if err := validateColumnPublishDurabilityClosure(closure); err != nil {
 		return ColumnPublishPlan{}, err
 	}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -7,6 +7,7 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestColumnPublishPlanDisabledFastPathAllocatesZeroM10A(t *testing.T) {
@@ -100,6 +101,20 @@ func TestColumnPublishPlanUsesFixedWidthAssetBytesM10A(t *testing.T) {
 	}
 	if plan.RequiredAssetBytes != asset.Bytes || plan.Lifecycle.PublishedBytes != asset.Bytes || plan.Lifecycle.PreparedBytes != asset.Bytes {
 		t.Fatalf("large byte counts not preserved: plan=%+v asset=%+v", plan, asset)
+	}
+}
+
+func TestColumnPublishPlanAllowsZeroAssetChecksumM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Ref.Checksum = 0
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+
+	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(identity, asset))
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan zero asset checksum: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 || plan.PreparedAssets[0].Ref.Checksum != 0 {
+		t.Fatalf("zero asset checksum was not preserved: %+v", plan.PreparedAssets)
 	}
 }
 
@@ -437,6 +452,33 @@ func TestColumnPublishPlanCopiesClosurePreparedAssetsM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanCopiesPreparedAssetsForSystemDeltaHookM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	var hookAssets []ColumnPreparedAsset
+	input.Hooks.BuildSystemDelta = func(in ColumnPublishSystemDeltaInput) error {
+		hookAssets = in.Plan.PreparedAssets
+		in.Plan.PreparedAssets[0].Ref.Offset += int64(asset.Bytes)
+		return nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 {
+		t.Fatalf("prepared assets=%d want 1", len(plan.PreparedAssets))
+	}
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after hook mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+	hookAssets[0].Ref.Offset += int64(asset.Bytes)
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after hook-owned slice mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -666,6 +708,56 @@ func TestColumnManifestPublishSystemDeltaRejectsPublishedRootMismatchM10A(t *tes
 	})
 	if err == nil || !strings.Contains(err.Error(), "published root identity record") {
 		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder err=%v want published root identity mismatch", err)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsMalformedPublishedRootIdentityM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseMeta := col.Meta()
+	state := d.State()
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 14, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef3456}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	rootTable, err := memtable.NewWithCapacityMode(1, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new root memtable: %v", err)
+	}
+	rootTable.Set([]byte(columnManifestIdentityRecordKey), []byte{1, 2, 3})
+	rootTable.Freeze()
+
+	_, _, err = d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     rootTable.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+			BaseMeta:           baseMeta,
+			BaseCommitSeq:      state.CommitSeq,
+			BaseSystemRoot:     state.SystemRootPageID,
+			BaseManifestRootID: 0,
+			Plan:               plan,
+		}, rootIDs)
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid identity record") || !strings.Contains(err.Error(), "malformed identity record length") {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder err=%v want malformed published root identity", err)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -1302,6 +1302,61 @@ func TestColumnManifestPublishSystemDeltaRejectsStaleSnapshotBaseM10A(t *testing
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRejectsMissingSnapshotBaseM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseState := d.State()
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef6789}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		baseCommitSeq  uint64
+		baseSystemRoot uint64
+	}{
+		{name: "missing commit", baseSystemRoot: baseState.SystemRootPageID},
+		{name: "missing root", baseCommitSeq: baseState.CommitSeq},
+		{name: "missing both"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+				BaseMeta:           col.Meta(),
+				BaseCommitSeq:      tt.baseCommitSeq,
+				BaseSystemRoot:     tt.baseSystemRoot,
+				BaseManifestRootID: 0,
+				Plan:               plan,
+			}, []uint64{123})
+			if iter != nil {
+				_ = iter.Close()
+				t.Fatalf("returned iterator with err=%v", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), "requires BaseCommitSeq and BaseSystemRoot") {
+				t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want missing snapshot base rejection", err)
+			}
+		})
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaRejectsIdentityMismatchM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -511,6 +511,32 @@ func TestColumnPublishPlanAllowsReorderedClosurePreparedAssetsM10A(t *testing.T)
 	}
 }
 
+func TestColumnPublishPlanAllowsClosurePreparedAssetReasonMismatchM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Reason = "manifest builder"
+	closureAsset := asset
+	closureAsset.Reason = "closure validator"
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: []ColumnPreparedAsset{closureAsset},
+			RequiredAssets: 1,
+			RequiredBytes:  closureAsset.Bytes,
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan reason-only closure asset mismatch: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 || plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset should retain manifest asset including reason: %+v", plan.PreparedAssets)
+	}
+}
+
 func TestColumnPublishPlanCopiesPreparedAssetsForManifestHookM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -240,6 +240,16 @@ func TestColumnPublishPlanFailsClosedBeforeRootPublishM10A(t *testing.T) {
 			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation",
 		},
 		{
+			name: "root delta failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.BuildRootDelta = func(ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error) {
+					*calls = append(*calls, "root_delta")
+					return ColumnManifestRootDelta{}, errStage
+				}
+			},
+			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation,root_delta",
+		},
+		{
 			name: "system delta failure",
 			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
 				input.Hooks.BuildSystemDelta = func(ColumnPublishSystemDeltaInput) error {
@@ -879,7 +889,7 @@ func TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A(t *te
 	if cfg := reopened.Meta().Options.ColumnStore; cfg == nil || cfg.ActiveManifest != nil || cfg.RecoveryAuthoritativeManifest != nil || cfg.RecoveryAuthoritativeAppliedCommandLSN != 0 {
 		t.Fatalf("failed publish leaked column metadata: %+v", cfg)
 	}
-	if id, ok := reopened.ColumnStoreCacheIdentity(); !ok || id.ManifestRoot != 0 || id.ManifestGeneration != 0 {
+	if id, ok := reopened.ColumnStoreCacheIdentity(); !ok || id.ManifestRoot != 0 || id.ManifestGeneration != 0 || id.RecoveryAuthoritativeAppliedCommandLSN != 0 {
 		t.Fatalf("failed publish leaked root identity: %+v ok=%v", id, ok)
 	}
 }

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -965,7 +965,8 @@ func TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A(t *testing.T) 
 	if err != nil {
 		t.Fatalf("open collection: %v", err)
 	}
-	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef5678}, testColumnPublishPreparedAssetM10A()))
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef5678}, testColumnPublishPreparedAssetM10A())
+	plan, err := BuildColumnPublishPlan(planInput)
 	if err != nil {
 		t.Fatalf("BuildColumnPublishPlan: %v", err)
 	}
@@ -982,6 +983,54 @@ func TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A(t *testing.T) 
 	}
 	if err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
 		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want stale plan base rejection", err)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsStaleSnapshotBaseM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseMeta := col.Meta()
+	baseState := d.State()
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "other"}); err != nil {
+		t.Fatalf("create other collection: %v", err)
+	}
+	if state := d.State(); state.CommitSeq == baseState.CommitSeq || state.SystemRootPageID == baseState.SystemRootPageID {
+		t.Fatalf("test requires collection create to advance commit/root: before=%+v after=%+v", baseState, state)
+	}
+
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef5678}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           baseMeta,
+		BaseCommitSeq:      baseState.CommitSeq,
+		BaseSystemRoot:     baseState.SystemRootPageID,
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "concurrent schema modification") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want stale snapshot base rejection", err)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -253,12 +253,22 @@ func TestColumnPublishPlanFailsClosedBeforeRootPublishM10A(t *testing.T) {
 		{
 			name: "system delta failure",
 			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.BuildRootDelta = func(in ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error) {
+					*calls = append(*calls, "root_delta")
+					return ColumnManifestRootDelta{
+						RootName:       in.ColumnStore.ManifestRoot.Name,
+						BaseRootID:     in.BaseManifestRootID,
+						StoragePolicy:  in.ColumnStore.ManifestRoot.StoragePolicy,
+						Identity:       in.Manifest.Identity,
+						IdentityRecord: encodeColumnManifestIdentityRecordArray(in.Manifest.Identity),
+					}, nil
+				}
 				input.Hooks.BuildSystemDelta = func(ColumnPublishSystemDeltaInput) error {
 					*calls = append(*calls, "system_delta")
 					return errStage
 				}
 			},
-			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation,system_delta",
+			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation,root_delta,system_delta",
 		},
 	}
 	for _, tt := range tests {
@@ -682,6 +692,50 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	}
 	if rawCfg.RecoveryAuthoritativeManifest == nil || *rawCfg.RecoveryAuthoritativeManifest != identity {
 		t.Fatalf("raw recovery-authoritative manifest was not stored normalized: %+v", rawCfg)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsInvalidRootIDsM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 15, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcba},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	for _, rootIDs := range [][]uint64{nil, []uint64{}, []uint64{0}} {
+		iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+			BaseMeta:           col.Meta(),
+			BaseManifestRootID: 0,
+			Plan:               plan,
+		}, rootIDs)
+		if iter != nil {
+			_ = iter.Close()
+			t.Fatalf("rootIDs=%v returned iterator with err=%v", rootIDs, err)
+		}
+		if err == nil {
+			t.Fatalf("rootIDs=%v err=nil, want invalid rootIDs rejection", rootIDs)
+		}
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -385,6 +385,22 @@ func TestColumnPublishPlanRejectsInvalidRootDeltaM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanRejectsNegativeManifestBytesM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 8, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xbeefcafe}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.EncodeManifest = func(ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+		return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: -1}, nil
+	}
+	plan, err := BuildColumnPublishPlan(input)
+	if err == nil || !strings.Contains(err.Error(), "manifest byte count") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want negative manifest byte count rejection", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("negative manifest bytes returned enabled plan: %+v", plan)
+	}
+}
+
 func TestColumnPublishPlanRejectsUnsupportedAssetKindM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	asset.Ref.Kind = ColumnAssetKind("future-kind")
@@ -722,10 +738,13 @@ func TestColumnManifestPublishSystemDeltaRejectsInvalidRootIDsM10A(t *testing.T)
 	if err != nil {
 		t.Fatalf("BuildColumnPublishPlan: %v", err)
 	}
+	state := d.State()
 
 	for _, rootIDs := range [][]uint64{nil, []uint64{}, []uint64{0}} {
 		iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
 			BaseMeta:           col.Meta(),
+			BaseCommitSeq:      state.CommitSeq,
+			BaseSystemRoot:     state.SystemRootPageID,
 			BaseManifestRootID: 0,
 			Plan:               plan,
 		}, rootIDs)
@@ -736,6 +755,74 @@ func TestColumnManifestPublishSystemDeltaRejectsInvalidRootIDsM10A(t *testing.T)
 		if err == nil {
 			t.Fatalf("rootIDs=%v err=nil, want invalid rootIDs rejection", rootIDs)
 		}
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsMissingLSNM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 16, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbb},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*ColumnPublishPlan)
+		want   string
+	}{
+		{
+			name: "applied",
+			mutate: func(plan *ColumnPublishPlan) {
+				plan.AppliedCommandLSN = 0
+			},
+			want: "AppliedCommandLSN",
+		},
+		{
+			name: "recovery authoritative",
+			mutate: func(plan *ColumnPublishPlan) {
+				plan.RecoveryAuthoritativeAppliedCommandLSN = 0
+			},
+			want: "recovery-authoritative AppliedCommandLSN",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutated := plan
+			tt.mutate(&mutated)
+			iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+				BaseMeta:           col.Meta(),
+				BaseManifestRootID: 0,
+				Plan:               mutated,
+			}, []uint64{123})
+			if iter != nil {
+				_ = iter.Close()
+				t.Fatalf("returned iterator with err=%v", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -577,6 +577,54 @@ func TestColumnManifestPublishSystemDeltaRejectsIdentityMismatchM10A(t *testing.
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRejectsPublishedRootMismatchM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseMeta := col.Meta()
+	state := d.State()
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 14, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef3456}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	wrongDelta := plan.RootDelta
+	wrongDelta.Identity = ColumnManifestIdentity{Generation: 99, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1111222233334444}
+	wrongDelta.IdentityRecord = encodeColumnManifestIdentityRecordArray(wrongDelta.Identity)
+	ordered, err := wrongDelta.OrderedRootPublishInput()
+	if err != nil {
+		t.Fatalf("OrderedRootPublishInput: %v", err)
+	}
+	_, _, err = d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{ordered}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+			BaseMeta:           baseMeta,
+			BaseCommitSeq:      state.CommitSeq,
+			BaseSystemRoot:     state.SystemRootPageID,
+			BaseManifestRootID: 0,
+			Plan:               plan,
+		}, rootIDs)
+	})
+	if err == nil || !strings.Contains(err.Error(), "published root identity record") {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder err=%v want published root identity mismatch", err)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -382,6 +382,12 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 			AppliedCommandLSN:     101,
 			BaseManifestRootID:    44,
 			Hooks: ColumnPublishPlanHooks{
+				ExtractDocuments: func() error {
+					return nil
+				},
+				EncodeDeclaredColumns: func(ColumnPublishDeclaredColumnEncodeInput) error {
+					return nil
+				},
 				PrepareAssets: func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
 					return prepared, nil
 				},
@@ -391,8 +397,13 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 				ValidateClosure: func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
 					return closure, nil
 				},
+				BuildSystemDelta: func(ColumnPublishSystemDeltaInput) error {
+					return nil
+				},
 			},
 		}
+		var stages ColumnPublishStageMetrics
+		var last ColumnPublishPlan
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			plan, err := BuildColumnPublishPlan(input)
@@ -402,7 +413,26 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 			if !plan.Enabled || plan.RequiredAssetBytes != asset.Bytes {
 				b.Fatal(plan)
 			}
+			stages.DocumentExtraction += plan.StageMetrics.DocumentExtraction
+			stages.DeclaredColumnEncoding += plan.StageMetrics.DeclaredColumnEncoding
+			stages.AssetPreparation += plan.StageMetrics.AssetPreparation
+			stages.AssetFlushSync += plan.StageMetrics.AssetFlushSync
+			stages.ManifestEncode += plan.StageMetrics.ManifestEncode
+			stages.RootDeltaConstruction += plan.StageMetrics.RootDeltaConstruction
+			stages.SystemDeltaConstruction += plan.StageMetrics.SystemDeltaConstruction
+			last = plan
 		}
+		b.ReportMetric(float64(stages.DocumentExtraction.Nanoseconds())/float64(b.N), "extract_ns/op")
+		b.ReportMetric(float64(stages.DeclaredColumnEncoding.Nanoseconds())/float64(b.N), "declared_encode_ns/op")
+		b.ReportMetric(float64(stages.AssetPreparation.Nanoseconds())/float64(b.N), "asset_prepare_ns/op")
+		b.ReportMetric(float64(stages.AssetFlushSync.Nanoseconds())/float64(b.N), "asset_flush_sync_ns/op")
+		b.ReportMetric(float64(stages.ManifestEncode.Nanoseconds())/float64(b.N), "manifest_encode_ns/op")
+		b.ReportMetric(float64(stages.RootDeltaConstruction.Nanoseconds())/float64(b.N), "root_delta_ns/op")
+		b.ReportMetric(float64(stages.SystemDeltaConstruction.Nanoseconds())/float64(b.N), "system_delta_ns/op")
+		b.ReportMetric(float64(last.Rows), "rows/op")
+		b.ReportMetric(float64(last.RequiredAssetCount), "prepared_refs/op")
+		b.ReportMetric(float64(last.RequiredAssetBytes), "prepared_asset_B/op")
+		b.ReportMetric(float64(last.ManifestBytes), "manifest_B/op")
 	})
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -956,6 +956,14 @@ func TestColumnManifestPublishSystemDeltaRejectsMissingLSNM10A(t *testing.T) {
 			},
 			want: "recovery-authoritative AppliedCommandLSN",
 		},
+		{
+			name: "recovery authoritative below applied",
+			mutate: func(plan *ColumnPublishPlan) {
+				plan.AppliedCommandLSN = 203
+				plan.RecoveryAuthoritativeAppliedCommandLSN = 202
+			},
+			want: "recovery-authoritative AppliedCommandLSN regression",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -408,6 +408,35 @@ func TestColumnPublishPlanSnapshotsPreparedAssetsForClosureValidationM10A(t *tes
 	}
 }
 
+func TestColumnPublishPlanCopiesClosurePreparedAssetsM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	var closureAssets []ColumnPreparedAsset
+	input.Hooks.ValidateClosure = func(in ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		closureAssets = in.Prepared.Assets
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: closureAssets,
+			RequiredAssets: len(closureAssets),
+			RequiredBytes:  sumColumnPreparedAssetBytes(closureAssets),
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 {
+		t.Fatalf("prepared assets=%d want 1", len(plan.PreparedAssets))
+	}
+	closureAssets[0].Ref.Offset += int64(asset.Bytes)
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after closure-owned slice mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -65,12 +65,11 @@ func TestColumnPublishPlanRejectsNonEmptyDisabledColumnStoreM10A(t *testing.T) {
 		Operation:         ColumnPublishOperationInsert,
 		AppliedCommandLSN: 101,
 	}
-	const want = "collections: column publish plan requires enabled=true column_store"
 	for _, normalized := range []bool{false, true} {
 		input.ColumnStoreNormalized = normalized
 		plan, err := BuildColumnPublishPlan(input)
-		if err == nil || err.Error() != want {
-			t.Fatalf("BuildColumnPublishPlan normalized=%v err=%v want %q", normalized, err, want)
+		if !errors.Is(err, ErrColumnPublishPlanRequiresEnabledColumnStore) {
+			t.Fatalf("BuildColumnPublishPlan normalized=%v err=%v want sentinel %v", normalized, err, ErrColumnPublishPlanRequiresEnabledColumnStore)
 		}
 		if plan.Enabled {
 			t.Fatalf("invalid disabled column_store returned enabled plan: %+v", plan)

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -228,6 +228,90 @@ func TestColumnPublishPlanFailsClosedBeforeRootPublishM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanRejectsInvalidRootDeltaM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	tests := []struct {
+		name      string
+		mutate    func(*ColumnManifestRootDelta)
+		wantError string
+	}{
+		{
+			name: "wrong root name",
+			mutate: func(delta *ColumnManifestRootDelta) {
+				delta.RootName = "events/column/wrong"
+			},
+			wantError: "root name",
+		},
+		{
+			name: "wrong base root",
+			mutate: func(delta *ColumnManifestRootDelta) {
+				delta.BaseRootID++
+			},
+			wantError: "base root id",
+		},
+		{
+			name: "wrong storage policy",
+			mutate: func(delta *ColumnManifestRootDelta) {
+				delta.StoragePolicy = RootStorageCompressed
+			},
+			wantError: "storage policy",
+		},
+		{
+			name: "wrong identity",
+			mutate: func(delta *ColumnManifestRootDelta) {
+				delta.Identity.Generation++
+			},
+			wantError: "identity",
+		},
+		{
+			name: "wrong identity record",
+			mutate: func(delta *ColumnManifestRootDelta) {
+				delta.IdentityRecord[0] ^= 0xff
+			},
+			wantError: "identity record",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := testColumnPublishPlanInputM10A(identity, asset)
+			input.Hooks.BuildRootDelta = func(in ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error) {
+				delta := ColumnManifestRootDelta{
+					RootName:       in.ColumnStore.ManifestRoot.Name,
+					BaseRootID:     in.BaseManifestRootID,
+					StoragePolicy:  in.ColumnStore.ManifestRoot.StoragePolicy,
+					Identity:       in.Manifest.Identity,
+					IdentityRecord: encodeColumnManifestIdentityRecordArray(in.Manifest.Identity),
+				}
+				tt.mutate(&delta)
+				return delta, nil
+			}
+
+			plan, err := BuildColumnPublishPlan(input)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("BuildColumnPublishPlan err=%v want %q", err, tt.wantError)
+			}
+			if plan.Enabled {
+				t.Fatalf("invalid root delta returned enabled plan: %+v", plan)
+			}
+		})
+	}
+}
+
+func TestColumnPublishPlanRejectsUnsupportedAssetKindM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Ref.Kind = ColumnAssetKind("future-kind")
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+
+	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(identity, asset))
+	if err == nil || !strings.Contains(err.Error(), "unsupported column asset ref kind") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want unsupported kind", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("unsupported asset kind returned enabled plan: %+v", plan)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -1035,6 +1035,108 @@ func TestColumnManifestPublishSystemDeltaRejectsRecoveryLSNRegressionM10A(t *tes
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRejectsAppliedLSNBelowBaseRecoveryM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 18, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbe},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	plan.AppliedCommandLSN = 90
+	plan.RecoveryAuthoritativeAppliedCommandLSN = 100
+
+	baseMeta := col.Meta()
+	cfg := baseMeta.Options.ColumnStore.copy()
+	active := ColumnManifestIdentity{Generation: 17, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbd}
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &active
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 100
+	baseMeta.Options.ColumnStore = &cfg
+
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           baseMeta,
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+		t.Fatalf("returned iterator with err=%v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "AppliedCommandLSN regression") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want AppliedCommandLSN regression", err)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsNonAdvancingGenerationM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 18, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbf},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	baseMeta := col.Meta()
+	cfg := baseMeta.Options.ColumnStore.copy()
+	active := ColumnManifestIdentity{Generation: plan.UpdatedActiveManifest.Generation, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbe}
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &active
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = plan.AppliedCommandLSN
+	baseMeta.Options.ColumnStore = &cfg
+
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           baseMeta,
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+		t.Fatalf("returned iterator with err=%v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "manifest generation regression") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want generation regression", err)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaRejectsForeignCollectionM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -128,7 +128,6 @@ func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
 	var called []string
 	input := testColumnPublishPlanInputM10A(identity, asset)
-	input.MeasureAllocations = true
 	input.Hooks.ExtractDocuments = func() error {
 		called = append(called, "extract")
 		return nil

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -452,6 +452,39 @@ func TestColumnPublishPlanCopiesClosurePreparedAssetsM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanCopiesClosureForRootDeltaHookM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	var hookAssets []ColumnPreparedAsset
+	input.Hooks.BuildRootDelta = func(in ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error) {
+		hookAssets = in.Closure.PreparedAssets
+		in.Closure.PreparedAssets[0].Ref.Offset += int64(asset.Bytes)
+		return ColumnManifestRootDelta{
+			RootName:       in.ColumnStore.ManifestRoot.Name,
+			BaseRootID:     in.BaseManifestRootID,
+			StoragePolicy:  in.ColumnStore.ManifestRoot.StoragePolicy,
+			Identity:       in.Manifest.Identity,
+			IdentityRecord: encodeColumnManifestIdentityRecordArray(in.Manifest.Identity),
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 {
+		t.Fatalf("prepared assets=%d want 1", len(plan.PreparedAssets))
+	}
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after root hook mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+	hookAssets[0].Ref.Offset += int64(asset.Bytes)
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after root hook-owned slice mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+}
+
 func TestColumnPublishPlanCopiesPreparedAssetsForSystemDeltaHookM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -57,17 +57,22 @@ func TestColumnPublishPlanDisabledFastPathAllocatesZeroM10A(t *testing.T) {
 func TestColumnPublishPlanRejectsNonEmptyDisabledColumnStoreM10A(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	cfg.Enabled = false
-	plan, err := BuildColumnPublishPlan(ColumnPublishPlanInput{
+	input := ColumnPublishPlanInput{
 		Collection:        "events",
 		ColumnStore:       cfg,
 		Operation:         ColumnPublishOperationInsert,
 		AppliedCommandLSN: 101,
-	})
-	if err == nil || !strings.Contains(err.Error(), "requires enabled=true") {
-		t.Fatalf("BuildColumnPublishPlan err=%v want enabled=true validation", err)
 	}
-	if plan.Enabled {
-		t.Fatalf("invalid disabled column_store returned enabled plan: %+v", plan)
+	const want = "collections: column publish plan requires enabled=true column_store"
+	for _, normalized := range []bool{false, true} {
+		input.ColumnStoreNormalized = normalized
+		plan, err := BuildColumnPublishPlan(input)
+		if err == nil || err.Error() != want {
+			t.Fatalf("BuildColumnPublishPlan normalized=%v err=%v want %q", normalized, err, want)
+		}
+		if plan.Enabled {
+			t.Fatalf("invalid disabled column_store returned enabled plan: %+v", plan)
+		}
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -61,6 +62,7 @@ func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	input.MeasureAllocations = true
 	input.Hooks.ExtractDocuments = func() error {
 		called = append(called, "extract")
+		time.Sleep(time.Nanosecond)
 		return nil
 	}
 	input.Hooks.EncodeDeclaredColumns = func(ColumnPublishDeclaredColumnEncodeInput) error {
@@ -109,7 +111,7 @@ func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	if plan.Lifecycle.PublishedRefs != 1 || plan.Lifecycle.PublishedBytes != asset.Bytes || plan.Lifecycle.PreparedRefs != 1 || plan.Lifecycle.PreparedBytes != asset.Bytes {
 		t.Fatalf("unexpected lifecycle summary: %+v", plan.Lifecycle)
 	}
-	if plan.StageMetrics.Allocs == 0 {
+	if plan.StageMetrics.DocumentExtraction <= 0 {
 		t.Fatalf("stage metrics were not populated: %+v", plan.StageMetrics)
 	}
 }
@@ -364,6 +366,10 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	if err != nil {
 		t.Fatalf("BuildColumnPublishPlan: %v", err)
 	}
+	plan.RecoveryAuthoritativeAppliedCommandLSN = 202
+	if plan.RecoveryAuthoritativeAppliedCommandLSN == plan.AppliedCommandLSN {
+		t.Fatalf("test requires distinct applied and recovery-authoritative LSNs: %+v", plan)
+	}
 	ordered, err := plan.RootDelta.OrderedRootPublishInput()
 	if err != nil {
 		t.Fatalf("OrderedRootPublishInput: %v", err)
@@ -392,11 +398,11 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	if cfg == nil || cfg.ActiveManifest == nil || *cfg.ActiveManifest != identity {
 		t.Fatalf("active manifest not updated atomically: %+v", cfg)
 	}
-	if cfg.RecoveryAuthoritativeManifest == nil || *cfg.RecoveryAuthoritativeManifest != identity || cfg.RecoveryAuthoritativeAppliedCommandLSN != plan.AppliedCommandLSN {
+	if cfg.RecoveryAuthoritativeManifest == nil || *cfg.RecoveryAuthoritativeManifest != identity || cfg.RecoveryAuthoritativeAppliedCommandLSN != plan.RecoveryAuthoritativeAppliedCommandLSN {
 		t.Fatalf("recovery-authoritative metadata not updated atomically: %+v", cfg)
 	}
 	cacheID, ok := reopened.ColumnStoreCacheIdentity()
-	if !ok || cacheID.ManifestRoot != rootIDs[0] || cacheID.ManifestGeneration != identity.Generation || cacheID.RecoveryAuthoritativeAppliedCommandLSN != plan.AppliedCommandLSN {
+	if !ok || cacheID.ManifestRoot != rootIDs[0] || cacheID.ManifestGeneration != identity.Generation || cacheID.RecoveryAuthoritativeAppliedCommandLSN != plan.RecoveryAuthoritativeAppliedCommandLSN {
 		t.Fatalf("unexpected cache identity: %+v ok=%v rootIDs=%v", cacheID, ok, rootIDs)
 	}
 }
@@ -465,6 +471,7 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 	b.Run("disabled_hook", func(b *testing.B) {
 		input := ColumnPublishPlanInput{Collection: "events", ColumnStore: nil}
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			plan, err := BuildColumnPublishPlan(input)
 			if err != nil {
@@ -525,16 +532,17 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 			stages.DocumentExtraction += plan.StageMetrics.DocumentExtraction
 			stages.DeclaredColumnEncoding += plan.StageMetrics.DeclaredColumnEncoding
 			stages.AssetPreparation += plan.StageMetrics.AssetPreparation
-			stages.AssetFlushSync += plan.StageMetrics.AssetFlushSync
+			stages.AssetClosureValidation += plan.StageMetrics.AssetClosureValidation
 			stages.ManifestEncode += plan.StageMetrics.ManifestEncode
 			stages.RootDeltaConstruction += plan.StageMetrics.RootDeltaConstruction
 			stages.SystemDeltaConstruction += plan.StageMetrics.SystemDeltaConstruction
 			last = plan
 		}
+		b.StopTimer()
 		b.ReportMetric(float64(stages.DocumentExtraction.Nanoseconds())/float64(b.N), "extract_ns/op")
 		b.ReportMetric(float64(stages.DeclaredColumnEncoding.Nanoseconds())/float64(b.N), "declared_encode_ns/op")
 		b.ReportMetric(float64(stages.AssetPreparation.Nanoseconds())/float64(b.N), "asset_prepare_ns/op")
-		b.ReportMetric(float64(stages.AssetFlushSync.Nanoseconds())/float64(b.N), "asset_flush_sync_ns/op")
+		b.ReportMetric(float64(stages.AssetClosureValidation.Nanoseconds())/float64(b.N), "asset_closure_validation_ns/op")
 		b.ReportMetric(float64(stages.ManifestEncode.Nanoseconds())/float64(b.N), "manifest_encode_ns/op")
 		b.ReportMetric(float64(stages.RootDeltaConstruction.Nanoseconds())/float64(b.N), "root_delta_ns/op")
 		b.ReportMetric(float64(stages.SystemDeltaConstruction.Nanoseconds())/float64(b.N), "system_delta_ns/op")

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -312,6 +312,31 @@ func TestColumnPublishPlanRejectsUnsupportedAssetKindM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanRejectsClosurePreparedAssetMismatchM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	closureAsset := asset
+	closureAsset.Ref.Offset += int64(asset.Bytes)
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: []ColumnPreparedAsset{closureAsset},
+			RequiredAssets: 1,
+			RequiredBytes:  closureAsset.Bytes,
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err == nil || !strings.Contains(err.Error(), "does not match manifest prepared asset") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want closure prepared asset mismatch", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("mismatched closure prepared asset returned enabled plan: %+v", plan)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -1,0 +1,449 @@
+package collections
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestColumnPublishPlanDisabledFastPathAllocatesZeroM10A(t *testing.T) {
+	disabledCfg := &ColumnStoreConfig{}
+	var touched int
+	inputs := []ColumnPublishPlanInput{
+		{
+			Collection:  "events",
+			ColumnStore: nil,
+			Hooks: ColumnPublishPlanHooks{
+				ExtractDocuments: func() error {
+					touched++
+					return nil
+				},
+			},
+		},
+		{
+			Collection:  "events",
+			ColumnStore: disabledCfg,
+			Hooks: ColumnPublishPlanHooks{
+				PrepareAssets: func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+					touched++
+					return ColumnPublishPreparedAssets{}, nil
+				},
+			},
+		},
+	}
+	for _, input := range inputs {
+		allocs := testing.AllocsPerRun(1000, func() {
+			plan, err := BuildColumnPublishPlan(input)
+			if err != nil {
+				t.Fatalf("BuildColumnPublishPlan disabled: %v", err)
+			}
+			if plan.Enabled {
+				t.Fatalf("disabled plan returned enabled result: %+v", plan)
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("disabled BuildColumnPublishPlan allocated %f times, want 0", allocs)
+		}
+	}
+	if touched != 0 {
+		t.Fatalf("disabled BuildColumnPublishPlan touched hooks %d times, want 0", touched)
+	}
+}
+
+func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	var called []string
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.MeasureAllocations = true
+	input.Hooks.ExtractDocuments = func() error {
+		called = append(called, "extract")
+		return nil
+	}
+	input.Hooks.EncodeDeclaredColumns = func(ColumnPublishDeclaredColumnEncodeInput) error {
+		called = append(called, "encode_columns")
+		return nil
+	}
+	input.Hooks.BuildSystemDelta = func(in ColumnPublishSystemDeltaInput) error {
+		called = append(called, "system_delta")
+		if in.Plan.UpdatedActiveManifest != identity {
+			t.Fatalf("system delta saw identity %+v want %+v", in.Plan.UpdatedActiveManifest, identity)
+		}
+		return nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if !plan.Enabled {
+		t.Fatal("enabled column publish plan returned disabled result")
+	}
+	if got, want := strings.Join(called, ","), "extract,encode_columns,system_delta"; got != want {
+		t.Fatalf("stage order=%q want %q", got, want)
+	}
+	if plan.Collection != "events" || plan.Operation != ColumnPublishOperationInsert {
+		t.Fatalf("unexpected plan identity: %+v", plan)
+	}
+	if plan.AppliedCommandLSN != 101 || plan.RecoveryAuthoritativeAppliedCommandLSN != 101 {
+		t.Fatalf("unexpected applied LSNs: %+v", plan)
+	}
+	if plan.UpdatedActiveManifest != identity || plan.RecoveryAuthoritativeManifest != identity {
+		t.Fatalf("unexpected manifest identities: %+v", plan)
+	}
+	if plan.RootDelta.RootName != collectionColumnManifestRootName("events") || plan.RootDelta.BaseRootID != 44 {
+		t.Fatalf("unexpected root delta: %+v", plan.RootDelta)
+	}
+	if decoded, err := decodeColumnManifestIdentityRecord(plan.RootDelta.IdentityRecord[:]); err != nil || decoded.Generation != identity.Generation || decoded.Checksum != identity.Checksum {
+		t.Fatalf("bad deterministic identity record decoded=%+v err=%v", decoded, err)
+	}
+	if plan.RequiredAssetCount != 1 || plan.RequiredAssetBytes != asset.Bytes || !plan.RequiredAssetFlush || !plan.RequiredAssetSync {
+		t.Fatalf("unexpected required asset closure: %+v", plan)
+	}
+	if len(plan.PreparedAssets) != 1 || plan.PreparedAssets[0] != asset {
+		t.Fatalf("unexpected prepared assets: %+v", plan.PreparedAssets)
+	}
+	if plan.Lifecycle.PublishedRefs != 1 || plan.Lifecycle.PublishedBytes != asset.Bytes || plan.Lifecycle.PreparedRefs != 1 || plan.Lifecycle.PreparedBytes != asset.Bytes {
+		t.Fatalf("unexpected lifecycle summary: %+v", plan.Lifecycle)
+	}
+	if plan.StageMetrics.Allocs == 0 {
+		t.Fatalf("stage metrics were not populated: %+v", plan.StageMetrics)
+	}
+}
+
+func TestColumnPublishPlanFailsClosedBeforeRootPublishM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	errStage := errors.New("stage failed")
+	tests := []struct {
+		name      string
+		configure func(*ColumnPublishPlanInput, *[]string)
+		wantCalls string
+	}{
+		{
+			name: "extract failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.ExtractDocuments = func() error {
+					*calls = append(*calls, "extract")
+					return errStage
+				}
+			},
+			wantCalls: "extract",
+		},
+		{
+			name: "declared column encode failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.EncodeDeclaredColumns = func(ColumnPublishDeclaredColumnEncodeInput) error {
+					*calls = append(*calls, "encode_columns")
+					return errStage
+				}
+			},
+			wantCalls: "extract,encode_columns",
+		},
+		{
+			name: "asset prepare failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.PrepareAssets = func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+					*calls = append(*calls, "prepare_assets")
+					return ColumnPublishPreparedAssets{}, errStage
+				}
+			},
+			wantCalls: "extract,encode_columns,prepare_assets",
+		},
+		{
+			name: "manifest encode failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.EncodeManifest = func(ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+					*calls = append(*calls, "manifest_encode")
+					return ColumnPublishManifestEncodeResult{}, errStage
+				}
+			},
+			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode",
+		},
+		{
+			name: "closure validation failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+					*calls = append(*calls, "closure_validation")
+					return ColumnPublishDurabilityClosure{}, errStage
+				}
+			},
+			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation",
+		},
+		{
+			name: "system delta failure",
+			configure: func(input *ColumnPublishPlanInput, calls *[]string) {
+				input.Hooks.BuildSystemDelta = func(ColumnPublishSystemDeltaInput) error {
+					*calls = append(*calls, "system_delta")
+					return errStage
+				}
+			},
+			wantCalls: "extract,encode_columns,prepare_assets,manifest_encode,closure_validation,system_delta",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			input := testColumnPublishPlanInputM10A(identity, asset)
+			input.Hooks.ExtractDocuments = func() error {
+				calls = append(calls, "extract")
+				return nil
+			}
+			input.Hooks.EncodeDeclaredColumns = func(ColumnPublishDeclaredColumnEncodeInput) error {
+				calls = append(calls, "encode_columns")
+				return nil
+			}
+			input.Hooks.PrepareAssets = func(in ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+				calls = append(calls, "prepare_assets")
+				return ColumnPublishPreparedAssets{Assets: []ColumnPreparedAsset{asset}, RowCount: 10, ColumnPayloadBytes: asset.Bytes}, nil
+			}
+			input.Hooks.EncodeManifest = func(in ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+				calls = append(calls, "manifest_encode")
+				return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: 256}, nil
+			}
+			input.Hooks.ValidateClosure = func(in ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+				calls = append(calls, "closure_validation")
+				return ColumnPublishDurabilityClosure{PreparedAssets: []ColumnPreparedAsset{asset}, RequiredAssets: 1, RequiredBytes: asset.Bytes, FlushRequired: true, SyncRequired: true}, nil
+			}
+			input.Hooks.BuildSystemDelta = func(in ColumnPublishSystemDeltaInput) error {
+				calls = append(calls, "system_delta")
+				return nil
+			}
+			tt.configure(&input, &calls)
+
+			plan, err := BuildColumnPublishPlan(input)
+			if err == nil || !errors.Is(err, errStage) {
+				t.Fatalf("BuildColumnPublishPlan err=%v want %v", err, errStage)
+			}
+			if plan.Enabled {
+				t.Fatalf("failed plan returned enabled result: %+v", plan)
+			}
+			if got := strings.Join(calls, ","); got != tt.wantCalls {
+				t.Fatalf("calls=%q want %q", got, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseMeta := col.Meta()
+	state := d.State()
+	identity := ColumnManifestIdentity{Generation: 11, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef1234}
+	planInput := testColumnPublishPlanInputM10A(identity, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	ordered, err := plan.RootDelta.OrderedRootPublishInput()
+	if err != nil {
+		t.Fatalf("OrderedRootPublishInput: %v", err)
+	}
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{ordered}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+			BaseMeta:           baseMeta,
+			BaseCommitSeq:      state.CommitSeq,
+			BaseSystemRoot:     state.SystemRootPageID,
+			BaseManifestRootID: 0,
+			Plan:               plan,
+		}, rootIDs)
+	})
+	if err != nil {
+		t.Fatalf("publish column manifest root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("unexpected root IDs: %v", rootIDs)
+	}
+	reopened, err := NewCollectionManager(d).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open updated collection: %v", err)
+	}
+	meta := reopened.Meta()
+	cfg := meta.Options.ColumnStore
+	if cfg == nil || cfg.ActiveManifest == nil || *cfg.ActiveManifest != identity {
+		t.Fatalf("active manifest not updated atomically: %+v", cfg)
+	}
+	if cfg.RecoveryAuthoritativeManifest == nil || *cfg.RecoveryAuthoritativeManifest != identity || cfg.RecoveryAuthoritativeAppliedCommandLSN != plan.AppliedCommandLSN {
+		t.Fatalf("recovery-authoritative metadata not updated atomically: %+v", cfg)
+	}
+	cacheID, ok := reopened.ColumnStoreCacheIdentity()
+	if !ok || cacheID.ManifestRoot != rootIDs[0] || cacheID.ManifestGeneration != identity.Generation || cacheID.RecoveryAuthoritativeAppliedCommandLSN != plan.AppliedCommandLSN {
+		t.Fatalf("unexpected cache identity: %+v ok=%v rootIDs=%v", cacheID, ok, rootIDs)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	baseMeta := col.Meta()
+	state := d.State()
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x12345678}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	ordered, err := plan.RootDelta.OrderedRootPublishInput()
+	if err != nil {
+		t.Fatalf("OrderedRootPublishInput: %v", err)
+	}
+	_, _, err = d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{ordered}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+			BaseMeta:           baseMeta,
+			BaseCommitSeq:      state.CommitSeq,
+			BaseSystemRoot:     state.SystemRootPageID,
+			BaseManifestRootID: 999,
+			Plan:               plan,
+		}, rootIDs)
+	})
+	if err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
+		t.Fatalf("publish err=%v want concurrent root modification", err)
+	}
+	after := d.State()
+	if after.SystemRootPageID != state.SystemRootPageID || after.CommitSeq != state.CommitSeq {
+		t.Fatalf("failed publish changed backend state before=%+v after=%+v", state, after)
+	}
+	reopened, err := NewCollectionManager(d).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection after failed publish: %v", err)
+	}
+	if cfg := reopened.Meta().Options.ColumnStore; cfg == nil || cfg.ActiveManifest != nil || cfg.RecoveryAuthoritativeManifest != nil || cfg.RecoveryAuthoritativeAppliedCommandLSN != 0 {
+		t.Fatalf("failed publish leaked column metadata: %+v", cfg)
+	}
+	if id, ok := reopened.ColumnStoreCacheIdentity(); !ok || id.ManifestRoot != 0 || id.ManifestGeneration != 0 {
+		t.Fatalf("failed publish leaked root identity: %+v ok=%v", id, ok)
+	}
+}
+
+func BenchmarkColumnPublishPlanM10A(b *testing.B) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	b.Run("disabled_hook", func(b *testing.B) {
+		input := ColumnPublishPlanInput{Collection: "events", ColumnStore: nil}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			plan, err := BuildColumnPublishPlan(input)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if plan.Enabled {
+				b.Fatal(plan)
+			}
+		}
+	})
+	b.Run("enabled_skeleton", func(b *testing.B) {
+		cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+		if err != nil {
+			b.Fatal(err)
+		}
+		assets := []ColumnPreparedAsset{asset}
+		prepared := ColumnPublishPreparedAssets{Assets: assets, RowCount: 10, ColumnPayloadBytes: asset.Bytes}
+		closure := ColumnPublishDurabilityClosure{PreparedAssets: assets, RequiredAssets: 1, RequiredBytes: asset.Bytes, FlushRequired: true, SyncRequired: true}
+		input := ColumnPublishPlanInput{
+			Collection:            "events",
+			ColumnStore:           cfg,
+			ColumnStoreNormalized: true,
+			Operation:             ColumnPublishOperationInsert,
+			AppliedCommandLSN:     101,
+			BaseManifestRootID:    44,
+			Hooks: ColumnPublishPlanHooks{
+				PrepareAssets: func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+					return prepared, nil
+				},
+				EncodeManifest: func(ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+					return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: 256}, nil
+				},
+				ValidateClosure: func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+					return closure, nil
+				},
+			},
+		}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			plan, err := BuildColumnPublishPlan(input)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !plan.Enabled || plan.RequiredAssetBytes != asset.Bytes {
+				b.Fatal(plan)
+			}
+		}
+	})
+}
+
+func testColumnPublishPlanInputM10A(identity ColumnManifestIdentity, asset ColumnPreparedAsset) ColumnPublishPlanInput {
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		panic(err)
+	}
+	return ColumnPublishPlanInput{
+		Collection:            "events",
+		ColumnStore:           cfg,
+		ColumnStoreNormalized: true,
+		Operation:             ColumnPublishOperationInsert,
+		AppliedCommandLSN:     101,
+		BaseManifestRootID:    44,
+		Hooks: ColumnPublishPlanHooks{
+			PrepareAssets: func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+				return ColumnPublishPreparedAssets{Assets: []ColumnPreparedAsset{asset}, RowCount: 10, ColumnPayloadBytes: asset.Bytes}, nil
+			},
+			EncodeManifest: func(in ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+				return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: 256}, nil
+			},
+			ValidateClosure: func(in ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+				return ColumnPublishDurabilityClosure{PreparedAssets: []ColumnPreparedAsset{asset}, RequiredAssets: 1, RequiredBytes: asset.Bytes, FlushRequired: true, SyncRequired: true}, nil
+			},
+		},
+	}
+}
+
+func testColumnPublishPreparedAssetM10A() ColumnPreparedAsset {
+	return ColumnPreparedAsset{
+		Ref: ColumnAssetRef{
+			Kind:     ColumnAssetKindTCS1PartImage,
+			FileID:   7,
+			Offset:   4096,
+			Length:   8192,
+			Checksum: 0xdecafbad,
+		},
+		Bytes:        8192,
+		PublishID:    3,
+		GenerationID: 7,
+		Reason:       "m10a-test",
+	}
+}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -88,6 +88,21 @@ func TestColumnPublishPlanAllowsBenchmarkRelaxedProfileM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanUsesFixedWidthAssetBytesM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Bytes = 1 << 33
+	asset.Ref.Length = asset.Bytes
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+
+	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(identity, asset))
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan large asset: %v", err)
+	}
+	if plan.RequiredAssetBytes != asset.Bytes || plan.Lifecycle.PublishedBytes != asset.Bytes || plan.Lifecycle.PreparedBytes != asset.Bytes {
+		t.Fatalf("large byte counts not preserved: plan=%+v asset=%+v", plan, asset)
+	}
+}
+
 func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 
@@ -398,6 +399,36 @@ func TestColumnPublishPlanRejectsNegativeManifestBytesM10A(t *testing.T) {
 	}
 	if plan.Enabled {
 		t.Fatalf("negative manifest bytes returned enabled plan: %+v", plan)
+	}
+}
+
+func TestColumnPublishPlanRejectsPreparedAssetByteOverflowM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	hugeAsset := asset
+	hugeAsset.Ref.FileID = 8
+	hugeAsset.Ref.Length = math.MaxInt64
+	hugeAsset.Bytes = math.MaxInt64
+	oneByteAsset := asset
+	oneByteAsset.Ref.FileID = 9
+	oneByteAsset.Ref.Length = 1
+	oneByteAsset.Bytes = 1
+
+	identity := ColumnManifestIdentity{Generation: 9, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xbeefcaf1}
+	input := testColumnPublishPlanInputM10A(identity, hugeAsset)
+	input.Hooks.PrepareAssets = func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+		return ColumnPublishPreparedAssets{
+			Assets:             []ColumnPreparedAsset{hugeAsset, oneByteAsset},
+			RowCount:           2,
+			ColumnPayloadBytes: math.MaxInt64,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err == nil || !strings.Contains(err.Error(), "prepared asset bytes overflow") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want prepared asset byte overflow", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("overflowing prepared bytes returned enabled plan: %+v", plan)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -54,6 +53,41 @@ func TestColumnPublishPlanDisabledFastPathAllocatesZeroM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanRejectsNonEmptyDisabledColumnStoreM10A(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	cfg.Enabled = false
+	plan, err := BuildColumnPublishPlan(ColumnPublishPlanInput{
+		Collection:        "events",
+		ColumnStore:       cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: 101,
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires enabled=true") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want enabled=true validation", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("invalid disabled column_store returned enabled plan: %+v", plan)
+	}
+}
+
+func TestColumnPublishPlanAllowsBenchmarkRelaxedProfileM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	cfg := testColumnStoreConfig(nil)
+	cfg.ProfileSupport = ColumnStoreProfileBenchmarkRelaxed
+	input.ColumnStore = cfg
+	input.ColumnStoreNormalized = false
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan benchmark-relaxed: %v", err)
+	}
+	if !plan.Enabled || plan.RequiredAssetBytes != asset.Bytes {
+		t.Fatalf("unexpected benchmark-relaxed plan: %+v", plan)
+	}
+}
+
 func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
@@ -62,7 +96,6 @@ func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	input.MeasureAllocations = true
 	input.Hooks.ExtractDocuments = func() error {
 		called = append(called, "extract")
-		time.Sleep(time.Nanosecond)
 		return nil
 	}
 	input.Hooks.EncodeDeclaredColumns = func(ColumnPublishDeclaredColumnEncodeInput) error {
@@ -110,9 +143,6 @@ func TestColumnPublishPlanBuildsDurabilityClosureM10A(t *testing.T) {
 	}
 	if plan.Lifecycle.PublishedRefs != 1 || plan.Lifecycle.PublishedBytes != asset.Bytes || plan.Lifecycle.PreparedRefs != 1 || plan.Lifecycle.PreparedBytes != asset.Bytes {
 		t.Fatalf("unexpected lifecycle summary: %+v", plan.Lifecycle)
-	}
-	if plan.StageMetrics.DocumentExtraction <= 0 {
-		t.Fatalf("stage metrics were not populated: %+v", plan.StageMetrics)
 	}
 }
 
@@ -339,6 +369,30 @@ func TestColumnPublishPlanRejectsClosurePreparedAssetMismatchM10A(t *testing.T) 
 	}
 }
 
+func TestColumnPublishPlanSnapshotsPreparedAssetsForClosureValidationM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.ValidateClosure = func(in ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		in.Prepared.Assets[0].Ref.Offset += int64(asset.Bytes)
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: in.Prepared.Assets,
+			RequiredAssets: len(in.Prepared.Assets),
+			RequiredBytes:  sumColumnPreparedAssetBytes(in.Prepared.Assets),
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err == nil || !strings.Contains(err.Error(), "does not match manifest prepared asset") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want closure mutation mismatch", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("mutated closure prepared asset returned enabled plan: %+v", plan)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -404,6 +458,84 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	cacheID, ok := reopened.ColumnStoreCacheIdentity()
 	if !ok || cacheID.ManifestRoot != rootIDs[0] || cacheID.ManifestGeneration != identity.Generation || cacheID.RecoveryAuthoritativeAppliedCommandLSN != plan.RecoveryAuthoritativeAppliedCommandLSN {
 		t.Fatalf("unexpected cache identity: %+v ok=%v rootIDs=%v", cacheID, ok, rootIDs)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsForeignCollectionM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 11, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef1234}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	plan.Collection = "other"
+	plan.ManifestRootName = collectionColumnManifestRootName("other")
+	plan.RootDelta.RootName = plan.ManifestRootName
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           col.Meta(),
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "does not match collection") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want collection/root mismatch", err)
+	}
+}
+
+func TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 12, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef5678}, testColumnPublishPreparedAssetM10A()))
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if plan.ManifestRootBaseID == 0 || plan.RootDelta.BaseRootID == 0 {
+		t.Fatalf("test requires non-zero stale plan base: %+v", plan)
+	}
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           col.Meta(),
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want stale plan base rejection", err)
 	}
 }
 
@@ -521,6 +653,7 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 		var stages ColumnPublishStageMetrics
 		var last ColumnPublishPlan
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			plan, err := BuildColumnPublishPlan(input)
 			if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -539,6 +539,44 @@ func TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A(t *testing.T) 
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRejectsIdentityMismatchM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 13, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef9012}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	plan.UpdatedActiveManifest.Generation++
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           col.Meta(),
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "active manifest identity") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want active manifest identity mismatch", err)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -432,8 +432,8 @@ func TestColumnPublishPlanRejectsPreparedAssetByteOverflowM10A(t *testing.T) {
 	}
 
 	plan, err := BuildColumnPublishPlan(input)
-	if err == nil || !strings.Contains(err.Error(), "prepared asset[1] bytes overflow") {
-		t.Fatalf("BuildColumnPublishPlan err=%v want indexed prepared asset byte overflow", err)
+	if err == nil || !strings.Contains(err.Error(), "asset[1] bytes overflow") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want indexed asset byte overflow", err)
 	}
 	if plan.Enabled {
 		t.Fatalf("overflowing prepared bytes returned enabled plan: %+v", plan)
@@ -476,6 +476,38 @@ func TestColumnPublishPlanRejectsClosurePreparedAssetMismatchM10A(t *testing.T) 
 	}
 	if plan.Enabled {
 		t.Fatalf("mismatched closure prepared asset returned enabled plan: %+v", plan)
+	}
+}
+
+func TestColumnPublishPlanReportsClosureAssetValidationBeforeByteSumM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	invalid := asset
+	invalid.Ref.Kind = ColumnAssetKind("future-kind")
+	invalid.Ref.Length = math.MaxInt64
+	invalid.Bytes = math.MaxInt64
+	overflow := asset
+	overflow.Ref.FileID = 8
+	overflow.Ref.Offset = math.MaxInt64
+	overflow.Ref.Length = 1
+	overflow.Bytes = 1
+	input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: []ColumnPreparedAsset{invalid, overflow},
+			RequiredAssets: 2,
+			RequiredBytes:  math.MaxInt64,
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err == nil || !strings.Contains(err.Error(), "closure asset[0]") || !strings.Contains(err.Error(), "unsupported column asset ref kind") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want closure asset validation before byte sum", err)
+	}
+	if plan.Enabled {
+		t.Fatalf("invalid closure asset returned enabled plan: %+v", plan)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -826,6 +826,56 @@ func TestColumnManifestPublishSystemDeltaRejectsMissingLSNM10A(t *testing.T) {
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRejectsRecoveryLSNRegressionM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 17, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbc},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+
+	baseMeta := col.Meta()
+	cfg := baseMeta.Options.ColumnStore.copy()
+	active := ColumnManifestIdentity{Generation: 16, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcba}
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &active
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = plan.RecoveryAuthoritativeAppliedCommandLSN + 1
+	baseMeta.Options.ColumnStore = &cfg
+
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           baseMeta,
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+		t.Fatalf("returned iterator with err=%v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "recovery-authoritative AppliedCommandLSN regression") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want recovery-authoritative LSN regression", err)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaRejectsForeignCollectionM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -404,6 +404,34 @@ func TestColumnPublishPlanRejectsClosurePreparedAssetMismatchM10A(t *testing.T) 
 	}
 }
 
+func TestColumnPublishPlanCopiesPreparedAssetsForManifestHookM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.ValidateClosure = nil
+	var hookAssets []ColumnPreparedAsset
+	input.Hooks.EncodeManifest = func(in ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+		hookAssets = in.Prepared.Assets
+		in.Prepared.Assets[0].Ref.Offset += int64(asset.Bytes)
+		return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: 256}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if len(plan.PreparedAssets) != 1 {
+		t.Fatalf("prepared assets=%d want 1", len(plan.PreparedAssets))
+	}
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after manifest hook mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+	hookAssets[0].Ref.Offset += int64(asset.Bytes)
+	if plan.PreparedAssets[0] != asset {
+		t.Fatalf("plan prepared asset changed after manifest hook-owned slice mutation: got %+v want %+v", plan.PreparedAssets[0], asset)
+	}
+}
+
 func TestColumnPublishPlanSnapshotsPreparedAssetsForClosureValidationM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -527,6 +528,44 @@ func TestColumnPublishPlanCopiesClosureForRootDeltaHookM10A(t *testing.T) {
 	}
 }
 
+func TestColumnPublishPlanPassesHookOwnedColumnStoreConfigM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	if input.ColumnStore.ManifestRoot == nil || len(input.ColumnStore.Columns) == 0 {
+		t.Fatalf("test requires normalized manifest root and columns: %+v", input.ColumnStore)
+	}
+	rootName := input.ColumnStore.ManifestRoot.Name
+	storagePolicy := input.ColumnStore.ManifestRoot.StoragePolicy
+	firstColumn := input.ColumnStore.Columns[0].Name
+	input.Hooks.BuildRootDelta = func(in ColumnPublishRootDeltaInput) (ColumnManifestRootDelta, error) {
+		in.ColumnStore.ManifestRoot.Name = "events/corrupted-column-manifest"
+		in.ColumnStore.ManifestRoot.StoragePolicy = RootStoragePolicy("corrupted")
+		in.ColumnStore.Columns[0].Name = "corrupted"
+		return ColumnManifestRootDelta{
+			RootName:       rootName,
+			BaseRootID:     in.BaseManifestRootID,
+			StoragePolicy:  storagePolicy,
+			Identity:       in.Manifest.Identity,
+			IdentityRecord: encodeColumnManifestIdentityRecordArray(in.Manifest.Identity),
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if plan.ManifestRootName != rootName || plan.RootDelta.RootName != rootName {
+		t.Fatalf("hook-owned config mutation leaked into root names: plan=%+v root=%q", plan, rootName)
+	}
+	if input.ColumnStore.ManifestRoot.Name != rootName || input.ColumnStore.ManifestRoot.StoragePolicy != storagePolicy {
+		t.Fatalf("input manifest root mutated by hook: %+v", input.ColumnStore.ManifestRoot)
+	}
+	if input.ColumnStore.Columns[0].Name != firstColumn {
+		t.Fatalf("input columns mutated by hook: got %q want %q", input.ColumnStore.Columns[0].Name, firstColumn)
+	}
+}
+
 func TestColumnPublishPlanCopiesPreparedAssetsForSystemDeltaHookM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
@@ -581,6 +620,10 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	if err != nil {
 		t.Fatalf("BuildColumnPublishPlan: %v", err)
 	}
+	plan.UpdatedActiveManifest.Format = ""
+	plan.UpdatedActiveManifest.Version = 0
+	plan.RecoveryAuthoritativeManifest.Format = ""
+	plan.RecoveryAuthoritativeManifest.Version = 0
 	plan.RecoveryAuthoritativeAppliedCommandLSN = 202
 	if plan.RecoveryAuthoritativeAppliedCommandLSN == plan.AppliedCommandLSN {
 		t.Fatalf("test requires distinct applied and recovery-authoritative LSNs: %+v", plan)
@@ -619,6 +662,26 @@ func TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A(t *t
 	cacheID, ok := reopened.ColumnStoreCacheIdentity()
 	if !ok || cacheID.ManifestRoot != rootIDs[0] || cacheID.ManifestGeneration != identity.Generation || cacheID.RecoveryAuthoritativeAppliedCommandLSN != plan.RecoveryAuthoritativeAppliedCommandLSN {
 		t.Fatalf("unexpected cache identity: %+v ok=%v rootIDs=%v", cacheID, ok, rootIDs)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	raw, ok, err := getSystemValue(snap, systemCollectionMetaKey("events"))
+	if err != nil || !ok {
+		t.Fatalf("load raw collection metadata: ok=%v err=%v", ok, err)
+	}
+	var disk collectionMetaDisk
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		t.Fatalf("decode raw collection metadata: %v", err)
+	}
+	rawCfg := disk.Options.ColumnStore
+	if rawCfg == nil || rawCfg.ActiveManifest == nil || *rawCfg.ActiveManifest != identity {
+		t.Fatalf("raw active manifest was not stored normalized: %+v", rawCfg)
+	}
+	if rawCfg.RecoveryAuthoritativeManifest == nil || *rawCfg.RecoveryAuthoritativeManifest != identity {
+		t.Fatalf("raw recovery-authoritative manifest was not stored normalized: %+v", rawCfg)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -864,6 +864,51 @@ func TestColumnManifestPublishSystemDeltaRejectsInvalidRootIDsM10A(t *testing.T)
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaDoesNotReadPublishedRootBeforeCommitM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(
+		ColumnManifestIdentity{Generation: 15, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcddcbd},
+		testColumnPublishPreparedAssetM10A(),
+	)
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	state := d.State()
+
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           col.Meta(),
+		BaseCommitSeq:      state.CommitSeq,
+		BaseSystemRoot:     state.SystemRootPageID,
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123456789})
+	if err != nil {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator: %v", err)
+	}
+	if iter == nil {
+		t.Fatal("buildColumnManifestPublishSystemDeltaIterator returned nil iterator")
+	}
+	_ = iter.Close()
+}
+
 func TestColumnManifestPublishSystemDeltaRejectsMissingLSNM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1185,7 +1230,7 @@ func TestColumnManifestPublishSystemDeltaRejectsIdentityMismatchM10A(t *testing.
 	}
 }
 
-func TestColumnManifestPublishSystemDeltaRejectsPublishedRootMismatchM10A(t *testing.T) {
+func TestColumnManifestPublishSystemDeltaDefersPublishedRootMismatchToOpenM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -1228,12 +1273,15 @@ func TestColumnManifestPublishSystemDeltaRejectsPublishedRootMismatchM10A(t *tes
 			Plan:               plan,
 		}, rootIDs)
 	})
-	if err == nil || !strings.Contains(err.Error(), "published root identity record") {
-		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder err=%v want published root identity mismatch", err)
+	if err != nil {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder: %v", err)
+	}
+	if _, err := NewCollectionManager(d).OpenCollection("events"); err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("OpenCollection err=%v want committed root identity mismatch", err)
 	}
 }
 
-func TestColumnManifestPublishSystemDeltaRejectsMalformedPublishedRootIdentityM10A(t *testing.T) {
+func TestColumnManifestPublishSystemDeltaDefersMalformedPublishedRootIdentityToOpenM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -1278,8 +1326,12 @@ func TestColumnManifestPublishSystemDeltaRejectsMalformedPublishedRootIdentityM1
 			Plan:               plan,
 		}, rootIDs)
 	})
+	if err != nil {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder: %v", err)
+	}
+	_, err = NewCollectionManager(d).OpenCollection("events")
 	if err == nil || !strings.Contains(err.Error(), "invalid identity record") || !strings.Contains(err.Error(), "malformed identity record length") {
-		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder err=%v want malformed published root identity", err)
+		t.Fatalf("OpenCollection err=%v want malformed committed root identity", err)
 	}
 }
 

--- a/TreeDB/collections/column_publish_plan_test.go
+++ b/TreeDB/collections/column_publish_plan_test.go
@@ -86,12 +86,21 @@ func TestColumnPublishPlanAllowsBenchmarkRelaxedProfileM10A(t *testing.T) {
 	cfg.ProfileSupport = ColumnStoreProfileBenchmarkRelaxed
 	input.ColumnStore = cfg
 	input.ColumnStoreNormalized = false
+	input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: []ColumnPreparedAsset{asset},
+			RequiredAssets: 1,
+			RequiredBytes:  asset.Bytes,
+			FlushRequired:  false,
+			SyncRequired:   false,
+		}, nil
+	}
 
 	plan, err := BuildColumnPublishPlan(input)
 	if err != nil {
 		t.Fatalf("BuildColumnPublishPlan benchmark-relaxed: %v", err)
 	}
-	if !plan.Enabled || plan.RequiredAssetBytes != asset.Bytes {
+	if !plan.Enabled || plan.RequiredAssetBytes != asset.Bytes || plan.RequiredAssetFlush || plan.RequiredAssetSync {
 		t.Fatalf("unexpected benchmark-relaxed plan: %+v", plan)
 	}
 }
@@ -424,8 +433,8 @@ func TestColumnPublishPlanRejectsPreparedAssetByteOverflowM10A(t *testing.T) {
 	}
 
 	plan, err := BuildColumnPublishPlan(input)
-	if err == nil || !strings.Contains(err.Error(), "prepared asset bytes overflow") {
-		t.Fatalf("BuildColumnPublishPlan err=%v want prepared asset byte overflow", err)
+	if err == nil || !strings.Contains(err.Error(), "prepared asset[1] bytes overflow") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want indexed prepared asset byte overflow", err)
 	}
 	if plan.Enabled {
 		t.Fatalf("overflowing prepared bytes returned enabled plan: %+v", plan)
@@ -438,8 +447,8 @@ func TestColumnPublishPlanRejectsUnsupportedAssetKindM10A(t *testing.T) {
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
 
 	plan, err := BuildColumnPublishPlan(testColumnPublishPlanInputM10A(identity, asset))
-	if err == nil || !strings.Contains(err.Error(), "unsupported column asset ref kind") {
-		t.Fatalf("BuildColumnPublishPlan err=%v want unsupported kind", err)
+	if err == nil || !strings.Contains(err.Error(), "prepared asset[0]") || !strings.Contains(err.Error(), "unsupported column asset ref kind") {
+		t.Fatalf("BuildColumnPublishPlan err=%v want indexed unsupported kind", err)
 	}
 	if plan.Enabled {
 		t.Fatalf("unsupported asset kind returned enabled plan: %+v", plan)
@@ -468,6 +477,37 @@ func TestColumnPublishPlanRejectsClosurePreparedAssetMismatchM10A(t *testing.T) 
 	}
 	if plan.Enabled {
 		t.Fatalf("mismatched closure prepared asset returned enabled plan: %+v", plan)
+	}
+}
+
+func TestColumnPublishPlanAllowsReorderedClosurePreparedAssetsM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	second := asset
+	second.Ref.FileID = 8
+	second.Ref.Offset += asset.Bytes
+	second.PublishID++
+	second.GenerationID++
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.Hooks.PrepareAssets = func(ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+		return ColumnPublishPreparedAssets{Assets: []ColumnPreparedAsset{asset, second}, RowCount: 20, ColumnPayloadBytes: asset.Bytes + second.Bytes}, nil
+	}
+	input.Hooks.ValidateClosure = func(ColumnPublishClosureValidationInput) (ColumnPublishDurabilityClosure, error) {
+		return ColumnPublishDurabilityClosure{
+			PreparedAssets: []ColumnPreparedAsset{second, asset},
+			RequiredAssets: 2,
+			RequiredBytes:  asset.Bytes + second.Bytes,
+			FlushRequired:  true,
+			SyncRequired:   true,
+		}, nil
+	}
+
+	plan, err := BuildColumnPublishPlan(input)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan reordered closure assets: %v", err)
+	}
+	if len(plan.PreparedAssets) != 2 || plan.PreparedAssets[0] != asset || plan.PreparedAssets[1] != second {
+		t.Fatalf("plan prepared assets should retain manifest order: %+v", plan.PreparedAssets)
 	}
 }
 
@@ -508,7 +548,7 @@ func TestColumnPublishPlanSnapshotsPreparedAssetsForClosureValidationM10A(t *tes
 		return ColumnPublishDurabilityClosure{
 			PreparedAssets: in.Prepared.Assets,
 			RequiredAssets: len(in.Prepared.Assets),
-			RequiredBytes:  sumColumnPreparedAssetBytes(in.Prepared.Assets),
+			RequiredBytes:  mustSumColumnPreparedAssetBytes(t, in.Prepared.Assets),
 			FlushRequired:  true,
 			SyncRequired:   true,
 		}, nil
@@ -523,6 +563,41 @@ func TestColumnPublishPlanSnapshotsPreparedAssetsForClosureValidationM10A(t *tes
 	}
 }
 
+func TestColumnPublishPlanCopiesCurrentManifestForHooksM10A(t *testing.T) {
+	asset := testColumnPublishPreparedAssetM10A()
+	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	current := ColumnManifestIdentity{Generation: 6, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabc123}
+	input := testColumnPublishPlanInputM10A(identity, asset)
+	input.CurrentManifest = &current
+	var prepareSeen, manifestSeen ColumnManifestIdentity
+	input.Hooks.PrepareAssets = func(in ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
+		if in.CurrentManifest == nil {
+			t.Fatal("PrepareAssets CurrentManifest is nil")
+		}
+		prepareSeen = *in.CurrentManifest
+		in.CurrentManifest.Generation = 99
+		return ColumnPublishPreparedAssets{Assets: []ColumnPreparedAsset{asset}, RowCount: 10, ColumnPayloadBytes: asset.Bytes}, nil
+	}
+	input.Hooks.EncodeManifest = func(in ColumnPublishManifestEncodeInput) (ColumnPublishManifestEncodeResult, error) {
+		if in.CurrentManifest == nil {
+			t.Fatal("EncodeManifest CurrentManifest is nil")
+		}
+		manifestSeen = *in.CurrentManifest
+		in.CurrentManifest.Generation = 100
+		return ColumnPublishManifestEncodeResult{Identity: identity, ManifestBytes: 256}, nil
+	}
+
+	if _, err := BuildColumnPublishPlan(input); err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	if prepareSeen != current || manifestSeen != current {
+		t.Fatalf("hooks saw mutated current manifest: prepare=%+v manifest=%+v want=%+v", prepareSeen, manifestSeen, current)
+	}
+	if *input.CurrentManifest != current {
+		t.Fatalf("input CurrentManifest mutated: got %+v want %+v", *input.CurrentManifest, current)
+	}
+}
+
 func TestColumnPublishPlanCopiesClosurePreparedAssetsM10A(t *testing.T) {
 	asset := testColumnPublishPreparedAssetM10A()
 	identity := ColumnManifestIdentity{Generation: 7, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
@@ -533,7 +608,7 @@ func TestColumnPublishPlanCopiesClosurePreparedAssetsM10A(t *testing.T) {
 		return ColumnPublishDurabilityClosure{
 			PreparedAssets: closureAssets,
 			RequiredAssets: len(closureAssets),
-			RequiredBytes:  sumColumnPreparedAssetBytes(closureAssets),
+			RequiredBytes:  mustSumColumnPreparedAssetBytes(t, closureAssets),
 			FlushRequired:  true,
 			SyncRequired:   true,
 		}, nil
@@ -947,6 +1022,44 @@ func TestColumnManifestPublishSystemDeltaRejectsForeignCollectionM10A(t *testing
 	}
 }
 
+func TestColumnManifestPublishSystemDeltaRevalidatesRootStoragePolicyM10A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		t.Fatalf("create column-enabled collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	planInput := testColumnPublishPlanInputM10A(ColumnManifestIdentity{Generation: 11, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xabcdef1234}, testColumnPublishPreparedAssetM10A())
+	planInput.BaseManifestRootID = 0
+	plan, err := BuildColumnPublishPlan(planInput)
+	if err != nil {
+		t.Fatalf("BuildColumnPublishPlan: %v", err)
+	}
+	plan.RootDelta.StoragePolicy = RootStoragePolicy("corrupted")
+	iter, err := col.buildColumnManifestPublishSystemDeltaIterator(ColumnManifestPublishSystemDeltaInput{
+		BaseMeta:           col.Meta(),
+		BaseManifestRootID: 0,
+		Plan:               plan,
+	}, []uint64{123})
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "unsupported root storage policy") {
+		t.Fatalf("buildColumnManifestPublishSystemDeltaIterator err=%v want storage policy rejection", err)
+	}
+}
+
 func TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1311,8 +1424,8 @@ func BenchmarkColumnPublishPlanM10A(b *testing.B) {
 		b.ReportMetric(float64(stages.RootDeltaConstruction.Nanoseconds())/float64(b.N), "root_delta_ns/op")
 		b.ReportMetric(float64(stages.SystemDeltaConstruction.Nanoseconds())/float64(b.N), "system_delta_ns/op")
 		b.ReportMetric(float64(last.Rows), "rows/op")
-		b.ReportMetric(float64(last.RequiredAssetCount), "prepared_refs/op")
-		b.ReportMetric(float64(last.RequiredAssetBytes), "prepared_asset_B/op")
+		b.ReportMetric(float64(last.RequiredAssetCount), "required_refs/op")
+		b.ReportMetric(float64(last.RequiredAssetBytes), "required_asset_B/op")
 		b.ReportMetric(float64(last.ManifestBytes), "manifest_B/op")
 	})
 }
@@ -1341,6 +1454,15 @@ func testColumnPublishPlanInputM10A(identity ColumnManifestIdentity, asset Colum
 			},
 		},
 	}
+}
+
+func mustSumColumnPreparedAssetBytes(t testing.TB, assets []ColumnPreparedAsset) int64 {
+	t.Helper()
+	total, err := checkedSumColumnPreparedAssetBytes(assets)
+	if err != nil {
+		t.Fatalf("checkedSumColumnPreparedAssetBytes: %v", err)
+	}
+	return total
 }
 
 func testColumnPublishPreparedAssetM10A() ColumnPreparedAsset {

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -27,6 +27,7 @@ const (
 	columnManifestIdentityRecordKey             = "\x00column-manifest/identity"
 )
 
+// columnManifestIdentityRecordKeyBytes returns a fresh caller-owned key copy.
 func columnManifestIdentityRecordKeyBytes() []byte {
 	return []byte(columnManifestIdentityRecordKey)
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -820,9 +820,8 @@ func columnManifestIdentityIterator(identity ColumnManifestIdentity) *systemTarg
 }
 
 func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSize]byte) *systemTargetIterator {
-	recordCopy := record
 	return &systemTargetIterator{entries: []systemTargetEntry{{
 		key:   []byte(columnManifestIdentityRecordKey),
-		value: recordCopy[:],
+		value: record[:],
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -14,19 +14,23 @@ import (
 )
 
 const (
-	columnManifestFormatTCS1                 = "tcs1"
-	columnManifestIdentityMagic              = uint32(0x54434d49) // TCMI
-	columnManifestIdentityVersion            = uint16(1)
-	columnManifestIdentityMagicOffset        = 0
-	columnManifestIdentityEncodingVersionOff = 4
-	columnManifestIdentityManifestVersionOff = 6
-	columnManifestIdentityGenerationOffset   = 8
-	columnManifestIdentityChecksumOffset     = 16
-	columnManifestIdentityReservedOffset     = 24
-	columnManifestIdentityReservedSize       = 4
-	columnManifestIdentityRecordSize         = columnManifestIdentityReservedOffset + columnManifestIdentityReservedSize
-	columnManifestIdentityRecordKey          = "\x00column-manifest/identity"
+	columnManifestFormatTCS1                    = "tcs1"
+	columnManifestIdentityMagic                 = uint32(0x54434d49) // TCMI
+	columnManifestIdentityVersion               = uint16(1)
+	columnManifestIdentityMagicOffset           = 0
+	columnManifestIdentityEncodingVersionOffset = 4
+	columnManifestIdentityManifestVersionOffset = 6
+	columnManifestIdentityGenerationOffset      = 8
+	columnManifestIdentityChecksumOffset        = 16
+	columnManifestIdentityReservedOffset        = 24
+	columnManifestIdentityReservedSize          = 4
+	columnManifestIdentityRecordSize            = columnManifestIdentityReservedOffset + columnManifestIdentityReservedSize
+	columnManifestIdentityRecordKey             = "\x00column-manifest/identity"
 )
+
+// columnManifestIdentityRecordKeyBytes is shared read-only input for root lookup
+// and publish iterators; callers must not mutate it.
+var columnManifestIdentityRecordKeyBytes = []byte(columnManifestIdentityRecordKey)
 
 type ColumnStoreValueType string
 
@@ -559,7 +563,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	if rootID == 0 {
 		return fmt.Errorf("collections: active column manifest generation %d for %q is missing root descriptor %q", identity.Generation, catalog.meta.Name, rootName)
 	}
-	entry, err := snap.GetEntryAtRoot(rootID, []byte(columnManifestIdentityRecordKey))
+	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes)
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return fmt.Errorf("collections: active column manifest root %d for %q is missing identity record", rootID, catalog.meta.Name)
 	}
@@ -583,7 +587,7 @@ func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection st
 	if rootID == 0 {
 		return fmt.Errorf("collections: missing published column manifest root for %q", collection)
 	}
-	entry, err := snap.GetEntryAtRoot(rootID, []byte(columnManifestIdentityRecordKey))
+	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes)
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return fmt.Errorf("collections: published column manifest root %d for %q is missing identity record", rootID, collection)
 	}
@@ -609,9 +613,9 @@ func encodeColumnManifestIdentityRecord(identity ColumnManifestIdentity) []byte 
 
 func encodeColumnManifestIdentityRecordArray(identity ColumnManifestIdentity) [columnManifestIdentityRecordSize]byte {
 	var out [columnManifestIdentityRecordSize]byte
-	binary.BigEndian.PutUint32(out[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOff], columnManifestIdentityMagic)
-	binary.BigEndian.PutUint16(out[columnManifestIdentityEncodingVersionOff:columnManifestIdentityManifestVersionOff], columnManifestIdentityVersion)
-	binary.BigEndian.PutUint16(out[columnManifestIdentityManifestVersionOff:columnManifestIdentityGenerationOffset], identity.Version)
+	binary.BigEndian.PutUint32(out[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOffset], columnManifestIdentityMagic)
+	binary.BigEndian.PutUint16(out[columnManifestIdentityEncodingVersionOffset:columnManifestIdentityManifestVersionOffset], columnManifestIdentityVersion)
+	binary.BigEndian.PutUint16(out[columnManifestIdentityManifestVersionOffset:columnManifestIdentityGenerationOffset], identity.Version)
 	binary.BigEndian.PutUint64(out[columnManifestIdentityGenerationOffset:columnManifestIdentityChecksumOffset], identity.Generation)
 	binary.BigEndian.PutUint64(out[columnManifestIdentityChecksumOffset:columnManifestIdentityReservedOffset], identity.Checksum)
 	binary.BigEndian.PutUint32(out[columnManifestIdentityReservedOffset:columnManifestIdentityRecordSize], 0)
@@ -622,17 +626,17 @@ func decodeColumnManifestIdentityRecord(raw []byte) (columnManifestIdentityRecor
 	if len(raw) != columnManifestIdentityRecordSize {
 		return columnManifestIdentityRecord{}, fmt.Errorf("malformed identity record length %d", len(raw))
 	}
-	if magic := binary.BigEndian.Uint32(raw[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOff]); magic != columnManifestIdentityMagic {
+	if magic := binary.BigEndian.Uint32(raw[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOffset]); magic != columnManifestIdentityMagic {
 		return columnManifestIdentityRecord{}, fmt.Errorf("bad identity magic 0x%x", magic)
 	}
-	if version := binary.BigEndian.Uint16(raw[columnManifestIdentityEncodingVersionOff:columnManifestIdentityManifestVersionOff]); version != columnManifestIdentityVersion {
+	if version := binary.BigEndian.Uint16(raw[columnManifestIdentityEncodingVersionOffset:columnManifestIdentityManifestVersionOffset]); version != columnManifestIdentityVersion {
 		return columnManifestIdentityRecord{}, fmt.Errorf("unsupported identity version %d", version)
 	}
 	if reserved := binary.BigEndian.Uint32(raw[columnManifestIdentityReservedOffset:columnManifestIdentityRecordSize]); reserved != 0 {
-		return columnManifestIdentityRecord{}, fmt.Errorf("non-zero identity reserved field %d", reserved)
+		return columnManifestIdentityRecord{}, fmt.Errorf("non-zero identity reserved trailer field 0x%08x", reserved)
 	}
 	return columnManifestIdentityRecord{
-		Version:    binary.BigEndian.Uint16(raw[columnManifestIdentityManifestVersionOff:columnManifestIdentityGenerationOffset]),
+		Version:    binary.BigEndian.Uint16(raw[columnManifestIdentityManifestVersionOffset:columnManifestIdentityGenerationOffset]),
 		Generation: binary.BigEndian.Uint64(raw[columnManifestIdentityGenerationOffset:columnManifestIdentityChecksumOffset]),
 		Checksum:   binary.BigEndian.Uint64(raw[columnManifestIdentityChecksumOffset:columnManifestIdentityReservedOffset]),
 	}, nil
@@ -843,7 +847,7 @@ func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSi
 	value := make([]byte, columnManifestIdentityRecordSize)
 	copy(value, record[:])
 	return &systemTargetIterator{entries: []systemTargetEntry{{
-		key:   []byte(columnManifestIdentityRecordKey),
+		key:   columnManifestIdentityRecordKeyBytes,
 		value: value,
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -14,11 +14,18 @@ import (
 )
 
 const (
-	columnManifestFormatTCS1         = "tcs1"
-	columnManifestIdentityMagic      = uint32(0x54434d49) // TCMI
-	columnManifestIdentityVersion    = uint16(1)
-	columnManifestIdentityRecordSize = 28
-	columnManifestIdentityRecordKey  = "\x00column-manifest/identity"
+	columnManifestFormatTCS1                 = "tcs1"
+	columnManifestIdentityMagic              = uint32(0x54434d49) // TCMI
+	columnManifestIdentityVersion            = uint16(1)
+	columnManifestIdentityMagicOffset        = 0
+	columnManifestIdentityEncodingVersionOff = 4
+	columnManifestIdentityManifestVersionOff = 6
+	columnManifestIdentityGenerationOffset   = 8
+	columnManifestIdentityChecksumOffset     = 16
+	columnManifestIdentityReservedOffset     = 24
+	columnManifestIdentityReservedSize       = 4
+	columnManifestIdentityRecordSize         = columnManifestIdentityReservedOffset + columnManifestIdentityReservedSize
+	columnManifestIdentityRecordKey          = "\x00column-manifest/identity"
 )
 
 type ColumnStoreValueType string
@@ -595,12 +602,12 @@ func encodeColumnManifestIdentityRecord(identity ColumnManifestIdentity) []byte 
 
 func encodeColumnManifestIdentityRecordArray(identity ColumnManifestIdentity) [columnManifestIdentityRecordSize]byte {
 	var out [columnManifestIdentityRecordSize]byte
-	binary.BigEndian.PutUint32(out[0:4], columnManifestIdentityMagic)
-	binary.BigEndian.PutUint16(out[4:6], columnManifestIdentityVersion)
-	binary.BigEndian.PutUint16(out[6:8], identity.Version)
-	binary.BigEndian.PutUint64(out[8:16], identity.Generation)
-	binary.BigEndian.PutUint64(out[16:24], identity.Checksum)
-	binary.BigEndian.PutUint32(out[24:28], 0)
+	binary.BigEndian.PutUint32(out[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOff], columnManifestIdentityMagic)
+	binary.BigEndian.PutUint16(out[columnManifestIdentityEncodingVersionOff:columnManifestIdentityManifestVersionOff], columnManifestIdentityVersion)
+	binary.BigEndian.PutUint16(out[columnManifestIdentityManifestVersionOff:columnManifestIdentityGenerationOffset], identity.Version)
+	binary.BigEndian.PutUint64(out[columnManifestIdentityGenerationOffset:columnManifestIdentityChecksumOffset], identity.Generation)
+	binary.BigEndian.PutUint64(out[columnManifestIdentityChecksumOffset:columnManifestIdentityReservedOffset], identity.Checksum)
+	binary.BigEndian.PutUint32(out[columnManifestIdentityReservedOffset:columnManifestIdentityRecordSize], 0)
 	return out
 }
 
@@ -608,19 +615,19 @@ func decodeColumnManifestIdentityRecord(raw []byte) (columnManifestIdentityRecor
 	if len(raw) != columnManifestIdentityRecordSize {
 		return columnManifestIdentityRecord{}, fmt.Errorf("malformed identity record length %d", len(raw))
 	}
-	if magic := binary.BigEndian.Uint32(raw[0:4]); magic != columnManifestIdentityMagic {
+	if magic := binary.BigEndian.Uint32(raw[columnManifestIdentityMagicOffset:columnManifestIdentityEncodingVersionOff]); magic != columnManifestIdentityMagic {
 		return columnManifestIdentityRecord{}, fmt.Errorf("bad identity magic 0x%x", magic)
 	}
-	if version := binary.BigEndian.Uint16(raw[4:6]); version != columnManifestIdentityVersion {
+	if version := binary.BigEndian.Uint16(raw[columnManifestIdentityEncodingVersionOff:columnManifestIdentityManifestVersionOff]); version != columnManifestIdentityVersion {
 		return columnManifestIdentityRecord{}, fmt.Errorf("unsupported identity version %d", version)
 	}
-	if reserved := binary.BigEndian.Uint32(raw[24:28]); reserved != 0 {
+	if reserved := binary.BigEndian.Uint32(raw[columnManifestIdentityReservedOffset:columnManifestIdentityRecordSize]); reserved != 0 {
 		return columnManifestIdentityRecord{}, fmt.Errorf("non-zero identity reserved field %d", reserved)
 	}
 	return columnManifestIdentityRecord{
-		Version:    binary.BigEndian.Uint16(raw[6:8]),
-		Generation: binary.BigEndian.Uint64(raw[8:16]),
-		Checksum:   binary.BigEndian.Uint64(raw[16:24]),
+		Version:    binary.BigEndian.Uint16(raw[columnManifestIdentityManifestVersionOff:columnManifestIdentityGenerationOffset]),
+		Generation: binary.BigEndian.Uint64(raw[columnManifestIdentityGenerationOffset:columnManifestIdentityChecksumOffset]),
+		Checksum:   binary.BigEndian.Uint64(raw[columnManifestIdentityChecksumOffset:columnManifestIdentityReservedOffset]),
 	}, nil
 }
 

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -523,6 +523,18 @@ func validateColumnManifestIdentityFor(label string, identity ColumnManifestIden
 	return nil
 }
 
+// normalizeColumnManifestIdentityDefaults is used by M10A publish-plan
+// assembly before fail-closed identity validation.
+func normalizeColumnManifestIdentityDefaults(identity *ColumnManifestIdentity) {
+	if identity == nil {
+		return
+	}
+	normalizeColumnManifestIdentityFormat(identity)
+	if identity.Version == 0 {
+		identity.Version = columnManifestIdentityVersion
+	}
+}
+
 func normalizeColumnManifestIdentityFormat(identity *ColumnManifestIdentity) {
 	if identity == nil {
 		return

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -28,9 +27,9 @@ const (
 	columnManifestIdentityRecordKey             = "\x00column-manifest/identity"
 )
 
-// columnManifestIdentityRecordKeyBytes is shared read-only input for root lookup
-// and publish iterators; callers must not mutate it.
-var columnManifestIdentityRecordKeyBytes = []byte(columnManifestIdentityRecordKey)
+func columnManifestIdentityRecordKeyBytes() []byte {
+	return []byte(columnManifestIdentityRecordKey)
+}
 
 type ColumnStoreValueType string
 
@@ -563,7 +562,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	if rootID == 0 {
 		return fmt.Errorf("collections: active column manifest generation %d for %q is missing root descriptor %q", identity.Generation, catalog.meta.Name, rootName)
 	}
-	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes)
+	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes())
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return fmt.Errorf("collections: active column manifest root %d for %q is missing identity record", rootID, catalog.meta.Name)
 	}
@@ -579,29 +578,6 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	}
 	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
 		return fmt.Errorf("collections: active column manifest identity mismatch for %q", catalog.meta.Name)
-	}
-	return nil
-}
-
-func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection string, rootID uint64, expected [columnManifestIdentityRecordSize]byte) error {
-	if rootID == 0 {
-		return fmt.Errorf("collections: missing published column manifest root for %q", collection)
-	}
-	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return fmt.Errorf("collections: published column manifest root %d for %q is missing identity record", rootID, collection)
-	}
-	if err != nil {
-		return fmt.Errorf("collections: published column manifest root %d for %q is unreadable: %w", rootID, collection, err)
-	}
-	if entry.Flags&node.FlagTombstone != 0 {
-		return fmt.Errorf("collections: published column manifest root %d for %q has deleted identity record", rootID, collection)
-	}
-	if _, err := decodeColumnManifestIdentityRecord(entry.Value); err != nil {
-		return fmt.Errorf("collections: published column manifest root %d for %q has invalid identity record: %w", rootID, collection, err)
-	}
-	if !bytes.Equal(entry.Value, expected[:]) {
-		return fmt.Errorf("collections: published root identity record mismatch: column manifest root %d for %q does not match column publish plan", rootID, collection)
 	}
 	return nil
 }
@@ -847,7 +823,7 @@ func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSi
 	value := make([]byte, columnManifestIdentityRecordSize)
 	copy(value, record[:])
 	return &systemTargetIterator{entries: []systemTargetEntry{{
-		key:   columnManifestIdentityRecordKeyBytes,
+		key:   columnManifestIdentityRecordKeyBytes(),
 		value: value,
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -820,8 +820,7 @@ func columnManifestIdentityIterator(identity ColumnManifestIdentity) *systemTarg
 }
 
 func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSize]byte) *systemTargetIterator {
-	value := make([]byte, columnManifestIdentityRecordSize)
-	copy(value, record[:])
+	value := record[:]
 	return &systemTargetIterator{entries: []systemTargetEntry{{
 		key:   newColumnManifestIdentityRecordKey(),
 		value: value,

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -566,9 +566,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 
 func encodeColumnManifestIdentityRecord(identity ColumnManifestIdentity) []byte {
 	record := encodeColumnManifestIdentityRecordArray(identity)
-	out := make([]byte, len(record))
-	copy(out, record[:])
-	return out
+	return record[:]
 }
 
 func encodeColumnManifestIdentityRecordArray(identity ColumnManifestIdentity) [columnManifestIdentityRecordSize]byte {
@@ -797,8 +795,13 @@ func writeHashBool(d *xxhash.Digest, value bool) {
 }
 
 func columnManifestIdentityIterator(identity ColumnManifestIdentity) *systemTargetIterator {
+	return columnManifestIdentityRecordIterator(encodeColumnManifestIdentityRecordArray(identity))
+}
+
+func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSize]byte) *systemTargetIterator {
+	recordCopy := record
 	return &systemTargetIterator{entries: []systemTargetEntry{{
 		key:   []byte(columnManifestIdentityRecordKey),
-		value: encodeColumnManifestIdentityRecord(identity),
+		value: recordCopy[:],
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -560,6 +561,23 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	}
 	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
 		return fmt.Errorf("collections: active column manifest identity mismatch for %q", catalog.meta.Name)
+	}
+	return nil
+}
+
+func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection string, rootID uint64, expected [columnManifestIdentityRecordSize]byte) error {
+	entry, err := snap.GetEntryAtRoot(rootID, []byte(columnManifestIdentityRecordKey))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return fmt.Errorf("collections: published column manifest root %d for %q is missing identity record", rootID, collection)
+	}
+	if err != nil {
+		return fmt.Errorf("collections: published column manifest root %d for %q is unreadable: %w", rootID, collection, err)
+	}
+	if entry.Flags&node.FlagTombstone != 0 {
+		return fmt.Errorf("collections: published column manifest root %d for %q has deleted identity record", rootID, collection)
+	}
+	if !bytes.Equal(entry.Value, expected[:]) {
+		return fmt.Errorf("collections: published root identity record for %q does not match column publish plan", collection)
 	}
 	return nil
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -820,8 +820,10 @@ func columnManifestIdentityIterator(identity ColumnManifestIdentity) *systemTarg
 }
 
 func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSize]byte) *systemTargetIterator {
+	value := make([]byte, columnManifestIdentityRecordSize)
+	copy(value, record[:])
 	return &systemTargetIterator{entries: []systemTargetEntry{{
 		key:   []byte(columnManifestIdentityRecordKey),
-		value: record[:],
+		value: value,
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -614,6 +614,9 @@ func decodeColumnManifestIdentityRecord(raw []byte) (columnManifestIdentityRecor
 	if version := binary.BigEndian.Uint16(raw[4:6]); version != columnManifestIdentityVersion {
 		return columnManifestIdentityRecord{}, fmt.Errorf("unsupported identity version %d", version)
 	}
+	if reserved := binary.BigEndian.Uint32(raw[24:28]); reserved != 0 {
+		return columnManifestIdentityRecord{}, fmt.Errorf("non-zero identity reserved field %d", reserved)
+	}
 	return columnManifestIdentityRecord{
 		Version:    binary.BigEndian.Uint16(raw[6:8]),
 		Generation: binary.BigEndian.Uint64(raw[8:16]),

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -27,8 +27,7 @@ const (
 	columnManifestIdentityRecordKey             = "\x00column-manifest/identity"
 )
 
-// columnManifestIdentityRecordKeyBytes returns a fresh caller-owned key copy.
-func columnManifestIdentityRecordKeyBytes() []byte {
+func newColumnManifestIdentityRecordKey() []byte {
 	return []byte(columnManifestIdentityRecordKey)
 }
 
@@ -563,7 +562,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	if rootID == 0 {
 		return fmt.Errorf("collections: active column manifest generation %d for %q is missing root descriptor %q", identity.Generation, catalog.meta.Name, rootName)
 	}
-	entry, err := snap.GetEntryAtRoot(rootID, columnManifestIdentityRecordKeyBytes())
+	entry, err := snap.GetEntryAtRoot(rootID, newColumnManifestIdentityRecordKey())
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return fmt.Errorf("collections: active column manifest root %d for %q is missing identity record", rootID, catalog.meta.Name)
 	}
@@ -824,7 +823,7 @@ func columnManifestIdentityRecordIterator(record [columnManifestIdentityRecordSi
 	value := make([]byte, columnManifestIdentityRecordSize)
 	copy(value, record[:])
 	return &systemTargetIterator{entries: []systemTargetEntry{{
-		key:   columnManifestIdentityRecordKeyBytes(),
+		key:   newColumnManifestIdentityRecordKey(),
 		value: value,
 	}}}
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	columnManifestFormatTCS1        = "tcs1"
-	columnManifestIdentityMagic     = uint32(0x54434d49) // TCMI
-	columnManifestIdentityVersion   = uint16(1)
-	columnManifestIdentityRecordKey = "\x00column-manifest/identity"
+	columnManifestFormatTCS1         = "tcs1"
+	columnManifestIdentityMagic      = uint32(0x54434d49) // TCMI
+	columnManifestIdentityVersion    = uint16(1)
+	columnManifestIdentityRecordSize = 28
+	columnManifestIdentityRecordKey  = "\x00column-manifest/identity"
 )
 
 type ColumnStoreValueType string
@@ -564,7 +565,14 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 }
 
 func encodeColumnManifestIdentityRecord(identity ColumnManifestIdentity) []byte {
-	out := make([]byte, 28)
+	record := encodeColumnManifestIdentityRecordArray(identity)
+	out := make([]byte, len(record))
+	copy(out, record[:])
+	return out
+}
+
+func encodeColumnManifestIdentityRecordArray(identity ColumnManifestIdentity) [columnManifestIdentityRecordSize]byte {
+	var out [columnManifestIdentityRecordSize]byte
 	binary.BigEndian.PutUint32(out[0:4], columnManifestIdentityMagic)
 	binary.BigEndian.PutUint16(out[4:6], columnManifestIdentityVersion)
 	binary.BigEndian.PutUint16(out[6:8], identity.Version)
@@ -575,7 +583,7 @@ func encodeColumnManifestIdentityRecord(identity ColumnManifestIdentity) []byte 
 }
 
 func decodeColumnManifestIdentityRecord(raw []byte) (columnManifestIdentityRecord, error) {
-	if len(raw) != 28 {
+	if len(raw) != columnManifestIdentityRecordSize {
 		return columnManifestIdentityRecord{}, fmt.Errorf("malformed identity record length %d", len(raw))
 	}
 	if magic := binary.BigEndian.Uint32(raw[0:4]); magic != columnManifestIdentityMagic {

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -577,7 +577,7 @@ func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection st
 		return fmt.Errorf("collections: published column manifest root %d for %q has deleted identity record", rootID, collection)
 	}
 	if !bytes.Equal(entry.Value, expected[:]) {
-		return fmt.Errorf("collections: published root identity record for %q does not match column publish plan", collection)
+		return fmt.Errorf("collections: published root identity record mismatch: column manifest root %d for %q does not match column publish plan", rootID, collection)
 	}
 	return nil
 }

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -566,6 +566,9 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 }
 
 func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection string, rootID uint64, expected [columnManifestIdentityRecordSize]byte) error {
+	if rootID == 0 {
+		return fmt.Errorf("collections: missing published column manifest root for %q", collection)
+	}
 	entry, err := snap.GetEntryAtRoot(rootID, []byte(columnManifestIdentityRecordKey))
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return fmt.Errorf("collections: published column manifest root %d for %q is missing identity record", rootID, collection)

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -576,6 +576,9 @@ func validateColumnManifestPublishedRoot(snap *backenddb.Snapshot, collection st
 	if entry.Flags&node.FlagTombstone != 0 {
 		return fmt.Errorf("collections: published column manifest root %d for %q has deleted identity record", rootID, collection)
 	}
+	if _, err := decodeColumnManifestIdentityRecord(entry.Value); err != nil {
+		return fmt.Errorf("collections: published column manifest root %d for %q has invalid identity record: %w", rootID, collection, err)
+	}
 	if !bytes.Equal(entry.Value, expected[:]) {
 		return fmt.Errorf("collections: published root identity record mismatch: column manifest root %d for %q does not match column publish plan", rootID, collection)
 	}

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -1,12 +1,48 @@
 package collections
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
+
+func TestColumnManifestIdentityRecordKeyBytesReturnsFreshSliceM10A(t *testing.T) {
+	first := columnManifestIdentityRecordKeyBytes()
+	second := columnManifestIdentityRecordKeyBytes()
+	if string(first) != columnManifestIdentityRecordKey || string(second) != columnManifestIdentityRecordKey {
+		t.Fatalf("unexpected identity key copies: first=%q second=%q", string(first), string(second))
+	}
+	if len(first) == 0 {
+		t.Fatal("identity record key must be non-empty")
+	}
+	first[0] ^= 0xff
+	if string(second) != columnManifestIdentityRecordKey {
+		t.Fatalf("identity key copy was mutated through another caller: %q", string(second))
+	}
+	if fresh := columnManifestIdentityRecordKeyBytes(); string(fresh) != columnManifestIdentityRecordKey {
+		t.Fatalf("fresh identity key copy was mutated: %q", string(fresh))
+	}
+}
+
+func TestColumnManifestIdentityRecordIteratorUsesPrivateKeySliceM10A(t *testing.T) {
+	identity := ColumnManifestIdentity{Generation: 42, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
+	first := columnManifestIdentityIterator(identity)
+	second := columnManifestIdentityIterator(identity)
+	defer func() { _ = first.Close() }()
+	defer func() { _ = second.Close() }()
+	firstKey := first.UnsafeKey()
+	secondKey := second.UnsafeKey()
+	if !bytes.Equal(firstKey, []byte(columnManifestIdentityRecordKey)) || !bytes.Equal(secondKey, []byte(columnManifestIdentityRecordKey)) {
+		t.Fatalf("unexpected iterator keys: first=%q second=%q", string(firstKey), string(secondKey))
+	}
+	firstKey[0] ^= 0xff
+	if string(second.UnsafeKey()) != columnManifestIdentityRecordKey {
+		t.Fatalf("iterator key slice was shared across iterators: %q", string(second.UnsafeKey()))
+	}
+}
 
 func TestColumnStoreMetadataRoundTripsReopenAndCacheIdentity(t *testing.T) {
 	dir := t.TempDir()

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -194,8 +194,8 @@ func TestColumnManifestIdentityRecordRejectsNonZeroReserved(t *testing.T) {
 	record := encodeColumnManifestIdentityRecord(identity)
 	record[columnManifestIdentityReservedOffset+columnManifestIdentityReservedSize-1] = 1
 	decoded, err := decodeColumnManifestIdentityRecord(record)
-	if err == nil || !strings.Contains(err.Error(), "reserved") {
-		t.Fatalf("decodeColumnManifestIdentityRecord decoded=%+v err=%v want reserved-field rejection", decoded, err)
+	if err == nil || !strings.Contains(err.Error(), "reserved trailer field 0x00000001") {
+		t.Fatalf("decodeColumnManifestIdentityRecord decoded=%+v err=%v want hex reserved-field rejection", decoded, err)
 	}
 }
 

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -190,9 +190,9 @@ func TestColumnStoreActiveManifestFailsClosedOnIdentityMismatch(t *testing.T) {
 }
 
 func TestColumnManifestIdentityRecordRejectsNonZeroReserved(t *testing.T) {
-	identity := ColumnManifestIdentity{Generation: 42, Version: 1, Checksum: 0xfeedbeef}
+	identity := ColumnManifestIdentity{Generation: 42, Version: columnManifestIdentityVersion, Checksum: 0xfeedbeef}
 	record := encodeColumnManifestIdentityRecord(identity)
-	record[27] = 1
+	record[columnManifestIdentityReservedOffset+columnManifestIdentityReservedSize-1] = 1
 	decoded, err := decodeColumnManifestIdentityRecord(record)
 	if err == nil || !strings.Contains(err.Error(), "reserved") {
 		t.Fatalf("decodeColumnManifestIdentityRecord decoded=%+v err=%v want reserved-field rejection", decoded, err)

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestColumnManifestIdentityRecordKeyBytesReturnsFreshSliceM10A(t *testing.T) {
-	first := columnManifestIdentityRecordKeyBytes()
-	second := columnManifestIdentityRecordKeyBytes()
+	first := newColumnManifestIdentityRecordKey()
+	second := newColumnManifestIdentityRecordKey()
 	if string(first) != columnManifestIdentityRecordKey || string(second) != columnManifestIdentityRecordKey {
 		t.Fatalf("unexpected identity key copies: first=%q second=%q", string(first), string(second))
 	}
@@ -22,7 +22,7 @@ func TestColumnManifestIdentityRecordKeyBytesReturnsFreshSliceM10A(t *testing.T)
 	if string(second) != columnManifestIdentityRecordKey {
 		t.Fatalf("identity key copy was mutated through another caller: %q", string(second))
 	}
-	if fresh := columnManifestIdentityRecordKeyBytes(); string(fresh) != columnManifestIdentityRecordKey {
+	if fresh := newColumnManifestIdentityRecordKey(); string(fresh) != columnManifestIdentityRecordKey {
 		t.Fatalf("fresh identity key copy was mutated: %q", string(fresh))
 	}
 }

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -189,6 +189,16 @@ func TestColumnStoreActiveManifestFailsClosedOnIdentityMismatch(t *testing.T) {
 	}
 }
 
+func TestColumnManifestIdentityRecordRejectsNonZeroReserved(t *testing.T) {
+	identity := ColumnManifestIdentity{Generation: 42, Version: 1, Checksum: 0xfeedbeef}
+	record := encodeColumnManifestIdentityRecord(identity)
+	record[27] = 1
+	decoded, err := decodeColumnManifestIdentityRecord(record)
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("decodeColumnManifestIdentityRecord decoded=%+v err=%v want reserved-field rejection", decoded, err)
+	}
+}
+
 func TestColumnStoreMetadataValidation(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Refs #1534.

## Summary

Implements M10A: a production-facing column publish-plan seam under `TreeDB/collections`.

- Adds `ColumnAssetRef`, prepared asset refs, durability-closure summaries, lifecycle summaries, manifest root deltas, and `BuildColumnPublishPlan`.
- Keeps nil or truly empty disabled column-store configs on an immediate zero-allocation return path before normalization, hooks, metadata, asset managers, or stage accounting.
- Rejects non-empty disabled column-store metadata instead of silently bypassing normalization.
- Adds a root+metadata system-delta helper that publishes `collection/column/manifest` and updates active/recovery manifest metadata in the same backend publish.
- Keeps M10A as a planning/API boundary only; real insert/update/delete write-path wiring remains M10B.

## Correctness / TDD

- Added tests first for disabled zero-allocation behavior, deterministic binary manifest identity records, durability closure accounting, fail-closed planning stages, and atomic root+metadata publication.
- Failure coverage includes document extraction, declared-column encode, asset preparation/write, manifest encode, closure validation, system-delta construction, invalid root deltas, unsupported asset refs, mutated closure refs, stale plan bases, identity mismatches, and wrong root IDs.
- Post-review hardening now rejects non-empty disabled `column_store`, accepts normalized benchmark-relaxed profile support, snapshots prepared assets before closure validation, preserves root-delta identity record bytes during ordered-root publish, and rejects foreign/stale system deltas.
- The system-delta path now validates `BaseCommitSeq`, `BaseSystemRoot`, `BaseManifestRootID`, collection name, manifest root name, active manifest identity, recovery-authoritative manifest identity, and byte-stable root-delta identity inputs before encoding metadata. Published-root identity-record validation is intentionally deferred to collection-open/catalog validation because the newly built compressed root is not safely readable through the pre-commit snapshot.
- The system-delta failure tests verify backend commit sequence/system root and column metadata/root identity remain unchanged after a failed publish.

## Performance / Benchmark Evidence

Current head after review fixes: `4a9b16de9b074f20dae98c39ad863fa955a7b07e`.

Publish-plan overhead, current head:

```text
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnPublishPlanM10A' \
  -benchmem -benchtime=500ms -count=6 -cpu=1
```

```text
ColumnPublishPlanM10A/disabled_hook:    33.02 ns/op +/- 1%, 0 B/op, 0 allocs/op
ColumnPublishPlanM10A/enabled_skeleton: 725.5 ns/op +/- 1%, 192 B/op, 2 allocs/op
```

Enabled skeleton stage medians from the same run:

```text
asset closure validation: 71.75 ns/op +/- 1%
asset preparation:        40.72 ns/op +/- 1%
declared encode hook:     16.42 ns/op +/- 5%
extract hook:             17.84 ns/op +/- 4%
manifest encode hook:     43.61 ns/op +/- 1%
root delta:               36.64 ns/op +/- 1%
system delta hook:        31.91 ns/op +/- 2%
rows/op:                  10
prepared refs/op:         1
prepared asset bytes/op:  8192
manifest bytes/op:        256
```

Throughput interpretation:

- Disabled/no-column check remains allocation-free at about 30.3M checks/sec.
- Enabled skeleton planning is about 1.38M plans/sec, or about 13.8M synthetic planned rows/sec for the benchmark's 10-row shape.
- The 2 enabled allocations are deliberate closure-safety costs: one stable prepared-asset snapshot and one defensive closure-hook input copy. They are bounded by prepared-ref count and keep closure mutation from changing the manifest snapshot.
- This benchmark intentionally excludes real document extraction, physical column encoding, asset write/fsync, and backend root publication. M10B/M10C carry those durable write/recovery throughput gates.

## Gate Status

- PASS: `GOWORK=off go test ./TreeDB/collections -run 'TestColumnManifestPublishSystemDeltaRejectsPublishedRootMismatchM10A|TestColumnManifestPublishSystemDeltaRejectsIdentityMismatchM10A|TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A|TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A' -count=1`
- PASS: `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPublishPlan|TestColumnManifestPublishSystemDelta|TestColumnStore' -count=1`
- PASS: `GOWORK=off go test ./TreeDB/collections ./TreeDB/db -count=1`
- PASS: `git diff --check`
- PASS: disabled publish-plan path remains 0 B/op and 0 allocs/op.
- PASS: enabled publish-plan skeleton stays sub-microsecond with bounded 2-allocation closure-safety overhead.

## Artifacts

- `/tmp/gomap_m10a_rootverify_bench_count6.txt`
- `/tmp/gomap_m10a_rootverify_benchstat_count6.txt`
- `/tmp/gomap_m10a_identityguard_bench_count6.txt`
- `/tmp/gomap_m10a_identityguard_benchstat_count6.txt`
- `/tmp/gomap_m10a_reviewthreads_bench_count6.txt`
- `/tmp/gomap_m10a_reviewthreads_benchstat_count6.txt`
- `/tmp/gomap_m10a_head_publish_plan_only_bench_cpu1_2s_count6.txt`
- `/tmp/gomap_m10a_parent_shape_insert_durable_count5_exact.txt`
- `/tmp/gomap_m10a_head_shape_insert_durable_count5.txt`
- `/tmp/gomap_m10a_parent_control_plane_count6.txt`
- `/tmp/gomap_m10a_head_control_publish_plan_count6_v2.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable, multi-stage column publish pipeline with staged extraction/encoding, asset preparation, deterministic root construction, lifecycle counters, per-stage timing, and atomic system-metadata updates.

* **Tests**
  * Expanded unit, integration, and benchmark coverage for fast-paths, failure/rollback, concurrency/staleness checks, asset validation/isolation, identity-record validation, system-delta behavior, and related flush/maintenance scenarios.

* **Refactor**
  * Fixed-size manifest identity record format with strict encode/decode validation and reserved-field enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Latest Review-Fix Refresh (May 18, 2026)

Current pushed head: `a89231f08804`.

This refresh addresses latest review findings without changing the M10A benchmark scope:

- `validateColumnManifestPublishedRoot` now rejects zero root IDs before snapshot lookup.
- System-delta failure coverage now proves the root delta is built before the system delta can fail.
- Invalid published root ID coverage now rejects nil, empty, and zero `rootIDs` inputs.

Local validation after the refresh:

```sh
go test ./TreeDB/collections -run 'TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejectsInvalidRootIDsM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1
git diff --check
```

Result: both commands passed locally. The earlier publish-plan benchmark evidence remains the relevant performance gate: disabled publish-plan path is allocation-free, and enabled skeleton planning remains sub-microsecond with bounded closure-safety allocations.

### Latest Review-Fix Refresh (May 18, 2026, follow-up, head `41c144fd5c09`)

Current head: `41c144fd5c09e572cb8a22d302c158f1ca55daf5`.

Review-fix details:
- Identity-record decode now rejects non-zero reserved trailer bytes so manifest identity records stay canonical before byte-stable root comparisons.
- Manifest encode accounting now rejects negative `ManifestBytes` before an enabled publish plan can be returned.
- System-delta publication now rejects zero `AppliedCommandLSN` and zero recovery-authoritative applied-command LSN at the publication boundary.
- The invalid-rootIDs test now supplies the current base commit/system root so it cannot pass on unrelated precondition failures.

Local validation after propagation:
- `go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithCommandWALContextRootBuilderFailureClosesReturnedDeltas|TestPublishOrderedRootDeltaBatchGroupWithCommandWALSystemBuilderFailureClosesContextDeltas|TestPublishOrderedRootDeltaGroupWithCommandWALContextRootBuilderFailureClosesReturnedIterators' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnPublishPlanRejectsNegativeManifestBytesM10A|TestColumnManifestPublishSystemDeltaRejects(MissingLSN|InvalidRootIDs).*M10A|TestColumnQueryPlannerM11B|TestColumnSkipScan.*M11B|TestColumnStore.*M10C|TestColumnStoreCommandWALMutationsPublishManifestM10B|TestColumnManifestRootDeltaPublishInputs.*M10B|TestCollectionCommandWALUpdateByIDTemplateV1NewShapeReplay|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1`
- `go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuite.*M11B|TestColumnStoreQuery.*M11B|TestColumnStoreSuiteREADMEDocumentsCommandM11A|TestColumnStoreSuiteReportsParityMismatchM11A' -count=1`
- `GOWORK=off go test ./experiments/colgranule -run 'TestColumnMutationReplayProfileM9D|TestColumnMutationReplay.*M9D|TestJSONBenchMutationReplay.*M9D|TestColumnMutationAdapter.*M9D' -count=1`
- `git diff --check`

CI/review status: latest-head GitHub checks and AI reviews were re-requested after this push; this section records the local evidence for that exact head.
### Latest Current-Head Evidence (May 18, 2026, head `6100622d8323`)

Current head: `6100622d8323fd700e55f6da228dc6838aeb144a`.

Exact-head validation:

```sh
go test ./TreeDB/collections -run 'TestColumnPublishPlan.*M10A|TestColumnManifestIdentityRecordLayout|TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPublishPlanM10A$' -benchmem -count=5
```

Result: both commands passed locally on Apple M3. The disabled publish-plan path remains the required zero-allocation guardrail at `37.7-38.1 ns/op`, `0 B/op`, `0 allocs/op`. The enabled planning skeleton remains a small planning-only cost at `1270-1284 ns/op`, `2176 B/op`, `28 allocs/op` for the 10-row fixture, with `256 manifest_B/op` and one prepared asset ref. This PR still intentionally excludes row mutation, physical column asset writes, fsync, and backend root publication; M10B/M10C own those durable write/recovery gates.

### Latest Review-Fix Refresh (May 18, 2026, head `1ce6368bf383`)

Current head: `1ce6368bf383585e32d9106350f6f7ceeba7c162`.

Review-fix details:
- System-delta publication now rejects recovery-authoritative AppliedCommandLSN regressions relative to the base collection metadata before publishing updated column metadata.
- Column publish prepared-asset byte summation now fails closed on int64 overflow instead of allowing lifecycle/accounting counters to wrap.

Local validation:
- `go test ./TreeDB/collections -run 'TestColumnPublishPlanRejectsPreparedAssetByteOverflowM10A|TestColumnPublishPlanRejectsNegativeManifestBytesM10A|TestColumnManifestPublishSystemDeltaRejectsRecoveryLSNRegressionM10A|TestColumnManifestPublishSystemDeltaRejectsMissingLSNM10A|TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnManifestPublishSystemDeltaUpdatesRootAndMetadataTogetherM10A' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnManifest|TestColumnPublishPlan|TestColumnStoreActiveManifest|TestColumnStoreMetadata' -count=1`
- `git diff --check`

Result: all local validation passed. The benchmark gate remains the previously recorded exact-head M10A publish-plan evidence: disabled publish-plan path is allocation-free, and enabled skeleton planning remains a bounded planning-only cost; these review-fix checks do not change the benchmark scope. GitHub CI and AI reviews were re-requested on this latest head.


---

### Latest Current-Head Benchmark Evidence (May 18, 2026, final confirmation head `1ce6368bf383`)

Current head: `1ce6368bf383585e32d9106350f6f7ceeba7c162`.

This confirms the M10A publish-plan performance gate on the latest pushed head after the recovery-LSN regression and prepared-asset byte-overflow hardening.

Exact-head validation:

```sh
go test ./TreeDB/collections -run 'TestColumnPublishPlan.*M10A|TestColumnManifestIdentityRecordLayout|TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPublishPlanM10A$' -benchmem -count=5
```

Result: focused validation passed locally on Apple M3, and the benchmark passed on the exact head.

Current-head benchmark refresh:

```text
ColumnPublishPlanM10A/disabled_hook:    37.94-38.13 ns/op, 0 B/op, 0 allocs/op
ColumnPublishPlanM10A/enabled_skeleton: 1278-1293 ns/op, 2176 B/op, 28 allocs/op
```

Additional benchmark counters: `256 manifest_B/op`, `8192 prepared_asset_B/op`, and `1 prepared_refs/op` for the enabled skeleton fixture.

Interpretation: the disabled/no-column publish-plan path remains allocation-free. The enabled skeleton cost remains a bounded planning-only cost and intentionally excludes row mutation, physical column asset writes, fsync, and backend root publication; those are covered by M10B/M10C gates.


---

### Latest Current-Head Validation (May 18, 2026, head `041bcbbd1714`)

This refresh includes the bottom-stack quarantine-provenance propagation plus the M10A same-snapshot base validation fix for the column publish system-delta iterator.

Exact-head validation:

```sh
go test ./TreeDB/collections -run 'TestColumnPublishPlan.*M10A|TestColumnManifestPublishSystemDelta.*M10A|TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnStoreActiveManifest|TestColumnStoreMetadata' -count=1
GOWORK=off go test ./experiments/colgranule/... -count=1
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPublishPlanM10A$' -benchmem -count=5
git diff --check
```

Current-head benchmark refresh on Apple M3:

```text
ColumnPublishPlanM10A/disabled_hook:    37.63-39.33 ns/op, 0 B/op, 0 allocs/op
ColumnPublishPlanM10A/enabled_skeleton: 1280-1398 ns/op, 2176 B/op, 28 allocs/op
```

The disabled/no-column publish-plan path remains allocation-free. The enabled skeleton cost remains bounded planning-only work; the same-snapshot validation changes iterator safety and does not add hot query-path work.


---

### Latest Current-Head Evidence (May 18, 2026, M9 propagation + stale-snapshot fix head `041bcbbd1714`)

Current head: `041bcbbd171483e643901c6ed76ef20adef5b421`.

This refresh merges the latest M9D base, carries M9B quarantine-provenance hardening through the stack, and adds stale snapshot/base validation at the M10A column manifest publish boundary.

Exact-head validation:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager.*Quarantine|TestColumnMutationReplayProfileM9D|TestColumnMutationReplay.*M9D|TestJSONBenchMutationReplay.*M9D|TestColumnMutationAdapter.*M9D' -count=1
go test ./TreeDB/collections -run 'TestColumnManifestPublishSystemDeltaRejectsStalePlanBaseM10A|TestColumnManifestPublishSystemDeltaRejectsStaleSnapshotBaseM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A|TestColumnPublishPlan.*M10A' -count=1
git diff --check
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPublishPlanM10A$' -benchmem -count=5
```

Result: focused colgranule passed in `1.224s`, focused collections passed in `0.339s`, `git diff --check` passed, and the benchmark passed in `13.354s` on Apple M3.

Current-head benchmark refresh:

```text
ColumnPublishPlanM10A/disabled_hook:    37.65-38.09 ns/op, 0 B/op, 0 allocs/op
ColumnPublishPlanM10A/enabled_skeleton: 1270-1294 ns/op, 2176 B/op, 28 allocs/op
```

Additional enabled-skeleton counters remain `256 manifest_B/op`, `8192 prepared_asset_B/op`, `1 prepared_refs/op`, and `10 rows/op`.

Interpretation: stale snapshot validation is now enforced before system metadata publication while preserving the disabled path's zero-allocation guardrail and the enabled skeleton's bounded planning-only cost.


### Latest Current-Head Evidence (May 18, 2026, final M9B propagation head `2d02504f816d`)
Current head: `2d02504f816d1722f1e7397e4b747e04c99e97ad`.

This refresh merges the final lower-stack quarantine-provenance fix through M10A. The M10A publish-plan benchmark evidence above remains the milestone performance contract: disabled column hooks stay tens of ns/op with `0 B/op` and `0 allocs/op`, and the enabled skeleton remains bounded to the explicit prepared-asset/manifest allocations.

Post-propagation validation at the propagated stack head passed:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.947s`, unified-bench tests passed in `0.686s`, and `git diff --check` passed.


### Latest Current-Head Evidence (May 18, 2026, final lifecycle-hardening propagation head `80ac444a6ff4`)
Current head: `80ac444a6ff453dc940f3db18d2e447eab84d526`.

This refresh merges the final lower-stack lifecycle-review hardening through this chained PR. The chunk-specific benchmark/performance evidence above remains the milestone contract for this PR; this section records the current propagated head and stack-level validation after the lower-stack change.

Post-propagation validation at the final top stack head passed from a clean worktree:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.565s`, unified-bench tests passed in `0.866s`, and `git diff --check` passed.

## Current-head validation update (2026-05-18, stack head 15100fcd6d48)

Current pushed head for this PR: `80ac444a6ff453dc940f3db18d2e447eab84d526`. The M9+ chain was revalidated after the final M9B lifecycle/provenance fix was propagated through M11B. The ancestry audit passes for #1598 -> #1603 -> #1604 -> #1605 -> #1606 -> #1607 -> #1608 -> #1609, so the top-head validation includes this PR's code plus its descendants.

Focused validation:
- `go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1`: PASS on top head `15100fcd6d48`.
- `git diff --check`: PASS.

Performance evidence:
- M9B exact head `1628bd982cf6`: `BenchmarkColumnAssetReachabilitySummaryView10KReuse` = 4.135-4.159 ms/op, 0 B/op, 0 allocs/op; `BenchmarkColumnAssetManagerReclamation10K` = 0.799-0.807 ms/op, 2.400 MiB/op, 1 alloc/op.
- M11B top head `15100fcd6d48`: row baseline query suite = 59.7-60.3 ms/op, 108.8-109.9 MB/s, 70K rows/op; B-tree index baseline query suite = 70.8-70.9 ms/op, 92.5 MB/s, 70K rows/op.
- M11 reporting remains unified-bench/benchprof-compatible: JSON, Markdown, and HTML artifacts are required, while the PR text reports throughput directly for review without opening profile artifacts.

CI/review status at this refresh: latest-head GitHub checks were queued or in progress with no latest-head failures observed. AI reviews will be re-requested after this evidence refresh; stale-run cleanup is limited to M9+ branches and explicitly excludes #1615.

<!-- m9plus-current-head-evidence-start -->
## Current-Head Evidence Refresh (2026-05-18)

Chunk: `M10A` (column publish-plan API).
Current head: `d31b73134653d3adebbd0ff962d9223f966af81f` on `codex/colgranule-m10a-publish-plan-api`; base `codex/colgranule-m9d-replay-profile-contract`.
GitHub Actions current-head rollup at refresh time: `1` successful, `25` queued/in-progress, `0` failing/cancelled; final gate remains all latest-head checks green.

Local / current validation:
- `go test ./TreeDB/collections -run 'TestCollection(IndexedOverlayRootValidationRejectsStaleOverlayDescriptors|CompactRootOverlaysFoldsIntoBaseRoots)$' -count=20`: PASS (`0.740s`).
- `go test ./TreeDB/collections -count=1`: PASS (`3.114s`).
- `git diff --check`: PASS.

Performance / benchmark evidence:
- `BenchmarkColumnPublishPlanM10A`, `-count=5`: disabled hook `37.86-38.74 ns/op`, `0 B/op`, `0 allocs/op`.
- Enabled skeleton path `1.517-1.552 us/op`, `2176 B/op`, `28 allocs/op`, `10 rows/op`, `256 manifest_B/op`, `8192 required_asset_B/op`, `1 required_refs/op`.
- Enabled breakdown stayed in sub-microsecond components: asset closure validation about `279.8-288.9 ns/op`, asset prepare about `243.0-249.6 ns/op`, declared encode about `217.0-226.0 ns/op`, manifest encode about `276.3-288.1 ns/op`.
<!-- m9plus-current-head-evidence-end -->

<!-- m9plus-current-head-closeout-start -->

## Current-head closeout evidence (2026-05-18 UTC)


This PR current head: `2453042140bc6eeb44622e630c7090ae6713fdb9` on `codex/colgranule-m10a-publish-plan-api`. Chunk: `M10A` (publish-plan API).

Current M9+ stack heads after M10C review-fix propagation:

| Chunk | PR | Current head | Branch |
|---|---:|---|---|
| M9B | #1598 | `01a265dccf95` | `codex/colgranule-m9b-lifecycle-durability-closure` |
| M9C | #1603 | `d358313f407e` | `codex/colgranule-m9c-control-plane-durability` |
| M9D | #1604 | `8d862dc70391` | `codex/colgranule-m9d-replay-profile-contract` |
| M10A | #1605 | `2453042140bc` | `codex/colgranule-m10a-publish-plan-api` |
| M10B | #1606 | `1c5f94e05423` | `codex/colgranule-m10b-root-publication` |
| M10C | #1607 | `338a38211123` | `codex/colgranule-m10c-recovery-parity` |
| M11A | #1608 | `eb0cf90d8d5b` | `codex/colgranule-m11a-native-column-bench` |
| M11B | #1609 | `81c0454810b8` | `codex/colgranule-m11b-planner-skipscan` |

Validation on the current #1609 top stack head `81c0454810b8`:
- `GOWORK=off go test ./experiments/colgranule/... -count=1`: PASS (`experiments/colgranule` 3.568s, `cmd/jsonbench_compare` 1.108s).
- `go test ./TreeDB/collections -run 'TestColumnManifest|TestColumnPublishPlan|TestColumnStore(ReplayIntentBypassesRelaxedDurabilityGateM10C|AssignedForegroundIntentDoesNotBypassRelaxedDurabilityGateM10C|RelaxedProfilesRejectForegroundWritesM10C|BenchmarkRelaxedAllowsDurableCommandWALWritesM10C|ReadOnlyOpenWithUnappliedCollectionFrameFailsM10C)|ColumnStore|ColumnPublish|M10A|M10B|M10C|M11A|M11B' -count=1`: PASS (`1.198s`).
- `go test ./TreeDB/db -run 'CommandWAL|OrderedRoot|M10C|Replay|ConcurrentModification|TestCommandWALReplayIntentRequiresActiveRecoveryFrameM10C' -count=1`: PASS (`2.027s`).
- `go test ./cmd/unified_bench -run 'TestInstallAllocsProfileRate|TestCanonicalDBName|TestResolveDBs|TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B|TestColumnStoreSuiteProfiledQueries|TestColumnStoreSuitePlanner|TestBenchprof|TestBenchConfigHasAnyProfileOutput|TestRunBenchmarkCPUProfileStartFailureRemovesArtifactM11A|TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1`: PASS (`1.223s`).
- `git diff --check`: PASS.

Performance / benchmark evidence refreshed on the current #1609 top stack head:
- M9D durable replay after the review-thread hardening and asset-before-manifest durability fix: `BenchmarkColumnMutationReplayM9D/small_1k/durable`, `-benchtime=1x -count=3`, Apple M3: `44.425-78.078 ms/op`, `14.140K-24.851K rows/sec`, `18.718-18.723 MiB/op`, `824-829 allocs/op`, `2,254,369 column_asset_bytes/op`, `61,398 command_bytes/op`, `1,728 manifest_control_bytes/op`, `0 row_remainder_bytes/op`.
- M10C command-WAL replay smoke after timer cleanup: `BenchmarkColumnStoreCommandWALReplayM10C`, `-benchtime=1x -count=1`, `column_store=false`: `1.340247375 s/op`, `12.225K replay_docs/s`, `95.50 replay_frames/s`, `123,094,440 B/op`, `179,355 allocs/op`; `column_store=true`: `1.224755625 s/op`, `13.377K replay_docs/s`, `104.5 replay_frames/s`, `120,537,256 B/op`, `199,956 allocs/op`.
- M11B top-head planner baseline smoke: row baseline `75.676750 ms/op`, `86.66 MB/s`, `70,000 rows/op`, `31,341,704 B/op`, `656,801 allocs/op`.
- M11B top-head planner baseline smoke: B-tree index baseline `70.437709 ms/op`, `93.10 MB/s`, `70,000 rows/op`, `23,500,296 B/op`, `516,780 allocs/op`.
- The review-thread fixes are outside the M11B planner/query hot path except for propagated M9D/M10C correctness and benchmark-accounting improvements. M9B, M9C, M10A, and M10B benchmark contracts remain unchanged by this propagation.

CI / review state at this refresh:
- Review fixes included in these heads: M9C removes the unused pre-M10A identity-default helper, M10A reintroduces it at the publish-plan boundary where it is actually called, M9D uses a typed sync-mode error and avoids full manifest/index clones on publish rollback, and M10C exports column manifest identity sentinel errors, rejects fabricated replay intents outside the active recovery frame, restores replay LSN without per-frame `defer`, preserves default profile support setup, and keeps the replay benchmark timer stopped before reset.
- At the evidence refresh, #1598 latest-head checks were green; #1603 had latest-head checks mostly green with a few in progress; #1604-#1609 latest-head checks were queued with no latest-head failure observed yet.
- Fresh AI review and latest-head CI still need to settle cleanly before the M9+ execution goal can be closed.
- No CI stale-run cleanup is part of this refresh. PR #1615 and branch `codex/column-vector-dynamic-overlay-publish-capacity`, including protected heads `41dcc85e4f434926e6b2ab61eb0b70b673f1a16a` and `7fe6891c1ef308e4cba473a5eb828cc0748f779c`, remain excluded from any cleanup.

Completion note: these PRs are not done until latest-head CI and fresh AI review feedback settle cleanly on the newly pushed heads.

<!-- m9plus-current-head-closeout-end -->



