### PR TITLE
TreeDB/collections: reduce dynamic overlay publish allocation

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -176,7 +176,7 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	start := time.Now()
-	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
+	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, g.baseDocIndex, current.overlay)
 	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
@@ -435,7 +435,7 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows
 	return next
 }
 
-func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation) (rows int, idBytes int, tombstones int, tombstoneIDBytes int) {
+func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation, baseDocIndex map[string]int, overlay *ColumnVectorDynamicOverlaySnapshot) (rows int, idBytes int, tombstones int, tombstoneIDBytes int) {
 	for _, mutation := range mutations {
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationInsert, ColumnVectorDynamicMutationUpdate:
@@ -444,8 +444,10 @@ func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMu
 		}
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationUpdate, ColumnVectorDynamicMutationDelete:
-			tombstones++
-			tombstoneIDBytes += len(mutation.DocumentID)
+			if _, baseFound := baseDocIndex[string(mutation.DocumentID)]; baseFound && !overlay.documentTombstonedWriter(mutation.DocumentID) {
+				tombstones++
+				tombstoneIDBytes += len(mutation.DocumentID)
+			}
 		}
 	}
 	return rows, idBytes, tombstones, tombstoneIDBytes

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -176,21 +176,26 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	start := time.Now()
-	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, g.baseDocIndex, current.overlay, current.base.Dims())
+	mutationPlan, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, g.baseDocIndex, current.overlay, current.base.Dims())
 	if err != nil {
 		return stats, err
 	}
-	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendCapacity)
+	nextOverlay := current.overlay.clone(current.overlayGeneration+1, mutationPlan.appendCapacity)
 	inserted, updated, deleted := 0, 0, 0
