### PR TITLE
TreeDB column store post-V1: vectorize physical q1/q5 reducers

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -29,6 +29,7 @@ const (
 )
 
 const columnAssetSegmentWriteLockStripes = 64
+const columnPhysicalAssetReadScratchPoolMaxRetainBytes = 16 << 20
 
 // columnAssetSegmentWriteLocks is a bounded stripe set keyed by canonical
 // segment path. Writers to the same segment share a process-local offset lock
@@ -621,7 +622,7 @@ func newColumnPhysicalAssetReadCache(rootDir string, namespace string) (columnPh
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
 	if c.scratch != nil {
-		columnPhysicalAssetReadScratchPool.Put(c.scratch[:0])
+		putColumnPhysicalAssetReadScratch(c.scratch)
 		c.scratch = nil
 	}
 	if c.file != nil {
@@ -656,20 +657,32 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 	if ref.Length >= 0 && ref.Length <= int64(maxCollectionInt) && cap(dst) < int(ref.Length) {
 		if cap(c.scratch) < int(ref.Length) {
 			if c.scratch != nil {
-				columnPhysicalAssetReadScratchPool.Put(c.scratch[:0])
+				putColumnPhysicalAssetReadScratch(c.scratch)
 			}
-			if pooled, ok := columnPhysicalAssetReadScratchPool.Get().([]byte); ok && cap(pooled) >= int(ref.Length) {
-				c.scratch = pooled[:0]
-			} else {
-				if ok && pooled != nil {
-					columnPhysicalAssetReadScratchPool.Put(pooled[:0])
-				}
-				c.scratch = make([]byte, int(ref.Length))
-			}
+			c.scratch = getColumnPhysicalAssetReadScratch(int(ref.Length))
 		}
 		dst = c.scratch
 	}
 	return readColumnPhysicalAssetFromFile(file, ref, dst)
+}
+
+func getColumnPhysicalAssetReadScratch(minLen int) []byte {
+	if minLen <= columnPhysicalAssetReadScratchPoolMaxRetainBytes {
+		if pooled, ok := columnPhysicalAssetReadScratchPool.Get().([]byte); ok {
+			if cap(pooled) >= minLen {
+				return pooled[:0]
+			}
+			putColumnPhysicalAssetReadScratch(pooled)
+		}
+	}
+	return make([]byte, 0, minLen)
+}
+
+func putColumnPhysicalAssetReadScratch(scratch []byte) {
+	if scratch == nil || cap(scratch) > columnPhysicalAssetReadScratchPoolMaxRetainBytes {
+		return
+	}
+	columnPhysicalAssetReadScratchPool.Put(scratch[:0])
 }
 
 func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File, error) {

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -35,6 +35,8 @@ const columnAssetSegmentWriteLockStripes = 64
 // without retaining one mutex per temp dir or segment path forever.
 var columnAssetSegmentWriteLocks [columnAssetSegmentWriteLockStripes]sync.Mutex
 
+var columnPhysicalAssetReadScratchPool sync.Pool
+
 // columnAssetSegmentAllocationLocks serialize same-process segment file-id
 // allocation by namespace without retaining one lock per temp dir forever.
 // O_EXCL still protects against external process races.
@@ -597,6 +599,7 @@ type columnPhysicalAssetReadCache struct {
 	fileID     uint32
 	file       *os.File
 	files      map[uint32]*os.File
+	scratch    []byte
 	hits       uint64
 	misses     uint64
 }
@@ -617,6 +620,10 @@ func newColumnPhysicalAssetReadCache(rootDir string, namespace string) (columnPh
 
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
+	if c.scratch != nil {
+		columnPhysicalAssetReadScratchPool.Put(c.scratch[:0])
+		c.scratch = nil
+	}
 	if c.file != nil {
 		if err := c.file.Close(); err != nil && closeErr == nil {
 			closeErr = err
@@ -645,6 +652,22 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 	file, err := c.fileForRef(ref)
 	if err != nil {
 		return nil, err
+	}
+	if ref.Length >= 0 && ref.Length <= int64(maxCollectionInt) && cap(dst) < int(ref.Length) {
+		if cap(c.scratch) < int(ref.Length) {
+			if c.scratch != nil {
+				columnPhysicalAssetReadScratchPool.Put(c.scratch[:0])
+			}
+			if pooled, ok := columnPhysicalAssetReadScratchPool.Get().([]byte); ok && cap(pooled) >= int(ref.Length) {
+				c.scratch = pooled[:0]
+			} else {
+				if ok && pooled != nil {
+					columnPhysicalAssetReadScratchPool.Put(pooled[:0])
+				}
+				c.scratch = make([]byte, int(ref.Length))
+			}
+		}
+		dst = c.scratch
 	}
 	return readColumnPhysicalAssetFromFile(file, ref, dst)
 }

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -88,6 +88,17 @@ var errColumnPhysicalScanCancelled = errors.New("collections: physical column sc
 // scanner path; mutation-bearing manifests fall back to the M13C visibility
 // overlay before reducing.
 func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	mutationParts, err := c.columnPhysicalQueryMutationPartsHint()
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
+	if mutationParts > 0 {
+		cfg, err := c.columnPhysicalQueryColumnStoreConfig()
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, err
+		}
+		return c.runColumnPhysicalQueryWithVisibility(cfg, req)
+	}
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
 	if closeView != nil {
 		defer closeView()
@@ -119,9 +130,6 @@ func (c *Collection) runColumnPhysicalQueryDirectInSnapshotView(view columnPhysi
 	result.Diagnostics.ScanNanos = scanNanos
 	result.Diagnostics.ReduceRows = exec.reduceRows
 	if err != nil {
-		if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
-			return result, true, err
-		}
 		return result, true, err
 	}
 	result.Groups = exec.groups()
@@ -183,6 +191,7 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
 		if err != nil {
 			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
 		}
+		// rawScratch may alias readCache.scratch; the direct reducer consumes raw synchronously and does not retain it.
 		rawScratch = raw
 		diag.PhysicalBytesScanned += int64(len(raw))
 		summary, err := reduceColumnPhysicalAssetDirect(raw, ref, view.CollectionName, &cfg, assetRef.Reason, exec)
@@ -310,6 +319,9 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	if result, ok, err := c.runColumnPhysicalQueryDirectInSnapshotView(view, req, 0, 0, nil); ok {
 		if err != nil {
+			if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
+				return c.runColumnPhysicalQueryWithVisibility(view.Config, req)
+			}
 			return result, err
 		}
 		result.Diagnostics.WorkerCount = 1
@@ -390,6 +402,22 @@ func (c *Collection) columnPhysicalQueryColumnStoreConfig() (ColumnStoreConfig, 
 		return ColumnStoreConfig{}, fmt.Errorf("%w: physical column query requires enabled column_store", ErrColumnQueryPlanUnsupported)
 	}
 	return cfg.copy(), nil
+}
+
+func (c *Collection) columnPhysicalQueryMutationPartsHint() (uint64, error) {
+	if c == nil {
+		return 0, errCollectionNil
+	}
+	c.catalogMu.RLock()
+	defer c.catalogMu.RUnlock()
+	if c.catalog == nil {
+		return 0, errCollectionNotFound
+	}
+	cfg := c.catalog.meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled {
+		return 0, fmt.Errorf("%w: physical column query requires enabled column_store", ErrColumnQueryPlanUnsupported)
+	}
+	return cfg.PhysicalMutationParts, nil
 }
 
 func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) ColumnPhysicalQueryDiagnostics {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -53,6 +53,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	AssetRefs                  int
 	MutationParts              int
 	DecodedBlocks              int
+	DirectReduceBlocks         int
 	ScheduledGranules          int
 	SkippedGranules            int
 	RowsScanned                int
@@ -87,38 +88,117 @@ var errColumnPhysicalScanCancelled = errors.New("collections: physical column sc
 // scanner path; mutation-bearing manifests fall back to the M13C visibility
 // overlay before reducing.
 func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
-	cfg, err := c.columnPhysicalQueryColumnStoreConfig()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
-	if cfg.PhysicalMutationParts > 0 {
-		return c.runColumnPhysicalQueryWithVisibility(cfg, req)
+	if view.MutationParts > 0 {
+		return c.runColumnPhysicalQueryWithVisibility(view.Config, req)
 	}
-	exec, err := newColumnPhysicalQueryExecutor(cfg, req)
+	return c.runColumnPhysicalQueryInSnapshotView(view, req)
+}
+
+func (c *Collection) runColumnPhysicalQueryDirectInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, refModulo, refRemainder int, shouldCancel func() bool) (ColumnPhysicalQueryResult, bool, error) {
+	exec, err := newColumnPhysicalQueryExecutor(view.Config, req)
 	if err != nil {
-		return ColumnPhysicalQueryResult{}, err
+		return ColumnPhysicalQueryResult{}, false, err
+	}
+	if !exec.supportsDirectAssetReduce() {
+		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	scanStart := time.Now()
-	diag, err := c.scanColumnPhysicalRows(columnPhysicalScanRequest{
-		ProjectedColumns:  exec.projected,
-		Visitor:           exec.visit,
-		RequireInsertOnly: true,
-	})
+	diag, err := c.scanColumnPhysicalQueryDirectInSnapshotView(view, exec, refModulo, refRemainder, shouldCancel)
 	scanNanos := time.Since(scanStart).Nanoseconds()
 	result := ColumnPhysicalQueryResult{
 		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
 	}
+	result.Diagnostics.DirectReduceBlocks = diag.DecodedBlocks
 	result.Diagnostics.ScanNanos = scanNanos
 	result.Diagnostics.ReduceRows = exec.reduceRows
 	if err != nil {
 		if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
-			return c.runColumnPhysicalQueryWithVisibility(cfg, req)
+			return result, true, err
 		}
-		return result, err
+		return result, true, err
 	}
 	result.Groups = exec.groups()
 	result.Diagnostics.ResultGroups = len(result.Groups)
-	return result, nil
+	return result, true, nil
+}
+
+func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
+	view columnPhysicalScanSnapshotView,
+	exec *columnPhysicalQueryExecutor,
+	refModulo int,
+	refRemainder int,
+	shouldCancel func() bool,
+) (columnPhysicalScanDiagnostics, error) {
+	cfg := view.Config
+	diag := view.Diagnostics
+	if c == nil {
+		return diag, errCollectionNil
+	}
+	if c.db == nil {
+		return diag, errCollectionDBNil
+	}
+	if !view.ColumnStoreEnabled || !cfg.Enabled {
+		return diag, errors.New("collections: physical column scan requires enabled column_store")
+	}
+	if cfg.ActiveManifest == nil {
+		return diag, errors.New("collections: physical column scan requires active column manifest")
+	}
+	if view.MutationParts != 0 {
+		return diag, errColumnPhysicalQueryNeedsVisibility
+	}
+	if refModulo < 0 {
+		return diag, errors.New("collections: physical column scan ref ordinal modulo cannot be negative")
+	}
+	if refModulo == 0 && refRemainder != 0 {
+		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d requires non-zero modulo", refRemainder)
+	}
+	if refModulo > 0 && (refRemainder < 0 || refRemainder >= refModulo) {
+		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", refRemainder, refModulo)
+	}
+	diag.ProjectedColumns = len(exec.projected)
+	readCache, err := newColumnPhysicalAssetReadCache(view.ColumnAssetRootDir, view.AssetNamespace)
+	if err != nil {
+		return diag, err
+	}
+	defer func() { _ = readCache.close() }()
+	var rawScratch []byte
+	start, step := columnPhysicalScanRefOrdinalPartition(columnPhysicalScanRequest{RefOrdinalModulo: refModulo, RefOrdinalRemainder: refRemainder})
+	for ordinal := start; ordinal < len(view.AssetRefs); ordinal += step {
+		assetRef := view.AssetRefs[ordinal]
+		if shouldCancel != nil && shouldCancel() {
+			return diag, errColumnPhysicalScanCancelled
+		}
+		diag.ScheduledGranules++
+		ref := assetRef.Ref
+		raw, err := readCache.read(ref, rawScratch)
+		diag.SegmentFileCacheHits = readCache.hits
+		diag.SegmentFileCacheMisses = readCache.misses
+		if err != nil {
+			return diag, fmt.Errorf("collections: column physical scan read generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
+		}
+		rawScratch = raw
+		diag.PhysicalBytesScanned += int64(len(raw))
+		summary, err := reduceColumnPhysicalAssetDirect(raw, ref, view.CollectionName, &cfg, assetRef.Reason, exec)
+		if err != nil {
+			if errors.Is(err, errColumnPhysicalAssetManifestOperationMismatch) {
+				return diag, errColumnPhysicalQueryNeedsVisibility
+			}
+			return diag, fmt.Errorf("collections: column physical direct reduce generation=%d part_id=%d: %w", ref.Generation, ref.PartID, err)
+		}
+		diag.DecodedBlocks++
+		diag.RowsScanned += summary.rows
+		diag.DeletedRows += summary.deleted
+	}
+	diag.SegmentFileCacheHits = readCache.hits
+	diag.SegmentFileCacheMisses = readCache.misses
+	return diag, nil
 }
 
 // RunColumnPhysicalQueryParallel executes an insert-only physical query by
@@ -151,11 +231,13 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
+	direct := merged.supportsDirectAssetReduce()
 
 	type workerResult struct {
-		exec *columnPhysicalQueryExecutor
-		diag columnPhysicalScanDiagnostics
-		err  error
+		exec         *columnPhysicalQueryExecutor
+		diag         columnPhysicalScanDiagnostics
+		directBlocks int
+		err          error
 	}
 	results := make([]workerResult, workers)
 	start := time.Now()
@@ -172,18 +254,25 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 				results[worker].err = err
 				return
 			}
-			diag, err := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
-				ProjectedColumns:    exec.projected,
-				Visitor:             exec.visit,
-				RequireInsertOnly:   true,
-				RefOrdinalModulo:    workers,
-				RefOrdinalRemainder: worker,
-				ShouldCancel:        cancel.Load,
-			})
+			var diag columnPhysicalScanDiagnostics
+			var directBlocks int
+			if direct {
+				diag, err = c.scanColumnPhysicalQueryDirectInSnapshotView(view, exec, workers, worker, cancel.Load)
+				directBlocks = diag.DecodedBlocks
+			} else {
+				diag, err = c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+					ProjectedColumns:    exec.projected,
+					Visitor:             exec.visit,
+					RequireInsertOnly:   true,
+					RefOrdinalModulo:    workers,
+					RefOrdinalRemainder: worker,
+					ShouldCancel:        cancel.Load,
+				})
+			}
 			if err != nil {
 				cancel.Store(true)
 			}
