### PR TITLE
Decoded column graph docs and demo scaffolding

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -160,6 +160,11 @@ The initial API lives in `TreeDB/collections`:
   expose live/deleted counts, memory and disk bytes, persisted epoch state,
   snapshot dirtiness, candidate counts, selected strategy, exact fallback
   reason, rebuild duration, and recall-at-k.
+- `VectorIndexDefinition.Strategy = VectorIndexStrategyColumnGraph` selects the
+  explicit column-backed graph path. This path loads vector, inverse-norm, and
+  adjacency-list physical column assets into `ColumnVectorGraph`, runs graph
+  search without fetching documents, then materializes documents after top-k
+  selection through `Collection.SearchVectorIndex`.
 
 Smoke benchmark:
 
@@ -192,6 +197,18 @@ The tiny BERT embedding demo in `../examples/vector_search/tiny_bert/` is a
 caller-side fixture/demo; TreeDB core does not generate embeddings. Export it
 with `--output-jsonl` and set `TREEDB_VECTOR_BENCH_JSONL` to run
 `BenchmarkCollectionVectorTinyBERTFixture`.
+
+The column-backed graph path is documented in
+`TreeDB/docs/spec/collections-column-graph-vector-search.md`. Start with:
+
+```sh
+GOWORK=off go run ./cmd/treedb_column_graph_demo -json
+scripts/bench_column_graph_main_path.sh
+```
+
+For opt-in public Deep1B/DEEP dataset evidence, use
+`scripts/bench_column_vector_deep1b.sh`; it downloads data outside the repo into
+`$COLUMN_VECTOR_DEEP1B_DIR`.
 
 Optional external engine baseline: build with `-tags usearch_bench` after
 installing the USearch C library and headers for the host. This runs the same

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -117,7 +117,11 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     collection ANN vector graph into a native persisted TreeDB secondary index.
 - `TreeDB/docs/spec/collections-column-vector-contract-seam.md`
   - current contract seam for explicit `column_graph` vector indexes; documents
-    status/fallback behavior and the missing physical column asset milestones.
+    physical column asset loading, status/fallback behavior, and remaining
+    build/rebuild plus mutation-maintenance milestones.
+- `TreeDB/docs/spec/collections-column-graph-vector-search.md`
+  - user-facing quickstart, demo, benchmark scripts, Deep1B dataset guidance,
+    current evidence, and caveats for explicit `column_graph` vector indexes.
 - `TreeDB/docs/spec/collections-native-fastpath-roadmap.md`
   - draft implementation roadmap for the native cached collections rewrite,
     including PR slices, acceptance criteria, and performance gates.

--- a/TreeDB/docs/spec/collections-column-graph-vector-search.md
+++ b/TreeDB/docs/spec/collections-column-graph-vector-search.md
@@ -37,7 +37,7 @@ meta := collections.CollectionMeta{
 					Name:       "embedding",
 					Path:       "embedding",
 					ValueType:  collections.ColumnStoreValueFloat32Vector,
-					VectorDims: 128,
+					VectorDims: 3,
 				},
 				{
 					Name:      "embedding_inv_norm",
@@ -62,13 +62,17 @@ meta := collections.CollectionMeta{
 		Name:       "embedding",
 		Field:      "embedding",
 		Metric:     collections.VectorMetricCosine,
-		Dimensions: 128,
+		Dimensions: 3,
 		M:          16,
 		EfSearch:   128,
 		Strategy:   collections.VectorIndexStrategyColumnGraph,
 	}},
 }
 ```
+
+This quickstart uses a tiny 3-dimensional graph so the example document is
+literal rather than abbreviated. Production and benchmark configurations should
+set `VectorDims` and `Dimensions` to the actual embedding width.
 
 Documents must include the source vector plus graph side columns until the
 column-graph build/rebuild seam lands:
@@ -112,7 +116,10 @@ GOWORK=off go run ./cmd/treedb_column_graph_demo -json
 The demo creates a database, inserts a tiny graph, checkpoints, reopens, and
 searches through the public collection API. It intentionally writes the
 inverse-norm and adjacency columns in the documents so it can prove the
-persisted column-asset loader without adding fake vector persistence.
+persisted column-asset loader without adding fake vector persistence. By
+default it requires the persisted `column_graph` path; pass `-allow-fallback`
+when you want the demo to print exact-fallback diagnostics instead of failing
+closed.
 
 ## Real Public Dataset
 

--- a/TreeDB/docs/spec/collections-column-graph-vector-search.md
+++ b/TreeDB/docs/spec/collections-column-graph-vector-search.md
@@ -1,8 +1,8 @@
 # Column Graph Vector Search
 
 Status: pre-alpha. The `column_graph` strategy is explicit and feature-gated so
-TreeDB can prove the persisted column-store search path without replacing the
-native vector index by default.
+TreeDB can prove persisted column graph assets without replacing the native
+vector index by default. This is not column-store-native search yet.
 
 ## What It Is
 
@@ -13,12 +13,36 @@ TreeDB has two vector-index paths today:
   persists native vector-index roots, and reloads those roots on reopen.
 - Column graph vector indexes: an explicit `column_graph` strategy that loads
   vector, inverse-norm, and adjacency-list columns from physical column-store
-  assets, constructs an immutable `ColumnVectorGraph`, runs graph search, then
-  materializes documents after top-k selection.
+  assets, decodes them into an immutable in-memory `ColumnVectorGraph`, runs
+  graph search over that in-memory graph, then materializes documents after
+  top-k selection.
 
 The column graph path does not create a vector-only sidecar format. It uses the
 normal collection column manifest/root lifecycle and the physical column asset
 scanner.
+
+## What It Is Not
+
+This path does not search directly over TreeDB column-store granules, resident
+column readers, marks, or decoded-block caches. The current flow is:
+
+```text
+physical column assets on disk
+-> manifest/root lookup and physical scan
+-> decode into Go slices
+-> in-memory ColumnVectorGraph.SearchCosine
+```
+
+The target future flow for column-store-native vector search is different:
+
+```text
+column-store-native graph reader/cache
+-> fetch vector rows and adjacency through generic column APIs
+-> search without materializing a full decoded graph copy
+```
+
+Until that exists, treat the search-kernel benchmarks below as an in-memory
+ceiling after column-asset decode, not as proof of native column-store search.
 
 ## Quickstart
 
@@ -116,10 +140,11 @@ GOWORK=off go run ./cmd/treedb_column_graph_demo -json
 The demo creates a database, inserts a tiny graph, checkpoints, reopens, and
 searches through the public collection API. It intentionally writes the
 inverse-norm and adjacency columns in the documents so it can prove the
-persisted column-asset loader without adding fake vector persistence. By
-default it requires the persisted `column_graph` path; pass `-allow-fallback`
-when you want the demo to print exact-fallback diagnostics instead of failing
-closed.
+persisted column-asset loader without adding fake vector persistence. Search is
+still performed over the decoded in-memory `ColumnVectorGraph`, not directly
+over column-store granules. By default it requires the persisted `column_graph`
+path; pass `-allow-fallback` when you want the demo to print exact-fallback
+diagnostics instead of failing closed.
 
 ## Real Public Dataset
 
@@ -166,9 +191,11 @@ GOWORK=off go test ./TreeDB/collections \
   -count=3
 ```
 