+	appendVectorIndex := 0
 	for mutationIndex, mutation := range mutations {
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationInsert:
-			if err := g.applyInsert(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
+			invNorm := mutationPlan.vectorInvNorm(appendVectorIndex)
+			appendVectorIndex++
+			if err := g.applyInsert(nextOverlay, mutation.DocumentID, mutation.Vector, invNorm); err != nil {
 				return stats, fmt.Errorf("collections: dynamic insert mutation %d: %w", mutationIndex, err)
 			}
 			inserted++
 		case ColumnVectorDynamicMutationUpdate:
-			if err := g.applyUpdate(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
+			invNorm := mutationPlan.vectorInvNorm(appendVectorIndex)
+			appendVectorIndex++
+			if err := g.applyUpdate(nextOverlay, mutation.DocumentID, mutation.Vector, invNorm); err != nil {
 				return stats, fmt.Errorf("collections: dynamic update mutation %d: %w", mutationIndex, err)
 			}
 			updated++
@@ -303,17 +308,17 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	return results, trace, nil
 }
 
-func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32) error {
+func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32, invNorm float32) error {
 	if overlay.HasLiveDocument(documentID) {
 		return fmt.Errorf("document %q already exists in overlay", documentID)
 	}
 	if _, ok := g.baseDocIndex[string(documentID)]; ok && !overlay.documentTombstonedWriter(documentID) {
 		return fmt.Errorf("document %q already exists in base", documentID)
 	}
-	return overlay.appendLiveDocument(documentID, vector)
+	return overlay.appendPrevalidatedLiveDocument(documentID, vector, invNorm)
 }
 
-func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32) error {
+func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32, invNorm float32) error {
 	overlayFound := overlay.tombstoneOverlayDocument(documentID)
 	_, baseFound := g.baseDocIndex[string(documentID)]
 	baseLive := baseFound && !overlay.documentTombstonedWriter(documentID)
@@ -323,7 +328,7 @@ func (g *ColumnVectorDynamicGraph) applyUpdate(overlay *ColumnVectorDynamicOverl
 	if baseLive {
 		overlay.addTombstone(documentID)
 	}
-	return overlay.appendLiveDocument(documentID, vector)
+	return overlay.appendPrevalidatedLiveDocument(documentID, vector, invNorm)
 }
 
 func (g *ColumnVectorDynamicGraph) applyDelete(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte) error {
@@ -400,6 +405,30 @@ type columnVectorDynamicOverlayAppendCapacity struct {
 	tombstoneIDBytes int
 }
 
+type columnVectorDynamicMutationPlan struct {
+	appendCapacity        columnVectorDynamicOverlayAppendCapacity
+	vectorInvNormSmall    [8]float32
+	vectorInvNormOverflow []float32
+	vectorInvNormCount    int
+}
+
+func (p *columnVectorDynamicMutationPlan) addVectorInvNorm(invNorm float32) {
+	if p.vectorInvNormCount < len(p.vectorInvNormSmall) {
+		p.vectorInvNormSmall[p.vectorInvNormCount] = invNorm
+		p.vectorInvNormCount++
+		return
+	}
+	p.vectorInvNormOverflow = append(p.vectorInvNormOverflow, invNorm)
+	p.vectorInvNormCount++
+}
+
+func (p *columnVectorDynamicMutationPlan) vectorInvNorm(index int) float32 {
+	if index < len(p.vectorInvNormSmall) {
+		return p.vectorInvNormSmall[index]
+	}
+	return p.vectorInvNormOverflow[index-len(p.vectorInvNormSmall)]
+}
+
 func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlaySnapshot {
 	return &ColumnVectorDynamicOverlaySnapshot{
 		dims:            dims,
@@ -458,8 +487,8 @@ type columnVectorDynamicOverlayLiveChange struct {
 	live bool
 }
 
-func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorDynamicMutation, baseDocIndex map[string]int, overlay *ColumnVectorDynamicOverlaySnapshot, dims int) (columnVectorDynamicOverlayAppendCapacity, error) {
-	var appendCapacity columnVectorDynamicOverlayAppendCapacity
+func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorDynamicMutation, baseDocIndex map[string]int, overlay *ColumnVectorDynamicOverlaySnapshot, dims int) (columnVectorDynamicMutationPlan, error) {
+	var plan columnVectorDynamicMutationPlan
 	state := columnVectorDynamicMutationValidationState{
 		baseDocIndex: baseDocIndex,
 		overlay:      overlay,
@@ -468,26 +497,29 @@ func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorD
 	state.baseTombstones = state.baseTombstoneSmall[:0]
 	for mutationIndex, mutation := range mutations {
 		if len(mutation.DocumentID) == 0 {
-			return appendCapacity, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
+			return plan, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
 		}
 		key := string(mutation.DocumentID)
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationInsert:
-			if err := columnVectorDynamicValidateMutationVector("insert", mutationIndex, mutation.Vector, dims); err != nil {
-				return appendCapacity, err
+			invNorm, err := columnVectorDynamicValidateMutationVector("insert", mutationIndex, mutation.Vector, dims)
+			if err != nil {
+				return plan, err
 			}
 			if state.documentLiveInOverlay(mutation.DocumentID, key) {
-				return appendCapacity, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in overlay", mutationIndex, mutation.DocumentID)
+				return plan, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in overlay", mutationIndex, mutation.DocumentID)
 			}
 			if state.documentLiveInBase(mutation.DocumentID, key) {
-				return appendCapacity, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in base", mutationIndex, mutation.DocumentID)
+				return plan, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in base", mutationIndex, mutation.DocumentID)
 			}
 			state.setOverlayLive(key, true)
-			appendCapacity.rows++
-			appendCapacity.idBytes += len(mutation.DocumentID)
+			plan.addVectorInvNorm(invNorm)
+			plan.appendCapacity.rows++
+			plan.appendCapacity.idBytes += len(mutation.DocumentID)
 		case ColumnVectorDynamicMutationUpdate:
-			if err := columnVectorDynamicValidateMutationVector("update", mutationIndex, mutation.Vector, dims); err != nil {
-				return appendCapacity, err
+			invNorm, err := columnVectorDynamicValidateMutationVector("update", mutationIndex, mutation.Vector, dims)
+			if err != nil {
+				return plan, err
 			}
 			overlayFound := state.documentLiveInOverlay(mutation.DocumentID, key)
 			if overlayFound {
@@ -495,15 +527,16 @@ func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorD
 			}
 			baseLive := state.documentLiveInBase(mutation.DocumentID, key)
 			if !overlayFound && !baseLive {
-				return appendCapacity, fmt.Errorf("collections: dynamic update mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
+				return plan, fmt.Errorf("collections: dynamic update mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
 			}
 			if baseLive && state.setBaseTombstoned(key) {
-				appendCapacity.tombstones++
-				appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
+				plan.appendCapacity.tombstones++
+				plan.appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
 			}
 			state.setOverlayLive(key, true)
-			appendCapacity.rows++
-			appendCapacity.idBytes += len(mutation.DocumentID)
+			plan.addVectorInvNorm(invNorm)
+			plan.appendCapacity.rows++
+			plan.appendCapacity.idBytes += len(mutation.DocumentID)
 		case ColumnVectorDynamicMutationDelete:
 			overlayFound := state.documentLiveInOverlay(mutation.DocumentID, key)
 			if overlayFound {
@@ -511,34 +544,43 @@ func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorD
 			}
 			baseLive := state.documentLiveInBase(mutation.DocumentID, key)
 			if !overlayFound && !baseLive {
-				return appendCapacity, fmt.Errorf("collections: dynamic delete mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
+				return plan, fmt.Errorf("collections: dynamic delete mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
 			}
 			if baseLive && state.setBaseTombstoned(key) {
-				appendCapacity.tombstones++
-				appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
+				plan.appendCapacity.tombstones++
+				plan.appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
 			}
 		default:
-			return appendCapacity, fmt.Errorf("collections: dynamic mutation %d has unsupported kind %d", mutationIndex, mutation.Kind)
+			return plan, fmt.Errorf("collections: dynamic mutation %d has unsupported kind %d", mutationIndex, mutation.Kind)
 		}
 	}
-	if uint64(len(overlay.idArena))+uint64(appendCapacity.idBytes) > columnVectorGraphMaxUint32 {
-		return appendCapacity, errors.New("collections: dynamic overlay document ID arena exceeds uint32 offsets")
+	if uint64(len(overlay.idArena))+uint64(plan.appendCapacity.idBytes) > columnVectorGraphMaxUint32 {
+		return plan, errors.New("collections: dynamic overlay document ID arena exceeds uint32 offsets")
 	}
-	return appendCapacity, nil
+	return plan, nil
 }
 
-func columnVectorDynamicValidateMutationVector(kind string, mutationIndex int, vector []float32, dims int) error {
+func columnVectorDynamicValidateMutationVector(kind string, mutationIndex int, vector []float32, dims int) (float32, error) {
+	invNorm, err := columnVectorDynamicValidateVector(vector, dims)
+	if err != nil {
+		return 0, fmt.Errorf("collections: dynamic %s mutation %d: %w", kind, mutationIndex, err)
+	}
+	return invNorm, nil
+}
+
+func columnVectorDynamicValidateVector(vector []float32, dims int) (float32, error) {
 	if len(vector) != dims {
-		return fmt.Errorf("collections: dynamic %s mutation %d: vector has dimension %d, want %d", kind, mutationIndex, len(vector), dims)
+		return 0, fmt.Errorf("vector has dimension %d, want %d", len(vector), dims)
 	}
 	normSquared, badDim, badValue := columnVectorGraphNormSquared(vector)
 	if badDim >= 0 {
-		return fmt.Errorf("collections: dynamic %s mutation %d: vector dim %d is not finite: %g", kind, mutationIndex, badDim, badValue)
+		return 0, fmt.Errorf("vector dim %d is not finite: %g", badDim, badValue)
 	}
-	if _, err := validateColumnVectorGraphQueryInvNorm(normSquared); err != nil {
-		return fmt.Errorf("collections: dynamic %s mutation %d: %w", kind, mutationIndex, err)
+	invNorm, err := validateColumnVectorGraphQueryInvNorm(normSquared)
+	if err != nil {
+		return 0, err
 	}
-	return nil
+	return invNorm, nil
 }
 
 func (s *columnVectorDynamicMutationValidationState) documentLiveInOverlay(documentID []byte, key string) bool {
@@ -740,16 +782,16 @@ func (o *ColumnVectorDynamicOverlaySnapshot) documentTombstonedWriter(documentID
 }
 
 func (o *ColumnVectorDynamicOverlaySnapshot) appendLiveDocument(documentID []byte, vector []float32) error {
-	if len(vector) != o.dims {
-		return fmt.Errorf("vector has dimension %d, want %d", len(vector), o.dims)
-	}
-	normSquared, badDim, badValue := columnVectorGraphNormSquared(vector)
-	if badDim >= 0 {
-		return fmt.Errorf("vector dim %d is not finite: %g", badDim, badValue)
-	}
-	invNorm, err := validateColumnVectorGraphQueryInvNorm(normSquared)
+	invNorm, err := columnVectorDynamicValidateVector(vector, o.dims)
 	if err != nil {
 		return err
+	}
+	return o.appendPrevalidatedLiveDocument(documentID, vector, invNorm)
+}
+
+func (o *ColumnVectorDynamicOverlaySnapshot) appendPrevalidatedLiveDocument(documentID []byte, vector []float32, invNorm float32) error {
+	if len(vector) != o.dims {
+		return fmt.Errorf("vector has dimension %d, want %d", len(vector), o.dims)
 	}
 	if uint64(len(o.idArena))+uint64(len(documentID)) > columnVectorGraphMaxUint32 {
 		return errors.New("overlay document ID arena exceeds uint32 offsets")

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -176,8 +176,8 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	start := time.Now()
-	appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
-	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendRows, appendIDBytes, appendTombstones)
+	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
+	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
 		if len(mutation.DocumentID) == 0 {
@@ -388,6 +388,7 @@ type ColumnVectorDynamicOverlaySnapshot struct {
 	live            []bool
 	liveRows        int
 	liveDocIndex    map[string]int
+	tombstoneArena  []byte
 	tombstoneDocIDs [][]byte
 	tombstoneDocSet map[string]struct{}
 }
@@ -401,7 +402,7 @@ func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlay
 	}
 }
 
-func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows int, appendIDBytes int, appendTombstones int) *ColumnVectorDynamicOverlaySnapshot {
+func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows int, appendIDBytes int, appendTombstones int, appendTombstoneIDBytes int) *ColumnVectorDynamicOverlaySnapshot {
 	appendValues := columnVectorDynamicOverlayVectorValueCapacity(appendRows, o.dims)
 	liveDocCapacity := columnVectorDynamicSliceCapacity(len(o.liveDocIndex), appendRows)
 	tombstoneSetCapacity := columnVectorDynamicSliceCapacity(max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs)), appendTombstones)
@@ -414,6 +415,7 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows
 		idOffsets:       cloneUint32SliceWithExtraCapacity(o.idOffsets, appendRows),
 		live:            cloneBoolSliceWithExtraCapacity(o.live, appendRows),
 		liveRows:        o.liveRows,
+		tombstoneArena:  make([]byte, 0, appendTombstoneIDBytes),
 		tombstoneDocIDs: cloneByteSlicesWithExtraCapacity(o.tombstoneDocIDs, appendTombstones),
 		liveDocIndex:    make(map[string]int, liveDocCapacity),
 		tombstoneDocSet: make(map[string]struct{}, tombstoneSetCapacity),
@@ -433,7 +435,7 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows
 	return next
 }
 
-func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation) (rows int, idBytes int, tombstones int) {
+func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation) (rows int, idBytes int, tombstones int, tombstoneIDBytes int) {
 	for _, mutation := range mutations {
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationInsert, ColumnVectorDynamicMutationUpdate:
@@ -443,9 +445,10 @@ func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMu
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationUpdate, ColumnVectorDynamicMutationDelete:
 			tombstones++
+			tombstoneIDBytes += len(mutation.DocumentID)
 		}
 	}
-	return rows, idBytes, tombstones
+	return rows, idBytes, tombstones, tombstoneIDBytes
 }
 
 func columnVectorDynamicOverlayVectorValueCapacity(rows int, dims int) int {
@@ -600,7 +603,9 @@ func (o *ColumnVectorDynamicOverlaySnapshot) addTombstone(documentID []byte) {
 	if _, exists := o.tombstoneDocSet[key]; exists {
 		return
 	}
-	o.tombstoneDocIDs = append(o.tombstoneDocIDs, bytes.Clone(documentID))
+	start := len(o.tombstoneArena)
+	o.tombstoneArena = append(o.tombstoneArena, documentID...)
+	o.tombstoneDocIDs = append(o.tombstoneDocIDs, o.tombstoneArena[start:len(o.tombstoneArena):len(o.tombstoneArena)])
 	o.tombstoneDocSet[key] = struct{}{}
 }
 

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -176,13 +176,13 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	start := time.Now()
-	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, g.baseDocIndex, current.overlay)
-	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
+	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, g.baseDocIndex, current.overlay, current.base.Dims())
+	if err != nil {
+		return stats, err
+	}
+	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendCapacity)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
-		if len(mutation.DocumentID) == 0 {
-			return stats, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
-		}
 		switch mutation.Kind {
 		case ColumnVectorDynamicMutationInsert:
 			if err := g.applyInsert(nextOverlay, mutation.DocumentID, mutation.Vector); err != nil {
@@ -393,6 +393,13 @@ type ColumnVectorDynamicOverlaySnapshot struct {
 	tombstoneDocSet map[string]struct{}
 }
 
+type columnVectorDynamicOverlayAppendCapacity struct {
+	rows             int
+	idBytes          int
+	tombstones       int
+	tombstoneIDBytes int
+}
+
 func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlaySnapshot {
 	return &ColumnVectorDynamicOverlaySnapshot{
 		dims:            dims,
@@ -402,21 +409,21 @@ func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlay
 	}
 }
 
-func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows int, appendIDBytes int, appendTombstones int, appendTombstoneIDBytes int) *ColumnVectorDynamicOverlaySnapshot {
-	appendValues := columnVectorDynamicOverlayVectorValueCapacity(appendRows, o.dims)
-	liveDocCapacity := columnVectorDynamicSliceCapacity(len(o.liveDocIndex), appendRows)
-	tombstoneSetCapacity := columnVectorDynamicSliceCapacity(max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs)), appendTombstones)
+func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendCapacity columnVectorDynamicOverlayAppendCapacity) *ColumnVectorDynamicOverlaySnapshot {
+	appendValues := columnVectorDynamicOverlayVectorValueCapacity(appendCapacity.rows, o.dims)
+	liveDocCapacity := columnVectorDynamicSliceCapacity(len(o.liveDocIndex), appendCapacity.rows)
+	tombstoneSetCapacity := columnVectorDynamicSliceCapacity(max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs)), appendCapacity.tombstones)
 	next := &ColumnVectorDynamicOverlaySnapshot{
 		generation:      generation,
 		dims:            o.dims,
 		vectors:         cloneFloat32SliceWithExtraCapacity(o.vectors, appendValues),
-		invNorms:        cloneFloat32SliceWithExtraCapacity(o.invNorms, appendRows),
-		idArena:         cloneByteSliceWithExtraCapacity(o.idArena, appendIDBytes),
-		idOffsets:       cloneUint32SliceWithExtraCapacity(o.idOffsets, appendRows),
-		live:            cloneBoolSliceWithExtraCapacity(o.live, appendRows),
+		invNorms:        cloneFloat32SliceWithExtraCapacity(o.invNorms, appendCapacity.rows),
+		idArena:         cloneByteSliceWithExtraCapacity(o.idArena, appendCapacity.idBytes),
+		idOffsets:       cloneUint32SliceWithExtraCapacity(o.idOffsets, appendCapacity.rows),
+		live:            cloneBoolSliceWithExtraCapacity(o.live, appendCapacity.rows),
 		liveRows:        o.liveRows,
-		tombstoneArena:  make([]byte, 0, appendTombstoneIDBytes),
-		tombstoneDocIDs: cloneByteSlicesWithExtraCapacity(o.tombstoneDocIDs, appendTombstones),
+		tombstoneArena:  make([]byte, 0, appendCapacity.tombstoneIDBytes),
+		tombstoneDocIDs: cloneByteSlicesWithExtraCapacity(o.tombstoneDocIDs, appendCapacity.tombstones),
 		liveDocIndex:    make(map[string]int, liveDocCapacity),
 		tombstoneDocSet: make(map[string]struct{}, tombstoneSetCapacity),
 	}
@@ -435,22 +442,194 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows
 	return next
 }
 
-func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation, baseDocIndex map[string]int, overlay *ColumnVectorDynamicOverlaySnapshot) (rows int, idBytes int, tombstones int, tombstoneIDBytes int) {
-	for _, mutation := range mutations {
-		switch mutation.Kind {
-		case ColumnVectorDynamicMutationInsert, ColumnVectorDynamicMutationUpdate:
-			rows++
-			idBytes += len(mutation.DocumentID)
+type columnVectorDynamicMutationValidationState struct {
+	baseDocIndex       map[string]int
+	overlay            *ColumnVectorDynamicOverlaySnapshot
+	overlayLiveSmall   [8]columnVectorDynamicOverlayLiveChange
+	overlayLive        []columnVectorDynamicOverlayLiveChange
+	overlayLiveMap     map[string]bool
+	baseTombstoneSmall [8]string
+	baseTombstones     []string
+	baseTombstoneMap   map[string]struct{}
+}
+
+type columnVectorDynamicOverlayLiveChange struct {
+	key  string
+	live bool
+}
+
+func columnVectorDynamicValidateMutationAppendCapacity(mutations []ColumnVectorDynamicMutation, baseDocIndex map[string]int, overlay *ColumnVectorDynamicOverlaySnapshot, dims int) (columnVectorDynamicOverlayAppendCapacity, error) {
+	var appendCapacity columnVectorDynamicOverlayAppendCapacity
+	state := columnVectorDynamicMutationValidationState{
+		baseDocIndex: baseDocIndex,
+		overlay:      overlay,
+	}
+	state.overlayLive = state.overlayLiveSmall[:0]
+	state.baseTombstones = state.baseTombstoneSmall[:0]
+	for mutationIndex, mutation := range mutations {
+		if len(mutation.DocumentID) == 0 {
+			return appendCapacity, fmt.Errorf("collections: dynamic mutation %d has empty document ID", mutationIndex)
 		}
+		key := string(mutation.DocumentID)
 		switch mutation.Kind {
-		case ColumnVectorDynamicMutationUpdate, ColumnVectorDynamicMutationDelete:
-			if _, baseFound := baseDocIndex[string(mutation.DocumentID)]; baseFound && !overlay.documentTombstonedWriter(mutation.DocumentID) {
-				tombstones++
-				tombstoneIDBytes += len(mutation.DocumentID)
+		case ColumnVectorDynamicMutationInsert:
+			if err := columnVectorDynamicValidateMutationVector("insert", mutationIndex, mutation.Vector, dims); err != nil {
+				return appendCapacity, err
+			}
+			if state.documentLiveInOverlay(mutation.DocumentID, key) {
+				return appendCapacity, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in overlay", mutationIndex, mutation.DocumentID)
+			}
+			if state.documentLiveInBase(mutation.DocumentID, key) {
+				return appendCapacity, fmt.Errorf("collections: dynamic insert mutation %d: document %q already exists in base", mutationIndex, mutation.DocumentID)
+			}
+			state.setOverlayLive(key, true)
+			appendCapacity.rows++
+			appendCapacity.idBytes += len(mutation.DocumentID)
+		case ColumnVectorDynamicMutationUpdate:
+			if err := columnVectorDynamicValidateMutationVector("update", mutationIndex, mutation.Vector, dims); err != nil {
+				return appendCapacity, err
+			}
+			overlayFound := state.documentLiveInOverlay(mutation.DocumentID, key)
+			if overlayFound {
+				state.setOverlayLive(key, false)
+			}
+			baseLive := state.documentLiveInBase(mutation.DocumentID, key)
+			if !overlayFound && !baseLive {
+				return appendCapacity, fmt.Errorf("collections: dynamic update mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
+			}
+			if baseLive && state.setBaseTombstoned(key) {
+				appendCapacity.tombstones++
+				appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
+			}
+			state.setOverlayLive(key, true)
+			appendCapacity.rows++
+			appendCapacity.idBytes += len(mutation.DocumentID)
+		case ColumnVectorDynamicMutationDelete:
+			overlayFound := state.documentLiveInOverlay(mutation.DocumentID, key)
+			if overlayFound {
+				state.setOverlayLive(key, false)
+			}
+			baseLive := state.documentLiveInBase(mutation.DocumentID, key)
+			if !overlayFound && !baseLive {
+				return appendCapacity, fmt.Errorf("collections: dynamic delete mutation %d: document %q does not exist", mutationIndex, mutation.DocumentID)
+			}
+			if baseLive && state.setBaseTombstoned(key) {
+				appendCapacity.tombstones++
+				appendCapacity.tombstoneIDBytes += len(mutation.DocumentID)
+			}
+		default:
+			return appendCapacity, fmt.Errorf("collections: dynamic mutation %d has unsupported kind %d", mutationIndex, mutation.Kind)
+		}
+	}
+	if uint64(len(overlay.idArena))+uint64(appendCapacity.idBytes) > columnVectorGraphMaxUint32 {
+		return appendCapacity, errors.New("collections: dynamic overlay document ID arena exceeds uint32 offsets")
+	}
+	return appendCapacity, nil
+}
+
+func columnVectorDynamicValidateMutationVector(kind string, mutationIndex int, vector []float32, dims int) error {
+	if len(vector) != dims {
+		return fmt.Errorf("collections: dynamic %s mutation %d: vector has dimension %d, want %d", kind, mutationIndex, len(vector), dims)
+	}
+	normSquared, badDim, badValue := columnVectorGraphNormSquared(vector)
+	if badDim >= 0 {
+		return fmt.Errorf("collections: dynamic %s mutation %d: vector dim %d is not finite: %g", kind, mutationIndex, badDim, badValue)
+	}
+	if _, err := validateColumnVectorGraphQueryInvNorm(normSquared); err != nil {
+		return fmt.Errorf("collections: dynamic %s mutation %d: %w", kind, mutationIndex, err)
+	}
+	return nil
+}
+
+func (s *columnVectorDynamicMutationValidationState) documentLiveInOverlay(documentID []byte, key string) bool {
+	if s.overlayLiveMap != nil {
+		if live, found := s.overlayLiveMap[key]; found {
+			return live
+		}
+	} else {
+		for i := range s.overlayLive {
+			change := s.overlayLive[i]
+			if change.key == key {
+				return change.live
 			}
 		}
 	}
-	return rows, idBytes, tombstones, tombstoneIDBytes
+	return s.overlay.HasLiveDocument(documentID)
+}
+
+func (s *columnVectorDynamicMutationValidationState) documentLiveInBase(documentID []byte, key string) bool {
+	if _, found := s.baseDocIndex[key]; !found {
+		return false
+	}
+	if s.overlay.documentTombstonedWriter(documentID) {
+		return false
+	}
+	if s.baseDocumentTombstoned(key) {
+		return false
+	}
+	return true
+}
+
+func (s *columnVectorDynamicMutationValidationState) setOverlayLive(key string, live bool) {
+	if s.overlayLiveMap != nil {
+		s.overlayLiveMap[key] = live
+		return
+	}
+	for i := range s.overlayLive {
+		if s.overlayLive[i].key == key {
+			s.overlayLive[i].live = live
+			return
+		}
+	}
+	if len(s.overlayLive) < cap(s.overlayLive) {
+		s.overlayLive = append(s.overlayLive, columnVectorDynamicOverlayLiveChange{key: key, live: live})
+		return
+	}
+	s.overlayLiveMap = make(map[string]bool, len(s.overlayLive)+1)
+	for _, change := range s.overlayLive {
+		s.overlayLiveMap[change.key] = change.live
+	}
+	s.overlayLive = nil
+	s.overlayLiveMap[key] = live
+}
+
+func (s *columnVectorDynamicMutationValidationState) setBaseTombstoned(key string) bool {
+	if s.baseTombstoneMap != nil {
+		if _, found := s.baseTombstoneMap[key]; found {
+			return false
+		}
+		s.baseTombstoneMap[key] = struct{}{}
+		return true
+	}
+	for _, tombstone := range s.baseTombstones {
+		if tombstone == key {
+			return false
+		}
+	}
+	if len(s.baseTombstones) < cap(s.baseTombstones) {
+		s.baseTombstones = append(s.baseTombstones, key)
+		return true
+	}
+	s.baseTombstoneMap = make(map[string]struct{}, len(s.baseTombstones)+1)
+	for _, tombstone := range s.baseTombstones {
+		s.baseTombstoneMap[tombstone] = struct{}{}
+	}
+	s.baseTombstones = nil
+	s.baseTombstoneMap[key] = struct{}{}
+	return true
+}
+
+func (s *columnVectorDynamicMutationValidationState) baseDocumentTombstoned(key string) bool {
+	if s.baseTombstoneMap != nil {
+		_, found := s.baseTombstoneMap[key]
+		return found
+	}
+	for _, tombstone := range s.baseTombstones {
+		if tombstone == key {
+			return true
+		}
+	}
+	return false
 }
 
 func columnVectorDynamicOverlayVectorValueCapacity(rows int, dims int) int {

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -176,7 +176,8 @@ func (g *ColumnVectorDynamicGraph) ApplyBatch(mutations []ColumnVectorDynamicMut
 	}
 
 	start := time.Now()
-	nextOverlay := current.overlay.clone(current.overlayGeneration + 1)
+	appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
+	nextOverlay := current.overlay.clone(current.overlayGeneration+1, appendRows, appendIDBytes, appendTombstones)
 	inserted, updated, deleted := 0, 0, 0
 	for mutationIndex, mutation := range mutations {
 		if len(mutation.DocumentID) == 0 {
@@ -400,19 +401,22 @@ func newColumnVectorDynamicOverlaySnapshot(dims int) *ColumnVectorDynamicOverlay
 	}
 }
 
-func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64) *ColumnVectorDynamicOverlaySnapshot {
+func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64, appendRows int, appendIDBytes int, appendTombstones int) *ColumnVectorDynamicOverlaySnapshot {
+	appendValues := columnVectorDynamicOverlayVectorValueCapacity(appendRows, o.dims)
+	liveDocCapacity := columnVectorDynamicSliceCapacity(len(o.liveDocIndex), appendRows)
+	tombstoneSetCapacity := columnVectorDynamicSliceCapacity(max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs)), appendTombstones)
 	next := &ColumnVectorDynamicOverlaySnapshot{
 		generation:      generation,
 		dims:            o.dims,
-		vectors:         append([]float32(nil), o.vectors...),
-		invNorms:        append([]float32(nil), o.invNorms...),
-		idArena:         append([]byte(nil), o.idArena...),
-		idOffsets:       append([]uint32(nil), o.idOffsets...),
-		live:            append([]bool(nil), o.live...),
+		vectors:         cloneFloat32SliceWithExtraCapacity(o.vectors, appendValues),
+		invNorms:        cloneFloat32SliceWithExtraCapacity(o.invNorms, appendRows),
+		idArena:         cloneByteSliceWithExtraCapacity(o.idArena, appendIDBytes),
+		idOffsets:       cloneUint32SliceWithExtraCapacity(o.idOffsets, appendRows),
+		live:            cloneBoolSliceWithExtraCapacity(o.live, appendRows),
 		liveRows:        o.liveRows,
-		tombstoneDocIDs: append([][]byte(nil), o.tombstoneDocIDs...),
-		liveDocIndex:    make(map[string]int, len(o.liveDocIndex)),
-		tombstoneDocSet: make(map[string]struct{}, max(len(o.tombstoneDocSet), len(o.tombstoneDocIDs))),
+		tombstoneDocIDs: cloneByteSlicesWithExtraCapacity(o.tombstoneDocIDs, appendTombstones),
+		liveDocIndex:    make(map[string]int, liveDocCapacity),
+		tombstoneDocSet: make(map[string]struct{}, tombstoneSetCapacity),
 	}
 	for key, ordinal := range o.liveDocIndex {
 		next.liveDocIndex[key] = ordinal
@@ -427,6 +431,73 @@ func (o *ColumnVectorDynamicOverlaySnapshot) clone(generation uint64) *ColumnVec
 		}
 	}
 	return next
+}
+
+func columnVectorDynamicMutationAppendCapacity(mutations []ColumnVectorDynamicMutation) (rows int, idBytes int, tombstones int) {
+	for _, mutation := range mutations {
+		switch mutation.Kind {
+		case ColumnVectorDynamicMutationInsert, ColumnVectorDynamicMutationUpdate:
+			rows++
+			idBytes += len(mutation.DocumentID)
+		}
+		switch mutation.Kind {
+		case ColumnVectorDynamicMutationUpdate, ColumnVectorDynamicMutationDelete:
+			tombstones++
+		}
+	}
+	return rows, idBytes, tombstones
+}
+
+func columnVectorDynamicOverlayVectorValueCapacity(rows int, dims int) int {
+	if rows <= 0 || dims <= 0 {
+		return 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if rows > maxInt/dims {
+		return 0
+	}
+	return rows * dims
+}
+
+func columnVectorDynamicSliceCapacity(length int, extra int) int {
+	if extra <= 0 {
+		return length
+	}
+	maxInt := int(^uint(0) >> 1)
+	if extra > maxInt-length {
+		return length
+	}
+	return length + extra
+}
+
+func cloneFloat32SliceWithExtraCapacity(src []float32, extra int) []float32 {
+	dst := make([]float32, len(src), columnVectorDynamicSliceCapacity(len(src), extra))
+	copy(dst, src)
+	return dst
+}
+
+func cloneByteSliceWithExtraCapacity(src []byte, extra int) []byte {
+	dst := make([]byte, len(src), columnVectorDynamicSliceCapacity(len(src), extra))
+	copy(dst, src)
+	return dst
+}
+
+func cloneUint32SliceWithExtraCapacity(src []uint32, extra int) []uint32 {
+	dst := make([]uint32, len(src), columnVectorDynamicSliceCapacity(len(src), extra))
+	copy(dst, src)
+	return dst
+}
+
+func cloneBoolSliceWithExtraCapacity(src []bool, extra int) []bool {
+	dst := make([]bool, len(src), columnVectorDynamicSliceCapacity(len(src), extra))
+	copy(dst, src)
+	return dst
+}
+
+func cloneByteSlicesWithExtraCapacity(src [][]byte, extra int) [][]byte {
+	dst := make([][]byte, len(src), columnVectorDynamicSliceCapacity(len(src), extra))
+	copy(dst, src)
+	return dst
 }
 
 // Rows returns all overlay vector rows, including tombstoned superseded rows.

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -336,8 +336,8 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("update-001"), Vector: vector},
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-001")},
 	}
-	appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
-	next := overlay.clone(overlay.generation+1, appendRows, appendIDBytes, appendTombstones)
+	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
+	next := overlay.clone(overlay.generation+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
 	if spare := cap(next.vectors) - len(next.vectors); spare < appendRows*next.dims {
 		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendRows*next.dims)
 	}
@@ -356,6 +356,9 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 	if spare := cap(next.tombstoneDocIDs) - len(next.tombstoneDocIDs); spare < appendTombstones {
 		t.Fatalf("tombstone spare capacity=%d want at least %d", spare, appendTombstones)
 	}
+	if spare := cap(next.tombstoneArena) - len(next.tombstoneArena); spare < appendTombstoneIDBytes {
+		t.Fatalf("tombstone arena spare capacity=%d want at least %d", spare, appendTombstoneIDBytes)
+	}
 
 	vectorBacking := &next.vectors[0]
 	invNormBacking := &next.invNorms[0]
@@ -363,6 +366,7 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 	idOffsetsBacking := &next.idOffsets[0]
 	liveBacking := &next.live[0]
 	tombstoneBacking := &next.tombstoneDocIDs[0]
+	tombstoneArenaCap := cap(next.tombstoneArena)
 	if err := next.appendLiveDocument([]byte("insert-001"), vector); err != nil {
 		t.Fatalf("append insert: %v", err)
 	}
@@ -388,6 +392,9 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 	}
 	if &next.tombstoneDocIDs[0] != tombstoneBacking {
 		t.Fatal("tombstone append reallocated despite clone capacity")
+	}
+	if cap(next.tombstoneArena) != tombstoneArenaCap {
+		t.Fatal("tombstone arena append reallocated despite clone capacity")
 	}
 }
 
@@ -456,7 +463,7 @@ func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
 				{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("publish-update-000000001"), Vector: updateVector},
 				{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("publish-delete-000000001")},
 			}
