### PR TITLE
Decoded comparator benchmarks for physical column graph assets

### DIFF
--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -540,37 +540,18 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathLoad(b *testing.B) {
 		b.Fatalf("close warm load db: %v", err)
 	}
 
-	loader := testColumnVectorGraphIndexLoader{
-		result: ColumnVectorGraphIndexLoadResult{
-			Graph: fixture.graph,
-			Status: VectorIndexLoadStatus{
-				Strategy:                      VectorIndexStrategyColumnGraph,
-				PhysicalColumnAssetsSupported: true,
-				BytesDisk:                     loadStatus.BytesDisk,
-			},
-		},
-	}
-	opts := VectorIndexOptions{
-		Name:       indexName,
-		Field:      "embedding",
-		Metric:     VectorMetricCosine,
-		Dimensions: dims,
-		Strategy:   VectorIndexStrategyColumnGraph,
-	}
+	opts := vectorIndexOptionsFromDefinition(fixture.def)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d, err := backenddb.Open(backenddb.Options{Dir: fixture.dir})
-		if err != nil {
-			b.Fatalf("reopen db: %v", err)
-		}
+		d := openCollectionCommandWALDB(b, fixture.dir)
 		col, err := NewCollectionManager(d).OpenCollection("docs")
 		if err != nil {
 			_ = d.Close()
 			b.Fatalf("open collection: %v", err)
 		}
-		loaded, status, err := col.loadColumnGraphVectorIndexSnapshot(opts, loader)
+		loaded, status, err := col.LoadColumnGraphVectorIndexSnapshot(opts)
 		if err != nil {
 			_ = d.Close()
 			b.Fatalf("load column graph vector index: %v", err)
@@ -806,6 +787,59 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathSearchWithDocumentFetchPar
 	b.ReportMetric(float64(warmBytes), "document_bytes/search")
 }
 
+func BenchmarkCollectionVectorIndexColumnGraphMainPathPublicSearch(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	indexName := "embedding_column_graph_public_search"
+	d, col, graph, loadStatus := openColumnGraphVectorBenchmarkMainPath(b, docs, dims, indexName)
+	defer func() { _ = d.Close() }()
+	query, ok := graph.VectorAt(nil, docs/3)
+	if !ok {
+		b.Fatal("missing query vector")
+	}
+	opts := VectorIndexSearchOptions{
+		TopK:                 vectorBenchmarkTopK,
+		EfSearch:             128,
+		DisableExactFallback: true,
+	}
+	var kernelScratch ColumnVectorGraphSearchScratch
+	_, kernelTrace, err := graph.SearchCosine(query, ColumnVectorGraphSearchOptions{
+		TopK:     opts.TopK,
+		EfSearch: opts.EfSearch,
+	}, &kernelScratch)
+	if err != nil {
+		b.Fatalf("warm public column_graph kernel trace: %v", err)
+	}
+	warm, warmTrace, err := col.SearchVectorIndex(indexName, query, opts)
+	if err != nil {
+		b.Fatalf("warm public column_graph search: %v", err)
+	}
+	if len(warm) != opts.TopK || warmTrace.Strategy != columnVectorGraphStrategyCosine {
+		b.Fatalf("warm public results=%d trace=%+v", len(warm), warmTrace)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(kernelTrace.CandidatesExamined * graph.Dims() * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, trace, err := col.SearchVectorIndex(indexName, query, opts)
+		if err != nil {
+			b.Fatalf("public column_graph search: %v", err)
+		}
+		if len(results) != opts.TopK || trace.Strategy != columnVectorGraphStrategyCosine {
+			b.Fatalf("public results=%d trace=%+v", len(results), trace)
+		}
+		columnVectorGraphBenchSink += int64(len(results[0].DocumentID) + len(results[0].Document) + trace.CandidatesExamined)
+	}
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(loadStatus.RootID), "manifest_root_id")
+	b.ReportMetric(float64(loadStatus.BytesDisk), "column_graph_bytes")
+	b.ReportMetric(float64(graph.Edges())/float64(graph.Rows()), "edges/node")
+	b.ReportMetric(float64(kernelTrace.CandidatesExamined), "candidates/search")
+	b.ReportMetric(float64(kernelTrace.EdgesVisited), "edges/search")
+}
+
 func BenchmarkCollectionVectorIndexColumnGraphMainPathOpenLoadSearchWithDocumentFetch(b *testing.B) {
 	docs := vectorBenchmarkDocs(b)
 	dims := vectorBenchmarkDims(b)
@@ -816,21 +850,12 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathOpenLoadSearchWithDocument
 		b.Fatal("missing query vector")
 	}
 	opts := ColumnVectorGraphSearchOptions{TopK: vectorBenchmarkTopK, EfSearch: 128}
