### PR TITLE
[codex] Add column store quickstart

### DIFF
--- a/examples/column_store_quickstart/README.md
+++ b/examples/column_store_quickstart/README.md
@@ -1,22 +1,23 @@
 # TreeDB Activity Event Column Store
 
-Activity streams are a natural fit for a collection that needs both primary
-reads and scan-friendly analytics. In this walkthrough, a feed service receives
-events from web, iOS, and Android clients. Each event records when something
-happened, who acted, what action they took, which client sent it, and which feed
-item was touched.
+This command models a small feed-service activity stream. The service receives
+events from web, iOS, and Android clients whenever someone posts, likes,
+reposts, or follows. Each row records when the event happened, who acted, what
+they did, which client sent it, and which feed item was touched.
 
-That shape is useful in two different ways. Product and debugging paths often
-need the complete event by id. Operational questions usually scan the same few
-dimensions: event time, action type, and actor. TreeDB stores the full row as
-JSON for the primary read path, while also writing those scan-heavy fields into
-physical column lanes.
+The storage goal is deliberately mixed:
 
-The command writes a small activity feed into TreeDB, checkpoints it, reopens
-the database, reads one event back by id, and runs two column scans over the
-same data.
+- Keep the full event available by id for product paths, debugging, and audit
+  views.
+- Keep the hot rollup dimensions scan-friendly for operational questions over a
+  slice of the feed.
 
-Run it from the repository root:
+TreeDB supports that shape by storing each event as JSON while also writing a
+few selected fields into physical column lanes.
+
+## Run
+
+Run from the repository root:
 
 ```sh
 GOWORK=off go run ./examples/column_store_quickstart
@@ -29,9 +30,9 @@ GOWORK=off go run ./examples/column_store_quickstart -rows 1000
 GOWORK=off go run ./examples/column_store_quickstart -dir /tmp/gomap-column-demo -keep
 ```
 
-## Data Shape
+## Event Shape
 
-Rows model activity events such as posts, likes, reposts, and follows:
+Rows model activity events:
 
 ```json
 {
@@ -43,24 +44,45 @@ Rows model activity events such as posts, likes, reposts, and follows:
 }
 ```
 
-The collection keeps three fields in the column store:
+## Storage Layout
 
-- `time_us`: ordered `int64` event time
-- `action`: dictionary-capable string for event mix queries
-- `actor`: dictionary-capable string for per-actor rollups
+The collection stores the complete JSON row, then promotes the fields that are
+useful for scans:
 
-The remaining JSON fields stay in the retained payload. A primary read can
-still reconstruct the full event from the retained payload and the column lanes.
+| Field | Storage | Motivation |
+| --- | --- | --- |
+| `time_us` | `int64` column, sort key | Event ordering and per-actor time spans. |
+| `action` | Dictionary-capable string column | Group the feed slice by activity type. |
+| `actor` | Dictionary-capable string column | Roll up activity by identity. |
+| `client` | Retained JSON payload | Useful on primary reads, not scanned here. |
+| `subject` | Retained JSON payload | Useful on primary reads, not scanned here. |
+
+Primary reads reconstruct the full document from the retained payload plus the
+column lanes. Column scans can answer rollup questions without reconstructing
+every JSON row.
+
+## Flow
+
+The command performs the full lifecycle that a small application path would
+exercise:
+
+1. Generate activity-event JSON rows.
+2. Create a durable TreeDB collection with column storage enabled.
+3. Insert the batch and checkpoint the database.
+4. Reopen the database to prove the persisted shape is readable.
+5. Fetch one event by id.
+6. Run two explicit physical column scans.
 
 ## Queries
 
-`events_by_action` answers the operational question, "What kind of activity is
-dominating this slice of the feed?"
+| Query | Column Work | Question |
+| --- | --- | --- |
+| `events_by_action` | Group-count on `action`. | What kind of activity is dominating this feed slice? |
+| `active_window_by_actor` | Group by `actor`; compute `max(time_us)-min(time_us)`. | How spread out is each actor's activity in the batch? |
 
-`active_window_by_actor` groups by actor and calculates the observed time span
-between that actor's first and last event in the batch.
+## Output Excerpt
 
-The output keeps the read path and scan path visible:
+The terminal output starts by making the read path and scan path visible:
 
 ```text
 Activity event column store
@@ -116,18 +138,6 @@ The plan is forced to serial_column_scan so the physical column path is explicit
 │  events_by_action        serial_column_scan  48    4       ...    ...    0          1         │
 │  active_window_by_actor  serial_column_scan  48    9       ...    ...    0          1         │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────╯
-
-What activity is in this feed slice?
-The first scan groups on the dictionary-coded action lane.
-
-╭─────────────────────────╮
-│  Events by Action       │
-│                         │
-│  action         events  │
-│  ─────────────  ──────  │
-│  graph.follow   8       │
-│  post.created   19      │
-╰─────────────────────────╯
 ```
 
 Headings and box labels are bold in a normal terminal. Set `NO_COLOR=1` to

