### PR TITLE
collections: add column_graph vector contract seam

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -818,6 +818,7 @@ type VectorIndexDefinition struct {
 	EfConstruction   int                 `json:"ef_construction,omitempty"`
 	EfSearch         int                 `json:"ef_search,omitempty"`
 	Encoding         VectorIndexEncoding `json:"encoding,omitempty"`
+	Strategy         VectorIndexStrategy `json:"strategy,omitempty"`
 	SchemaGeneration uint64              `json:"schema_generation,omitempty"`
 }
 
@@ -3104,7 +3105,7 @@ func (c *Collection) CreateVectorIndex(def VectorIndexDefinition) (*CollectionMe
 		return nil, err
 	}
 	var runtime *VectorIndex
-	if registerEmptyRuntime {
+	if registerEmptyRuntime && vectorIndexDefinitionStrategy(normalizedDef) != VectorIndexStrategyColumnGraph {
 		runtime, err = newVectorIndex(c, vectorIndexOptionsFromDefinition(normalizedDef))
 		if err != nil {
 			return nil, err
@@ -3124,7 +3125,7 @@ func (c *Collection) CreateVectorIndex(def VectorIndexDefinition) (*CollectionMe
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
-	if registerEmptyRuntime {
+	if runtime != nil {
 		c.RegisterVectorIndex(runtime)
 	}
 	return newMeta.copy(), nil
@@ -17944,6 +17945,17 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, name)
+	if err != nil || catalog == nil {
+		return catalog, err
+	}
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		return nil, err
+	}
+	return catalog, nil
+}
+
+func loadCollectionCatalogWithoutColumnRootValidation(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {
 	raw, ok, err := getSystemValue(snap, systemCollectionMetaKey(name))
 	if err != nil || !ok {
 		return nil, err
@@ -17972,11 +17984,7 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 	if err != nil {
 		return nil, err
 	}
-	catalog := newCollectionCatalogWithOverlays(meta, roots, rootOverlays)
-	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
-		return nil, err
-	}
-	return catalog, nil
+	return newCollectionCatalogWithOverlays(meta, roots, rootOverlays), nil
 }
 
 func loadCollectionCatalogRootOverlays(snap *backenddb.Snapshot, rootNames []string) (map[string][]uint64, error) {
@@ -18683,8 +18691,13 @@ func normalizeVectorIndexDefinition(def VectorIndexDefinition) (VectorIndexDefin
 	if err != nil {
 		return VectorIndexDefinition{}, err
 	}
+	strategy, err := normalizeVectorIndexStrategy(def.Strategy)
+	if err != nil {
+		return VectorIndexDefinition{}, err
+	}
 	def.Metric = metric
 	def.Encoding = encoding
+	def.Strategy = strategy
 	if def.M <= 0 {
 		def.M = defaultVectorIndexM
 	}
@@ -18905,6 +18918,9 @@ func collectionRootNames(meta CollectionMeta) []string {
 		out = append(out, collectionSecondaryRootName(meta.Name, idx.Name))
 	}
 	for _, idx := range meta.VectorIndexes {
+		if vectorIndexDefinitionStrategy(idx) == VectorIndexStrategyColumnGraph {
+			continue
+		}
 		out = append(out, collectionVectorIndexRootName(meta.Name, idx.Name))
 	}
 	return out
@@ -18920,6 +18936,9 @@ func collectionCommandWALVectorRootInvalidations(meta CollectionMeta, catalog *c
 	}
 	rootNames := make([]string, 0, len(meta.VectorIndexes))
 	for _, idx := range meta.VectorIndexes {
+		if vectorIndexDefinitionStrategy(idx) == VectorIndexStrategyColumnGraph {
+			continue
+		}
 		rootName := collectionVectorIndexRootName(meta.Name, idx.Name)
 		if _, exists := baseRootIDs[rootName]; exists {
 			continue

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -653,7 +653,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	rootName := collectionColumnManifestRootName(catalog.meta.Name)
 	rootID := catalog.rootID(rootName)
 	if rootID == 0 {
-		return fmt.Errorf("%w: active column manifest generation %d for %q root %q", errColumnManifestRootDescriptorMissing, identity.Generation, catalog.meta.Name, rootName)
+		return fmt.Errorf("%w: active column manifest generation %d for %q is missing root descriptor %q", errColumnManifestRootDescriptorMissing, identity.Generation, catalog.meta.Name, rootName)
 	}
 	entry, err := snap.GetEntryAtRoot(rootID, newColumnManifestIdentityRecordKey())
 	if errors.Is(err, tree.ErrKeyNotFound) {
@@ -663,11 +663,11 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 		return fmt.Errorf("collections: active column manifest root %d for %q is unreadable: %w", rootID, catalog.meta.Name, err)
 	}
 	if entry.Flags&node.FlagTombstone != 0 {
-		return fmt.Errorf("%w: active column manifest root %d for %q", errColumnManifestIdentityDeleted, rootID, catalog.meta.Name)
+		return fmt.Errorf("%w: active column manifest root %d for %q has deleted identity record", errColumnManifestIdentityDeleted, rootID, catalog.meta.Name)
 	}
 	record, err := decodeColumnManifestIdentityRecord(entry.Value)
 	if err != nil {
-		return fmt.Errorf("%w: active column manifest root %d for %q: %w", errColumnManifestIdentityInvalid, rootID, catalog.meta.Name, err)
+		return fmt.Errorf("%w: active column manifest root %d for %q has invalid identity record: %w", errColumnManifestIdentityInvalid, rootID, catalog.meta.Name, err)
 	}
 	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
 		return fmt.Errorf("%w for %q", errColumnManifestIdentityMismatch, catalog.meta.Name)

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -47,6 +47,19 @@ var (
 	// ErrColumnManifestIdentityNonZeroReserved is returned when a column manifest
 	// identity record has non-zero reserved trailer bytes.
 	ErrColumnManifestIdentityNonZeroReserved = errors.New("collections: non-zero column manifest identity reserved trailer")
+	// ErrColumnManifestRootDescriptorMissing is returned when collection metadata
+	// references an active column manifest but the corresponding catalog root is
+	// absent.
+	ErrColumnManifestRootDescriptorMissing = errors.New("collections: column manifest root descriptor missing")
+	// ErrColumnManifestIdentityDeleted is returned when a published column
+	// manifest root has a tombstoned identity record.
+	ErrColumnManifestIdentityDeleted = errors.New("collections: column manifest identity record deleted")
+	// ErrColumnManifestIdentityInvalid wraps malformed identity-record decode
+	// failures observed while validating a published column manifest root.
+	ErrColumnManifestIdentityInvalid = errors.New("collections: invalid column manifest identity record")
+	// ErrColumnManifestIdentityMismatch is returned when the active manifest
+	// identity in collection metadata does not match the published root identity.
+	ErrColumnManifestIdentityMismatch = errors.New("collections: column manifest identity mismatch")
 )
 
 var (
@@ -55,6 +68,10 @@ var (
 	errColumnManifestIdentityBadMagic           = ErrColumnManifestIdentityBadMagic
 	errColumnManifestIdentityUnsupportedVersion = ErrColumnManifestIdentityUnsupportedVersion
 	errColumnManifestIdentityNonZeroReserved    = ErrColumnManifestIdentityNonZeroReserved
+	errColumnManifestRootDescriptorMissing      = ErrColumnManifestRootDescriptorMissing
+	errColumnManifestIdentityDeleted            = ErrColumnManifestIdentityDeleted
+	errColumnManifestIdentityInvalid            = ErrColumnManifestIdentityInvalid
+	errColumnManifestIdentityMismatch           = ErrColumnManifestIdentityMismatch
 )
 
 type ColumnStoreValueType string
@@ -636,7 +653,7 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 	rootName := collectionColumnManifestRootName(catalog.meta.Name)
 	rootID := catalog.rootID(rootName)
 	if rootID == 0 {
-		return fmt.Errorf("collections: active column manifest generation %d for %q is missing root descriptor %q", identity.Generation, catalog.meta.Name, rootName)
+		return fmt.Errorf("%w: active column manifest generation %d for %q root %q", errColumnManifestRootDescriptorMissing, identity.Generation, catalog.meta.Name, rootName)
 	}
 	entry, err := snap.GetEntryAtRoot(rootID, newColumnManifestIdentityRecordKey())
 	if errors.Is(err, tree.ErrKeyNotFound) {
@@ -646,14 +663,14 @@ func validateColumnStoreCatalogRoot(snap *backenddb.Snapshot, catalog *collectio
 		return fmt.Errorf("collections: active column manifest root %d for %q is unreadable: %w", rootID, catalog.meta.Name, err)
 	}
 	if entry.Flags&node.FlagTombstone != 0 {
-		return fmt.Errorf("collections: active column manifest root %d for %q has deleted identity record", rootID, catalog.meta.Name)
+		return fmt.Errorf("%w: active column manifest root %d for %q", errColumnManifestIdentityDeleted, rootID, catalog.meta.Name)
 	}
 	record, err := decodeColumnManifestIdentityRecord(entry.Value)
 	if err != nil {
-		return fmt.Errorf("collections: active column manifest root %d for %q has invalid identity record: %w", rootID, catalog.meta.Name, err)
+		return fmt.Errorf("%w: active column manifest root %d for %q: %w", errColumnManifestIdentityInvalid, rootID, catalog.meta.Name, err)
 	}
 	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
-		return fmt.Errorf("collections: active column manifest identity mismatch for %q", catalog.meta.Name)
+		return fmt.Errorf("%w for %q", errColumnManifestIdentityMismatch, catalog.meta.Name)
 	}
 	return nil
 }

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -56,6 +56,7 @@ const (
 	vectorIndexFallbackColumnGraphMetric          = "column_graph_requires_cosine"
 	vectorIndexFallbackColumnGraphEncoding        = "column_graph_requires_float32"
 	vectorIndexFallbackColumnGraphReprobeRequired = "column_graph_reprobe_outside_native_rebuild"
+	vectorIndexFallbackColumnGraphHandleMissing   = "column_graph_requires_column_graph_handle"
 )
 
 var errVectorIndexStaleRuntime = errors.New("collections: vector index runtime handle is stale")

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -31,35 +31,38 @@ const (
 )
 
 const (
-	vectorIndexFallbackMissingVectorIndexMetadata = "missing_vector_index_metadata"
-	vectorIndexFallbackMissingGraphRoot           = "missing_graph_root"
-	vectorIndexFallbackMissingGraphRootEntry      = "missing_graph_root_entry"
-	vectorIndexFallbackInvalidGraphRootKey        = "invalid_graph_root_key"
-	vectorIndexFallbackInvalidGraphRootEntry      = "invalid_graph_root_entry"
-	vectorIndexFallbackStaleRuntimeIndex          = "stale_runtime_index_ignored"
-	vectorIndexFallbackMetaMismatch               = "meta_mismatch"
-	vectorIndexFallbackInvalidEncoding            = "invalid_encoding"
-	vectorIndexFallbackMetaEncodingMismatch       = "meta_encoding_mismatch"
-	vectorIndexFallbackMetaDimensionMismatch      = "meta_dimension_mismatch"
-	vectorIndexFallbackInvalidDimensions          = "invalid_dimensions"
-	vectorIndexFallbackInvalidEdgeNode            = "invalid_edge_node"
-	vectorIndexFallbackInvalidTombstone           = "invalid_tombstone"
-	vectorIndexFallbackInvalidDocMapNode          = "invalid_docmap_node"
-	vectorIndexFallbackInvalidEntry               = "invalid_entry"
-	vectorIndexFallbackMissingManifest            = "missing_manifest"
-	vectorIndexFallbackInvalidManifest            = "invalid_manifest"
-	vectorIndexFallbackStrategyMismatch           = "strategy_mismatch"
-	vectorIndexFallbackColumnGraphStrategyMissing = "column_graph_strategy_not_selected"
-	vectorIndexFallbackColumnGraphPhysicalMissing = "physical_column_asset_support_missing"
-	vectorIndexFallbackColumnGraphManifestMissing = "column_graph_manifest_root_missing"
-	vectorIndexFallbackColumnGraphManifestInvalid = "column_graph_manifest_root_mismatch"
-	vectorIndexFallbackColumnGraphMetric          = "column_graph_requires_cosine"
-	vectorIndexFallbackColumnGraphEncoding        = "column_graph_requires_float32"
-	vectorIndexFallbackColumnGraphReprobeRequired = "column_graph_reprobe_outside_native_rebuild"
-	vectorIndexFallbackColumnGraphHandleMissing   = "column_graph_requires_column_graph_handle"
+	vectorIndexFallbackMissingVectorIndexMetadata      = "missing_vector_index_metadata"
+	vectorIndexFallbackMissingGraphRoot                = "missing_graph_root"
+	vectorIndexFallbackMissingGraphRootEntry           = "missing_graph_root_entry"
+	vectorIndexFallbackInvalidGraphRootKey             = "invalid_graph_root_key"
+	vectorIndexFallbackInvalidGraphRootEntry           = "invalid_graph_root_entry"
+	vectorIndexFallbackStaleRuntimeIndex               = "stale_runtime_index_ignored"
+	vectorIndexFallbackMetaMismatch                    = "meta_mismatch"
+	vectorIndexFallbackInvalidEncoding                 = "invalid_encoding"
+	vectorIndexFallbackMetaEncodingMismatch            = "meta_encoding_mismatch"
+	vectorIndexFallbackMetaDimensionMismatch           = "meta_dimension_mismatch"
+	vectorIndexFallbackInvalidDimensions               = "invalid_dimensions"
+	vectorIndexFallbackInvalidEdgeNode                 = "invalid_edge_node"
+	vectorIndexFallbackInvalidTombstone                = "invalid_tombstone"
+	vectorIndexFallbackInvalidDocMapNode               = "invalid_docmap_node"
+	vectorIndexFallbackInvalidEntry                    = "invalid_entry"
+	vectorIndexFallbackMissingManifest                 = "missing_manifest"
+	vectorIndexFallbackInvalidManifest                 = "invalid_manifest"
+	vectorIndexFallbackStrategyMismatch                = "strategy_mismatch"
+	vectorIndexFallbackColumnGraphStrategyMissing      = "column_graph_strategy_not_selected"
+	vectorIndexFallbackColumnGraphPhysicalMissing      = "physical_column_asset_support_missing"
+	vectorIndexFallbackColumnGraphManifestMissing      = "column_graph_manifest_root_missing"
+	vectorIndexFallbackColumnGraphManifestRootMismatch = "column_graph_manifest_root_mismatch"
+	vectorIndexFallbackColumnGraphMetric               = "column_graph_requires_cosine"
+	vectorIndexFallbackColumnGraphEncoding             = "column_graph_requires_float32"
+	vectorIndexFallbackColumnGraphReprobeRequired      = "column_graph_reprobe_outside_native_rebuild"
+	vectorIndexFallbackColumnGraphHandleMissing        = "column_graph_requires_column_graph_handle"
 )
 
-var errVectorIndexStaleRuntime = errors.New("collections: vector index runtime handle is stale")
+var (
+	errVectorIndexStaleRuntime   = errors.New("collections: vector index runtime handle is stale")
+	errColumnGraphRequiresLoader = errors.New("collections: column_graph vector indexes require the column-backed graph loader, not the native runtime builder")
+)
 
 // VectorIndexEncoding selects the process-local ANN vector copy format. The
 // collection row remains canonical; float32 indexes can rerank directly from the
@@ -283,6 +286,9 @@ func (c *Collection) buildVectorIndexPrepared(opts VectorIndexOptions, register,
 	if c.db == nil {
 		return nil, errCollectionDBNil
 	}
+	if def, ok := findVectorIndex(c.meta.VectorIndexes, vectorIndexOptionName(opts)); ok && vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		return nil, errColumnGraphRequiresLoader
+	}
 	index, err := newVectorIndex(c, opts)
 	if err != nil {
 		return nil, err
@@ -341,7 +347,7 @@ func newVectorIndex(c *Collection, opts VectorIndexOptions) (*VectorIndex, error
 		return nil, err
 	}
 	if strategy == VectorIndexStrategyColumnGraph {
-		return nil, errors.New("collections: column_graph vector indexes require the column-backed graph loader, not the native runtime builder")
+		return nil, errColumnGraphRequiresLoader
 	}
 	fieldPath, err := parseVectorFieldPath(opts.Field)
 	if err != nil {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -55,6 +55,7 @@ const (
 	vectorIndexFallbackColumnGraphManifestInvalid = "column_graph_manifest_root_mismatch"
 	vectorIndexFallbackColumnGraphMetric          = "column_graph_requires_cosine"
 	vectorIndexFallbackColumnGraphEncoding        = "column_graph_requires_float32"
+	vectorIndexFallbackColumnGraphReprobeRequired = "column_graph_reprobe_outside_native_rebuild"
 )
 
 var errVectorIndexStaleRuntime = errors.New("collections: vector index runtime handle is stale")

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -48,6 +48,8 @@ const (
 	vectorIndexFallbackInvalidEntry               = "invalid_entry"
 	vectorIndexFallbackMissingManifest            = "missing_manifest"
 	vectorIndexFallbackInvalidManifest            = "invalid_manifest"
+	vectorIndexFallbackStrategyMismatch           = "strategy_mismatch"
+	vectorIndexFallbackColumnGraphStrategyMissing = "column_graph_strategy_not_selected"
 	vectorIndexFallbackColumnGraphPhysicalMissing = "physical_column_asset_support_missing"
 	vectorIndexFallbackColumnGraphManifestMissing = "column_graph_manifest_root_missing"
 	vectorIndexFallbackColumnGraphManifestInvalid = "column_graph_manifest_root_mismatch"

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -48,6 +48,11 @@ const (
 	vectorIndexFallbackInvalidEntry               = "invalid_entry"
 	vectorIndexFallbackMissingManifest            = "missing_manifest"
 	vectorIndexFallbackInvalidManifest            = "invalid_manifest"
+	vectorIndexFallbackColumnGraphPhysicalMissing = "physical_column_asset_support_missing"
+	vectorIndexFallbackColumnGraphManifestMissing = "column_graph_manifest_root_missing"
+	vectorIndexFallbackColumnGraphManifestInvalid = "column_graph_manifest_root_mismatch"
+	vectorIndexFallbackColumnGraphMetric          = "column_graph_requires_cosine"
+	vectorIndexFallbackColumnGraphEncoding        = "column_graph_requires_float32"
 )
 
 var errVectorIndexStaleRuntime = errors.New("collections: vector index runtime handle is stale")
@@ -106,6 +111,23 @@ func (e *VectorIndexEncoding) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
+// VectorIndexStrategy selects the physical/vector-search lifecycle backing a
+// declared collection vector index. The zero value is the existing native
+// runtime/native-root path so older metadata remains unchanged.
+type VectorIndexStrategy string
+
+const (
+	VectorIndexStrategyNativeRuntime VectorIndexStrategy = "native_runtime"
+	VectorIndexStrategyColumnGraph   VectorIndexStrategy = "column_graph"
+)
+
+func (s VectorIndexStrategy) String() string {
+	if s == "" {
+		return string(VectorIndexStrategyNativeRuntime)
+	}
+	return string(s)
+}
+
 // VectorIndexOptions configures an in-memory vector secondary index built from
 // collection rows. The index stores stable collection document IDs and vector
 // copies for graph search; TreeDB collection rows remain canonical for returned
@@ -120,6 +142,7 @@ type VectorIndexOptions struct {
 	EfSearch            int
 	RebuildDeletedRatio float64
 	Encoding            VectorIndexEncoding
+	Strategy            VectorIndexStrategy
 	schemaGeneration    uint64
 }
 
@@ -309,6 +332,13 @@ func newVectorIndex(c *Collection, opts VectorIndexOptions) (*VectorIndex, error
 	if opts.Name == "" {
 		opts.Name = vectorIndexDefaultName(opts.Field)
 	}
+	strategy, err := normalizeVectorIndexStrategy(opts.Strategy)
+	if err != nil {
+		return nil, err
+	}
+	if strategy == VectorIndexStrategyColumnGraph {
+		return nil, errors.New("collections: column_graph vector indexes require the column-backed graph loader, not the native runtime builder")
+	}
 	fieldPath, err := parseVectorFieldPath(opts.Field)
 	if err != nil {
 		return nil, err
@@ -385,6 +415,33 @@ func parseVectorIndexEncoding(value string) (VectorIndexEncoding, error) {
 	}
 }
 
+func normalizeVectorIndexStrategy(strategy VectorIndexStrategy) (VectorIndexStrategy, error) {
+	switch strings.TrimSpace(strings.ToLower(string(strategy))) {
+	case "", "native", "native_runtime", "ann_graph":
+		return "", nil
+	case string(VectorIndexStrategyColumnGraph):
+		return VectorIndexStrategyColumnGraph, nil
+	default:
+		return "", fmt.Errorf("collections: unsupported vector index strategy %q", strategy)
+	}
+}
+
+func vectorIndexDefinitionStrategy(def VectorIndexDefinition) VectorIndexStrategy {
+	strategy, err := normalizeVectorIndexStrategy(def.Strategy)
+	if err != nil {
+		return def.Strategy
+	}
+	return strategy
+}
+
+func vectorIndexOptionsStrategy(opts VectorIndexOptions) VectorIndexStrategy {
+	strategy, err := normalizeVectorIndexStrategy(opts.Strategy)
+	if err != nil {
+		return opts.Strategy
+	}
+	return strategy
+}
+
 // RegisterVectorIndex attaches an in-memory vector index to this collection so
 // successful collection inserts, updates, and deletes keep the index in sync.
 func (c *Collection) RegisterVectorIndex(index *VectorIndex) {
@@ -398,7 +455,11 @@ func (c *Collection) RegisterVectorIndex(index *VectorIndex) {
 	}
 	index.collection = c
 	if def, ok := findVectorIndex(c.meta.VectorIndexes, index.name); ok {
-		index.recordNativeDefinition(def)
+		if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+			index.setNativePersistent(false)
+		} else {
+			index.recordNativeDefinition(def)
+		}
 	} else {
 		index.setNativePersistent(false)
 	}
@@ -561,6 +622,9 @@ func (c *Collection) ensureDeclaredNativeVectorIndexesLoaded() error {
 		}
 	}
 	for _, def := range c.meta.VectorIndexes {
+		if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+			continue
+		}
 		if index := c.registeredVectorIndex(def.Name); index != nil {
 			continue
 		}
@@ -604,6 +668,12 @@ func (c *Collection) declaredNativeVectorIndexesLoadedForCurrentCatalog() bool {
 		return true
 	}
 	for _, def := range defs {
+		if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+			if index := c.registeredVectorIndex(def.Name); index != nil {
+				return false
+			}
+			continue
+		}
 		index := c.registeredVectorIndex(def.Name)
 		if index == nil || index.validateNativeSnapshotDefinition(def) != "" {
 			return false
@@ -885,8 +955,8 @@ func collectionMetaDeclaresVectorIndex(meta CollectionMeta, name string) bool {
 	if name == "" {
 		return false
 	}
-	_, ok := findVectorIndex(meta.VectorIndexes, name)
-	return ok
+	def, ok := findVectorIndex(meta.VectorIndexes, name)
+	return ok && vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph
 }
 
 // InsertDocument adds or replaces one committed collection document in the

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"errors"
-	"strings"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -220,15 +219,12 @@ func columnGraphCatalogRootUnavailableReason(err error) string {
 		errors.Is(err, errColumnManifestIdentityMalformed) ||
 		errors.Is(err, errColumnManifestIdentityBadMagic) ||
 		errors.Is(err, errColumnManifestIdentityUnsupportedVersion) ||
-		errors.Is(err, errColumnManifestIdentityNonZeroReserved) {
-		return vectorIndexFallbackColumnGraphManifestInvalid
-	}
-	msg := err.Error()
-	if strings.Contains(msg, "missing root descriptor") ||
-		strings.Contains(msg, "deleted identity record") ||
-		strings.Contains(msg, "invalid identity record") ||
-		strings.Contains(msg, "identity mismatch") {
-		return vectorIndexFallbackColumnGraphManifestInvalid
+		errors.Is(err, errColumnManifestIdentityNonZeroReserved) ||
+		errors.Is(err, errColumnManifestRootDescriptorMissing) ||
+		errors.Is(err, errColumnManifestIdentityDeleted) ||
+		errors.Is(err, errColumnManifestIdentityInvalid) ||
+		errors.Is(err, errColumnManifestIdentityMismatch) {
+		return vectorIndexFallbackColumnGraphManifestRootMismatch
 	}
 	return ""
 }

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -1,6 +1,11 @@
 package collections
 
-import backenddb "github.com/snissn/gomap/TreeDB/db"
+import (
+	"errors"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
 
 // ColumnVectorGraphIndexLoader is the product-contract boundary for the future
 // physical column asset implementation. The loader must read vector, invNorm,
@@ -103,10 +108,14 @@ func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalogWithLoader(sna
 		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestMissing)
 		return nil, status, nil
 	}
-	if validateColumnStoreCatalogRoot(snap, catalog) != nil {
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		reason := columnGraphCatalogRootUnavailableReason(err)
+		if reason == "" {
+			return nil, status, err
+		}
 		// Report manifest/root mismatches as explicit status so operational
 		// callers can show rebuild-needed state instead of failing discovery.
-		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestInvalid)
+		setColumnGraphUnavailable(&status, reason)
 		return nil, status, nil
 	}
 	if loader == nil {
@@ -168,7 +177,9 @@ func setColumnGraphUnavailable(status *VectorIndexLoadStatus, reason string) {
 	}
 	status.Loaded = false
 	status.ColumnGraphLoaded = false
-	status.PhysicalColumnAssetsSupported = false
+	if reason == vectorIndexFallbackColumnGraphPhysicalMissing {
+		status.PhysicalColumnAssetsSupported = false
+	}
 	status.ExactFallbackReason = reason
 	status.ColumnGraphUnavailableReason = reason
 	status.RebuildNeeded = true
@@ -183,7 +194,11 @@ func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorInde
 		reason = update.ExactFallbackReason
 	}
 	if reason != "" {
+		supported := status.PhysicalColumnAssetsSupported || update.PhysicalColumnAssetsSupported
 		setColumnGraphUnavailable(status, reason)
+		if reason != vectorIndexFallbackColumnGraphPhysicalMissing {
+			status.PhysicalColumnAssetsSupported = supported
+		}
 		if update.BytesDisk != 0 {
 			status.BytesDisk = update.BytesDisk
 		}
@@ -195,6 +210,27 @@ func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorInde
 	if update.BytesDisk != 0 {
 		status.BytesDisk = update.BytesDisk
 	}
+}
+
+func columnGraphCatalogRootUnavailableReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, errColumnManifestIdentityMissing) ||
+		errors.Is(err, errColumnManifestIdentityMalformed) ||
+		errors.Is(err, errColumnManifestIdentityBadMagic) ||
+		errors.Is(err, errColumnManifestIdentityUnsupportedVersion) ||
+		errors.Is(err, errColumnManifestIdentityNonZeroReserved) {
+		return vectorIndexFallbackColumnGraphManifestInvalid
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "missing root descriptor") ||
+		strings.Contains(msg, "deleted identity record") ||
+		strings.Contains(msg, "invalid identity record") ||
+		strings.Contains(msg, "identity mismatch") {
+		return vectorIndexFallbackColumnGraphManifestInvalid
+	}
+	return ""
 }
 
 func (c *Collection) columnGraphVectorIndexStatusFromCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition) (VectorIndexStatus, error) {

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -41,6 +41,10 @@ var defaultColumnVectorGraphIndexLoader ColumnVectorGraphIndexLoader = unsupport
 // be scanned into ColumnVectorGraphColumns, this reports a precise unavailable
 // status instead of falling back to the native runtime graph.
 func (c *Collection) LoadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
+	return c.loadColumnGraphVectorIndexSnapshot(opts, defaultColumnVectorGraphIndexLoader)
+}
+
+func (c *Collection) loadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions, loader ColumnVectorGraphIndexLoader) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
 	status := VectorIndexLoadStatus{Strategy: VectorIndexStrategyColumnGraph, RebuildNeeded: true}
 	if c == nil {
 		return nil, status, errCollectionNil
@@ -66,10 +70,14 @@ func (c *Collection) LoadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions)
 		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackMissingVectorIndexMetadata)
 		return nil, status, nil
 	}
-	return c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
+	return c.loadColumnGraphVectorIndexSnapshotFromCatalogWithLoader(snap, catalog, def, loader)
 }
 
 func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
+	return c.loadColumnGraphVectorIndexSnapshotFromCatalogWithLoader(snap, catalog, def, defaultColumnVectorGraphIndexLoader)
+}
+
+func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalogWithLoader(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition, loader ColumnVectorGraphIndexLoader) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
 	status := baseColumnGraphLoadStatus(catalog)
 	if vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph {
 		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphStrategyMissing)
@@ -101,8 +109,11 @@ func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backend
 		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestInvalid)
 		return nil, status, nil
 	}
+	if loader == nil {
+		loader = unsupportedColumnVectorGraphIndexLoader{}
+	}
 
-	result, err := defaultColumnVectorGraphIndexLoader.LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput{
+	result, err := loader.LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput{
 		Collection:             c,
 		Snapshot:               snap,
 		Definition:             def,

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -70,9 +70,9 @@ func (c *Collection) LoadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions)
 }
 
 func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
-	status := baseColumnGraphLoadStatus(catalog, def)
+	status := baseColumnGraphLoadStatus(catalog)
 	if vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph {
-		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing)
+		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphStrategyMissing)
 		status.RootName = collectionColumnManifestRootName(catalog.meta.Name)
 		status.RootID = catalog.rootID(status.RootName)
 		status.Epoch = status.RootID