-This is a synthetic benchmark, but it exercises real collection metadata,
-physical column assets, manifest/root reopen, `ColumnVectorGraph` load/search,
-and public document materialization variants.
+This is a synthetic benchmark. It exercises real collection metadata, physical
+column assets, manifest/root reopen, decode into an in-memory
+`ColumnVectorGraph`, in-memory graph search, and public document
+materialization variants. It does not measure direct search over native
+column-store reader APIs.
 
 ## Current Evidence
 
@@ -190,18 +217,19 @@ Representative results:
 
 | Benchmark | Result |
 | --- | ---: |
-| Load reopened physical column graph | 15.7-16.4 ms/op |
-| Kernel search, graph only | 10.47-10.57 us/search, 0 B/op, 0 allocs/op |
-| Kernel search, parallel | 2.10-2.36 us/op, 0 B/op, 0 allocs/op |
-| Kernel search plus document fetch | 0.47 ms/search, 0 allocs/op after warmed buffer |
-| Public `SearchVectorIndex` | 5.1-5.4 ms/search, about 21.7 MB/op, 30,463 allocs/op |
-| Open, load, search, document fetch | usually 17-18 ms/op after one slower first sample |
+| Decode persisted column assets into in-memory graph | 15.7-16.4 ms/op |
+| In-memory graph search after column decode | 10.47-10.57 us/search, 0 B/op, 0 allocs/op |
+| Parallel in-memory graph search after column decode | 2.10-2.36 us/op, 0 B/op, 0 allocs/op |
+| In-memory graph search plus TreeDB document fetch | 0.47 ms/search, 0 allocs/op after warmed buffer |
+| Public `SearchVectorIndex`, currently reload/decode per call | 5.1-5.4 ms/search, about 21.7 MB/op, 30,463 allocs/op |
+| Cold DB/open plus column decode plus in-memory search plus document fetch | usually 17-18 ms/op after one slower first sample |
 
-Interpretation: the reopened `ColumnVectorGraph` kernel remains the current
-steady-state ceiling and is zero-allocation with warmed scratch. The public API
-path is intentionally slower today because it reloads/scans physical assets for
-each call before materializing documents. That is the next lifecycle-cache seam,
-not a reason to add a vector-specific storage shortcut.
+Interpretation: the reopened `ColumnVectorGraph` kernel is only the current
+in-memory ceiling after column-asset decode. It is zero-allocation with warmed
+scratch, but it is not column-store-native search. The public API path is
+slower today because it reloads/scans/decodes physical assets for each call
+before materializing documents. The correct follow-on is a generic
+column-store-native graph reader/cache, not a vector-specific storage shortcut.
 
 ## Best Practices
 
@@ -213,6 +241,8 @@ not a reason to add a vector-specific storage shortcut.
   top-k IDs are selected.
 - Treat loaded `ColumnVectorGraph` instances as immutable shared state. Use one
   `ColumnVectorGraphSearchScratch` per goroutine for lower-level kernel calls.
+- Do not treat `ColumnVectorGraph.SearchCosine` as native column-store search.
+  It searches decoded in-memory slices loaded from column assets.
 - Expect mutation-bearing physical manifests to report rebuild-needed until the
   dynamic overlay or rebuild-maintenance seam lands.
 - For final storage numbers, compact through TreeDB's normal storage
@@ -227,5 +257,8 @@ not a reason to add a vector-specific storage shortcut.
   unavailable/rebuild-needed rather than maintaining it in place.
 - Repeated public searches currently reload the physical graph each call. Reuse
   a loaded `ColumnVectorGraph` directly in lower-level benchmarks when measuring
-  the search-kernel ceiling.
+  the in-memory search-kernel ceiling after column-asset decode.
+- True column-store-native search still needs a generic column-store graph
+  reader/cache that can traverse adjacency and score vector rows without
+  materializing a full decoded `ColumnVectorGraph`.
 - Deep1B benchmark scripts are opt-in and should not be added to routine CI.

