### PR TITLE
collections: add typed vector column values

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -714,6 +714,23 @@ func (c *manifestCursor) float32SliceWithExpectedLength(expected int) []float32 
 	return c.float32SliceAfterLength(n)
 }
 
+func (c *manifestCursor) skipFloat32SliceWithExpectedLength(expected int) uint64 {
+	n := c.u64()
+	if c.err != nil {
+		return 0
+	}
+	if expected < 0 || n != uint64(expected) {
+		c.err = fmt.Errorf("collections: float32_vector length=%d want vector_dims=%d", n, expected)
+		return 0
+	}
+	byteLen, ok := c.fixedWidthSliceByteLen(n, 4, "float32_vector")
+	if !ok {
+		return 0
+	}
+	c.pos += int(byteLen)
+	return n
+}
+
 func (c *manifestCursor) float32SliceAfterLength(n uint64) []float32 {
 	if c.err != nil {
 		return nil

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -404,6 +404,70 @@ func TestColumnPhysicalAssetScannerRejectsMismatchedVectorLength(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetScannerUnprojectedVectorTruncationNamesVectorType(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+			{Name: "score", Path: "score", ValueType: ColumnStoreValueFloat32},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+
+	var raw bytes.Buffer
+	writeManifestUint32(&raw, columnPhysicalAssetMagic)
+	writeManifestUint16(&raw, columnPhysicalAssetVersion)
+	writeManifestString(&raw, "vectors")
+	writeManifestString(&raw, normalized.AssetManager.Namespace)
+	writeManifestUint64(&raw, 2)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 9)
+	writeManifestString(&raw, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&raw, normalized.SchemaHash)
+	writeManifestUint64(&raw, uint64(len(normalized.Columns)))
+	writeManifestUint64(&raw, 1)
+	for _, col := range normalized.Columns {
+		writeManifestString(&raw, col.Name)
+		writeManifestString(&raw, col.Path)
+		writeManifestString(&raw, string(col.ValueType))
+		writeManifestBool(&raw, col.Nullable)
+		writeManifestBool(&raw, col.Dictionary)
+		writeManifestUint64(&raw, uint64(col.VectorDims))
+	}
+	writeManifestBytes(&raw, []byte("v1"))
+	writeManifestBool(&raw, false)
+	writeManifestString(&raw, string(ColumnStoreValueFloat32Vector))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestUint64(&raw, 3)
+	writeManifestUint32(&raw, math.Float32bits(1))
+
+	encoded := raw.Bytes()
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 2,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"score"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
+		t.Fatalf("visitor should not run for truncated vector: %+v", row)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "short column binary float32_vector") {
+		t.Fatalf("scanColumnPhysicalAssetRows err=%v want float32_vector truncation label", err)
+	}
+}
+
 func TestColumnPhysicalAssetDecodeV1CompatibilityM12C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)
@@ -1547,9 +1611,10 @@ func BenchmarkColumnPhysicalAssetVectorScanV1(b *testing.B) {
 		cases := []struct {
 			name      string
 			projected []string
+			vector    bool
 		}{
 			{name: "score_only_skip_vector_adj", projected: []string{"embedding_inv_norm"}},
-			{name: "vector_and_adjacency", projected: []string{"embedding", "embedding_neighbors"}},
+			{name: "vector_and_adjacency", projected: []string{"embedding", "embedding_neighbors"}, vector: true},
 		}
 		for _, tc := range cases {
 			b.Run(fmt.Sprintf("rows_%d/%s", rows, tc.name), func(b *testing.B) {
@@ -1559,20 +1624,22 @@ func BenchmarkColumnPhysicalAssetVectorScanV1(b *testing.B) {
 				}
 				var scanned int64
 				var sum int64
+				consumeRow := func(row columnPhysicalScanRowView) error {
+					sum += int64(row.Values[0].Float32 * 1000)
+					return nil
+				}
+				if tc.vector {
+					consumeRow = func(row columnPhysicalScanRowView) error {
+						sum += int64(len(row.Values[0].Float32Vector) + len(row.Values[1].AdjacencyList))
+						return nil
+					}
+				}
 				b.ReportAllocs()
 				b.SetBytes(int64(len(encoded)))
 				b.ReportMetric(float64(rows), "rows/op")
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					summary, err := scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
-						switch tc.name {
-						case "score_only_skip_vector_adj":
-							sum += int64(row.Values[0].Float32 * 1000)
-						case "vector_and_adjacency":
-							sum += int64(len(row.Values[0].Float32Vector) + len(row.Values[1].AdjacencyList))
-						}
-						return nil
-					})
+					summary, err := scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, consumeRow)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1098,12 +1098,9 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 				}
 				rowValues[outputIdx].Float32Vector = value
 			} else {
-				n := cur.skipUint32Slice()
+				cur.skipFloat32SliceWithExpectedLength(col.VectorDims)
 				if cur.err != nil {
 					return cur.err
-				}
-				if n != uint64(col.VectorDims) {
-					return fmt.Errorf("column[%d] float32_vector length=%d want vector_dims=%d", colIdx, n, col.VectorDims)
 				}
 			}
 		case ColumnStoreValueAdjacencyList:


### PR DESCRIPTION
Implements the V1 #1646 slice for generic typed column values needed by native column-store vector search later.

This PR intentionally does not wire vector search, `ColumnVectorGraph`, `SearchCosine`, `column_graph`, sidecar indices, Deep1B tooling, decoded graph loaders, or product API behavior. It only teaches the generic column-store physical asset path to declare, encode, decode, scan, validate, and reconstruct:

- scalar `float32`
- fixed-dimension `float32_vector`
- `uint32` adjacency-list columns via `adjacency_list`

Stacked on #1647.

## Column Graph Native Workstream (#1646)

### Copied/Adapted From Old Stack

- Copied: none verbatim as a product path.
- Adapted: generic typed value support from the old decoded integration stack: value-type constants, `vector_dims` schema metadata, JSON extraction, V4 physical asset metadata, encode/decode/scan support, and fail-closed vector length validation.
- Oracle/comparator only: none in this PR.
- Quarantined/not copied: decoded `ColumnVectorGraph` loaders, vector index/search API code, benchmark/demo/docs paths that describe decoded graph search, Deep1B/geometric codecs, overlays, and sidecar cache behavior.

### Path Identity

- Native reader: not implemented in this PR.
- Decoded comparator: not implemented in this PR.
- Legacy/native vector index: unchanged.
- Unsupported/fail-closed: malformed vector dimensions and mismatched vector payload lengths fail during schema validation, encode/decode, or scan.

### Base And Dependency State

- Base branch: `codex/column-graph-native-v0-inventory`
- Base commit: `27ad4c81149b77ef4f888637e798117fc1ae35bc`
- Base PR/head: #1647 / `codex/column-graph-native-v0-inventory`
- #1621/#1634 assumptions: generic physical column asset encode/decode/scan/root machinery is treated as the integration base; this PR adds typed payload support without changing locator/cache APIs.
- Missing generic column-store primitives: native ordinal-to-granule lookup, row/batch reader, bounded decoded-block cache, and reader accounting remain future V1/V2B work.
- Parent review fixes propagated: yes, includes #1647 markdownlint/template fix.

### Evidence

- Tests: added schema validation, metadata hash, typed physical asset round-trip, vector length fail-closed encode/decode/scan tests.
- Benchmarks: added `BenchmarkColumnPhysicalAssetVectorScanV1` plus reran existing physical asset encode/decode/scan benches.
- Status/fallback proof: no public status/fallback behavior is introduced in this PR.
- Performance attribution: selected vector/adjacency projection allocates decoded slices by design in the current generic scan API; scalar-only projection skips vector/adjacency payloads with 0 allocations.
- Local regressions found/fixed: existing non-nullable-null asset test was updated for stricter encode-time fail-closed validation.

### Test Plan Start

- Milestone tasks targeted: V1 typed column value substrate for vector/invNorm/adjacency physical assets.
- Tests to add before or with implementation: value-type metadata validation, vector dimension schema hashing, vector/float32/adjacency JSON extraction, physical asset round-trip, projected and unprojected vector length mismatch scan failures.
- Existing tests to preserve: scalar column-store metadata, physical asset codec, V1 compatibility, scan, reconstruction, and physical column package tests.
- #1646 test-list changes made before implementation: direct issue-body edit was not practical due issue size; this PR body records the V1 test-list slice.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR: physical asset encode/decode/serial scan and new vector physical scan with `B/op` and `allocs/op`.
- Baseline/comparator command or reason not applicable: existing scalar physical asset benchmarks serve as regression guard; vector scan benchmark is new because this typed payload path did not exist on V0.
- Expected setup/search/materialization boundary: benchmark setup builds encoded assets outside timed loops; timed scope is physical asset scan/decode for the selected projection only.
- Upstream costs explicitly out of scope: row/batch native reader, locator cache, bounded decoded-block cache, public vector search API, and graph traversal.
- Local performance risks to watch: accidental allocations when skipping unprojected vector/adjacency values, per-row string conversions in scan validation, full vector decode when only scalar projection is selected.