@@ -95,7 +95,9 @@ func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backend
 		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestMissing)
 		return nil, status, nil
 	}
-	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+	if validateColumnStoreCatalogRoot(snap, catalog) != nil {
+		// Report manifest/root mismatches as explicit status so operational
+		// callers can show rebuild-needed state instead of failing discovery.
 		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestInvalid)
 		return nil, status, nil
 	}
@@ -128,7 +130,7 @@ func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backend
 	return result.Graph, status, nil
 }
 
-func baseColumnGraphLoadStatus(catalog *collectionCatalog, def VectorIndexDefinition) VectorIndexLoadStatus {
+func baseColumnGraphLoadStatus(catalog *collectionCatalog) VectorIndexLoadStatus {
 	rootName := collectionColumnManifestRootName(catalog.meta.Name)
 	rootID := catalog.rootID(rootName)
 	return VectorIndexLoadStatus{
@@ -165,11 +167,16 @@ func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorInde
 	if status == nil {
 		return
 	}
-	if update.ExactFallbackReason != "" {
-		setColumnGraphUnavailable(status, update.ExactFallbackReason)
+	reason := update.ColumnGraphUnavailableReason
+	if reason == "" {
+		reason = update.ExactFallbackReason
 	}
-	if update.ColumnGraphUnavailableReason != "" {
-		setColumnGraphUnavailable(status, update.ColumnGraphUnavailableReason)
+	if reason != "" {
+		setColumnGraphUnavailable(status, reason)
+		if update.BytesDisk != 0 {
+			status.BytesDisk = update.BytesDisk
+		}
+		return
 	}
 	if update.PhysicalColumnAssetsSupported {
 		status.PhysicalColumnAssetsSupported = true

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -1,0 +1,213 @@
+package collections
+
+import backenddb "github.com/snissn/gomap/TreeDB/db"
+
+// ColumnVectorGraphIndexLoader is the product-contract boundary for the future
+// physical column asset implementation. The loader must read vector, invNorm,
+// and adjacency-list column assets referenced by the collection column manifest
+// and return an immutable ColumnVectorGraph. It must not invent a vector-only
+// sidecar format.
+type ColumnVectorGraphIndexLoader interface {
+	LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput) (ColumnVectorGraphIndexLoadResult, error)
+}
+
+type ColumnVectorGraphIndexLoadInput struct {
+	Collection             *Collection
+	Snapshot               *backenddb.Snapshot
+	Definition             VectorIndexDefinition
+	ColumnStore            ColumnStoreConfig
+	ColumnManifestRootName string
+	ColumnManifestRootID   uint64
+	ActiveManifest         *ColumnManifestIdentity
+}
+
+type ColumnVectorGraphIndexLoadResult struct {
+	Graph  *ColumnVectorGraph
+	Status VectorIndexLoadStatus
+}
+
+type unsupportedColumnVectorGraphIndexLoader struct{}
+
+func (unsupportedColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput) (ColumnVectorGraphIndexLoadResult, error) {
+	return ColumnVectorGraphIndexLoadResult{
+		Status: columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing),
+	}, nil
+}
+
+var defaultColumnVectorGraphIndexLoader ColumnVectorGraphIndexLoader = unsupportedColumnVectorGraphIndexLoader{}
+
+// LoadColumnGraphVectorIndexSnapshot loads an explicit column_graph vector
+// index through the column-backed graph seam. Until physical column assets can
+// be scanned into ColumnVectorGraphColumns, this reports a precise unavailable
+// status instead of falling back to the native runtime graph.
+func (c *Collection) LoadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
+	status := VectorIndexLoadStatus{Strategy: VectorIndexStrategyColumnGraph, RebuildNeeded: true}
+	if c == nil {
+		return nil, status, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, status, errCollectionDBNil
+	}
+	name := vectorIndexOptionName(opts)
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, status, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
+	if err != nil {
+		return nil, status, err
+	}
+	if catalog == nil {
+		return nil, status, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
+	if !ok {
+		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackMissingVectorIndexMetadata)
+		return nil, status, nil
+	}
+	return c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
+}
+
+func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
+	status := baseColumnGraphLoadStatus(catalog, def)
+	if vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph {
+		status = columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing)
+		status.RootName = collectionColumnManifestRootName(catalog.meta.Name)
+		status.RootID = catalog.rootID(status.RootName)
+		status.Epoch = status.RootID
+		return nil, status, nil
+	}
+	if def.Metric != VectorMetricCosine {
+		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphMetric)
+		return nil, status, nil
+	}
+	if def.Encoding != VectorIndexEncodingFloat32 {
+		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphEncoding)
+		return nil, status, nil
+	}
+	cfg := catalog.meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled || cfg.ActiveManifest == nil {
+		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphPhysicalMissing)
+		return nil, status, nil
+	}
+	if status.RootID == 0 {
+		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestMissing)
+		return nil, status, nil
+	}
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphManifestInvalid)
+		return nil, status, nil
+	}
+
+	result, err := defaultColumnVectorGraphIndexLoader.LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput{
+		Collection:             c,
+		Snapshot:               snap,
+		Definition:             def,
+		ColumnStore:            *cfg,
+		ColumnManifestRootName: status.RootName,
+		ColumnManifestRootID:   status.RootID,
+		ActiveManifest:         cloneColumnManifestIdentityPtr(cfg.ActiveManifest),
+	})
+	if err != nil {
+		return nil, status, err
+	}
+	mergeColumnGraphLoadStatus(&status, result.Status)
+	if result.Graph == nil {
+		if status.ExactFallbackReason == "" {
+			setColumnGraphUnavailable(&status, vectorIndexFallbackColumnGraphPhysicalMissing)
+		}
+		return nil, status, nil
+	}
+	status.Loaded = true
+	status.ColumnGraphLoaded = true
+	status.ColumnGraphUnavailableReason = ""
+	status.ExactFallbackReason = ""
+	status.PhysicalColumnAssetsSupported = true
+	status.RebuildNeeded = false
+	return result.Graph, status, nil
+}
+
+func baseColumnGraphLoadStatus(catalog *collectionCatalog, def VectorIndexDefinition) VectorIndexLoadStatus {
+	rootName := collectionColumnManifestRootName(catalog.meta.Name)
+	rootID := catalog.rootID(rootName)
+	return VectorIndexLoadStatus{
+		Strategy:      VectorIndexStrategyColumnGraph,
+		RootName:      rootName,
+		RootID:        rootID,
+		Epoch:         rootID,
+		RebuildNeeded: true,
+	}
+}
+
+func columnGraphUnavailableLoadStatus(reason string) VectorIndexLoadStatus {
+	status := VectorIndexLoadStatus{
+		Strategy:      VectorIndexStrategyColumnGraph,
+		RebuildNeeded: true,
+	}
+	setColumnGraphUnavailable(&status, reason)
+	return status
+}
+
+func setColumnGraphUnavailable(status *VectorIndexLoadStatus, reason string) {
+	if status == nil {
+		return
+	}
+	status.Loaded = false
+	status.ColumnGraphLoaded = false
+	status.PhysicalColumnAssetsSupported = false
+	status.ExactFallbackReason = reason
+	status.ColumnGraphUnavailableReason = reason
+	status.RebuildNeeded = true
+}
+
+func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorIndexLoadStatus) {
+	if status == nil {
+		return
+	}
+	if update.ExactFallbackReason != "" {
+		setColumnGraphUnavailable(status, update.ExactFallbackReason)
+	}
+	if update.ColumnGraphUnavailableReason != "" {
+		setColumnGraphUnavailable(status, update.ColumnGraphUnavailableReason)
+	}
+	if update.PhysicalColumnAssetsSupported {
+		status.PhysicalColumnAssetsSupported = true
+	}
+	if update.BytesDisk != 0 {
+		status.BytesDisk = update.BytesDisk
+	}
+}
+
+func (c *Collection) columnGraphVectorIndexStatusFromCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog, def VectorIndexDefinition) (VectorIndexStatus, error) {
+	_, loadStatus, err := c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
+	if err != nil {
+		return VectorIndexStatus{}, err
+	}
+	return vectorIndexStatusFromColumnGraphLoad(def, loadStatus), nil
+}
+
+func vectorIndexStatusFromColumnGraphLoad(def VectorIndexDefinition, loadStatus VectorIndexLoadStatus) VectorIndexStatus {
+	return VectorIndexStatus{
+		Definition:                    def,
+		Name:                          def.Name,
+		RootName:                      loadStatus.RootName,
+		RootID:                        loadStatus.RootID,
+		Strategy:                      VectorIndexStrategyColumnGraph,
+		ExactFallbackReason:           loadStatus.ExactFallbackReason,
+		ColumnGraphLoaded:             loadStatus.ColumnGraphLoaded,
+		ColumnGraphUnavailableReason:  loadStatus.ColumnGraphUnavailableReason,
+		PhysicalColumnAssetsSupported: loadStatus.PhysicalColumnAssetsSupported,
+		RebuildNeeded:                 loadStatus.RebuildNeeded || !loadStatus.ColumnGraphLoaded || loadStatus.ExactFallbackReason != "",
+	}
+}
+
+func columnGraphRebuildUnsupportedStatus(def VectorIndexDefinition, loadStatus VectorIndexLoadStatus) VectorIndexStatus {
+	status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
+	if status.ExactFallbackReason == "" {
+		status.ExactFallbackReason = vectorIndexFallbackColumnGraphPhysicalMissing
+		status.ColumnGraphUnavailableReason = vectorIndexFallbackColumnGraphPhysicalMissing
+	}
+	status.RebuildNeeded = true
+	return status
+}

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -68,6 +68,72 @@ func TestCollectionVectorIndexColumnGraphContractReportsPhysicalAssetsMissing(t 
 	}
 }
 
