### PR TITLE
TreeDB/collections: report dynamic overlay steady-write metrics

### DIFF
--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -1069,7 +1069,9 @@ func reportColumnVectorDynamicReadMetrics(b *testing.B, elapsed time.Duration, p
 	if elapsed > 0 {
 		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "read_qps")
 		if b.N > 0 {
-			b.ReportMetric(float64(elapsed.Nanoseconds())/float64(b.N), "read_ns/op")
+			// Distinguish explicit wall-clock read-loop timing from testing's
+			// built-in ns/op, which may include concurrent writer setup/teardown.
+			b.ReportMetric(float64(elapsed.Nanoseconds())/float64(b.N), "read_wall_ns/op")
 		}
 	}
 	if publishedBatches > 0 && elapsed > 0 {

--- a/TreeDB/collections/column_vector_dynamic_overlay_test.go
+++ b/TreeDB/collections/column_vector_dynamic_overlay_test.go
@@ -459,6 +459,9 @@ func TestColumnVectorDynamicGraphSearchAllocs(t *testing.T) {
 	} else if len(results) != opts.TopK {
 		t.Fatalf("warm results=%d want %d", len(results), opts.TopK)
 	}
+	// The parallel read/write benchmark intentionally includes writer publish
+	// allocations. This guard isolates the warmed hot read path and proves
+	// SearchCosine itself remains allocation-free with caller-owned scratch.
 	allocs := testing.AllocsPerRun(1000, func() {
 		results, trace, err := graph.SearchCosine(query, opts, &scratch)
 		if err != nil {
@@ -851,6 +854,10 @@ func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadOnly(b *testing.B,
 	reportColumnVectorDynamicReadMetrics(b, elapsed, 0, 0, 0)
 }
 
+// benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite measures
+// concurrent steady-state reads while one writer publishes copy-on-write overlay
+// generations. Reported B/op and allocs/op include writer publish work; the hot
+// read path is guarded separately by TestColumnVectorDynamicGraphSearchAllocs.
 func benchmarkColumnVectorDynamicGraphSearchCosineParallelReadWrite(b *testing.B, graph *ColumnVectorDynamicGraph, query []float32, opts ColumnVectorGraphSearchOptions, rows int, dims int) {
 	b.Helper()
 	b.SetParallelism(1)
@@ -1061,10 +1068,14 @@ func reportColumnVectorDynamicReadMetrics(b *testing.B, elapsed time.Duration, p
 	b.Helper()
 	if elapsed > 0 {
 		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "read_qps")
+		if b.N > 0 {
+			b.ReportMetric(float64(elapsed.Nanoseconds())/float64(b.N), "read_ns/op")
+		}
 	}
 	if publishedBatches > 0 && elapsed > 0 {
 		b.ReportMetric(float64(publishedBatches)/elapsed.Seconds(), "publishes/s")
 		b.ReportMetric(float64(publishedMutations)/elapsed.Seconds(), "mutations/s")
+		b.ReportMetric(float64(publishedMutations)/float64(publishedBatches), "mutations/publish")
 		b.ReportMetric(float64(publishNanos)/float64(publishedBatches), "publish_ns/op")
 	}
 }


### PR DESCRIPTION
## Summary
- merge latest integration head `9da83c743` into the dynamic overlay benchmark branch
- keep dynamic overlay search isolated from the main PR stack while inheriting current M10B/M10C/M11A/M11B column-store planner work
- preserve the benchmark discipline: shared immutable base graph, worker-local warmed scratch, no document fetch in the search loop, and explicit read/write metrics

## Local validation
Latest head `fc1bb079d` on Apple M3:
- `git diff --check`
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraph|TestColumnVectorDynamicGraph|TestColumnQueryPlannerM11B|TestColumnSkipScan|TestColumnPublish' -count=1`\n- `GOWORK=off go test ./cmd/unified_bench -run 'TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile|TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing|TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A|TestColumnStoreSuite.*M11A|TestColumnStoreSuite.*M11B|TestColumnStoreQueryNamesReturnsDefensiveCopyM11A' -count=1`\n- `GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorDynamicGraph(ConcurrentReadersAndWriter|SearchAllocs|SearchTombstonesAndOverlay|SnapshotStableAcrossOverlayPublishes)' -count=1`\n- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorDynamicGraphSearchCosineScale/rows_100k' -benchmem -benchtime=100ms -count=1`\n- `GOWORK=off go test ./TreeDB/collections -count=1`\n- `GOWORK=off go test ./cmd/unified_bench -count=1`\n\n## 100k benchmark smoke\nLatest post-integration head `fc1bb079d` (integration base `9da83c743`) on Apple M3:\n\n- `parallel_read_only`: 9,082 ns/op, 110,109 read_qps, 0 B/op, 0 allocs/op, 315 base candidates/search, 2,128 edges/search, 16.00 edges/node, 256 overlay scanned/search.\n- `parallel_read_write`: 58,078 ns/op, 17,218 read_qps, 2,937 publishes/s, 8,678 mutations/s, 2.955 mutations/publish, 340,286 publish_ns/op, 171,429 B/op, 4 allocs/op.\n\nThe non-zero read/write allocation numbers include concurrent writer publish work and copy-on-write overlay generations. The warmed reader `SearchCosine` hot path remains covered by `TestColumnVectorDynamicGraphSearchAllocs`, and the read-only parallel benchmark remains 0 B/op, 0 allocs/op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments for allocation-guard and benchmark test scenarios

* **Tests**
  * Improved metrics reporting to conditionally emit read performance metrics
  * Added metrics tracking for publish operations during benchmarking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->