### Test Plan Close

- Additional tests found during implementation/review: encode-time non-nullable null behavior is now fail-closed and the existing test was aligned to expect encode rejection.
- Tests added or changed:
  - `TestColumnStoreMetadataValidation`
  - `TestColumnStoreVectorMetadataNormalizes`
  - `TestColumnPhysicalAssetVectorValueTypesRoundTrip`
  - `TestEncodeColumnPhysicalAssetRejectsMismatchedVectorLength`
  - `TestDecodeColumnPhysicalAssetRejectsMismatchedVectorLength`
  - `TestColumnPhysicalAssetScannerRejectsMismatchedVectorLength`
- Failing tests fixed: `TestColumnPhysicalAssetRejectsNonNullableNullM12A` updated for stricter encode-time validation.
- #1646 test-list changes made at close: not edited directly; this PR body lists the fulfilled V1 test phrases.
- Residual untested gaps, if any: no native reader/cache API tests yet because this PR is only typed value substrate.

Validation:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnStoreMetadataValidation|TestColumnStoreVectorMetadataNormalizes|TestColumnPhysicalAssetVectorValueTypesRoundTrip|TestEncodeColumnPhysicalAssetRejectsMismatchedVectorLength|TestDecodeColumnPhysicalAssetRejectsMismatchedVectorLength|TestColumnPhysicalAssetScannerRejectsMismatchedVectorLength' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	0.492s

GOWORK=off go test ./TreeDB/collections -run 'TestColumnStore|TestColumnPhysicalAsset|TestColumnPhysicalScan|TestColumnReconstruction' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	7.619s

GOWORK=off go test ./TreeDB/collections -run 'Test.*Column.*' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	10.717s

GOWORK=off go test ./TreeDB/collections -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	9.265s

git diff --check
```

### Performance Plan Close

- Benchmark commands run:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalAsset(Encode|Decode|SerialScan|VectorScan)' -benchmem -benchtime=500ms -count=3
```

- Results summary with throughput/latency/allocations on Apple M3:
  - Existing scalar encode: ~109-113 us/op, ~938-968 MB/s, 262082-262083 B/op, 12 allocs/op.
  - Existing scalar decode: ~158-167 us/op, ~631-670 MB/s, 540960-540961 B/op, 7182 allocs/op.
  - Existing scalar serial scan 1024 rows: ~37.1-37.7 us/op, 0 B/op, 0 allocs/op.
  - Existing scalar serial scan 8192 rows: ~298-333 us/op, 0 B/op, 0 allocs/op.
  - New vector scan 1024 rows, scalar projection skipping vector+adjacency: ~48.8-54.1 us/op, 0 B/op, 0 allocs/op.
  - New vector scan 8192 rows, scalar projection skipping vector+adjacency: ~390-395 us/op, 0 B/op, 0 allocs/op.
  - New vector scan 1024 rows, projecting vector+adjacency: ~218 us/op, ~589834 B/op, 2048 allocs/op.
  - New vector scan 8192 rows, projecting vector+adjacency: ~1.52-1.53 ms/op, ~4718607 B/op, 16384 allocs/op.
- Before/after or baseline comparison: scalar scan remains zero-alloc; vector skip path is also zero-alloc. Projecting vectors/adjacency allocates one decoded slice per selected vector and adjacency value under the current generic scan API.
- Local slow/heavy code found and fixed: vector/adjacency skip path validates lengths without decoding or allocating.
- Remaining upstream or deferred costs: bounded decoded-block cache, row/batch reader, native ordinal lookup, and vector-search-specific accounting remain future #1646 work.

### AI Review Loop

- Codex latest-head review: requested after PR open.
- Copilot latest-head review: requested after PR open.
- CodeRabbit latest-head review: requested after PR open.
- Review comments/threads resolved or explicitly dismissed: pending.
- Re-requested after final meaningful push: pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for float32, float32-vector, and adjacency-list column value types; per-column vector-dimension metadata and versioned serialization.

* **Bug Fixes / Validation**
  * Stricter manifest, encoding and decoding checks: type/schema consistency, nullability, exact vector-dimension and length validation, and safer binary bounds handling; schema hashing includes vector dims.

* **Tests**
  * Added round-trip, rejection, scanner, and benchmark tests covering vector/scalar/adjacency encodings and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->