### PR TITLE
TreeDB/collections: adapt dynamic base tombstone overfetch

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -273,8 +273,12 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	if baseTopK > baseMaxTopK {
 		baseTopK = baseMaxTopK
 	}
+	if cap(scratch.results) < opts.TopK {
+		scratch.results = make([]VectorSearchResult, 0, opts.TopK)
+	}
 	var baseResults []VectorSearchResult
 	var baseTrace ColumnVectorGraphSearchTrace
+	filteredBaseResults := scratch.results[:0]
 	totalBaseCandidatesExamined := 0
 	totalBaseEdgesVisited := 0
 	// Tombstones are usually sparse in the base result prefix. Start at the user
@@ -292,7 +296,8 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 		trace.BaseSearches++
 		totalBaseCandidatesExamined += baseTrace.CandidatesExamined
 		totalBaseEdgesVisited += baseTrace.EdgesVisited
-		baseReturned, baseTombstoned := columnVectorDynamicCountBaseResults(baseResults, overlay)
+		var baseReturned, baseTombstoned int
+		filteredBaseResults, baseReturned, baseTombstoned = columnVectorDynamicFilterBaseResults(filteredBaseResults, baseResults, overlay, opts.TopK)
 		if baseReturned >= opts.TopK || baseTopK >= baseMaxTopK {
 			trace.BaseReturned = baseReturned
 			trace.BaseTombstoned = baseTombstoned
@@ -316,16 +321,7 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	trace.BaseTrace = baseTrace
 	trace.EdgesVisited = totalBaseEdgesVisited
 
-	if cap(scratch.results) < opts.TopK {
-		scratch.results = make([]VectorSearchResult, 0, opts.TopK)
-	}
-	results := scratch.results[:0]
-	for _, result := range baseResults {
-		if overlay.DocumentTombstoned(result.DocumentID) {
-			continue
-		}
-		results = appendBoundedVectorSearchResult(results, result, opts.TopK)
-	}
+	results := filteredBaseResults
 
 	overlayResults, overlayScanned := overlay.searchCosine(query, queryInvNorm, opts.TopK, scratch)
 	trace.OverlayScanned = overlayScanned
@@ -343,7 +339,8 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	return results, trace, nil
 }
 
