### PR TITLE
TreeDB/collections: tighten dynamic vector overlay search breadth

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -262,7 +262,7 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	}
 
 	baseOpts := opts
-	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.LiveRows(), overlay.Tombstones())
+	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.Tombstones())
 	if baseOpts.EfSearch < baseOpts.TopK {
 		baseOpts.EfSearch = baseOpts.TopK
 	}
@@ -355,7 +355,7 @@ func columnVectorDynamicPublishStats(snapshot *ColumnVectorDynamicGraphSnapshot,
 	return stats
 }
 
-func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, tombstones int) int {
+func columnVectorDynamicBaseTopK(baseRows int, topK int, tombstones int) int {
 	if topK <= 0 || baseRows <= 0 {
 		return 0
 	}
@@ -363,10 +363,6 @@ func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, to
 		return baseRows
 	}
 	baseTopK := topK
-	if overlayLiveRows > baseRows-baseTopK {
-		return baseRows
-	}
-	baseTopK += overlayLiveRows
 	if tombstones > baseRows-baseTopK {
 		return baseRows
 	}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -150,6 +151,65 @@ func TestColumnVectorDynamicGraphApplyBatchEmptyIsNoOp(t *testing.T) {
 	}
 }
 
+func TestColumnVectorDynamicGraphSnapshotStableAcrossOverlayPublishes(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(64, 16, 8, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 7)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	firstVector := append([]float32(nil), query...)
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{{
+		Kind:       ColumnVectorDynamicMutationInsert,
+		DocumentID: []byte("dyn-stable"),
+		Vector:     firstVector,
+	}}); err != nil {
+		t.Fatalf("seed overlay: %v", err)
+	}
+	previous := graph.Snapshot().Overlay()
+	if previous.Rows() != 1 || previous.LiveRows() != 1 {
+		t.Fatalf("previous overlay rows=%d live=%d, want 1/1", previous.Rows(), previous.LiveRows())
+	}
+
+	for i := 0; i < 32; i++ {
+		vector := vectorBenchmarkEmbedding(30_000+i, base.Dims())
+		mutations := []ColumnVectorDynamicMutation{{
+			Kind:       ColumnVectorDynamicMutationInsert,
+			DocumentID: []byte(fmt.Sprintf("dyn-next-%03d", i)),
+			Vector:     vector,
+		}}
+		if i == 0 {
+			mutations = append(mutations, ColumnVectorDynamicMutation{
+				Kind:       ColumnVectorDynamicMutationDelete,
+				DocumentID: []byte("dyn-stable"),
+			})
+		}
+		if _, err := graph.ApplyBatch(mutations); err != nil {
+			t.Fatalf("ApplyBatch %d: %v", i, err)
+		}
+	}
+
+	if previous.Rows() != 1 || previous.LiveRows() != 1 || !previous.live[0] {
+		t.Fatalf("previous overlay mutated rows=%d liveRows=%d live=%v", previous.Rows(), previous.LiveRows(), previous.live)
+	}
+	if got := previous.documentID(0); !bytes.Equal(got, []byte("dyn-stable")) {
+		t.Fatalf("previous documentID=%q want dyn-stable", got)
+	}
+	if got := previous.vectorAt(0); !slices.Equal(got, firstVector) {
+		t.Fatalf("previous vector mutated")
+	}
+	current := graph.Snapshot().Overlay()
+	if current.Rows() <= previous.Rows() || current.LiveRows() == 0 {
+		t.Fatalf("current overlay rows=%d live=%d, want later generation", current.Rows(), current.LiveRows())
+	}
+}
+
 func TestColumnVectorDynamicGraphRejectsEmptyBaseDocumentID(t *testing.T) {
 	columns := columnVectorGraphTestColumns(16, 16, 4, false)
 	columns.DocumentIDs[7] = nil
@@ -238,6 +298,18 @@ func TestColumnVectorDynamicGraphSearchAllocs(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("hot dynamic SearchCosine allocs/run=%g want 0", allocs)
+	}
+}
+
+func TestColumnVectorDynamicBaseTopKCompensatesTombstonesOnly(t *testing.T) {
+	if got, want := columnVectorDynamicBaseTopK(100, 10, 0), 10; got != want {
+		t.Fatalf("without tombstones baseTopK=%d want %d", got, want)
+	}
+	if got, want := columnVectorDynamicBaseTopK(100, 10, 7), 17; got != want {
+		t.Fatalf("with tombstones baseTopK=%d want %d", got, want)
+	}
+	if got, want := columnVectorDynamicBaseTopK(100, 10, 95), 100; got != want {
+		t.Fatalf("capped baseTopK=%d want %d", got, want)
 	}
 }
 
@@ -415,7 +487,7 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 		}
 		scratches[i] = scratch
 	}
-	batches := columnVectorDynamicBenchmarkMutationBatches(b, rows, dims, 4096)
+	batches := columnVectorDynamicBenchmarkMutationBatches(b, rows, dims, columnVectorDynamicBenchmarkBatchCount(b.N))
 	var publishedBatches atomic.Int64
 	var publishedMutations atomic.Int64
 	var publishNanos atomic.Int64
@@ -433,7 +505,14 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 				return
 			default:
 			}
