### PR TITLE
TreeDB column store M13B: add physical query adapter

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -32,6 +32,9 @@ type columnDeclaredValue struct {
 	Int64  int64
 	Double float64
 	String string
+	// StringBytes is used by physical scan/query hot paths as an asset-buffer
+	// view; String remains the owned representation for full asset decoding.
+	StringBytes []byte
 }
 
 type columnDeclaredRow struct {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -1,0 +1,431 @@
+package collections
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ColumnPhysicalQueryKind names the small M13B physical aggregate/projection
+// shapes supported directly by the column asset scanner.
+type ColumnPhysicalQueryKind string
+
+const (
+	// ColumnPhysicalQueryGroupCount counts rows by a string group column.
+	ColumnPhysicalQueryGroupCount         ColumnPhysicalQueryKind = "group_count"
+	ColumnPhysicalQueryGroupCountDistinct ColumnPhysicalQueryKind = "group_count_distinct"
+	ColumnPhysicalQueryHourCount          ColumnPhysicalQueryKind = "hour_count"
+	ColumnPhysicalQueryGroupMinInt64      ColumnPhysicalQueryKind = "group_min_int64"
+	ColumnPhysicalQueryGroupMaxInt64      ColumnPhysicalQueryKind = "group_max_int64"
+	ColumnPhysicalQueryGroupInt64Span     ColumnPhysicalQueryKind = "group_int64_span"
+)
+
+// ColumnPhysicalQueryRequest describes one explicit physical column query. It
+// does not invoke planner routing; M14 owns forced/automatic route selection.
+type ColumnPhysicalQueryRequest struct {
+	Kind           ColumnPhysicalQueryKind
+	GroupColumn    string
+	ValueColumn    string
+	DistinctColumn string
+}
+
+// ColumnPhysicalQueryGroup is one reduced result row. Count is populated for
+// count-style queries; Int64 is populated for min/max/span-style queries.
+type ColumnPhysicalQueryGroup struct {
+	Key   string
+	Count int
+	Int64 int64
+}
+
+// ColumnPhysicalQueryDiagnostics reports scan and reduce work for a physical
+// query without counting full-document row materialization.
+type ColumnPhysicalQueryDiagnostics struct {
+	ManifestRoot               uint64
+	ManifestGeneration         uint64
+	RecoveryManifestGeneration uint64
+	AppliedCommandLSN          uint64
+	ManifestRecords            int
+	AssetRefs                  int
+	DecodedBlocks              int
+	ScheduledGranules          int
+	SkippedGranules            int
+	RowsScanned                int
+	DeletedRows                int
+	ProjectedColumns           int
+	RowMaterializations        int
+	PhysicalBytesScanned       int64
+	ReduceRows                 int
+	ResultGroups               int
+}
+
+// ColumnPhysicalQueryResult is the reduced result and diagnostics from an
+// explicit physical column query.
+type ColumnPhysicalQueryResult struct {
+	Groups      []ColumnPhysicalQueryGroup
+	Diagnostics ColumnPhysicalQueryDiagnostics
+}
+
+// RunColumnPhysicalQuery executes an explicit serial physical column query over
+// the recovery-authoritative manifest. It fails closed for update/delete rows
+// until the M13 visibility overlay lands.
+func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	cfg, err := c.columnPhysicalQueryColumnStoreConfig()
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+	exec, err := newColumnPhysicalQueryExecutor(cfg, req)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+	diag, err := c.scanColumnPhysicalRows(columnPhysicalScanRequest{
+		ProjectedColumns: exec.projected,
+		Visitor:          exec.visit,
+	})
+	result := ColumnPhysicalQueryResult{
+		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
+	}
+	result.Diagnostics.ReduceRows = exec.reduceRows
+	if err != nil {
+		return result, err
+	}
+	result.Groups = exec.groups()
+	result.Diagnostics.ResultGroups = len(result.Groups)
+	return result, nil
+}
+
+func (c *Collection) columnPhysicalQueryColumnStoreConfig() (ColumnStoreConfig, error) {
+	if c == nil {
+		return ColumnStoreConfig{}, errCollectionNil
+	}
+	c.catalogMu.RLock()
+	defer c.catalogMu.RUnlock()
+	if c.catalog == nil {
+		return ColumnStoreConfig{}, errCollectionNotFound
+	}
+	cfg := c.catalog.meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled {
+		return ColumnStoreConfig{}, fmt.Errorf("%w: physical column query requires enabled column_store", ErrColumnQueryPlanUnsupported)
+	}
+	return cfg.copy(), nil
+}
+
+func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) ColumnPhysicalQueryDiagnostics {
+	return ColumnPhysicalQueryDiagnostics{
+		ManifestRoot:               diag.ManifestRoot,
+		ManifestGeneration:         diag.ManifestGeneration,
+		RecoveryManifestGeneration: diag.RecoveryManifestGeneration,
+		AppliedCommandLSN:          diag.AppliedCommandLSN,
+		ManifestRecords:            diag.ManifestRecords,
+		AssetRefs:                  diag.AssetRefs,
+		DecodedBlocks:              diag.DecodedBlocks,
+		ScheduledGranules:          diag.ScheduledGranules,
+		SkippedGranules:            diag.SkippedGranules,
+		RowsScanned:                diag.RowsScanned,
+		DeletedRows:                diag.DeletedRows,
+		ProjectedColumns:           diag.ProjectedColumns,
+		RowMaterializations:        diag.RowMaterializations,
+		PhysicalBytesScanned:       diag.PhysicalBytesScanned,
+	}
+}
+
+type columnPhysicalQueryExecutor struct {
+	kind        ColumnPhysicalQueryKind
+	projected   []string
+	groupIdx    int
+	valueIdx    int
+	distinctIdx int
+	interner    columnPhysicalQueryStringInterner
+
+	counts       map[string]int
+	distinct     map[string]map[string]struct{}
+	hourCounts   [24]int
+	int64Values  map[string]int64
+	int64Spans   map[string]columnPhysicalQuerySpan
+	reduceRows   int
+	resultGroups []ColumnPhysicalQueryGroup
+}
+
+type columnPhysicalQuerySpan struct {
+	min int64
+	max int64
+}
+
+func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (*columnPhysicalQueryExecutor, error) {
+	exec := &columnPhysicalQueryExecutor{
+		kind:        req.Kind,
+		groupIdx:    -1,
+		valueIdx:    -1,
+		distinctIdx: -1,
+	}
+	addProjection := func(name string, wantType ColumnStoreValueType, role string) (int, error) {
+		if name == "" {
+			return -1, fmt.Errorf("%w: physical column query %s column is required", ErrColumnQueryPlanUnsupported, role)
+		}
+		col, ok := columnPhysicalQueryDeclaredColumn(cfg, name)
+		if !ok {
+			return -1, fmt.Errorf("%w: physical column query requested undeclared column %q", ErrColumnQueryPlanUnsupported, name)
+		}
+		if col.ValueType != wantType {
+			return -1, fmt.Errorf("%w: physical column query %s column %q has type %q, want %q", ErrColumnQueryPlanUnsupported, role, name, col.ValueType, wantType)
+		}
+		for idx, existing := range exec.projected {
+			if existing == name {
+				return idx, nil
+			}
+		}
+		exec.projected = append(exec.projected, name)
+		return len(exec.projected) - 1, nil
+	}
+
+	var err error
+	switch req.Kind {
+	case ColumnPhysicalQueryGroupCount:
+		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		exec.counts = make(map[string]int)
+	case ColumnPhysicalQueryGroupCountDistinct:
+		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		if err == nil {
+			exec.distinctIdx, err = addProjection(req.DistinctColumn, ColumnStoreValueString, "distinct")
+		}
+		exec.distinct = make(map[string]map[string]struct{})
+	case ColumnPhysicalQueryHourCount:
+		exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
+		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		if err == nil {
+			exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+		}
+		exec.int64Values = make(map[string]int64)
+	case ColumnPhysicalQueryGroupInt64Span:
+		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		if err == nil {
+			exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+		}
+		exec.int64Spans = make(map[string]columnPhysicalQuerySpan)
+	default:
+		err = fmt.Errorf("%w: unsupported physical column query kind %q", ErrColumnQueryPlanUnsupported, req.Kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return exec, nil
+}
+
+func columnPhysicalQueryDeclaredColumn(cfg ColumnStoreConfig, name string) (ColumnStoreColumn, bool) {
+	for _, col := range cfg.Columns {
+		if col.Name == name {
+			return col, true
+		}
+	}
+	return ColumnStoreColumn{}, false
+}
+
+func (e *columnPhysicalQueryExecutor) visit(row columnPhysicalScanRowView) error {
+	if row.Deleted || row.Operation != ColumnPublishOperationInsert {
+		return fmt.Errorf("%w: physical column query mutation visibility overlay is not implemented for operation=%s deleted=%v", ErrColumnQueryPlanUnsupported, row.Operation, row.Deleted)
+	}
+	e.reduceRows++
+	switch e.kind {
+	case ColumnPhysicalQueryGroupCount:
+		key, err := e.stringKey(row.Values[e.groupIdx])
+		if err != nil {
+			return err
+		}
+		e.counts[key]++
+	case ColumnPhysicalQueryGroupCountDistinct:
+		key, err := e.stringKey(row.Values[e.groupIdx])
+		if err != nil {
+			return err
+		}
+		distinct, err := e.stringKey(row.Values[e.distinctIdx])
+		if err != nil {
+			return err
+		}
+		set := e.distinct[key]
+		if set == nil {
+			set = make(map[string]struct{})
+			e.distinct[key] = set
+		}
+		set[distinct] = struct{}{}
+	case ColumnPhysicalQueryHourCount:
+		value, err := columnPhysicalQueryInt64Value(row.Values[e.valueIdx])
+		if err != nil {
+			return err
+		}
+		hour := int((value / 3_600_000_000) % 24)
+		if hour < 0 {
+			hour += 24
+		}
+		e.hourCounts[hour]++
+	case ColumnPhysicalQueryGroupMinInt64:
+		key, value, err := e.stringInt64(row)
+		if err != nil {
+			return err
+		}
+		if cur, ok := e.int64Values[key]; !ok || value < cur {
+			e.int64Values[key] = value
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		key, value, err := e.stringInt64(row)
+		if err != nil {
+			return err
+		}
+		if cur, ok := e.int64Values[key]; !ok || value > cur {
+			e.int64Values[key] = value
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		key, value, err := e.stringInt64(row)
+		if err != nil {
+			return err
+		}
+		cur, ok := e.int64Spans[key]
+		if !ok {
+			e.int64Spans[key] = columnPhysicalQuerySpan{min: value, max: value}
+			return nil
+		}
+		if value < cur.min {
+			cur.min = value
+		}
+		if value > cur.max {
+			cur.max = value
+		}
+		e.int64Spans[key] = cur
+	}
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) stringInt64(row columnPhysicalScanRowView) (string, int64, error) {
+	key, err := e.stringKey(row.Values[e.groupIdx])
+	if err != nil {
+		return "", 0, err
+	}
+	value, err := columnPhysicalQueryInt64Value(row.Values[e.valueIdx])
+	if err != nil {
+		return "", 0, err
+	}
+	return key, value, nil
+}
+
+func (e *columnPhysicalQueryExecutor) stringKey(value columnDeclaredValue) (string, error) {
+	raw, err := columnPhysicalQueryStringBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return e.interner.intern(raw), nil
+}
+
+func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
+	e.resultGroups = e.resultGroups[:0]
+	switch e.kind {
+	case ColumnPhysicalQueryGroupCount:
+		for key, count := range e.counts {
+			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Count: count})
+		}
+	case ColumnPhysicalQueryGroupCountDistinct:
+		for key, set := range e.distinct {
+			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Count: len(set)})
+		}
+	case ColumnPhysicalQueryHourCount:
+		for hour, count := range e.hourCounts {
+			if count == 0 {
+				continue
+			}
+			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Count: count})
+		}
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
+		for key, value := range e.int64Values {
+			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		for key, span := range e.int64Spans {
+			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
+		}
+	}
+	sort.Slice(e.resultGroups, func(i, j int) bool {
+		return e.resultGroups[i].Key < e.resultGroups[j].Key
+	})
+	return e.resultGroups
+}
+
+func columnPhysicalQueryStringBytes(value columnDeclaredValue) ([]byte, error) {
+	if value.Type != ColumnStoreValueString {
+		return nil, fmt.Errorf("%w: physical column query expected string value, got %q", ErrColumnQueryPlanUnsupported, value.Type)
+	}
+	if value.Null {
+		return nil, fmt.Errorf("%w: physical column query does not support null string group values yet", ErrColumnQueryPlanUnsupported)
+	}
+	if value.StringBytes != nil {
+		return value.StringBytes, nil
+	}
+	return []byte(value.String), nil
+}
+
+func columnPhysicalQueryInt64Value(value columnDeclaredValue) (int64, error) {
+	if value.Type != ColumnStoreValueInt64 {
+		return 0, fmt.Errorf("%w: physical column query expected int64 value, got %q", ErrColumnQueryPlanUnsupported, value.Type)
+	}
+	if value.Null {
+		return 0, fmt.Errorf("%w: physical column query does not support null int64 values yet", ErrColumnQueryPlanUnsupported)
+	}
+	return value.Int64, nil
+}
+
+func columnPhysicalQueryHourKey(hour int) string {
+	if hour < 0 || hour >= 24 {
+		return "hour_invalid"
+	}
+	return [...]string{
+		"hour_00", "hour_01", "hour_02", "hour_03", "hour_04", "hour_05",
+		"hour_06", "hour_07", "hour_08", "hour_09", "hour_10", "hour_11",
+		"hour_12", "hour_13", "hour_14", "hour_15", "hour_16", "hour_17",
+		"hour_18", "hour_19", "hour_20", "hour_21", "hour_22", "hour_23",
+	}[hour]
+}
+
+type columnPhysicalQueryStringInterner struct {
+	buckets map[uint64][]columnPhysicalQueryStringEntry
+}
+
+type columnPhysicalQueryStringEntry struct {
+	key string
+}
+
+func (i *columnPhysicalQueryStringInterner) intern(raw []byte) string {
+	if i.buckets == nil {
+		i.buckets = make(map[uint64][]columnPhysicalQueryStringEntry, 16)
+	}
+	hash := columnPhysicalQueryHashBytes(raw)
+	bucket := i.buckets[hash]
+	for _, entry := range bucket {
+		if columnPhysicalQueryStringEqualBytes(entry.key, raw) {
+			return entry.key
+		}
+	}
+	key := string(raw)
+	i.buckets[hash] = append(bucket, columnPhysicalQueryStringEntry{key: key})
+	return key
+}
+
+func columnPhysicalQueryHashBytes(raw []byte) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	hash := uint64(offset64)
+	for _, b := range raw {
+		hash ^= uint64(b)
+		hash *= prime64
+	}
+	return hash
+}
+
+func columnPhysicalQueryStringEqualBytes(s string, raw []byte) bool {
+	if len(s) != len(raw) {
+		return false
+	}
+	for i := range raw {
+		if s[i] != raw[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -304,11 +304,16 @@ func (e *columnPhysicalQueryExecutor) stringInt64(row columnPhysicalScanRowView)
 }
 
 func (e *columnPhysicalQueryExecutor) stringKey(value columnDeclaredValue) (string, error) {
-	raw, err := columnPhysicalQueryStringBytes(value)
-	if err != nil {
-		return "", err
+	if value.Type != ColumnStoreValueString {
+		return "", fmt.Errorf("%w: physical column query expected string value, got %q", ErrColumnQueryPlanUnsupported, value.Type)
 	}
-	return e.interner.intern(raw), nil
+	if value.Null {
+		return "", fmt.Errorf("%w: physical column query does not support null string group values yet", ErrColumnQueryPlanUnsupported)
+	}
+	if value.StringBytes != nil {
+		return e.interner.internBytes(value.StringBytes), nil
+	}
+	return e.interner.internString(value.String), nil
 }
 
 func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
@@ -342,19 +347,6 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 		return e.resultGroups[i].Key < e.resultGroups[j].Key
 	})
 	return e.resultGroups
-}
-
-func columnPhysicalQueryStringBytes(value columnDeclaredValue) ([]byte, error) {
-	if value.Type != ColumnStoreValueString {
-		return nil, fmt.Errorf("%w: physical column query expected string value, got %q", ErrColumnQueryPlanUnsupported, value.Type)
-	}
-	if value.Null {
-		return nil, fmt.Errorf("%w: physical column query does not support null string group values yet", ErrColumnQueryPlanUnsupported)
-	}
-	if value.StringBytes != nil {
-		return value.StringBytes, nil
-	}
-	return []byte(value.String), nil
 }
 
 func columnPhysicalQueryInt64Value(value columnDeclaredValue) (int64, error) {
@@ -399,7 +391,7 @@ type columnPhysicalQueryStringEntry struct {
 	key string
 }
 
-func (i *columnPhysicalQueryStringInterner) intern(raw []byte) string {
+func (i *columnPhysicalQueryStringInterner) internBytes(raw []byte) string {
 	if i.buckets == nil {
 		i.buckets = make(map[uint64][]columnPhysicalQueryStringEntry, 16)
 	}
@@ -415,6 +407,21 @@ func (i *columnPhysicalQueryStringInterner) intern(raw []byte) string {
 	return key
 }
 
+func (i *columnPhysicalQueryStringInterner) internString(raw string) string {
+	if i.buckets == nil {
+		i.buckets = make(map[uint64][]columnPhysicalQueryStringEntry, 16)
+	}
+	hash := columnPhysicalQueryHashString(raw)
+	bucket := i.buckets[hash]
+	for _, entry := range bucket {
+		if entry.key == raw {
+			return entry.key
+		}
+	}
+	i.buckets[hash] = append(bucket, columnPhysicalQueryStringEntry{key: raw})
+	return raw
+}
+
 func columnPhysicalQueryHashBytes(raw []byte) uint64 {
 	const (
 		offset64 = 14695981039346656037
@@ -423,6 +430,19 @@ func columnPhysicalQueryHashBytes(raw []byte) uint64 {
 	hash := uint64(offset64)
 	for _, b := range raw {
 		hash ^= uint64(b)
+		hash *= prime64
+	}
+	return hash
+}
+
+func columnPhysicalQueryHashString(raw string) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	hash := uint64(offset64)
+	for i := 0; i < len(raw); i++ {
+		hash ^= uint64(raw[i])
 		hash *= prime64
 	}
 	return hash

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -19,6 +19,8 @@ const (
 	ColumnPhysicalQueryGroupInt64Span     ColumnPhysicalQueryKind = "group_int64_span"
 )
 
+const columnPhysicalQueryHourUS = int64(3_600_000_000)
+
 // ColumnPhysicalQueryRequest describes one explicit physical column query. It
 // does not invoke planner routing; M14 owns forced/automatic route selection.
 type ColumnPhysicalQueryRequest struct {
@@ -251,11 +253,7 @@ func (e *columnPhysicalQueryExecutor) visit(row columnPhysicalScanRowView) error
 		if err != nil {
 			return err
 		}
-		hour := int((value / 3_600_000_000) % 24)
-		if hour < 0 {
-			hour += 24
-		}
-		e.hourCounts[hour]++
+		e.hourCounts[columnPhysicalQueryUTCHour(value)]++
 	case ColumnPhysicalQueryGroupMinInt64:
 		key, value, err := e.stringInt64(row)
 		if err != nil {
@@ -367,6 +365,18 @@ func columnPhysicalQueryInt64Value(value columnDeclaredValue) (int64, error) {
 		return 0, fmt.Errorf("%w: physical column query does not support null int64 values yet", ErrColumnQueryPlanUnsupported)
 	}
 	return value.Int64, nil
+}
+
+func columnPhysicalQueryUTCHour(timeUS int64) int {
+	hours := timeUS / columnPhysicalQueryHourUS
+	if timeUS < 0 && timeUS%columnPhysicalQueryHourUS != 0 {
+		hours--
+	}
+	hour := int(hours % 24)
+	if hour < 0 {
+		hour += 24
+	}
+	return hour
 }
 
 func columnPhysicalQueryHourKey(hour int) string {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -219,6 +219,60 @@ func TestColumnPhysicalQueryAdapterRejectsUnsupportedShapeM13B(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQueryValueValidationM13B(t *testing.T) {
+	var exec columnPhysicalQueryExecutor
+	if got, err := exec.stringKey(columnDeclaredValue{Type: ColumnStoreValueString, StringBytes: []byte("alpha")}); err != nil || got != "alpha" {
+		t.Fatalf("stringKey bytes got %q err=%v", got, err)
+	}
+	if got, err := exec.stringKey(columnDeclaredValue{Type: ColumnStoreValueString, String: "beta"}); err != nil || got != "beta" {
+		t.Fatalf("stringKey string got %q err=%v", got, err)
+	}
+	if _, err := exec.stringKey(columnDeclaredValue{Type: ColumnStoreValueInt64, Int64: 7}); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "expected string") {
+		t.Fatalf("wrong-type stringKey err=%v want expected string unsupported", err)
+	}
+	if _, err := exec.stringKey(columnDeclaredValue{Type: ColumnStoreValueString, Null: true}); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "null string") {
+		t.Fatalf("null stringKey err=%v want null string unsupported", err)
+	}
+	if got, err := columnPhysicalQueryInt64Value(columnDeclaredValue{Type: ColumnStoreValueInt64, Int64: 42}); err != nil || got != 42 {
+		t.Fatalf("int64 value got %d err=%v", got, err)
+	}
+	if _, err := columnPhysicalQueryInt64Value(columnDeclaredValue{Type: ColumnStoreValueString, String: "42"}); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "expected int64") {
+		t.Fatalf("wrong-type int64 err=%v want expected int64 unsupported", err)
+	}
+	if _, err := columnPhysicalQueryInt64Value(columnDeclaredValue{Type: ColumnStoreValueInt64, Null: true}); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "null int64") {
+		t.Fatalf("null int64 err=%v want null int64 unsupported", err)
+	}
+}
+
+func TestColumnPhysicalQueryStringKeyFallbackAllocationsM13B(t *testing.T) {
+	var exec columnPhysicalQueryExecutor
+	bytesValue := columnDeclaredValue{Type: ColumnStoreValueString, StringBytes: []byte("alpha")}
+	stringValue := columnDeclaredValue{Type: ColumnStoreValueString, String: "beta"}
+	if _, err := exec.stringKey(bytesValue); err != nil {
+		t.Fatalf("warm bytes stringKey: %v", err)
+	}
+	if _, err := exec.stringKey(stringValue); err != nil {
+		t.Fatalf("warm string stringKey: %v", err)
+	}
+
+	if allocs := testing.AllocsPerRun(100, func() {
+		got, err := exec.stringKey(bytesValue)
+		if err != nil || got != "alpha" {
+			panic(fmt.Sprintf("bytes stringKey got %q err=%v", got, err))
+		}
+	}); allocs != 0 {
+		t.Fatalf("bytes stringKey allocs/run=%.2f want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		got, err := exec.stringKey(stringValue)
+		if err != nil || got != "beta" {
+			panic(fmt.Sprintf("string stringKey got %q err=%v", got, err))
+		}
+	}); allocs != 0 {
+		t.Fatalf("string fallback allocs/run=%.2f want 0", allocs)
+	}
+}
+
 func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
 	smallEvents := columnPhysicalQueryFixtureEventsM13B(128)
 	small, closeSmall := openColumnPhysicalQueryFixtureM13B(t, smallEvents)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1,0 +1,447 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(96)
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	tests := []struct {
+		name      string
+		hashName  string
+		req       ColumnPhysicalQueryRequest
+		wantCount int
+	}{
+		{
+			name:      "q1",
+			hashName:  "q1",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+			wantCount: 4,
+		},
+		{
+			name:      "q2",
+			hashName:  "q2",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+			wantCount: 4,
+		},
+		{
+			name:      "q3",
+			hashName:  "q3",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
+			wantCount: 24,
+		},
+		{
+			name:      "q4a",
+			hashName:  "q4a",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount: 12,
+		},
+		{
+			name:      "q4b",
+			hashName:  "q4b",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount: 12,
+		},
+		{
+			name:      "q5",
+			hashName:  "q5",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount: 12,
+		},
+		{
+			name:      "q5_metadata",
+			hashName:  "q5",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount: 12,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := reopened.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery(%s): %v", tc.name, err)
+			}
+			if got := len(result.Groups); got != tc.wantCount {
+				t.Fatalf("result groups=%d want %d: %+v", got, tc.wantCount, result.Groups)
+			}
+			gotHash := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B(tc.name, result.Groups))
+			wantHash := columnPhysicalQueryReferenceHashM13B(tc.hashName, events)
+			if gotHash != wantHash {
+				t.Fatalf("%s hash=%016x want %016x lines=%v", tc.name, gotHash, wantHash, columnPhysicalQueryLinesM13B(tc.name, result.Groups))
+			}
+			if result.Diagnostics.RowMaterializations != 0 {
+				t.Fatalf("%s row materializations=%d want zero for physical aggregate/projection adapter", tc.name, result.Diagnostics.RowMaterializations)
+			}
+			if result.Diagnostics.AssetRefs == 0 || result.Diagnostics.DecodedBlocks == 0 || result.Diagnostics.PhysicalBytesScanned <= 0 {
+				t.Fatalf("%s missing physical diagnostics: %+v", tc.name, result.Diagnostics)
+			}
+			if result.Diagnostics.ReduceRows != len(events) {
+				t.Fatalf("%s reduce rows=%d want %d", tc.name, result.Diagnostics.ReduceRows, len(events))
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalQueryAdapterFailsClosedOnMutationRowsM13B(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	col := openColumnStoreCollectionM10B(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","did":"d1"}`),
+		[]byte(`{"time_us":2,"kind":"post","did":"d2"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"time_us":3,"kind":"like","did":"d1"}`), true, nil
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("Update: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopen)
+	_, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupCount,
+		GroupColumn: "kind",
+	})
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "mutation visibility") {
+		t.Fatalf("mutation query err=%v want fail-closed mutation visibility unsupported", err)
+	}
+}
+
+func TestColumnPhysicalQueryAdapterRejectsUnsupportedShapeM13B(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(4)
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	tests := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+		want string
+	}{
+		{
+			name: "missing group",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount},
+			want: "group column",
+		},
+		{
+			name: "undeclared value",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "missing"},
+			want: "undeclared column",
+		},
+		{
+			name: "unknown kind",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryKind("unknown")},
+			want: "unsupported physical column query kind",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := reopened.RunColumnPhysicalQuery(tc.req)
+			if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("RunColumnPhysicalQuery err=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
+	smallEvents := columnPhysicalQueryFixtureEventsM13B(128)
+	small, closeSmall := openColumnPhysicalQueryFixtureM13B(t, smallEvents)
+	defer closeSmall()
+	largeEvents := columnPhysicalQueryFixtureEventsM13B(2048)
+	large, closeLarge := openColumnPhysicalQueryFixtureM13B(t, largeEvents)
+	defer closeLarge()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+
+	smallAllocs := testing.AllocsPerRun(5, func() {
+		if _, err := small.RunColumnPhysicalQuery(req); err != nil {
+			t.Fatalf("small RunColumnPhysicalQuery: %v", err)
+		}
+	})
+	largeAllocs := testing.AllocsPerRun(5, func() {
+		if _, err := large.RunColumnPhysicalQuery(req); err != nil {
+			t.Fatalf("large RunColumnPhysicalQuery: %v", err)
+		}
+	})
+	if largeAllocs > smallAllocs+64 {
+		t.Fatalf("allocation slope looks row-linear: small=%.0f large=%.0f", smallAllocs, largeAllocs)
+	}
+}
+
+func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		b.Run(fmt.Sprintf("q1_rows_%d", rows), func(b *testing.B) {
+			collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
+			defer closeFn()
+			req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+			preview, err := collection.RunColumnPhysicalQuery(req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ReportAllocs()
+			b.ResetTimer()
+			var reducedRows int64
+			for i := 0; i < b.N; i++ {
+				result, err := collection.RunColumnPhysicalQuery(req)
+				if err != nil {
+					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				}
+				if len(result.Groups) == 0 {
+					b.Fatal("empty result")
+				}
+				reducedRows += int64(result.Diagnostics.ReduceRows)
+			}
+			if reducedRows > 0 {
+				elapsed := b.Elapsed()
+				b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
+				b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
+			}
+		})
+		b.Run(fmt.Sprintf("q5_rows_%d", rows), func(b *testing.B) {
+			collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
+			defer closeFn()
+			req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}
+			preview, err := collection.RunColumnPhysicalQuery(req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ReportAllocs()
+			b.ResetTimer()
+			var reducedRows int64
+			for i := 0; i < b.N; i++ {
+				result, err := collection.RunColumnPhysicalQuery(req)
+				if err != nil {
+					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				}
+				if len(result.Groups) == 0 {
+					b.Fatal("empty result")
+				}
+				reducedRows += int64(result.Diagnostics.ReduceRows)
+			}
+			if reducedRows > 0 {
+				elapsed := b.Elapsed()
+				b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
+				b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
+			}
+		})
+	}
+}
+
+type columnPhysicalQueryEventM13B struct {
+	ID     string
+	TimeUS int64
+	Kind   string
+	Did    string
+}
+
+func columnPhysicalQueryFixtureEventsM13B(rows int) []columnPhysicalQueryEventM13B {
+	out := make([]columnPhysicalQueryEventM13B, rows)
+	const baseTimeUS = int64(1_700_000_000_000_000)
+	for i := 0; i < rows; i++ {
+		out[i] = columnPhysicalQueryEventM13B{
+			ID:     fmt.Sprintf("e%06d", i),
+			TimeUS: baseTimeUS + int64(i%24)*3_600_000_000 + int64(i/24),
+			Kind:   fmt.Sprintf("kind_%02d", i%4),
+			Did:    fmt.Sprintf("did_%02d", i%12),
+		}
+	}
+	return out
+}
+
+func openColumnPhysicalQueryFixtureM13B(tb testing.TB, events []columnPhysicalQueryEventM13B) (*Collection, func()) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open setup DB: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)},
+	}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Checkpoint setup DB: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection setup: %v", err)
+	}
+	ids := make([][]byte, len(events))
+	docs := make([][]byte, len(events))
+	for i, event := range events {
+		ids[i] = []byte(event.ID)
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"%s","did":"%s","payload":"ignored_%d"}`, event.TimeUS, event.Kind, event.Did, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		_ = d.Close()
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("Close before reopen: %v", err)
+	}
+
+	reopen, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open reopened DB: %v", err)
+	}
+	reopened, err := NewCollectionManager(reopen).OpenCollection("events")
+	if err != nil {
+		_ = reopen.Close()
+		tb.Fatalf("OpenCollection reopened: %v", err)
+	}
+	return reopened, func() { _ = reopen.Close() }
+}
+
+func columnPhysicalQueryReferenceHashM13B(name string, events []columnPhysicalQueryEventM13B) uint64 {
+	return columnPhysicalQueryHashLinesM13B(columnPhysicalQueryReferenceLinesM13B(name, events))
+}
+
+func columnPhysicalQueryReferenceLinesM13B(name string, events []columnPhysicalQueryEventM13B) []string {
+	switch name {
+	case "q1":
+		counts := make(map[string]int)
+		for _, event := range events {
+			counts[event.Kind]++
+		}
+		return columnPhysicalQueryIntLinesM13B(name, counts)
+	case "q2":
+		distinct := make(map[string]map[string]struct{})
+		for _, event := range events {
+			set := distinct[event.Kind]
+			if set == nil {
+				set = make(map[string]struct{})
+				distinct[event.Kind] = set
+			}
+			set[event.Did] = struct{}{}
+		}
+		counts := make(map[string]int)
+		for key, set := range distinct {
+			counts[key] = len(set)
+		}
+		return columnPhysicalQueryIntLinesM13B(name, counts)
+	case "q3":
+		counts := make(map[string]int)
+		for _, event := range events {
+			counts[fmt.Sprintf("hour_%02d", (event.TimeUS/3_600_000_000)%24)]++
+		}
+		return columnPhysicalQueryIntLinesM13B(name, counts)
+	case "q4a":
+		values := make(map[string]int64)
+		for _, event := range events {
+			if cur, ok := values[event.Did]; !ok || event.TimeUS < cur {
+				values[event.Did] = event.TimeUS
+			}
+		}
+		return columnPhysicalQueryInt64LinesM13B(name, values)
+	case "q4b":
+		values := make(map[string]int64)
+		for _, event := range events {
+			if cur, ok := values[event.Did]; !ok || event.TimeUS > cur {
+				values[event.Did] = event.TimeUS
+			}
+		}
+		return columnPhysicalQueryInt64LinesM13B(name, values)
+	case "q5":
+		type span struct {
+			min int64
+			max int64
+		}
+		values := make(map[string]span)
+		for _, event := range events {
+			cur, ok := values[event.Did]
+			if !ok {
+				values[event.Did] = span{min: event.TimeUS, max: event.TimeUS}
+				continue
+			}
+			if event.TimeUS < cur.min {
+				cur.min = event.TimeUS
+			}
+			if event.TimeUS > cur.max {
+				cur.max = event.TimeUS
+			}
+			values[event.Did] = cur
+		}
+		lines := make([]string, 0, len(values))
+		for key, value := range values {
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", name, key, value.max-value.min))
+		}
+		return lines
+	default:
+		panic(name)
+	}
+}
+
+func columnPhysicalQueryLinesM13B(name string, groups []ColumnPhysicalQueryGroup) []string {
+	lines := make([]string, 0, len(groups))
+	for _, group := range groups {
+		switch name {
+		case "q1", "q2", "q3":
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", name, group.Key, group.Count))
+		case "q4a", "q4b", "q5", "q5_metadata":
+			hashName := name
+			if name == "q5_metadata" {
+				hashName = "q5"
+			}
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", hashName, group.Key, group.Int64))
+		default:
+			panic(name)
+		}
+	}
+	return lines
+}
+
+func columnPhysicalQueryIntLinesM13B(prefix string, values map[string]int) []string {
+	lines := make([]string, 0, len(values))
+	for key, value := range values {
+		lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, key, value))
+	}
+	return lines
+}
+
+func columnPhysicalQueryInt64LinesM13B(prefix string, values map[string]int64) []string {
+	lines := make([]string, 0, len(values))
+	for key, value := range values {
+		lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, key, value))
+	}
+	return lines
+}
+
+func columnPhysicalQueryHashLinesM13B(lines []string) uint64 {
+	sort.Strings(lines)
+	h := fnv.New64a()
+	for _, line := range lines {
+		_, _ = h.Write([]byte(line))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64()
+}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -93,6 +93,62 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQueryAdapterUsesFloorHourForNegativeTimeUSM13B(t *testing.T) {
+	const hourUS = columnPhysicalQueryHourUS
+	events := []columnPhysicalQueryEventM13B{
+		{ID: "e1", TimeUS: -1, Kind: "like", Did: "d1"},
+		{ID: "e2", TimeUS: -hourUS, Kind: "post", Did: "d2"},
+		{ID: "e3", TimeUS: -hourUS - 1, Kind: "follow", Did: "d3"},
+		{ID: "e4", TimeUS: 0, Kind: "like", Did: "d4"},
+		{ID: "e5", TimeUS: hourUS, Kind: "post", Did: "d5"},
+	}
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	result, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery negative hours: %v", err)
+	}
+	got := make(map[string]int, len(result.Groups))
+	for _, group := range result.Groups {
+		got[group.Key] = group.Count
+	}
+	want := map[string]int{
+		"hour_00": 1,
+		"hour_01": 1,
+		"hour_22": 1,
+		"hour_23": 2,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("hour groups=%v want %v", got, want)
+	}
+	for key, count := range want {
+		if got[key] != count {
+			t.Fatalf("hour group %s=%d want %d groups=%v", key, got[key], count, got)
+		}
+	}
+}
+
+func TestColumnPhysicalQueryUTCHourM13B(t *testing.T) {
+	const hourUS = columnPhysicalQueryHourUS
+	tests := []struct {
+		timeUS int64
+		want   int
+	}{
+		{timeUS: -hourUS - 1, want: 22},
+		{timeUS: -hourUS, want: 23},
+		{timeUS: -1, want: 23},
+		{timeUS: 0, want: 0},
+		{timeUS: hourUS - 1, want: 0},
+		{timeUS: hourUS, want: 1},
+	}
+	for _, tt := range tests {
+		if got := columnPhysicalQueryUTCHour(tt.timeUS); got != tt.want {
+			t.Fatalf("columnPhysicalQueryUTCHour(%d)=%d want %d", tt.timeUS, got, tt.want)
+		}
+	}
+}
+
 func TestColumnPhysicalQueryAdapterFailsClosedOnMutationRowsM13B(t *testing.T) {
 	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
 	d := openCollectionCommandWALDB(t, dir)
@@ -352,7 +408,7 @@ func columnPhysicalQueryReferenceLinesM13B(name string, events []columnPhysicalQ
 	case "q3":
 		counts := make(map[string]int)
 		for _, event := range events {
-			counts[fmt.Sprintf("hour_%02d", (event.TimeUS/3_600_000_000)%24)]++
+			counts[columnPhysicalQueryHourKey(columnPhysicalQueryUTCHour(event.TimeUS))]++
 		}
 		return columnPhysicalQueryIntLinesM13B(name, counts)
 	case "q4a":

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -292,8 +292,9 @@ func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
 			t.Fatalf("large RunColumnPhysicalQuery: %v", err)
 		}
 	})
-	if largeAllocs > smallAllocs+64 {
-		t.Fatalf("allocation slope looks row-linear: small=%.0f large=%.0f", smallAllocs, largeAllocs)
+	const maxExtraFixtureAllocs = 64 // permits manifest/fixture-scale setup drift while still rejecting row-linear allocation.
+	if largeAllocs > smallAllocs+maxExtraFixtureAllocs {
+		t.Fatalf("allocation slope looks row-linear: small=%.0f large=%.0f max_extra=%.0f", smallAllocs, largeAllocs, float64(maxExtraFixtureAllocs))
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -526,7 +526,7 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, cfg ColumnStoreConfig, pro
 			}
 		case ColumnStoreValueString:
 			if selected {
-				rowValues[outputIdx].String = cur.string()
+				rowValues[outputIdx].StringBytes = cur.stringBytes()
 			} else {
 				_ = cur.stringBytes()
 			}

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -183,7 +183,7 @@ func TestColumnPhysicalSerialScannerDoesNotEnablePlannerRoutingM13A(t *testing.T
 	if plan.Supported {
 		t.Fatalf("forced serial plan supported before M14 routing: %+v", plan)
 	}
-	if got := plan.Diagnostics.UnsupportedPlanReason; got != "physical column scanner is not implemented yet" {
+	if got := plan.Diagnostics.UnsupportedPlanReason; got != "physical column query routing is disabled until physical asset capabilities are advertised" {
 		t.Fatalf("unsupported reason=%q want physical scanner disabled", got)
 	}
 }
@@ -345,10 +345,17 @@ func assertColumnPhysicalScanRowM13A(t testing.TB, row columnPhysicalScanRowForT
 		if len(row.Values) < 2 {
 			t.Fatalf("kind projection missing from values=%+v", row.Values)
 		}
-		if row.Values[1].Type != ColumnStoreValueString || row.Values[1].Null || row.Values[1].String != kind {
+		if row.Values[1].Type != ColumnStoreValueString || row.Values[1].Null || columnPhysicalScanStringForTest(row.Values[1]) != kind {
 			t.Fatalf("kind value=%+v want %q", row.Values[1], kind)
 		}
 	}
+}
+
+func columnPhysicalScanStringForTest(value columnDeclaredValue) string {
+	if value.StringBytes != nil {
+		return string(value.StringBytes)
+	}
+	return value.String
 }
 
 func prepareColumnPhysicalScannerCorruptionFixtureM13A(t *testing.T) (string, ColumnAssetRef) {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -239,7 +239,7 @@ func TestColumnPhysicalSerialScannerDoesNotEnablePlannerRoutingM13A(t *testing.T
 	if plan.Supported {
 		t.Fatalf("forced serial plan supported before M14 routing: %+v", plan)
 	}
-	if got := plan.Diagnostics.UnsupportedPlanReason; got != "physical column query routing is disabled until physical asset capabilities are advertised" {
+	if got := plan.Diagnostics.UnsupportedPlanReason; got != columnQueryUnsupportedNoPhysicalAssetsReason {
 		t.Fatalf("unsupported reason=%q want physical scanner disabled", got)
 	}
 }
@@ -617,6 +617,9 @@ func assertColumnPhysicalScanRowM13A(t testing.TB, row columnPhysicalScanRowForT
 		}
 		if row.Values[1].Type != ColumnStoreValueString || row.Values[1].Null || columnPhysicalScanStringForTest(row.Values[1]) != kind {
 			t.Fatalf("kind value=%+v want %q", row.Values[1], kind)
+		}
+		if row.Values[1].StringBytes != nil && row.Values[1].String != "" {
+			t.Fatalf("kind value kept stale String=%q beside StringBytes=%q", row.Values[1].String, row.Values[1].StringBytes)
 		}
 	}
 }

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -265,7 +265,7 @@ func physicalColumnQuerySupported(catalog *collectionCatalog, identity ColumnSto
 func physicalColumnQueryUnsupportedReason(identity ColumnStoreCacheIdentity, identityOK bool, req ColumnQueryPlanRequest, kind ColumnQueryPlanKind) string {
 	switch {
 	case req.Capabilities.PhysicalAssetCount <= 0:
-		return "physical column scanner is not implemented yet"
+		return "physical column query routing is disabled until physical asset capabilities are advertised"
 	case !columnQueryManifestRecoveryAuthoritative(identity, identityOK):
 		return "active column manifest is not recovery-authoritative"
 	}

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -17,6 +17,8 @@ const (
 	ColumnQueryPlanParallelColumnScan ColumnQueryPlanKind = "parallel_column_scan"
 )
 
+const columnQueryUnsupportedNoPhysicalAssetsReason = "physical column query has no physical assets available"
+
 var ErrColumnQueryPlanUnsupported = errors.New("collections: column query plan unsupported")
 
 type ColumnQueryPredicateOperator string
@@ -265,7 +267,7 @@ func physicalColumnQuerySupported(catalog *collectionCatalog, identity ColumnSto
 func physicalColumnQueryUnsupportedReason(identity ColumnStoreCacheIdentity, identityOK bool, req ColumnQueryPlanRequest, kind ColumnQueryPlanKind) string {
 	switch {
 	case req.Capabilities.PhysicalAssetCount <= 0:
-		return "physical column query routing is disabled until physical asset capabilities are advertised"
+		return columnQueryUnsupportedNoPhysicalAssetsReason
 	case !columnQueryManifestRecoveryAuthoritative(identity, identityOK):
 		return "active column manifest is not recovery-authoritative"
 	}

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -560,7 +560,7 @@ func TestColumnQueryPlannerM11BRecoveryAuthoritativeDoesNotRequireManifestRoot(t
 	if !plan.Diagnostics.RecoveryAuthoritative {
 		t.Fatalf("zero manifest root should not hide recovery-authoritative generation match: %+v", plan.Diagnostics)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column scanner is not implemented yet"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 }
@@ -878,13 +878,13 @@ func TestColumnQueryPlannerM11BReportsPhysicalGateBeforeMissingAggregateName(t *
 	if plan.Supported {
 		t.Fatalf("expected aggregate metadata without physical assets to fail closed: %+v", plan)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column scanner is not implemented yet"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 
 	identity.ManifestRoot = 0
 	plan = planColumnQueryForCatalog(catalog, identity, true, req)
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column scanner is not implemented yet"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
 		t.Fatalf("zero-root/no-assets unsupported reason=%q want %q", got, want)
 	}
 }

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -560,7 +560,7 @@ func TestColumnQueryPlannerM11BRecoveryAuthoritativeDoesNotRequireManifestRoot(t
 	if !plan.Diagnostics.RecoveryAuthoritative {
 		t.Fatalf("zero manifest root should not hide recovery-authoritative generation match: %+v", plan.Diagnostics)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 }
@@ -878,13 +878,13 @@ func TestColumnQueryPlannerM11BReportsPhysicalGateBeforeMissingAggregateName(t *
 	if plan.Supported {
 		t.Fatalf("expected aggregate metadata without physical assets to fail closed: %+v", plan)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 
 	identity.ManifestRoot = 0
 	plan = planColumnQueryForCatalog(catalog, identity, true, req)
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "physical column query routing is disabled until physical asset capabilities are advertised"; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("zero-root/no-assets unsupported reason=%q want %q", got, want)
 	}
 }

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -69,7 +69,7 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: row_store_baseline, b_tree_index_baseline; fail-closed until physical assets exist: serial_column_scan, aggregate_metadata, parallel_column_scan)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: row_store_baseline, b_tree_index_baseline; fail-closed until M14 planner routing is enabled: serial_column_scan, aggregate_metadata, parallel_column_scan)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 	)
@@ -468,8 +468,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			ManifestRoot:                    manifestIdentity.ManifestRoot,
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
-		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus M12A isolated physical column asset writer",
-		PhysicalColumnQuery:    "M12A publishes physical column assets but physical scanners are not implemented yet; serial/aggregate/parallel physical labels fail closed through the planner",
+		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M13B explicit serial query adapter",
+		PhysicalColumnQuery:    "M13B provides an explicit serial physical query adapter; unified-bench serial/aggregate/parallel physical labels intentionally remain fail-closed through the planner until M14 routing",
 		BenchmarkOnlyRelaxed:   false,
 		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, scan, reduce, and parity hash stages are timed separately for the forced execution label",
 	}
@@ -1097,9 +1097,9 @@ func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.Co
 		EstimatedRows:         rows,
 		ForceKind:             forceKind,
 		Capabilities: collections.ColumnQueryPlannerCapabilities{
-			// M12A publishes physical column assets but deliberately has no
-			// scanner yet; keep physical planner gates unreachable until a
-			// later scanner milestone wires real asset reads.
+			// M13B has an explicit physical scanner/query adapter, but
+			// unified-bench forced physical labels stay unreachable until M14
+			// wires planner capabilities to real manifest state.
 			SerialColumnScan:       true,
 			AggregateMetadata:      true,
 			ParallelColumnScan:     true,
@@ -1566,7 +1566,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 
 	sb.WriteString("## Forced Path Labels\n\n")
 	sb.WriteString(fmt.Sprintf("- supported: %s\n", markdownCodeList(report.SupportedForcedPaths)))
-	sb.WriteString(fmt.Sprintf("- fail-closed until physical planner paths exist: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
+	sb.WriteString(fmt.Sprintf("- fail-closed until M14 physical planner routing: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
 	if report.Artifacts.ColumnJSON != "" {
 		sb.WriteString("\n## Artifacts\n\n")
 		columnStoreWriteArtifactLine(&sb, "column JSON", report.Artifacts.ColumnJSON)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -970,7 +970,7 @@ func TestColumnStoreSuiteRejectsForcedColumnPathM11B(t *testing.T) {
 	if !strings.Contains(msg, "serial_column_scan") ||
 		!strings.Contains(msg, "unsupported") ||
 		!strings.Contains(msg, "refusing to route through row store") ||
-		!strings.Contains(msg, "reason=physical column query routing is disabled until physical asset capabilities are advertised") {
+		!strings.Contains(msg, "reason=physical column query has no physical assets available") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -346,7 +346,7 @@ func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
 	for _, want := range []string{
 		"- manifest_control_missing: `manifest`, `dictionary`",
 		"- supported: `row_store_baseline`, `physical_column`",
-		"- fail-closed until physical planner paths exist: `planner_skipscan`, `aggregate_metadata`",
+		"- fail-closed until M14 physical planner routing: `planner_skipscan`, `aggregate_metadata`",
 	} {
 		if !strings.Contains(md, want) {
 			t.Fatalf("markdown missing %q:\n%s", want, md)
@@ -970,7 +970,7 @@ func TestColumnStoreSuiteRejectsForcedColumnPathM11B(t *testing.T) {
 	if !strings.Contains(msg, "serial_column_scan") ||
 		!strings.Contains(msg, "unsupported") ||
 		!strings.Contains(msg, "refusing to route through row store") ||
-		!strings.Contains(msg, "reason=physical column scanner is not implemented yet") {
+		!strings.Contains(msg, "reason=physical column query routing is disabled until physical asset capabilities are advertised") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## What Landed

M13B adds an explicit production TreeDB physical column query adapter over the M13A serial scanner:

- Added `Collection.RunColumnPhysicalQuery` for JSONBench-shaped physical queries over reopened durable column assets.
- Supported insert-only physical shapes: q1 group count, q2 group distinct count, q3 hour count, q4a min time by id, q4b max time by id, q5/q5_metadata span by id.
- Added diagnostics for manifest generation, recovery generation, asset refs, decoded blocks, physical bytes scanned, row materializations, reduce rows, and result groups.
- Added fail-closed handling for update/delete rows until M13C visibility overlay lands.
- Kept planner routing and `unified-bench` forced physical labels disabled until M14. M13B does not silently enable `serial_column_scan`, `aggregate_metadata`, or `parallel_column_scan`.
- Changed scanner string projection to use asset-buffer byte views in the hot path, with interning in the reducer so repeated group keys do not allocate per row.

## Assumption Ledger

- V1-final behavior: physical projection/aggregate queries read declared columns from recovery-authoritative column asset manifests without full-document row materialization.
- Provisional behavior: q5_metadata is a scan-backed alias in M13B; aggregate-metadata fast paths remain a later M13/M14 capability.
- Deliberately unsupported behavior: update/delete visibility is rejected with `ErrColumnQueryPlanUnsupported`; M13C owns delta/tombstone latest-visible overlay and reconstruction.
- Follow-up issue/PR: #1621 M13C/M14 must add visibility overlay, reconstruction, planner capabilities, and unified-bench physical path routing before benchmark claims are exposed.

## Performance / Benchmark Evidence

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysical(QueryAdapterM13B|AssetSerialScanM13A|CollectionSerialScanM13A)' -benchmem -count=3
```