-	loader := testColumnVectorGraphIndexLoader{
-		result: ColumnVectorGraphIndexLoadResult{
-			Graph: fixture.graph,
-			Status: VectorIndexLoadStatus{
-				Strategy:                      VectorIndexStrategyColumnGraph,
-				PhysicalColumnAssetsSupported: true,
-				BytesDisk:                     fixture.bytesDisk,
-			},
-		},
-	}
 	vectorOpts := vectorIndexOptionsFromDefinition(fixture.def)
 
 	// This deliberately measures the slower DB-facing path: open collection,
-	// validate column_graph status through the loader seam, search, then fetch
-	// the selected documents. Build/index setup stays outside the timed loop.
+	// validate column_graph status through the real physical loader, search,
+	// then fetch the selected documents. Build/index setup stays outside the
+	// timed loop.
 	var scratch ColumnVectorGraphSearchScratch
 	var documentBuf []byte
 	warmD, warmCol, warmGraph, warmLoadStatus := openLoadedColumnGraphVectorBenchmarkMainPath(b, fixture)
@@ -861,7 +886,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathOpenLoadSearchWithDocument
 			_ = d.Close()
 			b.Fatalf("open collection: %v", err)
 		}
-		graph, status, err := col.loadColumnGraphVectorIndexSnapshot(vectorOpts, loader)
+		graph, status, err := col.LoadColumnGraphVectorIndexSnapshot(vectorOpts)
 		if err != nil {
 			_ = d.Close()
 			b.Fatalf("load column graph vector index: %v", err)
@@ -1572,15 +1597,17 @@ func openLoadedNativeVectorBenchmarkIndex(tb testing.TB, docs, dims int, name st
 }
 
 type columnGraphVectorBenchmarkMainPathFixture struct {
-	dir       string
-	def       VectorIndexDefinition
-	graph     *ColumnVectorGraph
-	bytesDisk int64
+	dir   string
+	def   VectorIndexDefinition
+	graph *ColumnVectorGraph
 }
 
 func setupColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name string) columnGraphVectorBenchmarkMainPathFixture {
 	tb.Helper()
 	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
 	def := VectorIndexDefinition{
 		Name:       name,
 		Field:      "embedding",
@@ -1590,18 +1617,13 @@ func setupColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name
 		EfSearch:   128,
 		Strategy:   VectorIndexStrategyColumnGraph,
 	}
-	active := ColumnManifestIdentity{
-		Generation: 1,
-		Version:    columnManifestIdentityVersion,
-		Checksum:   0x434f4c4752415048,
-	}
-	d, err := backenddb.Open(backenddb.Options{Dir: dir})
-	if err != nil {
-		tb.Fatalf("open db: %v", err)
-	}
+	d := openCollectionCommandWALDB(tb, dir)
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
-		Name:          "docs",
+		Name: "docs",
+		Options: CollectionOptions{
+			ColumnStore: columnGraphVectorBenchmarkColumnStore(nil, dims),
+		},
 		VectorIndexes: []VectorIndexDefinition{def},
 	}); err != nil {
 		_ = d.Close()
@@ -1612,29 +1634,22 @@ func setupColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name
 		_ = d.Close()
 		tb.Fatalf("open collection: %v", err)
 	}