-			batch := batches[seq%len(batches)]
+			if seq >= len(batches) {
+				select {
+				case errs <- fmt.Errorf("exhausted %d prebuilt mutation batches during timed run; increase columnVectorDynamicBenchmarkBatchCount", len(batches)):
+				default:
+				}
+				return
+			}
+			batch := batches[seq]
 			stats, err := graph.ApplyBatch(batch)
 			if err != nil {
 				select {
@@ -490,6 +569,22 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B
 	}
 	reportColumnVectorDynamicGraphMetrics(b, graph.Snapshot(), finalTrace)
 	reportColumnVectorDynamicReadMetrics(b, elapsed, publishedBatchCount, publishedMutationCount, publishNanoCount)
+}
+
+func columnVectorDynamicBenchmarkBatchCount(readIterations int) int {
+	const minBatches = 4096
+	const maxBatches = 65536
+	count := minBatches
+	if readIterations > 0 {
+		count = readIterations*4 + 1024
+	}
+	if count < minBatches {
+		return minBatches
+	}
+	if count > maxBatches {
+		return maxBatches
+	}
+	return count
 }
 
 func openColumnVectorDynamicGraphBenchmark(b *testing.B, base *ColumnVectorGraph, query []float32, overlayRows int) *ColumnVectorDynamicGraph {

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -164,7 +164,8 @@ func TestColumnVectorDynamicGraphSnapshotStableAcrossOverlayPublishes(t *testing
 	if !ok {
 		t.Fatal("missing query vector")
 	}
-	firstVector := append([]float32(nil), query...)
+	expectedVector := append([]float32(nil), query...)
+	firstVector := append([]float32(nil), expectedVector...)
 	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{{
 		Kind:       ColumnVectorDynamicMutationInsert,
 		DocumentID: []byte("dyn-stable"),
@@ -195,13 +196,13 @@ func TestColumnVectorDynamicGraphSnapshotStableAcrossOverlayPublishes(t *testing
 		}
 	}
 
-	if previous.Rows() != 1 || previous.LiveRows() != 1 || !previous.live[0] {
-		t.Fatalf("previous overlay mutated rows=%d liveRows=%d live=%v", previous.Rows(), previous.LiveRows(), previous.live)
+	if previous.Rows() != 1 || previous.LiveRows() != 1 || !previous.HasLiveDocument([]byte("dyn-stable")) {
+		t.Fatalf("previous overlay mutated rows=%d liveRows=%d hasLive=%v", previous.Rows(), previous.LiveRows(), previous.HasLiveDocument([]byte("dyn-stable")))
 	}
 	if got := previous.documentID(0); !bytes.Equal(got, []byte("dyn-stable")) {
 		t.Fatalf("previous documentID=%q want dyn-stable", got)
 	}
-	if got := previous.vectorAt(0); !slices.Equal(got, firstVector) {
+	if got := previous.vectorAt(0); !slices.Equal(got, expectedVector) {
 		t.Fatalf("previous vector mutated")
 	}
 	current := graph.Snapshot().Overlay()


### PR DESCRIPTION
## Summary
- Bound dynamic overlay base graph search to `TopK + tombstones` instead of `TopK + overlay live rows + tombstones`; overlay candidates are merged separately and do not require extra base candidates.
- Make the read/write benchmark prebuild enough unique mutation batches for the current `b.N` and fail explicitly if exhausted, rather than wrapping into duplicate dynamic insert IDs.
- Add focused coverage for snapshot stability across overlay publishes and for the base-top-k tombstone compensation rule.
- Harden the snapshot-stability test against expected-vector aliasing and avoid asserting on overlay internals.

## Local validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorDynamicGraph|TestColumnVectorDynamicBaseTopK' -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSnapshotStableAcrossOverlayPublishes|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay|TestColumnVectorDynamicGraphSameBatchDeleteInsertUsesWriterTombstones' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_only|BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_write' -benchmem -benchtime=200ms -count=1`
- `GOWORK=off GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/(parallel_read_only|parallel_read_write)$' -benchmem -benchtime=100ms -count=1`

## Benchmark evidence
Compared with the same corrected read/write benchmark using the prior `TopK + overlay live rows + tombstones` breadth rule:

- `sec/op`: 424.6us -> 150.9us (`-64.47%`, p=0.008, n=5)
- `read_qps`: 2.355k -> 6.629k (`+181.49%`, p=0.008, n=5)
- `total_candidates/search`: 28.12k -> 11.07k (`-60.64%`, p=0.008, n=5)
- `edges/search`: 214.96k -> 66.37k (`-69.13%`, p=0.008, n=5)
- `B/op`: 2640.6Ki -> 957.8Ki (`-63.73%`, p=0.008, n=5)
- `allocs/op`: 22 -> 10 (`-54.55%`, p=0.008, n=5)

Final 100k smoke on this branch:

- `parallel_read_only`: 7825 ns/op, 127803 read_qps, 571 total_candidates/search, 2128 edges/search, 0 B/op, 0 allocs/op
- `parallel_read_write`: 98164 ns/op, 10187 read_qps, 8556 mutations/s, 347255 publish_ns/op, 9552 total_candidates/search, 640261 B/op, 8 allocs/op

Final 1M smoke on this branch (`GOMAXPROCS=8`, `-benchtime=100ms`):

- `parallel_read_only`: 8886 ns/op, 112535 read_qps, 695 total_candidates/search, 2688 edges/search, 0 B/op, 0 allocs/op
- `parallel_read_write`: 98795 ns/op, 10122 read_qps, 7712 mutations/s, 385464 publish_ns/op, 7600 total_candidates/search, 535017 B/op, 7 allocs/op

A separate append-only payload-sharing experiment was tested and not kept: it reduced some copy bytes but let the exact-scan overlay grow faster and directionally regressed read QPS without improving publish latency once this base breadth fix was applied.