Selected results from final local run on Apple M3:

```text
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_1024   36.5-37.0 us/op   2.77-2.81 GB/s   0 B/op       0 allocs/op
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_8192   292-293 us/op      2.79-2.80 GB/s   0 B/op       0 allocs/op
BenchmarkColumnPhysicalCollectionSerialScanM13A        72.8-73.2 us/op    1.40-1.41 GB/s   ~111 KiB/op  53 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q1_rows_1024   108.5-108.9 us/op  914-918 MB/s     105.9-106.3 ns/row   9.41-9.44M rows/s   ~113.9 KiB/op  83 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q5_rows_1024   124.2 us/op        801 MB/s         121.3 ns/row          8.24M rows/s        ~115.7 KiB/op  105 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q1_rows_8192   758-765 us/op      1.04 GB/s        92.6-93.4 ns/row      10.7-10.8M rows/s  ~810.3 KiB/op  83 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q5_rows_8192   879-895 us/op      888-904 MB/s     107.3-109.3 ns/row    9.15-9.32M rows/s  ~812.1 KiB/op  105 allocs/op
```

## Throughput Interpretation

- The raw physical asset scanner remains allocation-free for numeric projection and is bounded by serial decode/memory bandwidth.
- The M13B query adapter has constant allocation counts from 1K to 8K rows for q1/q5; allocations scale with manifest/control setup, whole-asset read buffers, result/group maps, and distinct/group state, not with every scanned row.
- `B/op` grows with physical asset bytes because M13B still reads each asset into a fresh raw buffer through the one-shot collection scanner. A reusable scan session/asset reader is the right later optimization; Go arenas are not needed.
- No row materializations are reported for the physical aggregate/projection adapter.