-			appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
+			appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
 			b.ReportAllocs()
 			b.ReportMetric(float64(tc.rows), "overlay_rows")
 			b.ReportMetric(float64(tc.tombstones), "overlay_tombstones")
@@ -464,7 +471,7 @@ func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
 			b.ReportMetric(float64(appendTombstones), "append_tombstones/op")
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				next := overlay.clone(uint64(i+1), appendRows, appendIDBytes, appendTombstones)
+				next := overlay.clone(uint64(i+1), appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
 				if err := next.appendLiveDocument(mutations[0].DocumentID, mutations[0].Vector); err != nil {
 					b.Fatalf("append insert: %v", err)
 				}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -336,7 +336,11 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("update-001"), Vector: vector},
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-001")},
 	}
-	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
+	baseDocIndex := map[string]int{
+		"update-001": 1,
+		"base-001":   2,
+	}
+	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
 	next := overlay.clone(overlay.generation+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
 	if spare := cap(next.vectors) - len(next.vectors); spare < appendRows*next.dims {
 		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendRows*next.dims)
@@ -395,6 +399,30 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 	}
 	if cap(next.tombstoneArena) != tombstoneArenaCap {
 		t.Fatal("tombstone arena append reallocated despite clone capacity")
+	}
+}
+
+func TestColumnVectorDynamicMutationAppendCapacitySkipsOverlayOnlyTombstones(t *testing.T) {
+	overlay := newColumnVectorDynamicOverlaySnapshot(4)
+	vector := []float32{1, 0, 0, 0}
+	if err := overlay.appendLiveDocument([]byte("overlay-update"), vector); err != nil {
+		t.Fatalf("append overlay-update: %v", err)
+	}
+	if err := overlay.appendLiveDocument([]byte("overlay-delete"), vector); err != nil {
+		t.Fatalf("append overlay-delete: %v", err)
+	}
+	baseDocIndex := map[string]int{"base-live": 0}
+	mutations := []ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("overlay-update"), Vector: vector},
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("overlay-delete")},
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-live")},
+	}
+	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
+	if appendRows != 1 || appendIDBytes != len("overlay-update") {
+		t.Fatalf("append rows=%d idBytes=%d, want one overlay replacement", appendRows, appendIDBytes)
+	}
+	if appendTombstones != 1 || appendTombstoneIDBytes != len("base-live") {
+		t.Fatalf("tombstone capacity count=%d bytes=%d, want only base-live", appendTombstones, appendTombstoneIDBytes)
 	}
 }
 