-			results[worker] = workerResult{exec: exec, diag: diag, err: err}
+			results[worker] = workerResult{exec: exec, diag: diag, directBlocks: directBlocks, err: err}
 		}()
 	}
 	wg.Wait()
@@ -193,6 +282,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	for worker := range results {
 		workerResult := results[worker]
 		result.Diagnostics = mergeColumnPhysicalQueryDiagnostics(result.Diagnostics, columnPhysicalQueryDiagnosticsFromScan(workerResult.diag))
+		result.Diagnostics.DirectReduceBlocks += workerResult.directBlocks
 		if workerResult.err != nil {
 			if firstErr == nil || errors.Is(firstErr, errColumnPhysicalScanCancelled) {
 				firstErr = workerResult.err
@@ -218,6 +308,13 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if result, ok, err := c.runColumnPhysicalQueryDirectInSnapshotView(view, req, 0, 0, nil); ok {
+		if err != nil {
+			return result, err
+		}
+		result.Diagnostics.WorkerCount = 1
+		return result, nil
+	}
 	exec, err := newColumnPhysicalQueryExecutor(view.Config, req)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
@@ -340,6 +437,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 		left.MutationParts = right.MutationParts
 	}
 	left.DecodedBlocks += right.DecodedBlocks
+	left.DirectReduceBlocks += right.DirectReduceBlocks
 	left.ScheduledGranules += right.ScheduledGranules
 	left.SkippedGranules += right.SkippedGranules
 	left.RowsScanned += right.RowsScanned
@@ -355,12 +453,14 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 }
 
 type columnPhysicalQueryExecutor struct {
-	kind        ColumnPhysicalQueryKind
-	projected   []string
-	groupIdx    int
-	valueIdx    int
-	distinctIdx int
-	interner    columnPhysicalQueryStringInterner
+	kind           ColumnPhysicalQueryKind
+	projected      []string
+	groupIdx       int
+	valueIdx       int
+	distinctIdx    int
+	groupColumnIdx int
+	valueColumnIdx int
+	interner       columnPhysicalQueryStringInterner
 
 	counts       map[string]int
 	distinct     map[string]map[string]struct{}
@@ -378,54 +478,56 @@ type columnPhysicalQuerySpan struct {
 
 func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (*columnPhysicalQueryExecutor, error) {
 	exec := &columnPhysicalQueryExecutor{
-		kind:        req.Kind,
-		groupIdx:    -1,
-		valueIdx:    -1,
-		distinctIdx: -1,
+		kind:           req.Kind,
+		groupIdx:       -1,
+		valueIdx:       -1,
+		distinctIdx:    -1,
+		groupColumnIdx: -1,
+		valueColumnIdx: -1,
 	}
-	addProjection := func(name string, wantType ColumnStoreValueType, role string) (int, error) {
+	addProjection := func(name string, wantType ColumnStoreValueType, role string) (int, int, error) {
 		if name == "" {
-			return -1, fmt.Errorf("%w: physical column query %s column is required", ErrColumnQueryPlanUnsupported, role)
+			return -1, -1, fmt.Errorf("%w: physical column query %s column is required", ErrColumnQueryPlanUnsupported, role)
 		}
-		col, ok := columnPhysicalQueryDeclaredColumn(cfg, name)
+		col, columnIdx, ok := columnPhysicalQueryDeclaredColumn(cfg, name)
 		if !ok {
-			return -1, fmt.Errorf("%w: physical column query requested undeclared column %q", ErrColumnQueryPlanUnsupported, name)
+			return -1, -1, fmt.Errorf("%w: physical column query requested undeclared column %q", ErrColumnQueryPlanUnsupported, name)
 		}
 		if col.ValueType != wantType {
-			return -1, fmt.Errorf("%w: physical column query %s column %q has type %q, want %q", ErrColumnQueryPlanUnsupported, role, name, col.ValueType, wantType)
+			return -1, -1, fmt.Errorf("%w: physical column query %s column %q has type %q, want %q", ErrColumnQueryPlanUnsupported, role, name, col.ValueType, wantType)
 		}
 		for idx, existing := range exec.projected {
 			if existing == name {
-				return idx, nil
+				return idx, columnIdx, nil
 			}
 		}
 		exec.projected = append(exec.projected, name)
-		return len(exec.projected) - 1, nil
+		return len(exec.projected) - 1, columnIdx, nil
 	}
 
 	var err error
 	switch req.Kind {
 	case ColumnPhysicalQueryGroupCount:
-		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		exec.groupIdx, exec.groupColumnIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
 		exec.counts = make(map[string]int)
 	case ColumnPhysicalQueryGroupCountDistinct:
-		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		exec.groupIdx, exec.groupColumnIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
 		if err == nil {
-			exec.distinctIdx, err = addProjection(req.DistinctColumn, ColumnStoreValueString, "distinct")
+			exec.distinctIdx, _, err = addProjection(req.DistinctColumn, ColumnStoreValueString, "distinct")
 		}
 		exec.distinct = make(map[string]map[string]struct{})
 	case ColumnPhysicalQueryHourCount:
-		exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+		exec.valueIdx, exec.valueColumnIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
 	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
-		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		exec.groupIdx, exec.groupColumnIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
 		if err == nil {
-			exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+			exec.valueIdx, exec.valueColumnIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
 		}
 		exec.int64Values = make(map[string]int64)
 	case ColumnPhysicalQueryGroupInt64Span:
-		exec.groupIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
+		exec.groupIdx, exec.groupColumnIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
 		if err == nil {
-			exec.valueIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
+			exec.valueIdx, exec.valueColumnIdx, err = addProjection(req.ValueColumn, ColumnStoreValueInt64, "value")
 		}
 		exec.int64Spans = make(map[string]columnPhysicalQuerySpan)
 	default:
@@ -437,13 +539,27 @@ func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQue
 	return exec, nil
 }
 
-func columnPhysicalQueryDeclaredColumn(cfg ColumnStoreConfig, name string) (ColumnStoreColumn, bool) {
-	for _, col := range cfg.Columns {
+func columnPhysicalQueryDeclaredColumn(cfg ColumnStoreConfig, name string) (ColumnStoreColumn, int, bool) {
+	for idx, col := range cfg.Columns {
 		if col.Name == name {
-			return col, true
+			return col, idx, true
 		}
 	}
-	return ColumnStoreColumn{}, false
+	return ColumnStoreColumn{}, -1, false
+}
+
+func (e *columnPhysicalQueryExecutor) supportsDirectAssetReduce() bool {
+	if e == nil {
+		return false
+	}
+	switch e.kind {
+	case ColumnPhysicalQueryGroupCount:
+		return e.groupColumnIdx >= 0
+	case ColumnPhysicalQueryGroupInt64Span:
+		return e.groupColumnIdx >= 0 && e.valueColumnIdx >= 0
+	default:
+		return false
+	}
 }
 
 func (e *columnPhysicalQueryExecutor) visit(row columnPhysicalScanRowView) error {
@@ -517,6 +633,242 @@ func (e *columnPhysicalQueryExecutor) visitValues(values []columnDeclaredValue) 
 		}
 		e.int64Spans[key] = cur
 	}
+	return nil
+}
+
+func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg *ColumnStoreConfig, expectedOperation ColumnPublishOperation, exec *columnPhysicalQueryExecutor) (columnPhysicalAssetScanSummary, error) {
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("bad column physical asset magic=0x%08x", magic)
+	}
+	version := cur.u16()
+	if !isSupportedColumnPhysicalAssetVersion(version) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset version=%d", version)
+	}
+	collection := cur.stringBytes()
+	namespace := cur.stringBytes()
+	generation := cur.u64()
+	partID := cur.u64()
+	appliedCommandLSN := cur.u64()
+	operationBytes := cur.stringBytes()
+	operation, operationOK := columnPhysicalScanOperationFromBytes(operationBytes)
+	schemaHash := cur.u64()
+	columnCount := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return columnPhysicalAssetScanSummary{}, err
+	}
+	if columnCount > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column_count=%d overflows int max=%d", columnCount, maxCollectionInt)
+	}
+	if rowCount > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset row_count=%d overflows int max=%d", rowCount, maxCollectionInt)
+	}
+	header := columnPhysicalAssetScanHeader{
+		Collection:        collection,
+		Namespace:         namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		Operation:         operation,
+		SchemaHash:        schemaHash,
+		ColumnCount:       int(columnCount),
+		RowCount:          int(rowCount),
+	}
+	if !operationOK {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", operationBytes)
+	}
+	if version == columnPhysicalAssetVersionV1 && header.Operation == ColumnPublishOperationDelete {
+		return columnPhysicalAssetScanSummary{}, errors.New("legacy v1 column physical asset delete operation unsupported")
+	}
+	if err := validateColumnPhysicalAssetScanHeader(header, ref, expectedCollection, cfg); err != nil {
+		return columnPhysicalAssetScanSummary{}, err
+	}
+	if expectedOperation != "" && header.Operation != expectedOperation {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("%w: manifest reason=%q asset operation=%q", errColumnPhysicalAssetManifestOperationMismatch, expectedOperation, header.Operation)
+	}
+	if header.Operation != ColumnPublishOperationInsert {
+		return columnPhysicalAssetScanSummary{}, errColumnPhysicalQueryNeedsVisibility
+	}
+	if header.ColumnCount != len(cfg.Columns) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset columns=%d want %d", header.ColumnCount, len(cfg.Columns))
+	}
+	for colIdx := 0; colIdx < header.ColumnCount; colIdx++ {
+		name := cur.stringBytes()
+		path := cur.stringBytes()
+		valueType := cur.stringBytes()
+		nullable := cur.bool()
+		dictionary := cur.bool()
+		if cur.err != nil {
+			return columnPhysicalAssetScanSummary{}, cur.err
+		}
+		want := cfg.Columns[colIdx]
+		if !columnPhysicalBytesEqualString(name, want.Name) ||
+			!columnPhysicalBytesEqualString(path, want.Path) ||
+			!columnPhysicalBytesEqualString(valueType, string(want.ValueType)) ||
+			nullable != want.Nullable ||
+			dictionary != want.Dictionary {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t} want %+v",
+				colIdx, string(name), string(path), string(valueType), nullable, dictionary, want)
+		}
+	}
+	var summary columnPhysicalAssetScanSummary
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		_ = cur.bytesView()
+		deleted := false
+		if version >= columnPhysicalAssetVersionV2 {
+			deleted = cur.bool()
+		}
+		if cur.err != nil {
+			return columnPhysicalAssetScanSummary{}, cur.err
+		}
+		if deleted {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("%w: operation=%s deleted=%v", errColumnPhysicalQueryNeedsVisibility, header.Operation, deleted)
+		}
+		group, groupOK, value, valueOK, err := scanColumnPhysicalDirectQueryRowValues(&cur, version, cfg, exec)
+		if err != nil {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("row[%d]: %w", rowIdx, err)
+		}
+		switch exec.kind {
+		case ColumnPhysicalQueryGroupCount:
+			if err := exec.visitDirectGroupCount(group, groupOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		case ColumnPhysicalQueryGroupInt64Span:
+			if err := exec.visitDirectGroupInt64Span(group, groupOK, value, valueOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		default:
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("%w: unsupported direct physical column query kind %q", ErrColumnQueryPlanUnsupported, exec.kind)
+		}
+		summary.rows++
+	}
+	if cur.err != nil {
+		return columnPhysicalAssetScanSummary{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return columnPhysicalAssetScanSummary{}, errors.New("trailing bytes in column physical asset")
+	}
+	return summary, nil
+}
+
+func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16, cfg *ColumnStoreConfig, exec *columnPhysicalQueryExecutor) ([]byte, bool, int64, bool, error) {
+	var group []byte
+	var groupOK bool
+	var value int64
+	var valueOK bool
+	for colIdx, col := range cfg.Columns {
+		typeBytes := cur.stringBytes()
+		if cur.err != nil {
+			return nil, false, 0, false, cur.err
+		}
+		if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
+			return nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
+		}
+		null := cur.bool()
+		if cur.err != nil {
+			return nil, false, 0, false, cur.err
+		}
+		present := true
+		if version >= columnPhysicalAssetVersion {
+			present = cur.bool()
+			if cur.err != nil {
+				return nil, false, 0, false, cur.err
+			}
+		}
+		selectedGroup := colIdx == exec.groupColumnIdx
+		selectedValue := colIdx == exec.valueColumnIdx
+		if !present {
+			if !null {
+				return nil, false, 0, false, fmt.Errorf("column[%d] absent value is not null", colIdx)
+			}
+			if !col.Nullable {
+				return nil, false, 0, false, fmt.Errorf("column[%d] is absent but column is not nullable", colIdx)
+			}
+			if selectedGroup || selectedValue {
+				return nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
+			}
+			continue
+		}
+		if null {
+			if !col.Nullable {
+				return nil, false, 0, false, fmt.Errorf("column[%d] is null but column is not nullable", colIdx)
+			}
+			if selectedGroup || selectedValue {
+				return nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
+			}
+			continue
+		}
+		switch col.ValueType {
+		case ColumnStoreValueBool:
+			_ = cur.bool()
+		case ColumnStoreValueInt64:
+			v := int64(cur.u64())
+			if selectedValue {
+				value = v
+				valueOK = true
+			}
+		case ColumnStoreValueDouble:
+			_ = cur.u64()
+		case ColumnStoreValueString:
+			v := cur.stringBytes()
+			if selectedGroup {
+				group = v
+				groupOK = true
+			}
+		default:
+			return nil, false, 0, false, fmt.Errorf("unsupported column physical value type %q", col.ValueType)
+		}
+		if cur.err != nil {
+			return nil, false, 0, false, cur.err
+		}
+	}
+	return group, groupOK, value, valueOK, nil
+}
+
+func columnPhysicalQueryNullDirectError(valueType ColumnStoreValueType) error {
+	switch valueType {
+	case ColumnStoreValueString:
+		return fmt.Errorf("%w: physical column query does not support null string group values yet", ErrColumnQueryPlanUnsupported)
+	case ColumnStoreValueInt64:
+		return fmt.Errorf("%w: physical column query does not support null int64 values yet", ErrColumnQueryPlanUnsupported)
+	default:
+		return fmt.Errorf("%w: physical column query does not support null %s values yet", ErrColumnQueryPlanUnsupported, valueType)
+	}
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectGroupCount(group []byte, groupOK bool) error {
+	if !groupOK {
+		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
+	}
+	key := e.interner.internBytes(group)
+	e.counts[key]++
+	e.reduceRows++
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectGroupInt64Span(group []byte, groupOK bool, value int64, valueOK bool) error {
+	if !groupOK {
+		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
+	}
+	if !valueOK {
+		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
+	}
+	key := e.interner.internBytes(group)
+	cur, ok := e.int64Spans[key]
+	if !ok {
+		e.int64Spans[key] = columnPhysicalQuerySpan{min: value, max: value}
+		e.reduceRows++
+		return nil
+	}
+	if value < cur.min {
+		cur.min = value
+	}
+	if value > cur.max {
+		cur.max = value
+	}
+	e.int64Spans[key] = cur
+	e.reduceRows++
 	return nil
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -25,16 +25,18 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 	defer closeFn()
 
 	tests := []struct {
-		name      string
-		hashName  string
-		req       ColumnPhysicalQueryRequest
-		wantCount int
+		name       string
+		hashName   string
+		req        ColumnPhysicalQueryRequest
+		wantCount  int
+		wantDirect bool
 	}{
 		{
-			name:      "q1",
-			hashName:  "q1",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			wantCount: 4,
+			name:       "q1",
+			hashName:   "q1",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+			wantCount:  4,
+			wantDirect: true,
 		},
 		{
 			name:      "q2",
@@ -61,16 +63,18 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			wantCount: 12,
 		},
 		{
-			name:      "q5",
-			hashName:  "q5",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			wantCount: 12,
+			name:       "q5",
+			hashName:   "q5",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount:  12,
+			wantDirect: true,
 		},
 		{
-			name:      "q5_metadata",
-			hashName:  "q5",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			wantCount: 12,
+			name:       "q5_metadata",
+			hashName:   "q5",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount:  12,
+			wantDirect: true,
 		},
 	}
 
@@ -93,6 +97,12 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			}
 			if result.Diagnostics.AssetRefs == 0 || result.Diagnostics.DecodedBlocks == 0 || result.Diagnostics.PhysicalBytesScanned <= 0 {
 				t.Fatalf("%s missing physical diagnostics: %+v", tc.name, result.Diagnostics)
+			}
+			if tc.wantDirect && result.Diagnostics.DirectReduceBlocks != result.Diagnostics.DecodedBlocks {
+				t.Fatalf("%s direct reduce blocks=%d want decoded blocks=%d diagnostics=%+v", tc.name, result.Diagnostics.DirectReduceBlocks, result.Diagnostics.DecodedBlocks, result.Diagnostics)
+			}
+			if !tc.wantDirect && result.Diagnostics.DirectReduceBlocks != 0 {
+				t.Fatalf("%s direct reduce blocks=%d want zero for non-vectorized shape diagnostics=%+v", tc.name, result.Diagnostics.DirectReduceBlocks, result.Diagnostics)
 			}
 			if result.Diagnostics.ReduceRows != len(events) {
 				t.Fatalf("%s reduce rows=%d want %d", tc.name, result.Diagnostics.ReduceRows, len(events))
@@ -284,6 +294,9 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			}
 			if parallel.Diagnostics.RowMaterializations != 0 {
 				t.Fatalf("parallel row materializations=%d want zero diagnostics=%+v", parallel.Diagnostics.RowMaterializations, parallel.Diagnostics)
+			}
+			if parallel.Diagnostics.DirectReduceBlocks != parallel.Diagnostics.DecodedBlocks {
+				t.Fatalf("parallel direct reduce blocks=%d want decoded blocks=%d diagnostics=%+v", parallel.Diagnostics.DirectReduceBlocks, parallel.Diagnostics.DecodedBlocks, parallel.Diagnostics)
 			}
 			if got, want := parallel.Diagnostics.ReduceRows, serial.Diagnostics.ReduceRows; got != want {
 				t.Fatalf("parallel reduce rows=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)


### PR DESCRIPTION
## Summary

This is the first #1634 post-V1 optimization PR, based on the measured latest-head attribution that direct TCPA scanning is not the primary blocker but q1/q5 reducer shape and per-query asset-buffer allocation still cost visible throughput.

Changes:
- Adds an insert-only direct TCPA reducer path for physical q1 (`group_count`) and q5 (`group_int64_span`).
- Keeps q2/q3/q4 and mutation/visibility-bearing manifests on the existing fail-closed row-view/visibility paths.
- Adds `DirectReduceBlocks` diagnostics so tests can prove the optimized path is used only for the intended shapes.
- Reuses typed column asset read buffers through the column physical asset read cache scratch pool to avoid allocating the TCPA asset image on every repeated query scan.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64. Base comparison is the #1634 latest-head refresh at #1636 head `3ed99fd05fa28687ed681b51a87e1bac2e10c402`; this PR head is `78f3268adad8`.

Package benchmark command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B' -benchmem -benchtime=20x -count=1
```

Results:
- q1 8192: `643621 ns/op`, `12.79M rows/s`, `78.17 ns/row`, `5658 B/op`, `50 allocs/op`.
- q5 8192: `660038 ns/op`, `12.45M rows/s`, `80.33 ns/row`, `7341 B/op`, `72 allocs/op`.
- Previous latest-head refresh for the same benchmark: q1 8192 `785062 ns/op`, `10.51M rows/s`, `95.11 ns/row`, `833669 B/op`, `60 allocs/op`; q5 8192 `878410 ns/op`, `9.37M rows/s`, `106.7 ns/row`, `835437 B/op`, `82 allocs/op`.

Routed production serial command:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_vector_reducers_20260520_110500 -path-label native-fastpath -column-store-path serial_column_scan -progress=false
```

Routed serial results:
- q1: `12.12M rows/s`, `1202.38 MiB/s`, `82.5 ns/row`, `B/read=10404660`, `row_materializations=0`, parity pass.
- q5: `10.10M rows/s`, `1002.06 MiB/s`, `99.0 ns/row`, `B/read=10404660`, `row_materializations=0`, parity pass.
- Latest-head refresh baseline: q1 `10.99M rows/s`, q5 `8.80M rows/s`.

Routed production parallel command:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_vector_reducers_parallel_20260520_110507 -path-label native-fastpath -column-store-path parallel_column_scan -progress=false
```

Routed parallel results:
- q1: `20.99M rows/s`, `2082.61 MiB/s`, `47.6 ns/row`, parity pass.
- q5: `17.20M rows/s`, `1706.98 MiB/s`, `58.1 ns/row`, parity pass.
- Latest-head refresh baseline: q1 `20.41M rows/s`, q5 `15.53M rows/s`.

Byte accounting from routed runs remains stable:
- `retained_payload_bytes=3368750`
- `column_asset_bytes=10404660`
- `manifest_control_bytes=28`
- `command_wal_bytes_before_checkpoint=11172291`
- `db_total_bytes=24119432`

## Granule / ClickHouse Equivalent Comparison

These are context comparisons, not PR gates. The production path in this PR includes durable TreeDB collection integration, manifest/recovery validation, typed column asset manager reads, planner/query adapter, parity/reporting, and row-oriented TCPA decode. The older granule and ClickHouse comparisons are useful ceilings/baselines, but not apples-to-apples with routed production.

Earlier `experiments/colgranule` JSONBench hot-kernel equivalent from the #1634 latest-head refresh (`/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`):
- q1 encoded reducer: `412.80M rows/s`.
- q2 encoded reducer: `237.61M rows/s`.
- q3 encoded reducer: `191.61M rows/s`.
- q5 encoded reducer: `138.03M rows/s`.
- q5 metadata kernel: `399.71M rows/s`.

Historical local ClickHouse-equivalent comparison from [experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md](experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md), generated from 1,000,000 JSONBench rows against local ClickHouse `26.4.3.1` on Darwin arm64:
- q1 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.004284s`, about `233.43M rows/s`.
- q2 ClickHouse local: `0.027s`, about `37.04M rows/s`; granule column-kernel best `0.038895s`, about `25.71M rows/s`.
- q3 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.006631s`, about `150.81M rows/s`.
- q4 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.009869s`, about `101.33M rows/s`.
- q5 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.010027s`, about `99.73M rows/s`.

Interpretation for this PR: #1649 moves routed production q1/q5 in the right direction (`serial` q1/q5 `12.12M`/`10.10M rows/s`, `parallel` q1/q5 `20.99M`/`17.20M rows/s`), but production still remains well below the earlier granule hot-kernel and historical ClickHouse-equivalent numbers. That remaining gap is expected while TCPA is row-oriented and production still lacks true vector/block reducers for every shape, metadata assets, mark pruning, dictionaries, and locators.

## Throughput Interpretation

This is not a final analytical-kernel optimization. TCPA remains row-oriented at rest, so this PR does not claim ClickHouse-like column-vector layout. The win comes from reducing directly while decoding q1/q5-compatible TCPA rows, avoiding projected row-value scratch construction for these two insert-only shapes, and reusing the read buffer for repeated scans.

The remaining allocation count is mostly fixed query/setup overhead: snapshot/manifest validation, read-cache/file setup, maps/interner/results, and diagnostics. The large row/asset-buffer B/op source is removed from the repeated package benchmark path.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery(AdapterExecutesJSONBenchShapesM13B|ParallelMatchesSerialInsertOnlyM14B|AdapterAllocationSlopeM13B|AdapterAppliesMutationVisibilityM13C)' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- Routed `serial_column_scan` 100K durable unified-bench passed parity for q1-q5/q5_metadata.
- Routed `parallel_column_scan` 100K durable unified-bench passed parity for q1-q5/q5_metadata.

## Artifacts

- Serial routed artifacts: `/tmp/gomap_1634_vector_reducers_20260520_110500`
- Parallel routed artifacts: `/tmp/gomap_1634_vector_reducers_parallel_20260520_110507`
- Package allocation profile used for attribution: `/tmp/gomap_1634_q1_allocs.pprof`
- Review-fix package benchmark refresh: `/tmp/gomap_1649_reviewfix_adapter_bench.txt`

## Assumptions / Non-Goals

- This PR intentionally optimizes only insert-only q1/q5 physical query shapes.
- Mutation visibility, q2/q3/q4, mark pruning, dictionaries, locators, and real aggregate metadata fast paths remain outside this PR.
- The scratch pool is scoped to typed column physical asset reads; it does not mix column assets with ordinary row value-log or leaf-log storage.

Fixes part of #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized column query execution with an improved reduction path for better performance
  * Enhanced memory efficiency through intelligent buffer reuse
  * Added diagnostics metrics for deeper visibility into query execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->