## Granule / ClickHouse Equivalent Comparison

These comparisons are context only, not M13B gates. M13B measures reopened durable TreeDB collection assets through the production physical query adapter; the older granule numbers measure the pre-production encoded/block reducer kernels before the full TreeDB engine, manifest/recovery validation, typed asset manager, planner adapter, and parity/reporting were in the timed path.

Later same-machine #1634 granule refresh (`/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`):

- q1 encoded reducer: `412.80M rows/s`.
- q2 encoded reducer: `237.61M rows/s`.
- q3 encoded reducer: `191.61M rows/s`.
- q5 encoded reducer: `138.03M rows/s`.
- q5 metadata kernel: `399.71M rows/s`.

Historical local ClickHouse-equivalent comparison from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1,000,000 JSONBench rows against local ClickHouse `26.4.3.1` on Darwin arm64:

- q1 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.004284s`, about `233.43M rows/s`.
- q2 ClickHouse local: `0.027s`, about `37.04M rows/s`; granule column-kernel best `0.038895s`, about `25.71M rows/s`.
- q3 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.006631s`, about `150.81M rows/s`.
- q4 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.009869s`, about `101.33M rows/s`.
- q5 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.010027s`, about `99.73M rows/s`.

Interpretation for this PR: M13B proves production q1-q5/q5_metadata physical-query parity and fail-closed behavior, not final analytical-kernel speed. The expected gap versus the old granule and ClickHouse-equivalent context is tracked for post-V1 optimization in #1634.

