### PR TITLE
TreeDB column store M14B: route physical query execution

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2988,6 +2988,9 @@ func rejectCreateIndexOnRetainedColumnField(meta CollectionMeta, def IndexDefini
 	if field == "" {
 		return nil
 	}
+	if meta.Options.ColumnStore.RetainedPayload == ColumnRetainedPayloadNone {
+		return fmt.Errorf("collections: CreateIndex on retained-payload-none collection field %q is unsupported because primary rows omit indexed payload fields", field)
+	}
 	for _, col := range meta.Options.ColumnStore.Columns {
 		if field == strings.TrimSpace(col.Path) {
 			return fmt.Errorf("collections: CreateIndex on retained-payload column field %q is unsupported because primary rows omit declared column payloads", field)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2981,17 +2981,18 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 }
 
 func rejectCreateIndexOnRetainedColumnField(meta CollectionMeta, def IndexDefinition) error {
-	if !columnStoreNeedsRetainedPayloadTransform(meta) || meta.Options.ColumnStore == nil {
+	cfg := meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled || cfg.RetainedPayload == ColumnRetainedPayloadFull {
 		return nil
 	}
 	field := strings.TrimSpace(def.Field)
 	if field == "" {
 		return nil
 	}
-	if meta.Options.ColumnStore.RetainedPayload == ColumnRetainedPayloadNone {
-		return fmt.Errorf("collections: CreateIndex on retained-payload-none collection field %q is unsupported because primary rows omit indexed payload fields", field)
+	if cfg.RetainedPayload == ColumnRetainedPayloadNone {
+		return fmt.Errorf("collections: CreateIndex on retained-payload-none collection field %q is unsupported because primary rows retain no JSON payload for index maintenance", field)
 	}
-	for _, col := range meta.Options.ColumnStore.Columns {
+	for _, col := range cfg.Columns {
 		if field == strings.TrimSpace(col.Path) {
 			return fmt.Errorf("collections: CreateIndex on retained-payload column field %q is unsupported because primary rows omit declared column payloads", field)
 		}

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -288,6 +288,8 @@ type columnPhysicalAssetReadCache struct {
 	fileID     uint32
 	file       *os.File
 	files      map[uint32]*os.File
+	hits       uint64
+	misses     uint64
 }
 
 func newColumnPhysicalAssetReadCache(rootDir string, namespace string) (columnPhysicalAssetReadCache, error) {
@@ -343,10 +345,12 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 		return nil, err
 	}
 	if c.file != nil && c.fileID == ref.FileID {
+		c.hits++
 		return c.file, nil
 	}
 	if c.files != nil {
 		if file := c.files[ref.FileID]; file != nil {
+			c.hits++
 			return file, nil
 		}
 	}
@@ -354,6 +358,7 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 	if err != nil {
 		return nil, err
 	}
+	c.misses++
 	if c.file == nil && c.files == nil {
 		c.fileID = ref.FileID
 		c.file = file

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -354,11 +354,11 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 			return file, nil
 		}
 	}
+	c.misses++
 	file, err := os.Open(filepath.Join(c.segmentDir, columnAssetSegmentFileName(ref.FileID)))
 	if err != nil {
 		return nil, err
 	}
-	c.misses++
 	if c.file == nil && c.files == nil {
 		c.fileID = ref.FileID
 		c.file = file

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -64,6 +64,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	VisibilityRows             int
 	ReconstructionRows         int
 	ResultGroups               int
+	WorkerCount                int
 	SegmentFileCacheHits       uint64
 	SegmentFileCacheMisses     uint64
 	ScanNanos                  int64
@@ -205,6 +206,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 		}
 	}
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	result.Diagnostics.WorkerCount = workers
 	if firstErr != nil {
 		result.Diagnostics.ReduceRows = merged.reduceRows
 		return result, firstErr
@@ -230,6 +232,7 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 	result := ColumnPhysicalQueryResult{
 		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
 	}
+	result.Diagnostics.WorkerCount = 1
 	result.Diagnostics.ScanNanos = scanNanos
 	result.Diagnostics.ReduceRows = exec.reduceRows
 	if err != nil {
@@ -253,6 +256,7 @@ func (c *Collection) runColumnPhysicalQueryWithVisibility(cfg ColumnStoreConfig,
 	result := ColumnPhysicalQueryResult{
 		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(visible.Diagnostics),
 	}
+	result.Diagnostics.WorkerCount = 1
 	result.Diagnostics.VisibilityRows = len(visible.Rows)
 	result.Diagnostics.ScanNanos = visibilityNanos
 	result.Diagnostics.VisibilityNanos = visibilityNanos

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -161,7 +161,6 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	var cancel atomic.Bool
 	var wg sync.WaitGroup
 	for worker := 0; worker < workers; worker++ {
-		worker := worker
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -64,6 +64,8 @@ type ColumnPhysicalQueryDiagnostics struct {
 	VisibilityRows             int
 	ReconstructionRows         int
 	ResultGroups               int
+	DecodedBlockCacheHits      uint64
+	DecodedBlockCacheMisses    uint64
 	ScanNanos                  int64
 	VisibilityNanos            int64
 	ReduceNanos                int64
@@ -133,10 +135,14 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	if view.MutationParts > 0 {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires insert-only manifest until partitioned visibility execution lands", ErrColumnQueryPlanUnsupported)
 	}
+	if maxWorkers <= 1 {
+		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires at least two workers", ErrColumnQueryPlanUnsupported)
+	}
+	if len(view.AssetRefs) <= 1 {
+		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires more than one asset ref", ErrColumnQueryPlanUnsupported)
+	}
 	workers := maxWorkers
-	if refs := len(view.AssetRefs); maxWorkers <= 1 || refs <= 1 {
-		return c.runColumnPhysicalQueryInSnapshotView(view, req)
-	} else if workers > refs {
+	if refs := len(view.AssetRefs); workers > refs {
 		workers = refs
 	}
 	cfg := view.Config

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -121,13 +121,17 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	if maxWorkers <= 1 {
 		return c.RunColumnPhysicalQuery(req)
 	}
-	cfg, err := c.columnPhysicalQueryColumnStoreConfig()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
-	if cfg.PhysicalMutationParts > 0 {
+	if view.MutationParts > 0 {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires insert-only manifest until partitioned visibility execution lands", ErrColumnQueryPlanUnsupported)
 	}
+	cfg := view.Config
 	merged, err := newColumnPhysicalQueryExecutor(cfg, req)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
@@ -151,7 +155,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 				results[worker].err = err
 				return
 			}
-			diag, err := c.scanColumnPhysicalRows(columnPhysicalScanRequest{
+			diag, err := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
 				ProjectedColumns:    exec.projected,
 				Visitor:             exec.visit,
 				RequireInsertOnly:   true,

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -308,6 +308,8 @@ func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) 
 		ProjectedColumns:           diag.ProjectedColumns,
 		RowMaterializations:        diag.RowMaterializations,
 		PhysicalBytesScanned:       diag.PhysicalBytesScanned,
+		DecodedBlockCacheHits:      diag.DecodedBlockCacheHits,
+		DecodedBlockCacheMisses:    diag.DecodedBlockCacheMisses,
 	}
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -200,11 +200,13 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 		}
 		if err := merged.mergeFrom(workerResult.exec); err != nil {
 			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+			result.Diagnostics.ReduceRows = merged.reduceRows
 			return result, err
 		}
 	}
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	if firstErr != nil {
+		result.Diagnostics.ReduceRows = merged.reduceRows
 		return result, firstErr
 	}
 	result.Groups = merged.groups()

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -112,6 +113,76 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 	return result, nil
 }
 
+// RunColumnPhysicalQueryParallel executes an insert-only physical query by
+// partitioning immutable manifest refs across worker-local serial scanners.
+// Mutation-bearing manifests stay fail-closed until partitioned visibility
+// reconstruction is available.
+func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryRequest, maxWorkers int) (ColumnPhysicalQueryResult, error) {
+	if maxWorkers <= 1 {
+		return c.RunColumnPhysicalQuery(req)
+	}
+	cfg, err := c.columnPhysicalQueryColumnStoreConfig()
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+	if cfg.PhysicalMutationParts > 0 {
+		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires insert-only manifest until partitioned visibility execution lands", ErrColumnQueryPlanUnsupported)
+	}
+	merged, err := newColumnPhysicalQueryExecutor(cfg, req)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+
+	type workerResult struct {
+		exec *columnPhysicalQueryExecutor
+		diag columnPhysicalScanDiagnostics
+		err  error
+	}
+	results := make([]workerResult, maxWorkers)
+	start := time.Now()
+	var wg sync.WaitGroup
+	for worker := 0; worker < maxWorkers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			exec, err := newColumnPhysicalQueryExecutor(cfg, req)
+			if err != nil {
+				results[worker].err = err
+				return
+			}
+			diag, err := c.scanColumnPhysicalRows(columnPhysicalScanRequest{
+				ProjectedColumns:    exec.projected,
+				Visitor:             exec.visit,
+				RequireInsertOnly:   true,
+				RefOrdinalModulo:    maxWorkers,
+				RefOrdinalRemainder: worker,
+			})
+			results[worker] = workerResult{exec: exec, diag: diag, err: err}
+		}()
+	}
+	wg.Wait()
+
+	result := ColumnPhysicalQueryResult{}
+	for worker := range results {
+		workerResult := results[worker]
+		result.Diagnostics = mergeColumnPhysicalQueryDiagnostics(result.Diagnostics, columnPhysicalQueryDiagnosticsFromScan(workerResult.diag))
+		if workerResult.err != nil {
+			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+			return result, workerResult.err
+		}
+		if err := merged.mergeFrom(workerResult.exec); err != nil {
+			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+			return result, err
+		}
+	}
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	result.Groups = merged.groups()
+	result.Diagnostics.ReduceRows = merged.reduceRows
+	result.Diagnostics.ResultGroups = len(result.Groups)
+	return result, nil
+}
+
 var errColumnPhysicalQueryNeedsVisibility = errors.New("collections: physical column query requires mutation visibility overlay")
 
 func (c *Collection) runColumnPhysicalQueryWithVisibility(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
@@ -181,6 +252,39 @@ func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) 
 		RowMaterializations:        diag.RowMaterializations,
 		PhysicalBytesScanned:       diag.PhysicalBytesScanned,
 	}
+}
+
+func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnostics) ColumnPhysicalQueryDiagnostics {
+	if left.ManifestRoot == 0 {
+		left.ManifestRoot = right.ManifestRoot
+		left.ManifestGeneration = right.ManifestGeneration
+		left.RecoveryManifestGeneration = right.RecoveryManifestGeneration
+		left.AppliedCommandLSN = right.AppliedCommandLSN
+		left.ManifestRecords = right.ManifestRecords
+		left.AssetRefs = right.AssetRefs
+		left.ProjectedColumns = right.ProjectedColumns
+	}
+	if right.ManifestRecords > left.ManifestRecords {
+		left.ManifestRecords = right.ManifestRecords
+	}
+	if right.AssetRefs > left.AssetRefs {
+		left.AssetRefs = right.AssetRefs
+	}
+	if right.ProjectedColumns > left.ProjectedColumns {
+		left.ProjectedColumns = right.ProjectedColumns
+	}
+	left.MutationParts += right.MutationParts
+	left.DecodedBlocks += right.DecodedBlocks
+	left.ScheduledGranules += right.ScheduledGranules
+	left.SkippedGranules += right.SkippedGranules
+	left.RowsScanned += right.RowsScanned
+	left.DeletedRows += right.DeletedRows
+	left.RowMaterializations += right.RowMaterializations
+	left.PhysicalBytesScanned += right.PhysicalBytesScanned
+	left.ReduceRows += right.ReduceRows
+	left.VisibilityRows += right.VisibilityRows
+	left.ReconstructionRows += right.ReconstructionRows
+	return left
 }
 
 type columnPhysicalQueryExecutor struct {
@@ -404,6 +508,67 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 		return e.resultGroups[i].Key < e.resultGroups[j].Key
 	})
 	return e.resultGroups
+}
+
+func (e *columnPhysicalQueryExecutor) mergeFrom(other *columnPhysicalQueryExecutor) error {
+	if e == nil || other == nil {
+		return errors.New("collections: cannot merge nil physical column query executor")
+	}
+	if e.kind != other.kind {
+		return fmt.Errorf("collections: cannot merge physical column query kind %q into %q", other.kind, e.kind)
+	}
+	switch e.kind {
+	case ColumnPhysicalQueryGroupCount:
+		for key, count := range other.counts {
+			e.counts[key] += count
+		}
+	case ColumnPhysicalQueryGroupCountDistinct:
+		for key, otherSet := range other.distinct {
+			set := e.distinct[key]
+			if set == nil {
+				set = make(map[string]struct{}, len(otherSet))
+				e.distinct[key] = set
+			}
+			for value := range otherSet {
+				set[value] = struct{}{}
+			}
+		}
+	case ColumnPhysicalQueryHourCount:
+		for hour, count := range other.hourCounts {
+			e.hourCounts[hour] += count
+		}
+	case ColumnPhysicalQueryGroupMinInt64:
+		for key, value := range other.int64Values {
+			if cur, ok := e.int64Values[key]; !ok || value < cur {
+				e.int64Values[key] = value
+			}
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		for key, value := range other.int64Values {
+			if cur, ok := e.int64Values[key]; !ok || value > cur {
+				e.int64Values[key] = value
+			}
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		for key, span := range other.int64Spans {
+			cur, ok := e.int64Spans[key]
+			if !ok {
+				e.int64Spans[key] = span
+				continue
+			}
+			if span.min < cur.min {
+				cur.min = span.min
+			}
+			if span.max > cur.max {
+				cur.max = span.max
+			}
+			e.int64Spans[key] = cur
+		}
+	default:
+		return fmt.Errorf("%w: unsupported physical column query kind %q", ErrColumnQueryPlanUnsupported, e.kind)
+	}
+	e.reduceRows += other.reduceRows
+	return nil
 }
 
 func columnPhysicalQueryStringBytes(value columnDeclaredValue) ([]byte, error) {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -123,9 +123,6 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 // Mutation-bearing manifests stay fail-closed until partitioned visibility
 // reconstruction is available.
 func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryRequest, maxWorkers int) (ColumnPhysicalQueryResult, error) {
-	if maxWorkers <= 1 {
-		return c.RunColumnPhysicalQuery(req)
-	}
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
 	if closeView != nil {
 		defer closeView()
@@ -137,7 +134,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires insert-only manifest until partitioned visibility execution lands", ErrColumnQueryPlanUnsupported)
 	}
 	workers := maxWorkers
-	if refs := len(view.AssetRefs); refs <= 1 {
+	if refs := len(view.AssetRefs); maxWorkers <= 1 || refs <= 1 {
 		return c.runColumnPhysicalQueryInSnapshotView(view, req)
 	} else if workers > refs {
 		workers = refs

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -64,8 +64,8 @@ type ColumnPhysicalQueryDiagnostics struct {
 	VisibilityRows             int
 	ReconstructionRows         int
 	ResultGroups               int
-	DecodedBlockCacheHits      uint64
-	DecodedBlockCacheMisses    uint64
+	SegmentFileCacheHits       uint64
+	SegmentFileCacheMisses     uint64
 	ScanNanos                  int64
 	VisibilityNanos            int64
 	ReduceNanos                int64
@@ -161,6 +161,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	var cancel atomic.Bool
 	var wg sync.WaitGroup
 	for worker := 0; worker < workers; worker++ {
+		worker := worker
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -307,8 +308,8 @@ func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) 
 		ProjectedColumns:           diag.ProjectedColumns,
 		RowMaterializations:        diag.RowMaterializations,
 		PhysicalBytesScanned:       diag.PhysicalBytesScanned,
-		DecodedBlockCacheHits:      diag.DecodedBlockCacheHits,
-		DecodedBlockCacheMisses:    diag.DecodedBlockCacheMisses,
+		SegmentFileCacheHits:       diag.SegmentFileCacheHits,
+		SegmentFileCacheMisses:     diag.SegmentFileCacheMisses,
 	}
 }
 
@@ -344,8 +345,8 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.ReduceRows += right.ReduceRows
 	left.VisibilityRows += right.VisibilityRows
 	left.ReconstructionRows += right.ReconstructionRows
-	left.DecodedBlockCacheHits += right.DecodedBlockCacheHits
-	left.DecodedBlockCacheMisses += right.DecodedBlockCacheMisses
+	left.SegmentFileCacheHits += right.SegmentFileCacheHits
+	left.SegmentFileCacheMisses += right.SegmentFileCacheMisses
 	return left
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -138,7 +138,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	}
 	workers := maxWorkers
 	if refs := len(view.AssetRefs); refs <= 1 {
-		return c.RunColumnPhysicalQuery(req)
+		return c.runColumnPhysicalQueryInSnapshotView(view, req)
 	} else if workers > refs {
 		workers = refs
 	}
@@ -206,6 +206,31 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	}
 	result.Groups = merged.groups()
 	result.Diagnostics.ReduceRows = merged.reduceRows
+	result.Diagnostics.ResultGroups = len(result.Groups)
+	return result, nil
+}
+
+func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	exec, err := newColumnPhysicalQueryExecutor(view.Config, req)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+	scanStart := time.Now()
+	diag, err := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+		ProjectedColumns:  exec.projected,
+		Visitor:           exec.visit,
+		RequireInsertOnly: true,
+	})
+	scanNanos := time.Since(scanStart).Nanoseconds()
+	result := ColumnPhysicalQueryResult{
+		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
+	}
+	result.Diagnostics.ScanNanos = scanNanos
+	result.Diagnostics.ReduceRows = exec.reduceRows
+	if err != nil {
+		return result, err
+	}
+	result.Groups = exec.groups()
 	result.Diagnostics.ResultGroups = len(result.Groups)
 	return result, nil
 }

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -343,6 +343,8 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.ReduceRows += right.ReduceRows
 	left.VisibilityRows += right.VisibilityRows
 	left.ReconstructionRows += right.ReconstructionRows
+	left.DecodedBlockCacheHits += right.DecodedBlockCacheHits
+	left.DecodedBlockCacheMisses += right.DecodedBlockCacheMisses
 	return left
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -76,6 +77,8 @@ type ColumnPhysicalQueryResult struct {
 	Diagnostics ColumnPhysicalQueryDiagnostics
 }
 
+var errColumnPhysicalScanCancelled = errors.New("collections: physical column scan cancelled")
+
 // RunColumnPhysicalQuery executes an explicit serial physical column query over
 // the recovery-authoritative manifest. Insert-only manifests use the direct
 // scanner path; mutation-bearing manifests fall back to the M13C visibility
@@ -133,6 +136,12 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	if view.MutationParts > 0 {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical column query requires insert-only manifest until partitioned visibility execution lands", ErrColumnQueryPlanUnsupported)
 	}
+	workers := maxWorkers
+	if refs := len(view.AssetRefs); refs <= 1 {
+		return c.RunColumnPhysicalQuery(req)
+	} else if workers > refs {
+		workers = refs
+	}
 	cfg := view.Config
 	merged, err := newColumnPhysicalQueryExecutor(cfg, req)
 	if err != nil {
@@ -144,16 +153,18 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 		diag columnPhysicalScanDiagnostics
 		err  error
 	}
-	results := make([]workerResult, maxWorkers)
+	results := make([]workerResult, workers)
 	start := time.Now()
+	var cancel atomic.Bool
 	var wg sync.WaitGroup
-	for worker := 0; worker < maxWorkers; worker++ {
+	for worker := 0; worker < workers; worker++ {
 		worker := worker
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			exec, err := newColumnPhysicalQueryExecutor(cfg, req)
 			if err != nil {
+				cancel.Store(true)
 				results[worker].err = err
 				return
 			}
@@ -161,21 +172,28 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 				ProjectedColumns:    exec.projected,
 				Visitor:             exec.visit,
 				RequireInsertOnly:   true,
-				RefOrdinalModulo:    maxWorkers,
+				RefOrdinalModulo:    workers,
 				RefOrdinalRemainder: worker,
+				ShouldCancel:        cancel.Load,
 			})
+			if err != nil {
+				cancel.Store(true)
+			}
 			results[worker] = workerResult{exec: exec, diag: diag, err: err}
 		}()
 	}
 	wg.Wait()
 
 	result := ColumnPhysicalQueryResult{}
+	var firstErr error
 	for worker := range results {
 		workerResult := results[worker]
 		result.Diagnostics = mergeColumnPhysicalQueryDiagnostics(result.Diagnostics, columnPhysicalQueryDiagnosticsFromScan(workerResult.diag))
 		if workerResult.err != nil {
-			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
-			return result, workerResult.err
+			if firstErr == nil || errors.Is(firstErr, errColumnPhysicalScanCancelled) {
+				firstErr = workerResult.err
+			}
+			continue
 		}
 		if err := merged.mergeFrom(workerResult.exec); err != nil {
 			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
@@ -183,6 +201,9 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 		}
 	}
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	if firstErr != nil {
+		return result, firstErr
+	}
 	result.Groups = merged.groups()
 	result.Diagnostics.ReduceRows = merged.reduceRows
 	result.Diagnostics.ResultGroups = len(result.Groups)
@@ -279,7 +300,9 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	if right.ProjectedColumns > left.ProjectedColumns {
 		left.ProjectedColumns = right.ProjectedColumns
 	}
