### PR TITLE
Decoded comparator: load column_graph indexes from physical assets

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -18246,6 +18246,16 @@ func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, er
 // collection is exhausted, or fn returns false. The returned boolean is true
 // only when additional documents were present beyond the maxDocuments limit.
 func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
+	return c.scanDocumentsFuncWithCatalogResolver(maxDocuments, fn, func(snap *backenddb.Snapshot, _ string) (*collectionCatalog, error) {
+		return c.catalogForSnapshot(snap)
+	})
+}
+
+func (c *Collection) scanDocumentsFuncWithoutColumnRootValidation(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
+	return c.scanDocumentsFuncWithCatalogResolver(maxDocuments, fn, loadCollectionCatalogWithoutColumnRootValidation)
+}
+
+func (c *Collection) scanDocumentsFuncWithCatalogResolver(maxDocuments int, fn func(DocumentRecord) (bool, error), loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) (bool, error) {
 	if c == nil {
 		return false, errCollectionNil
 	}
@@ -18266,7 +18276,13 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 		return false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshot(snap)
+	if loadCatalog == nil {
+		loadCatalog = loadCollectionCatalog
+	}
+	c.catalogMu.RLock()
+	collectionName := c.meta.Name
+	c.catalogMu.RUnlock()
+	catalog, err := loadCatalog(snap, collectionName)
 	if err != nil {
 		return false, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -17217,6 +17217,28 @@ func (c *Collection) StoredDocumentJSON(document []byte) ([]byte, error) {
 // The returned slice is owned by the caller. Missing documents return
 // (dst[:0], false, nil).
 func (c *Collection) GetInto(documentID []byte, dst []byte) ([]byte, bool, error) {
+	return c.getIntoWithCatalogResolver(documentID, dst, func(snap *backenddb.Snapshot, _ string) (*collectionCatalog, error) {
+		return c.catalogForSnapshot(snap)
+	})
+}
+
+func (c *Collection) getWithoutColumnRootValidation(documentID []byte) ([]byte, error) {
+	out, found, err := c.getIntoWithCatalogResolver(documentID, nil, loadCollectionCatalogWithoutColumnRootValidation)
+	if err != nil || !found {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return []byte{}, nil
+	}
+	if cap(out) == len(out) {
+		return out, nil
+	}
+	owned := make([]byte, len(out))
+	copy(owned, out)
+	return owned, nil
+}
+
+func (c *Collection) getIntoWithCatalogResolver(documentID []byte, dst []byte, loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) ([]byte, bool, error) {
 	if c == nil {
 		return dst[:0], false, errCollectionNil
 	}
@@ -17234,7 +17256,13 @@ func (c *Collection) GetInto(documentID []byte, dst []byte) ([]byte, bool, error
 		return dst[:0], false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshot(snap)
+	if loadCatalog == nil {
+		loadCatalog = loadCollectionCatalog
+	}
+	c.catalogMu.RLock()
+	collectionName := c.meta.Name
+	c.catalogMu.RUnlock()
+	catalog, err := loadCatalog(snap, collectionName)
 	if err != nil {
 		return dst[:0], false, err
 	}
@@ -17425,6 +17453,16 @@ func (c *Collection) FindByIndexValueLimit(indexName string, value any, maxResul
 }
 
 func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) ([][]byte, bool, error) {
+	return c.findByIndexRangeWithCatalogResolver(indexName, opts, func(snap *backenddb.Snapshot, _ string) (*collectionCatalog, error) {
+		return c.catalogForSnapshotWithWriteDomainLocked(snap)
+	})
+}
+
+func (c *Collection) findByIndexRangeWithoutColumnRootValidation(indexName string, opts IndexRangeOptions) ([][]byte, bool, error) {
+	return c.findByIndexRangeWithCatalogResolver(indexName, opts, loadCollectionCatalogWithoutColumnRootValidation)
+}
+
+func (c *Collection) findByIndexRangeWithCatalogResolver(indexName string, opts IndexRangeOptions, loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) ([][]byte, bool, error) {
 	if opts.Limit < 0 {
 		return nil, false, errors.New("collections: index range limit cannot be negative")
 	}
@@ -17433,13 +17471,13 @@ func (c *Collection) FindByIndexRange(indexName string, opts IndexRangeOptions) 
 		capHint = opts.Limit
 	}
 	var out [][]byte
-	truncated, found, err := c.scanIndexRange(indexName, opts, func(id []byte) (bool, error) {
+	truncated, found, err := c.scanIndexRangeWithCatalogResolver(indexName, opts, func(id []byte) (bool, error) {
 		if out == nil {
 			out = make([][]byte, 0, capHint)
 		}
 		out = append(out, id)
 		return true, nil
-	})
+	}, loadCatalog)
 	if err != nil {
 		return nil, false, err
 	}
@@ -17699,8 +17737,17 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 }
 
 func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn func(id []byte) (bool, error)) (bool, bool, error) {
+	return c.scanIndexRangeWithCatalogResolver(indexName, opts, fn, func(snap *backenddb.Snapshot, _ string) (*collectionCatalog, error) {
+		return c.catalogForSnapshotWithWriteDomainLocked(snap)
+	})
+}
+
+func (c *Collection) scanIndexRangeWithCatalogResolver(indexName string, opts IndexRangeOptions, fn func(id []byte) (bool, error), loadCatalog func(*backenddb.Snapshot, string) (*collectionCatalog, error)) (bool, bool, error) {
 	if c == nil {
 		return false, false, errCollectionNil
+	}
+	if c.db == nil {
+		return false, false, errCollectionDBNil
 	}
 	if err := ValidateIndexName(indexName); err != nil {
 		return false, false, err
@@ -17730,7 +17777,13 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 		return false, false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshotWithWriteDomainLocked(snap)
+	if loadCatalog == nil {
+		loadCatalog = loadCollectionCatalog
+	}
+	c.catalogMu.RLock()
+	collectionName := c.meta.Name
+	c.catalogMu.RUnlock()
+	catalog, err := loadCatalog(snap, collectionName)
 	if err != nil {
 		return false, false, err
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -101,6 +101,37 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalVisibilityIndexClonesVectorAndAdjacencyValues(t *testing.T) {
+	var idx columnPhysicalVisibilityIndex
+	id := []byte("doc-a")
+	vector := []float32{1, 2, 3}
+	adjacency := []uint32{4, 5, 6}
+	idx.upsert(columnPhysicalScanRowView{
+		Generation: 1,
+		PartID:     1,
+		Operation:  ColumnPublishOperationInsert,
+		ID:         id,
+		Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: vector},
+			{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: adjacency},
+		},
+	})
+
+	id[0] = 'X'
+	vector[0] = 99
+	adjacency[0] = 99
+
+	if got, want := string(idx.rows[0].ID), "doc-a"; got != want {
+		t.Fatalf("visible row id=%q want %q", got, want)
+	}
+	if got, want := idx.rows[0].Values[0].Float32Vector, []float32{1, 2, 3}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("visible vector=%v want %v", got, want)
+	}
+	if got, want := idx.rows[0].Values[1].AdjacencyList, []uint32{4, 5, 6}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("visible adjacency=%v want %v", got, want)
+	}
+}
+
 func TestColumnPhysicalQueryAdapterUsesFloorHourForNegativeTimeUSM13B(t *testing.T) {
 	const hourUS = columnPhysicalQueryHourUS
 	events := []columnPhysicalQueryEventM13B{

--- a/TreeDB/collections/column_physical_visibility.go
+++ b/TreeDB/collections/column_physical_visibility.go
@@ -330,6 +330,12 @@ func cloneColumnDeclaredValuesInto(out []columnDeclaredValue, values []columnDec
 			out[i].String = string(values[i].StringBytes)
 			out[i].StringBytes = nil
 		}
+		if values[i].Float32Vector != nil {
+			out[i].Float32Vector = append([]float32(nil), values[i].Float32Vector...)
+		}
+		if values[i].AdjacencyList != nil {
+			out[i].AdjacencyList = append([]uint32(nil), values[i].AdjacencyList...)
+		}
 	}
 	return out
 }

--- a/TreeDB/collections/column_physical_visibility.go
+++ b/TreeDB/collections/column_physical_visibility.go
@@ -248,6 +248,12 @@ func (idx *columnPhysicalVisibilityIndex) cloneColumnDeclaredValues(values []col
 			out[i].StringBytes = idx.cloneBytes(out[i].StringBytes)
 			out[i].String = ""
 		}
+		if out[i].Float32Vector != nil {
+			out[i].Float32Vector = append([]float32(nil), out[i].Float32Vector...)
+		}
+		if out[i].AdjacencyList != nil {
+			out[i].AdjacencyList = append([]uint32(nil), out[i].AdjacencyList...)
+		}
 	}
 	return out
 }

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -55,6 +55,10 @@ const (
 	vectorIndexFallbackColumnGraphManifestRootMismatch = "column_graph_manifest_root_mismatch"
 	vectorIndexFallbackColumnGraphMetric               = "column_graph_requires_cosine"
 	vectorIndexFallbackColumnGraphEncoding             = "column_graph_requires_float32"
+	vectorIndexFallbackColumnGraphSchema               = "column_graph_physical_schema_mismatch"
+	vectorIndexFallbackColumnGraphVisibility           = "column_graph_requires_insert_only_manifest"
+	vectorIndexFallbackColumnGraphEmpty                = "column_graph_empty"
+	vectorIndexFallbackColumnGraphInvalid              = "column_graph_physical_graph_invalid"
 	vectorIndexFallbackColumnGraphReprobeRequired      = "column_graph_reprobe_outside_native_rebuild"
 	vectorIndexFallbackColumnGraphHandleMissing        = "column_graph_requires_column_graph_handle"
 )

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -116,7 +116,7 @@ func (physicalColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(input Col
 		status.BytesDisk = diag.PhysicalBytesScanned
 		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
 	}
-	graph, err := NewColumnVectorGraphFromColumns(ColumnVectorGraphColumns{
+	graph, graphErr := NewColumnVectorGraphFromColumns(ColumnVectorGraphColumns{
 		DocumentIDs:     state.documentIDs,
 		Vectors:         state.vectors,
 		InvNorms:        state.invNorms,
@@ -126,9 +126,10 @@ func (physicalColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(input Col
 		EntryPoint:      0,
 		EfSearch:        input.Definition.EfSearch,
 	})
-	if err != nil {
+	if graphErr != nil {
 		status = columnGraphPhysicalUnavailableLoadStatus(vectorIndexFallbackColumnGraphInvalid)
 		status.BytesDisk = diag.PhysicalBytesScanned
+		status.ColumnGraphUnavailableDetail = graphErr.Error()
 		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
 	}
 	status.Loaded = true
@@ -371,6 +372,7 @@ func (c *Collection) loadColumnGraphVectorIndexSnapshotFromCatalogWithLoader(sna
 	status.Loaded = true
 	status.ColumnGraphLoaded = true
 	status.ColumnGraphUnavailableReason = ""
+	status.ColumnGraphUnavailableDetail = ""
 	status.ExactFallbackReason = ""
 	status.PhysicalColumnAssetsSupported = true
 	status.RebuildNeeded = false
@@ -439,6 +441,9 @@ func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorInde
 		if update.BytesDisk != 0 {
 			status.BytesDisk = update.BytesDisk
 		}
+		if update.ColumnGraphUnavailableDetail != "" {
+			status.ColumnGraphUnavailableDetail = update.ColumnGraphUnavailableDetail
+		}
 		return
 	}
 	if update.PhysicalColumnAssetsSupported {
@@ -485,6 +490,7 @@ func vectorIndexStatusFromColumnGraphLoad(def VectorIndexDefinition, loadStatus 
 		ExactFallbackReason:           loadStatus.ExactFallbackReason,
 		ColumnGraphLoaded:             loadStatus.ColumnGraphLoaded,
 		ColumnGraphUnavailableReason:  loadStatus.ColumnGraphUnavailableReason,
+		ColumnGraphUnavailableDetail:  loadStatus.ColumnGraphUnavailableDetail,
 		PhysicalColumnAssetsSupported: loadStatus.PhysicalColumnAssetsSupported,
 		RebuildNeeded:                 loadStatus.RebuildNeeded || !loadStatus.ColumnGraphLoaded || loadStatus.ExactFallbackReason != "",
 	}

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -107,6 +107,7 @@ func (physicalColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(input Col
 			}
 			status = columnGraphPhysicalUnavailableLoadStatus(reason)
 			status.BytesDisk = diag.PhysicalBytesScanned
+			status.ColumnGraphUnavailableDetail = state.unavailableDetail
 			return ColumnVectorGraphIndexLoadResult{Status: status}, nil
 		}
 		return ColumnVectorGraphIndexLoadResult{Status: status}, err
@@ -223,6 +224,7 @@ type columnVectorGraphPhysicalLoadState struct {
 	offsets           []uint32
 	neighbors         []uint32
 	unavailableReason string
+	unavailableDetail string
 }
 
 func (s *columnVectorGraphPhysicalLoadState) visit(row columnPhysicalScanRowView) error {
@@ -261,6 +263,9 @@ func (s *columnVectorGraphPhysicalLoadState) visit(row columnPhysicalScanRowView
 func (s *columnVectorGraphPhysicalLoadState) fail(reason string, detail string) error {
 	if s.unavailableReason == "" {
 		s.unavailableReason = reason
+	}
+	if detail != "" && s.unavailableDetail == "" {
+		s.unavailableDetail = detail
 	}
 	if detail == "" {
 		return errColumnVectorGraphPhysicalLoadUnavailable
@@ -441,9 +446,7 @@ func mergeColumnGraphLoadStatus(status *VectorIndexLoadStatus, update VectorInde
 		if update.BytesDisk != 0 {
 			status.BytesDisk = update.BytesDisk
 		}
-		if update.ColumnGraphUnavailableDetail != "" {
-			status.ColumnGraphUnavailableDetail = update.ColumnGraphUnavailableDetail
-		}
+		status.ColumnGraphUnavailableDetail = update.ColumnGraphUnavailableDetail
 		return
 	}
 	if update.PhysicalColumnAssetsSupported {

--- a/TreeDB/collections/vector_index_column_graph.go
+++ b/TreeDB/collections/vector_index_column_graph.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"errors"
+	"fmt"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -38,12 +39,239 @@ func (unsupportedColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(Column
 	}, nil
 }
 
-var defaultColumnVectorGraphIndexLoader ColumnVectorGraphIndexLoader = unsupportedColumnVectorGraphIndexLoader{}
+type physicalColumnVectorGraphIndexLoader struct{}
+
+var errColumnVectorGraphPhysicalLoadUnavailable = errors.New("collections: column graph physical load unavailable")
+
+var defaultColumnVectorGraphIndexLoader ColumnVectorGraphIndexLoader = physicalColumnVectorGraphIndexLoader{}
+
+func (physicalColumnVectorGraphIndexLoader) LoadColumnVectorGraphIndex(input ColumnVectorGraphIndexLoadInput) (ColumnVectorGraphIndexLoadResult, error) {
+	status := VectorIndexLoadStatus{
+		Strategy:                      VectorIndexStrategyColumnGraph,
+		PhysicalColumnAssetsSupported: true,
+		RebuildNeeded:                 true,
+	}
+	if input.Collection == nil {
+		return ColumnVectorGraphIndexLoadResult{Status: status}, errCollectionNil
+	}
+	if input.Snapshot == nil || input.Collection.db == nil {
+		return ColumnVectorGraphIndexLoadResult{Status: status}, errCollectionDBNil
+	}
+	if !input.ColumnStore.Enabled || input.ColumnStore.ActiveManifest == nil {
+		return ColumnVectorGraphIndexLoadResult{Status: columnGraphUnavailableLoadStatus(vectorIndexFallbackColumnGraphPhysicalMissing)}, nil
+	}
+	if input.ColumnStore.PhysicalMutationParts > 0 {
+		status = columnGraphPhysicalUnavailableLoadStatus(vectorIndexFallbackColumnGraphVisibility)
+		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+	}
+	columns, reason := resolveColumnVectorGraphPhysicalColumns(input.Definition, input.ColumnStore)
+	if reason != "" {
+		status = columnGraphPhysicalUnavailableLoadStatus(reason)
+		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+	}
+	catalog, err := loadCollectionCatalogWithoutColumnRootValidation(input.Snapshot, input.Collection.meta.Name)
+	if err != nil {
+		return ColumnVectorGraphIndexLoadResult{Status: status}, err
+	}
+	if catalog == nil {
+		return ColumnVectorGraphIndexLoadResult{Status: status}, errCollectionNotFound
+	}
+	state := columnVectorGraphPhysicalLoadState{
+		dimensions: input.Definition.Dimensions,
+		offsets:    []uint32{0},
+	}
+	diag, err := input.Collection.scanColumnPhysicalRowsAtSnapshot(
+		input.Snapshot,
+		catalog,
+		catalog.meta.Name,
+		input.ColumnManifestRootID,
+		input.ColumnStore,
+		true,
+		columnPhysicalScanRequest{
+			ProjectedColumns:  []string{columns.vector, columns.invNorm, columns.neighbors},
+			Visitor:           state.visit,
+			RequireInsertOnly: true,
+		},
+	)
+	status.BytesDisk = diag.PhysicalBytesScanned
+	if err != nil {
+		if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
+			status = columnGraphPhysicalUnavailableLoadStatus(vectorIndexFallbackColumnGraphVisibility)
+			status.BytesDisk = diag.PhysicalBytesScanned
+			return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+		}
+		if errors.Is(err, errColumnVectorGraphPhysicalLoadUnavailable) {
+			reason := state.unavailableReason
+			if reason == "" {
+				reason = vectorIndexFallbackColumnGraphInvalid
+			}
+			status = columnGraphPhysicalUnavailableLoadStatus(reason)
+			status.BytesDisk = diag.PhysicalBytesScanned
+			return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+		}
+		return ColumnVectorGraphIndexLoadResult{Status: status}, err
+	}
+	if len(state.documentIDs) == 0 {
+		status = columnGraphPhysicalUnavailableLoadStatus(vectorIndexFallbackColumnGraphEmpty)
+		status.BytesDisk = diag.PhysicalBytesScanned
+		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+	}
+	graph, err := NewColumnVectorGraphFromColumns(ColumnVectorGraphColumns{
+		DocumentIDs:     state.documentIDs,
+		Vectors:         state.vectors,
+		InvNorms:        state.invNorms,
+		NeighborOffsets: state.offsets,
+		Neighbors:       state.neighbors,
+		Dimensions:      input.Definition.Dimensions,
+		EntryPoint:      0,
+		EfSearch:        input.Definition.EfSearch,
+	})
+	if err != nil {
+		status = columnGraphPhysicalUnavailableLoadStatus(vectorIndexFallbackColumnGraphInvalid)
+		status.BytesDisk = diag.PhysicalBytesScanned
+		return ColumnVectorGraphIndexLoadResult{Status: status}, nil
+	}
+	status.Loaded = true
+	status.ColumnGraphLoaded = true
+	status.RebuildNeeded = false
+	return ColumnVectorGraphIndexLoadResult{Graph: graph, Status: status}, nil
+}
+
+type columnVectorGraphPhysicalColumns struct {
+	vector    string
+	invNorm   string
+	neighbors string
+}
+
+func resolveColumnVectorGraphPhysicalColumns(def VectorIndexDefinition, cfg ColumnStoreConfig) (columnVectorGraphPhysicalColumns, string) {
+	if def.Dimensions <= 0 {
+		return columnVectorGraphPhysicalColumns{}, vectorIndexFallbackColumnGraphSchema
+	}
+	vectorName, ok := findColumnVectorGraphPhysicalColumn(cfg, ColumnStoreValueFloat32Vector, def.Dimensions, columnGraphVectorColumnCandidates(def)...)
+	if !ok {
+		return columnVectorGraphPhysicalColumns{}, vectorIndexFallbackColumnGraphSchema
+	}
+	invNormName, ok := findColumnVectorGraphPhysicalColumn(cfg, ColumnStoreValueFloat32, 0, columnGraphSideColumnCandidates(def, vectorName, "_inv_norm")...)
+	if !ok {
+		return columnVectorGraphPhysicalColumns{}, vectorIndexFallbackColumnGraphSchema
+	}
+	neighborsName, ok := findColumnVectorGraphPhysicalColumn(cfg, ColumnStoreValueAdjacencyList, 0, columnGraphSideColumnCandidates(def, vectorName, "_neighbors")...)
+	if !ok {
+		return columnVectorGraphPhysicalColumns{}, vectorIndexFallbackColumnGraphSchema
+	}
+	return columnVectorGraphPhysicalColumns{
+		vector:    vectorName,
+		invNorm:   invNormName,
+		neighbors: neighborsName,
+	}, ""
+}
+
+func findColumnVectorGraphPhysicalColumn(cfg ColumnStoreConfig, valueType ColumnStoreValueType, vectorDims int, candidates ...string) (string, bool) {
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		for _, col := range cfg.Columns {
+			if col.Name != candidate && col.Path != candidate {
+				continue
+			}
+			if col.ValueType != valueType {
+				continue
+			}
+			if valueType == ColumnStoreValueFloat32Vector && col.VectorDims != vectorDims {
+				continue
+			}
+			return col.Name, true
+		}
+	}
+	return "", false
+}
+
+func columnGraphVectorColumnCandidates(def VectorIndexDefinition) []string {
+	var candidates []string
+	candidates = appendUniqueColumnGraphCandidate(candidates, def.Field)
+	candidates = appendUniqueColumnGraphCandidate(candidates, def.Name)
+	return candidates
+}
+
+func columnGraphSideColumnCandidates(def VectorIndexDefinition, vectorName string, suffix string) []string {
+	var candidates []string
+	candidates = appendUniqueColumnGraphCandidate(candidates, def.Name+suffix)
+	candidates = appendUniqueColumnGraphCandidate(candidates, def.Field+suffix)
+	candidates = appendUniqueColumnGraphCandidate(candidates, vectorName+suffix)
+	return candidates
+}
+
+func appendUniqueColumnGraphCandidate(candidates []string, candidate string) []string {
+	if candidate == "" {
+		return candidates
+	}
+	for _, existing := range candidates {
+		if existing == candidate {
+			return candidates
+		}
+	}
+	return append(candidates, candidate)
+}
+
+type columnVectorGraphPhysicalLoadState struct {
+	dimensions        int
+	documentIDs       [][]byte
+	vectors           []float32
+	invNorms          []float32
+	offsets           []uint32
+	neighbors         []uint32
+	unavailableReason string
+}
+
+func (s *columnVectorGraphPhysicalLoadState) visit(row columnPhysicalScanRowView) error {
+	if row.Deleted || row.Operation != ColumnPublishOperationInsert {
+		return s.fail(vectorIndexFallbackColumnGraphVisibility, "row requires mutation visibility")
+	}
+	if len(row.Values) != 3 {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "projected value count mismatch")
+	}
+	vector := row.Values[0]
+	if vector.Type != ColumnStoreValueFloat32Vector || !vector.Present || vector.Null || len(vector.Float32Vector) != s.dimensions {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "invalid vector column value")
+	}
+	invNorm := row.Values[1]
+	if invNorm.Type != ColumnStoreValueFloat32 || !invNorm.Present || invNorm.Null {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "invalid inverse norm column value")
+	}
+	adjacency := row.Values[2]
+	if adjacency.Type != ColumnStoreValueAdjacencyList || !adjacency.Present || adjacency.Null {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "invalid adjacency column value")
+	}
+	if uint64(len(s.documentIDs)) >= columnVectorGraphMaxUint32 {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "row ordinal space exhausted")
+	}
+	if uint64(len(s.neighbors))+uint64(len(adjacency.AdjacencyList)) > columnVectorGraphMaxUint32 {
+		return s.fail(vectorIndexFallbackColumnGraphInvalid, "neighbor ordinal space exhausted")
+	}
+	s.documentIDs = append(s.documentIDs, append([]byte(nil), row.ID...))
+	s.vectors = append(s.vectors, vector.Float32Vector...)
+	s.invNorms = append(s.invNorms, invNorm.Float32)
+	s.neighbors = append(s.neighbors, adjacency.AdjacencyList...)
+	s.offsets = append(s.offsets, uint32(len(s.neighbors)))
+	return nil
+}
+
+func (s *columnVectorGraphPhysicalLoadState) fail(reason string, detail string) error {
+	if s.unavailableReason == "" {
+		s.unavailableReason = reason
+	}
+	if detail == "" {
+		return errColumnVectorGraphPhysicalLoadUnavailable
+	}
+	return fmt.Errorf("%w: %s", errColumnVectorGraphPhysicalLoadUnavailable, detail)
+}
 
 // LoadColumnGraphVectorIndexSnapshot loads an explicit column_graph vector
-// index through the column-backed graph seam. Until physical column assets can
-// be scanned into ColumnVectorGraphColumns, this reports a precise unavailable
-// status instead of falling back to the native runtime graph.
+// index through the column-backed graph seam. The default loader scans
+// projected vector, inverse-norm, and adjacency physical columns into an
+// immutable ColumnVectorGraph without fetching full documents. Mutation-bearing
+// manifests remain rebuild-needed until dynamic overlay maintenance lands.
 func (c *Collection) LoadColumnGraphVectorIndexSnapshot(opts VectorIndexOptions) (*ColumnVectorGraph, VectorIndexLoadStatus, error) {
 	return c.loadColumnGraphVectorIndexSnapshot(opts, defaultColumnVectorGraphIndexLoader)
 }
@@ -165,6 +393,16 @@ func columnGraphUnavailableLoadStatus(reason string) VectorIndexLoadStatus {
 	status := VectorIndexLoadStatus{
 		Strategy:      VectorIndexStrategyColumnGraph,
 		RebuildNeeded: true,
+	}
+	setColumnGraphUnavailable(&status, reason)
+	return status
+}
+
+func columnGraphPhysicalUnavailableLoadStatus(reason string) VectorIndexLoadStatus {
+	status := VectorIndexLoadStatus{
+		Strategy:                      VectorIndexStrategyColumnGraph,
+		PhysicalColumnAssetsSupported: true,
+		RebuildNeeded:                 true,
 	}
 	setColumnGraphUnavailable(&status, reason)
 	return status

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -241,6 +241,20 @@ func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.
 	if status.RootID == 0 || status.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphManifestRootMismatch {
 		t.Fatalf("unexpected mismatch status: %+v", status)
 	}
+	results, trace, err := col.SearchVectorIndex(def.Name, []float32{1, 0}, VectorIndexSearchOptions{TopK: 1})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex fallback for mismatch: %v", err)
+	}
+	if len(results) != 0 || trace.Strategy != "vector_index_exact_fallback" || trace.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch {
+		t.Fatalf("fallback results=%+v trace=%+v want exact fallback for manifest mismatch", results, trace)
+	}
+	_, disabledTrace, err := col.SearchVectorIndex(def.Name, []float32{1, 0}, VectorIndexSearchOptions{
+		TopK:                 1,
+		DisableExactFallback: true,
+	})
+	if err == nil || disabledTrace.ExactFallbackReason != vectorIndexFallbackColumnGraphManifestRootMismatch {
+		t.Fatalf("disabled fallback err=%v trace=%+v want manifest mismatch fallback reason", err, disabledTrace)
+	}
 	rebuild, err := col.RebuildVectorIndex(def.Name)
 	if err != nil {
 		t.Fatalf("RebuildVectorIndex should report mismatch status, not error: %v", err)
@@ -456,6 +470,25 @@ func TestCollectionSearchVectorIndexUsesColumnGraphPhysicalAssets(t *testing.T) 
 	}
 	if len(results) != 2 || string(results[0].DocumentID) != "a" || len(results[0].Document) == 0 {
 		t.Fatalf("results=%+v trace=%+v want materialized doc a first", results, trace)
+	}
+}
+
+func TestCollectionSearchVectorIndexColumnGraphAllowsUnderfilledResultsWithFallbackDisabled(t *testing.T) {
+	reopened, closeFn := openColumnGraphPhysicalAssetFixture(t)
+	defer closeFn()
+
+	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0}, VectorIndexSearchOptions{
+		TopK:                 10,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex underfilled: %v", err)
+	}
+	if trace.Strategy != columnVectorGraphStrategyCosine || trace.ExactFallbackReason != "" || trace.ReturnedCount != 2 {
+		t.Fatalf("trace=%+v want column graph with two returned rows and no exact fallback", trace)
+	}
+	if len(results) != 2 || string(results[0].DocumentID) != "a" || string(results[1].DocumentID) != "b" {
+		t.Fatalf("underfilled results=%+v trace=%+v", results, trace)
 	}
 }
 

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -194,6 +194,27 @@ func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t
 	if status.ColumnGraphUnavailableDetail != "test detail" {
 		t.Fatalf("unavailable detail=%q want test detail", status.ColumnGraphUnavailableDetail)
 	}
+	mergeColumnGraphLoadStatus(&status, VectorIndexLoadStatus{
+		PhysicalColumnAssetsSupported: true,
+		ColumnGraphUnavailableReason:  vectorIndexFallbackColumnGraphInvalid,
+	})
+	if status.ColumnGraphUnavailableDetail != "" {
+		t.Fatalf("unavailable detail=%q want cleared after detail-less update", status.ColumnGraphUnavailableDetail)
+	}
+}
+
+func TestColumnGraphPhysicalLoadFailureRecordsDetail(t *testing.T) {
+	state := columnVectorGraphPhysicalLoadState{}
+	err := state.fail(vectorIndexFallbackColumnGraphInvalid, "invalid vector column value")
+	if !errors.Is(err, errColumnVectorGraphPhysicalLoadUnavailable) {
+		t.Fatalf("fail err=%v want errColumnVectorGraphPhysicalLoadUnavailable", err)
+	}
+	if state.unavailableReason != vectorIndexFallbackColumnGraphInvalid {
+		t.Fatalf("unavailable reason=%q want %q", state.unavailableReason, vectorIndexFallbackColumnGraphInvalid)
+	}
+	if state.unavailableDetail != "invalid vector column value" {
+		t.Fatalf("unavailable detail=%q want physical scan detail", state.unavailableDetail)
+	}
 }
 
 func TestColumnGraphRebuildUnsupportedStatusPreservesReprobeReason(t *testing.T) {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -1,7 +1,10 @@
 package collections
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -391,6 +394,228 @@ func TestCollectionVectorIndexColumnGraphMutationsRemainRebuildNeeded(t *testing
 	}
 }
 
+func TestCollectionVectorIndexColumnGraphLoadsPhysicalAssets(t *testing.T) {
+	reopened, closeFn := openColumnGraphPhysicalAssetFixture(t)
+	defer closeFn()
+
+	def := columnGraphVectorIndexTestDefinition()
+	graph, status, err := reopened.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadColumnGraphVectorIndexSnapshot: %v", err)
+	}
+	if graph == nil {
+		t.Fatalf("graph not loaded status=%+v", status)
+	}
+	if !status.Loaded || !status.ColumnGraphLoaded || !status.PhysicalColumnAssetsSupported || status.RebuildNeeded || status.ExactFallbackReason != "" {
+		t.Fatalf("unexpected loaded status: %+v", status)
+	}
+	if status.BytesDisk <= 0 {
+		t.Fatalf("loaded status bytes_disk=%d want physical bytes", status.BytesDisk)
+	}
+	if graph.Rows() != 2 || graph.Dims() != 2 || graph.Edges() != 2 {
+		t.Fatalf("graph rows=%d dims=%d edges=%d", graph.Rows(), graph.Dims(), graph.Edges())
+	}
+
+	var scratch ColumnVectorGraphSearchScratch
+	results, trace, err := graph.SearchCosine([]float32{1, 0}, ColumnVectorGraphSearchOptions{TopK: 2}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(results) != 2 || string(results[0].DocumentID) != "a" {
+		t.Fatalf("results=%+v trace=%+v want doc a first", results, trace)
+	}
+	if trace.ReturnedCount != 2 || trace.CandidatesExamined == 0 || trace.EdgesVisited == 0 {
+		t.Fatalf("unexpected trace: %+v", trace)
+	}
+
+	opStatus, err := reopened.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	if !opStatus.ColumnGraphLoaded || !opStatus.PhysicalColumnAssetsSupported || opStatus.RebuildNeeded || opStatus.ExactFallbackReason != "" {
+		t.Fatalf("unexpected operational status: %+v", opStatus)
+	}
+	if opStatus.Registered || opStatus.NativeRuntimeUsed || opStatus.NativeRootLoaded {
+		t.Fatalf("column_graph status used native runtime/root: %+v", opStatus)
+	}
+}
+
+func TestCollectionSearchVectorIndexUsesColumnGraphPhysicalAssets(t *testing.T) {
+	reopened, closeFn := openColumnGraphPhysicalAssetFixture(t)
+	defer closeFn()
+
+	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0}, VectorIndexSearchOptions{
+		TopK:                 2,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex: %v", err)
+	}
+	if trace.Strategy != columnVectorGraphStrategyCosine || trace.ExactFallbackReason != "" {
+		t.Fatalf("trace=%+v want column graph without exact fallback", trace)
+	}
+	if len(results) != 2 || string(results[0].DocumentID) != "a" || len(results[0].Document) == 0 {
+		t.Fatalf("results=%+v trace=%+v want materialized doc a first", results, trace)
+	}
+}
+
+func TestCollectionVectorIndexColumnGraphPhysicalMutationManifestReportsRebuildNeeded(t *testing.T) {
+	reopened, closeFn := openColumnGraphPhysicalAssetFixture(t)
+	defer closeFn()
+
+	def := columnGraphVectorIndexTestDefinition()
+	if _, _, err := reopened.Update([]byte("a"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"embedding":[1,0],"embedding_inv_norm":1,"embedding_neighbors":[1]}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	status, err := reopened.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	if status.Strategy != VectorIndexStrategyColumnGraph || !status.PhysicalColumnAssetsSupported || status.ColumnGraphLoaded || !status.RebuildNeeded {
+		t.Fatalf("unexpected mutation status flags: %+v", status)
+	}
+	if status.ExactFallbackReason != vectorIndexFallbackColumnGraphVisibility || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphVisibility {
+		t.Fatalf("mutation fallback reason=%q column reason=%q want %q: %+v", status.ExactFallbackReason, status.ColumnGraphUnavailableReason, vectorIndexFallbackColumnGraphVisibility, status)
+	}
+	if status.Registered || status.NativeRuntimeUsed || status.NativeRootLoaded {
+		t.Fatalf("mutation status used native runtime/root: %+v", status)
+	}
+}
+
+func TestCollectionSearchVectorIndexColumnGraphFallsBackAfterMutation(t *testing.T) {
+	reopened, closeFn := openColumnGraphPhysicalAssetFixture(t)
+	defer closeFn()
+
+	if _, _, err := reopened.Update([]byte("a"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"embedding":[0,1],"embedding_inv_norm":1,"embedding_neighbors":[1]}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0}, VectorIndexSearchOptions{TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex fallback: %v", err)
+	}
+	if trace.Strategy != "vector_index_exact_fallback" || trace.ExactFallbackReason != vectorIndexFallbackColumnGraphVisibility {
+		t.Fatalf("trace=%+v want exact fallback for mutation-bearing column graph", trace)
+	}
+	if len(results) != 2 || string(results[0].DocumentID) != "a" || string(results[1].DocumentID) != "b" {
+		t.Fatalf("fallback results=%+v trace=%+v", results, trace)
+	}
+
+	_, disabledTrace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0}, VectorIndexSearchOptions{
+		TopK:                 2,
+		DisableExactFallback: true,
+	})
+	if err == nil || disabledTrace.ExactFallbackReason != vectorIndexFallbackColumnGraphVisibility {
+		t.Fatalf("disabled fallback err=%v trace=%+v want column_graph visibility error", err, disabledTrace)
+	}
+}
+
+func TestCollectionSearchVectorIndexColumnGraphSurvivesColumnAssetRewriteAndGC(t *testing.T) {
+	dir, reopened, closeFn := openColumnGraphPhysicalAssetFixtureWithDir(t)
+	closed := false
+	defer func() {
+		if !closed {
+			closeFn()
+		}
+	}()
+
+	beforeRefs := columnManifestAssetRefsForCollectionM12A(t, reopened.db, reopened)
+	if len(beforeRefs) == 0 {
+		t.Fatal("manifest refs empty, test requires live vector physical assets")
+	}
+	candidate := writeColumnGraphVectorAssetRewriteCandidate(t, reopened.db, reopened, 3, 99)
+	if candidate.FileID != beforeRefs[0].FileID {
+		t.Fatalf("candidate file_id=%d live file_id=%d, test requires mixed segment", candidate.FileID, beforeRefs[0].FileID)
+	}
+	oldSegmentPath, err := columnAssetSegmentPath(reopened.db.ColumnAssetRootDir(), candidate)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+
+	rewrite, err := reopened.ColumnAssetRewrite(context.Background(), ColumnAssetRewriteOptions{
+		Detailed:      true,
+		CandidateRefs: []ColumnAssetRef{candidate},
+	})
+	if err != nil {
+		t.Fatalf("ColumnAssetRewrite: %v", err)
+	}
+	if rewrite.SegmentsRewritten != 1 || rewrite.RefsRemapped != len(beforeRefs) {
+		t.Fatalf("rewrite stats=%+v want one rewritten segment and %d remapped refs", rewrite, len(beforeRefs))
+	}
+	afterRefs := columnManifestAssetRefsForCollectionM12A(t, reopened.db, reopened)
+	assertColumnAssetRefsRemappedM15C(t, beforeRefs, afterRefs)
+	assertColumnGraphSearchUsesPhysicalAssets(t, reopened)
+	if _, err := os.Stat(oldSegmentPath); err != nil {
+		t.Fatalf("rewrite removed old mixed segment before GC: %v", err)
+	}
+
+	closeFn()
+	closed = true
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopenedAfterRewrite, err := NewCollectionManager(reopen).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection after rewrite: %v", err)
+	}
+	reopenRefs := columnManifestAssetRefsForCollectionM12A(t, reopen, reopenedAfterRewrite)
+	assertColumnAssetRefsEqualM15C(t, afterRefs, reopenRefs)
+	assertColumnGraphSearchUsesPhysicalAssets(t, reopenedAfterRewrite)
+
+	gcStats, err := reopenedAfterRewrite.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
+		CandidateRefs: append(append([]ColumnAssetRef(nil), rewrite.SupersededRefs...), candidate),
+	})
+	if err != nil {
+		t.Fatalf("ColumnAssetGC after vector rewrite: %v", err)
+	}
+	if gcStats.SegmentsDeleted != 1 || gcStats.BytesDeleted == 0 {
+		t.Fatalf("gc stats=%+v want old mixed segment deleted after remap", gcStats)
+	}
+	if _, err := os.Stat(oldSegmentPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old segment still exists or unexpected stat error: %v", err)
+	}
+	assertColumnGraphSearchUsesPhysicalAssets(t, reopenedAfterRewrite)
+}
+
+func TestCollectionVectorIndexColumnGraphReportsPhysicalSchemaMismatch(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	active := ColumnManifestIdentity{Generation: 7, Version: columnManifestIdentityVersion, Checksum: 0x1111}
+	cfg := columnGraphVectorIndexTestColumnStore(&active)
+	cfg.Columns = cfg.Columns[:1]
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", VectorIndexes: []VectorIndexDefinition{def}}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	publishColumnStoreCatalogForTest(t, d, CollectionMeta{
+		Name:          "docs",
+		Options:       CollectionOptions{ColumnStore: cfg},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}, active)
+
+	graph, status, err := col.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		t.Fatalf("LoadColumnGraphVectorIndexSnapshot: %v", err)
+	}
+	if graph != nil {
+		t.Fatalf("loaded graph despite physical schema mismatch")
+	}
+	if !status.PhysicalColumnAssetsSupported || status.ExactFallbackReason != vectorIndexFallbackColumnGraphSchema || status.ColumnGraphUnavailableReason != vectorIndexFallbackColumnGraphSchema || !status.RebuildNeeded {
+		t.Fatalf("unexpected schema mismatch status: %+v", status)
+	}
+}
+
 func TestCollectionVectorIndexColumnGraphStrategyJSON(t *testing.T) {
 	meta, err := normalizeCollectionMeta(CollectionMeta{
 		Name: "docs",
@@ -456,6 +681,114 @@ func columnGraphVectorIndexTestColumnStore(active *ColumnManifestIdentity) *Colu
 		cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
 	}
 	return cfg
+}
+
+func openColumnGraphPhysicalAssetFixture(t *testing.T) (*Collection, func()) {
+	t.Helper()
+	_, reopened, closeFn := openColumnGraphPhysicalAssetFixtureWithDir(t)
+	return reopened, closeFn
+}
+
+func openColumnGraphPhysicalAssetFixtureWithDir(t *testing.T) (string, *Collection, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	def := columnGraphVectorIndexTestDefinition()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorIndexTestColumnStore(nil),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0],"embedding_inv_norm":1,"embedding_neighbors":[1]}`),
+			[]byte(`{"embedding":[0,1],"embedding_inv_norm":1,"embedding_neighbors":[0]}`),
+		},
+	); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close seed DB: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	reopened, err := NewCollectionManager(reopen).OpenCollection("docs")
+	if err != nil {
+		_ = reopen.Close()
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	return dir, reopened, func() { _ = reopen.Close() }
+}
+
+func writeColumnGraphVectorAssetRewriteCandidate(t testing.TB, d *backenddb.DB, col *Collection, generation, partID uint64) ColumnAssetRef {
+	t.Helper()
+	cfg := col.Meta().Options.ColumnStore
+	if cfg == nil || cfg.AssetManager == nil {
+		t.Fatalf("missing column store config: %+v", cfg)
+	}
+	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        col.Meta().Name,
+		Namespace:         cfg.AssetManager.Namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: d.State().AppliedCommandLSN + 1,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        cfg.SchemaHash,
+		Columns:           cfg.Columns,
+		Rows: []columnDeclaredRow{{
+			ID: []byte("candidate"),
+			Values: []columnDeclaredValue{
+				{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{1, 0}},
+				{Type: ColumnStoreValueFloat32, Present: true, Float32: 1},
+				{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: []uint32{0}},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
+	}
+	ref, err := writeColumnPhysicalAssetToManager(d.ColumnAssetRootDir(), *cfg, encoded, generation, partID)
+	if err != nil {
+		t.Fatalf("writeColumnPhysicalAssetToManager: %v", err)
+	}
+	return ref
+}
+
+func assertColumnGraphSearchUsesPhysicalAssets(t testing.TB, col *Collection) {
+	t.Helper()
+	results, trace, err := col.SearchVectorIndex("embedding", []float32{1, 0}, VectorIndexSearchOptions{
+		TopK:                 2,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex: %v", err)
+	}
+	if trace.Strategy != columnVectorGraphStrategyCosine || trace.ExactFallbackReason != "" {
+		t.Fatalf("trace=%+v want column graph without exact fallback", trace)
+	}
+	if len(results) != 2 || string(results[0].DocumentID) != "a" || len(results[0].Document) == 0 {
+		t.Fatalf("results=%+v trace=%+v want materialized doc a first", results, trace)
+	}
 }
 
 type testColumnVectorGraphIndexLoader struct {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -268,6 +268,74 @@ func TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch(t *testing.
 	}
 }
 
+func TestCollectionVectorIndexColumnGraphExactFallbackRangeFilterBypassesColumnRootValidation(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	def := columnGraphVectorIndexTestDefinition()
+	cityIndex := IndexDefinition{Name: "city_idx", Field: "city", ValueType: IndexValueString}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:          "docs",
+		Indexes:       []IndexDefinition{cityIndex},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		[][]byte{
+			[]byte(`{"embedding":[1,0],"city":"hnl"}`),
+			[]byte(`{"embedding":[0,1],"city":"sea"}`),
+			[]byte(`{"embedding":[0.9,0.1],"city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	active := ColumnManifestIdentity{Generation: 7, Version: columnManifestIdentityVersion, Checksum: 0x1111}
+	rootIdentity := active
+	rootIdentity.Checksum = 0x2222
+	columnStore := columnGraphVectorIndexTestColumnStore(&active)
+	columnStore.RetainedPayload = ColumnRetainedPayloadFull
+	publishColumnStoreCatalogForTest(t, d, CollectionMeta{
+		Name:    "docs",
+		Indexes: []IndexDefinition{cityIndex},
+		Options: CollectionOptions{
+			ColumnStore: columnStore,
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}, rootIdentity)
+
+	results, trace, err := col.SearchVectorIndex(def.Name, []float32{1, 0}, VectorIndexSearchOptions{
+		TopK: 2,
+		IndexRangeFilter: &VectorIndexRangeFilter{
+			IndexName: cityIndex.Name,
+			Range: IndexRangeOptions{
+				Lower: IndexRangeBound{Value: "hnl", Inclusive: true},
+				Upper: IndexRangeBound{Value: "hnl", Inclusive: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex fallback with range filter: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a", "c")
+	if trace.Strategy != "vector_index_exact_fallback" || trace.ExactFallbackReason != "column_graph_filter_requires_exact" || trace.ReturnedCount != 2 {
+		t.Fatalf("trace=%+v want column_graph exact fallback with range-filter results", trace)
+	}
+}
+
 func TestCollectionVectorIndexColumnGraphOptionDoesNotLoadNativeIndex(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/vector_index_column_graph_test.go
+++ b/TreeDB/collections/vector_index_column_graph_test.go
@@ -179,6 +179,7 @@ func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t
 	mergeColumnGraphLoadStatus(&status, VectorIndexLoadStatus{
 		PhysicalColumnAssetsSupported: true,
 		ColumnGraphUnavailableReason:  vectorIndexFallbackColumnGraphManifestRootMismatch,
+		ColumnGraphUnavailableDetail:  "test detail",
 		BytesDisk:                     4096,
 	})
 	if status.PhysicalColumnAssetsSupported == false {
@@ -189,6 +190,9 @@ func TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures(t
 	}
 	if status.BytesDisk != 4096 || !status.RebuildNeeded {
 		t.Fatalf("unexpected status accounting: %+v", status)
+	}
+	if status.ColumnGraphUnavailableDetail != "test detail" {
+		t.Fatalf("unavailable detail=%q want test detail", status.ColumnGraphUnavailableDetail)
 	}
 }
 

--- a/TreeDB/collections/vector_index_ops.go
+++ b/TreeDB/collections/vector_index_ops.go
@@ -21,6 +21,7 @@ type VectorIndexStatus struct {
 	ExactFallbackReason           string
 	ColumnGraphLoaded             bool
 	ColumnGraphUnavailableReason  string
+	ColumnGraphUnavailableDetail  string
 	PhysicalColumnAssetsSupported bool
 	Registered                    bool
 	Stats                         VectorIndexStats

--- a/TreeDB/collections/vector_index_persist.go
+++ b/TreeDB/collections/vector_index_persist.go
@@ -64,6 +64,7 @@ type VectorIndexLoadStatus struct {
 	// mirrors ExactFallbackReason so older callers still see a safe fallback
 	// reason without understanding column_graph-specific status fields.
 	ColumnGraphUnavailableReason  string
+	ColumnGraphUnavailableDetail  string
 	PhysicalColumnAssetsSupported bool
 	RebuildNeeded                 bool
 }

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -19,12 +19,19 @@ func (c *Collection) SearchVectorIndex(name string, query []float32, opts Vector
 	if err := ValidateIndexName(name); err != nil {
 		return nil, trace, err
 	}
-	def, err := c.declaredVectorIndexDefinition(name)
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, trace, err
+	}
+	def, err := c.declaredVectorIndexDefinitionPreparedWithoutColumnRootValidation(name)
 	if err != nil {
 		return nil, trace, err
 	}
 	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
 		return c.searchColumnGraphVectorIndex(def, query, opts)
+	}
+	def, err = c.declaredVectorIndexDefinitionPrepared(name)
+	if err != nil {
+		return nil, trace, err
 	}
 
 	index := c.registeredVectorIndex(def.Name)
@@ -70,9 +77,6 @@ func (c *Collection) searchColumnGraphVectorIndex(def VectorIndexDefinition, que
 		return nil, trace, err
 	}
 	trace.ReturnedCount = len(attached)
-	if len(attached) < opts.TopK {
-		return c.searchVectorIndexExactFallback(def, query, opts, trace, "column_graph_underfilled_results")
-	}
 	return attached, trace, nil
 }
 
@@ -85,7 +89,11 @@ func (c *Collection) searchVectorIndexExactFallback(def VectorIndexDefinition, q
 	if opts.DisableExactFallback {
 		return nil, trace, fmt.Errorf("collections: vector index %q unavailable: %s", def.Name, reason)
 	}
-	exact, err := c.SearchVectorsExact(query, VectorSearchOptions{
+	searchExact := c.SearchVectorsExact
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		searchExact = c.searchVectorsExactWithoutColumnRootValidation
+	}
+	exact, err := searchExact(query, VectorSearchOptions{
 		Field:            def.Field,
 		Metric:           def.Metric,
 		TopK:             opts.TopK,

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -1,0 +1,128 @@
+package collections
+
+import "fmt"
+
+// SearchVectorIndex searches a declared collection vector index by name. Native
+// indexes use the existing runtime graph path. Explicit column_graph indexes
+// load the persisted ColumnVectorGraph, run graph traversal/scoring/top-k
+// without fetching full documents, then materialize documents for returned
+// top-k IDs. If the selected persisted path cannot load and exact fallback is
+// not disabled, the collection exact scan remains the correctness path.
+func (c *Collection) SearchVectorIndex(name string, query []float32, opts VectorIndexSearchOptions) ([]VectorSearchResult, VectorIndexTrace, error) {
+	trace := VectorIndexTrace{Strategy: "vector_index"}
+	if c == nil {
+		return nil, trace, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, trace, errCollectionDBNil
+	}
+	if err := ValidateIndexName(name); err != nil {
+		return nil, trace, err
+	}
+	def, err := c.declaredVectorIndexDefinition(name)
+	if err != nil {
+		return nil, trace, err
+	}
+	if vectorIndexDefinitionStrategy(def) == VectorIndexStrategyColumnGraph {
+		return c.searchColumnGraphVectorIndex(def, query, opts)
+	}
+
+	index := c.registeredVectorIndex(def.Name)
+	if index == nil {
+		loaded, status, err := c.LoadNativeVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+		if err != nil {
+			return nil, trace, err
+		}
+		if loaded == nil {
+			return c.searchVectorIndexExactFallback(def, query, opts, trace, status.ExactFallbackReason)
+		}
+		index = loaded
+	}
+	return index.Search(query, opts)
+}
+
+func (c *Collection) searchColumnGraphVectorIndex(def VectorIndexDefinition, query []float32, opts VectorIndexSearchOptions) ([]VectorSearchResult, VectorIndexTrace, error) {
+	trace := VectorIndexTrace{Strategy: columnVectorGraphStrategyCosine}
+	if opts.TopK <= 0 {
+		return nil, trace, fmt.Errorf("collections: vector search TopK must be positive")
+	}
+	if opts.Filter != nil || opts.IndexRangeFilter != nil {
+		return c.searchVectorIndexExactFallback(def, query, opts, trace, "column_graph_filter_requires_exact")
+	}
+	graph, status, err := c.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		return nil, trace, err
+	}
+	if graph == nil {
+		return c.searchVectorIndexExactFallback(def, query, opts, trace, status.ExactFallbackReason)
+	}
+	var scratch ColumnVectorGraphSearchScratch
+	results, graphTrace, err := graph.SearchCosine(query, ColumnVectorGraphSearchOptions{
+		TopK:     opts.TopK,
+		EfSearch: opts.EfSearch,
+	}, &scratch)
+	if err != nil {
+		return nil, trace, err
+	}
+	trace = graphTrace.VectorIndexTrace
+	attached, err := c.attachColumnGraphVectorSearchResultDocuments(results, opts.TopK)
+	if err != nil {
+		return nil, trace, err
+	}
+	trace.ReturnedCount = len(attached)
+	if len(attached) < opts.TopK {
+		return c.searchVectorIndexExactFallback(def, query, opts, trace, "column_graph_underfilled_results")
+	}
+	return attached, trace, nil
+}
+
+func (c *Collection) searchVectorIndexExactFallback(def VectorIndexDefinition, query []float32, opts VectorIndexSearchOptions, trace VectorIndexTrace, reason string) ([]VectorSearchResult, VectorIndexTrace, error) {
+	if reason == "" {
+		reason = "unavailable"
+	}
+	trace.Strategy = "vector_index_exact_fallback"
+	trace.ExactFallbackReason = reason
+	if opts.DisableExactFallback {
+		return nil, trace, fmt.Errorf("collections: vector index %q unavailable: %s", def.Name, reason)
+	}
+	exact, err := c.SearchVectorsExact(query, VectorSearchOptions{
+		Field:            def.Field,
+		Metric:           def.Metric,
+		TopK:             opts.TopK,
+		Filter:           opts.Filter,
+		IndexRangeFilter: opts.IndexRangeFilter,
+	})
+	if err != nil {
+		return nil, trace, err
+	}
+	trace.ReturnedCount = len(exact)
+	return exact, trace, nil
+}
+
+func (c *Collection) attachColumnGraphVectorSearchResultDocuments(ranked []VectorSearchResult, topK int) ([]VectorSearchResult, error) {
+	limit := minInt(topK, len(ranked))
+	if limit == 0 {
+		return []VectorSearchResult{}, nil
+	}
+	results := make([]VectorSearchResult, 0, limit)
+	for i := range ranked {
+		if len(results) >= limit {
+			break
+		}
+		result := ranked[i]
+		document, err := c.Get(result.DocumentID)
+		if err != nil {
+			return nil, err
+		}
+		if document == nil {
+			continue
+		}
+		result.DocumentID = append([]byte(nil), result.DocumentID...)
+		result.Document = document
+		results = append(results, result)
+	}
+	if len(results) == 0 {
+		return []VectorSearchResult{}, nil
+	}
+	return results, nil
+}

--- a/TreeDB/collections/vector_search.go
+++ b/TreeDB/collections/vector_search.go
@@ -112,10 +112,14 @@ func (c *Collection) SearchVectorsExact(query []float32, opts VectorSearchOption
 }
 
 func (c *Collection) searchVectorsExactWithoutColumnRootValidation(query []float32, opts VectorSearchOptions) ([]VectorSearchResult, error) {
-	return c.searchVectorsExactWithScanner(query, opts, c.scanDocumentsFuncWithoutColumnRootValidation)
+	return c.searchVectorsExactWithReaders(query, opts, c.scanDocumentsFuncWithoutColumnRootValidation, c.vectorSearchIndexRangeDocumentIDsWithoutColumnRootValidation, c.getWithoutColumnRootValidation)
 }
 
 func (c *Collection) searchVectorsExactWithScanner(query []float32, opts VectorSearchOptions, scanDocuments func(int, func(DocumentRecord) (bool, error)) (bool, error)) ([]VectorSearchResult, error) {
+	return c.searchVectorsExactWithReaders(query, opts, scanDocuments, c.vectorSearchIndexRangeDocumentIDs, c.Get)
+}
+
+func (c *Collection) searchVectorsExactWithReaders(query []float32, opts VectorSearchOptions, scanDocuments func(int, func(DocumentRecord) (bool, error)) (bool, error), rangeDocumentIDs func(*VectorIndexRangeFilter, int) ([][]byte, bool, error), getDocument func([]byte) ([]byte, error)) ([]VectorSearchResult, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
@@ -147,6 +151,12 @@ func (c *Collection) searchVectorsExactWithScanner(query []float32, opts VectorS
 	}
 	if scanDocuments == nil {
 		scanDocuments = c.ScanDocumentsFunc
+	}
+	if rangeDocumentIDs == nil {
+		rangeDocumentIDs = c.vectorSearchIndexRangeDocumentIDs
+	}
+	if getDocument == nil {
+		getDocument = c.Get
 	}
 
 	materializer, err := c.NewStoredDocumentJSONMaterializer()
@@ -189,12 +199,12 @@ func (c *Collection) searchVectorsExactWithScanner(query []float32, opts VectorS
 	}
 
 	if opts.IndexRangeFilter != nil {
-		ids, _, err := c.vectorSearchIndexRangeDocumentIDs(opts.IndexRangeFilter, 0)
+		ids, _, err := rangeDocumentIDs(opts.IndexRangeFilter, 0)
 		if err != nil {
 			return nil, err
 		}
 		for _, id := range ids {
-			document, err := c.Get(id)
+			document, err := getDocument(id)
 			if err != nil {
 				return nil, err
 			}
@@ -234,15 +244,26 @@ func cloneDocumentRecord(record DocumentRecord) DocumentRecord {
 }
 
 func (c *Collection) vectorSearchIndexRangeDocumentIDs(filter *VectorIndexRangeFilter, limit int) ([][]byte, bool, error) {
+	return c.vectorSearchIndexRangeDocumentIDsWithFinder(filter, limit, c.FindByIndexRange)
+}
+
+func (c *Collection) vectorSearchIndexRangeDocumentIDsWithoutColumnRootValidation(filter *VectorIndexRangeFilter, limit int) ([][]byte, bool, error) {
+	return c.vectorSearchIndexRangeDocumentIDsWithFinder(filter, limit, c.findByIndexRangeWithoutColumnRootValidation)
+}
+
+func (c *Collection) vectorSearchIndexRangeDocumentIDsWithFinder(filter *VectorIndexRangeFilter, limit int, findRange func(string, IndexRangeOptions) ([][]byte, bool, error)) ([][]byte, bool, error) {
 	if filter == nil {
 		return nil, false, nil
 	}
 	if limit < 0 {
 		return nil, false, errors.New("collections: vector index range filter limit cannot be negative")
 	}
+	if findRange == nil {
+		findRange = c.FindByIndexRange
+	}
 	opts := filter.Range
 	opts.Limit = limit
-	ids, truncated, err := c.FindByIndexRange(filter.IndexName, opts)
+	ids, truncated, err := findRange(filter.IndexName, opts)
 	if err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/collections/vector_search.go
+++ b/TreeDB/collections/vector_search.go
@@ -108,6 +108,14 @@ type VectorIndexRangeFilter struct {
 // nearest TopK matches. The collection primary row remains the canonical vector
 // storage; missing or null vector fields are skipped.
 func (c *Collection) SearchVectorsExact(query []float32, opts VectorSearchOptions) ([]VectorSearchResult, error) {
+	return c.searchVectorsExactWithScanner(query, opts, c.ScanDocumentsFunc)
+}
+
+func (c *Collection) searchVectorsExactWithoutColumnRootValidation(query []float32, opts VectorSearchOptions) ([]VectorSearchResult, error) {
+	return c.searchVectorsExactWithScanner(query, opts, c.scanDocumentsFuncWithoutColumnRootValidation)
+}
+
+func (c *Collection) searchVectorsExactWithScanner(query []float32, opts VectorSearchOptions, scanDocuments func(int, func(DocumentRecord) (bool, error)) (bool, error)) ([]VectorSearchResult, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
@@ -136,6 +144,9 @@ func (c *Collection) SearchVectorsExact(query []float32, opts VectorSearchOption
 	}
 	if err := c.flushBufferedWrites(); err != nil {
 		return nil, err
+	}
+	if scanDocuments == nil {
+		scanDocuments = c.ScanDocumentsFunc
 	}
 
 	materializer, err := c.NewStoredDocumentJSONMaterializer()
@@ -200,7 +211,7 @@ func (c *Collection) SearchVectorsExact(query []float32, opts VectorSearchOption
 		return matches, nil
 	}
 
-	_, err = c.ScanDocumentsFunc(maxCollectionInt, func(record DocumentRecord) (bool, error) {
+	_, err = scanDocuments(maxCollectionInt, func(record DocumentRecord) (bool, error) {
 		if err := processRecord(record); err != nil {
 			return false, err
 		}


### PR DESCRIPTION
## Summary
- Replace the default `column_graph` loader stub with a physical column asset loader for vector, inverse-norm, and adjacency-list columns.
- Add public `Collection.SearchVectorIndex` routing for explicit `column_graph` indexes, including exact fallback/status behavior.
- Add tests for physical asset load/search, mutation rebuild-needed status, schema mismatch, range-filter fallback, status detail handling, and column asset rewrite/GC survival.

## Corrected Boundary
This PR loads real TreeDB physical column assets, but it does **not** search directly over native column-store granules/readers.

The loader path is:
```text
column manifest/root
-> physical asset scanner
-> decode projected vector/invNorm/adjacency columns
-> in-memory ColumnVectorGraph
```

The search path then uses `ColumnVectorGraph.SearchCosine` over decoded Go slices. That is intentional for this seam, but it is not the final column-store-native search design.

## Scope
- Stacked on #1642 to keep review small.
- No vector-only sidecar format is added; the loader uses the real column manifest/root and physical scanner path.
- The loaded search kernel is an in-memory graph copy populated from physical column assets.
- Mutation-bearing manifests still report rebuild-needed until overlay/rebuild maintenance lands.

## Validation
```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures|TestColumnGraphPhysicalLoadFailureRecordsDetail|TestCollectionVectorIndexColumnGraph' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionVectorIndexColumnGraphExactFallbackRangeFilterBypassesColumnRootValidation|TestCollectionVectorIndexColumnGraphReportsManifestRootMismatch|TestCollectionSearchVectorsExactIndexRangeFilter' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalVisibilityIndexClonesVectorAndAdjacencyValues|TestCollectionVectorIndexColumnGraph|TestCollectionSearchVectorIndex|TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures' -count=1
git diff --check
```

## Stack
- Base PR: #1642
- Next PR: #1644


## Follow-up Native Column-Store Search Ticket
True column-store-native vector search, without a full decoded in-memory graph, is tracked separately in #1646.
