### PR TITLE
TreeDB column store M13A: add serial physical scanner

### DIFF
--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -78,7 +78,7 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 		}
 	}
 
-	records := make([]columnManifestRecord, 0, 1+len(input.Prepared.Assets))
+	records := make([]columnManifestRecord, 0, 1+len(input.CurrentManifestRecords)+len(input.Prepared.Assets))
 	header, err := encodeColumnManifestHeaderRecord(input, generation)
 	if err != nil {
 		return ColumnPublishManifestEncodeResult{}, err
@@ -87,6 +87,11 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 		key:   []byte(columnManifestHeaderRecordKey),
 		value: header,
 	})
+	retained, err := retainedColumnManifestPartRecordsForWrite(input.CurrentManifestRecords, generation)
+	if err != nil {
+		return ColumnPublishManifestEncodeResult{}, err
+	}
+	records = append(records, retained...)
 	for _, asset := range input.Prepared.Assets {
 		partValue, err := encodeColumnManifestPartRecord(asset)
 		if err != nil {
@@ -110,6 +115,30 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 		ManifestBytes: columnManifestRecordsBytes(records),
 		Records:       cloneColumnManifestRecords(records),
 	}, nil
+}
+
+func retainedColumnManifestPartRecordsForWrite(records []columnManifestRecord, generation uint64) ([]columnManifestRecord, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+	retained := make([]columnManifestRecord, 0, len(records))
+	for _, record := range records {
+		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) {
+			continue
+		}
+		part, err := decodeColumnManifestPartRecord(record.value)
+		if err != nil {
+			return nil, err
+		}
+		if part.AssetRef.Generation >= generation {
+			continue
+		}
+		retained = append(retained, columnManifestRecord{
+			key:   bytes.Clone(record.key),
+			value: bytes.Clone(record.value),
+		})
+	}
+	return retained, nil
 }
 
 func encodeColumnManifestHeaderRecord(input ColumnPublishManifestEncodeInput, generation uint64) ([]byte, error) {

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -458,18 +458,26 @@ func (c *manifestCursor) u64() uint64 {
 }
 
 func (c *manifestCursor) string() string {
-	if c.err != nil {
+	value := c.stringBytes()
+	if value == nil {
 		return ""
+	}
+	return string(value)
+}
+
+func (c *manifestCursor) stringBytes() []byte {
+	if c.err != nil {
+		return nil
 	}
 	n := c.u64()
 	if c.err != nil {
-		return ""
+		return nil
 	}
 	if n > uint64(len(c.raw)-c.pos) {
 		c.err = errors.New("collections: short column manifest string")
-		return ""
+		return nil
 	}
-	value := string(c.raw[c.pos : c.pos+int(n)])
+	value := c.raw[c.pos : c.pos+int(n)]
 	c.pos += int(n)
 	return value
 }

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -463,7 +463,7 @@ func (c *manifestCursor) bool() bool {
 
 func (c *manifestCursor) bytes() []byte {
 	value := c.bytesView()
-	if value == nil {
+	if c.err != nil {
 		return nil
 	}
 	return bytes.Clone(value)

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -462,6 +462,14 @@ func (c *manifestCursor) bool() bool {
 }
 
 func (c *manifestCursor) bytes() []byte {
+	value := c.bytesView()
+	if value == nil {
+		return nil
+	}
+	return bytes.Clone(value)
+}
+
+func (c *manifestCursor) bytesView() []byte {
 	if c.err != nil {
 		return nil
 	}
@@ -473,7 +481,7 @@ func (c *manifestCursor) bytes() []byte {
 		c.err = errors.New("collections: short column binary bytes")
 		return nil
 	}
-	value := bytes.Clone(c.raw[c.pos : c.pos+int(n)])
+	value := c.raw[c.pos : c.pos+int(n)]
 	c.pos += int(n)
 	return value
 }

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -995,6 +995,7 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	// The preview scan provides the byte count; discard its visitor sum before timing.
 	sum = 0
 	b.ReportAllocs()
 	b.SetBytes(preview.PhysicalBytesScanned)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -923,7 +923,7 @@ func BenchmarkColumnPhysicalAssetSerialScanM13A(b *testing.B) {
 			b.SetBytes(int64(len(encoded)))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, func(row columnPhysicalScanRowView) error {
+				summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", normalized, projection, func(row columnPhysicalScanRowView) error {
 					if len(row.Values) != 1 {
 						return fmt.Errorf("values=%d want one projected value", len(row.Values))
 					}
@@ -1005,6 +1005,9 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 		diag, err := reopened.scanColumnPhysicalRows(req)
 		if err != nil {
 			b.Fatal(err)
+		}
+		if diag.PhysicalBytesScanned != preview.PhysicalBytesScanned {
+			b.Fatalf("physical bytes scanned=%d want preview %d", diag.PhysicalBytesScanned, preview.PhysicalBytesScanned)
 		}
 		rows += int64(diag.RowsScanned)
 	}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -20,6 +20,8 @@ var (
 	columnPhysicalAssetBenchRows  []columnDeclaredRow
 	columnPhysicalAssetBenchAsset columnPhysicalAsset
 	columnPhysicalAssetBenchRef   ColumnAssetRef
+	columnPhysicalScanBenchRows   int64
+	columnPhysicalScanBenchSum    int64
 )
 
 func encodeColumnPhysicalAssetV1ForTest(t *testing.T, input columnPhysicalAssetEncodeInput) []byte {
@@ -882,6 +884,128 @@ func BenchmarkColumnPhysicalAssetDecodeM12A(b *testing.B) {
 		}
 		columnPhysicalAssetBenchAsset = asset
 	}
+}
+
+func BenchmarkColumnPhysicalAssetSerialScanM13A(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		b.Run(fmt.Sprintf("rows_%d", rows), func(b *testing.B) {
+			normalized, extracted := makeColumnPhysicalAssetBenchmarkRows(b, rows)
+			encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+				Collection:        "events",
+				Namespace:         normalized.AssetManager.Namespace,
+				Generation:        1,
+				PartID:            1,
+				AppliedCommandLSN: 1,
+				Operation:         ColumnPublishOperationInsert,
+				SchemaHash:        normalized.SchemaHash,
+				Columns:           normalized.Columns,
+				Rows:              extracted,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			ref := ColumnAssetRef{
+				Kind:       ColumnAssetKindTCS1PartImage,
+				Namespace:  normalized.AssetManager.Namespace,
+				Generation: 1,
+				PartID:     1,
+				FileID:     columnAssetM12ASegmentFileID,
+				Length:     int64(len(encoded)),
+				Checksum:   page.Checksum(encoded),
+			}
+			projection, err := newColumnPhysicalScanProjection(*normalized, []string{"time_us"})
+			if err != nil {
+				b.Fatal(err)
+			}
+			var scanned int64
+			var sum int64
+			b.ReportAllocs()
+			b.SetBytes(int64(len(encoded)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				summary, err := scanColumnPhysicalAssetRows(encoded, ref, *normalized, projection, func(row columnPhysicalScanRowView) error {
+					if len(row.Values) != 1 {
+						return fmt.Errorf("values=%d want one projected value", len(row.Values))
+					}
+					sum += row.Values[0].Int64
+					return nil
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+				scanned += int64(summary.rows)
+			}
+			columnPhysicalScanBenchRows = scanned
+			columnPhysicalScanBenchSum = sum
+		})
+	}
+}
+
+func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
+	dir := b.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		b.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		b.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, docs, _ := makeColumnPhysicalAssetBenchmarkDocs(b, 1024)
+	ids := make([][]byte, len(docs))
+	values := make([][]byte, len(docs))
+	for i := range docs {
+		ids[i] = docs[i].ID
+		values[i] = docs[i].Document
+	}
+	if _, err := col.InsertBatch(ids, values); err != nil {
+		b.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		b.Fatal(err)
+	}
+	reopen, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = reopen.Close() })
+	reopened, err := NewCollectionManager(reopen).OpenCollection("events")
+	if err != nil {
+		b.Fatal(err)
+	}
+	req := columnPhysicalScanRequest{
+		ProjectedColumns: []string{"time_us"},
+		Visitor: func(row columnPhysicalScanRowView) error {
+			columnPhysicalScanBenchSum += row.Values[0].Int64
+			return nil
+		},
+	}
+	preview, err := reopened.scanColumnPhysicalRows(req)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(preview.PhysicalBytesScanned)
+	b.ResetTimer()
+	var rows int64
+	for i := 0; i < b.N; i++ {
+		diag, err := reopened.scanColumnPhysicalRows(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		rows += int64(diag.RowsScanned)
+	}
+	columnPhysicalScanBenchRows = rows
 }
 
 func BenchmarkColumnAssetManagerWriteM12A(b *testing.B) {

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -983,10 +983,11 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	var sum int64
 	req := columnPhysicalScanRequest{
 		ProjectedColumns: []string{"time_us"},
 		Visitor: func(row columnPhysicalScanRowView) error {
-			columnPhysicalScanBenchSum += row.Values[0].Int64
+			sum += row.Values[0].Int64
 			return nil
 		},
 	}
@@ -994,7 +995,7 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	columnPhysicalScanBenchSum = 0
+	sum = 0
 	b.ReportAllocs()
 	b.SetBytes(preview.PhysicalBytesScanned)
 	b.ResetTimer()
@@ -1007,6 +1008,7 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 		rows += int64(diag.RowsScanned)
 	}
 	columnPhysicalScanBenchRows = rows
+	columnPhysicalScanBenchSum = sum
 }
 
 func BenchmarkColumnAssetManagerWriteM12A(b *testing.B) {

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -923,7 +923,7 @@ func BenchmarkColumnPhysicalAssetSerialScanM13A(b *testing.B) {
 			b.SetBytes(int64(len(encoded)))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				summary, err := scanColumnPhysicalAssetRows(encoded, ref, *normalized, projection, func(row columnPhysicalScanRowView) error {
+				summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, func(row columnPhysicalScanRowView) error {
 					if len(row.Values) != 1 {
 						return fmt.Errorf("values=%d want one projected value", len(row.Values))
 					}
@@ -994,6 +994,7 @@ func BenchmarkColumnPhysicalCollectionSerialScanM13A(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	columnPhysicalScanBenchSum = 0
 	b.ReportAllocs()
 	b.SetBytes(preview.PhysicalBytesScanned)
 	b.ResetTimer()

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -143,7 +143,7 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 	if err := validateColumnManifestSnapshotForScan(manifest, records, cfg, *cfg.ActiveManifest, collectionName); err != nil {
 		return diag, err
 	}
-	refs, err := columnManifestAssetRefsFromRecordsForScan(records)
+	refs, err := columnManifestAssetRefsFromRecordsForScan(records, manifest.Generation)
 	if err != nil {
 		return diag, err
 	}
@@ -302,7 +302,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 			if err != nil {
 				return nil, err
 			}
-			if part.AssetRef.Generation == generation {
+			if part.AssetRef.Generation <= generation {
 				active = append(active, record)
 			}
 		}
@@ -310,7 +310,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 	return active, nil
 }
 
-func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord) ([]ColumnAssetRef, error) {
+func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, generation uint64) ([]ColumnAssetRef, error) {
 	refs := make([]ColumnAssetRef, 0, len(records))
 	for _, record := range records {
 		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) {
@@ -319,6 +319,9 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord) (
 		part, err := decodeColumnManifestPartRecord(record.value)
 		if err != nil {
 			return nil, err
+		}
+		if part.AssetRef.Generation > generation {
+			continue
 		}
 		refs = append(refs, part.AssetRef)
 	}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -26,10 +26,11 @@ type columnPhysicalScanDiagnostics struct {
 	DecodedBlocks              int
 	ScheduledGranules          int
 	// Reserved for M14 predicate pushdown; M13A schedules every manifest ref.
-	SkippedGranules      int
-	RowsScanned          int
-	DeletedRows          int
-	ProjectedColumns     int
+	SkippedGranules  int
+	RowsScanned      int
+	DeletedRows      int
+	ProjectedColumns int
+	// Counts full-document row materialization; M13A emits declared-column row views only.
 	RowMaterializations  int
 	PhysicalBytesScanned int64
 }
@@ -40,9 +41,9 @@ type columnPhysicalScanRowView struct {
 	AppliedCommandLSN uint64
 	Operation         ColumnPublishOperation
 	RowIndex          int
-	// ID aliases the raw asset buffer and is valid only until the visitor returns.
+	// ID is passed by value but aliases the raw asset buffer; copy to retain it.
 	ID []byte
-	// Values aliases scanner scratch and is valid only until the visitor returns.
+	// Values aliases scanner scratch; copy before the visitor returns to retain it.
 	Values  []columnDeclaredValue
 	Deleted bool
 }
@@ -403,10 +404,10 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 		}
 		rowValues := valuesBuf[:0]
 		if deleted {
+			// Delete assets encode no column values; the operation check enforces that contract.
 			if header.Operation != ColumnPublishOperationDelete {
 				return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
 			}
-			// Delete assets encode no column values for deleted rows; trailing bytes fail closed below.
 			summary.deleted++
 		} else {
 			if header.Operation == ColumnPublishOperationDelete {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -184,15 +184,15 @@ func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) 
 			count:          len(cfg.Columns),
 		}, nil
 	}
-	seen := make(map[string]struct{}, len(projected))
 	for outIdx, name := range projected {
 		if name == "" {
 			return columnPhysicalScanProjection{}, errors.New("collections: physical column scan projection contains empty column")
 		}
-		if _, ok := seen[name]; ok {
-			return columnPhysicalScanProjection{}, fmt.Errorf("collections: physical column scan duplicate projected column %q", name)
+		for prev := 0; prev < outIdx; prev++ {
+			if projected[prev] == name {
+				return columnPhysicalScanProjection{}, fmt.Errorf("collections: physical column scan duplicate projected column %q", name)
+			}
 		}
-		seen[name] = struct{}{}
 		found := false
 		for colIdx, col := range cfg.Columns {
 			if col.Name == name {
@@ -339,7 +339,8 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 	generation := cur.u64()
 	partID := cur.u64()
 	appliedCommandLSN := cur.u64()
-	operation, operationOK := columnPhysicalScanOperationFromBytes(cur.stringBytes())
+	operationBytes := cur.stringBytes()
+	operation, operationOK := columnPhysicalScanOperationFromBytes(operationBytes)
 	schemaHash := cur.u64()
 	columnCount := cur.u64()
 	rowCount := cur.u64()
@@ -361,7 +362,10 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 		RowCount:          int(rowCount),
 	}
 	if !operationOK {
-		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", string(operation))
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", operationBytes)
+	}
+	if version == columnPhysicalAssetVersionV1 && header.Operation == ColumnPublishOperationDelete {
+		return columnPhysicalAssetScanSummary{}, errors.New("legacy v1 column physical asset delete operation unsupported")
 	}
 	if err := validateColumnPhysicalAssetScanHeader(header, ref, expectedCollection, cfg); err != nil {
 		return columnPhysicalAssetScanSummary{}, err
@@ -389,9 +393,6 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 		}
 	}
 	valuesBuf := projection.values
-	if len(valuesBuf) < projection.count {
-		valuesBuf = make([]columnDeclaredValue, projection.count)
-	}
 	var summary columnPhysicalAssetScanSummary
 	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
 		id := cur.bytesView()
@@ -477,7 +478,7 @@ func columnPhysicalScanOperationFromBytes(raw []byte) (ColumnPublishOperation, b
 	case columnPhysicalBytesEqualString(raw, string(ColumnPublishOperationDelete)):
 		return ColumnPublishOperationDelete, true
 	default:
-		return ColumnPublishOperation(string(raw)), false
+		return "", false
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -47,12 +47,25 @@ type columnPhysicalScanRowView struct {
 
 type columnPhysicalScanProjection struct {
 	outputByColumn []int
+	values         []columnDeclaredValue
 	count          int
 }
 
 type columnPhysicalAssetScanSummary struct {
 	rows    int
 	deleted int
+}
+
+type columnPhysicalAssetScanHeader struct {
+	Collection        []byte
+	Namespace         []byte
+	Generation        uint64
+	PartID            uint64
+	AppliedCommandLSN uint64
+	Operation         ColumnPublishOperation
+	SchemaHash        uint64
+	RowCount          int
+	ColumnCount       int
 }
 
 func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (columnPhysicalScanDiagnostics, error) {
@@ -162,7 +175,11 @@ func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) 
 		for i := range cfg.Columns {
 			outputByColumn[i] = i
 		}
-		return columnPhysicalScanProjection{outputByColumn: outputByColumn, count: len(cfg.Columns)}, nil
+		return columnPhysicalScanProjection{
+			outputByColumn: outputByColumn,
+			values:         make([]columnDeclaredValue, len(cfg.Columns)),
+			count:          len(cfg.Columns),
+		}, nil
 	}
 	seen := make(map[string]struct{}, len(projected))
 	for outIdx, name := range projected {
@@ -185,7 +202,11 @@ func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) 
 			return columnPhysicalScanProjection{}, fmt.Errorf("collections: physical column scan requested undeclared column %q", name)
 		}
 	}
-	return columnPhysicalScanProjection{outputByColumn: outputByColumn, count: len(projected)}, nil
+	return columnPhysicalScanProjection{
+		outputByColumn: outputByColumn,
+		values:         make([]columnDeclaredValue, len(projected)),
+		count:          len(projected),
+	}, nil
 }
 
 func validateColumnManifestIdentityAtRootForScan(snap *backenddb.Snapshot, rootID uint64, identity ColumnManifestIdentity) error {
@@ -310,15 +331,13 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 	if version != columnPhysicalAssetVersionV1 && version != columnPhysicalAssetVersion {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset version=%d", version)
 	}
-	header := columnPhysicalAssetHeader{
-		Collection:        cur.string(),
-		Namespace:         cur.string(),
-		Generation:        cur.u64(),
-		PartID:            cur.u64(),
-		AppliedCommandLSN: cur.u64(),
-		Operation:         ColumnPublishOperation(cur.string()),
-		SchemaHash:        cur.u64(),
-	}
+	collection := cur.stringBytes()
+	namespace := cur.stringBytes()
+	generation := cur.u64()
+	partID := cur.u64()
+	appliedCommandLSN := cur.u64()
+	operation, operationOK := columnPhysicalScanOperationFromBytes(cur.stringBytes())
+	schemaHash := cur.u64()
 	columnCount := cur.u64()
 	rowCount := cur.u64()
 	if err := cur.err; err != nil {
@@ -327,8 +346,20 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 	if columnCount > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
 		return columnPhysicalAssetScanSummary{}, errors.New("column physical asset dimensions overflow int")
 	}
-	header.ColumnCount = int(columnCount)
-	header.RowCount = int(rowCount)
+	header := columnPhysicalAssetScanHeader{
+		Collection:        collection,
+		Namespace:         namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		Operation:         operation,
+		SchemaHash:        schemaHash,
+		ColumnCount:       int(columnCount),
+		RowCount:          int(rowCount),
+	}
+	if !operationOK {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", string(operation))
+	}
 	if err := validateColumnPhysicalAssetScanHeader(header, ref, cfg); err != nil {
 		return columnPhysicalAssetScanSummary{}, err
 	}
@@ -336,21 +367,28 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset columns=%d want %d", header.ColumnCount, len(cfg.Columns))
 	}
 	for colIdx := 0; colIdx < header.ColumnCount; colIdx++ {
-		got := ColumnStoreColumn{
-			Name:       cur.string(),
-			Path:       cur.string(),
-			ValueType:  ColumnStoreValueType(cur.string()),
-			Nullable:   cur.bool(),
-			Dictionary: cur.bool(),
-		}
+		name := cur.stringBytes()
+		path := cur.stringBytes()
+		valueType := cur.stringBytes()
+		nullable := cur.bool()
+		dictionary := cur.bool()
 		if cur.err != nil {
 			return columnPhysicalAssetScanSummary{}, cur.err
 		}
-		if got != cfg.Columns[colIdx] {
-			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]=%+v want %+v", colIdx, got, cfg.Columns[colIdx])
+		want := cfg.Columns[colIdx]
+		if !columnPhysicalBytesEqualString(name, want.Name) ||
+			!columnPhysicalBytesEqualString(path, want.Path) ||
+			!columnPhysicalBytesEqualString(valueType, string(want.ValueType)) ||
+			nullable != want.Nullable ||
+			dictionary != want.Dictionary {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t} want %+v",
+				colIdx, string(name), string(path), string(valueType), nullable, dictionary, want)
 		}
 	}
-	valuesBuf := make([]columnDeclaredValue, projection.count)
+	valuesBuf := projection.values
+	if len(valuesBuf) < projection.count {
+		valuesBuf = make([]columnDeclaredValue, projection.count)
+	}
 	var summary columnPhysicalAssetScanSummary
 	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
 		id := cur.bytesView()
@@ -401,12 +439,12 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 	return summary, nil
 }
 
-func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetHeader, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
+func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
 	if cfg.AssetManager == nil {
 		return errors.New("column physical asset scan requires asset manager")
 	}
-	if header.Namespace != cfg.AssetManager.Namespace || ref.Namespace != cfg.AssetManager.Namespace {
-		return fmt.Errorf("column physical asset namespace=%q ref_namespace=%q want %q", header.Namespace, ref.Namespace, cfg.AssetManager.Namespace)
+	if !columnPhysicalBytesEqualString(header.Namespace, cfg.AssetManager.Namespace) || ref.Namespace != cfg.AssetManager.Namespace {
+		return fmt.Errorf("column physical asset namespace=%q ref_namespace=%q want %q", string(header.Namespace), ref.Namespace, cfg.AssetManager.Namespace)
 	}
 	if header.Generation != ref.Generation {
 		return fmt.Errorf("column physical asset generation=%d does not match ref generation=%d", header.Generation, ref.Generation)
@@ -421,6 +459,19 @@ func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetHeader, ref
 		return fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
 	}
 	return nil
+}
+
+func columnPhysicalScanOperationFromBytes(raw []byte) (ColumnPublishOperation, bool) {
+	switch {
+	case columnPhysicalBytesEqualString(raw, string(ColumnPublishOperationInsert)):
+		return ColumnPublishOperationInsert, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnPublishOperationUpdate)):
+		return ColumnPublishOperationUpdate, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnPublishOperationDelete)):
+		return ColumnPublishOperationDelete, true
+	default:
+		return ColumnPublishOperation(string(raw)), false
+	}
 }
 
 func scanColumnPhysicalRowValues(cur *manifestCursor, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, rowValues []columnDeclaredValue) error {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1,0 +1,495 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+type columnPhysicalScanRequest struct {
+	ProjectedColumns []string
+	Visitor          func(columnPhysicalScanRowView) error
+}
+
+type columnPhysicalScanDiagnostics struct {
+	ManifestRoot               uint64
+	ManifestGeneration         uint64
+	RecoveryManifestGeneration uint64
+	AppliedCommandLSN          uint64
+	ManifestRecords            int
+	AssetRefs                  int
+	DecodedBlocks              int
+	ScheduledGranules          int
+	SkippedGranules            int
+	RowsScanned                int
+	DeletedRows                int
+	ProjectedColumns           int
+	RowMaterializations        int
+	PhysicalBytesScanned       int64
+}
+
+type columnPhysicalScanRowView struct {
+	Generation        uint64
+	PartID            uint64
+	AppliedCommandLSN uint64
+	Operation         ColumnPublishOperation
+	RowIndex          int
+	// ID and Values are valid only until the visitor returns.
+	ID      []byte
+	Deleted bool
+	Values  []columnDeclaredValue
+}
+
+type columnPhysicalScanProjection struct {
+	outputByColumn []int
+	count          int
+}
+
+type columnPhysicalAssetScanSummary struct {
+	rows    int
+	deleted int
+}
+
+func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (columnPhysicalScanDiagnostics, error) {
+	if c == nil {
+		return columnPhysicalScanDiagnostics{}, errCollectionNil
+	}
+	if c.db == nil {
+		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
+	}
+	c.catalogMu.RLock()
+	catalog := c.catalog
+	if catalog == nil {
+		c.catalogMu.RUnlock()
+		return columnPhysicalScanDiagnostics{}, errCollectionNotFound
+	}
+	collectionName := catalog.meta.Name
+	rootName := collectionColumnManifestRootName(collectionName)
+	rootID := catalog.rootID(rootName)
+	cfgPtr := catalog.meta.Options.ColumnStore
+	columnStoreEnabled := cfgPtr != nil
+	var cfg ColumnStoreConfig
+	if cfgPtr != nil {
+		cfg = cfgPtr.copy()
+	}
+	c.catalogMu.RUnlock()
+
+	if !columnStoreEnabled || !cfg.Enabled {
+		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires enabled column_store")
+	}
+	if cfg.ActiveManifest == nil {
+		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires active column manifest")
+	}
+	if cfg.RecoveryAuthoritativeManifest == nil {
+		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires recovery-authoritative column manifest")
+	}
+	if !columnManifestIdentityValueEqual(*cfg.ActiveManifest, *cfg.RecoveryAuthoritativeManifest) {
+		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires active recovery-authoritative manifest")
+	}
+	if rootID == 0 {
+		return columnPhysicalScanDiagnostics{}, fmt.Errorf("collections: physical column scan missing manifest root %q", rootName)
+	}
+	projection, err := newColumnPhysicalScanProjection(cfg, req.ProjectedColumns)
+	if err != nil {
+		return columnPhysicalScanDiagnostics{}, err
+	}
+
+	diag := columnPhysicalScanDiagnostics{
+		ManifestRoot:               rootID,
+		ManifestGeneration:         cfg.ActiveManifest.Generation,
+		RecoveryManifestGeneration: cfg.RecoveryAuthoritativeManifest.Generation,
+		AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
+		ProjectedColumns:           projection.count,
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return diag, errCollectionDBNil
+	}
+	defer func() { _ = snap.Close() }()
+
+	if err := validateColumnManifestIdentityAtRootForScan(snap, rootID, *cfg.ActiveManifest); err != nil {
+		return diag, err
+	}
+	records, err := loadColumnManifestRecordsFromRootForScan(snap, rootID)
+	if err != nil {
+		return diag, err
+	}
+	diag.ManifestRecords = len(records)
+	manifest, err := decodeColumnManifestRecords(records)
+	if err != nil {
+		return diag, err
+	}
+	if err := validateColumnManifestSnapshotForScan(manifest, records, cfg, *cfg.ActiveManifest, collectionName); err != nil {
+		return diag, err
+	}
+	refs, err := columnManifestAssetRefsFromRecordsForScan(records)
+	if err != nil {
+		return diag, err
+	}
+	diag.AssetRefs = len(refs)
+	diag.ScheduledGranules = len(refs)
+	for _, ref := range refs {
+		if ref.Generation > cfg.ActiveManifest.Generation {
+			return diag, fmt.Errorf("collections: column physical scan ref generation=%d is newer than active manifest generation=%d", ref.Generation, cfg.ActiveManifest.Generation)
+		}
+		raw, err := readColumnPhysicalAssetFromManager(c.db.ColumnAssetRootDir(), ref)
+		if err != nil {
+			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
+		}
+		diag.PhysicalBytesScanned += int64(len(raw))
+		summary, err := scanColumnPhysicalAssetRows(raw, ref, cfg, projection, req.Visitor)
+		if err != nil {
+			return diag, fmt.Errorf("collections: column physical scan decode generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
+		}
+		diag.DecodedBlocks++
+		diag.RowsScanned += summary.rows
+		diag.DeletedRows += summary.deleted
+	}
+	return diag, nil
+}
+
+func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) (columnPhysicalScanProjection, error) {
+	outputByColumn := make([]int, len(cfg.Columns))
+	for i := range outputByColumn {
+		outputByColumn[i] = -1
+	}
+	if len(projected) == 0 {
+		for i := range cfg.Columns {
+			outputByColumn[i] = i
+		}
+		return columnPhysicalScanProjection{outputByColumn: outputByColumn, count: len(cfg.Columns)}, nil
+	}
+	seen := make(map[string]struct{}, len(projected))
+	for outIdx, name := range projected {
+		if name == "" {
+			return columnPhysicalScanProjection{}, errors.New("collections: physical column scan projection contains empty column")
+		}
+		if _, ok := seen[name]; ok {
+			return columnPhysicalScanProjection{}, fmt.Errorf("collections: physical column scan duplicate projected column %q", name)
+		}
+		seen[name] = struct{}{}
+		found := false
+		for colIdx, col := range cfg.Columns {
+			if col.Name == name {
+				outputByColumn[colIdx] = outIdx
+				found = true
+				break
+			}
+		}
+		if !found {
+			return columnPhysicalScanProjection{}, fmt.Errorf("collections: physical column scan requested undeclared column %q", name)
+		}
+	}
+	return columnPhysicalScanProjection{outputByColumn: outputByColumn, count: len(projected)}, nil
+}
+
+func validateColumnManifestIdentityAtRootForScan(snap *backenddb.Snapshot, rootID uint64, identity ColumnManifestIdentity) error {
+	entry, err := snap.GetEntryAtRoot(rootID, newColumnManifestIdentityRecordKey())
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return fmt.Errorf("%w: physical column scan manifest root %d", ErrColumnManifestIdentityMissing, rootID)
+	}
+	if err != nil {
+		return fmt.Errorf("collections: physical column scan manifest root %d identity unreadable: %w", rootID, err)
+	}
+	if entry.Flags&node.FlagTombstone != 0 {
+		return fmt.Errorf("%w: physical column scan manifest root %d deleted identity", ErrColumnManifestIdentityMissing, rootID)
+	}
+	record, err := decodeColumnManifestIdentityRecord(entry.Value)
+	if err != nil {
+		return fmt.Errorf("collections: physical column scan manifest root %d invalid identity: %w", rootID, err)
+	}
+	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
+		return fmt.Errorf("collections: physical column scan manifest identity mismatch root=%+v active=%+v", record, identity)
+	}
+	return nil
+}
+
+func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID uint64) ([]columnManifestRecord, error) {
+	iter, err := snap.IteratorAtRoot(rootID, []byte(columnManifestHeaderRecordKey), nil)
+	if err != nil {
+		return nil, fmt.Errorf("collections: physical column scan manifest root %d unreadable: %w", rootID, err)
+	}
+	defer func() { _ = iter.Close() }()
+	records := make([]columnManifestRecord, 0, 8)
+	for iter.Valid() {
+		key := iter.UnsafeKey()
+		if !bytes.Equal(key, []byte(columnManifestHeaderRecordKey)) && !bytes.HasPrefix(key, []byte(columnManifestPartRecordPrefix)) {
+			break
+		}
+		if iter.IsDeleted() {
+			iter.Next()
+			continue
+		}
+		value, _, flags := iter.UnsafeEntry()
+		if flags&node.FlagPointer != 0 {
+			return nil, fmt.Errorf("collections: physical column scan manifest record %q must be inline", key)
+		}
+		records = append(records, columnManifestRecord{key: bytes.Clone(key), value: bytes.Clone(value)})
+		iter.Next()
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func validateColumnManifestSnapshotForScan(snapshot columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string) error {
+	if snapshot.Collection != collection {
+		return fmt.Errorf("collections: physical column scan manifest collection=%q want %q", snapshot.Collection, collection)
+	}
+	if snapshot.Generation != identity.Generation {
+		return fmt.Errorf("collections: physical column scan manifest generation=%d want %d", snapshot.Generation, identity.Generation)
+	}
+	if snapshot.SchemaHash != cfg.SchemaHash {
+		return fmt.Errorf("collections: physical column scan manifest schema_hash=%d want %d", snapshot.SchemaHash, cfg.SchemaHash)
+	}
+	if snapshot.AppliedCommandLSN != cfg.RecoveryAuthoritativeAppliedCommandLSN {
+		return fmt.Errorf("collections: physical column scan manifest AppliedCommandLSN=%d want recovery %d", snapshot.AppliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
+	}
+	activeRecords, err := activeColumnManifestRecordsForScan(records, snapshot.Generation)
+	if err != nil {
+		return err
+	}
+	checksum := checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+		Collection:        snapshot.Collection,
+		ColumnStore:       cfg,
+		Operation:         snapshot.Operation,
+		AppliedCommandLSN: snapshot.AppliedCommandLSN,
+	}, snapshot.Generation, activeRecords)
+	if checksum != identity.Checksum {
+		return fmt.Errorf("collections: physical column scan manifest checksum=%d want active identity checksum=%d", checksum, identity.Checksum)
+	}
+	return nil
+}
+
+func activeColumnManifestRecordsForScan(records []columnManifestRecord, generation uint64) ([]columnManifestRecord, error) {
+	active := make([]columnManifestRecord, 0, len(records))
+	for _, record := range records {
+		switch {
+		case bytes.Equal(record.key, []byte(columnManifestHeaderRecordKey)):
+			active = append(active, record)
+		case bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)):
+			part, err := decodeColumnManifestPartRecord(record.value)
+			if err != nil {
+				return nil, err
+			}
+			if part.AssetRef.Generation == generation {
+				active = append(active, record)
+			}
+		}
+	}
+	return active, nil
+}
+
+func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord) ([]ColumnAssetRef, error) {
+	refs := make([]ColumnAssetRef, 0, len(records))
+	for _, record := range records {
+		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) {
+			continue
+		}
+		part, err := decodeColumnManifestPartRecord(record.value)
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, part.AssetRef)
+	}
+	return refs, nil
+}
+
+func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("bad column physical asset magic=0x%08x", magic)
+	}
+	version := cur.u16()
+	if version != columnPhysicalAssetVersionV1 && version != columnPhysicalAssetVersion {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset version=%d", version)
+	}
+	header := columnPhysicalAssetHeader{
+		Collection:        cur.string(),
+		Namespace:         cur.string(),
+		Generation:        cur.u64(),
+		PartID:            cur.u64(),
+		AppliedCommandLSN: cur.u64(),
+		Operation:         ColumnPublishOperation(cur.string()),
+		SchemaHash:        cur.u64(),
+	}
+	columnCount := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return columnPhysicalAssetScanSummary{}, err
+	}
+	if columnCount > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, errors.New("column physical asset dimensions overflow int")
+	}
+	header.ColumnCount = int(columnCount)
+	header.RowCount = int(rowCount)
+	if err := validateColumnPhysicalAssetScanHeader(header, ref, cfg); err != nil {
+		return columnPhysicalAssetScanSummary{}, err
+	}
+	if header.ColumnCount != len(cfg.Columns) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset columns=%d want %d", header.ColumnCount, len(cfg.Columns))
+	}
+	for colIdx := 0; colIdx < header.ColumnCount; colIdx++ {
+		got := ColumnStoreColumn{
+			Name:       cur.string(),
+			Path:       cur.string(),
+			ValueType:  ColumnStoreValueType(cur.string()),
+			Nullable:   cur.bool(),
+			Dictionary: cur.bool(),
+		}
+		if cur.err != nil {
+			return columnPhysicalAssetScanSummary{}, cur.err
+		}
+		if got != cfg.Columns[colIdx] {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]=%+v want %+v", colIdx, got, cfg.Columns[colIdx])
+		}
+	}
+	valuesBuf := make([]columnDeclaredValue, projection.count)
+	var summary columnPhysicalAssetScanSummary
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		id := cur.bytesView()
+		deleted := false
+		if version >= columnPhysicalAssetVersion {
+			deleted = cur.bool()
+		}
+		if cur.err != nil {
+			return columnPhysicalAssetScanSummary{}, cur.err
+		}
+		rowValues := valuesBuf[:0]
+		if deleted {
+			if header.Operation != ColumnPublishOperationDelete {
+				return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
+			}
+			summary.deleted++
+		} else {
+			if header.Operation == ColumnPublishOperationDelete {
+				return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset delete row[%d] is not marked deleted", rowIdx)
+			}
+			rowValues = valuesBuf[:projection.count]
+			if err := scanColumnPhysicalRowValues(&cur, cfg, projection, rowValues); err != nil {
+				return columnPhysicalAssetScanSummary{}, fmt.Errorf("row[%d]: %w", rowIdx, err)
+			}
+		}
+		summary.rows++
+		if visitor != nil {
+			if err := visitor(columnPhysicalScanRowView{
+				Generation:        header.Generation,
+				PartID:            header.PartID,
+				AppliedCommandLSN: header.AppliedCommandLSN,
+				Operation:         header.Operation,
+				RowIndex:          rowIdx,
+				ID:                id,
+				Deleted:           deleted,
+				Values:            rowValues,
+			}); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		}
+	}
+	if cur.err != nil {
+		return columnPhysicalAssetScanSummary{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return columnPhysicalAssetScanSummary{}, errors.New("trailing bytes in column physical asset")
+	}
+	return summary, nil
+}
+
+func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetHeader, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
+	if cfg.AssetManager == nil {
+		return errors.New("column physical asset scan requires asset manager")
+	}
+	if header.Namespace != cfg.AssetManager.Namespace || ref.Namespace != cfg.AssetManager.Namespace {
+		return fmt.Errorf("column physical asset namespace=%q ref_namespace=%q want %q", header.Namespace, ref.Namespace, cfg.AssetManager.Namespace)
+	}
+	if header.Generation != ref.Generation {
+		return fmt.Errorf("column physical asset generation=%d does not match ref generation=%d", header.Generation, ref.Generation)
+	}
+	if header.PartID != ref.PartID {
+		return fmt.Errorf("column physical asset part_id=%d does not match ref part_id=%d", header.PartID, ref.PartID)
+	}
+	if header.SchemaHash != cfg.SchemaHash {
+		return fmt.Errorf("column physical asset schema_hash=%d want %d", header.SchemaHash, cfg.SchemaHash)
+	}
+	if !isSupportedColumnPhysicalAssetOperation(header.Operation) {
+		return fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+	}
+	return nil
+}
+
+func scanColumnPhysicalRowValues(cur *manifestCursor, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, rowValues []columnDeclaredValue) error {
+	for colIdx, col := range cfg.Columns {
+		typeBytes := cur.stringBytes()
+		if cur.err != nil {
+			return cur.err
+		}
+		if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
+			return fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
+		}
+		null := cur.bool()
+		if cur.err != nil {
+			return cur.err
+		}
+		outputIdx := projection.outputByColumn[colIdx]
+		selected := outputIdx >= 0
+		if selected {
+			rowValues[outputIdx] = columnDeclaredValue{
+				Type: col.ValueType,
+				Null: null,
+			}
+		}
+		if null {
+			if !col.Nullable {
+				return fmt.Errorf("column[%d] is null but column is not nullable", colIdx)
+			}
+			continue
+		}
+		switch col.ValueType {
+		case ColumnStoreValueBool:
+			value := cur.bool()
+			if selected {
+				rowValues[outputIdx].Bool = value
+			}
+		case ColumnStoreValueInt64:
+			value := int64(cur.u64())
+			if selected {
+				rowValues[outputIdx].Int64 = value
+			}
+		case ColumnStoreValueDouble:
+			value := math.Float64frombits(cur.u64())
+			if selected {
+				rowValues[outputIdx].Double = value
+			}
+		case ColumnStoreValueString:
+			if selected {
+				rowValues[outputIdx].String = cur.string()
+			} else {
+				_ = cur.stringBytes()
+			}
+		default:
+			return fmt.Errorf("unsupported column physical value type %q", col.ValueType)
+		}
+		if cur.err != nil {
+			return cur.err
+		}
+	}
+	return nil
+}
+
+func columnPhysicalBytesEqualString(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := range b {
+		if b[i] != s[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -78,11 +78,15 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 	if c.db == nil {
 		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
 	}
-	c.catalogMu.RLock()
-	catalog := c.catalog
-	if catalog == nil {
-		c.catalogMu.RUnlock()
-		return columnPhysicalScanDiagnostics{}, errCollectionNotFound
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return columnPhysicalScanDiagnostics{}, err
 	}
 	collectionName := catalog.meta.Name
 	rootName := collectionColumnManifestRootName(collectionName)
@@ -93,7 +97,6 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 	if cfgPtr != nil {
 		cfg = cfgPtr.copy()
 	}
-	c.catalogMu.RUnlock()
 
 	if !columnStoreEnabled || !cfg.Enabled {
 		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires enabled column_store")
@@ -122,11 +125,6 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 		AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
 		ProjectedColumns:           projection.count,
 	}
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return diag, errCollectionDBNil
-	}
-	defer func() { _ = snap.Close() }()
 
 	if err := validateColumnManifestIdentityAtRootForScan(snap, rootID, *cfg.ActiveManifest); err != nil {
 		return diag, err
@@ -158,7 +156,7 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
 		diag.PhysicalBytesScanned += int64(len(raw))
-		summary, err := scanColumnPhysicalAssetRows(raw, ref, collectionName, cfg, projection, req.Visitor)
+		summary, err := scanColumnPhysicalAssetRows(raw, ref, collectionName, &cfg, projection, req.Visitor)
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan decode generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
@@ -233,8 +231,13 @@ func validateColumnManifestIdentityAtRootForScan(snap *backenddb.Snapshot, rootI
 	return nil
 }
 
+var (
+	columnManifestHeaderRecordKeyScanBytes  = []byte(columnManifestHeaderRecordKey)
+	columnManifestPartRecordPrefixScanBytes = []byte(columnManifestPartRecordPrefix)
+)
+
 func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID uint64) ([]columnManifestRecord, error) {
-	iter, err := snap.IteratorAtRoot(rootID, []byte(columnManifestHeaderRecordKey), nil)
+	iter, err := snap.IteratorAtRoot(rootID, columnManifestHeaderRecordKeyScanBytes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("collections: physical column scan manifest root %d unreadable: %w", rootID, err)
 	}
@@ -242,7 +245,7 @@ func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID u
 	records := make([]columnManifestRecord, 0, 8)
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if !bytes.Equal(key, []byte(columnManifestHeaderRecordKey)) && !bytes.HasPrefix(key, []byte(columnManifestPartRecordPrefix)) {
+		if !bytes.Equal(key, columnManifestHeaderRecordKeyScanBytes) && !bytes.HasPrefix(key, columnManifestPartRecordPrefixScanBytes) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -295,9 +298,9 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 	active := make([]columnManifestRecord, 0, len(records))
 	for _, record := range records {
 		switch {
-		case bytes.Equal(record.key, []byte(columnManifestHeaderRecordKey)):
+		case bytes.Equal(record.key, columnManifestHeaderRecordKeyScanBytes):
 			active = append(active, record)
-		case bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)):
+		case bytes.HasPrefix(record.key, columnManifestPartRecordPrefixScanBytes):
 			part, err := decodeColumnManifestPartRecord(record.value)
 			if err != nil {
 				return nil, err
@@ -313,7 +316,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, generation uint64) ([]ColumnAssetRef, error) {
 	refs := make([]ColumnAssetRef, 0, len(records))
 	for _, record := range records {
-		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) {
+		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixScanBytes) {
 			continue
 		}
 		part, err := decodeColumnManifestPartRecord(record.value)
@@ -328,7 +331,7 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, g
 	return refs, nil
 }
 
-func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg *ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
 	cur := manifestCursor{raw: raw}
 	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("bad column physical asset magic=0x%08x", magic)
@@ -350,8 +353,11 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 	if err := cur.err; err != nil {
 		return columnPhysicalAssetScanSummary{}, err
 	}
-	if columnCount > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
-		return columnPhysicalAssetScanSummary{}, errors.New("column physical asset dimensions overflow int")
+	if columnCount > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column_count=%d overflows int max=%d", columnCount, maxCollectionInt)
+	}
+	if rowCount > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset row_count=%d overflows int max=%d", rowCount, maxCollectionInt)
 	}
 	header := columnPhysicalAssetScanHeader{
 		Collection:        collection,
@@ -424,6 +430,7 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 		}
 		summary.rows++
 		if visitor != nil {
+			// ID and Values alias the asset buffer and scanner scratch; visitors must copy to retain them.
 			if err := visitor(columnPhysicalScanRowView{
 				Generation:        header.Generation,
 				PartID:            header.PartID,
@@ -447,7 +454,10 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollect
 	return summary, nil
 }
 
-func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader, ref ColumnAssetRef, expectedCollection string, cfg ColumnStoreConfig) error {
+func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader, ref ColumnAssetRef, expectedCollection string, cfg *ColumnStoreConfig) error {
+	if cfg == nil {
+		return errors.New("column physical asset scan requires column store config")
+	}
 	if cfg.AssetManager == nil {
 		return errors.New("column physical asset scan requires asset manager")
 	}
@@ -485,7 +495,7 @@ func columnPhysicalScanOperationFromBytes(raw []byte) (ColumnPublishOperation, b
 	}
 }
 
-func scanColumnPhysicalRowValues(cur *manifestCursor, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, rowValues []columnDeclaredValue) error {
+func scanColumnPhysicalRowValues(cur *manifestCursor, cfg *ColumnStoreConfig, projection columnPhysicalScanProjection, rowValues []columnDeclaredValue) error {
 	for colIdx, col := range cfg.Columns {
 		typeBytes := cur.stringBytes()
 		if cur.err != nil {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -25,12 +25,13 @@ type columnPhysicalScanDiagnostics struct {
 	AssetRefs                  int
 	DecodedBlocks              int
 	ScheduledGranules          int
-	SkippedGranules            int
-	RowsScanned                int
-	DeletedRows                int
-	ProjectedColumns           int
-	RowMaterializations        int
-	PhysicalBytesScanned       int64
+	// Reserved for M14 predicate pushdown; M13A schedules every manifest ref.
+	SkippedGranules      int
+	RowsScanned          int
+	DeletedRows          int
+	ProjectedColumns     int
+	RowMaterializations  int
+	PhysicalBytesScanned int64
 }
 
 type columnPhysicalScanRowView struct {
@@ -39,10 +40,11 @@ type columnPhysicalScanRowView struct {
 	AppliedCommandLSN uint64
 	Operation         ColumnPublishOperation
 	RowIndex          int
-	// ID and Values are valid only until the visitor returns.
-	ID      []byte
-	Deleted bool
+	// ID aliases the raw asset buffer and is valid only until the visitor returns.
+	ID []byte
+	// Values aliases scanner scratch and is valid only until the visitor returns.
 	Values  []columnDeclaredValue
+	Deleted bool
 }
 
 type columnPhysicalScanProjection struct {
@@ -155,7 +157,7 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
 		diag.PhysicalBytesScanned += int64(len(raw))
-		summary, err := scanColumnPhysicalAssetRows(raw, ref, cfg, projection, req.Visitor)
+		summary, err := scanColumnPhysicalAssetRows(raw, ref, collectionName, cfg, projection, req.Visitor)
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan decode generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
@@ -322,7 +324,7 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord) (
 	return refs, nil
 }
 
-func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
 	cur := manifestCursor{raw: raw}
 	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("bad column physical asset magic=0x%08x", magic)
@@ -360,7 +362,7 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 	if !operationOK {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", string(operation))
 	}
-	if err := validateColumnPhysicalAssetScanHeader(header, ref, cfg); err != nil {
+	if err := validateColumnPhysicalAssetScanHeader(header, ref, expectedCollection, cfg); err != nil {
 		return columnPhysicalAssetScanSummary{}, err
 	}
 	if header.ColumnCount != len(cfg.Columns) {
@@ -404,6 +406,7 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 			if header.Operation != ColumnPublishOperationDelete {
 				return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
 			}
+			// Delete assets encode no column values for deleted rows; trailing bytes fail closed below.
 			summary.deleted++
 		} else {
 			if header.Operation == ColumnPublishOperationDelete {
@@ -439,9 +442,12 @@ func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, cfg ColumnStore
 	return summary, nil
 }
 
-func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
+func validateColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader, ref ColumnAssetRef, expectedCollection string, cfg ColumnStoreConfig) error {
 	if cfg.AssetManager == nil {
 		return errors.New("column physical asset scan requires asset manager")
+	}
+	if !columnPhysicalBytesEqualString(header.Collection, expectedCollection) {
+		return fmt.Errorf("column physical asset collection=%q want %q", string(header.Collection), expectedCollection)
 	}
 	if !columnPhysicalBytesEqualString(header.Namespace, cfg.AssetManager.Namespace) || ref.Namespace != cfg.AssetManager.Namespace {
 		return fmt.Errorf("column physical asset namespace=%q ref_namespace=%q want %q", string(header.Namespace), ref.Namespace, cfg.AssetManager.Namespace)
@@ -534,6 +540,7 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, cfg ColumnStoreConfig, pro
 }
 
 func columnPhysicalBytesEqualString(b []byte, s string) bool {
+	// Keep the scanner's success path independent of []byte->string conversion allocation behavior.
 	if len(b) != len(s) {
 		return false
 	}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -126,10 +126,10 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 		ProjectedColumns:           projection.count,
 	}
 
-	if err := validateColumnManifestIdentityAtRootForScan(snap, rootID, *cfg.ActiveManifest); err != nil {
+	if err := validateColumnManifestIdentityAtRoot(snap, rootID, *cfg.ActiveManifest); err != nil {
 		return diag, err
 	}
-	records, err := loadColumnManifestRecordsFromRootForScan(snap, rootID)
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
 	if err != nil {
 		return diag, err
 	}
@@ -138,7 +138,7 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 	if err != nil {
 		return diag, err
 	}
-	if err := validateColumnManifestSnapshotForScan(manifest, records, cfg, *cfg.ActiveManifest, collectionName); err != nil {
+	if err := validateColumnManifestSnapshot(manifest, records, cfg, *cfg.ActiveManifest, collectionName, "physical column scan"); err != nil {
 		return diag, err
 	}
 	refs, err := columnManifestAssetRefsFromRecordsForScan(records, manifest.Generation)
@@ -148,9 +148,6 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 	diag.AssetRefs = len(refs)
 	diag.ScheduledGranules = len(refs)
 	for _, ref := range refs {
-		if ref.Generation > cfg.ActiveManifest.Generation {
-			return diag, fmt.Errorf("collections: column physical scan ref generation=%d is newer than active manifest generation=%d", ref.Generation, cfg.ActiveManifest.Generation)
-		}
 		raw, err := readColumnPhysicalAssetFromManager(c.db.ColumnAssetRootDir(), ref)
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
@@ -210,23 +207,23 @@ func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) 
 	}, nil
 }
 
-func validateColumnManifestIdentityAtRootForScan(snap *backenddb.Snapshot, rootID uint64, identity ColumnManifestIdentity) error {
+func validateColumnManifestIdentityAtRoot(snap *backenddb.Snapshot, rootID uint64, identity ColumnManifestIdentity) error {
 	entry, err := snap.GetEntryAtRoot(rootID, newColumnManifestIdentityRecordKey())
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return fmt.Errorf("%w: physical column scan manifest root %d", ErrColumnManifestIdentityMissing, rootID)
+		return fmt.Errorf("%w: column manifest root %d", ErrColumnManifestIdentityMissing, rootID)
 	}
 	if err != nil {
-		return fmt.Errorf("collections: physical column scan manifest root %d identity unreadable: %w", rootID, err)
+		return fmt.Errorf("collections: column manifest root %d identity unreadable: %w", rootID, err)
 	}
 	if entry.Flags&node.FlagTombstone != 0 {
-		return fmt.Errorf("%w: physical column scan manifest root %d deleted identity", ErrColumnManifestIdentityMissing, rootID)
+		return fmt.Errorf("%w: column manifest root %d deleted identity", ErrColumnManifestIdentityMissing, rootID)
 	}
 	record, err := decodeColumnManifestIdentityRecord(entry.Value)
 	if err != nil {
-		return fmt.Errorf("collections: physical column scan manifest root %d invalid identity: %w", rootID, err)
+		return fmt.Errorf("collections: column manifest root %d invalid identity: %w", rootID, err)
 	}
 	if record.Generation != identity.Generation || record.Version != identity.Version || record.Checksum != identity.Checksum {
-		return fmt.Errorf("collections: physical column scan manifest identity mismatch root=%+v active=%+v", record, identity)
+		return fmt.Errorf("collections: column manifest identity mismatch root=%+v active=%+v", record, identity)
 	}
 	return nil
 }
@@ -236,10 +233,10 @@ var (
 	columnManifestPartRecordPrefixScanBytes = []byte(columnManifestPartRecordPrefix)
 )
 
-func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID uint64) ([]columnManifestRecord, error) {
+func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) ([]columnManifestRecord, error) {
 	iter, err := snap.IteratorAtRoot(rootID, columnManifestHeaderRecordKeyScanBytes, nil)
 	if err != nil {
-		return nil, fmt.Errorf("collections: physical column scan manifest root %d unreadable: %w", rootID, err)
+		return nil, fmt.Errorf("collections: column manifest root %d unreadable: %w", rootID, err)
 	}
 	defer func() { _ = iter.Close() }()
 	records := make([]columnManifestRecord, 0, 8)
@@ -254,7 +251,7 @@ func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID u
 		}
 		value, _, flags := iter.UnsafeEntry()
 		if flags&node.FlagPointer != 0 {
-			return nil, fmt.Errorf("collections: physical column scan manifest record %q must be inline", key)
+			return nil, fmt.Errorf("collections: column manifest record %q must be inline", key)
 		}
 		records = append(records, columnManifestRecord{key: bytes.Clone(key), value: bytes.Clone(value)})
 		iter.Next()
@@ -265,18 +262,18 @@ func loadColumnManifestRecordsFromRootForScan(snap *backenddb.Snapshot, rootID u
 	return records, nil
 }
 
-func validateColumnManifestSnapshotForScan(snapshot columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string) error {
+func validateColumnManifestSnapshot(snapshot columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, context string) error {
 	if snapshot.Collection != collection {
-		return fmt.Errorf("collections: physical column scan manifest collection=%q want %q", snapshot.Collection, collection)
+		return fmt.Errorf("collections: %s manifest collection=%q want %q", context, snapshot.Collection, collection)
 	}
 	if snapshot.Generation != identity.Generation {
-		return fmt.Errorf("collections: physical column scan manifest generation=%d want %d", snapshot.Generation, identity.Generation)
+		return fmt.Errorf("collections: %s manifest generation=%d want %d", context, snapshot.Generation, identity.Generation)
 	}
 	if snapshot.SchemaHash != cfg.SchemaHash {
-		return fmt.Errorf("collections: physical column scan manifest schema_hash=%d want %d", snapshot.SchemaHash, cfg.SchemaHash)
+		return fmt.Errorf("collections: %s manifest schema_hash=%d want %d", context, snapshot.SchemaHash, cfg.SchemaHash)
 	}
 	if snapshot.AppliedCommandLSN != cfg.RecoveryAuthoritativeAppliedCommandLSN {
-		return fmt.Errorf("collections: physical column scan manifest AppliedCommandLSN=%d want recovery %d", snapshot.AppliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
+		return fmt.Errorf("collections: %s manifest AppliedCommandLSN=%d want recovery %d", context, snapshot.AppliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
 	}
 	activeRecords, err := activeColumnManifestRecordsForScan(records, snapshot.Generation)
 	if err != nil {
@@ -289,7 +286,7 @@ func validateColumnManifestSnapshotForScan(snapshot columnManifestSnapshot, reco
 		AppliedCommandLSN: snapshot.AppliedCommandLSN,
 	}, snapshot.Generation, activeRecords)
 	if checksum != identity.Checksum {
-		return fmt.Errorf("collections: physical column scan manifest checksum=%d want active identity checksum=%d", checksum, identity.Checksum)
+		return fmt.Errorf("collections: %s manifest checksum=%d want active identity checksum=%d", context, checksum, identity.Checksum)
 	}
 	return nil
 }

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -243,6 +243,38 @@ func TestColumnPhysicalAssetSerialScanRejectsWrongCollectionM13A(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetSerialScanRejectsV1DeleteOperationM13A(t *testing.T) {
+	normalized, rows := makeColumnPhysicalAssetBenchmarkRows(t, 1)
+	encoded := encodeColumnPhysicalAssetV1ForTest(t, columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        1,
+		PartID:            1,
+		AppliedCommandLSN: 1,
+		Operation:         ColumnPublishOperationDelete,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows:              rows,
+	})
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 1,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"time_us"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, nil)
+	if err == nil || !strings.Contains(err.Error(), "legacy v1 column physical asset delete operation unsupported") {
+		t.Fatalf("scan err=%v want legacy v1 delete unsupported", err)
+	}
+}
+
 func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *testing.T) {
 	normalized, rows := makeColumnPhysicalAssetBenchmarkRows(t, 1024)
 	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -1,0 +1,278 @@
+package collections
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestColumnPhysicalSerialScannerReadsReopenedAssetsM13A(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","did":"d1","payload":"ignored"}`),
+		[]byte(`{"time_us":2,"kind":"post","did":"d2","payload":"ignored"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	insertLSN := d.State().AppliedCommandLSN
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopen)
+
+	var rows []columnPhysicalScanRowForTest
+	diag, err := reopened.scanColumnPhysicalRows(columnPhysicalScanRequest{
+		ProjectedColumns: []string{"time_us", "kind"},
+		Visitor: func(row columnPhysicalScanRowView) error {
+			rows = append(rows, copyColumnPhysicalScanRowForTest(row))
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalRows: %v", err)
+	}
+	if diag.ManifestGeneration != 1 || diag.RecoveryManifestGeneration != 1 || diag.AppliedCommandLSN != insertLSN {
+		t.Fatalf("unexpected scan manifest diagnostics: %+v want generation=1 appliedLSN=%d", diag, insertLSN)
+	}
+	if diag.AssetRefs != 1 || diag.DecodedBlocks != 1 || diag.ScheduledGranules != 1 || diag.RowsScanned != 2 || diag.ProjectedColumns != 2 {
+		t.Fatalf("unexpected scan diagnostics: %+v", diag)
+	}
+	if diag.RowMaterializations != 0 {
+		t.Fatalf("row materializations=%d want 0 for declared-column scan", diag.RowMaterializations)
+	}
+	if diag.PhysicalBytesScanned <= 0 {
+		t.Fatalf("physical bytes scanned=%d want positive", diag.PhysicalBytesScanned)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d want 2", len(rows))
+	}
+	assertColumnPhysicalScanRowM13A(t, rows[0], ColumnPublishOperationInsert, "e1", false, int64(1), "like")
+	assertColumnPhysicalScanRowM13A(t, rows[1], ColumnPublishOperationInsert, "e2", false, int64(2), "post")
+}
+
+func TestColumnPhysicalSerialScannerExposesMutationRowsM13A(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","did":"d1"}`),
+		[]byte(`{"time_us":2,"kind":"post","did":"d2"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"time_us":3,"kind":"like","did":"d1"}`), true, nil
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("Update: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("e2")}); err != nil || deleted != 1 {
+		_ = d.Close()
+		t.Fatalf("DeleteBatch deleted=%d err=%v, want one delete", deleted, err)
+	}
+	deleteLSN := d.State().AppliedCommandLSN
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopen)
+
+	var rows []columnPhysicalScanRowForTest
+	diag, err := reopened.scanColumnPhysicalRows(columnPhysicalScanRequest{
+		ProjectedColumns: []string{"time_us"},
+		Visitor: func(row columnPhysicalScanRowView) error {
+			rows = append(rows, copyColumnPhysicalScanRowForTest(row))
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalRows: %v", err)
+	}
+	if diag.ManifestGeneration != 3 || diag.AssetRefs != 3 || diag.DecodedBlocks != 3 || diag.RowsScanned != 4 || diag.DeletedRows != 1 {
+		t.Fatalf("unexpected scan diagnostics: %+v", diag)
+	}
+	if diag.AppliedCommandLSN != deleteLSN {
+		t.Fatalf("applied LSN=%d want delete LSN %d", diag.AppliedCommandLSN, deleteLSN)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("rows=%d want insert/update/delete rows", len(rows))
+	}
+	assertColumnPhysicalScanRowM13A(t, rows[0], ColumnPublishOperationInsert, "e1", false, int64(1), "")
+	assertColumnPhysicalScanRowM13A(t, rows[1], ColumnPublishOperationInsert, "e2", false, int64(2), "")
+	assertColumnPhysicalScanRowM13A(t, rows[2], ColumnPublishOperationUpdate, "e1", false, int64(3), "")
+	assertColumnPhysicalScanRowM13A(t, rows[3], ColumnPublishOperationDelete, "e2", true, 0, "")
+}
+
+func TestColumnPhysicalSerialScannerFailsClosedMissingAssetM13A(t *testing.T) {
+	dir, ref := prepareColumnPhysicalScannerCorruptionFixtureM13A(t)
+	assetPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), ref)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	if err := os.Remove(assetPath); err != nil {
+		t.Fatalf("Remove asset: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopen)
+	_, err = reopened.scanColumnPhysicalRows(columnPhysicalScanRequest{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("scan missing asset err=%v want os.ErrNotExist", err)
+	}
+}
+
+func TestColumnPhysicalSerialScannerFailsClosedCorruptAssetM13A(t *testing.T) {
+	dir, ref := prepareColumnPhysicalScannerCorruptionFixtureM13A(t)
+	assetPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), ref)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	file, err := os.OpenFile(assetPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile asset: %v", err)
+	}
+	if _, err := file.WriteAt([]byte{0xff}, ref.Offset); err != nil {
+		_ = file.Close()
+		t.Fatalf("corrupt asset: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close corrupt asset: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopen)
+	_, err = reopened.scanColumnPhysicalRows(columnPhysicalScanRequest{})
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("scan corrupt asset err=%v want checksum failure", err)
+	}
+}
+
+func TestColumnPhysicalSerialScannerDoesNotEnablePlannerRoutingM13A(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.Insert([]byte("e1"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	plan, err := col.PlanColumnQuery(ColumnQueryPlanRequest{
+		Name:             "q1",
+		ProjectedColumns: []string{"time_us"},
+		ForceKind:        ColumnQueryPlanSerialColumnScan,
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnQuery: %v", err)
+	}
+	if plan.Supported {
+		t.Fatalf("forced serial plan supported before M14 routing: %+v", plan)
+	}
+	if got := plan.Diagnostics.UnsupportedPlanReason; got != "physical column scanner is not implemented yet" {
+		t.Fatalf("unsupported reason=%q want physical scanner disabled", got)
+	}
+}
+
+func TestColumnPhysicalSerialScannerRejectsInvalidProjectionM13A(t *testing.T) {
+	cfg := *testColumnStoreConfig(nil)
+	for _, tc := range []struct {
+		name       string
+		projection []string
+		want       string
+	}{
+		{name: "empty column", projection: []string{""}, want: "empty column"},
+		{name: "duplicate", projection: []string{"time_us", "time_us"}, want: "duplicate projected column"},
+		{name: "undeclared", projection: []string{"missing"}, want: "undeclared column"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newColumnPhysicalScanProjection(cfg, tc.projection)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("projection err=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+type columnPhysicalScanRowForTest struct {
+	Generation        uint64
+	PartID            uint64
+	AppliedCommandLSN uint64
+	Operation         ColumnPublishOperation
+	ID                string
+	Deleted           bool
+	Values            []columnDeclaredValue
+}
+
+func copyColumnPhysicalScanRowForTest(row columnPhysicalScanRowView) columnPhysicalScanRowForTest {
+	values := append([]columnDeclaredValue(nil), row.Values...)
+	return columnPhysicalScanRowForTest{
+		Generation:        row.Generation,
+		PartID:            row.PartID,
+		AppliedCommandLSN: row.AppliedCommandLSN,
+		Operation:         row.Operation,
+		ID:                string(row.ID),
+		Deleted:           row.Deleted,
+		Values:            values,
+	}
+}
+
+func assertColumnPhysicalScanRowM13A(t testing.TB, row columnPhysicalScanRowForTest, operation ColumnPublishOperation, id string, deleted bool, timeUS int64, kind string) {
+	t.Helper()
+	if row.Operation != operation || row.ID != id || row.Deleted != deleted {
+		t.Fatalf("row=%+v want operation=%s id=%q deleted=%v", row, operation, id, deleted)
+	}
+	if deleted {
+		if len(row.Values) != 0 {
+			t.Fatalf("deleted row values=%+v want none", row.Values)
+		}
+		return
+	}
+	if len(row.Values) == 0 {
+		t.Fatalf("row values empty for %+v", row)
+	}
+	if row.Values[0].Type != ColumnStoreValueInt64 || row.Values[0].Null || row.Values[0].Int64 != timeUS {
+		t.Fatalf("time_us value=%+v want %d", row.Values[0], timeUS)
+	}
+	if kind != "" {
+		if len(row.Values) < 2 {
+			t.Fatalf("kind projection missing from values=%+v", row.Values)
+		}
+		if row.Values[1].Type != ColumnStoreValueString || row.Values[1].Null || row.Values[1].String != kind {
+			t.Fatalf("kind value=%+v want %q", row.Values[1], kind)
+		}
+	}
+}
+
+func prepareColumnPhysicalScannerCorruptionFixtureM13A(t *testing.T) (string, ColumnAssetRef) {
+	t.Helper()
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.Insert([]byte("e1"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
+		_ = d.Close()
+		t.Fatalf("Insert: %v", err)
+	}
+	refs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	if len(refs) != 1 {
+		_ = d.Close()
+		t.Fatalf("refs=%+v want one", refs)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return dir, refs[0]
+}

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestColumnPhysicalSerialScannerReadsReopenedAssetsM13A(t *testing.T) {
@@ -204,6 +205,64 @@ func TestColumnPhysicalSerialScannerRejectsInvalidProjectionM13A(t *testing.T) {
 				t.Fatalf("projection err=%v want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *testing.T) {
+	normalized, rows := makeColumnPhysicalAssetBenchmarkRows(t, 1024)
+	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        1,
+		PartID:            1,
+		AppliedCommandLSN: 1,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows:              rows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 1,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"time_us"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	var scanErr error
+	var sum int64
+	allocs := testing.AllocsPerRun(100, func() {
+		if scanErr != nil {
+			return
+		}
+		summary, err := scanColumnPhysicalAssetRows(encoded, ref, *normalized, projection, func(row columnPhysicalScanRowView) error {
+			sum += row.Values[0].Int64
+			return nil
+		})
+		if err != nil {
+			scanErr = err
+			return
+		}
+		if summary.rows != len(rows) {
+			scanErr = errors.New("unexpected scanned row count")
+		}
+	})
+	if scanErr != nil {
+		t.Fatalf("scanColumnPhysicalAssetRows: %v", scanErr)
+	}
+	if allocs != 0 {
+		t.Fatalf("allocs/run=%v want zero for numeric physical asset scan", allocs)
+	}
+	if sum == 0 {
+		t.Fatal("scan sum stayed zero")
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -119,6 +119,61 @@ func TestColumnPhysicalSerialScannerExposesMutationRowsM13A(t *testing.T) {
 	assertColumnPhysicalScanRowM13A(t, rows[3], ColumnPublishOperationDelete, "e2", true, 0, "")
 }
 
+func TestColumnPhysicalSerialScannerUsesSnapshotCatalogM13A(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.Insert([]byte("e1"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
+		t.Fatalf("first Insert: %v", err)
+	}
+
+	staleSnap := d.AcquireSnapshot()
+	if staleSnap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	staleCatalog, err := loadCollectionCatalog(staleSnap, "events")
+	if err != nil {
+		_ = staleSnap.Close()
+		t.Fatalf("load stale catalog: %v", err)
+	}
+	staleSystemRoot := snapshotSystemRoot(staleSnap)
+	staleCommitSeq := snapshotCommitSeq(staleSnap)
+	if err := staleSnap.Close(); err != nil {
+		t.Fatalf("close stale snapshot: %v", err)
+	}
+
+	if _, err := col.Insert([]byte("e2"), []byte(`{"time_us":2,"kind":"post","did":"d2"}`)); err != nil {
+		t.Fatalf("second Insert: %v", err)
+	}
+	col.catalogMu.Lock()
+	col.catalog = staleCatalog
+	col.catalogSystemRoot = staleSystemRoot
+	col.catalogCommitSeq = staleCommitSeq
+	col.catalogMu.Unlock()
+
+	var rows []columnPhysicalScanRowForTest
+	diag, err := col.scanColumnPhysicalRows(columnPhysicalScanRequest{
+		ProjectedColumns: []string{"time_us"},
+		Visitor: func(row columnPhysicalScanRowView) error {
+			rows = append(rows, copyColumnPhysicalScanRowForTest(row))
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalRows: %v", err)
+	}
+	if diag.ManifestGeneration != 2 || diag.AssetRefs != 2 || diag.RowsScanned != 2 {
+		t.Fatalf("scan diagnostics=%+v want latest snapshot generation=2 with two rows", diag)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d want latest snapshot rows", len(rows))
+	}
+	assertColumnPhysicalScanRowM13A(t, rows[0], ColumnPublishOperationInsert, "e1", false, int64(1), "")
+	assertColumnPhysicalScanRowM13A(t, rows[1], ColumnPublishOperationInsert, "e2", false, int64(2), "")
+}
+
 func TestColumnPhysicalSerialScannerFailsClosedMissingAssetM13A(t *testing.T) {
 	dir, ref := prepareColumnPhysicalScannerCorruptionFixtureM13A(t)
 	assetPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), ref)
@@ -238,7 +293,7 @@ func TestColumnPhysicalAssetSerialScanRejectsWrongCollectionM13A(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
 	}
-	_, err = scanColumnPhysicalAssetRows(encoded, ref, "other_events", *normalized, projection, nil)
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "other_events", normalized, projection, nil)
 	if err == nil || !strings.Contains(err.Error(), "collection") {
 		t.Fatalf("scan err=%v want collection mismatch", err)
 	}
@@ -270,7 +325,7 @@ func TestColumnPhysicalAssetSerialScanRejectsV1DeleteOperationM13A(t *testing.T)
 	if err != nil {
 		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
 	}
-	_, err = scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, nil)
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "events", normalized, projection, nil)
 	if err == nil || !strings.Contains(err.Error(), "legacy v1 column physical asset delete operation unsupported") {
 		t.Fatalf("scan err=%v want legacy v1 delete unsupported", err)
 	}
@@ -414,7 +469,7 @@ func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *test
 		if scanErr != nil {
 			return
 		}
-		summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, func(row columnPhysicalScanRowView) error {
+		summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", normalized, projection, func(row columnPhysicalScanRowView) error {
 			sum += row.Values[0].Int64
 			return nil
 		})

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"strings"
@@ -272,6 +273,109 @@ func TestColumnPhysicalAssetSerialScanRejectsV1DeleteOperationM13A(t *testing.T)
 	_, err = scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, nil)
 	if err == nil || !strings.Contains(err.Error(), "legacy v1 column physical asset delete operation unsupported") {
 		t.Fatalf("scan err=%v want legacy v1 delete unsupported", err)
+	}
+}
+
+func TestColumnManifestAssetRefsForScanRetainsChecksumCoveredGenerationsM13A(t *testing.T) {
+	stale := testColumnPublishPreparedAssetM10A()
+	stale.Ref.Generation = 2
+	stale.Ref.PartID = 1
+	stale.GenerationID = stale.Ref.Generation
+	staleValue, err := encodeColumnManifestPartRecord(stale)
+	if err != nil {
+		t.Fatalf("encode stale part: %v", err)
+	}
+	active := testColumnPublishPreparedAssetM10A()
+	active.Ref.Generation = 3
+	active.Ref.PartID = 2
+	active.GenerationID = active.Ref.Generation
+	activeValue, err := encodeColumnManifestPartRecord(active)
+	if err != nil {
+		t.Fatalf("encode active part: %v", err)
+	}
+
+	refs, err := columnManifestAssetRefsFromRecordsForScan([]columnManifestRecord{
+		{key: []byte(columnManifestHeaderRecordKey), value: []byte("header ignored by ref extraction")},
+		{key: columnManifestPartRecordKey(stale.Ref.Generation, stale.Ref.PartID), value: staleValue},
+		{key: columnManifestPartRecordKey(active.Ref.Generation, active.Ref.PartID), value: activeValue},
+	}, active.Ref.Generation)
+	if err != nil {
+		t.Fatalf("columnManifestAssetRefsFromRecordsForScan: %v", err)
+	}
+	if len(refs) != 2 ||
+		refs[0].Generation != stale.Ref.Generation || refs[0].PartID != stale.Ref.PartID ||
+		refs[1].Generation != active.Ref.Generation || refs[1].PartID != active.Ref.PartID {
+		t.Fatalf("refs=%+v want retained stale ref %+v and active ref %+v", refs, stale.Ref, active.Ref)
+	}
+}
+
+func TestColumnManifestEncodeChecksumsRetainedPartRecordsM13A(t *testing.T) {
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	retained := testColumnPublishPreparedAssetM10A()
+	retained.Ref.Generation = 1
+	retained.Ref.PartID = 1
+	retained.GenerationID = retained.Ref.Generation
+	retainedValue, err := encodeColumnManifestPartRecord(retained)
+	if err != nil {
+		t.Fatalf("encode retained part: %v", err)
+	}
+	next := testColumnPublishPreparedAssetM10A()
+	next.Ref.Generation = 2
+	next.Ref.PartID = 2
+	next.GenerationID = next.Ref.Generation
+	manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       *cfg,
+		Operation:         ColumnPublishOperationUpdate,
+		AppliedCommandLSN: 2,
+		CurrentManifest:   &ColumnManifestIdentity{Generation: 1, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 1},
+		CurrentManifestRecords: []columnManifestRecord{{
+			key:   columnManifestPartRecordKey(retained.Ref.Generation, retained.Ref.PartID),
+			value: retainedValue,
+		}},
+		Prepared: ColumnPublishPreparedAssets{
+			Assets:             []ColumnPreparedAsset{next},
+			RowCount:           1,
+			ColumnPayloadBytes: next.Bytes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnManifestForWrite: %v", err)
+	}
+	if len(manifest.Records) != 3 {
+		t.Fatalf("manifest records=%d want header + retained + next", len(manifest.Records))
+	}
+	active, err := activeColumnManifestRecordsForScan(manifest.Records, manifest.Identity.Generation)
+	if err != nil {
+		t.Fatalf("activeColumnManifestRecordsForScan: %v", err)
+	}
+	checksum := checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       ColumnStoreConfig{SchemaHash: cfg.SchemaHash},
+		Operation:         ColumnPublishOperationUpdate,
+		AppliedCommandLSN: 2,
+	}, manifest.Identity.Generation, active)
+	if checksum != manifest.Identity.Checksum {
+		t.Fatalf("checksum=%d want manifest identity checksum=%d", checksum, manifest.Identity.Checksum)
+	}
+	tampered := cloneColumnManifestRecords(active)
+	for i := range tampered {
+		if bytes.HasPrefix(tampered[i].key, []byte(columnManifestPartRecordPrefix)) && bytes.Contains(tampered[i].value, []byte(retained.Reason)) {
+			tampered[i].value[len(tampered[i].value)-1] ^= 0x01
+			break
+		}
+	}
+	tamperedChecksum := checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       ColumnStoreConfig{SchemaHash: cfg.SchemaHash},
+		Operation:         ColumnPublishOperationUpdate,
+		AppliedCommandLSN: 2,
+	}, manifest.Identity.Generation, tampered)
+	if tamperedChecksum == manifest.Identity.Checksum {
+		t.Fatal("tampered retained manifest part did not change checksum")
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -417,11 +417,16 @@ func TestColumnManifestEncodeChecksumsRetainedPartRecordsM13A(t *testing.T) {
 		t.Fatalf("checksum=%d want manifest identity checksum=%d", checksum, manifest.Identity.Checksum)
 	}
 	tampered := cloneColumnManifestRecords(active)
+	tamperedCount := 0
 	for i := range tampered {
 		if bytes.HasPrefix(tampered[i].key, []byte(columnManifestPartRecordPrefix)) && bytes.Contains(tampered[i].value, []byte(retained.Reason)) {
 			tampered[i].value[len(tampered[i].value)-1] ^= 0x01
+			tamperedCount++
 			break
 		}
+	}
+	if tamperedCount != 1 {
+		t.Fatalf("tampered retained manifest records=%d want 1", tamperedCount)
 	}
 	tamperedChecksum := checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
 		Collection:        "events",
@@ -432,6 +437,80 @@ func TestColumnManifestEncodeChecksumsRetainedPartRecordsM13A(t *testing.T) {
 	if tamperedChecksum == manifest.Identity.Checksum {
 		t.Fatal("tampered retained manifest part did not change checksum")
 	}
+}
+
+func TestColumnPublishRejectsTamperedExistingManifestBeforeCarryM13A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Ref.Generation = 1
+	asset.Ref.PartID = 1
+	asset.GenerationID = 1
+	asset.Reason = string(ColumnPublishOperationInsert)
+	manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       *cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			Assets:             []ColumnPreparedAsset{asset},
+			RowCount:           1,
+			ColumnPayloadBytes: asset.Bytes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnManifestForWrite: %v", err)
+	}
+	active := manifest.Identity
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &active
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+
+	rootID := publishColumnManifestRecordsForScanTestM13A(t, d, manifest.Identity, manifest.Records)
+	col := &Collection{db: d}
+	if _, err := col.loadColumnManifestRecordsForPublish(rootID, "events", *cfg); err != nil {
+		t.Fatalf("load untampered manifest for publish: %v", err)
+	}
+
+	tampered := cloneColumnManifestRecords(manifest.Records)
+	tamperedCount := 0
+	for i := range tampered {
+		if bytes.HasPrefix(tampered[i].key, []byte(columnManifestPartRecordPrefix)) {
+			tampered[i].value[len(tampered[i].value)-1] ^= 0x01
+			tamperedCount++
+			break
+		}
+	}
+	if tamperedCount != 1 {
+		t.Fatalf("tampered manifest part records=%d want 1", tamperedCount)
+	}
+	corruptRootID := publishColumnManifestRecordsForScanTestM13A(t, d, manifest.Identity, tampered)
+	_, err = col.loadColumnManifestRecordsForPublish(corruptRootID, "events", *cfg)
+	if err == nil || !strings.Contains(err.Error(), "column publish manifest checksum") {
+		t.Fatalf("load tampered manifest for publish err=%v want checksum rejection", err)
+	}
+}
+
+func publishColumnManifestRecordsForScanTestM13A(t testing.TB, d *backenddb.DB, identity ColumnManifestIdentity, records []columnManifestRecord) uint64 {
+	t.Helper()
+	iter := columnManifestRootRecordIterator(encodeColumnManifestIdentityRecordArray(identity), records)
+	defer func() { _ = iter.Close() }()
+	rootID, err := d.PublishOrderedRootIterator(0, iter)
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	if rootID == 0 {
+		t.Fatal("PublishOrderedRootIterator returned root 0")
+	}
+	return rootID
 }
 
 func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *testing.T) {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -208,6 +208,41 @@ func TestColumnPhysicalSerialScannerRejectsInvalidProjectionM13A(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetSerialScanRejectsWrongCollectionM13A(t *testing.T) {
+	normalized, rows := makeColumnPhysicalAssetBenchmarkRows(t, 4)
+	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        1,
+		PartID:            1,
+		AppliedCommandLSN: 1,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows:              rows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 1,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"time_us"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "other_events", *normalized, projection, nil)
+	if err == nil || !strings.Contains(err.Error(), "collection") {
+		t.Fatalf("scan err=%v want collection mismatch", err)
+	}
+}
+
 func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *testing.T) {
 	normalized, rows := makeColumnPhysicalAssetBenchmarkRows(t, 1024)
 	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
@@ -243,7 +278,7 @@ func TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A(t *test
 		if scanErr != nil {
 			return
 		}
-		summary, err := scanColumnPhysicalAssetRows(encoded, ref, *normalized, projection, func(row columnPhysicalScanRowView) error {
+		summary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", *normalized, projection, func(row columnPhysicalScanRowView) error {
 			sum += row.Values[0].Int64
 			return nil
 		})

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -68,14 +68,15 @@ type ColumnPreparedAsset struct {
 // ColumnPublishPlanInput contains the normalized collection state and stage
 // hooks required to build an atomic column manifest publish plan.
 type ColumnPublishPlanInput struct {
-	Collection            string
-	ColumnStore           *ColumnStoreConfig
-	ColumnStoreNormalized bool
-	Operation             ColumnPublishOperation
-	CurrentManifest       *ColumnManifestIdentity
-	AppliedCommandLSN     uint64
-	BaseManifestRootID    uint64
-	Hooks                 ColumnPublishPlanHooks
+	Collection             string
+	ColumnStore            *ColumnStoreConfig
+	ColumnStoreNormalized  bool
+	Operation              ColumnPublishOperation
+	CurrentManifest        *ColumnManifestIdentity
+	CurrentManifestRecords []columnManifestRecord
+	AppliedCommandLSN      uint64
+	BaseManifestRootID     uint64
+	Hooks                  ColumnPublishPlanHooks
 }
 
 // ColumnPublishPlanHooks provide the engine-specific stages for a publish plan.
@@ -118,12 +119,13 @@ type ColumnPublishPreparedAssets struct {
 
 // ColumnPublishManifestEncodeInput is passed to the manifest encoding stage.
 type ColumnPublishManifestEncodeInput struct {
-	Collection        string
-	ColumnStore       ColumnStoreConfig
-	Operation         ColumnPublishOperation
-	AppliedCommandLSN uint64
-	CurrentManifest   *ColumnManifestIdentity
-	Prepared          ColumnPublishPreparedAssets
+	Collection             string
+	ColumnStore            ColumnStoreConfig
+	Operation              ColumnPublishOperation
+	AppliedCommandLSN      uint64
+	CurrentManifest        *ColumnManifestIdentity
+	CurrentManifestRecords []columnManifestRecord
+	Prepared               ColumnPublishPreparedAssets
 }
 
 // ColumnPublishManifestEncodeResult identifies the encoded manifest generation.
@@ -641,12 +643,13 @@ func encodeColumnPublishManifest(input ColumnPublishPlanInput, cfg ColumnStoreCo
 		return ColumnPublishManifestEncodeResult{}, errors.New("collections: column publish manifest encode hook is required")
 	}
 	return input.Hooks.EncodeManifest(ColumnPublishManifestEncodeInput{
-		Collection:        input.Collection,
-		ColumnStore:       columnPublishHookConfig(cfg),
-		Operation:         input.Operation,
-		AppliedCommandLSN: input.AppliedCommandLSN,
-		CurrentManifest:   cloneColumnManifestIdentityPtr(input.CurrentManifest),
-		Prepared:          cloneColumnPublishPreparedAssets(prepared),
+		Collection:             input.Collection,
+		ColumnStore:            columnPublishHookConfig(cfg),
+		Operation:              input.Operation,
+		AppliedCommandLSN:      input.AppliedCommandLSN,
+		CurrentManifest:        cloneColumnManifestIdentityPtr(input.CurrentManifest),
+		CurrentManifestRecords: cloneColumnManifestRecords(input.CurrentManifestRecords),
+		Prepared:               cloneColumnPublishPreparedAssets(prepared),
 	})
 }
 

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -377,14 +377,19 @@ func (c *Collection) publishRootDeltaBatchGroupWithoutColumn(ordered []backenddb
 }
 
 func (c *Collection) buildColumnPublishPlanForCommandWALContext(ctx backenddb.CommandWALPublishContext, input columnWritePublishInput, baseManifestRootID uint64) (ColumnPublishPlan, error) {
+	currentRecords, err := c.loadColumnManifestRecordsForPublish(baseManifestRootID)
+	if err != nil {
+		return ColumnPublishPlan{}, err
+	}
 	return BuildColumnPublishPlan(ColumnPublishPlanInput{
-		Collection:            input.meta.Name,
-		ColumnStore:           input.meta.Options.ColumnStore,
-		ColumnStoreNormalized: true,
-		Operation:             input.operation,
-		CurrentManifest:       input.meta.Options.ColumnStore.ActiveManifest,
-		AppliedCommandLSN:     ctx.AppliedCommandLSN,
-		BaseManifestRootID:    baseManifestRootID,
+		Collection:             input.meta.Name,
+		ColumnStore:            input.meta.Options.ColumnStore,
+		ColumnStoreNormalized:  true,
+		Operation:              input.operation,
+		CurrentManifest:        input.meta.Options.ColumnStore.ActiveManifest,
+		CurrentManifestRecords: currentRecords,
+		AppliedCommandLSN:      ctx.AppliedCommandLSN,
+		BaseManifestRootID:     baseManifestRootID,
 		Hooks: ColumnPublishPlanHooks{
 			PrepareAssets: func(hookInput ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {
 				return c.prepareColumnPhysicalAssetsForCommand(input, hookInput)
@@ -392,6 +397,22 @@ func (c *Collection) buildColumnPublishPlanForCommandWALContext(ctx backenddb.Co
 			EncodeManifest: encodeColumnManifestIdentityForWrite,
 		},
 	})
+}
+
+func (c *Collection) loadColumnManifestRecordsForPublish(rootID uint64) ([]columnManifestRecord, error) {
+	if rootID == 0 {
+		return nil, nil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, errCollectionDBNil
+	}
+	defer func() { _ = snap.Close() }()
+	records, err := loadColumnManifestRecordsFromRootForScan(snap, rootID)
+	if err != nil {
+		return nil, fmt.Errorf("collections: load existing column manifest records: %w", err)
+	}
+	return records, nil
 }
 
 func (c *Collection) prepareColumnPhysicalAssetsForCommand(input columnWritePublishInput, hookInput ColumnPublishAssetPrepareInput) (ColumnPublishPreparedAssets, error) {

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -377,7 +377,7 @@ func (c *Collection) publishRootDeltaBatchGroupWithoutColumn(ordered []backenddb
 }
 
 func (c *Collection) buildColumnPublishPlanForCommandWALContext(ctx backenddb.CommandWALPublishContext, input columnWritePublishInput, baseManifestRootID uint64) (ColumnPublishPlan, error) {
-	currentRecords, err := c.loadColumnManifestRecordsForPublish(baseManifestRootID)
+	currentRecords, err := c.loadColumnManifestRecordsForPublish(baseManifestRootID, input.meta.Name, *input.meta.Options.ColumnStore)
 	if err != nil {
 		return ColumnPublishPlan{}, err
 	}
@@ -399,18 +399,31 @@ func (c *Collection) buildColumnPublishPlanForCommandWALContext(ctx backenddb.Co
 	})
 }
 
-func (c *Collection) loadColumnManifestRecordsForPublish(rootID uint64) ([]columnManifestRecord, error) {
+func (c *Collection) loadColumnManifestRecordsForPublish(rootID uint64, collectionName string, cfg ColumnStoreConfig) ([]columnManifestRecord, error) {
 	if rootID == 0 {
 		return nil, nil
+	}
+	if cfg.ActiveManifest == nil {
+		return nil, errors.New("collections: column publish existing manifest root requires active manifest identity")
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, errCollectionDBNil
 	}
 	defer func() { _ = snap.Close() }()
-	records, err := loadColumnManifestRecordsFromRootForScan(snap, rootID)
+	if err := validateColumnManifestIdentityAtRoot(snap, rootID, *cfg.ActiveManifest); err != nil {
+		return nil, fmt.Errorf("collections: validate existing column manifest identity for publish: %w", err)
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
 	if err != nil {
 		return nil, fmt.Errorf("collections: load existing column manifest records: %w", err)
+	}
+	manifest, err := decodeColumnManifestRecords(records)
+	if err != nil {
+		return nil, fmt.Errorf("collections: decode existing column manifest records for publish: %w", err)
+	}
+	if err := validateColumnManifestSnapshot(manifest, records, cfg, *cfg.ActiveManifest, collectionName, "column publish"); err != nil {
+		return nil, err
 	}
 	return records, nil
 }


### PR DESCRIPTION
## What Landed

M13A adds the first production serial physical scanner over durable TreeDB column assets, chained on top of #1625 / `eafe26f5bbd41255d4aa5b9a0d91cb2579325c95`.

- Loads the active recovery-authoritative column manifest from the collection manifest root and validates the root identity/checksum before scanning.
- Resolves `ColumnAssetRef` values through the typed isolated column asset manager namespace instead of row value-log payloads.
- Streams TCPA physical asset rows through an internal row-view visitor without reconstructing full JSON documents.
- Supports declared-column projection validation and rejects empty, duplicate, or undeclared projected columns.
- Validates direct asset scans against the expected collection, namespace, generation, part id, schema hash, and operation before rows are exposed.
- Exposes raw insert/update/delete asset rows for the future M13C visibility overlay, while keeping latest-visible reduction out of M13A.
- Fails closed on missing/corrupt physical assets and keeps forced planner routing disabled until M14.

## What Remains Blocked

- M13B: collection query adapter plus q1-q5/q4a/q4b/q5 reducers over the scanner.
- M13C: mutation visibility, retained-payload flip validation, full-document reconstruction, and additional negative recovery/corruption coverage.
- M14: planner and unified-bench physical routing.
- M15: destructive GC/rewrite/remap behavior for first-class column asset refs.

## Performance / Benchmark Evidence

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysical(AssetSerialScanM13A|CollectionSerialScanM13A)' -benchmem -count=3
```

Results on Apple M3 / darwin arm64 from pushed head `aade59d0bf715e3581a750e785fe55c2af39f0f5`:

| Benchmark | Rows/op | ns/op | Rows/sec | ns/row | MB/sec | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|
| `AssetSerialScanM13A/rows_1024` | 1,024 | 35,493 | 28.85M | 34.7 | 2891.66 | 0 | 0 |
| `AssetSerialScanM13A/rows_1024` | 1,024 | 35,253 | 29.05M | 34.4 | 2911.34 | 0 | 0 |
| `AssetSerialScanM13A/rows_1024` | 1,024 | 35,662 | 28.71M | 34.8 | 2877.95 | 0 | 0 |
| `AssetSerialScanM13A/rows_8192` | 8,192 | 284,579 | 28.79M | 34.7 | 2879.46 | 0 | 0 |
| `AssetSerialScanM13A/rows_8192` | 8,192 | 283,396 | 28.91M | 34.6 | 2891.48 | 0 | 0 |
| `AssetSerialScanM13A/rows_8192` | 8,192 | 282,916 | 28.96M | 34.5 | 2896.39 | 0 | 0 |
| `CollectionSerialScanM13A` | 1,024 | 73,431 | 13.94M | 71.7 | 1397.67 | 111,090 | 53 |
| `CollectionSerialScanM13A` | 1,024 | 73,315 | 13.97M | 71.6 | 1399.88 | 111,089 | 53 |
| `CollectionSerialScanM13A` | 1,024 | 73,643 | 13.90M | 71.9 | 1393.65 | 111,090 | 53 |

Storage/accounting notes for this PR:

- Direct scanner column asset bytes are approximately 102.6 KiB for 1,024-row assets and 819.5 KiB for 8,192-row assets, as reported through `b.SetBytes` / scanner diagnostics.
- Direct numeric-projection asset scan is explicitly guarded by `TestColumnPhysicalAssetSerialScanNumericProjectionHasZeroAllocsM13A` using `testing.AllocsPerRun`; it must remain `0 B/op`, `0 allocs/op`.
- Collection scanner `B/op` is dominated by per-scan manifest record cloning and raw asset buffer reads; M13A intentionally does not add a scanner cache or reusable collection-level execution context. This improved from 65 to 53 allocs/op after removing fixed header/schema string allocations.
- The scan path emits no command-WAL bytes, checkpoint bytes, or retained payload bytes; those are produced by the existing M12 write path used only to prepare the reopened benchmark fixture.
- No full-document row materialization is performed by this scanner path (`RowMaterializations == 0` in reopen tests); M13A emits declared-column row views only.

## Throughput Interpretation

This is a correctness-first serial scanner, not yet the final routed query engine. The important M13A perf result is that direct physical asset scanning is zero-allocation for numeric projections and has stable roughly 34-35 ns/row throughput from 1,024 to 8,192 rows. The remaining collection-level allocation is expected metadata/asset-buffer loading work and should be addressed by M13B/M14 query adapter caching or block reuse only if it becomes visible in routed query profiles.

## Gate Status

- PASS: `go test ./TreeDB/collections -run 'TestColumnPhysicalSerialScanner|TestColumnPhysicalAssetSerialScan' -count=1`
- PASS: `go test ./TreeDB/collections -count=1`
- PASS: `go test ./TreeDB/db -count=1`
- PASS: `go test ./cmd/unified_bench -count=1`
- PASS: `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysical(AssetSerialScanM13A|CollectionSerialScanM13A)' -benchmem -count=3`
- PASS: `git diff --check`
- PASS: missing/corrupt asset scan failures fail closed.
- PASS: direct asset collection/namespace/generation/part/schema/operation mismatches fail closed.
- PASS: forced serial planner routing remains unsupported before M14.

## Artifacts

- Benchmark evidence is included inline above from the local `go test -benchmem -count=3` run.
- No pprof/profile-dir artifacts were generated for M13A; M13B/M14 routed-query benchmarking will use unified-bench profile artifacts.

## Assumption Ledger

- V1-final behavior: this scanner feeds a production query adapter and visibility overlay; row-view slices must not be retained after visitor return.
- Provisional M13A behavior: raw insert/update/delete asset rows are exposed without latest-visible reduction.
- Deliberately unsupported in this PR: planner routing, unified-bench physical execution, marks/dictionaries/locators/aggregate metadata reducers, and destructive GC/rewrite/remap.
- Storage contract: physical scan reads isolated value-log-shaped column asset files under the typed column asset manager namespace, not generic row `value_vlog` entries.



## Review Hardening

Latest head: `d3024c2ec`

Addressed latest M13A review hardening:

- Manifest encoding carries retained previous-generation part records into the new manifest record set, so the active manifest identity checksum covers every retained column asset ref the scanner can reach.
- The scanner validates the same retained `<= active generation` record set and skips only future-generation refs, preventing unvalidated stale/tampered part records from being scanned while preserving mutation-row visibility.
- Physical scans now acquire the DB snapshot before resolving collection catalog/root/config metadata, so manifest selection is bound to the snapshot being scanned rather than a stale handle cache.
- Direct asset scanning passes the column-store config by pointer, hoists manifest record key bytes used by scan helpers, reports column/row dimension overflow fields explicitly, and documents visitor aliasing at the call site.
- Collection-scan benchmark now asserts timed `PhysicalBytesScanned` matches the preview byte count used for MB/sec reporting.
- Added retained-ref checksum tests and a stale-catalog snapshot scan regression test.

Validation:

```text
go test ./TreeDB/collections -run 'TestColumnPhysical.*M13A|TestColumnManifest.*M13A|TestColumnStoreMutationAssetsPublishAndReopenM12C|TestColumnStoreCommandWALReplayPublishesMutationAssetsM12C|TestColumnStoreSupportMatrixRejectsNonJSONMutationsBeforeExecutionM12C' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	1.124s

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalAssetSerialScanM13A$' -benchtime=1000x -benchmem -count=1
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_1024-8  	1000	 46904 ns/op	2188.17 MB/s	0 B/op	0 allocs/op
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_8192-8  	1000	269706 ns/op	3038.24 MB/s	0 B/op	0 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented end-to-end physical column scanning for collections, supporting row mutation detection, operation tracking, type validation, and selective column projection with comprehensive diagnostics.

* **Refactor**
  * Optimized string and byte-slice decoding mechanisms in column manifest and asset processing to improve efficiency.

* **Tests**
  * Added extensive benchmarks and test coverage for column scanning functionality, including validation of error handling and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->