--- a/TreeDB/docs/spec/collections-column-graph-vector-search.md
+++ b/TreeDB/docs/spec/collections-column-graph-vector-search.md
@@ -1,0 +1,224 @@
+# Column Graph Vector Search
+
+Status: pre-alpha. The `column_graph` strategy is explicit and feature-gated so
+TreeDB can prove the persisted column-store search path without replacing the
+native vector index by default.
+
+## What It Is
+
+TreeDB has two vector-index paths today:
+
+- Native/runtime vector indexes: the established collection lifecycle for
+  ordinary users. `BuildVectorIndex` builds an ANN graph from document vectors,
+  persists native vector-index roots, and reloads those roots on reopen.
+- Column graph vector indexes: an explicit `column_graph` strategy that loads
+  vector, inverse-norm, and adjacency-list columns from physical column-store
+  assets, constructs an immutable `ColumnVectorGraph`, runs graph search, then
+  materializes documents after top-k selection.
+
+The column graph path does not create a vector-only sidecar format. It uses the
+normal collection column manifest/root lifecycle and the physical column asset
+scanner.
+
+## Quickstart
+
+The current product seam expects the graph columns to already exist. Normal
+vector-index build/rebuild does not yet derive inverse norms or adjacency lists
+from ordinary vector documents.
+
+```go
+meta := collections.CollectionMeta{
+	Name: "docs",
+	Options: collections.CollectionOptions{
+		ColumnStore: &collections.ColumnStoreConfig{
+			Enabled: true,
+			Columns: []collections.ColumnStoreColumn{
+				{
+					Name:       "embedding",
+					Path:       "embedding",
+					ValueType:  collections.ColumnStoreValueFloat32Vector,
+					VectorDims: 128,
+				},
+				{
+					Name:      "embedding_inv_norm",
+					Path:      "embedding_inv_norm",
+					ValueType: collections.ColumnStoreValueFloat32,
+				},
+				{
+					Name:      "embedding_neighbors",
+					Path:      "embedding_neighbors",
+					ValueType: collections.ColumnStoreValueAdjacencyList,
+				},
+			},
+			RetainedPayload: collections.ColumnRetainedPayloadFull,
+			AssetManager: &collections.ColumnAssetManagerConfig{
+				Kind:              collections.ColumnAssetManagerValueLogShaped,
+				IsolatedNamespace: true,
+				Namespace:         "vector_graph_columns",
+			},
+		},
+	},
+	VectorIndexes: []collections.VectorIndexDefinition{{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     collections.VectorMetricCosine,
+		Dimensions: 128,
+		M:          16,
+		EfSearch:   128,
+		Strategy:   collections.VectorIndexStrategyColumnGraph,
+	}},
+}
+```
+
+Documents must include the source vector plus graph side columns until the
+column-graph build/rebuild seam lands:
+
+```json
+{
+  "title": "example",
+  "embedding": [0.1, 0.2, 0.3],
+  "embedding_inv_norm": 2.6726,
+  "embedding_neighbors": [17, 44, 91]
+}
+```
+
+After insert and checkpoint, reopen the DB and query the declared index:
+
+```go
+results, trace, err := col.SearchVectorIndex(
+	"embedding",
+	query,
+	collections.VectorIndexSearchOptions{
+		TopK:                 10,
+		EfSearch:             128,
+		DisableExactFallback: true,
+	},
+)
+```
+
+Check `trace.Strategy`, `trace.ExactFallbackReason`, and
+`Collection.VectorIndexStatus("embedding")` when integrating. A loaded physical
+column graph reports `ColumnGraphLoaded=true`,
+`PhysicalColumnAssetsSupported=true`, and `RebuildNeeded=false`.
+
+## Demo
+
+Run the small product-path demo:
+
+```sh
+GOWORK=off go run ./cmd/treedb_column_graph_demo -json
+```
+
+The demo creates a database, inserts a tiny graph, checkpoints, reopens, and
+searches through the public collection API. It intentionally writes the
+inverse-norm and adjacency columns in the documents so it can prove the
+persisted column-asset loader without adding fake vector persistence.
+
+## Real Public Dataset
+
+For public large-vector evidence, use the Yandex Research Deep1B/DEEP dataset.
+Yandex describes Deep1B as 96-dimensional L2-normalized image embeddings and
+publishes 10M and 1B base-vector downloads plus query vectors and ground truth:
+https://research.yandex.com/blog/benchmarks-for-billion-scale-similarity-search
+
+TreeDB does not store that dataset in the repository. The opt-in benchmark
+script downloads it into a cache directory when missing:
+
+```sh
+COLUMN_VECTOR_DEEP1B_DIR=$HOME/.cache/gomap/deep1b \
+COLUMN_VECTOR_DEEP1B_DOWNLOAD=1 \
+RUN_10M=false \
+BENCHTIME=500ms \
+COUNT=1 \
+scripts/bench_column_vector_deep1b.sh
+```
+
+Set `RUN_10M=true` for the larger 10M shape. The Deep1B benchmarks currently
+live under `experiments/colgranule` and measure persisted column-vector graph
+evidence. They are deliberately opt-in because downloading and scanning public
+datasets is not CI-safe.
+
+## Main-Path Benchmark Script
+
+For the collection product path, run:
+
+```sh
+scripts/bench_column_graph_main_path.sh
+```
+
+The script records output under `/tmp/gomap_column_graph_main_path_*` and runs:
+
+```sh
+TREEDB_VECTOR_BENCH_DOCS=10000 \
+TREEDB_VECTOR_BENCH_DIMS=64 \
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkCollectionVectorIndexColumnGraphMainPath' \
+  -benchmem \
+  -benchtime 500ms \
+  -count 3
+```
+
+This is a synthetic benchmark, but it exercises real collection metadata,
+physical column assets, manifest/root reopen, `ColumnVectorGraph` load/search,
+and public document materialization variants.
+
+## Current Evidence
+
+Local run on Apple M3, darwin/arm64:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkCollectionVectorIndexColumnGraphMainPath' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=3
+```
+
+Shape: 10,000 documents, 64 dimensions, degree 16, `TopK=10`,
+`EfSearch=128`, physical column graph assets 4,246,700 bytes.
+
+Representative results:
+
+| Benchmark | Result |
+| --- | ---: |
+| Load reopened physical column graph | 15.7-16.4 ms/op |
+| Kernel search, graph only | 10.47-10.57 us/search, 0 B/op, 0 allocs/op |
+| Kernel search, parallel | 2.10-2.36 us/op, 0 B/op, 0 allocs/op |
+| Kernel search plus document fetch | 0.47 ms/search, 0 allocs/op after warmed buffer |
+| Public `SearchVectorIndex` | 5.1-5.4 ms/search, about 21.7 MB/op, 30,463 allocs/op |
+| Open, load, search, document fetch | usually 17-18 ms/op after one slower first sample |
+
+Interpretation: the reopened `ColumnVectorGraph` kernel remains the current
+steady-state ceiling and is zero-allocation with warmed scratch. The public API
+path is intentionally slower today because it reloads/scans physical assets for
+each call before materializing documents. That is the next lifecycle-cache seam,
+not a reason to add a vector-specific storage shortcut.
+
+## Best Practices
+
+- Use `Strategy: column_graph` explicitly. Do not rely on it as the default
+  vector-index product path yet.
+- Keep canonical documents in the row store. Treat column vectors, inverse
+  norms, and adjacency lists as derived assets.
+- Keep graph traversal document-fetch-free. Materialize documents only after
+  top-k IDs are selected.
+- Treat loaded `ColumnVectorGraph` instances as immutable shared state. Use one
+  `ColumnVectorGraphSearchScratch` per goroutine for lower-level kernel calls.
+- Expect mutation-bearing physical manifests to report rebuild-needed until the
+  dynamic overlay or rebuild-maintenance seam lands.
+- For final storage numbers, compact through TreeDB's normal storage
+  maintenance path rather than hand-deleting column assets.
+
+## Current Caveats
+
+- `BuildVectorIndex` still builds the native vector-index path. It does not yet
+  synthesize column graph assets.
+- The column graph loader currently requires insert-only physical manifests.
+  Inserts, updates, or deletes after a graph is published mark the graph
+  unavailable/rebuild-needed rather than maintaining it in place.
+- Repeated public searches currently reload the physical graph each call. Reuse
+  a loaded `ColumnVectorGraph` directly in lower-level benchmarks when measuring
+  the search-kernel ceiling.
+- Deep1B benchmark scripts are opt-in and should not be added to routine CI.

--- a/TreeDB/docs/spec/collections-column-graph-vector-search.md
+++ b/TreeDB/docs/spec/collections-column-graph-vector-search.md
@@ -162,8 +162,8 @@ GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
   -bench 'BenchmarkCollectionVectorIndexColumnGraphMainPath' \
   -benchmem \
-  -benchtime 500ms \
-  -count 3
+  -benchtime=500ms \
+  -count=3
 ```
 
 This is a synthetic benchmark, but it exercises real collection metadata,

--- a/TreeDB/docs/spec/collections-column-vector-contract-seam.md
+++ b/TreeDB/docs/spec/collections-column-vector-contract-seam.md
@@ -1,24 +1,23 @@
 # Collection Column-Backed Vector Index Seam
 
-Status: implemented as a product-contract seam, not as a complete persisted
-column-backed vector-search product path.
+Status: implemented as a product-contract seam with real physical column-asset
+loading when vector, inverse-norm, and adjacency-list assets already exist.
 
 ## Current Reality
 
-TreeDB currently has two separate pieces of vector-index infrastructure:
+TreeDB currently has two vector-index paths:
 
 - The public collection vector-index lifecycle uses collection metadata plus
   native TreeDB vector-index roots. This path can declare, build, save, reopen,
   load, and query the native/runtime ANN graph.
