### PR TITLE
experiments/colgranule: add persisted vector graph evidence benchmarks

### DIFF
--- a/experiments/colgranule/adaptive_mark.go
+++ b/experiments/colgranule/adaptive_mark.go
@@ -120,7 +120,7 @@ func EstimateColumnBatchUncompressedBytes(batch ColumnBatch, defs []ColumnDefini
 			total += rows * def.VectorDims * 4
 		case ColumnTypeAdjacencyList:
 			column := batch.AdjacencyLists[def.Name]
-			total += len(column.Offsets)*4 + len(column.Values)*8
+			total += len(column.Offsets)*4 + len(column.Values)*4
 		default:
 			return 0, fmt.Errorf("colgranule: unsupported column type %s for adaptive mark sizing", def.Type)
 		}

--- a/experiments/colgranule/adaptive_mark_test.go
+++ b/experiments/colgranule/adaptive_mark_test.go
@@ -56,6 +56,27 @@ func TestEstimateAdaptiveRowsPerMark(t *testing.T) {
 	}
 }
 
+func TestEstimateColumnBatchUncompressedBytesUsesUint32AdjacencyValues(t *testing.T) {
+	batch := ColumnBatch{
+		Rows: 3,
+		AdjacencyLists: map[string]AdjacencyListColumn{
+			"neighbors": {
+				Offsets: []uint32{0, 2, 4, 6},
+				Values:  []uint32{1, 2, 0, 2, 0, 1},
+			},
+		},
+	}
+	got, err := EstimateColumnBatchUncompressedBytes(batch, []ColumnDefinition{
+		{Name: "neighbors", Type: ColumnTypeAdjacencyList},
+	})
+	if err != nil {
+		t.Fatalf("EstimateColumnBatchUncompressedBytes: %v", err)
+	}
+	if want := 4*4 + 6*4; got != want {
+		t.Fatalf("raw bytes=%d want %d", got, want)
+	}
+}
+
 func TestBuildColumnPartUsesAdaptiveMarkSizing(t *testing.T) {
 	rows := 20
 	batch := ColumnBatch{Rows: rows, Columns: map[string][]int64{

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/pierrec/lz4/v4"
+	"github.com/snissn/compress/zstd"
 )
 
 const DefaultRowsPerGranule = 8192
@@ -23,7 +24,7 @@ const (
 	EncodingBoolBitpackRLE
 	EncodingLowCardinalityUint32
 	EncodingRawFloat32Vector
-	EncodingRawInt64AdjacencyList
+	EncodingRawUint32AdjacencyList
 )
 
 func (e Encoding) String() string {
@@ -42,8 +43,8 @@ func (e Encoding) String() string {
 		return "low_cardinality_uint32"
 	case EncodingRawFloat32Vector:
 		return "raw_float32_vector"
-	case EncodingRawInt64AdjacencyList:
-		return "raw_int64_adjacency_list"
+	case EncodingRawUint32AdjacencyList:
+		return "raw_uint32_adjacency_list"
 	default:
 		return fmt.Sprintf("encoding_%d", e)
 	}
@@ -180,7 +181,7 @@ type GranuleReader struct {
 	codes       []uint32
 	vectors32   []float32
 	listOffsets []uint32
-	listValues  []int64
+	listValues  []uint32
 }
 
 func (r *GranuleReader) DecodeInt64(g EncodedGranule) ([]int64, error) {
@@ -603,6 +604,32 @@ func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression
 		report.CompressionKept = true
 		report.StoredBytes = len(out)
 		return CompressionSelection{Payload: out, Actual: CompressionLZ4, Scratch: out, Report: report}, nil
+	case CompressionZSTD:
+		start := time.Now()
+		enc, err := zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+		)
+		if err != nil {
+			return CompressionSelection{}, err
+		}
+		out := enc.EncodeAll(raw, dst[:0])
+		if err := enc.Close(); err != nil {
+			return CompressionSelection{}, err
+		}
+		report.CompressionNanos = time.Since(start).Nanoseconds()
+		report.CompressionAttempted = true
+		if len(out) >= len(raw) {
+			report.ActualCompression = CompressionNone
+			report.CompressionFallbackReason = "not_smaller"
+			report.StoredBytes = len(raw)
+			return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: out[:0], Report: report}, nil
+		}
+		report.ActualCompression = CompressionZSTD
+		report.CompressionKept = true
+		report.StoredBytes = len(out)
+		return CompressionSelection{Payload: out, Actual: CompressionZSTD, Scratch: out, Report: report}, nil
 	default:
 		return CompressionSelection{}, fmt.Errorf("colgranule: unsupported compression %d", compression)
 	}
@@ -670,6 +697,26 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 		if n != g.RawBytes {
 			return nil, fmt.Errorf("colgranule: lz4 decoded length=%d want=%d", n, g.RawBytes)
 		}
+		return out, nil
+	case CompressionZSTD:
+		dec, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+		if err != nil {
+			return nil, err
+		}
+		if cap(r.raw) < g.RawBytes {
+			r.raw = make([]byte, 0, g.RawBytes)
+		} else {
+			r.raw = r.raw[:0]
+		}
+		out, err := dec.DecodeAll(g.Payload, r.raw)
+		dec.Close()
+		if err != nil {
+			return nil, err
+		}
+		if len(out) != g.RawBytes {
+			return nil, fmt.Errorf("colgranule: zstd decoded length=%d want=%d", len(out), g.RawBytes)
+		}
+		r.raw = out
 		return out, nil
 	default:
 		return nil, fmt.Errorf("colgranule: unsupported compression %d", g.Compression)

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -723,6 +723,8 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 		if cap(r.raw) < g.RawBytes {
 			r.raw = make([]byte, 0, g.RawBytes)
 		} else {
+			// WithDecodeAllCapLimit(true) uses cap(dst)-len(dst) as the
+			// output ceiling, so keep capacity pinned to the expected raw size.
 			r.raw = r.raw[:0:g.RawBytes]
 		}
 		out, err := dec.DecodeAll(g.Payload, r.raw)

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/golang/snappy"
@@ -13,6 +14,16 @@ import (
 )
 
 const DefaultRowsPerGranule = 8192
+
+var (
+	sharedZSTDEncoderOnce sync.Once
+	sharedZSTDEncoder     *zstd.Encoder
+	sharedZSTDEncoderErr  error
+
+	sharedZSTDDecoderOnce sync.Once
+	sharedZSTDDecoder     *zstd.Decoder
+	sharedZSTDDecoderErr  error
+)
 
 type Encoding uint8
 
@@ -605,19 +616,12 @@ func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression
 		report.StoredBytes = len(out)
 		return CompressionSelection{Payload: out, Actual: CompressionLZ4, Scratch: out, Report: report}, nil
 	case CompressionZSTD:
-		start := time.Now()
-		enc, err := zstd.NewWriter(nil,
-			zstd.WithEncoderLevel(zstd.SpeedFastest),
-			zstd.WithEncoderCRC(false),
-			zstd.WithEncoderConcurrency(1),
-		)
+		enc, err := columnGranuleSharedZSTDEncoder()
 		if err != nil {
 			return CompressionSelection{}, err
 		}
+		start := time.Now()
 		out := enc.EncodeAll(raw, dst[:0])
-		if err := enc.Close(); err != nil {
-			return CompressionSelection{}, err
-		}
 		report.CompressionNanos = time.Since(start).Nanoseconds()
 		report.CompressionAttempted = true
 		if len(out) >= len(raw) {
@@ -633,6 +637,19 @@ func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression
 	default:
 		return CompressionSelection{}, fmt.Errorf("colgranule: unsupported compression %d", compression)
 	}
+}
+
+func columnGranuleSharedZSTDEncoder() (*zstd.Encoder, error) {
+	sharedZSTDEncoderOnce.Do(func() {
+		// EncodeAll is concurrency-safe; keep the heavy encoder out of per-block
+		// admission so zstd build/open metrics measure compression work.
+		sharedZSTDEncoder, sharedZSTDEncoderErr = zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+		)
+	})
+	return sharedZSTDEncoder, sharedZSTDEncoderErr
 }
 
 func compressPayload(raw []byte, encoding Encoding, compression Compression) (CompressionSelection, error) {
@@ -699,7 +716,7 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 		}
 		return out, nil
 	case CompressionZSTD:
-		dec, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+		dec, err := columnGranuleSharedZSTDDecoder()
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +726,6 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 			r.raw = r.raw[:0]
 		}
 		out, err := dec.DecodeAll(g.Payload, r.raw)
-		dec.Close()
 		if err != nil {
 			return nil, err
 		}
@@ -721,6 +737,15 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("colgranule: unsupported compression %d", g.Compression)
 	}