@@ -463,7 +491,11 @@ func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
 				{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("publish-update-000000001"), Vector: updateVector},
 				{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("publish-delete-000000001")},
 			}
-			appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations)
+			baseDocIndex := map[string]int{
+				"publish-update-000000001": 1,
+				"publish-delete-000000001": 2,
+			}
+			appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
 			b.ReportAllocs()
 			b.ReportMetric(float64(tc.rows), "overlay_rows")
 			b.ReportMetric(float64(tc.tombstones), "overlay_tombstones")

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -340,10 +340,11 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 		"update-001": 1,
 		"base-001":   2,
 	}
-	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+	mutationPlan, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
 	if err != nil {
 		t.Fatalf("mutation append capacity: %v", err)
 	}
+	appendCapacity := mutationPlan.appendCapacity
 	next := overlay.clone(overlay.generation+1, appendCapacity)
 	if spare := cap(next.vectors) - len(next.vectors); spare < appendCapacity.rows*next.dims {
 		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendCapacity.rows*next.dims)
@@ -420,10 +421,11 @@ func TestColumnVectorDynamicMutationAppendCapacitySkipsOverlayOnlyTombstones(t *
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("overlay-delete")},
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-live")},
 	}
-	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+	mutationPlan, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
 	if err != nil {
 		t.Fatalf("mutation append capacity: %v", err)
 	}