-- `ColumnVectorGraph` is the lower-level column-shaped search kernel. It
-  searches immutable row-major vector, inverse-norm, and CSR adjacency columns
-  with caller-owned scratch. It does not fetch full documents in the traversal,
-  scoring, or top-k kernel.
+- Explicit `column_graph` indexes load vector, inverse-norm, and adjacency-list
+  data from physical column-store assets referenced by the collection column
+  manifest/root state, then construct an immutable `ColumnVectorGraph`.
 
-The full product path for a persisted column-backed vector index still depends
-on physical column-store support that writes, publishes, reopens, and scans the
-vector, inverse-norm, and adjacency-list assets through the collection column
-manifest/root lifecycle.
+`ColumnVectorGraph` searches immutable row-major vector, inverse-norm, and CSR
+adjacency columns with caller-owned scratch. It does not fetch full documents in
+the traversal, scoring, or top-k kernel. Public `SearchVectorIndex` materializes
+documents only after the graph kernel has selected top-k IDs.
 
 ## `column_graph` Strategy
 
@@ -44,6 +43,10 @@ creation, and native write-maintenance for explicit `column_graph` indexes. The
 strategy reports status through the normal vector-index operational APIs instead
 of silently returning native results.
 
+No vector-only sidecar persistence format is created. The default
+`column_graph` loader only uses the physical column asset scanner and the
+collection column manifest/root lifecycle.
+
 ## Status Contract
 
 `VectorIndexStatus` and `VectorIndexLoadStatus` report the selected strategy and
@@ -66,40 +69,46 @@ Current `column_graph` unavailable reasons include:
 - `column_graph_manifest_root_mismatch`
 - `column_graph_requires_cosine`
 - `column_graph_requires_float32`
+- `column_graph_physical_schema_mismatch`
+- `column_graph_requires_insert_only_manifest`
+- `column_graph_empty`
+- `column_graph_physical_graph_invalid`
 
 These reasons are also mirrored in `ExactFallbackReason` so existing callers
 that only inspect the older field still fail closed.
 
 ## Loader Boundary
 
-`ColumnVectorGraphIndexLoader` is the seam future physical column-store work
-must satisfy. A real loader must read vector, inverse-norm, and adjacency-list
-column assets referenced by the collection column manifest and construct an
+`ColumnVectorGraphIndexLoader` is the seam the physical column-store path
+satisfies. The default loader reads vector, inverse-norm, and adjacency-list
+column assets referenced by the collection column manifest and constructs an
 immutable `ColumnVectorGraph`.
 
-The current default loader returns
-`physical_column_asset_support_missing`. It does not create a vector-only
-sidecar format and does not bypass the column-store manifest/root architecture.
+The loader currently requires an insert-only physical manifest. If the active
+manifest includes mutation parts, or if the expected vector/invNorm/adjacency
+columns are missing or incompatible, status reports a precise unavailable or
+rebuild-needed reason instead of silently serving misleading results.
 
 ## Remaining Milestones
 
-Before `column_graph` can become the default product path, TreeDB still needs:
+Before `column_graph` can become the default vector-index product path, TreeDB
+still needs:
 
-1. Physical column asset writing for vector, inverse-norm, and adjacency-list
-   columns during vector-index build/rebuild.
-2. Durable publication of those assets through the collection column
-   manifest/root lifecycle.
-3. Reopen/scanner support that loads those published assets into
-   `ColumnVectorGraphColumns`.
-4. Mutation policy for inserts, updates, and deletes: maintain the graph, mark
+1. Vector-index build/rebuild plumbing that derives inverse norms and adjacency
+   graph columns and publishes them as normal physical column assets.
+2. Mutation policy for inserts, updates, and deletes: maintain the graph, mark
    it stale, or rebuild it explicitly.
-5. Public query wiring that uses `ColumnVectorGraph` for top-k selection and
-   materializes documents only after the graph kernel chooses result IDs.
+3. Dynamic overlay or rebuild integration for mutation-bearing manifests.
+4. Optional caching/open-handle lifecycle so repeated public
+   `SearchVectorIndex` calls do not have to rescan physical assets each time.
 
 ## What This Proves
 
 This seam proves that a normal collection can declare a column-backed vector
-index strategy and get explicit operational status without accidentally using
-the native graph path. It does not prove persisted column asset search, disk
-layout, compression, or end-to-end column-backed query performance. Those remain
-the responsibility of the physical column asset milestones above.
+index strategy, reopen physical column assets through the durable
+manifest/root lifecycle, load a `ColumnVectorGraph`, and serve public
+`SearchVectorIndex` calls without accidentally using the native graph path.
+
+It does not yet prove that normal vector-index build/rebuild creates all graph
+assets from ordinary vector documents, and it does not claim mutation-bearing
+manifests are maintained in place. Those remain explicit follow-on milestones.

--- a/TreeDB/docs/spec/collections-column-vector-contract-seam.md
+++ b/TreeDB/docs/spec/collections-column-vector-contract-seam.md
@@ -12,12 +12,18 @@ TreeDB currently has two vector-index paths:
   load, and query the native/runtime ANN graph.
 - Explicit `column_graph` indexes load vector, inverse-norm, and adjacency-list
   data from physical column-store assets referenced by the collection column
-  manifest/root state, then construct an immutable `ColumnVectorGraph`.
+  manifest/root state, then decode those assets into an immutable in-memory
+  `ColumnVectorGraph`.
 
 `ColumnVectorGraph` searches immutable row-major vector, inverse-norm, and CSR
-adjacency columns with caller-owned scratch. It does not fetch full documents in
+adjacency slices with caller-owned scratch. It does not fetch full documents in
 the traversal, scoring, or top-k kernel. Public `SearchVectorIndex` materializes
 documents only after the graph kernel has selected top-k IDs.
+
+This seam is not native column-store search. The current search kernel does not
+traverse adjacency or score vectors through TreeDB column-store reader APIs,
+granule caches, marks, or decoded-block caches. It searches a full decoded
+in-memory graph copy loaded from physical column assets.
 
 ## `column_graph` Strategy
 
@@ -81,8 +87,8 @@ that only inspect the older field still fail closed.
 
 `ColumnVectorGraphIndexLoader` is the seam the physical column-store path
 satisfies. The default loader reads vector, inverse-norm, and adjacency-list
-column assets referenced by the collection column manifest and constructs an
-immutable `ColumnVectorGraph`.
+column assets referenced by the collection column manifest and decodes them into
+an immutable in-memory `ColumnVectorGraph`.
 
 The loader currently requires an insert-only physical manifest. If the active
 manifest includes mutation parts, or if the expected vector/invNorm/adjacency
@@ -101,6 +107,9 @@ still needs:
 3. Dynamic overlay or rebuild integration for mutation-bearing manifests.
 4. Optional caching/open-handle lifecycle so repeated public
    `SearchVectorIndex` calls do not have to rescan physical assets each time.