+func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	active := ColumnManifestIdentity{Generation: 3, Version: columnManifestIdentityVersion, Checksum: 0x44}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorIndexTestColumnStore(nil),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	publishColumnStoreCatalogForTest(t, d, CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorIndexTestColumnStore(&active),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}, active)
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	graph := newColumnGraphVectorIndexTestGraph(t)
+	withColumnVectorGraphIndexLoaderForTest(t, testColumnVectorGraphIndexLoader{
+		result: ColumnVectorGraphIndexLoadResult{
+			Graph: graph,
+			Status: VectorIndexLoadStatus{
+				Strategy:                      VectorIndexStrategyColumnGraph,
+				PhysicalColumnAssetsSupported: true,
+				BytesDisk:                     123,
+			},
+		},
+	})
+
+	loadedGraph, graphStatus, err := col.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadColumnGraphVectorIndexSnapshot: %v", err)
+	}
+	if loadedGraph == nil || !graphStatus.Loaded || !graphStatus.ColumnGraphLoaded {
+		t.Fatalf("explicit column_graph loader did not report loaded graph: graph=%v status=%+v", loadedGraph != nil, graphStatus)
+	}
+
+	loaded, status, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadVectorIndexSnapshot: %v", err)
+	}
+	if loaded != nil || status.Loaded || status.ColumnGraphLoaded {
+		t.Fatalf("generic loader must not report a usable native index for column_graph, loaded=%v status=%+v", loaded != nil, status)
+	}
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphHandleMissing || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphHandleMissing {
+		t.Fatalf("unexpected generic column_graph load reason: %+v", status)
+	}
+	if !status.PhysicalColumnAssetsSupported || status.RebuildNeeded {
+		t.Fatalf("generic column_graph status lost physical support or requested rebuild: %+v", status)
+	}
+}
+
 func TestColumnGraphRebuildUnsupportedStatusPreservesReprobeReason(t *testing.T) {
 	def := columnGraphVectorIndexTestDefinition()
 	status := columnGraphRebuildUnsupportedStatus(def, columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphReprobeRequired))