+	appendCapacity := mutationPlan.appendCapacity
 	if appendCapacity.rows != 1 || appendCapacity.idBytes != len("overlay-update") {
 		t.Fatalf("append rows=%d idBytes=%d, want one overlay replacement", appendCapacity.rows, appendCapacity.idBytes)
 	}
@@ -440,10 +442,11 @@ func TestColumnVectorDynamicMutationAppendCapacityValidatesSequentialBatch(t *te
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-live")},
 		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("base-live"), Vector: vector},
 	}
-	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(validResurrection, baseDocIndex, overlay, overlay.dims)
+	mutationPlan, err := columnVectorDynamicValidateMutationAppendCapacity(validResurrection, baseDocIndex, overlay, overlay.dims)
 	if err != nil {
 		t.Fatalf("valid delete+insert capacity: %v", err)
 	}
+	appendCapacity := mutationPlan.appendCapacity
 	if appendCapacity.rows != 1 || appendCapacity.tombstones != 1 {
 		t.Fatalf("capacity after delete+insert rows=%d tombstones=%d, want 1/1", appendCapacity.rows, appendCapacity.tombstones)
 	}
@@ -526,10 +529,11 @@ func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
 				"publish-update-000000001": 1,
 				"publish-delete-000000001": 2,
 			}
-			appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+			mutationPlan, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
 			if err != nil {
 				b.Fatalf("mutation append capacity: %v", err)
 			}