-func columnVectorDynamicCountBaseResults(results []VectorSearchResult, overlay *ColumnVectorDynamicOverlaySnapshot) (int, int) {
+func columnVectorDynamicFilterBaseResults(dst []VectorSearchResult, results []VectorSearchResult, overlay *ColumnVectorDynamicOverlaySnapshot, topK int) ([]VectorSearchResult, int, int) {
+	dst = dst[:0]
 	returned := 0
 	tombstoned := 0
 	for _, result := range results {
@@ -352,8 +349,11 @@ func columnVectorDynamicCountBaseResults(results []VectorSearchResult, overlay *
 			continue
 		}
 		returned++
+		if len(dst) < topK {
+			dst = append(dst, result)
+		}
 	}
-	return returned, tombstoned
+	return dst, returned, tombstoned
 }
 
 func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32, invNorm float32) error {

--- a/TreeDB/collections/column_vector_dynamic_overlay.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay.go
@@ -50,6 +50,7 @@ type ColumnVectorDynamicGraphSearchTrace struct {
 	BaseTrace         ColumnVectorGraphSearchTrace
 	BaseGeneration    uint64
 	OverlayGeneration uint64
+	BaseSearches      int
 	BaseReturned      int
 	BaseTombstoned    int
 	OverlayRows       int
@@ -267,17 +268,53 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 		return nil, trace, err
 	}
 
-	baseOpts := opts
-	baseOpts.TopK = columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.Tombstones())
-	if baseOpts.EfSearch < baseOpts.TopK {
-		baseOpts.EfSearch = baseOpts.TopK
+	baseMaxTopK := columnVectorDynamicBaseTopK(base.Rows(), opts.TopK, overlay.Tombstones())
+	baseTopK := opts.TopK
+	if baseTopK > baseMaxTopK {
+		baseTopK = baseMaxTopK
 	}
-	baseResults, baseTrace, err := base.SearchCosine(query, baseOpts, &scratch.Base)
-	if err != nil {
-		return nil, trace, err
+	var baseResults []VectorSearchResult
+	var baseTrace ColumnVectorGraphSearchTrace
+	totalBaseCandidatesExamined := 0
+	totalBaseEdgesVisited := 0
+	// Tombstones are usually sparse in the base result prefix. Start at the user
+	// TopK and retry only when fetched base rows are hidden by the overlay.
+	for {
+		baseOpts := opts
+		baseOpts.TopK = baseTopK
+		if baseOpts.EfSearch < baseOpts.TopK {
+			baseOpts.EfSearch = baseOpts.TopK
+		}
+		baseResults, baseTrace, err = base.SearchCosine(query, baseOpts, &scratch.Base)
+		if err != nil {
+			return nil, trace, err
+		}
+		trace.BaseSearches++
+		totalBaseCandidatesExamined += baseTrace.CandidatesExamined
+		totalBaseEdgesVisited += baseTrace.EdgesVisited
+		baseReturned, baseTombstoned := columnVectorDynamicCountBaseResults(baseResults, overlay)
+		if baseReturned >= opts.TopK || baseTopK >= baseMaxTopK {
+			trace.BaseReturned = baseReturned
+			trace.BaseTombstoned = baseTombstoned
+			break
+		}
+		nextTopK := opts.TopK + baseTombstoned
+		speculativeTopK := baseTopK + max(baseTopK/2, opts.TopK)
+		if nextTopK < speculativeTopK {
+			nextTopK = speculativeTopK
+		}
+		if nextTopK <= baseTopK {
+			nextTopK = baseTopK + 1
+		}
+		if nextTopK > baseMaxTopK {
+			nextTopK = baseMaxTopK
+		}
+		baseTopK = nextTopK
 	}
+	baseTrace.CandidatesExamined = totalBaseCandidatesExamined
+	baseTrace.EdgesVisited = totalBaseEdgesVisited
 	trace.BaseTrace = baseTrace
-	trace.EdgesVisited = baseTrace.EdgesVisited
+	trace.EdgesVisited = totalBaseEdgesVisited
 
 	if cap(scratch.results) < opts.TopK {
 		scratch.results = make([]VectorSearchResult, 0, opts.TopK)
@@ -285,10 +322,8 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	results := scratch.results[:0]
 	for _, result := range baseResults {
 		if overlay.DocumentTombstoned(result.DocumentID) {
-			trace.BaseTombstoned++
 			continue
 		}
-		trace.BaseReturned++
 		results = appendBoundedVectorSearchResult(results, result, opts.TopK)
 	}
 
@@ -306,6 +341,19 @@ func (g *ColumnVectorDynamicGraph) SearchCosine(query []float32, opts ColumnVect
 	trace.ReturnedCount = len(results)
 	scratch.results = results
 	return results, trace, nil
+}
+
+func columnVectorDynamicCountBaseResults(results []VectorSearchResult, overlay *ColumnVectorDynamicOverlaySnapshot) (int, int) {
+	returned := 0
+	tombstoned := 0
+	for _, result := range results {
+		if overlay.DocumentTombstoned(result.DocumentID) {
+			tombstoned++
+			continue
+		}
+		returned++
+	}
+	return returned, tombstoned
 }
 
 func (g *ColumnVectorDynamicGraph) applyInsert(overlay *ColumnVectorDynamicOverlaySnapshot, documentID []byte, vector []float32, invNorm float32) error {

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -242,6 +242,111 @@ func TestColumnVectorDynamicGraphBaseSearchDoesNotOverfetchForOverlayOnlyRows(t 
 	}
 }
 
+func TestColumnVectorDynamicGraphBaseSearchIgnoresNonPrefixTombstones(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(128, 16, 127, true))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 64)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+	baseResults, _, err := base.SearchCosine(query, ColumnVectorGraphSearchOptions{TopK: 32, EfSearch: 128}, &ColumnVectorGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("base SearchCosine: %v", err)
+	}
+	protected := make(map[string]struct{}, len(baseResults))
+	for _, result := range baseResults {
+		protected[string(result.DocumentID)] = struct{}{}
+	}
+	mutations := make([]ColumnVectorDynamicMutation, 0, 32)
+	for ordinal := 0; ordinal < base.Rows() && len(mutations) < cap(mutations); ordinal++ {
+		documentID := []byte(fmt.Sprintf("doc-%06d", ordinal))
+		if _, found := protected[string(documentID)]; found {
+			continue
+		}
+		mutations = append(mutations, ColumnVectorDynamicMutation{
+			Kind:       ColumnVectorDynamicMutationDelete,
+			DocumentID: documentID,
+		})
+	}
+	if len(mutations) != cap(mutations) {
+		t.Fatalf("selected %d tombstones, want %d", len(mutations), cap(mutations))
+	}
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	if _, err := graph.ApplyBatch(mutations); err != nil {
+		t.Fatalf("ApplyBatch tombstones: %v", err)
+	}
+	results, trace, err := graph.SearchCosine(query, opts, &ColumnVectorDynamicGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) != opts.TopK {
+		t.Fatalf("results=%d want %d", len(results), opts.TopK)
+	}
+	if trace.BaseSearches != 1 {
+		t.Fatalf("base searches=%d want one search when tombstones are outside the fetched prefix", trace.BaseSearches)
+	}
+	if trace.BaseTrace.TopK != opts.TopK {
+		t.Fatalf("base topK=%d want query topK=%d despite unrelated tombstones", trace.BaseTrace.TopK, opts.TopK)
+	}
+	if trace.BaseTombstoned != 0 {
+		t.Fatalf("base tombstoned=%d want no fetched-prefix tombstones", trace.BaseTombstoned)
+	}
+}
+
+func TestColumnVectorDynamicGraphBaseSearchRetriesTombstonePrefix(t *testing.T) {
+	base, err := NewColumnVectorGraphFromColumns(columnVectorGraphTestColumns(128, 16, 127, true))
+	if err != nil {
+		t.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
+	}
+	query, ok := base.VectorAt(nil, 64)
+	if !ok {
+		t.Fatal("missing query vector")
+	}
+	opts := ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128}
+	baseResults, _, err := base.SearchCosine(query, opts, &ColumnVectorGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("base SearchCosine: %v", err)
+	}
+	if len(baseResults) != opts.TopK {
+		t.Fatalf("base results=%d want %d", len(baseResults), opts.TopK)
+	}
+	deletedID := append([]byte(nil), baseResults[0].DocumentID...)
+	graph, err := NewColumnVectorDynamicGraph(base)
+	if err != nil {
+		t.Fatalf("NewColumnVectorDynamicGraph: %v", err)
+	}
+	if _, err := graph.ApplyBatch([]ColumnVectorDynamicMutation{
+		{Kind: ColumnVectorDynamicMutationDelete, DocumentID: deletedID},
+	}); err != nil {
+		t.Fatalf("ApplyBatch tombstone: %v", err)
+	}
+	results, trace, err := graph.SearchCosine(query, opts, &ColumnVectorDynamicGraphSearchScratch{})
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) != opts.TopK {
+		t.Fatalf("results=%d want %d", len(results), opts.TopK)
+	}
+	if containsColumnVectorDynamicResult(results, deletedID) {
+		t.Fatalf("deleted base doc leaked into results: %+v", results)
+	}
+	if trace.BaseSearches != 2 {
+		t.Fatalf("base searches=%d want one retry after fetched-prefix tombstone", trace.BaseSearches)
+	}
+	if trace.BaseTrace.TopK != opts.TopK+1 {
+		t.Fatalf("base topK=%d want %d after one tombstone retry", trace.BaseTrace.TopK, opts.TopK+1)
+	}
+	if trace.BaseTombstoned != 1 {
+		t.Fatalf("base tombstoned=%d want one fetched-prefix tombstone", trace.BaseTombstoned)
+	}
+}
+
 func TestColumnVectorDynamicBaseTopKBoundsTombstoneOverfetch(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -843,6 +948,7 @@ func reportColumnVectorDynamicGraphMetrics(b *testing.B, snapshot ColumnVectorDy
 		b.ReportMetric(0, "edges/node")
 	}
 	b.ReportMetric(float64(trace.BaseTrace.CandidatesExamined), "base_candidates/search")
+	b.ReportMetric(float64(trace.BaseSearches), "base_searches/search")
 	b.ReportMetric(float64(trace.BaseTombstoned), "base_tombstoned/search")
 	b.ReportMetric(float64(trace.OverlayScanned), "overlay_scanned/search")
 	b.ReportMetric(float64(trace.MergeCandidates), "merge_candidates/search")


### PR DESCRIPTION
## Summary
- start dynamic overlay base search at the requested TopK and retry only when fetched base rows are tombstoned
- aggregate base candidates/edges across retries and report base_searches/search for dynamic benchmarks
- filter/count the successful base prefix in one pass, then reuse that live base slice for overlay merge
- add focused tests for unrelated tombstones outside the fetched prefix and for retrying a tombstoned prefix result

## Validation
- GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorDynamic(Graph|Overlay|Mutation|BaseTopK)|TestColumnVectorGraph' -count=1
- GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraphConcurrentReadersAndWriter|TestColumnVectorDynamicGraphSearchTombstonesAndOverlay|TestColumnVectorDynamicGraphBaseSearchIgnoresNonPrefixTombstones|TestColumnVectorDynamicGraphBaseSearchRetriesTombstonePrefix' -count=1
- GOWORK=off go test ./TreeDB/collections -count=1
- git diff --check
- GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k_dims_128_degree_16/parallel_read_(only|write)$' -benchmem -benchtime=500ms -count=6 on #1616 and this branch, then benchstat
- GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_1m_dims_128_degree_16/parallel_read_only$' -benchmem -benchtime=300ms -count=1

## Benchmark Evidence
Apple M3, darwin/arm64, compared against #1616 (codex/column-vector-dynamic-overlay-base-topk-trim):

- 100k read-only: 7.833µs -> 8.439µs, statistically unchanged (p=0.132, n=6); 315 base candidates/search, 2.128k edges/search, 571 total candidates/search unchanged; 0 B/op and 0 allocs/op unchanged.
- 100k read-write: 137.68µs -> 59.84µs (-56.54%, p=0.002, n=6); read_qps 7.272k -> 16.717k (+129.87%); base_candidates/search 6.878k -> 1.890k (-72.52%); edges/search 63.28k -> 12.77k (-79.82%); total_candidates/search 10.534k -> 4.043k (-61.63%); B/op 765.1Ki -> 223.8Ki (-70.75%); allocs/op 11 -> 4.5 (-59.09%).
- New metric: base_searches/search is 1.0 for read-only and 6.0 for read-write in the adaptive run.
- Caveat: the read-write benchmark runs the writer until the read benchmark completes. Faster reads shorten writer runtime, so final overlay size and related B/op are lower. The direct base candidates/edges counters are the primary structural evidence for the tombstone-overfetch reduction.
- 1M read-only smoke on this branch before the review-fix follow-up: 8833 ns/op, 113211 read_qps, 439 base_candidates/search, 2688 edges/search, 695 total_candidates/search, 0 B/op, 0 allocs/op.

Do not merge.
