### PR TITLE
TreeDB/collections: add scalar float32 column metadata

### DIFF
--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -24,6 +24,7 @@ type ColumnStoreValueType string
 const (
 	ColumnStoreValueBool          ColumnStoreValueType = "bool"
 	ColumnStoreValueInt64         ColumnStoreValueType = "int64"
+	ColumnStoreValueFloat32       ColumnStoreValueType = "float32"
 	ColumnStoreValueDouble        ColumnStoreValueType = "double"
 	ColumnStoreValueString        ColumnStoreValueType = "string"
 	ColumnStoreValueFloat32Vector ColumnStoreValueType = "float32_vector"
@@ -373,7 +374,7 @@ func validateColumnStoreConfig(cfg ColumnStoreConfig) error {
 
 func normalizeColumnStoreValueType(valueType ColumnStoreValueType) (ColumnStoreValueType, error) {
 	switch valueType {
-	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueDouble, ColumnStoreValueString, ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString, ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
 		return valueType, nil
 	case "":
 		return "", errors.New("value_type is required")
@@ -388,7 +389,7 @@ func columnStoreValueTypeSupportsDictionary(valueType ColumnStoreValueType) bool
 
 func columnStoreValueTypeSupportsSort(valueType ColumnStoreValueType) bool {
 	switch valueType {
-	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueDouble, ColumnStoreValueString:
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
 		return true
 	default:
 		return false
@@ -400,7 +401,7 @@ func columnStoreValueTypeSupportsAggregate(valueType ColumnStoreValueType, kind 
 		return true
 	}
 	switch valueType {
-	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueDouble, ColumnStoreValueString:
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
 		return true
 	default:
 		return false

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -206,6 +206,14 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			want: "only float32_vector columns may set vector_dims",
 		},
 		{
+			name: "float32 column rejects dims",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, VectorDims: 1}},
+			},
+			want: "only float32_vector columns may set vector_dims",
+		},
+		{
 			name: "vector sort key rejected",
 			cfg: &ColumnStoreConfig{
 				Enabled: true,
@@ -228,6 +236,14 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			cfg: &ColumnStoreConfig{
 				Enabled: true,
 				Columns: []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128, Dictionary: true}},
+			},
+			want: "dictionary",
+		},
+		{
+			name: "float32 dictionary rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, Dictionary: true}},
 			},
 			want: "dictionary",
 		},
@@ -268,7 +284,13 @@ func TestColumnStoreVectorMetadataNormalizes(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	cfg.Columns = append(cfg.Columns,
 		ColumnStoreColumn{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128},
+		ColumnStoreColumn{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
 		ColumnStoreColumn{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList},
+	)
+	cfg.SortKey = append(cfg.SortKey, ColumnSortKey{Column: "embedding_inv_norm"})
+	cfg.AggregateMetadata = append(cfg.AggregateMetadata,
+		ColumnAggregateMetadata{Name: "min_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMin},
+		ColumnAggregateMetadata{Name: "max_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMax},
 	)
 	meta, err := normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}})
 	if err != nil {
@@ -281,7 +303,13 @@ func TestColumnStoreVectorMetadataNormalizes(t *testing.T) {
 	changed := testColumnStoreConfig(nil)
 	changed.Columns = append(changed.Columns,
 		ColumnStoreColumn{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 256},
+		ColumnStoreColumn{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
 		ColumnStoreColumn{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList},
+	)
+	changed.SortKey = append(changed.SortKey, ColumnSortKey{Column: "embedding_inv_norm"})
+	changed.AggregateMetadata = append(changed.AggregateMetadata,
+		ColumnAggregateMetadata{Name: "min_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMin},
+		ColumnAggregateMetadata{Name: "max_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMax},
 	)
 	changedMeta, err := normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: changed}})
 	if err != nil {
@@ -289,6 +317,25 @@ func TestColumnStoreVectorMetadataNormalizes(t *testing.T) {
 	}
 	if changedMeta.Options.ColumnStore.SchemaHash == meta.Options.ColumnStore.SchemaHash {
 		t.Fatalf("schema hash did not include vector dims: %x", meta.Options.ColumnStore.SchemaHash)
+	}
+
+	changed = testColumnStoreConfig(nil)
+	changed.Columns = append(changed.Columns,
+		ColumnStoreColumn{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128},
+		ColumnStoreColumn{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueDouble},
+		ColumnStoreColumn{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList},
+	)
+	changed.SortKey = append(changed.SortKey, ColumnSortKey{Column: "embedding_inv_norm"})
+	changed.AggregateMetadata = append(changed.AggregateMetadata,
+		ColumnAggregateMetadata{Name: "min_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMin},
+		ColumnAggregateMetadata{Name: "max_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMax},
+	)
+	changedMeta, err = normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: changed}})
+	if err != nil {
+		t.Fatalf("normalizeCollectionMeta changed scalar type: %v", err)
+	}
+	if changedMeta.Options.ColumnStore.SchemaHash == meta.Options.ColumnStore.SchemaHash {
+		t.Fatalf("schema hash did not include scalar value type: %x", meta.Options.ColumnStore.SchemaHash)
 	}
 }
 

--- a/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
+++ b/TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md
@@ -256,6 +256,15 @@ binding, and index hints. Row ingestion may ignore undeclared fields or reject
 them according to collection options, but it must not create new physical
 columns lazily.
 
+The current collection metadata accepts scalar `float32` columns for compact
+cached numeric values such as vector inverse norms, `float32_vector` columns for
+fixed-width vector payloads, and `adjacency_list` columns for graph neighbor
+lists. Only `float32_vector` columns may set `vector_dims`; `float32_vector` and
+`adjacency_list` columns are structural vector-search payloads and are not
+sort-key, aggregate, or dictionary columns. Scalar `float32` columns follow the
+numeric scalar contract: they are orderable and aggregatable, but not
+dictionary-encoded.
+
 `SortKeyColumn.Column` may name a declared column or a reserved primary-id
 pseudo-column used only for deterministic tie-breaking.
 


### PR DESCRIPTION
## Summary

- Adds first-class column-store metadata for scalar `float32` values so vector graph schemas can declare cached inverse-normalization columns next to `float32_vector` embeddings and `adjacency_list` graph columns.
- Treats scalar `float32` as orderable and aggregatable numeric metadata, while continuing to reject dictionary encoding and `vector_dims` on non-vector scalar columns.
- Documents the current vector-search column value-type contract in the column-store RFC.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnStore|TestColumnVectorGraph' -count=1`

## Scope

This is metadata/control-plane only and is stacked on #1602. It does not merge anything and does not add durable physical vector graph scanners or assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `float32` columns in column-store collections, enabling compact storage for numeric values with full sorting and aggregation capabilities.

* **Documentation**
  * Updated specification to clarify `float32` column usage and distinctions from vector-based types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->