@@ -158,6 +224,13 @@ func TestCollectionVectorIndexColumnGraphOptionDoesNotLoadNativeIndex(t *testing
 	}
 	if rebuild, err := col.RebuildVectorIndex(def.Name); err != nil || !rebuild.NativeRuntimeUsed || !rebuild.NativeRootLoaded {
 		t.Fatalf("native rebuild status=%+v err=%v", rebuild, err)
+	}
+	nativeLoaded, nativeLoadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("native LoadVectorIndexSnapshot: %v", err)
+	}
+	if nativeLoaded == nil || nativeLoadStatus.Strategy != VectorIndexStrategyNativeRuntime || !nativeLoadStatus.NativeRuntimeUsed {
+		t.Fatalf("native load status missing native strategy/runtime: loaded=%v status=%+v", nativeLoaded != nil, nativeLoadStatus)
 	}
 
 	loaded, status, err := col.LoadVectorIndexSnapshot(VectorIndexOptions{
@@ -289,6 +362,41 @@ func columnGraphVectorIndexTestColumnStore(active *ColumnManifestIdentity) *Colu
 		cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
 	}
 	return cfg
+}
+
+type testColumnVectorGraphIndexLoader struct {
+	result ColumnVectorGraphIndexLoadResult
+	err    error
+}
+
+func (l testColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput) (ColumnVectorGraphIndexLoadResult, error) {
+	return l.result, l.err
+}
+
+func withColumnVectorGraphIndexLoaderForTest(t *testing.T, loader ColumnVectorGraphIndexLoader) {
+	t.Helper()
+	previous := defaultColumnVectorGraphIndexLoader
+	defaultColumnVectorGraphIndexLoader = loader
+	t.Cleanup(func() {
+		defaultColumnVectorGraphIndexLoader = previous
+	})
+}
+
+func newColumnGraphVectorIndexTestGraph(t *testing.T) *ColumnVectorGraph {
+	t.Helper()
+	graph, err := NewColumnVectorGraphFromColumns(ColumnVectorGraphColumns{
+		DocumentIDs:     [][]byte{[]byte("a")},
+		Vectors:         []float32{1, 0},
+		InvNorms:        []float32{1},
+		NeighborOffsets: []uint32{0, 0},
+		Dimensions:      2,
+		EntryPoint:      0,
+		EfSearch:        8,
+	})
+	if err != nil {
+		t.Fatalf("new column vector graph: %v", err)
+	}
+	return graph
 }
 
 func assertColumnGraphUnavailableStatus(t *testing.T, status VectorIndexStatus, reason string) {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -123,14 +123,35 @@ func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.
 	if err != nil {
 		t.Fatalf("LoadVectorIndexSnapshot: %v", err)
 	}
-	if loaded != nil || status.Loaded || status.ColumnGraphLoaded {
-		t.Fatalf("generic loader must not report a usable native index for column_graph, loaded=%v status=%+v", loaded != nil, status)
+	if loaded != nil || status.Loaded || !status.ColumnGraphLoaded {
+		t.Fatalf("generic loader must not report a usable native index while preserving column graph status, loaded=%v status=%+v", loaded != nil, status)
 	}
-	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphHandleMissing || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphHandleMissing {
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphHandleMissing || status.ColumnGraphUnavailableReason != "" {
 		t.Fatalf("unexpected generic column_graph load reason: %+v", status)
 	}
 	if !status.PhysicalColumnAssetsSupported || status.RebuildNeeded {
 		t.Fatalf("generic column_graph status lost physical support or requested rebuild: %+v", status)
+	}
+}
+
+func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t *testing.T) {
+	status := VectorIndexLoadStatus{
+		Strategy:                      VectorIndexStrategyColumnGraph,
+		PhysicalColumnAssetsSupported: true,
+	}
+	mergeColumnGraphLoadStatus(&status, VectorIndexLoadStatus{
+		PhysicalColumnAssetsSupported: true,
+		ColumnGraphUnavailableReason:  vectorIndexFallbackColumnGraphManifestInvalid,
+		BytesDisk:                     4096,
+	})
+	if status.PhysicalColumnAssetsSupported == false {
+		t.Fatalf("loader failure discarded physical column support: %+v", status)
+	}
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
+		t.Fatalf("unexpected fallback reason: %+v", status)
+	}
+	if status.BytesDisk != 4096 || !status.RebuildNeeded {
+		t.Fatalf("unexpected status accounting: %+v", status)
 	}
 }
 