+5. A column-store-native graph reader/search path that uses generic column-store
+   APIs for vector rows and adjacency without materializing the full graph into
+   decoded Go slices.
 
 ## What This Proves
 
@@ -110,5 +119,6 @@ manifest/root lifecycle, load a `ColumnVectorGraph`, and serve public
 `SearchVectorIndex` calls without accidentally using the native graph path.
 
 It does not yet prove that normal vector-index build/rebuild creates all graph
-assets from ordinary vector documents, and it does not claim mutation-bearing
-manifests are maintained in place. Those remain explicit follow-on milestones.
+assets from ordinary vector documents, it does not claim mutation-bearing
+manifests are maintained in place, and it does not prove column-store-native
+search. Those remain explicit follow-on milestones.

--- a/cmd/treedb_column_graph_demo/README.md
+++ b/cmd/treedb_column_graph_demo/README.md
@@ -3,7 +3,12 @@
 `treedb_column_graph_demo` is a small product-path demo for the explicit
 `column_graph` vector-index strategy. It creates a collection, writes vector,
 inverse-norm, and adjacency-list columns as normal column-store assets, closes
-and reopens the database, then searches through `Collection.SearchVectorIndex`.
+and reopens the database, loads those assets into an in-memory
+`ColumnVectorGraph`, then searches through `Collection.SearchVectorIndex`.
+
+This demo does not prove column-store-native search. Search currently runs on
+the decoded in-memory graph, not directly over TreeDB column-store granules or
+reader/cache APIs.
 
 Run it with:
 
@@ -22,10 +27,12 @@ The demo intentionally keeps the graph tiny. It proves the lifecycle boundary:
 4. Insert documents that include the three graph columns.
 5. Checkpoint, close, and reopen.
 6. Search through `Collection.SearchVectorIndex`.
-7. Print status showing whether the physical column graph was loaded.
+7. Print status showing whether the physical column assets were loaded into the
+   in-memory graph.
 
 Current caveat: normal vector-index `BuildVectorIndex` does not yet derive and
 publish inverse-norm or adjacency-list columns from ordinary vector documents.
 Until that build/rebuild seam lands, this demo writes those columns explicitly
 so the loader can prove the persisted column-asset path without adding a
-vector-only sidecar format.
+vector-only sidecar format. True column-store-native vector search is a
+separate follow-on.