-	left.MutationParts += right.MutationParts
+	if right.MutationParts > left.MutationParts {
+		left.MutationParts = right.MutationParts
+	}
 	left.DecodedBlocks += right.DecodedBlocks
 	left.ScheduledGranules += right.ScheduledGranules
 	left.SkippedGranules += right.SkippedGranules

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -305,6 +305,49 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQuerySnapshotViewSingleRefUsesPinnedManifestM14B(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(16))
+	defer closeFn()
+
+	view, closeView, err := reopened.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	if got, want := len(view.AssetRefs), 1; got != want {
+		t.Fatalf("asset refs=%d want single-ref fixture", got)
+	}
+	if _, err := reopened.InsertBatch([][]byte{[]byte("e_published_after_pin")}, [][]byte{
+		[]byte(`{"time_us":1700000000000999,"kind":"after_pin","did":"did_after","payload":"ignored"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch after pinned view: %v", err)
+	}
+
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+	pinned, err := reopened.runColumnPhysicalQueryInSnapshotView(view, req)
+	if err != nil {
+		t.Fatalf("runColumnPhysicalQueryInSnapshotView: %v", err)
+	}
+	latest, err := reopened.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("latest RunColumnPhysicalQuery: %v", err)
+	}
+	if got, want := pinned.Diagnostics.ReduceRows, 16; got != want {
+		t.Fatalf("pinned reduce rows=%d want %d diagnostics=%+v", got, want, pinned.Diagnostics)
+	}
+	if got, want := latest.Diagnostics.ReduceRows, 17; got != want {
+		t.Fatalf("latest reduce rows=%d want %d diagnostics=%+v", got, want, latest.Diagnostics)
+	}
+	if _, ok := columnPhysicalQueryGroupCountsM14B(pinned.Groups)["after_pin"]; ok {
+		t.Fatalf("pinned view included post-pin row: groups=%+v diagnostics=%+v", pinned.Groups, pinned.Diagnostics)
+	}
+	if got := columnPhysicalQueryGroupCountsM14B(latest.Groups)["after_pin"]; got != 1 {
+		t.Fatalf("latest view after_pin count=%d want 1 groups=%+v diagnostics=%+v", got, latest.Groups, latest.Diagnostics)
+	}
+}
+
 func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *testing.T) {
 	reopened, closeFn, _ := openColumnPhysicalMutationFixtureM13C(t, 64)
 	defer closeFn()
@@ -316,6 +359,14 @@ func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *test
 	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "partitioned visibility execution") {
 		t.Fatalf("RunColumnPhysicalQueryParallel err=%v want fail-closed partitioned visibility error", err)
 	}
+}
+
+func columnPhysicalQueryGroupCountsM14B(groups []ColumnPhysicalQueryGroup) map[string]int {
+	out := make(map[string]int, len(groups))
+	for _, group := range groups {
+		out[group.Key] = group.Count
+	}
+	return out
 }
 
 func TestColumnPhysicalScanHonorsCancellationBeforeSchedulingRefsM14B(t *testing.T) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -352,12 +352,14 @@ func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *test
 	reopened, closeFn, _ := openColumnPhysicalMutationFixtureM13C(t, 64)
 	defer closeFn()
 
-	_, err := reopened.RunColumnPhysicalQueryParallel(ColumnPhysicalQueryRequest{
-		Kind:        ColumnPhysicalQueryGroupCount,
-		GroupColumn: "kind",
-	}, 4)
-	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "partitioned visibility execution") {
-		t.Fatalf("RunColumnPhysicalQueryParallel err=%v want fail-closed partitioned visibility error", err)
+	for _, workers := range []int{1, 4} {
+		_, err := reopened.RunColumnPhysicalQueryParallel(ColumnPhysicalQueryRequest{
+			Kind:        ColumnPhysicalQueryGroupCount,
+			GroupColumn: "kind",
+		}, workers)
+		if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "partitioned visibility execution") {
+			t.Fatalf("RunColumnPhysicalQueryParallel workers=%d err=%v want fail-closed partitioned visibility error", workers, err)
+		}
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -196,6 +196,65 @@ func TestColumnPhysicalQueryKeepsInsertOnlyMultiGenerationOnDirectPathM13C(t *te
 	}
 }
 
+func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 8)
+	defer closeFn()
+
+	tests := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+	}{
+		{
+			name: "count",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+		},
+		{
+			name: "span",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serial, err := reopened.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("serial RunColumnPhysicalQuery: %v", err)
+			}
+			parallel, err := reopened.RunColumnPhysicalQueryParallel(tc.req, 4)
+			if err != nil {
+				t.Fatalf("parallel RunColumnPhysicalQuery: %v", err)
+			}
+			if !reflect.DeepEqual(parallel.Groups, serial.Groups) {
+				t.Fatalf("parallel groups=%+v want serial %+v", parallel.Groups, serial.Groups)
+			}
+			if parallel.Diagnostics.RowMaterializations != 0 {
+				t.Fatalf("parallel row materializations=%d want zero diagnostics=%+v", parallel.Diagnostics.RowMaterializations, parallel.Diagnostics)
+			}
+			if got, want := parallel.Diagnostics.ReduceRows, serial.Diagnostics.ReduceRows; got != want {
+				t.Fatalf("parallel reduce rows=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)
+			}
+			if got, want := parallel.Diagnostics.ScheduledGranules, serial.Diagnostics.ScheduledGranules; got != want {
+				t.Fatalf("parallel scheduled granules=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)
+			}
+			if parallel.Diagnostics.PhysicalBytesScanned != serial.Diagnostics.PhysicalBytesScanned {
+				t.Fatalf("parallel bytes=%d want serial %d diagnostics=%+v", parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *testing.T) {
+	reopened, closeFn, _ := openColumnPhysicalMutationFixtureM13C(t, 64)
+	defer closeFn()
+
+	_, err := reopened.RunColumnPhysicalQueryParallel(ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupCount,
+		GroupColumn: "kind",
+	}, 4)
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "partitioned visibility execution") {
+		t.Fatalf("RunColumnPhysicalQueryParallel err=%v want fail-closed partitioned visibility error", err)
+	}
+}
+
 func TestColumnStoreGetReconstructsRetainedPayloadM13C(t *testing.T) {
 	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
 	d := openCollectionCommandWALDB(t, dir)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -496,6 +496,19 @@ func TestColumnStoreRetainedPayloadNoneRejectsCreateIndexOnAnyFieldM13C(t *testi
 	}
 }
 
+func TestColumnStoreRetainedPayloadNoneAllowsIndexWhenColumnStoreDisabledM13C(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "events",
+		Options: CollectionOptions{ColumnStore: &ColumnStoreConfig{
+			RetainedPayload: ColumnRetainedPayloadNone,
+		}},
+	}
+	err := rejectCreateIndexOnRetainedColumnField(meta, IndexDefinition{Name: "payload_idx", Field: "payload", ValueType: IndexValueString})
+	if err != nil {
+		t.Fatalf("disabled column_store CreateIndex rejection err=%v want nil", err)
+	}
+}
+
 func TestColumnStoreRetainedPayloadDisablesDirectBufferedUpdateM13C(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -397,6 +397,28 @@ func TestColumnPhysicalScanHonorsCancellationBeforeSchedulingRefsM14B(t *testing
 	}
 }
 
+func TestColumnPhysicalScanRejectsRemainderWithoutModuloM14B(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 4)
+	defer closeFn()
+
+	view, closeView, err := reopened.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	_, err = reopened.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+		ProjectedColumns:    []string{"kind"},
+		Visitor:             func(columnPhysicalScanRowView) error { return nil },
+		RequireInsertOnly:   true,
+		RefOrdinalRemainder: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires non-zero modulo") {
+		t.Fatalf("scan err=%v want remainder without modulo rejection", err)
+	}
+}
+
 func TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B(t *testing.T) {
 	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1}
 	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -461,8 +461,8 @@ func TestColumnPhysicalScanRejectsRemainderWithoutModuloM14B(t *testing.T) {
 }
 
 func TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B(t *testing.T) {
-	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1, DecodedBlockCacheHits: 2, DecodedBlockCacheMisses: 3}
-	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3, DecodedBlockCacheHits: 5, DecodedBlockCacheMisses: 7}
+	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1, SegmentFileCacheHits: 2, SegmentFileCacheMisses: 3}
+	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3, SegmentFileCacheHits: 5, SegmentFileCacheMisses: 7}
 	merged := mergeColumnPhysicalQueryDiagnostics(left, right)
 	if got, want := merged.MutationParts, 2; got != want {
 		t.Fatalf("mutation parts=%d want view-level max %d", got, want)
@@ -470,10 +470,10 @@ func TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B(t
 	if got, want := merged.DecodedBlocks, 4; got != want {
 		t.Fatalf("decoded blocks=%d want summed work %d", got, want)
 	}
-	if got, want := merged.DecodedBlockCacheHits, uint64(7); got != want {
+	if got, want := merged.SegmentFileCacheHits, uint64(7); got != want {
 		t.Fatalf("cache hits=%d want summed %d", got, want)
 	}
-	if got, want := merged.DecodedBlockCacheMisses, uint64(10); got != want {
+	if got, want := merged.SegmentFileCacheMisses, uint64(10); got != want {
 		t.Fatalf("cache misses=%d want summed %d", got, want)
 	}
 }

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -437,14 +437,20 @@ func TestColumnPhysicalScanRejectsRemainderWithoutModuloM14B(t *testing.T) {
 }
 
 func TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B(t *testing.T) {
-	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1}
-	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3}
+	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1, DecodedBlockCacheHits: 2, DecodedBlockCacheMisses: 3}
+	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3, DecodedBlockCacheHits: 5, DecodedBlockCacheMisses: 7}
 	merged := mergeColumnPhysicalQueryDiagnostics(left, right)
 	if got, want := merged.MutationParts, 2; got != want {
 		t.Fatalf("mutation parts=%d want view-level max %d", got, want)
 	}
 	if got, want := merged.DecodedBlocks, 4; got != want {
 		t.Fatalf("decoded blocks=%d want summed work %d", got, want)
+	}
+	if got, want := merged.DecodedBlockCacheHits, uint64(7); got != want {
+		t.Fatalf("cache hits=%d want summed %d", got, want)
+	}
+	if got, want := merged.DecodedBlockCacheMisses, uint64(10); got != want {
+		t.Fatalf("cache misses=%d want summed %d", got, want)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -348,6 +348,21 @@ func TestColumnPhysicalQuerySnapshotViewSingleRefUsesPinnedManifestM14B(t *testi
 	}
 }
 
+func TestColumnPhysicalQueryParallelFailsClosedForSerialShapesM14B(t *testing.T) {
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+	multiRef, closeMulti := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 4)
+	defer closeMulti()
+	if _, err := multiRef.RunColumnPhysicalQueryParallel(req, 1); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "at least two workers") {
+		t.Fatalf("RunColumnPhysicalQueryParallel one worker err=%v want fail-closed worker-count error", err)
+	}
+
+	singleRef, closeSingle := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(16))
+	defer closeSingle()
+	if _, err := singleRef.RunColumnPhysicalQueryParallel(req, 4); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "more than one asset ref") {
+		t.Fatalf("RunColumnPhysicalQueryParallel one ref err=%v want fail-closed asset-ref error", err)
+	}
+}
+
 func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *testing.T) {
 	reopened, closeFn, _ := openColumnPhysicalMutationFixtureM13C(t, 64)
 	defer closeFn()

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -294,6 +294,13 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if parallel.Diagnostics.PhysicalBytesScanned != serial.Diagnostics.PhysicalBytesScanned {
 				t.Fatalf("parallel bytes=%d want serial %d diagnostics=%+v", parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics)
 			}
+			overPartitioned, err := reopened.RunColumnPhysicalQueryParallel(tc.req, 128)
+			if err != nil {
+				t.Fatalf("over-partitioned RunColumnPhysicalQueryParallel: %v", err)
+			}
+			if !reflect.DeepEqual(overPartitioned.Groups, serial.Groups) {
+				t.Fatalf("over-partitioned groups=%+v want serial %+v", overPartitioned.Groups, serial.Groups)
+			}
 		})
 	}
 }
@@ -308,6 +315,46 @@ func TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B(t *test
 	}, 4)
 	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "partitioned visibility execution") {
 		t.Fatalf("RunColumnPhysicalQueryParallel err=%v want fail-closed partitioned visibility error", err)
+	}
+}
+
+func TestColumnPhysicalScanHonorsCancellationBeforeSchedulingRefsM14B(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 4)
+	defer closeFn()
+
+	view, closeView, err := reopened.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	diag, err := reopened.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+		ProjectedColumns: []string{"kind"},
+		Visitor: func(columnPhysicalScanRowView) error {
+			t.Fatal("visitor should not run after cancellation")
+			return nil
+		},
+		RequireInsertOnly: true,
+		ShouldCancel:      func() bool { return true },
+	})
+	if !errors.Is(err, errColumnPhysicalScanCancelled) {
+		t.Fatalf("scan err=%v want cancellation", err)
+	}
+	if diag.ScheduledGranules != 0 || diag.DecodedBlocks != 0 || diag.RowsScanned != 0 {
+		t.Fatalf("cancelled scan scheduled work: %+v", diag)
+	}
+}
+
+func TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B(t *testing.T) {
+	left := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 1}
+	right := ColumnPhysicalQueryDiagnostics{MutationParts: 2, DecodedBlocks: 3}
+	merged := mergeColumnPhysicalQueryDiagnostics(left, right)
+	if got, want := merged.MutationParts, 2; got != want {
+		t.Fatalf("mutation parts=%d want view-level max %d", got, want)
+	}
+	if got, want := merged.DecodedBlocks, 4; got != want {
+		t.Fatalf("decoded blocks=%d want summed work %d", got, want)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -279,7 +279,7 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parallel RunColumnPhysicalQuery: %v", err)
 			}
-			if !reflect.DeepEqual(parallel.Groups, serial.Groups) {
+			if !equalColumnPhysicalQueryGroups(parallel.Groups, serial.Groups) {
 				t.Fatalf("parallel groups=%+v want serial %+v", parallel.Groups, serial.Groups)
 			}
 			if parallel.Diagnostics.RowMaterializations != 0 {
@@ -298,11 +298,35 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if err != nil {
 				t.Fatalf("over-partitioned RunColumnPhysicalQueryParallel: %v", err)
 			}
-			if !reflect.DeepEqual(overPartitioned.Groups, serial.Groups) {
+			if !equalColumnPhysicalQueryGroups(overPartitioned.Groups, serial.Groups) {
 				t.Fatalf("over-partitioned groups=%+v want serial %+v", overPartitioned.Groups, serial.Groups)
 			}
 		})
 	}
+}
+
+func equalColumnPhysicalQueryGroups(left, right []ColumnPhysicalQueryGroup) bool {
+	left = append([]ColumnPhysicalQueryGroup(nil), left...)
+	right = append([]ColumnPhysicalQueryGroup(nil), right...)
+	sort.Slice(left, func(i, j int) bool {
+		if left[i].Key != left[j].Key {
+			return left[i].Key < left[j].Key
+		}
+		if left[i].Count != left[j].Count {
+			return left[i].Count < left[j].Count
+		}
+		return left[i].Int64 < left[j].Int64
+	})
+	sort.Slice(right, func(i, j int) bool {
+		if right[i].Key != right[j].Key {
+			return right[i].Key < right[j].Key
+		}
+		if right[i].Count != right[j].Count {
+			return right[i].Count < right[j].Count
+		}
+		return right[i].Int64 < right[j].Int64
+	})
+	return reflect.DeepEqual(left, right)
 }
 
 func TestColumnPhysicalQuerySnapshotViewSingleRefUsesPinnedManifestM14B(t *testing.T) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -420,6 +420,31 @@ func TestColumnStoreRetainedPayloadRejectsCreateIndexOnDeclaredColumnM13C(t *tes
 	}
 }
 
+func TestColumnStoreRetainedPayloadNoneRejectsCreateIndexOnAnyFieldM13C(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	cfg := testColumnStoreConfig(nil)
+	cfg.RetainedPayload = ColumnRetainedPayloadNone
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: cfg},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "payload_idx", Field: "payload", ValueType: IndexValueString}); err == nil || !strings.Contains(err.Error(), "retained-payload-none") {
+		t.Fatalf("CreateIndex on retained-payload-none field err=%v want rejection", err)
+	}
+}
+
 func TestColumnStoreRetainedPayloadDisablesDirectBufferedUpdateM13C(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), Durability: backenddb.DurabilityWALOffRelaxed})
 	if err != nil {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -38,8 +38,10 @@ type columnPhysicalScanDiagnostics struct {
 	DeletedRows      int
 	ProjectedColumns int
 	// Counts full-document row materialization; M13A emits declared-column row views only.
-	RowMaterializations  int
-	PhysicalBytesScanned int64
+	RowMaterializations     int
+	PhysicalBytesScanned    int64
+	DecodedBlockCacheHits   uint64
+	DecodedBlockCacheMisses uint64
 }
 
 type columnPhysicalScanRowView struct {
@@ -293,6 +295,8 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 		diag.ScheduledGranules++
 		ref := assetRef.Ref
 		raw, err := readCache.read(ref, rawScratch)
+		diag.DecodedBlockCacheHits = readCache.hits
+		diag.DecodedBlockCacheMisses = readCache.misses
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
@@ -309,6 +313,8 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 		diag.RowsScanned += summary.rows
 		diag.DeletedRows += summary.deleted
 	}
+	diag.DecodedBlockCacheHits = readCache.hits
+	diag.DecodedBlockCacheMisses = readCache.misses
 	return diag, nil
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -271,6 +271,9 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 	if req.RefOrdinalModulo < 0 {
 		return diag, errors.New("collections: physical column scan ref ordinal modulo cannot be negative")
 	}
+	if req.RefOrdinalModulo == 0 && req.RefOrdinalRemainder != 0 {
+		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d requires non-zero modulo", req.RefOrdinalRemainder)
+	}
 	if req.RefOrdinalModulo > 0 && (req.RefOrdinalRemainder < 0 || req.RefOrdinalRemainder >= req.RefOrdinalModulo) {
 		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", req.RefOrdinalRemainder, req.RefOrdinalModulo)
 	}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -82,20 +82,42 @@ type columnManifestAssetRefForScan struct {
 	Reason ColumnPublishOperation
 }
 
+type columnPhysicalScanSnapshotView struct {
+	CollectionName     string
+	Config             ColumnStoreConfig
+	ColumnStoreEnabled bool
+	AssetRefs          []columnManifestAssetRefForScan
+	MutationParts      int
+	Diagnostics        columnPhysicalScanDiagnostics
+	ColumnAssetRootDir string
+	AssetNamespace     string
+}
+
 var errColumnPhysicalAssetManifestOperationMismatch = errors.New("collections: column physical asset operation does not match manifest reason")
 
 func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (columnPhysicalScanDiagnostics, error) {
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		return view.Diagnostics, err
+	}
+	return c.scanColumnPhysicalRowsInSnapshotView(view, req)
+}
+
+func (c *Collection) prepareColumnPhysicalScanSnapshotView() (columnPhysicalScanSnapshotView, func(), error) {
 	if c == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionNil
+		return columnPhysicalScanSnapshotView{}, nil, errCollectionNil
 	}
 	if c.db == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
+		return columnPhysicalScanSnapshotView{}, nil, errCollectionDBNil
 	}
 	c.catalogMu.RLock()
 	catalog := c.catalog
 	if catalog == nil {
 		c.catalogMu.RUnlock()
-		return columnPhysicalScanDiagnostics{}, errCollectionNotFound
+		return columnPhysicalScanSnapshotView{}, nil, errCollectionNotFound
 	}
 	collectionName := catalog.meta.Name
 	rootName := collectionColumnManifestRootName(collectionName)
@@ -110,10 +132,15 @@ func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (colu
 
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
+		return columnPhysicalScanSnapshotView{}, nil, errCollectionDBNil
 	}
-	defer func() { _ = snap.Close() }()
-	return c.scanColumnPhysicalRowsAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, req)
+	closeView := func() { _ = snap.Close() }
+	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled)
+	if err != nil {
+		closeView()
+		return view, nil, err
+	}
+	return view, closeView, nil
 }
 
 func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
@@ -125,36 +152,47 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 	columnStoreEnabled bool,
 	req columnPhysicalScanRequest,
 ) (columnPhysicalScanDiagnostics, error) {
+	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled)
+	if err != nil {
+		return view.Diagnostics, err
+	}
+	return c.scanColumnPhysicalRowsInSnapshotView(view, req)
+}
+
+func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	collectionName string,
+	rootID uint64,
+	cfg ColumnStoreConfig,
+	columnStoreEnabled bool,
+) (columnPhysicalScanSnapshotView, error) {
 	if c == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionNil
+		return columnPhysicalScanSnapshotView{}, errCollectionNil
 	}
 	if c.db == nil || snap == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionDBNil
+		return columnPhysicalScanSnapshotView{}, errCollectionDBNil
 	}
 	if catalog == nil {
-		return columnPhysicalScanDiagnostics{}, errCollectionNotFound
+		return columnPhysicalScanSnapshotView{}, errCollectionNotFound
 	}
 	if !columnStoreEnabled || !cfg.Enabled {
-		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires enabled column_store")
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: physical column scan requires enabled column_store")
 	}
 	if cfg.ActiveManifest == nil {
-		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires active column manifest")
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: physical column scan requires active column manifest")
 	}
 	if cfg.RecoveryAuthoritativeManifest == nil {
-		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires recovery-authoritative column manifest")
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: physical column scan requires recovery-authoritative column manifest")
 	}
 	if !columnManifestIdentityValueEqual(*cfg.ActiveManifest, *cfg.RecoveryAuthoritativeManifest) {
-		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires active recovery-authoritative manifest")
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: physical column scan requires active recovery-authoritative manifest")
 	}
 	if cfg.AssetManager == nil {
-		return columnPhysicalScanDiagnostics{}, errors.New("collections: physical column scan requires column asset manager metadata")
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: physical column scan requires column asset manager metadata")
 	}
 	if rootID == 0 {
-		return columnPhysicalScanDiagnostics{}, fmt.Errorf("collections: physical column scan missing manifest root %q", collectionColumnManifestRootName(collectionName))
-	}
-	projection, err := newColumnPhysicalScanProjection(cfg, req.ProjectedColumns)
-	if err != nil {
-		return columnPhysicalScanDiagnostics{}, err
+		return columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: physical column scan missing manifest root %q", collectionColumnManifestRootName(collectionName))
 	}
 
 	diag := columnPhysicalScanDiagnostics{
@@ -162,31 +200,72 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 		ManifestGeneration:         cfg.ActiveManifest.Generation,
 		RecoveryManifestGeneration: cfg.RecoveryAuthoritativeManifest.Generation,
 		AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
-		ProjectedColumns:           projection.count,
+	}
+	view := columnPhysicalScanSnapshotView{
+		CollectionName:     collectionName,
+		Config:             cfg,
+		ColumnStoreEnabled: columnStoreEnabled,
+		Diagnostics:        diag,
+		ColumnAssetRootDir: c.db.ColumnAssetRootDir(),
+		AssetNamespace:     cfg.AssetManager.Namespace,
 	}
 
 	if err := validateColumnManifestIdentityAtRootForScan(snap, rootID, *cfg.ActiveManifest); err != nil {
-		return diag, err
+		view.Diagnostics = diag
+		return view, err
 	}
 	records, err := loadColumnManifestRecordsFromRootForScan(snap, rootID)
 	if err != nil {
-		return diag, err
+		view.Diagnostics = diag
+		return view, err
 	}
 	diag.ManifestRecords = len(records)
 	manifest, err := decodeColumnManifestSnapshotForScan(records)
 	if err != nil {
-		return diag, err
+		view.Diagnostics = diag
+		return view, err
 	}
 	if err := validateColumnManifestSnapshotForScan(manifest, records, cfg, *cfg.ActiveManifest, collectionName); err != nil {
-		return diag, err
+		view.Diagnostics = diag
+		return view, err
 	}
 	refs, mutationParts, err := columnManifestAssetRefsFromRecordsForScan(records, manifest.Generation, cfg.AssetManager.Namespace)
 	if err != nil {
-		return diag, err
+		view.Diagnostics = diag
+		return view, err
 	}
 	diag.AssetRefs = len(refs)
 	diag.MutationParts = mutationParts
-	if req.RequireInsertOnly && mutationParts != 0 {
+	view.AssetRefs = refs
+	view.MutationParts = mutationParts
+	view.Diagnostics = diag
+	return view, nil
+}
+
+func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
+	view columnPhysicalScanSnapshotView,
+	req columnPhysicalScanRequest,
+) (columnPhysicalScanDiagnostics, error) {
+	cfg := view.Config
+	diag := view.Diagnostics
+	if c == nil {
+		return diag, errCollectionNil
+	}
+	if c.db == nil {
+		return diag, errCollectionDBNil
+	}
+	if !view.ColumnStoreEnabled || !cfg.Enabled {
+		return diag, errors.New("collections: physical column scan requires enabled column_store")
+	}
+	if cfg.ActiveManifest == nil {
+		return diag, errors.New("collections: physical column scan requires active column manifest")
+	}
+	projection, err := newColumnPhysicalScanProjection(cfg, req.ProjectedColumns)
+	if err != nil {
+		return diag, err
+	}
+	diag.ProjectedColumns = projection.count
+	if req.RequireInsertOnly && view.MutationParts != 0 {
 		return diag, errColumnPhysicalQueryNeedsVisibility
 	}
 	if req.RefOrdinalModulo < 0 {
@@ -195,14 +274,13 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 	if req.RefOrdinalModulo > 0 && (req.RefOrdinalRemainder < 0 || req.RefOrdinalRemainder >= req.RefOrdinalModulo) {
 		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", req.RefOrdinalRemainder, req.RefOrdinalModulo)
 	}
-	columnAssetRootDir := c.db.ColumnAssetRootDir()
-	readCache, err := newColumnPhysicalAssetReadCache(columnAssetRootDir, cfg.AssetManager.Namespace)
+	readCache, err := newColumnPhysicalAssetReadCache(view.ColumnAssetRootDir, view.AssetNamespace)
 	if err != nil {
 		return diag, err
 	}
 	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
-	for ordinal, assetRef := range refs {
+	for ordinal, assetRef := range view.AssetRefs {
 		if !columnPhysicalScanIncludesRefOrdinal(req, ordinal) {
 			continue
 		}
@@ -217,7 +295,7 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 		}
 		rawScratch = raw
 		diag.PhysicalBytesScanned += int64(len(raw))
-		summary, err := scanColumnPhysicalAssetRowsWithManifestOperation(raw, ref, collectionName, cfg, projection, assetRef.Reason, req.Visitor)
+		summary, err := scanColumnPhysicalAssetRowsWithManifestOperation(raw, ref, view.CollectionName, cfg, projection, assetRef.Reason, req.Visitor)
 		if err != nil {
 			if req.RequireInsertOnly && errors.Is(err, errColumnPhysicalAssetManifestOperationMismatch) {
 				return diag, errColumnPhysicalQueryNeedsVisibility

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -38,10 +38,10 @@ type columnPhysicalScanDiagnostics struct {
 	DeletedRows      int
 	ProjectedColumns int
 	// Counts full-document row materialization; M13A emits declared-column row views only.
-	RowMaterializations     int
-	PhysicalBytesScanned    int64
-	DecodedBlockCacheHits   uint64
-	DecodedBlockCacheMisses uint64
+	RowMaterializations    int
+	PhysicalBytesScanned   int64
+	SegmentFileCacheHits   uint64
+	SegmentFileCacheMisses uint64
 }
 
 type columnPhysicalScanRowView struct {
@@ -294,8 +294,8 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 		diag.ScheduledGranules++
 		ref := assetRef.Ref
 		raw, err := readCache.read(ref, rawScratch)
-		diag.DecodedBlockCacheHits = readCache.hits
-		diag.DecodedBlockCacheMisses = readCache.misses
+		diag.SegmentFileCacheHits = readCache.hits
+		diag.SegmentFileCacheMisses = readCache.misses
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
@@ -312,8 +312,8 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 		diag.RowsScanned += summary.rows
 		diag.DeletedRows += summary.deleted
 	}
-	diag.DecodedBlockCacheHits = readCache.hits
-	diag.DecodedBlockCacheMisses = readCache.misses
+	diag.SegmentFileCacheHits = readCache.hits
+	diag.SegmentFileCacheMisses = readCache.misses
 	return diag, nil
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -19,6 +19,7 @@ type columnPhysicalScanRequest struct {
 	RequireInsertOnly   bool
 	RefOrdinalModulo    int
 	RefOrdinalRemainder int
+	ShouldCancel        func() bool
 }
 
 type columnPhysicalScanDiagnostics struct {
@@ -280,6 +281,9 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
 	for ordinal, assetRef := range view.AssetRefs {
+		if req.ShouldCancel != nil && req.ShouldCancel() {
+			return diag, errColumnPhysicalScanCancelled
+		}
 		if !columnPhysicalScanIncludesRefOrdinal(req, ordinal) {
 			continue
 		}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -491,6 +491,9 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if sawHeader {
 				return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: duplicate column manifest binary header record")
 			}
+			// The decoded byte slices alias the inline manifest record; the
+			// planner scan validates and hashes them before advancing the
+			// iterator and never retains them.
 			header, err = decodeColumnManifestHeaderRecordForScan(value)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
@@ -536,8 +539,14 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			// all reachable lineage through the active generation. The header
 			// expected-parts check below is generation-local and intentionally
 			// only counts current-generation records.
+			if caps.PhysicalAssetCount == maxCollectionInt {
+				return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest physical asset count overflows int")
+			}
 			caps.PhysicalAssetCount++
 			if operation != ColumnPublishOperationInsert {
+				if caps.MutationParts == maxCollectionInt {
+					return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest mutation part count overflows int")
+				}
 				caps.MutationParts++
 			}
 			writeHashBytes(&d, key)
@@ -605,6 +614,9 @@ func decodeColumnManifestHeaderRecordForScan(raw []byte) (columnManifestHeaderRe
 func validateColumnManifestHeaderRecordForScan(header columnManifestHeaderRecordForScan, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string) error {
 	if !columnPhysicalBytesEqualString(header.collection, collection) {
 		return fmt.Errorf("collections: physical column planner manifest collection=%q want %q", string(header.collection), collection)
+	}
+	if _, ok := columnPhysicalScanOperationFromBytes(header.operation); !ok {
+		return fmt.Errorf("collections: unsupported column manifest header operation %q", string(header.operation))
 	}
 	if header.generation != identity.Generation {
 		return fmt.Errorf("collections: physical column planner manifest generation=%d want %d", header.generation, identity.Generation)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -285,12 +285,11 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 	}
 	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
-	for ordinal, assetRef := range view.AssetRefs {
+	start, step := columnPhysicalScanRefOrdinalPartition(req)
+	for ordinal := start; ordinal < len(view.AssetRefs); ordinal += step {
+		assetRef := view.AssetRefs[ordinal]
 		if req.ShouldCancel != nil && req.ShouldCancel() {
 			return diag, errColumnPhysicalScanCancelled
-		}
-		if !columnPhysicalScanIncludesRefOrdinal(req, ordinal) {
-			continue
 		}
 		diag.ScheduledGranules++
 		ref := assetRef.Ref
@@ -318,11 +317,11 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 	return diag, nil
 }
 
-func columnPhysicalScanIncludesRefOrdinal(req columnPhysicalScanRequest, ordinal int) bool {
+func columnPhysicalScanRefOrdinalPartition(req columnPhysicalScanRequest) (start int, step int) {
 	if req.RefOrdinalModulo <= 1 {
-		return true
+		return 0, 1
 	}
-	return ordinal%req.RefOrdinalModulo == req.RefOrdinalRemainder
+	return req.RefOrdinalRemainder, req.RefOrdinalModulo
 }
 
 func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) (columnPhysicalScanProjection, error) {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -584,8 +584,6 @@ func decodeColumnManifestHeaderRecordForScan(raw []byte) (columnManifestHeaderRe
 	if err := cur.err; err != nil {
 		return columnManifestHeaderRecordForScan{}, err
 	}
-	header.collection = bytes.Clone(header.collection)
-	header.operation = bytes.Clone(header.operation)
 	if header.rowCount > uint64(maxCollectionInt) {
 		return columnManifestHeaderRecordForScan{}, errors.New("collections: column manifest row count overflows int")
 	}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -14,9 +14,11 @@ import (
 )
 
 type columnPhysicalScanRequest struct {
-	ProjectedColumns  []string
-	Visitor           func(columnPhysicalScanRowView) error
-	RequireInsertOnly bool
+	ProjectedColumns    []string
+	Visitor             func(columnPhysicalScanRowView) error
+	RequireInsertOnly   bool
+	RefOrdinalModulo    int
+	RefOrdinalRemainder int
 }
 
 type columnPhysicalScanDiagnostics struct {
@@ -184,9 +186,14 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 	}
 	diag.AssetRefs = len(refs)
 	diag.MutationParts = mutationParts
-	diag.ScheduledGranules = len(refs)
 	if req.RequireInsertOnly && mutationParts != 0 {
 		return diag, errColumnPhysicalQueryNeedsVisibility
+	}
+	if req.RefOrdinalModulo < 0 {
+		return diag, errors.New("collections: physical column scan ref ordinal modulo cannot be negative")
+	}
+	if req.RefOrdinalModulo > 0 && (req.RefOrdinalRemainder < 0 || req.RefOrdinalRemainder >= req.RefOrdinalModulo) {
+		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", req.RefOrdinalRemainder, req.RefOrdinalModulo)
 	}
 	columnAssetRootDir := c.db.ColumnAssetRootDir()
 	readCache, err := newColumnPhysicalAssetReadCache(columnAssetRootDir, cfg.AssetManager.Namespace)
@@ -195,7 +202,11 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 	}
 	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
-	for _, assetRef := range refs {
+	for ordinal, assetRef := range refs {
+		if !columnPhysicalScanIncludesRefOrdinal(req, ordinal) {
+			continue
+		}
+		diag.ScheduledGranules++
 		ref := assetRef.Ref
 		if ref.Generation > cfg.ActiveManifest.Generation {
 			return diag, fmt.Errorf("collections: column physical scan ref generation=%d is newer than active manifest generation=%d", ref.Generation, cfg.ActiveManifest.Generation)
@@ -218,6 +229,13 @@ func (c *Collection) scanColumnPhysicalRowsAtSnapshot(
 		diag.DeletedRows += summary.deleted
 	}
 	return diag, nil
+}
+
+func columnPhysicalScanIncludesRefOrdinal(req columnPhysicalScanRequest, ordinal int) bool {
+	if req.RefOrdinalModulo <= 1 {
+		return true
+	}
+	return ordinal%req.RefOrdinalModulo == req.RefOrdinalRemainder
 }
 
 func newColumnPhysicalScanProjection(cfg ColumnStoreConfig, projected []string) (columnPhysicalScanProjection, error) {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -511,7 +511,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 				iter.Next()
 				continue
 			}
-			keyGeneration, err := columnManifestPartGenerationFromRecordKeyForScan(key)
+			keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(key)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
@@ -524,6 +524,9 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			}
 			if ref.Generation != keyGeneration {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+			}
+			if ref.PartID != keyPartID {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
 			}
 			operation, ok := columnPhysicalScanOperationFromBytes(reason)
 			if !ok {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -727,6 +727,42 @@ func TestColumnManifestPlannerCapabilitiesRejectPartIDKeyMismatchM14A(t *testing
 	}
 }
 
+func TestColumnManifestPlannerCapabilitiesRejectHeaderOperationM14A(t *testing.T) {
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	header, err := decodeColumnManifestHeaderRecordForScan(mustEncodeColumnManifestHeaderRecordForScanTestM14A(t, ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       *cfg,
+		Operation:         ColumnPublishOperation("rewrite"),
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			RowCount: 1,
+		},
+	}))
+	if err != nil {
+		t.Fatalf("decodeColumnManifestHeaderRecordForScan: %v", err)
+	}
+
+	err = validateColumnManifestHeaderRecordForScan(header, *cfg, ColumnManifestIdentity{
+		Generation: 1,
+	}, "events")
+	if err == nil || !strings.Contains(err.Error(), "unsupported column manifest header operation") {
+		t.Fatalf("validateColumnManifestHeaderRecordForScan err=%v want unsupported operation", err)
+	}
+}
+
+func mustEncodeColumnManifestHeaderRecordForScanTestM14A(t testing.TB, input ColumnPublishManifestEncodeInput) []byte {
+	t.Helper()
+	header, err := encodeColumnManifestHeaderRecord(input, 1)
+	if err != nil {
+		t.Fatalf("encodeColumnManifestHeaderRecord: %v", err)
+	}
+	return header
+}
+
 func publishColumnManifestRecordsForScanTestM13A(t testing.TB, d *backenddb.DB, identity ColumnManifestIdentity, records []columnManifestRecord) uint64 {
 	t.Helper()
 	iter := columnManifestRootRecordIterator(encodeColumnManifestIdentityRecordArray(identity), records)

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -247,6 +247,50 @@ func TestColumnPhysicalSerialScannerDoesNotEnableAutomaticPlannerRoutingM14B(t *
 	}
 }
 
+func TestColumnPhysicalScanSnapshotViewPinsManifestRefsM14B(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 4)
+	defer closeFn()
+
+	view, closeView, err := reopened.prepareColumnPhysicalScanSnapshotView()
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	defer closeView()
+	if got, want := len(view.AssetRefs), 4; got != want {
+		t.Fatalf("prepared refs=%d want %d", got, want)
+	}
+	preparedGeneration := view.Diagnostics.ManifestGeneration
+	if _, err := reopened.InsertBatch([][]byte{[]byte("new")}, [][]byte{
+		[]byte(`{"time_us":99,"kind":"kind_new","did":"did_new","payload":"after_view"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch after prepared view: %v", err)
+	}
+	if got := reopened.meta.Options.ColumnStore.ActiveManifest.Generation; got <= preparedGeneration {
+		t.Fatalf("active generation=%d did not advance past prepared generation %d", got, preparedGeneration)
+	}
+
+	var scanned int
+	diag, err := reopened.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+		ProjectedColumns: []string{"time_us", "kind"},
+		Visitor: func(row columnPhysicalScanRowView) error {
+			scanned++
+			if string(row.ID) == "new" {
+				t.Fatalf("prepared scan view observed row inserted after view preparation")
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalRowsInSnapshotView: %v", err)
+	}
+	if scanned != 4 || diag.RowsScanned != 4 || diag.ScheduledGranules != 4 || diag.AssetRefs != 4 {
+		t.Fatalf("scan diagnostics=%+v scanned=%d want only the four prepared refs", diag, scanned)
+	}
+	if diag.ManifestGeneration != preparedGeneration {
+		t.Fatalf("scan generation=%d want prepared generation %d", diag.ManifestGeneration, preparedGeneration)
+	}
+}
+
 func TestColumnPhysicalSerialScannerRejectsInvalidProjectionM13A(t *testing.T) {
 	cfg := *testColumnStoreConfig(nil)
 	for _, tc := range []struct {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -667,6 +667,66 @@ func TestColumnPublishRejectsTamperedExistingManifestBeforeCarryM13A(t *testing.
 	}
 }
 
+func TestColumnManifestPlannerCapabilitiesRejectPartIDKeyMismatchM14A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Ref.Generation = 1
+	asset.Ref.PartID = 1
+	asset.GenerationID = 1
+	asset.Reason = string(ColumnPublishOperationInsert)
+	input := ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       *cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			Assets:             []ColumnPreparedAsset{asset},
+			RowCount:           1,
+			ColumnPayloadBytes: asset.Bytes,
+		},
+	}
+	manifest, err := encodeColumnManifestForWrite(input)
+	if err != nil {
+		t.Fatalf("encodeColumnManifestForWrite: %v", err)
+	}
+
+	tampered := cloneColumnManifestRecords(manifest.Records)
+	tamperedCount := 0
+	for i := range tampered {
+		if bytes.HasPrefix(tampered[i].key, columnManifestPartRecordPrefixBytes) {
+			tampered[i].key = columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID+1)
+			tamperedCount++
+			break
+		}
+	}
+	if tamperedCount != 1 {
+		t.Fatalf("tampered manifest part keys=%d want 1", tamperedCount)
+	}
+	tamperedIdentity := manifest.Identity
+	tamperedIdentity.Checksum = checksumColumnManifestRecords(input, tamperedIdentity.Generation, tampered)
+	rootID := publishColumnManifestRecordsForScanTestM13A(t, d, tamperedIdentity, tampered)
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	_, err = loadColumnManifestPlannerCapabilitiesForScan(snap, rootID, *cfg, tamperedIdentity, "events")
+	if err == nil || !strings.Contains(err.Error(), "key part_id") {
+		t.Fatalf("loadColumnManifestPlannerCapabilitiesForScan err=%v want key part_id mismatch", err)
+	}
+}
+
 func publishColumnManifestRecordsForScanTestM13A(t testing.TB, d *backenddb.DB, identity ColumnManifestIdentity, records []columnManifestRecord) uint64 {
 	t.Helper()
 	iter := columnManifestRootRecordIterator(encodeColumnManifestIdentityRecordArray(identity), records)

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -227,7 +227,7 @@ func TestColumnPhysicalSerialScannerFailsClosedCorruptAssetM13A(t *testing.T) {
 	}
 }
 
