### PR TITLE
collections: support vector physical column values

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -301,8 +301,19 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 				if !value.Present && !value.Null {
 					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row[%d] column[%d] absent value is not null", rowIdx, colIdx)
 				}
+				if value.Type != input.Columns[colIdx].ValueType {
+					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row[%d] column[%d] type=%q want %q", rowIdx, colIdx, value.Type, input.Columns[colIdx].ValueType)
+				}
 				if !value.Present && !input.Columns[colIdx].Nullable {
 					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row[%d] column[%d] is absent but column is not nullable", rowIdx, colIdx)
+				}
+				if value.Null && !input.Columns[colIdx].Nullable {
+					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row[%d] column[%d] is null but column is not nullable", rowIdx, colIdx)
+				}
+				if !value.Null && value.Present {
+					if err := validateColumnDeclaredPhysicalValueShape(input.Columns[colIdx], value); err != nil {
+						return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row[%d] column[%d]: %w", rowIdx, colIdx, err)
+					}
 				}
 			}
 		case ColumnPublishOperationDelete:
@@ -681,6 +692,26 @@ func (c *manifestCursor) float32Slice() []float32 {
 	if c.err != nil {
 		return nil
 	}
+	return c.float32SliceAfterLength(n)
+}
+
+func (c *manifestCursor) float32SliceWithExpectedLength(expected int) []float32 {
+	n := c.u64()
+	if c.err != nil {
+		return nil
+	}
+	if expected < 0 {
+		c.err = errors.New("collections: column float32 slice expected length is negative")
+		return nil
+	}
+	if n != uint64(expected) {
+		c.err = fmt.Errorf("collections: column float32 slice length=%d want %d", n, expected)
+		return nil
+	}
+	return c.float32SliceAfterLength(n)
+}
+
+func (c *manifestCursor) float32SliceAfterLength(n uint64) []float32 {
 	if n > uint64(maxCollectionInt) {
 		c.err = errors.New("collections: column float32 slice length overflows int")
 		return nil
@@ -719,6 +750,10 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 func (c *manifestCursor) skipUint32Slice() uint64 {
 	n := c.u64()
 	if c.err != nil {
+		return 0
+	}
+	if n > uint64(maxCollectionInt) {
+		c.err = errors.New("collections: column uint32 slice length overflows int")
 		return 0
 	}
 	if n > uint64((len(c.raw)-c.pos)/4) {

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -479,7 +479,11 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 					case ColumnStoreValueString:
 						value.String = cur.string()
 					case ColumnStoreValueFloat32Vector:
-						value.Float32Vector = cur.float32Slice()
+						if version >= columnPhysicalAssetVersionV4 {
+							value.Float32Vector = cur.float32SliceWithExpectedLength(asset.Columns[colIdx].VectorDims)
+						} else {
+							value.Float32Vector = cur.float32Slice()
+						}
 					case ColumnStoreValueAdjacencyList:
 						value.AdjacencyList = cur.uint32Slice()
 					default:

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -2,11 +2,13 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -16,7 +18,8 @@ const (
 	columnPhysicalAssetMagic     = uint32(0x54435041) // TCPA
 	columnPhysicalAssetVersionV1 = uint16(1)
 	columnPhysicalAssetVersionV2 = uint16(2)
-	columnPhysicalAssetVersion   = uint16(3)
+	columnPhysicalAssetVersionV3 = uint16(3)
+	columnPhysicalAssetVersion   = uint16(4)
 )
 
 var ErrColumnDeclaredValueUnsupported = errors.New("collections: unsupported column declared value")
@@ -33,8 +36,13 @@ type columnDeclaredValue struct {
 	Null    bool
 	Bool    bool
 	Int64   int64
+	Float32 float32
 	Double  float64
 	String  string
+	// Float32Vector stores a decoded vector column value. It is used for first-
+	// class vector physical assets and is not part of scalar query hot paths.
+	Float32Vector []float32
+	AdjacencyList []uint32
 	// StringBytes is used by physical scan/query hot paths as an asset-buffer
 	// view; String remains the owned representation for full asset decoding.
 	StringBytes []byte
@@ -171,6 +179,16 @@ func convertColumnDeclaredValue(col ColumnStoreColumn, raw any, exists bool) (co
 			return columnDeclaredValue{}, err
 		}
 		value.Int64 = v
+	case ColumnStoreValueFloat32:
+		n, ok := raw.(json.Number)
+		if !ok {
+			return columnDeclaredValue{}, fmt.Errorf("expected float32 number got %T", raw)
+		}
+		v, err := parseJSONFloat32(n)
+		if err != nil {
+			return columnDeclaredValue{}, err
+		}
+		value.Float32 = v
 	case ColumnStoreValueDouble:
 		n, ok := raw.(json.Number)
 		if !ok {
@@ -187,10 +205,79 @@ func convertColumnDeclaredValue(col ColumnStoreColumn, raw any, exists bool) (co
 			return columnDeclaredValue{}, fmt.Errorf("expected string got %T", raw)
 		}
 		value.String = v
+	case ColumnStoreValueFloat32Vector:
+		values, err := convertJSONFloat32Vector(raw, col.VectorDims)
+		if err != nil {
+			return columnDeclaredValue{}, err
+		}
+		value.Float32Vector = values
+	case ColumnStoreValueAdjacencyList:
+		values, err := convertJSONUint32List(raw)
+		if err != nil {
+			return columnDeclaredValue{}, err
+		}
+		value.AdjacencyList = values
 	default:
 		return columnDeclaredValue{}, fmt.Errorf("unsupported declared value type %q", col.ValueType)
 	}
 	return value, nil
+}
+
+func parseJSONFloat32(n json.Number) (float32, error) {
+	v, err := strconv.ParseFloat(n.String(), 32)
+	if err != nil {
+		return 0, err
+	}
+	return float32(v), nil
+}
+
+func convertJSONFloat32Vector(raw any, dims int) ([]float32, error) {
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected float32_vector array got %T", raw)
+	}
+	if dims <= 0 {
+		return nil, fmt.Errorf("invalid float32_vector dims %d", dims)
+	}
+	if len(values) != dims {
+		return nil, fmt.Errorf("float32_vector length=%d want dims=%d", len(values), dims)
+	}
+	out := make([]float32, len(values))
+	for i, rawValue := range values {
+		n, ok := rawValue.(json.Number)
+		if !ok {
+			return nil, fmt.Errorf("float32_vector[%d] expected number got %T", i, rawValue)
+		}
+		v, err := parseJSONFloat32(n)
+		if err != nil {
+			return nil, fmt.Errorf("float32_vector[%d]: %w", i, err)
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func convertJSONUint32List(raw any) ([]uint32, error) {
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected adjacency_list array got %T", raw)
+	}
+	out := make([]uint32, len(values))
+	for i, rawValue := range values {
+		n, ok := rawValue.(json.Number)
+		if !ok {
+			return nil, fmt.Errorf("adjacency_list[%d] expected integer got %T", i, rawValue)
+		}
+		v, err := n.Int64()
+		if err != nil {
+			return nil, fmt.Errorf("adjacency_list[%d]: %w", i, err)
+		}
+		if v < 0 || v > int64(1<<32-1) {
+			return nil, fmt.Errorf("adjacency_list[%d]=%d outside uint32 range", i, v)
+		}
+		out[i] = uint32(v)
+	}
+	return out, nil
 }
 
 func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, columnPhysicalAssetSummary, error) {
@@ -246,6 +333,7 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		writeManifestString(&b, string(col.ValueType))
 		writeManifestBool(&b, col.Nullable)
 		writeManifestBool(&b, col.Dictionary)
+		writeManifestUint64(&b, uint64(col.VectorDims))
 	}
 	for _, row := range input.Rows {
 		writeManifestBytes(&b, row.ID)
@@ -268,10 +356,16 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 				writeManifestBool(&b, value.Bool)
 			case ColumnStoreValueInt64:
 				writeManifestUint64(&b, uint64(value.Int64))
+			case ColumnStoreValueFloat32:
+				writeManifestUint32(&b, math.Float32bits(value.Float32))
 			case ColumnStoreValueDouble:
 				writeManifestUint64(&b, math.Float64bits(value.Double))
 			case ColumnStoreValueString:
 				writeManifestString(&b, value.String)
+			case ColumnStoreValueFloat32Vector:
+				writeManifestFloat32Slice(&b, value.Float32Vector)
+			case ColumnStoreValueAdjacencyList:
+				writeManifestUint32Slice(&b, value.AdjacencyList)
 			default:
 				return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: unsupported column physical value type %q", value.Type)
 			}
@@ -326,6 +420,13 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 			Nullable:   cur.bool(),
 			Dictionary: cur.bool(),
 		}
+		if version >= columnPhysicalAssetVersion {
+			vectorDims := cur.u64()
+			if vectorDims > uint64(maxCollectionInt) {
+				return columnPhysicalAsset{}, errors.New("collections: column physical asset vector_dims overflow int")
+			}
+			asset.Columns[i].VectorDims = int(vectorDims)
+		}
 	}
 	for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
 		row := columnDeclaredRow{
@@ -341,7 +442,7 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 					Type: ColumnStoreValueType(cur.string()),
 					Null: cur.bool(),
 				}
-				if version >= columnPhysicalAssetVersion {
+				if version >= columnPhysicalAssetVersionV3 {
 					value.Present = cur.bool()
 				} else {
 					value.Present = true
@@ -359,10 +460,16 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 						value.Bool = cur.bool()
 					case ColumnStoreValueInt64:
 						value.Int64 = int64(cur.u64())
+					case ColumnStoreValueFloat32:
+						value.Float32 = math.Float32frombits(cur.u32())
 					case ColumnStoreValueDouble:
 						value.Double = math.Float64frombits(cur.u64())
 					case ColumnStoreValueString:
 						value.String = cur.string()
+					case ColumnStoreValueFloat32Vector:
+						value.Float32Vector = cur.float32Slice()
+					case ColumnStoreValueAdjacencyList:
+						value.AdjacencyList = cur.uint32Slice()
 					default:
 						return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical value type %q", value.Type)
 					}
@@ -457,6 +564,21 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 			if value.Null && !cfg.Columns[colIdx].Nullable {
 				return fmt.Errorf("collections: column physical asset row[%d] column[%d] is null but column is not nullable", rowIdx, colIdx)
 			}
+			if !value.Null && value.Present {
+				if err := validateColumnDeclaredPhysicalValueShape(cfg.Columns[colIdx], value); err != nil {
+					return fmt.Errorf("collections: column physical asset row[%d] column[%d]: %w", rowIdx, colIdx, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateColumnDeclaredPhysicalValueShape(col ColumnStoreColumn, value columnDeclaredValue) error {
+	switch col.ValueType {
+	case ColumnStoreValueFloat32Vector:
+		if len(value.Float32Vector) != col.VectorDims {
+			return fmt.Errorf("float32_vector length=%d want dims=%d", len(value.Float32Vector), col.VectorDims)
 		}
 	}
 	return nil
@@ -464,7 +586,7 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 
 func isSupportedColumnPhysicalAssetVersion(version uint16) bool {
 	switch version {
-	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersion:
+	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersion:
 		return true
 	default:
 		return false
@@ -495,6 +617,24 @@ func writeManifestBool(b *bytes.Buffer, value bool) {
 func writeManifestBytes(b *bytes.Buffer, value []byte) {
 	writeManifestUint64(b, uint64(len(value)))
 	_, _ = b.Write(value)
+}
+
+func writeManifestFloat32Slice(b *bytes.Buffer, values []float32) {
+	writeManifestUint64(b, uint64(len(values)))
+	var raw [4]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint32(raw[:], math.Float32bits(value))
+		_, _ = b.Write(raw[:])
+	}
+}
+
+func writeManifestUint32Slice(b *bytes.Buffer, values []uint32) {
+	writeManifestUint64(b, uint64(len(values)))
+	var raw [4]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint32(raw[:], value)
+		_, _ = b.Write(raw[:])
+	}
 }
 
 func (c *manifestCursor) bool() bool {
@@ -533,4 +673,48 @@ func (c *manifestCursor) bytesView() []byte {
 	value := c.raw[c.pos : c.pos+int(n)]
 	c.pos += int(n)
 	return value
+}
+
+func (c *manifestCursor) float32Slice() []float32 {
+	n := c.u64()
+	if c.err != nil {
+		return nil
+	}
+	if n > uint64(maxCollectionInt) {
+		c.err = errors.New("collections: column float32 slice length overflows int")
+		return nil
+	}
+	values := make([]float32, int(n))
+	for i := range values {
+		values[i] = math.Float32frombits(c.u32())
+	}
+	return values
+}
+
+func (c *manifestCursor) uint32Slice() []uint32 {
+	n := c.u64()
+	if c.err != nil {
+		return nil
+	}
+	if n > uint64(maxCollectionInt) {
+		c.err = errors.New("collections: column uint32 slice length overflows int")
+		return nil
+	}
+	values := make([]uint32, int(n))
+	for i := range values {
+		values[i] = c.u32()
+	}
+	return values
+}
+
+func (c *manifestCursor) skipUint32Slice() {
+	n := c.u64()
+	if c.err != nil {
+		return
+	}
+	if n > uint64((len(c.raw)-c.pos)/4) {
+		c.err = errors.New("collections: short column uint32 slice")
+		return
+	}
+	c.pos += int(n) * 4
 }

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -19,7 +19,8 @@ const (
 	columnPhysicalAssetVersionV1 = uint16(1)
 	columnPhysicalAssetVersionV2 = uint16(2)
 	columnPhysicalAssetVersionV3 = uint16(3)
-	columnPhysicalAssetVersion   = uint16(4)
+	columnPhysicalAssetVersionV4 = uint16(4)
+	columnPhysicalAssetVersion   = columnPhysicalAssetVersionV4
 )
 
 var ErrColumnDeclaredValueUnsupported = errors.New("collections: unsupported column declared value")
@@ -420,7 +421,7 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 			Nullable:   cur.bool(),
 			Dictionary: cur.bool(),
 		}
-		if version >= columnPhysicalAssetVersion {
+		if version >= columnPhysicalAssetVersionV4 {
 			vectorDims := cur.u64()
 			if vectorDims > uint64(maxCollectionInt) {
 				return columnPhysicalAsset{}, errors.New("collections: column physical asset vector_dims overflow int")
@@ -684,6 +685,10 @@ func (c *manifestCursor) float32Slice() []float32 {
 		c.err = errors.New("collections: column float32 slice length overflows int")
 		return nil
 	}
+	if n > uint64((len(c.raw)-c.pos)/4) {
+		c.err = errors.New("collections: short column float32 slice")
+		return nil
+	}
 	values := make([]float32, int(n))
 	for i := range values {
 		values[i] = math.Float32frombits(c.u32())
@@ -698,6 +703,10 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 	}
 	if n > uint64(maxCollectionInt) {
 		c.err = errors.New("collections: column uint32 slice length overflows int")
+		return nil
+	}
+	if n > uint64((len(c.raw)-c.pos)/4) {
+		c.err = errors.New("collections: short column uint32 slice")
 		return nil
 	}
 	values := make([]uint32, int(n))

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -716,14 +716,15 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 	return values
 }
 
-func (c *manifestCursor) skipUint32Slice() {
+func (c *manifestCursor) skipUint32Slice() uint64 {
 	n := c.u64()
 	if c.err != nil {
-		return
+		return 0
 	}
 	if n > uint64((len(c.raw)-c.pos)/4) {
 		c.err = errors.New("collections: short column uint32 slice")
-		return
+		return 0
 	}
 	c.pos += int(n) * 4
+	return n
 }

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -256,6 +256,42 @@ func TestColumnPhysicalAssetVectorValueTypesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEncodeColumnPhysicalAssetRejectsMismatchedVectorLength(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+			{Name: "embedding_neighbors", Path: "embedding_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	_, _, err = encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "vectors",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        2,
+		PartID:            1,
+		AppliedCommandLSN: 9,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows: []columnDeclaredRow{{
+			ID: []byte("v1"),
+			Values: []columnDeclaredValue{
+				{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{1, 2}},
+				{Type: ColumnStoreValueFloat32, Present: true, Float32: 0.5},
+				{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: []uint32{7, 11}},
+			},
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "row[0] column[0]: float32_vector length=2 want dims=3") {
+		t.Fatalf("encodeColumnPhysicalAsset err=%v want vector length mismatch", err)
+	}
+}
+
 func TestManifestCursorVectorSlicesRejectShortPayload(t *testing.T) {
 	t.Run("float32", func(t *testing.T) {
 		var raw bytes.Buffer
@@ -279,6 +315,17 @@ func TestManifestCursorVectorSlicesRejectShortPayload(t *testing.T) {
 		}
 		if cur.err == nil || !strings.Contains(cur.err.Error(), "short column uint32 slice") {
 			t.Fatalf("uint32Slice err=%v want short payload", cur.err)
+		}
+	})
+	t.Run("float32_expected_length_mismatch", func(t *testing.T) {
+		var raw bytes.Buffer
+		writeManifestUint64(&raw, uint64(maxCollectionInt))
+		cur := manifestCursor{raw: raw.Bytes()}
+		if got := cur.float32SliceWithExpectedLength(3); got != nil {
+			t.Fatalf("float32SliceWithExpectedLength=%v want nil", got)
+		}
+		if cur.err == nil || !strings.Contains(cur.err.Error(), "want 3") {
+			t.Fatalf("float32SliceWithExpectedLength err=%v want length mismatch", cur.err)
 		}
 	})
 }
@@ -346,6 +393,73 @@ func TestColumnPhysicalAssetScannerRejectsMismatchedUnprojectedVectorLength(t *t
 		return nil
 	})
 	if err == nil || !strings.Contains(err.Error(), "float32_vector length=2 want vector_dims=3") {
+		t.Fatalf("scanColumnPhysicalAssetRows err=%v want vector length mismatch", err)
+	}
+}
+
+func TestColumnPhysicalAssetScannerRejectsMismatchedProjectedVectorLength(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "score", Path: "score", ValueType: ColumnStoreValueFloat32},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+
+	var raw bytes.Buffer
+	writeManifestUint32(&raw, columnPhysicalAssetMagic)
+	writeManifestUint16(&raw, columnPhysicalAssetVersion)
+	writeManifestString(&raw, "vectors")
+	writeManifestString(&raw, normalized.AssetManager.Namespace)
+	writeManifestUint64(&raw, 2)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 9)
+	writeManifestString(&raw, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&raw, normalized.SchemaHash)
+	writeManifestUint64(&raw, uint64(len(normalized.Columns)))
+	writeManifestUint64(&raw, 1)
+	for _, col := range normalized.Columns {
+		writeManifestString(&raw, col.Name)
+		writeManifestString(&raw, col.Path)
+		writeManifestString(&raw, string(col.ValueType))
+		writeManifestBool(&raw, col.Nullable)
+		writeManifestBool(&raw, col.Dictionary)
+		writeManifestUint64(&raw, uint64(col.VectorDims))
+	}
+	writeManifestBytes(&raw, []byte("v1"))
+	writeManifestBool(&raw, false)
+	writeManifestString(&raw, string(ColumnStoreValueFloat32Vector))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestFloat32Slice(&raw, []float32{1, 2})
+	writeManifestString(&raw, string(ColumnStoreValueFloat32))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestUint32(&raw, math.Float32bits(0.5))
+
+	encoded := raw.Bytes()
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 2,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"embedding"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
+		t.Fatalf("visitor should not run for mismatched vector length: %+v", row)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "column float32 slice length=2 want 3") {
 		t.Fatalf("scanColumnPhysicalAssetRows err=%v want vector length mismatch", err)
 	}
 }
@@ -555,7 +669,7 @@ func TestColumnPhysicalAssetRejectsNonNullableNullM12A(t *testing.T) {
 	}
 	rows[0].Values[0].Null = true
 	rows[0].Values[0].Int64 = 0
-	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+	_, _, err = encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
 		Collection:        "events",
 		Namespace:         normalized.AssetManager.Namespace,
 		Generation:        7,
@@ -566,21 +680,8 @@ func TestColumnPhysicalAssetRejectsNonNullableNullM12A(t *testing.T) {
 		Columns:           normalized.Columns,
 		Rows:              rows,
 	})
-	if err != nil {
-		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
-	}
-	ref := ColumnAssetRef{
-		Kind:       ColumnAssetKindTCS1PartImage,
-		Namespace:  normalized.AssetManager.Namespace,
-		Generation: 7,
-		PartID:     3,
-		FileID:     1,
-		Offset:     0,
-		Length:     int64(len(encoded)),
-		Checksum:   page.Checksum(encoded),
-	}
-	if err := validateColumnPhysicalAssetForManifest(encoded, ref, *normalized); err == nil || !strings.Contains(err.Error(), "not nullable") {
-		t.Fatalf("validate nullable violation err=%v want not nullable failure", err)
+	if err == nil || !strings.Contains(err.Error(), "not nullable") {
+		t.Fatalf("encodeColumnPhysicalAsset err=%v want not nullable failure", err)
 	}
 }
 

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -256,6 +256,33 @@ func TestColumnPhysicalAssetVectorValueTypesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestManifestCursorVectorSlicesRejectShortPayload(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		var raw bytes.Buffer
+		writeManifestUint64(&raw, 2)
+		raw.Write([]byte{0, 0, 0, 0})
+		cur := manifestCursor{raw: raw.Bytes()}
+		if got := cur.float32Slice(); got != nil {
+			t.Fatalf("float32Slice=%v want nil", got)
+		}
+		if cur.err == nil || !strings.Contains(cur.err.Error(), "short column float32 slice") {
+			t.Fatalf("float32Slice err=%v want short payload", cur.err)
+		}
+	})
+	t.Run("uint32", func(t *testing.T) {
+		var raw bytes.Buffer
+		writeManifestUint64(&raw, 2)
+		raw.Write([]byte{0, 0, 0, 0})
+		cur := manifestCursor{raw: raw.Bytes()}
+		if got := cur.uint32Slice(); got != nil {
+			t.Fatalf("uint32Slice=%v want nil", got)
+		}
+		if cur.err == nil || !strings.Contains(cur.err.Error(), "short column uint32 slice") {
+			t.Fatalf("uint32Slice err=%v want short payload", cur.err)
+		}
+	})
+}
+
 func TestColumnPhysicalAssetDecodeV1CompatibilityM12C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -292,6 +292,38 @@ func TestEncodeColumnPhysicalAssetRejectsMismatchedVectorLength(t *testing.T) {
 	}
 }
 
+func TestDecodeColumnPhysicalAssetRejectsMismatchedVectorLength(t *testing.T) {
+	var raw bytes.Buffer
+	writeManifestUint32(&raw, columnPhysicalAssetMagic)
+	writeManifestUint16(&raw, columnPhysicalAssetVersion)
+	writeManifestString(&raw, "vectors")
+	writeManifestString(&raw, "vectors/column-assets")
+	writeManifestUint64(&raw, 2)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 9)
+	writeManifestString(&raw, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&raw, 123)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 1)
+	writeManifestString(&raw, "embedding")
+	writeManifestString(&raw, "embedding")
+	writeManifestString(&raw, string(ColumnStoreValueFloat32Vector))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, false)
+	writeManifestUint64(&raw, 3)
+	writeManifestBytes(&raw, []byte("v1"))
+	writeManifestBool(&raw, false)
+	writeManifestString(&raw, string(ColumnStoreValueFloat32Vector))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestFloat32Slice(&raw, []float32{1, 2})
+
+	_, err := decodeColumnPhysicalAsset(raw.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "column float32 slice length=2 want 3") {
+		t.Fatalf("decodeColumnPhysicalAsset err=%v want vector length mismatch", err)
+	}
+}
+
 func TestManifestCursorVectorSlicesRejectShortPayload(t *testing.T) {
 	t.Run("float32", func(t *testing.T) {
 		var raw bytes.Buffer

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -157,6 +157,105 @@ func TestColumnPhysicalAssetCodecRoundTripM12A(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetVectorValueTypesRoundTrip(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+			{Name: "embedding_neighbors", Path: "embedding_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	rows, err := extractColumnDeclaredRowsFromJSONDocuments(*normalized, []columnWriteDocument{{
+		ID:       []byte("v1"),
+		Document: []byte(`{"embedding":[1.0,0.5,-0.25],"embedding_inv_norm":0.87287156,"embedding_neighbors":[7,11,13,17]}`),
+	}})
+	if err != nil {
+		t.Fatalf("extractColumnDeclaredRowsFromJSONDocuments: %v", err)
+	}
+	if got := rows[0].Values[0].Float32Vector; len(got) != 3 || got[0] != 1 || got[1] != 0.5 || got[2] != -0.25 {
+		t.Fatalf("extracted vector=%v", got)
+	}
+	if got := rows[0].Values[1].Float32; math.Abs(float64(got-0.87287156)) > 1e-7 {
+		t.Fatalf("extracted inv_norm=%g", got)
+	}
+	if got := rows[0].Values[2].AdjacencyList; len(got) != 4 || got[0] != 7 || got[3] != 17 {
+		t.Fatalf("extracted adjacency=%v", got)
+	}
+
+	encoded, summary, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "vectors",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        2,
+		PartID:            1,
+		AppliedCommandLSN: 9,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows:              rows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
+	}
+	if summary.RowCount != 1 || summary.ColumnCount != 3 || summary.PayloadBytes != int64(len(encoded)) {
+		t.Fatalf("unexpected summary=%+v len=%d", summary, len(encoded))
+	}
+	decoded, err := decodeColumnPhysicalAsset(encoded)
+	if err != nil {
+		t.Fatalf("decodeColumnPhysicalAsset: %v", err)
+	}
+	if got := decoded.Columns[0].VectorDims; got != 3 {
+		t.Fatalf("decoded vector_dims=%d want 3", got)
+	}
+	if got := decoded.Rows[0].Values[0].Float32Vector; len(got) != 3 || got[2] != -0.25 {
+		t.Fatalf("decoded vector=%v", got)
+	}
+	if got := decoded.Rows[0].Values[2].AdjacencyList; len(got) != 4 || got[1] != 11 {
+		t.Fatalf("decoded adjacency=%v", got)
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 2,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	if err := validateColumnPhysicalAssetForManifest(encoded, ref, *normalized); err != nil {
+		t.Fatalf("validateColumnPhysicalAssetForManifest: %v", err)
+	}
+
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"embedding", "embedding_inv_norm", "embedding_neighbors"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	visited := 0
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
+		visited++
+		if got := row.Values[0].Float32Vector; len(got) != 3 || got[0] != 1 || got[2] != -0.25 {
+			t.Fatalf("scanned vector=%v", got)
+		}
+		if got := row.Values[1].Float32; math.Abs(float64(got-0.87287156)) > 1e-7 {
+			t.Fatalf("scanned inv_norm=%g", got)
+		}
+		if got := row.Values[2].AdjacencyList; len(got) != 4 || got[3] != 17 {
+			t.Fatalf("scanned adjacency=%v", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalAssetRows: %v", err)
+	}
+	if visited != 1 {
+		t.Fatalf("visited=%d want 1", visited)
+	}
+}
+
 func TestColumnPhysicalAssetDecodeV1CompatibilityM12C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)
@@ -253,6 +352,7 @@ func TestColumnPhysicalAssetRejectsUnsupportedOperationEmptyRowsM12C(t *testing.
 		writeManifestString(&raw, string(col.ValueType))
 		writeManifestBool(&raw, col.Nullable)
 		writeManifestBool(&raw, col.Dictionary)
+		writeManifestUint64(&raw, uint64(col.VectorDims))
 	}
 	encoded := raw.Bytes()
 	ref := ColumnAssetRef{

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -283,6 +283,73 @@ func TestManifestCursorVectorSlicesRejectShortPayload(t *testing.T) {
 	})
 }
 
+func TestColumnPhysicalAssetScannerRejectsMismatchedUnprojectedVectorLength(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "score", Path: "score", ValueType: ColumnStoreValueFloat32},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+
+	var raw bytes.Buffer
+	writeManifestUint32(&raw, columnPhysicalAssetMagic)
+	writeManifestUint16(&raw, columnPhysicalAssetVersion)
+	writeManifestString(&raw, "vectors")
+	writeManifestString(&raw, normalized.AssetManager.Namespace)
+	writeManifestUint64(&raw, 2)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 9)
+	writeManifestString(&raw, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&raw, normalized.SchemaHash)
+	writeManifestUint64(&raw, uint64(len(normalized.Columns)))
+	writeManifestUint64(&raw, 1)
+	for _, col := range normalized.Columns {
+		writeManifestString(&raw, col.Name)
+		writeManifestString(&raw, col.Path)
+		writeManifestString(&raw, string(col.ValueType))
+		writeManifestBool(&raw, col.Nullable)
+		writeManifestBool(&raw, col.Dictionary)
+		writeManifestUint64(&raw, uint64(col.VectorDims))
+	}
+	writeManifestBytes(&raw, []byte("v1"))
+	writeManifestBool(&raw, false)
+	writeManifestString(&raw, string(ColumnStoreValueFloat32Vector))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestFloat32Slice(&raw, []float32{1, 2})
+	writeManifestString(&raw, string(ColumnStoreValueFloat32))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestUint32(&raw, math.Float32bits(0.5))
+
+	encoded := raw.Bytes()
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 2,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"score"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
+		t.Fatalf("visitor should not run for mismatched vector length: %+v", row)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "float32_vector length=2 want vector_dims=3") {
+		t.Fatalf("scanColumnPhysicalAssetRows err=%v want vector length mismatch", err)
+	}
+}
+
 func TestColumnPhysicalAssetDecodeV1CompatibilityM12C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -857,6 +857,14 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 		valueType := cur.stringBytes()
 		nullable := cur.bool()
 		dictionary := cur.bool()