+			appendCapacity := mutationPlan.appendCapacity
 			b.ReportAllocs()
 			b.ReportMetric(float64(tc.rows), "overlay_rows")
 			b.ReportMetric(float64(tc.tombstones), "overlay_tombstones")

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -340,28 +340,31 @@ func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
 		"update-001": 1,
 		"base-001":   2,
 	}
-	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
-	next := overlay.clone(overlay.generation+1, appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
-	if spare := cap(next.vectors) - len(next.vectors); spare < appendRows*next.dims {
-		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendRows*next.dims)
+	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+	if err != nil {
+		t.Fatalf("mutation append capacity: %v", err)
 	}
-	if spare := cap(next.invNorms) - len(next.invNorms); spare < appendRows {
-		t.Fatalf("inv-norm spare capacity=%d want at least %d", spare, appendRows)
+	next := overlay.clone(overlay.generation+1, appendCapacity)
+	if spare := cap(next.vectors) - len(next.vectors); spare < appendCapacity.rows*next.dims {
+		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendCapacity.rows*next.dims)
 	}
-	if spare := cap(next.idArena) - len(next.idArena); spare < appendIDBytes {
-		t.Fatalf("id arena spare capacity=%d want at least %d", spare, appendIDBytes)
+	if spare := cap(next.invNorms) - len(next.invNorms); spare < appendCapacity.rows {
+		t.Fatalf("inv-norm spare capacity=%d want at least %d", spare, appendCapacity.rows)
 	}
-	if spare := cap(next.idOffsets) - len(next.idOffsets); spare < appendRows {
-		t.Fatalf("id offset spare capacity=%d want at least %d", spare, appendRows)
+	if spare := cap(next.idArena) - len(next.idArena); spare < appendCapacity.idBytes {
+		t.Fatalf("id arena spare capacity=%d want at least %d", spare, appendCapacity.idBytes)
 	}
-	if spare := cap(next.live) - len(next.live); spare < appendRows {
-		t.Fatalf("live spare capacity=%d want at least %d", spare, appendRows)
+	if spare := cap(next.idOffsets) - len(next.idOffsets); spare < appendCapacity.rows {
+		t.Fatalf("id offset spare capacity=%d want at least %d", spare, appendCapacity.rows)
 	}
-	if spare := cap(next.tombstoneDocIDs) - len(next.tombstoneDocIDs); spare < appendTombstones {
-		t.Fatalf("tombstone spare capacity=%d want at least %d", spare, appendTombstones)
+	if spare := cap(next.live) - len(next.live); spare < appendCapacity.rows {
+		t.Fatalf("live spare capacity=%d want at least %d", spare, appendCapacity.rows)
 	}
-	if spare := cap(next.tombstoneArena) - len(next.tombstoneArena); spare < appendTombstoneIDBytes {
-		t.Fatalf("tombstone arena spare capacity=%d want at least %d", spare, appendTombstoneIDBytes)
+	if spare := cap(next.tombstoneDocIDs) - len(next.tombstoneDocIDs); spare < appendCapacity.tombstones {
+		t.Fatalf("tombstone spare capacity=%d want at least %d", spare, appendCapacity.tombstones)
+	}
+	if spare := cap(next.tombstoneArena) - len(next.tombstoneArena); spare < appendCapacity.tombstoneIDBytes {
+		t.Fatalf("tombstone arena spare capacity=%d want at least %d", spare, appendCapacity.tombstoneIDBytes)
 	}
 
 	vectorBacking := &next.vectors[0]
@@ -417,12 +420,40 @@ func TestColumnVectorDynamicMutationAppendCapacitySkipsOverlayOnlyTombstones(t *
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("overlay-delete")},
 		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-live")},
 	}
-	appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
-	if appendRows != 1 || appendIDBytes != len("overlay-update") {
-		t.Fatalf("append rows=%d idBytes=%d, want one overlay replacement", appendRows, appendIDBytes)
+	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+	if err != nil {
+		t.Fatalf("mutation append capacity: %v", err)
 	}
-	if appendTombstones != 1 || appendTombstoneIDBytes != len("base-live") {
-		t.Fatalf("tombstone capacity count=%d bytes=%d, want only base-live", appendTombstones, appendTombstoneIDBytes)
+	if appendCapacity.rows != 1 || appendCapacity.idBytes != len("overlay-update") {
+		t.Fatalf("append rows=%d idBytes=%d, want one overlay replacement", appendCapacity.rows, appendCapacity.idBytes)
+	}
+	if appendCapacity.tombstones != 1 || appendCapacity.tombstoneIDBytes != len("base-live") {
+		t.Fatalf("tombstone capacity count=%d bytes=%d, want only base-live", appendCapacity.tombstones, appendCapacity.tombstoneIDBytes)
+	}
+}
+
+func TestColumnVectorDynamicMutationAppendCapacityValidatesSequentialBatch(t *testing.T) {
+	overlay := newColumnVectorDynamicOverlaySnapshot(4)
+	vector := []float32{1, 0, 0, 0}
+	baseDocIndex := map[string]int{"base-live": 0}
+	validResurrection := []ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-live")},
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("base-live"), Vector: vector},
+	}
+	appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(validResurrection, baseDocIndex, overlay, overlay.dims)
+	if err != nil {
+		t.Fatalf("valid delete+insert capacity: %v", err)
+	}
+	if appendCapacity.rows != 1 || appendCapacity.tombstones != 1 {
+		t.Fatalf("capacity after delete+insert rows=%d tombstones=%d, want 1/1", appendCapacity.rows, appendCapacity.tombstones)
+	}
+
+	duplicateInsert := []ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("dyn-dup"), Vector: vector},
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("dyn-dup"), Vector: vector},
+	}
+	if _, err := columnVectorDynamicValidateMutationAppendCapacity(duplicateInsert, baseDocIndex, overlay, overlay.dims); err == nil {
+		t.Fatal("duplicate insert validation succeeded")
 	}
 }
 
@@ -495,15 +526,18 @@ func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
 				"publish-update-000000001": 1,
 				"publish-delete-000000001": 2,
 			}
-			appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes := columnVectorDynamicMutationAppendCapacity(mutations, baseDocIndex, overlay)
+			appendCapacity, err := columnVectorDynamicValidateMutationAppendCapacity(mutations, baseDocIndex, overlay, overlay.dims)
+			if err != nil {
+				b.Fatalf("mutation append capacity: %v", err)
+			}
 			b.ReportAllocs()
 			b.ReportMetric(float64(tc.rows), "overlay_rows")
 			b.ReportMetric(float64(tc.tombstones), "overlay_tombstones")
-			b.ReportMetric(float64(appendRows), "append_rows/op")
-			b.ReportMetric(float64(appendTombstones), "append_tombstones/op")
+			b.ReportMetric(float64(appendCapacity.rows), "append_rows/op")
+			b.ReportMetric(float64(appendCapacity.tombstones), "append_tombstones/op")
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				next := overlay.clone(uint64(i+1), appendRows, appendIDBytes, appendTombstones, appendTombstoneIDBytes)
+				next := overlay.clone(uint64(i+1), appendCapacity)
 				if err := next.appendLiveDocument(mutations[0].DocumentID, mutations[0].Vector); err != nil {
 					b.Fatalf("append insert: %v", err)
 				}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -320,6 +320,77 @@ func TestColumnVectorDynamicGraphConcurrentReadersAndWriter(t *testing.T) {
 	}
 }
 