## Gate Status

Passing validation:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysical(QueryAdapter|SerialScanner|AssetSerialScan)|TestColumnQueryPlanner' -count=1
go test ./cmd/unified_bench -run 'TestColumnStore|TestBenchprof|TestProfile' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
go test ./TreeDB/db -count=1
git diff --check
```

M13B gates covered:

- JSONBench-equivalent insert-only q1/q2/q3/q4a/q4b/q5/q5_metadata reducer parity against an independent reference.
- Reopened durable TreeDB collection state, not experiment-only scanner calls.
- Fail-closed update/delete mutation rows until visibility overlay lands.
- Fail-closed planner/unified-bench physical routing remains disabled until M14.
- Allocation slope test covers q1 across 128 and 2048 rows; benchmark evidence covers q1/q5 across 1024 and 8192 rows.

Still blocked for later milestones:

- M13C mutation visibility overlay and full-document reconstruction.
- M14 planner capabilities and forced physical unified-bench routing.
- Aggregate metadata fast path for q5_metadata.
- Reusable scan/session buffers for reducing one-shot collection scanner allocation bytes.

## Artifacts

- No `unified-bench` physical execution artifact is claimed in this PR because M14 owns planner routing and benchmark path enablement.
- Benchmark evidence is included above from the final pushed head.
- The existing `cmd/unified_bench` artifact/report tests remain green and still keep forced physical labels fail-closed until M14.


## Review Hardening

Latest pushed head: `6b0acae13` for M13B.

The propagated head includes the latest M12C review hardening and preserves the M13B floor-hour query fix. No M13B query-adapter behavior was intentionally changed by the propagation.

Current validation evidence:

```text
go test ./TreeDB/collections -run 'TestColumnPhysical.*M13A|TestColumnPhysicalQuery.*M13B|TestColumnStoreMutationAssetsPublishAndReopenM12C|TestColumnStoreCommandWALReplayPublishesMutationAssetsM12C|TestColumnStoreSupportMatrixRejectsNonJSONMutationsBeforeExecutionM12C' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	1.636s
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced physical column query capability supporting group count, distinct count, hour grouping, min/max tracking, and span calculations with detailed execution diagnostics.

* **Bug Fixes**
  * Improved error messaging for column query routing availability.

* **Tests**
  * Added comprehensive test coverage and benchmarks for new physical query operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