--- a/examples/column_store_quickstart/README.md
+++ b/examples/column_store_quickstart/README.md
@@ -1,8 +1,15 @@
 # TreeDB Activity Event Column Store
 
 Activity streams are a natural fit for a collection that needs both primary
-reads and scan-friendly analytics. Each event is stored as JSON so the original
-row can be read back by key, while a few high-value fields are also written into
+reads and scan-friendly analytics. In this walkthrough, a feed service receives
+events from web, iOS, and Android clients. Each event records when something
+happened, who acted, what action they took, which client sent it, and which feed
+item was touched.
+
+That shape is useful in two different ways. Product and debugging paths often
+need the complete event by id. Operational questions usually scan the same few
+dimensions: event time, action type, and actor. TreeDB stores the full row as
+JSON for the primary read path, while also writing those scan-heavy fields into
 physical column lanes.
 
 The command writes a small activity feed into TreeDB, checkpoints it, reopens
@@ -57,8 +64,17 @@ The output keeps the read path and scan path visible:
 
 ```text
 Activity event column store
-Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it
-and scan those lanes for rollups.
+Scenario: a feed service receives activity events from web, iOS, and Android clients. Each row
+records when something happened, who acted, what action they took, which client sent it, and
+which feed item was touched.
+
+Why collect it: the application still needs exact event reads by id for debugging and
+user-facing workflows, while operators need fast rollups over a slice of the feed to see
+activity mix and actor spread.
+
+Storage shape: TreeDB stores the full event as JSON, then promotes time_us, action, and actor
+into physical column lanes because those are the fields scanned by the rollups below. Client
+and subject stay in the retained JSON payload.
 
 ╭──────────────────────────────────────────────────────────╮
 │  Dataset                                                 │
@@ -66,6 +82,8 @@ and scan those lanes for rollups.
 │  db:             /tmp/gomap-column-store-quickstart-...  │
 │  collection:     activity_events                         │
 │  rows ingested:  48                                      │
+│  source:         feed activity events from app clients    │
+│  row shape:      time_us, action, actor, client, subject  │
 │  column lanes:   time_us, action, actor                  │
 │  retained JSON:  client, subject                         │
 ╰──────────────────────────────────────────────────────────╯

--- a/examples/column_store_quickstart/README.md
+++ b/examples/column_store_quickstart/README.md
@@ -59,45 +59,53 @@ The output keeps the read path and scan path visible:
 Activity event column store
 Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it
 and scan those lanes for rollups.
-+-- Dataset ----------------------------------------------------+
-| db:             /tmp/gomap-column-store-quickstart-...        |
-| collection:     activity_events                               |
-| rows ingested:  48                                            |
-| column lanes:   time_us, action, actor                        |
-| retained JSON:  client, subject                               |
-+---------------------------------------------------------------+
+╭──────────────────────────────────────────────────────────╮
+│  Dataset                                                 │
+│                                                          │
+│  db:             /tmp/gomap-column-store-quickstart-...  │
+│  collection:     activity_events                         │
+│  rows ingested:  48                                      │
+│  column lanes:   time_us, action, actor                  │
+│  retained JSON:  client, subject                         │
+╰──────────────────────────────────────────────────────────╯
 
 Primary read after reopen
 The row is still fetched by id as a complete JSON document; the columnized fields are stitched
 back into the document.
-+-- Reconstructed row -----------+
-| id:       activity_0007        |
-| time_us:  1700000119002000     |
-| action:   post.created         |
-| actor:    did:plc:bruno        |
-| client:   ios                  |
-| subject:  feed:storage-updates |
-+--------------------------------+
+╭──────────────────────────────────╮
+│  Reconstructed row               │
+│                                  │
+│  id:       activity_0007         │
+│  time_us:  1700000119002000      │
+│  action:   post.created          │
+│  actor:    did:plc:bruno         │
+│  client:   ios                   │
+│  subject:  feed:storage-updates  │
+╰──────────────────────────────────╯
 
 Column scans over the same rows
 Both scans read the physical column lanes directly, so the rollups avoid reconstructing every
 JSON document.
 The plan is forced to serial_column_scan so the physical column path is explicit.
-+-- Scan plan and counters -------------------------------------------------------------------+
-| query                   plan                rows  groups  bytes  MiB/s  JSON rows  manifest |
-| ----------------------  ------------------  ----  ------  -----  -----  ---------  -------- |
-| events_by_action        serial_column_scan  48    4       ...    ...    0          1        |
-| active_window_by_actor  serial_column_scan  48    9       ...    ...    0          1        |
-+---------------------------------------------------------------------------------------------+
+╭───────────────────────────────────────────────────────────────────────────────────────────────╮
+│  Scan plan and counters                                                                       │
+│                                                                                               │
+│  query                   plan                rows  groups  bytes  MiB/s  JSON rows  manifest  │
+│  ──────────────────────  ──────────────────  ────  ──────  ─────  ─────  ─────────  ────────  │
+│  events_by_action        serial_column_scan  48    4       ...    ...    0          1         │
+│  active_window_by_actor  serial_column_scan  48    9       ...    ...    0          1         │
+╰───────────────────────────────────────────────────────────────────────────────────────────────╯
 
 What activity is in this feed slice?
 The first scan groups on the dictionary-coded action lane.
-+-- Events by Action ---+
-| action         events |
-| -------------  ------ |
-| graph.follow   8      |
-| post.created   19     |
-+-----------------------+
+╭─────────────────────────╮
+│  Events by Action       │
+│                         │
+│  action         events  │
+│  ─────────────  ──────  │
+│  graph.follow   8       │
+│  post.created   19      │
+╰─────────────────────────╯
 ```
 
 Headings and box labels are bold in a normal terminal. Set `NO_COLOR=1` to