+}
+
+func columnGranuleSharedZSTDDecoder() (*zstd.Decoder, error) {
+	sharedZSTDDecoderOnce.Do(func() {
+		// DecodeAll is concurrency-safe; the reader keeps destination buffers
+		// local while the shared decoder avoids per-payload setup cost.
+		sharedZSTDDecoder, sharedZSTDDecoderErr = zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+	})
+	return sharedZSTDDecoder, sharedZSTDDecoderErr
 }
 
 func validateGranule(g EncodedGranule) error {

--- a/experiments/colgranule/granule.go
+++ b/experiments/colgranule/granule.go
@@ -723,7 +723,7 @@ func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
 		if cap(r.raw) < g.RawBytes {
 			r.raw = make([]byte, 0, g.RawBytes)
 		} else {
-			r.raw = r.raw[:0]
+			r.raw = r.raw[:0:g.RawBytes]
 		}
 		out, err := dec.DecodeAll(g.Payload, r.raw)
 		if err != nil {
@@ -743,7 +743,11 @@ func columnGranuleSharedZSTDDecoder() (*zstd.Decoder, error) {
 	sharedZSTDDecoderOnce.Do(func() {
 		// DecodeAll is concurrency-safe; the reader keeps destination buffers
 		// local while the shared decoder avoids per-payload setup cost.
-		sharedZSTDDecoder, sharedZSTDDecoderErr = zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+		sharedZSTDDecoder, sharedZSTDDecoderErr = zstd.NewReader(
+			nil,
+			zstd.WithDecoderConcurrency(1),
+			zstd.WithDecodeAllCapLimit(true),
+		)
 	})
 	return sharedZSTDDecoder, sharedZSTDDecoderErr
 }

--- a/experiments/colgranule/granule_test.go
+++ b/experiments/colgranule/granule_test.go
@@ -235,8 +235,29 @@ func TestUnsupportedCodecIDsFailClosed(t *testing.T) {
 	if _, err := DecodeInt64(nil, badCompression); err == nil {
 		t.Fatal("DecodeInt64 with bad compression succeeded, want error")
 	}
-	if _, err := EncodeInt64(nil, []int64{1, 2, 3}, Config{Encoding: EncodingRawInt64, Compression: CompressionZSTD}); err == nil {
-		t.Fatal("EncodeInt64 with unsupported zstd succeeded, want error")
+}
+
+func TestZSTDCompressionAdmissionRoundTrip(t *testing.T) {
+	values := make([]int64, 8192)
+	for i := range values {
+		values[i] = int64(i % 8)
+	}
+	g, err := EncodeInt64(nil, values, Config{Encoding: EncodingRawInt64, Compression: CompressionZSTD})
+	if err != nil {
+		t.Fatalf("EncodeInt64(zstd): %v", err)
+	}
+	if g.CodecReport.RequestedCompression != CompressionZSTD || !g.CodecReport.CompressionAttempted {
+		t.Fatalf("codec report did not record zstd attempt: %+v", g.CodecReport)
+	}
+	if g.Compression != CompressionZSTD {
+		t.Fatalf("zstd admission compression=%s want zstd; report=%+v", g.Compression, g.CodecReport)
+	}
+	got, err := DecodeInt64(nil, g)
+	if err != nil {
+		t.Fatalf("DecodeInt64(zstd): %v", err)
+	}
+	if !slices.Equal(got, values) {
+		t.Fatal("DecodeInt64(zstd) did not round-trip values")
 	}
 }
 

--- a/experiments/colgranule/part.go
+++ b/experiments/colgranule/part.go
@@ -170,7 +170,7 @@ type ColumnPartBuilder struct {
 	bools       []bool
 	vectors32   []float32
 	listOffsets []uint32
-	listValues  []int64
+	listValues  []uint32
 	builder     *GranuleBuilder
 }
 
@@ -275,8 +275,8 @@ type ColumnPartScanner struct {
 	scratch     []int64
 	vectors32   []float32
 	listOffsets []uint32
-	listValues  []int64
-	listScratch []int64
+	listValues  []uint32
+	listScratch []uint32
 }
 
 type ProjectedScanResult struct {
@@ -295,7 +295,7 @@ type Float32VectorScanResult struct {
 type AdjacencyListScanResult struct {
 	Rows        int
 	Offsets     []uint32
-	Values      []int64
+	Values      []uint32
 	Diagnostics PartScanDiagnostics
 }
 
@@ -420,7 +420,7 @@ func (s *ColumnPartScanner) Float32VectorAt(locator RowLocator, columnName strin
 	return nil, fmt.Errorf("colgranule: locator row %d outside column %s", locator.PartRow, columnName)
 }
 
-func (s *ColumnPartScanner) AdjacencyListAt(locator RowLocator, columnName string, dst []int64) ([]int64, error) {
+func (s *ColumnPartScanner) AdjacencyListAt(locator RowLocator, columnName string, dst []uint32) ([]uint32, error) {
 	if s.part == nil {
 		return nil, errors.New("colgranule: nil part scanner")
 	}
@@ -444,9 +444,9 @@ func (s *ColumnPartScanner) AdjacencyListAt(locator RowLocator, columnName strin
 			if err != nil {
 				return nil, err
 			}
-			return decodeInt64AdjacencyListRowInto(dst[:0], raw, block.Descriptor.RowCount, row)
+			return decodeUint32AdjacencyListRowInto(dst[:0], raw, block.Descriptor.RowCount, row)
 		}
-		offsets, values, err := s.reader.DecodeInt64AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
+		offsets, values, err := s.reader.DecodeUint32AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func (s *ColumnPartScanner) AdjacencyListAt(locator RowLocator, columnName strin
 		s.listValues = values
 		start := int(offsets[row])
 		end := int(offsets[row+1])
-		out := ensureInt64Len(dst[:0], end-start)
+		out := ensureUint32Len(dst[:0], end-start)
 		copy(out, values[start:end])
 		return out, nil
 	}
@@ -477,7 +477,7 @@ func (s *ColumnPartScanner) ScanFloat32VectorsInto(columnName string, dst []floa
 	}, nil
 }
 
-func (s *ColumnPartScanner) ScanAdjacencyListsInto(columnName string, offsets []uint32, values []int64) (AdjacencyListScanResult, error) {
+func (s *ColumnPartScanner) ScanAdjacencyListsInto(columnName string, offsets []uint32, values []uint32) (AdjacencyListScanResult, error) {
 	if s.part == nil {
 		return AdjacencyListScanResult{}, errors.New("colgranule: nil part scanner")
 	}
@@ -558,7 +558,7 @@ func (s *ColumnPartScanner) scanFloat32VectorColumnInto(name string, dst []float
 	return out, dims, diagnostics, nil
 }
 
-func (s *ColumnPartScanner) scanAdjacencyListColumnInto(name string, offsetDst []uint32, valueDst []int64) ([]uint32, []int64, PartScanDiagnostics, error) {
+func (s *ColumnPartScanner) scanAdjacencyListColumnInto(name string, offsetDst []uint32, valueDst []uint32) ([]uint32, []uint32, PartScanDiagnostics, error) {
 	column, ok := s.part.Columns[name]
 	if !ok {
 		return nil, nil, PartScanDiagnostics{}, fmt.Errorf("colgranule: missing column %s", name)
@@ -571,7 +571,7 @@ func (s *ColumnPartScanner) scanAdjacencyListColumnInto(name string, offsetDst [
 	outValues := valueDst[:0]
 	var diagnostics PartScanDiagnostics
 	for _, block := range column.Blocks {
-		offsets, values, err := s.reader.DecodeInt64AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
+		offsets, values, err := s.reader.DecodeUint32AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
 		if err != nil {
 			return nil, nil, diagnostics, err
 		}
@@ -750,7 +750,7 @@ func appendFloat32VectorRowsFromRaw(out []float32, write int, raw []byte, blockR
 	return write, nil
 }
 
-func (s *ColumnPartScanner) scanAdjacencyListRowsInto(name string, offsetDst []uint32, valueDst []int64, rows []int) ([]uint32, []int64, PartScanDiagnostics, error) {
+func (s *ColumnPartScanner) scanAdjacencyListRowsInto(name string, offsetDst []uint32, valueDst []uint32, rows []int) ([]uint32, []uint32, PartScanDiagnostics, error) {
 	column, ok := s.part.Columns[name]
 	if !ok {
 		return nil, nil, PartScanDiagnostics{}, fmt.Errorf("colgranule: missing column %s", name)
@@ -795,7 +795,7 @@ func (s *ColumnPartScanner) scanAdjacencyListRowsInto(name string, offsetDst []u
 				return nil, nil, diagnostics, appendErr
 			}
 		} else {
-			offsets, values, err := s.reader.DecodeInt64AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
+			offsets, values, err := s.reader.DecodeUint32AdjacencyListsInto(s.listOffsets[:0], s.listValues[:0], block.Granule)
 			if err != nil {
 				return nil, nil, diagnostics, err
 			}
@@ -826,7 +826,7 @@ func (s *ColumnPartScanner) scanAdjacencyListRowsInto(name string, offsetDst []u
 	return outOffsets, outValues, diagnostics, nil
 }
 
-func appendAdjacencyRowsFromRaw(offsetDst []uint32, valueDst []int64, raw []byte, blockRows int, rows []int, first int) ([]uint32, []int64, error) {
+func appendAdjacencyRowsFromRaw(offsetDst []uint32, valueDst []uint32, raw []byte, blockRows int, rows []int, first int) ([]uint32, []uint32, error) {
 	offsetCount := blockRows + 1
 	offsetBytes, err := checkedMulInt(offsetCount, 4, "adjacency offset bytes")
 	if err != nil {
@@ -836,7 +836,7 @@ func appendAdjacencyRowsFromRaw(offsetDst []uint32, valueDst []int64, raw []byte
 		return nil, nil, fmt.Errorf("colgranule: adjacency raw bytes=%d below offsets=%d", len(raw), offsetBytes)
 	}
 	final := binary.LittleEndian.Uint32(raw[blockRows*4:])
-	valueBytes, err := checkedMulInt(int(final), 8, "adjacency value bytes")
+	valueBytes, err := checkedMulInt(int(final), 4, "adjacency value bytes")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -859,7 +859,7 @@ func appendAdjacencyRowsFromRaw(offsetDst []uint32, valueDst []int64, raw []byte
 			return nil, nil, fmt.Errorf("colgranule: invalid adjacency row offsets start=%d end=%d final=%d", start, end, final)
 		}
 		for i := int(start); i < int(end); i++ {
-			valueDst = append(valueDst, int64(binary.LittleEndian.Uint64(valueRaw[i*8:])))
+			valueDst = append(valueDst, binary.LittleEndian.Uint32(valueRaw[i*4:]))
 		}
 		if len(valueDst) > math.MaxUint32 {
 			return nil, nil, fmt.Errorf("colgranule: adjacency visible scan values=%d exceed uint32 offsets", len(valueDst))
@@ -1040,7 +1040,7 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 		if def.VectorDims != 0 {
 			return ColumnDefinition{}, fmt.Errorf("colgranule: adjacency column %s has vector dims %d", def.Name, def.VectorDims)
 		}
-		def.Encoding = EncodingRawInt64AdjacencyList
+		def.Encoding = EncodingRawUint32AdjacencyList
 		def.Cardinality = 0
 	default:
 		return ColumnDefinition{}, fmt.Errorf("colgranule: unsupported column type %s for %s", def.Type, def.Name)
@@ -1314,7 +1314,7 @@ func (b *ColumnPartBuilder) buildAdjacencyListBlockGranule(source AdjacencyListC
 		}
 		b.listOffsets[row-start+1] = uint32(len(b.listValues))
 	}
-	return b.builder.BuildInt64AdjacencyLists(b.listOffsets, b.listValues)
+	return b.builder.BuildUint32AdjacencyLists(b.listOffsets, b.listValues)
 }
 
 func exclusiveInt64Upper(v int64) int64 {

--- a/experiments/colgranule/part_image_decode.go
+++ b/experiments/colgranule/part_image_decode.go
@@ -621,7 +621,7 @@ func maxDecodedBlockRawBytes(columnType ColumnType, cardinality uint32, vectorDi
 		}
 		return checkedMulInt(values, 4, "float32 vector raw bytes")
 	case ColumnTypeAdjacencyList:
-		if encoding != EncodingRawInt64AdjacencyList {
+		if encoding != EncodingRawUint32AdjacencyList {
 			return 0, fmt.Errorf("unsupported adjacency-list encoding %d", encoding)
 		}
 		return int(^uint(0) >> 1), nil

--- a/experiments/colgranule/part_set.go
+++ b/experiments/colgranule/part_set.go
@@ -94,7 +94,7 @@ type ColumnPartSetFloat32VectorScanResult struct {
 type ColumnPartSetAdjacencyListScanResult struct {
 	Rows        int
 	Offsets     []uint32
-	Values      []int64
+	Values      []uint32
 	Diagnostics ColumnPartSetScanDiagnostics
 }
 
@@ -287,11 +287,11 @@ func (r *ColumnPartSetReader) ScanFloat32VectorAtLatestWithScratch(primaryID int
 	return value, true, nil
 }
 
-func (r *ColumnPartSetReader) AdjacencyListAtLatest(primaryID int64, columnName string, dst []int64) ([]int64, bool, error) {
+func (r *ColumnPartSetReader) AdjacencyListAtLatest(primaryID int64, columnName string, dst []uint32) ([]uint32, bool, error) {
 	return r.AdjacencyListAtLatestWithScratch(primaryID, columnName, dst, nil)
 }
 
-func (r *ColumnPartSetReader) AdjacencyListAtLatestWithScratch(primaryID int64, columnName string, dst []int64, scratch *ColumnPartSetPointLookupScratch) ([]int64, bool, error) {
+func (r *ColumnPartSetReader) AdjacencyListAtLatestWithScratch(primaryID int64, columnName string, dst []uint32, scratch *ColumnPartSetPointLookupScratch) ([]uint32, bool, error) {
 	if r == nil {
 		return nil, false, nil
 	}
@@ -306,11 +306,11 @@ func (r *ColumnPartSetReader) AdjacencyListAtLatestWithScratch(primaryID int64, 
 	return value, true, nil
 }
 
-func (r *ColumnPartSetReader) ScanAdjacencyListAtLatest(primaryID int64, columnName string, dst []int64) ([]int64, bool, error) {
+func (r *ColumnPartSetReader) ScanAdjacencyListAtLatest(primaryID int64, columnName string, dst []uint32) ([]uint32, bool, error) {
 	return r.ScanAdjacencyListAtLatestWithScratch(primaryID, columnName, dst, nil)
 }
 
-func (r *ColumnPartSetReader) ScanAdjacencyListAtLatestWithScratch(primaryID int64, columnName string, dst []int64, scratch *ColumnPartSetPointLookupScratch) ([]int64, bool, error) {
+func (r *ColumnPartSetReader) ScanAdjacencyListAtLatestWithScratch(primaryID int64, columnName string, dst []uint32, scratch *ColumnPartSetPointLookupScratch) ([]uint32, bool, error) {
 	ref, ok := r.scanLatestRowRef(primaryID)
 	if !ok {
 		return nil, false, nil
@@ -438,7 +438,7 @@ func (r *ColumnPartSetReader) ScanFloat32VectorsInto(columnName string, dst []fl
 	}, nil
 }
 
-func (r *ColumnPartSetReader) ScanAdjacencyListsInto(columnName string, offsets []uint32, values []int64) (ColumnPartSetAdjacencyListScanResult, error) {
+func (r *ColumnPartSetReader) ScanAdjacencyListsInto(columnName string, offsets []uint32, values []uint32) (ColumnPartSetAdjacencyListScanResult, error) {
 	if r == nil {
 		return ColumnPartSetAdjacencyListScanResult{}, fmt.Errorf("colgranule: nil part set reader")
 	}
@@ -621,7 +621,7 @@ func (r *ColumnPartSetReader) float32VectorAtRowRef(ref columnPartSetRowRef, col
 	return scratch.scanner.Float32VectorAt(ref.Locator, columnName, dst)
 }
 
-func (r *ColumnPartSetReader) adjacencyListAtRowRef(ref columnPartSetRowRef, columnName string, dst []int64, scratch *ColumnPartSetPointLookupScratch) ([]int64, error) {
+func (r *ColumnPartSetReader) adjacencyListAtRowRef(ref columnPartSetRowRef, columnName string, dst []uint32, scratch *ColumnPartSetPointLookupScratch) ([]uint32, error) {
 	if r == nil {
 		return nil, fmt.Errorf("colgranule: nil part set reader")
 	}

--- a/experiments/colgranule/part_test.go
+++ b/experiments/colgranule/part_test.go
@@ -222,3 +222,10 @@ func assertInt64s(t *testing.T, name string, got []int64, want []int64) {
 		t.Fatalf("%s=%v want %v", name, got, want)
 	}
 }
+
+func assertUint32s(t *testing.T, name string, got []uint32, want []uint32) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s=%v want %v", name, got, want)
+	}
+}

--- a/experiments/colgranule/vector_columns.go
+++ b/experiments/colgranule/vector_columns.go
@@ -14,7 +14,7 @@ type Float32VectorColumn struct {
 
 type AdjacencyListColumn struct {
 	Offsets []uint32
-	Values  []int64
+	Values  []uint32
 }
 
 func (b *GranuleBuilder) BuildFloat32Vectors(values []float32, dims int) (EncodedGranule, error) {
@@ -54,33 +54,33 @@ func (r *GranuleReader) DecodeFloat32VectorsInto(dst []float32, g EncodedGranule
 	return values, nil
 }
 
-func (b *GranuleBuilder) BuildInt64AdjacencyLists(offsets []uint32, values []int64) (EncodedGranule, error) {
+func (b *GranuleBuilder) BuildUint32AdjacencyLists(offsets []uint32, values []uint32) (EncodedGranule, error) {
 	rows, err := validateAdjacencyListValues(offsets, values)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
-	raw, err := encodeInt64AdjacencyListPayload(b.raw[:0], offsets, values)
+	raw, err := encodeUint32AdjacencyListPayload(b.raw[:0], offsets, values)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
 	b.raw = raw
-	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingRawInt64AdjacencyList, b.cfg.Compression)
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingRawUint32AdjacencyList, b.cfg.Compression)
 	if err != nil {
 		return EncodedGranule{}, err
 	}
 	b.compressed = selection.Scratch
-	return newEncodedGranule(rows, 0, 0, false, EncodingRawInt64AdjacencyList, selection), nil
+	return newEncodedGranule(rows, 0, 0, false, EncodingRawUint32AdjacencyList, selection), nil
 }
 
-func (r *GranuleReader) DecodeInt64AdjacencyListsInto(offsetDst []uint32, valueDst []int64, g EncodedGranule) ([]uint32, []int64, error) {
-	if g.Encoding != EncodingRawInt64AdjacencyList {
+func (r *GranuleReader) DecodeUint32AdjacencyListsInto(offsetDst []uint32, valueDst []uint32, g EncodedGranule) ([]uint32, []uint32, error) {
+	if g.Encoding != EncodingRawUint32AdjacencyList {
 		return nil, nil, fmt.Errorf("colgranule: adjacency-list decode got encoding %d", g.Encoding)
 	}
 	raw, err := r.decompressPayload(g)
 	if err != nil {
 		return nil, nil, err
 	}
-	offsets, values, err := decodeInt64AdjacencyListPayload(offsetDst, valueDst, raw, g.Rows)
+	offsets, values, err := decodeUint32AdjacencyListPayload(offsetDst, valueDst, raw, g.Rows)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -164,7 +164,7 @@ func decodeFloat32VectorRowInto(dst []float32, raw []byte, rows int, dims int, r
 	return out, nil
 }
 
-func validateAdjacencyListValues(offsets []uint32, values []int64) (int, error) {
+func validateAdjacencyListValues(offsets []uint32, values []uint32) (int, error) {
 	if len(offsets) < 2 {
 		return 0, errors.New("colgranule: adjacency list requires rows+1 offsets")
 	}
@@ -187,12 +187,12 @@ func validateAdjacencyListValues(offsets []uint32, values []int64) (int, error) 
 	return len(offsets) - 1, nil
 }
 
-func encodeInt64AdjacencyListPayload(dst []byte, offsets []uint32, values []int64) ([]byte, error) {
+func encodeUint32AdjacencyListPayload(dst []byte, offsets []uint32, values []uint32) ([]byte, error) {
 	offsetBytes, err := checkedMulInt(len(offsets), 4, "adjacency offset bytes")
 	if err != nil {
 		return nil, err
 	}
-	valueBytes, err := checkedMulInt(len(values), 8, "adjacency value bytes")
+	valueBytes, err := checkedMulInt(len(values), 4, "adjacency value bytes")
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +210,12 @@ func encodeInt64AdjacencyListPayload(dst []byte, offsets []uint32, values []int6
 	}
 	valueStart := offsetBytes
 	for i, value := range values {
-		binary.LittleEndian.PutUint64(dst[valueStart+i*8:], uint64(value))
+		binary.LittleEndian.PutUint32(dst[valueStart+i*4:], value)
 	}
 	return dst, nil
 }
 
-func decodeInt64AdjacencyListPayload(offsetDst []uint32, valueDst []int64, raw []byte, rows int) ([]uint32, []int64, error) {
+func decodeUint32AdjacencyListPayload(offsetDst []uint32, valueDst []uint32, raw []byte, rows int) ([]uint32, []uint32, error) {
 	if rows <= 0 {
 		return nil, nil, fmt.Errorf("colgranule: invalid adjacency rows %d", rows)
 	}
@@ -232,7 +232,7 @@ func decodeInt64AdjacencyListPayload(offsetDst []uint32, valueDst []int64, raw [
 		offsets[i] = binary.LittleEndian.Uint32(raw[i*4:])
 	}
 	valueCount := int(offsets[len(offsets)-1])
-	valueBytes, err := checkedMulInt(valueCount, 8, "adjacency value bytes")
+	valueBytes, err := checkedMulInt(valueCount, 4, "adjacency value bytes")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -243,10 +243,10 @@ func decodeInt64AdjacencyListPayload(offsetDst []uint32, valueDst []int64, raw [
 	if len(raw) != need {
 		return nil, nil, fmt.Errorf("colgranule: adjacency raw bytes=%d want=%d", len(raw), need)
 	}
-	values := ensureInt64Len(valueDst, valueCount)
+	values := ensureUint32Len(valueDst, valueCount)
 	valueRaw := raw[offsetBytes:]
 	for i := range values {
-		values[i] = int64(binary.LittleEndian.Uint64(valueRaw[i*8:]))
+		values[i] = binary.LittleEndian.Uint32(valueRaw[i*4:])
 	}
 	if _, err := validateAdjacencyListValues(offsets, values); err != nil {
 		return nil, nil, err
@@ -254,7 +254,7 @@ func decodeInt64AdjacencyListPayload(offsetDst []uint32, valueDst []int64, raw [
 	return offsets, values, nil
 }
 
-func decodeInt64AdjacencyListRowInto(dst []int64, raw []byte, rows int, row int) ([]int64, error) {
+func decodeUint32AdjacencyListRowInto(dst []uint32, raw []byte, rows int, row int) ([]uint32, error) {
 	if rows <= 0 {
 		return nil, fmt.Errorf("colgranule: invalid adjacency rows %d", rows)
 	}
@@ -275,7 +275,7 @@ func decodeInt64AdjacencyListRowInto(dst []int64, raw []byte, rows int, row int)
 	if start > end || end > final {
 		return nil, fmt.Errorf("colgranule: invalid adjacency row offsets start=%d end=%d final=%d", start, end, final)
 	}
-	valueBytes, err := checkedMulInt(int(final), 8, "adjacency value bytes")
+	valueBytes, err := checkedMulInt(int(final), 4, "adjacency value bytes")
 	if err != nil {
 		return nil, err
 	}
@@ -286,10 +286,10 @@ func decodeInt64AdjacencyListRowInto(dst []int64, raw []byte, rows int, row int)
 	if len(raw) != need {
 		return nil, fmt.Errorf("colgranule: adjacency raw bytes=%d want=%d", len(raw), need)
 	}
-	out := ensureInt64Len(dst, int(end-start))
+	out := ensureUint32Len(dst, int(end-start))
 	valueRaw := raw[offsetBytes:]
 	for i := range out {
-		out[i] = int64(binary.LittleEndian.Uint64(valueRaw[(int(start)+i)*8:]))
+		out[i] = binary.LittleEndian.Uint32(valueRaw[(int(start)+i)*4:])
 	}
 	return out, nil
 }

--- a/experiments/colgranule/vector_columns_test.go
+++ b/experiments/colgranule/vector_columns_test.go
@@ -41,7 +41,7 @@ func TestColumnPartBuildsFloat32VectorAndAdjacencyColumns(t *testing.T) {
 	if !slices.Equal(neighbors.Offsets, []uint32{0, 1, 4, 6, 8, 8}) {
 		t.Fatalf("neighbors offsets=%v", neighbors.Offsets)
 	}
-	assertInt64s(t, "neighbors", neighbors.Values, []int64{11, 21, 22, 23, 31, 32, 41, 42})
+	assertUint32s(t, "neighbors", neighbors.Values, []uint32{11, 21, 22, 23, 31, 32, 41, 42})
 
 	locator, ok := part.LocatePrimaryID(4)
 	if !ok {
@@ -56,7 +56,7 @@ func TestColumnPartBuildsFloat32VectorAndAdjacencyColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AdjacencyListAt: %v", err)
 	}
-	assertInt64s(t, "point neighbors", pointNeighbors, []int64{41, 42})
+	assertUint32s(t, "point neighbors", pointNeighbors, []uint32{41, 42})
 }
 
 func TestColumnPartVectorColumnsSurviveImageRoundTrip(t *testing.T) {
@@ -99,7 +99,7 @@ func TestColumnPartVectorColumnsSurviveImageRoundTrip(t *testing.T) {
 	if !slices.Equal(neighbors.Offsets, []uint32{0, 1, 4, 6, 8, 8}) {
 		t.Fatalf("image neighbors offsets=%v", neighbors.Offsets)
 	}
-	assertInt64s(t, "image neighbors", neighbors.Values, []int64{11, 21, 22, 23, 31, 32, 41, 42})
+	assertUint32s(t, "image neighbors", neighbors.Values, []uint32{11, 21, 22, 23, 31, 32, 41, 42})
 }
 
 func TestColumnPartVectorColumnsValidateShape(t *testing.T) {
@@ -114,7 +114,7 @@ func TestColumnPartVectorColumnsValidateShape(t *testing.T) {
 	batch = vectorPartTestBatch()
 	batch.AdjacencyLists["neighbors"] = AdjacencyListColumn{
 		Offsets: []uint32{0, 1, 3, 3, 4, 6},
-		Values:  []int64{11, 21, 22, 41, 42},
+		Values:  []uint32{11, 21, 22, 41, 42},
 	}
 	_, err = BuildColumnPart(1, opts, batch)
 	if err == nil || !strings.Contains(err.Error(), "final offset=6 values=5") {
@@ -142,7 +142,7 @@ func TestColumnMutationAdapterMergesVectorAndAdjacencyBatches(t *testing.T) {
 		AdjacencyLists: map[string]AdjacencyListColumn{
 			"neighbors": {
 				Offsets: []uint32{0, 2, 3},
-				Values:  []int64{31, 32, 11},
+				Values:  []uint32{31, 32, 11},
 			},
 		},
 	}
@@ -160,7 +160,7 @@ func TestColumnMutationAdapterMergesVectorAndAdjacencyBatches(t *testing.T) {
 		AdjacencyLists: map[string]AdjacencyListColumn{
 			"neighbors": {
 				Offsets: []uint32{0, 2},
-				Values:  []int64{21, 22},
+				Values:  []uint32{21, 22},
 			},
 		},
 	}
@@ -193,7 +193,7 @@ func TestColumnMutationAdapterMergesVectorAndAdjacencyBatches(t *testing.T) {
 	if !slices.Equal(neighbors.Offsets, []uint32{0, 1, 3, 5}) {
 		t.Fatalf("merged neighbor offsets=%v", neighbors.Offsets)
 	}
-	assertInt64s(t, "merged neighbors", neighbors.Values, []int64{11, 21, 22, 31, 32})
+	assertUint32s(t, "merged neighbors", neighbors.Values, []uint32{11, 21, 22, 31, 32})
 }
 
 func TestColumnPartSetCompactionPreservesVectorAndAdjacencyColumns(t *testing.T) {
@@ -226,7 +226,7 @@ func TestColumnPartSetCompactionPreservesVectorAndAdjacencyColumns(t *testing.T)
 				"embedding": {Dims: 3, Values: []float32{60, 61, 62}},
 			},
 			AdjacencyLists: map[string]AdjacencyListColumn{
-				"neighbors": {Offsets: []uint32{0, 3}, Values: []int64{61, 62, 63}},
+				"neighbors": {Offsets: []uint32{0, 3}, Values: []uint32{61, 62, 63}},
 			},
 		},
 		Updates: ColumnBatch{
@@ -238,7 +238,7 @@ func TestColumnPartSetCompactionPreservesVectorAndAdjacencyColumns(t *testing.T)
 				"embedding": {Dims: 3, Values: []float32{200, 201, 202}},
 			},
 			AdjacencyLists: map[string]AdjacencyListColumn{
-				"neighbors": {Offsets: []uint32{0, 2}, Values: []int64{2001, 2002}},
+				"neighbors": {Offsets: []uint32{0, 2}, Values: []uint32{2001, 2002}},
 			},
 		},
 		Deletes:                 []int64{3},
@@ -289,14 +289,14 @@ func TestColumnPartSetCompactionPreservesVectorAndAdjacencyColumns(t *testing.T)
 	if !slices.Equal(neighbors.Offsets, []uint32{0, 1, 3, 5, 5, 8}) {
 		t.Fatalf("compacted adjacency offsets=%v", neighbors.Offsets)
 	}
-	assertInt64s(t, "compacted neighbors", neighbors.Values, []int64{11, 2001, 2002, 41, 42, 61, 62, 63})
+	assertUint32s(t, "compacted neighbors", neighbors.Values, []uint32{11, 2001, 2002, 41, 42, 61, 62, 63})
 }
 
 func BenchmarkColumnPartVectorAdjacencyBuild(b *testing.B) {
 	opts := vectorPartBenchmarkOptions(8192, 128)
 	batch := vectorPartBenchmarkBatch(8192, 128, 16)
 	b.ReportAllocs()
-	b.SetBytes(int64(8192*128*4 + 8192*16*8))
+	b.SetBytes(int64(8192*128*4 + 8192*16*4))
 	for i := 0; i < b.N; i++ {
 		part, err := BuildColumnPart(uint64(i+1), opts, batch)
 		if err != nil {
@@ -347,7 +347,7 @@ func BenchmarkColumnPartAdjacencyScan(b *testing.B) {
 	offsets := warm.Offsets
 	values := warm.Values
 	b.ReportAllocs()
-	b.SetBytes(int64(len(values) * 8))
+	b.SetBytes(int64(len(values) * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		scan, err := scanner.ScanAdjacencyListsInto("neighbors", offsets, values)
@@ -408,7 +408,7 @@ func BenchmarkColumnPartAdjacencyPointLookup(b *testing.B) {
 	}
 	scratch := warm
 	b.ReportAllocs()
-	b.SetBytes(int64(len(scratch) * 8))
+	b.SetBytes(int64(len(scratch) * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		neighbors, err := scanner.AdjacencyListAt(locator, "neighbors", scratch)
@@ -416,7 +416,7 @@ func BenchmarkColumnPartAdjacencyPointLookup(b *testing.B) {
 			b.Fatalf("AdjacencyListAt: %v", err)
 		}
 		scratch = neighbors
-		benchSink += neighbors[0]
+		benchSink += int64(neighbors[0])
 	}
 }
 
@@ -455,7 +455,7 @@ func vectorPartTestBatch() ColumnBatch {
 		AdjacencyLists: map[string]AdjacencyListColumn{
 			"neighbors": {
 				Offsets: []uint32{0, 2, 3, 6, 6, 8},
-				Values:  []int64{31, 32, 11, 21, 22, 23, 41, 42},
+				Values:  []uint32{31, 32, 11, 21, 22, 23, 41, 42},
 			},
 		},
 	}
@@ -483,7 +483,7 @@ func vectorPartBenchmarkBatch(rows int, dims int, degree int) ColumnBatch {
 	ids := make([]int64, rows)
 	vectors := make([]float32, rows*dims)
 	offsets := make([]uint32, rows+1)
-	neighbors := make([]int64, rows*degree)
+	neighbors := make([]uint32, rows*degree)
 	for row := 0; row < rows; row++ {
 		ids[row] = int64(row)
 		for dim := 0; dim < dims; dim++ {
@@ -491,7 +491,7 @@ func vectorPartBenchmarkBatch(rows int, dims int, degree int) ColumnBatch {
 		}
 		offsets[row] = uint32(row * degree)
 		for edge := 0; edge < degree; edge++ {
-			neighbors[row*degree+edge] = int64((row + edge + 1) % rows)
+			neighbors[row*degree+edge] = uint32((row + edge + 1) % rows)
 		}
 	}
 	offsets[rows] = uint32(len(neighbors))

--- a/experiments/colgranule/vector_graph.go
+++ b/experiments/colgranule/vector_graph.go
@@ -310,7 +310,7 @@ func normalizeColumnVectorGraphOptions(opts ColumnVectorGraphOptions) ColumnVect
 }
 
 func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []float32, offsets []uint32, neighbors []uint32, rows int) error {
-	if rows < 0 || rows >= math.MaxUint32 {
+	if rows < 0 || rows > math.MaxUint32 {
 		return fmt.Errorf("colgranule: graph rows=%d outside uint32 neighbor ordinal range", rows)
 	}
 	rowLimit := uint32(rows)

--- a/experiments/colgranule/vector_graph.go
+++ b/experiments/colgranule/vector_graph.go
@@ -310,6 +310,11 @@ func normalizeColumnVectorGraphOptions(opts ColumnVectorGraphOptions) ColumnVect
 }
 
 func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []float32, offsets []uint32, neighbors []uint32, rows int) error {
+	if rows < 0 || rows > math.MaxUint32 {
+		return fmt.Errorf("colgranule: graph rows=%d outside uint32 neighbor ordinal range", rows)
+	}
+	rowLimit := uint32(rows)
+
 	vectorValues, err := checkedMulInt(rows, dims, "column vector graph values")
 	if err != nil {
 		return err
@@ -357,7 +362,7 @@ func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []fl
 		return fmt.Errorf("colgranule: graph final adjacency offset=%d values=%d", prev, len(neighbors))
 	}
 	for edge, neighbor := range neighbors {
-		if neighbor >= uint32(rows) {
+		if neighbor >= rowLimit {
 			return fmt.Errorf("colgranule: graph edge %d neighbor ordinal=%d outside rows=%d", edge, neighbor, rows)
 		}
 	}

--- a/experiments/colgranule/vector_graph.go
+++ b/experiments/colgranule/vector_graph.go
@@ -310,7 +310,7 @@ func normalizeColumnVectorGraphOptions(opts ColumnVectorGraphOptions) ColumnVect
 }
 
 func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []float32, offsets []uint32, neighbors []uint32, rows int) error {
-	if rows < 0 || rows > math.MaxUint32 {
+	if rows < 0 || rows >= math.MaxUint32 {
 		return fmt.Errorf("colgranule: graph rows=%d outside uint32 neighbor ordinal range", rows)
 	}
 	rowLimit := uint32(rows)

--- a/experiments/colgranule/vector_graph.go
+++ b/experiments/colgranule/vector_graph.go
@@ -69,7 +69,7 @@ type ColumnVectorGraph struct {
 	vectors          []float32
 	invNorms         []float32
 	neighborOffsets  []uint32
-	neighborOrdinals []int64
+	neighborOrdinals []uint32
 	entryOrdinal     int
 }
 
@@ -226,7 +226,7 @@ func (g *ColumnVectorGraph) NeighborOffsets(dst []uint32) []uint32 {
 }
 
 // NeighborOrdinals appends the CSR adjacency ordinals to dst.
-func (g *ColumnVectorGraph) NeighborOrdinals(dst []int64) []int64 {
+func (g *ColumnVectorGraph) NeighborOrdinals(dst []uint32) []uint32 {
 	if g == nil {
 		return dst
 	}
@@ -309,7 +309,7 @@ func normalizeColumnVectorGraphOptions(opts ColumnVectorGraphOptions) ColumnVect
 	return opts
 }
 
-func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []float32, offsets []uint32, neighbors []int64, rows int) error {
+func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []float32, offsets []uint32, neighbors []uint32, rows int) error {
 	vectorValues, err := checkedMulInt(rows, dims, "column vector graph values")
 	if err != nil {
 		return err
@@ -357,7 +357,7 @@ func validateColumnVectorGraphStorage(vectors []float32, dims int, invNorms []fl
 		return fmt.Errorf("colgranule: graph final adjacency offset=%d values=%d", prev, len(neighbors))
 	}
 	for edge, neighbor := range neighbors {
-		if neighbor < 0 || neighbor >= int64(rows) {
+		if neighbor >= uint32(rows) {
 			return fmt.Errorf("colgranule: graph edge %d neighbor ordinal=%d outside rows=%d", edge, neighbor, rows)
 		}
 	}

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -98,6 +98,22 @@ func TestColumnVectorGraphPersistedReopenPath(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphPersistedShuffledOrderIsPermutation(t *testing.T) {
+	for _, rows := range []int{1024, 1009, 1009 * 3} {
+		seen := make([]bool, rows)
+		for ordinal := 0; ordinal < rows; ordinal++ {
+			source := columnVectorGraphPersistedSourceForOrdinal(ordinal, rows, columnVectorGraphPersistedOrderShuffled)
+			if source < 0 || source >= rows {
+				t.Fatalf("rows=%d ordinal=%d source=%d out of range", rows, ordinal, source)
+			}
+			if seen[source] {
+				t.Fatalf("rows=%d duplicate source=%d", rows, source)
+			}
+			seen[source] = true
+		}
+	}
+}
+
 func BenchmarkColumnVectorGraphPersistedSearchCosine(b *testing.B) {
 	shapes := []struct {
 		name string
@@ -146,7 +162,7 @@ func benchmarkColumnVectorGraphPersistedSearchSerial(b *testing.B, fixture *colu
 		b.Fatalf("warm results=%d want %d", len(warm), fixture.opts.TopK)
 	}
 	b.ReportAllocs()
-	b.SetBytes(int64(warmStats.CandidatesExamined * fixture.graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphPersistedScoredBytes(warmStats.CandidatesExamined, fixture.graph.Dims()))
 	b.ResetTimer()
 	start := time.Now()
 	for i := 0; i < b.N; i++ {
@@ -189,7 +205,7 @@ func benchmarkColumnVectorGraphPersistedSearchParallel(b *testing.B, fixture *co
 	}
 	b.ReportAllocs()
 	b.SetParallelism(1)
-	b.SetBytes(int64(warmStats.CandidatesExamined * fixture.graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphPersistedScoredBytes(warmStats.CandidatesExamined, fixture.graph.Dims()))
 	b.ResetTimer()
 	start := time.Now()
 	b.RunParallel(func(pb *testing.PB) {
@@ -260,6 +276,10 @@ func reportColumnVectorGraphPersistedProductMetrics(b *testing.B, fixture *colum
 }
 
 func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, degree int, blockRows int, compression Compression, order columnVectorGraphPersistedOrder) *columnVectorGraphPersistedFixture {
+	return buildColumnVectorGraphPersistedFixtureWithPhaseTimer(tb, nil, rows, dims, degree, blockRows, compression, order)
+}
+
+func buildColumnVectorGraphPersistedFixtureWithPhaseTimer(tb testing.TB, phaseTimer *testing.B, rows int, dims int, degree int, blockRows int, compression Compression, order columnVectorGraphPersistedOrder) *columnVectorGraphPersistedFixture {
 	tb.Helper()
 	dir, err := os.MkdirTemp("", "colgranule-vector-graph-*")
 	if err != nil {
@@ -289,6 +309,9 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 	rowsPerPart := columnVectorGraphPersistedRowsPerPart(rows)
 	ordinalBySource := columnVectorGraphPersistedOrdinalBySource(rows, order)
 
+	if phaseTimer != nil {
+		phaseTimer.StartTimer()
+	}
 	buildStart := time.Now()
 	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
 	if err != nil {
@@ -327,7 +350,13 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 		tb.Fatalf("Close build workspace: %v", closeErr)
 	}
 	buildNanos := time.Since(buildStart).Nanoseconds()
+	if phaseTimer != nil {
+		phaseTimer.StopTimer()
+	}
 
+	if phaseTimer != nil {
+		phaseTimer.StartTimer()
+	}
 	openStart := time.Now()
 	reopened, err = OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
 	if err != nil {
@@ -342,13 +371,22 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 		tb.Fatalf("OpenColumnPartSetReader: %v", err)
 	}
 	openNanos := time.Since(openStart).Nanoseconds()
+	if phaseTimer != nil {
+		phaseTimer.StopTimer()
+	}
 
+	if phaseTimer != nil {
+		phaseTimer.StartTimer()
+	}
 	decodeStart := time.Now()
 	graph, loadStats, err := NewColumnVectorGraphFromPartSet(reader, ColumnVectorGraphOptions{})
 	if err != nil {
 		tb.Fatalf("NewColumnVectorGraphFromPartSet: %v", err)
 	}
 	decodeNanos := time.Since(decodeStart).Nanoseconds()
+	if phaseTimer != nil {
+		phaseTimer.StopTimer()
+	}
 
 	queryOrdinal := rows / 2
 	query, ok := graph.VectorAt(nil, queryOrdinal)
@@ -421,9 +459,28 @@ func columnVectorGraphPersistedOrdinalBySource(rows int, order columnVectorGraph
 
 func columnVectorGraphPersistedSourceForOrdinal(ordinal int, rows int, order columnVectorGraphPersistedOrder) int {
 	if order == columnVectorGraphPersistedOrderShuffled {
-		return (ordinal*1009 + 9173) % rows
+		multiplier := columnVectorGraphPersistedShuffleMultiplier(rows)
+		return int((int64(ordinal)*int64(multiplier) + 9173) % int64(rows))
 	}
 	return ordinal
+}
+
+func columnVectorGraphPersistedShuffleMultiplier(rows int) int {
+	multiplier := 1009
+	for columnVectorGraphPersistedGCD(multiplier, rows) != 1 {
+		multiplier += 2
+	}
+	return multiplier
+}
+
+func columnVectorGraphPersistedGCD(a int, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
 }
 
 func columnVectorGraphPersistedOrdinalForSource(source int, order columnVectorGraphPersistedOrder, ordinalBySource []int) int {
@@ -555,6 +612,10 @@ func metricToken(value string) string {
 	return value
 }
 
+func columnVectorGraphPersistedScoredBytes(candidates int, dims int) int64 {
+	return int64(candidates) * int64(dims) * 4
+}
+
 func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 	if os.Getenv("COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE") != "1" {
 		b.Skip("set COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE=1 to run the 100k persisted build/open/decode benchmark")
@@ -568,8 +629,10 @@ func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 			var lastAccounting columnVectorGraphPersistedAccounting
 			var lastLoadStats ColumnVectorGraphLoadStats
 			b.ReportAllocs()
+			b.ResetTimer()
+			b.StopTimer()
 			for i := 0; i < b.N; i++ {
-				fixture := buildColumnVectorGraphPersistedFixture(b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
+				fixture := buildColumnVectorGraphPersistedFixtureWithPhaseTimer(b, b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
 				totalBuildNanos += fixture.buildNanos
 				totalOpenNanos += fixture.openNanos
 				totalDecodeNanos += fixture.decodeNanos
@@ -579,9 +642,6 @@ func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 				b.StopTimer()
 				if err := fixture.Close(); err != nil {
 					b.Fatalf("Close persisted vector graph fixture: %v", err)
-				}
-				if i+1 < b.N {
-					b.StartTimer()
 				}
 			}
 			if b.N > 0 {

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -192,8 +192,7 @@ func benchmarkColumnVectorGraphPersistedSearchParallel(b *testing.B, fixture *co
 	b.RunParallel(func(pb *testing.PB) {
 		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
 		if workerID >= len(scratches) {
-			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
-			return
+			panic(fmt.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches)))
 		}
 		scratch := scratches[workerID]
 		var localSink int64

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -1,0 +1,505 @@
+package colgranule
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type columnVectorGraphPersistedOrder string
+
+const (
+	columnVectorGraphPersistedOrderLocal    columnVectorGraphPersistedOrder = "neighborhood_local"
+	columnVectorGraphPersistedOrderShuffled columnVectorGraphPersistedOrder = "shuffled"
+)
+
+type columnVectorGraphPersistedFixture struct {
+	graph       *ColumnVectorGraph
+	query       []float32
+	opts        ColumnVectorGraphSearchOptions
+	loadStats   ColumnVectorGraphLoadStats
+	buildNanos  int64
+	openNanos   int64
+	decodeNanos int64
+	accounting  columnVectorGraphPersistedAccounting
+}
+
+type columnVectorGraphPersistedAccounting struct {
+	rows                       int
+	encodedRawBytes            int
+	declaredColumnStoredBytes  int
+	assetBytes                 int
+	imageBytes                 int
+	settledDiskBytes           int64
+	vectorRawBytes             int
+	vectorStoredBytes          int
+	invNormRawBytes            int
+	invNormStoredBytes         int
+	adjacencyRawBytes          int
+	adjacencyStoredBytes       int
+	sourceDocumentVectorBytes  int
+	actualCompressionBlocks    map[string]int
+	compressionFallbackReasons map[string]int
+}
+
+func TestColumnVectorGraphPersistedReopenPath(t *testing.T) {
+	fixture := buildColumnVectorGraphPersistedFixture(t, 1024, 32, 8, 256, CompressionZSTD, columnVectorGraphPersistedOrderLocal)
+	if fixture.graph.Rows() != 1024 || fixture.graph.Dims() != 32 {
+		t.Fatalf("graph shape rows=%d dims=%d want rows=1024 dims=32", fixture.graph.Rows(), fixture.graph.Dims())
+	}
+	if fixture.loadStats.Rows != 1024 || fixture.loadStats.Edges != 1024*8 {
+		t.Fatalf("load stats=%+v want rows=1024 edges=%d", fixture.loadStats, 1024*8)
+	}
+	if fixture.accounting.sourceDocumentVectorBytes != 0 {
+		t.Fatalf("source document vector bytes=%d want 0 for column-only fixture", fixture.accounting.sourceDocumentVectorBytes)
+	}
+	var scratch ColumnVectorGraphSearchScratch
+	results, stats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) != fixture.opts.TopK {
+		t.Fatalf("results=%d want %d", len(results), fixture.opts.TopK)
+	}
+	if stats.CandidatesExamined == 0 || stats.EdgesVisited == 0 {
+		t.Fatalf("search stats=%+v want non-zero traversal", stats)
+	}
+}
+
+func BenchmarkColumnVectorGraphPersistedSearchCosine(b *testing.B) {
+	shapes := []struct {
+		name string
+		rows int
+	}{
+		{name: "100k", rows: 100_000},
+		{name: "1m", rows: 1_000_000},
+	}
+	compressions := []Compression{CompressionNone, CompressionSnappy, CompressionLZ4, CompressionZSTD}
+	orders := []columnVectorGraphPersistedOrder{columnVectorGraphPersistedOrderLocal, columnVectorGraphPersistedOrderShuffled}
+	for _, shape := range shapes {
+		shape := shape
+		b.Run(shape.name, func(b *testing.B) {
+			if shape.rows == 1_000_000 && os.Getenv("COLUMN_VECTOR_PERSISTED_1M") != "1" {
+				b.Skip("set COLUMN_VECTOR_PERSISTED_1M=1 to run the 1M persisted-column shape")
+			}
+			for _, order := range orders {
+				order := order
+				b.Run(string(order), func(b *testing.B) {
+					for _, compression := range compressions {
+						compression := compression
+						b.Run(compression.String(), func(b *testing.B) {
+							fixture := buildColumnVectorGraphPersistedFixture(b, shape.rows, 128, 16, 8192, compression, order)
+							b.Run("serial", func(b *testing.B) {
+								benchmarkColumnVectorGraphPersistedSearchSerial(b, fixture)
+							})
+							b.Run("parallel", func(b *testing.B) {
+								benchmarkColumnVectorGraphPersistedSearchParallel(b, fixture)
+							})
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func benchmarkColumnVectorGraphPersistedSearchSerial(b *testing.B, fixture *columnVectorGraphPersistedFixture) {
+	var scratch ColumnVectorGraphSearchScratch
+	warm, warmStats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, &scratch)
+	if err != nil {
+		b.Fatalf("warm SearchCosine: %v", err)
+	}
+	if len(warm) != fixture.opts.TopK {
+		b.Fatalf("warm results=%d want %d", len(warm), fixture.opts.TopK)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(warmStats.CandidatesExamined * fixture.graph.Dims() * 4))
+	b.ResetTimer()
+	start := time.Now()
+	for i := 0; i < b.N; i++ {
+		results, stats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, &scratch)
+		if err != nil {
+			b.Fatalf("SearchCosine: %v", err)
+		}
+		if len(results) != fixture.opts.TopK {
+			b.Fatalf("results=%d want %d", len(results), fixture.opts.TopK)
+		}
+		benchSink += int64(results[0].Ordinal + stats.CandidatesExamined + stats.EdgesVisited)
+	}
+	elapsed := time.Since(start)
+	b.StopTimer()
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "searches/s")
+	}
+	reportColumnVectorGraphPersistedMetrics(b, fixture, warmStats)
+}
+
+func benchmarkColumnVectorGraphPersistedSearchParallel(b *testing.B, fixture *columnVectorGraphPersistedFixture) {
+	workers := runtime.GOMAXPROCS(0)
+	scratches := make([]*ColumnVectorGraphSearchScratch, workers)
+	var warmStats ColumnVectorGraphSearchStats
+	for i := 0; i < workers; i++ {
+		scratch := new(ColumnVectorGraphSearchScratch)
+		warm, stats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, scratch)
+		if err != nil {
+			b.Fatalf("warm SearchCosine worker %d: %v", i, err)
+		}
+		if len(warm) != fixture.opts.TopK {
+			b.Fatalf("warm worker %d results=%d want %d", i, len(warm), fixture.opts.TopK)
+		}
+		warmStats = stats
+		scratches[i] = scratch
+	}
+	b.ReportAllocs()
+	b.SetParallelism(1)
+	b.SetBytes(int64(warmStats.CandidatesExamined * fixture.graph.Dims() * 4))
+	b.ResetTimer()
+	start := time.Now()
+	var nextWorker uint64
+	b.RunParallel(func(pb *testing.PB) {
+		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
+		if workerID >= len(scratches) {
+			b.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches))
+			return
+		}
+		scratch := scratches[workerID]
+		var localSink int64
+		for pb.Next() {
+			results, stats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, scratch)
+			if err != nil {
+				panic(err)
+			}
+			if len(results) != fixture.opts.TopK {
+				panic("unexpected column vector graph result count")
+			}
+			localSink += int64(results[0].Ordinal + stats.CandidatesExamined + stats.EdgesVisited)
+		}
+		atomic.AddInt64(&benchSink, localSink)
+	})
+	elapsed := time.Since(start)
+	b.StopTimer()
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "searches/s")
+	}
+	reportColumnVectorGraphPersistedMetrics(b, fixture, warmStats)
+}
+
+func reportColumnVectorGraphPersistedMetrics(b *testing.B, fixture *columnVectorGraphPersistedFixture, searchStats ColumnVectorGraphSearchStats) {
+	b.Helper()
+	accounting := fixture.accounting
+	rows := float64(accounting.rows)
+	if rows == 0 {
+		rows = 1
+	}
+	b.ReportMetric(float64(fixture.buildNanos)/1e6, "build_ms")
+	b.ReportMetric(float64(fixture.openNanos)/1e6, "open_ms")
+	b.ReportMetric(float64(fixture.decodeNanos)/1e6, "decode_ms")
+	b.ReportMetric(float64(accounting.encodedRawBytes)/rows, "encoded_raw_B/entry")
+	b.ReportMetric(float64(accounting.declaredColumnStoredBytes)/rows, "stored_B/entry")
+	b.ReportMetric(float64(accounting.assetBytes)/rows, "asset_B/entry")
+	b.ReportMetric(float64(accounting.imageBytes)/rows, "image_B/entry")
+	// Colgranule has no row-store checkpoint/GC/rewrite hook. This is the
+	// settled namespace size after part publish, manifest save, close, and reopen.
+	b.ReportMetric(float64(accounting.settledDiskBytes)/rows, "settled_disk_B/entry")
+	b.ReportMetric(float64(accounting.vectorRawBytes)/rows, "vector_raw_B/entry")
+	b.ReportMetric(float64(accounting.vectorStoredBytes)/rows, "vector_stored_B/entry")
+	b.ReportMetric(float64(accounting.invNormRawBytes)/rows, "invnorm_raw_B/entry")
+	b.ReportMetric(float64(accounting.invNormStoredBytes)/rows, "invnorm_stored_B/entry")
+	b.ReportMetric(float64(accounting.adjacencyRawBytes)/rows, "adjacency_raw_B/entry")
+	b.ReportMetric(float64(accounting.adjacencyStoredBytes)/rows, "adjacency_stored_B/entry")
+	b.ReportMetric(float64(accounting.sourceDocumentVectorBytes)/rows, "source_doc_vector_B/entry")
+	b.ReportMetric(float64(accounting.sourceDocumentVectorBytes+accounting.vectorRawBytes)/rows, "source_plus_column_vector_B/entry")
+	for compression, blocks := range accounting.actualCompressionBlocks {
+		b.ReportMetric(float64(blocks), "actual_"+metricToken(compression)+"_blocks")
+	}
+	for reason, blocks := range accounting.compressionFallbackReasons {
+		b.ReportMetric(float64(blocks), "fallback_"+metricToken(reason)+"_blocks")
+	}
+	b.ReportMetric(float64(fixture.loadStats.Edges)/float64(fixture.loadStats.Rows), "edges/node")
+	b.ReportMetric(float64(searchStats.CandidatesExamined), "candidates/search")
+	b.ReportMetric(float64(searchStats.EdgesVisited), "edges/search")
+}
+
+func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, degree int, blockRows int, compression Compression, order columnVectorGraphPersistedOrder) *columnVectorGraphPersistedFixture {
+	tb.Helper()
+	dir := tb.TempDir()
+	opts := columnVectorGraphPersistedOptions(rows, dims, blockRows, compression)
+	rowsPerPart := columnVectorGraphPersistedRowsPerPart(rows)
+	ordinalBySource := columnVectorGraphPersistedOrdinalBySource(rows, order)
+
+	buildStart := time.Now()
+	workspace, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
+	if err != nil {
+		tb.Fatalf("OpenColumnWorkspace(build): %v", err)
+	}
+	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
+		Collection:        "persisted_vector_graph",
+		StoreOptions:      opts,
+		InitialPartID:     1,
+		InitialGeneration: 1,
+	})
+	if err != nil {
+		tb.Fatalf("NewColumnMutationAdapter: %v", err)
+	}
+	for start := 0; start < rows; start += rowsPerPart {
+		end := min(start+rowsPerPart, rows)
+		batch := columnVectorGraphPersistedBatchRange(rows, dims, degree, start, end, order, ordinalBySource)
+		_, err := adapter.PublishBaseBatch(batch, ColumnPartCoverageOptions{
+			SourceRowRootGeneration: 1,
+			SourceRowVersionLower:   uint64(start),
+			SourceRowVersionUpper:   uint64(end),
+		})
+		if err != nil {
+			tb.Fatalf("PublishBaseBatch rows [%d,%d): %v", start, end, err)
+		}
+	}
+	if err := workspace.Close(); err != nil {
+		tb.Fatalf("Close build workspace: %v", err)
+	}
+	buildNanos := time.Since(buildStart).Nanoseconds()
+
+	openStart := time.Now()
+	reopened, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
+	if err != nil {
+		tb.Fatalf("OpenColumnWorkspace(reopen): %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := reopened.Close(); err != nil {
+			tb.Fatalf("Close reopened workspace: %v", err)
+		}
+	})
+	manifest, err := reopened.LoadCollectionManifest()
+	if err != nil {
+		tb.Fatalf("LoadCollectionManifest: %v", err)
+	}
+	reader, err := OpenColumnPartSetReader(reopened, manifest, ColumnPartImageReadOptions{})
+	if err != nil {
+		tb.Fatalf("OpenColumnPartSetReader: %v", err)
+	}
+	openNanos := time.Since(openStart).Nanoseconds()
+
+	decodeStart := time.Now()
+	graph, loadStats, err := NewColumnVectorGraphFromPartSet(reader, ColumnVectorGraphOptions{})
+	if err != nil {
+		tb.Fatalf("NewColumnVectorGraphFromPartSet: %v", err)
+	}
+	decodeNanos := time.Since(decodeStart).Nanoseconds()
+
+	queryOrdinal := rows / 2
+	query, ok := graph.VectorAt(nil, queryOrdinal)
+	if !ok {
+		tb.Fatalf("missing query vector ordinal %d", queryOrdinal)
+	}
+	accounting := columnVectorGraphPersistedByteAccounting(tb, reader)
+	settledDiskBytes, err := columnVectorGraphPersistedDirBytes(dir)
+	if err != nil {
+		tb.Fatalf("settled dir bytes: %v", err)
+	}
+	accounting.settledDiskBytes = settledDiskBytes
+	return &columnVectorGraphPersistedFixture{
+		graph:       graph,
+		query:       query,
+		opts:        ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128},
+		loadStats:   loadStats,
+		buildNanos:  buildNanos,
+		openNanos:   openNanos,
+		decodeNanos: decodeNanos,
+		accounting:  accounting,
+	}
+}
+
+func columnVectorGraphPersistedOptions(rows int, dims int, blockRows int, vectorCompression Compression) ColumnStoreOptions {
+	if blockRows <= 0 {
+		blockRows = DefaultRowsPerGranule
+	}
+	return ColumnStoreOptions{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CodecBlockRows: blockRows},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, VectorDims: dims, Compression: vectorCompression, CodecBlockRows: blockRows},
+			{Name: "embedding_inv_norm", Type: ColumnTypeFloat32Vector, VectorDims: 1, Compression: vectorCompression, CodecBlockRows: blockRows},
+			{Name: "neighbors", Type: ColumnTypeAdjacencyList, Compression: CompressionNone, CodecBlockRows: blockRows},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy: ColumnPartPolicy{
+			RowsPerGranule:        blockRows,
+			DefaultCodecBlockRows: blockRows,
+		},
+	}
+}
+
+func columnVectorGraphPersistedRowsPerPart(rows int) int {
+	const maxRowsPerPart = 100_000
+	if rows > maxRowsPerPart {
+		return maxRowsPerPart
+	}
+	return rows
+}
+
+func columnVectorGraphPersistedOrdinalBySource(rows int, order columnVectorGraphPersistedOrder) []int {
+	if order != columnVectorGraphPersistedOrderShuffled {
+		return nil
+	}
+	ordinalBySource := make([]int, rows)
+	for ordinal := 0; ordinal < rows; ordinal++ {
+		source := columnVectorGraphPersistedSourceForOrdinal(ordinal, rows, order)
+		ordinalBySource[source] = ordinal
+	}
+	return ordinalBySource
+}
+
+func columnVectorGraphPersistedSourceForOrdinal(ordinal int, rows int, order columnVectorGraphPersistedOrder) int {
+	if order == columnVectorGraphPersistedOrderShuffled {
+		return (ordinal*1009 + 9173) % rows
+	}
+	return ordinal
+}
+
+func columnVectorGraphPersistedOrdinalForSource(source int, order columnVectorGraphPersistedOrder, ordinalBySource []int) int {
+	if order == columnVectorGraphPersistedOrderShuffled {
+		return ordinalBySource[source]
+	}
+	return source
+}
+
+func columnVectorGraphPersistedBatchRange(rows int, dims int, degree int, start int, end int, order columnVectorGraphPersistedOrder, ordinalBySource []int) ColumnBatch {
+	chunkRows := end - start
+	ids := make([]int64, chunkRows)
+	vectors := make([]float32, chunkRows*dims)
+	invNorms := make([]float32, chunkRows)
+	offsets := make([]uint32, chunkRows+1)
+	neighbors := make([]uint32, 0, chunkRows*degree)
+	for localRow := 0; localRow < chunkRows; localRow++ {
+		ordinal := start + localRow
+		source := columnVectorGraphPersistedSourceForOrdinal(ordinal, rows, order)
+		ids[localRow] = int64(ordinal)
+		var normSquared float64
+		for dim := 0; dim < dims; dim++ {
+			value := columnVectorGraphPersistedVectorValue(source, dim)
+			vectors[localRow*dims+dim] = value
+			normSquared += float64(value) * float64(value)
+		}
+		invNorms[localRow] = float32(1 / math.Sqrt(normSquared))
+		offsets[localRow] = uint32(len(neighbors))
+		for edge := 0; edge < degree; edge++ {
+			step := edge/2 + 1
+			neighborSource := source + step
+			if edge%2 == 1 {
+				neighborSource = source - step
+			}
+			neighborSource %= rows
+			if neighborSource < 0 {
+				neighborSource += rows
+			}
+			neighborOrdinal := columnVectorGraphPersistedOrdinalForSource(neighborSource, order, ordinalBySource)
+			neighbors = append(neighbors, uint32(neighborOrdinal))
+		}
+	}
+	offsets[chunkRows] = uint32(len(neighbors))
+	return ColumnBatch{
+		Rows: chunkRows,
+		Columns: map[string][]int64{
+			"id": ids,
+		},
+		Float32Vectors: map[string]Float32VectorColumn{
+			"embedding":          {Dims: dims, Values: vectors},
+			"embedding_inv_norm": {Dims: 1, Values: invNorms},
+		},
+		AdjacencyLists: map[string]AdjacencyListColumn{
+			"neighbors": {Offsets: offsets, Values: neighbors},
+		},
+	}
+}
+
+func columnVectorGraphPersistedVectorValue(source int, dim int) float32 {
+	cluster := source / 32
+	return float32(((cluster+1)*(dim+17)%251)+1) / 251
+}
+
+func columnVectorGraphPersistedByteAccounting(tb testing.TB, reader *ColumnPartSetReader) columnVectorGraphPersistedAccounting {
+	tb.Helper()
+	out := columnVectorGraphPersistedAccounting{
+		actualCompressionBlocks:    make(map[string]int),
+		compressionFallbackReasons: make(map[string]int),
+	}
+	if reader == nil {
+		return out
+	}
+	for _, loaded := range reader.parts {
+		partAccounting := loaded.Part.ByteAccounting()
+		out.rows += partAccounting.Rows
+		out.encodedRawBytes += partAccounting.EncodedRawBytes
+		out.declaredColumnStoredBytes += partAccounting.DeclaredColumnStoredBytes
+		out.assetBytes += loaded.Ref.Part.AssetBytes
+		out.imageBytes += loaded.Ref.Part.ImageBytes
+		for _, detail := range partAccounting.ColumnsDetail {
+			switch detail.Column {
+			case "embedding":
+				out.vectorRawBytes += detail.EncodedRawBytes
+				out.vectorStoredBytes += detail.StoredBytes
+			case "embedding_inv_norm":
+				out.invNormRawBytes += detail.EncodedRawBytes
+				out.invNormStoredBytes += detail.StoredBytes
+			case "neighbors":
+				out.adjacencyRawBytes += detail.EncodedRawBytes
+				out.adjacencyStoredBytes += detail.StoredBytes
+			}
+		}
+		for _, compression := range partAccounting.CompressionDetail {
+			out.actualCompressionBlocks[compression.ActualCompression.String()] += compression.Blocks
+			if compression.FallbackReason != "" {
+				out.compressionFallbackReasons[compression.FallbackReason] += compression.Blocks
+			}
+		}
+	}
+	return out
+}
+
+func columnVectorGraphPersistedDirBytes(dir string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}
+
+func metricToken(value string) string {
+	value = strings.ReplaceAll(value, "/", "_")
+	value = strings.ReplaceAll(value, " ", "_")
+	value = strings.ReplaceAll(value, "-", "_")
+	if value == "" {
+		return "empty"
+	}
+	return value
+}
+
+func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
+	for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4, CompressionZSTD} {
+		compression := compression
+		b.Run(fmt.Sprintf("100k/%s/%s", columnVectorGraphPersistedOrderLocal, compression), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				fixture := buildColumnVectorGraphPersistedFixture(b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
+				benchSink += int64(fixture.graph.Rows() + fixture.loadStats.Edges)
+			}
+		})
+	}
+}

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -183,18 +183,20 @@ func benchmarkColumnVectorGraphPersistedSearchParallel(b *testing.B, fixture *co
 		warmStats = stats
 		scratches[i] = scratch
 	}
+	scratchPool := make(chan *ColumnVectorGraphSearchScratch, workers)
+	for _, scratch := range scratches {
+		scratchPool <- scratch
+	}
 	b.ReportAllocs()
 	b.SetParallelism(1)
 	b.SetBytes(int64(warmStats.CandidatesExamined * fixture.graph.Dims() * 4))
 	b.ResetTimer()
 	start := time.Now()
-	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
-		workerID := int(atomic.AddUint64(&nextWorker, 1)) - 1
-		if workerID >= len(scratches) {
-			panic(fmt.Errorf("RunParallel spawned worker %d, but only %d scratches were prewarmed", workerID+1, len(scratches)))
-		}
-		scratch := scratches[workerID]
+		scratch := <-scratchPool
+		defer func() {
+			scratchPool <- scratch
+		}()
 		var localSink int64
 		for pb.Next() {
 			results, stats, err := fixture.graph.SearchCosine(fixture.query, fixture.opts, scratch)
@@ -217,6 +219,14 @@ func benchmarkColumnVectorGraphPersistedSearchParallel(b *testing.B, fixture *co
 }
 
 func reportColumnVectorGraphPersistedMetrics(b *testing.B, fixture *columnVectorGraphPersistedFixture, searchStats ColumnVectorGraphSearchStats) {
+	b.Helper()
+	reportColumnVectorGraphPersistedProductMetrics(b, fixture)
+	b.ReportMetric(float64(fixture.loadStats.Edges)/float64(fixture.loadStats.Rows), "edges/node")
+	b.ReportMetric(float64(searchStats.CandidatesExamined), "candidates/search")
+	b.ReportMetric(float64(searchStats.EdgesVisited), "edges/search")
+}
+
+func reportColumnVectorGraphPersistedProductMetrics(b *testing.B, fixture *columnVectorGraphPersistedFixture) {
 	b.Helper()
 	accounting := fixture.accounting
 	rows := float64(accounting.rows)
@@ -247,9 +257,6 @@ func reportColumnVectorGraphPersistedMetrics(b *testing.B, fixture *columnVector
 	for reason, blocks := range accounting.compressionFallbackReasons {
 		b.ReportMetric(float64(blocks), "fallback_"+metricToken(reason)+"_blocks")
 	}
-	b.ReportMetric(float64(fixture.loadStats.Edges)/float64(fixture.loadStats.Rows), "edges/node")
-	b.ReportMetric(float64(searchStats.CandidatesExamined), "candidates/search")
-	b.ReportMetric(float64(searchStats.EdgesVisited), "edges/search")
 }
 
 func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, degree int, blockRows int, compression Compression, order columnVectorGraphPersistedOrder) *columnVectorGraphPersistedFixture {
@@ -549,17 +556,38 @@ func metricToken(value string) string {
 }
 
 func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
+	if os.Getenv("COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE") != "1" {
+		b.Skip("set COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE=1 to run the 100k persisted build/open/decode benchmark")
+	}
 	for _, compression := range []Compression{CompressionNone, CompressionSnappy, CompressionLZ4, CompressionZSTD} {
 		compression := compression
 		b.Run(fmt.Sprintf("100k/%s/%s", columnVectorGraphPersistedOrderLocal, compression), func(b *testing.B) {
+			var totalBuildNanos int64
+			var totalOpenNanos int64
+			var totalDecodeNanos int64
+			var lastFixture columnVectorGraphPersistedFixture
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				fixture := buildColumnVectorGraphPersistedFixture(b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
+				totalBuildNanos += fixture.buildNanos
+				totalOpenNanos += fixture.openNanos
+				totalDecodeNanos += fixture.decodeNanos
+				lastFixture = *fixture
 				benchSink += int64(fixture.graph.Rows() + fixture.loadStats.Edges)
 				b.StopTimer()
 				if err := fixture.Close(); err != nil {
 					b.Fatalf("Close persisted vector graph fixture: %v", err)
 				}
-				b.StartTimer()
+				if i+1 < b.N {
+					b.StartTimer()
+				}
+			}
+			if b.N > 0 {
+				lastFixture.buildNanos = totalBuildNanos / int64(b.N)
+				lastFixture.openNanos = totalOpenNanos / int64(b.N)
+				lastFixture.decodeNanos = totalDecodeNanos / int64(b.N)
+				reportColumnVectorGraphPersistedProductMetrics(b, &lastFixture)
+				b.ReportMetric(float64(lastFixture.loadStats.Edges)/float64(lastFixture.loadStats.Rows), "edges/node")
 			}
 		})
 	}

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -565,14 +565,16 @@ func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 			var totalBuildNanos int64
 			var totalOpenNanos int64
 			var totalDecodeNanos int64
-			var lastFixture columnVectorGraphPersistedFixture
+			var lastAccounting columnVectorGraphPersistedAccounting
+			var lastLoadStats ColumnVectorGraphLoadStats
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				fixture := buildColumnVectorGraphPersistedFixture(b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
 				totalBuildNanos += fixture.buildNanos
 				totalOpenNanos += fixture.openNanos
 				totalDecodeNanos += fixture.decodeNanos
-				lastFixture = *fixture
+				lastAccounting = fixture.accounting
+				lastLoadStats = fixture.loadStats
 				benchSink += int64(fixture.graph.Rows() + fixture.loadStats.Edges)
 				b.StopTimer()
 				if err := fixture.Close(); err != nil {
@@ -583,11 +585,14 @@ func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 				}
 			}
 			if b.N > 0 {
-				lastFixture.buildNanos = totalBuildNanos / int64(b.N)
-				lastFixture.openNanos = totalOpenNanos / int64(b.N)
-				lastFixture.decodeNanos = totalDecodeNanos / int64(b.N)
-				reportColumnVectorGraphPersistedProductMetrics(b, &lastFixture)
-				b.ReportMetric(float64(lastFixture.loadStats.Edges)/float64(lastFixture.loadStats.Rows), "edges/node")
+				avgFixture := &columnVectorGraphPersistedFixture{
+					buildNanos:  totalBuildNanos / int64(b.N),
+					openNanos:   totalOpenNanos / int64(b.N),
+					decodeNanos: totalDecodeNanos / int64(b.N),
+					accounting:  lastAccounting,
+				}
+				reportColumnVectorGraphPersistedProductMetrics(b, avgFixture)
+				b.ReportMetric(float64(lastLoadStats.Edges)/float64(lastLoadStats.Rows), "edges/node")
 			}
 		})
 	}

--- a/experiments/colgranule/vector_graph_persisted_bench_test.go
+++ b/experiments/colgranule/vector_graph_persisted_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +29,9 @@ type columnVectorGraphPersistedFixture struct {
 	openNanos   int64
 	decodeNanos int64
 	accounting  columnVectorGraphPersistedAccounting
+	cleanupOnce sync.Once
+	cleanup     func() error
+	cleanupErr  error
 }
 
 type columnVectorGraphPersistedAccounting struct {
@@ -48,8 +52,30 @@ type columnVectorGraphPersistedAccounting struct {
 	compressionFallbackReasons map[string]int
 }
 
+func (f *columnVectorGraphPersistedFixture) Close() error {
+	if f == nil {
+		return nil
+	}
+	f.cleanupOnce.Do(func() {
+		if f.cleanup != nil {
+			f.cleanupErr = f.cleanup()
+		}
+	})
+	return f.cleanupErr
+}
+
+func registerColumnVectorGraphPersistedFixtureCleanup(tb testing.TB, fixture *columnVectorGraphPersistedFixture) {
+	tb.Helper()
+	tb.Cleanup(func() {
+		if err := fixture.Close(); err != nil {
+			tb.Fatalf("Close persisted vector graph fixture: %v", err)
+		}
+	})
+}
+
 func TestColumnVectorGraphPersistedReopenPath(t *testing.T) {
 	fixture := buildColumnVectorGraphPersistedFixture(t, 1024, 32, 8, 256, CompressionZSTD, columnVectorGraphPersistedOrderLocal)
+	registerColumnVectorGraphPersistedFixtureCleanup(t, fixture)
 	if fixture.graph.Rows() != 1024 || fixture.graph.Dims() != 32 {
 		t.Fatalf("graph shape rows=%d dims=%d want rows=1024 dims=32", fixture.graph.Rows(), fixture.graph.Dims())
 	}
@@ -95,6 +121,7 @@ func BenchmarkColumnVectorGraphPersistedSearchCosine(b *testing.B) {
 						compression := compression
 						b.Run(compression.String(), func(b *testing.B) {
 							fixture := buildColumnVectorGraphPersistedFixture(b, shape.rows, 128, 16, 8192, compression, order)
+							registerColumnVectorGraphPersistedFixtureCleanup(b, fixture)
 							b.Run("serial", func(b *testing.B) {
 								benchmarkColumnVectorGraphPersistedSearchSerial(b, fixture)
 							})
@@ -228,7 +255,30 @@ func reportColumnVectorGraphPersistedMetrics(b *testing.B, fixture *columnVector
 
 func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, degree int, blockRows int, compression Compression, order columnVectorGraphPersistedOrder) *columnVectorGraphPersistedFixture {
 	tb.Helper()
-	dir := tb.TempDir()
+	dir, err := os.MkdirTemp("", "colgranule-vector-graph-*")
+	if err != nil {
+		tb.Fatalf("MkdirTemp: %v", err)
+	}
+	var reopened *ColumnWorkspace
+	cleanup := func() error {
+		var cleanupErr error
+		if reopened != nil {
+			if err := reopened.Close(); err != nil {
+				cleanupErr = err
+			}
+			reopened = nil
+		}
+		if err := os.RemoveAll(dir); err != nil && cleanupErr == nil {
+			cleanupErr = err
+		}
+		return cleanupErr
+	}
+	success := false
+	defer func() {
+		if !success {
+			_ = cleanup()
+		}
+	}()
 	opts := columnVectorGraphPersistedOptions(rows, dims, blockRows, compression)
 	rowsPerPart := columnVectorGraphPersistedRowsPerPart(rows)
 	ordinalBySource := columnVectorGraphPersistedOrdinalBySource(rows, order)
@@ -238,6 +288,12 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 	if err != nil {
 		tb.Fatalf("OpenColumnWorkspace(build): %v", err)
 	}
+	workspaceOpen := true
+	defer func() {
+		if workspaceOpen {
+			_ = workspace.Close()
+		}
+	}()
 	adapter, err := NewColumnMutationAdapter(workspace, ColumnMutationAdapterOptions{
 		Collection:        "persisted_vector_graph",
 		StoreOptions:      opts,
@@ -259,21 +315,18 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 			tb.Fatalf("PublishBaseBatch rows [%d,%d): %v", start, end, err)
 		}
 	}
-	if err := workspace.Close(); err != nil {
-		tb.Fatalf("Close build workspace: %v", err)
+	closeErr := workspace.Close()
+	workspaceOpen = false
+	if closeErr != nil {
+		tb.Fatalf("Close build workspace: %v", closeErr)
 	}
 	buildNanos := time.Since(buildStart).Nanoseconds()
 
 	openStart := time.Now()
-	reopened, err := OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
+	reopened, err = OpenColumnWorkspace(dir, ColumnWorkspaceOptions{Collection: "persisted_vector_graph"})
 	if err != nil {
 		tb.Fatalf("OpenColumnWorkspace(reopen): %v", err)
 	}
-	tb.Cleanup(func() {
-		if err := reopened.Close(); err != nil {
-			tb.Fatalf("Close reopened workspace: %v", err)
-		}
-	})
 	manifest, err := reopened.LoadCollectionManifest()
 	if err != nil {
 		tb.Fatalf("LoadCollectionManifest: %v", err)
@@ -296,13 +349,14 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 	if !ok {
 		tb.Fatalf("missing query vector ordinal %d", queryOrdinal)
 	}
+	query = append([]float32(nil), query...)
 	accounting := columnVectorGraphPersistedByteAccounting(tb, reader)
 	settledDiskBytes, err := columnVectorGraphPersistedDirBytes(dir)
 	if err != nil {
 		tb.Fatalf("settled dir bytes: %v", err)
 	}
 	accounting.settledDiskBytes = settledDiskBytes
-	return &columnVectorGraphPersistedFixture{
+	fixture := &columnVectorGraphPersistedFixture{
 		graph:       graph,
 		query:       query,
 		opts:        ColumnVectorGraphSearchOptions{TopK: 10, EfSearch: 128},
@@ -311,7 +365,10 @@ func buildColumnVectorGraphPersistedFixture(tb testing.TB, rows int, dims int, d
 		openNanos:   openNanos,
 		decodeNanos: decodeNanos,
 		accounting:  accounting,
+		cleanup:     cleanup,
 	}
+	success = true
+	return fixture
 }
 
 func columnVectorGraphPersistedOptions(rows int, dims int, blockRows int, vectorCompression Compression) ColumnStoreOptions {
@@ -499,6 +556,11 @@ func BenchmarkColumnVectorGraphPersistedBuildOpenDecode(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				fixture := buildColumnVectorGraphPersistedFixture(b, 100_000, 128, 16, 8192, compression, columnVectorGraphPersistedOrderLocal)
 				benchSink += int64(fixture.graph.Rows() + fixture.loadStats.Edges)
+				b.StopTimer()
+				if err := fixture.Close(); err != nil {
+					b.Fatalf("Close persisted vector graph fixture: %v", err)
+				}
+				b.StartTimer()
 			}
 		})
 	}

--- a/experiments/colgranule/vector_graph_test.go
+++ b/experiments/colgranule/vector_graph_test.go
@@ -134,7 +134,7 @@ func TestColumnVectorGraphSearchHandlesOverflowingFloat32Dot(t *testing.T) {
 		vectors:          []float32{1e20, 0, 0, 1e20},
 		invNorms:         []float32{1e-20, 1e-20},
 		neighborOffsets:  []uint32{0, 1, 2},
-		neighborOrdinals: []int64{1, 0},
+		neighborOrdinals: []uint32{1, 0},
 		entryOrdinal:     0,
 	}
 
@@ -177,7 +177,7 @@ func TestColumnVectorGraphSearchHandlesOverflowingScaledCosine(t *testing.T) {
 		vectors:          vectors,
 		invNorms:         []float32{invNorm, invNorm},
 		neighborOffsets:  []uint32{0, 1, 2},
-		neighborOrdinals: []int64{1, 0},
+		neighborOrdinals: []uint32{1, 0},
 		entryOrdinal:     0,
 	}
 
@@ -216,7 +216,7 @@ func TestColumnVectorGraphSearchHandlesUnderflowingFloat32Dot(t *testing.T) {
 		vectors:          []float32{value, -value},
 		invNorms:         []float32{invNorm, invNorm},
 		neighborOffsets:  []uint32{0, 1, 2},
-		neighborOrdinals: []int64{1, 0},
+		neighborOrdinals: []uint32{1, 0},
 		entryOrdinal:     0,
 	}
 
@@ -303,7 +303,7 @@ func TestColumnVectorGraphSearchExploresEqualDistanceBridge(t *testing.T) {
 		vectors:          []float32{1, 1, 1},
 		invNorms:         []float32{1, 1, 1},
 		neighborOffsets:  []uint32{0, 0, 1, 2},
-		neighborOrdinals: []int64{2, 0},
+		neighborOrdinals: []uint32{2, 0},
 		entryOrdinal:     1,
 	}
 
@@ -511,7 +511,7 @@ func columnVectorGraphTestBatch(rows int, dims int, degree int, complete bool) C
 	vectors := make([]float32, rows*dims)
 	invNorms := make([]float32, rows)
 	offsets := make([]uint32, rows+1)
-	neighbors := make([]int64, 0, rows*maxColumnVectorGraphDegree(rows, degree, complete))
+	neighbors := make([]uint32, 0, rows*maxColumnVectorGraphDegree(rows, degree, complete))
 	for row := 0; row < rows; row++ {
 		ids[row] = int64(row)
 		var normSquared float64
@@ -525,7 +525,7 @@ func columnVectorGraphTestBatch(rows int, dims int, degree int, complete bool) C
 		if complete {
 			for neighbor := 0; neighbor < rows; neighbor++ {
 				if neighbor != row {
-					neighbors = append(neighbors, int64(neighbor))
+					neighbors = append(neighbors, uint32(neighbor))
 				}
 			}
 			continue
@@ -540,7 +540,7 @@ func columnVectorGraphTestBatch(rows int, dims int, degree int, complete bool) C
 			if neighbor < 0 {
 				neighbor += rows
 			}
-			neighbors = append(neighbors, int64(neighbor))
+			neighbors = append(neighbors, uint32(neighbor))
 		}
 	}
 	offsets[rows] = uint32(len(neighbors))

--- a/experiments/colgranule/vector_graph_test.go
+++ b/experiments/colgranule/vector_graph_test.go
@@ -1,6 +1,7 @@
 package colgranule
 
 import (
+	"fmt"
 	"math"
 	"slices"
 	"strings"
@@ -95,16 +96,20 @@ func TestColumnVectorGraphRejectsStaleInvNorm(t *testing.T) {
 }
 
 func TestColumnVectorGraphRejectsRowsOutsideUint32OrdinalRange(t *testing.T) {
-	rows := int64(math.MaxUint32) + 1
-	if int64(int(rows)) != rows {
-		t.Skip("requires 64-bit int")
-	}
-	err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
-	if err == nil {
-		t.Fatal("validateColumnVectorGraphStorage succeeded with rows outside uint32 range")
-	}
-	if !strings.Contains(err.Error(), "uint32") {
-		t.Fatalf("error=%q want uint32 range validation", err)
+	for _, rows := range []int64{math.MaxUint32, int64(math.MaxUint32) + 1} {
+		rows := rows
+		t.Run(fmt.Sprintf("rows=%d", rows), func(t *testing.T) {
+			if int64(int(rows)) != rows {
+				t.Skip("requires 64-bit int")
+			}
+			err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
+			if err == nil {
+				t.Fatal("validateColumnVectorGraphStorage succeeded with rows outside uint32 range")
+			}
+			if !strings.Contains(err.Error(), "uint32") {
+				t.Fatalf("error=%q want uint32 range validation", err)
+			}
+		})
 	}
 }
 

--- a/experiments/colgranule/vector_graph_test.go
+++ b/experiments/colgranule/vector_graph_test.go
@@ -94,6 +94,20 @@ func TestColumnVectorGraphRejectsStaleInvNorm(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphRejectsRowsOutsideUint32OrdinalRange(t *testing.T) {
+	rows := int64(math.MaxUint32) + 1
+	if int64(int(rows)) != rows {
+		t.Skip("requires 64-bit int")
+	}
+	err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
+	if err == nil {
+		t.Fatal("validateColumnVectorGraphStorage succeeded with rows outside uint32 range")
+	}
+	if !strings.Contains(err.Error(), "uint32") {
+		t.Fatalf("error=%q want uint32 range validation", err)
+	}
+}
+
 func TestColumnVectorGraphRejectsLooseTinyInvNorm(t *testing.T) {
 	err := validateColumnVectorGraphStorage(
 		[]float32{1e20},

--- a/experiments/colgranule/vector_graph_test.go
+++ b/experiments/colgranule/vector_graph_test.go
@@ -1,7 +1,6 @@
 package colgranule
 
 import (
-	"fmt"
 	"math"
 	"slices"
 	"strings"
@@ -96,20 +95,30 @@ func TestColumnVectorGraphRejectsStaleInvNorm(t *testing.T) {
 }
 
 func TestColumnVectorGraphRejectsRowsOutsideUint32OrdinalRange(t *testing.T) {
-	for _, rows := range []int64{math.MaxUint32, int64(math.MaxUint32) + 1} {
-		rows := rows
-		t.Run(fmt.Sprintf("rows=%d", rows), func(t *testing.T) {
-			if int64(int(rows)) != rows {
-				t.Skip("requires 64-bit int")
-			}
-			err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
-			if err == nil {
-				t.Fatal("validateColumnVectorGraphStorage succeeded with rows outside uint32 range")
-			}
-			if !strings.Contains(err.Error(), "uint32") {
-				t.Fatalf("error=%q want uint32 range validation", err)
-			}
-		})
+	rows := int64(math.MaxUint32) + 1
+	if int64(int(rows)) != rows {
+		t.Skip("requires 64-bit int")
+	}
+	err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
+	if err == nil {
+		t.Fatal("validateColumnVectorGraphStorage succeeded with rows outside uint32 range")
+	}
+	if !strings.Contains(err.Error(), "uint32") {
+		t.Fatalf("error=%q want uint32 range validation", err)
+	}
+}
+
+func TestColumnVectorGraphMaxUint32RowsReachStorageValidation(t *testing.T) {
+	rows := int64(math.MaxUint32)
+	if int64(int(rows)) != rows {
+		t.Skip("requires 64-bit int")
+	}
+	err := validateColumnVectorGraphStorage(nil, 1, nil, nil, nil, int(rows))
+	if err == nil {
+		t.Fatal("validateColumnVectorGraphStorage unexpectedly succeeded with incomplete storage")
+	}
+	if strings.Contains(err.Error(), "uint32") {
+		t.Fatalf("error=%q should not reject MaxUint32 rows as outside uint32 range", err)
 	}
 }
 

--- a/experiments/colgranule/vector_part_set_test.go
+++ b/experiments/colgranule/vector_part_set_test.go
@@ -35,7 +35,7 @@ func TestColumnPartSetVectorAdjacencyVisibilityAndCompaction(t *testing.T) {
 				"embedding": {Dims: 3, Values: []float32{60, 61, 62}},
 			},
 			AdjacencyLists: map[string]AdjacencyListColumn{
-				"neighbors": {Offsets: []uint32{0, 3}, Values: []int64{61, 62, 63}},
+				"neighbors": {Offsets: []uint32{0, 3}, Values: []uint32{61, 62, 63}},
 			},
 		},
 		Updates: ColumnBatch{
@@ -47,7 +47,7 @@ func TestColumnPartSetVectorAdjacencyVisibilityAndCompaction(t *testing.T) {
 				"embedding": {Dims: 3, Values: []float32{200, 201, 202}},
 			},
 			AdjacencyLists: map[string]AdjacencyListColumn{
-				"neighbors": {Offsets: []uint32{0, 2}, Values: []int64{2001, 2002}},
+				"neighbors": {Offsets: []uint32{0, 2}, Values: []uint32{2001, 2002}},
 			},
 		},
 		Deletes:                 []int64{3},
@@ -76,7 +76,7 @@ func TestColumnPartSetVectorAdjacencyVisibilityAndCompaction(t *testing.T) {
 			60, 61, 62,
 		},
 		[]uint32{0, 1, 3, 3, 5, 8},
-		[]int64{11, 41, 42, 2001, 2002, 61, 62, 63},
+		[]uint32{11, 41, 42, 2001, 2002, 61, 62, 63},
 	)
 	vector, ok, err := reader.Float32VectorAtLatest(2, "embedding", nil)
 	if err != nil {
@@ -93,7 +93,7 @@ func TestColumnPartSetVectorAdjacencyVisibilityAndCompaction(t *testing.T) {
 	if !ok {
 		t.Fatal("inserted id 6 missing latest adjacency")
 	}
-	assertInt64s(t, "inserted adjacency", neighbors, []int64{61, 62, 63})
+	assertUint32s(t, "inserted adjacency", neighbors, []uint32{61, 62, 63})
 	if _, ok, err := reader.Float32VectorAtLatest(3, "embedding", nil); err != nil || ok {
 		t.Fatalf("deleted id 3 latest vector ok=%v err=%v", ok, err)
 	}
@@ -129,11 +129,11 @@ func TestColumnPartSetVectorAdjacencyVisibilityAndCompaction(t *testing.T) {
 			60, 61, 62,
 		},
 		[]uint32{0, 1, 3, 5, 5, 8},
-		[]int64{11, 2001, 2002, 41, 42, 61, 62, 63},
+		[]uint32{11, 2001, 2002, 41, 42, 61, 62, 63},
 	)
 }
 
-func assertVectorPartSetSnapshot(t *testing.T, reader *ColumnPartSetReader, wantIDs []int64, wantVectors []float32, wantNeighborOffsets []uint32, wantNeighbors []int64) {
+func assertVectorPartSetSnapshot(t *testing.T, reader *ColumnPartSetReader, wantIDs []int64, wantVectors []float32, wantNeighborOffsets []uint32, wantNeighbors []uint32) {
 	t.Helper()
 	ids, err := reader.ScanProjected([]string{"id"})
 	if err != nil {
@@ -158,7 +158,7 @@ func assertVectorPartSetSnapshot(t *testing.T, reader *ColumnPartSetReader, want
 	if !slices.Equal(neighbors.Offsets, wantNeighborOffsets) {
 		t.Fatalf("adjacency offsets=%v want %v", neighbors.Offsets, wantNeighborOffsets)
 	}
-	assertInt64s(t, "part-set neighbors", neighbors.Values, wantNeighbors)
+	assertUint32s(t, "part-set neighbors", neighbors.Values, wantNeighbors)
 }
 
 func BenchmarkColumnPartSetVectorScan(b *testing.B) {
@@ -190,7 +190,7 @@ func BenchmarkColumnPartSetAdjacencyScan(b *testing.B) {
 	offsets := warm.Offsets
 	values := warm.Values
 	b.ReportAllocs()
-	b.SetBytes(int64(len(values) * 8))
+	b.SetBytes(int64(len(values) * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		scan, err := reader.ScanAdjacencyListsInto("neighbors", offsets, values)
@@ -242,7 +242,7 @@ func BenchmarkColumnPartSetAdjacencyPointLookup(b *testing.B) {
 	}
 	scratch := warm
 	b.ReportAllocs()
-	b.SetBytes(int64(len(scratch) * 8))
+	b.SetBytes(int64(len(scratch) * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		neighbors, ok, err := reader.AdjacencyListAtLatestWithScratch(4096, "neighbors", scratch, &lookupScratch)
@@ -253,7 +253,7 @@ func BenchmarkColumnPartSetAdjacencyPointLookup(b *testing.B) {
 			b.Fatal("missing adjacency for id 4096")
 		}
 		scratch = neighbors
-		benchSink += neighbors[0]
+		benchSink += int64(neighbors[0])
 	}
 }
 
@@ -309,7 +309,7 @@ func vectorPartSetBenchmarkMutations(rows int, dims int, degree int, step int) (
 	ids := make([]int64, updateRows)
 	vectors := make([]float32, updateRows*dims)
 	offsets := make([]uint32, updateRows+1)
-	neighbors := make([]int64, updateRows*degree)
+	neighbors := make([]uint32, updateRows*degree)
 	deletes := make([]int64, 0, updateRows)
 	row := 0
 	for id := 0; id < rows; id += step {
@@ -319,7 +319,7 @@ func vectorPartSetBenchmarkMutations(rows int, dims int, degree int, step int) (
 		}
 		offsets[row] = uint32(row * degree)
 		for edge := 0; edge < degree; edge++ {
-			neighbors[row*degree+edge] = int64((id + edge + 17) % rows)
+			neighbors[row*degree+edge] = uint32((id + edge + 17) % rows)
 		}
 		if id+1 < rows {
 			deletes = append(deletes, int64(id+1))


### PR DESCRIPTION
## Summary

Adds a persisted-column evidence track for column-backed `ColumnVectorGraph` search.

This benchmark path builds `embedding`, `embedding_inv_norm`, and `neighbors` as real colgranule assets, closes and reopens the workspace, loads the collection manifest/part-set reader, constructs `ColumnVectorGraph` from the persisted path, and then times only `SearchCosine`.

## Benchmark Scope

- Adds `BenchmarkColumnVectorGraphPersistedSearchCosine` with 100k default and opt-in 1M shapes.
- Includes serial and real `b.RunParallel` variants.
- Uses `TopK=10`, `EfSearch=128`, 128 dims, degree 16.
- Keeps build/open/decode outside the timed search loop.
- Reports build/open/decode ms, raw/stored/asset/image/settled disk bytes per entry, compression block mix/fallbacks, source-document vector duplication bytes, candidates/search, edges/search, edges/node, QPS, `B/op`, and `allocs/op`.
- Tests `none`, `snappy`, `lz4`, and `zstd` vector/inv-norm compression and both neighborhood-local and shuffled vector order.
- Keeps adjacency raw for this track but changes adjacency values to persisted `uint32` instead of `int64`.
- Gates the build/open/decode benchmark behind `COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE=1` so package-wide benchmark sweeps do not rebuild 100k persisted fixtures accidentally.

## Product-Path Evidence

- The existing in-memory vector graph benchmarks remain the search-kernel ceiling.
- This PR is the persisted product-path evidence track: real persisted colgranule assets plus manifest/root reopen/load/decode before hot-loop search.
- The fixture is column-only, so `source_doc_vector_B/entry` is reported as `0`; `source_plus_column_vector_B/entry` exposes the accounting hook for future row-document duplication checks.
- Colgranule does not currently have TreeDB row-store checkpoint/GC/rewrite hooks, so `settled_disk_B/entry` is measured after part publish, manifest save, close, and reopen.
- ZSTD uses shared encoder/decoder state and caps `DecodeAll` to declared raw bytes via `WithDecodeAllCapLimit(true)` plus a destination slice capacity of exactly `g.RawBytes`.

## Local Validation

```sh
GOWORK=off go test ./experiments/colgranule -count=1
```

Result: `ok github.com/snissn/gomap/experiments/colgranule 2.512s`

```sh
GOWORK=off go test -race ./experiments/colgranule -run 'TestZSTDCompressionAdmissionRoundTrip|TestColumnVectorGraphRejectsRowsOutsideUint32OrdinalRange|TestColumnVectorGraphMaxUint32RowsReachStorageValidation|TestColumnVectorGraphPersistedReopenPath|TestColumnVectorGraphPersistedShuffledOrderIsPermutation|TestColumnVectorGraph' -count=1
```

Result: `ok github.com/snissn/gomap/experiments/colgranule 1.842s`

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' -bench '^BenchmarkColumnVectorGraphPersistedBuildOpenDecode' -benchtime=1x -count=1
```

Result: `PASS` with the build/open/decode benchmark skipped unless `COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE=1` is set.

```sh
COLUMN_VECTOR_PERSISTED_BUILD_OPEN_DECODE=1 GOWORK=off go test ./experiments/colgranule -run '^$' -bench '^BenchmarkColumnVectorGraphPersistedSearchCosine/100k/neighborhood_local/(none|zstd)/(serial|parallel)$|^BenchmarkColumnVectorGraphPersistedBuildOpenDecode/100k/neighborhood_local/zstd$' -benchmem -benchtime=200ms -count=1
```

Representative local output on Apple M3:

```text
BenchmarkColumnVectorGraphPersistedSearchCosine/100k/neighborhood_local/none/serial-8     12438 ns/op   80401 searches/s  624.1 settled_disk_B/entry  512.0 vector_stored_B/entry  0 B/op  0 allocs/op
BenchmarkColumnVectorGraphPersistedSearchCosine/100k/neighborhood_local/none/parallel-8    2459 ns/op  406599 searches/s  624.1 settled_disk_B/entry  512.0 vector_stored_B/entry  0 B/op  0 allocs/op
BenchmarkColumnVectorGraphPersistedSearchCosine/100k/neighborhood_local/zstd/serial-8     12480 ns/op   80126 searches/s  121.6 settled_disk_B/entry   13.35 vector_stored_B/entry 0 B/op  0 allocs/op
BenchmarkColumnVectorGraphPersistedSearchCosine/100k/neighborhood_local/zstd/parallel-8    2600 ns/op  384660 searches/s  121.6 settled_disk_B/entry   13.35 vector_stored_B/entry 0 B/op  0 allocs/op
BenchmarkColumnVectorGraphPersistedBuildOpenDecode/100k/neighborhood_local/zstd-8     172010167 ns/op  97.89 build_ms  27.38 open_ms  46.74 decode_ms  284225680 B/op  2414 allocs/op
```

The search benchmark reports setup/load evidence separately from the timed hot loop. In the latest 100k neighborhood-local run, `none` reported build/open/decode at `317.8ms/87.03ms/28.61ms`, while `zstd` reported `118.0ms/29.45ms/47.78ms`. Search itself stayed zero-allocation after load for both serial and parallel variants.

Earlier opt-in 1M smoke on the same branch family:

```sh
COLUMN_VECTOR_PERSISTED_1M=1 GOWORK=off go test ./experiments/colgranule -run '^$' -bench '^BenchmarkColumnVectorGraphPersistedSearchCosine/1m/neighborhood_local/(none|zstd)/serial$' -benchmem -benchtime=1x -count=1
```

Representative results:

```text
1m none serial:  14583 ns/op  68966 searches/s  624.1 settled_disk_B/entry  0 B/op  0 allocs/op
1m zstd serial:  14833 ns/op  67797 searches/s  121.5 settled_disk_B/entry  0 B/op  0 allocs/op
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZSTD compression for stored payloads with automatic fallback when compression isn't beneficial.
  * Migrated adjacency-list storage and public APIs from 64-bit to 32-bit values to reduce payload size and I/O.

* **Tests**
  * Added ZSTD compression round-trip validation.
  * Added persisted vector-graph benchmarks and reopen/permutation correctness tests.
  * Added unit tests for 32-bit adjacency-list sizing and uint32 boundary validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