-func TestColumnPhysicalSerialScannerDoesNotEnablePlannerRoutingM13A(t *testing.T) {
+func TestColumnPhysicalSerialScannerDoesNotEnableAutomaticPlannerRoutingM14B(t *testing.T) {
 	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
 	d := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = d.Close() }()
@@ -238,16 +238,12 @@ func TestColumnPhysicalSerialScannerDoesNotEnablePlannerRoutingM13A(t *testing.T
 	plan, err := col.PlanColumnQuery(ColumnQueryPlanRequest{
 		Name:             "q1",
 		ProjectedColumns: []string{"time_us"},
-		ForceKind:        ColumnQueryPlanSerialColumnScan,
 	})
 	if err != nil {
 		t.Fatalf("PlanColumnQuery: %v", err)
 	}
-	if plan.Supported {
-		t.Fatalf("forced serial plan supported before M14 routing: %+v", plan)
-	}
-	if got := plan.Diagnostics.UnsupportedPlanReason; got != "serial physical column scan capability is disabled" {
-		t.Fatalf("unsupported reason=%q want physical scanner disabled", got)
+	if !plan.Supported || plan.Kind != ColumnQueryPlanRowStoreBaseline {
+		t.Fatalf("automatic physical routing should remain disabled without a forced physical label: %+v", plan)
 	}
 }
 

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -17,7 +17,12 @@ const (
 	ColumnQueryPlanParallelColumnScan ColumnQueryPlanKind = "parallel_column_scan"
 )
 
-const columnQueryUnsupportedNoPhysicalAssetsReason = "physical column query has no physical assets available"
+const (
+	ColumnQueryUnsupportedNoPhysicalAssetsReason          = "physical column query has no physical assets available"
+	ColumnQueryUnsupportedSerialPhysicalDisabledReason    = "serial physical column scan capability is disabled"
+	ColumnQueryUnsupportedAggregateMetadataDisabledReason = "aggregate metadata capability is disabled"
+	ColumnQueryUnsupportedParallelPhysicalDisabledReason  = "parallel physical column scan capability is disabled"
+)
 
 var ErrColumnQueryPlanUnsupported = errors.New("collections: column query plan unsupported")
 
@@ -403,25 +408,25 @@ func physicalColumnQueryUnsupportedReason(identity ColumnStoreCacheIdentity, ide
 	case strings.TrimSpace(req.Capabilities.CapabilityError) != "":
 		return strings.TrimSpace(req.Capabilities.CapabilityError)
 	case req.Capabilities.PhysicalAssetCount <= 0:
-		return columnQueryUnsupportedNoPhysicalAssetsReason
+		return ColumnQueryUnsupportedNoPhysicalAssetsReason
 	case !columnQueryManifestRecoveryAuthoritative(identity, identityOK):
 		return "active column manifest is not recovery-authoritative"
 	}
 	switch kind {
 	case ColumnQueryPlanSerialColumnScan:
 		if !req.Capabilities.SerialColumnScan {
-			return "serial physical column scan capability is disabled"
+			return ColumnQueryUnsupportedSerialPhysicalDisabledReason
 		}
 	case ColumnQueryPlanAggregateMetadata:
 		if !req.Capabilities.AggregateMetadata {
-			return "aggregate metadata capability is disabled"
+			return ColumnQueryUnsupportedAggregateMetadataDisabledReason
 		}
 		if strings.TrimSpace(req.AggregateMetadataName) == "" {
 			return "query did not request aggregate metadata"
 		}
 	case ColumnQueryPlanParallelColumnScan:
 		if !req.Capabilities.ParallelColumnScan {
-			return "parallel physical column scan capability is disabled"
+			return ColumnQueryUnsupportedParallelPhysicalDisabledReason
 		}
 		if reason := parallelColumnQueryShapeUnsupportedReason(req); reason != "" {
 			return reason

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -22,6 +22,7 @@ const (
 	columnQueryUnsupportedSerialPhysicalDisabledReason    = "serial physical column scan capability is disabled"
 	columnQueryUnsupportedAggregateMetadataDisabledReason = "aggregate metadata capability is disabled"
 	columnQueryUnsupportedParallelPhysicalDisabledReason  = "parallel physical column scan capability is disabled"
+	columnQueryUnsupportedParallelMutationPartsReason     = "parallel physical column scan is disabled for mutation visibility metadata"
 )
 
 var ErrColumnQueryPlanUnsupported = errors.New("collections: column query plan unsupported")
@@ -430,6 +431,9 @@ func physicalColumnQueryUnsupportedReason(identity ColumnStoreCacheIdentity, ide
 			return "query did not request aggregate metadata"
 		}
 	case ColumnQueryPlanParallelColumnScan:
+		if req.Capabilities.MutationParts > 0 {
+			return columnQueryUnsupportedParallelMutationPartsReason
+		}
 		if !req.Capabilities.ParallelColumnScan {
 			return columnQueryUnsupportedParallelPhysicalDisabledReason
 		}

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -148,7 +148,7 @@ func (c *Collection) PlanColumnQuery(req ColumnQueryPlanRequest) (ColumnQueryPla
 		return ColumnQueryPlan{}, errCollectionNotFound
 	}
 	if columnStoreEnabled && columnQueryRequestNeedsPhysicalCapabilityDiscovery(req) {
-		req.Capabilities = c.deriveColumnQueryPlannerCapabilitiesM14A(collectionName, rootID, cfg, columnStoreEnabled, req.Capabilities)
+		req.Capabilities = c.deriveColumnQueryPlannerCapabilitiesM14B(collectionName, rootID, cfg, columnStoreEnabled, req)
 	}
 	identity, identityOK := columnStoreCacheIdentity(catalog, systemRoot, commitSeq)
 	return planColumnQueryForCatalog(catalog, identity, identityOK, req), nil
@@ -167,8 +167,8 @@ func columnQueryRequestNeedsPhysicalCapabilityDiscovery(req ColumnQueryPlanReque
 	}
 }
 
-func (c *Collection) deriveColumnQueryPlannerCapabilitiesM14A(collectionName string, rootID uint64, cfg ColumnStoreConfig, columnStoreEnabled bool, requested ColumnQueryPlannerCapabilities) ColumnQueryPlannerCapabilities {
-	caps := requested
+func (c *Collection) deriveColumnQueryPlannerCapabilitiesM14B(collectionName string, rootID uint64, cfg ColumnStoreConfig, columnStoreEnabled bool, req ColumnQueryPlanRequest) ColumnQueryPlannerCapabilities {
+	caps := req.Capabilities
 	caps.SerialColumnScan = false
 	caps.AggregateMetadata = false
 	caps.ParallelColumnScan = false
@@ -234,7 +234,21 @@ func (c *Collection) deriveColumnQueryPlannerCapabilitiesM14A(collectionName str
 	caps.MutationParts = manifestCaps.MutationParts
 	caps.VisibilityMetadata = manifestCaps.MutationParts > 0 || cfg.PhysicalMutationParts > 0
 	caps.ParallelWorkUnits = columnQueryParallelWorkUnits(caps)
+	if columnQueryForcedPhysicalExecution(req.ForceKind) && caps.PhysicalAssetCount > 0 {
+		caps.SerialColumnScan = true
+		caps.AggregateMetadata = len(cfg.AggregateMetadata) > 0
+		caps.ParallelColumnScan = caps.MutationParts == 0 && columnQueryParallelWorkerCount(caps) > 1
+	}
 	return caps
+}
+
+func columnQueryForcedPhysicalExecution(kind ColumnQueryPlanKind) bool {
+	switch kind {
+	case ColumnQueryPlanSerialColumnScan, ColumnQueryPlanAggregateMetadata, ColumnQueryPlanParallelColumnScan:
+		return true
+	default:
+		return false
+	}
 }
 
 func planColumnQueryForCatalog(catalog *collectionCatalog, identity ColumnStoreCacheIdentity, identityOK bool, req ColumnQueryPlanRequest) ColumnQueryPlan {

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -61,11 +61,11 @@ type ColumnQueryPlannerCapabilities struct {
 	PartCount int
 	// GranuleCount is the authoritative schedulable-unit count for parallel
 	// planning when the column asset layer exposes adaptive marks/granules.
-	GranuleCount            int
-	MaxParallelWorkers      int
-	DecodedBlockCacheHits   uint64
-	DecodedBlockCacheMisses uint64
-	PlannerCandidateBudget  int
+	GranuleCount           int
+	MaxParallelWorkers     int
+	SegmentFileCacheHits   uint64
+	SegmentFileCacheMisses uint64
+	PlannerCandidateBudget int
 	// M14A manifest-derived diagnostics. These do not enable execution by
 	// themselves; M14B owns routing physical plans to physical scanners.
 	MutationParts          int
@@ -94,34 +94,34 @@ type ColumnQueryPlanRequest struct {
 }
 
 type ColumnQueryPlanDiagnostics struct {
-	Reason                  string
-	CandidatePlans          int
-	ProjectedColumns        int
-	Predicates              int
-	RecoveryAuthoritative   bool
-	CapabilityError         string
-	PhysicalAssetCount      int
-	PartCount               int
-	GranuleCount            int
-	MutationParts           int
-	DeclaredColumnCount     int
-	AggregateMetadataCount  int
-	VisibilityMetadata      bool
-	ParallelWorkUnits       int
-	MaxParallelWorkers      int
-	WorkerCount             int
-	ScheduledGranules       int
-	SkippedGranules         int
-	DecodedBlockCacheHits   uint64
-	DecodedBlockCacheMisses uint64
-	SelectedIndexName       string
-	SelectedIndexField      string
-	SelectedManifestRoot    uint64
-	SelectedManifestGen     uint64
-	RecoveryManifestGen     uint64
-	AppliedCommandLSN       uint64
-	UnsupportedPlanKind     ColumnQueryPlanKind
-	UnsupportedPlanReason   string
+	Reason                 string
+	CandidatePlans         int
+	ProjectedColumns       int
+	Predicates             int
+	RecoveryAuthoritative  bool
+	CapabilityError        string
+	PhysicalAssetCount     int
+	PartCount              int
+	GranuleCount           int
+	MutationParts          int
+	DeclaredColumnCount    int
+	AggregateMetadataCount int
+	VisibilityMetadata     bool
+	ParallelWorkUnits      int
+	MaxParallelWorkers     int
+	WorkerCount            int
+	ScheduledGranules      int
+	SkippedGranules        int
+	SegmentFileCacheHits   uint64
+	SegmentFileCacheMisses uint64
+	SelectedIndexName      string
+	SelectedIndexField     string
+	SelectedManifestRoot   uint64
+	SelectedManifestGen    uint64
+	RecoveryManifestGen    uint64
+	AppliedCommandLSN      uint64
+	UnsupportedPlanKind    ColumnQueryPlanKind
+	UnsupportedPlanReason  string
 }
 
 type ColumnQueryPlan struct {
@@ -264,26 +264,26 @@ func (caps ColumnQueryPlannerCapabilities) effectiveCapabilityError() string {
 
 func planColumnQueryForCatalog(catalog *collectionCatalog, identity ColumnStoreCacheIdentity, identityOK bool, req ColumnQueryPlanRequest) ColumnQueryPlan {
 	diag := ColumnQueryPlanDiagnostics{
-		CandidatePlans:          columnQueryPlannerCandidateCount(catalog, identity, identityOK, req),
-		ProjectedColumns:        len(req.ProjectedColumns),
-		Predicates:              len(req.Predicates),
-		RecoveryAuthoritative:   columnQueryManifestRecoveryAuthoritative(identity, identityOK),
-		CapabilityError:         req.Capabilities.effectiveCapabilityError(),
-		PhysicalAssetCount:      req.Capabilities.PhysicalAssetCount,
-		PartCount:               req.Capabilities.PartCount,
-		GranuleCount:            req.Capabilities.GranuleCount,
-		MutationParts:           req.Capabilities.MutationParts,
-		DeclaredColumnCount:     req.Capabilities.DeclaredColumnCount,
-		AggregateMetadataCount:  req.Capabilities.AggregateMetadataCount,
-		VisibilityMetadata:      req.Capabilities.VisibilityMetadata,
-		ParallelWorkUnits:       req.Capabilities.ParallelWorkUnits,
-		MaxParallelWorkers:      req.Capabilities.MaxParallelWorkers,
-		DecodedBlockCacheHits:   req.Capabilities.DecodedBlockCacheHits,
-		DecodedBlockCacheMisses: req.Capabilities.DecodedBlockCacheMisses,
-		SelectedManifestRoot:    identity.ManifestRoot,
-		SelectedManifestGen:     identity.ManifestGeneration,
-		RecoveryManifestGen:     identity.RecoveryAuthoritativeGeneration,
-		AppliedCommandLSN:       identity.RecoveryAuthoritativeAppliedCommandLSN,
+		CandidatePlans:         columnQueryPlannerCandidateCount(catalog, identity, identityOK, req),
+		ProjectedColumns:       len(req.ProjectedColumns),
+		Predicates:             len(req.Predicates),
+		RecoveryAuthoritative:  columnQueryManifestRecoveryAuthoritative(identity, identityOK),
+		CapabilityError:        req.Capabilities.effectiveCapabilityError(),
+		PhysicalAssetCount:     req.Capabilities.PhysicalAssetCount,
+		PartCount:              req.Capabilities.PartCount,
+		GranuleCount:           req.Capabilities.GranuleCount,
+		MutationParts:          req.Capabilities.MutationParts,
+		DeclaredColumnCount:    req.Capabilities.DeclaredColumnCount,
+		AggregateMetadataCount: req.Capabilities.AggregateMetadataCount,
+		VisibilityMetadata:     req.Capabilities.VisibilityMetadata,
+		ParallelWorkUnits:      req.Capabilities.ParallelWorkUnits,
+		MaxParallelWorkers:     req.Capabilities.MaxParallelWorkers,
+		SegmentFileCacheHits:   req.Capabilities.SegmentFileCacheHits,
+		SegmentFileCacheMisses: req.Capabilities.SegmentFileCacheMisses,
+		SelectedManifestRoot:   identity.ManifestRoot,
+		SelectedManifestGen:    identity.ManifestGeneration,
+		RecoveryManifestGen:    identity.RecoveryAuthoritativeGeneration,
+		AppliedCommandLSN:      identity.RecoveryAuthoritativeAppliedCommandLSN,
 	}
 	if reason := physicalColumnQueryUnsupportedReasonForFallback(catalog, req); reason != "" {
 		diag.UnsupportedPlanReason = reason

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -165,7 +165,7 @@ func columnQueryRequestNeedsPhysicalCapabilityDiscovery(req ColumnQueryPlanReque
 	case "":
 		return true
 	default:
-		return false
+		return true
 	}
 }
 
@@ -234,7 +234,7 @@ func (c *Collection) deriveColumnQueryPlannerCapabilitiesM14B(collectionName str
 	// replace this fallback with finer granule counts when they land.
 	caps.GranuleCount = manifestCaps.PhysicalAssetCount
 	caps.MutationParts = manifestCaps.MutationParts
-	caps.VisibilityMetadata = manifestCaps.MutationParts > 0 || cfg.PhysicalMutationParts > 0
+	caps.VisibilityMetadata = caps.MutationParts > 0
 	caps.ParallelWorkUnits = columnQueryParallelWorkUnits(caps)
 	if columnQueryForcedPhysicalExecution(req.ForceKind) && caps.PhysicalAssetCount > 0 {
 		caps.SerialColumnScan = true

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -18,10 +18,10 @@ const (
 )
 
 const (
-	ColumnQueryUnsupportedNoPhysicalAssetsReason          = "physical column query has no physical assets available"
-	ColumnQueryUnsupportedSerialPhysicalDisabledReason    = "serial physical column scan capability is disabled"
-	ColumnQueryUnsupportedAggregateMetadataDisabledReason = "aggregate metadata capability is disabled"
-	ColumnQueryUnsupportedParallelPhysicalDisabledReason  = "parallel physical column scan capability is disabled"
+	columnQueryUnsupportedNoPhysicalAssetsReason          = "physical column query has no physical assets available"
+	columnQueryUnsupportedSerialPhysicalDisabledReason    = "serial physical column scan capability is disabled"
+	columnQueryUnsupportedAggregateMetadataDisabledReason = "aggregate metadata capability is disabled"
+	columnQueryUnsupportedParallelPhysicalDisabledReason  = "parallel physical column scan capability is disabled"
 )
 
 var ErrColumnQueryPlanUnsupported = errors.New("collections: column query plan unsupported")
@@ -399,25 +399,25 @@ func physicalColumnQueryUnsupportedReason(identity ColumnStoreCacheIdentity, ide
 	case strings.TrimSpace(req.Capabilities.CapabilityError) != "":
 		return strings.TrimSpace(req.Capabilities.CapabilityError)
 	case req.Capabilities.PhysicalAssetCount <= 0:
-		return ColumnQueryUnsupportedNoPhysicalAssetsReason
+		return columnQueryUnsupportedNoPhysicalAssetsReason
 	case !columnQueryManifestRecoveryAuthoritative(identity, identityOK):
 		return "active column manifest is not recovery-authoritative"
 	}
 	switch kind {
 	case ColumnQueryPlanSerialColumnScan:
 		if !req.Capabilities.SerialColumnScan {
-			return ColumnQueryUnsupportedSerialPhysicalDisabledReason
+			return columnQueryUnsupportedSerialPhysicalDisabledReason
 		}
 	case ColumnQueryPlanAggregateMetadata:
 		if !req.Capabilities.AggregateMetadata {
-			return ColumnQueryUnsupportedAggregateMetadataDisabledReason
+			return columnQueryUnsupportedAggregateMetadataDisabledReason
 		}
 		if strings.TrimSpace(req.AggregateMetadataName) == "" {
 			return "query did not request aggregate metadata"
 		}
 	case ColumnQueryPlanParallelColumnScan:
 		if !req.Capabilities.ParallelColumnScan {
-			return ColumnQueryUnsupportedParallelPhysicalDisabledReason
+			return columnQueryUnsupportedParallelPhysicalDisabledReason
 		}
 		if reason := parallelColumnQueryShapeUnsupportedReason(req); reason != "" {
 			return reason

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -372,8 +372,9 @@ func aggregateColumnQueryPlan(catalog *collectionCatalog, identity ColumnStoreCa
 	if !physicalColumnQuerySupported(catalog, identity, identityOK, req, ColumnQueryPlanAggregateMetadata) {
 		return false, ColumnQueryPlan{}
 	}
-	diag.Reason = "selected aggregate metadata"
-	diag.ScheduledGranules = 0
+	diag.Reason = "selected scan-backed aggregate metadata"
+	diag.ScheduledGranules = req.Capabilities.GranuleCount
+	diag.WorkerCount = 1
 	return true, ColumnQueryPlan{Kind: ColumnQueryPlanAggregateMetadata, Supported: true, Diagnostics: diag}
 }
 

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -337,7 +337,7 @@ func forcedColumnQueryPlan(catalog *collectionCatalog, identity ColumnStoreCache
 		return unsupportedColumnQueryPlan(ColumnQueryPlanSerialColumnScan, physicalColumnQueryUnsupportedReasonForCatalog(catalog, identity, identityOK, req, ColumnQueryPlanSerialColumnScan), diag)
 	case ColumnQueryPlanAggregateMetadata:
 		if ok, plan := aggregateColumnQueryPlan(catalog, identity, identityOK, req, diag); ok {
-			plan.Diagnostics.Reason = "forced aggregate metadata plan"
+			plan.Diagnostics.Reason = "forced scan-backed aggregate metadata plan"
 			return plan
 		}
 		return unsupportedColumnQueryPlan(ColumnQueryPlanAggregateMetadata, aggregateColumnQueryUnsupportedReason(catalog, identity, identityOK, req), diag)

--- a/TreeDB/collections/column_query_plan.go
+++ b/TreeDB/collections/column_query_plan.go
@@ -162,16 +162,7 @@ func (c *Collection) PlanColumnQuery(req ColumnQueryPlanRequest) (ColumnQueryPla
 }
 
 func columnQueryRequestNeedsPhysicalCapabilityDiscovery(req ColumnQueryPlanRequest) bool {
-	switch req.ForceKind {
-	case ColumnQueryPlanRowStoreBaseline, ColumnQueryPlanBTreeIndexBaseline:
-		return false
-	case ColumnQueryPlanSerialColumnScan, ColumnQueryPlanAggregateMetadata, ColumnQueryPlanParallelColumnScan:
-		return true
-	case "":
-		return true
-	default:
-		return true
-	}
+	return req.ForceKind != ColumnQueryPlanRowStoreBaseline && req.ForceKind != ColumnQueryPlanBTreeIndexBaseline
 }
 
 func (c *Collection) deriveColumnQueryPlannerCapabilitiesM14B(collectionName string, rootID uint64, cfg ColumnStoreConfig, req ColumnQueryPlanRequest) ColumnQueryPlannerCapabilities {

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -1214,65 +1215,126 @@ func TestColumnSkipScanIntoM11BReusesScratchWithoutAllocating(t *testing.T) {
 	}
 }
 
-func TestColumnQueryPlannerM14APopulatesManifestCapabilitiesButKeepsForcedPhysicalDisabled(t *testing.T) {
+func TestColumnQueryPlannerM14BRoutesForcedPhysicalPlansFromManifestCapabilities(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(32)
 	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
 	defer closeFn()
 
-	req := ColumnQueryPlanRequest{
-		Name:             "m14a_serial",
-		ProjectedColumns: []string{"time_us", "kind"},
-		ForceKind:        ColumnQueryPlanSerialColumnScan,
-		Capabilities: ColumnQueryPlannerCapabilities{
-			SerialColumnScan:   true,
-			AggregateMetadata:  true,
-			ParallelColumnScan: true,
-			PhysicalAssetCount: 999,
-			PartCount:          999,
-			GranuleCount:       999,
-			MaxParallelWorkers: 4,
+	tests := []struct {
+		name     string
+		req      ColumnQueryPlanRequest
+		wantKind ColumnQueryPlanKind
+		workers  int
+	}{
+		{
+			name: "serial",
+			req: ColumnQueryPlanRequest{
+				Name:             "m14b_serial",
+				ProjectedColumns: []string{"time_us", "kind"},
+				ForceKind:        ColumnQueryPlanSerialColumnScan,
+			},
+			wantKind: ColumnQueryPlanSerialColumnScan,
+			workers:  1,
+		},
+		{
+			name: "aggregate metadata",
+			req: ColumnQueryPlanRequest{
+				Name:                  "m14b_aggregate",
+				ProjectedColumns:      []string{"time_us", "did"},
+				AggregateMetadataName: "min_time_us",
+				ForceKind:             ColumnQueryPlanAggregateMetadata,
+			},
+			wantKind: ColumnQueryPlanAggregateMetadata,
 		},
 	}
-	plan, err := reopened.PlanColumnQuery(req)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.req
+			req.Capabilities = ColumnQueryPlannerCapabilities{
+				SerialColumnScan:       true,
+				AggregateMetadata:      true,
+				ParallelColumnScan:     true,
+				PhysicalAssetCount:     999,
+				PartCount:              999,
+				GranuleCount:           999,
+				MaxParallelWorkers:     4,
+				PlannerCandidateBudget: 5,
+			}
+			plan, err := reopened.PlanColumnQuery(req)
+			if err != nil {
+				t.Fatalf("PlanColumnQuery: %v", err)
+			}
+			if !plan.Supported {
+				t.Fatalf("forced physical plan unsupported: %+v", plan)
+			}
+			if plan.Kind != tc.wantKind {
+				t.Fatalf("plan kind=%q want %q diagnostics=%+v", plan.Kind, tc.wantKind, plan.Diagnostics)
+			}
+			if tc.workers > 0 && plan.Diagnostics.WorkerCount != tc.workers {
+				t.Fatalf("worker count=%d want %d diagnostics=%+v", plan.Diagnostics.WorkerCount, tc.workers, plan.Diagnostics)
+			}
+			if got := plan.Diagnostics.PhysicalAssetCount; got <= 0 || got == 999 {
+				t.Fatalf("physical asset count=%d want real manifest-derived count", got)
+			}
+			if got, want := plan.Diagnostics.PartCount, plan.Diagnostics.PhysicalAssetCount; got != want {
+				t.Fatalf("part count=%d want physical asset count %d", got, want)
+			}
+			if got, want := plan.Diagnostics.GranuleCount, plan.Diagnostics.PartCount; got != want {
+				t.Fatalf("granule count=%d want part-count fallback %d", got, want)
+			}
+			if got, want := plan.Diagnostics.ParallelWorkUnits, plan.Diagnostics.GranuleCount; got != want {
+				t.Fatalf("parallel work units=%d want granule count %d", got, want)
+			}
+			if got, want := plan.Diagnostics.DeclaredColumnCount, 3; got != want {
+				t.Fatalf("declared columns=%d want %d", got, want)
+			}
+			if got, want := plan.Diagnostics.AggregateMetadataCount, 3; got != want {
+				t.Fatalf("aggregate metadata count=%d want %d", got, want)
+			}
+			if plan.Diagnostics.MutationParts != 0 {
+				t.Fatalf("mutation parts=%d want zero for insert-only fixture", plan.Diagnostics.MutationParts)
+			}
+			if plan.Diagnostics.VisibilityMetadata {
+				t.Fatalf("visibility metadata unexpectedly set for insert-only fixture: %+v", plan.Diagnostics)
+			}
+			if !plan.Diagnostics.RecoveryAuthoritative || plan.Diagnostics.SelectedManifestRoot == 0 || plan.Diagnostics.SelectedManifestGen == 0 || plan.Diagnostics.AppliedCommandLSN == 0 {
+				t.Fatalf("manifest diagnostics were not populated from recovery-authoritative state: %+v", plan.Diagnostics)
+			}
+		})
+	}
+
+	parallelCollection, parallelClose := openColumnPhysicalInsertMultiGenerationFixtureM14B(t, 4)
+	defer parallelClose()
+	parallel, err := parallelCollection.PlanColumnQuery(ColumnQueryPlanRequest{
+		Name:             "m14b_parallel",
+		ProjectedColumns: []string{"time_us", "kind"},
+		ForceKind:        ColumnQueryPlanParallelColumnScan,
+		Capabilities: ColumnQueryPlannerCapabilities{
+			SerialColumnScan:       true,
+			AggregateMetadata:      true,
+			ParallelColumnScan:     true,
+			PhysicalAssetCount:     999,
+			PartCount:              999,
+			GranuleCount:           999,
+			MaxParallelWorkers:     4,
+			PlannerCandidateBudget: 5,
+		},
+	})
 	if err != nil {
-		t.Fatalf("PlanColumnQuery: %v", err)
+		t.Fatalf("PlanColumnQuery parallel: %v", err)
 	}
-	if plan.Supported {
-		t.Fatalf("forced physical plan unexpectedly supported: %+v", plan)
+	if !parallel.Supported || parallel.Kind != ColumnQueryPlanParallelColumnScan {
+		t.Fatalf("forced parallel plan unsupported: %+v", parallel)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "serial physical column scan capability is disabled"; got != want {
-		t.Fatalf("unsupported reason=%q want %q diagnostics=%+v", got, want, plan.Diagnostics)
+	if got, want := parallel.Diagnostics.WorkerCount, 4; got != want {
+		t.Fatalf("worker count=%d want %d diagnostics=%+v", got, want, parallel.Diagnostics)
 	}
-	if got := plan.Diagnostics.PhysicalAssetCount; got <= 0 || got == 999 {
-		t.Fatalf("physical asset count=%d want real manifest-derived count", got)
-	}
-	if got, want := plan.Diagnostics.PartCount, plan.Diagnostics.PhysicalAssetCount; got != want {
-		t.Fatalf("part count=%d want physical asset count %d", got, want)
-	}
-	if got, want := plan.Diagnostics.GranuleCount, plan.Diagnostics.PartCount; got != want {
-		t.Fatalf("granule count=%d want part-count fallback %d", got, want)
-	}
-	if got, want := plan.Diagnostics.ParallelWorkUnits, plan.Diagnostics.GranuleCount; got != want {
-		t.Fatalf("parallel work units=%d want granule count %d", got, want)
-	}
-	if got, want := plan.Diagnostics.DeclaredColumnCount, 3; got != want {
-		t.Fatalf("declared columns=%d want %d", got, want)
-	}
-	if got, want := plan.Diagnostics.AggregateMetadataCount, 3; got != want {
-		t.Fatalf("aggregate metadata count=%d want %d", got, want)
-	}
-	if plan.Diagnostics.MutationParts != 0 {
-		t.Fatalf("mutation parts=%d want zero for insert-only fixture", plan.Diagnostics.MutationParts)
-	}
-	if plan.Diagnostics.VisibilityMetadata {
-		t.Fatalf("visibility metadata unexpectedly set for insert-only fixture: %+v", plan.Diagnostics)
-	}
-	if !plan.Diagnostics.RecoveryAuthoritative || plan.Diagnostics.SelectedManifestRoot == 0 || plan.Diagnostics.SelectedManifestGen == 0 || plan.Diagnostics.AppliedCommandLSN == 0 {
-		t.Fatalf("manifest diagnostics were not populated from recovery-authoritative state: %+v", plan.Diagnostics)
+	if got := parallel.Diagnostics.PhysicalAssetCount; got < 4 || got == 999 {
+		t.Fatalf("physical asset count=%d want real multi-generation assets", got)
 	}
 }
 
-func TestColumnQueryPlannerM14APopulatesMutationVisibilityCapabilities(t *testing.T) {
+func TestColumnQueryPlannerM14BRoutesSerialMutationVisibilityButNotParallel(t *testing.T) {
 	reopened, closeFn, _ := openColumnPhysicalMutationFixtureM13C(t, 64)
 	defer closeFn()
 
@@ -1293,11 +1355,8 @@ func TestColumnQueryPlannerM14APopulatesMutationVisibilityCapabilities(t *testin
 	if err != nil {
 		t.Fatalf("PlanColumnQuery: %v", err)
 	}
-	if plan.Supported {
-		t.Fatalf("forced physical mutation plan unexpectedly supported before M14B: %+v", plan)
-	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, "serial physical column scan capability is disabled"; got != want {
-		t.Fatalf("unsupported reason=%q want %q diagnostics=%+v", got, want, plan.Diagnostics)
+	if !plan.Supported || plan.Kind != ColumnQueryPlanSerialColumnScan {
+		t.Fatalf("forced serial mutation plan not routed through physical visibility path: %+v", plan)
 	}
 	if got := plan.Diagnostics.PhysicalAssetCount; got <= 1 || got == 999 {
 		t.Fatalf("physical asset count=%d want real multi-part mutation manifest count", got)
@@ -1314,6 +1373,47 @@ func TestColumnQueryPlannerM14APopulatesMutationVisibilityCapabilities(t *testin
 	if got, want := plan.Diagnostics.GranuleCount, plan.Diagnostics.PartCount; got != want {
 		t.Fatalf("granule count=%d want part-count fallback %d", got, want)
 	}
+
+	parallel, err := reopened.PlanColumnQuery(ColumnQueryPlanRequest{
+		Name:             "m14b_parallel_mutation",
+		ProjectedColumns: []string{"time_us", "kind"},
+		ForceKind:        ColumnQueryPlanParallelColumnScan,
+		Capabilities: ColumnQueryPlannerCapabilities{
+			SerialColumnScan:   true,
+			AggregateMetadata:  true,
+			ParallelColumnScan: true,
+			MaxParallelWorkers: 4,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnQuery parallel: %v", err)
+	}
+	if parallel.Supported {
+		t.Fatalf("parallel mutation plan should fail closed until partitioned visibility execution lands: %+v", parallel)
+	}
+	if got, want := parallel.Diagnostics.UnsupportedPlanReason, "parallel physical column scan capability is disabled"; got != want {
+		t.Fatalf("parallel unsupported reason=%q want %q diagnostics=%+v", got, want, parallel.Diagnostics)
+	}
+}
+
+func openColumnPhysicalInsertMultiGenerationFixtureM14B(t *testing.T, batches int) (*Collection, func()) {
+	t.Helper()
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	col := openColumnStoreCollectionM10B(t, d)
+	for i := 0; i < batches; i++ {
+		id := []byte(fmt.Sprintf("e%d", i))
+		doc := []byte(fmt.Sprintf(`{"time_us":%d,"kind":"kind_%02d","did":"did_%02d","payload":"p%d"}`, i+1, i%4, i%8, i))
+		if _, err := col.InsertBatch([][]byte{id}, [][]byte{doc}); err != nil {
+			_ = d.Close()
+			t.Fatalf("InsertBatch %d: %v", i, err)
+		}
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close before reopen: %v", err)
+	}
+	reopen := openCollectionCommandWALDB(t, dir)
+	return openColumnStoreCollectionM10B(t, reopen), func() { _ = reopen.Close() }
 }
 
 func TestColumnQueryPlannerM14AFailsClosedWhenDBUnavailable(t *testing.T) {
@@ -1388,7 +1488,7 @@ func BenchmarkColumnQueryPlannerCapabilitiesM14A(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			if plan.Supported || plan.Diagnostics.UnsupportedPlanReason != "serial physical column scan capability is disabled" {
+			if !plan.Supported || plan.Kind != ColumnQueryPlanSerialColumnScan {
 				b.Fatalf("unexpected plan: %+v", plan)
 			}
 			assets += plan.Diagnostics.PhysicalAssetCount
@@ -1417,7 +1517,7 @@ func BenchmarkColumnQueryPlannerCapabilitiesM14A(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			if plan.Supported || !plan.Diagnostics.VisibilityMetadata {
+			if !plan.Supported || !plan.Diagnostics.VisibilityMetadata {
 				b.Fatalf("unexpected mutation plan: %+v", plan)
 			}
 			mutationParts += plan.Diagnostics.MutationParts

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -124,6 +124,14 @@ func TestColumnQueryPlannerM11BChoosesExpectedKindsForOneFixture(t *testing.T) {
 			if !plan.Diagnostics.RecoveryAuthoritative && plan.Kind != ColumnQueryPlanRowStoreBaseline && plan.Kind != ColumnQueryPlanBTreeIndexBaseline {
 				t.Fatalf("physical plan did not record recovery-authoritative manifest: %+v", plan.Diagnostics)
 			}
+			if tc.want == ColumnQueryPlanAggregateMetadata {
+				if plan.Diagnostics.ScheduledGranules != base.Capabilities.GranuleCount || plan.Diagnostics.WorkerCount != 1 {
+					t.Fatalf("aggregate metadata diagnostics=%+v want scan-backed granules=%d worker=1", plan.Diagnostics, base.Capabilities.GranuleCount)
+				}
+				if !strings.Contains(plan.Diagnostics.Reason, "scan-backed") {
+					t.Fatalf("aggregate metadata reason=%q want scan-backed disclosure", plan.Diagnostics.Reason)
+				}
+			}
 		})
 	}
 }
@@ -1245,6 +1253,7 @@ func TestColumnQueryPlannerM14BRoutesForcedPhysicalPlansFromManifestCapabilities
 				ForceKind:             ColumnQueryPlanAggregateMetadata,
 			},
 			wantKind: ColumnQueryPlanAggregateMetadata,
+			workers:  1,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -561,7 +561,7 @@ func TestColumnQueryPlannerM11BRecoveryAuthoritativeDoesNotRequireManifestRoot(t
 	if !plan.Diagnostics.RecoveryAuthoritative {
 		t.Fatalf("zero manifest root should not hide recovery-authoritative generation match: %+v", plan.Diagnostics)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 }
@@ -879,13 +879,13 @@ func TestColumnQueryPlannerM11BReportsPhysicalGateBeforeMissingAggregateName(t *
 	if plan.Supported {
 		t.Fatalf("expected aggregate metadata without physical assets to fail closed: %+v", plan)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 
 	identity.ManifestRoot = 0
 	plan = planColumnQueryForCatalog(catalog, identity, true, req)
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("zero-root/no-assets unsupported reason=%q want %q", got, want)
 	}
 }

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -1400,7 +1400,7 @@ func TestColumnQueryPlannerM14BRoutesSerialMutationVisibilityButNotParallel(t *t
 	if parallel.Supported {
 		t.Fatalf("parallel mutation plan should fail closed until partitioned visibility execution lands: %+v", parallel)
 	}
-	if got, want := parallel.Diagnostics.UnsupportedPlanReason, "parallel physical column scan capability is disabled"; got != want {
+	if got, want := parallel.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedParallelMutationPartsReason; got != want {
 		t.Fatalf("parallel unsupported reason=%q want %q diagnostics=%+v", got, want, parallel.Diagnostics)
 	}
 }

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -1487,9 +1487,6 @@ func TestColumnQueryPlannerM14AIgnoresCallerSuppliedCapabilityError(t *testing.T
 	if err != nil {
 		t.Fatalf("PlanColumnQuery: %v", err)
 	}
-	if plan.Supported {
-		t.Fatalf("forced physical plan unexpectedly supported: %+v", plan)
-	}
 	if got := plan.Diagnostics.CapabilityError; got != "" {
 		t.Fatalf("capability error=%q want caller-supplied value ignored", got)
 	}

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -1465,6 +1465,44 @@ func TestColumnQueryPlannerM14AFailsClosedWhenDBUnavailable(t *testing.T) {
 	}
 }
 
+func TestColumnQueryPlannerM14AFailsClosedUnknownForceKindClearsCallerCapabilities(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(16))
+	defer closeFn()
+
+	plan, err := reopened.PlanColumnQuery(ColumnQueryPlanRequest{
+		Name:             "m14a_unknown_force",
+		ProjectedColumns: []string{"time_us", "kind"},
+		ForceKind:        ColumnQueryPlanKind("unknown_physical_force"),
+		Capabilities: ColumnQueryPlannerCapabilities{
+			SerialColumnScan:   true,
+			AggregateMetadata:  true,
+			ParallelColumnScan: true,
+			PhysicalAssetCount: 999,
+			PartCount:          999,
+			GranuleCount:       999,
+			MaxParallelWorkers: 4,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnQuery: %v", err)
+	}
+	if plan.Supported {
+		t.Fatalf("unknown forced physical plan unexpectedly supported: %+v", plan)
+	}
+	if got := plan.Diagnostics.UnsupportedPlanReason; !strings.Contains(got, "unknown column query plan kind") {
+		t.Fatalf("unsupported reason=%q want unknown force-kind rejection diagnostics=%+v", got, plan.Diagnostics)
+	}
+	if got := plan.Diagnostics.PhysicalAssetCount; got <= 0 || got == 999 {
+		t.Fatalf("physical asset count=%d want manifest-derived count, not caller-supplied capabilities", got)
+	}
+	if got := plan.Diagnostics.UnsupportedPlanKind; got != ColumnQueryPlanKind("unknown_physical_force") {
+		t.Fatalf("unsupported plan kind=%q want unknown forced kind diagnostics=%+v", got, plan.Diagnostics)
+	}
+	if plan.Diagnostics.ScheduledGranules != 0 || plan.Diagnostics.WorkerCount != 0 {
+		t.Fatalf("unknown forced kind should not schedule physical work: %+v", plan.Diagnostics)
+	}
+}
+
 func BenchmarkColumnQueryPlannerCapabilitiesM14A(b *testing.B) {
 	b.Run("insert_manifest_rows_1024", func(b *testing.B) {
 		reopened, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(1024))

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -561,7 +561,7 @@ func TestColumnQueryPlannerM11BRecoveryAuthoritativeDoesNotRequireManifestRoot(t
 	if !plan.Diagnostics.RecoveryAuthoritative {
 		t.Fatalf("zero manifest root should not hide recovery-authoritative generation match: %+v", plan.Diagnostics)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 }
@@ -879,13 +879,13 @@ func TestColumnQueryPlannerM11BReportsPhysicalGateBeforeMissingAggregateName(t *
 	if plan.Supported {
 		t.Fatalf("expected aggregate metadata without physical assets to fail closed: %+v", plan)
 	}
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("unsupported reason=%q want %q", got, want)
 	}
 
 	identity.ManifestRoot = 0
 	plan = planColumnQueryForCatalog(catalog, identity, true, req)
-	if got, want := plan.Diagnostics.UnsupportedPlanReason, ColumnQueryUnsupportedNoPhysicalAssetsReason; got != want {
+	if got, want := plan.Diagnostics.UnsupportedPlanReason, columnQueryUnsupportedNoPhysicalAssetsReason; got != want {
 		t.Fatalf("zero-root/no-assets unsupported reason=%q want %q", got, want)
 	}
 }

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1123,11 +1123,21 @@ func goToolExecutable() string {
 	}
 	if goroot := runtime.GOROOT(); goroot != "" {
 		candidate := filepath.Join(goroot, "bin", name)
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+		if info, err := os.Stat(candidate); err == nil && goToolCandidateExecutable(info) {
 			return candidate
 		}
 	}
 	return "go"
+}
+
+func goToolCandidateExecutable(info os.FileInfo) bool {
+	if info == nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
 }
 
 func contentionProfilePath(globalPath, kind, testName, dbName string) string {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1113,7 +1113,9 @@ func runPprofDeltaCommand(basePath, afterPath string) ([]byte, string, error) {
 
 func goToolExecutable() string {
 	if path, err := exec.LookPath("go"); err == nil {
-		return path
+		if filepath.IsAbs(path) {
+			return path
+		}
 	}
 	name := "go"
 	if runtime.GOOS == "windows" {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1102,13 +1102,30 @@ func writePprofDeltaProfileWithRunner(basePath, afterPath, outPath string, runne
 func runPprofDeltaCommand(basePath, afterPath string) ([]byte, string, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "tool", "pprof", "-proto", "-base", basePath, afterPath)
+	cmd := exec.Command(goToolExecutable(), "tool", "pprof", "-proto", "-base", basePath, afterPath)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return nil, stderr.String(), err
 	}
 	return stdout.Bytes(), stderr.String(), nil
+}
+
+func goToolExecutable() string {
+	if path, err := exec.LookPath("go"); err == nil {
+		return path
+	}
+	name := "go"
+	if runtime.GOOS == "windows" {
+		name = "go.exe"
+	}
+	if goroot := runtime.GOROOT(); goroot != "" {
+		candidate := filepath.Join(goroot, "bin", name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return "go"
 }
 
 func contentionProfilePath(globalPath, kind, testName, dbName string) string {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1939,6 +1939,18 @@ func TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile(t *testing.T) {
 }
 
 func TestGoToolExecutableFallsBackToRuntimeGOROOTWhenPATHMissing(t *testing.T) {
+	goroot := runtime.GOROOT()
+	if goroot == "" {
+		t.Skip("runtime GOROOT unavailable")
+	}
+	name := "go"
+	if runtime.GOOS == "windows" {
+		name = "go.exe"
+	}
+	candidate := filepath.Join(goroot, "bin", name)
+	if info, err := os.Stat(candidate); err != nil || info.IsDir() {
+		t.Skipf("runtime GOROOT go tool unavailable at %s: stat=(%v, %v)", candidate, info, err)
+	}
 	t.Setenv("PATH", "")
 
 	path := goToolExecutable()

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1938,6 +1938,21 @@ func TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile(t *testing.T) {
 	}
 }
 
+func TestGoToolExecutableFallsBackToRuntimeGOROOTWhenPATHMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	path := goToolExecutable()
+	if path == "go" || path == "" {
+		t.Fatalf("goToolExecutable()=%q, want runtime GOROOT fallback", path)
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("goToolExecutable()=%q, want absolute fallback path", path)
+	}
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		t.Fatalf("goToolExecutable()=%q stat=(%v, %v), want executable file", path, info, err)
+	}
+}
+
 func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *testing.T) {
 	var events []string
 	profileTmpDir := t.TempDir()

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -113,8 +113,8 @@ type columnStoreSuiteReport struct {
 	BatchSize              int                          `json:"batch_size"`
 	Seed                   int64                        `json:"seed"`
 	CacheLabel             string                       `json:"cache_label"`
-	SupportedForcedPaths   []string                     `json:"supported_forced_paths"`
-	UnsupportedForcedPaths []string                     `json:"unsupported_forced_paths"`
+	AcceptedForcedPaths    []string                     `json:"accepted_forced_paths"`
+	FailClosedForcedPaths  []string                     `json:"fail_closed_forced_paths"`
 	Stages                 []columnStoreStageMetric     `json:"stages"`
 	Queries                []columnStoreQueryMetric     `json:"queries"`
 	Parity                 map[string]columnStoreParity `json:"parity"`
@@ -449,21 +449,21 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	}
 	totalReconstructableBytes := retainedPayloadBytes + columnAssetBytes + manifestControlBytes
 	report := columnStoreSuiteReport{
-		GeneratedAt:            time.Now().UTC().Format(time.RFC3339),
-		Suite:                  "column_store",
-		Profile:                profile,
-		Fixture:                fixture,
-		PathLabel:              strings.TrimSpace(opts.ExecutionPath),
-		ForcedPath:             forcedPath,
-		Rows:                   rows,
-		BatchSize:              batchSize,
-		Seed:                   seed,
-		CacheLabel:             "reopened_warm_process",
-		SupportedForcedPaths:   cloneStringSlice(columnStoreSuiteSupportedForcedPaths),
-		UnsupportedForcedPaths: cloneStringSlice(columnStoreSuiteUnsupportedForcedPaths),
-		Stages:                 stages,
-		Queries:                queries,
-		Parity:                 parity,
+		GeneratedAt:           time.Now().UTC().Format(time.RFC3339),
+		Suite:                 "column_store",
+		Profile:               profile,
+		Fixture:               fixture,
+		PathLabel:             strings.TrimSpace(opts.ExecutionPath),
+		ForcedPath:            forcedPath,
+		Rows:                  rows,
+		BatchSize:             batchSize,
+		Seed:                  seed,
+		CacheLabel:            "reopened_warm_process",
+		AcceptedForcedPaths:   cloneStringSlice(columnStoreSuiteSupportedForcedPaths),
+		FailClosedForcedPaths: cloneStringSlice(columnStoreSuiteUnsupportedForcedPaths),
+		Stages:                stages,
+		Queries:               queries,
+		Parity:                parity,
 		ByteAccounting: columnStoreByteAccounting{
 			SourceDocumentBytes:             sourceBytes,
 			RetainedPayloadBytes:            retainedPayloadBytes,
@@ -583,7 +583,7 @@ func columnStoreSuitePlanKind(path string) (collections.ColumnQueryPlanKind, err
 	case columnStorePathParallelColumnScan:
 		return collections.ColumnQueryPlanParallelColumnScan, nil
 	default:
-		return "", fmt.Errorf("column_store: unknown forced path %q; supported=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+		return "", fmt.Errorf("column_store: unknown forced path %q; accepted=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	}
 }
 
@@ -1795,8 +1795,9 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- schema_hash: %d\n\n", report.Manifest.SchemaHash))
 
 	sb.WriteString("## Forced Path Labels\n\n")
-	sb.WriteString(fmt.Sprintf("- supported: %s\n", markdownCodeList(report.SupportedForcedPaths)))
-	sb.WriteString(fmt.Sprintf("- unsupported/fail-closed: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
+	sb.WriteString("- accepted labels are CLI/planner labels, not a promise that every run has the required physical assets\n")
+	sb.WriteString(fmt.Sprintf("- accepted: %s\n", markdownCodeList(report.AcceptedForcedPaths)))
+	sb.WriteString(fmt.Sprintf("- fail-closed: %s\n", markdownCodeList(report.FailClosedForcedPaths)))
 	if report.Artifacts.ColumnJSON != "" {
 		sb.WriteString("\n## Artifacts\n\n")
 		columnStoreWriteArtifactLine(&sb, "column JSON", report.Artifacts.ColumnJSON)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1261,7 +1261,10 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s line mapping: %w", queryName, plan.Kind, err)
 	}
 	diag := result.Diagnostics
-	workers := plan.Diagnostics.WorkerCount
+	workers := diag.WorkerCount
+	if workers <= 0 {
+		workers = plan.Diagnostics.WorkerCount
+	}
 	if workers <= 0 {
 		workers = 1
 	}
@@ -1950,8 +1953,8 @@ func columnStoreQueryEffectiveRowsProcessed(q columnStoreQueryMetric) int {
 	if q.RowsProcessed != 0 {
 		return q.RowsProcessed
 	}
-	if q.Rows > 0 && q.RowMaterializations > 0 {
-		return q.Rows
+	if q.RowMaterializations > 0 {
+		return q.RowMaterializations
 	}
 	return 0
 }

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -69,7 +69,7 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata currently executes only q5_metadata and remains scan-backed until real metadata assets land)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 	)
@@ -1274,8 +1274,8 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		SkippedGranules:   diag.SkippedGranules,
 		ScheduledGranules: diag.ScheduledGranules,
 		WorkerCount:       workers,
-		CacheHits:         plan.Diagnostics.DecodedBlockCacheHits,
-		CacheMisses:       plan.Diagnostics.DecodedBlockCacheMisses,
+		CacheHits:         diag.DecodedBlockCacheHits,
+		CacheMisses:       diag.DecodedBlockCacheMisses,
 		ScanDuration:      scanDuration,
 		ReduceDuration:    reduceDuration,
 	}, nil

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -146,35 +146,35 @@ type columnStoreStageMetric struct {
 }
 
 type columnStoreQueryMetric struct {
-	Name                 string  `json:"name"`
-	PlanLabel            string  `json:"plan_label"`
-	AliasOf              string  `json:"alias_of,omitempty"`
-	ImplementationNote   string  `json:"implementation_note,omitempty"`
-	DurationMS           float64 `json:"duration_ms"`
-	Rows                 int     `json:"rows"`
-	RowsProcessed        int     `json:"rows_processed"`
-	RowsPerSecond        float64 `json:"rows_per_second"`
-	MiBPerSecond         float64 `json:"mib_per_second"`
-	NsPerRow             float64 `json:"ns_per_row"`
-	BytesRead            int64   `json:"bytes_read"`
-	RowMaterializations  int     `json:"row_materializations"`
-	ResultCount          int     `json:"result_count"`
-	RawHash              uint64  `json:"raw_hash"`
-	ProductionHash       uint64  `json:"production_hash"`
-	MetadataHits         int     `json:"metadata_hits"`
-	SkippedGranules      int     `json:"skipped_granules"`
-	ScheduledGranules    int     `json:"scheduled_granules"`
-	WorkerCount          int     `json:"worker_count"`
-	PlannerDurationMS    float64 `json:"planner_duration_ms"`
-	ScanDurationMS       float64 `json:"scan_duration_ms"`
-	ReduceDurationMS     float64 `json:"reduce_duration_ms"`
-	AdapterDurationMS    float64 `json:"adapter_duration_ms"`
-	ParityHashDurationMS float64 `json:"parity_hash_duration_ms"`
-	PlannerCandidates    int     `json:"planner_candidates"`
-	PlannerReason        string  `json:"planner_reason,omitempty"`
-	CacheHits            uint64  `json:"cache_hits"`
-	CacheMisses          uint64  `json:"cache_misses"`
-	CacheLabel           string  `json:"cache_label"`
+	Name                   string  `json:"name"`
+	PlanLabel              string  `json:"plan_label"`
+	AliasOf                string  `json:"alias_of,omitempty"`
+	ImplementationNote     string  `json:"implementation_note,omitempty"`
+	DurationMS             float64 `json:"duration_ms"`
+	Rows                   int     `json:"rows"`
+	RowsProcessed          int     `json:"rows_processed"`
+	RowsPerSecond          float64 `json:"rows_per_second"`
+	MiBPerSecond           float64 `json:"mib_per_second"`
+	NsPerRow               float64 `json:"ns_per_row"`
+	BytesRead              int64   `json:"bytes_read"`
+	RowMaterializations    int     `json:"row_materializations"`
+	ResultCount            int     `json:"result_count"`
+	RawHash                uint64  `json:"raw_hash"`
+	ProductionHash         uint64  `json:"production_hash"`
+	MetadataHits           int     `json:"metadata_hits"`
+	SkippedGranules        int     `json:"skipped_granules"`
+	ScheduledGranules      int     `json:"scheduled_granules"`
+	WorkerCount            int     `json:"worker_count"`
+	PlannerDurationMS      float64 `json:"planner_duration_ms"`
+	ScanDurationMS         float64 `json:"scan_duration_ms"`
+	ReduceDurationMS       float64 `json:"reduce_duration_ms"`
+	AdapterDurationMS      float64 `json:"adapter_duration_ms"`
+	ParityHashDurationMS   float64 `json:"parity_hash_duration_ms"`
+	PlannerCandidates      int     `json:"planner_candidates"`
+	PlannerReason          string  `json:"planner_reason,omitempty"`
+	SegmentFileCacheHits   uint64  `json:"segment_file_cache_hits"`
+	SegmentFileCacheMisses uint64  `json:"segment_file_cache_misses"`
+	CacheLabel             string  `json:"cache_label"`
 
 	duration time.Duration
 }
@@ -186,20 +186,20 @@ type columnStoreParity struct {
 }
 
 type columnStoreQueryExecution struct {
-	Lines               []string
-	RowsProcessed       int
-	BytesRead           int64
-	RowMaterializations int
-	ResultCount         int
-	MetadataHits        int
-	SkippedGranules     int
-	ScheduledGranules   int
-	WorkerCount         int
-	CacheHits           uint64
-	CacheMisses         uint64
-	ScanDuration        time.Duration
-	ReduceDuration      time.Duration
-	AdapterDuration     time.Duration
+	Lines                  []string
+	RowsProcessed          int
+	BytesRead              int64
+	RowMaterializations    int
+	ResultCount            int
+	MetadataHits           int
+	SkippedGranules        int
+	ScheduledGranules      int
+	WorkerCount            int
+	SegmentFileCacheHits   uint64
+	SegmentFileCacheMisses uint64
+	ScanDuration           time.Duration
+	ReduceDuration         time.Duration
+	AdapterDuration        time.Duration
 }
 
 type columnStoreByteAccounting struct {
@@ -1075,35 +1075,35 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			Name: name,
 			// PlanLabel records the executed planner kind after alias
 			// normalization, not necessarily the raw requested path string.
-			PlanLabel:            planLabel,
-			AliasOf:              columnStoreQueryAliasOf(name, planLabel),
-			ImplementationNote:   columnStoreQueryImplementationNote(name, path, planLabel),
-			DurationMS:           durationMS(elapsed),
-			duration:             elapsed,
-			Rows:                 rows,
-			RowsProcessed:        exec.RowsProcessed,
-			RowsPerSecond:        ratePerSecond(float64(exec.RowsProcessed), elapsed),
-			MiBPerSecond:         ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
-			NsPerRow:             nsPerRow(elapsed, exec.RowsProcessed),
-			BytesRead:            exec.BytesRead,
-			RowMaterializations:  exec.RowMaterializations,
-			ResultCount:          exec.ResultCount,
-			RawHash:              rawHash,
-			ProductionHash:       hash,
-			MetadataHits:         exec.MetadataHits,
-			SkippedGranules:      exec.SkippedGranules,
-			ScheduledGranules:    exec.ScheduledGranules,
-			WorkerCount:          exec.WorkerCount,
-			PlannerDurationMS:    durationMS(plannerElapsed),
-			ScanDurationMS:       durationMS(exec.ScanDuration),
-			ReduceDurationMS:     durationMS(exec.ReduceDuration),
-			AdapterDurationMS:    durationMS(exec.AdapterDuration),
-			ParityHashDurationMS: durationMS(parityHashElapsed),
-			PlannerCandidates:    plan.Diagnostics.CandidatePlans,
-			PlannerReason:        plan.Diagnostics.Reason,
-			CacheHits:            exec.CacheHits,
-			CacheMisses:          exec.CacheMisses,
-			CacheLabel:           "reopened_warm_process",
+			PlanLabel:              planLabel,
+			AliasOf:                columnStoreQueryAliasOf(name, planLabel),
+			ImplementationNote:     columnStoreQueryImplementationNote(name, path, planLabel),
+			DurationMS:             durationMS(elapsed),
+			duration:               elapsed,
+			Rows:                   rows,
+			RowsProcessed:          exec.RowsProcessed,
+			RowsPerSecond:          ratePerSecond(float64(exec.RowsProcessed), elapsed),
+			MiBPerSecond:           ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
+			NsPerRow:               nsPerRow(elapsed, exec.RowsProcessed),
+			BytesRead:              exec.BytesRead,
+			RowMaterializations:    exec.RowMaterializations,
+			ResultCount:            exec.ResultCount,
+			RawHash:                rawHash,
+			ProductionHash:         hash,
+			MetadataHits:           exec.MetadataHits,
+			SkippedGranules:        exec.SkippedGranules,
+			ScheduledGranules:      exec.ScheduledGranules,
+			WorkerCount:            exec.WorkerCount,
+			PlannerDurationMS:      durationMS(plannerElapsed),
+			ScanDurationMS:         durationMS(exec.ScanDuration),
+			ReduceDurationMS:       durationMS(exec.ReduceDuration),
+			AdapterDurationMS:      durationMS(exec.AdapterDuration),
+			ParityHashDurationMS:   durationMS(parityHashElapsed),
+			PlannerCandidates:      plan.Diagnostics.CandidatePlans,
+			PlannerReason:          plan.Diagnostics.Reason,
+			SegmentFileCacheHits:   exec.SegmentFileCacheHits,
+			SegmentFileCacheMisses: exec.SegmentFileCacheMisses,
+			CacheLabel:             "reopened_warm_process",
 		}
 		queries = append(queries, metric)
 	}
@@ -1184,18 +1184,18 @@ func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, ro
 			return columnStoreQueryExecution{}, fmt.Errorf("column_store: reduce %s: %w", queryName, err)
 		}
 		return columnStoreQueryExecution{
-			Lines:               lines,
-			RowsProcessed:       materialized,
-			BytesRead:           bytesRead,
-			RowMaterializations: materialized,
-			ResultCount:         len(lines),
-			ScheduledGranules:   plan.Diagnostics.ScheduledGranules,
-			SkippedGranules:     plan.Diagnostics.SkippedGranules,
-			WorkerCount:         1,
-			CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
-			CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
-			ScanDuration:        scanElapsed,
-			ReduceDuration:      reduceElapsed,
+			Lines:                  lines,
+			RowsProcessed:          materialized,
+			BytesRead:              bytesRead,
+			RowMaterializations:    materialized,
+			ResultCount:            len(lines),
+			ScheduledGranules:      plan.Diagnostics.ScheduledGranules,
+			SkippedGranules:        plan.Diagnostics.SkippedGranules,
+			WorkerCount:            1,
+			SegmentFileCacheHits:   plan.Diagnostics.SegmentFileCacheHits,
+			SegmentFileCacheMisses: plan.Diagnostics.SegmentFileCacheMisses,
+			ScanDuration:           scanElapsed,
+			ReduceDuration:         reduceElapsed,
 		}, nil
 	case collections.ColumnQueryPlanBTreeIndexBaseline:
 		scanStart := time.Now()
@@ -1211,18 +1211,18 @@ func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, ro
 			return columnStoreQueryExecution{}, fmt.Errorf("column_store: reduce %s: %w", queryName, err)
 		}
 		return columnStoreQueryExecution{
-			Lines:               lines,
-			RowsProcessed:       materialized,
-			BytesRead:           bytesRead,
-			RowMaterializations: materialized,
-			ResultCount:         len(lines),
-			ScheduledGranules:   plan.Diagnostics.ScheduledGranules,
-			SkippedGranules:     plan.Diagnostics.SkippedGranules,
-			WorkerCount:         1,
-			CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
-			CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
-			ScanDuration:        scanElapsed,
-			ReduceDuration:      reduceElapsed,
+			Lines:                  lines,
+			RowsProcessed:          materialized,
+			BytesRead:              bytesRead,
+			RowMaterializations:    materialized,
+			ResultCount:            len(lines),
+			ScheduledGranules:      plan.Diagnostics.ScheduledGranules,
+			SkippedGranules:        plan.Diagnostics.SkippedGranules,
+			WorkerCount:            1,
+			SegmentFileCacheHits:   plan.Diagnostics.SegmentFileCacheHits,
+			SegmentFileCacheMisses: plan.Diagnostics.SegmentFileCacheMisses,
+			ScanDuration:           scanElapsed,
+			ReduceDuration:         reduceElapsed,
 		}, nil
 	case collections.ColumnQueryPlanSerialColumnScan, collections.ColumnQueryPlanAggregateMetadata, collections.ColumnQueryPlanParallelColumnScan:
 		return executeColumnStoreSuitePhysicalQuery(collection, queryName, plan)
@@ -1283,15 +1283,15 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		// adapter but still scans column assets. Metadata-only reads remain an
 		// M14C measurement gate, so hits stay zero instead of pretending a fast
 		// path ran.
-		MetadataHits:      0,
-		SkippedGranules:   diag.SkippedGranules,
-		ScheduledGranules: diag.ScheduledGranules,
-		WorkerCount:       workers,
-		CacheHits:         diag.DecodedBlockCacheHits,
-		CacheMisses:       diag.DecodedBlockCacheMisses,
-		ScanDuration:      scanDuration,
-		ReduceDuration:    reduceDuration,
-		AdapterDuration:   adapterElapsed,
+		MetadataHits:           0,
+		SkippedGranules:        diag.SkippedGranules,
+		ScheduledGranules:      diag.ScheduledGranules,
+		WorkerCount:            workers,
+		SegmentFileCacheHits:   diag.SegmentFileCacheHits,
+		SegmentFileCacheMisses: diag.SegmentFileCacheMisses,
+		ScanDuration:           scanDuration,
+		ReduceDuration:         reduceDuration,
+		AdapterDuration:        adapterElapsed,
 	}, nil
 }
 
@@ -1760,7 +1760,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | B/read | rows materialized | cache hit/miss | hash parity | note |\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
 	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|\n")
 	for _, q := range report.Queries {
 		parity := "pass"
@@ -1776,7 +1776,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 			noteCell = "`" + note + "`"
 		}
 		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
-			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.BytesRead, q.RowMaterializations, q.CacheHits, q.CacheMisses, parity, noteCell))
+			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -71,7 +71,7 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: row_store_baseline, b_tree_index_baseline; fail-closed until M14 planner routing is enabled: serial_column_scan, aggregate_metadata, parallel_column_scan)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 	)
@@ -81,12 +81,11 @@ var (
 	columnStoreSuiteSupportedForcedPaths = []string{
 		columnStorePathRowStoreBaseline,
 		columnStorePathBTreeIndexBaseline,
-	}
-	columnStoreSuiteUnsupportedForcedPaths = []string{
 		columnStorePathSerialColumnScan,
 		columnStorePathAggregateMetadata,
 		columnStorePathParallelColumnScan,
 	}
+	columnStoreSuiteUnsupportedForcedPaths = []string{}
 	// These files are opportunistic control-plane telemetry for the benchmark
 	// report. Missing files are reported, not fatal, because the exact set can
 	// vary as TreeDB control metadata evolves.
@@ -176,6 +175,22 @@ type columnStoreParity struct {
 	Pass           bool   `json:"pass"`
 	RawHash        uint64 `json:"raw_hash"`
 	ProductionHash uint64 `json:"production_hash"`
+}
+
+type columnStoreQueryExecution struct {
+	Lines               []string
+	RowsProcessed       int
+	BytesRead           int64
+	RowMaterializations int
+	ResultCount         int
+	MetadataHits        int
+	SkippedGranules     int
+	ScheduledGranules   int
+	WorkerCount         int
+	CacheHits           uint64
+	CacheMisses         uint64
+	ScanDuration        time.Duration
+	ReduceDuration      time.Duration
 }
 
 type columnStoreByteAccounting struct {
@@ -473,8 +488,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			ManifestRoot:                    manifestIdentity.ManifestRoot,
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
-		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M13B explicit serial query adapter",
-		PhysicalColumnQuery:    "M13B provides an explicit serial physical query adapter; unified-bench serial/aggregate/parallel physical labels intentionally remain fail-closed through the planner until M14 routing",
+		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
+		PhysicalColumnQuery:    "M14B routes forced serial, scan-backed aggregate_metadata, and insert-only parallel_column_scan labels through the TreeDB physical query adapter; unsupported prerequisites fail closed before row fallback",
 		BenchmarkOnlyRelaxed:   false,
 		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, scan, reduce, and parity hash stages are timed separately for the forced execution label",
 	}
@@ -1017,8 +1032,9 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 	parity := make(map[string]columnStoreParity, len(columnStoreQueryNameList))
 	var firstErr error
 	for _, name := range columnStoreQueryNameList {
+		queryForceKind := columnStoreSuitePlanKindForQuery(path, name, forceKind)
 		plannerStart := time.Now()
-		plan, err := collection.PlanColumnQuery(columnStoreSuitePlanRequest(name, rows, forceKind))
+		plan, err := collection.PlanColumnQuery(columnStoreSuitePlanRequest(name, rows, queryForceKind))
 		plannerElapsed := time.Since(plannerStart)
 		if err != nil {
 			return nil, nil, err
@@ -1031,24 +1047,15 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			return nil, nil, fmt.Errorf("column_store: forced path %q unsupported for %s: refusing to route through row store; reason=%s: %w", path, name, reason, collections.ErrColumnQueryPlanUnsupported)
 		}
 
-		scanStart := time.Now()
-		events, materialized, bytesRead, err := scanColumnStoreSuiteEventsWithPlan(collection, rows, name, plan)
-		scanElapsed := time.Since(scanStart)
+		exec, err := executeColumnStoreSuiteQueryWithPlan(collection, rows, name, plan)
 		if err != nil {
 			return nil, nil, err
 		}
-		reduceStart := time.Now()
 		planLabel := string(plan.Kind)
-		lines, err := columnStoreQueryLines(columnStoreQueryHashLineName(name), events)
-		if err != nil {
-			return nil, nil, fmt.Errorf("column_store: reduce %s: %w", name, err)
-		}
-		reduceElapsed := time.Since(reduceStart)
 		parityHashStart := time.Now()
-		hash := columnStoreHashLines(lines)
+		hash := columnStoreHashLines(exec.Lines)
 		parityHashElapsed := time.Since(parityHashStart)
-		resultCount := len(lines)
-		elapsed := plannerElapsed + scanElapsed + reduceElapsed + parityHashElapsed
+		elapsed := plannerElapsed + exec.ScanDuration + exec.ReduceDuration + parityHashElapsed
 		rawHash := rawHashes[name]
 		pass := rawHash == hash
 		parity[name] = columnStoreParity{Pass: pass, RawHash: rawHash, ProductionHash: hash}
@@ -1059,50 +1066,37 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			Name: name,
 			// PlanLabel records the executed planner kind after alias
 			// normalization, not necessarily the raw requested path string.
-			PlanLabel:           planLabel,
-			AliasOf:             columnStoreQueryAliasOf(name, planLabel),
-			ImplementationNote:  columnStoreQueryImplementationNote(name, planLabel),
-			DurationMS:          durationMS(elapsed),
-			duration:            elapsed,
-			Rows:                rows,
-			RowsPerSecond:       ratePerSecond(float64(materialized), elapsed),
-			MiBPerSecond:        ratePerSecond(float64(bytesRead)/(1024*1024), elapsed),
-			NsPerRow:            nsPerRow(elapsed, materialized),
-			BytesRead:           bytesRead,
-			RowMaterializations: materialized,
-			ResultCount:         resultCount,
-			RawHash:             rawHash,
-			ProductionHash:      hash,
-			// TODO(#1534 M11C): populate from physical aggregate-metadata diagnostics.
-			MetadataHits:         0,
-			SkippedGranules:      plan.Diagnostics.SkippedGranules,
-			ScheduledGranules:    plan.Diagnostics.ScheduledGranules,
-			WorkerCount:          columnStoreSuiteMetricWorkerCount(plan),
+			PlanLabel:            planLabel,
+			AliasOf:              columnStoreQueryAliasOf(name, planLabel),
+			ImplementationNote:   columnStoreQueryImplementationNote(name, planLabel),
+			DurationMS:           durationMS(elapsed),
+			duration:             elapsed,
+			Rows:                 rows,
+			RowsPerSecond:        ratePerSecond(float64(exec.RowsProcessed), elapsed),
+			MiBPerSecond:         ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
+			NsPerRow:             nsPerRow(elapsed, exec.RowsProcessed),
+			BytesRead:            exec.BytesRead,
+			RowMaterializations:  exec.RowMaterializations,
+			ResultCount:          exec.ResultCount,
+			RawHash:              rawHash,
+			ProductionHash:       hash,
+			MetadataHits:         exec.MetadataHits,
+			SkippedGranules:      exec.SkippedGranules,
+			ScheduledGranules:    exec.ScheduledGranules,
+			WorkerCount:          exec.WorkerCount,
 			PlannerDurationMS:    durationMS(plannerElapsed),
-			ScanDurationMS:       durationMS(scanElapsed),
-			ReduceDurationMS:     durationMS(reduceElapsed),
+			ScanDurationMS:       durationMS(exec.ScanDuration),
+			ReduceDurationMS:     durationMS(exec.ReduceDuration),
 			ParityHashDurationMS: durationMS(parityHashElapsed),
 			PlannerCandidates:    plan.Diagnostics.CandidatePlans,
 			PlannerReason:        plan.Diagnostics.Reason,
-			CacheHits:            plan.Diagnostics.DecodedBlockCacheHits,
-			CacheMisses:          plan.Diagnostics.DecodedBlockCacheMisses,
+			CacheHits:            exec.CacheHits,
+			CacheMisses:          exec.CacheMisses,
 			CacheLabel:           "reopened_warm_process",
 		}
 		queries = append(queries, metric)
 	}
 	return queries, parity, firstErr
-}
-
-func columnStoreSuiteMetricWorkerCount(plan collections.ColumnQueryPlan) int {
-	if plan.Diagnostics.WorkerCount > 0 {
-		return plan.Diagnostics.WorkerCount
-	}
-	switch plan.Kind {
-	case collections.ColumnQueryPlanRowStoreBaseline, collections.ColumnQueryPlanBTreeIndexBaseline:
-		return 1
-	default:
-		return 0
-	}
 }
 
 func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.ColumnQueryPlanKind) collections.ColumnQueryPlanRequest {
@@ -1114,9 +1108,8 @@ func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.Co
 		EstimatedRows:         rows,
 		ForceKind:             forceKind,
 		Capabilities: collections.ColumnQueryPlannerCapabilities{
-			// M13B has an explicit physical scanner/query adapter, but
-			// unified-bench forced physical labels stay unreachable until M14
-			// wires planner capabilities to real manifest state.
+			// M14B still requires planner discovery to replace these caller
+			// placeholders with recovery-authoritative manifest facts.
 			SerialColumnScan:       true,
 			AggregateMetadata:      true,
 			ParallelColumnScan:     true,
@@ -1127,6 +1120,13 @@ func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.Co
 			PlannerCandidateBudget: 5,
 		},
 	}
+}
+
+func columnStoreSuitePlanKindForQuery(path, name string, forceKind collections.ColumnQueryPlanKind) collections.ColumnQueryPlanKind {
+	if path == columnStorePathAggregateMetadata && name != columnStoreQueryQ5Metadata {
+		return collections.ColumnQueryPlanSerialColumnScan
+	}
+	return forceKind
 }
 
 func columnStoreSuiteQueryIndexCandidates(name string) []string {
@@ -1157,15 +1157,159 @@ func columnStoreSuiteAggregateMetadataName(name string) string {
 	return ""
 }
 
-func scanColumnStoreSuiteEventsWithPlan(collection *collections.Collection, rows int, queryName string, plan collections.ColumnQueryPlan) ([]columnStoreDecodedEvent, int, int64, error) {
+func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, rows int, queryName string, plan collections.ColumnQueryPlan) (columnStoreQueryExecution, error) {
 	switch plan.Kind {
 	case collections.ColumnQueryPlanRowStoreBaseline:
-		return scanColumnStoreSuiteEvents(collection, rows)
+		scanStart := time.Now()
+		events, materialized, bytesRead, err := scanColumnStoreSuiteEvents(collection, rows)
+		scanElapsed := time.Since(scanStart)
+		if err != nil {
+			return columnStoreQueryExecution{}, err
+		}
+		reduceStart := time.Now()
+		lines, err := columnStoreQueryLines(columnStoreQueryHashLineName(queryName), events)
+		reduceElapsed := time.Since(reduceStart)
+		if err != nil {
+			return columnStoreQueryExecution{}, fmt.Errorf("column_store: reduce %s: %w", queryName, err)
+		}
+		return columnStoreQueryExecution{
+			Lines:               lines,
+			RowsProcessed:       materialized,
+			BytesRead:           bytesRead,
+			RowMaterializations: materialized,
+			ResultCount:         len(lines),
+			ScheduledGranules:   plan.Diagnostics.ScheduledGranules,
+			SkippedGranules:     plan.Diagnostics.SkippedGranules,
+			WorkerCount:         1,
+			CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
+			CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
+			ScanDuration:        scanElapsed,
+			ReduceDuration:      reduceElapsed,
+		}, nil
 	case collections.ColumnQueryPlanBTreeIndexBaseline:
-		return scanColumnStoreSuiteEventsByIndex(collection, rows, queryName, plan.IndexName)
+		scanStart := time.Now()
+		events, materialized, bytesRead, err := scanColumnStoreSuiteEventsByIndex(collection, rows, queryName, plan.IndexName)
+		scanElapsed := time.Since(scanStart)
+		if err != nil {
+			return columnStoreQueryExecution{}, err
+		}
+		reduceStart := time.Now()
+		lines, err := columnStoreQueryLines(columnStoreQueryHashLineName(queryName), events)
+		reduceElapsed := time.Since(reduceStart)
+		if err != nil {
+			return columnStoreQueryExecution{}, fmt.Errorf("column_store: reduce %s: %w", queryName, err)
+		}
+		return columnStoreQueryExecution{
+			Lines:               lines,
+			RowsProcessed:       materialized,
+			BytesRead:           bytesRead,
+			RowMaterializations: materialized,
+			ResultCount:         len(lines),
+			ScheduledGranules:   plan.Diagnostics.ScheduledGranules,
+			SkippedGranules:     plan.Diagnostics.SkippedGranules,
+			WorkerCount:         1,
+			CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
+			CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
+			ScanDuration:        scanElapsed,
+			ReduceDuration:      reduceElapsed,
+		}, nil
+	case collections.ColumnQueryPlanSerialColumnScan, collections.ColumnQueryPlanAggregateMetadata, collections.ColumnQueryPlanParallelColumnScan:
+		return executeColumnStoreSuitePhysicalQuery(collection, queryName, plan)
 	default:
-		return nil, 0, 0, fmt.Errorf("column_store: executable path %q is not implemented: %w", plan.Kind, collections.ErrColumnQueryPlanUnsupported)
+		return columnStoreQueryExecution{}, fmt.Errorf("column_store: executable path %q is not implemented: %w", plan.Kind, collections.ErrColumnQueryPlanUnsupported)
 	}
+}
+
+func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, queryName string, plan collections.ColumnQueryPlan) (columnStoreQueryExecution, error) {
+	req, err := columnStoreSuitePhysicalQueryRequest(queryName)
+	if err != nil {
+		return columnStoreQueryExecution{}, err
+	}
+	start := time.Now()
+	var result collections.ColumnPhysicalQueryResult
+	switch plan.Kind {
+	case collections.ColumnQueryPlanParallelColumnScan:
+		workers := plan.Diagnostics.WorkerCount
+		if workers <= 1 {
+			return columnStoreQueryExecution{}, fmt.Errorf("column_store: parallel physical plan for %s has worker_count=%d: %w", queryName, workers, collections.ErrColumnQueryPlanUnsupported)
+		}
+		result, err = collection.RunColumnPhysicalQueryParallel(req, workers)
+	case collections.ColumnQueryPlanSerialColumnScan, collections.ColumnQueryPlanAggregateMetadata:
+		result, err = collection.RunColumnPhysicalQuery(req)
+	default:
+		return columnStoreQueryExecution{}, fmt.Errorf("column_store: executable path %q is not physical: %w", plan.Kind, collections.ErrColumnQueryPlanUnsupported)
+	}
+	elapsed := time.Since(start)
+	if err != nil {
+		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s: %w", queryName, plan.Kind, err)
+	}
+	lines := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
+	diag := result.Diagnostics
+	workers := plan.Diagnostics.WorkerCount
+	if workers <= 0 {
+		workers = 1
+	}
+	return columnStoreQueryExecution{
+		Lines:               lines,
+		RowsProcessed:       diag.ReduceRows,
+		BytesRead:           diag.PhysicalBytesScanned,
+		RowMaterializations: diag.RowMaterializations,
+		ResultCount:         len(lines),
+		MetadataHits:        columnStoreSuitePhysicalMetadataHits(plan, diag),
+		SkippedGranules:     diag.SkippedGranules,
+		ScheduledGranules:   diag.ScheduledGranules,
+		WorkerCount:         workers,
+		CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
+		CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
+		ScanDuration:        elapsed,
+	}, nil
+}
+
+func columnStoreSuitePhysicalMetadataHits(plan collections.ColumnQueryPlan, diag collections.ColumnPhysicalQueryDiagnostics) int {
+	if plan.Kind != collections.ColumnQueryPlanAggregateMetadata {
+		return 0
+	}
+	// M14B routes the aggregate_metadata label through the physical query
+	// adapter but still scans column assets. Metadata-only reads remain an M14C
+	// measurement gate, so hits stay zero instead of pretending a fast path ran.
+	_ = diag
+	return 0
+}
+
+func columnStoreSuitePhysicalQueryRequest(name string) (collections.ColumnPhysicalQueryRequest, error) {
+	switch name {
+	case columnStoreQueryQ1:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}, nil
+	case columnStoreQueryQ2:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}, nil
+	case columnStoreQueryQ3:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}, nil
+	case columnStoreQueryQ4A:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}, nil
+	case columnStoreQueryQ4B:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"}, nil
+	case columnStoreQueryQ5, columnStoreQueryQ5Metadata:
+		return collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}, nil
+	default:
+		return collections.ColumnPhysicalQueryRequest{}, fmt.Errorf("column_store: unknown physical query %q", name)
+	}
+}
+
+func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) []string {
+	lines := make([]string, 0, len(groups))
+	switch queryName {
+	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
+		for _, group := range groups {
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, group.Key, group.Count))
+		}
+	case columnStoreQueryQ4A, columnStoreQueryQ4B, columnStoreQueryQ5, columnStoreQueryQ5Metadata:
+		for _, group := range groups {
+			lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, group.Key, group.Int64))
+		}
+	default:
+		return nil
+	}
+	return lines
 }
 
 func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([]columnStoreDecodedEvent, int, int64, error) {
@@ -1339,13 +1483,19 @@ func columnStoreQueryNameKnown(name string) bool {
 }
 
 func columnStoreQueryAliasOf(name, path string) string {
-	if name == columnStoreQueryQ5Metadata && (path == columnStorePathRowStoreBaseline || path == columnStorePathBTreeIndexBaseline) {
+	if name == columnStoreQueryQ5Metadata {
 		return columnStoreQueryQ5
 	}
 	return ""
 }
 
 func columnStoreQueryImplementationNote(name, path string) string {
+	if name == columnStoreQueryQ5Metadata && path == columnStorePathAggregateMetadata {
+		return "q5_alias_scan_backed_physical_aggregate_metadata_m14b_metadata_only_fast_path_deferred"
+	}
+	if name == columnStoreQueryQ5Metadata && (path == columnStorePathSerialColumnScan || path == columnStorePathParallelColumnScan) {
+		return path + "_q5_alias_physical_column_scan"
+	}
 	if name == columnStoreQueryQ5Metadata && path == columnStorePathBTreeIndexBaseline {
 		return "q5_alias_full_unbounded_secondary_index_scan_no_predicate_pushdown_until_physical_aggregate_metadata_path"
 	}
@@ -1657,7 +1807,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 
 	sb.WriteString("## Forced Path Labels\n\n")
 	sb.WriteString(fmt.Sprintf("- supported: %s\n", markdownCodeList(report.SupportedForcedPaths)))
-	sb.WriteString(fmt.Sprintf("- fail-closed until M14 physical planner routing: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
+	sb.WriteString(fmt.Sprintf("- unsupported/fail-closed: %s\n", markdownCodeList(report.UnsupportedForcedPaths)))
 	if report.Artifacts.ColumnJSON != "" {
 		sb.WriteString("\n## Artifacts\n\n")
 		columnStoreWriteArtifactLine(&sb, "column JSON", report.Artifacts.ColumnJSON)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -488,9 +488,9 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
 		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
-		PhysicalColumnQuery:    "M14B routes forced serial, scan-backed aggregate_metadata, and insert-only parallel_column_scan labels through the TreeDB physical query adapter; unsupported prerequisites fail closed before row fallback",
+		PhysicalColumnQuery:    "M14B routes forced serial, scan-backed aggregate_metadata, and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable only for q5_metadata and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
 		BenchmarkOnlyRelaxed:   false,
-		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, scan, reduce, and parity hash stages are timed separately for the forced execution label",
+		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, physical scan/reducer execution, row/B-tree reduce, and parity hash stages are timed separately for the forced execution label; M14B direct physical reducers are fused into scan timing unless visibility reconstruction reports a separate reduce phase",
 	}
 	if baseCfg.KeepDir {
 		report.DataDir = dataDir
@@ -1067,7 +1067,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			// normalization, not necessarily the raw requested path string.
 			PlanLabel:            planLabel,
 			AliasOf:              columnStoreQueryAliasOf(name, planLabel),
-			ImplementationNote:   columnStoreQueryImplementationNote(name, planLabel),
+			ImplementationNote:   columnStoreQueryImplementationNote(name, path, planLabel),
 			DurationMS:           durationMS(elapsed),
 			duration:             elapsed,
 			Rows:                 rows,
@@ -1243,11 +1243,22 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	if err != nil {
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s: %w", queryName, plan.Kind, err)
 	}
-	lines := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
+	lines, err := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
+	if err != nil {
+		return columnStoreQueryExecution{}, err
+	}
 	diag := result.Diagnostics
 	workers := plan.Diagnostics.WorkerCount
 	if workers <= 0 {
 		workers = 1
+	}
+	scanDuration := elapsed
+	if diag.ScanNanos > 0 {
+		scanDuration = time.Duration(diag.ScanNanos)
+	}
+	reduceDuration := time.Duration(0)
+	if diag.ReduceNanos > 0 {
+		reduceDuration = time.Duration(diag.ReduceNanos)
 	}
 	return columnStoreQueryExecution{
 		Lines:               lines,
@@ -1255,25 +1266,19 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		BytesRead:           diag.PhysicalBytesScanned,
 		RowMaterializations: diag.RowMaterializations,
 		ResultCount:         len(lines),
-		MetadataHits:        columnStoreSuitePhysicalMetadataHits(plan, diag),
-		SkippedGranules:     diag.SkippedGranules,
-		ScheduledGranules:   diag.ScheduledGranules,
-		WorkerCount:         workers,
-		CacheHits:           plan.Diagnostics.DecodedBlockCacheHits,
-		CacheMisses:         plan.Diagnostics.DecodedBlockCacheMisses,
-		ScanDuration:        elapsed,
+		// M14B routes the aggregate_metadata label through the physical query
+		// adapter but still scans column assets. Metadata-only reads remain an
+		// M14C measurement gate, so hits stay zero instead of pretending a fast
+		// path ran.
+		MetadataHits:      0,
+		SkippedGranules:   diag.SkippedGranules,
+		ScheduledGranules: diag.ScheduledGranules,
+		WorkerCount:       workers,
+		CacheHits:         plan.Diagnostics.DecodedBlockCacheHits,
+		CacheMisses:       plan.Diagnostics.DecodedBlockCacheMisses,
+		ScanDuration:      scanDuration,
+		ReduceDuration:    reduceDuration,
 	}, nil
-}
-
-func columnStoreSuitePhysicalMetadataHits(plan collections.ColumnQueryPlan, diag collections.ColumnPhysicalQueryDiagnostics) int {
-	if plan.Kind != collections.ColumnQueryPlanAggregateMetadata {
-		return 0
-	}
-	// M14B routes the aggregate_metadata label through the physical query
-	// adapter but still scans column assets. Metadata-only reads remain an M14C
-	// measurement gate, so hits stay zero instead of pretending a fast path ran.
-	_ = diag
-	return 0
 }
 
 func columnStoreSuitePhysicalQueryRequest(name string) (collections.ColumnPhysicalQueryRequest, error) {
@@ -1295,7 +1300,7 @@ func columnStoreSuitePhysicalQueryRequest(name string) (collections.ColumnPhysic
 	}
 }
 
-func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) []string {
+func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) ([]string, error) {
 	lines := make([]string, 0, len(groups))
 	switch queryName {
 	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
@@ -1307,9 +1312,9 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 			lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, group.Key, group.Int64))
 		}
 	default:
-		return nil
+		return nil, fmt.Errorf("column_store: unsupported physical query line mapping %q", queryName)
 	}
-	return lines
+	return lines, nil
 }
 
 func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([]columnStoreDecodedEvent, int, int64, error) {
@@ -1451,20 +1456,23 @@ func columnStoreQueryAliasOf(name, path string) string {
 	return ""
 }
 
-func columnStoreQueryImplementationNote(name, path string) string {
-	if name == columnStoreQueryQ5Metadata && path == columnStorePathAggregateMetadata {
+func columnStoreQueryImplementationNote(name, requestedPath, planPath string) string {
+	if requestedPath == columnStorePathAggregateMetadata && planPath == columnStorePathSerialColumnScan && name != columnStoreQueryQ5Metadata {
+		return "aggregate_metadata_forced_path_rerouted_to_serial_column_scan_no_metadata_asset_for_query_m14b"
+	}
+	if name == columnStoreQueryQ5Metadata && planPath == columnStorePathAggregateMetadata {
 		return "q5_alias_scan_backed_physical_aggregate_metadata_m14b_metadata_only_fast_path_deferred"
 	}
-	if name == columnStoreQueryQ5Metadata && (path == columnStorePathSerialColumnScan || path == columnStorePathParallelColumnScan) {
-		return path + "_q5_alias_physical_column_scan"
+	if name == columnStoreQueryQ5Metadata && (planPath == columnStorePathSerialColumnScan || planPath == columnStorePathParallelColumnScan) {
+		return planPath + "_q5_alias_physical_column_scan"
 	}
-	if name == columnStoreQueryQ5Metadata && path == columnStorePathBTreeIndexBaseline {
+	if name == columnStoreQueryQ5Metadata && planPath == columnStorePathBTreeIndexBaseline {
 		return "q5_alias_full_unbounded_secondary_index_scan_no_predicate_pushdown_until_physical_aggregate_metadata_path"
 	}
-	if name == columnStoreQueryQ5Metadata && path == columnStorePathRowStoreBaseline {
-		return path + "_alias_until_physical_aggregate_metadata_path"
+	if name == columnStoreQueryQ5Metadata && planPath == columnStorePathRowStoreBaseline {
+		return planPath + "_alias_until_physical_aggregate_metadata_path"
 	}
-	if path == columnStorePathBTreeIndexBaseline {
+	if planPath == columnStorePathBTreeIndexBaseline {
 		return "full_unbounded_secondary_index_scan_no_predicate_pushdown_m11b"
 	}
 	return ""
@@ -1500,6 +1508,26 @@ func columnStoreQueryHashLineName(name string) string {
 	return name
 }
 
+func columnStoreSuiteUTCHour(timeUS int64) int {
+	const hourUS = int64(3_600_000_000)
+	hours := timeUS / hourUS
+	if timeUS < 0 && timeUS%hourUS != 0 {
+		hours--
+	}
+	hour := int(hours % 24)
+	if hour < 0 {
+		hour += 24
+	}
+	return hour
+}
+
+func columnStoreSuiteHourKey(hour int) string {
+	if hour < 0 || hour >= 24 {
+		return "hour_invalid"
+	}
+	return fmt.Sprintf("hour_%02d", hour)
+}
+
 func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) ([]string, error) {
 	switch name {
 	case columnStoreQueryQ1:
@@ -1526,8 +1554,7 @@ func columnStoreQueryLines(name string, events []columnStoreDecodedEvent) ([]str
 	case columnStoreQueryQ3:
 		counts := make(map[string]int)
 		for _, event := range events {
-			hour := (event.TimeUS / 3_600_000_000) % 24
-			counts[fmt.Sprintf("hour_%02d", hour)]++
+			counts[columnStoreSuiteHourKey(columnStoreSuiteUTCHour(event.TimeUS))]++
 		}
 		return formatIntMapLines(name, counts), nil
 	case columnStoreQueryQ4A:

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -72,19 +72,26 @@ var (
 		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata currently executes only q5_metadata and remains scan-backed until real metadata assets land)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
-		columnStoreSuitePathCanonicalHelp,
+		columnStoreSuitePathList(columnStoreSuiteExecutableForcedPaths),
 	)
 	columnStoreSuitePathArg    = flag.String("column-store-path", columnStorePathRowStoreBaseline, columnStoreSuitePathUsage)
 	columnStoreSuiteFixtureArg = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
 
-	columnStoreSuiteSupportedForcedPaths = []string{
+	columnStoreSuiteAcceptedForcedPaths = []string{
 		columnStorePathRowStoreBaseline,
 		columnStorePathBTreeIndexBaseline,
 		columnStorePathSerialColumnScan,
 		columnStorePathAggregateMetadata,
 		columnStorePathParallelColumnScan,
 	}
-	columnStoreSuiteUnsupportedForcedPaths = []string{}
+	columnStoreSuiteExecutableForcedPaths = []string{
+		columnStorePathRowStoreBaseline,
+		columnStorePathBTreeIndexBaseline,
+		columnStorePathSerialColumnScan,
+		columnStorePathAggregateMetadata,
+		columnStorePathParallelColumnScan,
+	}
+	columnStoreSuiteFailClosedForcedPaths = []string{}
 	// These files are opportunistic control-plane telemetry for the benchmark
 	// report. Missing files are reported, not fatal, because the exact set can
 	// vary as TreeDB control metadata evolves.
@@ -462,8 +469,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		BatchSize:             batchSize,
 		Seed:                  seed,
 		CacheLabel:            "reopened_warm_process",
-		AcceptedForcedPaths:   cloneStringSlice(columnStoreSuiteSupportedForcedPaths),
-		FailClosedForcedPaths: cloneStringSlice(columnStoreSuiteUnsupportedForcedPaths),
+		AcceptedForcedPaths:   cloneStringSlice(columnStoreSuiteAcceptedForcedPaths),
+		FailClosedForcedPaths: cloneStringSlice(columnStoreSuiteFailClosedForcedPaths),
 		Stages:                stages,
 		Queries:               queries,
 		Parity:                parity,
@@ -586,7 +593,7 @@ func columnStoreSuitePlanKind(path string) (collections.ColumnQueryPlanKind, err
 	case columnStorePathParallelColumnScan:
 		return collections.ColumnQueryPlanParallelColumnScan, nil
 	default:
-		return "", fmt.Errorf("column_store: unknown forced path %q; supported=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+		return "", fmt.Errorf("column_store: unknown forced path %q; supported=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteAcceptedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteFailClosedForcedPaths))
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -160,6 +160,7 @@ type columnStoreQueryMetric struct {
 	PlannerDurationMS    float64 `json:"planner_duration_ms"`
 	ScanDurationMS       float64 `json:"scan_duration_ms"`
 	ReduceDurationMS     float64 `json:"reduce_duration_ms"`
+	AdapterDurationMS    float64 `json:"adapter_duration_ms"`
 	ParityHashDurationMS float64 `json:"parity_hash_duration_ms"`
 	PlannerCandidates    int     `json:"planner_candidates"`
 	PlannerReason        string  `json:"planner_reason,omitempty"`
@@ -190,6 +191,7 @@ type columnStoreQueryExecution struct {
 	CacheMisses         uint64
 	ScanDuration        time.Duration
 	ReduceDuration      time.Duration
+	AdapterDuration     time.Duration
 }
 
 type columnStoreByteAccounting struct {
@@ -1054,7 +1056,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 		parityHashStart := time.Now()
 		hash := columnStoreHashLines(exec.Lines)
 		parityHashElapsed := time.Since(parityHashStart)
-		elapsed := plannerElapsed + exec.ScanDuration + exec.ReduceDuration + parityHashElapsed
+		elapsed := plannerElapsed + exec.ScanDuration + exec.ReduceDuration + exec.AdapterDuration + parityHashElapsed
 		rawHash := rawHashes[name]
 		pass := rawHash == hash
 		parity[name] = columnStoreParity{Pass: pass, RawHash: rawHash, ProductionHash: hash}
@@ -1087,6 +1089,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			PlannerDurationMS:    durationMS(plannerElapsed),
 			ScanDurationMS:       durationMS(exec.ScanDuration),
 			ReduceDurationMS:     durationMS(exec.ReduceDuration),
+			AdapterDurationMS:    durationMS(exec.AdapterDuration),
 			ParityHashDurationMS: durationMS(parityHashElapsed),
 			PlannerCandidates:    plan.Diagnostics.CandidatePlans,
 			PlannerReason:        plan.Diagnostics.Reason,
@@ -1243,7 +1246,9 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	if err != nil {
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s: %w", queryName, plan.Kind, err)
 	}
+	adapterStart := time.Now()
 	lines, err := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
+	adapterElapsed := time.Since(adapterStart)
 	if err != nil {
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s line mapping: %w", queryName, plan.Kind, err)
 	}
@@ -1278,6 +1283,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		CacheMisses:       diag.DecodedBlockCacheMisses,
 		ScanDuration:      scanDuration,
 		ReduceDuration:    reduceDuration,
+		AdapterDuration:   adapterElapsed,
 	}, nil
 }
 
@@ -1746,8 +1752,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | B/read | rows materialized | cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | B/read | rows materialized | cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|\n")
 	for _, q := range report.Queries {
 		parity := "pass"
 		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
@@ -1761,8 +1767,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 		if note != "" {
 			noteCell = "`" + note + "`"
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
-			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.BytesRead, q.RowMaterializations, q.CacheHits, q.CacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
+			q.Name, q.PlanLabel, q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.BytesRead, q.RowMaterializations, q.CacheHits, q.CacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -69,9 +69,10 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata currently executes only q5_metadata and remains scan-backed until real metadata assets land)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata currently executes only q5_metadata and remains scan-backed until real metadata assets land)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
+		columnStoreSuitePathCanonicalHelp,
 	)
 	columnStoreSuitePathArg    = flag.String("column-store-path", columnStorePathRowStoreBaseline, columnStoreSuitePathUsage)
 	columnStoreSuiteFixtureArg = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
@@ -585,7 +586,7 @@ func columnStoreSuitePlanKind(path string) (collections.ColumnQueryPlanKind, err
 	case columnStorePathParallelColumnScan:
 		return collections.ColumnQueryPlanParallelColumnScan, nil
 	default:
-		return "", fmt.Errorf("column_store: unknown forced path %q; accepted=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
+		return "", fmt.Errorf("column_store: unknown forced path %q; supported=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteSupportedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteUnsupportedForcedPaths))
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1905,7 +1905,11 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 			duration = time.Duration(q.DurationMS * float64(time.Millisecond))
 		}
 		queryDuration += duration
-		queryRowsProcessed += q.RowsProcessed
+		rowsProcessed := q.RowsProcessed
+		if rowsProcessed == 0 {
+			rowsProcessed = q.Rows
+		}
+		queryRowsProcessed += rowsProcessed
 		results[columnStoreSuiteBenchMetricPrefix+q.Name] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	if queryDuration > 0 {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1245,7 +1245,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	}
 	lines, err := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
 	if err != nil {
-		return columnStoreQueryExecution{}, err
+		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s line mapping: %w", queryName, plan.Kind, err)
 	}
 	diag := result.Diagnostics
 	workers := plan.Diagnostics.WorkerCount
@@ -1905,11 +1905,7 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 			duration = time.Duration(q.DurationMS * float64(time.Millisecond))
 		}
 		queryDuration += duration
-		rowsProcessed := q.RowsProcessed
-		if rowsProcessed == 0 {
-			rowsProcessed = q.Rows
-		}
-		queryRowsProcessed += rowsProcessed
+		queryRowsProcessed += columnStoreQueryEffectiveRowsProcessed(q)
 		results[columnStoreSuiteBenchMetricPrefix+q.Name] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	if queryDuration > 0 {
@@ -1933,6 +1929,16 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 		TreeDBStats: map[string]map[string]string{columnStoreSuiteBenchDisplayName: stats},
 		DiskUsage:   map[string]dirDiskUsage{columnStoreSuiteBenchDisplayName: {TotalBytes: uint64(report.ByteAccounting.DBTotalBytes), TotalFiles: report.ByteAccounting.DBTotalFiles}},
 	}
+}
+
+func columnStoreQueryEffectiveRowsProcessed(q columnStoreQueryMetric) int {
+	if q.RowsProcessed != 0 {
+		return q.RowsProcessed
+	}
+	if q.Rows > 0 && q.RowMaterializations > 0 {
+		return q.Rows
+	}
+	return 0
 }
 
 func columnStoreSuitePruneMissingRuntimeDeltaArtifacts(paths columnStoreArtifactPaths) columnStoreArtifactPaths {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -593,7 +593,7 @@ func columnStoreSuitePlanKind(path string) (collections.ColumnQueryPlanKind, err
 	case columnStorePathParallelColumnScan:
 		return collections.ColumnQueryPlanParallelColumnScan, nil
 	default:
-		return "", fmt.Errorf("column_store: unknown forced path %q; supported=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteAcceptedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteFailClosedForcedPaths))
+		return "", fmt.Errorf("column_store: unknown forced path %q; accepted=%s aliases=%s fail_closed=%s; see -column-store-path help", path, columnStoreSuitePathList(columnStoreSuiteAcceptedForcedPaths), columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases), columnStoreSuitePathList(columnStoreSuiteFailClosedForcedPaths))
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -146,6 +146,7 @@ type columnStoreQueryMetric struct {
 	ImplementationNote   string  `json:"implementation_note,omitempty"`
 	DurationMS           float64 `json:"duration_ms"`
 	Rows                 int     `json:"rows"`
+	RowsProcessed        int     `json:"rows_processed"`
 	RowsPerSecond        float64 `json:"rows_per_second"`
 	MiBPerSecond         float64 `json:"mib_per_second"`
 	NsPerRow             float64 `json:"ns_per_row"`
@@ -1072,6 +1073,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			DurationMS:           durationMS(elapsed),
 			duration:             elapsed,
 			Rows:                 rows,
+			RowsProcessed:        exec.RowsProcessed,
 			RowsPerSecond:        ratePerSecond(float64(exec.RowsProcessed), elapsed),
 			MiBPerSecond:         ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
 			NsPerRow:             nsPerRow(elapsed, exec.RowsProcessed),
@@ -1908,7 +1910,7 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 	}
 	byName := make(map[string]columnStoreQueryMetric, len(report.Queries))
 	var queryDuration time.Duration
-	var queryMaterializations int
+	var queryRowsProcessed int
 	for _, q := range report.Queries {
 		byName[q.Name] = q
 		duration := q.duration
@@ -1916,11 +1918,11 @@ func columnStoreBenchRun(baseCfg BenchConfig, profile, dataDir string, report co
 			duration = time.Duration(q.DurationMS * float64(time.Millisecond))
 		}
 		queryDuration += duration
-		queryMaterializations += q.RowMaterializations
+		queryRowsProcessed += q.RowsProcessed
 		results[columnStoreSuiteBenchMetricPrefix+q.Name] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}
 	}
 	if queryDuration > 0 {
-		results[columnStoreSuiteBenchTestName] = map[string]float64{columnStoreSuiteBenchDisplayName: float64(queryMaterializations) / queryDuration.Seconds()}
+		results[columnStoreSuiteBenchTestName] = map[string]float64{columnStoreSuiteBenchDisplayName: float64(queryRowsProcessed) / queryDuration.Seconds()}
 	}
 	if q, ok := byName[columnStoreQueryQ1]; ok {
 		results[columnStoreSuiteAliasFullScanQ1] = map[string]float64{columnStoreSuiteBenchDisplayName: q.RowsPerSecond}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1252,7 +1252,7 @@ func TestColumnStoreSuitePlanKindMapsKnownPathsM11B(t *testing.T) {
 		msg := err.Error()
 		for _, want := range []string{
 			"future_alias",
-			"supported=",
+			"accepted=",
 			"aliases=",
 			"serial-column-scan",
 			"aggregate-metadata",

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func TestColumnStoreSuiteRetainedPayloadPreservesJSONNumbersM13C(t *testing.T) {
@@ -260,8 +261,11 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.Manifest.ActiveGeneration == 0 || report.Manifest.AppliedCommandLSN == 0 {
 		t.Fatalf("expected active/recovery-authoritative manifest identity: %+v", report.Manifest)
 	}
-	if len(report.UnsupportedForcedPaths) == 0 {
-		t.Fatalf("expected unsupported forced path labels to be recorded")
+	if len(report.UnsupportedForcedPaths) != 0 {
+		t.Fatalf("unexpected unsupported forced path labels after M14B routing: %+v", report.UnsupportedForcedPaths)
+	}
+	if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, columnStorePathSerialColumnScan) {
+		t.Fatalf("expected physical forced path labels to be recorded as supported: %+v", report.SupportedForcedPaths)
 	}
 	if report.Artifacts.CPUProfile == "" ||
 		report.Artifacts.AllocsProfile == "" ||
@@ -376,7 +380,7 @@ func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
 	for _, want := range []string{
 		"- manifest_control_missing: `manifest`, `dictionary`",
 		"- supported: `row_store_baseline`, `physical_column`",
-		"- fail-closed until M14 physical planner routing: `planner_skipscan`, `aggregate_metadata`",
+		"- unsupported/fail-closed: `planner_skipscan`, `aggregate_metadata`",
 	} {
 		if !strings.Contains(md, want) {
 			t.Fatalf("markdown missing %q:\n%s", want, md)
@@ -985,23 +989,115 @@ func TestColumnStoreQueryHashCanonicalizesQ5MetadataAliasM11A(t *testing.T) {
 	}
 }
 
-func TestColumnStoreSuiteRejectsForcedColumnPathM11B(t *testing.T) {
-	cfg := BenchConfig{Keys: 8, BatchSize: 4, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{Keys: 16, BatchSize: 8, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
 	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
-		ForcedPath: "serial_column_scan",
+		ProfileDir:    dir,
+		ExecutionPath: "native-fastpath",
+		ForcedPath:    columnStorePathSerialColumnScan,
 	})
-	if err == nil {
-		t.Fatal("expected forced serial column scan to fail closed")
+	if err != nil {
+		t.Fatalf("runColumnStoreSuite serial physical: %v", err)
 	}
-	if !errors.Is(err, collections.ErrColumnQueryPlanUnsupported) {
-		t.Fatalf("expected ErrColumnQueryPlanUnsupported, got %v", err)
+
+	var report columnStoreSuiteReport
+	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if err != nil {
+		t.Fatalf("read column_store_results.json: %v", err)
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "serial_column_scan") ||
-		!strings.Contains(msg, "unsupported") ||
-		!strings.Contains(msg, "refusing to route through row store") ||
-		!strings.Contains(msg, "reason=serial physical column scan capability is disabled") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal column_store_results.json: %v", err)
+	}
+	if got, want := report.ForcedPath, columnStorePathSerialColumnScan; got != want {
+		t.Fatalf("forced_path=%q want %q", got, want)
+	}
+	if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, columnStorePathSerialColumnScan) {
+		t.Fatalf("serial physical path not reported as supported: %+v", report.SupportedForcedPaths)
+	}
+	if report.ByteAccounting.ColumnAssetBytes <= 0 {
+		t.Fatalf("physical run did not report column assets: %+v", report.ByteAccounting)
+	}
+	queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
+	for _, q := range report.Queries {
+		if q.PlanLabel != columnStorePathSerialColumnScan {
+			t.Fatalf("query %s plan_label=%q want %q", q.Name, q.PlanLabel, columnStorePathSerialColumnScan)
+		}
+		if q.RowMaterializations != 0 {
+			t.Fatalf("query %s row_materializations=%d want zero physical row materialization", q.Name, q.RowMaterializations)
+		}
+		if q.BytesRead <= 0 || q.RowsPerSecond <= 0 || q.NsPerRow <= 0 {
+			t.Fatalf("query %s missing physical throughput metrics: %+v", q.Name, q)
+		}
+	}
+	if got, want := queryMetrics[columnStoreQueryQ5Metadata].ProductionHash, queryMetrics[columnStoreQueryQ5].ProductionHash; got != want {
+		t.Fatalf("q5_metadata production hash=%016x want q5 hash=%016x", got, want)
+	}
+	for name, parity := range report.Parity {
+		if !parity.Pass {
+			t.Fatalf("parity %s failed: %+v", name, parity)
+		}
+	}
+}
+
+func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *testing.T) {
+	tests := []struct {
+		name       string
+		forcedPath string
+		q5Plan     string
+		wantWorker int
+	}{
+		{name: "aggregate metadata", forcedPath: columnStorePathAggregateMetadata, q5Plan: columnStorePathAggregateMetadata, wantWorker: 1},
+		{name: "parallel", forcedPath: columnStorePathParallelColumnScan, q5Plan: columnStorePathParallelColumnScan, wantWorker: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := BenchConfig{Keys: 24, BatchSize: 6, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+			_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+				ProfileDir:    dir,
+				ExecutionPath: "native-fastpath",
+				ForcedPath:    tc.forcedPath,
+			})
+			if err != nil {
+				t.Fatalf("runColumnStoreSuite %s: %v", tc.forcedPath, err)
+			}
+
+			var report columnStoreSuiteReport
+			data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+			if err != nil {
+				t.Fatalf("read column_store_results.json: %v", err)
+			}
+			if err := json.Unmarshal(data, &report); err != nil {
+				t.Fatalf("unmarshal column_store_results.json: %v", err)
+			}
+			if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, tc.forcedPath) {
+				t.Fatalf("%s not reported as supported: %+v", tc.forcedPath, report.SupportedForcedPaths)
+			}
+			queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
+			for _, q := range report.Queries {
+				if q.RowMaterializations != 0 {
+					t.Fatalf("query %s row_materializations=%d want zero physical row materialization", q.Name, q.RowMaterializations)
+				}
+				if q.BytesRead <= 0 {
+					t.Fatalf("query %s bytes_read=%d want physical bytes", q.Name, q.BytesRead)
+				}
+				if tc.forcedPath == columnStorePathParallelColumnScan && q.WorkerCount != tc.wantWorker {
+					t.Fatalf("query %s worker_count=%d want %d for parallel path", q.Name, q.WorkerCount, tc.wantWorker)
+				}
+			}
+			if got := queryMetrics[columnStoreQueryQ5Metadata].PlanLabel; got != tc.q5Plan {
+				t.Fatalf("q5_metadata plan_label=%q want %q", got, tc.q5Plan)
+			}
+			if got, want := queryMetrics[columnStoreQueryQ5Metadata].ProductionHash, queryMetrics[columnStoreQueryQ5].ProductionHash; got != want {
+				t.Fatalf("q5_metadata production hash=%016x want q5 hash=%016x", got, want)
+			}
+			for name, parity := range report.Parity {
+				if !parity.Pass {
+					t.Fatalf("parity %s failed: %+v", name, parity)
+				}
+			}
+		})
 	}
 }
 
@@ -1110,7 +1206,7 @@ func TestColumnStoreSuitePathFlagDocumentsAliasesM11B(t *testing.T) {
 	if f == nil {
 		t.Fatal("missing column-store-path flag")
 	}
-	for _, want := range []string{"aliases:", "executable:", "fail-closed", "row-store-baseline", "b-tree-index-baseline", "serial-column-scan", "aggregate-metadata", "parallel-column-scan"} {
+	for _, want := range []string{"aliases:", "executable:", "row-store-baseline", "b-tree-index-baseline", "serial-column-scan", "aggregate-metadata", "parallel-column-scan"} {
 		if !strings.Contains(f.Usage, want) {
 			t.Fatalf("column-store-path help missing %q:\n%s", want, f.Usage)
 		}
@@ -1237,9 +1333,51 @@ func TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B(t *testing.T) {
 		if got != want {
 			t.Fatalf("columnStoreSuitePlanKind(%q)=%q want %q", alias, got, want)
 		}
-		if _, _, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, alias); !errors.Is(err, collections.ErrColumnQueryPlanUnsupported) {
-			t.Fatalf("physical alias %q err=%v want ErrColumnQueryPlanUnsupported", alias, err)
+		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, alias)
+		if err != nil {
+			t.Fatalf("physical alias %q: %v", alias, err)
 		}
+		if len(queries) != len(columnStoreQueryNameList) || len(parity) != len(columnStoreQueryNameList) {
+			t.Fatalf("physical alias %q queries=%d parity=%d want %d", alias, len(queries), len(parity), len(columnStoreQueryNameList))
+		}
+		for name, result := range parity {
+			if !result.Pass {
+				t.Fatalf("physical alias %q parity %s failed: %+v", alias, name, result)
+			}
+		}
+	}
+}
+
+func TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B(t *testing.T) {
+	const rows = 16
+	events, _ := buildColumnStoreSyntheticFixture(rows, 1)
+	dir := t.TempDir()
+	db, err := openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(columnStoreSuiteCollectionMeta(columnStorePathSerialColumnScan)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := insertColumnStoreFixture(collection, events, 8); err != nil {
+		t.Fatalf("insert fixture: %v", err)
+	}
+	rawHashes, err := columnStoreReferenceHashes(events)
+	if err != nil {
+		t.Fatalf("reference hashes: %v", err)
+	}
+	if err := os.RemoveAll(backenddb.ColumnAssetRootDirPath(dir)); err != nil {
+		t.Fatalf("remove column asset root: %v", err)
+	}
+	_, _, err = runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathSerialColumnScan)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing physical assets err=%v want os.ErrNotExist without row fallback", err)
 	}
 }
 
@@ -1407,6 +1545,15 @@ func TestColumnStoreSuiteReportsKeptDataDirM11A(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.RemoveAll(report.DataDir)
 	})
+}
+
+func columnStoreTestStringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestColumnStoreSuiteConfigUsesExplicitAggregateMetadataNamesM11A(t *testing.T) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -353,14 +353,30 @@ func TestColumnStoreBenchRunUsesDurationForAggregateM11A(t *testing.T) {
 		Rows:      30,
 		BatchSize: 10,
 		Queries: []columnStoreQueryMetric{
-			{Name: "q1", RowMaterializations: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
-			{Name: "q2", RowMaterializations: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
+			{Name: "q1", RowsProcessed: 10, RowMaterializations: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
+			{Name: "q2", RowsProcessed: 20, RowMaterializations: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
 		},
 	}, nil, 0)
 
 	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
 	if math.Abs(got-1000) > 1e-9 {
 		t.Fatalf("aggregate rows/sec=%f want 1000 from exact durations", got)
+	}
+}
+
+func TestColumnStoreBenchRunUsesRowsProcessedForPhysicalAggregateM14B(t *testing.T) {
+	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
+		Rows:      30,
+		BatchSize: 10,
+		Queries: []columnStoreQueryMetric{
+			{Name: "q1", RowsProcessed: 10, RowMaterializations: 0, RowsPerSecond: 1, duration: 10 * time.Millisecond},
+			{Name: "q2", RowsProcessed: 20, RowMaterializations: 0, RowsPerSecond: 1, duration: 20 * time.Millisecond},
+		},
+	}, nil, 0)
+
+	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
+	if math.Abs(got-1000) > 1e-9 {
+		t.Fatalf("aggregate rows/sec=%f want 1000 from physical rows processed", got)
 	}
 }
 
@@ -1023,6 +1039,9 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 		if q.PlanLabel != columnStorePathSerialColumnScan {
 			t.Fatalf("query %s plan_label=%q want %q", q.Name, q.PlanLabel, columnStorePathSerialColumnScan)
 		}
+		if q.RowsProcessed != report.Rows {
+			t.Fatalf("query %s rows_processed=%d want %d", q.Name, q.RowsProcessed, report.Rows)
+		}
 		if q.RowMaterializations != 0 {
 			t.Fatalf("query %s row_materializations=%d want zero physical row materialization", q.Name, q.RowMaterializations)
 		}
@@ -1078,6 +1097,9 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			for _, q := range report.Queries {
 				if q.RowMaterializations != 0 {
 					t.Fatalf("query %s row_materializations=%d want zero physical row materialization", q.Name, q.RowMaterializations)
+				}
+				if q.RowsProcessed != report.Rows {
+					t.Fatalf("query %s rows_processed=%d want %d", q.Name, q.RowsProcessed, report.Rows)
 				}
 				if q.BytesRead <= 0 {
 					t.Fatalf("query %s bytes_read=%d want physical bytes", q.Name, q.BytesRead)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -261,11 +261,11 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.Manifest.ActiveGeneration == 0 || report.Manifest.AppliedCommandLSN == 0 {
 		t.Fatalf("expected active/recovery-authoritative manifest identity: %+v", report.Manifest)
 	}
-	if len(report.UnsupportedForcedPaths) != 0 {
-		t.Fatalf("unexpected unsupported forced path labels after M14B routing: %+v", report.UnsupportedForcedPaths)
+	if len(report.FailClosedForcedPaths) != 0 {
+		t.Fatalf("unexpected fail-closed forced path labels after M14B routing: %+v", report.FailClosedForcedPaths)
 	}
-	if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, columnStorePathSerialColumnScan) {
-		t.Fatalf("expected physical forced path labels to be recorded as supported: %+v", report.SupportedForcedPaths)
+	if !columnStoreTestStringSliceContains(report.AcceptedForcedPaths, columnStorePathSerialColumnScan) {
+		t.Fatalf("expected physical forced path labels to be recorded as accepted: %+v", report.AcceptedForcedPaths)
 	}
 	if report.Artifacts.CPUProfile == "" ||
 		report.Artifacts.AllocsProfile == "" ||
@@ -420,14 +420,15 @@ func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
 		ByteAccounting: columnStoreByteAccounting{
 			ManifestControlMissing: []string{"manifest", "dictionary"},
 		},
-		SupportedForcedPaths:   []string{"row_store_baseline", "physical_column"},
-		UnsupportedForcedPaths: []string{"planner_skipscan", "aggregate_metadata"},
+		AcceptedForcedPaths:   []string{"row_store_baseline", "physical_column"},
+		FailClosedForcedPaths: []string{"planner_skipscan", "aggregate_metadata"},
 	})
 
 	for _, want := range []string{
 		"- manifest_control_missing: `manifest`, `dictionary`",
-		"- supported: `row_store_baseline`, `physical_column`",
-		"- unsupported/fail-closed: `planner_skipscan`, `aggregate_metadata`",
+		"- accepted labels are CLI/planner labels, not a promise that every run has the required physical assets",
+		"- accepted: `row_store_baseline`, `physical_column`",
+		"- fail-closed: `planner_skipscan`, `aggregate_metadata`",
 	} {
 		if !strings.Contains(md, want) {
 			t.Fatalf("markdown missing %q:\n%s", want, md)
@@ -1059,8 +1060,8 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 	if got, want := report.ForcedPath, columnStorePathSerialColumnScan; got != want {
 		t.Fatalf("forced_path=%q want %q", got, want)
 	}
-	if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, columnStorePathSerialColumnScan) {
-		t.Fatalf("serial physical path not reported as supported: %+v", report.SupportedForcedPaths)
+	if !columnStoreTestStringSliceContains(report.AcceptedForcedPaths, columnStorePathSerialColumnScan) {
+		t.Fatalf("serial physical path not reported as accepted: %+v", report.AcceptedForcedPaths)
 	}
 	if report.ByteAccounting.ColumnAssetBytes <= 0 {
 		t.Fatalf("physical run did not report column assets: %+v", report.ByteAccounting)
@@ -1121,8 +1122,8 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			if err := json.Unmarshal(data, &report); err != nil {
 				t.Fatalf("unmarshal column_store_results.json: %v", err)
 			}
-			if !columnStoreTestStringSliceContains(report.SupportedForcedPaths, tc.forcedPath) {
-				t.Fatalf("%s not reported as supported: %+v", tc.forcedPath, report.SupportedForcedPaths)
+			if !columnStoreTestStringSliceContains(report.AcceptedForcedPaths, tc.forcedPath) {
+				t.Fatalf("%s not reported as accepted: %+v", tc.forcedPath, report.AcceptedForcedPaths)
 			}
 			queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 			for _, q := range report.Queries {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -170,6 +170,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		if q.ScanDurationMS < 0 {
 			t.Fatalf("query %s scan_duration_ms=%v", q.Name, q.ScanDurationMS)
 		}
+		if q.AdapterDurationMS < 0 {
+			t.Fatalf("query %s adapter_duration_ms=%v", q.Name, q.AdapterDurationMS)
+		}
 		if q.PlannerCandidates == 0 || q.PlannerReason == "" {
 			t.Fatalf("query %s missing planner diagnostics: %+v", q.Name, q)
 		}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1095,6 +1095,14 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			}
 			queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 			for _, q := range report.Queries {
+				if tc.forcedPath == columnStorePathAggregateMetadata && q.Name != columnStoreQueryQ5Metadata {
+					if q.PlanLabel != columnStorePathSerialColumnScan {
+						t.Fatalf("query %s plan_label=%q want %q under aggregate_metadata forced path", q.Name, q.PlanLabel, columnStorePathSerialColumnScan)
+					}
+					if !strings.Contains(q.ImplementationNote, "rerouted_to_serial_column_scan") {
+						t.Fatalf("query %s missing aggregate reroute implementation note: %+v", q.Name, q)
+					}
+				}
 				if q.RowMaterializations != 0 {
 					t.Fatalf("query %s row_materializations=%d want zero physical row materialization", q.Name, q.RowMaterializations)
 				}
@@ -1394,12 +1402,61 @@ func TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B(t *testing.T
 	if err != nil {
 		t.Fatalf("reference hashes: %v", err)
 	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close before recovery-authoritative reopen: %v", err)
+	}
+	db, err = openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	manager = collections.NewCollectionManager(db)
+	collection, err = manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("reopen collection: %v", err)
+	}
 	if err := os.RemoveAll(backenddb.ColumnAssetRootDirPath(dir)); err != nil {
 		t.Fatalf("remove column asset root: %v", err)
 	}
 	_, _, err = runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathSerialColumnScan)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("missing physical assets err=%v want os.ErrNotExist without row fallback", err)
+	}
+}
+
+func TestColumnStoreSuiteQ3ReferenceUsesPhysicalHourSemanticsM14B(t *testing.T) {
+	events := []columnStoreDecodedEvent{
+		{TimeUS: -1},
+		{TimeUS: -3_600_000_000},
+		{TimeUS: -3_600_000_001},
+		{TimeUS: 0},
+	}
+	lines, err := columnStoreQueryLines(columnStoreQueryQ3, events)
+	if err != nil {
+		t.Fatalf("columnStoreQueryLines q3: %v", err)
+	}
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"q3:hour_23=2",
+		"q3:hour_22=1",
+		"q3:hour_00=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("q3 lines missing %q: %v", want, lines)
+		}
+	}
+	if strings.Contains(got, "hour_-") {
+		t.Fatalf("q3 lines used truncating negative hour bucket: %v", lines)
+	}
+}
+
+func TestColumnStoreSuitePhysicalQueryLinesFailsClosedOnUnknownMappingM14B(t *testing.T) {
+	if _, err := columnStoreSuitePhysicalQueryLines("future", "future_query", nil); err == nil {
+		t.Fatal("expected unknown physical query line mapping to fail")
+	} else if !strings.Contains(err.Error(), "future_query") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -380,6 +380,22 @@ func TestColumnStoreBenchRunUsesRowsProcessedForPhysicalAggregateM14B(t *testing
 	}
 }
 
+func TestColumnStoreBenchRunFallsBackToRowsForLegacyArtifactsM14B(t *testing.T) {
+	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
+		Rows:      30,
+		BatchSize: 10,
+		Queries: []columnStoreQueryMetric{
+			{Name: "q1", Rows: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
+			{Name: "q2", Rows: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
+		},
+	}, nil, 0)
+
+	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
+	if math.Abs(got-1000) > 1e-9 {
+		t.Fatalf("aggregate rows/sec=%f want 1000 from legacy rows fallback", got)
+	}
+}
+
 func TestRenderColumnStoreSuiteMarkdownCodeListsM11A(t *testing.T) {
 	md := renderColumnStoreSuiteMarkdown(columnStoreSuiteReport{
 		Profile:                "durable",
@@ -1386,7 +1402,11 @@ func TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B(t *testing.T
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer func() { _ = db.Close() }()
+	defer func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	}()
 	manager := collections.NewCollectionManager(db)
 	if _, err := manager.CreateCollection(columnStoreSuiteCollectionMeta(columnStorePathSerialColumnScan)); err != nil {
 		t.Fatalf("create collection: %v", err)
@@ -1417,8 +1437,21 @@ func TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B(t *testing.T
 	if err != nil {
 		t.Fatalf("reopen collection: %v", err)
 	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close before asset removal: %v", err)
+	}
+	db = nil
 	if err := os.RemoveAll(backenddb.ColumnAssetRootDirPath(dir)); err != nil {
 		t.Fatalf("remove column asset root: %v", err)
+	}
+	db, err = openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("reopen after asset removal: %v", err)
+	}
+	manager = collections.NewCollectionManager(db)
+	collection, err = manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("reopen collection after asset removal: %v", err)
 	}
 	_, _, err = runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathSerialColumnScan)
 	if !errors.Is(err, os.ErrNotExist) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1340,7 +1340,8 @@ func TestColumnStoreSuiteRunsBTreeIndexBaselineM11B(t *testing.T) {
 func TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B(t *testing.T) {
 	const rows = 16
 	events, _ := buildColumnStoreSyntheticFixture(rows, 1)
-	db, err := openColumnStoreSuiteDB(t.TempDir())
+	dir := t.TempDir()
+	db, err := openColumnStoreSuiteDB(dir)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -1375,6 +1376,21 @@ func TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B(t *testing.T) {
 		if q.WorkerCount != 1 {
 			t.Fatalf("query %s worker_count=%d want 1 for caller-thread row baseline", q.Name, q.WorkerCount)
 		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint before physical aliases: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close before physical aliases: %v", err)
+	}
+	db, err = openColumnStoreSuiteDB(dir)
+	if err != nil {
+		t.Fatalf("reopen before physical aliases: %v", err)
+	}
+	manager = collections.NewCollectionManager(db)
+	collection, err = manager.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("reopen collection before physical aliases: %v", err)
 	}
 
 	physicalAliases := map[string]collections.ColumnQueryPlanKind{

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -359,7 +359,7 @@ func TestColumnStoreBenchRunUsesDurationForAggregateM11A(t *testing.T) {
 	}, nil, 0)
 
 	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
-	if math.Abs(got-1000) > 1e-9 {
+	if math.Abs(got-1000) > 1e-6 {
 		t.Fatalf("aggregate rows/sec=%f want 1000 from exact durations", got)
 	}
 }
@@ -375,7 +375,7 @@ func TestColumnStoreBenchRunUsesRowsProcessedForPhysicalAggregateM14B(t *testing
 	}, nil, 0)
 
 	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
-	if math.Abs(got-1000) > 1e-9 {
+	if math.Abs(got-1000) > 1e-6 {
 		t.Fatalf("aggregate rows/sec=%f want 1000 from physical rows processed", got)
 	}
 }
@@ -385,14 +385,29 @@ func TestColumnStoreBenchRunFallsBackToRowsForLegacyArtifactsM14B(t *testing.T) 
 		Rows:      30,
 		BatchSize: 10,
 		Queries: []columnStoreQueryMetric{
-			{Name: "q1", Rows: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
-			{Name: "q2", Rows: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
+			{Name: "q1", Rows: 10, RowMaterializations: 10, RowsPerSecond: 1, duration: 10 * time.Millisecond},
+			{Name: "q2", Rows: 20, RowMaterializations: 20, RowsPerSecond: 1, duration: 20 * time.Millisecond},
 		},
 	}, nil, 0)
 
 	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
-	if math.Abs(got-1000) > 1e-9 {
+	if math.Abs(got-1000) > 1e-6 {
 		t.Fatalf("aggregate rows/sec=%f want 1000 from legacy rows fallback", got)
+	}
+}
+
+func TestColumnStoreBenchRunDoesNotFallbackForZeroProcessedPhysicalRowsM14B(t *testing.T) {
+	run := columnStoreBenchRun(BenchConfig{}, "durable", t.TempDir(), columnStoreSuiteReport{
+		Rows:      30,
+		BatchSize: 10,
+		Queries: []columnStoreQueryMetric{
+			{Name: "q1", Rows: 30, RowsProcessed: 0, RowMaterializations: 0, RowsPerSecond: 0, duration: 30 * time.Millisecond},
+		},
+	}, nil, 0)
+
+	got := run.Results[columnStoreSuiteBenchTestName][columnStoreSuiteBenchDisplayName]
+	if got != 0 {
+		t.Fatalf("aggregate rows/sec=%f want zero without legacy row materialization fallback", got)
 	}
 }
 


### PR DESCRIPTION
## What Landed

M14B wires forced physical column-store query labels through the production TreeDB planner/query/scanner path instead of row-materializing fallback:

- `serial_column_scan` now routes through the real physical query adapter when recovery-authoritative physical assets exist.
- `aggregate_metadata` now routes fail-closed through the physical adapter; in M14B it is scan-backed for q5 metadata parity, with metadata-only fast-path measurement deferred to M14C.
- `parallel_column_scan` now executes insert-only manifests by pinning one recovery-authoritative scan snapshot/view, partitioning that immutable ref list across worker-local serial scanners, then merging reducer state.
- Unsupported physical prerequisites still fail closed before execution or acknowledgement, including missing physical assets, disabled capabilities, undeclared columns, non-authoritative identity, and mutation-bearing parallel plans.
- unified-bench physical reports now show the selected physical plan, `rows_processed`, physical byte accounting, zero row materializations, worker counts, parity hashes, and HTML/MD/JSON artifacts for forced paths.
- Benchprof aggregate throughput now uses rows processed/reduced, not full row materializations, so physical paths no longer report a false zero aggregate rate.
- Profile delta generation now falls back to `runtime.GOROOT()/bin/go` when `PATH` is unavailable, keeping profile artifacts valid in stripped environments.

## Performance / Benchmark Evidence

Local machine: Apple M3, durable profile, synthetic JSONBench-shaped column-store fixture, 16,384 rows, batch size 1,024.

Command shape:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 16384 -batchsize 1024 -path-label native-fastpath -column-store-path <path> -profile-dir <artifact-dir> -format markdown
```

Representative query throughput:

| forced path | q1 plan | q1 rows/s | q1 MiB/s | q1 ns/row | q5_metadata plan | q5_metadata rows/s | q5_metadata MiB/s | q5_metadata ns/row | workers | rows processed | row materializations | parity |
|---|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---|
| `row_store_baseline` | `row_store_baseline` | 57,851 | 5.2 | 17,285.8 | `row_store_baseline` | 62,026 | 5.5 | 16,122.2 | 1 | 16,384 | 16,384 | pass |
| `serial_column_scan` | `serial_column_scan` | 5,142,431 | 511.2 | 194.5 | `serial_column_scan` | 5,144,045 | 511.3 | 194.4 | 1 | 16,384 | 0 | pass |
| `aggregate_metadata` | `serial_column_scan` | 6,895,382 | 685.4 | 145.0 | `aggregate_metadata` | 4,400,850 | 437.4 | 227.2 | 1 | 16,384 | 0 | pass |
| `parallel_column_scan` | `parallel_column_scan` | 11,295,742 | 1,122.8 | 88.5 | `parallel_column_scan` | 8,137,750 | 808.9 | 122.9 | 2 | 16,384 | 0 | pass |

Benchprof aggregate `Column store query phase` rates from the same artifacts are now positive for physical paths:

| forced path | aggregate rows/s |
|---|---:|
| `row_store_baseline` | 61,516 |
| `serial_column_scan` | 5,011,054 |
| `aggregate_metadata` | 4,942,916 |
| `parallel_column_scan` | 9,199,942 |

Byte accounting was stable across the four forced paths:

| metric | bytes |
|---|---:|
| source document bytes | 1,534,976 |
| retained payload bytes | 551,936 |
| column asset bytes | 1,707,664 |
| manifest/control bytes | 28 |
| ordinary value_vlog bytes | 0 |
| leaf_vlog bytes | 385,087 |
| command-WAL bytes before checkpoint | 1,832,916 |
| checkpoint stage bytes | 1,534,976 |
| DB total bytes | 4,188,235 |

Package-level allocation/throughput checks from pushed head:

```text
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_1024-8             39,841 ns/op   2653.15 MB/s      0 B/op   0 allocs/op
BenchmarkColumnPhysicalAssetSerialScanM13A/rows_8192-8            314,153 ns/op   2686.62 MB/s      0 B/op   0 allocs/op
BenchmarkColumnPhysicalCollectionSerialScanM13A-8                  75,870 ns/op   1393.23 MB/s 110,395 B/op  38 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q1_rows_1024-8            109,922 ns/op    933.69 MB/s    107.2 ns/row  9,328,691 rows/s 113,235 B/op 68 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q5_rows_1024-8            125,342 ns/op    818.82 MB/s    122.3 ns/row  8,177,328 rows/s 115,001 B/op 90 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q1_rows_8192-8            781,744 ns/op   1048.21 MB/s     95.21 ns/row 10,502,550 rows/s 834,167 B/op 68 allocs/op
BenchmarkColumnPhysicalQueryAdapterM13B/q5_rows_8192-8            885,203 ns/op    925.70 MB/s    108.0 ns/row  9,260,685 rows/s 835,948 B/op 90 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8   1,281 ns/op 0 B/op 0 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/mutation_manifest_rows_1024-8 32,125 ns/op 0 B/op 0 allocs/op
```

## Throughput Interpretation

The M14B routing gate is now real physical execution, not just planner labeling: physical paths read column asset bytes, report `rows_processed=16,384`, report `row_materializations=0`, and pass parity against the row-materialized reference hashes. The serial path is roughly two orders of magnitude faster than the row baseline on this small fixture because it avoids full JSON document materialization. The parallel path improves the insert-only fixture further by splitting manifest refs across two workers.

The `aggregate_metadata` label is intentionally honest in this PR: q5_metadata reaches a physical aggregate plan label, but still scans physical assets in M14B. Metadata-only hit counts remain zero and the actual metadata fast-path/interpretation gate stays in M14C.

Raw physical asset serial scan remains zero-alloc. Collection/query adapter allocations are from per-query manager/read/decoder setup and reducer structures; a reusable prepared scanner/executor would be the right follow-up if we want collection-level zero-alloc hot loops. Go arenas are not needed for this PR and would not address the scanner lifecycle contract.

## Granule / ClickHouse Equivalent Comparison

These comparisons are context only, not M14B gates. M14B measures routed production TreeDB query execution through `unified-bench`; the older granule numbers measure pre-production encoded/block reducer kernels before full durable TreeDB integration, manifest/recovery validation, typed asset manager reads, planner routing, artifact reporting, and parity checks were in the timed path.

Later same-machine #1634 granule refresh (`/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`):

- q1 encoded reducer: `412.80M rows/s`.
- q2 encoded reducer: `237.61M rows/s`.
- q3 encoded reducer: `191.61M rows/s`.
- q5 encoded reducer: `138.03M rows/s`.
- q5 metadata kernel: `399.71M rows/s`.

Historical local ClickHouse-equivalent comparison from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1,000,000 JSONBench rows against local ClickHouse `26.4.3.1` on Darwin arm64:

- q1 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.004284s`, about `233.43M rows/s`.
- q2 ClickHouse local: `0.027s`, about `37.04M rows/s`; granule column-kernel best `0.038895s`, about `25.71M rows/s`.
- q3 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.006631s`, about `150.81M rows/s`.
- q4 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.009869s`, about `101.33M rows/s`.
- q5 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.010027s`, about `99.73M rows/s`.

Interpretation for this PR: M14B proves that forced q1-q5/q5_metadata physical labels execute through production routing with parity and zero row materialization. It does not claim parity with the older granule kernels or ClickHouse; the remaining gap is expected until post-V1 work adds vector/block reducer paths, metadata assets, mark pruning, dictionaries, locators, and reusable reader/executor state.

## Gate Status

- TDD red phase was observed before implementation: new forced physical planner/unified-bench tests failed while physical capabilities were still disabled.
- Forced `serial_column_scan`, `aggregate_metadata`, and insert-only `parallel_column_scan` execute through planner -> physical query adapter -> physical scanner.
- Missing assets and unsupported physical prerequisites fail closed before row fallback.
- Mutation-bearing parallel physical scans fail closed until partitioned visibility execution lands.
- Parallel physical scans pin one manifest snapshot/view before launching workers, so merged worker results cannot mix manifest generations.
- JSONBench-shaped q1/q2/q3/q4a/q4b/q5/q5_metadata parity passes for row, serial, aggregate, and parallel forced labels.
- `column_asset_bytes > 0`, `rows_processed=16,384`, and `row_materializations=0` are reported for physical forced paths.
- Benchprof aggregate `Column store query phase` rates are positive for physical forced paths.
- Durable mode remains the measured production-supported mode.

## Tests Run

```sh
go test ./cmd/unified_bench -run 'TestGoToolExecutableFallsBackToRuntimeGOROOTWhenPATHMissing|TestColumnStoreBenchRunUsesRowsProcessedForPhysicalAggregateM14B|TestColumnStoreBenchRunUsesDurationForAggregateM11A|TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B|TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B' -count=1
go test ./TreeDB/collections -run 'TestColumnPhysicalScanSnapshotViewPinsManifestRefsM14B|TestColumnPhysicalQueryParallel.*M14B|TestColumnQueryPlannerM14B|TestColumnPhysicalQuery.*M13' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
go test ./TreeDB/db -count=1
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalAssetSerialScanM13A|BenchmarkColumnPhysicalCollectionSerialScanM13A|BenchmarkColumnPhysicalQueryAdapterM13B|BenchmarkColumnQueryPlannerCapabilitiesM14A' -benchmem -count=1
go build -o bin/unified-bench ./cmd/unified_bench
git diff --check
```

## Artifacts

Artifact root: `/tmp/gomap_m14b_fix2_20260519_035205`

- row baseline: `/tmp/gomap_m14b_fix2_20260519_035205/row_store_baseline/column_store_results.{json,md,html}` plus `benchprof_results.{json,md}`, `insights.{json,md,html}`, CPU/alloc/block/mutex/checkpoint profiles, and `trace.out`.
- serial physical: `/tmp/gomap_m14b_fix2_20260519_035205/serial_column_scan/column_store_results.{json,md,html}` plus matching benchprof/insights/profile artifacts.
- aggregate physical label: `/tmp/gomap_m14b_fix2_20260519_035205/aggregate_metadata/column_store_results.{json,md,html}` plus matching benchprof/insights/profile artifacts.
- parallel physical: `/tmp/gomap_m14b_fix2_20260519_035205/parallel_column_scan/column_store_results.{json,md,html}` plus matching benchprof/insights/profile artifacts.

## Remaining Blocked / Assumptions

- M14C owns the stable closeout comparison, aggregate metadata-only fast-path evidence, and final throughput interpretation.
- Parallel physical execution is insert-only in M14B; mutation-bearing parallel plans remain fail-closed until partitioned visibility execution is implemented.
- Automatic unforced physical routing remains disabled; M14B only makes explicit forced physical labels executable after recovery-authoritative capability discovery.

Refs #1621.

## Review Hardening

Latest pushed head: `4fe3e0f9ec360b7efd96d9ccc16b2be5ff3ffa5a` for M14B.

The latest head includes M14A propagation plus M14B review hardening:

- Forced `aggregate_metadata` runs now assert and report that non-`q5_metadata` queries reroute to serial physical scan.
- Missing physical assets are validated after checkpoint and recovery-authoritative reopen, and still fail closed without row fallback.
- Physical query result mapping now fails closed on unknown query labels.
- Physical scan timing reports the fused scan/reducer boundary honestly; metadata hits remain zero for M14B scan-backed aggregate labels.
- Parallel physical diagnostics treat `MutationParts` as view-level metadata, cap worker partitions to available refs, and cancel peer scans after worker failure.
- q3 reference parity now uses the same floor-based UTC-hour semantics as the physical reducer for negative/pre-epoch timestamps.
- `go` tool discovery now rejects relative `LookPath` results before falling back to `runtime.GOROOT()/bin/go`.

Current validation evidence:

```text
go test ./TreeDB/collections ./cmd/unified_bench -run 'TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B|TestColumnPhysicalQueryParallelFailsClosedForMutationVisibilityM14B|TestColumnPhysicalScanHonorsCancellationBeforeSchedulingRefsM14B|TestMergeColumnPhysicalQueryDiagnosticsTreatsMutationPartsAsViewLevelM14B|TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B|TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B|TestColumnStoreSuiteQ3ReferenceUsesPhysicalHourSemanticsM14B|TestColumnStoreSuitePhysicalQueryLinesFailsClosedOnUnknownMappingM14B|TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B|TestColumnQueryPlanner.*M14B|TestColumnQueryPlanner.*M14A|TestColumnPhysical.*M13A|TestColumnManifest.*M13A|TestColumnPhysicalQuery.*M13B|TestColumn.*M13C|TestColumnStoreSuiteRejectsForcedColumnPathM11B' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	4.446s
ok  	github.com/snissn/gomap/cmd/unified_bench	1.603s

go test ./TreeDB/collections ./cmd/unified_bench -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	10.469s
ok  	github.com/snissn/gomap/cmd/unified_bench	22.404s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel column query execution with per-worker partitioning, richer diagnostics, explicit worker-index capture, and accurately named segment-file cache hit/miss metrics
  * Snapshot-view manifest pinning for consistent scans

* **Bug Fixes**
  * Fail-closed for unsupported parallel mutation-visibility and invalid parallel configs (e.g. remainder without modulo)
  * Improved cancellation handling and combined worker error/diagnostic aggregation

* **Tests**
  * Extensive parity, pinning, cancellation, validation, diagnostics-merge, and suite physical-path tests

* **Chores**
  * Bench/suite and tooling updates to report physical execution, adapter metrics, and go-tool resolution behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