--- a/examples/column_store_quickstart/README.md
+++ b/examples/column_store_quickstart/README.md
@@ -1,0 +1,107 @@
+# TreeDB Activity Event Column Store
+
+Activity streams are a natural fit for a collection that needs both primary
+reads and scan-friendly analytics. Each event is stored as JSON so the original
+row can be read back by key, while a few high-value fields are also written into
+physical column lanes.
+
+The command writes a small activity feed into TreeDB, checkpoints it, reopens
+the database, reads one event back by id, and runs two column scans over the
+same data.
+
+Run it from the repository root:
+
+```sh
+GOWORK=off go run ./examples/column_store_quickstart
+```
+
+Useful flags:
+
+```sh
+GOWORK=off go run ./examples/column_store_quickstart -rows 1000
+GOWORK=off go run ./examples/column_store_quickstart -dir /tmp/gomap-column-demo -keep
+```
+
+## Data Shape
+
+Rows model activity events such as posts, likes, reposts, and follows:
+
+```json
+{
+  "time_us": 1700000119002000,
+  "action": "post.created",
+  "actor": "did:plc:bruno",
+  "client": "ios",
+  "subject": "feed:storage-updates"
+}
+```
+
+The collection keeps three fields in the column store:
+
+- `time_us`: ordered `int64` event time
+- `action`: dictionary-capable string for event mix queries
+- `actor`: dictionary-capable string for per-actor rollups
+
+The remaining JSON fields stay in the retained payload. A primary read can
+still reconstruct the full event from the retained payload and the column lanes.
+
+## Queries
+
+`events_by_action` answers the operational question, "What kind of activity is
+dominating this slice of the feed?"
+
+`active_window_by_actor` groups by actor and calculates the observed time span
+between that actor's first and last event in the batch.
+
+The output keeps the read path and scan path visible:
+
+```text
+Activity event column store
+Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it
+and scan those lanes for rollups.
++-- Dataset ----------------------------------------------------+
+| db:             /tmp/gomap-column-store-quickstart-...        |
+| collection:     activity_events                               |
+| rows ingested:  48                                            |
+| column lanes:   time_us, action, actor                        |
+| retained JSON:  client, subject                               |
++---------------------------------------------------------------+
+
+Primary read after reopen
+The row is still fetched by id as a complete JSON document; the columnized fields are stitched
+back into the document.
++-- Reconstructed row -----------+
+| id:       activity_0007        |
+| time_us:  1700000119002000     |
+| action:   post.created         |
+| actor:    did:plc:bruno        |
+| client:   ios                  |
+| subject:  feed:storage-updates |
++--------------------------------+
+
+Column scans over the same rows
+Both scans read the physical column lanes directly, so the rollups avoid reconstructing every
+JSON document.
+The plan is forced to serial_column_scan so the physical column path is explicit.
++-- Scan plan and counters -------------------------------------------------------------------+
+| query                   plan                rows  groups  bytes  MiB/s  JSON rows  manifest |
+| ----------------------  ------------------  ----  ------  -----  -----  ---------  -------- |
+| events_by_action        serial_column_scan  48    4       ...    ...    0          1        |
+| active_window_by_actor  serial_column_scan  48    9       ...    ...    0          1        |
++---------------------------------------------------------------------------------------------+
+
+What activity is in this feed slice?
+The first scan groups on the dictionary-coded action lane.
++-- Events by Action ---+
+| action         events |
+| -------------  ------ |
+| graph.follow   8      |
+| post.created   19     |
++-----------------------+
+```
+
+Headings and box labels are bold in a normal terminal. Set `NO_COLOR=1` to
+disable ANSI styling.
+
+For benchmark and profile evidence, use the column-store suite under
+`./bin/unified-bench`.