@@ -248,6 +269,45 @@ func TestCollectionVectorIndexColumnGraphOptionDoesNotLoadNativeIndex(t *testing
 	}
 	if status.Strategy != VectorIndexStrategyColumnGraph || status.ExactFallbackReason != vectorIndexFallbackColumnGraphStrategyMissing || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphStrategyMissing {
 		t.Fatalf("unexpected column_graph strategy-missing status: %+v", status)
+	}
+}
+
+func TestLoadVectorIndexSnapshotRejectsInvalidStrategyOption(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     VectorMetricCosine,
+			Dimensions: 2,
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	loaded, status, err := col.LoadVectorIndexSnapshot(VectorIndexOptions{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		Strategy:   "bogus",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported vector index strategy") {
+		t.Fatalf("LoadVectorIndexSnapshot err=%v want unsupported strategy", err)
+	}
+	if loaded != nil || status.Loaded {
+		t.Fatalf("invalid strategy should not load an index: loaded=%v status=%+v", loaded != nil, status)
 	}
 }
 

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -1,0 +1,231 @@
+package collections
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionVectorIndexColumnGraphContractReportsPhysicalAssetsMissing(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorIndexTestColumnStore(nil),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	status, err := col.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	assertColumnGraphUnavailableStatus(t, status, vectorIndexFallbackColumnGraphPhysicalMissing)
+	if status.Registered || status.NativeRuntimeUsed || status.NativeRootLoaded {
+		t.Fatalf("column_graph status used native runtime/root: %+v", status)
+	}
+
+	loaded, loadStatus, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadVectorIndexSnapshot: %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("LoadVectorIndexSnapshot returned native runtime for column_graph")
+	}
+	if loadStatus.Strategy != VectorIndexStrategyColumnGraph || loadStatus.ExactFallbackReason != vectorIndexFallbackColumnGraphPhysicalMissing || loadStatus.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphPhysicalMissing {
+		t.Fatalf("unexpected column_graph load status: %+v", loadStatus)
+	}
+
+	rebuild, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex returned error instead of status: %v", err)
+	}
+	assertColumnGraphUnavailableStatus(t, rebuild, vectorIndexFallbackColumnGraphPhysicalMissing)
+	if col.hasRegisteredVectorIndex(def.Name) {
+		t.Fatalf("column_graph rebuild registered a native runtime")
+	}
+}
+
+func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	active := ColumnManifestIdentity{Generation: 7, Version: columnManifestIdentityVersion, Checksum: 0x1111}
+	rootIdentity := active
+	rootIdentity.Checksum = 0x2222
+	publishColumnStoreCatalogForTest(t, d, CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorIndexTestColumnStore(&active),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}, rootIdentity)
+
+	graph, status, err := col.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadColumnGraphVectorIndexSnapshot: %v", err)
+	}
+	if graph != nil {
+		t.Fatalf("loaded graph despite manifest mismatch")
+	}
+	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
+		t.Fatalf("unexpected mismatch status: %+v", status)
+	}
+}
+
+func TestCollectionVectorIndexColumnGraphMutationsRemainRebuildNeeded(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:          "docs",
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, modified, err := col.Update([]byte("a"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"embedding":[0.9,0.1]}`), true, nil
+	}); err != nil || !modified {
+		t.Fatalf("update modified=%v err=%v", modified, err)
+	}
+	if deleted, err := col.DeleteDocument([]byte("b")); err != nil || !deleted {
+		t.Fatalf("delete deleted=%v err=%v", deleted, err)
+	}
+	status, err := col.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	assertColumnGraphUnavailableStatus(t, status, vectorIndexFallbackColumnGraphPhysicalMissing)
+	if col.hasRegisteredVectorIndex(def.Name) {
+		t.Fatalf("mutations registered a native runtime for column_graph")
+	}
+}
+
+func TestCollectionVectorIndexColumnGraphStrategyJSON(t *testing.T) {
+	meta, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     VectorMetricCosine,
+			Dimensions: 2,
+			Strategy:   VectorIndexStrategyColumnGraph,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize meta: %v", err)
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if !strings.Contains(string(raw), `"strategy":"column_graph"`) {
+		t.Fatalf("vector metadata JSON=%s want column_graph strategy", raw)
+	}
+	var decoded CollectionMeta
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal meta: %v", err)
+	}
+	decoded, err = normalizeCollectionMeta(decoded)
+	if err != nil {
+		t.Fatalf("normalize decoded meta: %v", err)
+	}
+	got, ok := findVectorIndex(decoded.VectorIndexes, "embedding")
+	if !ok || got.Strategy != VectorIndexStrategyColumnGraph {
+		t.Fatalf("decoded vector index=%+v ok=%v", got, ok)
+	}
+}
+
+func columnGraphVectorIndexTestDefinition() VectorIndexDefinition {
+	return VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		Strategy:   VectorIndexStrategyColumnGraph,
+	}
+}
+
+func columnGraphVectorIndexTestColumnStore(active *ColumnManifestIdentity) *ColumnStoreConfig {
+	var recovery *ColumnManifestIdentity
+	if active != nil {
+		copied := *active
+		recovery = &copied
+	}
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 2},
+			{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+			{Name: "embedding_neighbors", Path: "embedding_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+		},
+		ActiveManifest:                active,
+		RecoveryAuthoritativeManifest: recovery,
+	}
+	if active != nil {
+		cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	}
+	return cfg
+}
+
+func assertColumnGraphUnavailableStatus(t *testing.T, status VectorIndexStatus, reason string) {
+	t.Helper()
+	if status.Strategy != VectorIndexStrategyColumnGraph {
+		t.Fatalf("strategy=%q want column_graph: %+v", status.Strategy, status)
+	}
+	if status.ColumnGraphLoaded || status.PhysicalColumnAssetsSupported {
+		t.Fatalf("column_graph unexpectedly loaded/supported: %+v", status)
+	}
+	if status.ExactFallbackReason != reason || status.ColumnGraphUnavailableReason != reason {
+		t.Fatalf("fallback reason=%q column reason=%q want %q: %+v", status.ExactFallbackReason, status.ColumnGraphUnavailableReason, reason, status)
+	}
+	if !status.RebuildNeeded {
+		t.Fatalf("column_graph status should be rebuild-needed: %+v", status)
+	}
+}

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -100,7 +100,7 @@ func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.
 	}
 
 	graph := newColumnGraphVectorIndexTestGraph(t)
-	withColumnVectorGraphIndexLoaderForTest(t, testColumnVectorGraphIndexLoader{
+	loader := testColumnVectorGraphIndexLoader{
 		result: ColumnVectorGraphIndexLoadResult{
 			Graph: graph,
 			Status: VectorIndexLoadStatus{
@@ -109,9 +109,9 @@ func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.
 				BytesDisk:                     123,
 			},
 		},
-	})
+	}
 
-	loadedGraph, graphStatus, err := col.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	loadedGraph, graphStatus, err := col.loadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def), loader)
 	if err != nil {
 		t.Fatalf("LoadColumnGraphVectorIndexSnapshot: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.
 		t.Fatalf("explicit column_graph loader did not report loaded graph: graph=%v status=%+v", loadedGraph != nil, graphStatus)
 	}
 
-	loaded, status, err := col.LoadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	loaded, status, err := col.loadVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def), loader)
 	if err != nil {
 		t.Fatalf("LoadVectorIndexSnapshot: %v", err)
 	}
@@ -371,15 +371,6 @@ type testColumnVectorGraphIndexLoader struct {
 
 func (l testColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(ColumnVectorGraphIndexLoadInput) (ColumnVectorGraphIndexLoadResult, error) {
 	return l.result, l.err
-}
-
-func withColumnVectorGraphIndexLoaderForTest(t *testing.T, loader ColumnVectorGraphIndexLoader) {
-	t.Helper()
-	previous := defaultColumnVectorGraphIndexLoader
-	defaultColumnVectorGraphIndexLoader = loader
-	t.Cleanup(func() {
-		defaultColumnVectorGraphIndexLoader = previous
-	})
 }
 
 func newColumnGraphVectorIndexTestGraph(t *testing.T) *ColumnVectorGraph {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -134,6 +134,40 @@ func TestLoadVectorIndexSnapshotColumnGraphDoesNotReportNativeLoaded(t *testing.
 	}
 }
 
+func TestBuildVectorIndexRejectsDeclaredColumnGraphWithoutStrategyOption(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:          "docs",
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	_, err = col.BuildVectorIndex(VectorIndexOptions{
+		Name:       def.Name,
+		Field:      def.Field,
+		Metric:     def.Metric,
+		Dimensions: def.Dimensions,
+	})
+	if err == nil || !strings.Contains(err.Error(), "column_graph vector indexes require the column-backed graph loader") {
+		t.Fatalf("BuildVectorIndex err=%v want column_graph loader boundary", err)
+	}
+	if col.hasRegisteredVectorIndex(def.Name) {
+		t.Fatalf("BuildVectorIndex registered native runtime for declared column_graph index")
+	}
+}
+
 func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t *testing.T) {
 	status := VectorIndexLoadStatus{
 		Strategy:                      VectorIndexStrategyColumnGraph,
@@ -141,13 +175,13 @@ func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t
 	}
 	mergeColumnGraphLoadStatus(&status, VectorIndexLoadStatus{
 		PhysicalColumnAssetsSupported: true,
-		ColumnGraphUnavailableReason:  vectorIndexFallbackColumnGraphManifestInvalid,
+		ColumnGraphUnavailableReason:  vectorIndexFallbackColumnGraphManifestRootMismatch,
 		BytesDisk:                     4096,
 	})
 	if status.PhysicalColumnAssetsSupported == false {
 		t.Fatalf("loader failure discarded physical column support: %+v", status)
 	}
-	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestRootMismatch {
 		t.Fatalf("unexpected fallback reason: %+v", status)
 	}
 	if status.BytesDisk != 4096 || !status.RebuildNeeded {
@@ -201,14 +235,14 @@ func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.
 	if graph != nil {
 		t.Fatalf("loaded graph despite manifest mismatch")
 	}
-	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
+	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestRootMismatch {
 		t.Fatalf("unexpected mismatch status: %+v", status)
 	}
 	rebuild, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
 		t.Fatalf("RebuildVectorIndex should report mismatch status, not error: %v", err)
 	}
-	if rebuild.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || rebuild.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid || !rebuild.RebuildNeeded {
+	if rebuild.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch || rebuild.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestRootMismatch || !rebuild.RebuildNeeded {
 		t.Fatalf("unexpected rebuild mismatch status: %+v", rebuild)
 	}
 }

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -50,6 +50,13 @@ func TestCollectionVectorIndexColumnGraphContractReportsPhysicalAssetsMissing(t 
 	if loadStatus.Strategy != VectorIndexStrategyColumnGraph || loadStatus.ExactFallbackReason != vectorIndexFallbackColumnGraphPhysicalMissing || loadStatus.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphPhysicalMissing {
 		t.Fatalf("unexpected column_graph load status: %+v", loadStatus)
 	}
+	nativeLoaded, nativeStatus, err := col.LoadNativeVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadNativeVectorIndexSnapshot: %v", err)
+	}
+	if nativeLoaded != nil || nativeStatus.Strategy != VectorIndexStrategyNativeRuntime || nativeStatus.ExactFallbackReason != vectorIndexFallbackStrategyMismatch {
+		t.Fatalf("native loader should reject column_graph definition, loaded=%v status=%+v", nativeLoaded != nil, nativeStatus)
+	}
 
 	rebuild, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
@@ -98,6 +105,58 @@ func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.
 	}
 	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
 		t.Fatalf("unexpected mismatch status: %+v", status)
+	}
+}
+
+func TestCollectionVectorIndexColumnGraphOptionDoesNotLoadNativeIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := VectorIndexDefinition{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0]}`),
+			[]byte(`{"embedding":[0,1]}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if rebuild, err := col.RebuildVectorIndex(def.Name); err != nil || !rebuild.NativeRuntimeUsed || !rebuild.NativeRootLoaded {
+		t.Fatalf("native rebuild status=%+v err=%v", rebuild, err)
+	}
+
+	loaded, status, err := col.LoadVectorIndexSnapshot(VectorIndexOptions{
+		Name:       def.Name,
+		Field:      def.Field,
+		Metric:     def.Metric,
+		Dimensions: def.Dimensions,
+		Strategy:   VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		t.Fatalf("LoadVectorIndexSnapshot column_graph option: %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("column_graph option loaded native runtime")
+	}
+	if status.Strategy != VectorIndexStrategyColumnGraph || status.ExactFallbackReason != vectorIndexFallbackColumnGraphStrategyMissing || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphStrategyMissing {
+		t.Fatalf("unexpected column_graph strategy-missing status: %+v", status)
 	}
 }
 

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -68,6 +68,17 @@ func TestCollectionVectorIndexColumnGraphContractReportsPhysicalAssetsMissing(t 
 	}
 }
 
+func TestColumnGraphRebuildUnsupportedStatusPreservesReprobeReason(t *testing.T) {
+	def := columnGraphVectorIndexTestDefinition()
+	status := columnGraphRebuildUnsupportedStatus(def, columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphReprobeRequired))
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphReprobeRequired || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphReprobeRequired {
+		t.Fatalf("rebuild status reason=%q column reason=%q want %q: %+v", status.ExactFallbackReason, status.ColumnGraphUnavailableReason, vectorIndexFallbackColumnGraphReprobeRequired, status)
+	}
+	if !status.RebuildNeeded || status.ColumnGraphLoaded || status.PhysicalColumnAssetsSupported {
+		t.Fatalf("unexpected rebuild status flags: %+v", status)
+	}
+}
+
 func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -106,6 +106,13 @@ func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.
 	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid {
 		t.Fatalf("unexpected mismatch status: %+v", status)
 	}
+	rebuild, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex should report mismatch status, not error: %v", err)
+	}
+	if rebuild.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestInvalid || rebuild.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestInvalid || !rebuild.RebuildNeeded {
+		t.Fatalf("unexpected rebuild mismatch status: %+v", rebuild)
+	}
 }
 
 func TestCollectionVectorIndexColumnGraphOptionDoesNotLoadNativeIndex(t *testing.T) {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -60,12 +60,27 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := c.flushBufferedWrites(); err != nil {
 		return VectorIndexStatus{}, err
 	}
-	def, err := c.declaredVectorIndexDefinitionPrepared(name)
+	if err := ValidateIndexName(name); err != nil {
+		return VectorIndexStatus{}, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return VectorIndexStatus{}, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
 	if err != nil {
 		return VectorIndexStatus{}, err
 	}
+	if catalog == nil {
+		return VectorIndexStatus{}, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
+	if !ok {
+		return VectorIndexStatus{}, ErrIndexNotFound
+	}
 	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
-		graph, loadStatus, err := c.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+		graph, loadStatus, err := c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
 		if err != nil {
 			return VectorIndexStatus{}, err
 		}
@@ -77,6 +92,9 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
+	}
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		return VectorIndexStatus{}, err
 	}
 	index, err := c.buildVectorIndexPrepared(vectorIndexOptionsFromDefinition(def), false, false)
 	if err != nil {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -41,7 +41,9 @@ func (c *Collection) VectorIndexStatus(name string) (VectorIndexStatus, error) {
 // RebuildVectorIndex scans canonical collection documents, rebuilds the
 // declared HNSW graph, and publishes a full native vector-index root. It is an
 // operational maintenance call: collection writes wait while the rebuild scans
-// and publishes so the replacement graph cannot miss committed mutations.
+// and publishes so the replacement graph cannot miss committed mutations. For
+// explicit column_graph indexes, this is currently a status probe that returns
+// rebuild-needed until the physical column asset writer/publisher lands.
 func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) {
 	start := time.Now()
 	if c == nil {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -55,9 +55,6 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := ValidateIndexName(name); err != nil {
 		return VectorIndexStatus{}, err
 	}
-	if err := c.flushBufferedWrites(); err != nil {
-		return VectorIndexStatus{}, err
-	}
 	if status, handled, err := c.probeColumnGraphVectorIndexRebuild(name, start); err != nil || handled {
 		return status, err
 	}
@@ -82,14 +79,8 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
 	}
-	def, err = c.declaredVectorIndexDefinitionPrepared(name)
-	if err != nil {
+	if err := c.validateColumnStoreCatalogRootPrepared(); err != nil {
 		return VectorIndexStatus{}, err
-	}
-	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
-		status := columnGraphRebuildUnsupportedStatus(def, columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphReprobeRequired))
-		status.Duration = collectionObservedElapsedSince(start)
-		return status, nil
 	}
 	index, err := c.buildVectorIndexPrepared(vectorIndexOptionsFromDefinition(def), false, false)
 	if err != nil {
@@ -187,6 +178,28 @@ func (c *Collection) declaredVectorIndexDefinitionPrepared(name string) (VectorI
 
 func (c *Collection) declaredVectorIndexDefinitionPreparedWithoutColumnRootValidation(name string) (VectorIndexDefinition, error) {
 	return c.declaredVectorIndexDefinitionPreparedFromCatalog(name, loadCollectionCatalogWithoutColumnRootValidation)
+}
+
+func (c *Collection) validateColumnStoreCatalogRootPrepared() error {
+	if c == nil {
+		return errCollectionNil
+	}
+	if c.db == nil {
+		return errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	return validateColumnStoreCatalogRoot(snap, catalog)
 }
 
 func (c *Collection) declaredVectorIndexDefinitionPreparedFromCatalog(name string, loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) (VectorIndexDefinition, error) {
@@ -306,7 +319,6 @@ func (c *Collection) vectorIndexStatus(name string, inspectNativeRoot bool) (Vec
 		return status, nil
 	}
 	probe.recordLoadedSnapshot(status.RootID, bytesDisk)
-	status.NativeRuntimeUsed = true
 	status.NativeRootLoaded = true
 	status.NativeRootBytes = bytesDisk
 	if !status.Registered || registeredRuntimeStale {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -10,17 +10,22 @@ import (
 // vector index. Status checks may inspect the persisted graph root and are
 // intended for operational paths, not search hot paths.
 type VectorIndexStatus struct {
-	Definition          VectorIndexDefinition
-	Name                string
-	RootName            string
-	RootID              uint64
-	NativeRootLoaded    bool
-	NativeRootBytes     int64
-	ExactFallbackReason string
-	Registered          bool
-	Stats               VectorIndexStats
-	RebuildNeeded       bool
-	Duration            time.Duration
+	Definition                    VectorIndexDefinition
+	Name                          string
+	RootName                      string
+	RootID                        uint64
+	Strategy                      VectorIndexStrategy
+	NativeRuntimeUsed             bool
+	NativeRootLoaded              bool
+	NativeRootBytes               int64
+	ExactFallbackReason           string
+	ColumnGraphLoaded             bool
+	ColumnGraphUnavailableReason  string
+	PhysicalColumnAssetsSupported bool
+	Registered                    bool
+	Stats                         VectorIndexStats
+	RebuildNeeded                 bool
+	Duration                      time.Duration
 }
 
 // VectorIndexStatus returns persisted-root and runtime status for a declared
@@ -57,6 +62,20 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err != nil {
 		return VectorIndexStatus{}, err
 	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		graph, loadStatus, err := c.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+		if err != nil {
+			return VectorIndexStatus{}, err
+		}
+		if graph != nil {
+			status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
+			status.Duration = collectionObservedElapsedSince(start)
+			return status, nil
+		}
+		status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
+		status.Duration = collectionObservedElapsedSince(start)
+		return status, nil
+	}
 	index, err := c.buildVectorIndexPrepared(vectorIndexOptionsFromDefinition(def), false, false)
 	if err != nil {
 		return VectorIndexStatus{}, err
@@ -87,6 +106,8 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		Name:                def.Name,
 		RootName:            collectionVectorIndexRootName(c.meta.Name, def.Name),
 		RootID:              native.RootID,
+		Strategy:            VectorIndexStrategyNativeRuntime,
+		NativeRuntimeUsed:   true,
 		NativeRootLoaded:    native.Loaded,
 		NativeRootBytes:     native.BytesDisk,
 		ExactFallbackReason: native.ExactFallbackReason,
@@ -158,7 +179,7 @@ func (c *Collection) vectorIndexStatus(name string, inspectNativeRoot bool) (Vec
 		return VectorIndexStatus{}, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
 	if err != nil {
 		return VectorIndexStatus{}, err
 	}
@@ -168,6 +189,12 @@ func (c *Collection) vectorIndexStatus(name string, inspectNativeRoot bool) (Vec
 	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
 	if !ok {
 		return VectorIndexStatus{}, ErrIndexNotFound
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		return c.columnGraphVectorIndexStatusFromCatalog(snap, catalog, def)
+	}
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		return VectorIndexStatus{}, err
 	}
 
 	rootName := collectionVectorIndexRootName(catalog.meta.Name, def.Name)
@@ -181,12 +208,14 @@ func (c *Collection) vectorIndexStatus(name string, inspectNativeRoot bool) (Vec
 		Name:       def.Name,
 		RootName:   rootName,
 		RootID:     rootID,
+		Strategy:   VectorIndexStrategyNativeRuntime,
 	}
 	registeredRuntimeStale := false
 	if runtimeIdx := c.registeredVectorIndex(def.Name); runtimeIdx != nil {
 		status.Registered = true
 		registeredRuntimeStale = runtimeIdx.validateNativeSnapshotDefinition(def) != "" || rootID != runtimeIdx.nativeSnapshotBaseEpochForFullSave()
 		if !registeredRuntimeStale {
+			status.NativeRuntimeUsed = true
 			status.Stats = runtimeIdx.Stats()
 		}
 	}
@@ -220,6 +249,7 @@ func (c *Collection) vectorIndexStatus(name string, inspectNativeRoot bool) (Vec
 		return status, nil
 	}
 	probe.recordLoadedSnapshot(status.RootID, bytesDisk)
+	status.NativeRuntimeUsed = true
 	status.NativeRootLoaded = true
 	status.NativeRootBytes = bytesDisk
 	if !status.Registered || registeredRuntimeStale {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -55,35 +55,8 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := ValidateIndexName(name); err != nil {
 		return VectorIndexStatus{}, err
 	}
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return VectorIndexStatus{}, backenddb.ErrClosed
-	}
-	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
-	if err != nil {
-		return VectorIndexStatus{}, err
-	}
-	if catalog == nil {
-		return VectorIndexStatus{}, errCollectionNotFound
-	}
-	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
-	if !ok {
-		return VectorIndexStatus{}, ErrIndexNotFound
-	}
-	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
-		graph, loadStatus, err := c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
-		if err != nil {
-			return VectorIndexStatus{}, err
-		}
-		if graph != nil {
-			status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
-			status.Duration = collectionObservedElapsedSince(start)
-			return status, nil
-		}
-		status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
-		status.Duration = collectionObservedElapsedSince(start)
-		return status, nil
+	if status, handled, err := c.probeColumnGraphVectorIndexRebuild(name, start); err != nil || handled {
+		return status, err
 	}
 	// Native rebuild publishes a full replacement graph root. Hold the same
 	// mutation barrier used by writes across the primary scan and root publish
@@ -93,21 +66,18 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := c.flushBufferedWrites(); err != nil {
 		return VectorIndexStatus{}, err
 	}
-	def, err = c.declaredVectorIndexDefinitionPrepared(name)
+	def, err := c.declaredVectorIndexDefinitionPrepared(name)
 	if err != nil {
 		return VectorIndexStatus{}, err
 	}
 	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
-		graph, loadStatus, err := c.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
-		if err != nil {
-			return VectorIndexStatus{}, err
-		}
-		if graph != nil {
-			status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
-			status.Duration = collectionObservedElapsedSince(start)
-			return status, nil
-		}
-		status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
+		// The definition can change while waiting for the native rebuild barrier.
+		// Do not run the column_graph loader with writers blocked; callers can
+		// re-probe status outside the native rebuild path.
+		status := columnGraphRebuildUnsupportedStatus(
+			def,
+			columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing),
+		)
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
 	}
@@ -152,6 +122,40 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		Duration:            duration,
 	}
 	return status, nil
+}
+
+func (c *Collection) probeColumnGraphVectorIndexRebuild(name string, start time.Time) (VectorIndexStatus, bool, error) {
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return VectorIndexStatus{}, true, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
+	if err != nil {
+		return VectorIndexStatus{}, true, err
+	}
+	if catalog == nil {
+		return VectorIndexStatus{}, true, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
+	if !ok {
+		return VectorIndexStatus{}, true, ErrIndexNotFound
+	}
+	if vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph {
+		return VectorIndexStatus{}, false, nil
+	}
+	graph, loadStatus, err := c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
+	if err != nil {
+		return VectorIndexStatus{}, true, err
+	}
+	if graph != nil {
+		status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
+		status.Duration = collectionObservedElapsedSince(start)
+		return status, true, nil
+	}
+	status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
+	status.Duration = collectionObservedElapsedSince(start)
+	return status, true, nil
 }
 
 func (c *Collection) declaredVectorIndexDefinition(name string) (VectorIndexDefinition, error) {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -136,11 +136,14 @@ func (c *Collection) probeColumnGraphVectorIndexRebuild(name string, start time.
 		return VectorIndexStatus{}, true, err
 	}
 	if catalog == nil {
-		return VectorIndexStatus{}, true, errCollectionNotFound
+		// The pre-lock probe is opportunistic. A missing catalog/definition can
+		// still become visible after the native path takes the mutation barrier
+		// and flushes buffered writes, so fall through instead of failing early.
+		return VectorIndexStatus{}, false, nil
 	}
 	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
 	if !ok {
-		return VectorIndexStatus{}, true, ErrIndexNotFound
+		return VectorIndexStatus{}, false, nil
 	}
 	if vectorIndexDefinitionStrategy(def) != VectorIndexStrategyColumnGraph {
 		return VectorIndexStatus{}, false, nil

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -52,14 +52,6 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if c.db == nil {
 		return VectorIndexStatus{}, errCollectionDBNil
 	}
-	// Rebuild publishes a full replacement graph root. Hold the same mutation
-	// barrier used by writes across the primary scan and root publish so no
-	// committed write can be skipped by the clean replacement snapshot.
-	unlockMutation := c.lockMutation()
-	defer unlockMutation.Unlock()
-	if err := c.flushBufferedWrites(); err != nil {
-		return VectorIndexStatus{}, err
-	}
 	if err := ValidateIndexName(name); err != nil {
 		return VectorIndexStatus{}, err
 	}
@@ -93,8 +85,31 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
 	}
-	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+	// Native rebuild publishes a full replacement graph root. Hold the same
+	// mutation barrier used by writes across the primary scan and root publish
+	// so no committed write can be skipped by the clean replacement snapshot.
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
 		return VectorIndexStatus{}, err
+	}
+	def, err = c.declaredVectorIndexDefinitionPrepared(name)
+	if err != nil {
+		return VectorIndexStatus{}, err
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		graph, loadStatus, err := c.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+		if err != nil {
+			return VectorIndexStatus{}, err
+		}
+		if graph != nil {
+			status := vectorIndexStatusFromColumnGraphLoad(def, loadStatus)
+			status.Duration = collectionObservedElapsedSince(start)
+			return status, nil
+		}
+		status := columnGraphRebuildUnsupportedStatus(def, loadStatus)
+		status.Duration = collectionObservedElapsedSince(start)
+		return status, nil
 	}
 	index, err := c.buildVectorIndexPrepared(vectorIndexOptionsFromDefinition(def), false, false)
 	if err != nil {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -55,12 +55,16 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := ValidateIndexName(name); err != nil {
 		return VectorIndexStatus{}, err
 	}
+	if err := c.flushBufferedWrites(); err != nil {
+		return VectorIndexStatus{}, err
+	}
 	if status, handled, err := c.probeColumnGraphVectorIndexRebuild(name, start); err != nil || handled {
 		return status, err
 	}
 	// Native rebuild publishes a full replacement graph root. Hold the same
 	// mutation barrier used by writes across the primary scan and root publish
-	// so no committed write can be skipped by the clean replacement snapshot.
+	// so no committed write after the pre-lock probe can be skipped by the clean
+	// replacement snapshot.
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
 	if err := c.flushBufferedWrites(); err != nil {

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -70,7 +70,7 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 	if err := c.flushBufferedWrites(); err != nil {
 		return VectorIndexStatus{}, err
 	}
-	def, err := c.declaredVectorIndexDefinitionPrepared(name)
+	def, err := c.declaredVectorIndexDefinitionPreparedWithoutColumnRootValidation(name)
 	if err != nil {
 		return VectorIndexStatus{}, err
 	}
@@ -78,10 +78,7 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		// The definition can change while waiting for the native rebuild barrier.
 		// Do not run the column_graph loader with writers blocked; callers can
 		// re-probe status outside the native rebuild path.
-		status := columnGraphRebuildUnsupportedStatus(
-			def,
-			columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing),
-		)
+		status := columnGraphRebuildUnsupportedStatus(def, columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphReprobeRequired))
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
 	}
@@ -176,6 +173,14 @@ func (c *Collection) declaredVectorIndexDefinition(name string) (VectorIndexDefi
 }
 
 func (c *Collection) declaredVectorIndexDefinitionPrepared(name string) (VectorIndexDefinition, error) {
+	return c.declaredVectorIndexDefinitionPreparedFromCatalog(name, loadCollectionCatalog)
+}
+
+func (c *Collection) declaredVectorIndexDefinitionPreparedWithoutColumnRootValidation(name string) (VectorIndexDefinition, error) {
+	return c.declaredVectorIndexDefinitionPreparedFromCatalog(name, loadCollectionCatalogWithoutColumnRootValidation)
+}
+
+func (c *Collection) declaredVectorIndexDefinitionPreparedFromCatalog(name string, loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) (VectorIndexDefinition, error) {
 	if c == nil {
 		return VectorIndexDefinition{}, errCollectionNil
 	}
@@ -190,7 +195,7 @@ func (c *Collection) declaredVectorIndexDefinitionPrepared(name string) (VectorI
 		return VectorIndexDefinition{}, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := loadCatalog(snap, c.meta.Name)
 	if err != nil {
 		return VectorIndexDefinition{}, err
 	}

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -82,6 +82,15 @@ func (c *Collection) RebuildVectorIndex(name string) (VectorIndexStatus, error) 
 		status.Duration = collectionObservedElapsedSince(start)
 		return status, nil
 	}
+	def, err = c.declaredVectorIndexDefinitionPrepared(name)
+	if err != nil {
+		return VectorIndexStatus{}, err
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		status := columnGraphRebuildUnsupportedStatus(def, columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphReprobeRequired))
+		status.Duration = collectionObservedElapsedSince(start)
+		return status, nil
+	}
 	index, err := c.buildVectorIndexPrepared(vectorIndexOptionsFromDefinition(def), false, false)
 	if err != nil {
 		return VectorIndexStatus{}, err

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -56,6 +56,16 @@ type VectorIndexLoadStatus struct {
 	RootID              uint64
 	Epoch               uint64
 	BytesDisk           int64
+	Strategy            VectorIndexStrategy
+	NativeRuntimeUsed   bool
+	ColumnGraphLoaded   bool
+	// ColumnGraphUnavailableReason is set for explicit column_graph indexes
+	// when the persisted column-backed graph path cannot load. It intentionally
+	// mirrors ExactFallbackReason so older callers still see a safe fallback
+	// reason without understanding column_graph-specific status fields.
+	ColumnGraphUnavailableReason  string
+	PhysicalColumnAssetsSupported bool
+	RebuildNeeded                 bool
 }
 
 // VectorIndexPruneStatus reports persisted vector-index epoch cleanup.
@@ -719,6 +729,9 @@ func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIn
 	if err != nil {
 		return nil, status, err
 	}
+	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
+		return index, status, nil
+	}
 	if index != nil || status.Loaded || status.ExactFallbackReason != vectorIndexFallbackMissingVectorIndexMetadata {
 		return index, status, nil
 	}
@@ -729,7 +742,7 @@ func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIn
 // collection root. Missing or invalid graph roots return a non-loaded status so
 // callers can safely fall back to exact search.
 func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := VectorIndexLoadStatus{Strategy: VectorIndexStrategyNativeRuntime}
 	if c == nil {
 		return nil, status, errCollectionNil
 	}
@@ -742,7 +755,7 @@ func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 		return nil, status, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(snap, c.meta.Name)
 	if err != nil {
 		return nil, status, err
 	}
@@ -753,6 +766,13 @@ func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 	if !ok {
 		status.ExactFallbackReason = vectorIndexFallbackMissingVectorIndexMetadata
 		return nil, status, nil
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		_, status, err = c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
+		return nil, status, err
+	}
+	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
+		return nil, status, err
 	}
 	rootName := collectionVectorIndexRootName(catalog.meta.Name, def.Name)
 	status.RootName = rootName
@@ -778,6 +798,7 @@ func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 		return nil, status, nil
 	}
 	status.Loaded = true
+	status.NativeRuntimeUsed = true
 	status.RootID = rootID
 	status.Epoch = rootID
 	status.BytesDisk = bytesDisk
@@ -1459,6 +1480,7 @@ func vectorIndexOptionsFromDefinition(def VectorIndexDefinition) VectorIndexOpti
 		EfConstruction:   def.EfConstruction,
 		EfSearch:         def.EfSearch,
 		Encoding:         def.Encoding,
+		Strategy:         def.Strategy,
 		schemaGeneration: def.SchemaGeneration,
 	}
 }
@@ -1469,6 +1491,9 @@ func (idx *VectorIndex) validateNativeSnapshotDefinition(def VectorIndexDefiniti
 	}
 	if def.Field != idx.field {
 		return "field_mismatch"
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		return "strategy_mismatch"
 	}
 	if def.Metric != idx.metric {
 		return "metric_mismatch"

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -732,8 +732,12 @@ func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 // with ExactFallbackReason set and no error, so callers can safely use exact
 // search as the correctness fallback.
 func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
+	return c.loadVectorIndexSnapshot(opts, defaultColumnVectorGraphIndexLoader)
+}
+
+func (c *Collection) loadVectorIndexSnapshot(opts VectorIndexOptions, loader ColumnVectorGraphIndexLoader) (*VectorIndex, VectorIndexLoadStatus, error) {
 	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
-		graph, status, err := c.LoadColumnGraphVectorIndexSnapshot(opts)
+		graph, status, err := c.loadColumnGraphVectorIndexSnapshot(opts, loader)
 		if graph != nil {
 			// This API can only return a native *VectorIndex handle. Keep a
 			// successfully loaded column graph from being reported as a usable

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -736,7 +736,11 @@ func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIn
 }
 
 func (c *Collection) loadVectorIndexSnapshot(opts VectorIndexOptions, loader ColumnVectorGraphIndexLoader) (*VectorIndex, VectorIndexLoadStatus, error) {
-	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
+	strategy, err := normalizeVectorIndexStrategy(opts.Strategy)
+	if err != nil {
+		return nil, nativeRuntimeVectorIndexLoadStatus(), err
+	}
+	if strategy == VectorIndexStrategyColumnGraph {
 		graph, status, err := c.loadColumnGraphVectorIndexSnapshot(opts, loader)
 		if graph != nil {
 			// This API can only return a native *VectorIndex handle. Keep a
@@ -744,9 +748,7 @@ func (c *Collection) loadVectorIndexSnapshot(opts VectorIndexOptions, loader Col
 			// VectorIndex; callers that need the graph must use the explicit
 			// column_graph loader/search path.
 			status.Loaded = false
-			status.ColumnGraphLoaded = false
 			status.ExactFallbackReason = vectorIndexFallbackColumnGraphHandleMissing
-			status.ColumnGraphUnavailableReason = vectorIndexFallbackColumnGraphHandleMissing
 			status.RebuildNeeded = false
 		}
 		return nil, status, err

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -68,6 +68,10 @@ type VectorIndexLoadStatus struct {
 	RebuildNeeded                 bool
 }
 
+func nativeRuntimeVectorIndexLoadStatus() VectorIndexLoadStatus {
+	return VectorIndexLoadStatus{Strategy: VectorIndexStrategyNativeRuntime}
+}
+
 // VectorIndexPruneStatus reports persisted vector-index epoch cleanup.
 type VectorIndexPruneStatus struct {
 	IndexDir      string
@@ -91,7 +95,7 @@ func (idx *VectorIndex) SaveSnapshot() (VectorIndexLoadStatus, error) {
 // TreeDB collection-root content and publishes that root through the collection
 // root descriptor system state.
 func (idx *VectorIndex) SaveNativeSnapshot() (VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if idx == nil {
 		return status, errors.New("collections: vector index is nil")
 	}
@@ -116,7 +120,7 @@ func (idx *VectorIndex) SaveNativeSnapshot() (VectorIndexLoadStatus, error) {
 }
 
 func staleNativeSnapshotSaveStatus(c *Collection, idx *VectorIndex) (VectorIndexLoadStatus, bool, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if c == nil || idx == nil {
 		return status, false, nil
 	}
@@ -152,7 +156,7 @@ func staleNativeSnapshotSaveStatus(c *Collection, idx *VectorIndex) (VectorIndex
 // saveNativeSnapshotPrepared publishes the current graph after the caller has
 // already acquired the collection mutation barrier and flushed buffered writes.
 func (idx *VectorIndex) saveNativeSnapshotPrepared() (VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if idx == nil {
 		return status, errors.New("collections: vector index is nil")
 	}
@@ -230,6 +234,7 @@ func (idx *VectorIndex) saveNativeSnapshotPrepared() (VectorIndexLoadStatus, err
 		return status, unexpectedOrderedRootCountError(catalog.meta.Name, 1, len(rootIDs))
 	}
 	status.Loaded = true
+	status.NativeRuntimeUsed = true
 	status.RootID = rootIDs[0]
 	status.Epoch = rootIDs[0]
 	status.BytesDisk = bytesDisk
@@ -268,7 +273,7 @@ func (c *Collection) currentNativeVectorIndexRootID(name string) (uint64, error)
 // rebuild/shrink publication should continue to use SaveNativeSnapshot so
 // removed graph keys cannot survive.
 func (idx *VectorIndex) SaveNativeDeltaSnapshot() (VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if idx == nil {
 		return status, errors.New("collections: vector index is nil")
 	}
@@ -358,6 +363,7 @@ func (idx *VectorIndex) SaveNativeDeltaSnapshot() (VectorIndexLoadStatus, error)
 		return status, unexpectedOrderedRootCountError(catalog.meta.Name, 1, len(rootIDs))
 	}
 	status.Loaded = true
+	status.NativeRuntimeUsed = true
 	status.RootID = rootIDs[0]
 	status.Epoch = rootIDs[0]
 	status.BytesDisk = bytesDisk
@@ -600,7 +606,7 @@ func (c *Collection) prepareNativeVectorIndexCommandWALRootPublish(catalog *coll
 }
 
 func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if idx == nil {
 		return status, errors.New("collections: vector index is nil")
 	}
@@ -714,6 +720,7 @@ func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 		return status, err
 	}
 	status.Loaded = true
+	status.NativeRuntimeUsed = true
 	status.Epoch = epoch
 	status.BytesDisk = bytesDisk
 	idx.recordPersistedSnapshot(epoch, bytesDisk, snapshotSeq)
@@ -726,7 +733,18 @@ func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 // search as the correctness fallback.
 func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
 	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
-		_, status, err := c.LoadColumnGraphVectorIndexSnapshot(opts)
+		graph, status, err := c.LoadColumnGraphVectorIndexSnapshot(opts)
+		if graph != nil {
+			// This API can only return a native *VectorIndex handle. Keep a
+			// successfully loaded column graph from being reported as a usable
+			// VectorIndex; callers that need the graph must use the explicit
+			// column_graph loader/search path.
+			status.Loaded = false
+			status.ColumnGraphLoaded = false
+			status.ExactFallbackReason = vectorIndexFallbackColumnGraphHandleMissing
+			status.ColumnGraphUnavailableReason = vectorIndexFallbackColumnGraphHandleMissing
+			status.RebuildNeeded = false
+		}
 		return nil, status, err
 	}
 	index, status, err := c.LoadNativeVectorIndexSnapshot(opts)
@@ -745,7 +763,7 @@ func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIn
 // are rejected with strategy_mismatch; use LoadColumnGraphVectorIndexSnapshot
 // or LoadVectorIndexSnapshot with Strategy: column_graph for that seam.
 func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{Strategy: VectorIndexStrategyNativeRuntime}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if c == nil {
 		return nil, status, errCollectionNil
 	}
@@ -813,7 +831,7 @@ func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 }
 
 func (c *Collection) loadLegacyVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
-	status := VectorIndexLoadStatus{}
+	status := nativeRuntimeVectorIndexLoadStatus()
 	if c == nil {
 		return nil, status, errCollectionNil
 	}
@@ -867,6 +885,7 @@ func (c *Collection) loadLegacyVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 		return nil, status, nil
 	}
 	status.Loaded = true
+	status.NativeRuntimeUsed = true
 	status.Epoch = manifest.Epoch
 	status.BytesDisk = vectorIndexSnapshotBytes(manifestData, manifest.Files)
 	index.recordLoadedSnapshot(status.Epoch, status.BytesDisk)

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -725,12 +725,13 @@ func (idx *VectorIndex) saveLegacySnapshot() (VectorIndexLoadStatus, error) {
 // with ExactFallbackReason set and no error, so callers can safely use exact
 // search as the correctness fallback.
 func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
+	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
+		_, status, err := c.LoadColumnGraphVectorIndexSnapshot(opts)
+		return nil, status, err
+	}
 	index, status, err := c.LoadNativeVectorIndexSnapshot(opts)
 	if err != nil {
 		return nil, status, err
-	}
-	if vectorIndexOptionsStrategy(opts) == VectorIndexStrategyColumnGraph {
-		return index, status, nil
 	}
 	if index != nil || status.Loaded || status.ExactFallbackReason != vectorIndexFallbackMissingVectorIndexMetadata {
 		return index, status, nil
@@ -740,7 +741,9 @@ func (c *Collection) LoadVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIn
 
 // LoadNativeVectorIndexSnapshot loads a declared vector index from its TreeDB
 // collection root. Missing or invalid graph roots return a non-loaded status so
-// callers can safely fall back to exact search.
+// callers can safely fall back to exact search. Explicit column_graph indexes
+// are rejected with strategy_mismatch; use LoadColumnGraphVectorIndexSnapshot
+// or LoadVectorIndexSnapshot with Strategy: column_graph for that seam.
 func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*VectorIndex, VectorIndexLoadStatus, error) {
 	status := VectorIndexLoadStatus{Strategy: VectorIndexStrategyNativeRuntime}
 	if c == nil {
@@ -768,8 +771,9 @@ func (c *Collection) LoadNativeVectorIndexSnapshot(opts VectorIndexOptions) (*Ve
 		return nil, status, nil
 	}
 	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
-		_, status, err = c.loadColumnGraphVectorIndexSnapshotFromCatalog(snap, catalog, def)
-		return nil, status, err
+		status.ExactFallbackReason = vectorIndexFallbackStrategyMismatch
+		status.RebuildNeeded = true
+		return nil, status, nil
 	}
 	if err := validateColumnStoreCatalogRoot(snap, catalog); err != nil {
 		return nil, status, err

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -115,6 +115,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/native-ann-vector-index.md`
   - draft target architecture and implementation plan for turning the
     collection ANN vector graph into a native persisted TreeDB secondary index.
+- `TreeDB/docs/spec/collections-column-vector-contract-seam.md`
+  - current contract seam for explicit `column_graph` vector indexes; documents
+    status/fallback behavior and the missing physical column asset milestones.
 - `TreeDB/docs/spec/collections-native-fastpath-roadmap.md`
   - draft implementation roadmap for the native cached collections rewrite,
     including PR slices, acceptance criteria, and performance gates.

--- a/TreeDB/docs/spec/collections-column-vector-contract-seam.md
+++ b/TreeDB/docs/spec/collections-column-vector-contract-seam.md
@@ -1,0 +1,104 @@
+# Collection Column-Backed Vector Index Seam
+
+Status: implemented as a product-contract seam, not as a complete persisted
+column-backed vector-search product path.
+
+## Current Reality
+
+TreeDB currently has two separate pieces of vector-index infrastructure:
+
+- The public collection vector-index lifecycle uses collection metadata plus
+  native TreeDB vector-index roots. This path can declare, build, save, reopen,
+  load, and query the native/runtime ANN graph.
+- `ColumnVectorGraph` is the lower-level column-shaped search kernel. It
+  searches immutable row-major vector, inverse-norm, and CSR adjacency columns
+  with caller-owned scratch. It does not fetch full documents in the traversal,
+  scoring, or top-k kernel.
+
+The full product path for a persisted column-backed vector index still depends
+on physical column-store support that writes, publishes, reopens, and scans the
+vector, inverse-norm, and adjacency-list assets through the collection column
+manifest/root lifecycle.
+
+## `column_graph` Strategy
+
+Collection vector-index metadata now accepts an explicit strategy:
+
+```json
+{
+  "name": "embedding",
+  "field": "embedding",
+  "metric": "cosine",
+  "dimensions": 128,
+  "strategy": "column_graph"
+}
+```
+
+The omitted/default strategy remains the existing native/runtime path. Native
+metadata continues to omit `strategy` so older normalized metadata remains
+stable.
+
+Selecting `column_graph` is intentionally not a request to build a native HNSW
+root. TreeDB skips native runtime registration, native vector-root descriptor
+creation, and native write-maintenance for explicit `column_graph` indexes. The
+strategy reports status through the normal vector-index operational APIs instead
+of silently returning native results.
+
+## Status Contract
+
+`VectorIndexStatus` and `VectorIndexLoadStatus` report the selected strategy and
+column-graph availability:
+
+- `Strategy`: `native_runtime` or `column_graph`.
+- `NativeRuntimeUsed`: true only when the native/runtime graph is the active
+  path.
+- `ColumnGraphLoaded`: true only after a real column-backed graph is loaded.
+- `ColumnGraphUnavailableReason`: precise reason the column graph cannot load.
+- `PhysicalColumnAssetsSupported`: true only when physical column assets are
+  available through the loader boundary.
+- `RebuildNeeded`: true when the index cannot safely serve the selected path.
+
+Current `column_graph` unavailable reasons include:
+
+- `physical_column_asset_support_missing`
+- `column_graph_manifest_root_missing`
+- `column_graph_manifest_root_mismatch`
+- `column_graph_requires_cosine`
+- `column_graph_requires_float32`
+
+These reasons are also mirrored in `ExactFallbackReason` so existing callers
+that only inspect the older field still fail closed.
+
+## Loader Boundary
+
+`ColumnVectorGraphIndexLoader` is the seam future physical column-store work
+must satisfy. A real loader must read vector, inverse-norm, and adjacency-list
+column assets referenced by the collection column manifest and construct an
+immutable `ColumnVectorGraph`.
+
+The current default loader returns
+`physical_column_asset_support_missing`. It does not create a vector-only
+sidecar format and does not bypass the column-store manifest/root architecture.
+
+## Remaining Milestones
+
+Before `column_graph` can become the default product path, TreeDB still needs:
+
+1. Physical column asset writing for vector, inverse-norm, and adjacency-list
+   columns during vector-index build/rebuild.
+2. Durable publication of those assets through the collection column
+   manifest/root lifecycle.
+3. Reopen/scanner support that loads those published assets into
+   `ColumnVectorGraphColumns`.
+4. Mutation policy for inserts, updates, and deletes: maintain the graph, mark
+   it stale, or rebuild it explicitly.
+5. Public query wiring that uses `ColumnVectorGraph` for top-k selection and
+   materializes documents only after the graph kernel chooses result IDs.
+
+## What This Proves
+
+This seam proves that a normal collection can declare a column-backed vector
+index strategy and get explicit operational status without accidentally using
+the native graph path. It does not prove persisted column asset search, disk
+layout, compression, or end-to-end column-backed query performance. Those remain
+the responsibility of the physical column asset milestones above.

--- a/TreeDB/docs/spec/collections-column-vector-contract-seam.md
+++ b/TreeDB/docs/spec/collections-column-vector-contract-seam.md
@@ -60,6 +60,7 @@ column-graph availability:
 
 Current `column_graph` unavailable reasons include:
 
+- `column_graph_strategy_not_selected`
 - `physical_column_asset_support_missing`
 - `column_graph_manifest_root_missing`
 - `column_graph_manifest_root_mismatch`

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -618,7 +618,10 @@ payload:
 Version 3 adds first-class `vector_indexes` entries to the metadata envelope.
 Each vector index definition stores `name`, `field`, `metric`, `dimensions`,
 optional HNSW search/build settings (`m`, `ef_construction`, `ef_search`),
-`encoding`, and `schema_generation`. Decoders must reject metadata whose
+`encoding`, optional `strategy`, and `schema_generation`. The omitted/default
+strategy is the existing native/runtime vector-index path; `column_graph`
+selects the column-backed vector-index contract seam and must not publish a
+native vector root. Decoders must reject metadata whose
 `version` differs from the implementation's current collection metadata
 version instead of silently accepting older layouts with missing vector-index
 state.


### PR DESCRIPTION
## Summary

This PR adds an explicit `column_graph` vector-index strategy as a product-contract seam for the future persisted column-backed `ColumnVectorGraph` path.

It intentionally does **not** add a bespoke vector-only persistence path. If the real physical column-store asset writer/scanner/root publication path is not available, the public vector-index APIs fail closed with precise status instead of silently using the native/runtime graph.

## What changed

- Adds `strategy: "column_graph"` to vector-index metadata/options while leaving omitted/default strategy on the existing native/runtime path.
- Skips native runtime registration, native vector-root descriptor publication, and native write-maintenance when `column_graph` is explicitly selected.
- Adds `VectorIndexStatus` / `VectorIndexLoadStatus` fields for strategy, native-runtime usage, column-graph load state, physical column asset support, unavailable reason, and rebuild-needed state.
- Adds `ColumnVectorGraphIndexLoader` as the future physical column asset loader boundary. The current default loader returns `physical_column_asset_support_missing`.
- Allows status/load paths to inspect corrupt or mismatched column manifest/root metadata and report `column_graph_manifest_root_mismatch` instead of failing before status generation.
- Documents the contract seam, current limitations, and remaining physical column-store milestones.

## Current reality

- Native/runtime vector index persistence still uses TreeDB-native snapshot/root records.
- `ColumnVectorGraph` is the column-shaped in-memory search kernel for vector, invNorm, and adjacency columns.
- Full product integration still depends on real physical column asset writing, root/manifest publication, reopen/scanner support, and query API wiring through that persisted path.
- No fake vector sidecar, alternate file format, or shortcut persistence path was added.

## Status behavior

Current `column_graph` unavailable reasons include:

- `physical_column_asset_support_missing`
- `column_graph_manifest_root_missing`
- `column_graph_manifest_root_mismatch`
- `column_graph_requires_cosine`
- `column_graph_requires_float32`

The reason is mirrored into `ExactFallbackReason` for existing callers, and `RebuildNeeded` remains true until a real column graph loads.

## Tests

Added focused product-contract tests for:

- selecting `column_graph` and receiving explicit physical-asset-missing status,
- manifest/root metadata mismatch reporting,
- insert/update/delete after `column_graph` declaration remaining rebuild-needed without registering a native runtime,
- JSON metadata round-trip for `strategy: "column_graph"`.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionVectorIndexColumnGraph|TestColumnVectorGraph|TestColumnStore|TestColumnPublish|Test.*Vector' -count=1
# ok  	github.com/snissn/gomap/TreeDB/collections	2.778s

GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1
# ok  	github.com/snissn/gomap/cmd/treedb_vector_search_demo	1.900s

GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionVectorIndexColumnGraph|TestColumnVectorGraph.*Parallel|TestColumnVectorGraph' -count=1
# ok  	github.com/snissn/gomap/TreeDB/collections	1.823s
```

## Remaining milestones before `column_graph` can be the default product path

1. Physical column asset writing for vector, inverse-norm, and adjacency-list columns during vector-index build/rebuild.
2. Durable publication of those assets through the collection column manifest/root lifecycle.
3. Reopen/scanner support that loads those assets into `ColumnVectorGraphColumns`.
4. Mutation policy for inserts, updates, and deletes: maintain the graph, mark it stale, or rebuild it explicitly.
5. Public query wiring that uses `ColumnVectorGraph` for top-k selection and materializes documents only after the graph kernel chooses result IDs.

Do not merge until the branch has completed review and CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable vector-index strategies (native runtime vs. column_graph) that change loading, rebuild, registration, and root planning behavior; catalog loading is now a two-step, strategy-aware flow.

* **Status & Behavior**
  * Expanded index status to report strategy, native-runtime usage, column-graph load/unavailability reasons, physical-asset support, and rebuild-needed semantics.

* **Tests**
  * Added comprehensive tests for column_graph availability, manifest mismatches, mutations, rebuild semantics, and metadata round-trips.

* **Documentation**
  * Added column-graph contract spec and updated storage-format guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->