### PR TITLE
TreeDB/collections: trim dynamic base top-k overfetch

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -268,7 +268,7 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	}
 
 	baseOpts := opts
-	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.LiveRows(), overlay.Tombstones())
+	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.Tombstones())
 	if baseOpts.EfSearch < baseOpts.TopK {
 		baseOpts.EfSearch = baseOpts.TopK
 	}
@@ -361,7 +361,7 @@ func columnVectorDynamicPublishStats(snapshot *ColumnVectorDynamicGraphSnapshot,
 	return stats
 }
 
-func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, tombstones int) int {
+func columnVectorDynamicBaseTopK(baseRows int, topK int, tombstones int) int {
 	if topK <= 0 || baseRows <= 0 {
 		return 0
 	}
@@ -369,10 +369,6 @@ func columnVectorDynamicBaseTopK(baseRows int, topK int, overlayLiveRows int, to
 		return baseRows
 	}
 	baseTopK := topK
-	if overlayLiveRows > baseRows-baseTopK {
-		return baseRows
-	}
-	baseTopK += overlayLiveRows
 	if tombstones > baseRows-baseTopK {
 		return baseRows
 	}

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -199,6 +199,73 @@ func TestColumnVectorDynamicGraphSameBatchDeleteInsertUsesWriterTombstones(t *te
 	}
 }
 
+func TestColumnVectorDynamicGraphBaseSearchDoesNotOverfetchForOverlayOnlyRows(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(1024, 32, 16, false))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	mutations := make([]ColumnVectorDynamicMutation, 0, 512)
+	for i := 0; i < cap(mutations); i++ {
+		mutations = append(mutations, ColumnVectorDynamicMutation{
+			Kind:       ColumnVectorDynamicMutationInsert,
+			DocumentID: []byte(fmt.Sprintf("dyn-overlay-%03d", i)),
+			Vector:     vectorBenchmarkEmbedding(100_000+i, base.Dims()),
+		})
+	}
+	if _, err := graph.ApplyBatch(mutations); err != nil {
+		t.Fatalf("ApplyBatch overlay rows: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 257)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+	results, trace, err := graph.SearchCosine(query, opts, &ColumnVectorDynamicGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) != opts.TopK {
+		t.Fatalf("results=%d want %d", len(results), opts.TopK)
+	}
+	if trace.BaseTrace.TopK != opts.TopK {
+		t.Fatalf("base topK=%d want query topK=%d without overlay live-row overfetch", trace.BaseTrace.TopK, opts.TopK)
+	}
+	if trace.BaseTrace.EfSearch != opts.EfSearch {
+		t.Fatalf("base efSearch=%d want query efSearch=%d", trace.BaseTrace.EfSearch, opts.EfSearch)
+	}
+	if trace.OverlayScanned != len(mutations) {
+		t.Fatalf("overlay scanned=%d want %d", trace.OverlayScanned, len(mutations))
+	}
+}
+
+func TestColumnVectorDynamicBaseTopKBoundsTombstoneOverfetch(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseRows   int
+		topK       int
+		tombstones int
+		want       int
+	}{
+		{name: "empty", baseRows: 0, topK: 10, tombstones: 100, want: 0},
+		{name: "topk", baseRows: 1000, topK: 10, tombstones: 0, want: 10},
+		{name: "tombstones", baseRows: 1000, topK: 10, tombstones: 7, want: 17},
+		{name: "cap", baseRows: 1000, topK: 10, tombstones: 2000, want: 1000},
+		{name: "topk exceeds base", baseRows: 8, topK: 10, tombstones: 0, want: 8},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := columnVectorDynamicBaseTopK(tc.baseRows, tc.topK, tc.tombstones); got != tc.want {
+				t.Fatalf("columnVectorDynamicBaseTopK(%d, %d, %d)=%d want %d", tc.baseRows, tc.topK, tc.tombstones, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestColumnVectorDynamicGraphSearchAllocs(t *testing.T) {
 	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(1024, 64, 16, false))
 	if err != nil {


### PR DESCRIPTION
## Summary

Trim dynamic `ColumnVectorDynamicGraph` base search over-fetch so live overlay rows no longer inflate base ANN `TopK`. Overlay candidates are searched independently and merged with base candidates, so overlay live rows do not require additional base candidates; only tombstoned base documents still require conservative base over-fetch.

This keeps the read path allocation-free and adds focused coverage that overlay-only rows do not raise base `TopK`/`EfSearch`, plus unit coverage for tombstone over-fetch bounds.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorDynamic(Graph|Overlay|Mutation|BaseTopK)|TestColumnVectorGraph' -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay|TestColumnVectorDynamicGraphBaseSearchDoesNotOverfetchForOverlayOnlyRows' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_(only|write)$' -benchmem -benchtime=700ms -count=6`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/parallel_read_only$' -benchmem -benchtime=300ms -count=1`

## Benchmark evidence

100k base, 128 dims, degree 16, `TopK=10`, `EfSearch=128`, compared against #1615 head before this change:

- `parallel_read_only`: `13.360µs ± 2%` -> `7.971µs ± 4%` (`-40.33%`, p=0.002); read QPS `74.85k` -> `125.44k`; base candidates/search `808` -> `315`; edges/search `5600` -> `2128`; total candidates/search `1064` -> `571`; still `0 B/op`, `0 allocs/op`.
- `parallel_read_write`: `494.3µs ± 44%` -> `128.4µs ± 84%` (`-74.02%`, p=0.002); read QPS `2.040k` -> `8.001k`; base candidates/search `13.826k` -> `5.436k`; edges/search `140.48k` -> `51.61k`; `2264.4 KiB/op` -> `609.4 KiB/op`; `23.5 allocs/op` -> `9.0 allocs/op`.

1M read-only smoke:

- Before: `12.325µs/op`, `81,136 read_qps`, `628 base_candidates/search`, `4576 edges/search`, `884 total_candidates/search`, `0 B/op`, `0 allocs/op`.
- After: `9.013µs/op`, `110,950 read_qps`, `439 base_candidates/search`, `2688 edges/search`, `695 total_candidates/search`, `0 B/op`, `0 allocs/op`.

Read-write benchmark note: the writer runs concurrently until the fixed read iteration count completes, so faster readers shorten elapsed writer time and reduce final overlay size in the sampled run. The direct read-path counters still show the intended reduction in base candidates and graph edges visited.