--- a/examples/column_store_quickstart/README.md
+++ b/examples/column_store_quickstart/README.md
@@ -59,6 +59,7 @@ The output keeps the read path and scan path visible:
 Activity event column store
 Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it
 and scan those lanes for rollups.
+
 ╭──────────────────────────────────────────────────────────╮
 │  Dataset                                                 │
 │                                                          │
@@ -72,6 +73,7 @@ and scan those lanes for rollups.
 Primary read after reopen
 The row is still fetched by id as a complete JSON document; the columnized fields are stitched
 back into the document.
+
 ╭──────────────────────────────────╮
 │  Reconstructed row               │
 │                                  │
@@ -87,6 +89,7 @@ Column scans over the same rows
 Both scans read the physical column lanes directly, so the rollups avoid reconstructing every
 JSON document.
 The plan is forced to serial_column_scan so the physical column path is explicit.
+
 ╭───────────────────────────────────────────────────────────────────────────────────────────────╮
 │  Scan plan and counters                                                                       │
 │                                                                                               │
@@ -98,6 +101,7 @@ The plan is forced to serial_column_scan so the physical column path is explicit
 
 What activity is in this feed slice?
 The first scan groups on the dictionary-coded action lane.
+
 ╭─────────────────────────╮
 │  Events by Action       │
 │                         │

--- a/examples/column_store_quickstart/main.go
+++ b/examples/column_store_quickstart/main.go
@@ -119,12 +119,18 @@ func main() {
 	}
 
 	printTitle("Activity event column store")
-	printNarrative("Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it and scan those lanes for rollups.")
+	printNarrative("Scenario: a feed service receives activity events from web, iOS, and Android clients. Each row records when something happened, who acted, what action they took, which client sent it, and which feed item was touched.")
+	fmt.Println()
+	printNarrative("Why collect it: the application still needs exact event reads by id for debugging and user-facing workflows, while operators need fast rollups over a slice of the feed to see activity mix and actor spread.")
+	fmt.Println()
+	printNarrative("Storage shape: TreeDB stores the full event as JSON, then promotes time_us, action, and actor into physical column lanes because those are the fields scanned by the rollups below. Client and subject stay in the retained JSON payload.")
 	fmt.Println()
 	printBox("Dataset", keyValueLines([][2]string{
 		{"db", absDir},
 		{"collection", collectionName},
 		{"rows ingested", fmt.Sprintf("%d", len(events))},
+		{"source", "feed activity events from app clients"},
+		{"row shape", "time_us, action, actor, client, subject"},
 		{"column lanes", "time_us, action, actor"},
 		{"retained JSON", "client, subject"},
 	}))

