### PR TITLE
TreeDB/collections: prototype dynamic vector overlay benchmark

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -357,14 +357,18 @@ func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, to
 	if topK <= 0 || baseRows <= 0 {
 		return 0
 	}
-	baseTopK := topK + overlayLiveRows + tombstones
-	if baseTopK > baseRows {
-		baseTopK = baseRows
+	if topK >= baseRows {
+		return baseRows
 	}
-	if baseTopK < topK && topK < baseRows {
-		return topK
+	baseTopK := topK
+	if overlayLiveRows > baseRows-baseTopK {
+		return baseRows
 	}
-	return baseTopK
+	baseTopK += overlayLiveRows
+	if tombstones > baseRows-baseTopK {
+		return baseRows
+	}
+	return baseTopK + tombstones
 }
 
 // ColumnVectorDynamicOverlaySnapshot is an immutable exact-scan overlay

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -150,6 +150,7 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	nextOverlay := current.Overlay.clone(current.OverlayGeneration + 1)
+	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
 		if len(mutation.DocumentID) == 0 {
 			return stats, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
@@ -159,17 +160,17 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 			if err := g.applyInsert(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
 				return stats, fmt.Errorf("collections: dynamic insert mutation %d: %w", mutationIndex, err)
 			}
-			stats.Inserted++
+			inserted++
 		case ColumnVectorDynamicMutationUpdate:
 			if err := g.applyUpdate(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
 				return stats, fmt.Errorf("collections: dynamic update mutation %d: %w", mutationIndex, err)
 			}
-			stats.Updated++
+			updated++
 		case ColumnVectorDynamicMutationDelete:
 			if err := g.applyDelete(nextOverlay, mutation.DocumentID); err != nil {
 				return stats, fmt.Errorf("collections: dynamic delete mutation %d: %w", mutationIndex, err)
 			}
-			stats.Deleted++
+			deleted++
 		default:
 			return stats, fmt.Errorf("collections: dynamic mutation %d has unsupported kind %d", mutationIndex, mutation.Kind)
 		}
@@ -184,6 +185,9 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	g.snapshot.Store(nextSnapshot)
 	stats.BaseGeneration = nextSnapshot.BaseGeneration
 	stats.OverlayGeneration = nextSnapshot.OverlayGeneration
+	stats.Inserted = inserted
+	stats.Updated = updated
+	stats.Deleted = deleted
 	stats.OverlayRows = nextOverlay.Rows()
 	stats.OverlayLiveRows = nextOverlay.LiveRows()
 	stats.OverlayTombstones = nextOverlay.Tombstones()
@@ -275,7 +279,7 @@ func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverl
 	if overlay.HasLiveDocument(documentID) {
 		return fmt.Errorf("document %q already exists in overlay", documentID)
 	}
-	if _, ok := g.baseDocIndex[string(documentID)]; ok && !overlay.DocumentTombstoned(documentID) {
+	if _, ok := g.baseDocIndex[string(documentID)]; ok && !overlay.documentTombstonedWriter(documentID) {
 		return fmt.Errorf("document %q already exists in base", documentID)
 	}
 	return overlay.appendLiveDocument(documentID, vector)
@@ -284,7 +288,7 @@ func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverl
 func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32) error {
 	overlayFound := overlay.tombstoneOverlayDocument(documentID)
 	_, baseFound := g.baseDocIndex[string(documentID)]
-	baseLive := baseFound && !overlay.DocumentTombstoned(documentID)
+	baseLive := baseFound && !overlay.documentTombstonedWriter(documentID)
 	if !overlayFound && !baseLive {
 		return fmt.Errorf("document %q does not exist", documentID)
 	}
@@ -297,7 +301,7 @@ func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverl
 func (g *ColumnVectorDynamicGraph) applyDelete(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte) error {
 	overlayFound := overlay.tombstoneOverlayDocument(documentID)
 	_, baseFound := g.baseDocIndex[string(documentID)]
-	baseLive := baseFound && !overlay.DocumentTombstoned(documentID)
+	baseLive := baseFound && !overlay.documentTombstonedWriter(documentID)
 	if !overlayFound && !baseLive {
 		return fmt.Errorf("document %q does not exist", documentID)
 	}
@@ -424,6 +428,18 @@ func (o *ColumnVectorDynamicOverlaySnapshot) DocumentTombstoned(documentID []byt
 	}
 	_, found := slices.BinarySearchFunc(o.tombstoneDocIDs, documentID, bytes.Compare)
 	return found
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) documentTombstonedWriter(documentID []byte) bool {
+	if o == nil {
+		return false
+	}
+	for _, tombstone := range o.tombstoneDocIDs {
+		if bytes.Equal(tombstone, documentID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) appendLiveDocument(documentID []byte, vector []float32) error {

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -75,10 +75,30 @@ type ColumnVectorDynamicGraphSearchScratch struct {
 
 // ColumnVectorDynamicGraphSnapshot is one read-consistent dynamic graph view.
 type ColumnVectorDynamicGraphSnapshot struct {
-	Base              *ColumnVectorGraph
-	Overlay           *ColumnVectorDynamicOverlaySnapshot
-	BaseGeneration    uint64
-	OverlayGeneration uint64
+	base              *ColumnVectorGraph
+	overlay           *ColumnVectorDynamicOverlaySnapshot
+	baseGeneration    uint64
+	overlayGeneration uint64
+}
+
+// Base returns the immutable base graph for this snapshot.
+func (s ColumnVectorDynamicGraphSnapshot) Base() *ColumnVectorGraph {
+	return s.base
+}
+
+// Overlay returns the immutable exact-scan overlay for this snapshot.
+func (s ColumnVectorDynamicGraphSnapshot) Overlay() *ColumnVectorDynamicOverlaySnapshot {
+	return s.overlay
+}
+
+// BaseGeneration returns the base graph generation observed by this snapshot.
+func (s ColumnVectorDynamicGraphSnapshot) BaseGeneration() uint64 {
+	return s.baseGeneration
+}
+
+// OverlayGeneration returns the overlay generation observed by this snapshot.
+func (s ColumnVectorDynamicGraphSnapshot) OverlayGeneration() uint64 {
+	return s.overlayGeneration
 }
 
 // ColumnVectorDynamicGraph combines one immutable base ColumnVectorGraph with a
@@ -111,20 +131,25 @@ func NewColumnVectorDynamicGraph(base *ColumnVectorGraph) (*ColumnVectorDynamicG
 	}
 	graph := &ColumnVectorDynamicGraph{baseDocIndex: baseDocIndex}
 	graph.snapshot.Store(&ColumnVectorDynamicGraphSnapshot{
-		Base:              base,
-		BaseGeneration:    1,
-		Overlay:           newColumnVectorDynamicOverlaySnapshot(base.Dims()),
-		OverlayGeneration: 0,
+		base:              base,
+		baseGeneration:    1,
+		overlay:           newColumnVectorDynamicOverlaySnapshot(base.Dims()),
+		overlayGeneration: 0,
 	})
 	return graph, nil
 }
 
-// Snapshot returns the current immutable read snapshot.
-func (g *ColumnVectorDynamicGraph) Snapshot() *ColumnVectorDynamicGraphSnapshot {
+// Snapshot returns a value copy of the current immutable read snapshot. The
+// zero value is returned when the graph is nil or not initialized.
+func (g *ColumnVectorDynamicGraph) Snapshot() ColumnVectorDynamicGraphSnapshot {
 	if g == nil {
-		return nil
+		return ColumnVectorDynamicGraphSnapshot{}
 	}
-	return g.snapshot.Load()
+	snapshot := g.snapshot.Load()
+	if snapshot == nil {
+		return ColumnVectorDynamicGraphSnapshot{}
+	}
+	return *snapshot
 }
 
 // ApplyBatch publishes one copy-on-write overlay generation containing all
@@ -141,7 +166,7 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	defer g.mu.Unlock()
 
 	current := g.snapshot.Load()
-	if current == nil || current.Base == nil || current.Overlay == nil {
+	if current == nil || current.base == nil || current.overlay == nil {
 		return stats, errors.New("collections: dynamic column vector graph has no snapshot")
 	}
 	if len(mutations) == 0 {
@@ -149,7 +174,7 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 		return stats, nil
 	}
 
-	nextOverlay := current.Overlay.clone(current.OverlayGeneration + 1)
+	nextOverlay := current.overlay.clone(current.overlayGeneration + 1)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
 		if len(mutation.DocumentID) == 0 {
@@ -177,14 +202,14 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 	nextOverlay.sortAndDedupeTombstones()
 	nextSnapshot := &ColumnVectorDynamicGraphSnapshot{
-		Base:              current.Base,
-		BaseGeneration:    current.BaseGeneration,
-		Overlay:           nextOverlay,
-		OverlayGeneration: nextOverlay.generation,
+		base:              current.base,
+		baseGeneration:    current.baseGeneration,
+		overlay:           nextOverlay,
+		overlayGeneration: nextOverlay.generation,
 	}
 	g.snapshot.Store(nextSnapshot)
-	stats.BaseGeneration = nextSnapshot.BaseGeneration
-	stats.OverlayGeneration = nextSnapshot.OverlayGeneration
+	stats.BaseGeneration = nextSnapshot.baseGeneration
+	stats.OverlayGeneration = nextSnapshot.overlayGeneration
 	stats.Inserted = inserted
 	stats.Updated = updated
 	stats.Deleted = deleted
@@ -212,13 +237,13 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 		return nil, trace, errors.New("collections: dynamic column vector graph TopK must be positive")
 	}
 	snapshot := g.snapshot.Load()
-	if snapshot == nil || snapshot.Base == nil || snapshot.Overlay == nil {
+	if snapshot == nil || snapshot.base == nil || snapshot.overlay == nil {
 		return nil, trace, errors.New("collections: dynamic column vector graph has no snapshot")
 	}
-	base := snapshot.Base
-	overlay := snapshot.Overlay
-	trace.BaseGeneration = snapshot.BaseGeneration
-	trace.OverlayGeneration = snapshot.OverlayGeneration
+	base := snapshot.base
+	overlay := snapshot.overlay
+	trace.BaseGeneration = snapshot.baseGeneration
+	trace.OverlayGeneration = snapshot.overlayGeneration
 	trace.OverlayRows = overlay.Rows()
 	trace.OverlayLiveRows = overlay.LiveRows()
 	trace.OverlayTombstones = overlay.Tombstones()
@@ -317,13 +342,13 @@ func columnVectorDynamicPublishStats(snapshot *ColumnVectorDynamicGraphSnapshot,
 		Updated:           updated,
 		Deleted:           deleted,
 		PublishDuration:   duration,
-		BaseGeneration:    snapshot.BaseGeneration,
-		OverlayGeneration: snapshot.OverlayGeneration,
+		BaseGeneration:    snapshot.baseGeneration,
+		OverlayGeneration: snapshot.overlayGeneration,
 	}
-	if snapshot.Overlay != nil {
-		stats.OverlayRows = snapshot.Overlay.Rows()
-		stats.OverlayLiveRows = snapshot.Overlay.LiveRows()
-		stats.OverlayTombstones = snapshot.Overlay.Tombstones()
+	if snapshot.overlay != nil {
+		stats.OverlayRows = snapshot.overlay.Rows()
+		stats.OverlayLiveRows = snapshot.overlay.LiveRows()
+		stats.OverlayTombstones = snapshot.overlay.Tombstones()
 	}
 	return stats
 }

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -123,6 +123,9 @@ func NewColumnVectorDynamicGraph(base *ColumnVectorGraph) (*ColumnVectorDynamicG
 	baseDocIndex := make(map[string]int, base.Rows())
 	for ordinal := 0; ordinal < base.Rows(); ordinal++ {
 		documentID := base.documentID(ordinal)
+		if len(documentID) == 0 {
+			return nil, fmt.Errorf("collections: empty base document ID at ordinal %d", ordinal)
+		}
 		key := string(documentID)
 		if previous, ok := baseDocIndex[key]; ok {
 			return nil, fmt.Errorf("collections: duplicate base document ID %q at ordinals %d and %d", documentID, previous, ordinal)
@@ -170,7 +173,6 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 		return stats, errors.New("collections: dynamic column vector graph has no snapshot")
 	}
 	if len(mutations) == 0 {
-		stats = columnVectorDynamicPublishStats(current, 0, 0, 0, time.Since(start))
 		return stats, nil
 	}
 

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -160,7 +160,6 @@ func (g *ColumnVectorDynamicGraph) Snapshot() ColumnVectorDynamicGraphSnapshot {
 // tombstone the previous logical document and append the replacement vector, and
 // deletes tombstone the current logical document.
 func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMutation) (ColumnVectorDynamicPublishStats, error) {
-	start := time.Now()
 	var stats ColumnVectorDynamicPublishStats
 	if g == nil {
 		return stats, errors.New("collections: nil dynamic column vector graph")
@@ -176,6 +175,7 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 		return stats, nil
 	}
 
+	start := time.Now()
 	nextOverlay := current.overlay.clone(current.overlayGeneration + 1)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
@@ -388,13 +388,15 @@ type ColumnVectorDynamicOverlaySnapshot struct {
 	liveRows        int
 	liveDocIndex    map[string]int
 	tombstoneDocIDs [][]byte
+	tombstoneDocSet map[string]struct{}
 }
 
 func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlaySnapshot {
 	return &ColumnVectorDynamicOverlaySnapshot{
-		dims:         dims,
-		idOffsets:    []uint32{0},
-		liveDocIndex: make(map[string]int),
+		dims:            dims,
+		idOffsets:       []uint32{0},
+		liveDocIndex:    make(map[string]int),
+		tombstoneDocSet: make(map[string]struct{}),
 	}
 }
 
@@ -410,9 +412,19 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64) *ColumnVec
 		liveRows:        o.liveRows,
 		tombstoneDocIDs: append([][]byte(nil), o.tombstoneDocIDs...),
 		liveDocIndex:    make(map[string]int, len(o.liveDocIndex)),
+		tombstoneDocSet: make(map[string]struct{}, max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs))),
 	}
 	for key, ordinal := range o.liveDocIndex {
 		next.liveDocIndex[key] = ordinal
+	}
+	if len(o.tombstoneDocSet) > 0 {
+		for key := range o.tombstoneDocSet {
+			next.tombstoneDocSet[key] = struct{}{}
+		}
+	} else {
+		for _, documentID := range o.tombstoneDocIDs {
+			next.tombstoneDocSet[string(documentID)] = struct{}{}
+		}
 	}
 	return next
 }
@@ -465,12 +477,11 @@ func (o *ColumnVectorDynamicOverlaySnapshot) documentTombstonedWriter(documentID
 	if o == nil {
 		return false
 	}
-	for _, tombstone := range o.tombstoneDocIDs {
-		if bytes.Equal(tombstone, documentID) {
-			return true
-		}
+	if o.tombstoneDocSet == nil {
+		o.rebuildTombstoneDocSet()
 	}
-	return false
+	_, found := o.tombstoneDocSet[string(documentID)]
+	return found
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) appendLiveDocument(documentID []byte, vector []float32) error {
@@ -511,7 +522,15 @@ func (o *ColumnVectorDynamicOverlaySnapshot) tombstoneOverlayDocument(documentID
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) addTombstone(documentID []byte) {
+	if o.tombstoneDocSet == nil {
+		o.rebuildTombstoneDocSet()
+	}
+	key := string(documentID)
+	if _, exists := o.tombstoneDocSet[key]; exists {
+		return
+	}
 	o.tombstoneDocIDs = append(o.tombstoneDocIDs, bytes.Clone(documentID))
+	o.tombstoneDocSet[key] = struct{}{}
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) sortAndDedupeTombstones() {
@@ -526,6 +545,13 @@ func (o *ColumnVectorDynamicOverlaySnapshot) sortAndDedupeTombstones() {
 		}
 	}
 	o.tombstoneDocIDs = out
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) rebuildTombstoneDocSet() {
+	o.tombstoneDocSet = make(map[string]struct{}, len(o.tombstoneDocIDs))
+	for _, documentID := range o.tombstoneDocIDs {
+		o.tombstoneDocSet[string(documentID)] = struct{}{}
+	}
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) searchCosine(query []float32, queryInvNorm float32, topK int, scratch *ColumnVectorDynamicGraphSearchScratch) ([]VectorSearchResult, int) {

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -1,0 +1,527 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const columnVectorDynamicGraphStrategyCosine = "column_graph_dynamic_overlay_cosine"
+
+// ColumnVectorDynamicMutationKind identifies one logical overlay mutation.
+type ColumnVectorDynamicMutationKind uint8
+
+const (
+	ColumnVectorDynamicMutationInsert ColumnVectorDynamicMutationKind = iota + 1
+	ColumnVectorDynamicMutationUpdate
+	ColumnVectorDynamicMutationDelete
+)
+
+// ColumnVectorDynamicMutation is one copy-on-write mutation applied to the
+// current dynamic overlay generation.
+type ColumnVectorDynamicMutation struct {
+	Kind       ColumnVectorDynamicMutationKind
+	DocumentID []byte
+	Vector     []float32
+}
+
+// ColumnVectorDynamicPublishStats reports one overlay generation publication.
+type ColumnVectorDynamicPublishStats struct {
+	BaseGeneration    uint64
+	OverlayGeneration uint64
+	Inserted          int
+	Updated           int
+	Deleted           int
+	OverlayRows       int
+	OverlayLiveRows   int
+	OverlayTombstones int
+	PublishDuration   time.Duration
+}
+
+// ColumnVectorDynamicGraphSearchTrace reports one dynamic overlay search. The
+// hot search path intentionally reports counters only; timing of writer publish,
+// rebuild, and seal work is measured outside SearchCosine.
+type ColumnVectorDynamicGraphSearchTrace struct {
+	VectorIndexTrace
+	BaseTrace         ColumnVectorGraphSearchTrace
+	BaseGeneration    uint64
+	OverlayGeneration uint64
+	BaseReturned      int
+	BaseTombstoned    int
+	OverlayRows       int
+	OverlayLiveRows   int
+	OverlayTombstones int
+	OverlayScanned    int
+	OverlayCandidates int
+	MergeCandidates   int
+	EdgesVisited      int
+}
+
+// ColumnVectorDynamicGraphSearchScratch is caller-owned reusable dynamic graph
+// search workspace. It is not safe for concurrent use. SearchCosine returns
+// slices backed by this scratch, and reusing the scratch invalidates previously
+// returned result slices. Result document IDs alias immutable base or overlay
+// snapshot storage. Parallel searches are valid only when each goroutine owns
+// its own scratch.
+type ColumnVectorDynamicGraphSearchScratch struct {
+	Base    ColumnVectorGraphSearchScratch
+	overlay []VectorSearchResult
+	results []VectorSearchResult
+}
+
+// ColumnVectorDynamicGraphSnapshot is one read-consistent dynamic graph view.
+type ColumnVectorDynamicGraphSnapshot struct {
+	Base              *ColumnVectorGraph
+	Overlay           *ColumnVectorDynamicOverlaySnapshot
+	BaseGeneration    uint64
+	OverlayGeneration uint64
+}
+
+// ColumnVectorDynamicGraph combines one immutable base ColumnVectorGraph with a
+// copy-on-write exact-scan overlay. Readers atomically load one snapshot and do
+// not observe in-place mutation of either base or overlay state.
+type ColumnVectorDynamicGraph struct {
+	mu           sync.Mutex
+	snapshot     atomic.Pointer[ColumnVectorDynamicGraphSnapshot]
+	baseDocIndex map[string]int
+}
+
+// NewColumnVectorDynamicGraph returns a dynamic overlay wrapper around an
+// immutable base graph. The base graph and its borrowed columns must remain
+// immutable for the wrapper lifetime.
+func NewColumnVectorDynamicGraph(base *ColumnVectorGraph) (*ColumnVectorDynamicGraph, error) {
+	if base == nil {
+		return nil, errors.New("collections: nil column vector graph base")
+	}
+	if base.Rows() == 0 {
+		return nil, errors.New("collections: dynamic column vector graph base must have rows")
+	}
+	baseDocIndex := make(map[string]int, base.Rows())
+	for ordinal := 0; ordinal < base.Rows(); ordinal++ {
+		documentID := base.documentID(ordinal)
+		key := string(documentID)
+		if previous, ok := baseDocIndex[key]; ok {
+			return nil, fmt.Errorf("collections: duplicate base document ID %q at ordinals %d and %d", documentID, previous, ordinal)
+		}
+		baseDocIndex[key] = ordinal
+	}
+	graph := &ColumnVectorDynamicGraph{baseDocIndex: baseDocIndex}
+	graph.snapshot.Store(&ColumnVectorDynamicGraphSnapshot{
+		Base:              base,
+		BaseGeneration:    1,
+		Overlay:           newColumnVectorDynamicOverlaySnapshot(base.Dims()),
+		OverlayGeneration: 0,
+	})
+	return graph, nil
+}
+
+// Snapshot returns the current immutable read snapshot.
+func (g *ColumnVectorDynamicGraph) Snapshot() *ColumnVectorDynamicGraphSnapshot {
+	if g == nil {
+		return nil
+	}
+	return g.snapshot.Load()
+}
+
+// ApplyBatch publishes one copy-on-write overlay generation containing all
+// requested mutations. Inserts append vectors into overlay state, updates
+// tombstone the previous logical document and append the replacement vector, and
+// deletes tombstone the current logical document.
+func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMutation) (ColumnVectorDynamicPublishStats, error) {
+	start := time.Now()
+	var stats ColumnVectorDynamicPublishStats
+	if g == nil {
+		return stats, errors.New("collections: nil dynamic column vector graph")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	current := g.snapshot.Load()
+	if current == nil || current.Base == nil || current.Overlay == nil {
+		return stats, errors.New("collections: dynamic column vector graph has no snapshot")
+	}
+	if len(mutations) == 0 {
+		stats = columnVectorDynamicPublishStats(current, 0, 0, 0, time.Since(start))
+		return stats, nil
+	}
+
+	nextOverlay := current.Overlay.clone(current.OverlayGeneration + 1)
+	for mutationIndex, mutation := range mutations {
+		if len(mutation.DocumentID) == 0 {
+			return stats, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
+		}
+		switch mutation.Kind {
+		case ColumnVectorDynamicMutationInsert:
+			if err := g.applyInsert(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
+				return stats, fmt.Errorf("collections: dynamic insert mutation %d: %w", mutationIndex, err)
+			}
+			stats.Inserted++
+		case ColumnVectorDynamicMutationUpdate:
+			if err := g.applyUpdate(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
+				return stats, fmt.Errorf("collections: dynamic update mutation %d: %w", mutationIndex, err)
+			}
+			stats.Updated++
+		case ColumnVectorDynamicMutationDelete:
+			if err := g.applyDelete(nextOverlay, mutation.DocumentID); err != nil {
+				return stats, fmt.Errorf("collections: dynamic delete mutation %d: %w", mutationIndex, err)
+			}
+			stats.Deleted++
+		default:
+			return stats, fmt.Errorf("collections: dynamic mutation %d has unsupported kind %d", mutationIndex, mutation.Kind)
+		}
+	}
+	nextOverlay.sortAndDedupeTombstones()
+	nextSnapshot := &ColumnVectorDynamicGraphSnapshot{
+		Base:              current.Base,
+		BaseGeneration:    current.BaseGeneration,
+		Overlay:           nextOverlay,
+		OverlayGeneration: nextOverlay.generation,
+	}
+	g.snapshot.Store(nextSnapshot)
+	stats.BaseGeneration = nextSnapshot.BaseGeneration
+	stats.OverlayGeneration = nextSnapshot.OverlayGeneration
+	stats.OverlayRows = nextOverlay.Rows()
+	stats.OverlayLiveRows = nextOverlay.LiveRows()
+	stats.OverlayTombstones = nextOverlay.Tombstones()
+	stats.PublishDuration = time.Since(start)
+	return stats, nil
+}
+
+// SearchCosine searches the current immutable base snapshot and exact-scan
+// overlay snapshot, filters tombstoned base documents, and merges top-k results.
+// It does not fetch full documents.
+func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVectorGraphSearchOptions, scratch *ColumnVectorDynamicGraphSearchScratch) ([]VectorSearchResult, ColumnVectorDynamicGraphSearchTrace, error) {
+	trace := ColumnVectorDynamicGraphSearchTrace{
+		VectorIndexTrace: VectorIndexTrace{Strategy: columnVectorDynamicGraphStrategyCosine},
+	}
+	if g == nil {
+		return nil, trace, errors.New("collections: nil dynamic column vector graph")
+	}
+	if scratch == nil {
+		return nil, trace, errors.New("collections: nil dynamic column vector graph search scratch")
+	}
+	if opts.TopK <= 0 {
+		return nil, trace, errors.New("collections: dynamic column vector graph TopK must be positive")
+	}
+	snapshot := g.snapshot.Load()
+	if snapshot == nil || snapshot.Base == nil || snapshot.Overlay == nil {
+		return nil, trace, errors.New("collections: dynamic column vector graph has no snapshot")
+	}
+	base := snapshot.Base
+	overlay := snapshot.Overlay
+	trace.BaseGeneration = snapshot.BaseGeneration
+	trace.OverlayGeneration = snapshot.OverlayGeneration
+	trace.OverlayRows = overlay.Rows()
+	trace.OverlayLiveRows = overlay.LiveRows()
+	trace.OverlayTombstones = overlay.Tombstones()
+	if len(query) != base.Dims() {
+		return nil, trace, fmt.Errorf("collections: dynamic column vector graph query has dimension %d, want %d", len(query), base.Dims())
+	}
+	queryNormSquared, badDim, badValue := columnVectorGraphNormSquared(query)
+	if badDim >= 0 {
+		return nil, trace, fmt.Errorf("collections: dynamic column vector graph query dim %d is not finite: %g", badDim, badValue)
+	}
+	queryInvNorm, err := validateColumnVectorGraphQueryInvNorm(queryNormSquared)
+	if err != nil {
+		return nil, trace, err
+	}
+
+	baseOpts := opts
+	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.LiveRows(), overlay.Tombstones())
+	if baseOpts.EfSearch < baseOpts.TopK {
+		baseOpts.EfSearch = baseOpts.TopK
+	}
+	baseResults, baseTrace, err := base.SearchCosine(query, baseOpts, &scratch.Base)
+	if err != nil {
+		return nil, trace, err
+	}
+	trace.BaseTrace = baseTrace
+	trace.EdgesVisited = baseTrace.EdgesVisited
+
+	if cap(scratch.results) < opts.TopK {
+		scratch.results = make([]VectorSearchResult, 0, opts.TopK)
+	}
+	results := scratch.results[:0]
+	for _, result := range baseResults {
+		if overlay.DocumentTombstoned(result.DocumentID) {
+			trace.BaseTombstoned++
+			continue
+		}
+		trace.BaseReturned++
+		results = appendBoundedVectorSearchResult(results, result, opts.TopK)
+	}
+
+	overlayResults, overlayScanned := overlay.searchCosine(query, queryInvNorm, opts.TopK, scratch)
+	trace.OverlayScanned = overlayScanned
+	trace.OverlayCandidates = len(overlayResults)
+	trace.CandidatesExamined = baseTrace.CandidatesExamined + overlayScanned
+	for _, result := range overlayResults {
+		results = appendBoundedVectorSearchResult(results, result, opts.TopK)
+	}
+	trace.MergeCandidates = trace.BaseReturned + trace.OverlayCandidates
+	trace.CandidatesAfterTombstone = trace.BaseReturned + trace.OverlayScanned
+	trace.CandidatesAfterFilter = trace.MergeCandidates
+	trace.RerankCount = trace.MergeCandidates
+	trace.ReturnedCount = len(results)
+	scratch.results = results
+	return results, trace, nil
+}
+
+func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32) error {
+	if overlay.HasLiveDocument(documentID) {
+		return fmt.Errorf("document %q already exists in overlay", documentID)
+	}
+	if _, ok := g.baseDocIndex[string(documentID)]; ok && !overlay.DocumentTombstoned(documentID) {
+		return fmt.Errorf("document %q already exists in base", documentID)
+	}
+	return overlay.appendLiveDocument(documentID, vector)
+}
+
+func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32) error {
+	overlayFound := overlay.tombstoneOverlayDocument(documentID)
+	_, baseFound := g.baseDocIndex[string(documentID)]
+	baseLive := baseFound && !overlay.DocumentTombstoned(documentID)
+	if !overlayFound && !baseLive {
+		return fmt.Errorf("document %q does not exist", documentID)
+	}
+	if baseLive {
+		overlay.addTombstone(documentID)
+	}
+	return overlay.appendLiveDocument(documentID, vector)
+}
+
+func (g *ColumnVectorDynamicGraph) applyDelete(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte) error {
+	overlayFound := overlay.tombstoneOverlayDocument(documentID)
+	_, baseFound := g.baseDocIndex[string(documentID)]
+	baseLive := baseFound && !overlay.DocumentTombstoned(documentID)
+	if !overlayFound && !baseLive {
+		return fmt.Errorf("document %q does not exist", documentID)
+	}
+	if baseLive {
+		overlay.addTombstone(documentID)
+	}
+	return nil
+}
+
+func columnVectorDynamicPublishStats(snapshot *ColumnVectorDynamicGraphSnapshot, inserted int, updated int, deleted int, duration time.Duration) ColumnVectorDynamicPublishStats {
+	stats := ColumnVectorDynamicPublishStats{
+		Inserted:          inserted,
+		Updated:           updated,
+		Deleted:           deleted,
+		PublishDuration:   duration,
+		BaseGeneration:    snapshot.BaseGeneration,
+		OverlayGeneration: snapshot.OverlayGeneration,
+	}
+	if snapshot.Overlay != nil {
+		stats.OverlayRows = snapshot.Overlay.Rows()
+		stats.OverlayLiveRows = snapshot.Overlay.LiveRows()
+		stats.OverlayTombstones = snapshot.Overlay.Tombstones()
+	}
+	return stats
+}
+
+func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, tombstones int) int {
+	if topK <= 0 || baseRows <= 0 {
+		return 0
+	}
+	baseTopK := topK + overlayLiveRows + tombstones
+	if baseTopK > baseRows {
+		baseTopK = baseRows
+	}
+	if baseTopK < topK && topK < baseRows {
+		return topK
+	}
+	return baseTopK
+}
+
+// ColumnVectorDynamicOverlaySnapshot is an immutable exact-scan overlay
+// generation. It deliberately starts with a flat vector column plus tombstone
+// list: seal this into immutable mini-graphs or rebuild a new base graph once
+// overlay scan or tombstone filtering costs dominate base graph traversal.
+type ColumnVectorDynamicOverlaySnapshot struct {
+	generation      uint64
+	dims            int
+	vectors         []float32
+	invNorms        []float32
+	idArena         []byte
+	idOffsets       []uint32
+	live            []bool
+	liveRows        int
+	liveDocIndex    map[string]int
+	tombstoneDocIDs [][]byte
+}
+
+func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlaySnapshot {
+	return &ColumnVectorDynamicOverlaySnapshot{
+		dims:         dims,
+		idOffsets:    []uint32{0},
+		liveDocIndex: make(map[string]int),
+	}
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64) *ColumnVectorDynamicOverlaySnapshot {
+	next := &ColumnVectorDynamicOverlaySnapshot{
+		generation:      generation,
+		dims:            o.dims,
+		vectors:         append([]float32(nil), o.vectors...),
+		invNorms:        append([]float32(nil), o.invNorms...),
+		idArena:         append([]byte(nil), o.idArena...),
+		idOffsets:       append([]uint32(nil), o.idOffsets...),
+		live:            append([]bool(nil), o.live...),
+		liveRows:        o.liveRows,
+		tombstoneDocIDs: append([][]byte(nil), o.tombstoneDocIDs...),
+		liveDocIndex:    make(map[string]int, len(o.liveDocIndex)),
+	}
+	for key, ordinal := range o.liveDocIndex {
+		next.liveDocIndex[key] = ordinal
+	}
+	return next
+}
+
+// Rows returns all overlay vector rows, including tombstoned superseded rows.
+func (o *ColumnVectorDynamicOverlaySnapshot) Rows() int {
+	if o == nil {
+		return 0
+	}
+	return len(o.live)
+}
+
+// LiveRows returns overlay rows visible to readers.
+func (o *ColumnVectorDynamicOverlaySnapshot) LiveRows() int {
+	if o == nil {
+		return 0
+	}
+	return o.liveRows
+}
+
+// Tombstones returns the number of base document IDs hidden by this overlay.
+func (o *ColumnVectorDynamicOverlaySnapshot) Tombstones() int {
+	if o == nil {
+		return 0
+	}
+	return len(o.tombstoneDocIDs)
+}
+
+// HasLiveDocument reports whether documentID currently resolves to a live
+// overlay row. It is intended for writer-side validation.
+func (o *ColumnVectorDynamicOverlaySnapshot) HasLiveDocument(documentID []byte) bool {
+	if o == nil {
+		return false
+	}
+	ordinal, ok := o.liveDocIndex[string(documentID)]
+	return ok && ordinal >= 0 && ordinal < len(o.live) && o.live[ordinal]
+}
+
+// DocumentTombstoned reports whether a base document ID is hidden by this
+// overlay. It is allocation-free and safe for hot search use.
+func (o *ColumnVectorDynamicOverlaySnapshot) DocumentTombstoned(documentID []byte) bool {
+	if o == nil || len(o.tombstoneDocIDs) == 0 {
+		return false
+	}
+	_, found := slices.BinarySearchFunc(o.tombstoneDocIDs, documentID, bytes.Compare)
+	return found
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) appendLiveDocument(documentID []byte, vector []float32) error {
+	if len(vector) != o.dims {
+		return fmt.Errorf("vector has dimension %d, want %d", len(vector), o.dims)
+	}
+	normSquared, badDim, badValue := columnVectorGraphNormSquared(vector)
+	if badDim >= 0 {
+		return fmt.Errorf("vector dim %d is not finite: %g", badDim, badValue)
+	}
+	invNorm, err := validateColumnVectorGraphQueryInvNorm(normSquared)
+	if err != nil {
+		return err
+	}
+	if uint64(len(o.idArena))+uint64(len(documentID)) > columnVectorGraphMaxUint32 {
+		return errors.New("overlay document ID arena exceeds uint32 offsets")
+	}
+	ordinal := len(o.live)
+	o.vectors = append(o.vectors, vector...)
+	o.invNorms = append(o.invNorms, invNorm)
+	o.idArena = append(o.idArena, documentID...)
+	o.idOffsets = append(o.idOffsets, uint32(len(o.idArena)))
+	o.live = append(o.live, true)
+	o.liveRows++
+	o.liveDocIndex[string(documentID)] = ordinal
+	return nil
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) tombstoneOverlayDocument(documentID []byte) bool {
+	ordinal, ok := o.liveDocIndex[string(documentID)]
+	if !ok || ordinal < 0 || ordinal >= len(o.live) || !o.live[ordinal] {
+		return false
+	}
+	o.live[ordinal] = false
+	o.liveRows--
+	delete(o.liveDocIndex, string(documentID))
+	return true
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) addTombstone(documentID []byte) {
+	o.tombstoneDocIDs = append(o.tombstoneDocIDs, bytes.Clone(documentID))
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) sortAndDedupeTombstones() {
+	if len(o.tombstoneDocIDs) <= 1 {
+		return
+	}
+	slices.SortFunc(o.tombstoneDocIDs, bytes.Compare)
+	out := o.tombstoneDocIDs[:1]
+	for _, documentID := range o.tombstoneDocIDs[1:] {
+		if !bytes.Equal(documentID, out[len(out)-1]) {
+			out = append(out, documentID)
+		}
+	}
+	o.tombstoneDocIDs = out
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) searchCosine(query []float32, queryInvNorm float32, topK int, scratch *ColumnVectorDynamicGraphSearchScratch) ([]VectorSearchResult, int) {
+	if topK <= 0 || o == nil || o.liveRows == 0 {
+		if scratch != nil {
+			scratch.overlay = scratch.overlay[:0]
+			return scratch.overlay, 0
+		}
+		return nil, 0
+	}
+	if cap(scratch.overlay) < topK {
+		scratch.overlay = make([]VectorSearchResult, 0, topK)
+	}
+	results := scratch.overlay[:0]
+	scanned := 0
+	for ordinal, live := range o.live {
+		if !live {
+			continue
+		}
+		scanned++
+		vector := o.vectorAt(ordinal)
+		dot := columnVectorGraphDotProductFloat64(query, vector)
+		cosine := float32(dot) * queryInvNorm * o.invNorms[ordinal]
+		distance := float32(1 - clampColumnVectorGraphCosine(float64(cosine)))
+		if !columnVectorGraphFinite(distance) {
+			continue
+		}
+		results = appendBoundedVectorSearchResult(results, VectorSearchResult{
+			DocumentID: o.documentID(ordinal),
+			Distance:   distance,
+		}, topK)
+	}
+	scratch.overlay = results
+	return results, scanned
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) vectorAt(ordinal int) []float32 {
+	start := ordinal * o.dims
+	return o.vectors[start : start+o.dims : start+o.dims]
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) documentID(ordinal int) []byte {
+	start := o.idOffsets[ordinal]
+	end := o.idOffsets[ordinal+1]
+	return o.idArena[start:end:end]
+}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -99,6 +99,72 @@ func TestColumnVectorDynamicGraphSearchTombstonesAndOverlay(t *testing.T) {
 	}
 }
 
+func TestColumnVectorDynamicGraphApplyBatchDoesNotReportUnpublishedCounts(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(32, 16, 8, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 7)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	stats, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("dyn-before-error"), Vector: query},
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("doc-000001"), Vector: query},
+	})
+	if err == nil {
+		t.Fatal("ApplyBatch succeeded with duplicate base document insert")
+	}
+	if stats.Inserted != 0 || stats.Updated != 0 || stats.Deleted != 0 || stats.OverlayGeneration != 0 {
+		t.Fatalf("stats after failed batch=%+v want zero unpublished counts", stats)
+	}
+	snapshot := graph.Snapshot()
+	if snapshot.OverlayGeneration != 0 || snapshot.Overlay.Rows() != 0 || snapshot.Overlay.LiveRows() != 0 {
+		t.Fatalf("snapshot after failed batch generation=%d rows=%d live=%d, want unchanged empty overlay", snapshot.OverlayGeneration, snapshot.Overlay.Rows(), snapshot.Overlay.LiveRows())
+	}
+}
+
+func TestColumnVectorDynamicGraphSameBatchDeleteInsertUsesWriterTombstones(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(64, 16, 63, true))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000020")},
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000030")},
+	}); err != nil {
+		t.Fatalf("seed tombstones: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 10)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000010")},
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("doc-000010"), Vector: query},
+	}); err != nil {
+		t.Fatalf("same-batch delete+insert should see writer tombstone: %v", err)
+	}
+	results, trace, err := graph.SearchCosine(query, ColumnVectorGraphSearchOptions{TopK: 5, EfSearch: 64}, &ColumnVectorDynamicGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) == 0 || !bytes.Equal(results[0].DocumentID, []byte("doc-000010")) {
+		t.Fatalf("top result=%+v want reinserted doc-000010", results)
+	}
+	if trace.BaseTombstoned == 0 {
+		t.Fatalf("trace=%+v want tombstoned base candidate", trace)
+	}
+}
+
 func TestColumnVectorDynamicGraphSearchAllocs(t *testing.T) {
 	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(1024, 64, 16, false))
 	if err != nil {

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -123,8 +123,8 @@ func TestColumnVectorDynamicGraphApplyBatchDoesNotReportUnpublishedCounts(t *tes
 		t.Fatalf("stats after failed batch=%+v want zero unpublished counts", stats)
 	}
 	snapshot := graph.Snapshot()
-	if snapshot.OverlayGeneration != 0 || snapshot.Overlay.Rows() != 0 || snapshot.Overlay.LiveRows() != 0 {
-		t.Fatalf("snapshot after failed batch generation=%d rows=%d live=%d, want unchanged empty overlay", snapshot.OverlayGeneration, snapshot.Overlay.Rows(), snapshot.Overlay.LiveRows())
+	if snapshot.OverlayGeneration() != 0 || snapshot.Overlay().Rows() != 0 || snapshot.Overlay().LiveRows() != 0 {
+		t.Fatalf("snapshot after failed batch generation=%d rows=%d live=%d, want unchanged empty overlay", snapshot.OverlayGeneration(), snapshot.Overlay().Rows(), snapshot.Overlay().LiveRows())
 	}
 }
 
@@ -335,7 +335,7 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadOnly(b *testing.B,
 		scratches[i] = scratch
 	}
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Snapshot().Base.Dims() * 4))
+	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Snapshot().Base().Dims() * 4))
 	b.ResetTimer()
 	started := time.Now()
 	var nextWorker uint64