-	ids, documents := vectorBenchmarkWriteBatch(docs, dims)
+	columns := columnVectorGraphTestColumns(docs, dims, 16, false)
+	ids, documents := vectorGraphBenchmarkWriteBatch(columns)
 	vectorBenchmarkInsertBatches(tb, col, ids, documents, 512)
-	if err := col.Flush(); err != nil {
+	if err := d.Checkpoint(); err != nil {
 		_ = d.Close()
-		tb.Fatalf("flush benchmark collection: %v", err)
+		tb.Fatalf("checkpoint benchmark collection: %v", err)
 	}
-	publishColumnStoreCatalogForTest(tb, d, CollectionMeta{
-		Name: "docs",
-		Options: CollectionOptions{
-			ColumnStore: columnGraphVectorBenchmarkColumnStore(&active, dims),
-		},
-		VectorIndexes: []VectorIndexDefinition{def},
-	}, active)
 	if err := d.Close(); err != nil {
 		tb.Fatalf("close setup db: %v", err)
 	}
 
-	columns := columnVectorGraphTestColumns(docs, dims, 16, false)
 	graph, err := NewColumnVectorGraphFromColumns(columns)
 	if err != nil {
 		tb.Fatalf("NewColumnVectorGraphFromColumns: %v", err)
 	}
-	return columnGraphVectorBenchmarkMainPathFixture{dir: dir, def: def, graph: graph, bytesDisk: columnGraphVectorBenchmarkBytes(columns)}
+	return columnGraphVectorBenchmarkMainPathFixture{dir: dir, def: def, graph: graph}
 }
 
 func openColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name string) (*backenddb.DB, *Collection, *ColumnVectorGraph, VectorIndexLoadStatus) {
@@ -1645,35 +1660,26 @@ func openColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name 
 
 func openLoadedColumnGraphVectorBenchmarkMainPath(tb testing.TB, fixture columnGraphVectorBenchmarkMainPathFixture) (*backenddb.DB, *Collection, *ColumnVectorGraph, VectorIndexLoadStatus) {
 	tb.Helper()
-	d, err := backenddb.Open(backenddb.Options{Dir: fixture.dir})
-	if err != nil {
-		tb.Fatalf("reopen db: %v", err)
-	}
+	d := openCollectionCommandWALDB(tb, fixture.dir)
 	col, err := NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		_ = d.Close()
 		tb.Fatalf("open reopened collection: %v", err)
 	}
-	loader := testColumnVectorGraphIndexLoader{
-		result: ColumnVectorGraphIndexLoadResult{
-			Graph: fixture.graph,
-			Status: VectorIndexLoadStatus{
-				Strategy:                      VectorIndexStrategyColumnGraph,
-				PhysicalColumnAssetsSupported: true,
-				BytesDisk:                     fixture.bytesDisk,
-			},
-		},
-	}
-	loaded, status, err := col.loadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(fixture.def), loader)
+	loaded, status, err := col.LoadColumnGraphVectorIndexSnapshot(vectorIndexOptionsFromDefinition(fixture.def))
 	if err != nil {
 		_ = d.Close()
 		tb.Fatalf("load column_graph vector index: %v", err)
 	}