--- a/examples/column_store_quickstart/main.go
+++ b/examples/column_store_quickstart/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -442,7 +443,7 @@ func printBoxedTable(title string, headers []string, rows [][]string) {
 
 	separators := make([]string, len(widths))
 	for i, width := range widths {
-		separators[i] = strings.Repeat("-", width)
+		separators[i] = strings.Repeat("─", width)
 	}
 
 	lines := make([]string, 0, len(rows)+2)
@@ -470,34 +471,33 @@ func formatTableRow(cells []string, widths []int, header bool) string {
 }
 
 func printBox(title string, lines []string) {
-	width := visibleLen(" " + title + " ")
-	for _, line := range lines {
+	boxLines := lines
+	if title != "" {
+		boxLines = make([]string, 0, len(lines)+2)
+		boxLines = append(boxLines, bold(title), "")
+		boxLines = append(boxLines, lines...)
+	}
+
+	width := 0
+	for _, line := range boxLines {
 		if lineWidth := visibleLen(line); lineWidth > width {
 			width = lineWidth
 		}
 	}
 
-	fmt.Println(boxTop(title, width))
-	for _, line := range lines {
-		fmt.Printf("| %s%s |\n", line, strings.Repeat(" ", width-visibleLen(line)))
+	fmt.Println(boxTop(width))
+	for _, line := range boxLines {
+		fmt.Printf("│  %s%s  │\n", line, strings.Repeat(" ", width-visibleLen(line)))
 	}
 	fmt.Println(boxBottom(width))
 }
 
-func boxTop(title string, width int) string {
-	if title == "" {
-		return boxBottom(width)
-	}
-	label := " " + bold(title) + " "
-	labelWidth := visibleLen(label)
-	if width < labelWidth {
-		width = labelWidth
-	}
-	return "+--" + label + strings.Repeat("-", width-labelWidth) + "+"
+func boxTop(width int) string {
+	return "╭" + strings.Repeat("─", width+4) + "╮"
 }
 
 func boxBottom(width int) string {
-	return "+" + strings.Repeat("-", width+2) + "+"
+	return "╰" + strings.Repeat("─", width+4) + "╯"
 }
 
 func padRight(s string, width int) string {
@@ -521,6 +521,10 @@ func visibleLen(s string) int {
 				inEscape = false
 			}
 		default:
+			_, size := utf8.DecodeRuneInString(s[i:])
+			if size > 1 {
+				i += size - 1
+			}
 			width++
 		}
 	}

--- a/examples/column_store_quickstart/main.go
+++ b/examples/column_store_quickstart/main.go
@@ -1,0 +1,560 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+const (
+	collectionName = "activity_events"
+	narrativeWidth = 96
+)
+
+type querySpec struct {
+	Name        string
+	Title       string
+	KeyHeader   string
+	ValueHeader string
+	Limit       int
+	Request     collections.ColumnPhysicalQueryRequest
+}
+
+type queryRun struct {
+	Spec   querySpec
+	Plan   collections.ColumnQueryPlan
+	Result collections.ColumnPhysicalQueryResult
+}
+
+type activityEvent struct {
+	TimeUS  int64  `json:"time_us"`
+	Action  string `json:"action"`
+	Actor   string `json:"actor"`
+	Client  string `json:"client"`
+	Subject string `json:"subject"`
+}
+
+func main() {
+	var rows int
+	var dir string
+	var keep bool
+	flag.IntVar(&rows, "rows", 48, "number of activity events to write")
+	flag.StringVar(&dir, "dir", "", "TreeDB directory; empty uses a temporary directory")
+	flag.BoolVar(&keep, "keep", false, "keep the temporary directory after the run")
+	flag.Parse()
+
+	if rows <= 0 {
+		log.Fatal("-rows must be positive")
+	}
+
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "gomap-column-store-quickstart-*")
+		if err != nil {
+			log.Fatal(err)
+		}
+		dir = tmp
+		if !keep {
+			defer func() { _ = os.RemoveAll(tmp) }()
+		}
+	} else if err := os.MkdirAll(dir, 0o700); err != nil {
+		log.Fatal(err)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	events, ids, docs, err := buildEvents(rows)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, cleanup, err := treedb.OpenBackend(backendOptions(absDir))
+	if err != nil {
+		log.Fatal(err)
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(collectionMeta()); err != nil {
+		_ = cleanup()
+		log.Fatal(err)
+	}
+	collection, err := manager.OpenCollection(collectionName)
+	if err != nil {
+		_ = cleanup()
+		log.Fatal(err)
+	}
+	if _, err := collection.InsertBatch(ids, docs); err != nil {
+		_ = cleanup()
+		log.Fatal(err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = cleanup()
+		log.Fatal(err)
+	}
+	if err := cleanup(); err != nil {
+		log.Fatal(err)
+	}
+
+	reopened, reopenedCleanup, err := treedb.OpenBackend(backendOptions(absDir))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := reopenedCleanup(); err != nil {
+			log.Printf("close TreeDB: %v", err)
+		}
+	}()
+	reopenedCollection, err := collections.NewCollectionManager(reopened).OpenCollection(collectionName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	printTitle("Activity event column store")
+	printNarrative("Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it and scan those lanes for rollups.")
+	printBox("Dataset", keyValueLines([][2]string{
+		{"db", absDir},
+		{"collection", collectionName},
+		{"rows ingested", fmt.Sprintf("%d", len(events))},
+		{"column lanes", "time_us, action, actor"},
+		{"retained JSON", "client, subject"},
+	}))
+
+	sampleID := ids[min(7, len(ids)-1)]
+	reconstructed, err := reopenedCollection.Get(sampleID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	specs := []querySpec{
+		{
+			Name:        "events_by_action",
+			Title:       "Events by Action",
+			KeyHeader:   "action",
+			ValueHeader: "events",
+			Request: collections.ColumnPhysicalQueryRequest{
+				Kind:        collections.ColumnPhysicalQueryGroupCount,
+				GroupColumn: "action",
+			},
+		},
+		{
+			Name:        "active_window_by_actor",
+			Title:       "Active Window by Actor",
+			KeyHeader:   "actor",
+			ValueHeader: "span_us",
+			Limit:       8,
+			Request: collections.ColumnPhysicalQueryRequest{
+				Kind:        collections.ColumnPhysicalQueryGroupInt64Span,
+				GroupColumn: "actor",
+				ValueColumn: "time_us",
+			},
+		},
+	}
+	runs := make([]queryRun, 0, len(specs))
+	for _, spec := range specs {
+		run, err := runPlannedPhysicalQuery(reopenedCollection, spec, rows)
+		if err != nil {
+			log.Fatal(err)
+		}
+		runs = append(runs, run)
+	}
+
+	var sample activityEvent
+	if err := json.Unmarshal(reconstructed, &sample); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println()
+	printTitle("Primary read after reopen")
+	printNarrative("The row is still fetched by id as a complete JSON document; the columnized fields are stitched back into the document.")
+	printBox("Reconstructed row", keyValueLines([][2]string{
+		{"id", string(sampleID)},
+		{"time_us", fmt.Sprintf("%d", sample.TimeUS)},
+		{"action", sample.Action},
+		{"actor", sample.Actor},
+		{"client", sample.Client},
+		{"subject", sample.Subject},
+	}))
+	printQuerySummary(runs)
+	for _, run := range runs {
+		printGroupTable(run)
+	}
+}
+
+func backendOptions(dir string) treedb.Options {
+	opts := treedb.OptionsFor(treedb.ProfileDurable, dir)
+	opts.CommandWAL = true
+	opts.CommandWALStatsScan = true
+	opts.DisableBackgroundPrune = true
+	return opts
+}
+
+func collectionMeta() *collections.CollectionMeta {
+	return &collections.CollectionMeta{
+		Name: collectionName,
+		Options: collections.CollectionOptions{
+			DocumentFormat:               collections.DocumentFormatJSON,
+			DisableIndexedWriteMemtables: true,
+			ColumnStore: &collections.ColumnStoreConfig{
+				Enabled: true,
+				Columns: []collections.ColumnStoreColumn{
+					{Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
+					{Name: "action", Path: "action", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+					{Name: "actor", Path: "actor", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+				},
+				SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
+				AggregateMetadata: []collections.ColumnAggregateMetadata{
+					{Name: "min_time_us", Column: "time_us", Kind: collections.ColumnAggregateMin},
+					{Name: "max_time_us", Column: "time_us", Kind: collections.ColumnAggregateMax},
+				},
+				RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
+				Reconstruction:  collections.ColumnReconstructionRetainedPayloadAndColumns,
+				ProfileSupport:  collections.ColumnStoreProfileDurableOnly,
+			},
+		},
+	}
+}
+
+func buildEvents(rows int) ([]activityEvent, [][]byte, [][]byte, error) {
+	const baseTimeUS = int64(1_700_000_000_000_000)
+	actors := []string{
+		"did:plc:alice",
+		"did:plc:bruno",
+		"did:plc:chandra",
+		"did:plc:daria",
+		"did:plc:eli",
+		"did:plc:fran",
+		"did:plc:gita",
+		"did:plc:hugo",
+		"did:plc:ines",
+	}
+	clients := []string{"web", "ios", "android"}
+	subjects := []string{
+		"feed:launch-notes",
+		"feed:storage-updates",
+		"feed:index-health",
+		"feed:ops-review",
+	}
+
+	events := make([]activityEvent, rows)
+	ids := make([][]byte, rows)
+	docs := make([][]byte, rows)
+	for i := 0; i < rows; i++ {
+		event := activityEvent{
+			TimeUS:  baseTimeUS + int64(i*17)*1_000_000 + int64((i%5)*1000),
+			Action:  actionFor(i),
+			Actor:   actors[(i*5+i/3)%len(actors)],
+			Client:  clients[i%len(clients)],
+			Subject: subjects[(i*7)%len(subjects)],
+		}
+		doc, err := json.Marshal(event)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		events[i] = event
+		ids[i] = []byte(fmt.Sprintf("activity_%04d", i))
+		docs[i] = doc
+	}
+	return events, ids, docs, nil
+}
+
+func actionFor(i int) string {
+	switch {
+	case i%6 == 0:
+		return "graph.follow"
+	case i%5 == 0:
+		return "post.reposted"
+	case i%2 == 0:
+		return "post.liked"
+	default:
+		return "post.created"
+	}
+}
+
+func runPlannedPhysicalQuery(collection *collections.Collection, spec querySpec, rows int) (queryRun, error) {
+	plan, err := collection.PlanColumnQuery(collections.ColumnQueryPlanRequest{
+		Name:             spec.Name,
+		ProjectedColumns: projectedColumns(spec.Request),
+		EstimatedRows:    rows,
+		ForceKind:        collections.ColumnQueryPlanSerialColumnScan,
+	})
+	if err != nil {
+		return queryRun{}, err
+	}
+	if !plan.Supported {
+		return queryRun{}, fmt.Errorf("serial column scan unsupported for %s: %s", spec.Name, plan.Diagnostics.UnsupportedPlanReason)
+	}
+	result, err := collection.RunColumnPhysicalQuery(spec.Request)
+	if err != nil {
+		return queryRun{}, err
+	}
+	return queryRun{Spec: spec, Plan: plan, Result: result}, nil
+}
+
+func projectedColumns(req collections.ColumnPhysicalQueryRequest) []string {
+	seen := make(map[string]struct{}, 3)
+	out := make([]string, 0, 3)
+	for _, column := range []string{req.GroupColumn, req.ValueColumn, req.DistinctColumn} {
+		if column == "" {
+			continue
+		}
+		if _, ok := seen[column]; ok {
+			continue
+		}
+		seen[column] = struct{}{}
+		out = append(out, column)
+	}
+	return out
+}
+
+func printQuerySummary(runs []queryRun) {
+	fmt.Println()
+	printTitle("Column scans over the same rows")
+	printNarrative("Both scans read the physical column lanes directly, so the rollups avoid reconstructing every JSON document.")
+	printNarrative("The plan is forced to serial_column_scan so the physical column path is explicit.")
+
+	rows := make([][]string, 0, len(runs))
+	for _, run := range runs {
+		diag := run.Result.Diagnostics
+		rows = append(rows, []string{
+			run.Spec.Name,
+			string(run.Plan.Kind),
+			fmt.Sprintf("%d", diag.RowsScanned),
+			fmt.Sprintf("%d", diag.ResultGroups),
+			fmt.Sprintf("%d", diag.PhysicalBytesScanned),
+			fmt.Sprintf("%.1f", mibPerSecond(diag.PhysicalBytesScanned, diag.ScanNanos)),
+			fmt.Sprintf("%d", diag.RowMaterializations),
+			fmt.Sprintf("%d", diag.ManifestGeneration),
+		})
+	}
+	printBoxedTable("Scan plan and counters", []string{"query", "plan", "rows", "groups", "bytes", "MiB/s", "JSON rows", "manifest"}, rows)
+}
+
+func printGroupTable(run queryRun) {
+	groups := append([]collections.ColumnPhysicalQueryGroup(nil), run.Result.Groups...)
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Key < groups[j].Key })
+	limit := run.Spec.Limit
+	if limit <= 0 || limit > len(groups) {
+		limit = len(groups)
+	}
+
+	fmt.Println()
+	switch run.Spec.Name {
+	case "events_by_action":
+		printTitle("What activity is in this feed slice?")
+		printNarrative("The first scan groups on the dictionary-coded action lane.")
+	case "active_window_by_actor":
+		printTitle("How spread out is each actor's activity?")
+		printNarrative("The second scan groups on actor and computes max(time_us)-min(time_us) for each actor.")
+	default:
+		printTitle(run.Spec.Title)
+	}
+
+	rows := make([][]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		rows = append(rows, []string{
+			groups[i].Key,
+			fmt.Sprintf("%d", queryGroupValue(groups[i], run.Spec.Request.Kind)),
+		})
+	}
+	printBoxedTable(run.Spec.Title, []string{run.Spec.KeyHeader, run.Spec.ValueHeader}, rows)
+	if limit < len(groups) {
+		remaining := len(groups) - limit
+		fmt.Printf("%s %d more %s present in this slice.\n", bold("Note:"), remaining, plural("group is", "groups are", remaining))
+	}
+}
+
+func plural(singular, plural string, count int) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func printTitle(title string) {
+	fmt.Println(bold(title))
+}
+
+func printNarrative(text string) {
+	for _, line := range wrapText(text, narrativeWidth) {
+		fmt.Println(line)
+	}
+}
+
+func wrapText(text string, width int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{""}
+	}
+
+	lines := make([]string, 0, 2)
+	line := words[0]
+	for _, word := range words[1:] {
+		if visibleLen(line)+1+visibleLen(word) > width {
+			lines = append(lines, line)
+			line = word
+			continue
+		}
+		line += " " + word
+	}
+	lines = append(lines, line)
+	return lines
+}
+
+func keyValueLines(rows [][2]string) []string {
+	keyWidth := 0
+	for _, row := range rows {
+		if width := len(row[0]) + 1; width > keyWidth {
+			keyWidth = width
+		}
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		label := row[0] + ":"
+		lines = append(lines, bold(label)+strings.Repeat(" ", keyWidth-len(label)+2)+row[1])
+	}
+	return lines
+}
+
+func printBoxedTable(title string, headers []string, rows [][]string) {
+	widths := make([]int, len(headers))
+	for i, header := range headers {
+		widths[i] = visibleLen(header)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i >= len(widths) {
+				break
+			}
+			if width := visibleLen(cell); width > widths[i] {
+				widths[i] = width
+			}
+		}
+	}
+
+	separators := make([]string, len(widths))
+	for i, width := range widths {
+		separators[i] = strings.Repeat("-", width)
+	}
+
+	lines := make([]string, 0, len(rows)+2)
+	lines = append(lines, formatTableRow(headers, widths, true))
+	lines = append(lines, strings.Join(separators, "  "))
+	for _, row := range rows {
+		lines = append(lines, formatTableRow(row, widths, false))
+	}
+	printBox(title, lines)
+}
+
+func formatTableRow(cells []string, widths []int, header bool) string {
+	out := make([]string, len(widths))
+	for i := range widths {
+		cell := ""
+		if i < len(cells) {
+			cell = cells[i]
+		}
+		if header {
+			cell = bold(cell)
+		}
+		out[i] = padRight(cell, widths[i])
+	}
+	return strings.Join(out, "  ")
+}
+
+func printBox(title string, lines []string) {
+	width := visibleLen(" " + title + " ")
+	for _, line := range lines {
+		if lineWidth := visibleLen(line); lineWidth > width {
+			width = lineWidth
+		}
+	}
+
+	fmt.Println(boxTop(title, width))
+	for _, line := range lines {
+		fmt.Printf("| %s%s |\n", line, strings.Repeat(" ", width-visibleLen(line)))
+	}
+	fmt.Println(boxBottom(width))
+}
+
+func boxTop(title string, width int) string {
+	if title == "" {
+		return boxBottom(width)
+	}
+	label := " " + bold(title) + " "
+	labelWidth := visibleLen(label)
+	if width < labelWidth {
+		width = labelWidth
+	}
+	return "+--" + label + strings.Repeat("-", width-labelWidth) + "+"
+}
+
+func boxBottom(width int) string {
+	return "+" + strings.Repeat("-", width+2) + "+"
+}
+
+func padRight(s string, width int) string {
+	padding := width - visibleLen(s)
+	if padding <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", padding)
+}
+
+func visibleLen(s string) int {
+	width := 0
+	inEscape := false
+	for i := 0; i < len(s); i++ {
+		switch {
+		case !inEscape && s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[':
+			inEscape = true
+			i++
+		case inEscape:
+			if s[i] >= '@' && s[i] <= '~' {
+				inEscape = false
+			}
+		default:
+			width++
+		}
+	}
+	return width
+}
+
+func bold(s string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return s
+	}
+	return "\x1b[1m" + s + "\x1b[0m"
+}
+
+func queryGroupValue(group collections.ColumnPhysicalQueryGroup, kind collections.ColumnPhysicalQueryKind) int64 {
+	switch kind {
+	case collections.ColumnPhysicalQueryGroupCount,
+		collections.ColumnPhysicalQueryGroupCountDistinct,
+		collections.ColumnPhysicalQueryHourCount:
+		return int64(group.Count)
+	default:
+		return group.Int64
+	}
+}
+
+func mibPerSecond(bytes int64, nanos int64) float64 {
+	if bytes <= 0 || nanos <= 0 {
+		return 0
+	}
+	return float64(bytes) / (1024 * 1024) / (float64(nanos) / 1e9)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/examples/column_store_quickstart/main.go
+++ b/examples/column_store_quickstart/main.go
@@ -120,6 +120,7 @@ func main() {
 
 	printTitle("Activity event column store")
 	printNarrative("Write a short activity stream as JSON, keep the hot dimensions in column lanes, then reopen it and scan those lanes for rollups.")
+	fmt.Println()
 	printBox("Dataset", keyValueLines([][2]string{
 		{"db", absDir},
 		{"collection", collectionName},
@@ -175,6 +176,7 @@ func main() {
 	fmt.Println()
 	printTitle("Primary read after reopen")
 	printNarrative("The row is still fetched by id as a complete JSON document; the columnized fields are stitched back into the document.")
+	fmt.Println()
 	printBox("Reconstructed row", keyValueLines([][2]string{
 		{"id", string(sampleID)},
 		{"time_us", fmt.Sprintf("%d", sample.TimeUS)},
@@ -320,6 +322,7 @@ func printQuerySummary(runs []queryRun) {
 	printTitle("Column scans over the same rows")
 	printNarrative("Both scans read the physical column lanes directly, so the rollups avoid reconstructing every JSON document.")
 	printNarrative("The plan is forced to serial_column_scan so the physical column path is explicit.")
+	fmt.Println()
 
 	rows := make([][]string, 0, len(runs))
 	for _, run := range runs {
@@ -351,11 +354,14 @@ func printGroupTable(run queryRun) {
 	case "events_by_action":
 		printTitle("What activity is in this feed slice?")
 		printNarrative("The first scan groups on the dictionary-coded action lane.")
+		fmt.Println()
 	case "active_window_by_actor":
 		printTitle("How spread out is each actor's activity?")
 		printNarrative("The second scan groups on actor and computes max(time_us)-min(time_us) for each actor.")
+		fmt.Println()
 	default:
 		printTitle(run.Spec.Title)
+		fmt.Println()
 	}
 
 	rows := make([][]string, 0, limit)


### PR DESCRIPTION
## Summary

Adds a standalone TreeDB column-store quickstart under `examples/column_store_quickstart`.

The walkthrough writes a small activity-event stream, stores `time_us`, `action`, and `actor` in physical column lanes, reopens the database, reads one row back by id, and runs two explicit physical column scans:

- `events_by_action`
- `active_window_by_actor`

The terminal output is framed with narrative text, boxed sections, and readable scan counters so the example feels like a motivated use case rather than a raw harness.

## Validation

- `GOWORK=off go run .` from `examples/column_store_quickstart`
- `GOWORK=off go test ./examples/column_store_quickstart`
- `git diff --cached --check` before commit