@@ -514,25 +514,27 @@ func columnVectorDynamicScaleDocumentID(ordinal int) []byte {
 	return documentID
 }
 
-func reportColumnVectorDynamicGraphMetrics(b *testing.B, snapshot *ColumnVectorDynamicGraphSnapshot, trace ColumnVectorDynamicGraphSearchTrace) {
+func reportColumnVectorDynamicGraphMetrics(b *testing.B, snapshot ColumnVectorDynamicGraphSnapshot, trace ColumnVectorDynamicGraphSearchTrace) {
 	b.Helper()
-	if snapshot == nil || snapshot.Base == nil || snapshot.Overlay == nil {
+	base := snapshot.Base()
+	overlay := snapshot.Overlay()
+	if base == nil || overlay == nil {
 		return
 	}
-	graphBytes := columnVectorGraphPayloadBytes(snapshot.Base)
-	overlayBytes := columnVectorDynamicOverlayPayloadBytes(snapshot.Overlay)
-	b.ReportMetric(float64(snapshot.Base.Rows()), "base_rows")
-	b.ReportMetric(float64(snapshot.Base.Dims()), "dims")
-	b.ReportMetric(float64(snapshot.Base.Edges())/float64(snapshot.Base.Rows()), "edges/node")
+	graphBytes := columnVectorGraphPayloadBytes(base)
+	overlayBytes := columnVectorDynamicOverlayPayloadBytes(overlay)
+	b.ReportMetric(float64(base.Rows()), "base_rows")
+	b.ReportMetric(float64(base.Dims()), "dims")
+	b.ReportMetric(float64(base.Edges())/float64(base.Rows()), "edges/node")
 	b.ReportMetric(float64(trace.BaseTrace.CandidatesExamined), "base_candidates/search")
 	b.ReportMetric(float64(trace.BaseTombstoned), "base_tombstoned/search")
 	b.ReportMetric(float64(trace.OverlayScanned), "overlay_scanned/search")
 	b.ReportMetric(float64(trace.MergeCandidates), "merge_candidates/search")
 	b.ReportMetric(float64(trace.CandidatesExamined), "total_candidates/search")
 	b.ReportMetric(float64(trace.BaseTrace.EdgesVisited), "edges/search")
-	b.ReportMetric(float64(snapshot.Overlay.Rows()), "overlay_rows")
-	b.ReportMetric(float64(snapshot.Overlay.LiveRows()), "overlay_live_rows")
-	b.ReportMetric(float64(snapshot.Overlay.Tombstones()), "overlay_tombstones")
+	b.ReportMetric(float64(overlay.Rows()), "overlay_rows")
+	b.ReportMetric(float64(overlay.LiveRows()), "overlay_live_rows")
+	b.ReportMetric(float64(overlay.Tombstones()), "overlay_tombstones")
 	b.ReportMetric(float64(graphBytes), "base_payload_bytes")
 	b.ReportMetric(float64(overlayBytes), "overlay_payload_bytes")
 }

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -128,6 +128,40 @@ func TestColumnVectorDynamicGraphApplyBatchDoesNotReportUnpublishedCounts(t *tes
 	}
 }
 
+func TestColumnVectorDynamicGraphApplyBatchEmptyIsNoOp(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(16, 16, 4, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	stats, err := graph.ApplyBatch(nil)
+	if err != nil {
+		t.Fatalf("ApplyBatch(nil): %v", err)
+	}
+	if stats != (ColumnVectorDynamicPublishStats{}) {
+		t.Fatalf("ApplyBatch(nil) stats=%+v want zero no-op stats", stats)
+	}
+	snapshot := graph.Snapshot()
+	if snapshot.OverlayGeneration() != 0 || snapshot.Overlay().Rows() != 0 {
+		t.Fatalf("snapshot after empty batch generation=%d rows=%d, want unchanged empty overlay", snapshot.OverlayGeneration(), snapshot.Overlay().Rows())
+	}
+}
+
+func TestColumnVectorDynamicGraphRejectsEmptyBaseDocumentID(t *testing.T) {
+	columns := columnVectorGraphTestColumns(16, 16, 4, false)
+	columns.DocumentIDs[7] = nil
+	base, err := NewColumnVectorGraphFromColumns(columns)
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	if _, err := NewColumnVectorDynamicGraph(base); err == nil {
+		t.Fatal("NewColumnVectorDynamicGraph succeeded with empty base document ID")
+	}
+}
+
 func TestColumnVectorDynamicGraphSameBatchDeleteInsertUsesWriterTombstones(t *testing.T) {
 	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(64, 16, 63, true))
 	if err != nil {
@@ -390,6 +424,7 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 	done := make(chan struct{})
 	b.ReportAllocs()
 	b.ResetTimer()
+	started := time.Now()
 	go func() {
 		defer close(done)
 		for seq := 0; ; seq++ {
@@ -412,7 +447,6 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 			publishNanos.Add(int64(stats.PublishDuration))
 		}
 	}()
-	started := time.Now()
 	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
 		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
@@ -434,10 +468,13 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 		}
 		atomic.AddInt64(&columnVectorGraphBenchSink, localSink)
 	})