--- a/cmd/treedb_column_graph_demo/README.md
+++ b/cmd/treedb_column_graph_demo/README.md
@@ -1,0 +1,31 @@
+# TreeDB Column Graph Vector Demo
+
+`treedb_column_graph_demo` is a small product-path demo for the explicit
+`column_graph` vector-index strategy. It creates a collection, writes vector,
+inverse-norm, and adjacency-list columns as normal column-store assets, closes
+and reopens the database, then searches through `Collection.SearchVectorIndex`.
+
+Run it with:
+
+```sh
+GOWORK=off go run ./cmd/treedb_column_graph_demo -json
+```
+
+The demo intentionally keeps the graph tiny. It proves the lifecycle boundary:
+
+1. Open a TreeDB database with command WAL enabled.
+2. Create a collection with column-store columns for:
+   - `embedding` as `float32_vector`
+   - `embedding_inv_norm` as `float32`
+   - `embedding_neighbors` as `adjacency_list`
+3. Declare a vector index with `Strategy: column_graph`.
+4. Insert documents that include the three graph columns.
+5. Checkpoint, close, and reopen.
+6. Search through `Collection.SearchVectorIndex`.
+7. Print status showing whether the physical column graph was loaded.
+
+Current caveat: normal vector-index `BuildVectorIndex` does not yet derive and
+publish inverse-norm or adjacency-list columns from ordinary vector documents.
+Until that build/rebuild seam lands, this demo writes those columns explicitly
+so the loader can prove the persisted column-asset path without adding a
+vector-only sidecar format.

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -151,7 +151,9 @@ func runDemo(dir string, jsonOut bool, allowFallback bool) error {
 	if err != nil {
 		out.Trace = trace
 		out.Error = err.Error()
-		_ = writeDemoOutput(out, jsonOut)
+		if writeErr := writeDemoOutput(out, jsonOut); writeErr != nil {
+			return fmt.Errorf("column graph search: %w; additionally failed to write demo output: %v", err, writeErr)
+		}
 		return fmt.Errorf("column graph search: %w", err)
 	}
 

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -28,6 +28,7 @@ type demoStatus struct {
 	RebuildNeeded                 bool   `json:"rebuild_needed"`
 	ExactFallbackReason           string `json:"exact_fallback_reason,omitempty"`
 	ColumnGraphUnavailableReason  string `json:"column_graph_unavailable_reason,omitempty"`
+	ColumnGraphUnavailableDetail  string `json:"column_graph_unavailable_detail,omitempty"`
 }
 
 type demoResult struct {
@@ -114,6 +115,10 @@ func runDemo(dir string, jsonOut bool) error {
 		_ = db.Close()
 		return fmt.Errorf("insert docs: %w", err)
 	}
+	if err := col.Flush(); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("flush collection: %w", err)
+	}
 	if err := db.Checkpoint(); err != nil {
 		_ = db.Close()
 		return fmt.Errorf("checkpoint: %w", err)
@@ -136,9 +141,8 @@ func runDemo(dir string, jsonOut bool) error {
 		return fmt.Errorf("vector status: %w", err)
 	}
 	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0, 0}, collections.VectorIndexSearchOptions{
-		TopK:                 2,
-		EfSearch:             16,
-		DisableExactFallback: true,
+		TopK:     2,
+		EfSearch: 16,
 	})
 	if err != nil {
 		return fmt.Errorf("column graph search: %w", err)
@@ -151,11 +155,12 @@ func runDemo(dir string, jsonOut bool) error {
 		return enc.Encode(out)
 	}
 	fmt.Printf("TreeDB column_graph demo dir: %s\n", out.Dir)
-	fmt.Printf("status: loaded=%t physical_assets=%t rebuild_needed=%t fallback=%q root=%d\n",
+	fmt.Printf("status: loaded=%t physical_assets=%t rebuild_needed=%t fallback=%q detail=%q root=%d\n",
 		out.Status.ColumnGraphLoaded,
 		out.Status.PhysicalColumnAssetsSupported,
 		out.Status.RebuildNeeded,
 		out.Status.ExactFallbackReason,
+		out.Status.ColumnGraphUnavailableDetail,
 		out.Status.RootID,
 	)
 	fmt.Printf("trace: strategy=%s candidates=%d returned=%d fallback=%q\n",
@@ -180,6 +185,7 @@ func demoStatusFromVectorStatus(status collections.VectorIndexStatus) demoStatus
 		RebuildNeeded:                 status.RebuildNeeded,
 		ExactFallbackReason:           status.ExactFallbackReason,
 		ColumnGraphUnavailableReason:  status.ColumnGraphUnavailableReason,
+		ColumnGraphUnavailableDetail:  status.ColumnGraphUnavailableDetail,
 	}
 }
 

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type demoOutput struct {
+	Dir     string                       `json:"dir"`
+	Status  demoStatus                   `json:"status"`
+	Trace   collections.VectorIndexTrace `json:"trace"`
+	Results []demoResult                 `json:"results"`
+}
+
+type demoStatus struct {
+	RootName                      string `json:"root_name"`
+	RootID                        uint64 `json:"root_id"`
+	Strategy                      string `json:"strategy"`
+	ColumnGraphLoaded             bool   `json:"column_graph_loaded"`
+	PhysicalColumnAssetsSupported bool   `json:"physical_column_assets_supported"`
+	RebuildNeeded                 bool   `json:"rebuild_needed"`
+	ExactFallbackReason           string `json:"exact_fallback_reason,omitempty"`
+	ColumnGraphUnavailableReason  string `json:"column_graph_unavailable_reason,omitempty"`
+}
+
+type demoResult struct {
+	DocumentID string          `json:"document_id"`
+	Distance   float32         `json:"distance"`
+	Document   json.RawMessage `json:"document"`
+}
+
+func main() {
+	dir := flag.String("dir", "", "TreeDB directory to create; defaults to a temporary directory")
+	keepDir := flag.Bool("keep-dir", false, "keep the temporary directory after the demo")
+	jsonOut := flag.Bool("json", false, "emit JSON instead of text")
+	flag.Parse()
+
+	dbDir := *dir
+	tempDir := false
+	if dbDir == "" {
+		var err error
+		dbDir, err = os.MkdirTemp("", "treedb-column-graph-demo-*")
+		if err != nil {
+			log.Fatalf("create temp dir: %v", err)
+		}
+		tempDir = true
+	}
+	if tempDir && !*keepDir {
+		defer func() { _ = os.RemoveAll(dbDir) }()
+	}
+	if err := runDemo(dbDir, *jsonOut); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runDemo(dir string, jsonOut bool) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create db dir: %w", err)
+	}
+	if entries, err := os.ReadDir(dir); err != nil {
+		return fmt.Errorf("read db dir: %w", err)
+	} else if len(entries) != 0 {
+		return fmt.Errorf("demo dir must be empty: %s", dir)
+	}
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{
+		RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1},
+	}); err != nil {
+		return fmt.Errorf("enable command WAL format: %w", err)
+	}
+
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true})
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "docs",
+		Options: collections.CollectionOptions{
+			ColumnStore: columnGraphDemoColumnStore(),
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:       "embedding",
+			Field:      "embedding",
+			Metric:     collections.VectorMetricCosine,
+			Dimensions: 3,
+			M:          2,
+			EfSearch:   16,
+			Strategy:   collections.VectorIndexStrategyColumnGraph,
+		}},
+	}); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("create collection: %w", err)
+	}
+	col, err := manager.OpenCollection("docs")
+	if err != nil {
+		_ = db.Close()
+		return fmt.Errorf("open collection: %w", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("doc-a"), []byte("doc-b"), []byte("doc-c")},
+		[][]byte{
+			[]byte(`{"title":"north","embedding":[1,0,0],"embedding_inv_norm":1,"embedding_neighbors":[1,2]}`),
+			[]byte(`{"title":"east","embedding":[0,1,0],"embedding_inv_norm":1,"embedding_neighbors":[0,2]}`),
+			[]byte(`{"title":"up","embedding":[0,0,1],"embedding_inv_norm":1,"embedding_neighbors":[0,1]}`),
+		},
+	); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("insert docs: %w", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("checkpoint: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		return fmt.Errorf("close seed db: %w", err)
+	}
+
+	reopen, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true})
+	if err != nil {
+		return fmt.Errorf("reopen db: %w", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	reopened, err := collections.NewCollectionManager(reopen).OpenCollection("docs")
+	if err != nil {
+		return fmt.Errorf("open reopened collection: %w", err)
+	}
+	status, err := reopened.VectorIndexStatus("embedding")
+	if err != nil {
+		return fmt.Errorf("vector status: %w", err)
+	}
+	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0, 0}, collections.VectorIndexSearchOptions{
+		TopK:                 2,
+		EfSearch:             16,
+		DisableExactFallback: true,
+	})
+	if err != nil {
+		return fmt.Errorf("column graph search: %w", err)
+	}
+
+	out := demoOutput{Dir: filepath.Clean(dir), Status: demoStatusFromVectorStatus(status), Trace: trace, Results: demoResults(results)}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	fmt.Printf("TreeDB column_graph demo dir: %s\n", out.Dir)
+	fmt.Printf("status: loaded=%t physical_assets=%t rebuild_needed=%t fallback=%q root=%d\n",
+		out.Status.ColumnGraphLoaded,
+		out.Status.PhysicalColumnAssetsSupported,
+		out.Status.RebuildNeeded,
+		out.Status.ExactFallbackReason,
+		out.Status.RootID,
+	)
+	fmt.Printf("trace: strategy=%s candidates=%d returned=%d fallback=%q\n",
+		trace.Strategy,
+		trace.CandidatesExamined,
+		trace.ReturnedCount,
+		trace.ExactFallbackReason,
+	)
+	for i, result := range results {
+		fmt.Printf("%d. id=%s distance=%.6f doc=%s\n", i+1, result.DocumentID, result.Distance, result.Document)
+	}
+	return nil
+}
+
+func demoStatusFromVectorStatus(status collections.VectorIndexStatus) demoStatus {
+	return demoStatus{
+		RootName:                      status.RootName,
+		RootID:                        status.RootID,
+		Strategy:                      status.Strategy.String(),
+		ColumnGraphLoaded:             status.ColumnGraphLoaded,
+		PhysicalColumnAssetsSupported: status.PhysicalColumnAssetsSupported,
+		RebuildNeeded:                 status.RebuildNeeded,
+		ExactFallbackReason:           status.ExactFallbackReason,
+		ColumnGraphUnavailableReason:  status.ColumnGraphUnavailableReason,
+	}
+}
+
+func demoResults(results []collections.VectorSearchResult) []demoResult {
+	out := make([]demoResult, len(results))
+	for i, result := range results {
+		out[i] = demoResult{
+			DocumentID: string(result.DocumentID),
+			Distance:   result.Distance,
+			Document:   append(json.RawMessage(nil), result.Document...),
+		}
+	}
+	return out
+}
+
+func columnGraphDemoColumnStore() *collections.ColumnStoreConfig {
+	return &collections.ColumnStoreConfig{
+		Enabled: true,
+		Columns: []collections.ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: collections.ColumnStoreValueFloat32},
+			{Name: "embedding_neighbors", Path: "embedding_neighbors", ValueType: collections.ColumnStoreValueAdjacencyList},
+		},
+		RetainedPayload: collections.ColumnRetainedPayloadFull,
+		AssetManager: &collections.ColumnAssetManagerConfig{
+			Kind:              collections.ColumnAssetManagerValueLogShaped,
+			IsolatedNamespace: true,
+			Namespace:         "column_graph_demo",
+		},
+	}
+}

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -17,6 +17,7 @@ type demoOutput struct {
 	Status  demoStatus                   `json:"status"`
 	Trace   collections.VectorIndexTrace `json:"trace"`
 	Results []demoResult                 `json:"results"`
+	Error   string                       `json:"error,omitempty"`
 }
 
 type demoStatus struct {
@@ -41,6 +42,7 @@ func main() {
 	dir := flag.String("dir", "", "TreeDB directory to create; defaults to a temporary directory")
 	keepDir := flag.Bool("keep-dir", false, "keep the temporary directory after the demo")
 	jsonOut := flag.Bool("json", false, "emit JSON instead of text")
+	allowFallback := flag.Bool("allow-fallback", false, "allow exact fallback instead of requiring the persisted column_graph path")
 	flag.Parse()
 
 	dbDir := *dir
@@ -56,12 +58,12 @@ func main() {
 	if tempDir && !*keepDir {
 		defer func() { _ = os.RemoveAll(dbDir) }()
 	}
-	if err := runDemo(dbDir, *jsonOut); err != nil {
+	if err := runDemo(dbDir, *jsonOut, *allowFallback); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func runDemo(dir string, jsonOut bool) error {
+func runDemo(dir string, jsonOut bool, allowFallback bool) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create db dir: %w", err)
 	}
@@ -140,15 +142,25 @@ func runDemo(dir string, jsonOut bool) error {
 	if err != nil {
 		return fmt.Errorf("vector status: %w", err)
 	}
+	out := demoOutput{Dir: filepath.Clean(dir), Status: demoStatusFromVectorStatus(status)}
 	results, trace, err := reopened.SearchVectorIndex("embedding", []float32{1, 0, 0}, collections.VectorIndexSearchOptions{
-		TopK:     2,
-		EfSearch: 16,
+		TopK:                 2,
+		EfSearch:             16,
+		DisableExactFallback: !allowFallback,
 	})
 	if err != nil {
+		out.Trace = trace
+		out.Error = err.Error()
+		_ = writeDemoOutput(out, jsonOut)
 		return fmt.Errorf("column graph search: %w", err)
 	}
 
-	out := demoOutput{Dir: filepath.Clean(dir), Status: demoStatusFromVectorStatus(status), Trace: trace, Results: demoResults(results)}
+	out.Trace = trace
+	out.Results = demoResults(results)
+	return writeDemoOutput(out, jsonOut)
+}
+
+func writeDemoOutput(out demoOutput, jsonOut bool) error {
 	if jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -164,12 +176,15 @@ func runDemo(dir string, jsonOut bool) error {
 		out.Status.RootID,
 	)
 	fmt.Printf("trace: strategy=%s candidates=%d returned=%d fallback=%q\n",
-		trace.Strategy,
-		trace.CandidatesExamined,
-		trace.ReturnedCount,
-		trace.ExactFallbackReason,
+		out.Trace.Strategy,
+		out.Trace.CandidatesExamined,
+		out.Trace.ReturnedCount,
+		out.Trace.ExactFallbackReason,
 	)
-	for i, result := range results {
+	if out.Error != "" {
+		fmt.Printf("error: %s\n", out.Error)
+	}
+	for i, result := range out.Results {
 		fmt.Printf("%d. id=%s distance=%.6f doc=%s\n", i+1, result.DocumentID, result.Distance, result.Document)
 	}
 	return nil

--- a/scripts/bench_column_graph_main_path.sh
+++ b/scripts/bench_column_graph_main_path.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${RUN_DIR:="/tmp/gomap_column_graph_main_path_$(date +%Y%m%d_%H%M%S)"}"
+: "${TREEDB_VECTOR_BENCH_DOCS:=10000}"
+: "${TREEDB_VECTOR_BENCH_DIMS:=64}"
+: "${BENCHTIME:=500ms}"
+: "${COUNT:=3}"
+: "${BENCH_REGEX:=BenchmarkCollectionVectorIndexColumnGraphMainPath}"
+
+mkdir -p "${RUN_DIR}"
+
+cat > "${RUN_DIR}/README.md" <<EOF
+# TreeDB Column Graph Main-Path Benchmark
+
+Command:
+
+\`\`\`sh
+TREEDB_VECTOR_BENCH_DOCS=${TREEDB_VECTOR_BENCH_DOCS} \\
+TREEDB_VECTOR_BENCH_DIMS=${TREEDB_VECTOR_BENCH_DIMS} \\
+GOWORK=off go test ./TreeDB/collections \\
+  -run '^$' \\
+  -bench '${BENCH_REGEX}' \\
+  -benchmem \\
+  -benchtime '${BENCHTIME}' \\
+  -count '${COUNT}'
+\`\`\`
+
+This benchmark uses synthetic vectors but exercises the collection product path:
+real column-store assets, manifest/root reopen, ColumnVectorGraph load/search,
+and optional public document materialization variants. For the opt-in public
+Deep1B dataset path, use scripts/bench_column_vector_deep1b.sh.
+EOF
+
+cd "${ROOT_DIR}"
+TREEDB_VECTOR_BENCH_DOCS="${TREEDB_VECTOR_BENCH_DOCS}" \
+TREEDB_VECTOR_BENCH_DIMS="${TREEDB_VECTOR_BENCH_DIMS}" \
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench "${BENCH_REGEX}" \
+  -benchmem \
+  -benchtime "${BENCHTIME}" \
+  -count "${COUNT}" \
+  | tee "${RUN_DIR}/column_graph_main_path.txt"
+
+printf 'wrote %s\n' "${RUN_DIR}"

--- a/scripts/bench_column_graph_main_path.sh
+++ b/scripts/bench_column_graph_main_path.sh
@@ -37,9 +37,13 @@ GOWORK=off go test ./TreeDB/collections \\
 ~~~
 
 This benchmark uses synthetic vectors but exercises the collection product path:
-real column-store assets, manifest/root reopen, ColumnVectorGraph load/search,
-and optional public document materialization variants. For the opt-in public
-Deep1B dataset path, use scripts/bench_column_vector_deep1b.sh.
+real column-store assets, manifest/root reopen, decode into an in-memory
+ColumnVectorGraph, in-memory graph search, and optional public document
+materialization variants.
+
+It does not measure column-store-native search over granules, marks, reader
+caches, or decoded-block caches. For the opt-in public Deep1B dataset path, use
+scripts/bench_column_vector_deep1b.sh.
 EOF
 
 cd "${ROOT_DIR}"

--- a/scripts/bench_column_graph_main_path.sh
+++ b/scripts/bench_column_graph_main_path.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [[ -z "${RUN_DIR:-}" ]]; then
   RUN_DIR="$(mktemp -d /tmp/gomap_column_graph_main_path_XXXXXX)"
+elif [[ -e "${RUN_DIR}" ]] && [[ ! -d "${RUN_DIR}" ]]; then
+  printf 'RUN_DIR exists and is not a directory: %s\n' "${RUN_DIR}" >&2
+  exit 1
 elif [[ -d "${RUN_DIR}" ]] && [[ -n "$(find "${RUN_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
   printf 'RUN_DIR exists and is not empty: %s\n' "${RUN_DIR}" >&2
   exit 1
@@ -22,16 +25,16 @@ cat > "${RUN_DIR}/README.md" <<EOF
 
 Command:
 
-\`\`\`sh
+~~~sh
 TREEDB_VECTOR_BENCH_DOCS=${TREEDB_VECTOR_BENCH_DOCS} \\
 TREEDB_VECTOR_BENCH_DIMS=${TREEDB_VECTOR_BENCH_DIMS} \\
 GOWORK=off go test ./TreeDB/collections \\
   -run '^$' \\
   -bench "${BENCH_REGEX}" \\
   -benchmem \\
-  -benchtime "${BENCHTIME}" \\
-  -count "${COUNT}"
-\`\`\`
+  -benchtime="${BENCHTIME}" \\
+  -count="${COUNT}"
+~~~
 
 This benchmark uses synthetic vectors but exercises the collection product path:
 real column-store assets, manifest/root reopen, ColumnVectorGraph load/search,
@@ -46,8 +49,8 @@ GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
   -bench "${BENCH_REGEX}" \
   -benchmem \
-  -benchtime "${BENCHTIME}" \
-  -count "${COUNT}" \
+  -benchtime="${BENCHTIME}" \
+  -count="${COUNT}" \
   | tee "${RUN_DIR}/column_graph_main_path.txt"
 
 printf 'wrote %s\n' "${RUN_DIR}"

--- a/scripts/bench_column_graph_main_path.sh
+++ b/scripts/bench_column_graph_main_path.sh
@@ -3,14 +3,19 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-: "${RUN_DIR:="/tmp/gomap_column_graph_main_path_$(date +%Y%m%d_%H%M%S)"}"
+if [[ -z "${RUN_DIR:-}" ]]; then
+  RUN_DIR="$(mktemp -d /tmp/gomap_column_graph_main_path_XXXXXX)"
+elif [[ -d "${RUN_DIR}" ]] && [[ -n "$(find "${RUN_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  printf 'RUN_DIR exists and is not empty: %s\n' "${RUN_DIR}" >&2
+  exit 1
+else
+  mkdir -p "${RUN_DIR}"
+fi
 : "${TREEDB_VECTOR_BENCH_DOCS:=10000}"
 : "${TREEDB_VECTOR_BENCH_DIMS:=64}"
 : "${BENCHTIME:=500ms}"
 : "${COUNT:=3}"
 : "${BENCH_REGEX:=BenchmarkCollectionVectorIndexColumnGraphMainPath}"
-
-mkdir -p "${RUN_DIR}"
 
 cat > "${RUN_DIR}/README.md" <<EOF
 # TreeDB Column Graph Main-Path Benchmark
@@ -22,10 +27,10 @@ TREEDB_VECTOR_BENCH_DOCS=${TREEDB_VECTOR_BENCH_DOCS} \\
 TREEDB_VECTOR_BENCH_DIMS=${TREEDB_VECTOR_BENCH_DIMS} \\
 GOWORK=off go test ./TreeDB/collections \\
   -run '^$' \\
-  -bench '${BENCH_REGEX}' \\
+  -bench "${BENCH_REGEX}" \\
   -benchmem \\
-  -benchtime '${BENCHTIME}' \\
-  -count '${COUNT}'
+  -benchtime "${BENCHTIME}" \\
+  -count "${COUNT}"
 \`\`\`
 
 This benchmark uses synthetic vectors but exercises the collection product path:


### PR DESCRIPTION
## Summary
- Adds a user-facing `column_graph` vector search guide with quickstart, status/fallback advice, current caveats, best practices, benchmark evidence at the 10k x 64 product-main-path shape, and a hard boundary that this is not column-store-native search yet.
- Adds `cmd/treedb_column_graph_demo` as a small runnable product-path demo: create collection, insert vector/invNorm/adjacency columns, checkpoint, reopen, load physical column assets into an in-memory graph, public `SearchVectorIndex`.
- Adds `scripts/bench_column_graph_main_path.sh` and documents the existing opt-in Deep1B runner for public Yandex DEEP/Deep1B dataset evidence.

## Corrected Boundary
The docs now state the current path plainly:
```text
physical column assets on disk
-> manifest/root lookup and physical scan
-> decode into Go slices
-> in-memory ColumnVectorGraph.SearchCosine
```

This PR does not claim direct search over TreeDB column-store granules, resident column readers, marks, or decoded-block caches. True column-store-native vector search is a separate follow-on.

## Dataset Note
The guide links to the public Yandex Research Deep1B/DEEP dataset page and keeps dataset downloads outside the repo. The script path is opt-in/manual because 1M/10M dataset runs are not CI-safe.

## Validation
```sh
GOWORK=off go test ./cmd/treedb_column_graph_demo -count=1
GOWORK=off go run ./cmd/treedb_column_graph_demo -json
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures|TestColumnGraphPhysicalLoadFailureRecordsDetail|TestColumnPhysicalVisibilityIndexClonesVectorAndAdjacencyValues|TestCollectionVectorIndexColumnGraph|TestCollectionSearchVectorIndex|TestColumnGraphUnavailableStatusPreservesPhysicalSupportForLoaderFailures' -count=1
RUN_DIR=$(mktemp -d /tmp/gomap_column_graph_main_path_smoke_XXXXXX) TREEDB_VECTOR_BENCH_DOCS=128 TREEDB_VECTOR_BENCH_DIMS=16 BENCHTIME=1x COUNT=1 BENCH_REGEX='BenchmarkCollectionVectorIndexColumnGraphMainPathLoad$' scripts/bench_column_graph_main_path.sh
git diff --check
```

Latest wording-only validation:
```sh
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./cmd/treedb_column_graph_demo -count=1
RUN_DIR=$(mktemp -d /tmp/gomap_column_graph_description_smoke_XXXXXX) TREEDB_VECTOR_BENCH_DOCS=16 TREEDB_VECTOR_BENCH_DIMS=8 BENCHTIME=1x COUNT=1 BENCH_REGEX='BenchmarkCollectionVectorIndexColumnGraphMainPathLoad$' scripts/bench_column_graph_main_path.sh
git diff --check
```

Demo output excerpt:
```json
{
  "status": {
    "strategy": "column_graph",
    "column_graph_loaded": true,
    "physical_column_assets_supported": true,
    "rebuild_needed": false
  },
  "trace": {
    "Strategy": "column_graph_cosine",
    "ReturnedCount": 2,
    "ExactFallbackReason": ""
  },
  "results": [
    {"document_id": "doc-a", "distance": 0},
    {"document_id": "doc-b", "distance": 1}
  ]
}
```

## Stack
- Base PR: #1644
- This PR is documentation/demo/script only; it does not add engine optimizations.


## Follow-up Native Column-Store Search Ticket
True column-store-native vector search, without a full decoded in-memory graph, is tracked separately in #1646.