+func TestColumnVectorDynamicOverlayClonePreallocatesBatchAppend(t *testing.T) {
+	overlay := newColumnVectorDynamicOverlaySnapshot(4)
+	vector := []float32{1, 0, 0, 0}
+	for i := 0; i < 4; i++ {
+		if err := overlay.appendLiveDocument([]byte(fmt.Sprintf("seed-%03d", i)), vector); err != nil {
+			t.Fatalf("append seed %d: %v", i, err)
+		}
+	}
+	overlay.addTombstone([]byte("base-000"))
+	overlay.sortAndDedupeTombstones()
+
+	mutations := []ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("insert-001"), Vector: vector},
+		{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("update-001"), Vector: vector},
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("base-001")},
+	}
+	appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
+	next := overlay.clone(overlay.generation+1, appendRows, appendIDBytes, appendTombstones)
+	if spare := cap(next.vectors) - len(next.vectors); spare < appendRows*next.dims {
+		t.Fatalf("vector spare capacity=%d want at least %d", spare, appendRows*next.dims)
+	}
+	if spare := cap(next.invNorms) - len(next.invNorms); spare < appendRows {
+		t.Fatalf("inv-norm spare capacity=%d want at least %d", spare, appendRows)
+	}
+	if spare := cap(next.idArena) - len(next.idArena); spare < appendIDBytes {
+		t.Fatalf("id arena spare capacity=%d want at least %d", spare, appendIDBytes)
+	}
+	if spare := cap(next.idOffsets) - len(next.idOffsets); spare < appendRows {
+		t.Fatalf("id offset spare capacity=%d want at least %d", spare, appendRows)
+	}
+	if spare := cap(next.live) - len(next.live); spare < appendRows {
+		t.Fatalf("live spare capacity=%d want at least %d", spare, appendRows)
+	}
+	if spare := cap(next.tombstoneDocIDs) - len(next.tombstoneDocIDs); spare < appendTombstones {
+		t.Fatalf("tombstone spare capacity=%d want at least %d", spare, appendTombstones)
+	}
+
+	vectorBacking := &next.vectors[0]
+	invNormBacking := &next.invNorms[0]
+	idArenaBacking := &next.idArena[0]
+	idOffsetsBacking := &next.idOffsets[0]
+	liveBacking := &next.live[0]
+	tombstoneBacking := &next.tombstoneDocIDs[0]
+	if err := next.appendLiveDocument([]byte("insert-001"), vector); err != nil {
+		t.Fatalf("append insert: %v", err)
+	}
+	if err := next.appendLiveDocument([]byte("update-001"), vector); err != nil {
+		t.Fatalf("append update: %v", err)
+	}
+	next.addTombstone([]byte("base-001"))
+	next.addTombstone([]byte("base-002"))
+	if &next.vectors[0] != vectorBacking {
+		t.Fatal("vector append reallocated despite clone capacity")
+	}
+	if &next.invNorms[0] != invNormBacking {
+		t.Fatal("inverse-norm append reallocated despite clone capacity")
+	}
+	if &next.idArena[0] != idArenaBacking {
+		t.Fatal("document ID arena append reallocated despite clone capacity")
+	}
+	if &next.idOffsets[0] != idOffsetsBacking {
+		t.Fatal("document ID offset append reallocated despite clone capacity")
+	}
+	if &next.live[0] != liveBacking {
+		t.Fatal("live-row append reallocated despite clone capacity")
+	}
+	if &next.tombstoneDocIDs[0] != tombstoneBacking {
+		t.Fatal("tombstone append reallocated despite clone capacity")
+	}
+}
+
 func BenchmarkColumnVectorDynamicGraphSearchCosineScale(b *testing.B) {
 	cases := []struct {
 		name   string
@@ -346,6 +417,65 @@ func BenchmarkColumnVectorDynamicGraphSearchCosineScale(b *testing.B) {
 				graph := openColumnVectorDynamicGraphBenchmark(b, base, query, 256)
 				benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b, graph, query, opts, tc.rows, tc.dims)
 			})
+		})
+	}
+}
+
+func BenchmarkColumnVectorDynamicOverlayPublishCloneAppend(b *testing.B) {
+	cases := []struct {
+		name       string
+		rows       int
+		tombstones int
+		dims       int
+	}{
+		{name: "overlay_256_tombstones_0_dims_128", rows: 256, tombstones: 0, dims: 128},
+		{name: "overlay_8192_tombstones_4096_dims_128", rows: 8192, tombstones: 4096, dims: 128},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			overlay := newColumnVectorDynamicOverlaySnapshot(tc.dims)
+			vector := make([]float32, tc.dims)
+			for i := 0; i < tc.rows; i++ {
+				fillVectorBenchmarkEmbedding(vector, 1_000_000+i)
+				if err := overlay.appendLiveDocument([]byte(fmt.Sprintf("seed-%09d", i)), vector); err != nil {
+					b.Fatalf("seed append %d: %v", i, err)
+				}
+			}
+			for i := 0; i < tc.tombstones; i++ {
+				overlay.addTombstone(columnVectorDynamicScaleDocumentID(i))
+			}
+			overlay.sortAndDedupeTombstones()
+
+			insertVector := make([]float32, tc.dims)
+			updateVector := make([]float32, tc.dims)
+			fillVectorBenchmarkEmbedding(insertVector, 2_000_000)
+			fillVectorBenchmarkEmbedding(updateVector, 3_000_000)
+			mutations := []ColumnVectorDynamicMutation{
+				{Kind: ColumnVectorDynamicMutationInsert, DocumentID: []byte("publish-insert-000000001"), Vector: insertVector},
+				{Kind: ColumnVectorDynamicMutationUpdate, DocumentID: []byte("publish-update-000000001"), Vector: updateVector},
+				{Kind: ColumnVectorDynamicMutationDelete, DocumentID: []byte("publish-delete-000000001")},
+			}
+			appendRows, appendIDBytes, appendTombstones := columnVectorDynamicMutationAppendCapacity(mutations)
+			b.ReportAllocs()
+			b.ReportMetric(float64(tc.rows), "overlay_rows")
+			b.ReportMetric(float64(tc.tombstones), "overlay_tombstones")
+			b.ReportMetric(float64(appendRows), "append_rows/op")
+			b.ReportMetric(float64(appendTombstones), "append_tombstones/op")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				next := overlay.clone(uint64(i+1), appendRows, appendIDBytes, appendTombstones)
+				if err := next.appendLiveDocument(mutations[0].DocumentID, mutations[0].Vector); err != nil {
+					b.Fatalf("append insert: %v", err)
+				}
+				if err := next.appendLiveDocument(mutations[1].DocumentID, mutations[1].Vector); err != nil {
+					b.Fatalf("append update: %v", err)
+				}
+				next.addTombstone(mutations[1].DocumentID)
+				next.addTombstone(mutations[2].DocumentID)
+				next.sortAndDedupeTombstones()
+				columnVectorGraphBenchSink += int64(next.Rows() + next.LiveRows() + next.Tombstones() + cap(next.vectors))
+			}
 		})
 	}
 }

--- a/docs/benchmarks/column_vector_dynamic_overlay.md
+++ b/docs/benchmarks/column_vector_dynamic_overlay.md
@@ -64,7 +64,7 @@ Local M11 follow-up evidence:
 
 ```sh
 GOWORK=off go test ./TreeDB/collections \
-  -run 'TestColumnVectorDynamicGraph|TestColumnVectorDynamicOverlay|TestColumnVectorGraph' \
+  -run 'TestColumnVectorDynamic(Graph|Overlay|Mutation)|TestColumnVectorGraph' \
   -count=1
 
 GOWORK=off go test -race ./TreeDB/collections \
@@ -95,15 +95,15 @@ GOWORK=off go test ./TreeDB/collections \
 
 Latest #1615 Apple M3 smoke results:
 
-- 100k read-only: `13030-13194 ns/op`, `75792-76744 read_qps`,
+- 100k read-only: `12977-13429 ns/op`, `74463-77061 read_qps`,
   `1064 total_candidates/search`, `5600 edges/search`, `0 B/op`,
   `0 allocs/op`.
-- 100k read-write: `337121-456932 ns/op`, `2189-2966 read_qps`,
-  `18306 total_candidates/search`, `708812-760204 publish_ns/op`,
-  `1563561-2630119 B/op`, `18-26 allocs/op`.
-- Isolated publish clone+append: `15529-16244 ns/op`, `160265-160266 B/op`,
-  and `18 allocs/op` for the 256-row overlay shape; `474182-481100 ns/op`,
-  `5179013-5179014 B/op`, and `64 allocs/op` for the
+- 100k read-write: `332162-451084 ns/op`, `2217-3011 read_qps`,
+  `18306 total_candidates/search`, `654288-768199 publish_ns/op`,
+  `1598732-2268984 B/op`, `18-23 allocs/op`.
+- Isolated publish clone+append: `15563-16056 ns/op`, `160265-160266 B/op`,
+  and `18 allocs/op` for the 256-row overlay shape; `491165-499048 ns/op`,
+  `5179011-5179014 B/op`, and `64 allocs/op` for the
   8192-row/4096-tombstone shape.
 
 Earlier 1M scale smoke from the same dynamic-overlay track:

--- a/docs/benchmarks/column_vector_dynamic_overlay.md
+++ b/docs/benchmarks/column_vector_dynamic_overlay.md
@@ -93,23 +93,27 @@ GOWORK=off go test ./TreeDB/collections \
   -count=1
 ```
 