-	elapsed := time.Since(started)
-	b.StopTimer()
 	close(stop)
 	<-done
+	elapsed := time.Since(started)
+	publishedBatchCount := publishedBatches.Load()
+	publishedMutationCount := publishedMutations.Load()
+	publishNanoCount := publishNanos.Load()
+	b.StopTimer()
 	select {
 	case err := <-errs:
 		b.Fatalf("writer ApplyBatch: %v", err)
@@ -452,7 +489,7 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 		b.Fatalf("final results=%d want %d", len(finalResults), opts.TopK)
 	}
 	reportColumnVectorDynamicGraphMetrics(b, graph.Snapshot(), finalTrace)
-	reportColumnVectorDynamicReadMetrics(b, elapsed, publishedBatches.Load(), publishedMutations.Load(), publishNanos.Load())
+	reportColumnVectorDynamicReadMetrics(b, elapsed, publishedBatchCount, publishedMutationCount, publishNanoCount)
 }
 
 func openColumnVectorDynamicGraphBenchmark(b *testing.B, base *ColumnVectorGraph, query []float32, overlayRows int) *ColumnVectorDynamicGraph {

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -1,0 +1,510 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestColumnVectorDynamicGraphSearchTombstonesAndOverlay(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(64, 16, 63, true))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 10)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 5, EfSearch: 64}
+	var scratch ColumnVectorDynamicGraphSearchScratch
+	results, _, err := graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("initial SearchCosine: %v", err)
+	}
+	if len(results) == 0 || !bytes.Equal(results[0].DocumentID, []byte("doc-000010")) {
+		t.Fatalf("initial top result=%+v want doc-000010", results)
+	}
+
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000010")},
+	}); err != nil {
+		t.Fatalf("delete base doc: %v", err)
+	}
+	results, trace, err := graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("after delete SearchCosine: %v", err)
+	}
+	if containsColumnVectorDynamicResult(results, []byte("doc-000010")) {
+		t.Fatalf("deleted base doc leaked into results: %+v", results)
+	}
+	if trace.BaseTombstoned == 0 {
+		t.Fatalf("trace=%+v want at least one tombstoned base candidate", trace)
+	}
+
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("aaa-dynamic"), Vector: query},
+	}); err != nil {
+		t.Fatalf("insert overlay doc: %v", err)
+	}
+	results, trace, err = graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("after insert SearchCosine: %v", err)
+	}
+	if len(results) == 0 || !bytes.Equal(results[0].DocumentID, []byte("aaa-dynamic")) {
+		t.Fatalf("overlay insert top result=%+v want aaa-dynamic", results)
+	}
+	if trace.OverlayScanned != 1 || trace.OverlayCandidates != 1 {
+		t.Fatalf("trace=%+v want one scanned overlay candidate", trace)
+	}
+
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("aaa-dynamic")},
+		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("doc-000011"), Vector: query},
+	}); err != nil {
+		t.Fatalf("delete overlay and update base doc: %v", err)
+	}
+	results, trace, err = graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("after update SearchCosine: %v", err)
+	}
+	if len(results) == 0 || !bytes.Equal(results[0].DocumentID, []byte("doc-000011")) {
+		t.Fatalf("updated base doc top result=%+v want doc-000011", results)
+	}
+	if containsColumnVectorDynamicResult(results, []byte("aaa-dynamic")) {
+		t.Fatalf("deleted overlay doc leaked into results: %+v", results)
+	}
+	if trace.BaseTombstoned < 2 {
+		t.Fatalf("trace=%+v want both deleted and updated base docs tombstoned", trace)
+	}
+
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000011")},
+	}); err != nil {
+		t.Fatalf("delete updated base doc: %v", err)
+	}
+	results, _, err = graph.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("after final delete SearchCosine: %v", err)
+	}
+	if containsColumnVectorDynamicResult(results, []byte("doc-000011")) {
+		t.Fatalf("deleted updated doc leaked into results: %+v", results)
+	}
+}
+
+func TestColumnVectorDynamicGraphSearchAllocs(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(1024, 64, 16, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 511)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("doc-000123"), Vector: query},
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("dyn-alloc"), Vector: query},
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("doc-000511")},
+	}); err != nil {
+		t.Fatalf("ApplyBatch: %v", err)
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+	var scratch ColumnVectorDynamicGraphSearchScratch
+	if results, _, err := graph.SearchCosine(query, opts, &scratch); err != nil {
+		t.Fatalf("warm SearchCosine: %v", err)
+	} else if len(results) != opts.TopK {
+		t.Fatalf("warm results=%d want %d", len(results), opts.TopK)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		results, trace, err := graph.SearchCosine(query, opts, &scratch)
+		if err != nil {
+			panic(err)
+		}
+		if len(results) != opts.TopK {
+			panic("unexpected dynamic column vector graph result count")
+		}
+		columnVectorGraphBenchSink += int64(len(results[0].DocumentID) + trace.CandidatesExamined + trace.EdgesVisited)
+	})
+	if allocs != 0 {
+		t.Fatalf("hot dynamic SearchCosine allocs/run=%g want 0", allocs)
+	}
+}
+
+func TestColumnVectorDynamicGraphConcurrentReadersAndWriter(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(1024, 32, 16, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 257)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+	var stop uint32
+	errs := make(chan error, 16)
+	var readers sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		readers.Add(1)
+		go func(worker int) {
+			defer readers.Done()
+			var scratch ColumnVectorDynamicGraphSearchScratch
+			if results, _, err := graph.SearchCosine(query, opts, &scratch); err != nil {
+				errs <- fmt.Errorf("worker %d warm SearchCosine: %w", worker, err)
+				return
+			} else if len(results) != opts.TopK {
+				errs <- fmt.Errorf("worker %d warm results=%d want %d", worker, len(results), opts.TopK)
+				return
+			}
+			for atomic.LoadUint32(&stop) == 0 {
+				results, trace, err := graph.SearchCosine(query, opts, &scratch)
+				if err != nil {
+					errs <- fmt.Errorf("worker %d SearchCosine: %w", worker, err)
+					return
+				}
+				if len(results) != opts.TopK {
+					errs <- fmt.Errorf("worker %d results=%d want %d", worker, len(results), opts.TopK)
+					return
+				}
+				if trace.BaseGeneration == 0 {
+					errs <- fmt.Errorf("worker %d trace has zero base generation: %+v", worker, trace)
+					return
+				}
+			}
+		}(worker)
+	}
+
+	for i := 0; i < 64; i++ {
+		mutations := []ColumnVectorDynamicMutation{
+			{
+				Kind:       ColumnVectorDynamicMutationUpdate,
+				DocumentID: []byte(fmt.Sprintf("doc-%06d", 100+i%32)),
+				Vector:     vectorBenchmarkEmbedding(10_000+i, base.Dims()),
+			},
+			{
+				Kind:       ColumnVectorDynamicMutationInsert,
+				DocumentID: []byte(fmt.Sprintf("dyn-%06d", i)),
+				Vector:     vectorBenchmarkEmbedding(20_000+i, base.Dims()),
+			},
+		}
+		if i >= 8 {
+			mutations = append(mutations, ColumnVectorDynamicMutation{
+				Kind:       ColumnVectorDynamicMutationDelete,
+				DocumentID: []byte(fmt.Sprintf("dyn-%06d", i-8)),
+			})
+		}
+		if _, err := graph.ApplyBatch(mutations); err != nil {
+			atomic.StoreUint32(&stop, 1)
+			t.Fatalf("ApplyBatch %d: %v", i, err)
+		}
+	}
+	atomic.StoreUint32(&stop, 1)
+	readers.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func BenchmarkColumnVectorDynamicGraphSearchCosineScale(b *testing.B) {
+	cases := []struct {
+		name   string
+		rows   int
+		dims   int
+		degree int
+	}{
+		{name: "rows_100k_dims_128_degree_16", rows: 100_000, dims: 128, degree: 16},
+		{name: "rows_1m_dims_128_degree_16", rows: 1_000_000, dims: 128, degree: 16},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			if tc.rows >= 1_000_000 && testing.Short() {
+				b.Skip("skipping 1M-row dynamic scale benchmark in -short mode")
+			}
+			base, query := openColumnVectorGraphScaleBenchmark(b, tc.rows, tc.dims, tc.degree)
+			opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+			b.Run("parallel_read_only", func(b *testing.B) {
+				graph := openColumnVectorDynamicGraphBenchmark(b, base, query, 256)
+				benchmarkColumnVectorDynamicGraphSearchCosineParallelReadOnly(b, graph, query, opts)
+			})
+			b.Run("parallel_read_write", func(b *testing.B) {
+				graph := openColumnVectorDynamicGraphBenchmark(b, base, query, 256)
+				benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b, graph, query, opts, tc.rows, tc.dims)
+			})
+		})
+	}
+}
+
+func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadOnly(b *testing.B, graph *ColumnVectorDynamicGraph, query []float32, opts ColumnVectorGraphSearchOptions) {
+	b.Helper()
+	b.SetParallelism(1)
+	workers := runtime.GOMAXPROCS(0)
+	scratches := make([]*ColumnVectorDynamicGraphSearchScratch, workers)
+	var warmTrace ColumnVectorDynamicGraphSearchTrace
+	for i := 0; i < workers; i++ {
+		scratch := new(ColumnVectorDynamicGraphSearchScratch)
+		warm, trace, err := graph.SearchCosine(query, opts, scratch)
+		if err != nil {
+			b.Fatalf("warm SearchCosine worker %d: %v", i, err)
+		}
+		if len(warm) != opts.TopK {
+			b.Fatalf("warm worker %d results=%d want %d", i, len(warm), opts.TopK)
+		}
+		warmTrace = trace
+		scratches[i] = scratch
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Snapshot().Base.Dims() * 4))
+	b.ResetTimer()
+	started := time.Now()
+	var nextWorker uint64
+	b.RunParallel(func(pb *testing.PB) {
+		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
+		if workerID >= len(scratches) {
+			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
+			return
+		}
+		scratch := scratches[workerID]
+		var localSink int64
+		for pb.Next() {
+			results, trace, err := graph.SearchCosine(query, opts, scratch)
+			if err != nil {
+				panic(err)
+			}
+			if len(results) != opts.TopK {
+				panic("unexpected dynamic column vector graph result count")
+			}
+			localSink += int64(len(results[0].DocumentID) + trace.CandidatesExamined + trace.EdgesVisited)
+		}
+		atomic.AddInt64(&columnVectorGraphBenchSink, localSink)
+	})
+	elapsed := time.Since(started)
+	b.StopTimer()
+	reportColumnVectorDynamicGraphMetrics(b, graph.Snapshot(), warmTrace)
+	reportColumnVectorDynamicReadMetrics(b, elapsed, 0, 0, 0)
+}
+
+func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B, graph *ColumnVectorDynamicGraph, query []float32, opts ColumnVectorGraphSearchOptions, rows int, dims int) {
+	b.Helper()
+	b.SetParallelism(1)
+	workers := runtime.GOMAXPROCS(0)
+	scratches := make([]*ColumnVectorDynamicGraphSearchScratch, workers)
+	for i := 0; i < workers; i++ {
+		scratch := new(ColumnVectorDynamicGraphSearchScratch)
+		warm, _, err := graph.SearchCosine(query, opts, scratch)
+		if err != nil {
+			b.Fatalf("warm SearchCosine worker %d: %v", i, err)
+		}
+		if len(warm) != opts.TopK {
+			b.Fatalf("warm worker %d results=%d want %d", i, len(warm), opts.TopK)
+		}
+		scratches[i] = scratch
+	}
+	batches := columnVectorDynamicBenchmarkMutationBatches(b, rows, dims, 4096)
+	var publishedBatches atomic.Int64
+	var publishedMutations atomic.Int64
+	var publishNanos atomic.Int64
+	errs := make(chan error, 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	go func() {
+		defer close(done)
+		for seq := 0; ; seq++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			batch := batches[seq%len(batches)]
+			stats, err := graph.ApplyBatch(batch)
+			if err != nil {
+				select {
+				case errs <- err:
+				default:
+				}
+				return
+			}
+			publishedBatches.Add(1)
+			publishedMutations.Add(int64(len(batch)))
+			publishNanos.Add(int64(stats.PublishDuration))
+		}
+	}()
+	started := time.Now()
+	var nextWorker uint64
+	b.RunParallel(func(pb *testing.PB) {
+		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
+		if workerID >= len(scratches) {
+			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
+			return
+		}
+		scratch := scratches[workerID]
+		var localSink int64
+		for pb.Next() {
+			results, trace, err := graph.SearchCosine(query, opts, scratch)
+			if err != nil {
+				panic(err)
+			}
+			if len(results) != opts.TopK {
+				panic("unexpected dynamic column vector graph result count")
+			}
+			localSink += int64(len(results[0].DocumentID) + trace.CandidatesExamined + trace.EdgesVisited)
+		}
+		atomic.AddInt64(&columnVectorGraphBenchSink, localSink)
+	})
+	elapsed := time.Since(started)
+	b.StopTimer()
+	close(stop)
+	<-done
+	select {
+	case err := <-errs:
+		b.Fatalf("writer ApplyBatch: %v", err)
+	default:
+	}
+	var finalScratch ColumnVectorDynamicGraphSearchScratch
+	finalResults, finalTrace, err := graph.SearchCosine(query, opts, &finalScratch)
+	if err != nil {
+		b.Fatalf("final SearchCosine: %v", err)
+	}
+	if len(finalResults) != opts.TopK {
+		b.Fatalf("final results=%d want %d", len(finalResults), opts.TopK)
+	}
+	reportColumnVectorDynamicGraphMetrics(b, graph.Snapshot(), finalTrace)
+	reportColumnVectorDynamicReadMetrics(b, elapsed, publishedBatches.Load(), publishedMutations.Load(), publishNanos.Load())
+}
+
+func openColumnVectorDynamicGraphBenchmark(b *testing.B, base *ColumnVectorGraph, query []float32, overlayRows int) *ColumnVectorDynamicGraph {
+	b.Helper()
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		b.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	mutations := make([]ColumnVectorDynamicMutation, 0, overlayRows)
+	for i := 0; i < overlayRows; i++ {
+		vector := make([]float32, len(query))
+		fillVectorBenchmarkEmbedding(vector, 1_000_000+i)
+		mutations = append(mutations, ColumnVectorDynamicMutation{
+			Kind:       ColumnVectorDynamicMutationInsert,
+			DocumentID: []byte(fmt.Sprintf("dyn-seed-%09d", i)),
+			Vector:     vector,
+		})
+	}
+	if _, err := graph.ApplyBatch(mutations); err != nil {
+		b.Fatalf("seed dynamic overlay: %v", err)
+	}
+	return graph
+}
+
+func columnVectorDynamicBenchmarkMutationBatches(tb testing.TB, rows int, dims int, batchCount int) [][]ColumnVectorDynamicMutation {
+	tb.Helper()
+	batches := make([][]ColumnVectorDynamicMutation, batchCount)
+	for seq := 0; seq < batchCount; seq++ {
+		updateVector := make([]float32, dims)
+		insertVector := make([]float32, dims)
+		fillVectorBenchmarkEmbedding(updateVector, 2_000_000+seq)
+		fillVectorBenchmarkEmbedding(insertVector, 3_000_000+seq)
+		mutations := []ColumnVectorDynamicMutation{
+			{
+				Kind:       ColumnVectorDynamicMutationUpdate,
+				DocumentID: columnVectorDynamicScaleDocumentID(seq % rows),
+				Vector:     updateVector,
+			},
+			{
+				Kind:       ColumnVectorDynamicMutationInsert,
+				DocumentID: []byte(fmt.Sprintf("dyn-write-%09d", seq)),
+				Vector:     insertVector,
+			},
+		}
+		if seq >= 64 {
+			mutations = append(mutations, ColumnVectorDynamicMutation{
+				Kind:       ColumnVectorDynamicMutationDelete,
+				DocumentID: []byte(fmt.Sprintf("dyn-write-%09d", seq-64)),
+			})
+		}
+		batches[seq] = mutations
+	}
+	return batches
+}
+
+func columnVectorDynamicScaleDocumentID(ordinal int) []byte {
+	documentID := make([]byte, len("doc-000000000"))
+	fillColumnVectorGraphOrdinalID(documentID, ordinal)
+	return documentID
+}
+
+func reportColumnVectorDynamicGraphMetrics(b *testing.B, snapshot *ColumnVectorDynamicGraphSnapshot, trace ColumnVectorDynamicGraphSearchTrace) {
+	b.Helper()
+	if snapshot == nil || snapshot.Base == nil || snapshot.Overlay == nil {
+		return
+	}
+	graphBytes := columnVectorGraphPayloadBytes(snapshot.Base)
+	overlayBytes := columnVectorDynamicOverlayPayloadBytes(snapshot.Overlay)
+	b.ReportMetric(float64(snapshot.Base.Rows()), "base_rows")
+	b.ReportMetric(float64(snapshot.Base.Dims()), "dims")
+	b.ReportMetric(float64(snapshot.Base.Edges())/float64(snapshot.Base.Rows()), "edges/node")
+	b.ReportMetric(float64(trace.BaseTrace.CandidatesExamined), "base_candidates/search")
+	b.ReportMetric(float64(trace.BaseTombstoned), "base_tombstoned/search")
+	b.ReportMetric(float64(trace.OverlayScanned), "overlay_scanned/search")
+	b.ReportMetric(float64(trace.MergeCandidates), "merge_candidates/search")
+	b.ReportMetric(float64(trace.CandidatesExamined), "total_candidates/search")
+	b.ReportMetric(float64(trace.BaseTrace.EdgesVisited), "edges/search")
+	b.ReportMetric(float64(snapshot.Overlay.Rows()), "overlay_rows")
+	b.ReportMetric(float64(snapshot.Overlay.LiveRows()), "overlay_live_rows")
+	b.ReportMetric(float64(snapshot.Overlay.Tombstones()), "overlay_tombstones")
+	b.ReportMetric(float64(graphBytes), "base_payload_bytes")
+	b.ReportMetric(float64(overlayBytes), "overlay_payload_bytes")
+}
+
+func reportColumnVectorDynamicReadMetrics(b *testing.B, elapsed time.Duration, publishedBatches int64, publishedMutations int64, publishNanos int64) {
+	b.Helper()
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "read_qps")
+	}
+	if publishedBatches > 0 && elapsed > 0 {
+		b.ReportMetric(float64(publishedBatches)/elapsed.Seconds(), "publishes/s")
+		b.ReportMetric(float64(publishedMutations)/elapsed.Seconds(), "mutations/s")
+		b.ReportMetric(float64(publishNanos)/float64(publishedBatches), "publish_ns/op")
+	}
+}
+
+func columnVectorDynamicOverlayPayloadBytes(overlay *ColumnVectorDynamicOverlaySnapshot) int64 {
+	if overlay == nil {
+		return 0
+	}
+	var tombstoneBytes int
+	for _, documentID := range overlay.tombstoneDocIDs {
+		tombstoneBytes += len(documentID)
+	}
+	return int64(len(overlay.vectors)*4 +
+		len(overlay.invNorms)*4 +
+		len(overlay.idArena) +
+		len(overlay.idOffsets)*4 +
+		len(overlay.live) +
+		len(overlay.tombstoneDocIDs)*24 +
+		tombstoneBytes)
+}
+
+func containsColumnVectorDynamicResult(results []VectorSearchResult, documentID []byte) bool {
+	for _, result := range results {
+		if bytes.Equal(result.DocumentID, documentID) {
+			return true
+		}
+	}
+	return false
+}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -521,11 +521,16 @@ func reportColumnVectorDynamicGraphMetrics(b *testing.B, snapshot ColumnVectorDy
 	if base == nil || overlay == nil {
 		return
 	}
+	baseRows := base.Rows()
 	graphBytes := columnVectorGraphPayloadBytes(base)
 	overlayBytes := columnVectorDynamicOverlayPayloadBytes(overlay)
-	b.ReportMetric(float64(base.Rows()), "base_rows")
+	b.ReportMetric(float64(baseRows), "base_rows")
 	b.ReportMetric(float64(base.Dims()), "dims")
-	b.ReportMetric(float64(base.Edges())/float64(base.Rows()), "edges/node")
+	if baseRows > 0 {
+		b.ReportMetric(float64(base.Edges())/float64(baseRows), "edges/node")
+	} else {
+		b.ReportMetric(0, "edges/node")
+	}
 	b.ReportMetric(float64(trace.BaseTrace.CandidatesExamined), "base_candidates/search")
 	b.ReportMetric(float64(trace.BaseTombstoned), "base_tombstoned/search")
 	b.ReportMetric(float64(trace.OverlayScanned), "overlay_scanned/search")

--- a/docs/benchmarks/column_vector_dynamic_overlay.md
+++ b/docs/benchmarks/column_vector_dynamic_overlay.md
@@ -1,0 +1,84 @@
+# Column Vector Dynamic Overlay Benchmarks
+
+This prototype track measures a dynamic graph search path while column-store
+persistence work continues. Readers share one immutable `ColumnVectorGraph`
+base snapshot. Writers publish copy-on-write overlay generations containing
+appended vectors, deleted overlay rows, and sorted base-document tombstones.
+
+Search scope:
+
+- Atomically load one base generation plus one overlay generation.
+- Run base `SearchCosine` with caller-owned warmed scratch.
+- Exact-scan live overlay vectors without fetching full documents.
+- Filter tombstoned base documents and merge top-k results.
+- Return result document IDs that alias immutable snapshot storage.
+
+Primary benchmark smoke:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+The benchmark shapes are:
+
+- `rows_100k_dims_128_degree_16/parallel_read_only`
+- `rows_100k_dims_128_degree_16/parallel_read_write`
+- `rows_1m_dims_128_degree_16/parallel_read_only`
+- `rows_1m_dims_128_degree_16/parallel_read_write`
+
+Run with `-short` to skip the 1M shape. Setup, base graph build, overlay seed,
+query vector selection, and writer mutation-batch construction are outside the
+timed loop.
+
+Concurrency discipline:
+
+- `ColumnVectorDynamicGraph` publishes immutable snapshots through an atomic
+  pointer.
+- `ColumnVectorGraph` and overlay snapshot buffers are read-only for readers.
+- Each benchmark worker owns one warmed
+  `ColumnVectorDynamicGraphSearchScratch`.
+- The read-only benchmark is expected to stay at `0 B/op` and `0 allocs/op`.
+- The read-write benchmark includes writer copy-on-write publish cost in
+  `B/op` and `allocs/op`; use `TestColumnVectorDynamicGraphSearchAllocs` as
+  the hot read allocation guard.
+
+Reported metrics separate the major costs:
+
+- `base_candidates/search`, `edges/search`, and `edges/node` cover immutable
+  base graph traversal.
+- `overlay_scanned/search`, `overlay_rows`, `overlay_live_rows`, and
+  `overlay_tombstones` cover the exact-scan overlay.
+- `merge_candidates/search` and `base_tombstoned/search` cover tombstone and
+  merge behavior.
+- `read_qps`, `publishes/s`, `mutations/s`, and `publish_ns/op` cover
+  concurrent read/write behavior.
+- `base_payload_bytes` and `overlay_payload_bytes` approximate the in-memory
+  payload footprint.
+
+Sealing and rebuild model:
+
+- Start with exact-scan overlay while deltas are small.
+- Seal larger deltas into immutable mini-graph segments when
+  `overlay_scanned/search` becomes comparable to base candidate count or when
+  tombstones force a materially larger base `TopK`.
+- Rebuild and publish a new base graph when tombstones or sealed segments make
+  read amplification dominate writer publish cost.
+- Keep rebuild/seal timing separate from query timing; publish the rebuilt base
+  by swapping a new immutable snapshot rather than mutating the current base.
+
+Focused validation:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run 'TestColumnVectorDynamicGraph|TestColumnVectorGraph' \
+  -count=1
+
+GOWORK=off go test -race ./TreeDB/collections \
+  -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay' \
+  -count=1
+```


### PR DESCRIPTION
## Summary

Adds an isolated dynamic-overlay prototype and benchmark track for column-backed vector graph search:

- shared immutable `ColumnVectorGraph` base snapshots loaded through an atomic snapshot pointer
- copy-on-write overlay generations for insert/update/delete batches
- base `SearchCosine` plus exact overlay scan, tombstone filtering, and top-k merge without full document fetches
- worker-local `ColumnVectorDynamicGraphSearchScratch` for parallel search
- 100k and 1M parallel read-only and read-while-write benchmark shapes
- focused correctness, allocation, and race tests
- benchmark notes documenting hot-loop scope, allocation interpretation, and seal/rebuild triggers

This PR is intentionally based on `integration/vector-colstore-m11-sync-plus-1610` so the diff stays focused on the dynamic overlay track. That base branch is the current vector-column integration head plus #1610.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorDynamicGraph|TestColumnVectorGraph' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.576s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay|TestColumnVectorDynamicGraphSameBatchDeleteInsertUsesWriterTombstones' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.587s
```

100k smoke:

```text
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_only-8   23071 ns/op 43344 read_qps  1064 total_candidates/search 0 B/op 0 allocs/op
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_write-8 488648 ns/op  2046 read_qps 18306 total_candidates/search 3410 mutations/s 871737 publish_ns/op 2340562 B/op 20 allocs/op
```

1M smoke:

```text
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/parallel_read_only-8     13502 ns/op 74062 read_qps   884 total_candidates/search 0 B/op 0 allocs/op
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/parallel_read_write-8  271770 ns/op  3680 read_qps 15793 total_candidates/search 6870 mutations/s 433466 publish_ns/op 1567044 B/op 17 allocs/op
```

## Notes

Read-only search remains zero-allocation with warmed worker-local scratch. The read-write benchmark intentionally includes writer copy-on-write publish allocation and overlay growth cost in `B/op`/`allocs/op`; `TestColumnVectorDynamicGraphSearchAllocs` guards the hot read path.

CodeRabbit findings addressed:

- `1f740b017`: failed batches no longer report unpublished mutation counts, and writer-side tombstone checks no longer rely on binary-searching unsorted in-flight tombstones.
- `618a5adaa`: `Snapshot()` now returns a value copy with unexported fields and read-only accessors, so callers cannot overwrite the published snapshot fields.
- `d52b7d025`: guarded `edges/node` against zero-row metric input and simplified the base top-k helper by removing the unreachable branch.
- `caf5e6c9d`: rejects empty base document IDs, makes empty mutation batches return zero no-op stats, and aligns read-write publish counters with the measured benchmark interval.
- `82f73a9cf`: starts `PublishDuration` after no-op handling inside the writer lock and adds a writer tombstone set so mutation validation avoids O(batch_size * tombstones) linear scans while readers keep the sorted slice path.

Do not merge yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic vector search with real-time insert, update, and delete operations
  * Atomic snapshot publishing for consistent search results across dynamically changing data
  * Thread-safe concurrent access with efficient overlay filtering for vector search

* **Documentation**
  * Added benchmarking guide for dynamic vector search performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->