### PR TITLE
Optimize leaf prefix search benchmarks

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -48,29 +48,6 @@ func compareLeafKey(a, b []byte) int {
 	return bytes.Compare(a, b)
 }
 
-func compareSmallBigEndian(a, b []byte) (int, bool) {
-	if len(a) != len(b) || len(a) > 8 {
-		return 0, false
-	}
-	if len(a) == 0 {
-		return 0, true
-	}
-
-	var av uint64
-	var bv uint64
-	for i := 0; i < len(a); i++ {
-		av = (av << 8) | uint64(a[i])
-		bv = (bv << 8) | uint64(b[i])
-	}
-	if av < bv {
-		return -1, true
-	}
-	if av > bv {
-		return 1, true
-	}
-	return 0, true
-}
-
 func composePrefixVirtualKeyU64(prev uint64, prefixLen int, suffix []byte) (uint64, bool) {
 	if prefixLen < 0 || prefixLen > 8 || len(suffix) != 8-prefixLen {
 		return 0, false
@@ -1446,48 +1423,6 @@ func (n *Node) searchLeafColumnarV2(key []byte) (uint16, bool, error) {
 	return uint16(i), false, nil
 }
 
-func compareLeafPrefixVirtualKey(prevKey []byte, prefixLen int, suffix []byte, target []byte) int {
-	// Compare prevKey[:prefixLen] + suffix against target without allocating.
-	n := prefixLen
-	if len(target) < n {
-		n = len(target)
-	}
-	if n > 0 {
-		if cmp, ok := compareSmallBigEndian(prevKey[:n], target[:n]); ok {
-			if cmp != 0 {
-				return cmp
-			}
-		} else if cmp := bytes.Compare(prevKey[:n], target[:n]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(target) < prefixLen {
-		// target is a strict prefix of the virtual key.
-		return 1
-	}
-	t := target[prefixLen:]
-	n = len(suffix)
-	if len(t) < n {
-		n = len(t)
-	}
-	if n > 0 {
-		if cmp, ok := compareSmallBigEndian(suffix[:n], t[:n]); ok {
-			if cmp != 0 {
-				return cmp
-			}
-		} else if cmp := bytes.Compare(suffix[:n], t[:n]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(t) < len(suffix) {
-		return 1
-	}
-	if len(t) > len(suffix) {
-		return -1
-	}
-	return 0
-}
-
 func (n *Node) leafRestartKeyViewAtIndex(index uint16) ([]byte, error) {
 	off, err := n.getOffset(index)
 	if err != nil {
@@ -1591,12 +1526,11 @@ func (n *Node) searchLeafPrefixBlock(blockStart, blockEnd uint16, target []byte)
 		}
 		suffix := n.data[keyStart:keyEnd]
 
-		cmp = compareLeafPrefixVirtualKey(prevKey, layout.prefixLen, suffix, target)
-		if cmp >= 0 {
-			return idx, cmp == 0, nil
-		}
-
 		if layout.prefixLen == 0 {
+			cmp = compareLeafKey(suffix, target)
+			if cmp >= 0 {
+				return idx, cmp == 0, nil
+			}
 			prevKey = suffix
 			continue
 		}
@@ -1611,6 +1545,10 @@ func (n *Node) searchLeafPrefixBlock(blockStart, blockEnd uint16, target []byte)
 		}
 		copy(cur[layout.prefixLen:], suffix)
 		prevKey = cur
+		cmp = compareLeafKey(prevKey, target)
+		if cmp >= 0 {
+			return idx, cmp == 0, nil
+		}
 	}
 
 	return blockEnd, false, nil
@@ -1829,12 +1767,11 @@ func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16
 			return 0, false, ErrCorruptedNode
 		}
 
-		cmp = compareLeafPrefixVirtualKey(prevKey, prefixLen, suffix, target)
-		if cmp >= 0 {
-			return idx, cmp == 0, nil
-		}
-
 		if prefixLen == 0 {
+			cmp = compareLeafKey(suffix, target)
+			if cmp >= 0 {
+				return idx, cmp == 0, nil
+			}
 			prevKey = suffix
 			continue
 		}
@@ -1854,6 +1791,10 @@ func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16
 		}
 		copy(cur[prefixLen:], suffix)
 		prevKey = cur
+		cmp = compareLeafKey(prevKey, target)
+		if cmp >= 0 {
+			return idx, cmp == 0, nil
+		}
 	}
 
 	return blockEnd, false, nil

--- a/experiments/rust_leaf_bench/matched_c/main.c
+++ b/experiments/rust_leaf_bench/matched_c/main.c
@@ -28,7 +28,13 @@ enum {
 typedef struct {
   int prefix;
   int columnar;
+  int key_kind;
 } Options;
+
+enum {
+  KEY_KIND_BYTES = 0,
+  KEY_KIND_FIXED_BE8 = 1
+};
 
 typedef struct {
   size_t key_off;
@@ -70,6 +76,14 @@ typedef struct {
 } BytesTable;
 
 typedef struct {
+  uint8_t *data;
+  size_t *offsets;
+  size_t count;
+  size_t len;
+  size_t cap;
+} VarBytesTable;
+
+typedef struct {
   size_t prefixLen;
   size_t suffixLen;
   size_t keyOff;
@@ -92,6 +106,12 @@ typedef struct {
   BytesTable queries;
 } SearchCtx;
 
+typedef struct {
+  int iters;
+  Page *page;
+  VarBytesTable queries;
+} VarSearchCtx;
+
 typedef uint64_t (*BenchFn)(void *);
 
 static volatile uint64_t sink;
@@ -100,16 +120,24 @@ static int env_int_any(const char **names, int n_names, int def);
 static void run_case(const char *name, int iters, BenchFn fn, void *ctx);
 static uint64_t splitmix_next(SplitMix64 *rng);
 static void splitmix_fill(SplitMix64 *rng, uint8_t *dst, size_t len);
+static uint64_t load_be64_unaligned(const uint8_t *src);
 static BytesTable make_bench_keys(size_t count, size_t prefix_bytes);
 static BytesTable make_bench_values(size_t count);
 static void free_table(BytesTable *table);
 static uint8_t *table_at(BytesTable table, size_t index);
+static void var_table_init(VarBytesTable *table, size_t count, size_t bytes);
+static void var_table_push(VarBytesTable *table, const uint8_t *value, size_t value_len);
+static void free_var_table(VarBytesTable *table);
+static uint8_t *var_table_at(VarBytesTable table, size_t index, size_t *value_len);
 static void fill_be8(uint8_t *dst, uint64_t v);
 static void fill_be16(uint8_t *dst, uint64_t a, uint64_t b);
+static size_t fill_variable_len_key(uint8_t *dst, size_t i);
 static uint64_t bench_builder_prepared(void *raw);
 static void setup_search_columnar(int fixed_be8, Page *page, BytesTable *queries);
+static void setup_search_columnar_variable_len(Page *page, VarBytesTable *queries);
 static void setup_search_prefix_variant(Options opts, Page *page, BytesTable *queries);
 static uint64_t bench_search_prepared(void *raw);
+static uint64_t bench_search_prepared_var(void *raw);
 static void builder_init(Builder *b, Options opts);
 static int builder_add_leaf_entry(Builder *b, const uint8_t *key, size_t key_len,
                                   const uint8_t *value, size_t value_len, uint8_t flags);
@@ -139,6 +167,8 @@ static void search_plain(const Page *page, const uint8_t *key, size_t key_len, i
                          int *found);
 static void search_columnar_v2(const Page *page, const uint8_t *key, size_t key_len,
                                int *idx, int *found);
+static void search_columnar_v2_fixed_be8(const Page *page, const uint8_t *key, int *idx,
+                                         int *found);
 static void search_prefix_v2(const Page *page, const uint8_t *key, size_t key_len, int *idx,
                              int *found);
 static void search_prefix_block(const Page *page, int block_start, int block_end,
@@ -181,15 +211,24 @@ int main(void) {
   SearchCtx columnar_variable = {search_iters, &columnar_variable_page, columnar_variable_queries};
   run_case("search/columnar_variable16", search_iters, bench_search_prepared, &columnar_variable);
 
+  Page columnar_variable_len_page;
+  VarBytesTable columnar_variable_len_queries;
+  setup_search_columnar_variable_len(&columnar_variable_len_page, &columnar_variable_len_queries);
+  VarSearchCtx columnar_variable_len = {search_iters, &columnar_variable_len_page,
+                                        columnar_variable_len_queries};
+  run_case("search/columnar_variable_len", search_iters, bench_search_prepared_var,
+           &columnar_variable_len);
+
   Page prefix_page;
   BytesTable prefix_queries;
-  setup_search_prefix_variant((Options){1, 0}, &prefix_page, &prefix_queries);
+  setup_search_prefix_variant((Options){1, 0, KEY_KIND_BYTES}, &prefix_page, &prefix_queries);
   SearchCtx prefix = {search_iters, &prefix_page, prefix_queries};
   run_case("search/prefix_v2", search_iters, bench_search_prepared, &prefix);
 
   Page columnar_prefix_page;
   BytesTable columnar_prefix_queries;
-  setup_search_prefix_variant((Options){1, 1}, &columnar_prefix_page, &columnar_prefix_queries);
+  setup_search_prefix_variant((Options){1, 1, KEY_KIND_BYTES}, &columnar_prefix_page,
+                              &columnar_prefix_queries);
   SearchCtx columnar_prefix = {search_iters, &columnar_prefix_page, columnar_prefix_queries};
   run_case("search/columnar_prefix_v2", search_iters, bench_search_prepared, &columnar_prefix);
 
@@ -199,6 +238,7 @@ int main(void) {
   free_table(&keys_prefix_light);
   free_table(&columnar_fixed_queries);
   free_table(&columnar_variable_queries);
+  free_var_table(&columnar_variable_len_queries);
   free_table(&prefix_queries);
   free_table(&columnar_prefix_queries);
   return (int)(sink & 0);
@@ -253,6 +293,19 @@ static void splitmix_fill(SplitMix64 *rng, uint8_t *dst, size_t len) {
   }
 }
 
+static uint64_t load_be64_unaligned(const uint8_t *src) {
+  uint64_t v = 0;
+  memcpy(&v, src, sizeof(v));
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_bswap64(v);
+#else
+  return ((v & 0x00000000000000ffULL) << 56) | ((v & 0x000000000000ff00ULL) << 40) |
+         ((v & 0x0000000000ff0000ULL) << 24) | ((v & 0x00000000ff000000ULL) << 8) |
+         ((v & 0x000000ff00000000ULL) >> 8) | ((v & 0x0000ff0000000000ULL) >> 24) |
+         ((v & 0x00ff000000000000ULL) >> 40) | ((v & 0xff00000000000000ULL) >> 56);
+#endif
+}
+
 static int key_cmp_32(const void *a, const void *b) {
   return memcmp(a, b, BENCH_KEY_SIZE);
 }
@@ -296,6 +349,45 @@ static uint8_t *table_at(BytesTable table, size_t index) {
   return table.data + index * table.len;
 }
 
+static void var_table_init(VarBytesTable *table, size_t count, size_t bytes) {
+  table->data = malloc(bytes);
+  table->offsets = malloc((count + 1) * sizeof(table->offsets[0]));
+  if (table->data == NULL || table->offsets == NULL) {
+    abort();
+  }
+  table->count = 0;
+  table->len = 0;
+  table->cap = bytes;
+  table->offsets[0] = 0;
+}
+
+static void var_table_push(VarBytesTable *table, const uint8_t *value, size_t value_len) {
+  if (table->len + value_len > table->cap) {
+    abort();
+  }
+  memcpy(table->data + table->len, value, value_len);
+  table->len += value_len;
+  table->count++;
+  table->offsets[table->count] = table->len;
+}
+
+static void free_var_table(VarBytesTable *table) {
+  free(table->data);
+  free(table->offsets);
+  table->data = NULL;
+  table->offsets = NULL;
+  table->count = 0;
+  table->len = 0;
+  table->cap = 0;
+}
+
+static uint8_t *var_table_at(VarBytesTable table, size_t index, size_t *value_len) {
+  size_t start = table.offsets[index];
+  size_t end = table.offsets[index + 1];
+  *value_len = end - start;
+  return table.data + start;
+}
+
 static void fill_be8(uint8_t *dst, uint64_t v) {
   for (int i = 7; i >= 0; i--) {
     dst[7 - i] = (uint8_t)(v >> (8 * i));
@@ -307,10 +399,19 @@ static void fill_be16(uint8_t *dst, uint64_t a, uint64_t b) {
   fill_be8(dst + 8, b);
 }
 
+static size_t fill_variable_len_key(uint8_t *dst, size_t i) {
+  size_t key_len = 9 + (i % (BENCH_KEY_SIZE - 8));
+  fill_be8(dst, (uint64_t)i);
+  for (size_t j = 8; j < key_len; j++) {
+    dst[j] = (uint8_t)(i * 31 + (j - 8));
+  }
+  return key_len;
+}
+
 static uint64_t bench_builder_prepared(void *raw) {
   BuildCtx *ctx = (BuildCtx *)raw;
   Builder b;
-  builder_init(&b, (Options){ctx->prefix, 0});
+  builder_init(&b, (Options){ctx->prefix, 0, KEY_KIND_BYTES});
   uint64_t checksum = 0;
   for (int i = 0; i < ctx->iters;) {
     size_t k = (size_t)i & (ctx->keys.count - 1);
@@ -326,7 +427,7 @@ static uint64_t bench_builder_prepared(void *raw) {
       checksum += (uint64_t)b.count;
       i++;
     } else {
-      builder_init(&b, (Options){ctx->prefix, 0});
+      builder_init(&b, (Options){ctx->prefix, 0, KEY_KIND_BYTES});
     }
   }
   return checksum;
@@ -334,7 +435,7 @@ static uint64_t bench_builder_prepared(void *raw) {
 
 static void setup_search_columnar(int fixed_be8, Page *page, BytesTable *queries) {
   Builder b;
-  builder_init(&b, (Options){0, 1});
+  builder_init(&b, (Options){0, 1, fixed_be8 ? KEY_KIND_FIXED_BE8 : KEY_KIND_BYTES});
   int inserted = 0;
   uint8_t key[16];
   for (int i = 0; i < BENCH_KEY_COUNT; i++) {
@@ -361,6 +462,26 @@ static void setup_search_columnar(int fixed_be8, Page *page, BytesTable *queries
     } else {
       fill_be16(table_at(*queries, i), (uint64_t)i, (uint64_t)i * 17ULL + 3ULL);
     }
+  }
+}
+
+static void setup_search_columnar_variable_len(Page *page, VarBytesTable *queries) {
+  Builder b;
+  builder_init(&b, (Options){0, 1, KEY_KIND_BYTES});
+  int inserted = 0;
+  uint8_t key[BENCH_KEY_SIZE];
+  for (int i = 0; i < BENCH_KEY_COUNT; i++) {
+    size_t key_len = fill_variable_len_key(key, (size_t)i);
+    if (!builder_add_leaf_entry(&b, key, key_len, NULL, 0, FLAG_POINTER)) {
+      break;
+    }
+    inserted++;
+  }
+  builder_finish(&b, page);
+  var_table_init(queries, (size_t)inserted, (size_t)inserted * BENCH_KEY_SIZE);
+  for (int i = 0; i < inserted; i++) {
+    size_t key_len = fill_variable_len_key(key, (size_t)i);
+    var_table_push(queries, key, key_len);
   }
 }
 
@@ -411,6 +532,20 @@ static uint64_t bench_search_prepared(void *raw) {
     int found = 0;
     uint8_t *query = table_at(ctx->queries, (size_t)i % ctx->queries.count);
     page_search_leaf(ctx->page, query, ctx->queries.len, &idx, &found);
+    checksum += (uint64_t)idx + (uint64_t)found;
+  }
+  return checksum;
+}
+
+static uint64_t bench_search_prepared_var(void *raw) {
+  VarSearchCtx *ctx = (VarSearchCtx *)raw;
+  uint64_t checksum = 0;
+  for (int i = 0; i < ctx->iters; i++) {
+    int idx = 0;
+    int found = 0;
+    size_t query_len = 0;
+    uint8_t *query = var_table_at(ctx->queries, (size_t)i % ctx->queries.count, &query_len);
+    page_search_leaf(ctx->page, query, query_len, &idx, &found);
     checksum += (uint64_t)idx + (uint64_t)found;
   }
   return checksum;
@@ -753,15 +888,6 @@ static void finish_columnar_prefix_v2(const Builder *b, Page *page) {
 }
 
 static int compare_leaf_key(const uint8_t *a, size_t a_len, const uint8_t *b, size_t b_len) {
-  if (a_len == 8 && b_len == 8) {
-    uint64_t av = 0;
-    uint64_t bv = 0;
-    for (int i = 0; i < 8; i++) {
-      av = (av << 8) | a[i];
-      bv = (bv << 8) | b[i];
-    }
-    return (av > bv) - (av < bv);
-  }
   size_t n = a_len < b_len ? a_len : b_len;
   int cmp = memcmp(a, b, n);
   if (cmp != 0) {
@@ -775,7 +901,11 @@ static void page_search_leaf(Page *page, const uint8_t *key, size_t key_len, int
   if (page->opts.columnar && page->opts.prefix) {
     search_columnar_prefix_v2(page, key, key_len, idx, found);
   } else if (page->opts.columnar) {
-    search_columnar_v2(page, key, key_len, idx, found);
+    if (page->opts.key_kind == KEY_KIND_FIXED_BE8) {
+      search_columnar_v2_fixed_be8(page, key, idx, found);
+    } else {
+      search_columnar_v2(page, key, key_len, idx, found);
+    }
   } else if (page->opts.prefix) {
     search_prefix_v2(page, key, key_len, idx, found);
   } else {
@@ -823,6 +953,43 @@ static void columnar_key_at(const Page *page, int index, const uint8_t **key, si
   int key_end = index + 1 < page->count ? page_offset_at(page, index + 1) : PAGE_SIZE;
   *key = &page->data[key_start];
   *key_len = (size_t)(key_end - key_start);
+}
+
+static uint64_t columnar_fixed_be8_at(const Page *page, int index) {
+  return load_be64_unaligned(&page->data[page_offset_at(page, index)]);
+}
+
+static void search_columnar_v2_fixed_be8(const Page *page, const uint8_t *key, int *idx,
+                                         int *found) {
+  uint64_t target = load_be64_unaligned(key);
+  if (page->count <= SMALL_SEARCH_THRESHOLD) {
+    for (int i = 0; i < page->count; i++) {
+      uint64_t entry = columnar_fixed_be8_at(page, i);
+      if (entry >= target) {
+        *idx = i;
+        *found = entry == target;
+        return;
+      }
+    }
+    *idx = page->count;
+    *found = 0;
+    return;
+  }
+  int lo = 0;
+  int hi = page->count;
+  while (lo < hi) {
+    int mid = (int)((unsigned)(lo + hi) >> 1);
+    if (columnar_fixed_be8_at(page, mid) < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  *idx = lo;
+  *found = 0;
+  if (lo < page->count) {
+    *found = columnar_fixed_be8_at(page, lo) == target;
+  }
 }
 
 static void search_columnar_v2(const Page *page, const uint8_t *key, size_t key_len,
@@ -892,32 +1059,6 @@ static void prefix_restart_key(const Page *page, int index, const uint8_t **key,
   *key_len = layout.suffixLen;
 }
 
-static int compare_prefix_virtual_key(const uint8_t *prev, size_t prev_len, size_t prefix_len,
-                                      const uint8_t *suffix, size_t suffix_len,
-                                      const uint8_t *target, size_t target_len) {
-  (void)prev_len;
-  size_t n = prefix_len < target_len ? prefix_len : target_len;
-  if (n > 0) {
-    int cmp = memcmp(prev, target, n);
-    if (cmp != 0) {
-      return cmp < 0 ? -1 : 1;
-    }
-  }
-  if (target_len < prefix_len) {
-    return 1;
-  }
-  const uint8_t *tail = target + prefix_len;
-  size_t tail_len = target_len - prefix_len;
-  n = suffix_len < tail_len ? suffix_len : tail_len;
-  if (n > 0) {
-    int cmp = memcmp(suffix, tail, n);
-    if (cmp != 0) {
-      return cmp < 0 ? -1 : 1;
-    }
-  }
-  return (suffix_len > tail_len) - (suffix_len < tail_len);
-}
-
 static void search_prefix_v2(const Page *page, const uint8_t *key, size_t key_len, int *idx,
                              int *found) {
   if (page->count == 0) {
@@ -974,25 +1115,21 @@ static void search_prefix_block(const Page *page, int block_start, int block_end
     return;
   }
   uint8_t prev[BENCH_KEY_SIZE];
-  uint8_t next[BENCH_KEY_SIZE];
   memcpy(prev, restart, restart_len);
   size_t prev_len = restart_len;
   for (int i = block_start + 1; i < block_end; i++) {
     int off = page_offset_at(page, i);
     prefixLayout layout = parse_prefix_layout(page->data, off);
     const uint8_t *suffix = &page->data[off + (int)layout.keyOff];
-    cmp = compare_prefix_virtual_key(prev, prev_len, layout.prefixLen, suffix, layout.suffixLen,
-                                     target, target_len);
+    size_t key_len = layout.prefixLen + layout.suffixLen;
+    memcpy(prev + layout.prefixLen, suffix, layout.suffixLen);
+    prev_len = key_len;
+    cmp = compare_leaf_key(prev, prev_len, target, target_len);
     if (cmp >= 0) {
       *idx = i;
       *found = cmp == 0;
       return;
     }
-    size_t key_len = layout.prefixLen + layout.suffixLen;
-    memcpy(next, prev, layout.prefixLen);
-    memcpy(next + layout.prefixLen, suffix, layout.suffixLen);
-    memcpy(prev, next, key_len);
-    prev_len = key_len;
   }
   *idx = block_end;
   *found = 0;
@@ -1068,7 +1205,6 @@ static void search_columnar_prefix_block(const Page *page, int block_start, int 
     return;
   }
   uint8_t prev[BENCH_KEY_SIZE];
-  uint8_t next[BENCH_KEY_SIZE];
   memcpy(prev, restart, restart_len);
   size_t prev_len = restart_len;
   for (int i = block_start + 1; i < block_end; i++) {
@@ -1076,18 +1212,15 @@ static void search_columnar_prefix_block(const Page *page, int block_start, int 
     size_t suffix_len = 0;
     columnar_prefix_suffix_at(page, i, &suffix, &suffix_len);
     size_t prefix_len = columnar_prefix_len_at(page, i);
-    cmp = compare_prefix_virtual_key(prev, prev_len, prefix_len, suffix, suffix_len, target,
-                                     target_len);
+    size_t key_len = prefix_len + suffix_len;
+    memcpy(prev + prefix_len, suffix, suffix_len);
+    prev_len = key_len;
+    cmp = compare_leaf_key(prev, prev_len, target, target_len);
     if (cmp >= 0) {
       *idx = i;
       *found = cmp == 0;
       return;
     }
-    size_t key_len = prefix_len + suffix_len;
-    memcpy(next, prev, prefix_len);
-    memcpy(next + prefix_len, suffix, suffix_len);
-    memcpy(prev, next, key_len);
-    prev_len = key_len;
   }
   *idx = block_end;
   *found = 0;

--- a/experiments/rust_leaf_bench/matched_c/main.c
+++ b/experiments/rust_leaf_bench/matched_c/main.c
@@ -296,6 +296,8 @@ static void splitmix_fill(SplitMix64 *rng, uint8_t *dst, size_t len) {
 static uint64_t load_be64_unaligned(const uint8_t *src) {
   uint64_t v = 0;
   memcpy(&v, src, sizeof(v));
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #if defined(__GNUC__) || defined(__clang__)
   return __builtin_bswap64(v);
 #else
@@ -303,6 +305,9 @@ static uint64_t load_be64_unaligned(const uint8_t *src) {
          ((v & 0x0000000000ff0000ULL) << 24) | ((v & 0x00000000ff000000ULL) << 8) |
          ((v & 0x000000ff00000000ULL) >> 8) | ((v & 0x0000ff0000000000ULL) >> 24) |
          ((v & 0x00ff000000000000ULL) >> 40) | ((v & 0xff00000000000000ULL) >> 56);
+#endif
+#else
+  return v;
 #endif
 }
 

--- a/experiments/rust_leaf_bench/matched_go/main.go
+++ b/experiments/rust_leaf_bench/matched_go/main.go
@@ -32,7 +32,15 @@ const (
 type options struct {
 	prefix   bool
 	columnar bool
+	keyKind  keyKind
 }
+
+type keyKind uint8
+
+const (
+	keyKindBytes keyKind = iota
+	keyKindFixedBE8
+)
 
 type columnarEntry struct {
 	keyOff    int
@@ -114,16 +122,16 @@ func main() {
 		})
 		ran = true
 	}
-	if selectedCase == "search/columnar_fixed_be8_direct" {
-		page, queries := setupSearchColumnar(true)
-		runCase("search/columnar_fixed_be8_direct", searchIters, func() uint64 {
-			return benchSearchPreparedColumnarFixedBE8(searchIters, page, queries)
-		})
-		ran = true
-	}
 	if caseEnabled(selectedCase, "search/columnar_variable16") {
 		page, queries := setupSearchColumnar(false)
 		runCase("search/columnar_variable16", searchIters, func() uint64 {
+			return benchSearchPrepared(searchIters, page, queries)
+		})
+		ran = true
+	}
+	if caseEnabled(selectedCase, "search/columnar_variable_len") {
+		page, queries := setupSearchColumnarVariableLen()
+		runCase("search/columnar_variable_len", searchIters, func() uint64 {
 			return benchSearchPrepared(searchIters, page, queries)
 		})
 		ran = true
@@ -237,6 +245,15 @@ func be16(a, b uint64) []byte {
 	return out
 }
 
+func fillVariableLenKey(dst []byte, i int) []byte {
+	keyLen := 9 + (i % (benchKeySize - 8))
+	binary.BigEndian.PutUint64(dst[:8], uint64(i))
+	for j := 8; j < keyLen; j++ {
+		dst[j] = byte(i*31 + (j - 8))
+	}
+	return dst[:keyLen]
+}
+
 func benchBuilderPrepared(iters int, prefix bool, keys, values [][]byte) uint64 {
 	b := newBuilder(options{prefix: prefix})
 	var checksum uint64
@@ -254,7 +271,11 @@ func benchBuilderPrepared(iters int, prefix bool, keys, values [][]byte) uint64 
 }
 
 func setupSearchColumnar(fixedBE8 bool) (*page, [][]byte) {
-	b := newBuilder(options{columnar: true})
+	kind := keyKindBytes
+	if fixedBE8 {
+		kind = keyKindFixedBE8
+	}
+	b := newBuilder(options{columnar: true, keyKind: kind})
 	inserted := 0
 	for i := 0; i < benchKeyCount; i++ {
 		key := be8(uint64(i))
@@ -278,23 +299,31 @@ func setupSearchColumnar(fixedBE8 bool) (*page, [][]byte) {
 	return p, queries
 }
 
+func setupSearchColumnarVariableLen() (*page, [][]byte) {
+	b := newBuilder(options{columnar: true, keyKind: keyKindBytes})
+	inserted := 0
+	var key [benchKeySize]byte
+	for i := 0; i < benchKeyCount; i++ {
+		if !b.addLeafEntry(fillVariableLenKey(key[:], i), nil, flagPointer) {
+			break
+		}
+		inserted++
+	}
+
+	p := b.finish()
+	queries := make([][]byte, inserted)
+	for i := range queries {
+		q := make([]byte, len(fillVariableLenKey(key[:], i)))
+		copy(q, fillVariableLenKey(key[:], i))
+		queries[i] = q
+	}
+	return p, queries
+}
+
 func benchSearchPrepared(iters int, p *page, queries [][]byte) uint64 {
 	var checksum uint64
 	for i := 0; i < iters; i++ {
 		idx, found := p.searchLeaf(queries[i%len(queries)])
-		checksum += uint64(idx)
-		if found {
-			checksum++
-		}
-	}
-	return checksum
-}
-
-func benchSearchPreparedColumnarFixedBE8(iters int, p *page, queries [][]byte) uint64 {
-	var checksum uint64
-	for i := 0; i < iters; i++ {
-		target := binary.BigEndian.Uint64(queries[i%len(queries)])
-		idx, found := p.searchColumnarV2FixedBE8(target)
 		checksum += uint64(idx)
 		if found {
 			checksum++
@@ -593,6 +622,9 @@ func (p *page) searchLeaf(key []byte) (int, bool) {
 		return p.searchColumnarPrefixV2(key)
 	}
 	if p.opts.columnar {
+		if p.opts.keyKind == keyKindFixedBE8 {
+			return p.searchColumnarV2FixedBE8(key)
+		}
 		return p.searchColumnarV2(key)
 	}
 	if p.opts.prefix {
@@ -648,12 +680,13 @@ func (p *page) searchColumnarV2(key []byte) (int, bool) {
 	return lo, false
 }
 
-func (p *page) searchColumnarV2FixedBE8(target uint64) (int, bool) {
+func (p *page) searchColumnarV2FixedBE8(key []byte) (int, bool) {
+	target := binary.BigEndian.Uint64(key)
 	if p.count <= smallSearchThreshold {
 		for idx := 0; idx < p.count; idx++ {
-			cmp := p.compareColumnarFixedBE8At(idx, target)
-			if cmp >= 0 {
-				return idx, cmp == 0
+			entry := p.columnarFixedBE8At(idx)
+			if entry >= target {
+				return idx, entry == target
 			}
 		}
 		return p.count, false
@@ -661,28 +694,21 @@ func (p *page) searchColumnarV2FixedBE8(target uint64) (int, bool) {
 	lo, hi := 0, p.count
 	for lo < hi {
 		mid := int(uint(lo+hi) >> 1)
-		if p.compareColumnarFixedBE8At(mid, target) < 0 {
+		if p.columnarFixedBE8At(mid) < target {
 			lo = mid + 1
 		} else {
 			hi = mid
 		}
 	}
 	if lo < p.count {
-		return lo, p.compareColumnarFixedBE8At(lo, target) == 0
+		return lo, p.columnarFixedBE8At(lo) == target
 	}
 	return lo, false
 }
 
-func (p *page) compareColumnarFixedBE8At(index int, target uint64) int {
+func (p *page) columnarFixedBE8At(index int) uint64 {
 	keyStart := p.offsetAt(index)
-	entry := binary.BigEndian.Uint64(p.data[keyStart : keyStart+8])
-	if entry < target {
-		return -1
-	}
-	if entry > target {
-		return 1
-	}
-	return 0
+	return binary.BigEndian.Uint64(p.data[keyStart : keyStart+8])
 }
 
 func (p *page) columnarKeyAt(index int) []byte {
@@ -743,13 +769,13 @@ func (p *page) searchPrefixBlock(blockStart, blockEnd int, target []byte) (int, 
 		off := p.offsetAt(idx)
 		layout := parsePrefixLayout(p.data, off)
 		suffix := p.data[off+layout.keyOff : off+layout.keyOff+layout.suffixLen]
-		cmp = comparePrefixVirtualKey(prev[:prevLen], layout.prefixLen, suffix, target)
-		if cmp >= 0 {
-			return idx, cmp == 0
-		}
 		keyLen := layout.prefixLen + layout.suffixLen
 		copy(prev[layout.prefixLen:keyLen], suffix)
 		prevLen = keyLen
+		cmp = compareLeafKey(prev[:prevLen], target)
+		if cmp >= 0 {
+			return idx, cmp == 0
+		}
 	}
 	return blockEnd, false
 }
@@ -808,13 +834,13 @@ func (p *page) searchColumnarPrefixBlock(blockStart, blockEnd int, target []byte
 	for idx := blockStart + 1; idx < blockEnd; idx++ {
 		prefixLen := p.columnarPrefixLenAt(idx)
 		suffix := p.columnarPrefixSuffixAt(idx)
-		cmp = comparePrefixVirtualKey(prev[:prevLen], prefixLen, suffix, target)
-		if cmp >= 0 {
-			return idx, cmp == 0
-		}
 		keyLen := prefixLen + len(suffix)
 		copy(prev[prefixLen:keyLen], suffix)
 		prevLen = keyLen
+		cmp = compareLeafKey(prev[:prevLen], target)
+		if cmp >= 0 {
+			return idx, cmp == 0
+		}
 	}
 	return blockEnd, false
 }
@@ -925,50 +951,7 @@ func parsePrefixLayout(data []byte, off int) prefixLayout {
 }
 
 func compareLeafKey(a, b []byte) int {
-	if len(a) == 8 && len(b) == 8 {
-		av := binary.BigEndian.Uint64(a)
-		bv := binary.BigEndian.Uint64(b)
-		if av < bv {
-			return -1
-		}
-		if av > bv {
-			return 1
-		}
-		return 0
-	}
 	return bytes.Compare(a, b)
-}
-
-func comparePrefixVirtualKey(prevKey []byte, prefixLen int, suffix []byte, target []byte) int {
-	n := prefixLen
-	if len(target) < n {
-		n = len(target)
-	}
-	if n > 0 {
-		if cmp := bytes.Compare(prevKey[:n], target[:n]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(target) < prefixLen {
-		return 1
-	}
-	tail := target[prefixLen:]
-	n = len(suffix)
-	if len(tail) < n {
-		n = len(tail)
-	}
-	if n > 0 {
-		if cmp := bytes.Compare(suffix[:n], tail[:n]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(suffix) < len(tail) {
-		return -1
-	}
-	if len(suffix) > len(tail) {
-		return 1
-	}
-	return 0
 }
 
 func putU16(dst []byte, v uint16) {

--- a/experiments/rust_leaf_bench/run_leaf_smoke.sh
+++ b/experiments/rust_leaf_bench/run_leaf_smoke.sh
@@ -9,11 +9,11 @@ COUNT="${COUNT:-1}"
 CC="${CC:-cc}"
 CFLAGS="${CFLAGS:--O3 -std=c11 -Wall -Wextra}"
 
-GO_OUT="$(mktemp /tmp/treedb_leaf_go_XXXXXX.txt)"
-MATCHED_GO_OUT="$(mktemp /tmp/treedb_leaf_matched_go_XXXXXX.txt)"
-MATCHED_C_OUT="$(mktemp /tmp/treedb_leaf_matched_c_XXXXXX.txt)"
-RUST_OUT="$(mktemp /tmp/treedb_leaf_rust_XXXXXX.txt)"
-PARSED_OUT="$(mktemp /tmp/treedb_leaf_parsed_XXXXXX.tsv)"
+GO_OUT="$(mktemp /tmp/treedb_leaf_go_XXXXXX)"
+MATCHED_GO_OUT="$(mktemp /tmp/treedb_leaf_matched_go_XXXXXX)"
+MATCHED_C_OUT="$(mktemp /tmp/treedb_leaf_matched_c_XXXXXX)"
+RUST_OUT="$(mktemp /tmp/treedb_leaf_rust_XXXXXX)"
+PARSED_OUT="$(mktemp /tmp/treedb_leaf_parsed_XXXXXX)"
 MATCHED_C_BIN="$(mktemp /tmp/treedb_leaf_matched_c_bin_XXXXXX)"
 trap 'rm -f "$MATCHED_C_BIN"' EXIT
 
@@ -88,8 +88,9 @@ BEGIN {
   order[3] = "builder/prefix_light"
   order[4] = "search/columnar_fixed_be8"
   order[5] = "search/columnar_variable16"
-  order[6] = "search/prefix_v2"
-  order[7] = "search/columnar_prefix_v2"
+  order[6] = "search/columnar_variable_len"
+  order[7] = "search/prefix_v2"
+  order[8] = "search/columnar_prefix_v2"
 }
 $1 == "GO" { go[$2] = $3 + 0 }
 $1 == "MATCHED_GO" { matched_go[$2] = $3 + 0 }
@@ -98,7 +99,7 @@ $1 == "RUST" { rust[$2] = $3 + 0 }
 END {
   printf "%-30s %13s %13s %10s %10s %10s %10s %8s\n", "case", "prod go ns/op", "match go ns/op", "c ns/op", "rust ns/op", "c/mgo", "r/mgo", "r/c"
   printf "%-30s %13s %13s %10s %10s %10s %10s %8s\n", "----", "-------------", "-------------", "-------", "----------", "-----", "-----", "---"
-  for (i = 1; i <= 7; i++) {
+  for (i = 1; i <= 8; i++) {
     c = order[i]
     g = go[c]
     mg = matched_go[c]

--- a/experiments/rust_leaf_bench/src/main.rs
+++ b/experiments/rust_leaf_bench/src/main.rs
@@ -1,7 +1,12 @@
 use std::cmp::Ordering;
 use std::env;
+use std::ffi::{c_int, c_void};
 use std::hint::black_box;
 use std::time::Instant;
+
+extern "C" {
+    fn memcmp(a: *const c_void, b: *const c_void, n: usize) -> c_int;
+}
 
 const PAGE_SIZE: usize = 4096;
 const NODE_HEADER_SIZE: usize = 16;
@@ -24,9 +29,16 @@ const LEAF_COLUMNAR_PREFIX_V2_META_SIZE: usize = 7;
 struct Options {
     prefix: bool,
     columnar: bool,
+    key_kind: KeyKind,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum KeyKind {
+    Bytes,
+    FixedBe8,
+}
+
+#[derive(Clone, Copy, Default)]
 struct ColumnarEntry {
     key_off: usize,
     key_len: usize,
@@ -37,24 +49,80 @@ struct ColumnarEntry {
 }
 
 struct Builder {
-    data: Vec<u8>,
+    data: [u8; PAGE_SIZE],
     opts: Options,
     count: usize,
     heap_start: usize,
     dir_end: usize,
     leaf_index: usize,
-    prev_key: Vec<u8>,
-    arena: Vec<u8>,
-    value_arena: Vec<u8>,
-    entries: Vec<ColumnarEntry>,
+    prev_key: [u8; BENCH_KEY_SIZE],
+    prev_key_len: usize,
+    arena: [u8; PAGE_SIZE],
+    value_arena: [u8; PAGE_SIZE],
+    arena_len: usize,
+    value_arena_len: usize,
+    entries: [ColumnarEntry; BENCH_KEY_COUNT],
+    entries_len: usize,
     key_bytes: usize,
     value_bytes: usize,
 }
 
 struct Page {
-    data: Vec<u8>,
+    data: [u8; PAGE_SIZE],
     opts: Options,
     count: usize,
+}
+
+struct BytesTable {
+    data: Vec<u8>,
+    count: usize,
+    len: usize,
+}
+
+struct VarBytesTable {
+    data: Vec<u8>,
+    offsets: Vec<usize>,
+}
+
+impl VarBytesTable {
+    fn with_capacity(count: usize, bytes: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(bytes),
+            offsets: Vec::with_capacity(count + 1),
+        }
+    }
+
+    fn push(&mut self, value: &[u8]) {
+        if self.offsets.is_empty() {
+            self.offsets.push(0);
+        }
+        self.data.extend_from_slice(value);
+        self.offsets.push(self.data.len());
+    }
+
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    #[inline(always)]
+    fn at(&self, i: usize) -> &[u8] {
+        &self.data[self.offsets[i]..self.offsets[i + 1]]
+    }
+}
+
+impl BytesTable {
+    #[inline(always)]
+    fn at(&self, i: usize) -> &[u8] {
+        let off = i * self.len;
+        &self.data[off..off + self.len]
+    }
+
+    #[inline(always)]
+    fn at_mut(&mut self, i: usize) -> &mut [u8] {
+        let off = i * self.len;
+        &mut self.data[off..off + self.len]
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -131,10 +199,18 @@ fn main() {
         });
         ran = true;
     }
+    if case_enabled(&selected_case, "search/columnar_variable_len") {
+        let (mut page, queries) = setup_search_columnar_variable_len();
+        run_case("search/columnar_variable_len", search_iters, || {
+            bench_search_prepared_var(search_iters, &mut page, &queries)
+        });
+        ran = true;
+    }
     if case_enabled(&selected_case, "search/prefix_v2") {
         let (mut page, queries) = setup_search_prefix_variant(Options {
             prefix: true,
             columnar: false,
+            key_kind: KeyKind::Bytes,
         });
         run_case("search/prefix_v2", search_iters, || {
             bench_search_prepared(search_iters, &mut page, &queries)
@@ -145,6 +221,7 @@ fn main() {
         let (mut page, queries) = setup_search_prefix_variant(Options {
             prefix: true,
             columnar: true,
+            key_kind: KeyKind::Bytes,
         });
         run_case("search/columnar_prefix_v2", search_iters, || {
             bench_search_prepared(search_iters, &mut page, &queries)
@@ -193,11 +270,11 @@ where
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
-fn make_bench_keys(count: usize, prefix_bytes: usize) -> Vec<Vec<u8>> {
+fn make_bench_keys(count: usize, prefix_bytes: usize) -> BytesTable {
     let mut keys = Vec::with_capacity(count);
     let mut rng = Rng::new(1);
     for _ in 0..count {
-        let mut key = vec![0u8; BENCH_KEY_SIZE];
+        let mut key = [0u8; BENCH_KEY_SIZE];
         let p = prefix_bytes.min(BENCH_KEY_SIZE);
         for b in &mut key[..p] {
             *b = 0x42;
@@ -206,47 +283,64 @@ fn make_bench_keys(count: usize, prefix_bytes: usize) -> Vec<Vec<u8>> {
         keys.push(key);
     }
     keys.sort();
-    keys
-}
 
-#[cfg_attr(feature = "profile-attribution", inline(never))]
-fn make_bench_values(count: usize) -> Vec<Vec<u8>> {
-    let mut values = Vec::with_capacity(count);
-    let mut rng = Rng::new(2);
-    for _ in 0..count {
-        let mut value = vec![0u8; BENCH_VALUE_SIZE];
-        rng.fill(&mut value);
-        values.push(value);
+    let mut data = Vec::with_capacity(count * BENCH_KEY_SIZE);
+    for key in keys {
+        data.extend_from_slice(&key);
     }
-    values
-}
-
-fn be8(v: u64) -> Vec<u8> {
-    v.to_be_bytes().to_vec()
-}
-
-fn be16(a: u64, b: u64) -> Vec<u8> {
-    let mut out = Vec::with_capacity(16);
-    out.extend_from_slice(&a.to_be_bytes());
-    out.extend_from_slice(&b.to_be_bytes());
-    out
+    BytesTable {
+        data,
+        count,
+        len: BENCH_KEY_SIZE,
+    }
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
-fn bench_builder_prepared(iters: usize, prefix: bool, keys: &[Vec<u8>], values: &[Vec<u8>]) -> u64 {
+fn make_bench_values(count: usize) -> BytesTable {
+    let mut table = BytesTable {
+        data: vec![0u8; count * BENCH_VALUE_SIZE],
+        count,
+        len: BENCH_VALUE_SIZE,
+    };
+    let mut rng = Rng::new(2);
+    for i in 0..count {
+        rng.fill(table.at_mut(i));
+    }
+    table
+}
+
+fn fill_be8(dst: &mut [u8], v: u64) {
+    dst[..8].copy_from_slice(&v.to_be_bytes());
+}
+
+fn fill_be16(dst: &mut [u8], a: u64, b: u64) {
+    fill_be8(&mut dst[..8], a);
+    fill_be8(&mut dst[8..16], b);
+}
+
+#[cfg_attr(feature = "profile-attribution", inline(never))]
+fn bench_builder_prepared(
+    iters: usize,
+    prefix: bool,
+    keys: &BytesTable,
+    values: &BytesTable,
+) -> u64 {
     let mut builder = Builder::new(Options {
         prefix,
         columnar: false,
+        key_kind: KeyKind::Bytes,
     });
     let mut checksum = 0u64;
     let mut i = 0usize;
     while i < iters {
-        let idx = i & (keys.len() - 1);
+        let idx = i & (keys.count - 1);
+        let key = keys.at(idx);
+        let value = values.at(idx);
         let (entry_size, prefix_len, suffix_len) =
-            builder.leaf_entry_size_with_prefix(&keys[idx], &values[idx], FLAG_INLINE);
+            builder.leaf_entry_size_with_prefix(key, value, FLAG_INLINE);
         match builder.add_leaf_entry_with_prefix(
-            &keys[idx],
-            &values[idx],
+            key,
+            value,
             FLAG_INLINE,
             entry_size,
             prefix_len,
@@ -260,6 +354,7 @@ fn bench_builder_prepared(iters: usize, prefix: bool, keys: &[Vec<u8>], values: 
                 builder.reset(Options {
                     prefix,
                     columnar: false,
+                    key_kind: KeyKind::Bytes,
                 });
             }
         }
@@ -268,74 +363,151 @@ fn bench_builder_prepared(iters: usize, prefix: bool, keys: &[Vec<u8>], values: 
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
-fn setup_search_columnar(fixed_be8: bool) -> (Page, Vec<Vec<u8>>) {
+fn setup_search_columnar(fixed_be8: bool) -> (Page, BytesTable) {
     let mut builder = Builder::new(Options {
         prefix: false,
         columnar: true,
+        key_kind: if fixed_be8 {
+            KeyKind::FixedBe8
+        } else {
+            KeyKind::Bytes
+        },
     });
     let mut inserted = 0usize;
+    let mut key = [0u8; 16];
     for i in 0..BENCH_KEY_COUNT {
-        let key = if fixed_be8 {
-            be8(i as u64)
+        let key_len = if fixed_be8 {
+            fill_be8(&mut key[..8], i as u64);
+            8
         } else {
-            be16(i as u64, (i as u64).wrapping_mul(17).wrapping_add(3))
+            fill_be16(
+                &mut key,
+                i as u64,
+                (i as u64).wrapping_mul(17).wrapping_add(3),
+            );
+            16
         };
-        if builder.add_leaf_entry(&key, &[], FLAG_POINTER).is_err() {
+        if builder
+            .add_leaf_entry(&key[..key_len], &[], FLAG_POINTER)
+            .is_err()
+        {
             break;
         }
         inserted += 1;
     }
     let page = builder.finish();
-    let mut queries = Vec::with_capacity(inserted);
+    let query_len = if fixed_be8 { 8 } else { 16 };
+    let mut queries = BytesTable {
+        data: vec![0u8; inserted * query_len],
+        count: inserted,
+        len: query_len,
+    };
     for i in 0..inserted {
-        queries.push(if fixed_be8 {
-            be8(i as u64)
+        if fixed_be8 {
+            fill_be8(queries.at_mut(i), i as u64);
         } else {
-            be16(i as u64, (i as u64).wrapping_mul(17).wrapping_add(3))
-        });
+            fill_be16(
+                queries.at_mut(i),
+                i as u64,
+                (i as u64).wrapping_mul(17).wrapping_add(3),
+            );
+        }
     }
     (page, queries)
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
-fn bench_search_prepared(iters: usize, page: &mut Page, queries: &[Vec<u8>]) -> u64 {
+fn setup_search_columnar_variable_len() -> (Page, VarBytesTable) {
+    let mut builder = Builder::new(Options {
+        prefix: false,
+        columnar: true,
+        key_kind: KeyKind::Bytes,
+    });
+    let mut inserted = 0usize;
+    let mut key = [0u8; BENCH_KEY_SIZE];
+    for i in 0..BENCH_KEY_COUNT {
+        let key_len = fill_variable_len_key(&mut key, i);
+        if builder
+            .add_leaf_entry(&key[..key_len], &[], FLAG_POINTER)
+            .is_err()
+        {
+            break;
+        }
+        inserted += 1;
+    }
+
+    let page = builder.finish();
+    let mut queries = VarBytesTable::with_capacity(inserted, inserted * BENCH_KEY_SIZE);
+    for i in 0..inserted {
+        let key_len = fill_variable_len_key(&mut key, i);
+        queries.push(&key[..key_len]);
+    }
+    (page, queries)
+}
+
+fn fill_variable_len_key(dst: &mut [u8; BENCH_KEY_SIZE], i: usize) -> usize {
+    let key_len = 9 + (i % (BENCH_KEY_SIZE - 8));
+    fill_be8(&mut dst[..8], i as u64);
+    for (j, b) in dst[8..key_len].iter_mut().enumerate() {
+        *b = i.wrapping_mul(31).wrapping_add(j) as u8;
+    }
+    key_len
+}
+
+#[cfg_attr(feature = "profile-attribution", inline(never))]
+fn bench_search_prepared(iters: usize, page: &mut Page, queries: &BytesTable) -> u64 {
     let mut checksum = 0u64;
     for i in 0..iters {
-        let (idx, found) = page.search_leaf(black_box(&queries[i % queries.len()]));
+        let (idx, found) = page.search_leaf(black_box(queries.at(i % queries.count)));
         checksum = checksum.wrapping_add(idx as u64 + found as u64);
     }
     checksum
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
-fn setup_search_prefix_variant(opts: Options) -> (Page, Vec<Vec<u8>>) {
+fn bench_search_prepared_var(iters: usize, page: &mut Page, queries: &VarBytesTable) -> u64 {
+    let mut checksum = 0u64;
+    for i in 0..iters {
+        let (idx, found) = page.search_leaf(black_box(queries.at(i % queries.len())));
+        checksum = checksum.wrapping_add(idx as u64 + found as u64);
+    }
+    checksum
+}
+
+#[cfg_attr(feature = "profile-attribution", inline(never))]
+fn setup_search_prefix_variant(opts: Options) -> (Page, BytesTable) {
     const KEY_COUNT: usize = 128;
     let keys = make_bench_keys(KEY_COUNT, 24);
     let mut builder = Builder::new(opts);
-    for (i, key) in keys.iter().enumerate() {
+    for i in 0..keys.count {
+        let key = keys.at(i);
         let flags = match i % 3 {
             0 => FLAG_INLINE,
             1 => FLAG_POINTER,
             _ => FLAG_TOMBSTONE,
         };
+        let value = [i as u8, i.wrapping_add(1) as u8];
         let value = if flags == FLAG_INLINE {
-            vec![i as u8, i.wrapping_add(1) as u8]
+            &value[..]
         } else {
-            Vec::new()
+            &[]
         };
         builder
-            .add_leaf_entry(key, &value, flags)
+            .add_leaf_entry(key, value, flags)
             .expect("prefix setup should fit");
     }
     let page = builder.finish();
-    let mut queries = Vec::with_capacity(4096);
+    let mut queries = BytesTable {
+        data: vec![0u8; 4096 * BENCH_KEY_SIZE],
+        count: 4096,
+        len: BENCH_KEY_SIZE,
+    };
     for i in 0..4096 {
-        let mut q = keys[i % keys.len()].clone();
-        if i & 1 == 1 && !q.is_empty() {
-            let last = q.len() - 1;
-            q[last] ^= 0x01;
+        let q = queries.at_mut(i);
+        q.copy_from_slice(keys.at(i % keys.count));
+        if i & 1 == 1 {
+            q[BENCH_KEY_SIZE - 1] ^= 0x01;
         }
-        queries.push(q);
     }
     (page, queries)
 }
@@ -347,16 +519,20 @@ impl Builder {
     #[cfg_attr(feature = "profile-attribution", inline(never))]
     fn new(opts: Options) -> Self {
         Self {
-            data: vec![0u8; PAGE_SIZE],
+            data: [0u8; PAGE_SIZE],
             opts,
             count: 0,
             heap_start: PAGE_SIZE,
             dir_end: NODE_HEADER_SIZE,
             leaf_index: 0,
-            prev_key: Vec::new(),
-            arena: Vec::new(),
-            value_arena: Vec::new(),
-            entries: Vec::new(),
+            prev_key: [0u8; BENCH_KEY_SIZE],
+            prev_key_len: 0,
+            arena: [0u8; PAGE_SIZE],
+            value_arena: [0u8; PAGE_SIZE],
+            arena_len: 0,
+            value_arena_len: 0,
+            entries: [ColumnarEntry::default(); BENCH_KEY_COUNT],
+            entries_len: 0,
             key_bytes: 0,
             value_bytes: 0,
         }
@@ -369,10 +545,10 @@ impl Builder {
         self.heap_start = PAGE_SIZE;
         self.dir_end = NODE_HEADER_SIZE;
         self.leaf_index = 0;
-        self.prev_key.clear();
-        self.arena.clear();
-        self.value_arena.clear();
-        self.entries.clear();
+        self.prev_key_len = 0;
+        self.arena_len = 0;
+        self.value_arena_len = 0;
+        self.entries_len = 0;
         self.key_bytes = 0;
         self.value_bytes = 0;
     }
@@ -395,9 +571,9 @@ impl Builder {
         let mut suffix_len = key.len();
         if self.opts.prefix
             && self.leaf_index % LEAF_PREFIX_RESTART_INTERVAL != 0
-            && !self.prev_key.is_empty()
+            && self.prev_key_len > 0
         {
-            prefix_len = shared_prefix_len(key, &self.prev_key).min(key.len());
+            prefix_len = shared_prefix_len(key, &self.prev_key[..self.prev_key_len]).min(key.len());
             suffix_len = key.len() - prefix_len;
         }
 
@@ -499,8 +675,8 @@ impl Builder {
         self.count += 1;
         self.leaf_index += 1;
         if self.opts.prefix {
-            self.prev_key.clear();
-            self.prev_key.extend_from_slice(key);
+            self.prev_key[..key.len()].copy_from_slice(key);
+            self.prev_key_len = key.len();
         }
         Ok(())
     }
@@ -518,22 +694,26 @@ impl Builder {
             return Err(ErrFull);
         }
 
-        let key_off = self.arena.len();
-        self.arena.extend_from_slice(key);
-        let value_off = self.arena.len();
+        let key_off = self.arena_len;
+        self.arena[self.arena_len..self.arena_len + key.len()].copy_from_slice(key);
+        self.arena_len += key.len();
+        let value_off = self.arena_len;
         if flags & FLAG_POINTER != 0 {
-            self.arena.resize(self.arena.len() + VALUE_PTR_SIZE, 0);
+            self.arena[self.arena_len..self.arena_len + VALUE_PTR_SIZE].fill(0);
+            self.arena_len += VALUE_PTR_SIZE;
         } else if flags & FLAG_TOMBSTONE == 0 {
-            self.arena.extend_from_slice(value);
+            self.arena[self.arena_len..self.arena_len + value.len()].copy_from_slice(value);
+            self.arena_len += value.len();
         }
-        self.entries.push(ColumnarEntry {
+        self.entries[self.entries_len] = ColumnarEntry {
             key_off,
             key_len: key.len(),
             value_off,
             value_len: value.len(),
             flags,
             prefix_len: 0,
-        });
+        };
+        self.entries_len += 1;
         self.key_bytes += key.len();
         self.value_bytes += val_size;
         self.dir_end += DIRECTORY_ENTRY_SIZE + LEAF_COLUMNAR_V2_META_SIZE;
@@ -566,31 +746,35 @@ impl Builder {
             return Err(ErrFull);
         }
 
-        let key_off = self.arena.len();
-        self.arena.extend_from_slice(&key[prefix_len..]);
-        let value_off = self.value_arena.len();
+        let key_off = self.arena_len;
+        self.arena[self.arena_len..self.arena_len + suffix_len].copy_from_slice(&key[prefix_len..]);
+        self.arena_len += suffix_len;
+        let value_off = self.value_arena_len;
         if flags & FLAG_POINTER != 0 {
-            self.value_arena
-                .resize(self.value_arena.len() + VALUE_PTR_SIZE, 0);
+            self.value_arena[self.value_arena_len..self.value_arena_len + VALUE_PTR_SIZE].fill(0);
+            self.value_arena_len += VALUE_PTR_SIZE;
         } else if flags & FLAG_TOMBSTONE == 0 {
-            self.value_arena.extend_from_slice(value);
+            self.value_arena[self.value_arena_len..self.value_arena_len + value.len()]
+                .copy_from_slice(value);
+            self.value_arena_len += value.len();
         }
-        self.entries.push(ColumnarEntry {
+        self.entries[self.entries_len] = ColumnarEntry {
             key_off,
             key_len: suffix_len,
             value_off,
             value_len: value.len(),
             flags,
             prefix_len,
-        });
+        };
+        self.entries_len += 1;
         self.key_bytes = next_key_bytes;
         self.value_bytes = next_value_bytes;
         self.count = next_count;
         self.leaf_index += 1;
         self.dir_end = dir_end;
         self.heap_start = heap_start;
-        self.prev_key.clear();
-        self.prev_key.extend_from_slice(key);
+        self.prev_key[..key.len()].copy_from_slice(key);
+        self.prev_key_len = key.len();
         Ok(())
     }
 
@@ -619,7 +803,7 @@ impl Builder {
 
         let mut key_off = keys_start;
         let mut val_off = values_start;
-        for (i, e) in self.entries.iter().enumerate() {
+        for (i, e) in self.entries[..self.entries_len].iter().enumerate() {
             put_u16(
                 &mut self.data[key_dir_start + i * 2..key_dir_start + i * 2 + 2],
                 key_off as u16,
@@ -661,10 +845,12 @@ impl Builder {
         let suffix_start = PAGE_SIZE - self.key_bytes;
         let values_start = suffix_start - self.value_bytes;
 
-        self.data[values_start..suffix_start].copy_from_slice(&self.value_arena);
-        self.data[suffix_start..].copy_from_slice(&self.arena);
+        self.data[values_start..suffix_start]
+            .copy_from_slice(&self.value_arena[..self.value_arena_len]);
+        self.data[suffix_start..suffix_start + self.arena_len]
+            .copy_from_slice(&self.arena[..self.arena_len]);
 
-        for (i, e) in self.entries.iter().enumerate() {
+        for (i, e) in self.entries[..self.entries_len].iter().enumerate() {
             put_u16(
                 &mut self.data[key_dir_start + i * 2..key_dir_start + i * 2 + 2],
                 (suffix_start + e.key_off) as u16,
@@ -683,12 +869,15 @@ impl Builder {
 }
 
 impl Page {
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn search_leaf(&mut self, key: &[u8]) -> (usize, bool) {
         if self.opts.columnar && self.opts.prefix {
             self.search_columnar_prefix_v2(key)
         } else if self.opts.columnar {
-            self.search_columnar_v2(key)
+            match self.opts.key_kind {
+                KeyKind::FixedBe8 => self.search_columnar_v2_fixed_be8(key),
+                KeyKind::Bytes => self.search_columnar_v2(key),
+            }
         } else if self.opts.prefix {
             self.search_prefix_v2(key)
         } else {
@@ -767,6 +956,43 @@ impl Page {
         &self.data[key_start..key_end]
     }
 
+    #[inline(always)]
+    fn search_columnar_v2_fixed_be8(&self, key: &[u8]) -> (usize, bool) {
+        debug_assert_eq!(key.len(), 8);
+        let target = u64::from_be_bytes(key.try_into().unwrap());
+        if self.count <= SMALL_SEARCH_THRESHOLD {
+            for idx in 0..self.count {
+                let entry = self.columnar_fixed_be8_at(idx);
+                if entry >= target {
+                    return (idx, entry == target);
+                }
+            }
+            return (self.count, false);
+        }
+
+        let mut lo = 0usize;
+        let mut hi = self.count;
+        while lo < hi {
+            let mid = (lo + hi) >> 1;
+            if self.columnar_fixed_be8_at(mid) < target {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        if lo < self.count {
+            (lo, self.columnar_fixed_be8_at(lo) == target)
+        } else {
+            (lo, false)
+        }
+    }
+
+    #[inline(always)]
+    fn columnar_fixed_be8_at(&self, index: usize) -> u64 {
+        let key_start = self.offset_at(index);
+        u64::from_be_bytes(self.data[key_start..key_start + 8].try_into().unwrap())
+    }
+
     #[cfg_attr(feature = "profile-attribution", inline(never))]
     fn search_prefix_v2(&mut self, key: &[u8]) -> (usize, bool) {
         if self.count == 0 {
@@ -804,7 +1030,7 @@ impl Page {
         self.search_prefix_block(block_start, block_end, key)
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn search_prefix_block(
         &mut self,
         block_start: usize,
@@ -828,26 +1054,25 @@ impl Page {
             let off = self.offset_at(idx);
             let layout = parse_prefix_layout(&self.data, off);
             let suffix = &self.data[off + layout.key_off..off + layout.key_off + layout.suffix_len];
-            let cmp =
-                compare_prefix_virtual_key(&prev[..prev_len], layout.prefix_len, suffix, target);
-            if cmp != Ordering::Less {
-                return (idx, cmp == Ordering::Equal);
-            }
             let key_len = layout.prefix_len + layout.suffix_len;
             prev[layout.prefix_len..key_len].copy_from_slice(suffix);
             prev_len = key_len;
+            let cmp = compare_leaf_key(&prev[..prev_len], target);
+            if cmp != Ordering::Less {
+                return (idx, cmp == Ordering::Equal);
+            }
         }
         (block_end, false)
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn prefix_restart_key(&self, index: usize) -> &[u8] {
         let off = self.offset_at(index);
         let layout = parse_prefix_layout(&self.data, off);
         &self.data[off + layout.key_off..off + layout.key_off + layout.suffix_len]
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn search_columnar_prefix_v2(&mut self, key: &[u8]) -> (usize, bool) {
         if self.count == 0 {
             return (0, false);
@@ -883,7 +1108,7 @@ impl Page {
         self.search_columnar_prefix_block(block_start, block_end, key)
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn search_columnar_prefix_block(
         &mut self,
         block_start: usize,
@@ -905,18 +1130,18 @@ impl Page {
         for idx in block_start + 1..block_end {
             let prefix_len = self.columnar_prefix_len_at(idx);
             let suffix = self.columnar_prefix_suffix_at(idx);
-            let cmp = compare_prefix_virtual_key(&prev[..prev_len], prefix_len, suffix, target);
-            if cmp != Ordering::Less {
-                return (idx, cmp == Ordering::Equal);
-            }
             let key_len = prefix_len + suffix.len();
             prev[prefix_len..key_len].copy_from_slice(suffix);
             prev_len = key_len;
+            let cmp = compare_leaf_key(&prev[..prev_len], target);
+            if cmp != Ordering::Less {
+                return (idx, cmp == Ordering::Equal);
+            }
         }
         (block_end, false)
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn columnar_prefix_suffix_at(&self, index: usize) -> &[u8] {
         let key_start = self.offset_at(index);
         let key_end = if index + 1 < self.count {
@@ -927,14 +1152,14 @@ impl Page {
         &self.data[key_start..key_end]
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn columnar_prefix_len_at(&self, index: usize) -> usize {
         let flags_start = NODE_HEADER_SIZE + self.count * 4;
         let prefix_start = flags_start + self.count;
         get_u16(&self.data[prefix_start + index * 2..prefix_start + index * 2 + 2]) as usize
     }
 
-    #[cfg_attr(feature = "profile-attribution", inline(never))]
+    #[inline(always)]
     fn offset_at(&self, index: usize) -> usize {
         get_u16(&self.data[NODE_HEADER_SIZE + index * 2..NODE_HEADER_SIZE + index * 2 + 2]) as usize
     }
@@ -1009,7 +1234,7 @@ fn read_uvarint(src: &[u8]) -> (u64, usize) {
     (0, 0)
 }
 
-#[cfg_attr(feature = "profile-attribution", inline(never))]
+#[inline(always)]
 fn parse_prefix_layout(data: &[u8], off: usize) -> PrefixLayout {
     let shared8 = data[off];
     let suffix8 = data[off + 1];
@@ -1037,39 +1262,22 @@ fn parse_prefix_layout(data: &[u8], off: usize) -> PrefixLayout {
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]
 fn compare_leaf_key(a: &[u8], b: &[u8]) -> Ordering {
-    if a.len() == 8 && b.len() == 8 {
-        return u64::from_be_bytes(a.try_into().unwrap())
-            .cmp(&u64::from_be_bytes(b.try_into().unwrap()));
-    }
-    a.cmp(b)
+    compare_bytes(a, b)
 }
 
-#[cfg_attr(feature = "profile-attribution", inline(never))]
-fn compare_prefix_virtual_key(
-    prev_key: &[u8],
-    prefix_len: usize,
-    suffix: &[u8],
-    target: &[u8],
-) -> Ordering {
-    let prefix_cmp_len = prefix_len.min(target.len());
-    if prefix_cmp_len > 0 {
-        let cmp = prev_key[..prefix_cmp_len].cmp(&target[..prefix_cmp_len]);
-        if cmp != Ordering::Equal {
-            return cmp;
+#[inline(always)]
+fn compare_bytes(a: &[u8], b: &[u8]) -> Ordering {
+    let n = a.len().min(b.len());
+    if n > 0 {
+        let cmp = unsafe { memcmp(a.as_ptr().cast::<c_void>(), b.as_ptr().cast::<c_void>(), n) };
+        if cmp < 0 {
+            return Ordering::Less;
+        }
+        if cmp > 0 {
+            return Ordering::Greater;
         }
     }
-    if target.len() < prefix_len {
-        return Ordering::Greater;
-    }
-    let target_tail = &target[prefix_len..];
-    let suffix_cmp_len = suffix.len().min(target_tail.len());
-    if suffix_cmp_len > 0 {
-        let cmp = suffix[..suffix_cmp_len].cmp(&target_tail[..suffix_cmp_len]);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
-    }
-    suffix.len().cmp(&target_tail.len())
+    a.len().cmp(&b.len())
 }
 
 #[cfg_attr(feature = "profile-attribution", inline(never))]


### PR DESCRIPTION
## Summary

- optimize production prefix leaf search by reconstructing each fallback key before comparison and removing the now-unused virtual prefix comparator
- keep the Rust/C/matched-Go leaf benchmark harnesses aligned with explicit fixed-BE8 and variable-length key cases
- add the variable-length search row to the smoke benchmark summary

## Validation

- `cargo build --release --manifest-path experiments/rust_leaf_bench/Cargo.toml`
- `cc -O3 -std=c11 -Wall -Wextra experiments/rust_leaf_bench/matched_c/main.c -o /tmp/treedb_leaf_matched_c_pr_check`
- `go test ./TreeDB/node -run 'TestLeafColumnarPrefix|TestLeafPrefix|TestLeafColumnar' -count=1`
- `go test ./TreeDB/node -run '^$' -bench 'BenchmarkSearchLeaf_(PrefixV2|ColumnarPrefixV2)$' -benchtime=2s -count=3`

Focused prefix benchmark on this branch:

```text
BenchmarkSearchLeaf_PrefixV2-8            190.3 ns/op
BenchmarkSearchLeaf_PrefixV2-8            188.4 ns/op
BenchmarkSearchLeaf_PrefixV2-8            188.4 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8     84.88 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8     86.81 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8     85.40 ns/op
```

For comparison, clean origin/main in the same temporary worktree measured:

```text
BenchmarkSearchLeaf_PrefixV2-8            230.1 ns/op
BenchmarkSearchLeaf_PrefixV2-8            230.3 ns/op
BenchmarkSearchLeaf_PrefixV2-8            230.8 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8    122.1 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8    121.4 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8    121.0 ns/op
```

Final integrated smoke:

- `BENCHTIME=2s ./run_leaf_smoke.sh`

Key rows from the final smoke:

```text
BenchmarkSearchLeaf_PrefixV2-8                   202.9 ns/op
BenchmarkSearchLeaf_ColumnarPrefixV2-8            86.52 ns/op
MATCHED_GO search/prefix_v2                       83.86 ns/op
MATCHED_GO search/columnar_prefix_v2              79.71 ns/op
MATCHED_C  search/prefix_v2                       71.80 ns/op
MATCHED_C  search/columnar_prefix_v2              77.51 ns/op
RESULT     search/prefix_v2                       69.53 ns/op
RESULT     search/columnar_prefix_v2              62.98 ns/op
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark and runtime support for variable-length keys and a new fixed-8-byte key mode.

* **Refactor**
  * Simplified leaf search comparison to always compare reconstructed keys for prefix-compressed pages.
  * Converted storage to fixed-size arena allocations from heap-backed vectors.

* **Chores**
  * Updated benchmark scripts and harnesses to include the new columnar variable-length case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->