-Current Apple M3 smoke results:
+Latest #1615 Apple M3 smoke results:
 
-- 100k read-only: `7834-7879 ns/op`, `126928-127646 read_qps`,
-  `571 total_candidates/search`, `2128 edges/search`, `0 B/op`,
+- 100k read-only: `13030-13194 ns/op`, `75792-76744 read_qps`,
+  `1064 total_candidates/search`, `5600 edges/search`, `0 B/op`,
   `0 allocs/op`.
-- 100k read-write: `51727-145113 ns/op`, `6891-19332 read_qps`,
-  `6662-10547 total_candidates/search`, `253864-433061 publish_ns/op`,
-  `269551-784993 B/op`, `4-10 allocs/op`.
+- 100k read-write: `337121-456932 ns/op`, `2189-2966 read_qps`,
+  `18306 total_candidates/search`, `708812-760204 publish_ns/op`,
+  `1563561-2630119 B/op`, `18-26 allocs/op`.
+- Isolated publish clone+append: `15529-16244 ns/op`, `160265-160266 B/op`,
+  and `18 allocs/op` for the 256-row overlay shape; `474182-481100 ns/op`,
+  `5179013-5179014 B/op`, and `64 allocs/op` for the
+  8192-row/4096-tombstone shape.
+
+Earlier 1M scale smoke from the same dynamic-overlay track:
+
 - 1M read-only: `8850 ns/op`, `112996 read_qps`,
   `695 total_candidates/search`, `2688 edges/search`, `0 B/op`,
   `0 allocs/op`.
 - 1M read-write: `127760 ns/op`, `7827 read_qps`,
   `8902 total_candidates/search`, `400424 publish_ns/op`, `711480 B/op`,
   `9 allocs/op`.
-- Isolated publish clone+append: `160265 B/op` and `18 allocs/op` for the
-  256-row overlay shape; `5179012-5179020 B/op` and `64 allocs/op` for the
-  8192-row/4096-tombstone shape.
 
 Interpretation: warmed read-only search stays allocation-free at 100k and 1M
 because all mutable state is worker-local scratch. Read-write benchmark

--- a/docs/benchmarks/column_vector_dynamic_overlay.md
+++ b/docs/benchmarks/column_vector_dynamic_overlay.md
@@ -138,7 +138,7 @@ Focused validation:
 
 ```sh
 GOWORK=off go test ./TreeDB/collections \
-  -run 'TestColumnVectorDynamicGraph|TestColumnVectorGraph' \
+  -run 'TestColumnVectorDynamic(Graph|Overlay|Mutation)|TestColumnVectorGraph' \
   -count=1
 
 GOWORK=off go test -race ./TreeDB/collections \

--- a/docs/benchmarks/column_vector_dynamic_overlay.md
+++ b/docs/benchmarks/column_vector_dynamic_overlay.md
@@ -60,6 +60,65 @@ Reported metrics separate the major costs:
 - `base_payload_bytes` and `overlay_payload_bytes` approximate the in-memory
   payload footprint.
 
+Local M11 follow-up evidence:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run 'TestColumnVectorDynamicGraph|TestColumnVectorDynamicOverlay|TestColumnVectorGraph' \
+  -count=1
+
+GOWORK=off go test -race ./TreeDB/collections \
+  -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay' \
+  -count=1
+
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkColumnVectorDynamicOverlayPublishCloneAppend' \
+  -benchmem \
+  -benchtime=300ms \
+  -count=5
+
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_(only|write)$' \
+  -benchmem \
+  -benchtime=300ms \
+  -count=3
+
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/parallel_read_(only|write)$' \
+  -benchmem \
+  -benchtime=100ms \
+  -count=1
+```
+
+Current Apple M3 smoke results:
+
+- 100k read-only: `7834-7879 ns/op`, `126928-127646 read_qps`,
+  `571 total_candidates/search`, `2128 edges/search`, `0 B/op`,
+  `0 allocs/op`.
+- 100k read-write: `51727-145113 ns/op`, `6891-19332 read_qps`,
+  `6662-10547 total_candidates/search`, `253864-433061 publish_ns/op`,
+  `269551-784993 B/op`, `4-10 allocs/op`.
+- 1M read-only: `8850 ns/op`, `112996 read_qps`,
+  `695 total_candidates/search`, `2688 edges/search`, `0 B/op`,
+  `0 allocs/op`.
+- 1M read-write: `127760 ns/op`, `7827 read_qps`,
+  `8902 total_candidates/search`, `400424 publish_ns/op`, `711480 B/op`,
+  `9 allocs/op`.
+- Isolated publish clone+append: `160265 B/op` and `18 allocs/op` for the
+  256-row overlay shape; `5179012-5179020 B/op` and `64 allocs/op` for the
+  8192-row/4096-tombstone shape.
+
+Interpretation: warmed read-only search stays allocation-free at 100k and 1M
+because all mutable state is worker-local scratch. Read-write benchmark
+allocations are writer-side copy-on-write publish and overlay growth costs, not
+full-document fetches or shared reader scratch. The largest read amplification
+comes from exact overlay scans plus base over-fetch to compensate tombstoned
+base documents; those counters are the trigger for sealing mini-graphs or
+rebuilding a compacted base generation.
+
 Sealing and rebuild model:
 
 - Start with exact-scan overlay while deltas are small.


### PR DESCRIPTION
## Summary

Adds a focused follow-up to the dynamic column-vector overlay benchmark track:

- preallocates copy-on-write overlay clone capacity for the current mutation batch
- validates mutation batches before cloning so rejected batches do not reserve large vector/ID/tombstone buffers
- replaces positional clone capacity hints with a named append-capacity struct
- arena-packs newly appended base tombstone document IDs instead of allocating one cloned byte slice per tombstone
- avoids reserving tombstone arena bytes for overlay-only update/delete batches that do not publish base tombstones
- carries prevalidated vector inverse norms through ApplyBatch so inserts/updates do not rescan vectors while holding the writer lock
- adds focused clone+append benchmark and preallocation/regression guards
- records current 100k dynamic overlay benchmark evidence and labels earlier 1M scale smoke separately
- aligns the benchmark doc's focused validation regex with the dynamic graph, overlay, and mutation test prefixes

This PR is intentionally stacked on #1612 (`codex/column-vector-dynamic-overlay-bench`) so the diff stays limited to dynamic overlay publish-allocation work. It does not merge anything.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorDynamic(Graph|Overlay|Mutation)|TestColumnVectorGraph' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.512s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.522s

GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicOverlayPublishCloneAppend|BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_(only|write)$' -benchmem -benchtime=300ms -count=3
```

Focused tests and race validation above were rerun on current head `7fe6891c`. The benchmark numbers below were captured on `41dcc85e4`; `7fe6891c` is a docs-only validation-regex alignment, so the benchmarked code is unchanged.

```text
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_only-8   12977-13429 ns/op  74463-77061 read_qps  1064 total_candidates/search  5600 edges/search  0 B/op        0 allocs/op
BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_write-8 332162-451084 ns/op 2217-3011 read_qps   18306 total_candidates/search 654288-768199 publish_ns/op 1598732-2268984 B/op 18-23 allocs/op
BenchmarkColumnVectorDynamicOverlayPublishCloneAppend/overlay_256_tombstones_0_dims_128-8              15563-16056 ns/op  160265-160266 B/op   18 allocs/op
BenchmarkColumnVectorDynamicOverlayPublishCloneAppend/overlay_8192_tombstones_4096_dims_128-8          491165-499048 ns/op 5179011-5179014 B/op 64 allocs/op
```

The read-only path remains allocation-free with warmed worker-local scratch. Read-write `B/op` and `allocs/op` intentionally include writer copy-on-write publish cost and overlay growth, not document fetches or shared reader scratch.

## Review cleanup

- Addressed and resolved the Codex thread about overlay-only update/delete batches preallocating unused tombstone arena bytes.
- Addressed and resolved Copilot threads by validating before clone preallocation, replacing positional clone capacity hints with a struct, and reconciling the PR/docs benchmark evidence.
- Addressed the latest Copilot threads by including `TestColumnVectorDynamicMutation...` in the documented validation regex and reusing validation-computed inverse norms instead of rescanning insert/update vectors during ApplyBatch.
- Accepted Copilot's docs-only follow-up `7fe6891c`, which aligns the remaining focused-validation command in the benchmark doc.
- Re-requested Codex and Copilot review on current head `7fe6891c`.

Do not merge yet.
