### PR TITLE
TreeDB/collections: guard skip-scan suffix pruning

### DIFF
--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -492,6 +492,9 @@ func columnSkipScanMarkDisjoint(mark ColumnSkipScanMark, prefixPredicates []Colu
 		if pos >= len(mark.MinKeys) || pos >= len(mark.MaxKeys) {
 			return false
 		}
+		if pos > 0 && !columnSkipScanMarkSharesEqualityPrefix(mark, prefixPredicates, pos) {
+			continue
+		}
 		minKey := mark.MinKeys[pos]
 		maxKey := mark.MaxKeys[pos]
 		if !pred.Lower.Unbounded && len(pred.Lower.Key) > 0 {
@@ -508,4 +511,20 @@ func columnSkipScanMarkDisjoint(mark ColumnSkipScanMark, prefixPredicates []Colu
 		}
 	}
 	return false
+}
+
+func columnSkipScanMarkSharesEqualityPrefix(mark ColumnSkipScanMark, prefixPredicates []ColumnSkipScanPredicate, positions int) bool {
+	for pos := 0; pos < positions; pos++ {
+		if pos >= len(mark.MinKeys) || pos >= len(mark.MaxKeys) {
+			return false
+		}
+		pred := prefixPredicates[pos]
+		if !columnSkipScanPredicateIsEquality(pred) {
+			return false
+		}
+		if !bytes.Equal(mark.MinKeys[pos], pred.Lower.Key) || !bytes.Equal(mark.MaxKeys[pos], pred.Lower.Key) {
+			return false
+		}
+	}
+	return true
 }

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -458,6 +458,31 @@ func TestColumnSkipScanM11BPrunesOnlyLeftPrefixMarks(t *testing.T) {
 		t.Fatalf("range-then-later skipped=%v want none", rangeThenLaterColumn.SkippedMarks)
 	}
 
+	spanningEqualityPrefix := PlanColumnSkipScan([]ColumnSkipScanPredicate{
+		{
+			Position: 0,
+			Lower:    ColumnSkipScanBound{Key: []byte{0x01}, Inclusive: true},
+			Upper:    ColumnSkipScanBound{Key: []byte{0x01}, Inclusive: true},
+		},
+		{
+			Position: 1,
+			Lower:    ColumnSkipScanBound{Key: []byte{0x05}, Inclusive: true},
+			Upper:    ColumnSkipScanBound{Key: []byte{0x05}, Inclusive: true},
+		},
+	}, []ColumnSkipScanMark{
+		{Name: "spans-first-column", Rows: 10, MinKeys: [][]byte{{0x01}, {0x01}}, MaxKeys: [][]byte{{0x02}, {0x01}}},
+		{Name: "shares-first-column", Rows: 10, MinKeys: [][]byte{{0x01}, {0x01}}, MaxKeys: [][]byte{{0x01}, {0x01}}},
+	})
+	if got, want := spanningEqualityPrefix.LeftPrefixColumns, 2; got != want {
+		t.Fatalf("spanning-equality-prefix left prefix=%d want %d", got, want)
+	}
+	if got, want := spanningEqualityPrefix.ScheduledMarks, []int{0}; !equalInts(got, want) {
+		t.Fatalf("spanning-equality-prefix scheduled=%v want %v", got, want)
+	}
+	if got, want := spanningEqualityPrefix.SkippedMarks, []int{1}; !equalInts(got, want) {
+		t.Fatalf("spanning-equality-prefix skipped=%v want %v", got, want)
+	}
+
 	highPositionOnly := PlanColumnSkipScan([]ColumnSkipScanPredicate{{
 		Position: 1_000_000,
 		Lower:    ColumnSkipScanBound{Key: []byte{0x01}, Inclusive: true},


### PR DESCRIPTION
## Summary

Adds a narrow M11B follow-up for the active Codex review thread on #1609:

- keeps first-column mark pruning unchanged
- only applies suffix-column pruning when the mark endpoints share every preceding equality-prefix key
- adds a regression case where a composite mark spans earlier equality-prefix values and must remain scheduled

This is intentionally stacked on `codex/colgranule-m11b-planner-skipscan` so it can be audited or merged independently without modifying the other agent's branch directly.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnSkipScan|TestColumnQueryPlannerM11B' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.775s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 2.940s
```

Do not merge yet.