-	if loaded == nil || loaded != fixture.graph || !status.ColumnGraphLoaded || !status.PhysicalColumnAssetsSupported || status.RootID == 0 {
+	if loaded == nil || !status.ColumnGraphLoaded || !status.PhysicalColumnAssetsSupported || status.RootID == 0 {
 		_ = d.Close()
-		tb.Fatalf("unexpected column_graph benchmark load status loaded=%v same=%v status=%+v", loaded != nil, loaded == fixture.graph, status)
+		tb.Fatalf("unexpected column_graph benchmark load status loaded=%v status=%+v", loaded != nil, status)
 	}
-	return d, col, fixture.graph, status
+	if loaded.Rows() != fixture.graph.Rows() || loaded.Dims() != fixture.graph.Dims() || loaded.Edges() != fixture.graph.Edges() {
+		_ = d.Close()
+		tb.Fatalf("unexpected column_graph shape rows=%d/%d dims=%d/%d edges=%d/%d", loaded.Rows(), fixture.graph.Rows(), loaded.Dims(), fixture.graph.Dims(), loaded.Edges(), fixture.graph.Edges())
+	}
+	return d, col, loaded, status
 }
 
 func columnGraphVectorBenchmarkColumnStore(active *ColumnManifestIdentity, dims int) *ColumnStoreConfig {
@@ -1701,12 +1707,37 @@ func columnGraphVectorBenchmarkColumnStore(active *ColumnManifestIdentity, dims 
 	return cfg
 }
 
-func columnGraphVectorBenchmarkBytes(columns ColumnVectorGraphColumns) int64 {
-	var documentIDBytes int
-	for _, id := range columns.DocumentIDs {
-		documentIDBytes += len(id)
+func vectorGraphBenchmarkWriteBatch(columns ColumnVectorGraphColumns) ([][]byte, [][]byte) {
+	rows := len(columns.DocumentIDs)
+	ids := make([][]byte, rows)
+	documents := make([][]byte, rows)
+	for row := 0; row < rows; row++ {
+		ids[row] = append([]byte(nil), columns.DocumentIDs[row]...)
+		vector := columns.Vectors[row*columns.Dimensions : (row+1)*columns.Dimensions]
+		neighbors := columns.Neighbors[columns.NeighborOffsets[row]:columns.NeighborOffsets[row+1]]
+		documents[row] = vectorGraphBenchmarkDocument(row, vector, columns.InvNorms[row], neighbors)
 	}
-	return int64(len(columns.Vectors)*4 + len(columns.InvNorms)*4 + len(columns.NeighborOffsets)*4 + len(columns.Neighbors)*4 + documentIDBytes)
+	return ids, documents
+}
+
+func vectorGraphBenchmarkDocument(id int, vector []float32, invNorm float32, neighbors []uint32) []byte {
+	out := make([]byte, 0, 64+len(vector)*10+len(neighbors)*4)
+	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	for i, value := range vector {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, fmt.Sprintf("%.7g", value)...)
+	}
+	out = append(out, fmt.Sprintf(`],"embedding_inv_norm":%.7g,"embedding_neighbors":[`, invNorm)...)
+	for i, neighbor := range neighbors {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = strconv.AppendUint(out, uint64(neighbor), 10)
+	}
+	out = append(out, ']', '}')
+	return out
 }
 
 func fetchColumnGraphBenchmarkDocuments(tb testing.TB, col *Collection, results []VectorSearchResult, buf *[]byte) int {

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -819,7 +819,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathPublicSearch(b *testing.B)
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(kernelTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		results, trace, err := col.SearchVectorIndex(indexName, query, opts)
@@ -836,7 +836,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathPublicSearch(b *testing.B)
 	b.ReportMetric(float64(loadStatus.RootID), "manifest_root_id")
 	b.ReportMetric(float64(loadStatus.BytesDisk), "column_graph_bytes")
 	b.ReportMetric(float64(graph.Edges())/float64(graph.Rows()), "edges/node")
-	b.ReportMetric(float64(kernelTrace.CandidatesExamined), "candidates/search")
+	b.ReportMetric(float64(warmTrace.CandidatesExamined), "candidates/search")
 	b.ReportMetric(float64(kernelTrace.EdgesVisited), "edges/search")
 }
 
@@ -1637,6 +1637,10 @@ func setupColumnGraphVectorBenchmarkMainPath(tb testing.TB, docs, dims int, name
 	columns := columnVectorGraphTestColumns(docs, dims, 16, false)
 	ids, documents := vectorGraphBenchmarkWriteBatch(columns)
 	vectorBenchmarkInsertBatches(tb, col, ids, documents, 512)
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("flush benchmark collection: %v", err)
+	}
 	if err := d.Checkpoint(); err != nil {
 		_ = d.Close()
 		tb.Fatalf("checkpoint benchmark collection: %v", err)
@@ -1720,16 +1724,20 @@ func vectorGraphBenchmarkWriteBatch(columns ColumnVectorGraphColumns) ([][]byte,
 	return ids, documents
 }
 
-func vectorGraphBenchmarkDocument(id int, vector []float32, invNorm float32, neighbors []uint32) []byte {
+func vectorGraphBenchmarkDocument(row int, vector []float32, invNorm float32, neighbors []uint32) []byte {
 	out := make([]byte, 0, 64+len(vector)*10+len(neighbors)*4)
-	out = append(out, fmt.Sprintf(`{"group":%d,"embedding":[`, id%16)...)
+	out = append(out, `{"group":`...)
+	out = strconv.AppendInt(out, int64(row%16), 10)
+	out = append(out, `,"embedding":[`...)
 	for i, value := range vector {
 		if i > 0 {
 			out = append(out, ',')
 		}
-		out = append(out, fmt.Sprintf("%.7g", value)...)
+		out = strconv.AppendFloat(out, float64(value), 'g', 7, 32)
 	}
-	out = append(out, fmt.Sprintf(`],"embedding_inv_norm":%.7g,"embedding_neighbors":[`, invNorm)...)
+	out = append(out, `],"embedding_inv_norm":`...)
+	out = strconv.AppendFloat(out, float64(invNorm), 'g', 7, 32)
+	out = append(out, `,"embedding_neighbors":[`...)
 	for i, neighbor := range neighbors {
 		if i > 0 {
 			out = append(out, ',')

--- a/TreeDB/collections/vector_search_bench_test.go
+++ b/TreeDB/collections/vector_search_bench_test.go
@@ -25,6 +25,13 @@ const (
 
 var vectorDistanceBenchmarkSink float32
 
+func columnVectorGraphBenchmarkSearchBytes(candidates int, dims int) int64 {
+	if candidates <= 0 || dims <= 0 {
+		return 0
+	}
+	return int64(candidates) * int64(dims) * int64(4)
+}
+
 func BenchmarkVectorDistanceToFloat32NodeCosinePrepared(b *testing.B) {
 	docs := minInt(vectorBenchmarkDocs(b), 4096)
 	dims := vectorBenchmarkDims(b)
@@ -591,7 +598,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathSearch(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, graph.Dims()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		results, trace, err := graph.SearchCosine(query, opts, &scratch)
@@ -640,7 +647,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathSearchParallel(b *testing.
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, graph.Dims()))
 	b.ResetTimer()
 	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
@@ -694,7 +701,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathSearchWithDocumentFetch(b 
 	warmBytes := fetchColumnGraphBenchmarkDocuments(b, col, warm, &documentBuf)
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, graph.Dims()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		results, trace, err := graph.SearchCosine(query, opts, &scratch)
@@ -748,7 +755,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathSearchWithDocumentFetchPar
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, graph.Dims()))
 	b.ResetTimer()
 	var nextWorker uint64
 	b.RunParallel(func(pb *testing.PB) {
@@ -819,7 +826,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathPublicSearch(b *testing.B)
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, graph.Dims()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		results, trace, err := col.SearchVectorIndex(indexName, query, opts)
@@ -874,7 +881,7 @@ func BenchmarkCollectionVectorIndexColumnGraphMainPathOpenLoadSearchWithDocument
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(int64(warmTrace.CandidatesExamined * fixture.graph.Dims() * 4))
+	b.SetBytes(columnVectorGraphBenchmarkSearchBytes(warmTrace.CandidatesExamined, fixture.graph.Dims()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		d, err := backenddb.Open(backenddb.Options{Dir: fixture.dir})
@@ -1679,9 +1686,13 @@ func openLoadedColumnGraphVectorBenchmarkMainPath(tb testing.TB, fixture columnG
 		_ = d.Close()
 		tb.Fatalf("unexpected column_graph benchmark load status loaded=%v status=%+v", loaded != nil, status)
 	}
-	if loaded.Rows() != fixture.graph.Rows() || loaded.Dims() != fixture.graph.Dims() || loaded.Edges() != fixture.graph.Edges() {
+	if loaded.Rows() != fixture.graph.Rows() || loaded.Dims() != fixture.graph.Dims() {
 		_ = d.Close()
-		tb.Fatalf("unexpected column_graph shape rows=%d/%d dims=%d/%d edges=%d/%d", loaded.Rows(), fixture.graph.Rows(), loaded.Dims(), fixture.graph.Dims(), loaded.Edges(), fixture.graph.Edges())
+		tb.Fatalf("unexpected column_graph shape rows=%d/%d dims=%d/%d", loaded.Rows(), fixture.graph.Rows(), loaded.Dims(), fixture.graph.Dims())
+	}
+	if loaded.Rows() > 1 && loaded.Edges() == 0 {
+		_ = d.Close()
+		tb.Fatalf("unexpected column_graph empty adjacency rows=%d edges=%d", loaded.Rows(), loaded.Edges())
 	}
 	return d, col, loaded, status
 }


### PR DESCRIPTION
## Summary
- Converts the `column_graph` main-path benchmarks from an injected test loader to the real physical column asset loader.
- Adds a public `SearchVectorIndex` benchmark variant so the PR shows both the loaded in-memory kernel ceiling and the current public API cost.
- Keeps setup/build/index-load/document-fetch separated across benchmark variants and uses 64-bit arithmetic for reported scanned bytes.

## Corrected Boundary
These benchmarks do **not** measure column-store-native vector search.

They measure two separate things:
- physical column assets being scanned/decoded into an in-memory `ColumnVectorGraph`,
- `ColumnVectorGraph.SearchCosine` searching that decoded in-memory graph.

They do not search directly over TreeDB column-store granules, marks, reader caches, or decoded-block caches.

## Benchmark Evidence
Host: Apple M3, darwin/arm64.

Command:
```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionVectorIndexColumnGraphMainPath' \
  -benchmem \
  -benchtime=500ms \
  -count=3
```

Shape: 10,000 docs, 64 dims, degree 16, TopK=10, EfSearch=128, physical column graph assets 4,246,700 bytes.

Representative results:
- Decode persisted column assets into in-memory graph: 15.7-16.4 ms/op, about 124 MB/op.
- In-memory graph search after column decode: 10.47-10.57 us/search, 0 B/op, 0 allocs/op.
- Parallel in-memory graph search after column decode: 2.10-2.36 us/op, 0 B/op, 0 allocs/op.
- In-memory graph search plus TreeDB document fetch: about 0.47 ms/search serial, 0 allocs/op after warmed document buffer.
- Public `SearchVectorIndex`, currently reload/decode per call: 5.1-5.4 ms/search, about 21.7 MB/op, 30,463 allocs/op.

Interpretation: the persisted physical-asset path can feed the existing zero-alloc in-memory `ColumnVectorGraph` search kernel once loaded. The public API path is slower because it reloads/scans/decodes physical assets per call before materializing docs. The next step is a generic column-store-native graph reader/cache; this PR does not add a vector-specific shortcut.

## Validation
```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionVectorIndexColumnGraphMainPath(PublicSearch|Load)$' -benchmem -benchtime=1x -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionVectorIndexColumnGraph|TestCollectionSearchVectorIndex' -count=1
git diff --check
```

## Stack
- Base PR: #1643
- Next PR: #1645


## Follow-up Native Column-Store Search Ticket
True column-store-native vector search, without a full decoded in-memory graph, is tracked separately in #1646.