+		vectorDims := 0
+		if version >= columnPhysicalAssetVersion {
+			rawVectorDims := cur.u64()
+			if rawVectorDims > uint64(maxCollectionInt) {
+				return columnPhysicalAssetScanSummary{}, errors.New("column physical asset vector_dims overflow int")
+			}
+			vectorDims = int(rawVectorDims)
+		}
 		if cur.err != nil {
 			return columnPhysicalAssetScanSummary{}, cur.err
 		}
@@ -865,9 +873,10 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 			!columnPhysicalBytesEqualString(path, want.Path) ||
 			!columnPhysicalBytesEqualString(valueType, string(want.ValueType)) ||
 			nullable != want.Nullable ||
-			dictionary != want.Dictionary {
-			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t} want %+v",
-				colIdx, string(name), string(path), string(valueType), nullable, dictionary, want)
+			dictionary != want.Dictionary ||
+			vectorDims != want.VectorDims {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t VectorDims:%d} want %+v",
+				colIdx, string(name), string(path), string(valueType), nullable, dictionary, vectorDims, want)
 		}
 	}
 	valuesBuf := projection.values
@@ -978,7 +987,7 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			return cur.err
 		}
 		present := true
-		if version >= columnPhysicalAssetVersion {
+		if version >= columnPhysicalAssetVersionV3 {
 			present = cur.bool()
 			if cur.err != nil {
 				return cur.err
@@ -1019,6 +1028,11 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			if selected {
 				rowValues[outputIdx].Int64 = value
 			}
+		case ColumnStoreValueFloat32:
+			value := math.Float32frombits(cur.u32())
+			if selected {
+				rowValues[outputIdx].Float32 = value
+			}
 		case ColumnStoreValueDouble:
 			value := math.Float64frombits(cur.u64())
 			if selected {
@@ -1029,6 +1043,18 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 				rowValues[outputIdx].StringBytes = cur.stringBytes()
 			} else {
 				_ = cur.stringBytes()
+			}
+		case ColumnStoreValueFloat32Vector:
+			if selected {
+				rowValues[outputIdx].Float32Vector = cur.float32Slice()
+			} else {
+				cur.skipUint32Slice()
+			}
+		case ColumnStoreValueAdjacencyList:
+			if selected {
+				rowValues[outputIdx].AdjacencyList = cur.uint32Slice()
+			} else {
+				cur.skipUint32Slice()
 			}
 		default:
 			return fmt.Errorf("unsupported column physical value type %q", col.ValueType)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1046,9 +1046,22 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			}
 		case ColumnStoreValueFloat32Vector:
 			if selected {
-				rowValues[outputIdx].Float32Vector = cur.float32Slice()
+				value := cur.float32Slice()
+				if cur.err != nil {
+					return cur.err
+				}
+				if len(value) != col.VectorDims {
+					return fmt.Errorf("column[%d] float32_vector length=%d want vector_dims=%d", colIdx, len(value), col.VectorDims)
+				}
+				rowValues[outputIdx].Float32Vector = value
 			} else {
-				cur.skipUint32Slice()
+				n := cur.skipUint32Slice()
+				if cur.err != nil {
+					return cur.err
+				}
+				if n != uint64(col.VectorDims) {
+					return fmt.Errorf("column[%d] float32_vector length=%d want vector_dims=%d", colIdx, n, col.VectorDims)
+				}
 			}
 		case ColumnStoreValueAdjacencyList:
 			if selected {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1063,8 +1063,14 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 		case ColumnStoreValueAdjacencyList:
 			if selected {
 				rowValues[outputIdx].AdjacencyList = cur.uint32Slice()
+				if cur.err != nil {
+					return cur.err
+				}
 			} else {
 				cur.skipUint32Slice()
+				if cur.err != nil {
+					return cur.err
+				}
 			}
 		default:
 			return fmt.Errorf("unsupported column physical value type %q", col.ValueType)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1046,12 +1046,9 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			}
 		case ColumnStoreValueFloat32Vector:
 			if selected {
-				value := cur.float32Slice()
+				value := cur.float32SliceWithExpectedLength(col.VectorDims)
 				if cur.err != nil {
 					return cur.err
-				}
-				if len(value) != col.VectorDims {
-					return fmt.Errorf("column[%d] float32_vector length=%d want vector_dims=%d", colIdx, len(value), col.VectorDims)
 				}
 				rowValues[outputIdx].Float32Vector = value
 			} else {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -858,7 +858,7 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 		nullable := cur.bool()
 		dictionary := cur.bool()
 		vectorDims := 0
-		if version >= columnPhysicalAssetVersion {
+		if version >= columnPhysicalAssetVersionV4 {
 			rawVectorDims := cur.u64()
 			if rawVectorDims > uint64(maxCollectionInt) {
 				return columnPhysicalAssetScanSummary{}, errors.New("column physical asset vector_dims overflow int")

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -283,6 +283,8 @@ func columnDeclaredValueToJSON(value columnDeclaredValue) (any, error) {
 		return value.Bool, nil
 	case ColumnStoreValueInt64:
 		return value.Int64, nil
+	case ColumnStoreValueFloat32:
+		return value.Float32, nil
 	case ColumnStoreValueDouble:
 		return value.Double, nil
 	case ColumnStoreValueString:
@@ -290,6 +292,10 @@ func columnDeclaredValueToJSON(value columnDeclaredValue) (any, error) {
 			return string(value.StringBytes), nil
 		}
 		return value.String, nil
+	case ColumnStoreValueFloat32Vector:
+		return append([]float32(nil), value.Float32Vector...), nil
+	case ColumnStoreValueAdjacencyList:
+		return append([]uint32(nil), value.AdjacencyList...), nil
 	default:
 		return nil, fmt.Errorf("unsupported declared value type %q", value.Type)
 	}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -51,10 +51,13 @@ var (
 type ColumnStoreValueType string
 
 const (
-	ColumnStoreValueBool   ColumnStoreValueType = "bool"
-	ColumnStoreValueInt64  ColumnStoreValueType = "int64"
-	ColumnStoreValueDouble ColumnStoreValueType = "double"
-	ColumnStoreValueString ColumnStoreValueType = "string"
+	ColumnStoreValueBool          ColumnStoreValueType = "bool"
+	ColumnStoreValueInt64         ColumnStoreValueType = "int64"
+	ColumnStoreValueFloat32       ColumnStoreValueType = "float32"
+	ColumnStoreValueDouble        ColumnStoreValueType = "double"
+	ColumnStoreValueString        ColumnStoreValueType = "string"
+	ColumnStoreValueFloat32Vector ColumnStoreValueType = "float32_vector"
+	ColumnStoreValueAdjacencyList ColumnStoreValueType = "adjacency_list"
 )
 
 type ColumnSortDirection string
@@ -141,6 +144,7 @@ type ColumnStoreColumn struct {
 	ValueType  ColumnStoreValueType `json:"value_type"`
 	Nullable   bool                 `json:"nullable,omitempty"`
 	Dictionary bool                 `json:"dictionary,omitempty"`
+	VectorDims int                  `json:"vector_dims,omitempty"`
 }
 
 type ColumnSortKey struct {
@@ -377,6 +381,7 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		return nil
 	}
 	columnNames := make(map[string]struct{}, len(cfg.Columns))
+	columnTypes := make(map[string]ColumnStoreValueType, len(cfg.Columns))
 	columnPaths := make(map[string]struct{}, len(cfg.Columns))
 	for i := range cfg.Columns {
 		col := cfg.Columns[i]
@@ -386,8 +391,19 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		if err := ValidateIndexPath(col.Path); err != nil {
 			return fmt.Errorf("collections: invalid column %q path: %w", col.Name, err)
 		}
-		if _, err := normalizeColumnStoreValueType(col.ValueType); err != nil {
+		valueType, err := normalizeColumnStoreValueType(col.ValueType)
+		if err != nil {
 			return fmt.Errorf("collections: invalid column %q value_type: %w", col.Name, err)
+		}
+		if valueType == ColumnStoreValueFloat32Vector {
+			if col.VectorDims <= 0 {
+				return fmt.Errorf("collections: invalid column %q vector_dims: must be positive", col.Name)
+			}
+		} else if col.VectorDims != 0 {
+			return fmt.Errorf("collections: invalid column %q vector_dims: only float32_vector columns may set vector_dims", col.Name)
+		}
+		if col.Dictionary && !columnStoreValueTypeSupportsDictionary(valueType) {
+			return fmt.Errorf("collections: invalid column %q dictionary: unsupported for value_type %q", col.Name, valueType)
 		}
 		if _, ok := columnNames[col.Name]; ok {
 			return fmt.Errorf("collections: duplicate column %q", col.Name)
@@ -396,11 +412,15 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 			return fmt.Errorf("collections: duplicate column path %q", col.Path)
 		}
 		columnNames[col.Name] = struct{}{}
+		columnTypes[col.Name] = valueType
 		columnPaths[col.Path] = struct{}{}
 	}
 	for _, sortKey := range cfg.SortKey {
 		if _, ok := columnNames[sortKey.Column]; !ok {
 			return fmt.Errorf("collections: sort key references unknown column %q", sortKey.Column)
+		}
+		if !columnStoreValueTypeSupportsSort(columnTypes[sortKey.Column]) {
+			return fmt.Errorf("collections: sort key column %q value_type %q is not orderable", sortKey.Column, columnTypes[sortKey.Column])
 		}
 		switch sortKey.Direction {
 		case ColumnSortAscending, ColumnSortDescending:
@@ -420,6 +440,9 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		}
 		if err := validateColumnAggregateKind(aggregate.Kind, aggregate.Column); err != nil {
 			return fmt.Errorf("collections: invalid aggregate metadata %q: %w", aggregate.Name, err)
+		}
+		if aggregate.Column != "" && !columnStoreValueTypeSupportsAggregate(columnTypes[aggregate.Column], aggregate.Kind) {
+			return fmt.Errorf("collections: aggregate metadata %q kind %q does not support value_type %q", aggregate.Name, aggregate.Kind, columnTypes[aggregate.Column])
 		}
 		if _, ok := aggregateNames[aggregate.Name]; ok {
 			return fmt.Errorf("collections: duplicate aggregate metadata %q", aggregate.Name)
@@ -505,12 +528,37 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 
 func normalizeColumnStoreValueType(valueType ColumnStoreValueType) (ColumnStoreValueType, error) {
 	switch valueType {
-	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueDouble, ColumnStoreValueString:
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString, ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
 		return valueType, nil
 	case "":
 		return "", errors.New("value_type is required")
 	default:
 		return "", fmt.Errorf("unsupported value_type %q", valueType)
+	}
+}
+
+func columnStoreValueTypeSupportsDictionary(valueType ColumnStoreValueType) bool {
+	return valueType == ColumnStoreValueString
+}
+
+func columnStoreValueTypeSupportsSort(valueType ColumnStoreValueType) bool {
+	switch valueType {
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
+		return true
+	default:
+		return false
+	}
+}
+
+func columnStoreValueTypeSupportsAggregate(valueType ColumnStoreValueType, kind ColumnAggregateKind) bool {
+	if kind == ColumnAggregateCount {
+		return true
+	}
+	switch valueType {
+	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -814,6 +862,7 @@ func hashColumnStoreSchema(cfg *ColumnStoreConfig) uint64 {
 		writeHashString(&d, string(col.ValueType))
 		writeHashBool(&d, col.Nullable)
 		writeHashBool(&d, col.Dictionary)
+		writeHashInt(&d, col.VectorDims)
 	}
 	for _, sortKey := range cfg.SortKey {
 		writeHashString(&d, sortKey.Column)
@@ -860,6 +909,12 @@ func writeHashBool(d *xxhash.Digest, value bool) {
 	if value {
 		b[0] = 1
 	}
+	_, _ = d.Write(b[:])
+}
+
+func writeHashInt(d *xxhash.Digest, value int) {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(value))
 	_, _ = d.Write(b[:])
 }
 

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -554,12 +554,25 @@ func columnStoreValueTypeSupportsSort(valueType ColumnStoreValueType) bool {
 }
 
 func columnStoreValueTypeSupportsAggregate(valueType ColumnStoreValueType, kind ColumnAggregateKind) bool {
-	if kind == ColumnAggregateCount {
+	switch kind {
+	case ColumnAggregateCount:
 		return true
-	}
-	switch valueType {
-	case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
-		return true
+	case ColumnAggregateMin, ColumnAggregateMax:
+		return columnStoreValueTypeSupportsSort(valueType)
+	case ColumnAggregateSum:
+		switch valueType {
+		case ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble:
+			return true
+		default:
+			return false
+		}
+	case ColumnAggregateCountDistinct:
+		switch valueType {
+		case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
+			return true
+		default:
+			return false
+		}
 	default:
 		return false
 	}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -433,16 +433,19 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		if err := ValidateIndexName(aggregate.Name); err != nil {
 			return fmt.Errorf("collections: invalid aggregate metadata %q name: %w", aggregate.Name, err)
 		}
+		var columnType ColumnStoreValueType
 		if aggregate.Column != "" {
-			if _, ok := columnNames[aggregate.Column]; !ok {
+			var ok bool
+			columnType, ok = columnTypes[aggregate.Column]
+			if !ok {
 				return fmt.Errorf("collections: aggregate metadata %q references unknown column %q", aggregate.Name, aggregate.Column)
 			}
 		}
 		if err := validateColumnAggregateKind(aggregate.Kind, aggregate.Column); err != nil {
 			return fmt.Errorf("collections: invalid aggregate metadata %q: %w", aggregate.Name, err)
 		}
-		if aggregate.Column != "" && !columnStoreValueTypeSupportsAggregate(columnTypes[aggregate.Column], aggregate.Kind) {
-			return fmt.Errorf("collections: aggregate metadata %q kind %q does not support value_type %q", aggregate.Name, aggregate.Kind, columnTypes[aggregate.Column])
+		if aggregate.Column != "" && !columnStoreValueTypeSupportsAggregate(columnType, aggregate.Kind) {
+			return fmt.Errorf("collections: aggregate metadata %q kind %q does not support value_type %q", aggregate.Name, aggregate.Kind, columnType)
 		}
 		if _, ok := aggregateNames[aggregate.Name]; ok {
 			return fmt.Errorf("collections: duplicate aggregate metadata %q", aggregate.Name)

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -862,7 +862,9 @@ func hashColumnStoreSchema(cfg *ColumnStoreConfig) uint64 {
 		writeHashString(&d, string(col.ValueType))
 		writeHashBool(&d, col.Nullable)
 		writeHashBool(&d, col.Dictionary)
-		writeHashInt(&d, col.VectorDims)
+		if col.ValueType == ColumnStoreValueFloat32Vector {
+			writeHashInt(&d, col.VectorDims)
+		}
 	}
 	for _, sortKey := range cfg.SortKey {
 		writeHashString(&d, sortKey.Column)

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -374,6 +374,24 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			want: "does not support",
 		},
 		{
+			name: "string sum aggregate rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled:           true,
+				Columns:           []ColumnStoreColumn{{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString}},
+				AggregateMetadata: []ColumnAggregateMetadata{{Name: "sum_kind", Column: "kind", Kind: ColumnAggregateSum}},
+			},
+			want: "does not support",
+		},
+		{
+			name: "adjacency count distinct aggregate rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled:           true,
+				Columns:           []ColumnStoreColumn{{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList}},
+				AggregateMetadata: []ColumnAggregateMetadata{{Name: "distinct_neighbors", Column: "neighbors", Kind: ColumnAggregateCountDistinct}},
+			},
+			want: "does not support",
+		},
+		{
 			name: "vector dictionary rejected",
 			cfg: &ColumnStoreConfig{
 				Enabled: true,

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -332,6 +332,64 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			want: "unknown column",
 		},
 		{
+			name: "vector column requires dims",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector}},
+			},
+			want: "vector_dims",
+		},
+		{
+			name: "adjacency column rejects dims",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList, VectorDims: 16}},
+			},
+			want: "only float32_vector columns may set vector_dims",
+		},
+		{
+			name: "float32 column rejects dims",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, VectorDims: 1}},
+			},
+			want: "only float32_vector columns may set vector_dims",
+		},
+		{
+			name: "vector sort key rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128}},
+				SortKey: []ColumnSortKey{{Column: "embedding"}},
+			},
+			want: "not orderable",
+		},
+		{
+			name: "vector aggregate rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled:           true,
+				Columns:           []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128}},
+				AggregateMetadata: []ColumnAggregateMetadata{{Name: "min_embedding", Column: "embedding", Kind: ColumnAggregateMin}},
+			},
+			want: "does not support",
+		},
+		{
+			name: "vector dictionary rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128, Dictionary: true}},
+			},
+			want: "dictionary",
+		},
+		{
+			name: "float32 dictionary rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, Dictionary: true}},
+			},
+			want: "dictionary",
+		},
+		{
 			name: "unsupported locator",
 			cfg: &ColumnStoreConfig{
 				Enabled: true,
@@ -457,6 +515,46 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 				t.Fatalf("normalizeCollectionMeta err=%v want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestColumnStoreVectorMetadataNormalizes(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = append(cfg.Columns,
+		ColumnStoreColumn{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128},
+		ColumnStoreColumn{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+		ColumnStoreColumn{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList},
+	)
+	cfg.SortKey = append(cfg.SortKey, ColumnSortKey{Column: "embedding_inv_norm"})
+	cfg.AggregateMetadata = append(cfg.AggregateMetadata,
+		ColumnAggregateMetadata{Name: "min_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMin},
+		ColumnAggregateMetadata{Name: "max_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMax},
+	)
+	meta, err := normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}})
+	if err != nil {
+		t.Fatalf("normalizeCollectionMeta: %v", err)
+	}
+	if meta.Options.ColumnStore.SchemaHash == 0 {
+		t.Fatal("schema hash was not populated")
+	}
+
+	changed := testColumnStoreConfig(nil)
+	changed.Columns = append(changed.Columns,
+		ColumnStoreColumn{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 256},
+		ColumnStoreColumn{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+		ColumnStoreColumn{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList},
+	)
+	changed.SortKey = append(changed.SortKey, ColumnSortKey{Column: "embedding_inv_norm"})
+	changed.AggregateMetadata = append(changed.AggregateMetadata,
+		ColumnAggregateMetadata{Name: "min_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMin},
+		ColumnAggregateMetadata{Name: "max_embedding_inv_norm", Column: "embedding_inv_norm", Kind: ColumnAggregateMax},
+	)
+	changedMeta, err := normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: changed}})
+	if err != nil {
+		t.Fatalf("normalizeCollectionMeta changed: %v", err)
+	}
+	if changedMeta.Options.ColumnStore.SchemaHash == meta.Options.ColumnStore.SchemaHash {
+		t.Fatalf("schema hash did not include vector dims: %x", meta.Options.ColumnStore.SchemaHash)
 	}
 }
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -476,7 +476,7 @@ bool     Dictionary
 u64      VectorDims         // non-zero only for float32_vector
 ```
 
-Version 4 row values are:
+Within each non-deleted version 4 row, every declared column value entry is:
 
 ```text
 string   ValueType

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -497,8 +497,13 @@ u64 + u32[N]     float32_vector bits
 u64 + u32[N]     adjacency_list uint32 ordinals
 ```
 
-Version 3 row values added the `Present` flag but did not encode
-`vector_dims` in column descriptors. Version 2 row values are otherwise:
+Version 3 row value entries added the `Present` flag shown above but did not
+encode `vector_dims` in column descriptors. Version 2 row value entries omitted
+`Present`; every non-deleted declared-column entry was encoded as `ValueType`,
+`Null`, and an optional payload when `Null=false`. Version 4 keeps the version 3
+row value-entry layout and extends each column descriptor with `VectorDims`.
+
+Version 2 and later row records include delete state:
 
 ```text
 bytes    RowID

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -463,7 +463,42 @@ columns  declared column descriptors
 rows     versioned row payloads
 ```
 
-Version 2 row payloads are:
+Version 4 is the current writer format. It extends column descriptors with
+`vector_dims` so `float32_vector` assets can validate fixed-width row values:
+
+```text
+string   ColumnName
+string   ColumnPath
+string   ValueType          // bool, int64, float32, double, string,
+                            // float32_vector, adjacency_list
+bool     Nullable
+bool     Dictionary
+u64      VectorDims         // non-zero only for float32_vector
+```
+
+Version 4 row values are:
+
+```text
+string   ValueType
+bool     Null
+bool     Present            // false represents an omitted nullable JSON path
+payload  omitted when Present=false or Null=true
+```
+
+Payload encodings are:
+
+```text
+bool             bool
+u64              int64 bits
+u32              float32 bits
+u64              float64 bits
+string           string
+u64 + u32[N]     float32_vector bits
+u64 + u32[N]     adjacency_list uint32 ordinals
+```
+
+Version 3 row values added the `Present` flag but did not encode
+`vector_dims` in column descriptors. Version 2 row values are otherwise:
 
 ```text
 bytes    RowID
@@ -485,7 +520,7 @@ values   declared column values
 ```
 
 M12C and later decoders may read version 1 as `Deleted=false` for pre-v2 assets.
-Writers emit version 2.
+Writers emit version 4.
 
 ## 8. Commit-Log Segment Format
 


### PR DESCRIPTION
## Summary

This PR adds the generic physical column value types needed before column-backed vector graph indexes can use the #1621 physical column asset stack:

- `float32` scalar values for inverse norms.
- fixed-dimension `float32_vector` values for vector columns.
- `adjacency_list` values encoded as `uint32` neighbor ordinals.
- physical TCPA encode/decode/scan/reconstruction support for those value types.
- schema validation and storage-format documentation for vector dimensions and adjacency-list restrictions.

This is intentionally not a vector search optimization PR. It does not change graph traversal, ANN construction, reducers, Deep1B benchmarks, or #1634 performance work.

## Assumption Ledger

- V1-final behavior: vector, inverse-norm, and adjacency data must be represented as typed physical column assets reachable through the normal column manifest/root lifecycle.
- Provisional behavior: this PR only adds generic typed physical value support; higher-level `column_graph` index build/load/public search wiring remains in follow-up branches.
- Deliberately unsupported behavior: no new vector-only sidecar persistence, no document-fetching search path changes, no compression/codec/optimizer work, and no #1634 reducer/query performance changes.
- Follow-up issue/PR: the next integration PR should compose this with the existing vector-index stack and `column_graph` contract seam, then load `ColumnVectorGraph` from real published assets.

## Correctness

- Validates `float32_vector` columns require positive `VectorDims` and rejects vector dimensions on non-vector types.
- Keeps vector and adjacency-list columns out of sort/aggregate/dictionary roles that are not physically supported by this typed value shape.
- Includes `VectorDims` in the column schema hash so incompatible vector dimensions cannot silently share schema identity.
- Covers physical asset round-trip scanning/reconstruction for `float32`, `float32_vector`, and `adjacency_list` rows.

## Performance / Benchmark Evidence

Correctness-only branch. No throughput win is claimed and no #1634 optimization candidate is implemented.

Focused validation was run locally against base `codex/colgranule-m15c-column-asset-rewrite` at `1983216c6`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalAssetVectorValueTypesRoundTrip|TestColumnStoreMetadataValidation|TestColumnStoreVectorMetadataNormalizes|TestColumnPhysical' -count=1
# ok  	github.com/snissn/gomap/TreeDB/collections	1.486s

git diff --check origin/codex/colgranule-m15c-column-asset-rewrite...HEAD
# no output
```

## Throughput Interpretation

This PR should be treated as a schema/physical-asset enablement step, not a performance result. Any later vector-search throughput evidence must come from the product path that builds, publishes, reopens, loads, and searches `ColumnVectorGraph` through real column assets.

## Gate Status

- Generic physical value support: implemented.
- Public `column_graph` lifecycle wiring: not included here.
- Vector graph search kernel changes: not included here.
- #1634 optimization work: explicitly out of scope.
- Merge: do not merge until review and CI are green.

## Artifacts

No external benchmark artifacts for this correctness-only branch. CI will provide the pushed-head validation artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added float32 scalar, float32_vector and adjacency_list column types; per-column vector-dimension metadata; writer format advanced to version 4; schema/hash includes vector dims.

* **Bug Fixes**
  * Stronger validation and error reporting: nullable/present consistency, vector-length checks, payload bounds checks, and updated presence semantics for newer assets.

* **Tests**
  * Added round-trip, mismatch, short-payload, and encode-time rejection tests for vectors and adjacency lists.

* **Documentation**
  * Storage-format spec updated to writer version 4 with new encodings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->