### PR TITLE
cmd/unified_bench: add native column-store suite

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -172,6 +172,7 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
   - `longmix` — long-ish mixed workload + settle boundary with fragmentation reports
   - `sload_readheavy` — settled point reads with value-log pointers + forkchoice-style batch commits
   - `maintenance_budget` — sweep TreeDB maintenance K values; reports checkpoint time vs index size, recommends K
+  - `column_store` — native TreeDB column-store benchmark/artifact suite; writes stage-separated throughput, parity, byte-accounting, manifest/recovery, `column_store_results.{json,md,html}`, `benchprof_results.{json,md}`, and `insights.{md,json,html}` when `-profile-dir` is set
 - `-outdir` output directory for suite artifacts (plots/images; used by `-suite readme`)
 
 ## Standard Profile Workflow (`benchprof`)
@@ -207,6 +208,44 @@ This writes:
 For TreeDB runs, `benchprof_results.json` also preserves selected TreeDB stats
 under `runs[].treedb_stats`, including ordered-root/root-apply and cache
 counters used by raw-engine review gates.
+
+## Column Store Suite
+
+Use `column_store` as the canonical native TreeDB column-store benchmark entry
+point. M11A measures the production column-enabled collection manifest/control
+path with a durable command-WAL profile and a deterministic JSONBench-shaped
+fixture. The only runnable execution label in M11A is `row_store_baseline`; the
+physical column labels (`b_tree_index_baseline`, `serial_column_scan`,
+`aggregate_metadata`, `parallel_column_scan`) fail closed rather than silently
+falling back to row materialization.
+
+```bash
+OUT=$(mktemp -d /tmp/gomap_column_store_profiles_XXXXXX)
+
+./bin/unified-bench \
+  -suite column_store \
+  -dbs treedb \
+  -profile durable \
+  -keys 100000 \
+  -batchsize 1000 \
+  -profile-dir "$OUT" \
+  -path-label native-fastpath \
+  -column-store-path row_store_baseline \
+  -progress=false
+```
+
+The suite writes:
+
+- `column_store_results.json`, `column_store_results.md`, `column_store_results.html`
+- `benchprof_results.json`, `benchprof_results.md`
+- `insights.md`, `insights.json`, `insights.html`
+
+PR descriptions for column-store milestones should paste the command, row count,
+profile, forced path, q1-q5/q5_metadata rows/sec, MiB/sec, ns/row,
+materialized-row count, parity status, byte accounting, manifest/recovery
+identity, and the generated HTML artifact paths. If a forced physical column
+path is not implemented yet, the PR must call that out explicitly and include
+the fail-closed evidence.
 
 ## Notes
 

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -214,7 +214,9 @@ counters used by raw-engine review gates.
 Use `column_store` as the canonical native TreeDB column-store benchmark entry
 point. M11A measures the production column-enabled collection manifest/control
 path with a durable command-WAL profile and a deterministic JSONBench-shaped
-fixture. The only runnable execution label in M11A is `row_store_baseline`; the
+fixture. `-profile balanced` is accepted as a `durable` alias for the column
+store suite so the unified-bench default still exercises the durable gate. The
+only runnable execution label in M11A is `row_store_baseline`; the
 physical column labels (`b_tree_index_baseline`, `serial_column_scan`,
 `aggregate_metadata`, `parallel_column_scan`) fail closed rather than silently
 falling back to row materialization.
@@ -246,7 +248,9 @@ profile, forced path, q1-q5/q5_metadata rows/sec, MiB/sec, ns/row,
 materialized-row count, parity status, byte accounting, manifest/recovery
 identity, and the generated HTML artifact paths. If a forced physical column
 path is not implemented yet, the PR must call that out explicitly and include
-the fail-closed evidence.
+the fail-closed evidence. M11A reports `column_asset_bytes=0` with a note because
+physical column assets are not published yet; `retained_payload_bytes` equals the
+source JSONBench payload until compressed retained-payload accounting lands.
 
 ## Notes
 

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -239,6 +239,7 @@ The suite writes:
 - `column_store_results.json`, `column_store_results.md`, `column_store_results.html`
 - `benchprof_results.json`, `benchprof_results.md`
 - `insights.md`, `insights.json`, `insights.html`
+- configured runtime profiles, including `cpu_column_store_treedb_column_store.pprof`, `allocs_column_store_treedb_column_store.pprof`, `checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof`, `block.pprof`, `mutex.pprof`, `trace.out`, and the query-phase delta `block_column_store_treedb_column_store.pprof` / `mutex_column_store_treedb_column_store.pprof` when those profile classes are enabled
 
 PR descriptions for column-store milestones should paste the command, row count,
 profile, forced path, q1-q5/q5_metadata rows/sec, MiB/sec, ns/row,

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -241,7 +241,7 @@ The suite writes:
 - `column_store_results.json`, `column_store_results.md`, `column_store_results.html`
 - `benchprof_results.json`, `benchprof_results.md`
 - `insights.md`, `insights.json`, `insights.html`
-- configured runtime profiles, including `cpu_column_store_treedb_column_store.pprof`, `allocs_column_store_treedb_column_store.pprof`, `checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof`, `block.pprof`, `mutex.pprof`, `trace.out`, and the query-phase delta `block_column_store_treedb_column_store.pprof` / `mutex_column_store_treedb_column_store.pprof` when those profile classes are enabled
+- configured runtime profiles, including `cpu_column_store_treedb_column_store.pprof`, `allocs_column_store_treedb_column_store.pprof`, `checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof`, `block.pprof`, `mutex.pprof`, `trace.out`, and the query-phase delta `block_column_store_treedb_column_store.pprof` / `mutex_column_store_treedb_column_store.pprof` when those profile classes produce non-empty deltas
 
 PR descriptions for column-store milestones should paste the command, row count,
 profile, forced path, q1-q5/q5_metadata rows/sec, MiB/sec, ns/row,

--- a/cmd/unified_bench/db_registry.go
+++ b/cmd/unified_bench/db_registry.go
@@ -93,12 +93,17 @@ func resolveDBs(arg, excludeArg string) []string {
 	}
 
 	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
 	for _, name := range candidates {
 		name = canonicalDBName(name)
 		if _, skip := excludedSet[name]; skip {
 			continue
 		}
 		if _, ok := dbFactories[name]; ok {
+			if _, duplicate := seen[name]; duplicate {
+				continue
+			}
+			seen[name] = struct{}{}
 			out = append(out, name)
 			continue
 		}

--- a/cmd/unified_bench/db_registry.go
+++ b/cmd/unified_bench/db_registry.go
@@ -16,6 +16,7 @@ var (
 )
 
 func RegisterDB(name string, factory DBFactory) {
+	name = normalizeDBNameForLookup(name)
 	if _, exists := dbFactories[name]; !exists {
 		dbOrder = append(dbOrder, name)
 	}
@@ -27,14 +28,22 @@ func RegisterDB(name string, factory DBFactory) {
 // listings. This is useful for benchmark variants that should not run by
 // default.
 func RegisterHiddenDB(name string, factory DBFactory) {
+	name = normalizeDBNameForLookup(name)
 	dbFactories[name] = factory
 }
 
 func RegisterAlias(alias, target string) {
+	alias = normalizeDBNameForLookup(alias)
+	target = normalizeDBNameForLookup(target)
 	dbAliases[alias] = target
 }
 
+func normalizeDBNameForLookup(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
 func canonicalDBName(name string) string {
+	name = normalizeDBNameForLookup(name)
 	original := name
 	target, isAlias := dbAliases[name]
 	if !isAlias {
@@ -42,7 +51,7 @@ func canonicalDBName(name string) string {
 	}
 	seen := map[string]struct{}{name: {}}
 	for {
-		name = target
+		name = normalizeDBNameForLookup(target)
 		target, isAlias = dbAliases[name]
 		if !isAlias {
 			return name

--- a/cmd/unified_bench/db_registry.go
+++ b/cmd/unified_bench/db_registry.go
@@ -35,10 +35,22 @@ func RegisterAlias(alias, target string) {
 }
 
 func canonicalDBName(name string) string {
-	if target, isAlias := dbAliases[name]; isAlias {
-		return target
+	target, isAlias := dbAliases[name]
+	if !isAlias {
+		return name
 	}
-	return name
+	seen := map[string]struct{}{name: {}}
+	for {
+		name = target
+		target, isAlias = dbAliases[name]
+		if !isAlias {
+			return name
+		}
+		if _, cycle := seen[name]; cycle {
+			return name
+		}
+		seen[name] = struct{}{}
+	}
 }
 
 func GetDBFactory(name string) (DBFactory, error) {

--- a/cmd/unified_bench/db_registry.go
+++ b/cmd/unified_bench/db_registry.go
@@ -35,6 +35,7 @@ func RegisterAlias(alias, target string) {
 }
 
 func canonicalDBName(name string) string {
+	original := name
 	target, isAlias := dbAliases[name]
 	if !isAlias {
 		return name
@@ -47,7 +48,7 @@ func canonicalDBName(name string) string {
 			return name
 		}
 		if _, cycle := seen[name]; cycle {
-			return name
+			return original
 		}
 		seen[name] = struct{}{}
 	}

--- a/cmd/unified_bench/db_registry.go
+++ b/cmd/unified_bench/db_registry.go
@@ -34,10 +34,15 @@ func RegisterAlias(alias, target string) {
 	dbAliases[alias] = target
 }
 
-func GetDBFactory(name string) (DBFactory, error) {
+func canonicalDBName(name string) string {
 	if target, isAlias := dbAliases[name]; isAlias {
-		name = target
+		return target
 	}
+	return name
+}
+
+func GetDBFactory(name string) (DBFactory, error) {
+	name = canonicalDBName(name)
 	f, ok := dbFactories[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown DB: %q", name)
@@ -62,6 +67,10 @@ func GetRegisteredDBsList() string {
 func resolveDBs(arg, excludeArg string) []string {
 	requested := parseList(arg)
 	excluded := parseList(excludeArg)
+	excludedSet := make(map[string]struct{}, len(excluded))
+	for _, name := range excluded {
+		excludedSet[canonicalDBName(name)] = struct{}{}
+	}
 
 	var candidates []string
 	if contains(requested, "all") {
@@ -72,17 +81,13 @@ func resolveDBs(arg, excludeArg string) []string {
 
 	out := make([]string, 0, len(candidates))
 	for _, name := range candidates {
-		if contains(excluded, name) {
+		name = canonicalDBName(name)
+		if _, skip := excludedSet[name]; skip {
 			continue
 		}
 		if _, ok := dbFactories[name]; ok {
 			out = append(out, name)
 			continue
-		}
-		if target, isAlias := dbAliases[name]; isAlias {
-			if _, ok := dbFactories[target]; ok {
-				out = append(out, target)
-			}
 		}
 	}
 	return out

--- a/cmd/unified_bench/db_registry_test.go
+++ b/cmd/unified_bench/db_registry_test.go
@@ -50,6 +50,19 @@ func TestResolveDBsDedupesCanonicalAliasesM11A(t *testing.T) {
 	}
 }
 
+func TestCanonicalDBNameNormalizesNonCLIInputsM11A(t *testing.T) {
+	withDBAliasesForTest(t, map[string]string{
+		"treedb_alias": "treedb",
+	})
+
+	if got := canonicalDBName(" TREEDB_ALIAS "); got != "treedb" {
+		t.Fatalf("canonicalDBName normalized alias=%q, want treedb", got)
+	}
+	if got := canonicalDBName(" TREEDB "); got != "treedb" {
+		t.Fatalf("canonicalDBName normalized name=%q, want treedb", got)
+	}
+}
+
 func TestCanonicalDBNameStopsAliasCyclesM11A(t *testing.T) {
 	withDBAliasesForTest(t, map[string]string{
 		"alias_a": "alias_b",

--- a/cmd/unified_bench/db_registry_test.go
+++ b/cmd/unified_bench/db_registry_test.go
@@ -43,3 +43,15 @@ func TestCanonicalDBNameStopsAliasCyclesM11A(t *testing.T) {
 		t.Fatalf("canonicalDBName(alias_a)=%q, want alias_a", got)
 	}
 }
+
+func TestCanonicalDBNameStopsTransitiveAliasCyclesAtOriginalM11A(t *testing.T) {
+	withDBAliasesForTest(t, map[string]string{
+		"alias_a": "alias_b",
+		"alias_b": "alias_c",
+		"alias_c": "alias_b",
+	})
+
+	if got := canonicalDBName("alias_a"); got != "alias_a" {
+		t.Fatalf("canonicalDBName(alias_a)=%q, want alias_a", got)
+	}
+}

--- a/cmd/unified_bench/db_registry_test.go
+++ b/cmd/unified_bench/db_registry_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func withDBAliasesForTest(t *testing.T, aliases map[string]string) {
+	t.Helper()
+	saved := make(map[string]string, len(dbAliases))
+	for name, target := range dbAliases {
+		saved[name] = target
+	}
+	dbAliases = aliases
+	t.Cleanup(func() {
+		dbAliases = saved
+	})
+}
+
+func TestCanonicalDBNameResolvesTransitiveAliasesM11A(t *testing.T) {
+	withDBAliasesForTest(t, map[string]string{
+		"treedb_indirect": "treedbcached",
+		"treedbcached":    "treedb",
+	})
+
+	if got := canonicalDBName("treedb_indirect"); got != "treedb" {
+		t.Fatalf("canonicalDBName(treedb_indirect)=%q, want treedb", got)
+	}
+
+	got := resolveDBs("treedb_indirect", "")
+	if want := []string{"treedb"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveDBs transitive alias=%v, want %v", got, want)
+	}
+}
+
+func TestCanonicalDBNameStopsAliasCyclesM11A(t *testing.T) {
+	withDBAliasesForTest(t, map[string]string{
+		"alias_a": "alias_b",
+		"alias_b": "alias_a",
+	})
+
+	if got := canonicalDBName("alias_a"); got != "alias_a" {
+		t.Fatalf("canonicalDBName(alias_a)=%q, want alias_a", got)
+	}
+}

--- a/cmd/unified_bench/db_registry_test.go
+++ b/cmd/unified_bench/db_registry_test.go
@@ -33,6 +33,23 @@ func TestCanonicalDBNameResolvesTransitiveAliasesM11A(t *testing.T) {
 	}
 }
 
+func TestResolveDBsDedupesCanonicalAliasesM11A(t *testing.T) {
+	withDBAliasesForTest(t, map[string]string{
+		"treedb_alias":    "treedb",
+		"treedb_indirect": "treedb_alias",
+	})
+
+	got := resolveDBs("treedb,treedb_alias,treedb_indirect", "")
+	if want := []string{"treedb"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveDBs duplicate aliases=%v, want %v", got, want)
+	}
+
+	got = resolveDBs("treedb,treedb_alias,treedb_indirect", "treedb_alias")
+	if len(got) != 0 {
+		t.Fatalf("resolveDBs excluded canonical alias=%v, want empty", got)
+	}
+}
+
 func TestCanonicalDBNameStopsAliasCyclesM11A(t *testing.T) {
 	withDBAliasesForTest(t, map[string]string{
 		"alias_a": "alias_b",

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -502,7 +502,7 @@ func main() {
 		TreeDBDisableReadChecksum:        *treedbDisableReadChecksum,
 		TreeDBDisablePiggybackCompaction: *treedbDisablePiggyback,
 	}
-	if baseCfg.CPUProfile != "" {
+	if strings.TrimSpace(baseCfg.CPUProfile) != "" {
 		tests := parseList(*cpuProfileTestsArg)
 		if len(tests) > 0 && tests[0] != "" {
 			baseCfg.CPUProfileTests = make(map[string]struct{}, len(tests))
@@ -514,7 +514,7 @@ func main() {
 			}
 		}
 	}
-	if baseCfg.AllocsProfile != "" {
+	if strings.TrimSpace(baseCfg.AllocsProfile) != "" {
 		tests := parseList(*allocsProfileTests)
 		if len(tests) > 0 && tests[0] != "" {
 			baseCfg.AllocsProfileTests = make(map[string]struct{}, len(tests))
@@ -526,7 +526,7 @@ func main() {
 			}
 		}
 	}
-	if baseCfg.CheckpointCPUProfile != "" {
+	if strings.TrimSpace(baseCfg.CheckpointCPUProfile) != "" {
 		tests := parseList(*checkpointCPUProfileTests)
 		if len(tests) > 0 && tests[0] != "" {
 			baseCfg.CheckpointCPUProfileTests = make(map[string]struct{}, len(tests))
@@ -698,7 +698,11 @@ func main() {
 		log.Fatalf("keycounts: %v", err)
 	}
 
-	hasAnyProfiling := baseCfg.CPUProfile != "" || baseCfg.AllocsProfile != "" || baseCfg.BlockProfile != "" || baseCfg.MutexProfile != "" || baseCfg.TraceProfile != ""
+	hasAnyProfiling := strings.TrimSpace(baseCfg.CPUProfile) != "" ||
+		strings.TrimSpace(baseCfg.AllocsProfile) != "" ||
+		strings.TrimSpace(baseCfg.BlockProfile) != "" ||
+		strings.TrimSpace(baseCfg.MutexProfile) != "" ||
+		strings.TrimSpace(baseCfg.TraceProfile) != ""
 	if hasAnyProfiling && len(keyCounts) > 1 {
 		log.Fatalf("profiling flags require a single key count (got %d): disable sweep keycounts or omit -cpuprofile/-allocsprofile/-blockprofile/-mutexprofile/-trace", len(keyCounts))
 	}
@@ -859,6 +863,21 @@ func shouldAllocsProfile(cfg BenchConfig, testName string) bool {
 	}
 	_, ok := cfg.AllocsProfileTests[strings.ToLower(testName)]
 	return ok
+}
+
+func installAllocsProfileRate(cfg BenchConfig) func() {
+	if strings.TrimSpace(cfg.AllocsProfile) == "" {
+		return func() {}
+	}
+	rate := cfg.AllocsProfileRate
+	if rate <= 0 {
+		rate = 512 * 1024
+	}
+	prevRate := runtime.MemProfileRate
+	runtime.MemProfileRate = rate
+	return func() {
+		runtime.MemProfileRate = prevRate
+	}
 }
 
 func shouldCheckpointCPUProfile(cfg BenchConfig, testName string) bool {
@@ -1977,17 +1996,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	cfg.ReadWorkers = resolveReadWorkers(cfg.ReadWorkers)
 	profileHooks := profileHooksFromConfig(cfg)
 
-	if cfg.AllocsProfile != "" {
-		rate := cfg.AllocsProfileRate
-		if rate <= 0 {
-			rate = 512 * 1024
-		}
-		prevRate := runtime.MemProfileRate
-		runtime.MemProfileRate = rate
-		defer func() {
-			runtime.MemProfileRate = prevRate
-		}()
-	}
+	defer installAllocsProfileRate(cfg)()
 	keyShapeName := strings.ToLower(strings.TrimSpace(cfg.KeyShape))
 	if keyShapeName == "" {
 		keyShapeName = "be8"
@@ -4013,7 +4022,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			// CPU profile if enabled (only for single key count)
 			var cpuFile *os.File
 			if shouldCPUProfile(cfg, testName) {
-				path := cfg.CPUProfile + "_" + testName + "_" + inst.Name + ".pprof"
+				path := strings.TrimSpace(cfg.CPUProfile) + "_" + testName + "_" + inst.Name + ".pprof"
 				f, err := os.Create(path)
 				if err != nil {
 					return BenchRun{}, fmt.Errorf("cpuprofile %s: %w", path, err)
@@ -4106,7 +4115,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						_ = os.Remove(mutexAfterPath)
 						return BenchRun{}, fmt.Errorf("allocsprofile snapshot %s/%s: %w", testName, inst.Name, snapErr)
 					}
-					allocPath := cfg.AllocsProfile + "_" + testName + "_" + inst.Name + ".pprof"
+					allocPath := strings.TrimSpace(cfg.AllocsProfile) + "_" + testName + "_" + inst.Name + ".pprof"
 					deltaErr := profileHooks.writeAllocsDeltaProfile(allocBasePath, allocAfterPath, allocPath)
 					_ = os.Remove(allocBasePath)
 					_ = os.Remove(allocAfterPath)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4129,9 +4129,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					if !wrote {
 						_ = os.Remove(blockPath)
-						_ = os.Remove(mutexBasePath)
-						_ = os.Remove(mutexAfterPath)
-						return BenchRun{}, fmt.Errorf("blockprofile %s/%s (%s): %w", testName, inst.Name, blockPath, errEmptyPprofDeltaOutput)
 					}
 				}
 			}
@@ -4149,7 +4146,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					if !wrote {
 						_ = os.Remove(mutexPath)
-						return BenchRun{}, fmt.Errorf("mutexprofile %s/%s (%s): %w", testName, inst.Name, mutexPath, errEmptyPprofDeltaOutput)
 					}
 				}
 			}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1180,6 +1180,21 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %q: %w", dir, err)
 	}
+	return writeBenchprofArtifactsToPaths(filepath.Join(dir, "benchprof_results.json"), filepath.Join(dir, "benchprof_results.md"), executionPath, runs)
+}
+
+func writeBenchprofArtifactsToPaths(jsonPath, markdownPath, executionPath string, runs []BenchRun) error {
+	jsonPath = strings.TrimSpace(jsonPath)
+	markdownPath = strings.TrimSpace(markdownPath)
+	if jsonPath == "" || markdownPath == "" {
+		return errors.New("benchprof: json and markdown artifact paths are required")
+	}
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir %q: %w", filepath.Dir(jsonPath), err)
+	}
+	if err := os.MkdirAll(filepath.Dir(markdownPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir %q: %w", filepath.Dir(markdownPath), err)
+	}
 	if err := validateBenchprofExecutionPath(executionPath); err != nil {
 		return err
 	}
@@ -1203,7 +1218,7 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if err != nil {
 		return fmt.Errorf("marshal benchprof_results.json: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "benchprof_results.json"), js, 0o644); err != nil {
+	if err := os.WriteFile(jsonPath, js, 0o644); err != nil {
 		return fmt.Errorf("write benchprof_results.json: %w", err)
 	}
 
@@ -1216,7 +1231,7 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if executionPath != "" {
 		md = fmt.Sprintf("- execution path: `%s`\n\n%s", executionPath, md)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "benchprof_results.md"), []byte(md), 0o644); err != nil {
+	if err := os.WriteFile(markdownPath, []byte(md), 0o644); err != nil {
 		return fmt.Errorf("write benchprof_results.md: %w", err)
 	}
 	return nil

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -876,7 +876,7 @@ func startCheckpointCPUProfile(cfg BenchConfig, testName, dbName string) (*os.Fi
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s): %w", testName, dbName, err)
 	}
-	if err := pprof.StartCPUProfile(f); err != nil {
+	if err := startCPUProfileFn(f); err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("checkpoint cpu profile start: %w", err)
 	}
@@ -884,6 +884,7 @@ func startCheckpointCPUProfile(cfg BenchConfig, testName, dbName string) (*os.Fi
 }
 
 var (
+	startCPUProfileFn                 = pprof.StartCPUProfile
 	stopCPUProfileFn                  = pprof.StopCPUProfile
 	writeAllocsSnapshotTempFn         = writeAllocsSnapshotTemp
 	writeAllocsDeltaProfileFn         = writeAllocsDeltaProfile
@@ -3964,7 +3965,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					return BenchRun{}, fmt.Errorf("cpuprofile %s: %w", path, err)
 				}
 				cpuFile = f
-				if err := pprof.StartCPUProfile(cpuFile); err != nil {
+				if err := startCPUProfileFn(cpuFile); err != nil {
 					_ = cpuFile.Close()
 					return BenchRun{}, fmt.Errorf("cpuprofile start %s: %w", path, err)
 				}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -881,7 +881,7 @@ func startCheckpointCPUProfile(cfg BenchConfig, profileHooks benchmarkProfileHoo
 	if profileHooks.startCPUProfile == nil {
 		_ = f.Close()
 		_ = os.Remove(path)
-		return nil, errors.New("checkpoint cpu profile start hook is nil")
+		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s) start hook is nil: path=%s", testName, dbName, path)
 	}
 	if err := profileHooks.startCPUProfile(f); err != nil {
 		_ = f.Close()

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -880,6 +880,7 @@ func startCheckpointCPUProfile(cfg BenchConfig, profileHooks benchmarkProfileHoo
 	}
 	if err := profileHooks.startCPUProfile(f); err != nil {
 		_ = f.Close()
+		_ = os.Remove(path)
 		return nil, fmt.Errorf("checkpoint cpu profile start: %w", err)
 	}
 	return f, nil

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -184,6 +184,8 @@ type BenchConfig struct {
 	TreeDBCacheStatsBeforeReads bool
 	TreeDBCacheStatsAfterTests  bool
 	TreeDBVlogRewriteAfterRun   bool
+
+	profileHooks *benchmarkProfileHooks
 }
 
 type dirDiskUsage struct {
@@ -876,24 +878,61 @@ func startCheckpointCPUProfile(cfg BenchConfig, testName, dbName string) (*os.Fi
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s): %w", testName, dbName, err)
 	}
-	if err := startCPUProfileFn(f); err != nil {
+	if err := profileHooksFromConfig(cfg).startCPUProfile(f); err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("checkpoint cpu profile start: %w", err)
 	}
 	return f, nil
 }
 
-var (
-	startCPUProfileFn                 = pprof.StartCPUProfile
-	stopCPUProfileFn                  = pprof.StopCPUProfile
-	writeAllocsSnapshotTempFn         = writeAllocsSnapshotTemp
-	writeAllocsDeltaProfileFn         = writeAllocsDeltaProfile
-	writeRuntimeProfileSnapshotTempFn = writeRuntimeProfileSnapshotTemp
-	writeRuntimeProfileDeltaProfileFn = writeRuntimeProfileDeltaProfile
-	runPprofDeltaCommandFn            = runPprofDeltaCommand
+type benchmarkProfileHooks struct {
+	startCPUProfile                 func(io.Writer) error
+	stopCPUProfile                  func()
+	writeAllocsSnapshotTemp         func(string) (string, error)
+	writeAllocsDeltaProfile         func(string, string, string) error
+	writeRuntimeProfileSnapshotTemp func(string, string) (string, error)
+	writeRuntimeProfileDeltaProfile func(string, string, string) (bool, error)
+}
 
-	errEmptyPprofDeltaOutput = errors.New("empty pprof delta output")
-)
+func defaultBenchmarkProfileHooks() benchmarkProfileHooks {
+	return benchmarkProfileHooks{
+		startCPUProfile:                 pprof.StartCPUProfile,
+		stopCPUProfile:                  pprof.StopCPUProfile,
+		writeAllocsSnapshotTemp:         writeAllocsSnapshotTemp,
+		writeAllocsDeltaProfile:         writeAllocsDeltaProfile,
+		writeRuntimeProfileSnapshotTemp: writeRuntimeProfileSnapshotTemp,
+		writeRuntimeProfileDeltaProfile: writeRuntimeProfileDeltaProfile,
+	}
+}
+
+func profileHooksFromConfig(cfg BenchConfig) benchmarkProfileHooks {
+	hooks := defaultBenchmarkProfileHooks()
+	if cfg.profileHooks == nil {
+		return hooks
+	}
+	override := *cfg.profileHooks
+	if override.startCPUProfile != nil {
+		hooks.startCPUProfile = override.startCPUProfile
+	}
+	if override.stopCPUProfile != nil {
+		hooks.stopCPUProfile = override.stopCPUProfile
+	}
+	if override.writeAllocsSnapshotTemp != nil {
+		hooks.writeAllocsSnapshotTemp = override.writeAllocsSnapshotTemp
+	}
+	if override.writeAllocsDeltaProfile != nil {
+		hooks.writeAllocsDeltaProfile = override.writeAllocsDeltaProfile
+	}
+	if override.writeRuntimeProfileSnapshotTemp != nil {
+		hooks.writeRuntimeProfileSnapshotTemp = override.writeRuntimeProfileSnapshotTemp
+	}
+	if override.writeRuntimeProfileDeltaProfile != nil {
+		hooks.writeRuntimeProfileDeltaProfile = override.writeRuntimeProfileDeltaProfile
+	}
+	return hooks
+}
+
+var errEmptyPprofDeltaOutput = errors.New("empty pprof delta output")
 
 func writeAllocsSnapshot(path string) error {
 	// MemProfile data can lag behind current allocations until GC updates the
@@ -973,7 +1012,11 @@ func writeRuntimeProfileSnapshotTemp(prefix, profileName string) (string, error)
 }
 
 func writeRuntimeProfileDeltaProfile(basePath, afterPath, outPath string) (bool, error) {
-	err := writePprofDeltaProfile(basePath, afterPath, outPath)
+	return writeRuntimeProfileDeltaProfileWithRunner(basePath, afterPath, outPath, runPprofDeltaCommand)
+}
+
+func writeRuntimeProfileDeltaProfileWithRunner(basePath, afterPath, outPath string, runner func(string, string) ([]byte, string, error)) (bool, error) {
+	err := writePprofDeltaProfileWithRunner(basePath, afterPath, outPath, runner)
 	if err == nil {
 		return true, nil
 	}
@@ -985,7 +1028,11 @@ func writeRuntimeProfileDeltaProfile(basePath, afterPath, outPath string) (bool,
 }
 
 func writePprofDeltaProfile(basePath, afterPath, outPath string) error {
-	stdout, stderrText, err := runPprofDeltaCommandFn(basePath, afterPath)
+	return writePprofDeltaProfileWithRunner(basePath, afterPath, outPath, runPprofDeltaCommand)
+}
+
+func writePprofDeltaProfileWithRunner(basePath, afterPath, outPath string, runner func(string, string) ([]byte, string, error)) error {
+	stdout, stderrText, err := runner(basePath, afterPath)
 	if err != nil {
 		return fmt.Errorf("%v: %s", err, strings.TrimSpace(stderrText))
 	}
@@ -1922,6 +1969,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		return BenchRun{}, fmt.Errorf("invalid keys: %d", cfg.Keys)
 	}
 	cfg.ReadWorkers = resolveReadWorkers(cfg.ReadWorkers)
+	profileHooks := profileHooksFromConfig(cfg)
 
 	if cfg.AllocsProfile != "" {
 		rate := cfg.AllocsProfileRate
@@ -3878,7 +3926,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				checkpointErr := cp.Checkpoint()
 
 				if checkpointCPUFile != nil {
-					stopCPUProfileFn()
+					profileHooks.stopCPUProfile()
 					_ = checkpointCPUFile.Close()
 				}
 
@@ -3965,7 +4013,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					return BenchRun{}, fmt.Errorf("cpuprofile %s: %w", path, err)
 				}
 				cpuFile = f
-				if err := startCPUProfileFn(cpuFile); err != nil {
+				if err := profileHooks.startCPUProfile(cpuFile); err != nil {
 					_ = cpuFile.Close()
 					return BenchRun{}, fmt.Errorf("cpuprofile start %s: %w", path, err)
 				}
@@ -3973,10 +4021,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 
 			allocBasePath := ""
 			if shouldAllocsProfile(cfg, testName) {
-				allocBasePath, err = writeAllocsSnapshotTempFn("unified_bench_allocs_base")
+				allocBasePath, err = profileHooks.writeAllocsSnapshotTemp("unified_bench_allocs_base")
 				if err != nil {
 					if cpuFile != nil {
-						stopCPUProfileFn()
+						profileHooks.stopCPUProfile()
 						_ = cpuFile.Close()
 					}
 					return BenchRun{}, fmt.Errorf("allocsprofile baseline %s/%s: %w", testName, inst.Name, err)
@@ -3984,10 +4032,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			blockBasePath := ""
 			if cfg.BlockProfile != "" {
-				blockBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_block_base", "block")
+				blockBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_block_base", "block")
 				if err != nil {
 					if cpuFile != nil {
-						stopCPUProfileFn()
+						profileHooks.stopCPUProfile()
 						_ = cpuFile.Close()
 					}
 					_ = os.Remove(allocBasePath)
@@ -3996,10 +4044,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			mutexBasePath := ""
 			if cfg.MutexProfile != "" {
-				mutexBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_mutex_base", "mutex")
+				mutexBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_mutex_base", "mutex")
 				if err != nil {
 					if cpuFile != nil {
-						stopCPUProfileFn()
+						profileHooks.stopCPUProfile()
 						_ = cpuFile.Close()
 					}
 					_ = os.Remove(allocBasePath)
@@ -4011,7 +4059,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			opsPerSec, runErr := fn(inst.Wrapper, rng)
 
 			if cpuFile != nil {
-				stopCPUProfileFn()
+				profileHooks.stopCPUProfile()
 				_ = cpuFile.Close()
 			}
 
@@ -4019,7 +4067,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			mutexAfterPath := ""
 			if runErr == nil {
 				if blockBasePath != "" {
-					blockAfterPath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_block_after", "block")
+					blockAfterPath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_block_after", "block")
 					if err != nil {
 						_ = os.Remove(allocBasePath)
 						_ = os.Remove(blockBasePath)
@@ -4028,7 +4076,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 				}
 				if mutexBasePath != "" {
-					mutexAfterPath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_mutex_after", "mutex")
+					mutexAfterPath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_mutex_after", "mutex")
 					if err != nil {
 						_ = os.Remove(allocBasePath)
 						_ = os.Remove(blockBasePath)
@@ -4043,7 +4091,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if runErr != nil {
 					_ = os.Remove(allocBasePath)
 				} else {
-					allocAfterPath, snapErr := writeAllocsSnapshotTempFn("unified_bench_allocs_after")
+					allocAfterPath, snapErr := profileHooks.writeAllocsSnapshotTemp("unified_bench_allocs_after")
 					if snapErr != nil {
 						_ = os.Remove(allocBasePath)
 						_ = os.Remove(blockBasePath)
@@ -4053,7 +4101,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						return BenchRun{}, fmt.Errorf("allocsprofile snapshot %s/%s: %w", testName, inst.Name, snapErr)
 					}
 					allocPath := cfg.AllocsProfile + "_" + testName + "_" + inst.Name + ".pprof"
-					deltaErr := writeAllocsDeltaProfileFn(allocBasePath, allocAfterPath, allocPath)
+					deltaErr := profileHooks.writeAllocsDeltaProfile(allocBasePath, allocAfterPath, allocPath)
 					_ = os.Remove(allocBasePath)
 					_ = os.Remove(allocAfterPath)
 					if deltaErr != nil {
@@ -4071,13 +4119,19 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = os.Remove(blockAfterPath)
 				} else {
 					blockPath := contentionProfilePath(cfg.BlockProfile, "block", testName, inst.Name)
-					_, deltaErr := writeRuntimeProfileDeltaProfileFn(blockBasePath, blockAfterPath, blockPath)
+					wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(blockBasePath, blockAfterPath, blockPath)
 					_ = os.Remove(blockBasePath)
 					_ = os.Remove(blockAfterPath)
 					if deltaErr != nil {
 						_ = os.Remove(mutexBasePath)
 						_ = os.Remove(mutexAfterPath)
 						return BenchRun{}, fmt.Errorf("blockprofile %s/%s (%s): %w", testName, inst.Name, blockPath, deltaErr)
+					}
+					if !wrote {
+						_ = os.Remove(blockPath)
+						_ = os.Remove(mutexBasePath)
+						_ = os.Remove(mutexAfterPath)
+						return BenchRun{}, fmt.Errorf("blockprofile %s/%s (%s): %w", testName, inst.Name, blockPath, errEmptyPprofDeltaOutput)
 					}
 				}
 			}
@@ -4087,11 +4141,15 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = os.Remove(mutexAfterPath)
 				} else {
 					mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", testName, inst.Name)
-					_, deltaErr := writeRuntimeProfileDeltaProfileFn(mutexBasePath, mutexAfterPath, mutexPath)
+					wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(mutexBasePath, mutexAfterPath, mutexPath)
 					_ = os.Remove(mutexBasePath)
 					_ = os.Remove(mutexAfterPath)
 					if deltaErr != nil {
 						return BenchRun{}, fmt.Errorf("mutexprofile %s/%s (%s): %w", testName, inst.Name, mutexPath, deltaErr)
+					}
+					if !wrote {
+						_ = os.Remove(mutexPath)
+						return BenchRun{}, fmt.Errorf("mutexprofile %s/%s (%s): %w", testName, inst.Name, mutexPath, errEmptyPprofDeltaOutput)
 					}
 				}
 			}
@@ -4155,7 +4213,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			checkpointErr := cp.Checkpoint()
 
 			if checkpointCPUFile != nil {
-				stopCPUProfileFn()
+				profileHooks.stopCPUProfile()
 				_ = checkpointCPUFile.Close()
 			}
 

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -840,7 +840,7 @@ func main() {
 }
 
 func shouldCPUProfile(cfg BenchConfig, testName string) bool {
-	if cfg.CPUProfile == "" {
+	if strings.TrimSpace(cfg.CPUProfile) == "" {
 		return false
 	}
 	if len(cfg.CPUProfileTests) == 0 {
@@ -851,7 +851,7 @@ func shouldCPUProfile(cfg BenchConfig, testName string) bool {
 }
 
 func shouldAllocsProfile(cfg BenchConfig, testName string) bool {
-	if cfg.AllocsProfile == "" {
+	if strings.TrimSpace(cfg.AllocsProfile) == "" {
 		return false
 	}
 	if len(cfg.AllocsProfileTests) == 0 {
@@ -862,7 +862,7 @@ func shouldAllocsProfile(cfg BenchConfig, testName string) bool {
 }
 
 func shouldCheckpointCPUProfile(cfg BenchConfig, testName string) bool {
-	if cfg.CheckpointCPUProfile == "" {
+	if strings.TrimSpace(cfg.CheckpointCPUProfile) == "" {
 		return false
 	}
 	if len(cfg.CheckpointCPUProfileTests) == 0 {
@@ -873,10 +873,15 @@ func shouldCheckpointCPUProfile(cfg BenchConfig, testName string) bool {
 }
 
 func startCheckpointCPUProfile(cfg BenchConfig, profileHooks benchmarkProfileHooks, testName, dbName string) (*os.File, error) {
-	path := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(testName), sanitizeProfileSegment(dbName))
+	path := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", strings.TrimSpace(cfg.CheckpointCPUProfile), sanitizeProfileSegment(testName), sanitizeProfileSegment(dbName))
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s): %w", testName, dbName, err)
+	}
+	if profileHooks.startCPUProfile == nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return nil, errors.New("checkpoint cpu profile start hook is nil")
 	}
 	if err := profileHooks.startCPUProfile(f); err != nil {
 		_ = f.Close()

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -905,7 +905,7 @@ func startCheckpointCPUProfile(cfg BenchConfig, profileHooks benchmarkProfileHoo
 	if err := profileHooks.startCPUProfile(f); err != nil {
 		_ = f.Close()
 		_ = os.Remove(path)
-		return nil, fmt.Errorf("checkpoint cpu profile start: %w", err)
+		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s) start path=%s: %w", testName, dbName, path, err)
 	}
 	return f, nil
 }

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1067,6 +1067,19 @@ func runBenchprof(dir string) {
 	}
 }
 
+func runBenchprofStrict(dir string) error {
+	if err := benchprof.RunFromProfilesDir(dir); err != nil {
+		return fmt.Errorf("benchprof: %w", err)
+	}
+	for _, name := range []string{"insights.md", "insights.json", "insights.html"} {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("benchprof: expected %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
 func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %q: %w", dir, err)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -672,6 +672,18 @@ func main() {
 				log.Fatalf("maintenance_budget suite: %v", err)
 			}
 			fmt.Print(out)
+		case "column_store", "column-store":
+			out, err := runColumnStoreSuite(baseCfg, columnStoreSuiteOptions{
+				ProfileDir:    strings.TrimSpace(*profileDir),
+				ExecutionPath: strings.TrimSpace(*pathLabel),
+				ForcedPath:    strings.TrimSpace(*columnStoreSuitePathArg),
+				Fixture:       strings.TrimSpace(*columnStoreSuiteFixtureArg),
+				RunBenchprof:  true,
+			})
+			if err != nil {
+				log.Fatalf("column_store suite: %v", err)
+			}
+			fmt.Print(out)
 		default:
 			log.Fatalf("unknown suite: %q", suite)
 		}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -872,13 +872,13 @@ func shouldCheckpointCPUProfile(cfg BenchConfig, testName string) bool {
 	return ok
 }
 
-func startCheckpointCPUProfile(cfg BenchConfig, testName, dbName string) (*os.File, error) {
+func startCheckpointCPUProfile(cfg BenchConfig, profileHooks benchmarkProfileHooks, testName, dbName string) (*os.File, error) {
 	path := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(testName), sanitizeProfileSegment(dbName))
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint cpu profile (%s/%s): %w", testName, dbName, err)
 	}
-	if err := profileHooksFromConfig(cfg).startCPUProfile(f); err != nil {
+	if err := profileHooks.startCPUProfile(f); err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("checkpoint cpu profile start: %w", err)
 	}
@@ -3916,7 +3916,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					err               error
 				)
 				if shouldCheckpointCPUProfile(cfg, testName) {
-					checkpointCPUFile, err = startCheckpointCPUProfile(cfg, testName, inst.Wrapper.Name())
+					checkpointCPUFile, err = startCheckpointCPUProfile(cfg, profileHooks, testName, inst.Wrapper.Name())
 					if err != nil {
 						return BenchRun{}, fmt.Errorf("checkpoint %s before %s profiling: %w", inst.Name, testName, err)
 					}
@@ -4203,7 +4203,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				err               error
 			)
 			if shouldCheckpointCPUProfile(cfg, checkpointPostRunLabel) {
-				checkpointCPUFile, err = startCheckpointCPUProfile(cfg, checkpointPostRunLabel, inst.Wrapper.Name())
+				checkpointCPUFile, err = startCheckpointCPUProfile(cfg, profileHooks, checkpointPostRunLabel, inst.Wrapper.Name())
 				if err != nil {
 					return BenchRun{}, fmt.Errorf("checkpoint %s after run profiling: %w", inst.Name, err)
 				}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -698,13 +698,8 @@ func main() {
 		log.Fatalf("keycounts: %v", err)
 	}
 
-	hasAnyProfiling := strings.TrimSpace(baseCfg.CPUProfile) != "" ||
-		strings.TrimSpace(baseCfg.AllocsProfile) != "" ||
-		strings.TrimSpace(baseCfg.BlockProfile) != "" ||
-		strings.TrimSpace(baseCfg.MutexProfile) != "" ||
-		strings.TrimSpace(baseCfg.TraceProfile) != ""
-	if hasAnyProfiling && len(keyCounts) > 1 {
-		log.Fatalf("profiling flags require a single key count (got %d): disable sweep keycounts or omit -cpuprofile/-allocsprofile/-blockprofile/-mutexprofile/-trace", len(keyCounts))
+	if benchConfigHasAnyProfileOutput(baseCfg) && len(keyCounts) > 1 {
+		log.Fatalf("profiling flags require a single key count (got %d): disable sweep keycounts or omit -cpuprofile/-allocsprofile/-checkpoint-cpuprofile/-blockprofile/-mutexprofile/-trace", len(keyCounts))
 	}
 
 	if len(keyCounts) == 1 {
@@ -865,8 +860,36 @@ func shouldAllocsProfile(cfg BenchConfig, testName string) bool {
 	return ok
 }
 
-func installAllocsProfileRate(cfg BenchConfig) func() {
+func benchConfigHasAnyProfileOutput(cfg BenchConfig) bool {
+	return strings.TrimSpace(cfg.CPUProfile) != "" ||
+		strings.TrimSpace(cfg.AllocsProfile) != "" ||
+		strings.TrimSpace(cfg.CheckpointCPUProfile) != "" ||
+		strings.TrimSpace(cfg.BlockProfile) != "" ||
+		strings.TrimSpace(cfg.MutexProfile) != "" ||
+		strings.TrimSpace(cfg.TraceProfile) != ""
+}
+
+func benchConfigUsesAllocsProfile(cfg BenchConfig) bool {
 	if strings.TrimSpace(cfg.AllocsProfile) == "" {
+		return false
+	}
+	if len(cfg.AllocsProfileTests) == 0 {
+		return true
+	}
+	tests := normalizeTests(parseList(cfg.TestsArg))
+	if contains(tests, "all") {
+		return true
+	}
+	for _, testName := range tests {
+		if _, ok := cfg.AllocsProfileTests[strings.ToLower(testName)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func installAllocsProfileRate(cfg BenchConfig) func() {
+	if !benchConfigUsesAllocsProfile(cfg) {
 		return func() {}
 	}
 	rate := cfg.AllocsProfileRate
@@ -4033,6 +4056,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				cpuFile = f
 				if err := profileHooks.startCPUProfile(cpuFile); err != nil {
 					_ = cpuFile.Close()
+					_ = os.Remove(path)
 					return BenchRun{}, fmt.Errorf("cpuprofile start %s: %w", path, err)
 				}
 			}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -3833,8 +3833,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	}
 
 	settledBeforeScans := false
+	blockProfilePath := strings.TrimSpace(cfg.BlockProfile)
+	mutexProfilePath := strings.TrimSpace(cfg.MutexProfile)
+	traceProfilePath := strings.TrimSpace(cfg.TraceProfile)
 
-	if cfg.BlockProfile != "" {
+	if blockProfilePath != "" {
 		rate := cfg.BlockProfileRate
 		if rate <= 0 {
 			rate = 1
@@ -3842,7 +3845,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		runtime.SetBlockProfileRate(rate)
 		defer runtime.SetBlockProfileRate(0)
 
-		f, err := os.Create(cfg.BlockProfile)
+		f, err := os.Create(blockProfilePath)
 		if err != nil {
 			return BenchRun{}, fmt.Errorf("blockprofile: %w", err)
 		}
@@ -3852,7 +3855,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		}()
 	}
 
-	if cfg.MutexProfile != "" {
+	if mutexProfilePath != "" {
 		frac := cfg.MutexProfileFraction
 		if frac <= 0 {
 			frac = 1
@@ -3860,7 +3863,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		runtime.SetMutexProfileFraction(frac)
 		defer runtime.SetMutexProfileFraction(0)
 
-		f, err := os.Create(cfg.MutexProfile)
+		f, err := os.Create(mutexProfilePath)
 		if err != nil {
 			return BenchRun{}, fmt.Errorf("mutexprofile: %w", err)
 		}
@@ -3870,8 +3873,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		}()
 	}
 
-	if cfg.TraceProfile != "" {
-		f, err := os.Create(cfg.TraceProfile)
+	if traceProfilePath != "" {
+		f, err := os.Create(traceProfilePath)
 		if err != nil {
 			return BenchRun{}, fmt.Errorf("trace: %w", err)
 		}
@@ -4046,7 +4049,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 			}
 			blockBasePath := ""
-			if cfg.BlockProfile != "" {
+			if blockProfilePath != "" {
 				blockBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_block_base", "block")
 				if err != nil {
 					if cpuFile != nil {
@@ -4058,7 +4061,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 			}
 			mutexBasePath := ""
-			if cfg.MutexProfile != "" {
+			if mutexProfilePath != "" {
 				mutexBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_mutex_base", "mutex")
 				if err != nil {
 					if cpuFile != nil {
@@ -4133,7 +4136,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = os.Remove(blockBasePath)
 					_ = os.Remove(blockAfterPath)
 				} else {
-					blockPath := contentionProfilePath(cfg.BlockProfile, "block", testName, inst.Name)
+					blockPath := contentionProfilePath(blockProfilePath, "block", testName, inst.Name)
 					wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(blockBasePath, blockAfterPath, blockPath)
 					_ = os.Remove(blockBasePath)
 					_ = os.Remove(blockAfterPath)
@@ -4152,7 +4155,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = os.Remove(mutexBasePath)
 					_ = os.Remove(mutexAfterPath)
 				} else {
-					mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", testName, inst.Name)
+					mutexPath := contentionProfilePath(mutexProfilePath, "mutex", testName, inst.Name)
 					wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(mutexBasePath, mutexAfterPath, mutexPath)
 					_ = os.Remove(mutexBasePath)
 					_ = os.Remove(mutexAfterPath)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -891,11 +891,10 @@ func benchConfigUsesAllocsProfile(cfg BenchConfig) bool {
 	return false
 }
 
-func installAllocsProfileRate(cfg BenchConfig) func() {
-	if !benchConfigUsesAllocsProfile(cfg) {
+func installAllocsProfileRateForEnabled(enabled bool, rate int) func() {
+	if !enabled {
 		return func() {}
 	}
-	rate := cfg.AllocsProfileRate
 	if rate <= 0 {
 		rate = 512 * 1024
 	}
@@ -904,6 +903,10 @@ func installAllocsProfileRate(cfg BenchConfig) func() {
 	return func() {
 		runtime.MemProfileRate = prevRate
 	}
+}
+
+func installAllocsProfileRate(cfg BenchConfig) func() {
+	return installAllocsProfileRateForEnabled(benchConfigUsesAllocsProfile(cfg), cfg.AllocsProfileRate)
 }
 
 func shouldCheckpointCPUProfile(cfg BenchConfig, testName string) bool {
@@ -3883,15 +3886,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		if rate <= 0 {
 			rate = 1
 		}
-		runtime.SetBlockProfileRate(rate)
-		defer runtime.SetBlockProfileRate(0)
-
 		f, err := os.Create(blockProfilePath)
 		if err != nil {
 			return BenchRun{}, fmt.Errorf("blockprofile: %w", err)
 		}
+		runtime.SetBlockProfileRate(rate)
 		defer func() {
-			_ = pprof.Lookup("block").WriteTo(f, 0)
+			runtime.SetBlockProfileRate(0)
+			if prof := pprof.Lookup("block"); prof != nil {
+				_ = prof.WriteTo(f, 0)
+			}
 			_ = f.Close()
 		}()
 	}
@@ -3901,16 +3905,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		if frac <= 0 {
 			frac = 1
 		}
-		runtime.SetMutexProfileFraction(frac)
-		defer runtime.SetMutexProfileFraction(0)
-
 		f, err := os.Create(mutexProfilePath)
 		if err != nil {
 			return BenchRun{}, fmt.Errorf("mutexprofile: %w", err)
 		}
+		prevFrac := runtime.SetMutexProfileFraction(frac)
 		defer func() {
-			_ = pprof.Lookup("mutex").WriteTo(f, 0)
+			runtime.SetMutexProfileFraction(0)
+			if prof := pprof.Lookup("mutex"); prof != nil {
+				_ = prof.WriteTo(f, 0)
+			}
 			_ = f.Close()
+			runtime.SetMutexProfileFraction(prevFrac)
 		}()
 	}
 

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -877,6 +877,9 @@ func benchConfigUsesAllocsProfile(cfg BenchConfig) bool {
 		return true
 	}
 	tests := normalizeTests(parseList(cfg.TestsArg))
+	if len(tests) == 0 {
+		return true
+	}
 	if contains(tests, "all") {
 		return true
 	}

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2248,6 +2248,35 @@ func TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A(t *testing.T) {
 	}
 }
 
+func TestRunBenchmarkRestoresPreviousMutexProfileFractionM11A(t *testing.T) {
+	originalFraction := runtime.SetMutexProfileFraction(0)
+	t.Cleanup(func() {
+		runtime.SetMutexProfileFraction(originalFraction)
+	})
+	runtime.SetMutexProfileFraction(3)
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:                 16,
+		ValueSize:            16,
+		BatchSize:            8,
+		RangeQueries:         1,
+		RangeSpan:            4,
+		DBsArg:               "treedb",
+		TestsArg:             "sequential_write",
+		KeepDir:              false,
+		Progress:             false,
+		SeedUsed:             1,
+		MutexProfile:         filepath.Join(t.TempDir(), "mutex.pprof"),
+		MutexProfileFraction: 1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if gotPrev := runtime.SetMutexProfileFraction(0); gotPrev != 3 {
+		t.Fatalf("mutex profile fraction was not restored: previous=%d want 3", gotPrev)
+	}
+}
+
 func TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A(t *testing.T) {
 	whitespacePath := " \t "
 	_ = os.Remove(whitespacePath)

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2032,6 +2032,68 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 	}
 }
 
+func TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A(t *testing.T) {
+	var deltas []string
+	profileTmpDir := t.TempDir()
+	newProfilePath := func(prefix string) (string, error) {
+		f, err := os.CreateTemp(profileTmpDir, prefix+"_*.pprof")
+		if err != nil {
+			return "", err
+		}
+		path := f.Name()
+		if err := f.Close(); err != nil {
+			_ = os.Remove(path)
+			return "", err
+		}
+		return path, nil
+	}
+
+	profileHooks := &benchmarkProfileHooks{
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			return newProfilePath(prefix)
+		},
+		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
+			deltas = append(deltas, filepath.Base(outPath))
+			if err := os.WriteFile(outPath, []byte("stale"), 0o644); err != nil {
+				return false, err
+			}
+			return false, nil
+		},
+	}
+
+	outDir := t.TempDir()
+	_, err := runBenchmark(BenchConfig{
+		Keys:         64,
+		ValueSize:    16,
+		BatchSize:    16,
+		RangeQueries: 4,
+		RangeSpan:    4,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+
+		BlockProfile: filepath.Join(outDir, "block.pprof"),
+		MutexProfile: filepath.Join(outDir, "mutex.pprof"),
+		profileHooks: profileHooks,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	for _, name := range []string{
+		"block_sequential_write_treedb.pprof",
+		"mutex_sequential_write_treedb.pprof",
+	} {
+		if _, statErr := os.Stat(filepath.Join(outDir, name)); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("expected omitted empty delta artifact %s, stat err=%v", name, statErr)
+		}
+	}
+	if got, want := strings.Join(deltas, ","), "block_sequential_write_treedb.pprof,mutex_sequential_write_treedb.pprof"; got != want {
+		t.Fatalf("contention deltas = %s, want %s", got, want)
+	}
+}
+
 func TestRenderTreeDBDiskUsageString_EmitsValueLogWithoutWAL(t *testing.T) {
 	out := renderTreeDBDiskUsageString(map[string]treeDBDiskUsage{
 		"treedb": {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -1915,20 +1916,16 @@ func TestWriteBenchprofArtifacts_RequiresExecutionPath(t *testing.T) {
 }
 
 func TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile(t *testing.T) {
-	origRunPprofDeltaCommandFn := runPprofDeltaCommandFn
-	runPprofDeltaCommandFn = func(basePath, afterPath string) ([]byte, string, error) {
+	runner := func(basePath, afterPath string) ([]byte, string, error) {
 		return nil, "", nil
 	}
-	defer func() {
-		runPprofDeltaCommandFn = origRunPprofDeltaCommandFn
-	}()
 
 	outPath := filepath.Join(t.TempDir(), "block_random_read_treedb.pprof")
 	if err := os.WriteFile(outPath, []byte("stale"), 0o644); err != nil {
 		t.Fatalf("seed stale output: %v", err)
 	}
 
-	wrote, err := writeRuntimeProfileDeltaProfile("base.pprof", "after.pprof", outPath)
+	wrote, err := writeRuntimeProfileDeltaProfileWithRunner("base.pprof", "after.pprof", outPath, runner)
 	if err != nil {
 		t.Fatalf("writeRuntimeProfileDeltaProfile: %v", err)
 	}
@@ -1941,19 +1938,6 @@ func TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile(t *testing.T) {
 }
 
 func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *testing.T) {
-	origStopCPUProfileFn := stopCPUProfileFn
-	origWriteAllocsSnapshotTempFn := writeAllocsSnapshotTempFn
-	origWriteAllocsDeltaProfileFn := writeAllocsDeltaProfileFn
-	origWriteRuntimeProfileSnapshotTempFn := writeRuntimeProfileSnapshotTempFn
-	origWriteRuntimeProfileDeltaProfileFn := writeRuntimeProfileDeltaProfileFn
-	defer func() {
-		stopCPUProfileFn = origStopCPUProfileFn
-		writeAllocsSnapshotTempFn = origWriteAllocsSnapshotTempFn
-		writeAllocsDeltaProfileFn = origWriteAllocsDeltaProfileFn
-		writeRuntimeProfileSnapshotTempFn = origWriteRuntimeProfileSnapshotTempFn
-		writeRuntimeProfileDeltaProfileFn = origWriteRuntimeProfileDeltaProfileFn
-	}()
-
 	var events []string
 	profileTmpDir := t.TempDir()
 	newProfilePath := func(prefix string) (string, error) {
@@ -1969,25 +1953,29 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 		return path, nil
 	}
 
-	stopCPUProfileFn = func() {
-		events = append(events, "cpu_stop")
-		origStopCPUProfileFn()
-	}
-	writeAllocsSnapshotTempFn = func(prefix string) (string, error) {
-		events = append(events, prefix)
-		return newProfilePath(prefix)
-	}
-	writeRuntimeProfileSnapshotTempFn = func(prefix, profileName string) (string, error) {
-		events = append(events, prefix)
-		return newProfilePath(prefix)
-	}
-	writeAllocsDeltaProfileFn = func(basePath, afterPath, outPath string) error {
-		events = append(events, "alloc_delta")
-		return nil
-	}
-	writeRuntimeProfileDeltaProfileFn = func(basePath, afterPath, outPath string) (bool, error) {
-		events = append(events, filepath.Base(outPath))
-		return true, nil
+	profileHooks := &benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			return nil
+		},
+		stopCPUProfile: func() {
+			events = append(events, "cpu_stop")
+		},
+		writeAllocsSnapshotTemp: func(prefix string) (string, error) {
+			events = append(events, prefix)
+			return newProfilePath(prefix)
+		},
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			events = append(events, prefix)
+			return newProfilePath(prefix)
+		},
+		writeAllocsDeltaProfile: func(basePath, afterPath, outPath string) error {
+			events = append(events, "alloc_delta")
+			return nil
+		},
+		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
+			events = append(events, filepath.Base(outPath))
+			return true, nil
+		},
 	}
 
 	outDir := t.TempDir()
@@ -2007,6 +1995,7 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 		AllocsProfile: filepath.Join(outDir, "allocs"),
 		BlockProfile:  filepath.Join(outDir, "block.pprof"),
 		MutexProfile:  filepath.Join(outDir, "mutex.pprof"),
+		profileHooks:  profileHooks,
 	})
 	if err != nil {
 		t.Fatalf("runBenchmark: %v", err)

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -2029,6 +2030,48 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 	}
 	if mutexAfterIdx > allocAfterIdx {
 		t.Fatalf("expected mutex_after before allocs_after, events=%v", events)
+	}
+}
+
+func TestInstallAllocsProfileRateIgnoresWhitespaceOnlyPrefixM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
+	t.Cleanup(func() {
+		runtime.MemProfileRate = prevRate
+	})
+	runtime.MemProfileRate = 4096
+
+	restore := installAllocsProfileRate(BenchConfig{
+		AllocsProfile:     " \t ",
+		AllocsProfileRate: 1,
+	})
+	if got := runtime.MemProfileRate; got != 4096 {
+		restore()
+		t.Fatalf("MemProfileRate changed for whitespace-only allocs profile: got %d", got)
+	}
+	restore()
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate restore changed whitespace-only allocs profile: got %d", got)
+	}
+}
+
+func TestInstallAllocsProfileRateRestoresEnabledPrefixM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
+	t.Cleanup(func() {
+		runtime.MemProfileRate = prevRate
+	})
+	runtime.MemProfileRate = 4096
+
+	restore := installAllocsProfileRate(BenchConfig{
+		AllocsProfile:     filepath.Join(t.TempDir(), "allocs"),
+		AllocsProfileRate: 1,
+	})
+	if got := runtime.MemProfileRate; got != 1 {
+		restore()
+		t.Fatalf("MemProfileRate was not set for enabled allocs profile: got %d", got)
+	}
+	restore()
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate was not restored for enabled allocs profile: got %d", got)
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2054,6 +2054,61 @@ func TestInstallAllocsProfileRateIgnoresWhitespaceOnlyPrefixM11A(t *testing.T) {
 	}
 }
 
+func TestBenchConfigHasAnyProfileOutputIncludesCheckpointCPUM11A(t *testing.T) {
+	if benchConfigHasAnyProfileOutput(BenchConfig{}) {
+		t.Fatal("empty config should not report profile output")
+	}
+	if !benchConfigHasAnyProfileOutput(BenchConfig{CheckpointCPUProfile: " checkpoint_cpu "}) {
+		t.Fatal("checkpoint CPU profile should count as profile output")
+	}
+}
+
+func TestInstallAllocsProfileRateIgnoresFilteredTestsM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
+	t.Cleanup(func() {
+		runtime.MemProfileRate = prevRate
+	})
+	runtime.MemProfileRate = 4096
+
+	restore := installAllocsProfileRate(BenchConfig{
+		AllocsProfile:      filepath.Join(t.TempDir(), "allocs"),
+		AllocsProfileRate:  1,
+		TestsArg:           "sequential_write",
+		AllocsProfileTests: map[string]struct{}{"random_read": {}},
+	})
+	if got := runtime.MemProfileRate; got != 4096 {
+		restore()
+		t.Fatalf("MemProfileRate changed for filtered allocs profile: got %d", got)
+	}
+	restore()
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate restore changed filtered allocs profile: got %d", got)
+	}
+}
+
+func TestInstallAllocsProfileRateAppliesMatchingTestFilterM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
+	t.Cleanup(func() {
+		runtime.MemProfileRate = prevRate
+	})
+	runtime.MemProfileRate = 4096
+
+	restore := installAllocsProfileRate(BenchConfig{
+		AllocsProfile:      filepath.Join(t.TempDir(), "allocs"),
+		AllocsProfileRate:  1,
+		TestsArg:           "sequential_write",
+		AllocsProfileTests: map[string]struct{}{"sequential_write": {}},
+	})
+	if got := runtime.MemProfileRate; got != 1 {
+		restore()
+		t.Fatalf("MemProfileRate was not set for matching allocs profile filter: got %d", got)
+	}
+	restore()
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate was not restored for matching allocs profile filter: got %d", got)
+	}
+}
+
 func TestInstallAllocsProfileRateRestoresEnabledPrefixM11A(t *testing.T) {
 	prevRate := runtime.MemProfileRate
 	t.Cleanup(func() {
@@ -2072,6 +2127,39 @@ func TestInstallAllocsProfileRateRestoresEnabledPrefixM11A(t *testing.T) {
 	restore()
 	if got := runtime.MemProfileRate; got != 4096 {
 		t.Fatalf("MemProfileRate was not restored for enabled allocs profile: got %d", got)
+	}
+}
+
+func TestRunBenchmarkCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
+	profileHooks := &benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			return errors.New("start failed")
+		},
+		stopCPUProfile: func() {},
+	}
+	outDir := t.TempDir()
+	prefix := filepath.Join(outDir, "cpu")
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:         8,
+		ValueSize:    16,
+		BatchSize:    4,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+		CPUProfile:   prefix,
+		profileHooks: profileHooks,
+	})
+	if err == nil {
+		t.Fatal("expected CPU profile start failure")
+	}
+	path := prefix + "_sequential_write_treedb.pprof"
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed CPU profile artifact to be removed, stat err=%v", statErr)
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2137,6 +2137,47 @@ func TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A(t *testing.T) {
 	}
 }
 
+func TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A(t *testing.T) {
+	whitespacePath := " \t "
+	_ = os.Remove(whitespacePath)
+	t.Cleanup(func() { _ = os.Remove(whitespacePath) })
+
+	var runtimeSnapshots int
+	profileHooks := &benchmarkProfileHooks{
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			runtimeSnapshots++
+			return "", errors.New("runtime profile snapshot should be disabled for whitespace-only profile")
+		},
+	}
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:         64,
+		ValueSize:    16,
+		BatchSize:    16,
+		RangeQueries: 4,
+		RangeSpan:    4,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+
+		BlockProfile: whitespacePath,
+		MutexProfile: whitespacePath,
+		TraceProfile: whitespacePath,
+		profileHooks: profileHooks,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if runtimeSnapshots != 0 {
+		t.Fatalf("runtime profile snapshots = %d, want 0", runtimeSnapshots)
+	}
+	if _, statErr := os.Stat(whitespacePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("whitespace trace/profile path was created, stat err=%v", statErr)
+	}
+}
+
 func TestRenderTreeDBDiskUsageString_EmitsValueLogWithoutWAL(t *testing.T) {
 	out := renderTreeDBDiskUsageString(map[string]treeDBDiskUsage{
 		"treedb": {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1974,7 +1974,7 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 		},
 		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
 			events = append(events, filepath.Base(outPath))
-			return true, nil
+			return false, nil
 		},
 	}
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2086,6 +2086,29 @@ func TestInstallAllocsProfileRateIgnoresFilteredTestsM11A(t *testing.T) {
 	}
 }
 
+func TestInstallAllocsProfileRateTreatsEmptyTestsAsFullSelectionM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
+	t.Cleanup(func() {
+		runtime.MemProfileRate = prevRate
+	})
+	runtime.MemProfileRate = 4096
+
+	restore := installAllocsProfileRate(BenchConfig{
+		AllocsProfile:      filepath.Join(t.TempDir(), "allocs"),
+		AllocsProfileRate:  1,
+		TestsArg:           " \t ",
+		AllocsProfileTests: map[string]struct{}{"random_read": {}},
+	})
+	if got := runtime.MemProfileRate; got != 1 {
+		restore()
+		t.Fatalf("MemProfileRate was not set for default full test selection: got %d", got)
+	}
+	restore()
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate was not restored for default full test selection: got %d", got)
+	}
+}
+
 func TestInstallAllocsProfileRateAppliesMatchingTestFilterM11A(t *testing.T) {
 	prevRate := runtime.MemProfileRate
 	t.Cleanup(func() {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -824,8 +824,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile %s: %w", blockPath, deltaErr)
 		}
 		if !wrote {
-			cleanup(blockPath, mutexBasePath)
-			return nil, nil, nil, fmt.Errorf("column_store: blockprofile %s: %w", blockPath, errEmptyPprofDeltaOutput)
+			cleanup(blockPath)
 		}
 	}
 	if mutexBasePath != "" {
@@ -842,7 +841,6 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		}
 		if !wrote {
 			cleanup(mutexPath)
-			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile %s: %w", mutexPath, errEmptyPprofDeltaOutput)
 		}
 	}
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1100,16 +1100,19 @@ h1{font-size:22px}
 }
 
 func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report columnStoreSuiteReport, stats map[string]string, checkpointDuration time.Duration) BenchRun {
+	const aggregateTestName = "column_store"
+
 	cfg := baseCfg
 	cfg.Keys = report.Rows
 	cfg.BatchSize = report.BatchSize
 	cfg.Profile = profile
 	cfg.DBsArg = "treedb"
-	testOrder := []string{"alias_full_scan_from_q1", "alias_prefix_scan_from_q4a", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
+	testOrder := []string{aggregateTestName, "alias_full_scan_from_q1", "alias_prefix_scan_from_q4a", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
 	cfg.TestsArg = strings.Join(testOrder, ",")
 	dbName := "TreeDB Column Store"
 	results := make(map[string]map[string]float64)
 	displayNames := map[string]string{
+		aggregateTestName:            "Column store query phase",
 		"alias_full_scan_from_q1":    "Alias full scan from q1",
 		"alias_prefix_scan_from_q4a": "Alias prefix scan from q4a",
 		"column_store_q1":            "Column q1",
@@ -1121,9 +1124,16 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 		"column_store_q5_metadata":   "Column q5 metadata",
 	}
 	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
+	var queryDurationMS float64
+	var queryMaterializations int
 	for _, q := range report.Queries {
 		byName[q.Name] = q
+		queryDurationMS += q.DurationMS
+		queryMaterializations += q.RowMaterializations
 		results["column_store_"+q.Name] = map[string]float64{dbName: q.RowsPerSecond}
+	}
+	if queryDurationMS > 0 {
+		results[aggregateTestName] = map[string]float64{dbName: float64(queryMaterializations) / (queryDurationMS / 1000)}
 	}
 	if q, ok := byName["q1"]; ok {
 		results["alias_full_scan_from_q1"] = map[string]float64{dbName: q.RowsPerSecond}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -692,29 +692,11 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 }
 
 func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
-	var cpuFile *os.File
-	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
-		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
-		f, err := os.Create(profilePath)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile %s: %w", profilePath, err)
-		}
-		cpuFile = f
-		if err := pprof.StartCPUProfile(cpuFile); err != nil {
-			_ = cpuFile.Close()
-			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile start %s: %w", profilePath, err)
-		}
-	}
-
 	allocBasePath := ""
 	var err error
 	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
 		allocBasePath, err = writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_base")
 		if err != nil {
-			if cpuFile != nil {
-				stopCPUProfileFn()
-				_ = cpuFile.Close()
-			}
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile baseline: %w", err)
 		}
 	}
@@ -722,10 +704,6 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 	if cfg.BlockProfile != "" {
 		blockBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_block_base", "block")
 		if err != nil {
-			if cpuFile != nil {
-				stopCPUProfileFn()
-				_ = cpuFile.Close()
-			}
 			_ = os.Remove(allocBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile baseline: %w", err)
 		}
@@ -734,13 +712,29 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 	if cfg.MutexProfile != "" {
 		mutexBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_mutex_base", "mutex")
 		if err != nil {
-			if cpuFile != nil {
-				stopCPUProfileFn()
-				_ = cpuFile.Close()
-			}
 			_ = os.Remove(allocBasePath)
 			_ = os.Remove(blockBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile baseline: %w", err)
+		}
+	}
+
+	var cpuFile *os.File
+	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
+		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		f, err := os.Create(profilePath)
+		if err != nil {
+			_ = os.Remove(allocBasePath)
+			_ = os.Remove(blockBasePath)
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile %s: %w", profilePath, err)
+		}
+		cpuFile = f
+		if err := startCPUProfileFn(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			_ = os.Remove(allocBasePath)
+			_ = os.Remove(blockBasePath)
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile start %s: %w", profilePath, err)
 		}
 	}
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -420,6 +420,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
 	if strings.TrimSpace(opts.ProfileDir) != "" {
 		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg)
+		report.Artifacts = columnStoreOmitMissingOptionalArtifacts(report.Artifacts)
 		md = renderColumnStoreSuiteMarkdown(report)
 		if err := writeColumnStoreSuiteArtifacts(opts.ProfileDir, opts.ExecutionPath, report, md, run); err != nil {
 			return "", err
@@ -514,6 +515,25 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 		paths.TraceProfile = cfg.TraceProfile
 	}
 	return paths
+}
+
+func columnStoreOmitMissingOptionalArtifacts(paths columnStoreArtifactPaths) columnStoreArtifactPaths {
+	if columnStoreArtifactMissing(paths.BlockDeltaProfile) {
+		paths.BlockDeltaProfile = ""
+	}
+	if columnStoreArtifactMissing(paths.MutexDeltaProfile) {
+		paths.MutexDeltaProfile = ""
+	}
+	return paths
+}
+
+func columnStoreArtifactMissing(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return errors.Is(err, os.ErrNotExist)
 }
 
 func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -65,6 +65,7 @@ type columnStoreSuiteReport struct {
 	Suite                  string                       `json:"suite"`
 	Profile                string                       `json:"profile"`
 	Fixture                string                       `json:"fixture"`
+	DataDir                string                       `json:"data_dir,omitempty"`
 	PathLabel              string                       `json:"path_label,omitempty"`
 	ForcedPath             string                       `json:"forced_path"`
 	Rows                   int                          `json:"rows"`
@@ -83,6 +84,7 @@ type columnStoreSuiteReport struct {
 	PhysicalColumnQuery    string                       `json:"physical_column_query"`
 	BenchmarkOnlyRelaxed   bool                         `json:"benchmark_only_relaxed"`
 	StageSeparatedBoundary string                       `json:"stage_separated_boundary"`
+	ProfileFinalizeError   string                       `json:"profile_finalize_error,omitempty"`
 }
 
 type columnStoreStageMetric struct {
@@ -162,11 +164,12 @@ type columnStoreArtifactPaths struct {
 }
 
 type columnStoreFixtureEvent struct {
-	ID     string
-	TimeUS int64
-	Kind   string
-	Did    string
-	Doc    []byte
+	ID      string
+	IDBytes []byte
+	TimeUS  int64
+	Kind    string
+	Did     string
+	Doc     []byte
 }
 
 type columnStoreDecodedEvent struct {
@@ -186,6 +189,7 @@ func (d *columnStoreSuiteDBLabel) Set([]byte, []byte) error   { return nil }
 func (d *columnStoreSuiteDBLabel) Delete([]byte) error        { return nil }
 
 func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (string, error) {
+	profileHooks := profileHooksFromConfig(baseCfg)
 	profile, err := columnStoreSuiteEffectiveProfile(baseCfg.Profile)
 	if err != nil {
 		return "", err
@@ -303,7 +307,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	start = time.Now()
 	checkpointErr := db.Checkpoint()
 	if checkpointCPUFile != nil {
-		stopCPUProfileFn()
+		profileHooks.stopCPUProfile()
 		_ = checkpointCPUFile.Close()
 	}
 	if checkpointErr != nil {
@@ -327,7 +331,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		return "", fmt.Errorf("column_store: reopen collection: %w", err)
 	}
 	reopenDuration := time.Since(start)
-	stages = append(stages, columnStoreStageFromDuration("reopen", reopenDuration, rows, sourceBytes))
+	stages = append(stages, columnStoreStageFromDuration("reopen_recovery", reopenDuration, rows, sourceBytes))
 
 	manifestIdentity, ok := collection.ColumnStoreCacheIdentity()
 	if !ok {
@@ -339,15 +343,16 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		return "", err
 	}
 	if corrupt := strings.TrimSpace(opts.CorruptReferenceForTest); corrupt != "" {
+		if !columnStoreQueryNameKnown(corrupt) {
+			return "", fmt.Errorf("column_store: unknown corrupt reference query %q", corrupt)
+		}
 		rawHashes[corrupt]++
 	}
 	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(baseCfg, collection, rows, rawHashes, forcedPath)
 	if err != nil {
 		return "", err
 	}
-	if err := finishRuntimeProfiles(); err != nil {
-		return "", err
-	}
+	profileFinalizeErr := finishRuntimeProfiles()
 	runtimeProfilesActive = false
 
 	totalBytes, totalFiles, err := columnStoreSuiteDirUsage(dataDir)
@@ -358,6 +363,9 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err != nil {
 		return "", fmt.Errorf("column_store: manifest/control byte accounting: %w", err)
 	}
+	retainedPayloadBytes := sourceBytes
+	columnAssetBytes := int64(0)
+	totalReconstructableBytes := retainedPayloadBytes + columnAssetBytes + manifestControlBytes
 	report := columnStoreSuiteReport{
 		GeneratedAt:            time.Now().UTC().Format(time.RFC3339),
 		Suite:                  "column_store",
@@ -376,14 +384,14 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		Parity:                 parity,
 		ByteAccounting: columnStoreByteAccounting{
 			SourceDocumentBytes:             sourceBytes,
-			RetainedPayloadBytes:            sourceBytes,
+			RetainedPayloadBytes:            retainedPayloadBytes,
 			RetainedPayloadBytesNote:        "M11A retains the source JSONBench payload as the reconstructable row baseline; compressed retained payload accounting is future work",
-			ColumnAssetBytes:                0,
+			ColumnAssetBytes:                columnAssetBytes,
 			ColumnAssetBytesNote:            "not measured in M11A because physical column assets are not published yet",
 			ManifestControlBytes:            manifestControlBytes,
 			ManifestControlMissing:          manifestControlMissing,
 			CommandWALBytesBeforeCheckpoint: commandWALBytesBeforeCheckpoint,
-			TotalReconstructableBytes:       sourceBytes + manifestControlBytes,
+			TotalReconstructableBytes:       totalReconstructableBytes,
 			DBTotalBytes:                    totalBytes,
 			DBTotalFiles:                    totalFiles,
 		},
@@ -397,7 +405,13 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path",
 		PhysicalColumnQuery:    "not implemented in M11A; forced physical column labels fail closed",
 		BenchmarkOnlyRelaxed:   false,
-		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen, and q1-q5 row-store baseline scans are timed separately",
+		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, and q1-q5 row-store baseline scans are timed separately",
+	}
+	if baseCfg.KeepDir {
+		report.DataDir = dataDir
+	}
+	if profileFinalizeErr != nil {
+		report.ProfileFinalizeError = profileFinalizeErr.Error()
 	}
 
 	md := renderColumnStoreSuiteMarkdown(report)
@@ -415,8 +429,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		}
 	}
 	// Keep artifacts available for diagnosis even when parity is the failing gate.
-	if parityErr != nil {
-		return "", parityErr
+	if parityErr != nil || profileFinalizeErr != nil {
+		return "", errors.Join(parityErr, profileFinalizeErr)
 	}
 	return md, nil
 }
@@ -501,19 +515,27 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 }
 
 func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {
+	excluded := make(map[string]struct{})
 	for _, db := range parseList(excludeArg) {
-		switch strings.ToLower(strings.TrimSpace(db)) {
+		normalized := strings.ToLower(strings.TrimSpace(db))
+		switch normalized {
 		case "", "none":
 			continue
 		case "all", "treedb":
 			return fmt.Errorf("column_store: native suite requires TreeDB but -dbs-exclude=%q excludes it", excludeArg)
+		default:
+			excluded[normalized] = struct{}{}
 		}
 	}
 
 	dbs := parseList(dbsArg)
 	hasTreeDB := false
 	for _, db := range dbs {
-		switch strings.ToLower(strings.TrimSpace(db)) {
+		normalized := strings.ToLower(strings.TrimSpace(db))
+		if _, skip := excluded[normalized]; skip {
+			continue
+		}
+		switch normalized {
 		case "", "all", "treedb":
 			hasTreeDB = true
 		default:
@@ -547,7 +569,7 @@ func buildColumnStoreSyntheticFixture(rows int, seed int64) ([]columnStoreFixtur
 		payloadID := uint32(uint64(i) * uint64(2654435761))
 		doc := []byte(fmt.Sprintf(`{"time_us":%d,"kind":"%s","did":"%s","payload":"p%08x","group":%d}`,
 			timeUS, kind, did, payloadID, i%32))
-		out[i] = columnStoreFixtureEvent{ID: id, TimeUS: timeUS, Kind: kind, Did: did, Doc: doc}
+		out[i] = columnStoreFixtureEvent{ID: id, IDBytes: []byte(id), TimeUS: timeUS, Kind: kind, Did: did, Doc: doc}
 		bytesTotal += int64(len(doc))
 	}
 	return out, bytesTotal
@@ -563,7 +585,7 @@ func columnStoreSuiteConfig() *collections.ColumnStoreConfig {
 		},
 		SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
 		AggregateMetadata: []collections.ColumnAggregateMetadata{
-			{Name: "q5_did_time_span", Column: "time_us", Kind: collections.ColumnAggregateMin},
+			{Name: "q5_did_time_span_min", Column: "time_us", Kind: collections.ColumnAggregateMin},
 			{Name: "q5_did_time_span_max", Column: "time_us", Kind: collections.ColumnAggregateMax},
 		},
 		RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
@@ -583,18 +605,18 @@ func openColumnStoreSuiteDB(dir string) (*backenddb.DB, error) {
 }
 
 func insertColumnStoreFixture(collection *collections.Collection, events []columnStoreFixtureEvent, batchSize int) error {
+	idsAll := make([][]byte, len(events))
+	docsAll := make([][]byte, len(events))
+	for i := range events {
+		idsAll[i] = events[i].IDBytes
+		docsAll[i] = events[i].Doc
+	}
 	for start := 0; start < len(events); start += batchSize {
 		end := start + batchSize
 		if end > len(events) {
 			end = len(events)
 		}
-		ids := make([][]byte, end-start)
-		docs := make([][]byte, end-start)
-		for i := start; i < end; i++ {
-			ids[i-start] = []byte(events[i].ID)
-			docs[i-start] = events[i].Doc
-		}
-		if _, err := collection.InsertBatch(ids, docs); err != nil {
+		if _, err := collection.InsertBatch(idsAll[start:end], docsAll[start:end]); err != nil {
 			return fmt.Errorf("column_store: InsertBatch rows %d-%d: %w", start, end, err)
 		}
 	}
@@ -608,7 +630,7 @@ func columnStoreReferenceHashes(events []columnStoreFixtureEvent) (map[string]ui
 	}
 	out := make(map[string]uint64)
 	for _, name := range columnStoreQueryNames() {
-		hash, _, err := columnStoreQueryHash(name, decoded)
+		hash, _, err := columnStoreQueryHash(columnStoreQueryCanonicalName(name, columnStorePathRowStoreBaseline), decoded)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +650,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		return out
 	}
 
-	if cfg.AllocsProfile != "" {
+	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
 		rate := cfg.AllocsProfileRate
 		if rate <= 0 {
 			rate = 512 * 1024
@@ -653,13 +675,15 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		runtime.SetBlockProfileRate(rate)
 		cleanups = append(cleanups, func() error {
-			defer runtime.SetBlockProfileRate(0)
-			defer f.Close()
+			runtime.SetBlockProfileRate(0)
 			prof := pprof.Lookup("block")
+			var writeErr error
 			if prof == nil {
-				return fmt.Errorf("block profile unavailable")
+				writeErr = fmt.Errorf("block profile unavailable")
+			} else {
+				writeErr = prof.WriteTo(f, 0)
 			}
-			return prof.WriteTo(f, 0)
+			return errors.Join(writeErr, f.Close())
 		})
 	}
 
@@ -675,13 +699,15 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		prevFrac := runtime.SetMutexProfileFraction(frac)
 		cleanups = append(cleanups, func() error {
-			defer runtime.SetMutexProfileFraction(prevFrac)
-			defer f.Close()
+			runtime.SetMutexProfileFraction(prevFrac)
 			prof := pprof.Lookup("mutex")
+			var writeErr error
 			if prof == nil {
-				return fmt.Errorf("mutex profile unavailable")
+				writeErr = fmt.Errorf("mutex profile unavailable")
+			} else {
+				writeErr = prof.WriteTo(f, 0)
 			}
-			return prof.WriteTo(f, 0)
+			return errors.Join(writeErr, f.Close())
 		})
 	}
 
@@ -706,49 +732,53 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 }
 
 func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
+	profileHooks := profileHooksFromConfig(cfg)
+	cleanup := func(paths ...string) {
+		for _, path := range paths {
+			if path != "" {
+				_ = os.Remove(path)
+			}
+		}
+	}
 	allocBasePath := ""
 	var err error
 	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
-		allocBasePath, err = writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_base")
+		allocBasePath, err = profileHooks.writeAllocsSnapshotTemp("unified_bench_column_store_allocs_base")
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile baseline: %w", err)
 		}
 	}
 	blockBasePath := ""
 	if cfg.BlockProfile != "" {
-		blockBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_block_base", "block")
+		blockBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_block_base", "block")
 		if err != nil {
-			_ = os.Remove(allocBasePath)
+			cleanup(allocBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile baseline: %w", err)
 		}
 	}
 	mutexBasePath := ""
 	if cfg.MutexProfile != "" {
-		mutexBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_mutex_base", "mutex")
+		mutexBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_mutex_base", "mutex")
 		if err != nil {
-			_ = os.Remove(allocBasePath)
-			_ = os.Remove(blockBasePath)
+			cleanup(allocBasePath, blockBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile baseline: %w", err)
 		}
 	}
 
 	var cpuFile *os.File
+	cpuProfilePath := ""
 	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
 		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		f, err := os.Create(profilePath)
 		if err != nil {
-			_ = os.Remove(allocBasePath)
-			_ = os.Remove(blockBasePath)
-			_ = os.Remove(mutexBasePath)
+			cleanup(allocBasePath, blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile %s: %w", profilePath, err)
 		}
 		cpuFile = f
-		if err := startCPUProfileFn(cpuFile); err != nil {
+		cpuProfilePath = profilePath
+		if err := profileHooks.startCPUProfile(cpuFile); err != nil {
 			_ = cpuFile.Close()
-			_ = os.Remove(profilePath)
-			_ = os.Remove(allocBasePath)
-			_ = os.Remove(blockBasePath)
-			_ = os.Remove(mutexBasePath)
+			cleanup(profilePath, allocBasePath, blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile start %s: %w", profilePath, err)
 		}
 	}
@@ -756,62 +786,61 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 	queries, parity, runErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, path)
 
 	if cpuFile != nil {
-		stopCPUProfileFn()
+		profileHooks.stopCPUProfile()
 		_ = cpuFile.Close()
 	}
 	if queries == nil {
-		_ = os.Remove(allocBasePath)
-		_ = os.Remove(blockBasePath)
-		_ = os.Remove(mutexBasePath)
+		cleanup(cpuProfilePath, allocBasePath, blockBasePath, mutexBasePath)
 		return nil, nil, nil, runErr
 	}
 
 	if allocBasePath != "" {
-		allocAfterPath, snapErr := writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_after")
+		allocAfterPath, snapErr := profileHooks.writeAllocsSnapshotTemp("unified_bench_column_store_allocs_after")
 		if snapErr != nil {
-			_ = os.Remove(allocBasePath)
-			_ = os.Remove(blockBasePath)
-			_ = os.Remove(mutexBasePath)
+			cleanup(allocBasePath, blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile snapshot: %w", snapErr)
 		}
 		allocPath := fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
-		deltaErr := writeAllocsDeltaProfileFn(allocBasePath, allocAfterPath, allocPath)
-		_ = os.Remove(allocBasePath)
-		_ = os.Remove(allocAfterPath)
+		deltaErr := profileHooks.writeAllocsDeltaProfile(allocBasePath, allocAfterPath, allocPath)
+		cleanup(allocBasePath, allocAfterPath)
 		if deltaErr != nil {
-			_ = os.Remove(blockBasePath)
-			_ = os.Remove(mutexBasePath)
+			cleanup(blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile %s: %w", allocPath, deltaErr)
 		}
 	}
 	if blockBasePath != "" {
-		blockAfterPath, snapErr := writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_block_after", "block")
+		blockAfterPath, snapErr := profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_block_after", "block")
 		if snapErr != nil {
-			_ = os.Remove(blockBasePath)
-			_ = os.Remove(mutexBasePath)
+			cleanup(blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile snapshot: %w", snapErr)
 		}
 		blockPath := contentionProfilePath(cfg.BlockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
-		_, deltaErr := writeRuntimeProfileDeltaProfileFn(blockBasePath, blockAfterPath, blockPath)
-		_ = os.Remove(blockBasePath)
-		_ = os.Remove(blockAfterPath)
+		wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(blockBasePath, blockAfterPath, blockPath)
+		cleanup(blockBasePath, blockAfterPath)
 		if deltaErr != nil {
-			_ = os.Remove(mutexBasePath)
+			cleanup(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile %s: %w", blockPath, deltaErr)
+		}
+		if !wrote {
+			cleanup(blockPath, mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: blockprofile %s: %w", blockPath, errEmptyPprofDeltaOutput)
 		}
 	}
 	if mutexBasePath != "" {
-		mutexAfterPath, snapErr := writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_mutex_after", "mutex")
+		mutexAfterPath, snapErr := profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_mutex_after", "mutex")
 		if snapErr != nil {
-			_ = os.Remove(mutexBasePath)
+			cleanup(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile snapshot: %w", snapErr)
 		}
 		mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
-		_, deltaErr := writeRuntimeProfileDeltaProfileFn(mutexBasePath, mutexAfterPath, mutexPath)
-		_ = os.Remove(mutexBasePath)
-		_ = os.Remove(mutexAfterPath)
+		wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(mutexBasePath, mutexAfterPath, mutexPath)
+		cleanup(mutexBasePath, mutexAfterPath)
 		if deltaErr != nil {
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile %s: %w", mutexPath, deltaErr)
+		}
+		if !wrote {
+			cleanup(mutexPath)
+			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile %s: %w", mutexPath, errEmptyPprofDeltaOutput)
 		}
 	}
 
@@ -823,12 +852,13 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 	parity := make(map[string]columnStoreParity, len(columnStoreQueryNames()))
 	var firstErr error
 	for _, name := range columnStoreQueryNames() {
+		hashName := columnStoreQueryCanonicalName(name, path)
 		start := time.Now()
 		events, materialized, bytesRead, err := scanColumnStoreSuiteEvents(collection, rows)
 		if err != nil {
 			return nil, nil, err
 		}
-		hash, resultCount, err := columnStoreQueryHash(name, events)
+		hash, resultCount, err := columnStoreQueryHash(hashName, events)
 		if err != nil {
 			return nil, nil, fmt.Errorf("column_store: reduce %s: %w", name, err)
 		}
@@ -881,7 +911,7 @@ func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([
 		return nil, 0, 0, fmt.Errorf("column_store: scan documents: %w", err)
 	}
 	if truncated {
-		return nil, 0, 0, fmt.Errorf("column_store: scan truncated at %d rows", rows+1)
+		return nil, 0, 0, fmt.Errorf("column_store: scan exceeded expected rows=%d (sentinel limit=%d)", rows, rows+1)
 	}
 	if materialized != rows {
 		return nil, 0, 0, fmt.Errorf("column_store: scanned %d rows, want %d", materialized, rows)
@@ -889,8 +919,17 @@ func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([
 	return events, materialized, bytesRead, nil
 }
 
-func columnStoreQueryNames() []string {
-	return []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
+var columnStoreQueryNameList = []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
+
+func columnStoreQueryNames() []string { return columnStoreQueryNameList }
+
+func columnStoreQueryNameKnown(name string) bool {
+	for _, candidate := range columnStoreQueryNameList {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func columnStoreQueryAliasOf(name, path string) string {
@@ -905,6 +944,13 @@ func columnStoreQueryImplementationNote(name, path string) string {
 		return "row_store_baseline_alias_until_physical_aggregate_metadata_path"
 	}
 	return ""
+}
+
+func columnStoreQueryCanonicalName(name, path string) string {
+	if alias := columnStoreQueryAliasOf(name, path); alias != "" {
+		return alias
+	}
+	return name
 }
 
 func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int, error) {
@@ -1102,11 +1148,17 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- rows: %s\n", formatInt(report.Rows)))
 	sb.WriteString(fmt.Sprintf("- batchsize: %s\n", formatInt(report.BatchSize)))
 	sb.WriteString(fmt.Sprintf("- forced path: `%s`\n", report.ForcedPath))
+	if report.DataDir != "" {
+		sb.WriteString(fmt.Sprintf("- data-dir: `%s`\n", report.DataDir))
+	}
 	if report.PathLabel != "" {
 		sb.WriteString(fmt.Sprintf("- path-label: `%s`\n", report.PathLabel))
 	}
 	sb.WriteString(fmt.Sprintf("- scope: %s\n", report.ProductionScope))
 	sb.WriteString(fmt.Sprintf("- physical column query: %s\n", report.PhysicalColumnQuery))
+	if report.ProfileFinalizeError != "" {
+		sb.WriteString(fmt.Sprintf("- profile finalize error: `%s`\n", report.ProfileFinalizeError))
+	}
 	sb.WriteString(fmt.Sprintf("- timing boundary: %s\n\n", report.StageSeparatedBoundary))
 
 	sb.WriteString("## Stage Timings\n\n")
@@ -1129,8 +1181,12 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 		if note == "" && q.AliasOf != "" {
 			note = "alias_of_" + q.AliasOf
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %d | %d | %d | %d | %s | `%s` |\n",
-			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.BytesRead, q.RowMaterializations, q.SkippedGranules, q.MetadataHits, parity, note))
+		noteCell := "-"
+		if note != "" {
+			noteCell = "`" + note + "`"
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %d | %d | %d | %d | %s | %s |\n",
+			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.BytesRead, q.RowMaterializations, q.SkippedGranules, q.MetadataHits, parity, noteCell))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -685,7 +685,6 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		runtime.SetBlockProfileRate(rate)
 		cleanups = append(cleanups, func() error {
-			runtime.SetBlockProfileRate(0)
 			prof := pprof.Lookup("block")
 			var writeErr error
 			if prof == nil {
@@ -693,6 +692,9 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 			} else {
 				writeErr = prof.WriteTo(f, 0)
 			}
+			// The runtime exposes no previous block profile rate, so the suite
+			// writes the active profile before returning sampling to off.
+			runtime.SetBlockProfileRate(0)
 			return errors.Join(writeErr, f.Close())
 		})
 	}
@@ -813,7 +815,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			cleanup(allocBasePath, blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile snapshot: %w", snapErr)
 		}
-		allocPath := fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		allocPath := fmt.Sprintf("%s_%s_%s.pprof", strings.TrimSpace(cfg.AllocsProfile), columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		deltaErr := profileHooks.writeAllocsDeltaProfile(allocBasePath, allocAfterPath, allocPath)
 		cleanup(allocBasePath, allocAfterPath)
 		if deltaErr != nil {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -216,10 +216,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err := validateColumnStoreSuiteDBSelection(baseCfg.DBsArg, baseCfg.DBsExcludeArg); err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(opts.ProfileDir) != "" {
-		if err := validateBenchprofExecutionPath(strings.TrimSpace(opts.ExecutionPath)); err != nil {
-			return "", err
-		}
+	if err := validateColumnStoreSuiteExecutionPath(opts.ProfileDir, opts.ExecutionPath); err != nil {
+		return "", err
 	}
 	finishRuntimeProfiles, err := startColumnStoreSuiteRuntimeProfiles(baseCfg)
 	if err != nil {
@@ -419,7 +417,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	md := renderColumnStoreSuiteMarkdown(report)
 	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
 	if strings.TrimSpace(opts.ProfileDir) != "" {
-		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg)
+		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg, opts.RunBenchprof)
 		report.Artifacts = columnStoreSuitePruneMissingRuntimeDeltaArtifacts(report.Artifacts)
 		md = renderColumnStoreSuiteMarkdown(report)
 		if err := writeColumnStoreSuiteArtifacts(opts.ProfileDir, opts.ExecutionPath, report, md, run); err != nil {
@@ -469,9 +467,23 @@ func validateColumnStoreSuiteForcedPath(path string) error {
 		return nil
 	}
 	if columnStoreSuitePathListed(path, columnStoreSuiteUnsupportedForcedPaths) {
-		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; refusing to route through row store; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	}
 	return fmt.Errorf("column_store: unknown forced path %q; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+}
+
+func validateColumnStoreSuiteExecutionPath(profileDir, executionPath string) error {
+	executionPath = strings.TrimSpace(executionPath)
+	if strings.TrimSpace(profileDir) == "" && executionPath == "" {
+		return nil
+	}
+	if err := validateBenchprofExecutionPath(executionPath); err != nil {
+		return err
+	}
+	if executionPath != "native-fastpath" {
+		return fmt.Errorf("column_store: native suite requires -path-label native-fastpath; got %q", executionPath)
+	}
+	return nil
 }
 
 func columnStoreSuitePathListed(path string, paths []string) bool {
@@ -483,16 +495,18 @@ func columnStoreSuitePathListed(path string, paths []string) bool {
 	return false
 }
 
-func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) columnStoreArtifactPaths {
+func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig, runBenchprof bool) columnStoreArtifactPaths {
 	paths := columnStoreArtifactPaths{
 		ColumnJSON:        filepath.Join(profileDir, "column_store_results.json"),
 		ColumnMarkdown:    filepath.Join(profileDir, "column_store_results.md"),
 		ColumnHTML:        filepath.Join(profileDir, "column_store_results.html"),
 		BenchprofJSON:     filepath.Join(profileDir, "benchprof_results.json"),
 		BenchprofMarkdown: filepath.Join(profileDir, "benchprof_results.md"),
-		InsightsMarkdown:  filepath.Join(profileDir, "insights.md"),
-		InsightsJSON:      filepath.Join(profileDir, "insights.json"),
-		InsightsHTML:      filepath.Join(profileDir, "insights.html"),
+	}
+	if runBenchprof {
+		paths.InsightsMarkdown = filepath.Join(profileDir, "insights.md")
+		paths.InsightsJSON = filepath.Join(profileDir, "insights.json")
+		paths.InsightsHTML = filepath.Join(profileDir, "insights.html")
 	}
 	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
 		paths.CPUProfile = fmt.Sprintf("%s_%s_%s.pprof", strings.TrimSpace(cfg.CPUProfile), columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
@@ -522,7 +536,7 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 
 func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {
 	for _, db := range parseList(excludeArg) {
-		normalized := canonicalDBName(strings.ToLower(strings.TrimSpace(db)))
+		normalized := canonicalDBName(db)
 		switch normalized {
 		case "", "none":
 			continue
@@ -661,14 +675,9 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 	}
 
 	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
-		rate := cfg.AllocsProfileRate
-		if rate <= 0 {
-			rate = 512 * 1024
-		}
-		prevRate := runtime.MemProfileRate
-		runtime.MemProfileRate = rate
+		restoreMemRate := installAllocsProfileRateForEnabled(true, cfg.AllocsProfileRate)
 		restore := func() error {
-			runtime.MemProfileRate = prevRate
+			restoreMemRate()
 			return nil
 		}
 		cleanups = append(cleanups, runtimeProfileCleanup{
@@ -694,6 +703,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		runtime.SetBlockProfileRate(rate)
 		cleanups = append(cleanups, runtimeProfileCleanup{
 			finish: func() error {
+				runtime.SetBlockProfileRate(0)
 				prof := pprof.Lookup("block")
 				var writeErr error
 				if prof == nil {
@@ -701,9 +711,6 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 				} else {
 					writeErr = prof.WriteTo(f, 0)
 				}
-				// The runtime exposes no previous block profile rate, so the suite
-				// writes the active profile before returning sampling to off.
-				runtime.SetBlockProfileRate(0)
 				return errors.Join(writeErr, f.Close())
 			},
 			abort: func() error {
@@ -726,7 +733,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		prevFrac := runtime.SetMutexProfileFraction(frac)
 		cleanups = append(cleanups, runtimeProfileCleanup{
 			finish: func() error {
-				runtime.SetMutexProfileFraction(prevFrac)
+				runtime.SetMutexProfileFraction(0)
 				prof := pprof.Lookup("mutex")
 				var writeErr error
 				if prof == nil {
@@ -734,6 +741,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 				} else {
 					writeErr = prof.WriteTo(f, 0)
 				}
+				runtime.SetMutexProfileFraction(prevFrac)
 				return errors.Join(writeErr, f.Close())
 			},
 			abort: func() error {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -666,12 +666,16 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		})
 	}
 
-	if cfg.BlockProfile != "" {
+	blockProfile := strings.TrimSpace(cfg.BlockProfile)
+	mutexProfile := strings.TrimSpace(cfg.MutexProfile)
+	traceProfile := strings.TrimSpace(cfg.TraceProfile)
+
+	if blockProfile != "" {
 		rate := cfg.BlockProfileRate
 		if rate <= 0 {
 			rate = 1
 		}
-		f, err := os.Create(cfg.BlockProfile)
+		f, err := os.Create(blockProfile)
 		if err != nil {
 			_ = finish()
 			return nil, fmt.Errorf("column_store: blockprofile: %w", err)
@@ -690,12 +694,12 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		})
 	}
 
-	if cfg.MutexProfile != "" {
+	if mutexProfile != "" {
 		frac := cfg.MutexProfileFraction
 		if frac <= 0 {
 			frac = 1
 		}
-		f, err := os.Create(cfg.MutexProfile)
+		f, err := os.Create(mutexProfile)
 		if err != nil {
 			_ = finish()
 			return nil, fmt.Errorf("column_store: mutexprofile: %w", err)
@@ -714,8 +718,8 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		})
 	}
 
-	if cfg.TraceProfile != "" {
-		f, err := os.Create(cfg.TraceProfile)
+	if traceProfile != "" {
+		f, err := os.Create(traceProfile)
 		if err != nil {
 			_ = finish()
 			return nil, fmt.Errorf("column_store: trace: %w", err)
@@ -1367,10 +1371,8 @@ func columnStoreExistingOptionalArtifactPath(path string) string {
 	}
 	if _, err := os.Stat(path); err == nil {
 		return path
-	} else if errors.Is(err, os.ErrNotExist) {
-		return ""
 	}
-	return path
+	return ""
 }
 
 func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStoreSuiteReport, md string, run BenchRun) error {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -495,13 +495,13 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 		InsightsHTML:      filepath.Join(profileDir, "insights.html"),
 	}
 	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
-		paths.CPUProfile = fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		paths.CPUProfile = fmt.Sprintf("%s_%s_%s.pprof", strings.TrimSpace(cfg.CPUProfile), columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	}
 	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
-		paths.AllocsProfile = fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		paths.AllocsProfile = fmt.Sprintf("%s_%s_%s.pprof", strings.TrimSpace(cfg.AllocsProfile), columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	}
 	if shouldCheckpointCPUProfile(cfg, columnStoreSuiteBenchTestName) {
-		paths.CheckpointCPUProfile = fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
+		paths.CheckpointCPUProfile = fmt.Sprintf("%s_checkpoint_%s_%s.pprof", strings.TrimSpace(cfg.CheckpointCPUProfile), sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
 	}
 	blockProfile := strings.TrimSpace(cfg.BlockProfile)
 	if blockProfile != "" {
@@ -781,7 +781,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 	var cpuFile *os.File
 	cpuProfilePath := ""
 	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
-		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		profilePath := fmt.Sprintf("%s_%s_%s.pprof", strings.TrimSpace(cfg.CPUProfile), columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		f, err := os.Create(profilePath)
 		if err != nil {
 			cleanup(allocBasePath, blockBasePath, mutexBasePath)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -503,16 +503,19 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 	if shouldCheckpointCPUProfile(cfg, columnStoreSuiteBenchTestName) {
 		paths.CheckpointCPUProfile = fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
 	}
-	if strings.TrimSpace(cfg.BlockProfile) != "" {
-		paths.BlockProfile = cfg.BlockProfile
-		paths.BlockDeltaProfile = contentionProfilePath(cfg.BlockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	blockProfile := strings.TrimSpace(cfg.BlockProfile)
+	if blockProfile != "" {
+		paths.BlockProfile = blockProfile
+		paths.BlockDeltaProfile = contentionProfilePath(blockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	}
-	if strings.TrimSpace(cfg.MutexProfile) != "" {
-		paths.MutexProfile = cfg.MutexProfile
-		paths.MutexDeltaProfile = contentionProfilePath(cfg.MutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	mutexProfile := strings.TrimSpace(cfg.MutexProfile)
+	if mutexProfile != "" {
+		paths.MutexProfile = mutexProfile
+		paths.MutexDeltaProfile = contentionProfilePath(mutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	}
-	if strings.TrimSpace(cfg.TraceProfile) != "" {
-		paths.TraceProfile = cfg.TraceProfile
+	traceProfile := strings.TrimSpace(cfg.TraceProfile)
+	if traceProfile != "" {
+		paths.TraceProfile = traceProfile
 	}
 	return paths
 }
@@ -756,7 +759,8 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		}
 	}
 	blockBasePath := ""
-	if cfg.BlockProfile != "" {
+	blockProfile := strings.TrimSpace(cfg.BlockProfile)
+	if blockProfile != "" {
 		blockBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_block_base", "block")
 		if err != nil {
 			cleanup(allocBasePath)
@@ -764,7 +768,8 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		}
 	}
 	mutexBasePath := ""
-	if cfg.MutexProfile != "" {
+	mutexProfile := strings.TrimSpace(cfg.MutexProfile)
+	if mutexProfile != "" {
 		mutexBasePath, err = profileHooks.writeRuntimeProfileSnapshotTemp("unified_bench_column_store_mutex_base", "mutex")
 		if err != nil {
 			cleanup(allocBasePath, blockBasePath)
@@ -821,7 +826,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			cleanup(blockBasePath, mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile snapshot: %w", snapErr)
 		}
-		blockPath := contentionProfilePath(cfg.BlockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		blockPath := contentionProfilePath(blockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(blockBasePath, blockAfterPath, blockPath)
 		cleanup(blockBasePath, blockAfterPath)
 		if deltaErr != nil {
@@ -838,7 +843,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			cleanup(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile snapshot: %w", snapErr)
 		}
-		mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		mutexPath := contentionProfilePath(mutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		wrote, deltaErr := profileHooks.writeRuntimeProfileDeltaProfile(mutexBasePath, mutexAfterPath, mutexPath)
 		cleanup(mutexBasePath, mutexAfterPath)
 		if deltaErr != nil {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -299,7 +299,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 
 	var checkpointCPUFile *os.File
 	if shouldCheckpointCPUProfile(baseCfg, columnStoreSuiteBenchTestName) {
-		checkpointCPUFile, err = startCheckpointCPUProfile(baseCfg, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+		checkpointCPUFile, err = startCheckpointCPUProfile(baseCfg, profileHooks, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		if err != nil {
 			_ = db.Close()
 			return "", fmt.Errorf("column_store: checkpoint profiling: %w", err)
@@ -631,7 +631,7 @@ func columnStoreReferenceHashes(events []columnStoreFixtureEvent) (map[string]ui
 		decoded[i] = columnStoreDecodedEvent{TimeUS: events[i].TimeUS, Kind: events[i].Kind, Did: events[i].Did}
 	}
 	out := make(map[string]uint64)
-	for _, name := range columnStoreQueryNames() {
+	for _, name := range columnStoreQueryNameList {
 		hash, _, err := columnStoreQueryHash(columnStoreQueryCanonicalName(name, columnStorePathRowStoreBaseline), decoded)
 		if err != nil {
 			return nil, err
@@ -850,10 +850,10 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 }
 
 func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
-	queries := make([]columnStoreQueryMetric, 0, len(columnStoreQueryNames()))
-	parity := make(map[string]columnStoreParity, len(columnStoreQueryNames()))
+	queries := make([]columnStoreQueryMetric, 0, len(columnStoreQueryNameList))
+	parity := make(map[string]columnStoreParity, len(columnStoreQueryNameList))
 	var firstErr error
-	for _, name := range columnStoreQueryNames() {
+	for _, name := range columnStoreQueryNameList {
 		hashName := columnStoreQueryCanonicalName(name, path)
 		start := time.Now()
 		events, materialized, bytesRead, err := scanColumnStoreSuiteEvents(collection, rows)
@@ -922,9 +922,11 @@ func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([
 	return events, materialized, bytesRead, nil
 }
 
-var columnStoreQueryNameList = []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
+var columnStoreQueryNameList = [...]string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
 
-func columnStoreQueryNames() []string { return columnStoreQueryNameList }
+func columnStoreQueryNames() []string {
+	return append([]string(nil), columnStoreQueryNameList[:]...)
+}
 
 func columnStoreQueryNameKnown(name string) bool {
 	for _, candidate := range columnStoreQueryNameList {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1,0 +1,854 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"html"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	columnStorePathRowStoreBaseline   = "row_store_baseline"
+	columnStorePathBTreeIndexBaseline = "b_tree_index_baseline"
+)
+
+var (
+	columnStoreSuitePathArg    = flag.String("column-store-path", columnStorePathRowStoreBaseline, "Forced column-store execution label for -suite column_store (row_store_baseline; physical column labels fail closed until implemented)")
+	columnStoreSuiteFixtureArg = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
+)
+
+type columnStoreSuiteOptions struct {
+	ProfileDir              string
+	ExecutionPath           string
+	ForcedPath              string
+	Fixture                 string
+	RunBenchprof            bool
+	CorruptReferenceForTest string
+}
+
+type columnStoreSuiteReport struct {
+	GeneratedAt            string                       `json:"generated_at"`
+	Suite                  string                       `json:"suite"`
+	Profile                string                       `json:"profile"`
+	Fixture                string                       `json:"fixture"`
+	PathLabel              string                       `json:"path_label,omitempty"`
+	ForcedPath             string                       `json:"forced_path"`
+	Rows                   int                          `json:"rows"`
+	BatchSize              int                          `json:"batch_size"`
+	Seed                   int64                        `json:"seed"`
+	CacheLabel             string                       `json:"cache_label"`
+	SupportedForcedPaths   []string                     `json:"supported_forced_paths"`
+	UnsupportedForcedPaths []string                     `json:"unsupported_forced_paths"`
+	Stages                 []columnStoreStageMetric     `json:"stages"`
+	Queries                []columnStoreQueryMetric     `json:"queries"`
+	Parity                 map[string]columnStoreParity `json:"parity"`
+	ByteAccounting         columnStoreByteAccounting    `json:"byte_accounting"`
+	Manifest               columnStoreManifestMetric    `json:"manifest"`
+	Artifacts              columnStoreArtifactPaths     `json:"artifacts,omitempty"`
+	ProductionScope        string                       `json:"production_scope"`
+	PhysicalColumnQuery    string                       `json:"physical_column_query"`
+	BenchmarkOnlyRelaxed   bool                         `json:"benchmark_only_relaxed"`
+	StageSeparatedBoundary string                       `json:"stage_separated_boundary"`
+}
+
+type columnStoreStageMetric struct {
+	Name          string  `json:"name"`
+	DurationMS    float64 `json:"duration_ms"`
+	Rows          int     `json:"rows,omitempty"`
+	RowsPerSecond float64 `json:"rows_per_second,omitempty"`
+	Bytes         int64   `json:"bytes,omitempty"`
+	MiBPerSecond  float64 `json:"mib_per_second,omitempty"`
+}
+
+type columnStoreQueryMetric struct {
+	Name                string  `json:"name"`
+	PlanLabel           string  `json:"plan_label"`
+	DurationMS          float64 `json:"duration_ms"`
+	Rows                int     `json:"rows"`
+	RowsPerSecond       float64 `json:"rows_per_second"`
+	MiBPerSecond        float64 `json:"mib_per_second"`
+	NsPerRow            float64 `json:"ns_per_row"`
+	BytesRead           int64   `json:"bytes_read"`
+	RowMaterializations int     `json:"row_materializations"`
+	ResultCount         int     `json:"result_count"`
+	RawHash             uint64  `json:"raw_hash"`
+	ProductionHash      uint64  `json:"production_hash"`
+	MetadataHits        int     `json:"metadata_hits"`
+	SkippedGranules     int     `json:"skipped_granules"`
+	CacheLabel          string  `json:"cache_label"`
+}
+
+type columnStoreParity struct {
+	Pass           bool   `json:"pass"`
+	RawHash        uint64 `json:"raw_hash"`
+	ProductionHash uint64 `json:"production_hash"`
+}
+
+type columnStoreByteAccounting struct {
+	SourceDocumentBytes       int64 `json:"source_document_bytes"`
+	RetainedPayloadBytes      int64 `json:"retained_payload_bytes"`
+	ColumnAssetBytes          int64 `json:"column_asset_bytes"`
+	ManifestControlBytes      int64 `json:"manifest_control_bytes"`
+	CommandWALBytes           int64 `json:"command_wal_bytes"`
+	TotalReconstructableBytes int64 `json:"total_reconstructable_bytes"`
+	DBTotalBytes              int64 `json:"db_total_bytes"`
+	DBTotalFiles              int   `json:"db_total_files"`
+}
+
+type columnStoreManifestMetric struct {
+	ActiveGeneration                uint64 `json:"active_generation"`
+	RecoveryAuthoritativeGeneration uint64 `json:"recovery_authoritative_generation"`
+	AppliedCommandLSN               uint64 `json:"applied_command_lsn"`
+	ManifestRoot                    uint64 `json:"manifest_root"`
+	SchemaHash                      uint64 `json:"schema_hash"`
+}
+
+type columnStoreArtifactPaths struct {
+	ColumnJSON        string `json:"column_json,omitempty"`
+	ColumnMarkdown    string `json:"column_markdown,omitempty"`
+	ColumnHTML        string `json:"column_html,omitempty"`
+	BenchprofJSON     string `json:"benchprof_json,omitempty"`
+	BenchprofMarkdown string `json:"benchprof_markdown,omitempty"`
+	InsightsMarkdown  string `json:"insights_markdown,omitempty"`
+	InsightsJSON      string `json:"insights_json,omitempty"`
+	InsightsHTML      string `json:"insights_html,omitempty"`
+}
+
+type columnStoreFixtureEvent struct {
+	ID     string
+	TimeUS int64
+	Kind   string
+	Did    string
+	Doc    []byte
+}
+
+type columnStoreDecodedEvent struct {
+	TimeUS int64  `json:"time_us"`
+	Kind   string `json:"kind"`
+	Did    string `json:"did"`
+}
+
+type columnStoreSuiteDBLabel struct {
+	name string
+}
+
+func (d *columnStoreSuiteDBLabel) Name() string               { return d.name }
+func (d *columnStoreSuiteDBLabel) Close() error               { return nil }
+func (d *columnStoreSuiteDBLabel) Get([]byte) ([]byte, error) { return nil, nil }
+func (d *columnStoreSuiteDBLabel) Set([]byte, []byte) error   { return nil }
+func (d *columnStoreSuiteDBLabel) Delete([]byte) error        { return nil }
+
+func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (string, error) {
+	profile, err := columnStoreSuiteEffectiveProfile(baseCfg.Profile)
+	if err != nil {
+		return "", err
+	}
+	fixture := strings.TrimSpace(opts.Fixture)
+	if fixture == "" {
+		fixture = strings.TrimSpace(*columnStoreSuiteFixtureArg)
+	}
+	if fixture == "" {
+		fixture = "synthetic"
+	}
+	if fixture != "synthetic" {
+		return "", fmt.Errorf("column_store: unsupported fixture %q; synthetic is the M11A CI fixture and JSONBENCH_DATA large mode is not wired yet", fixture)
+	}
+	forcedPath := normalizeColumnStoreSuitePath(opts.ForcedPath)
+	if forcedPath == "" {
+		forcedPath = normalizeColumnStoreSuitePath(*columnStoreSuitePathArg)
+	}
+	if err := validateColumnStoreSuiteForcedPath(forcedPath); err != nil {
+		return "", err
+	}
+	if !columnStoreSuiteDBsIncludeTreeDB(baseCfg.DBsArg) {
+		return "", fmt.Errorf("column_store: native suite only supports TreeDB; got -dbs=%q", baseCfg.DBsArg)
+	}
+	if strings.TrimSpace(opts.ProfileDir) != "" {
+		if err := validateBenchprofExecutionPath(strings.TrimSpace(opts.ExecutionPath)); err != nil {
+			return "", err
+		}
+	}
+
+	rows := baseCfg.Keys
+	if rows <= 0 {
+		rows = 1
+	}
+	batchSize := baseCfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = 128
+	}
+	if batchSize > rows {
+		batchSize = rows
+	}
+	seed := baseCfg.SeedUsed
+	if seed == 0 {
+		seed = 1
+	}
+
+	stages := make([]columnStoreStageMetric, 0, 5)
+	start := time.Now()
+	fixtureEvents, sourceBytes := buildColumnStoreSyntheticFixture(rows, seed)
+	stages = append(stages, columnStoreStage("fixture_generate", start, rows, sourceBytes))
+
+	dataDir, err := os.MkdirTemp("", "unified-bench-column-store-*")
+	if err != nil {
+		return "", fmt.Errorf("column_store: create temp dir: %w", err)
+	}
+	if !baseCfg.KeepDir {
+		defer os.RemoveAll(dataDir)
+	}
+
+	start = time.Now()
+	db, err := openColumnStoreSuiteDB(dataDir)
+	if err != nil {
+		return "", err
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "events",
+		Options: collections.CollectionOptions{
+			DocumentFormat:               collections.DocumentFormatJSON,
+			DisableIndexedWriteMemtables: true,
+			ColumnStore:                  columnStoreSuiteConfig(),
+		},
+	}); err != nil {
+		_ = db.Close()
+		return "", fmt.Errorf("column_store: create collection: %w", err)
+	}
+	collection, err := manager.OpenCollection("events")
+	if err != nil {
+		_ = db.Close()
+		return "", fmt.Errorf("column_store: open collection: %w", err)
+	}
+	stages = append(stages, columnStoreStage("open_create", start, 0, 0))
+
+	start = time.Now()
+	if err := insertColumnStoreFixture(collection, fixtureEvents, batchSize); err != nil {
+		_ = db.Close()
+		return "", err
+	}
+	stages = append(stages, columnStoreStage("ingest_insert_batch", start, rows, sourceBytes))
+	commandWALBytesBeforeCheckpoint, _ := columnStoreSuiteDirUsage(backenddb.WALDirPath(dataDir))
+
+	start = time.Now()
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return "", fmt.Errorf("column_store: checkpoint: %w", err)
+	}
+	checkpointDuration := time.Since(start)
+	stages = append(stages, columnStoreStageFromDuration("checkpoint", checkpointDuration, rows, sourceBytes))
+	if err := db.Close(); err != nil {
+		return "", fmt.Errorf("column_store: close before reopen: %w", err)
+	}
+
+	start = time.Now()
+	db, err = openColumnStoreSuiteDB(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("column_store: reopen: %w", err)
+	}
+	defer db.Close()
+	collection, err = collections.NewCollectionManager(db).OpenCollection("events")
+	if err != nil {
+		return "", fmt.Errorf("column_store: reopen collection: %w", err)
+	}
+	reopenDuration := time.Since(start)
+	stages = append(stages, columnStoreStageFromDuration("reopen", reopenDuration, rows, sourceBytes))
+
+	manifestIdentity, ok := collection.ColumnStoreCacheIdentity()
+	if !ok {
+		return "", errors.New("column_store: reopened collection has no column-store manifest identity")
+	}
+
+	rawHashes := columnStoreReferenceHashes(fixtureEvents)
+	if corrupt := strings.TrimSpace(opts.CorruptReferenceForTest); corrupt != "" {
+		rawHashes[corrupt]++
+	}
+	queries, parity, parityErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, forcedPath)
+
+	totalBytes, totalFiles := columnStoreSuiteDirUsage(dataDir)
+	manifestControlBytes := int64(28 + len("events/column/manifest"))
+	report := columnStoreSuiteReport{
+		GeneratedAt:            time.Now().UTC().Format(time.RFC3339),
+		Suite:                  "column_store",
+		Profile:                profile,
+		Fixture:                fixture,
+		PathLabel:              strings.TrimSpace(opts.ExecutionPath),
+		ForcedPath:             forcedPath,
+		Rows:                   rows,
+		BatchSize:              batchSize,
+		Seed:                   seed,
+		CacheLabel:             "reopened_warm_process",
+		SupportedForcedPaths:   []string{columnStorePathRowStoreBaseline},
+		UnsupportedForcedPaths: []string{columnStorePathBTreeIndexBaseline, "serial_column_scan", "aggregate_metadata", "parallel_column_scan"},
+		Stages:                 stages,
+		Queries:                queries,
+		Parity:                 parity,
+		ByteAccounting: columnStoreByteAccounting{
+			SourceDocumentBytes:       sourceBytes,
+			RetainedPayloadBytes:      sourceBytes,
+			ColumnAssetBytes:          0,
+			ManifestControlBytes:      manifestControlBytes,
+			CommandWALBytes:           commandWALBytesBeforeCheckpoint,
+			TotalReconstructableBytes: sourceBytes + manifestControlBytes,
+			DBTotalBytes:              totalBytes,
+			DBTotalFiles:              totalFiles,
+		},
+		Manifest: columnStoreManifestMetric{
+			ActiveGeneration:                manifestIdentity.ManifestGeneration,
+			RecoveryAuthoritativeGeneration: manifestIdentity.RecoveryAuthoritativeGeneration,
+			AppliedCommandLSN:               manifestIdentity.RecoveryAuthoritativeAppliedCommandLSN,
+			ManifestRoot:                    manifestIdentity.ManifestRoot,
+			SchemaHash:                      manifestIdentity.SchemaHash,
+		},
+		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path",
+		PhysicalColumnQuery:    "not implemented in M11A; forced physical column labels fail closed",
+		BenchmarkOnlyRelaxed:   false,
+		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen, and q1-q5 row-store baseline scans are timed separately",
+	}
+
+	md := renderColumnStoreSuiteMarkdown(report)
+	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
+	if strings.TrimSpace(opts.ProfileDir) != "" {
+		report.Artifacts = columnStoreArtifactPaths{
+			ColumnJSON:        filepath.Join(opts.ProfileDir, "column_store_results.json"),
+			ColumnMarkdown:    filepath.Join(opts.ProfileDir, "column_store_results.md"),
+			ColumnHTML:        filepath.Join(opts.ProfileDir, "column_store_results.html"),
+			BenchprofJSON:     filepath.Join(opts.ProfileDir, "benchprof_results.json"),
+			BenchprofMarkdown: filepath.Join(opts.ProfileDir, "benchprof_results.md"),
+			InsightsMarkdown:  filepath.Join(opts.ProfileDir, "insights.md"),
+			InsightsJSON:      filepath.Join(opts.ProfileDir, "insights.json"),
+			InsightsHTML:      filepath.Join(opts.ProfileDir, "insights.html"),
+		}
+		md = renderColumnStoreSuiteMarkdown(report)
+		if err := writeColumnStoreSuiteArtifacts(opts.ProfileDir, opts.ExecutionPath, report, md, run); err != nil {
+			return "", err
+		}
+		if opts.RunBenchprof {
+			runBenchprof(opts.ProfileDir)
+		}
+	}
+	if parityErr != nil {
+		return "", parityErr
+	}
+	return md, nil
+}
+
+func columnStoreSuiteEffectiveProfile(profile string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", "durable", "balanced":
+		return "durable", nil
+	case "fast", "unsafe", "wal_on_fast":
+		return "", fmt.Errorf("column_store: profile %q is benchmark-relaxed and unsupported for M11A production column-store writes; use -profile durable", profile)
+	default:
+		return "", fmt.Errorf("column_store: unsupported profile %q; use durable for the M11A production gate", profile)
+	}
+}
+
+func normalizeColumnStoreSuitePath(path string) string {
+	path = strings.ToLower(strings.TrimSpace(path))
+	switch path {
+	case "", "row-store-baseline", "row_store", "row":
+		return columnStorePathRowStoreBaseline
+	case "b-tree-index-baseline", "btree_index_baseline", "b_tree", "index":
+		return columnStorePathBTreeIndexBaseline
+	default:
+		return path
+	}
+}
+
+func validateColumnStoreSuiteForcedPath(path string) error {
+	switch path {
+	case columnStorePathRowStoreBaseline:
+		return nil
+	case columnStorePathBTreeIndexBaseline, "serial_column_scan", "aggregate_metadata", "parallel_column_scan":
+		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; refusing to route through row store", path)
+	default:
+		return fmt.Errorf("column_store: unknown forced path %q", path)
+	}
+}
+
+func columnStoreSuiteDBsIncludeTreeDB(dbsArg string) bool {
+	dbs := parseList(dbsArg)
+	if len(dbs) == 0 {
+		return true
+	}
+	for _, db := range dbs {
+		switch strings.ToLower(strings.TrimSpace(db)) {
+		case "", "all", "treedb":
+			return true
+		}
+	}
+	return false
+}
+
+func buildColumnStoreSyntheticFixture(rows int, seed int64) ([]columnStoreFixtureEvent, int64) {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]columnStoreFixtureEvent, rows)
+	var bytesTotal int64
+	const baseTimeUS = int64(1_700_000_000_000_000)
+	for i := 0; i < rows; i++ {
+		timeUS := baseTimeUS + int64((i*7919)%86400)*1_000_000 + int64(rng.Intn(1000))
+		kind := fmt.Sprintf("kind_%02d", i%8)
+		did := fmt.Sprintf("d%06d", i%1024)
+		id := fmt.Sprintf("e%09d", i)
+		doc := []byte(fmt.Sprintf(`{"time_us":%d,"kind":"%s","did":"%s","payload":"p%08x","group":%d}`,
+			timeUS, kind, did, uint32(i*2654435761), i%32))
+		out[i] = columnStoreFixtureEvent{ID: id, TimeUS: timeUS, Kind: kind, Did: did, Doc: doc}
+		bytesTotal += int64(len(doc))
+	}
+	return out, bytesTotal
+}
+
+func columnStoreSuiteConfig() *collections.ColumnStoreConfig {
+	return &collections.ColumnStoreConfig{
+		Enabled: true,
+		Columns: []collections.ColumnStoreColumn{
+			{Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
+			{Name: "kind", Path: "kind", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+			{Name: "did", Path: "did", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+		},
+		SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
+		AggregateMetadata: []collections.ColumnAggregateMetadata{
+			{Name: "q5_did_time_span", Column: "time_us", Kind: collections.ColumnAggregateMin},
+			{Name: "q5_did_time_span_max", Column: "time_us", Kind: collections.ColumnAggregateMax},
+		},
+		RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
+		Reconstruction:  collections.ColumnReconstructionRetainedPayloadAndColumns,
+		ProfileSupport:  collections.ColumnStoreProfileDurableOnly,
+	}
+}
+
+func openColumnStoreSuiteDB(dir string) (*backenddb.DB, error) {
+	return backenddb.Open(backenddb.Options{
+		Dir:                    dir,
+		CommandWAL:             true,
+		CommandWALStatsScan:    true,
+		Durability:             backenddb.DurabilityDurable,
+		DisableBackgroundPrune: true,
+	})
+}
+
+func insertColumnStoreFixture(collection *collections.Collection, events []columnStoreFixtureEvent, batchSize int) error {
+	for start := 0; start < len(events); start += batchSize {
+		end := start + batchSize
+		if end > len(events) {
+			end = len(events)
+		}
+		ids := make([][]byte, end-start)
+		docs := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			ids[i-start] = []byte(events[i].ID)
+			docs[i-start] = events[i].Doc
+		}
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			return fmt.Errorf("column_store: InsertBatch rows %d-%d: %w", start, end, err)
+		}
+	}
+	return nil
+}
+
+func columnStoreReferenceHashes(events []columnStoreFixtureEvent) map[string]uint64 {
+	decoded := make([]columnStoreDecodedEvent, len(events))
+	for i := range events {
+		decoded[i] = columnStoreDecodedEvent{TimeUS: events[i].TimeUS, Kind: events[i].Kind, Did: events[i].Did}
+	}
+	out := make(map[string]uint64)
+	for _, name := range columnStoreQueryNames() {
+		hash, _ := columnStoreQueryHash(name, decoded)
+		out[name] = hash
+	}
+	return out
+}
+
+func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
+	queries := make([]columnStoreQueryMetric, 0, len(columnStoreQueryNames()))
+	parity := make(map[string]columnStoreParity, len(columnStoreQueryNames()))
+	var firstErr error
+	for _, name := range columnStoreQueryNames() {
+		start := time.Now()
+		events, materialized, bytesRead, err := scanColumnStoreSuiteEvents(collection, rows)
+		elapsed := time.Since(start)
+		if err != nil {
+			return nil, nil, err
+		}
+		hash, resultCount := columnStoreQueryHash(name, events)
+		rawHash := rawHashes[name]
+		pass := rawHash == hash
+		parity[name] = columnStoreParity{Pass: pass, RawHash: rawHash, ProductionHash: hash}
+		if !pass && firstErr == nil {
+			firstErr = fmt.Errorf("column_store: parity mismatch for %s: raw=%016x production=%016x", name, rawHash, hash)
+		}
+		metric := columnStoreQueryMetric{
+			Name:                name,
+			PlanLabel:           path,
+			DurationMS:          durationMS(elapsed),
+			Rows:                rows,
+			RowsPerSecond:       ratePerSecond(float64(materialized), elapsed),
+			MiBPerSecond:        ratePerSecond(float64(bytesRead)/(1024*1024), elapsed),
+			NsPerRow:            nsPerRow(elapsed, materialized),
+			BytesRead:           bytesRead,
+			RowMaterializations: materialized,
+			ResultCount:         resultCount,
+			RawHash:             rawHash,
+			ProductionHash:      hash,
+			MetadataHits:        0,
+			SkippedGranules:     0,
+			CacheLabel:          "reopened_warm_process",
+		}
+		queries = append(queries, metric)
+	}
+	return queries, parity, firstErr
+}
+
+func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([]columnStoreDecodedEvent, int, int64, error) {
+	events := make([]columnStoreDecodedEvent, 0, rows)
+	var materialized int
+	var bytesRead int64
+	truncated, err := collection.ScanDocumentsFunc(rows+1, func(record collections.DocumentRecord) (bool, error) {
+		var event columnStoreDecodedEvent
+		if err := json.Unmarshal(record.Document, &event); err != nil {
+			return false, err
+		}
+		events = append(events, event)
+		materialized++
+		bytesRead += int64(len(record.Document))
+		return true, nil
+	})
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("column_store: scan documents: %w", err)
+	}
+	if truncated {
+		return nil, 0, 0, fmt.Errorf("column_store: scan truncated at %d rows", rows+1)
+	}
+	if materialized != rows {
+		return nil, 0, 0, fmt.Errorf("column_store: scanned %d rows, want %d", materialized, rows)
+	}
+	return events, materialized, bytesRead, nil
+}
+
+func columnStoreQueryNames() []string {
+	return []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
+}
+
+func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int) {
+	lines := columnStoreQueryLines(name, events)
+	sort.Strings(lines)
+	h := fnv.New64a()
+	for _, line := range lines {
+		_, _ = h.Write([]byte(line))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64(), len(lines)
+}
+
+func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []string {
+	switch name {
+	case "q1":
+		counts := make(map[string]int)
+		for _, event := range events {
+			counts[event.Kind]++
+		}
+		return formatIntMapLines(name, counts)
+	case "q2":
+		distinct := make(map[string]map[string]struct{})
+		for _, event := range events {
+			set := distinct[event.Kind]
+			if set == nil {
+				set = make(map[string]struct{})
+				distinct[event.Kind] = set
+			}
+			set[event.Did] = struct{}{}
+		}
+		counts := make(map[string]int)
+		for kind, set := range distinct {
+			counts[kind] = len(set)
+		}
+		return formatIntMapLines(name, counts)
+	case "q3":
+		counts := make(map[string]int)
+		for _, event := range events {
+			hour := (event.TimeUS / 3_600_000_000) % 24
+			counts[fmt.Sprintf("hour_%02d", hour)]++
+		}
+		return formatIntMapLines(name, counts)
+	case "q4a":
+		mins := make(map[string]int64)
+		for _, event := range events {
+			if cur, ok := mins[event.Did]; !ok || event.TimeUS < cur {
+				mins[event.Did] = event.TimeUS
+			}
+		}
+		return formatInt64MapLines(name, mins)
+	case "q4b":
+		maxs := make(map[string]int64)
+		for _, event := range events {
+			if cur, ok := maxs[event.Did]; !ok || event.TimeUS > cur {
+				maxs[event.Did] = event.TimeUS
+			}
+		}
+		return formatInt64MapLines(name, maxs)
+	case "q5", "q5_metadata":
+		type span struct {
+			min int64
+			max int64
+		}
+		spans := make(map[string]span)
+		for _, event := range events {
+			cur, ok := spans[event.Did]
+			if !ok {
+				spans[event.Did] = span{min: event.TimeUS, max: event.TimeUS}
+				continue
+			}
+			if event.TimeUS < cur.min {
+				cur.min = event.TimeUS
+			}
+			if event.TimeUS > cur.max {
+				cur.max = event.TimeUS
+			}
+			spans[event.Did] = cur
+		}
+		lines := make([]string, 0, len(spans))
+		for did, sp := range spans {
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", name, did, sp.max-sp.min))
+		}
+		return lines
+	default:
+		return nil
+	}
+}
+
+func formatIntMapLines(prefix string, values map[string]int) []string {
+	lines := make([]string, 0, len(values))
+	for key, value := range values {
+		lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, key, value))
+	}
+	return lines
+}
+
+func formatInt64MapLines(prefix string, values map[string]int64) []string {
+	lines := make([]string, 0, len(values))
+	for key, value := range values {
+		lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, key, value))
+	}
+	return lines
+}
+
+func columnStoreStage(name string, start time.Time, rows int, bytes int64) columnStoreStageMetric {
+	return columnStoreStageFromDuration(name, time.Since(start), rows, bytes)
+}
+
+func columnStoreStageFromDuration(name string, elapsed time.Duration, rows int, bytes int64) columnStoreStageMetric {
+	return columnStoreStageMetric{
+		Name:          name,
+		DurationMS:    durationMS(elapsed),
+		Rows:          rows,
+		RowsPerSecond: ratePerSecond(float64(rows), elapsed),
+		Bytes:         bytes,
+		MiBPerSecond:  ratePerSecond(float64(bytes)/(1024*1024), elapsed),
+	}
+}
+
+func durationMS(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}
+
+func ratePerSecond(v float64, d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return v / d.Seconds()
+}
+
+func nsPerRow(d time.Duration, rows int) float64 {
+	if rows <= 0 {
+		return math.NaN()
+	}
+	return float64(d.Nanoseconds()) / float64(rows)
+}
+
+func columnStoreSuiteDirUsage(root string) (int64, int) {
+	var bytes int64
+	var files int
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry == nil || entry.IsDir() {
+			return nil
+		}
+		info, statErr := entry.Info()
+		if statErr != nil {
+			return nil
+		}
+		bytes += info.Size()
+		files++
+		return nil
+	})
+	return bytes, files
+}
+
+func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
+	var sb strings.Builder
+	sb.WriteString("# unified_bench suite: column_store\n\n")
+	sb.WriteString(fmt.Sprintf("- profile: `%s`\n", report.Profile))
+	sb.WriteString(fmt.Sprintf("- fixture: `%s`\n", report.Fixture))
+	sb.WriteString(fmt.Sprintf("- rows: %s\n", formatInt(report.Rows)))
+	sb.WriteString(fmt.Sprintf("- batchsize: %s\n", formatInt(report.BatchSize)))
+	sb.WriteString(fmt.Sprintf("- forced path: `%s`\n", report.ForcedPath))
+	if report.PathLabel != "" {
+		sb.WriteString(fmt.Sprintf("- path-label: `%s`\n", report.PathLabel))
+	}
+	sb.WriteString(fmt.Sprintf("- scope: %s\n", report.ProductionScope))
+	sb.WriteString(fmt.Sprintf("- physical column query: %s\n", report.PhysicalColumnQuery))
+	sb.WriteString(fmt.Sprintf("- timing boundary: %s\n\n", report.StageSeparatedBoundary))
+
+	sb.WriteString("## Stage Timings\n\n")
+	sb.WriteString("| stage | ms | rows/s | MiB/s | bytes |\n")
+	sb.WriteString("|---|---:|---:|---:|---:|\n")
+	for _, st := range report.Stages {
+		sb.WriteString(fmt.Sprintf("| `%s` | %.3f | %.3f | %.3f | %d |\n", st.Name, st.DurationMS, st.RowsPerSecond, st.MiBPerSecond, st.Bytes))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Query Throughput And Parity\n\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | B/read | rows materialized | skipped granules | metadata hits | hash parity |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---|\n")
+	for _, q := range report.Queries {
+		parity := "pass"
+		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
+			parity = "FAIL"
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %d | %d | %d | %d | %s |\n",
+			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.BytesRead, q.RowMaterializations, q.SkippedGranules, q.MetadataHits, parity))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Byte Accounting\n\n")
+	sb.WriteString(fmt.Sprintf("- source_document_bytes: %d\n", report.ByteAccounting.SourceDocumentBytes))
+	sb.WriteString(fmt.Sprintf("- retained_payload_bytes: %d\n", report.ByteAccounting.RetainedPayloadBytes))
+	sb.WriteString(fmt.Sprintf("- column_asset_bytes: %d\n", report.ByteAccounting.ColumnAssetBytes))
+	sb.WriteString(fmt.Sprintf("- manifest_control_bytes: %d\n", report.ByteAccounting.ManifestControlBytes))
+	sb.WriteString(fmt.Sprintf("- command_wal_bytes: %d\n", report.ByteAccounting.CommandWALBytes))
+	sb.WriteString(fmt.Sprintf("- total_reconstructable_bytes: %d\n", report.ByteAccounting.TotalReconstructableBytes))
+	sb.WriteString(fmt.Sprintf("- db_total_bytes: %d across %d files\n\n", report.ByteAccounting.DBTotalBytes, report.ByteAccounting.DBTotalFiles))
+
+	sb.WriteString("## Manifest Recovery\n\n")
+	sb.WriteString(fmt.Sprintf("- active_generation: %d\n", report.Manifest.ActiveGeneration))
+	sb.WriteString(fmt.Sprintf("- recovery_authoritative_generation: %d\n", report.Manifest.RecoveryAuthoritativeGeneration))
+	sb.WriteString(fmt.Sprintf("- applied_command_lsn: %d\n", report.Manifest.AppliedCommandLSN))
+	sb.WriteString(fmt.Sprintf("- manifest_root: %d\n", report.Manifest.ManifestRoot))
+	sb.WriteString(fmt.Sprintf("- schema_hash: %d\n\n", report.Manifest.SchemaHash))
+
+	sb.WriteString("## Forced Path Labels\n\n")
+	sb.WriteString(fmt.Sprintf("- supported: `%s`\n", strings.Join(report.SupportedForcedPaths, "`, `")))
+	sb.WriteString(fmt.Sprintf("- fail-closed until physical planner paths exist: `%s`\n", strings.Join(report.UnsupportedForcedPaths, "`, `")))
+	if report.Artifacts.ColumnJSON != "" {
+		sb.WriteString("\n## Artifacts\n\n")
+		sb.WriteString(fmt.Sprintf("- column JSON: `%s`\n", report.Artifacts.ColumnJSON))
+		sb.WriteString(fmt.Sprintf("- column markdown: `%s`\n", report.Artifacts.ColumnMarkdown))
+		sb.WriteString(fmt.Sprintf("- column HTML: `%s`\n", report.Artifacts.ColumnHTML))
+		sb.WriteString(fmt.Sprintf("- benchprof JSON: `%s`\n", report.Artifacts.BenchprofJSON))
+		sb.WriteString(fmt.Sprintf("- benchprof markdown: `%s`\n", report.Artifacts.BenchprofMarkdown))
+		sb.WriteString(fmt.Sprintf("- insights HTML: `%s`\n", report.Artifacts.InsightsHTML))
+	}
+	return sb.String()
+}
+
+func renderColumnStoreSuiteHTML(report columnStoreSuiteReport) string {
+	md := renderColumnStoreSuiteMarkdown(report)
+	return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>unified_bench column_store</title>
+<style>
+body{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:32px;line-height:1.4;color:#17202a;background:#fbfaf7}
+pre{white-space:pre-wrap;background:#111827;color:#f9fafb;padding:20px;border-radius:12px;overflow:auto}
+h1{font-size:22px}
+</style>
+</head>
+<body>
+<h1>unified_bench column_store</h1>
+<pre>` + html.EscapeString(md) + `</pre>
+</body>
+</html>
+`
+}
+
+func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report columnStoreSuiteReport, stats map[string]string, checkpointDuration time.Duration) BenchRun {
+	cfg := baseCfg
+	cfg.Keys = report.Rows
+	cfg.BatchSize = report.BatchSize
+	cfg.Profile = profile
+	cfg.DBsArg = "treedb"
+	cfg.TestsArg = "full_scan,prefix_scan,column_store_q1,column_store_q2,column_store_q3,column_store_q4a,column_store_q4b,column_store_q5,column_store_q5_metadata"
+	dbName := "TreeDB Column Store"
+	results := make(map[string]map[string]float64)
+	displayNames := map[string]string{
+		"full_scan":                "Full Scan",
+		"prefix_scan":              "Prefix/Selective Scan",
+		"column_store_q1":          "Column q1",
+		"column_store_q2":          "Column q2",
+		"column_store_q3":          "Column q3",
+		"column_store_q4a":         "Column q4a",
+		"column_store_q4b":         "Column q4b",
+		"column_store_q5":          "Column q5",
+		"column_store_q5_metadata": "Column q5 metadata",
+	}
+	testOrder := []string{"full_scan", "prefix_scan", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
+	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
+	for _, q := range report.Queries {
+		byName[q.Name] = q
+		results["column_store_"+q.Name] = map[string]float64{dbName: q.RowsPerSecond}
+	}
+	if q, ok := byName["q1"]; ok {
+		results["full_scan"] = map[string]float64{dbName: q.RowsPerSecond}
+	}
+	if q, ok := byName["q4a"]; ok {
+		results["prefix_scan"] = map[string]float64{dbName: q.RowsPerSecond}
+	}
+	return BenchRun{
+		Config:       cfg,
+		Instances:    []*DBInstance{{Name: "treedb_column_store", Wrapper: &columnStoreSuiteDBLabel{name: dbName}, Dir: dataDir}},
+		TestOrder:    testOrder,
+		DisplayNames: displayNames,
+		Results:      results,
+		CheckpointDurations: map[string]map[string]time.Duration{
+			checkpointPostRunLabel: {dbName: checkpointDuration},
+		},
+		TreeDBStats: map[string]map[string]string{dbName: stats},
+		DiskUsage:   map[string]dirDiskUsage{dbName: {TotalBytes: uint64(report.ByteAccounting.DBTotalBytes), TotalFiles: report.ByteAccounting.DBTotalFiles}},
+	}
+}
+
+func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStoreSuiteReport, md string, run BenchRun) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("column_store: create profile dir: %w", err)
+	}
+	js, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("column_store: marshal report: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "column_store_results.json"), js, 0o644); err != nil {
+		return fmt.Errorf("column_store: write json: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "column_store_results.md"), []byte(md), 0o644); err != nil {
+		return fmt.Errorf("column_store: write markdown: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "column_store_results.html"), []byte(renderColumnStoreSuiteHTML(report)), 0o644); err != nil {
+		return fmt.Errorf("column_store: write html: %w", err)
+	}
+	if err := writeBenchprofArtifacts(dir, strings.TrimSpace(executionPath), []BenchRun{run}); err != nil {
+		return fmt.Errorf("column_store: write benchprof artifacts: %w", err)
+	}
+	return nil
+}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -729,6 +729,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		if err := trace.Start(f); err != nil {
 			_ = f.Close()
+			_ = os.Remove(traceProfile)
 			_ = finish()
 			return nil, fmt.Errorf("column_store: trace start: %w", err)
 		}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -43,6 +43,9 @@ var (
 		"aggregate_metadata",
 		"parallel_column_scan",
 	}
+	// These files are opportunistic control-plane telemetry for the benchmark
+	// report. Missing files are reported, not fatal, because the exact set can
+	// vary as TreeDB control metadata evolves.
 	columnStoreSuiteManifestControlFiles = []string{
 		"vlog_ref_counts.meta",
 	}
@@ -120,7 +123,9 @@ type columnStoreParity struct {
 type columnStoreByteAccounting struct {
 	SourceDocumentBytes             int64    `json:"source_document_bytes"`
 	RetainedPayloadBytes            int64    `json:"retained_payload_bytes"`
+	RetainedPayloadBytesNote        string   `json:"retained_payload_bytes_note,omitempty"`
 	ColumnAssetBytes                int64    `json:"column_asset_bytes"`
+	ColumnAssetBytesNote            string   `json:"column_asset_bytes_note,omitempty"`
 	ManifestControlBytes            int64    `json:"manifest_control_bytes"`
 	ManifestControlMissing          []string `json:"manifest_control_missing,omitempty"`
 	CommandWALBytesBeforeCheckpoint int64    `json:"command_wal_bytes_before_checkpoint"`
@@ -372,7 +377,9 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		ByteAccounting: columnStoreByteAccounting{
 			SourceDocumentBytes:             sourceBytes,
 			RetainedPayloadBytes:            sourceBytes,
+			RetainedPayloadBytesNote:        "M11A retains the source JSONBench payload as the reconstructable row baseline; compressed retained payload accounting is future work",
 			ColumnAssetBytes:                0,
+			ColumnAssetBytesNote:            "not measured in M11A because physical column assets are not published yet",
 			ManifestControlBytes:            manifestControlBytes,
 			ManifestControlMissing:          manifestControlMissing,
 			CommandWALBytesBeforeCheckpoint: commandWALBytesBeforeCheckpoint,
@@ -407,6 +414,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			}
 		}
 	}
+	// Keep artifacts available for diagnosis even when parity is the failing gate.
 	if parityErr != nil {
 		return "", parityErr
 	}
@@ -415,7 +423,10 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 
 func columnStoreSuiteEffectiveProfile(profile string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(profile)) {
-	case "", "durable", "balanced":
+	case "", "durable":
+		return "durable", nil
+	case "balanced":
+		// Accept unified-bench's default profile as an alias for the durable gate.
 		return "durable", nil
 	case "fast", "unsafe", "wal_on_fast":
 		return "", fmt.Errorf("column_store: profile %q is benchmark-relaxed and unsupported for M11A production column-store writes; use -profile durable", profile)
@@ -1126,7 +1137,13 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("## Byte Accounting\n\n")
 	sb.WriteString(fmt.Sprintf("- source_document_bytes: %d\n", report.ByteAccounting.SourceDocumentBytes))
 	sb.WriteString(fmt.Sprintf("- retained_payload_bytes: %d\n", report.ByteAccounting.RetainedPayloadBytes))
+	if report.ByteAccounting.RetainedPayloadBytesNote != "" {
+		sb.WriteString(fmt.Sprintf("- retained_payload_bytes_note: %s\n", report.ByteAccounting.RetainedPayloadBytesNote))
+	}
 	sb.WriteString(fmt.Sprintf("- column_asset_bytes: %d\n", report.ByteAccounting.ColumnAssetBytes))
+	if report.ByteAccounting.ColumnAssetBytesNote != "" {
+		sb.WriteString(fmt.Sprintf("- column_asset_bytes_note: %s\n", report.ByteAccounting.ColumnAssetBytesNote))
+	}
 	sb.WriteString(fmt.Sprintf("- manifest_control_bytes: %d\n", report.ByteAccounting.ManifestControlBytes))
 	if len(report.ByteAccounting.ManifestControlMissing) != 0 {
 		sb.WriteString(fmt.Sprintf("- manifest_control_missing: `%s`\n", strings.Join(report.ByteAccounting.ManifestControlMissing, "`, `")))

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -11,6 +11,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
 	"sort"
 	"strings"
 	"time"
@@ -27,6 +30,19 @@ const (
 var (
 	columnStoreSuitePathArg    = flag.String("column-store-path", columnStorePathRowStoreBaseline, "Forced column-store execution label for -suite column_store (row_store_baseline; physical column labels fail closed until implemented)")
 	columnStoreSuiteFixtureArg = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
+
+	columnStoreSuiteSupportedForcedPaths = []string{
+		columnStorePathRowStoreBaseline,
+	}
+	columnStoreSuiteUnsupportedForcedPaths = []string{
+		columnStorePathBTreeIndexBaseline,
+		"serial_column_scan",
+		"aggregate_metadata",
+		"parallel_column_scan",
+	}
+	columnStoreSuiteManifestControlFiles = []string{
+		"vlog_ref_counts.meta",
+	}
 )
 
 type columnStoreSuiteOptions struct {
@@ -172,14 +188,24 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err := validateColumnStoreSuiteForcedPath(forcedPath); err != nil {
 		return "", err
 	}
-	if !columnStoreSuiteDBsIncludeTreeDB(baseCfg.DBsArg) {
-		return "", fmt.Errorf("column_store: native suite only supports TreeDB; got -dbs=%q", baseCfg.DBsArg)
+	if err := validateColumnStoreSuiteDBSelection(baseCfg.DBsArg, baseCfg.DBsExcludeArg); err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(opts.ProfileDir) != "" {
 		if err := validateBenchprofExecutionPath(strings.TrimSpace(opts.ExecutionPath)); err != nil {
 			return "", err
 		}
 	}
+	finishRuntimeProfiles, err := startColumnStoreSuiteRuntimeProfiles(baseCfg)
+	if err != nil {
+		return "", err
+	}
+	runtimeProfilesActive := true
+	defer func() {
+		if runtimeProfilesActive {
+			_ = finishRuntimeProfiles()
+		}
+	}()
 
 	rows := baseCfg.Keys
 	if rows <= 0 {
@@ -240,12 +266,30 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		return "", err
 	}
 	stages = append(stages, columnStoreStage("ingest_insert_batch", start, rows, sourceBytes))
-	commandWALBytesBeforeCheckpoint, _ := columnStoreSuiteDirUsage(backenddb.WALDirPath(dataDir))
+	commandWALBytesBeforeCheckpoint, _, err := columnStoreSuiteDirUsage(backenddb.WALDirPath(dataDir))
+	if err != nil {
+		_ = db.Close()
+		return "", fmt.Errorf("column_store: command WAL byte accounting: %w", err)
+	}
+
+	var checkpointCPUFile *os.File
+	if shouldCheckpointCPUProfile(baseCfg, checkpointPostRunLabel) {
+		checkpointCPUFile, err = startCheckpointCPUProfile(baseCfg, checkpointPostRunLabel, "TreeDB Column Store")
+		if err != nil {
+			_ = db.Close()
+			return "", fmt.Errorf("column_store: checkpoint profiling: %w", err)
+		}
+	}
 
 	start = time.Now()
-	if err := db.Checkpoint(); err != nil {
+	checkpointErr := db.Checkpoint()
+	if checkpointCPUFile != nil {
+		stopCPUProfileFn()
+		_ = checkpointCPUFile.Close()
+	}
+	if checkpointErr != nil {
 		_ = db.Close()
-		return "", fmt.Errorf("column_store: checkpoint: %w", err)
+		return "", fmt.Errorf("column_store: checkpoint: %w", checkpointErr)
 	}
 	checkpointDuration := time.Since(start)
 	stages = append(stages, columnStoreStageFromDuration("checkpoint", checkpointDuration, rows, sourceBytes))
@@ -275,10 +319,23 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if corrupt := strings.TrimSpace(opts.CorruptReferenceForTest); corrupt != "" {
 		rawHashes[corrupt]++
 	}
-	queries, parity, parityErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, forcedPath)
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(baseCfg, collection, rows, rawHashes, forcedPath)
+	if err != nil {
+		return "", err
+	}
+	if err := finishRuntimeProfiles(); err != nil {
+		return "", err
+	}
+	runtimeProfilesActive = false
 
-	totalBytes, totalFiles := columnStoreSuiteDirUsage(dataDir)
-	manifestControlBytes := int64(28 + len("events/column/manifest"))
+	totalBytes, totalFiles, err := columnStoreSuiteDirUsage(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("column_store: DB byte accounting: %w", err)
+	}
+	manifestControlBytes, err := columnStoreSuiteManifestControlUsage(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("column_store: manifest/control byte accounting: %w", err)
+	}
 	report := columnStoreSuiteReport{
 		GeneratedAt:            time.Now().UTC().Format(time.RFC3339),
 		Suite:                  "column_store",
@@ -290,8 +347,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		BatchSize:              batchSize,
 		Seed:                   seed,
 		CacheLabel:             "reopened_warm_process",
-		SupportedForcedPaths:   []string{columnStorePathRowStoreBaseline},
-		UnsupportedForcedPaths: []string{columnStorePathBTreeIndexBaseline, "serial_column_scan", "aggregate_metadata", "parallel_column_scan"},
+		SupportedForcedPaths:   cloneStringSlice(columnStoreSuiteSupportedForcedPaths),
+		UnsupportedForcedPaths: cloneStringSlice(columnStoreSuiteUnsupportedForcedPaths),
 		Stages:                 stages,
 		Queries:                queries,
 		Parity:                 parity,
@@ -336,7 +393,9 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			return "", err
 		}
 		if opts.RunBenchprof {
-			runBenchprof(opts.ProfileDir)
+			if err := runBenchprofStrict(opts.ProfileDir); err != nil {
+				return "", err
+			}
 		}
 	}
 	if parityErr != nil {
@@ -373,24 +432,44 @@ func validateColumnStoreSuiteForcedPath(path string) error {
 	case columnStorePathRowStoreBaseline:
 		return nil
 	case columnStorePathBTreeIndexBaseline, "serial_column_scan", "aggregate_metadata", "parallel_column_scan":
-		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; refusing to route through row store", path)
+		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	default:
-		return fmt.Errorf("column_store: unknown forced path %q", path)
+		return fmt.Errorf("column_store: unknown forced path %q; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	}
 }
 
-func columnStoreSuiteDBsIncludeTreeDB(dbsArg string) bool {
-	dbs := parseList(dbsArg)
-	if len(dbs) == 0 {
-		return true
+func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {
+	for _, db := range parseList(excludeArg) {
+		switch strings.ToLower(strings.TrimSpace(db)) {
+		case "", "none":
+			continue
+		case "all", "treedb":
+			return fmt.Errorf("column_store: native suite requires TreeDB but -dbs-exclude=%q excludes it", excludeArg)
+		}
 	}
+
+	dbs := parseList(dbsArg)
+	hasTreeDB := false
 	for _, db := range dbs {
 		switch strings.ToLower(strings.TrimSpace(db)) {
 		case "", "all", "treedb":
-			return true
+			hasTreeDB = true
+		default:
+			return fmt.Errorf("column_store: native suite only supports TreeDB; got -dbs=%q", dbsArg)
 		}
 	}
-	return false
+	if !hasTreeDB {
+		return fmt.Errorf("column_store: native suite requires TreeDB; got -dbs=%q", dbsArg)
+	}
+	return nil
+}
+
+func columnStoreSuitePathList(paths []string) string {
+	return strings.Join(paths, ",")
+}
+
+func cloneStringSlice(in []string) []string {
+	return append([]string(nil), in...)
 }
 
 func buildColumnStoreSyntheticFixture(rows int, seed int64) ([]columnStoreFixtureEvent, int64) {
@@ -472,6 +551,215 @@ func columnStoreReferenceHashes(events []columnStoreFixtureEvent) map[string]uin
 	return out
 }
 
+func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error) {
+	var cleanups []func() error
+	finish := func() error {
+		var out error
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			out = errors.Join(out, cleanups[i]())
+		}
+		cleanups = nil
+		return out
+	}
+
+	if cfg.AllocsProfile != "" {
+		rate := cfg.AllocsProfileRate
+		if rate <= 0 {
+			rate = 512 * 1024
+		}
+		prevRate := runtime.MemProfileRate
+		runtime.MemProfileRate = rate
+		cleanups = append(cleanups, func() error {
+			runtime.MemProfileRate = prevRate
+			return nil
+		})
+	}
+
+	if cfg.BlockProfile != "" {
+		rate := cfg.BlockProfileRate
+		if rate <= 0 {
+			rate = 1
+		}
+		runtime.SetBlockProfileRate(rate)
+		f, err := os.Create(cfg.BlockProfile)
+		if err != nil {
+			_ = finish()
+			return nil, fmt.Errorf("column_store: blockprofile: %w", err)
+		}
+		cleanups = append(cleanups, func() error {
+			defer runtime.SetBlockProfileRate(0)
+			defer f.Close()
+			prof := pprof.Lookup("block")
+			if prof == nil {
+				return fmt.Errorf("block profile unavailable")
+			}
+			return prof.WriteTo(f, 0)
+		})
+	}
+
+	if cfg.MutexProfile != "" {
+		frac := cfg.MutexProfileFraction
+		if frac <= 0 {
+			frac = 1
+		}
+		runtime.SetMutexProfileFraction(frac)
+		f, err := os.Create(cfg.MutexProfile)
+		if err != nil {
+			_ = finish()
+			return nil, fmt.Errorf("column_store: mutexprofile: %w", err)
+		}
+		cleanups = append(cleanups, func() error {
+			defer runtime.SetMutexProfileFraction(0)
+			defer f.Close()
+			prof := pprof.Lookup("mutex")
+			if prof == nil {
+				return fmt.Errorf("mutex profile unavailable")
+			}
+			return prof.WriteTo(f, 0)
+		})
+	}
+
+	if cfg.TraceProfile != "" {
+		f, err := os.Create(cfg.TraceProfile)
+		if err != nil {
+			_ = finish()
+			return nil, fmt.Errorf("column_store: trace: %w", err)
+		}
+		if err := trace.Start(f); err != nil {
+			_ = f.Close()
+			_ = finish()
+			return nil, fmt.Errorf("column_store: trace start: %w", err)
+		}
+		cleanups = append(cleanups, func() error {
+			trace.Stop()
+			return f.Close()
+		})
+	}
+
+	return finish, nil
+}
+
+func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
+	const testName = "column_store"
+	const dbName = "treedb_column_store"
+
+	var cpuFile *os.File
+	if shouldCPUProfile(cfg, testName) {
+		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, testName, dbName)
+		f, err := os.Create(profilePath)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile %s: %w", profilePath, err)
+		}
+		cpuFile = f
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile start %s: %w", profilePath, err)
+		}
+	}
+
+	allocBasePath := ""
+	var err error
+	if shouldAllocsProfile(cfg, testName) {
+		allocBasePath, err = writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_base")
+		if err != nil {
+			if cpuFile != nil {
+				stopCPUProfileFn()
+				_ = cpuFile.Close()
+			}
+			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile baseline: %w", err)
+		}
+	}
+	blockBasePath := ""
+	if cfg.BlockProfile != "" {
+		blockBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_block_base", "block")
+		if err != nil {
+			if cpuFile != nil {
+				stopCPUProfileFn()
+				_ = cpuFile.Close()
+			}
+			_ = os.Remove(allocBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: blockprofile baseline: %w", err)
+		}
+	}
+	mutexBasePath := ""
+	if cfg.MutexProfile != "" {
+		mutexBasePath, err = writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_mutex_base", "mutex")
+		if err != nil {
+			if cpuFile != nil {
+				stopCPUProfileFn()
+				_ = cpuFile.Close()
+			}
+			_ = os.Remove(allocBasePath)
+			_ = os.Remove(blockBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile baseline: %w", err)
+		}
+	}
+
+	queries, parity, runErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, path)
+
+	if cpuFile != nil {
+		stopCPUProfileFn()
+		_ = cpuFile.Close()
+	}
+	if queries == nil {
+		_ = os.Remove(allocBasePath)
+		_ = os.Remove(blockBasePath)
+		_ = os.Remove(mutexBasePath)
+		return queries, parity, runErr, nil
+	}
+
+	if allocBasePath != "" {
+		allocAfterPath, snapErr := writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_after")
+		if snapErr != nil {
+			_ = os.Remove(allocBasePath)
+			_ = os.Remove(blockBasePath)
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile snapshot: %w", snapErr)
+		}
+		allocPath := fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, testName, dbName)
+		deltaErr := writeAllocsDeltaProfileFn(allocBasePath, allocAfterPath, allocPath)
+		_ = os.Remove(allocBasePath)
+		_ = os.Remove(allocAfterPath)
+		if deltaErr != nil {
+			_ = os.Remove(blockBasePath)
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile %s: %w", allocPath, deltaErr)
+		}
+	}
+	if blockBasePath != "" {
+		blockAfterPath, snapErr := writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_block_after", "block")
+		if snapErr != nil {
+			_ = os.Remove(blockBasePath)
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: blockprofile snapshot: %w", snapErr)
+		}
+		blockPath := contentionProfilePath(cfg.BlockProfile, "block", testName, dbName)
+		_, deltaErr := writeRuntimeProfileDeltaProfileFn(blockBasePath, blockAfterPath, blockPath)
+		_ = os.Remove(blockBasePath)
+		_ = os.Remove(blockAfterPath)
+		if deltaErr != nil {
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: blockprofile %s: %w", blockPath, deltaErr)
+		}
+	}
+	if mutexBasePath != "" {
+		mutexAfterPath, snapErr := writeRuntimeProfileSnapshotTempFn("unified_bench_column_store_mutex_after", "mutex")
+		if snapErr != nil {
+			_ = os.Remove(mutexBasePath)
+			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile snapshot: %w", snapErr)
+		}
+		mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", testName, dbName)
+		_, deltaErr := writeRuntimeProfileDeltaProfileFn(mutexBasePath, mutexAfterPath, mutexPath)
+		_ = os.Remove(mutexBasePath)
+		_ = os.Remove(mutexAfterPath)
+		if deltaErr != nil {
+			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile %s: %w", mutexPath, deltaErr)
+		}
+	}
+
+	return queries, parity, runErr, nil
+}
+
 func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
 	queries := make([]columnStoreQueryMetric, 0, len(columnStoreQueryNames()))
 	parity := make(map[string]columnStoreParity, len(columnStoreQueryNames()))
@@ -479,11 +767,11 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 	for _, name := range columnStoreQueryNames() {
 		start := time.Now()
 		events, materialized, bytesRead, err := scanColumnStoreSuiteEvents(collection, rows)
-		elapsed := time.Since(start)
 		if err != nil {
 			return nil, nil, err
 		}
 		hash, resultCount := columnStoreQueryHash(name, events)
+		elapsed := time.Since(start)
 		rawHash := rawHashes[name]
 		pass := rawHash == hash
 		parity[name] = columnStoreParity{Pass: pass, RawHash: rawHash, ProductionHash: hash}
@@ -678,22 +966,47 @@ func nsPerRow(d time.Duration, rows int) float64 {
 	return float64(d.Nanoseconds()) / float64(rows)
 }
 
-func columnStoreSuiteDirUsage(root string) (int64, int) {
+func columnStoreSuiteDirUsage(root string) (int64, int, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return 0, 0, fmt.Errorf("empty path")
+	}
 	var bytes int64
 	var files int
-	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry == nil || entry.IsDir() {
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry == nil || entry.IsDir() {
 			return nil
 		}
 		info, statErr := entry.Info()
 		if statErr != nil {
-			return nil
+			return statErr
 		}
 		bytes += info.Size()
 		files++
 		return nil
-	})
-	return bytes, files
+	}); err != nil {
+		return 0, 0, err
+	}
+	return bytes, files, nil
+}
+
+func columnStoreSuiteManifestControlUsage(root string) (int64, error) {
+	var total int64
+	for _, rel := range columnStoreSuiteManifestControlFiles {
+		path := filepath.Join(root, rel)
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %w", rel, err)
+		}
+		if info.IsDir() {
+			return 0, fmt.Errorf("%s is a directory", rel)
+		}
+		total += info.Size()
+	}
+	return total, nil
 }
 
 func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
@@ -758,6 +1071,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 		sb.WriteString(fmt.Sprintf("- column HTML: `%s`\n", report.Artifacts.ColumnHTML))
 		sb.WriteString(fmt.Sprintf("- benchprof JSON: `%s`\n", report.Artifacts.BenchprofJSON))
 		sb.WriteString(fmt.Sprintf("- benchprof markdown: `%s`\n", report.Artifacts.BenchprofMarkdown))
+		sb.WriteString(fmt.Sprintf("- insights markdown: `%s`\n", report.Artifacts.InsightsMarkdown))
+		sb.WriteString(fmt.Sprintf("- insights JSON: `%s`\n", report.Artifacts.InsightsJSON))
 		sb.WriteString(fmt.Sprintf("- insights HTML: `%s`\n", report.Artifacts.InsightsHTML))
 	}
 	return sb.String()
@@ -790,31 +1105,31 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 	cfg.BatchSize = report.BatchSize
 	cfg.Profile = profile
 	cfg.DBsArg = "treedb"
-	cfg.TestsArg = "full_scan,prefix_scan,column_store_q1,column_store_q2,column_store_q3,column_store_q4a,column_store_q4b,column_store_q5,column_store_q5_metadata"
+	testOrder := []string{"alias_full_scan_from_q1", "alias_prefix_scan_from_q4a", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
+	cfg.TestsArg = strings.Join(testOrder, ",")
 	dbName := "TreeDB Column Store"
 	results := make(map[string]map[string]float64)
 	displayNames := map[string]string{
-		"full_scan":                "Full Scan",
-		"prefix_scan":              "Prefix/Selective Scan",
-		"column_store_q1":          "Column q1",
-		"column_store_q2":          "Column q2",
-		"column_store_q3":          "Column q3",
-		"column_store_q4a":         "Column q4a",
-		"column_store_q4b":         "Column q4b",
-		"column_store_q5":          "Column q5",
-		"column_store_q5_metadata": "Column q5 metadata",
+		"alias_full_scan_from_q1":    "Alias full scan from q1",
+		"alias_prefix_scan_from_q4a": "Alias prefix scan from q4a",
+		"column_store_q1":            "Column q1",
+		"column_store_q2":            "Column q2",
+		"column_store_q3":            "Column q3",
+		"column_store_q4a":           "Column q4a",
+		"column_store_q4b":           "Column q4b",
+		"column_store_q5":            "Column q5",
+		"column_store_q5_metadata":   "Column q5 metadata",
 	}
-	testOrder := []string{"full_scan", "prefix_scan", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
 	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
 	for _, q := range report.Queries {
 		byName[q.Name] = q
 		results["column_store_"+q.Name] = map[string]float64{dbName: q.RowsPerSecond}
 	}
 	if q, ok := byName["q1"]; ok {
-		results["full_scan"] = map[string]float64{dbName: q.RowsPerSecond}
+		results["alias_full_scan_from_q1"] = map[string]float64{dbName: q.RowsPerSecond}
 	}
 	if q, ok := byName["q4a"]; ok {
-		results["prefix_scan"] = map[string]float64{dbName: q.RowsPerSecond}
+		results["alias_prefix_scan_from_q4a"] = map[string]float64{dbName: q.RowsPerSecond}
 	}
 	return BenchRun{
 		Config:       cfg,

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -327,7 +327,10 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		return "", errors.New("column_store: reopened collection has no column-store manifest identity")
 	}
 
-	rawHashes := columnStoreReferenceHashes(fixtureEvents)
+	rawHashes, err := columnStoreReferenceHashes(fixtureEvents)
+	if err != nil {
+		return "", err
+	}
 	if corrupt := strings.TrimSpace(opts.CorruptReferenceForTest); corrupt != "" {
 		rawHashes[corrupt]++
 	}
@@ -584,17 +587,20 @@ func insertColumnStoreFixture(collection *collections.Collection, events []colum
 	return nil
 }
 
-func columnStoreReferenceHashes(events []columnStoreFixtureEvent) map[string]uint64 {
+func columnStoreReferenceHashes(events []columnStoreFixtureEvent) (map[string]uint64, error) {
 	decoded := make([]columnStoreDecodedEvent, len(events))
 	for i := range events {
 		decoded[i] = columnStoreDecodedEvent{TimeUS: events[i].TimeUS, Kind: events[i].Kind, Did: events[i].Did}
 	}
 	out := make(map[string]uint64)
 	for _, name := range columnStoreQueryNames() {
-		hash, _ := columnStoreQueryHash(name, decoded)
+		hash, _, err := columnStoreQueryHash(name, decoded)
+		if err != nil {
+			return nil, err
+		}
 		out[name] = hash
 	}
-	return out
+	return out, nil
 }
 
 func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error) {
@@ -626,12 +632,12 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		if rate <= 0 {
 			rate = 1
 		}
-		runtime.SetBlockProfileRate(rate)
 		f, err := os.Create(cfg.BlockProfile)
 		if err != nil {
 			_ = finish()
 			return nil, fmt.Errorf("column_store: blockprofile: %w", err)
 		}
+		runtime.SetBlockProfileRate(rate)
 		cleanups = append(cleanups, func() error {
 			defer runtime.SetBlockProfileRate(0)
 			defer f.Close()
@@ -648,14 +654,14 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		if frac <= 0 {
 			frac = 1
 		}
-		runtime.SetMutexProfileFraction(frac)
 		f, err := os.Create(cfg.MutexProfile)
 		if err != nil {
 			_ = finish()
 			return nil, fmt.Errorf("column_store: mutexprofile: %w", err)
 		}
+		prevFrac := runtime.SetMutexProfileFraction(frac)
 		cleanups = append(cleanups, func() error {
-			defer runtime.SetMutexProfileFraction(0)
+			defer runtime.SetMutexProfileFraction(prevFrac)
 			defer f.Close()
 			prof := pprof.Lookup("mutex")
 			if prof == nil {
@@ -813,7 +819,10 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 		if err != nil {
 			return nil, nil, err
 		}
-		hash, resultCount := columnStoreQueryHash(name, events)
+		hash, resultCount, err := columnStoreQueryHash(name, events)
+		if err != nil {
+			return nil, nil, fmt.Errorf("column_store: reduce %s: %w", name, err)
+		}
 		elapsed := time.Since(start)
 		rawHash := rawHashes[name]
 		pass := rawHash == hash
@@ -873,25 +882,28 @@ func columnStoreQueryNames() []string {
 	return []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
 }
 
-func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int) {
-	lines := columnStoreQueryLines(name, events)
+func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int, error) {
+	lines, err := columnStoreQueryLines(name, events)
+	if err != nil {
+		return 0, 0, err
+	}
 	sort.Strings(lines)
 	h := fnv.New64a()
 	for _, line := range lines {
 		_, _ = h.Write([]byte(line))
 		_, _ = h.Write([]byte{0})
 	}
-	return h.Sum64(), len(lines)
+	return h.Sum64(), len(lines), nil
 }
 
-func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []string {
+func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) ([]string, error) {
 	switch name {
 	case "q1":
 		counts := make(map[string]int)
 		for _, event := range events {
 			counts[event.Kind]++
 		}
-		return formatIntMapLines(name, counts)
+		return formatIntMapLines(name, counts), nil
 	case "q2":
 		distinct := make(map[string]map[string]struct{})
 		for _, event := range events {
@@ -906,14 +918,14 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []stri
 		for kind, set := range distinct {
 			counts[kind] = len(set)
 		}
-		return formatIntMapLines(name, counts)
+		return formatIntMapLines(name, counts), nil
 	case "q3":
 		counts := make(map[string]int)
 		for _, event := range events {
 			hour := (event.TimeUS / 3_600_000_000) % 24
 			counts[fmt.Sprintf("hour_%02d", hour)]++
 		}
-		return formatIntMapLines(name, counts)
+		return formatIntMapLines(name, counts), nil
 	case "q4a":
 		mins := make(map[string]int64)
 		for _, event := range events {
@@ -921,7 +933,7 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []stri
 				mins[event.Did] = event.TimeUS
 			}
 		}
-		return formatInt64MapLines(name, mins)
+		return formatInt64MapLines(name, mins), nil
 	case "q4b":
 		maxs := make(map[string]int64)
 		for _, event := range events {
@@ -929,7 +941,7 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []stri
 				maxs[event.Did] = event.TimeUS
 			}
 		}
-		return formatInt64MapLines(name, maxs)
+		return formatInt64MapLines(name, maxs), nil
 	case "q5", "q5_metadata":
 		type span struct {
 			min int64
@@ -954,9 +966,9 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) []stri
 		for did, sp := range spans {
 			lines = append(lines, fmt.Sprintf("%s:%s=%d", name, did, sp.max-sp.min))
 		}
-		return lines
+		return lines, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unknown column_store query %q", name)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -94,6 +94,8 @@ type columnStoreStageMetric struct {
 type columnStoreQueryMetric struct {
 	Name                string  `json:"name"`
 	PlanLabel           string  `json:"plan_label"`
+	AliasOf             string  `json:"alias_of,omitempty"`
+	ImplementationNote  string  `json:"implementation_note,omitempty"`
 	DurationMS          float64 `json:"duration_ms"`
 	Rows                int     `json:"rows"`
 	RowsPerSecond       float64 `json:"rows_per_second"`
@@ -732,6 +734,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		cpuFile = f
 		if err := startCPUProfileFn(cpuFile); err != nil {
 			_ = cpuFile.Close()
+			_ = os.Remove(profilePath)
 			_ = os.Remove(allocBasePath)
 			_ = os.Remove(blockBasePath)
 			_ = os.Remove(mutexBasePath)
@@ -749,7 +752,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		_ = os.Remove(allocBasePath)
 		_ = os.Remove(blockBasePath)
 		_ = os.Remove(mutexBasePath)
-		return queries, parity, runErr, nil
+		return nil, nil, nil, runErr
 	}
 
 	if allocBasePath != "" {
@@ -828,6 +831,8 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 		metric := columnStoreQueryMetric{
 			Name:                name,
 			PlanLabel:           path,
+			AliasOf:             columnStoreQueryAliasOf(name, path),
+			ImplementationNote:  columnStoreQueryImplementationNote(name, path),
 			DurationMS:          durationMS(elapsed),
 			Rows:                rows,
 			RowsPerSecond:       ratePerSecond(float64(materialized), elapsed),
@@ -875,6 +880,20 @@ func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([
 
 func columnStoreQueryNames() []string {
 	return []string{"q1", "q2", "q3", "q4a", "q4b", "q5", "q5_metadata"}
+}
+
+func columnStoreQueryAliasOf(name, path string) string {
+	if name == "q5_metadata" && path == columnStorePathRowStoreBaseline {
+		return "q5"
+	}
+	return ""
+}
+
+func columnStoreQueryImplementationNote(name, path string) string {
+	if name == "q5_metadata" && path == columnStorePathRowStoreBaseline {
+		return "row_store_baseline_alias_until_physical_aggregate_metadata_path"
+	}
+	return ""
 }
 
 func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int, error) {
@@ -1088,15 +1107,19 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | B/read | rows materialized | skipped granules | metadata hits | hash parity |\n")
-	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---|\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | B/read | rows materialized | skipped granules | metadata hits | hash parity | note |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|\n")
 	for _, q := range report.Queries {
 		parity := "pass"
 		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
 			parity = "FAIL"
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %d | %d | %d | %d | %s |\n",
-			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.BytesRead, q.RowMaterializations, q.SkippedGranules, q.MetadataHits, parity))
+		note := q.ImplementationNote
+		if note == "" && q.AliasOf != "" {
+			note = "alias_of_" + q.AliasOf
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %d | %d | %d | %d | %s | `%s` |\n",
+			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.BytesRead, q.RowMaterializations, q.SkippedGranules, q.MetadataHits, parity, note))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -114,6 +114,8 @@ type columnStoreQueryMetric struct {
 	MetadataHits        int     `json:"metadata_hits"`
 	SkippedGranules     int     `json:"skipped_granules"`
 	CacheLabel          string  `json:"cache_label"`
+
+	duration time.Duration
 }
 
 type columnStoreParity struct {
@@ -875,6 +877,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			AliasOf:             columnStoreQueryAliasOf(name, path),
 			ImplementationNote:  columnStoreQueryImplementationNote(name, path),
 			DurationMS:          durationMS(elapsed),
+			duration:            elapsed,
 			Rows:                rows,
 			RowsPerSecond:       ratePerSecond(float64(materialized), elapsed),
 			MiBPerSecond:        ratePerSecond(float64(bytesRead)/(1024*1024), elapsed),
@@ -954,7 +957,7 @@ func columnStoreQueryCanonicalName(name, path string) string {
 }
 
 func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64, int, error) {
-	lines, err := columnStoreQueryLines(name, events)
+	lines, err := columnStoreQueryLines(columnStoreQueryHashLineName(name), events)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -965,6 +968,16 @@ func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64
 		_, _ = h.Write([]byte{0})
 	}
 	return h.Sum64(), len(lines), nil
+}
+
+func columnStoreQueryHashLineName(name string) string {
+	// q5_metadata is an execution/reporting label until the physical metadata
+	// path exists; parity hashes use q5's logical result lines so alias
+	// equivalence is directly testable.
+	if name == "q5_metadata" {
+		return "q5"
+	}
+	return name
 }
 
 func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) ([]string, error) {
@@ -1013,7 +1026,7 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) ([]str
 			}
 		}
 		return formatInt64MapLines(name, maxs), nil
-	case "q5", "q5_metadata":
+	case "q5":
 		type span struct {
 			min int64
 			max int64
@@ -1202,7 +1215,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	}
 	sb.WriteString(fmt.Sprintf("- manifest_control_bytes: %d\n", report.ByteAccounting.ManifestControlBytes))
 	if len(report.ByteAccounting.ManifestControlMissing) != 0 {
-		sb.WriteString(fmt.Sprintf("- manifest_control_missing: `%s`\n", strings.Join(report.ByteAccounting.ManifestControlMissing, "`, `")))
+		sb.WriteString(fmt.Sprintf("- manifest_control_missing: %s\n", markdownCodeList(report.ByteAccounting.ManifestControlMissing)))
 	}
 	sb.WriteString(fmt.Sprintf("- command_wal_bytes_before_checkpoint: %d\n", report.ByteAccounting.CommandWALBytesBeforeCheckpoint))
 	sb.WriteString(fmt.Sprintf("- total_reconstructable_bytes: %d\n", report.ByteAccounting.TotalReconstructableBytes))
@@ -1216,8 +1229,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- schema_hash: %d\n\n", report.Manifest.SchemaHash))
 
 	sb.WriteString("## Forced Path Labels\n\n")
-	sb.WriteString(fmt.Sprintf("- supported: `%s`\n", strings.Join(report.SupportedForcedPaths, "`, `")))
-	sb.WriteString(fmt.Sprintf("- fail-closed until physical planner paths exist: `%s`\n", strings.Join(report.UnsupportedForcedPaths, "`, `")))
+	sb.WriteString(fmt.Sprintf("- supported: %s\n", markdownCodeList(report.SupportedForcedPaths)))
+	sb.WriteString(fmt.Sprintf("- fail-closed until physical planner paths exist: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
 	if report.Artifacts.ColumnJSON != "" {
 		sb.WriteString("\n## Artifacts\n\n")
 		columnStoreWriteArtifactLine(&sb, "column JSON", report.Artifacts.ColumnJSON)
@@ -1245,6 +1258,22 @@ func columnStoreWriteArtifactLine(sb *strings.Builder, label, path string) {
 		return
 	}
 	sb.WriteString(fmt.Sprintf("- %s: `%s`\n", label, path))
+}
+
+func markdownCodeList(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	var sb strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteByte('`')
+		sb.WriteString(value)
+		sb.WriteByte('`')
+	}
+	return sb.String()
 }
 
 func renderColumnStoreSuiteHTML(report columnStoreSuiteReport) string {
@@ -1290,16 +1319,20 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 		"column_store_q5_metadata":    "Column q5 metadata",
 	}
 	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
-	var queryDurationMS float64
+	var queryDuration time.Duration
 	var queryMaterializations int
 	for _, q := range report.Queries {
 		byName[q.Name] = q
-		queryDurationMS += q.DurationMS
+		duration := q.duration
+		if duration == 0 && q.DurationMS > 0 {
+			duration = time.Duration(q.DurationMS * float64(time.Millisecond))
+		}
+		queryDuration += duration
 		queryMaterializations += q.RowMaterializations
 		results["column_store_"+q.Name] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
-	if queryDurationMS > 0 {
-		results[columnStoreSuiteBenchTestName] = map[string]float64{columnStoreSuiteBenchDisplayName: float64(queryMaterializations) / (queryDurationMS / 1000)}
+	if queryDuration > 0 {
+		results[columnStoreSuiteBenchTestName] = map[string]float64{columnStoreSuiteBenchDisplayName: float64(queryMaterializations) / queryDuration.Seconds()}
 	}
 	if q, ok := byName["q1"]; ok {
 		results["alias_full_scan_from_q1"] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -25,6 +25,9 @@ import (
 const (
 	columnStorePathRowStoreBaseline   = "row_store_baseline"
 	columnStorePathBTreeIndexBaseline = "b_tree_index_baseline"
+	columnStoreSuiteBenchTestName     = "column_store"
+	columnStoreSuiteBenchDBName       = "treedb_column_store"
+	columnStoreSuiteBenchDisplayName  = "TreeDB Column Store"
 )
 
 var (
@@ -113,14 +116,15 @@ type columnStoreParity struct {
 }
 
 type columnStoreByteAccounting struct {
-	SourceDocumentBytes       int64 `json:"source_document_bytes"`
-	RetainedPayloadBytes      int64 `json:"retained_payload_bytes"`
-	ColumnAssetBytes          int64 `json:"column_asset_bytes"`
-	ManifestControlBytes      int64 `json:"manifest_control_bytes"`
-	CommandWALBytes           int64 `json:"command_wal_bytes"`
-	TotalReconstructableBytes int64 `json:"total_reconstructable_bytes"`
-	DBTotalBytes              int64 `json:"db_total_bytes"`
-	DBTotalFiles              int   `json:"db_total_files"`
+	SourceDocumentBytes       int64    `json:"source_document_bytes"`
+	RetainedPayloadBytes      int64    `json:"retained_payload_bytes"`
+	ColumnAssetBytes          int64    `json:"column_asset_bytes"`
+	ManifestControlBytes      int64    `json:"manifest_control_bytes"`
+	ManifestControlMissing    []string `json:"manifest_control_missing,omitempty"`
+	CommandWALBytes           int64    `json:"command_wal_bytes"`
+	TotalReconstructableBytes int64    `json:"total_reconstructable_bytes"`
+	DBTotalBytes              int64    `json:"db_total_bytes"`
+	DBTotalFiles              int      `json:"db_total_files"`
 }
 
 type columnStoreManifestMetric struct {
@@ -132,14 +136,22 @@ type columnStoreManifestMetric struct {
 }
 
 type columnStoreArtifactPaths struct {
-	ColumnJSON        string `json:"column_json,omitempty"`
-	ColumnMarkdown    string `json:"column_markdown,omitempty"`
-	ColumnHTML        string `json:"column_html,omitempty"`
-	BenchprofJSON     string `json:"benchprof_json,omitempty"`
-	BenchprofMarkdown string `json:"benchprof_markdown,omitempty"`
-	InsightsMarkdown  string `json:"insights_markdown,omitempty"`
-	InsightsJSON      string `json:"insights_json,omitempty"`
-	InsightsHTML      string `json:"insights_html,omitempty"`
+	ColumnJSON           string `json:"column_json,omitempty"`
+	ColumnMarkdown       string `json:"column_markdown,omitempty"`
+	ColumnHTML           string `json:"column_html,omitempty"`
+	BenchprofJSON        string `json:"benchprof_json,omitempty"`
+	BenchprofMarkdown    string `json:"benchprof_markdown,omitempty"`
+	InsightsMarkdown     string `json:"insights_markdown,omitempty"`
+	InsightsJSON         string `json:"insights_json,omitempty"`
+	InsightsHTML         string `json:"insights_html,omitempty"`
+	CPUProfile           string `json:"cpu_profile,omitempty"`
+	AllocsProfile        string `json:"allocs_profile,omitempty"`
+	CheckpointCPUProfile string `json:"checkpoint_cpu_profile,omitempty"`
+	BlockProfile         string `json:"block_profile,omitempty"`
+	MutexProfile         string `json:"mutex_profile,omitempty"`
+	TraceProfile         string `json:"trace_profile,omitempty"`
+	BlockDeltaProfile    string `json:"block_delta_profile,omitempty"`
+	MutexDeltaProfile    string `json:"mutex_delta_profile,omitempty"`
 }
 
 type columnStoreFixtureEvent struct {
@@ -273,8 +285,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	}
 
 	var checkpointCPUFile *os.File
-	if shouldCheckpointCPUProfile(baseCfg, checkpointPostRunLabel) {
-		checkpointCPUFile, err = startCheckpointCPUProfile(baseCfg, checkpointPostRunLabel, "TreeDB Column Store")
+	if shouldCheckpointCPUProfile(baseCfg, columnStoreSuiteBenchTestName) {
+		checkpointCPUFile, err = startCheckpointCPUProfile(baseCfg, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		if err != nil {
 			_ = db.Close()
 			return "", fmt.Errorf("column_store: checkpoint profiling: %w", err)
@@ -332,7 +344,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err != nil {
 		return "", fmt.Errorf("column_store: DB byte accounting: %w", err)
 	}
-	manifestControlBytes, err := columnStoreSuiteManifestControlUsage(dataDir)
+	manifestControlBytes, manifestControlMissing, err := columnStoreSuiteManifestControlUsage(dataDir)
 	if err != nil {
 		return "", fmt.Errorf("column_store: manifest/control byte accounting: %w", err)
 	}
@@ -357,6 +369,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			RetainedPayloadBytes:      sourceBytes,
 			ColumnAssetBytes:          0,
 			ManifestControlBytes:      manifestControlBytes,
+			ManifestControlMissing:    manifestControlMissing,
 			CommandWALBytes:           commandWALBytesBeforeCheckpoint,
 			TotalReconstructableBytes: sourceBytes + manifestControlBytes,
 			DBTotalBytes:              totalBytes,
@@ -378,16 +391,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	md := renderColumnStoreSuiteMarkdown(report)
 	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
 	if strings.TrimSpace(opts.ProfileDir) != "" {
-		report.Artifacts = columnStoreArtifactPaths{
-			ColumnJSON:        filepath.Join(opts.ProfileDir, "column_store_results.json"),
-			ColumnMarkdown:    filepath.Join(opts.ProfileDir, "column_store_results.md"),
-			ColumnHTML:        filepath.Join(opts.ProfileDir, "column_store_results.html"),
-			BenchprofJSON:     filepath.Join(opts.ProfileDir, "benchprof_results.json"),
-			BenchprofMarkdown: filepath.Join(opts.ProfileDir, "benchprof_results.md"),
-			InsightsMarkdown:  filepath.Join(opts.ProfileDir, "insights.md"),
-			InsightsJSON:      filepath.Join(opts.ProfileDir, "insights.json"),
-			InsightsHTML:      filepath.Join(opts.ProfileDir, "insights.html"),
-		}
+		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg)
 		md = renderColumnStoreSuiteMarkdown(report)
 		if err := writeColumnStoreSuiteArtifacts(opts.ProfileDir, opts.ExecutionPath, report, md, run); err != nil {
 			return "", err
@@ -428,14 +432,56 @@ func normalizeColumnStoreSuitePath(path string) string {
 }
 
 func validateColumnStoreSuiteForcedPath(path string) error {
-	switch path {
-	case columnStorePathRowStoreBaseline:
+	if columnStoreSuitePathListed(path, columnStoreSuiteSupportedForcedPaths) {
 		return nil
-	case columnStorePathBTreeIndexBaseline, "serial_column_scan", "aggregate_metadata", "parallel_column_scan":
-		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
-	default:
-		return fmt.Errorf("column_store: unknown forced path %q; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	}
+	if columnStoreSuitePathListed(path, columnStoreSuiteUnsupportedForcedPaths) {
+		return fmt.Errorf("column_store: forced path %q is not implemented in M11A; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+	}
+	return fmt.Errorf("column_store: unknown forced path %q; supported=%s fail_closed=%s", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+}
+
+func columnStoreSuitePathListed(path string, paths []string) bool {
+	for _, candidate := range paths {
+		if path == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) columnStoreArtifactPaths {
+	paths := columnStoreArtifactPaths{
+		ColumnJSON:        filepath.Join(profileDir, "column_store_results.json"),
+		ColumnMarkdown:    filepath.Join(profileDir, "column_store_results.md"),
+		ColumnHTML:        filepath.Join(profileDir, "column_store_results.html"),
+		BenchprofJSON:     filepath.Join(profileDir, "benchprof_results.json"),
+		BenchprofMarkdown: filepath.Join(profileDir, "benchprof_results.md"),
+		InsightsMarkdown:  filepath.Join(profileDir, "insights.md"),
+		InsightsJSON:      filepath.Join(profileDir, "insights.json"),
+		InsightsHTML:      filepath.Join(profileDir, "insights.html"),
+	}
+	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
+		paths.CPUProfile = fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	}
+	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
+		paths.AllocsProfile = fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	}
+	if shouldCheckpointCPUProfile(cfg, columnStoreSuiteBenchTestName) {
+		paths.CheckpointCPUProfile = fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
+	}
+	if strings.TrimSpace(cfg.BlockProfile) != "" {
+		paths.BlockProfile = cfg.BlockProfile
+		paths.BlockDeltaProfile = contentionProfilePath(cfg.BlockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	}
+	if strings.TrimSpace(cfg.MutexProfile) != "" {
+		paths.MutexProfile = cfg.MutexProfile
+		paths.MutexDeltaProfile = contentionProfilePath(cfg.MutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	}
+	if strings.TrimSpace(cfg.TraceProfile) != "" {
+		paths.TraceProfile = cfg.TraceProfile
+	}
+	return paths
 }
 
 func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {
@@ -640,12 +686,9 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 }
 
 func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
-	const testName = "column_store"
-	const dbName = "treedb_column_store"
-
 	var cpuFile *os.File
-	if shouldCPUProfile(cfg, testName) {
-		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, testName, dbName)
+	if shouldCPUProfile(cfg, columnStoreSuiteBenchTestName) {
+		profilePath := fmt.Sprintf("%s_%s_%s.pprof", cfg.CPUProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		f, err := os.Create(profilePath)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("column_store: cpuprofile %s: %w", profilePath, err)
@@ -659,7 +702,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 
 	allocBasePath := ""
 	var err error
-	if shouldAllocsProfile(cfg, testName) {
+	if shouldAllocsProfile(cfg, columnStoreSuiteBenchTestName) {
 		allocBasePath, err = writeAllocsSnapshotTempFn("unified_bench_column_store_allocs_base")
 		if err != nil {
 			if cpuFile != nil {
@@ -716,7 +759,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			_ = os.Remove(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: allocsprofile snapshot: %w", snapErr)
 		}
-		allocPath := fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, testName, dbName)
+		allocPath := fmt.Sprintf("%s_%s_%s.pprof", cfg.AllocsProfile, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		deltaErr := writeAllocsDeltaProfileFn(allocBasePath, allocAfterPath, allocPath)
 		_ = os.Remove(allocBasePath)
 		_ = os.Remove(allocAfterPath)
@@ -733,7 +776,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			_ = os.Remove(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: blockprofile snapshot: %w", snapErr)
 		}
-		blockPath := contentionProfilePath(cfg.BlockProfile, "block", testName, dbName)
+		blockPath := contentionProfilePath(cfg.BlockProfile, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		_, deltaErr := writeRuntimeProfileDeltaProfileFn(blockBasePath, blockAfterPath, blockPath)
 		_ = os.Remove(blockBasePath)
 		_ = os.Remove(blockAfterPath)
@@ -748,7 +791,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 			_ = os.Remove(mutexBasePath)
 			return nil, nil, nil, fmt.Errorf("column_store: mutexprofile snapshot: %w", snapErr)
 		}
-		mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", testName, dbName)
+		mutexPath := contentionProfilePath(cfg.MutexProfile, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 		_, deltaErr := writeRuntimeProfileDeltaProfileFn(mutexBasePath, mutexAfterPath, mutexPath)
 		_ = os.Remove(mutexBasePath)
 		_ = os.Remove(mutexAfterPath)
@@ -993,20 +1036,25 @@ func columnStoreSuiteDirUsage(root string) (int64, int, error) {
 	return bytes, files, nil
 }
 
-func columnStoreSuiteManifestControlUsage(root string) (int64, error) {
+func columnStoreSuiteManifestControlUsage(root string) (int64, []string, error) {
 	var total int64
+	var missing []string
 	for _, rel := range columnStoreSuiteManifestControlFiles {
 		path := filepath.Join(root, rel)
 		info, err := os.Stat(path)
 		if err != nil {
-			return 0, fmt.Errorf("%s: %w", rel, err)
+			if os.IsNotExist(err) {
+				missing = append(missing, rel)
+				continue
+			}
+			return 0, nil, fmt.Errorf("%s: %w", rel, err)
 		}
 		if info.IsDir() {
-			return 0, fmt.Errorf("%s is a directory", rel)
+			return 0, nil, fmt.Errorf("%s is a directory", rel)
 		}
 		total += info.Size()
 	}
-	return total, nil
+	return total, missing, nil
 }
 
 func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
@@ -1050,6 +1098,9 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- retained_payload_bytes: %d\n", report.ByteAccounting.RetainedPayloadBytes))
 	sb.WriteString(fmt.Sprintf("- column_asset_bytes: %d\n", report.ByteAccounting.ColumnAssetBytes))
 	sb.WriteString(fmt.Sprintf("- manifest_control_bytes: %d\n", report.ByteAccounting.ManifestControlBytes))
+	if len(report.ByteAccounting.ManifestControlMissing) != 0 {
+		sb.WriteString(fmt.Sprintf("- manifest_control_missing: `%s`\n", strings.Join(report.ByteAccounting.ManifestControlMissing, "`, `")))
+	}
 	sb.WriteString(fmt.Sprintf("- command_wal_bytes: %d\n", report.ByteAccounting.CommandWALBytes))
 	sb.WriteString(fmt.Sprintf("- total_reconstructable_bytes: %d\n", report.ByteAccounting.TotalReconstructableBytes))
 	sb.WriteString(fmt.Sprintf("- db_total_bytes: %d across %d files\n\n", report.ByteAccounting.DBTotalBytes, report.ByteAccounting.DBTotalFiles))
@@ -1066,16 +1117,31 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- fail-closed until physical planner paths exist: `%s`\n", strings.Join(report.UnsupportedForcedPaths, "`, `")))
 	if report.Artifacts.ColumnJSON != "" {
 		sb.WriteString("\n## Artifacts\n\n")
-		sb.WriteString(fmt.Sprintf("- column JSON: `%s`\n", report.Artifacts.ColumnJSON))
-		sb.WriteString(fmt.Sprintf("- column markdown: `%s`\n", report.Artifacts.ColumnMarkdown))
-		sb.WriteString(fmt.Sprintf("- column HTML: `%s`\n", report.Artifacts.ColumnHTML))
-		sb.WriteString(fmt.Sprintf("- benchprof JSON: `%s`\n", report.Artifacts.BenchprofJSON))
-		sb.WriteString(fmt.Sprintf("- benchprof markdown: `%s`\n", report.Artifacts.BenchprofMarkdown))
-		sb.WriteString(fmt.Sprintf("- insights markdown: `%s`\n", report.Artifacts.InsightsMarkdown))
-		sb.WriteString(fmt.Sprintf("- insights JSON: `%s`\n", report.Artifacts.InsightsJSON))
-		sb.WriteString(fmt.Sprintf("- insights HTML: `%s`\n", report.Artifacts.InsightsHTML))
+		columnStoreWriteArtifactLine(&sb, "column JSON", report.Artifacts.ColumnJSON)
+		columnStoreWriteArtifactLine(&sb, "column markdown", report.Artifacts.ColumnMarkdown)
+		columnStoreWriteArtifactLine(&sb, "column HTML", report.Artifacts.ColumnHTML)
+		columnStoreWriteArtifactLine(&sb, "benchprof JSON", report.Artifacts.BenchprofJSON)
+		columnStoreWriteArtifactLine(&sb, "benchprof markdown", report.Artifacts.BenchprofMarkdown)
+		columnStoreWriteArtifactLine(&sb, "insights markdown", report.Artifacts.InsightsMarkdown)
+		columnStoreWriteArtifactLine(&sb, "insights JSON", report.Artifacts.InsightsJSON)
+		columnStoreWriteArtifactLine(&sb, "insights HTML", report.Artifacts.InsightsHTML)
+		columnStoreWriteArtifactLine(&sb, "CPU profile", report.Artifacts.CPUProfile)
+		columnStoreWriteArtifactLine(&sb, "allocs profile", report.Artifacts.AllocsProfile)
+		columnStoreWriteArtifactLine(&sb, "checkpoint CPU profile", report.Artifacts.CheckpointCPUProfile)
+		columnStoreWriteArtifactLine(&sb, "block profile", report.Artifacts.BlockProfile)
+		columnStoreWriteArtifactLine(&sb, "mutex profile", report.Artifacts.MutexProfile)
+		columnStoreWriteArtifactLine(&sb, "trace", report.Artifacts.TraceProfile)
+		columnStoreWriteArtifactLine(&sb, "block delta profile", report.Artifacts.BlockDeltaProfile)
+		columnStoreWriteArtifactLine(&sb, "mutex delta profile", report.Artifacts.MutexDeltaProfile)
 	}
 	return sb.String()
+}
+
+func columnStoreWriteArtifactLine(sb *strings.Builder, label, path string) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	sb.WriteString(fmt.Sprintf("- %s: `%s`\n", label, path))
 }
 
 func renderColumnStoreSuiteHTML(report columnStoreSuiteReport) string {
@@ -1100,28 +1166,25 @@ h1{font-size:22px}
 }
 
 func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report columnStoreSuiteReport, stats map[string]string, checkpointDuration time.Duration) BenchRun {
-	const aggregateTestName = "column_store"
-
 	cfg := baseCfg
 	cfg.Keys = report.Rows
 	cfg.BatchSize = report.BatchSize
 	cfg.Profile = profile
 	cfg.DBsArg = "treedb"
-	testOrder := []string{aggregateTestName, "alias_full_scan_from_q1", "alias_prefix_scan_from_q4a", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
+	testOrder := []string{columnStoreSuiteBenchTestName, "alias_full_scan_from_q1", "alias_prefix_scan_from_q4a", "column_store_q1", "column_store_q2", "column_store_q3", "column_store_q4a", "column_store_q4b", "column_store_q5", "column_store_q5_metadata"}
 	cfg.TestsArg = strings.Join(testOrder, ",")
-	dbName := "TreeDB Column Store"
 	results := make(map[string]map[string]float64)
 	displayNames := map[string]string{
-		aggregateTestName:            "Column store query phase",
-		"alias_full_scan_from_q1":    "Alias full scan from q1",
-		"alias_prefix_scan_from_q4a": "Alias prefix scan from q4a",
-		"column_store_q1":            "Column q1",
-		"column_store_q2":            "Column q2",
-		"column_store_q3":            "Column q3",
-		"column_store_q4a":           "Column q4a",
-		"column_store_q4b":           "Column q4b",
-		"column_store_q5":            "Column q5",
-		"column_store_q5_metadata":   "Column q5 metadata",
+		columnStoreSuiteBenchTestName: "Column store query phase",
+		"alias_full_scan_from_q1":     "Alias full scan from q1",
+		"alias_prefix_scan_from_q4a":  "Alias prefix scan from q4a",
+		"column_store_q1":             "Column q1",
+		"column_store_q2":             "Column q2",
+		"column_store_q3":             "Column q3",
+		"column_store_q4a":            "Column q4a",
+		"column_store_q4b":            "Column q4b",
+		"column_store_q5":             "Column q5",
+		"column_store_q5_metadata":    "Column q5 metadata",
 	}
 	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
 	var queryDurationMS float64
@@ -1130,28 +1193,28 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 		byName[q.Name] = q
 		queryDurationMS += q.DurationMS
 		queryMaterializations += q.RowMaterializations
-		results["column_store_"+q.Name] = map[string]float64{dbName: q.RowsPerSecond}
+		results["column_store_"+q.Name] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	if queryDurationMS > 0 {
-		results[aggregateTestName] = map[string]float64{dbName: float64(queryMaterializations) / (queryDurationMS / 1000)}
+		results[columnStoreSuiteBenchTestName] = map[string]float64{columnStoreSuiteBenchDisplayName: float64(queryMaterializations) / (queryDurationMS / 1000)}
 	}
 	if q, ok := byName["q1"]; ok {
-		results["alias_full_scan_from_q1"] = map[string]float64{dbName: q.RowsPerSecond}
+		results["alias_full_scan_from_q1"] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	if q, ok := byName["q4a"]; ok {
-		results["alias_prefix_scan_from_q4a"] = map[string]float64{dbName: q.RowsPerSecond}
+		results["alias_prefix_scan_from_q4a"] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	return BenchRun{
 		Config:       cfg,
-		Instances:    []*DBInstance{{Name: "treedb_column_store", Wrapper: &columnStoreSuiteDBLabel{name: dbName}, Dir: dataDir}},
+		Instances:    []*DBInstance{{Name: columnStoreSuiteBenchDBName, Wrapper: &columnStoreSuiteDBLabel{name: columnStoreSuiteBenchDisplayName}, Dir: dataDir}},
 		TestOrder:    testOrder,
 		DisplayNames: displayNames,
 		Results:      results,
 		CheckpointDurations: map[string]map[string]time.Duration{
-			checkpointPostRunLabel: {dbName: checkpointDuration},
+			columnStoreSuiteBenchTestName: {columnStoreSuiteBenchDisplayName: checkpointDuration},
 		},
-		TreeDBStats: map[string]map[string]string{dbName: stats},
-		DiskUsage:   map[string]dirDiskUsage{dbName: {TotalBytes: uint64(report.ByteAccounting.DBTotalBytes), TotalFiles: report.ByteAccounting.DBTotalFiles}},
+		TreeDBStats: map[string]map[string]string{columnStoreSuiteBenchDisplayName: stats},
+		DiskUsage:   map[string]dirDiskUsage{columnStoreSuiteBenchDisplayName: {TotalBytes: uint64(report.ByteAccounting.DBTotalBytes), TotalFiles: report.ByteAccounting.DBTotalFiles}},
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1364,17 +1364,31 @@ func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStor
 	if err != nil {
 		return fmt.Errorf("column_store: marshal report: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.json"), js, 0o644); err != nil {
+	if err := writeColumnStoreSuiteArtifactFile(columnStoreSuiteArtifactPath(report.Artifacts.ColumnJSON, filepath.Join(dir, "column_store_results.json")), js); err != nil {
 		return fmt.Errorf("column_store: write json: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.md"), []byte(md), 0o644); err != nil {
+	if err := writeColumnStoreSuiteArtifactFile(columnStoreSuiteArtifactPath(report.Artifacts.ColumnMarkdown, filepath.Join(dir, "column_store_results.md")), []byte(md)); err != nil {
 		return fmt.Errorf("column_store: write markdown: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.html"), []byte(renderColumnStoreSuiteHTML(report)), 0o644); err != nil {
+	if err := writeColumnStoreSuiteArtifactFile(columnStoreSuiteArtifactPath(report.Artifacts.ColumnHTML, filepath.Join(dir, "column_store_results.html")), []byte(renderColumnStoreSuiteHTML(report))); err != nil {
 		return fmt.Errorf("column_store: write html: %w", err)
 	}
 	if err := writeBenchprofArtifacts(dir, strings.TrimSpace(executionPath), []BenchRun{run}); err != nil {
 		return fmt.Errorf("column_store: write benchprof artifacts: %w", err)
 	}
 	return nil
+}
+
+func columnStoreSuiteArtifactPath(recorded, fallback string) string {
+	if strings.TrimSpace(recorded) != "" {
+		return recorded
+	}
+	return fallback
+}
+
+func writeColumnStoreSuiteArtifactFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
 }

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -116,15 +116,15 @@ type columnStoreParity struct {
 }
 
 type columnStoreByteAccounting struct {
-	SourceDocumentBytes       int64    `json:"source_document_bytes"`
-	RetainedPayloadBytes      int64    `json:"retained_payload_bytes"`
-	ColumnAssetBytes          int64    `json:"column_asset_bytes"`
-	ManifestControlBytes      int64    `json:"manifest_control_bytes"`
-	ManifestControlMissing    []string `json:"manifest_control_missing,omitempty"`
-	CommandWALBytes           int64    `json:"command_wal_bytes"`
-	TotalReconstructableBytes int64    `json:"total_reconstructable_bytes"`
-	DBTotalBytes              int64    `json:"db_total_bytes"`
-	DBTotalFiles              int      `json:"db_total_files"`
+	SourceDocumentBytes             int64    `json:"source_document_bytes"`
+	RetainedPayloadBytes            int64    `json:"retained_payload_bytes"`
+	ColumnAssetBytes                int64    `json:"column_asset_bytes"`
+	ManifestControlBytes            int64    `json:"manifest_control_bytes"`
+	ManifestControlMissing          []string `json:"manifest_control_missing,omitempty"`
+	CommandWALBytesBeforeCheckpoint int64    `json:"command_wal_bytes_before_checkpoint"`
+	TotalReconstructableBytes       int64    `json:"total_reconstructable_bytes"`
+	DBTotalBytes                    int64    `json:"db_total_bytes"`
+	DBTotalFiles                    int      `json:"db_total_files"`
 }
 
 type columnStoreManifestMetric struct {
@@ -368,15 +368,15 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		Queries:                queries,
 		Parity:                 parity,
 		ByteAccounting: columnStoreByteAccounting{
-			SourceDocumentBytes:       sourceBytes,
-			RetainedPayloadBytes:      sourceBytes,
-			ColumnAssetBytes:          0,
-			ManifestControlBytes:      manifestControlBytes,
-			ManifestControlMissing:    manifestControlMissing,
-			CommandWALBytes:           commandWALBytesBeforeCheckpoint,
-			TotalReconstructableBytes: sourceBytes + manifestControlBytes,
-			DBTotalBytes:              totalBytes,
-			DBTotalFiles:              totalFiles,
+			SourceDocumentBytes:             sourceBytes,
+			RetainedPayloadBytes:            sourceBytes,
+			ColumnAssetBytes:                0,
+			ManifestControlBytes:            manifestControlBytes,
+			ManifestControlMissing:          manifestControlMissing,
+			CommandWALBytesBeforeCheckpoint: commandWALBytesBeforeCheckpoint,
+			TotalReconstructableBytes:       sourceBytes + manifestControlBytes,
+			DBTotalBytes:                    totalBytes,
+			DBTotalFiles:                    totalFiles,
 		},
 		Manifest: columnStoreManifestMetric{
 			ActiveGeneration:                manifestIdentity.ManifestGeneration,
@@ -531,8 +531,9 @@ func buildColumnStoreSyntheticFixture(rows int, seed int64) ([]columnStoreFixtur
 		kind := fmt.Sprintf("kind_%02d", i%8)
 		did := fmt.Sprintf("d%06d", i%1024)
 		id := fmt.Sprintf("e%09d", i)
+		payloadID := uint32(uint64(i) * uint64(2654435761))
 		doc := []byte(fmt.Sprintf(`{"time_us":%d,"kind":"%s","did":"%s","payload":"p%08x","group":%d}`,
-			timeUS, kind, did, uint32(i*2654435761), i%32))
+			timeUS, kind, did, payloadID, i%32))
 		out[i] = columnStoreFixtureEvent{ID: id, TimeUS: timeUS, Kind: kind, Did: did, Doc: doc}
 		bytesTotal += int64(len(doc))
 	}
@@ -1107,7 +1108,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	if len(report.ByteAccounting.ManifestControlMissing) != 0 {
 		sb.WriteString(fmt.Sprintf("- manifest_control_missing: `%s`\n", strings.Join(report.ByteAccounting.ManifestControlMissing, "`, `")))
 	}
-	sb.WriteString(fmt.Sprintf("- command_wal_bytes: %d\n", report.ByteAccounting.CommandWALBytes))
+	sb.WriteString(fmt.Sprintf("- command_wal_bytes_before_checkpoint: %d\n", report.ByteAccounting.CommandWALBytesBeforeCheckpoint))
 	sb.WriteString(fmt.Sprintf("- total_reconstructable_bytes: %d\n", report.ByteAccounting.TotalReconstructableBytes))
 	sb.WriteString(fmt.Sprintf("- db_total_bytes: %d across %d files\n\n", report.ByteAccounting.DBTotalBytes, report.ByteAccounting.DBTotalFiles))
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -638,11 +638,23 @@ func columnStoreReferenceHashes(events []columnStoreFixtureEvent) (map[string]ui
 }
 
 func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error) {
-	var cleanups []func() error
+	type runtimeProfileCleanup struct {
+		finish func() error
+		abort  func() error
+	}
+	var cleanups []runtimeProfileCleanup
 	finish := func() error {
 		var out error
 		for i := len(cleanups) - 1; i >= 0; i-- {
-			out = errors.Join(out, cleanups[i]())
+			out = errors.Join(out, cleanups[i].finish())
+		}
+		cleanups = nil
+		return out
+	}
+	abort := func() error {
+		var out error
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			out = errors.Join(out, cleanups[i].abort())
 		}
 		cleanups = nil
 		return out
@@ -655,9 +667,13 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		prevRate := runtime.MemProfileRate
 		runtime.MemProfileRate = rate
-		cleanups = append(cleanups, func() error {
+		restore := func() error {
 			runtime.MemProfileRate = prevRate
 			return nil
+		}
+		cleanups = append(cleanups, runtimeProfileCleanup{
+			finish: restore,
+			abort:  restore,
 		})
 	}
 
@@ -672,22 +688,28 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		f, err := os.Create(blockProfile)
 		if err != nil {
-			_ = finish()
+			_ = abort()
 			return nil, fmt.Errorf("column_store: blockprofile: %w", err)
 		}
 		runtime.SetBlockProfileRate(rate)
-		cleanups = append(cleanups, func() error {
-			prof := pprof.Lookup("block")
-			var writeErr error
-			if prof == nil {
-				writeErr = fmt.Errorf("block profile unavailable")
-			} else {
-				writeErr = prof.WriteTo(f, 0)
-			}
-			// The runtime exposes no previous block profile rate, so the suite
-			// writes the active profile before returning sampling to off.
-			runtime.SetBlockProfileRate(0)
-			return errors.Join(writeErr, f.Close())
+		cleanups = append(cleanups, runtimeProfileCleanup{
+			finish: func() error {
+				prof := pprof.Lookup("block")
+				var writeErr error
+				if prof == nil {
+					writeErr = fmt.Errorf("block profile unavailable")
+				} else {
+					writeErr = prof.WriteTo(f, 0)
+				}
+				// The runtime exposes no previous block profile rate, so the suite
+				// writes the active profile before returning sampling to off.
+				runtime.SetBlockProfileRate(0)
+				return errors.Join(writeErr, f.Close())
+			},
+			abort: func() error {
+				runtime.SetBlockProfileRate(0)
+				return errors.Join(f.Close(), os.Remove(blockProfile))
+			},
 		})
 	}
 
@@ -698,38 +720,50 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 		}
 		f, err := os.Create(mutexProfile)
 		if err != nil {
-			_ = finish()
+			_ = abort()
 			return nil, fmt.Errorf("column_store: mutexprofile: %w", err)
 		}
 		prevFrac := runtime.SetMutexProfileFraction(frac)
-		cleanups = append(cleanups, func() error {
-			runtime.SetMutexProfileFraction(prevFrac)
-			prof := pprof.Lookup("mutex")
-			var writeErr error
-			if prof == nil {
-				writeErr = fmt.Errorf("mutex profile unavailable")
-			} else {
-				writeErr = prof.WriteTo(f, 0)
-			}
-			return errors.Join(writeErr, f.Close())
+		cleanups = append(cleanups, runtimeProfileCleanup{
+			finish: func() error {
+				runtime.SetMutexProfileFraction(prevFrac)
+				prof := pprof.Lookup("mutex")
+				var writeErr error
+				if prof == nil {
+					writeErr = fmt.Errorf("mutex profile unavailable")
+				} else {
+					writeErr = prof.WriteTo(f, 0)
+				}
+				return errors.Join(writeErr, f.Close())
+			},
+			abort: func() error {
+				runtime.SetMutexProfileFraction(prevFrac)
+				return errors.Join(f.Close(), os.Remove(mutexProfile))
+			},
 		})
 	}
 
 	if traceProfile != "" {
 		f, err := os.Create(traceProfile)
 		if err != nil {
-			_ = finish()
+			_ = abort()
 			return nil, fmt.Errorf("column_store: trace: %w", err)
 		}
 		if err := trace.Start(f); err != nil {
 			_ = f.Close()
 			_ = os.Remove(traceProfile)
-			_ = finish()
+			_ = abort()
 			return nil, fmt.Errorf("column_store: trace start: %w", err)
 		}
-		cleanups = append(cleanups, func() error {
-			trace.Stop()
-			return f.Close()
+		cleanups = append(cleanups, runtimeProfileCleanup{
+			finish: func() error {
+				trace.Stop()
+				return f.Close()
+			},
+			abort: func() error {
+				trace.Stop()
+				return errors.Join(f.Close(), os.Remove(traceProfile))
+			},
 		})
 	}
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -234,11 +234,11 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 
 	rows := baseCfg.Keys
 	if rows <= 0 {
-		rows = 1
+		return "", fmt.Errorf("column_store: invalid keys: %d", rows)
 	}
 	batchSize := baseCfg.BatchSize
 	if batchSize <= 0 {
-		batchSize = 128
+		return "", fmt.Errorf("column_store: invalid batchsize: %d", batchSize)
 	}
 	if batchSize > rows {
 		batchSize = rows

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1428,7 +1428,9 @@ func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStor
 	if err := writeColumnStoreSuiteArtifactFile(columnStoreSuiteArtifactPath(report.Artifacts.ColumnHTML, filepath.Join(dir, "column_store_results.html")), []byte(renderColumnStoreSuiteHTML(report))); err != nil {
 		return fmt.Errorf("column_store: write html: %w", err)
 	}
-	if err := writeBenchprofArtifacts(dir, strings.TrimSpace(executionPath), []BenchRun{run}); err != nil {
+	benchprofJSON := columnStoreSuiteArtifactPath(report.Artifacts.BenchprofJSON, filepath.Join(dir, "benchprof_results.json"))
+	benchprofMarkdown := columnStoreSuiteArtifactPath(report.Artifacts.BenchprofMarkdown, filepath.Join(dir, "benchprof_results.md"))
+	if err := writeBenchprofArtifactsToPaths(benchprofJSON, benchprofMarkdown, strings.TrimSpace(executionPath), []BenchRun{run}); err != nil {
 		return fmt.Errorf("column_store: write benchprof artifacts: %w", err)
 	}
 	return nil

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -420,6 +420,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
 	if strings.TrimSpace(opts.ProfileDir) != "" {
 		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg)
+		report.Artifacts = columnStoreSuitePruneMissingRuntimeDeltaArtifacts(report.Artifacts)
 		md = renderColumnStoreSuiteMarkdown(report)
 		if err := writeColumnStoreSuiteArtifacts(opts.ProfileDir, opts.ExecutionPath, report, md, run); err != nil {
 			return "", err
@@ -1354,6 +1355,24 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 	}
 }
 
+func columnStoreSuitePruneMissingRuntimeDeltaArtifacts(paths columnStoreArtifactPaths) columnStoreArtifactPaths {
+	paths.BlockDeltaProfile = columnStoreExistingOptionalArtifactPath(paths.BlockDeltaProfile)
+	paths.MutexDeltaProfile = columnStoreExistingOptionalArtifactPath(paths.MutexDeltaProfile)
+	return paths
+}
+
+func columnStoreExistingOptionalArtifactPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	if _, err := os.Stat(path); err == nil {
+		return path
+	} else if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	return path
+}
+
 func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStoreSuiteReport, md string, run BenchRun) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("column_store: create profile dir: %w", err)
@@ -1362,17 +1381,27 @@ func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStor
 	if err != nil {
 		return fmt.Errorf("column_store: marshal report: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.json"), js, 0o644); err != nil {
+	jsonPath := columnStoreArtifactPathOrFallback(report.Artifacts.ColumnJSON, dir, "column_store_results.json")
+	if err := os.WriteFile(jsonPath, js, 0o644); err != nil {
 		return fmt.Errorf("column_store: write json: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.md"), []byte(md), 0o644); err != nil {
+	markdownPath := columnStoreArtifactPathOrFallback(report.Artifacts.ColumnMarkdown, dir, "column_store_results.md")
+	if err := os.WriteFile(markdownPath, []byte(md), 0o644); err != nil {
 		return fmt.Errorf("column_store: write markdown: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "column_store_results.html"), []byte(renderColumnStoreSuiteHTML(report)), 0o644); err != nil {
+	htmlPath := columnStoreArtifactPathOrFallback(report.Artifacts.ColumnHTML, dir, "column_store_results.html")
+	if err := os.WriteFile(htmlPath, []byte(renderColumnStoreSuiteHTML(report)), 0o644); err != nil {
 		return fmt.Errorf("column_store: write html: %w", err)
 	}
 	if err := writeBenchprofArtifacts(dir, strings.TrimSpace(executionPath), []BenchRun{run}); err != nil {
 		return fmt.Errorf("column_store: write benchprof artifacts: %w", err)
 	}
 	return nil
+}
+
+func columnStoreArtifactPathOrFallback(path, dir, filename string) string {
+	if strings.TrimSpace(path) != "" {
+		return path
+	}
+	return filepath.Join(dir, filename)
 }

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1371,8 +1371,10 @@ func columnStoreExistingOptionalArtifactPath(path string) string {
 	}
 	if _, err := os.Stat(path); err == nil {
 		return path
+	} else if errors.Is(err, os.ErrNotExist) {
+		return ""
 	}
-	return ""
+	return path
 }
 
 func writeColumnStoreSuiteArtifacts(dir, executionPath string, report columnStoreSuiteReport, md string, run BenchRun) error {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -521,28 +521,20 @@ func columnStoreArtifactPathsForProfileDir(profileDir string, cfg BenchConfig) c
 }
 
 func validateColumnStoreSuiteDBSelection(dbsArg, excludeArg string) error {
-	excluded := make(map[string]struct{})
 	for _, db := range parseList(excludeArg) {
-		normalized := strings.ToLower(strings.TrimSpace(db))
+		normalized := canonicalDBName(strings.ToLower(strings.TrimSpace(db)))
 		switch normalized {
 		case "", "none":
 			continue
 		case "all", "treedb":
 			return fmt.Errorf("column_store: native suite requires TreeDB but -dbs-exclude=%q excludes it", excludeArg)
-		default:
-			excluded[normalized] = struct{}{}
 		}
 	}
 
-	dbs := parseList(dbsArg)
 	hasTreeDB := false
-	for _, db := range dbs {
-		normalized := strings.ToLower(strings.TrimSpace(db))
-		if _, skip := excluded[normalized]; skip {
-			continue
-		}
-		switch normalized {
-		case "", "all", "treedb":
+	for _, db := range resolveDBs(dbsArg, excludeArg) {
+		switch db {
+		case "treedb":
 			hasTreeDB = true
 		default:
 			return fmt.Errorf("column_store: native suite only supports TreeDB; got -dbs=%q", dbsArg)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -543,6 +543,26 @@ func TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteArtifactsOmitMissingRuntimeDeltaPathsM11A(t *testing.T) {
+	dir := t.TempDir()
+	blockDeltaPath := filepath.Join(dir, "block_delta.pprof")
+	mutexDeltaPath := filepath.Join(dir, "mutex_delta.pprof")
+	if err := os.WriteFile(blockDeltaPath, []byte("delta"), 0o644); err != nil {
+		t.Fatalf("write block delta: %v", err)
+	}
+
+	paths := columnStoreSuitePruneMissingRuntimeDeltaArtifacts(columnStoreArtifactPaths{
+		BlockDeltaProfile: blockDeltaPath,
+		MutexDeltaProfile: mutexDeltaPath,
+	})
+	if paths.BlockDeltaProfile != blockDeltaPath {
+		t.Fatalf("block delta path=%q want %q", paths.BlockDeltaProfile, blockDeltaPath)
+	}
+	if paths.MutexDeltaProfile != "" {
+		t.Fatalf("missing mutex delta path should be omitted, got %q", paths.MutexDeltaProfile)
+	}
+}
+
 func TestColumnStoreSuiteProfiledQueriesReturnHardErrorsSeparatelyM11A(t *testing.T) {
 	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 4, 2)
 	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -528,6 +528,12 @@ func TestColumnStoreSuiteCheckpointCPUProfileStartFailureRemovesArtifactM11A(t *
 		}
 		t.Fatal("expected checkpoint CPU profile start failure")
 	}
+	msg := err.Error()
+	if !strings.Contains(msg, columnStoreSuiteBenchTestName) ||
+		!strings.Contains(msg, columnStoreSuiteBenchDBName) ||
+		!strings.Contains(msg, cfg.CheckpointCPUProfile) {
+		t.Fatalf("error=%v, want checkpoint CPU start failure test/db/path context", err)
+	}
 	profilePath := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
 	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected failed checkpoint CPU profile artifact to be removed, stat err=%v", statErr)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -534,6 +534,27 @@ func TestColumnStoreSuiteCheckpointCPUProfileStartFailureRemovesArtifactM11A(t *
 	}
 }
 
+func TestColumnStoreSuiteCheckpointCPUProfileNilStartHookReturnsErrorM11A(t *testing.T) {
+	cfg := BenchConfig{
+		CheckpointCPUProfile: filepath.Join(t.TempDir(), "checkpoint_cpu"),
+	}
+
+	f, err := startCheckpointCPUProfile(cfg, benchmarkProfileHooks{}, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if err == nil {
+		if f != nil {
+			_ = f.Close()
+		}
+		t.Fatal("expected checkpoint CPU profile nil hook error")
+	}
+	if !strings.Contains(err.Error(), "start hook is nil") {
+		t.Fatalf("error=%v, want nil hook context", err)
+	}
+	profilePath := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
+	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed checkpoint CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
 func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
 	profileHooks := &benchmarkProfileHooks{
 		startCPUProfile: func(_ io.Writer) error {
@@ -692,15 +713,30 @@ func TestColumnStoreSuiteProfiledQueriesSkipWhitespaceOnlyRuntimeProfilePathsM11
 
 func TestColumnStoreSuiteArtifactsTrimRuntimeProfilePathsM11A(t *testing.T) {
 	dir := t.TempDir()
+	cpuPath := filepath.Join(dir, "cpu")
+	allocsPath := filepath.Join(dir, "allocs")
+	checkpointPath := filepath.Join(dir, "checkpoint_cpu")
 	blockPath := filepath.Join(dir, "block.pprof")
 	mutexPath := filepath.Join(dir, "mutex.pprof")
 	tracePath := filepath.Join(dir, "trace.out")
 
 	paths := columnStoreArtifactPathsForProfileDir(dir, BenchConfig{
-		BlockProfile: " \t" + blockPath + "\t ",
-		MutexProfile: " \t" + mutexPath + "\t ",
-		TraceProfile: " \t" + tracePath + "\t ",
+		CPUProfile:           " \t" + cpuPath + "\t ",
+		AllocsProfile:        " \t" + allocsPath + "\t ",
+		CheckpointCPUProfile: " \t" + checkpointPath + "\t ",
+		BlockProfile:         " \t" + blockPath + "\t ",
+		MutexProfile:         " \t" + mutexPath + "\t ",
+		TraceProfile:         " \t" + tracePath + "\t ",
 	})
+	if paths.CPUProfile != fmt.Sprintf("%s_%s_%s.pprof", cpuPath, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
+		t.Fatalf("cpu artifact path was not trimmed: %+v", paths)
+	}
+	if paths.AllocsProfile != fmt.Sprintf("%s_%s_%s.pprof", allocsPath, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
+		t.Fatalf("allocs artifact path was not trimmed: %+v", paths)
+	}
+	if paths.CheckpointCPUProfile != fmt.Sprintf("%s_checkpoint_%s_%s.pprof", checkpointPath, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName)) {
+		t.Fatalf("checkpoint artifact path was not trimmed: %+v", paths)
+	}
 	if paths.BlockProfile != blockPath || paths.MutexProfile != mutexPath || paths.TraceProfile != tracePath {
 		t.Fatalf("runtime artifact paths were not trimmed: %+v", paths)
 	}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -153,8 +153,14 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.ByteAccounting.CommandWALBytesBeforeCheckpoint == 0 {
 		t.Fatalf("expected command WAL bytes in byte accounting: %+v", report.ByteAccounting)
 	}
+	if report.ByteAccounting.RetainedPayloadBytesNote == "" || report.ByteAccounting.ColumnAssetBytesNote == "" {
+		t.Fatalf("expected M11A byte-accounting placeholder notes: %+v", report.ByteAccounting)
+	}
 	if !strings.Contains(string(data), `"command_wal_bytes_before_checkpoint"`) {
 		t.Fatalf("column store JSON missing before-checkpoint command WAL label:\n%s", data)
+	}
+	if !strings.Contains(string(data), `"column_asset_bytes_note"`) || !strings.Contains(string(data), `"retained_payload_bytes_note"`) {
+		t.Fatalf("column store JSON missing byte-accounting notes:\n%s", data)
 	}
 	if strings.Contains(string(data), `"command_wal_bytes":`) {
 		t.Fatalf("column store JSON contains ambiguous command WAL label:\n%s", data)
@@ -165,6 +171,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 	if !strings.Contains(string(columnMarkdown), "command_wal_bytes_before_checkpoint") {
 		t.Fatalf("column store markdown missing before-checkpoint command WAL label:\n%s", columnMarkdown)
+	}
+	if !strings.Contains(string(columnMarkdown), "column_asset_bytes_note") || !strings.Contains(string(columnMarkdown), "retained_payload_bytes_note") {
+		t.Fatalf("column store markdown missing byte-accounting notes:\n%s", columnMarkdown)
 	}
 	if report.ByteAccounting.ManifestControlBytes == 0 || report.ByteAccounting.DBTotalBytes == 0 || report.ByteAccounting.DBTotalFiles == 0 {
 		t.Fatalf("expected measured manifest/control and DB byte accounting: %+v", report.ByteAccounting)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -915,6 +915,49 @@ func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteRejectsInvalidKeysAndBatchSizeM11A(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     BenchConfig
+		wantErr string
+	}{
+		{
+			name:    "zero keys",
+			cfg:     BenchConfig{Keys: 0, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1},
+			wantErr: "invalid keys: 0",
+		},
+		{
+			name:    "negative keys",
+			cfg:     BenchConfig{Keys: -1, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1},
+			wantErr: "invalid keys: -1",
+		},
+		{
+			name:    "zero batch",
+			cfg:     BenchConfig{Keys: 4, BatchSize: 0, DBsArg: "treedb", Profile: "durable", SeedUsed: 1},
+			wantErr: "invalid batchsize: 0",
+		},
+		{
+			name:    "negative batch",
+			cfg:     BenchConfig{Keys: 4, BatchSize: -1, DBsArg: "treedb", Profile: "durable", SeedUsed: 1},
+			wantErr: "invalid batchsize: -1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runColumnStoreSuite(tc.cfg, columnStoreSuiteOptions{
+				ForcedPath: columnStorePathRowStoreBaseline,
+			})
+			if err == nil {
+				t.Fatal("expected invalid column_store config to fail")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("unexpected error %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestColumnStoreSuiteReportsParityMismatchM11A(t *testing.T) {
 	dir := t.TempDir()
 	cfg := BenchConfig{Keys: 16, BatchSize: 8, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/trace"
 	"strings"
 	"testing"
 	"time"
@@ -510,6 +511,29 @@ func TestColumnStoreSuiteCheckpointCPUProfileUsesResolvedHooksM11A(t *testing.T)
 	}
 }
 
+func TestColumnStoreSuiteCheckpointCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
+	profileHooks := benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			return errors.New("checkpoint start failed")
+		},
+	}
+	cfg := BenchConfig{
+		CheckpointCPUProfile: filepath.Join(t.TempDir(), "checkpoint_cpu"),
+	}
+
+	f, err := startCheckpointCPUProfile(cfg, profileHooks, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if err == nil {
+		if f != nil {
+			_ = f.Close()
+		}
+		t.Fatal("expected checkpoint CPU profile start failure")
+	}
+	profilePath := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
+	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed checkpoint CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
 func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
 	profileHooks := &benchmarkProfileHooks{
 		startCPUProfile: func(_ io.Writer) error {
@@ -532,6 +556,34 @@ func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T)
 	profilePath := fmt.Sprintf("%s_%s_%s.pprof", profilePrefix, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected failed CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
+func TestColumnStoreSuiteRuntimeTraceStartFailureRemovesArtifactM11A(t *testing.T) {
+	activeTracePath := filepath.Join(t.TempDir(), "active_trace.out")
+	activeTrace, err := os.Create(activeTracePath)
+	if err != nil {
+		t.Fatalf("create active trace: %v", err)
+	}
+	if err := trace.Start(activeTrace); err != nil {
+		_ = activeTrace.Close()
+		t.Skipf("runtime trace unavailable: %v", err)
+	}
+	defer func() {
+		trace.Stop()
+		_ = activeTrace.Close()
+	}()
+
+	tracePath := filepath.Join(t.TempDir(), "trace.out")
+	finish, err := startColumnStoreSuiteRuntimeProfiles(BenchConfig{TraceProfile: tracePath})
+	if err == nil {
+		if finish != nil {
+			_ = finish()
+		}
+		t.Fatal("expected trace start failure while trace is already active")
+	}
+	if _, statErr := os.Stat(tracePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed trace artifact to be removed, stat err=%v", statErr)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -147,8 +147,21 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("parity %s has zero hash: %+v", name, parity)
 		}
 	}
-	if report.ByteAccounting.CommandWALBytes == 0 {
+	if report.ByteAccounting.CommandWALBytesBeforeCheckpoint == 0 {
 		t.Fatalf("expected command WAL bytes in byte accounting: %+v", report.ByteAccounting)
+	}
+	if !strings.Contains(string(data), `"command_wal_bytes_before_checkpoint"`) {
+		t.Fatalf("column store JSON missing before-checkpoint command WAL label:\n%s", data)
+	}
+	if strings.Contains(string(data), `"command_wal_bytes":`) {
+		t.Fatalf("column store JSON contains ambiguous command WAL label:\n%s", data)
+	}
+	columnMarkdown, err := os.ReadFile(filepath.Join(dir, "column_store_results.md"))
+	if err != nil {
+		t.Fatalf("read column_store_results.md: %v", err)
+	}
+	if !strings.Contains(string(columnMarkdown), "command_wal_bytes_before_checkpoint") {
+		t.Fatalf("column store markdown missing before-checkpoint command WAL label:\n%s", columnMarkdown)
 	}
 	if report.ByteAccounting.ManifestControlBytes == 0 || report.ByteAccounting.DBTotalBytes == 0 || report.ByteAccounting.DBTotalFiles == 0 {
 		t.Fatalf("expected measured manifest/control and DB byte accounting: %+v", report.ByteAccounting)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -812,18 +812,22 @@ func TestColumnStoreSuiteArtifactsOmitMissingRuntimeDeltaPathsM11A(t *testing.T)
 	}
 }
 
-func TestColumnStoreSuiteArtifactsOmitRuntimeDeltaStatErrorsM11A(t *testing.T) {
+func TestColumnStoreSuiteArtifactsPreserveRuntimeDeltaStatErrorsM11A(t *testing.T) {
 	dir := t.TempDir()
 	notDir := filepath.Join(dir, "not-dir")
 	if err := os.WriteFile(notDir, []byte("file"), 0o644); err != nil {
 		t.Fatalf("write not-dir marker: %v", err)
 	}
+	blockDeltaPath := filepath.Join(notDir, "block_delta.pprof")
 	paths := columnStoreSuitePruneMissingRuntimeDeltaArtifacts(columnStoreArtifactPaths{
-		BlockDeltaProfile: filepath.Join(notDir, "block_delta.pprof"),
+		BlockDeltaProfile: blockDeltaPath,
 		MutexDeltaProfile: " \t ",
 	})
-	if paths.BlockDeltaProfile != "" || paths.MutexDeltaProfile != "" {
-		t.Fatalf("stat-error/blank optional delta paths should be omitted: %+v", paths)
+	if paths.BlockDeltaProfile != blockDeltaPath {
+		t.Fatalf("stat-error optional delta path should be preserved, got %+v", paths)
+	}
+	if paths.MutexDeltaProfile != "" {
+		t.Fatalf("blank optional delta path should be omitted: %+v", paths)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -121,9 +123,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if got, want := report.ForcedPath, columnStorePathRowStoreBaseline; got != want {
 		t.Fatalf("forced_path=%q want %q", got, want)
 	}
-	if len(report.Queries) < 7 {
-		t.Fatalf("expected q1-q5/q4a/q4b/q5_metadata query metrics, got %d", len(report.Queries))
-	}
+	queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 	for _, q := range report.Queries {
 		if q.PlanLabel != columnStorePathRowStoreBaseline {
 			t.Fatalf("query %s plan_label=%q want %q", q.Name, q.PlanLabel, columnStorePathRowStoreBaseline)
@@ -137,6 +137,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		if q.RowMaterializations != report.Rows {
 			t.Fatalf("query %s row_materializations=%d want %d", q.Name, q.RowMaterializations, report.Rows)
 		}
+	}
+	if q := queryMetrics["q5_metadata"]; q.AliasOf != "q5" || q.ImplementationNote == "" {
+		t.Fatalf("q5_metadata should be explicitly reported as a q5 alias placeholder: %+v", q)
 	}
 	assertColumnStoreParityCoverageM11A(t, report.Parity)
 	for name, parity := range report.Parity {
@@ -348,6 +351,46 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 	}
 }
 
+func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
+	origStartCPUProfileFn := startCPUProfileFn
+	t.Cleanup(func() {
+		startCPUProfileFn = origStartCPUProfileFn
+	})
+	startCPUProfileFn = func(_ io.Writer) error {
+		return errors.New("start failed")
+	}
+
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
+	profilePrefix := filepath.Join(t.TempDir(), "cpu")
+	_, _, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		CPUProfile: profilePrefix,
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	if err == nil {
+		t.Fatal("expected CPU profile start failure")
+	}
+	if parityErr != nil {
+		t.Fatalf("hard CPU profile error returned as parity error: %v", parityErr)
+	}
+	profilePath := fmt.Sprintf("%s_%s_%s.pprof", profilePrefix, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
+func TestColumnStoreSuiteProfiledQueriesReturnHardErrorsSeparatelyM11A(t *testing.T) {
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 4, 2)
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)
+	if err == nil {
+		t.Fatal("expected hard query error")
+	}
+	if parityErr != nil {
+		t.Fatalf("hard query error returned as parity error: %v", parityErr)
+	}
+	if queries != nil || parity != nil {
+		t.Fatalf("expected no query/parity output on hard failure, queries=%v parity=%v", queries, parity)
+	}
+}
+
 func TestColumnStoreQueryHashRejectsUnknownQueryM11A(t *testing.T) {
 	_, _, err := columnStoreQueryHash("missing_query", nil)
 	if err == nil {
@@ -521,22 +564,42 @@ func BenchmarkColumnStoreSuiteRowBaselineQueriesM11A(b *testing.B) {
 		if err != nil {
 			b.Fatalf("queries: %v", err)
 		}
-		if len(queries) != queryCount {
-			b.Fatalf("queries=%d want %d", len(queries), queryCount)
-		}
+		assertColumnStoreQueryMetricCoverageM11A(b, queries)
+		assertColumnStoreParityCoverageM11A(b, parity)
 		for name, p := range parity {
 			if !p.Pass {
 				b.Fatalf("parity failed for %s: %+v", name, p)
 			}
 		}
-		if len(parity) != queryCount {
-			b.Fatalf("parity=%d want %d", len(parity), queryCount)
-		}
 	}
 	b.ReportMetric(float64(rows*queryCount), "rows/op")
 }
 
-func assertColumnStoreParityCoverageM11A(t *testing.T, parity map[string]columnStoreParity) {
+func assertColumnStoreQueryMetricCoverageM11A(t testing.TB, queries []columnStoreQueryMetric) map[string]columnStoreQueryMetric {
+	t.Helper()
+	names := columnStoreQueryNames()
+	if len(queries) != len(names) {
+		t.Fatalf("query metrics=%d want %d", len(queries), len(names))
+	}
+	byName := make(map[string]columnStoreQueryMetric, len(queries))
+	for _, q := range queries {
+		if _, exists := byName[q.Name]; exists {
+			t.Fatalf("duplicate query metric for %s", q.Name)
+		}
+		byName[q.Name] = q
+	}
+	for _, name := range names {
+		if _, ok := byName[name]; !ok {
+			t.Fatalf("missing query metric for %s", name)
+		}
+	}
+	if len(byName) != len(names) {
+		t.Fatalf("query metrics include unexpected names: %+v", byName)
+	}
+	return byName
+}
+
+func assertColumnStoreParityCoverageM11A(t testing.TB, parity map[string]columnStoreParity) {
 	t.Helper()
 	names := columnStoreQueryNames()
 	if len(parity) != len(names) {
@@ -547,4 +610,40 @@ func assertColumnStoreParityCoverageM11A(t *testing.T, parity map[string]columnS
 			t.Fatalf("missing parity entry for %s", name)
 		}
 	}
+}
+
+func newColumnStoreSuiteTestCollectionM11A(t testing.TB, rows, batchSize int) (*collections.Collection, []columnStoreFixtureEvent, map[string]uint64) {
+	t.Helper()
+	events, _ := buildColumnStoreSyntheticFixture(rows, 1)
+	dir := t.TempDir()
+	db, err := openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "events",
+		Options: collections.CollectionOptions{
+			DocumentFormat:               collections.DocumentFormatJSON,
+			DisableIndexedWriteMemtables: true,
+			ColumnStore:                  columnStoreSuiteConfig(),
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := insertColumnStoreFixture(collection, events, batchSize); err != nil {
+		t.Fatalf("insert fixture: %v", err)
+	}
+	rawHashes, err := columnStoreReferenceHashes(events)
+	if err != nil {
+		t.Fatalf("reference hashes: %v", err)
+	}
+	return collection, events, rawHashes
 }

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -328,6 +328,26 @@ func TestColumnStoreSuiteRuntimeProfilesDoNotEnableOnCreateFailureM11A(t *testin
 	}
 }
 
+func TestColumnStoreSuiteRuntimeProfilesRemoveStartedArtifactsOnLaterCreateFailureM11A(t *testing.T) {
+	dir := t.TempDir()
+	blockPath := filepath.Join(dir, "block.pprof")
+	_, err := startColumnStoreSuiteRuntimeProfiles(BenchConfig{
+		BlockProfile:         blockPath,
+		BlockProfileRate:     1,
+		MutexProfile:         filepath.Join(dir, "missing", "mutex.pprof"),
+		MutexProfileFraction: 1,
+	})
+	if err == nil {
+		t.Fatal("expected mutex profile create failure")
+	}
+	if !strings.Contains(err.Error(), "mutexprofile") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(blockPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected started block profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
 func TestColumnStoreSuiteRuntimeProfilesDoNotChangeMemRateWhenFilteredM11A(t *testing.T) {
 	prevRate := runtime.MemProfileRate
 	t.Cleanup(func() {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -436,6 +436,35 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 	}
 }
 
+func TestColumnStoreSuiteCheckpointCPUProfileUsesResolvedHooksM11A(t *testing.T) {
+	var events []string
+	profileHooks := benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			events = append(events, "checkpoint_cpu_start")
+			return nil
+		},
+		stopCPUProfile: func() {
+			events = append(events, "checkpoint_cpu_stop")
+		},
+	}
+	cfg := BenchConfig{
+		CheckpointCPUProfile: filepath.Join(t.TempDir(), "checkpoint_cpu"),
+	}
+
+	f, err := startCheckpointCPUProfile(cfg, profileHooks, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if err != nil {
+		t.Fatalf("start checkpoint CPU profile: %v", err)
+	}
+	profileHooks.stopCPUProfile()
+	if err := f.Close(); err != nil {
+		t.Fatalf("close checkpoint CPU profile: %v", err)
+	}
+
+	if got, want := strings.Join(events, ","), "checkpoint_cpu_start,checkpoint_cpu_stop"; got != want {
+		t.Fatalf("checkpoint CPU profile hooks = %s, want %s", got, want)
+	}
+}
+
 func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
 	profileHooks := &benchmarkProfileHooks{
 		startCPUProfile: func(_ io.Writer) error {
@@ -836,6 +865,23 @@ func assertColumnStoreQueryMetricCoverageM11A(t testing.TB, queries []columnStor
 		t.Fatalf("query metrics include unexpected names: %+v", byName)
 	}
 	return byName
+}
+
+func TestColumnStoreQueryNamesReturnsDefensiveCopyM11A(t *testing.T) {
+	names := columnStoreQueryNames()
+	if len(names) == 0 {
+		t.Fatal("columnStoreQueryNames returned no names")
+	}
+	names[0] = "mutated"
+	names = append(names, "extra")
+
+	fresh := columnStoreQueryNames()
+	if got, want := fresh[0], "q1"; got != want {
+		t.Fatalf("fresh query names first entry = %q, want %q", got, want)
+	}
+	if len(fresh) != len(columnStoreQueryNameList) {
+		t.Fatalf("fresh query names len = %d, want %d", len(fresh), len(columnStoreQueryNameList))
+	}
 }
 
 func assertColumnStoreParityCoverageM11A(t testing.TB, parity map[string]columnStoreParity) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -65,9 +65,11 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		"column_store_results.html",
 		"cpu_column_store_treedb_column_store.pprof",
 		"allocs_column_store_treedb_column_store.pprof",
-		"checkpoint_cpu_checkpoint_post_run_treedb_column_store.pprof",
+		"checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof",
 		"block.pprof",
+		"block_column_store_treedb_column_store.pprof",
 		"mutex.pprof",
+		"mutex_column_store_treedb_column_store.pprof",
 		"trace.out",
 	} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
@@ -155,6 +157,16 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if len(report.UnsupportedForcedPaths) == 0 {
 		t.Fatalf("expected unsupported forced path labels to be recorded")
 	}
+	if report.Artifacts.CPUProfile == "" ||
+		report.Artifacts.AllocsProfile == "" ||
+		report.Artifacts.CheckpointCPUProfile == "" ||
+		report.Artifacts.BlockProfile == "" ||
+		report.Artifacts.BlockDeltaProfile == "" ||
+		report.Artifacts.MutexProfile == "" ||
+		report.Artifacts.MutexDeltaProfile == "" ||
+		report.Artifacts.TraceProfile == "" {
+		t.Fatalf("expected all configured profile artifacts to be recorded: %+v", report.Artifacts)
+	}
 }
 
 func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
@@ -229,6 +241,19 @@ func TestColumnStoreSuiteDirUsageFailsOnMissingPathM11A(t *testing.T) {
 	_, _, err := columnStoreSuiteDirUsage(filepath.Join(t.TempDir(), "missing"))
 	if err == nil {
 		t.Fatal("expected missing path to fail")
+	}
+}
+
+func TestColumnStoreSuiteManifestControlUsageTreatsMissingFilesAsZeroM11A(t *testing.T) {
+	bytes, missing, err := columnStoreSuiteManifestControlUsage(t.TempDir())
+	if err != nil {
+		t.Fatalf("manifest/control usage: %v", err)
+	}
+	if bytes != 0 {
+		t.Fatalf("manifest/control bytes=%d want 0", bytes)
+	}
+	if len(missing) != len(columnStoreSuiteManifestControlFiles) {
+		t.Fatalf("missing manifest/control files=%v want %v", missing, columnStoreSuiteManifestControlFiles)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -944,6 +944,12 @@ func TestColumnStoreSuiteAppliesDBExclusionsBeforeMixedCheckM11A(t *testing.T) {
 	if err := validateColumnStoreSuiteDBSelection("treedb,leveldb", "leveldb"); err != nil {
 		t.Fatalf("expected excluded non-TreeDB selection to pass: %v", err)
 	}
+	if err := validateColumnStoreSuiteDBSelection("treedbcached", ""); err != nil {
+		t.Fatalf("expected TreeDB alias selection to pass: %v", err)
+	}
+	if err := validateColumnStoreSuiteDBSelection("treedb,leveldb", "leveldb,treedbcached"); err == nil || !strings.Contains(err.Error(), "excludes it") {
+		t.Fatalf("expected TreeDB alias exclusion to reject suite, got %v", err)
+	}
 	err := validateColumnStoreSuiteDBSelection("leveldb", "leveldb")
 	if err == nil {
 		t.Fatal("expected all selected DBs excluded to fail")

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{
+		Keys:      64,
+		BatchSize: 16,
+		DBsArg:    "treedb",
+		Profile:   "durable",
+		Progress:  false,
+		SeedUsed:  1,
+	}
+
+	out, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:    dir,
+		ExecutionPath: "native-fastpath",
+		ForcedPath:    columnStorePathRowStoreBaseline,
+		RunBenchprof:  true,
+	})
+	if err != nil {
+		t.Fatalf("runColumnStoreSuite: %v", err)
+	}
+
+	for _, want := range []string{
+		"# unified_bench suite: column_store",
+		"q1",
+		"q4a",
+		"q4b",
+		"q5_metadata",
+		"row_store_baseline",
+		"Parity",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("suite output missing %q:\n%s", want, out)
+		}
+	}
+
+	for _, name := range []string{
+		"benchprof_results.json",
+		"benchprof_results.md",
+		"insights.md",
+		"insights.json",
+		"insights.html",
+		"column_store_results.json",
+		"column_store_results.md",
+		"column_store_results.html",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("expected %s: %v", name, err)
+		}
+	}
+
+	var report columnStoreSuiteReport
+	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if err != nil {
+		t.Fatalf("read column_store_results.json: %v", err)
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal column_store_results.json: %v", err)
+	}
+	if got, want := report.Suite, "column_store"; got != want {
+		t.Fatalf("suite=%q want %q", got, want)
+	}
+	if got, want := report.Profile, "durable"; got != want {
+		t.Fatalf("profile=%q want %q", got, want)
+	}
+	if got, want := report.PathLabel, "native-fastpath"; got != want {
+		t.Fatalf("path_label=%q want %q", got, want)
+	}
+	if got, want := report.ForcedPath, columnStorePathRowStoreBaseline; got != want {
+		t.Fatalf("forced_path=%q want %q", got, want)
+	}
+	if len(report.Queries) < 7 {
+		t.Fatalf("expected q1-q5/q4a/q4b/q5_metadata query metrics, got %d", len(report.Queries))
+	}
+	for _, q := range report.Queries {
+		if q.PlanLabel != columnStorePathRowStoreBaseline {
+			t.Fatalf("query %s plan_label=%q want %q", q.Name, q.PlanLabel, columnStorePathRowStoreBaseline)
+		}
+		if q.RowsPerSecond <= 0 {
+			t.Fatalf("query %s rows_per_second=%v", q.Name, q.RowsPerSecond)
+		}
+		if q.RowMaterializations != report.Rows {
+			t.Fatalf("query %s row_materializations=%d want %d", q.Name, q.RowMaterializations, report.Rows)
+		}
+	}
+	for name, parity := range report.Parity {
+		if !parity.Pass {
+			t.Fatalf("parity %s failed: %+v", name, parity)
+		}
+		if parity.RawHash == 0 || parity.ProductionHash == 0 {
+			t.Fatalf("parity %s has zero hash: %+v", name, parity)
+		}
+	}
+	if report.ByteAccounting.CommandWALBytes == 0 {
+		t.Fatalf("expected command WAL bytes in byte accounting: %+v", report.ByteAccounting)
+	}
+	if report.Manifest.ActiveGeneration == 0 || report.Manifest.AppliedCommandLSN == 0 {
+		t.Fatalf("expected active/recovery-authoritative manifest identity: %+v", report.Manifest)
+	}
+	if len(report.UnsupportedForcedPaths) == 0 {
+		t.Fatalf("expected unsupported forced path labels to be recorded")
+	}
+}
+
+func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
+	cfg := BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ForcedPath: "serial_column_scan",
+	})
+	if err == nil {
+		t.Fatal("expected forced serial column scan to fail closed")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "serial_column_scan") || !strings.Contains(msg, "refusing to route through row store") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteReportsParityMismatchM11A(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{Keys: 16, BatchSize: 8, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:              dir,
+		ExecutionPath:           "native-fastpath",
+		ForcedPath:              columnStorePathRowStoreBaseline,
+		CorruptReferenceForTest: "q1",
+	})
+	if err == nil {
+		t.Fatal("expected parity mismatch")
+	}
+	if !strings.Contains(err.Error(), "parity mismatch") || !strings.Contains(err.Error(), "q1") {
+		t.Fatalf("unexpected parity error: %v", err)
+	}
+
+	var report columnStoreSuiteReport
+	data, readErr := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if readErr != nil {
+		t.Fatalf("expected column_store_results.json after mismatch: %v", readErr)
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if report.Parity["q1"].Pass {
+		t.Fatalf("expected q1 parity to be recorded as failed: %+v", report.Parity["q1"])
+	}
+}
+
+func TestColumnStoreSuiteREADMEDocumentsCommandM11A(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"-suite column_store",
+		"-column-store-path row_store_baseline",
+		"column_store_results.html",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("README missing %q", want)
+		}
+	}
+}
+
+func BenchmarkColumnStoreSuiteRowBaselineQueriesM11A(b *testing.B) {
+	const rows = 10_000
+	const batchSize = 1_000
+
+	events, sourceBytes := buildColumnStoreSyntheticFixture(rows, 1)
+	dir := b.TempDir()
+	db, err := openColumnStoreSuiteDB(dir)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "events",
+		Options: collections.CollectionOptions{
+			DocumentFormat:               collections.DocumentFormatJSON,
+			DisableIndexedWriteMemtables: true,
+			ColumnStore:                  columnStoreSuiteConfig(),
+		},
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("events")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+	if err := insertColumnStoreFixture(collection, events, batchSize); err != nil {
+		b.Fatalf("insert fixture: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		b.Fatalf("checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+
+	db, err = openColumnStoreSuiteDB(dir)
+	if err != nil {
+		b.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+	collection, err = collections.NewCollectionManager(db).OpenCollection("events")
+	if err != nil {
+		b.Fatalf("reopen collection: %v", err)
+	}
+
+	rawHashes := columnStoreReferenceHashes(events)
+	queryCount := len(columnStoreQueryNames())
+	b.ReportAllocs()
+	b.SetBytes(sourceBytes * int64(queryCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathRowStoreBaseline)
+		if err != nil {
+			b.Fatalf("queries: %v", err)
+		}
+		if len(queries) != queryCount {
+			b.Fatalf("queries=%d want %d", len(queries), queryCount)
+		}
+		for name, p := range parity {
+			if !p.Pass {
+				b.Fatalf("parity failed for %s: %+v", name, p)
+			}
+		}
+	}
+	b.ReportMetric(float64(rows*queryCount), "rows/op")
+}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,9 +74,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		"allocs_column_store_treedb_column_store.pprof",
 		"checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof",
 		"block.pprof",
-		"block_column_store_treedb_column_store.pprof",
 		"mutex.pprof",
-		"mutex_column_store_treedb_column_store.pprof",
 		"trace.out",
 	} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
@@ -214,11 +213,20 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		report.Artifacts.AllocsProfile == "" ||
 		report.Artifacts.CheckpointCPUProfile == "" ||
 		report.Artifacts.BlockProfile == "" ||
-		report.Artifacts.BlockDeltaProfile == "" ||
 		report.Artifacts.MutexProfile == "" ||
-		report.Artifacts.MutexDeltaProfile == "" ||
 		report.Artifacts.TraceProfile == "" {
 		t.Fatalf("expected all configured profile artifacts to be recorded: %+v", report.Artifacts)
+	}
+	for label, path := range map[string]string{
+		"block": report.Artifacts.BlockDeltaProfile,
+		"mutex": report.Artifacts.MutexDeltaProfile,
+	} {
+		if path == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("reported %s delta artifact %s: %v", label, path, err)
+		}
 	}
 }
 
@@ -293,7 +301,7 @@ func TestColumnStoreBenchRunUsesDurationForAggregateM11A(t *testing.T) {
 	}, nil, 0)
 
 	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
-	if got != 1000 {
+	if math.Abs(got-1000) > 1e-9 {
 		t.Fatalf("aggregate rows/sec=%f want 1000 from exact durations", got)
 	}
 }
@@ -805,7 +813,7 @@ func TestColumnStoreSuiteArtifactsTrimRuntimeProfilePathsM11A(t *testing.T) {
 		BlockProfile:         " \t" + blockPath + "\t ",
 		MutexProfile:         " \t" + mutexPath + "\t ",
 		TraceProfile:         " \t" + tracePath + "\t ",
-	})
+	}, true)
 	if paths.CPUProfile != fmt.Sprintf("%s_%s_%s.pprof", cpuPath, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
 		t.Fatalf("cpu artifact path was not trimmed: %+v", paths)
 	}
@@ -823,6 +831,13 @@ func TestColumnStoreSuiteArtifactsTrimRuntimeProfilePathsM11A(t *testing.T) {
 	}
 	if paths.MutexDeltaProfile != contentionProfilePath(mutexPath, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
 		t.Fatalf("mutex delta path=%q", paths.MutexDeltaProfile)
+	}
+	if paths.InsightsMarkdown == "" || paths.InsightsJSON == "" || paths.InsightsHTML == "" {
+		t.Fatalf("runBenchprof=true should advertise insights artifacts: %+v", paths)
+	}
+	withoutBenchprof := columnStoreArtifactPathsForProfileDir(dir, BenchConfig{}, false)
+	if withoutBenchprof.InsightsMarkdown != "" || withoutBenchprof.InsightsJSON != "" || withoutBenchprof.InsightsHTML != "" {
+		t.Fatalf("runBenchprof=false should not advertise insights artifacts: %+v", withoutBenchprof)
 	}
 }
 
@@ -925,7 +940,21 @@ func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
 		t.Fatal("expected forced serial column scan to fail closed")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "serial_column_scan") || !strings.Contains(msg, "not implemented") || !strings.Contains(msg, "supported=") {
+	if !strings.Contains(msg, "serial_column_scan") || !strings.Contains(msg, "not implemented") || !strings.Contains(msg, "refusing to route through row store") || !strings.Contains(msg, "supported=") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteRejectsOraclePathLabelM11A(t *testing.T) {
+	_, err := runColumnStoreSuite(BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}, columnStoreSuiteOptions{
+		ProfileDir:    t.TempDir(),
+		ExecutionPath: "oracle",
+		ForcedPath:    columnStorePathRowStoreBaseline,
+	})
+	if err == nil {
+		t.Fatal("expected oracle path-label to fail closed")
+	}
+	if !strings.Contains(err.Error(), "requires -path-label native-fastpath") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -75,6 +75,28 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		}
 	}
 
+	var benchprof benchprofExport
+	benchprofData, err := os.ReadFile(filepath.Join(dir, "benchprof_results.json"))
+	if err != nil {
+		t.Fatalf("read benchprof_results.json: %v", err)
+	}
+	if err := json.Unmarshal(benchprofData, &benchprof); err != nil {
+		t.Fatalf("unmarshal benchprof_results.json: %v", err)
+	}
+	if len(benchprof.Runs) != 1 {
+		t.Fatalf("benchprof runs=%d want 1", len(benchprof.Runs))
+	}
+	if got := benchprof.Runs[0].Results["column_store"]["TreeDB Column Store"]; got <= 0 {
+		t.Fatalf("benchprof column_store aggregate rows/sec=%f want positive", got)
+	}
+	benchprofMarkdown, err := os.ReadFile(filepath.Join(dir, "benchprof_results.md"))
+	if err != nil {
+		t.Fatalf("read benchprof_results.md: %v", err)
+	}
+	if !strings.Contains(string(benchprofMarkdown), "Column store query phase") {
+		t.Fatalf("benchprof markdown missing aggregate column_store display name:\n%s", benchprofMarkdown)
+	}
+
 	var report columnStoreSuiteReport
 	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
 	if err != nil {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 )
@@ -217,6 +218,46 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		report.Artifacts.MutexDeltaProfile == "" ||
 		report.Artifacts.TraceProfile == "" {
 		t.Fatalf("expected all configured profile artifacts to be recorded: %+v", report.Artifacts)
+	}
+}
+
+func TestColumnStoreBenchRunUsesDurationForAggregateM11A(t *testing.T) {
+	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
+		Rows:      30,
+		BatchSize: 10,
+		Queries: []columnStoreQueryMetric{
+			{Name: "q1", RowMaterializations: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
+			{Name: "q2", RowMaterializations: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
+		},
+	}, nil, 0)
+
+	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
+	if got != 1000 {
+		t.Fatalf("aggregate rows/sec=%f want 1000 from exact durations", got)
+	}
+}
+
+func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
+	md := renderColumnStoreSuiteMarkdown(columnStoreSuiteReport{
+		Profile:                "durable",
+		Fixture:                "fixture",
+		ForcedPath:             columnStorePathRowStoreBaseline,
+		StageSeparatedBoundary: "boundary",
+		ByteAccounting: columnStoreByteAccounting{
+			ManifestControlMissing: []string{"manifest", "dictionary"},
+		},
+		SupportedForcedPaths:   []string{"row_store_baseline", "physical_column"},
+		UnsupportedForcedPaths: []string{"planner_skipscan", "aggregate_metadata"},
+	})
+
+	for _, want := range []string{
+		"- manifest_control_missing: `manifest`, `dictionary`",
+		"- supported: `row_store_baseline`, `physical_column`",
+		"- fail-closed until physical planner paths exist: `planner_skipscan`, `aggregate_metadata`",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, md)
+		}
 	}
 }
 
@@ -495,6 +536,26 @@ func TestColumnStoreQueryHashRejectsUnknownQueryM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreQueryHashCanonicalizesQ5MetadataAliasM11A(t *testing.T) {
+	events := []columnStoreDecodedEvent{
+		{TimeUS: 10, Kind: "create", Did: "did:example:a"},
+		{TimeUS: 40, Kind: "update", Did: "did:example:a"},
+		{TimeUS: 25, Kind: "create", Did: "did:example:b"},
+		{TimeUS: 55, Kind: "delete", Did: "did:example:b"},
+	}
+	q5Hash, q5Count, err := columnStoreQueryHash("q5", events)
+	if err != nil {
+		t.Fatalf("q5 hash: %v", err)
+	}
+	aliasHash, aliasCount, err := columnStoreQueryHash("q5_metadata", events)
+	if err != nil {
+		t.Fatalf("q5_metadata hash: %v", err)
+	}
+	if q5Hash != aliasHash || q5Count != aliasCount {
+		t.Fatalf("q5_metadata hash/count=(%016x,%d) want q5=(%016x,%d)", aliasHash, aliasCount, q5Hash, q5Count)
+	}
+}
+
 func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
 	cfg := BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
 	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
@@ -644,6 +705,40 @@ func TestColumnStoreSuiteConfigUsesExplicitAggregateMetadataNamesM11A(t *testing
 	}
 	if strings.Contains(got, "q5_did_time_span,") || strings.HasSuffix(got, "q5_did_time_span") {
 		t.Fatalf("aggregate metadata min name is ambiguous: %q", got)
+	}
+}
+
+func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
+	md := renderColumnStoreSuiteMarkdown(columnStoreSuiteReport{
+		Suite: "column_store",
+		ByteAccounting: columnStoreByteAccounting{
+			ManifestControlMissing: []string{"vlog_ref_counts.meta", "column_manifest.meta"},
+		},
+		SupportedForcedPaths:   []string{"row_store_baseline", "diagnostic"},
+		UnsupportedForcedPaths: []string{"serial_column_scan", "aggregate_metadata"},
+	})
+	for _, want := range []string{
+		"- manifest_control_missing: `vlog_ref_counts.meta`, `column_manifest.meta`",
+		"- supported: `row_store_baseline`, `diagnostic`",
+		"- fail-closed until physical planner paths exist: `serial_column_scan`, `aggregate_metadata`",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, md)
+		}
+	}
+}
+
+func TestColumnStoreBenchRunUsesMeasuredDurationForAggregateM11A(t *testing.T) {
+	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
+		Rows:      1,
+		BatchSize: 1,
+		Queries: []columnStoreQueryMetric{
+			{Name: "q1", RowMaterializations: 7, DurationMS: 0, duration: time.Second},
+		},
+	}, nil, 0)
+	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
+	if got != 7 {
+		t.Fatalf("aggregate query-phase rows/sec=%f want 7 from measured duration", got)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -188,6 +189,149 @@ func TestColumnStoreSuiteRuntimeProfilesDoNotEnableOnCreateFailureM11A(t *testin
 	}
 	if gotPrev := runtime.SetMutexProfileFraction(0); gotPrev != 0 {
 		t.Fatalf("mutex profiler was left enabled after create failure: previous fraction=%d", gotPrev)
+	}
+}
+
+func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T) {
+	origStartCPUProfileFn := startCPUProfileFn
+	origStopCPUProfileFn := stopCPUProfileFn
+	origWriteAllocsSnapshotTempFn := writeAllocsSnapshotTempFn
+	origWriteAllocsDeltaProfileFn := writeAllocsDeltaProfileFn
+	origWriteRuntimeProfileSnapshotTempFn := writeRuntimeProfileSnapshotTempFn
+	origWriteRuntimeProfileDeltaProfileFn := writeRuntimeProfileDeltaProfileFn
+	t.Cleanup(func() {
+		startCPUProfileFn = origStartCPUProfileFn
+		stopCPUProfileFn = origStopCPUProfileFn
+		writeAllocsSnapshotTempFn = origWriteAllocsSnapshotTempFn
+		writeAllocsDeltaProfileFn = origWriteAllocsDeltaProfileFn
+		writeRuntimeProfileSnapshotTempFn = origWriteRuntimeProfileSnapshotTempFn
+		writeRuntimeProfileDeltaProfileFn = origWriteRuntimeProfileDeltaProfileFn
+	})
+
+	var events []string
+	profileTmpDir := t.TempDir()
+	newProfilePath := func(prefix string) (string, error) {
+		f, err := os.CreateTemp(profileTmpDir, prefix+"_*.pprof")
+		if err != nil {
+			return "", err
+		}
+		path := f.Name()
+		if err := f.Close(); err != nil {
+			_ = os.Remove(path)
+			return "", err
+		}
+		return path, nil
+	}
+	startCPUProfileFn = func(_ io.Writer) error {
+		events = append(events, "cpu_start")
+		return nil
+	}
+	stopCPUProfileFn = func() {
+		events = append(events, "cpu_stop")
+	}
+	writeAllocsSnapshotTempFn = func(prefix string) (string, error) {
+		events = append(events, prefix)
+		return newProfilePath(prefix)
+	}
+	writeRuntimeProfileSnapshotTempFn = func(prefix, profileName string) (string, error) {
+		events = append(events, prefix)
+		return newProfilePath(prefix)
+	}
+	writeAllocsDeltaProfileFn = func(basePath, afterPath, outPath string) error {
+		events = append(events, "alloc_delta")
+		return nil
+	}
+	writeRuntimeProfileDeltaProfileFn = func(basePath, afterPath, outPath string) (bool, error) {
+		events = append(events, filepath.Base(outPath))
+		return true, nil
+	}
+
+	fixture, _ := buildColumnStoreSyntheticFixture(8, 1)
+	dir := t.TempDir()
+	db, err := openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "events",
+		Options: collections.CollectionOptions{
+			DocumentFormat:               collections.DocumentFormatJSON,
+			DisableIndexedWriteMemtables: true,
+			ColumnStore:                  columnStoreSuiteConfig(),
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := insertColumnStoreFixture(collection, fixture, 4); err != nil {
+		t.Fatalf("insert fixture: %v", err)
+	}
+	rawHashes, err := columnStoreReferenceHashes(fixture)
+	if err != nil {
+		t.Fatalf("reference hashes: %v", err)
+	}
+
+	_, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		CPUProfile:           filepath.Join(profileTmpDir, "cpu"),
+		AllocsProfile:        filepath.Join(profileTmpDir, "allocs"),
+		AllocsProfileRate:    1,
+		BlockProfile:         filepath.Join(profileTmpDir, "block.pprof"),
+		MutexProfile:         filepath.Join(profileTmpDir, "mutex.pprof"),
+		MutexProfileFraction: 1,
+	}, collection, len(fixture), rawHashes, columnStorePathRowStoreBaseline)
+	if err != nil {
+		t.Fatalf("profiled queries: %v", err)
+	}
+	if parityErr != nil {
+		t.Fatalf("parity: %v", parityErr)
+	}
+	assertColumnStoreParityCoverageM11A(t, parity)
+
+	indexOf := func(target string) int {
+		for i, event := range events {
+			if event == target {
+				return i
+			}
+		}
+		return -1
+	}
+	cpuStartIdx := indexOf("cpu_start")
+	cpuStopIdx := indexOf("cpu_stop")
+	if cpuStartIdx < 0 || cpuStopIdx < 0 {
+		t.Fatalf("missing CPU profile events: %v", events)
+	}
+	for _, baseline := range []string{
+		"unified_bench_column_store_allocs_base",
+		"unified_bench_column_store_block_base",
+		"unified_bench_column_store_mutex_base",
+	} {
+		idx := indexOf(baseline)
+		if idx < 0 {
+			t.Fatalf("missing baseline event %s: %v", baseline, events)
+		}
+		if idx > cpuStartIdx {
+			t.Fatalf("expected %s before cpu_start: %v", baseline, events)
+		}
+	}
+	for _, after := range []string{
+		"unified_bench_column_store_allocs_after",
+		"unified_bench_column_store_block_after",
+		"unified_bench_column_store_mutex_after",
+	} {
+		idx := indexOf(after)
+		if idx < 0 {
+			t.Fatalf("missing after event %s: %v", after, events)
+		}
+		if cpuStopIdx > idx {
+			t.Fatalf("expected cpu_stop before %s: %v", after, events)
+		}
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -229,9 +229,11 @@ func TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A(t *testing.T)
 	report := columnStoreSuiteReport{
 		Suite: "column_store",
 		Artifacts: columnStoreArtifactPaths{
-			ColumnJSON:     filepath.Join(recordedDir, "custom_column.json"),
-			ColumnMarkdown: filepath.Join(recordedDir, "custom_column.md"),
-			ColumnHTML:     filepath.Join(recordedDir, "custom_column.html"),
+			ColumnJSON:        filepath.Join(recordedDir, "custom_column.json"),
+			ColumnMarkdown:    filepath.Join(recordedDir, "custom_column.md"),
+			ColumnHTML:        filepath.Join(recordedDir, "custom_column.html"),
+			BenchprofJSON:     filepath.Join(recordedDir, "custom_benchprof.json"),
+			BenchprofMarkdown: filepath.Join(recordedDir, "custom_benchprof.md"),
 		},
 	}
 	run := BenchRun{
@@ -262,8 +264,21 @@ func TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A(t *testing.T)
 			t.Fatalf("expected no fallback column artifact %s, stat err=%v", name, err)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(defaultDir, "benchprof_results.json")); err != nil {
-		t.Fatalf("expected benchprof artifact in profile dir: %v", err)
+	for _, path := range []string{
+		report.Artifacts.BenchprofJSON,
+		report.Artifacts.BenchprofMarkdown,
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected recorded benchprof artifact path %s: %v", path, err)
+		}
+	}
+	for _, name := range []string{
+		"benchprof_results.json",
+		"benchprof_results.md",
+	} {
+		if _, err := os.Stat(filepath.Join(defaultDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected no fallback benchprof artifact %s, stat err=%v", name, err)
+		}
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -588,6 +588,32 @@ func TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteRuntimeProfilesTrimPaddedPathsM11A(t *testing.T) {
+	dir := t.TempDir()
+	blockPath := filepath.Join(dir, "block.pprof")
+	mutexPath := filepath.Join(dir, "mutex.pprof")
+	tracePath := filepath.Join(dir, "trace.out")
+
+	finish, err := startColumnStoreSuiteRuntimeProfiles(BenchConfig{
+		BlockProfile:         " \t" + blockPath + "\t ",
+		BlockProfileRate:     1,
+		MutexProfile:         " \t" + mutexPath + "\t ",
+		MutexProfileFraction: 1,
+		TraceProfile:         " \t" + tracePath + "\t ",
+	})
+	if err != nil {
+		t.Fatalf("startColumnStoreSuiteRuntimeProfiles: %v", err)
+	}
+	if err := finish(); err != nil {
+		t.Fatalf("finish runtime profiles: %v", err)
+	}
+	for _, path := range []string{blockPath, mutexPath, tracePath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected trimmed profile path %q to exist: %v", path, err)
+		}
+	}
+}
+
 func TestColumnStoreSuiteArtifactsOmitMissingRuntimeDeltaPathsM11A(t *testing.T) {
 	dir := t.TempDir()
 	blockDeltaPath := filepath.Join(dir, "block_delta.pprof")
@@ -612,6 +638,21 @@ func TestColumnStoreSuiteArtifactsOmitMissingRuntimeDeltaPathsM11A(t *testing.T)
 	}
 	if paths.BlockProfile != blockPath || paths.MutexProfile != mutexPath {
 		t.Fatalf("base runtime profile artifacts should remain advertised: %+v", paths)
+	}
+}
+
+func TestColumnStoreSuiteArtifactsOmitRuntimeDeltaStatErrorsM11A(t *testing.T) {
+	dir := t.TempDir()
+	notDir := filepath.Join(dir, "not-dir")
+	if err := os.WriteFile(notDir, []byte("file"), 0o644); err != nil {
+		t.Fatalf("write not-dir marker: %v", err)
+	}
+	paths := columnStoreSuitePruneMissingRuntimeDeltaArtifacts(columnStoreArtifactPaths{
+		BlockDeltaProfile: filepath.Join(notDir, "block_delta.pprof"),
+		MutexDeltaProfile: " \t ",
+	})
+	if paths.BlockDeltaProfile != "" || paths.MutexDeltaProfile != "" {
+		t.Fatalf("stat-error/blank optional delta paths should be omitted: %+v", paths)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -169,6 +170,37 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteRuntimeProfilesDoNotEnableOnCreateFailureM11A(t *testing.T) {
+	prevMutexFraction := runtime.SetMutexProfileFraction(0)
+	t.Cleanup(func() {
+		runtime.SetMutexProfileFraction(prevMutexFraction)
+	})
+
+	_, err := startColumnStoreSuiteRuntimeProfiles(BenchConfig{
+		MutexProfile:         filepath.Join(t.TempDir(), "missing", "mutex.pprof"),
+		MutexProfileFraction: 1,
+	})
+	if err == nil {
+		t.Fatal("expected mutex profile create failure")
+	}
+	if !strings.Contains(err.Error(), "mutexprofile") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPrev := runtime.SetMutexProfileFraction(0); gotPrev != 0 {
+		t.Fatalf("mutex profiler was left enabled after create failure: previous fraction=%d", gotPrev)
+	}
+}
+
+func TestColumnStoreQueryHashRejectsUnknownQueryM11A(t *testing.T) {
+	_, _, err := columnStoreQueryHash("missing_query", nil)
+	if err == nil {
+		t.Fatal("expected unknown query to fail")
+	}
+	if !strings.Contains(err.Error(), "unknown column_store query") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
 	cfg := BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
 	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
@@ -319,7 +351,10 @@ func BenchmarkColumnStoreSuiteRowBaselineQueriesM11A(b *testing.B) {
 		b.Fatalf("reopen collection: %v", err)
 	}
 
-	rawHashes := columnStoreReferenceHashes(events)
+	rawHashes, err := columnStoreReferenceHashes(events)
+	if err != nil {
+		b.Fatalf("reference hashes: %v", err)
+	}
 	queryCount := len(columnStoreQueryNames())
 	b.ReportAllocs()
 	b.SetBytes(sourceBytes * int64(queryCount))

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -588,6 +588,29 @@ func TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteOmitsMissingOptionalDeltaArtifactsM11A(t *testing.T) {
+	dir := t.TempDir()
+	mutexPath := filepath.Join(dir, "mutex_delta.pprof")
+	if err := os.WriteFile(mutexPath, []byte("mutex"), 0o644); err != nil {
+		t.Fatalf("write mutex delta: %v", err)
+	}
+	paths := columnStoreOmitMissingOptionalArtifacts(columnStoreArtifactPaths{
+		BlockDeltaProfile: filepath.Join(dir, "missing_block_delta.pprof"),
+		MutexDeltaProfile: mutexPath,
+		BlockProfile:      filepath.Join(dir, "block.pprof"),
+		MutexProfile:      filepath.Join(dir, "mutex.pprof"),
+	})
+	if paths.BlockDeltaProfile != "" {
+		t.Fatalf("missing block delta still advertised: %+v", paths)
+	}
+	if paths.MutexDeltaProfile != mutexPath {
+		t.Fatalf("existing mutex delta was removed: %+v", paths)
+	}
+	if paths.BlockProfile == "" || paths.MutexProfile == "" {
+		t.Fatalf("base profile artifacts should remain advertised: %+v", paths)
+	}
+}
+
 func TestColumnStoreSuiteProfiledQueriesReturnHardErrorsSeparatelyM11A(t *testing.T) {
 	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 4, 2)
 	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -546,8 +546,11 @@ func TestColumnStoreSuiteCheckpointCPUProfileNilStartHookReturnsErrorM11A(t *tes
 		}
 		t.Fatal("expected checkpoint CPU profile nil hook error")
 	}
-	if !strings.Contains(err.Error(), "start hook is nil") {
-		t.Fatalf("error=%v, want nil hook context", err)
+	msg := err.Error()
+	if !strings.Contains(msg, "start hook is nil") ||
+		!strings.Contains(msg, columnStoreSuiteBenchTestName) ||
+		!strings.Contains(msg, columnStoreSuiteBenchDBName) {
+		t.Fatalf("error=%v, want nil hook test/db context", err)
 	}
 	profilePath := fmt.Sprintf("%s_checkpoint_%s_%s.pprof", cfg.CheckpointCPUProfile, sanitizeProfileSegment(columnStoreSuiteBenchTestName), sanitizeProfileSegment(columnStoreSuiteBenchDBName))
 	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -221,6 +221,51 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 }
 
+func TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A(t *testing.T) {
+	dir := t.TempDir()
+	defaultDir := filepath.Join(dir, "default")
+	recordedDir := filepath.Join(dir, "recorded")
+	report := columnStoreSuiteReport{
+		Suite: "column_store",
+		Artifacts: columnStoreArtifactPaths{
+			ColumnJSON:     filepath.Join(recordedDir, "custom_column.json"),
+			ColumnMarkdown: filepath.Join(recordedDir, "custom_column.md"),
+			ColumnHTML:     filepath.Join(recordedDir, "custom_column.html"),
+		},
+	}
+	run := BenchRun{
+		Config: BenchConfig{Keys: 1, Profile: "durable"},
+		Results: map[string]map[string]float64{
+			"column_store": {columnStoreSuiteBenchDisplayName: 1},
+		},
+	}
+
+	if err := writeColumnStoreSuiteArtifacts(defaultDir, "native-fastpath", report, "# column store", run); err != nil {
+		t.Fatalf("writeColumnStoreSuiteArtifacts: %v", err)
+	}
+	for _, path := range []string{
+		report.Artifacts.ColumnJSON,
+		report.Artifacts.ColumnMarkdown,
+		report.Artifacts.ColumnHTML,
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected recorded artifact path %s: %v", path, err)
+		}
+	}
+	for _, name := range []string{
+		"column_store_results.json",
+		"column_store_results.md",
+		"column_store_results.html",
+	} {
+		if _, err := os.Stat(filepath.Join(defaultDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected no fallback column artifact %s, stat err=%v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(defaultDir, "benchprof_results.json")); err != nil {
+		t.Fatalf("expected benchprof artifact in profile dir: %v", err)
+	}
+}
+
 func TestColumnStoreBenchRunUsesDurationForAggregateM11A(t *testing.T) {
 	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
 		Rows:      30,

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -13,12 +13,21 @@ import (
 func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	dir := t.TempDir()
 	cfg := BenchConfig{
-		Keys:      64,
-		BatchSize: 16,
-		DBsArg:    "treedb",
-		Profile:   "durable",
-		Progress:  false,
-		SeedUsed:  1,
+		Keys:                 64,
+		BatchSize:            16,
+		DBsArg:               "treedb",
+		Profile:              "durable",
+		Progress:             false,
+		SeedUsed:             1,
+		CPUProfile:           filepath.Join(dir, "cpu"),
+		AllocsProfile:        filepath.Join(dir, "allocs"),
+		AllocsProfileRate:    1,
+		CheckpointCPUProfile: filepath.Join(dir, "checkpoint_cpu"),
+		BlockProfile:         filepath.Join(dir, "block.pprof"),
+		BlockProfileRate:     1,
+		MutexProfile:         filepath.Join(dir, "mutex.pprof"),
+		MutexProfileFraction: 1,
+		TraceProfile:         filepath.Join(dir, "trace.out"),
 	}
 
 	out, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
@@ -54,6 +63,12 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		"column_store_results.json",
 		"column_store_results.md",
 		"column_store_results.html",
+		"cpu_column_store_treedb_column_store.pprof",
+		"allocs_column_store_treedb_column_store.pprof",
+		"checkpoint_cpu_checkpoint_post_run_treedb_column_store.pprof",
+		"block.pprof",
+		"mutex.pprof",
+		"trace.out",
 	} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Fatalf("expected %s: %v", name, err)
@@ -87,13 +102,17 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		if q.PlanLabel != columnStorePathRowStoreBaseline {
 			t.Fatalf("query %s plan_label=%q want %q", q.Name, q.PlanLabel, columnStorePathRowStoreBaseline)
 		}
-		if q.RowsPerSecond <= 0 {
-			t.Fatalf("query %s rows_per_second=%v", q.Name, q.RowsPerSecond)
+		if q.DurationMS < 0 || q.RowsPerSecond < 0 {
+			t.Fatalf("query %s has invalid timing metrics: %+v", q.Name, q)
+		}
+		if q.BytesRead <= 0 {
+			t.Fatalf("query %s bytes_read=%d", q.Name, q.BytesRead)
 		}
 		if q.RowMaterializations != report.Rows {
 			t.Fatalf("query %s row_materializations=%d want %d", q.Name, q.RowMaterializations, report.Rows)
 		}
 	}
+	assertColumnStoreParityCoverageM11A(t, report.Parity)
 	for name, parity := range report.Parity {
 		if !parity.Pass {
 			t.Fatalf("parity %s failed: %+v", name, parity)
@@ -104,6 +123,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 	if report.ByteAccounting.CommandWALBytes == 0 {
 		t.Fatalf("expected command WAL bytes in byte accounting: %+v", report.ByteAccounting)
+	}
+	if report.ByteAccounting.ManifestControlBytes == 0 || report.ByteAccounting.DBTotalBytes == 0 || report.ByteAccounting.DBTotalFiles == 0 {
+		t.Fatalf("expected measured manifest/control and DB byte accounting: %+v", report.ByteAccounting)
 	}
 	if report.Manifest.ActiveGeneration == 0 || report.Manifest.AppliedCommandLSN == 0 {
 		t.Fatalf("expected active/recovery-authoritative manifest identity: %+v", report.Manifest)
@@ -122,7 +144,7 @@ func TestColumnStoreSuiteRejectsForcedColumnPathM11A(t *testing.T) {
 		t.Fatal("expected forced serial column scan to fail closed")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "serial_column_scan") || !strings.Contains(msg, "refusing to route through row store") {
+	if !strings.Contains(msg, "serial_column_scan") || !strings.Contains(msg, "not implemented") || !strings.Contains(msg, "supported=") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -151,8 +173,40 @@ func TestColumnStoreSuiteReportsParityMismatchM11A(t *testing.T) {
 	if err := json.Unmarshal(data, &report); err != nil {
 		t.Fatalf("unmarshal report: %v", err)
 	}
-	if report.Parity["q1"].Pass {
-		t.Fatalf("expected q1 parity to be recorded as failed: %+v", report.Parity["q1"])
+	assertColumnStoreParityCoverageM11A(t, report.Parity)
+	q1, ok := report.Parity["q1"]
+	if !ok {
+		t.Fatal("missing q1 parity entry")
+	}
+	if q1.Pass {
+		t.Fatalf("expected q1 parity to be recorded as failed: %+v", q1)
+	}
+}
+
+func TestColumnStoreSuiteRejectsMixedDBSelectionM11A(t *testing.T) {
+	err := validateColumnStoreSuiteDBSelection("treedb,leveldb", "")
+	if err == nil {
+		t.Fatal("expected mixed DB selection to fail")
+	}
+	if !strings.Contains(err.Error(), "only supports TreeDB") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteRejectsExcludedTreeDBM11A(t *testing.T) {
+	err := validateColumnStoreSuiteDBSelection("all", "treedb")
+	if err == nil {
+		t.Fatal("expected TreeDB exclusion to fail")
+	}
+	if !strings.Contains(err.Error(), "excludes it") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteDirUsageFailsOnMissingPathM11A(t *testing.T) {
+	_, _, err := columnStoreSuiteDirUsage(filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatal("expected missing path to fail")
 	}
 }
 
@@ -236,6 +290,22 @@ func BenchmarkColumnStoreSuiteRowBaselineQueriesM11A(b *testing.B) {
 				b.Fatalf("parity failed for %s: %+v", name, p)
 			}
 		}
+		if len(parity) != queryCount {
+			b.Fatalf("parity=%d want %d", len(parity), queryCount)
+		}
 	}
 	b.ReportMetric(float64(rows*queryCount), "rows/op")
+}
+
+func assertColumnStoreParityCoverageM11A(t *testing.T, parity map[string]columnStoreParity) {
+	t.Helper()
+	names := columnStoreQueryNames()
+	if len(parity) != len(names) {
+		t.Fatalf("parity entries=%d want %d", len(parity), len(names))
+	}
+	for _, name := range names {
+		if _, ok := parity[name]; !ok {
+			t.Fatalf("missing parity entry for %s", name)
+		}
+	}
 }

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -708,40 +708,6 @@ func TestColumnStoreSuiteConfigUsesExplicitAggregateMetadataNamesM11A(t *testing
 	}
 }
 
-func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
-	md := renderColumnStoreSuiteMarkdown(columnStoreSuiteReport{
-		Suite: "column_store",
-		ByteAccounting: columnStoreByteAccounting{
-			ManifestControlMissing: []string{"vlog_ref_counts.meta", "column_manifest.meta"},
-		},
-		SupportedForcedPaths:   []string{"row_store_baseline", "diagnostic"},
-		UnsupportedForcedPaths: []string{"serial_column_scan", "aggregate_metadata"},
-	})
-	for _, want := range []string{
-		"- manifest_control_missing: `vlog_ref_counts.meta`, `column_manifest.meta`",
-		"- supported: `row_store_baseline`, `diagnostic`",
-		"- fail-closed until physical planner paths exist: `serial_column_scan`, `aggregate_metadata`",
-	} {
-		if !strings.Contains(md, want) {
-			t.Fatalf("markdown missing %q:\n%s", want, md)
-		}
-	}
-}
-
-func TestColumnStoreBenchRunUsesMeasuredDurationForAggregateM11A(t *testing.T) {
-	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
-		Rows:      1,
-		BatchSize: 1,
-		Queries: []columnStoreQueryMetric{
-			{Name: "q1", RowMaterializations: 7, DurationMS: 0, duration: time.Second},
-		},
-	}, nil, 0)
-	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
-	if got != 7 {
-		t.Fatalf("aggregate query-phase rows/sec=%f want 7 from measured duration", got)
-	}
-}
-
 func TestColumnStoreSuiteDirUsageFailsOnMissingPathM11A(t *testing.T) {
 	_, _, err := columnStoreSuiteDirUsage(filepath.Join(t.TempDir(), "missing"))
 	if err == nil {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -517,9 +517,10 @@ func TestColumnStoreSuiteHardQueryFailureRemovesCPUArtifactM11A(t *testing.T) {
 	}
 }
 
-func TestColumnStoreSuiteRuntimeDeltaRequiresOutputM11A(t *testing.T) {
+func TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A(t *testing.T) {
 	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
 	profileDir := t.TempDir()
+	blockPath := filepath.Join(profileDir, "block.pprof")
 	profileHooks := &benchmarkProfileHooks{
 		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
 			path := filepath.Join(profileDir, prefix+".pprof")
@@ -530,14 +531,15 @@ func TestColumnStoreSuiteRuntimeDeltaRequiresOutputM11A(t *testing.T) {
 		},
 	}
 	_, _, _, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
-		BlockProfile: filepath.Join(profileDir, "block.pprof"),
+		BlockProfile: blockPath,
 		profileHooks: profileHooks,
 	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
-	if err == nil {
-		t.Fatal("expected empty block delta output to fail")
+	if err != nil {
+		t.Fatalf("empty block delta output should be skipped: %v", err)
 	}
-	if !errors.Is(err, errEmptyPprofDeltaOutput) {
-		t.Fatalf("expected errEmptyPprofDeltaOutput, got %v", err)
+	outPath := contentionProfilePath(blockPath, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if _, statErr := os.Stat(outPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected empty block delta artifact to be omitted, stat err=%v", statErr)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -141,6 +141,12 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if q := queryMetrics["q5_metadata"]; q.AliasOf != "q5" || q.ImplementationNote == "" {
 		t.Fatalf("q5_metadata should be explicitly reported as a q5 alias placeholder: %+v", q)
 	}
+	if got, want := queryMetrics["q5_metadata"].ProductionHash, queryMetrics["q5"].ProductionHash; got != want {
+		t.Fatalf("q5_metadata production hash=%016x want q5 hash=%016x", got, want)
+	}
+	if got, want := queryMetrics["q5_metadata"].RawHash, queryMetrics["q5"].RawHash; got != want {
+		t.Fatalf("q5_metadata raw hash=%016x want q5 hash=%016x", got, want)
+	}
 	assertColumnStoreParityCoverageM11A(t, report.Parity)
 	for name, parity := range report.Parity {
 		if !parity.Pass {
@@ -155,6 +161,21 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 	if report.ByteAccounting.RetainedPayloadBytesNote == "" || report.ByteAccounting.ColumnAssetBytesNote == "" {
 		t.Fatalf("expected M11A byte-accounting placeholder notes: %+v", report.ByteAccounting)
+	}
+	if got, want := report.ByteAccounting.TotalReconstructableBytes, report.ByteAccounting.RetainedPayloadBytes+report.ByteAccounting.ColumnAssetBytes+report.ByteAccounting.ManifestControlBytes; got != want {
+		t.Fatalf("total_reconstructable_bytes=%d want retained+column+manifest=%d", got, want)
+	}
+	var sawReopenRecovery bool
+	for _, stage := range report.Stages {
+		if stage.Name == "reopen_recovery" {
+			sawReopenRecovery = true
+		}
+		if stage.Name == "reopen" {
+			t.Fatalf("stage name should use reopen_recovery, got legacy stage: %+v", stage)
+		}
+	}
+	if !sawReopenRecovery {
+		t.Fatalf("missing reopen_recovery stage: %+v", report.Stages)
 	}
 	if !strings.Contains(string(data), `"command_wal_bytes_before_checkpoint"`) {
 		t.Fatalf("column store JSON missing before-checkpoint command WAL label:\n%s", data)
@@ -174,6 +195,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	}
 	if !strings.Contains(string(columnMarkdown), "column_asset_bytes_note") || !strings.Contains(string(columnMarkdown), "retained_payload_bytes_note") {
 		t.Fatalf("column store markdown missing byte-accounting notes:\n%s", columnMarkdown)
+	}
+	if strings.Contains(string(columnMarkdown), "| `` |") {
+		t.Fatalf("column store markdown should render empty notes as placeholder:\n%s", columnMarkdown)
 	}
 	if report.ByteAccounting.ManifestControlBytes == 0 || report.ByteAccounting.DBTotalBytes == 0 || report.ByteAccounting.DBTotalFiles == 0 {
 		t.Fatalf("expected measured manifest/control and DB byte accounting: %+v", report.ByteAccounting)
@@ -217,22 +241,30 @@ func TestColumnStoreSuiteRuntimeProfilesDoNotEnableOnCreateFailureM11A(t *testin
 	}
 }
 
-func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T) {
-	origStartCPUProfileFn := startCPUProfileFn
-	origStopCPUProfileFn := stopCPUProfileFn
-	origWriteAllocsSnapshotTempFn := writeAllocsSnapshotTempFn
-	origWriteAllocsDeltaProfileFn := writeAllocsDeltaProfileFn
-	origWriteRuntimeProfileSnapshotTempFn := writeRuntimeProfileSnapshotTempFn
-	origWriteRuntimeProfileDeltaProfileFn := writeRuntimeProfileDeltaProfileFn
+func TestColumnStoreSuiteRuntimeProfilesDoNotChangeMemRateWhenFilteredM11A(t *testing.T) {
+	prevRate := runtime.MemProfileRate
 	t.Cleanup(func() {
-		startCPUProfileFn = origStartCPUProfileFn
-		stopCPUProfileFn = origStopCPUProfileFn
-		writeAllocsSnapshotTempFn = origWriteAllocsSnapshotTempFn
-		writeAllocsDeltaProfileFn = origWriteAllocsDeltaProfileFn
-		writeRuntimeProfileSnapshotTempFn = origWriteRuntimeProfileSnapshotTempFn
-		writeRuntimeProfileDeltaProfileFn = origWriteRuntimeProfileDeltaProfileFn
+		runtime.MemProfileRate = prevRate
 	})
+	runtime.MemProfileRate = 4096
 
+	finish, err := startColumnStoreSuiteRuntimeProfiles(BenchConfig{
+		AllocsProfile:      filepath.Join(t.TempDir(), "allocs"),
+		AllocsProfileRate:  1,
+		AllocsProfileTests: map[string]struct{}{"not_column_store": {}},
+	})
+	if err != nil {
+		t.Fatalf("start runtime profiles: %v", err)
+	}
+	if err := finish(); err != nil {
+		t.Fatalf("finish runtime profiles: %v", err)
+	}
+	if got := runtime.MemProfileRate; got != 4096 {
+		t.Fatalf("MemProfileRate changed despite allocs test filter: got %d", got)
+	}
+}
+
+func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T) {
 	var events []string
 	profileTmpDir := t.TempDir()
 	newProfilePath := func(prefix string) (string, error) {
@@ -247,28 +279,30 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 		}
 		return path, nil
 	}
-	startCPUProfileFn = func(_ io.Writer) error {
-		events = append(events, "cpu_start")
-		return nil
-	}
-	stopCPUProfileFn = func() {
-		events = append(events, "cpu_stop")
-	}
-	writeAllocsSnapshotTempFn = func(prefix string) (string, error) {
-		events = append(events, prefix)
-		return newProfilePath(prefix)
-	}
-	writeRuntimeProfileSnapshotTempFn = func(prefix, profileName string) (string, error) {
-		events = append(events, prefix)
-		return newProfilePath(prefix)
-	}
-	writeAllocsDeltaProfileFn = func(basePath, afterPath, outPath string) error {
-		events = append(events, "alloc_delta")
-		return nil
-	}
-	writeRuntimeProfileDeltaProfileFn = func(basePath, afterPath, outPath string) (bool, error) {
-		events = append(events, filepath.Base(outPath))
-		return true, nil
+	profileHooks := &benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			events = append(events, "cpu_start")
+			return nil
+		},
+		stopCPUProfile: func() {
+			events = append(events, "cpu_stop")
+		},
+		writeAllocsSnapshotTemp: func(prefix string) (string, error) {
+			events = append(events, prefix)
+			return newProfilePath(prefix)
+		},
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			events = append(events, prefix)
+			return newProfilePath(prefix)
+		},
+		writeAllocsDeltaProfile: func(basePath, afterPath, outPath string) error {
+			events = append(events, "alloc_delta")
+			return nil
+		},
+		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
+			events = append(events, filepath.Base(outPath))
+			return true, nil
+		},
 	}
 
 	fixture, _ := buildColumnStoreSyntheticFixture(8, 1)
@@ -310,6 +344,7 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 		BlockProfile:         filepath.Join(profileTmpDir, "block.pprof"),
 		MutexProfile:         filepath.Join(profileTmpDir, "mutex.pprof"),
 		MutexProfileFraction: 1,
+		profileHooks:         profileHooks,
 	}, collection, len(fixture), rawHashes, columnStorePathRowStoreBaseline)
 	if err != nil {
 		t.Fatalf("profiled queries: %v", err)
@@ -361,18 +396,17 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 }
 
 func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T) {
-	origStartCPUProfileFn := startCPUProfileFn
-	t.Cleanup(func() {
-		startCPUProfileFn = origStartCPUProfileFn
-	})
-	startCPUProfileFn = func(_ io.Writer) error {
-		return errors.New("start failed")
+	profileHooks := &benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error {
+			return errors.New("start failed")
+		},
 	}
 
 	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
 	profilePrefix := filepath.Join(t.TempDir(), "cpu")
 	_, _, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
-		CPUProfile: profilePrefix,
+		CPUProfile:   profilePrefix,
+		profileHooks: profileHooks,
 	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
 	if err == nil {
 		t.Fatal("expected CPU profile start failure")
@@ -383,6 +417,57 @@ func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T)
 	profilePath := fmt.Sprintf("%s_%s_%s.pprof", profilePrefix, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
 	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected failed CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
+func TestColumnStoreSuiteHardQueryFailureRemovesCPUArtifactM11A(t *testing.T) {
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 4, 2)
+	profileDir := t.TempDir()
+	profilePrefix := filepath.Join(profileDir, "cpu")
+	profileHooks := &benchmarkProfileHooks{
+		startCPUProfile: func(_ io.Writer) error { return nil },
+		stopCPUProfile:  func() {},
+	}
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		CPUProfile:   profilePrefix,
+		profileHooks: profileHooks,
+	}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)
+	if err == nil {
+		t.Fatal("expected hard query error")
+	}
+	if parityErr != nil {
+		t.Fatalf("hard query error returned as parity error: %v", parityErr)
+	}
+	if queries != nil || parity != nil {
+		t.Fatalf("expected no query/parity output on hard failure, queries=%v parity=%v", queries, parity)
+	}
+	profilePath := fmt.Sprintf("%s_%s_%s.pprof", profilePrefix, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if _, statErr := os.Stat(profilePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected hard-failure CPU profile artifact to be removed, stat err=%v", statErr)
+	}
+}
+
+func TestColumnStoreSuiteRuntimeDeltaRequiresOutputM11A(t *testing.T) {
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
+	profileDir := t.TempDir()
+	profileHooks := &benchmarkProfileHooks{
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			path := filepath.Join(profileDir, prefix+".pprof")
+			return path, os.WriteFile(path, []byte("snapshot"), 0o644)
+		},
+		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
+			return false, nil
+		},
+	}
+	_, _, _, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		BlockProfile: filepath.Join(profileDir, "block.pprof"),
+		profileHooks: profileHooks,
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	if err == nil {
+		t.Fatal("expected empty block delta output to fail")
+	}
+	if !errors.Is(err, errEmptyPprofDeltaOutput) {
+		t.Fatalf("expected errEmptyPprofDeltaOutput, got %v", err)
 	}
 }
 
@@ -458,12 +543,39 @@ func TestColumnStoreSuiteReportsParityMismatchM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteRejectsUnknownCorruptReferenceM11A(t *testing.T) {
+	cfg := BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ForcedPath:              columnStorePathRowStoreBaseline,
+		CorruptReferenceForTest: "missing_query",
+	})
+	if err == nil {
+		t.Fatal("expected unknown corrupt reference query to fail")
+	}
+	if !strings.Contains(err.Error(), "unknown corrupt reference query") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestColumnStoreSuiteRejectsMixedDBSelectionM11A(t *testing.T) {
 	err := validateColumnStoreSuiteDBSelection("treedb,leveldb", "")
 	if err == nil {
 		t.Fatal("expected mixed DB selection to fail")
 	}
 	if !strings.Contains(err.Error(), "only supports TreeDB") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteAppliesDBExclusionsBeforeMixedCheckM11A(t *testing.T) {
+	if err := validateColumnStoreSuiteDBSelection("treedb,leveldb", "leveldb"); err != nil {
+		t.Fatalf("expected excluded non-TreeDB selection to pass: %v", err)
+	}
+	err := validateColumnStoreSuiteDBSelection("leveldb", "leveldb")
+	if err == nil {
+		t.Fatal("expected all selected DBs excluded to fail")
+	}
+	if !strings.Contains(err.Error(), "requires TreeDB") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -475,6 +587,63 @@ func TestColumnStoreSuiteRejectsExcludedTreeDBM11A(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "excludes it") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestColumnStoreSuiteReportsKeptDataDirM11A(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{
+		Keys:      8,
+		BatchSize: 4,
+		DBsArg:    "treedb",
+		Profile:   "durable",
+		Progress:  false,
+		SeedUsed:  1,
+		KeepDir:   true,
+	}
+	out, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:    dir,
+		ExecutionPath: "native-fastpath",
+		ForcedPath:    columnStorePathRowStoreBaseline,
+	})
+	if err != nil {
+		t.Fatalf("runColumnStoreSuite: %v", err)
+	}
+
+	var report columnStoreSuiteReport
+	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if err != nil {
+		t.Fatalf("read column_store_results.json: %v", err)
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if report.DataDir == "" {
+		t.Fatalf("expected kept data dir in report: %+v", report)
+	}
+	if _, err := os.Stat(report.DataDir); err != nil {
+		t.Fatalf("expected kept data dir to exist: %v", err)
+	}
+	if !strings.Contains(out, "data-dir") {
+		t.Fatalf("markdown output missing kept data-dir:\n%s", out)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(report.DataDir)
+	})
+}
+
+func TestColumnStoreSuiteConfigUsesExplicitAggregateMetadataNamesM11A(t *testing.T) {
+	cfg := columnStoreSuiteConfig()
+	var names []string
+	for _, agg := range cfg.AggregateMetadata {
+		names = append(names, agg.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "q5_did_time_span_min") || !strings.Contains(got, "q5_did_time_span_max") {
+		t.Fatalf("aggregate metadata names=%q", got)
+	}
+	if strings.Contains(got, "q5_did_time_span,") || strings.HasSuffix(got, "q5_did_time_span") {
+		t.Fatalf("aggregate metadata min name is ambiguous: %q", got)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -614,6 +614,52 @@ func TestColumnStoreSuiteRuntimeProfilesTrimPaddedPathsM11A(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteProfiledQueriesSkipWhitespaceOnlyRuntimeProfilePathsM11A(t *testing.T) {
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
+	profileHooks := &benchmarkProfileHooks{
+		writeRuntimeProfileSnapshotTemp: func(prefix, profileName string) (string, error) {
+			t.Fatalf("runtime profile snapshot should not run for whitespace-only %s path", profileName)
+			return "", nil
+		},
+		writeRuntimeProfileDeltaProfile: func(basePath, afterPath, outPath string) (bool, error) {
+			t.Fatalf("runtime profile delta should not run for whitespace-only path %q", outPath)
+			return false, nil
+		},
+	}
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		BlockProfile: " \t ",
+		MutexProfile: " \n ",
+		profileHooks: profileHooks,
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	if err != nil || parityErr != nil {
+		t.Fatalf("whitespace-only runtime profiles should be ignored: err=%v parityErr=%v", err, parityErr)
+	}
+	assertColumnStoreQueryMetricCoverageM11A(t, queries)
+	assertColumnStoreParityCoverageM11A(t, parity)
+}
+
+func TestColumnStoreSuiteArtifactsTrimRuntimeProfilePathsM11A(t *testing.T) {
+	dir := t.TempDir()
+	blockPath := filepath.Join(dir, "block.pprof")
+	mutexPath := filepath.Join(dir, "mutex.pprof")
+	tracePath := filepath.Join(dir, "trace.out")
+
+	paths := columnStoreArtifactPathsForProfileDir(dir, BenchConfig{
+		BlockProfile: " \t" + blockPath + "\t ",
+		MutexProfile: " \t" + mutexPath + "\t ",
+		TraceProfile: " \t" + tracePath + "\t ",
+	})
+	if paths.BlockProfile != blockPath || paths.MutexProfile != mutexPath || paths.TraceProfile != tracePath {
+		t.Fatalf("runtime artifact paths were not trimmed: %+v", paths)
+	}
+	if paths.BlockDeltaProfile != contentionProfilePath(blockPath, "block", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
+		t.Fatalf("block delta path=%q", paths.BlockDeltaProfile)
+	}
+	if paths.MutexDeltaProfile != contentionProfilePath(mutexPath, "mutex", columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName) {
+		t.Fatalf("mutex delta path=%q", paths.MutexDeltaProfile)
+	}
+}
+
 func TestColumnStoreSuiteArtifactsOmitMissingRuntimeDeltaPathsM11A(t *testing.T) {
 	dir := t.TempDir()
 	blockDeltaPath := filepath.Join(dir, "block_delta.pprof")

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -711,6 +711,40 @@ func TestColumnStoreSuiteProfiledQueriesSkipWhitespaceOnlyRuntimeProfilePathsM11
 	assertColumnStoreParityCoverageM11A(t, parity)
 }
 
+func TestColumnStoreSuiteProfiledQueriesTrimAllocsDeltaPathM11A(t *testing.T) {
+	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 8, 4)
+	dir := t.TempDir()
+	allocsPrefix := filepath.Join(dir, "allocs")
+	var gotOutPath string
+	profileHooks := &benchmarkProfileHooks{
+		writeAllocsSnapshotTemp: func(prefix string) (string, error) {
+			path := filepath.Join(dir, prefix+".pprof")
+			return path, os.WriteFile(path, []byte("snapshot"), 0o644)
+		},
+		writeAllocsDeltaProfile: func(basePath, afterPath, outPath string) error {
+			gotOutPath = outPath
+			return os.WriteFile(outPath, []byte("delta"), 0o644)
+		},
+	}
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
+		AllocsProfile:     " \t" + allocsPrefix + "\t ",
+		AllocsProfileRate: 1,
+		profileHooks:      profileHooks,
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	if err != nil || parityErr != nil {
+		t.Fatalf("profiled queries failed: err=%v parityErr=%v", err, parityErr)
+	}
+	assertColumnStoreQueryMetricCoverageM11A(t, queries)
+	assertColumnStoreParityCoverageM11A(t, parity)
+	wantOutPath := fmt.Sprintf("%s_%s_%s.pprof", allocsPrefix, columnStoreSuiteBenchTestName, columnStoreSuiteBenchDBName)
+	if gotOutPath != wantOutPath {
+		t.Fatalf("allocs delta out path=%q want %q", gotOutPath, wantOutPath)
+	}
+	if _, err := os.Stat(wantOutPath); err != nil {
+		t.Fatalf("expected trimmed allocs delta artifact: %v", err)
+	}
+}
+
 func TestColumnStoreSuiteArtifactsTrimRuntimeProfilePathsM11A(t *testing.T) {
 	dir := t.TempDir()
 	cpuPath := filepath.Join(dir, "cpu")


### PR DESCRIPTION
## Summary

Adds the native TreeDB column-store benchmark entry point to `unified-bench`:

- `-suite column_store` with durable-only production column-enabled collection setup.
- Stage-separated reporting for fixture generation, collection create, ingest, checkpoint, reopen, and q1-q5/q5_metadata scans.
- Column-store artifact outputs: `column_store_results.json`, `column_store_results.md`, `column_store_results.html`.
- Existing benchprof artifact integration: `benchprof_results.json`, `benchprof_results.md`, `insights.md`, `insights.json`, `insights.html`.
- TDD coverage for artifact creation, q1-q5 parity, manifest/recovery identity, command-WAL byte accounting, README command docs, and fail-closed physical path labels.

M11A scope is intentionally explicit: the runnable path is `row_store_baseline` over a production column-enabled TreeDB collection. Physical column scan labels fail closed in this PR rather than silently falling back to row materialization. This PR establishes the canonical benchmark/reporting contract that M11B will use for physical column query paths.

## Performance / Benchmark Evidence

### Native column-store suite, 100K durable row baseline

Evidence head: `cfb9e8bbc` (`cfb9e8bbc06d284445fa6ff0e6875ec12e73725a`); parent/base: `5b021a65f` (`5b021a65ff5540351e95beee9fd0679e94e047e2`) from `codex/colgranule-m10c-recovery-parity`.

Command:

```bash
OUT=$(mktemp -d /tmp/gomap_m11a_column_store_profiles_XXXXXX)
GOWORK=off ./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 100000 \
  -batchsize 1000 \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path row_store_baseline \
  -progress=false
```

Artifact directory from the evidence run:

```text
/tmp/gomap_m11a_column_store_profiles_7Fyskk
```

Generated artifacts:

- `column_store_results.json`
- `column_store_results.md`
- `column_store_results.html`
- `benchprof_results.json`
- `benchprof_results.md`
- `insights.md`
- `insights.json`
- `insights.html`

Stage timings:

| stage | throughput | bandwidth | latency |
|---|---:|---:|---:|
| fixture_generate | 1.96M rows/s | 175.36 MiB/s | 50.95 ms |
| ingest_insert_batch | 1.92M rows/s | 171.35 MiB/s | 52.14 ms |
| checkpoint | 10.73M rows/s | 958.98 MiB/s | 9.32 ms |
| reopen/recovery | 1.14M rows/s | 102.21 MiB/s | 87.42 ms |

Query throughput and parity, all on `row_store_baseline`:

| query | rows/s | MiB/s | ns/row | materialized rows | skipped granules | metadata hits | parity |
|---|---:|---:|---:|---:|---:|---:|---|
| q1 | 1.236M | 110.46 | 808.9 | 100,000 | 0 | 0 | pass |
| q2 | 1.226M | 109.54 | 815.7 | 100,000 | 0 | 0 | pass |
| q3 | 1.263M | 112.80 | 792.1 | 100,000 | 0 | 0 | pass |
| q4a | 1.232M | 110.04 | 811.9 | 100,000 | 0 | 0 | pass |
| q4b | 1.248M | 111.53 | 801.1 | 100,000 | 0 | 0 | pass |
| q5 | 1.235M | 110.36 | 809.6 | 100,000 | 0 | 0 | pass |
| q5_metadata | 1.257M | 112.27 | 795.8 | 100,000 | 0 | 0 | pass |

Byte accounting:

| metric | bytes/files |
|---|---:|
| source_document_bytes | 9,368,750 |
| retained_payload_bytes | 9,368,750 |
| column_asset_bytes | 0 |
| manifest_control_bytes | 50 |
| command_wal_bytes before checkpoint cleanup | 11,182,519 |
| total_reconstructable_bytes | 9,368,800 |
| db_total_bytes | 22,979,424 across 7 files |

Manifest/recovery identity:

| metric | value |
|---|---:|
| active_generation | 100 |
| recovery_authoritative_generation | 100 |
| applied_command_lsn | 101 |
| manifest_root | 2808 |
| schema_hash | 4015221257123424876 |

### Allocation benchmark for q1-q5/q5_metadata row-baseline loop

Command:

```bash
GOWORK=off go test ./cmd/unified_bench \
  -run '^$' \
  -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' \
  -benchmem \
  -benchtime=10x \
  -count=3
```

Result:

```text
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A-8    10  65680550 ns/op   99.85 MB/s  70000 rows/op  31343608 B/op  656748 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A-8    10  60197817 ns/op  108.94 MB/s  70000 rows/op  31343679 B/op  656749 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A-8    10  60121512 ns/op  109.08 MB/s  70000 rows/op  31343717 B/op  656749 allocs/op
```

Interpretation: this is intentionally measuring the M11A baseline path, which materializes full JSON rows for each of 7 query shapes. The high allocation count is expected for this baseline because each query performs document scans, JSON decode, and aggregate map construction. This gives M11B a concrete allocation/throughput target to beat when physical column assets and aggregate metadata paths are wired in.

### Fail-closed physical path evidence

Command:

```bash
GOWORK=off ./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 128 \
  -batchsize 64 \
  -column-store-path serial_column_scan \
  -progress=false
```

Result: `rc=1`, with:

```text
column_store suite: column_store: forced path "serial_column_scan" is not implemented in M11A; refusing to route through row store
```

### Current-head propagation refresh

Current pushed head after #1607 propagation: `bedafb0bdf0d47645ea19af3134e26418b041199`.

Current-head validation and smoke command:

```sh
GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof ./internal/benchprof -count=1
GOWORK=off go test ./TreeDB/db ./TreeDB/collections ./experiments/colgranule/... -count=1
GOWORK=off go build -o /tmp/gomap_unified_bench_m11a ./cmd/unified_bench
OUT=$(mktemp -d /tmp/gomap_m11a_profiles_current_XXXXXX)
/tmp/gomap_unified_bench_m11a -suite column_store -dbs treedb -profile durable   -keys 4096 -batchsize 512 -profile-dir "$OUT"   -path-label native-fastpath -column-store-path row_store_baseline -progress=false
GOWORK=off go test ./cmd/unified_bench -run '^$'   -bench 'BenchmarkColumnStoreSuiteRowBaselineQueriesM11A'   -benchmem -benchtime=500ms -count=3 -cpu=1
benchstat /tmp/gomap_m11a_current_bench_count3.txt
```

Current-head smoke artifact directory: `/tmp/gomap_m11a_profiles_current_Xgustp`.

Current-head smoke results over 4,096 durable rows:

- Ingest: ~`1.585M rows/s`, ~`141.63 MiB/s`.
- Reopen/recovery: ~`138.7K rows/s`, ~`12.40 MiB/s`.
- q1-q5/q5_metadata row-baseline parity: pass for every query.
- q1 throughput: ~`864.7K rows/s`, ~`77.25 MiB/s`, ~`1156.5 ns/row`.
- q5_metadata throughput: ~`1.104M rows/s`, ~`98.64 MiB/s`, ~`905.8 ns/row`.
- Artifacts generated: `column_store_results.json/md/html`, `benchprof_results.json/md`, and `insights.md/json/html`.

Current-head allocation benchmark refresh:

- `BenchmarkColumnStoreSuiteRowBaselineQueriesM11A`: ~`62.98 ms/op`, ~`99.32 MiB/s`, `70K rows/op`, ~`29.89 MiB/op`, ~`656.7K allocs/op`.

The current-head refresh keeps M11A's performance claim narrow: this PR establishes the durable benchmark/reporting contract and row-materialized baseline, including HTML artifacts and explicit allocation evidence. It does not claim physical column-scan throughput.

## Throughput Interpretation

The q1-q5 numbers here are not claimed as physical column-store query throughput. They are the durable production collection row-baseline throughput for the canonical benchmark harness. That distinction is part of the gate: M11A must report row materializations, metadata hits, skipped granules, byte accounting, and forced path labels so later PRs cannot accidentally hide a row fallback behind a column label.

The ingest/checkpoint/reopen timings validate that the benchmark is running against a durable command-WAL production collection with recovery-authoritative column manifest identity. The command-WAL bytes are captured before checkpoint cleanup so the PR body preserves write-amplification evidence even when post-checkpoint WAL files are reclaimed.


## Gate Status

- Pass: `column_store_results.json/md/html`, `benchprof_results.json/md`, and `insights.md/json/html` are generated by the M11A suite under `-profile-dir`.
- Pass: q1-q5/q5_metadata parity passes against the raw synthetic JSONBench-shaped reference fixture.
- Pass: durable command-WAL profile is enforced for production column-store writes; relaxed profiles are rejected for this M11A gate.
- Pass: manifest/recovery identity is non-zero and recovery-authoritative after checkpoint/reopen.
- Pass: command-WAL bytes are captured before checkpoint cleanup so write-amplification evidence remains visible.
- Pass: forced physical column labels fail closed; `serial_column_scan` exits non-zero instead of silently row-materializing.
- Pass: focused allocation benchmark reports `ns/op`, `MB/s`, `rows/op`, `B/op`, and `allocs/op` for the row-baseline q1-q5/q5_metadata loop.
- Caveat: M11A intentionally reports row-store baseline throughput, not physical column asset throughput. M11B must use this harness to add and prove the real column paths.
- Pass: current-head local validation and benchmark evidence are recorded above; GitHub Actions and AI-review status remain part of the final readiness audit for the latest pushed head.

## Artifacts

Evidence run profile directory:

```text
/tmp/gomap_m11a_column_store_profiles_7Fyskk
```

Generated report files:

- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/column_store_results.json`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/column_store_results.md`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/column_store_results.html`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/benchprof_results.json`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/benchprof_results.md`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/insights.md`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/insights.json`
- `/tmp/gomap_m11a_column_store_profiles_7Fyskk/insights.html`

## Validation

- `GOWORK=off go test ./cmd/unified_bench -run 'TestRunColumnStoreSuite|TestColumnStoreSuite' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench`
- `GOWORK=off ./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 2048 -batchsize 256 -profile-dir "$OUT" -path-label native-fastpath -column-store-path row_store_baseline -progress=false`
- `GOWORK=off ./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path row_store_baseline -progress=false`
- `GOWORK=off go test ./cmd/unified_bench -run '^$' -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' -benchmem -benchtime=10x -count=3`
- Forced `serial_column_scan` path exits non-zero and refuses row fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native column‑store benchmark suite that runs deterministic fixtures, multi‑query scans, parity/hash checks, byte‑accounting, manifest recovery metrics, runtime profiling, and artifact generation (results, profiles, benchprof, insights).

* **Tests**
  * Added extensive integration, validation, negative, and benchmark tests covering artifacts, parity checks, profiling edge cases, config/flag validation, and README verification.

* **Documentation**
  * Updated README with suite flags, example command, expected outputs, and a checklist for run/config evidence.

* **Bug Fixes**
  * Normalized DB name/alias resolution to avoid cycles and inconsistent DB selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

## Latest Review-Fix Refresh (May 18, 2026)

Current pushed head: `9bbfc75bd8c0`.

This refresh only propagates the latest M10A-M10C safety and benchmark-accounting fixes through M11A. It does not change the M11A benchmark contract: `unified-bench -suite column_store` still establishes the durable row-store baseline, q1-q5/q5_metadata parity checks, command-WAL byte accounting, and JSON/Markdown/HTML plus benchprof/insights artifacts.

Focused local validation after propagation:

```sh
go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuite.*M11B|TestColumnStoreQuery.*M11B|TestColumnStoreSuiteREADMEDocumentsCommandM11A|TestColumnStoreSuiteReportsParityMismatchM11A' -count=1
go test ./TreeDB/collections -run 'TestColumnQueryPlannerM11B|TestColumnSkipScan.*M11B|TestColumnStore.*M10C|TestColumnStoreCommandWALMutationsPublishManifestM10B|TestColumnManifestRootDeltaPublishInputs.*M10B|TestCollectionCommandWALUpdateByIDTemplateV1NewShapeReplay|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithCommandWALContextRootBuilderFailureClosesReturnedDeltas|TestPublishOrderedRootDeltaBatchGroupWithCommandWALSystemBuilderFailureClosesContextDeltas|TestPublishOrderedRootDeltaGroupWithCommandWALContextRootBuilderFailureClosesReturnedIterators' -count=1
GOWORK=off go test ./experiments/colgranule -run 'TestColumnMutationReplayProfileM9D|TestColumnMutationReplay.*M9D|TestJSONBenchMutationReplay.*M9D|TestColumnMutationAdapter.*M9D' -count=1
git diff --check
```

Result: all commands passed locally. The existing M11A performance evidence remains scoped to the durable row-baseline benchmark/reporting contract and HTML artifact generation.

### Latest Review-Fix Refresh (May 18, 2026, follow-up, head `a3343162d5aa`)

Current head: `a3343162d5aa0a809f17b36836d76295d10e3e2f`.

Review-fix propagation:
- Carries the M10A publish-boundary hardening for canonical identity records, non-negative manifest byte accounting, non-zero applied/recovery LSN metadata, and tightened invalid-rootIDs coverage.
- No milestone-local behavior change beyond preserving these lower-stack invariants through this branch.

Local validation after propagation:
- `go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithCommandWALContextRootBuilderFailureClosesReturnedDeltas|TestPublishOrderedRootDeltaBatchGroupWithCommandWALSystemBuilderFailureClosesContextDeltas|TestPublishOrderedRootDeltaGroupWithCommandWALContextRootBuilderFailureClosesReturnedIterators' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnManifestIdentityRecordRejectsNonZeroReserved|TestColumnPublishPlanRejectsNegativeManifestBytesM10A|TestColumnManifestPublishSystemDeltaRejects(MissingLSN|InvalidRootIDs).*M10A|TestColumnQueryPlannerM11B|TestColumnSkipScan.*M11B|TestColumnStore.*M10C|TestColumnStoreCommandWALMutationsPublishManifestM10B|TestColumnManifestRootDeltaPublishInputs.*M10B|TestCollectionCommandWALUpdateByIDTemplateV1NewShapeReplay|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1`
- `go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuite.*M11B|TestColumnStoreQuery.*M11B|TestColumnStoreSuiteREADMEDocumentsCommandM11A|TestColumnStoreSuiteReportsParityMismatchM11A' -count=1`
- `GOWORK=off go test ./experiments/colgranule -run 'TestColumnMutationReplayProfileM9D|TestColumnMutationReplay.*M9D|TestJSONBenchMutationReplay.*M9D|TestColumnMutationAdapter.*M9D' -count=1`
- `git diff --check`

CI/review status: latest-head GitHub checks and AI reviews were re-requested after this push; this section records the local evidence for that exact head.


---

### Latest Base-Alignment Refresh (May 18, 2026, head `d883eac86c7d`)

Current head: `d883eac86c7d3cebf01f1e483c10d86f70776af5`.

This refresh merges the latest M10C head (`35b6d8d68565`) into M11A so the native column benchmark PR is tested against the current recovery-parity and command-WAL publication stack. No milestone-local behavior change beyond stack propagation.

Local validation for this exact head:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -run 'TestColumnStore.*M10C|TestColumnStore.*M10B|TestColumnManifestIdentityRecordLayout|Test.*Column.*M11A|Test.*NativeColumn.*' -count=1
```

Result:

- `./TreeDB/collections`: pass, 0.605s
- `./cmd/unified_bench`: pass, 3.187s

CI/review status: latest-head GitHub checks and AI reviews are being re-requested after this push; this section records local evidence for the exact head.
### Latest Current-Head Evidence (May 18, 2026, head `85b1838f3edb`)

Current head: `85b1838f3edb739856ff8d3651459f6594c026d9`.

This is the current M11A native column benchmark branch after merging the latest M10C recovery branch.

Exact-head validation:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -run 'TestColumnStore.*M10C|TestColumnStore.*M10B|TestColumnStoreStaleColumnRootPreflightDoesNotAppendCommandWALM10B|TestColumnManifestIdentityRecordLayout|Test.*Column.*M11A|Test.*NativeColumn.*' -count=1
go test ./cmd/unified_bench -run '^$' -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' -benchmem -benchtime=500ms -count=3 -cpu=1
```

Result: both commands passed locally on Apple M3. Row-baseline benchmark: `59.69-60.31 ms/op`, `108.73-109.86 MB/s`, `70K rows/op`, `31.34 MB/op`, `656.8K allocs/op`.

Interpretation: M11A remains intentionally scoped to the canonical durable benchmark/reporting contract and the row-materialized baseline. These numbers are not claimed as physical column-scan throughput; they preserve the baseline, parity, byte-accounting, profile/artifact, and HTML-result contract that later physical-column PRs must beat without hiding a row fallback.

---

### Latest Current-Head Evidence (May 18, 2026, final propagation head `2638f794dd7c`)

Current head: `2638f794dd7c3289a6aebb3eab81cbea86d3e719`.

This refresh merges the current M10C recovery-parity head into M11A. M11A remains scoped to the canonical durable benchmark/reporting contract and row-materialized baseline, including JSON/Markdown/HTML output expectations.

Exact-head validation:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -run 'TestColumnStore.*M10C|TestColumnStore.*M10B|TestColumnStoreStaleColumnRootPreflightDoesNotAppendCommandWALM10B|TestColumnManifestIdentityRecordLayout|Test.*Column.*M11A|Test.*NativeColumn.*' -count=1
go test ./cmd/unified_bench -run '^$' -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' -benchmem -benchtime=500ms -count=3 -cpu=1
```

Result: focused collections passed in `0.891s`, focused unified-bench tests passed in `3.917s`, and the row-baseline benchmark passed in `3.152s` on Apple M3.

Row-baseline benchmark refresh:

```text
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A   102.570688 ms/op   63.94 MB/s   70,000 rows/op   31,344,196 B/op   656,756 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A   107.000250 ms/op   61.29 MB/s   70,000 rows/op   31,344,196 B/op   656,756 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A    89.220750 ms/op   73.50 MB/s   70,000 rows/op   31,344,122 B/op   656,756 allocs/op
```

Interpretation: these are intentionally row-store baseline numbers for q1-q5/q5_metadata over the native benchmark harness. They preserve the parity/artifact/byte-accounting contract that physical column paths must beat later without hiding row fallback.


---

### Latest Current-Head Evidence (May 18, 2026, M10C propagation head `f3fad9a55f1c`)

Current head: `f3fad9a55f1c4f25d7c21a04ab1c34a36d3cad7e`.

This refresh merges the latest M10C recovery-parity head into M11A. M11A remains the native benchmark/reporting contract and row-materialized baseline milestone.

Exact-head validation:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -run 'TestColumnStore.*M10C|TestColumnStore.*M10B|TestColumnStoreStaleColumnRootPreflightDoesNotAppendCommandWALM10B|TestColumnManifestIdentityRecordLayout|TestColumnManifestPublishSystemDeltaRejectsStaleSnapshotBaseM10A|Test.*Column.*M11A|Test.*NativeColumn.*' -count=1
go test ./experiments/colgranule -run 'TestColumnAssetManager.*Quarantine|TestColumnMutationReplayProfileM9D|TestColumnMutationReplay.*M9D|TestJSONBenchMutationReplay.*M9D|TestColumnMutationAdapter.*M9D' -count=1
git diff --check
go test ./cmd/unified_bench -run '^$' -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' -benchmem -benchtime=500ms -count=3 -cpu=1
```

Result: focused collections passed in `0.812s`, focused unified-bench tests passed in `3.396s`, focused colgranule passed in `0.954s`, `git diff --check` passed, and the row-baseline benchmark passed in `3.453s` on Apple M3.

Row-baseline benchmark refresh:

```text
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A   60.942611 ms/op   107.61 MB/s   70,000 rows/op   31,344,088 B/op   656,756 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A   60.402310 ms/op   108.57 MB/s   70,000 rows/op   31,344,083 B/op   656,756 allocs/op
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A   60.008227 ms/op   109.29 MB/s   70,000 rows/op   31,344,083 B/op   656,756 allocs/op
```

Interpretation: this remains the durable row-store baseline and artifact/reporting contract, not a physical column-scan throughput claim.


### Latest Current-Head Evidence (May 18, 2026, final M9B propagation head `f3ea0c86ca6c`)
Current head: `f3ea0c86ca6c7aa697c40ba1b574f3a6edffd889`.

This refresh merges the final lower-stack quarantine-provenance fix through M11A. The M11A native benchmark/reporting contract remains unchanged: the PR records the row-materialized baseline, parity/error handling, selected TreeDB stats export, profiling artifact discipline, and HTML/JSON/Markdown reporting requirements for the canonical column-store benchmark suite.

Post-propagation validation at the propagated stack head passed:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.947s`, unified-bench tests passed in `0.686s`, and `git diff --check` passed.


### Latest Current-Head Evidence (May 18, 2026, final lifecycle-hardening propagation head `b3db4fe19a6a`)
Current head: `b3db4fe19a6a624db03f9bb571d17772684af852`.

This refresh merges the final lower-stack lifecycle-review hardening through this chained PR. The chunk-specific benchmark/performance evidence above remains the milestone contract for this PR; this section records the current propagated head and stack-level validation after the lower-stack change.

Post-propagation validation at the final top stack head passed from a clean worktree:

```sh
go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1
go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1
git diff --check
```

Result: colgranule passed in `1.144s`, collections passed in `0.565s`, unified-bench tests passed in `0.866s`, and `git diff --check` passed.

## Current-head validation update (2026-05-18, stack head 15100fcd6d48)

Current pushed head for this PR: `bd07af2a2e91979cd7bd6dddf037570c97913640`. The M9+ chain was revalidated after the final M9B lifecycle/provenance fix was propagated through M11B. The ancestry audit passes for #1598 -> #1603 -> #1604 -> #1605 -> #1606 -> #1607 -> #1608 -> #1609, so the top-head validation includes this PR's code plus its descendants.

Focused validation:
- `go test ./experiments/colgranule -run 'TestColumnAssetManager|TestColumnAssetReachability|TestColumnAssetStore|TestColumnMutationAdapter|TestColumnMutationReplayProfileContractM9D' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./TreeDB/collections -run 'Test(ColumnPublishPlan|ColumnManifestPublishSystemDelta|ColumnStoreCommandWAL|ColumnQueryPlanner).*M(10A|10B|10C|11B)' -count=1`: PASS on top head `15100fcd6d48`.
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11' -count=1`: PASS on top head `15100fcd6d48`.
- `git diff --check`: PASS.

Performance evidence:
- M9B exact head `1628bd982cf6`: `BenchmarkColumnAssetReachabilitySummaryView10KReuse` = 4.135-4.159 ms/op, 0 B/op, 0 allocs/op; `BenchmarkColumnAssetManagerReclamation10K` = 0.799-0.807 ms/op, 2.400 MiB/op, 1 alloc/op.
- M11B top head `15100fcd6d48`: row baseline query suite = 59.7-60.3 ms/op, 108.8-109.9 MB/s, 70K rows/op; B-tree index baseline query suite = 70.8-70.9 ms/op, 92.5 MB/s, 70K rows/op.
- M11 reporting remains unified-bench/benchprof-compatible: JSON, Markdown, and HTML artifacts are required, while the PR text reports throughput directly for review without opening profile artifacts.

CI/review status for this historical refresh is superseded by the final closeout below; the latest pushed M9+ heads now have green latest-head checks, CLEAN merge state, and zero unresolved review threads. Stale-run cleanup remains out of scope and #1615 remains excluded.


---

### Latest Review-Cleanup Evidence (May 18, 2026, head `04ae8cf74203`)

Current pushed head: `04ae8cf742037b7e6163b7fa5784e0c78a0ee010`.

This refresh keeps the M11A contract unchanged and tightens review evidence around the benchmark/reporting harness: q5_metadata parity hashes canonicalize to q5 logical result rows, aggregate query-phase throughput uses measured `time.Duration` rather than rounded milliseconds, markdown code-list rendering uses per-item code spans, and duplicate review-evidence tests were removed after the remote branch advanced.

Exact-head local validation:

```sh
go test ./cmd/unified_bench -run 'Test(ColumnStoreBenchRunUsesDurationForAggregateM11A|RenderColumnStoreSuiteMarkdownCodeListsM11A|ColumnStoreQueryHashCanonicalizesQ5MetadataAliasM11A|RunColumnStoreSuiteWritesArtifactsAndMetricsM11A)' -count=1
go test ./cmd/unified_bench -count=1
git diff --check
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuiteRowBaselineQueriesM11A' -benchmem -benchtime=1x -count=1
```

Result: focused unified-bench tests passed in `2.322s`, full unified-bench tests passed in `12.586s`, `git diff --check` passed, and the row-baseline benchmark smoke passed on Apple M3:

```text
BenchmarkColumnStoreSuiteRowBaselineQueriesM11A-8  1  64.571625 ms/op  101.56 MB/s  70000 rows/op  31339656 B/op  656784 allocs/op
```

Review status at this refresh: CodeRabbit status is success for the latest head and all 36 previously unresolved AI review threads on #1608 were resolved after verifying the latest code/tests covered them. GitHub Actions for the latest head are queued; stale-run cleanup remains limited to stale M9+ branch runs and explicitly excludes #1615.


---

### Latest Current-Head Evidence (May 18, 2026, review-cleanup head `04ae8cf74`)

Current pushed head: `04ae8cf742037b7e6163b7fa5784e0c78a0ee010`.

This refresh tightens the M11A review evidence without changing the benchmark scope: aggregate query-phase throughput now uses exact measured durations rather than rounded millisecond JSON fields, `q5_metadata` parity hashes canonicalize to q5 result lines, and Markdown list rendering is covered by focused tests.

Exact-head local validation:

```sh
go test ./cmd/unified_bench -run 'Test(ColumnStoreBenchRunUsesDurationForAggregateM11A|RenderColumnStoreSuiteMarkdownCodeListsM11A|RunColumnStoreSuiteWritesArtifactsAndMetricsM11A)' -count=1
go test ./cmd/unified_bench -count=1
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuiteRowBaselineQueriesM11A' -benchmem -benchtime=1x -count=1
git diff --check
```

Result: focused M11A tests passed in `2.313s`, full `cmd/unified_bench` passed in `12.459s`, and `git diff --check` passed. Benchmark smoke on Apple M3: `60.804458 ms/op`, `107.86 MB/s`, `70,000 rows/op`, `31,339,656 B/op`, `656,784 allocs/op`.

Review/CI status: latest-head CodeRabbit status is successful and PR review threads are resolved; GitHub Actions are queued for this exact head after stale M11A-only runs were cancelled. Stale-run cleanup explicitly excluded PR #1615 and its heads.


---

## Current-head propagation validation (2026-05-18, head `528b91eff`)

Current pushed head for this PR: `528b91eff96c2c39ce321ed016a40dc043bc8e18`.

This refresh only propagates the M10C review cleanup through M11A: identity-record corruption tests now use shared layout offsets, replay fixture copying rejects non-regular files, and the replay fixture WAL directory setup is explicit. The M11A benchmark/reporting contract is unchanged.

Exact current-head validation on Apple M3:

```sh
go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuiteREADMEDocumentsCommandM11A|TestColumnStoreSuiteReportsParityMismatchM11A|TestColumnStoreBenchRunUsesDurationForAggregateM11A|TestColumnStoreQueryHashCanonicalizesQ5MetadataAliasM11A|TestRenderColumnStoreSuiteMarkdownCodeListsM11A' -count=1
go test ./TreeDB/collections -run 'TestColumnStore.*M10C|TestColumnStoreCommandWALMutationsPublishManifestM10B|TestColumnManifestRootDeltaPublishInputs.*M10B|TestColumnPublishPlanFailsClosedBeforeRootPublishM10A|TestColumnManifestPublishSystemDeltaRejects.*M10A' -count=1
git diff --check
```

Result: focused unified-bench passed in `2.137s`, focused collections passed in `0.756s`, and `git diff --check` passed. The existing M11A performance evidence remains the milestone benchmark contract because this propagation changed only lower-stack test/fixture hardening.

<!-- m9plus-current-head-evidence-start -->
## Current-Head Evidence Refresh (2026-05-18)

Chunk: `M11A` (native TreeDB column-store suite in unified-bench).
Current head: `7bcb2d6af844455c178756f38ff5b6bf2267c586` on `codex/colgranule-m11a-native-column-bench`; base `codex/colgranule-m10c-recovery-parity`.
GitHub Actions rollup for this historical refresh is superseded by the final closeout below; the latest pushed M9+ heads now have green latest-head checks and CLEAN merge state.

Local / current validation:
- `go test ./cmd/unified_bench -count=1`: PASS (`38.048s`).
- `go test ./TreeDB/collections -count=1`: PASS (`17.912s`).
- `BenchmarkColumnStoreSuiteRowBaselineQueriesM11A`, `-benchtime=1x -count=1`: PASS (`0.639s`).
- `git diff --check`: PASS.

Performance / benchmark evidence:
- Row-baseline query suite: `70.76 ms/op`, `92.69 MB/s`, `70000 rows/op`, `31,339,944 B/op`, `656,786 allocs/op`.

Throughput interpretation: this current head includes the propagated M10C delete-miss/replay safety fix while keeping the native column-store suite wired through unified-bench with path-label discipline, profile artifacts, alias handling, and row-baseline throughput/allocation evidence for parity tracking.
<!-- m9plus-current-head-evidence-end -->



## Current-Head Refresh (2026-05-18)

Head: `d1b208506570c422bed939a5737fa29f2caf23b6`.

Validation on Apple M3:
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*DB.*M11A|TestColumnStoreSuiteCheckpointCPUProfile.*M11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1`: PASS (`1.184s`).
- `go test ./TreeDB/collections -run 'M10A|M10B|M10C|M11A|ColumnPublish|ColumnStore' -count=1`: PASS (`0.789s`).
- `git diff --check`: PASS.

Final-head row-baseline benchmark smoke:
- `go test ./cmd/unified_bench -run '^$' -bench '^BenchmarkColumnStoreSuiteRowBaselineQueriesM11A$' -benchmem -benchtime=1x -count=1`: PASS.
- Row baseline: `65.602 ms/op`, `99.97 MB/s`, `70,000 rows/op`, `31,340,152 B/op`, `656,790 allocs/op`.

Interpretation: M11A remains the durable native benchmark/reporting contract and row-materialized baseline. The current head keeps JSON/Markdown/HTML artifact expectations and explicit allocation reporting intact; it still does not claim physical column-scan throughput.





---

## Latest Review-Thread Closeout (2026-05-18, head `15de2e0bd`)

Current pushed head for this PR: `15de2e0bd0a28f7c92c2ef323650195d3649f4d3`.

This refresh carries the M10C/M10B review closeout through M11A while preserving the native `unified-bench -suite column_store` milestone boundary. The M11A-local review fixes remain in place for alias-cycle canonicalization, alloc-profile runtime gating, and checkpoint CPU profile error context.

Focused local validation on Apple M3:

```sh
go test ./cmd/unified_bench -run 'TestCanonicalDBName|TestResolveDBs|TestColumnStoreSuiteCheckpointCPUProfile.*M11A|TestInstallAllocsProfileRate|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1
go test ./TreeDB/collections -run 'TestColumnManifestRootDescriptorSystemDeltaReturnsPreparedUpdatedMetaM10B|M10A|M10B|M10C|M11A|ColumnPublish|ColumnStore' -count=1
git diff --check
```

Result: unified-bench passed in `1.679s`; collections passed in `3.039s`; `git diff --check` passed.

Performance interpretation: this propagation does not change the M11A benchmark hot path. The M11A performance contract remains the durable row-baseline q1-q5/q5_metadata evidence above with JSON/Markdown/HTML artifact generation and fail-closed physical column labels.


---

## Latest Runtime-Profile Review Fix (2026-05-18, head `dd42be37d`)

Current pushed head for this PR: `dd42be37d21a5cc67260df46b98f26fed5d15285`.

This refresh normalizes block, mutex, and trace profile paths with `strings.TrimSpace` before enabling runtime profiling or constructing per-test contention-profile paths. It aligns runtime-profile handling with the existing CPU/alloc profile semantics and prevents whitespace-only profile flags from creating invalid artifacts or bypassing single-keycount profile guards.

Focused local validation on Apple M3:

```sh
go test ./cmd/unified_bench -run 'TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A|TestInstallAllocsProfileRate|TestCanonicalDBName|TestResolveDBs|TestColumnStoreSuiteCheckpointCPUProfile.*M11A|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B' -count=1
git diff --check
```

Result: unified-bench passed in `1.315s`; `git diff --check` passed.

Performance interpretation: this change only affects profiling setup/diagnostics, not the benchmarked row-baseline query loop. The M11A performance contract remains the durable row-baseline q1-q5/q5_metadata evidence above with JSON/Markdown/HTML artifacts and fail-closed physical column labels.


---

## Latest Review-Fix Refresh (2026-05-18, head `0a0e85aa0`)

Scope:
- Propagated #1607/#1606 fixes through the native column benchmark PR.
- Fixed alloc-profile setup so an empty or whitespace `TestsArg` is treated as the default full test selection when `-allocsprofile-tests` is present.
- Added a regression test proving `runtime.MemProfileRate` is installed for default full-run alloc sampling.

Validation:
- `go test ./cmd/unified_bench -run 'TestInstallAllocsProfileRate|TestCanonicalDBName|TestResolveDBs|TestWriteColumnStoreSuiteArtifactsUsesRecordedColumnPathsM11A|TestBenchprof|TestColumnStoreSuite.*M11A|TestBenchConfigHasAnyProfileOutput|TestRunBenchmarkCPUProfileStartFailureRemovesArtifactM11A|TestRunBenchmark_IgnoresWhitespaceOnlyRuntimeProfilesM11A|TestRunBenchmark_EmptyContentionDeltaOmitsArtifactM11A' -count=1`: PASS (`2.648s`).
- `go test ./TreeDB/collections -run 'M10B|M10C|M11A|ColumnStore' -count=1`: PASS (`3.120s`).
- `go test ./TreeDB/db -run 'CommandWAL|OrderedRoot|M10C|Replay|ConcurrentModification' -count=1`: PASS (`4.257s`).
- `git diff --check`: PASS.

Performance:
- `BenchmarkColumnStoreSuiteRowBaselineQueriesM11A` (`-benchtime=1x`, Apple M3): `68.15 ms/op`, `96.23 MB/s`, `70,000 rows/op`, `31.34 MB/op`, `656,786 allocs/op`.
- The latest fix affects profile setup only; it does not change query execution semantics.

CI/review:
- Latest-head GitHub Actions were queued at the evidence refresh. No CI cancellation was performed.

<!-- m9plus-current-head-closeout-start -->

## Current-head closeout evidence (2026-05-18 UTC)


This PR current head: `0d14e97cb254c0d4cbb69869f38d6a6c320a2fd0` on `codex/colgranule-m11a-native-column-bench`. Chunk: `M11A` (native column benchmark).

Current M9+ stack heads after M10C review-thread closeout and propagation:

| Chunk | PR | Current head | Branch |
|---|---:|---|---|
| M9B | #1598 | `01a265dccf95` | `codex/colgranule-m9b-lifecycle-durability-closure` |
| M9C | #1603 | `d358313f407e` | `codex/colgranule-m9c-control-plane-durability` |
| M9D | #1604 | `8d862dc70391` | `codex/colgranule-m9d-replay-profile-contract` |
| M10A | #1605 | `2453042140bc` | `codex/colgranule-m10a-publish-plan-api` |
| M10B | #1606 | `1c5f94e05423` | `codex/colgranule-m10b-root-publication` |
| M10C | #1607 | `d52f65c4c167` | `codex/colgranule-m10c-recovery-parity` |
| M11A | #1608 | `0d14e97cb254` | `codex/colgranule-m11a-native-column-bench` |
| M11B | #1609 | `0616d21611aa` | `codex/colgranule-m11b-planner-skipscan` |

Exact-head M11A propagation validation on `0d14e97cb254`:
- `go test ./TreeDB/collections -count=1`: PASS (`9.681s`).
- `go test ./cmd/unified_bench -count=1`: PASS (`32.731s`).
- `go test ./TreeDB/db -count=1`: PASS (`81.111s`).
- `git diff --check`: PASS.

Related lower/top propagation validation:
- #1607 head `d52f65c4c167`: `go test ./TreeDB/collections -count=1` PASS (`11.065s`), `go test ./TreeDB/db -count=1` PASS (`73.928s`), focused replay-intent and manifest identity slices PASS.
- #1609 head `0616d21611aa`: `go test ./TreeDB/collections -count=1` PASS (`11.923s`), `go test ./cmd/unified_bench -count=1` PASS (`32.574s`), `go test ./TreeDB/db -count=1` PASS (`81.235s`), `git diff --check HEAD~1..HEAD` PASS.

Performance / benchmark evidence refreshed on the current #1609 top stack head `0616d21611aa`:
- M9D durable replay after the review-thread hardening and asset-before-manifest durability fix: `BenchmarkColumnMutationReplayM9D/small_1k/durable`, `-benchtime=1x -count=3`, Apple M3: `44.425-78.078 ms/op`, `14.140K-24.851K rows/sec`, `18.718-18.723 MiB/op`, `824-829 allocs/op`, `2,254,369 column_asset_bytes/op`, `61,398 command_bytes/op`, `1,728 manifest_control_bytes/op`, `0 row_remainder_bytes/op`.
- M10C current top-head replay smoke: `BenchmarkColumnStoreCommandWALReplayM10C`, `-benchtime=1x -count=1`, Apple M3: `column_store=false` `1.513077250 s/op`, `10.828K replay_docs/s`, `84.60 replay_frames/s`, `123,093,736 B/op`, `179,350 allocs/op`; `column_store=true` `1.354441291 s/op`, `12.097K replay_docs/s`, `94.50 replay_frames/s`, `120,537,528 B/op`, `199,959 allocs/op`.
- M11B current top-head planner baseline smoke: row baseline `68.966959 ms/op`, `95.09 MB/s`, `70,000 rows/op`, `31,341,864 B/op`, `656,802 allocs/op`.
- M11B current top-head planner baseline smoke: B-tree index baseline `69.130667 ms/op`, `94.87 MB/s`, `70,000 rows/op`, `23,500,664 B/op`, `516,785 allocs/op`.
- The latest M11A commit is stack propagation only. The M11A milestone-local benchmark contract remains the native `unified-bench -suite column_store` artifact/profile surface with JSON, Markdown, HTML, and automatic benchprof outputs; physical column labels remain fail-closed until durable physical assets/scanners land.

CI / review state at this refresh:
- Review threads: zero unresolved review threads across #1598, #1603, #1604, #1605, #1606, #1607, #1608, and #1609 at refresh.
- Codex review: current-head Codex reviews for #1607/#1608/#1609 settled with no unresolved findings; #1608's current-head review body contained no actual suggestions after the standard template.
- CodeRabbit status: latest-head CodeRabbit review/status is success or informational-only with no unresolved review threads.
- Copilot status: current-head requests on #1607-#1609 hit Copilot infrastructure errors; this is treated as flaky tooling, not a code gate, because all Copilot/Codex/CodeRabbit review threads are resolved.
- GitHub Actions: #1598, #1603, #1604, #1605, #1606, #1607, #1608, and #1609 latest-head checks are green and merge state is CLEAN at final refresh.
- No CI stale-run cleanup is part of this refresh. PR #1615 and branch `codex/column-vector-dynamic-overlay-publish-capacity`, including protected heads `41dcc85e4f434926e6b2ab61eb0b70b673f1a16a` and `7fe6891c1ef308e4cba473a5eb828cc0748f779c`, remain excluded from any cleanup.

Completion note: this M11A head has clean latest-head CI, clean merge state, refreshed performance evidence, and zero unresolved AI review threads.

<!-- m9plus-current-head-closeout-end -->

