### PR TITLE
TreeDB/collections: add column vector graph scale benchmarks

### DIFF
--- a/TreeDB/collections/column_vector_graph.go
+++ b/TreeDB/collections/column_vector_graph.go
@@ -561,6 +561,8 @@ func sortTopColumnVectorGraphOrdinalCandidates(candidates []vectorIndexCandidate
 		sortVectorIndexCandidates(candidates)
 		return candidates
 	}
+	// Selection-sort only the returned prefix. This is O(n*k), which is cheaper
+	// than a full candidate sort for the small top-k used by vector search.
 	for i := 0; i < limit; i++ {
 		best := i
 		for j := i + 1; j < len(candidates); j++ {
@@ -581,6 +583,8 @@ func (g *ColumnVectorGraph) sortTopCandidates(candidates []vectorIndexCandidate,
 		g.sortCandidates(candidates)
 		return candidates
 	}
+	// Selection-sort only the returned prefix. This is O(n*k), which is cheaper
+	// than a full candidate sort for the small top-k used by vector search.
 	for i := 0; i < limit; i++ {
 		best := i
 		for j := i + 1; j < len(candidates); j++ {

--- a/TreeDB/collections/column_vector_graph.go
+++ b/TreeDB/collections/column_vector_graph.go
@@ -189,11 +189,11 @@ func (g *ColumnVectorGraph) SearchCosine(query []float32, opts ColumnVectorGraph
 	}
 	efSearch := g.normalizeEfSearch(opts.EfSearch, opts.TopK)
 	trace.EfSearch = efSearch
-	candidates, edgesVisited, candidatesExamined := g.searchCandidates(query, queryInvNorm, efSearch, scratch)
+	candidates, edgesVisited, candidatesExamined, candidateCount := g.searchCandidates(query, queryInvNorm, efSearch, opts.TopK, scratch)
 	trace.CandidatesExamined = candidatesExamined
-	trace.CandidatesAfterTombstone = len(candidates)
-	trace.CandidatesAfterFilter = len(candidates)
-	trace.RerankCount = len(candidates)
+	trace.CandidatesAfterTombstone = candidateCount
+	trace.CandidatesAfterFilter = candidateCount
+	trace.RerankCount = candidateCount
 	trace.EdgesVisited = edgesVisited
 	resultLimit := opts.TopK
 	if rows := g.Rows(); resultLimit > rows {
@@ -410,21 +410,21 @@ func (g *ColumnVectorGraph) normalizeEfSearch(efSearch int, topK int) int {
 	return efSearch
 }
 
-func (g *ColumnVectorGraph) searchCandidates(query []float32, queryInvNorm float32, limit int, scratch *ColumnVectorGraphSearchScratch) ([]vectorIndexCandidate, int, int) {
+func (g *ColumnVectorGraph) searchCandidates(query []float32, queryInvNorm float32, limit int, topK int, scratch *ColumnVectorGraphSearchScratch) ([]vectorIndexCandidate, int, int, int) {
 	if g.ordinalTieOrder {
-		return g.searchCandidatesOrdinalTies(query, queryInvNorm, limit, &scratch.graph)
+		return g.searchCandidatesOrdinalTies(query, queryInvNorm, limit, topK, &scratch.graph)
 	}
-	return g.searchCandidatesDocumentTies(query, queryInvNorm, limit, scratch)
+	return g.searchCandidatesDocumentTies(query, queryInvNorm, limit, topK, scratch)
 }
 
-func (g *ColumnVectorGraph) searchCandidatesOrdinalTies(query []float32, queryInvNorm float32, limit int, scratch *vectorIndexSearchScratch) ([]vectorIndexCandidate, int, int) {
+func (g *ColumnVectorGraph) searchCandidatesOrdinalTies(query []float32, queryInvNorm float32, limit int, topK int, scratch *vectorIndexSearchScratch) ([]vectorIndexCandidate, int, int, int) {
 	if g.entryPoint < 0 || g.entryPoint >= g.Rows() || limit <= 0 {
-		return nil, 0, 0
+		return nil, 0, 0, 0
 	}
 	visited, mark := scratch.nextVisitedEpoch(g.Rows())
 	entry := vectorIndexCandidate{nodeID: g.entryPoint, distance: g.cosineDistance(query, queryInvNorm, g.entryPoint)}
 	if !columnVectorGraphFinite(entry.distance) {
-		return nil, 0, 1
+		return nil, 0, 1, 0
 	}
 	visited[entry.nodeID] = mark
 	queue := scratch.queue[:0]
@@ -477,19 +477,20 @@ func (g *ColumnVectorGraph) searchCandidatesOrdinalTies(query []float32, queryIn
 	scratch.queue = queue[:0]
 	scratch.best = best[:0]
 	out := append(scratch.out[:0], best...)
+	candidateCount := len(out)
+	out = sortTopColumnVectorGraphOrdinalCandidates(out, topK)
 	scratch.out = out
-	sortVectorIndexCandidates(out)
-	return out, edgesVisited, candidatesExamined
+	return out, edgesVisited, candidatesExamined, candidateCount
 }
 
-func (g *ColumnVectorGraph) searchCandidatesDocumentTies(query []float32, queryInvNorm float32, limit int, scratch *ColumnVectorGraphSearchScratch) ([]vectorIndexCandidate, int, int) {
+func (g *ColumnVectorGraph) searchCandidatesDocumentTies(query []float32, queryInvNorm float32, limit int, topK int, scratch *ColumnVectorGraphSearchScratch) ([]vectorIndexCandidate, int, int, int) {
 	if g.entryPoint < 0 || g.entryPoint >= g.Rows() || limit <= 0 {
-		return nil, 0, 0
+		return nil, 0, 0, 0
 	}
 	visited, mark := scratch.graph.nextVisitedEpoch(g.Rows())
 	entry := vectorIndexCandidate{nodeID: g.entryPoint, distance: g.cosineDistance(query, queryInvNorm, g.entryPoint)}
 	if !columnVectorGraphFinite(entry.distance) {
-		return nil, 0, 1
+		return nil, 0, 1, 0
 	}
 	visited[entry.nodeID] = mark
 	queue := scratch.queue[:0]
@@ -542,13 +543,54 @@ func (g *ColumnVectorGraph) searchCandidatesDocumentTies(query []float32, queryI
 	scratch.queue = queue[:0]
 	scratch.best = best[:0]
 	out := append(scratch.out[:0], best...)
+	candidateCount := len(out)
+	out = g.sortTopCandidates(out, topK)
 	scratch.out = out
-	g.sortCandidates(out)
-	return out, edgesVisited, candidatesExamined
+	return out, edgesVisited, candidatesExamined, candidateCount
 }
 
 func (g *ColumnVectorGraph) sortCandidates(candidates []vectorIndexCandidate) {
 	slices.SortFunc(candidates, g.compareCandidates)
+}
+
+func sortTopColumnVectorGraphOrdinalCandidates(candidates []vectorIndexCandidate, limit int) []vectorIndexCandidate {
+	if limit <= 0 || len(candidates) == 0 {
+		return candidates[:0]
+	}
+	if limit >= len(candidates) {
+		sortVectorIndexCandidates(candidates)
+		return candidates
+	}
+	for i := 0; i < limit; i++ {
+		best := i
+		for j := i + 1; j < len(candidates); j++ {
+			if vectorIndexCandidateLess(candidates[j], candidates[best]) {
+				best = j
+			}
+		}
+		candidates[i], candidates[best] = candidates[best], candidates[i]
+	}
+	return candidates[:limit]
+}
+
+func (g *ColumnVectorGraph) sortTopCandidates(candidates []vectorIndexCandidate, limit int) []vectorIndexCandidate {
+	if limit <= 0 || len(candidates) == 0 {
+		return candidates[:0]
+	}
+	if limit >= len(candidates) {
+		g.sortCandidates(candidates)
+		return candidates
+	}
+	for i := 0; i < limit; i++ {
+		best := i
+		for j := i + 1; j < len(candidates); j++ {
+			if g.candidateLess(candidates[j], candidates[best]) {
+				best = j
+			}
+		}
+		candidates[i], candidates[best] = candidates[best], candidates[i]
+	}
+	return candidates[:limit]
 }
 
 func (g *ColumnVectorGraph) compareCandidates(left, right vectorIndexCandidate) int {

--- a/TreeDB/collections/column_vector_graph_test.go
+++ b/TreeDB/collections/column_vector_graph_test.go
@@ -28,7 +28,7 @@ func TestColumnVectorGraphSearchMatchesExactCompleteGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchCosine: %v", err)
 	}
-	if trace.ReturnedCount != 7 || trace.CandidatesExamined != graph.Rows() {
+	if trace.ReturnedCount != 7 || trace.CandidatesExamined != graph.Rows() || trace.CandidatesAfterFilter != graph.Rows() || trace.RerankCount != graph.Rows() {
 		t.Fatalf("trace=%+v want returned=7 candidates=%d", trace, graph.Rows())
 	}
 	exact := exactColumnVectorGraphCosine(t, graph, query, 7)
@@ -741,6 +741,200 @@ func BenchmarkColumnVectorGraphSearchCosineParallel(b *testing.B) {
 	b.ReportMetric(float64(graph.Edges())/float64(graph.Rows()), "edges/node")
 	b.ReportMetric(float64(warmTrace.CandidatesExamined), "candidates/search")
 	b.ReportMetric(float64(warmTrace.EdgesVisited), "edges/search")
+}
+
+func BenchmarkColumnVectorGraphSearchCosineScale(b *testing.B) {
+	cases := []struct {
+		name   string
+		rows   int
+		dims   int
+		degree int
+	}{
+		{name: "rows_100k_dims_128_degree_16", rows: 100_000, dims: 128, degree: 16},
+		{name: "rows_1m_dims_128_degree_16", rows: 1_000_000, dims: 128, degree: 16},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			graph, query := openColumnVectorGraphScaleBenchmark(b, tc.rows, tc.dims, tc.degree)
+			opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+			b.Run("serial", func(b *testing.B) {
+				benchmarkColumnVectorGraphSearchCosineScaleSerial(b, graph, query, opts)
+			})
+			b.Run("parallel", func(b *testing.B) {
+				benchmarkColumnVectorGraphSearchCosineScaleParallel(b, graph, query, opts)
+			})
+		})
+	}
+}
+
+func benchmarkColumnVectorGraphSearchCosineScaleSerial(b *testing.B, graph *ColumnVectorGraph, query []float32, opts ColumnVectorGraphSearchOptions) {
+	b.Helper()
+	var scratch ColumnVectorGraphSearchScratch
+	warm, warmTrace, err := graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		b.Fatalf("warm SearchCosine: %v", err)
+	}
+	if len(warm) != opts.TopK {
+		b.Fatalf("warm results=%d want %d", len(warm), opts.TopK)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, trace, err := graph.SearchCosine(query, opts, &scratch)
+		if err != nil {
+			b.Fatalf("SearchCosine: %v", err)
+		}
+		if len(results) != opts.TopK {
+			b.Fatalf("results=%d want %d", len(results), opts.TopK)
+		}
+		columnVectorGraphBenchSink += int64(len(results[0].DocumentID) + trace.CandidatesExamined + trace.EdgesVisited)
+	}
+	reportColumnVectorGraphScaleMetrics(b, graph, warmTrace)
+}
+
+func benchmarkColumnVectorGraphSearchCosineScaleParallel(b *testing.B, graph *ColumnVectorGraph, query []float32, opts ColumnVectorGraphSearchOptions) {
+	b.Helper()
+	b.SetParallelism(1)
+	workers := runtime.GOMAXPROCS(0)
+	var warmTrace ColumnVectorGraphSearchTrace
+	scratches := make([]*ColumnVectorGraphSearchScratch, workers)
+	for i := 0; i < workers; i++ {
+		scratch := new(ColumnVectorGraphSearchScratch)
+		warm, trace, err := graph.SearchCosine(query, opts, scratch)
+		if err != nil {
+			b.Fatalf("warm SearchCosine worker %d: %v", i, err)
+		}
+		if len(warm) != opts.TopK {
+			b.Fatalf("warm worker %d results=%d want %d", i, len(warm), opts.TopK)
+		}
+		warmTrace = trace
+		scratches[i] = scratch
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.ResetTimer()
+	var nextWorker uint64
+	b.RunParallel(func(pb *testing.PB) {
+		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
+		if workerID >= len(scratches) {
+			panic(fmt.Sprintf("RunParallel spawned %d workers, but only %d scratches were prewarmed", workerID+1, len(scratches)))
+		}
+		scratch := scratches[workerID]
+		var localSink int64
+		for pb.Next() {
+			results, trace, err := graph.SearchCosine(query, opts, scratch)
+			if err != nil {
+				panic(err)
+			}
+			if len(results) != opts.TopK {
+				panic("unexpected column vector graph result count")
+			}
+			localSink += int64(len(results[0].DocumentID) + trace.CandidatesExamined + trace.EdgesVisited)
+		}
+		atomic.AddInt64(&columnVectorGraphBenchSink, localSink)
+	})
+	reportColumnVectorGraphScaleMetrics(b, graph, warmTrace)
+}
+
+func openColumnVectorGraphScaleBenchmark(b *testing.B, rows int, dims int, degree int) (*ColumnVectorGraph, []float32) {
+	b.Helper()
+	columns := columnVectorGraphScaleColumns(b, rows, dims, degree)
+	graph, err := NewColumnVectorGraphFromColumns(columns)
+	if err != nil {
+		b.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	queryOrdinal := rows / 3
+	query, ok := graph.VectorAt(nil, queryOrdinal)
+	if !ok {
+		b.Fatalf("missing query vector ordinal %d", queryOrdinal)
+	}
+	return graph, query
+}
+
+func columnVectorGraphScaleColumns(tb testing.TB, rows int, dims int, degree int) ColumnVectorGraphColumns {
+	tb.Helper()
+	if rows <= 0 || dims <= 0 || degree <= 0 {
+		tb.Fatalf("invalid scale graph shape rows=%d dims=%d degree=%d", rows, dims, degree)
+	}
+	if uint64(rows)*uint64(degree) > columnVectorGraphMaxUint32 {
+		tb.Fatalf("scale graph shape rows=%d degree=%d overflows uint32 adjacency offsets", rows, degree)
+	}
+	ids := make([][]byte, rows)
+	const idWidth = len("doc-000000000")
+	idArena := make([]byte, rows*idWidth)
+	vectors := make([]float32, rows*dims)
+	invNorms := make([]float32, rows)
+	offsets := make([]uint32, rows+1)
+	neighbors := make([]uint32, rows*degree)
+	for row := 0; row < rows; row++ {
+		id := idArena[row*idWidth : (row+1)*idWidth]
+		fillColumnVectorGraphOrdinalID(id, row)
+		ids[row] = id
+
+		vector := vectors[row*dims : (row+1)*dims]
+		fillVectorBenchmarkEmbedding(vector, row)
+		invNorms[row] = float32(1 / math.Sqrt(vectorNormSquared(vector)))
+
+		edgeStart := row * degree
+		offsets[row] = uint32(edgeStart)
+		for edge := 0; edge < degree; edge++ {
+			step := edge/2 + 1
+			neighbor := row + step
+			if edge%2 == 1 {
+				neighbor = row - step
+			}
+			neighbor %= rows
+			if neighbor < 0 {
+				neighbor += rows
+			}
+			neighbors[edgeStart+edge] = uint32(neighbor)
+		}
+	}
+	offsets[rows] = uint32(len(neighbors))
+	return ColumnVectorGraphColumns{
+		DocumentIDs:     ids,
+		Vectors:         vectors,
+		InvNorms:        invNorms,
+		NeighborOffsets: offsets,
+		Neighbors:       neighbors,
+		Dimensions:      dims,
+		EntryPoint:      0,
+		EfSearch:        defaultVectorIndexEfSearch,
+	}
+}
+
+func fillColumnVectorGraphOrdinalID(dst []byte, ordinal int) {
+	copy(dst, "doc-")
+	for i, divisor := 4, 100_000_000; i < len(dst); i, divisor = i+1, divisor/10 {
+		dst[i] = byte('0' + (ordinal/divisor)%10)
+	}
+}
+
+func reportColumnVectorGraphScaleMetrics(b *testing.B, graph *ColumnVectorGraph, trace ColumnVectorGraphSearchTrace) {
+	b.Helper()
+	graphBytes := columnVectorGraphPayloadBytes(graph)
+	b.ReportMetric(float64(graph.Rows()), "rows")
+	b.ReportMetric(float64(graph.Dims()), "dims")
+	b.ReportMetric(float64(graph.Edges())/float64(graph.Rows()), "edges/node")
+	b.ReportMetric(float64(trace.CandidatesExamined), "candidates/search")
+	b.ReportMetric(float64(trace.EdgesVisited), "edges/search")
+	b.ReportMetric(float64(graphBytes), "graph_payload_bytes")
+	b.ReportMetric(float64(graphBytes)/float64(graph.Rows()), "graph_payload_bytes/node")
+}
+
+func columnVectorGraphPayloadBytes(graph *ColumnVectorGraph) int64 {
+	if graph == nil {
+		return 0
+	}
+	return int64(len(graph.vectors)*4 +
+		len(graph.invNorms)*4 +
+		len(graph.neighborOffsets)*4 +
+		len(graph.neighbors)*4 +
+		len(graph.idArena) +
+		len(graph.idOffsets)*4 +
+		len(graph.idRanks)*4)
 }
 
 func BenchmarkColumnVectorGraphBuildFromColumns(b *testing.B) {

--- a/TreeDB/collections/column_vector_graph_test.go
+++ b/TreeDB/collections/column_vector_graph_test.go
@@ -28,7 +28,11 @@ func TestColumnVectorGraphSearchMatchesExactCompleteGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchCosine: %v", err)
 	}
-	if trace.ReturnedCount != 7 || trace.CandidatesExamined != graph.Rows() || trace.CandidatesAfterFilter != graph.Rows() || trace.RerankCount != graph.Rows() {
+	if trace.ReturnedCount != 7 ||
+		trace.CandidatesExamined != graph.Rows() ||
+		trace.CandidatesAfterTombstone != graph.Rows() ||
+		trace.CandidatesAfterFilter != graph.Rows() ||
+		trace.RerankCount != graph.Rows() {
 		t.Fatalf("trace=%+v want returned=7 candidates=%d", trace, graph.Rows())
 	}
 	exact := exactColumnVectorGraphCosine(t, graph, query, 7)

--- a/TreeDB/collections/column_vector_graph_test.go
+++ b/TreeDB/collections/column_vector_graph_test.go
@@ -668,6 +668,7 @@ func BenchmarkColumnVectorGraphSearchCosine(b *testing.B) {
 		b.Fatalf("warm results=%d want %d", len(warm), opts.TopK)
 	}
 	b.ReportAllocs()
+	// Approximate bytes scored per search: candidates touched * dims * sizeof(float32).
 	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -716,13 +717,15 @@ func BenchmarkColumnVectorGraphSearchCosineParallel(b *testing.B) {
 		scratches[i] = scratch
 	}
 	b.ReportAllocs()
+	// Approximate bytes scored per search: candidates touched * dims * sizeof(float32).
 	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
 	b.ResetTimer()
 	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
 		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
 		if workerID >= len(scratches) {
-			panic(fmt.Sprintf("RunParallel spawned %d workers, but only %d scratches were prewarmed", workerID+1, len(scratches)))
+			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
+			return
 		}
 		scratch := scratches[workerID]
 		var localSink int64
@@ -756,6 +759,9 @@ func BenchmarkColumnVectorGraphSearchCosineScale(b *testing.B) {
 	for _, tc := range cases {
 		tc := tc
 		b.Run(tc.name, func(b *testing.B) {
+			if tc.rows >= 1_000_000 && testing.Short() {
+				b.Skip("skipping 1M-row scale benchmark in -short mode")
+			}
 			graph, query := openColumnVectorGraphScaleBenchmark(b, tc.rows, tc.dims, tc.degree)
 			opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
 			b.Run("serial", func(b *testing.B) {
@@ -779,6 +785,7 @@ func benchmarkColumnVectorGraphSearchCosineScaleSerial(b *testing.B, graph *Colu
 		b.Fatalf("warm results=%d want %d", len(warm), opts.TopK)
 	}
 	b.ReportAllocs()
+	// Approximate bytes scored per search: candidates touched * dims * sizeof(float32).
 	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -813,13 +820,15 @@ func benchmarkColumnVectorGraphSearchCosineScaleParallel(b *testing.B, graph *Co
 		scratches[i] = scratch
 	}
 	b.ReportAllocs()
+	// Approximate bytes scored per search: candidates touched * dims * sizeof(float32).
 	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
 	b.ResetTimer()
 	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
 		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
 		if workerID >= len(scratches) {
-			panic(fmt.Sprintf("RunParallel spawned %d workers, but only %d scratches were prewarmed", workerID+1, len(scratches)))
+			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
+			return
 		}
 		scratch := scratches[workerID]
 		var localSink int64

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -1347,6 +1347,11 @@ func vectorBenchmarkDocument(id, dims int) []byte {
 
 func vectorBenchmarkEmbedding(id, dims int) []float32 {
 	out := make([]float32, dims)
+	fillVectorBenchmarkEmbedding(out, id)
+	return out
+}
+
+func fillVectorBenchmarkEmbedding(out []float32, id int) {
 	var norm float64
 	x := float64(id + 1)
 	for i := range out {
@@ -1359,5 +1364,4 @@ func vectorBenchmarkEmbedding(id, dims int) []float32 {
 	for i := range out {
 		out[i] = float32(float64(out[i]) * scale)
 	}
-	return out
 }

--- a/docs/benchmarks/column_vector_graph_scale.md
+++ b/docs/benchmarks/column_vector_graph_scale.md
@@ -39,7 +39,8 @@ The reported `B/op` and `allocs/op` are for warmed hot-loop search. Graph
 construction, column loading, index build, and document materialization are
 outside the timed loop. `graph_payload_bytes` is an approximate in-memory
 payload footprint for vectors, inverse norms, CSR adjacency, and compact
-document IDs.
+document IDs. `graph_payload_bytes/node` reports that approximate footprint
+divided by the row count.
 
 Optional comparators:
 

--- a/docs/benchmarks/column_vector_graph_scale.md
+++ b/docs/benchmarks/column_vector_graph_scale.md
@@ -1,0 +1,58 @@
+# Column Vector Graph Scale Benchmarks
+
+This track isolates column-backed `ColumnVectorGraph.SearchCosine` traversal
+and scoring at larger row counts. The Go benchmark builds the graph before the
+timed loop, treats the graph as immutable, warms worker-local scratch, and does
+not fetch full documents.
+
+Primary TreeDB in-process benchmark:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkColumnVectorGraphSearchCosineScale' \
+  -benchmem \
+  -benchtime 500ms \
+  -count 5
+```
+
+The benchmark has these shapes:
+
+- `rows_100k_dims_128_degree_16/serial`
+- `rows_100k_dims_128_degree_16/parallel`
+- `rows_1m_dims_128_degree_16/serial`
+- `rows_1m_dims_128_degree_16/parallel`
+
+For a lighter default run that only executes the 100k shape:
+
+```sh
+scripts/bench_column_vector_graph_scale.sh
+```
+
+Set `RUN_1M=true` to include the 1M shape:
+
+```sh
+RUN_1M=true scripts/bench_column_vector_graph_scale.sh
+```
+
+The reported `B/op` and `allocs/op` are for warmed hot-loop search. Graph
+construction, column loading, index build, and document materialization are
+outside the timed loop. `graph_payload_bytes` is an approximate in-memory
+payload footprint for vectors, inverse norms, CSR adjacency, and compact
+document IDs.
+
+Optional comparators:
+
+- `RUN_USEARCH=true scripts/bench_column_vector_graph_scale.sh` runs the
+  existing in-process usearch search benchmark with setup outside the timed
+  loop. Override `USEARCH_DOCS=1000000` for the 1M shape.
+- `RUN_VECTOR_DB_COMPARE=true scripts/bench_column_vector_graph_scale.sh` runs
+  the existing persistent vector-db comparison path. It defaults to
+  `treedb,vectorlite`; set `COMPARE_BACKENDS=pgvector` or include `pgvector`
+  only when a PostgreSQL+pgvector service or Docker is intentionally available.
+
+Interpret comparator output carefully: `ColumnVectorGraph` measures in-process
+graph traversal and vector scoring only, while PostgreSQL+pgvector includes
+client/server query latency. The vector-db comparison reports insert, build,
+reopen/load, validation, and search phases separately so build/load time is not
+confused with query throughput.

--- a/scripts/bench_column_vector_graph_scale.sh
+++ b/scripts/bench_column_vector_graph_scale.sh
@@ -43,6 +43,11 @@ if [[ "$RUN_USEARCH" == "true" ]]; then
 fi
 
 if [[ "$RUN_VECTOR_DB_COMPARE" == "true" ]]; then
+	compare_script="$ROOT/scripts/bench_vector_db_compare.sh"
+	if [[ ! -f "$compare_script" ]]; then
+		echo "ERROR: $compare_script not found" >&2
+		exit 1
+	fi
 	COMPARE_DOCS="${COMPARE_DOCS:-100000}"
 	COMPARE_DIMS="${COMPARE_DIMS:-128}"
 	COMPARE_QUERIES="${COMPARE_QUERIES:-50000}"
@@ -55,5 +60,5 @@ if [[ "$RUN_VECTOR_DB_COMPARE" == "true" ]]; then
 		QUERIES="$COMPARE_QUERIES" \
 		VALIDATE_QUERIES="$COMPARE_VALIDATE_QUERIES" \
 		BACKENDS="$COMPARE_BACKENDS" \
-		scripts/bench_vector_db_compare.sh
+		"$compare_script"
 fi

--- a/scripts/bench_column_vector_graph_scale.sh
+++ b/scripts/bench_column_vector_graph_scale.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/gomap_column_vector_graph_scale_$(date +%Y%m%d_%H%M%S)}"
+BENCHTIME="${BENCHTIME:-500ms}"
+COUNT="${COUNT:-5}"
+RUN_1M="${RUN_1M:-false}"
+RUN_USEARCH="${RUN_USEARCH:-false}"
+RUN_VECTOR_DB_COMPARE="${RUN_VECTOR_DB_COMPARE:-false}"
+
+mkdir -p "$RUN_DIR"
+
+if [[ "$RUN_1M" == "true" ]]; then
+	column_regex='BenchmarkColumnVectorGraphSearchCosineScale'
+else
+	column_regex='BenchmarkColumnVectorGraphSearchCosineScale/rows_100k'
+fi
+
+echo "run dir: $RUN_DIR"
+echo "column graph benchmark regex: $column_regex"
+GOWORK=off go test ./TreeDB/collections \
+	-run '^$' \
+	-bench "$column_regex" \
+	-benchmem \
+	-benchtime "$BENCHTIME" \
+	-count "$COUNT" | tee "$RUN_DIR/column_vector_graph_scale.txt"
+
+if [[ "$RUN_USEARCH" == "true" ]]; then
+	USEARCH_DOCS="${USEARCH_DOCS:-100000}"
+	USEARCH_DIMS="${USEARCH_DIMS:-128}"
+	echo "running usearch comparator docs=$USEARCH_DOCS dims=$USEARCH_DIMS"
+	TREEDB_VECTOR_BENCH_DOCS="$USEARCH_DOCS" \
+		TREEDB_VECTOR_BENCH_DIMS="$USEARCH_DIMS" \
+		GOWORK=off go test -tags usearch_bench ./TreeDB/collections \
+		-run '^$' \
+		-bench 'BenchmarkCollectionVectorUSearchBaseline$' \
+		-benchmem \
+		-benchtime "$BENCHTIME" \
+		-count "$COUNT" | tee "$RUN_DIR/usearch_baseline.txt"
+fi
+
+if [[ "$RUN_VECTOR_DB_COMPARE" == "true" ]]; then
+	COMPARE_DOCS="${COMPARE_DOCS:-100000}"
+	COMPARE_DIMS="${COMPARE_DIMS:-128}"
+	COMPARE_QUERIES="${COMPARE_QUERIES:-50000}"
+	COMPARE_VALIDATE_QUERIES="${COMPARE_VALIDATE_QUERIES:-64}"
+	COMPARE_BACKENDS="${COMPARE_BACKENDS:-treedb,vectorlite}"
+	echo "running vector-db compare docs=$COMPARE_DOCS dims=$COMPARE_DIMS backends=$COMPARE_BACKENDS"
+	RUN_DIR="$RUN_DIR/vector_db_compare" \
+		DOCS="$COMPARE_DOCS" \
+		DIMS="$COMPARE_DIMS" \
+		QUERIES="$COMPARE_QUERIES" \
+		VALIDATE_QUERIES="$COMPARE_VALIDATE_QUERIES" \
+		BACKENDS="$COMPARE_BACKENDS" \
+		scripts/bench_vector_db_compare.sh
+fi


### PR DESCRIPTION
## Summary

- Adds `BenchmarkColumnVectorGraphSearchCosineScale` with 100k and 1M row shapes, each with serial and real `b.RunParallel` variants.
- Keeps setup/build outside the timed loop: graph construction, query copy, and worker scratch warmup all happen before `ResetTimer`; hot search does not fetch full documents.
- Reports `B/op`, `allocs/op`, candidates/search, edges/search, edges/node, rows, dims, approximate `graph_payload_bytes`, and `graph_payload_bytes/node`.
- Adds `scripts/bench_column_vector_graph_scale.sh` and a runbook documenting opt-in usearch and vector-db/pgvector comparator paths without mixing TreeDB in-process traversal with service latency.
- Optimizes final result production by ordering only returned top-k candidates while preserving the trace candidate count for the full ef-search candidate set.
- Review follow-up documents the small-top-k selection-sort intent, adds a `testing.Short()` guard for the 1M benchmark shape, avoids a hard panic if future `RunParallel` worker behavior changes, guards the opt-in vector-db comparator script, and extends trace-contract coverage for `CandidatesAfterTombstone`.

## Local validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraph' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphSearchCosineScale/rows_100k' -benchmem -benchtime=500ms -count=3`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphSearchCosineScale/rows_1m' -benchmem -benchtime=200ms -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphSearchCosine($|Parallel$)' -benchmem -benchtime=500ms -count=3`
- `BENCHTIME=100ms COUNT=1 scripts/bench_column_vector_graph_scale.sh`

Latest review follow-up validation on `53813a284`:

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraph' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphSearchCosineScale/rows_100k' -benchmem -benchtime=200ms -count=1`

## Benchmark evidence

100k, before top-k selection optimization:

```text
serial:   13305 / 13275 / 13256 ns/op, 0 B/op, 0 allocs/op
parallel:  2686 /  2721 /  2801 ns/op, 0 B/op, 0 allocs/op
```

100k, after optimization:

```text
serial:   12510 / 12475 / 12655 ns/op, 0 B/op, 0 allocs/op, 315 candidates/search, 2128 edges/search, 60,100,008 graph_payload_bytes
parallel:  2527 /  2570 /  2623 ns/op, 0 B/op, 0 allocs/op, 315 candidates/search, 2128 edges/search
```

Latest review follow-up smoke on `53813a284`:

```text
serial:   12577 ns/op, 0 B/op, 0 allocs/op, 315 candidates/search, 2128 edges/search, 60,100,008 graph_payload_bytes, 601.0 graph_payload_bytes/node
parallel:  2439 ns/op, 0 B/op, 0 allocs/op, 315 candidates/search, 2128 edges/search, 60,100,008 graph_payload_bytes, 601.0 graph_payload_bytes/node
```

1M smoke, before vs after optimization:

```text
before: serial 19151 ns/op, parallel 3540 ns/op, 0 B/op, 0 allocs/op
 after: serial 16842 ns/op, parallel 3373 ns/op, 0 B/op, 0 allocs/op, 439 candidates/search, 2688 edges/search, 601,000,008 graph_payload_bytes
```

## Scope

This is a benchmark/performance-evidence track stacked on #1602. It does not merge anything and does not require external services in CI. usearch and PostgreSQL+pgvector comparator runs are explicitly manual/opt-in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected accuracy of search trace metrics reporting for candidate evaluation and filtering.

* **Tests**
  * Added new benchmarks for vector search performance at larger row counts with scale metrics.

* **Documentation**
  * Added guide for column vector graph scale benchmarking with interpretation guidance.

* **Chores**
  * Added benchmarking script with configurable parameters and optional comparison tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->