### PR TITLE
TreeDB column store post-V1: vectorize physical q2/q3 reducers

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -878,7 +878,7 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 func columnPhysicalQueryNullDirectError(valueType ColumnStoreValueType) error {
 	switch valueType {
 	case ColumnStoreValueString:
-		return fmt.Errorf("%w: physical column query does not support null string group values yet", ErrColumnQueryPlanUnsupported)
+		return fmt.Errorf("%w: physical column query does not support null string values yet", ErrColumnQueryPlanUnsupported)
 	case ColumnStoreValueInt64:
 		return fmt.Errorf("%w: physical column query does not support null int64 values yet", ErrColumnQueryPlanUnsupported)
 	default:

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -481,14 +481,15 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 }
 
 type columnPhysicalQueryExecutor struct {
-	kind           ColumnPhysicalQueryKind
-	projected      []string
-	groupIdx       int
-	valueIdx       int
-	distinctIdx    int
-	groupColumnIdx int
-	valueColumnIdx int
-	interner       columnPhysicalQueryStringInterner
+	kind              ColumnPhysicalQueryKind
+	projected         []string
+	groupIdx          int
+	valueIdx          int
+	distinctIdx       int
+	groupColumnIdx    int
+	valueColumnIdx    int
+	distinctColumnIdx int
+	interner          columnPhysicalQueryStringInterner
 
 	counts       map[string]int
 	distinct     map[string]map[string]struct{}
@@ -506,12 +507,13 @@ type columnPhysicalQuerySpan struct {
 
 func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (*columnPhysicalQueryExecutor, error) {
 	exec := &columnPhysicalQueryExecutor{
-		kind:           req.Kind,
-		groupIdx:       -1,
-		valueIdx:       -1,
-		distinctIdx:    -1,
-		groupColumnIdx: -1,
-		valueColumnIdx: -1,
+		kind:              req.Kind,
+		groupIdx:          -1,
+		valueIdx:          -1,
+		distinctIdx:       -1,
+		groupColumnIdx:    -1,
+		valueColumnIdx:    -1,
+		distinctColumnIdx: -1,
 	}
 	addProjection := func(name string, wantType ColumnStoreValueType, role string) (int, int, error) {
 		if name == "" {
@@ -541,7 +543,7 @@ func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQue
 	case ColumnPhysicalQueryGroupCountDistinct:
 		exec.groupIdx, exec.groupColumnIdx, err = addProjection(req.GroupColumn, ColumnStoreValueString, "group")
 		if err == nil {
-			exec.distinctIdx, _, err = addProjection(req.DistinctColumn, ColumnStoreValueString, "distinct")
+			exec.distinctIdx, exec.distinctColumnIdx, err = addProjection(req.DistinctColumn, ColumnStoreValueString, "distinct")
 		}
 		exec.distinct = make(map[string]map[string]struct{})
 	case ColumnPhysicalQueryHourCount:
@@ -583,6 +585,10 @@ func (e *columnPhysicalQueryExecutor) supportsDirectAssetReduce() bool {
 	switch e.kind {
 	case ColumnPhysicalQueryGroupCount:
 		return e.groupColumnIdx >= 0
+	case ColumnPhysicalQueryGroupCountDistinct:
+		return e.groupColumnIdx >= 0 && e.distinctColumnIdx >= 0
+	case ColumnPhysicalQueryHourCount:
+		return e.valueColumnIdx >= 0
 	case ColumnPhysicalQueryGroupInt64Span:
 		return e.groupColumnIdx >= 0 && e.valueColumnIdx >= 0
 	default:
@@ -753,13 +759,21 @@ func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCol
 		if deleted {
 			return columnPhysicalAssetScanSummary{}, fmt.Errorf("%w: operation=%s deleted=%v", errColumnPhysicalQueryNeedsVisibility, header.Operation, deleted)
 		}
-		group, groupOK, value, valueOK, err := scanColumnPhysicalDirectQueryRowValues(&cur, version, cfg, exec)
+		group, groupOK, distinct, distinctOK, value, valueOK, err := scanColumnPhysicalDirectQueryRowValues(&cur, version, cfg, exec)
 		if err != nil {
 			return columnPhysicalAssetScanSummary{}, fmt.Errorf("row[%d]: %w", rowIdx, err)
 		}
 		switch exec.kind {
 		case ColumnPhysicalQueryGroupCount:
 			if err := exec.visitDirectGroupCount(group, groupOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		case ColumnPhysicalQueryGroupCountDistinct:
+			if err := exec.visitDirectGroupCountDistinct(group, groupOK, distinct, distinctOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		case ColumnPhysicalQueryHourCount:
+			if err := exec.visitDirectHourCount(value, valueOK); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
 			}
 		case ColumnPhysicalQueryGroupInt64Span:
@@ -780,50 +794,53 @@ func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCol
 	return summary, nil
 }
 
-func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16, cfg *ColumnStoreConfig, exec *columnPhysicalQueryExecutor) ([]byte, bool, int64, bool, error) {
+func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16, cfg *ColumnStoreConfig, exec *columnPhysicalQueryExecutor) ([]byte, bool, []byte, bool, int64, bool, error) {
 	var group []byte
 	var groupOK bool
+	var distinct []byte
+	var distinctOK bool
 	var value int64
 	var valueOK bool
 	for colIdx, col := range cfg.Columns {
 		typeBytes := cur.stringBytes()
 		if cur.err != nil {
-			return nil, false, 0, false, cur.err
+			return nil, false, nil, false, 0, false, cur.err
 		}
 		if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
-			return nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
+			return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
 		}
 		null := cur.bool()
 		if cur.err != nil {
-			return nil, false, 0, false, cur.err
+			return nil, false, nil, false, 0, false, cur.err
 		}
 		present := true
 		if version >= columnPhysicalAssetVersion {
 			present = cur.bool()
 			if cur.err != nil {
-				return nil, false, 0, false, cur.err
+				return nil, false, nil, false, 0, false, cur.err
 			}
 		}
 		selectedGroup := colIdx == exec.groupColumnIdx
 		selectedValue := colIdx == exec.valueColumnIdx
+		selectedDistinct := colIdx == exec.distinctColumnIdx
 		if !present {
 			if !null {
-				return nil, false, 0, false, fmt.Errorf("column[%d] absent value is not null", colIdx)
+				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] absent value is not null", colIdx)
 			}
 			if !col.Nullable {
-				return nil, false, 0, false, fmt.Errorf("column[%d] is absent but column is not nullable", colIdx)
+				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] is absent but column is not nullable", colIdx)
 			}
-			if selectedGroup || selectedValue {
-				return nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
+			if selectedGroup || selectedValue || selectedDistinct {
+				return nil, false, nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
 			}
 			continue
 		}
 		if null {
 			if !col.Nullable {
-				return nil, false, 0, false, fmt.Errorf("column[%d] is null but column is not nullable", colIdx)
+				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] is null but column is not nullable", colIdx)
 			}
-			if selectedGroup || selectedValue {
-				return nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
+			if selectedGroup || selectedValue || selectedDistinct {
+				return nil, false, nil, false, 0, false, columnPhysicalQueryNullDirectError(col.ValueType)
 			}
 			continue
 		}
@@ -844,14 +861,18 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 				group = v
 				groupOK = true
 			}
+			if selectedDistinct {
+				distinct = v
+				distinctOK = true
+			}
 		default:
-			return nil, false, 0, false, fmt.Errorf("unsupported column physical value type %q", col.ValueType)
+			return nil, false, nil, false, 0, false, fmt.Errorf("unsupported column physical value type %q", col.ValueType)
 		}
 		if cur.err != nil {
-			return nil, false, 0, false, cur.err
+			return nil, false, nil, false, 0, false, cur.err
 		}
 	}
-	return group, groupOK, value, valueOK, nil
+	return group, groupOK, distinct, distinctOK, value, valueOK, nil
 }
 
 func columnPhysicalQueryNullDirectError(valueType ColumnStoreValueType) error {
@@ -871,6 +892,34 @@ func (e *columnPhysicalQueryExecutor) visitDirectGroupCount(group []byte, groupO
 	}
 	key := e.interner.internBytes(group)
 	e.counts[key]++
+	e.reduceRows++
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectGroupCountDistinct(group []byte, groupOK bool, distinct []byte, distinctOK bool) error {
+	if !groupOK {
+		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
+	}
+	if !distinctOK {
+		return fmt.Errorf("%w: physical column query missing string distinct value", ErrColumnQueryPlanUnsupported)
+	}
+	key := e.interner.internBytes(group)
+	distinctKey := e.interner.internBytes(distinct)
+	set := e.distinct[key]
+	if set == nil {
+		set = make(map[string]struct{})
+		e.distinct[key] = set
+	}
+	set[distinctKey] = struct{}{}
+	e.reduceRows++
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectHourCount(value int64, valueOK bool) error {
+	if !valueOK {
+		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
+	}
+	e.hourCounts[columnPhysicalQueryUTCHour(value)]++
 	e.reduceRows++
 	return nil
 }

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -39,16 +39,18 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			wantDirect: true,
 		},
 		{
-			name:      "q2",
-			hashName:  "q2",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			wantCount: 4,
+			name:       "q2",
+			hashName:   "q2",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+			wantCount:  4,
+			wantDirect: true,
 		},
 		{
-			name:      "q3",
-			hashName:  "q3",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			wantCount: 24,
+			name:       "q3",
+			hashName:   "q3",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
+			wantCount:  24,
+			wantDirect: true,
 		},
 		{
 			name:      "q4a",
@@ -273,6 +275,14 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 		{
 			name: "count",
 			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+		},
+		{
+			name: "count_distinct",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+		},
+		{
+			name: "hour_count",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
 		},
 		{
 			name: "span",
@@ -1700,62 +1710,44 @@ func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
 
 func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 	for _, rows := range []int{1024, 8192} {
-		b.Run(fmt.Sprintf("q1_rows_%d", rows), func(b *testing.B) {
-			collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
-			defer closeFn()
-			req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
-			preview, err := collection.RunColumnPhysicalQuery(req)
-			if err != nil {
-				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
-			}
-			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
-			b.ReportAllocs()
-			b.ResetTimer()
-			var reducedRows int64
-			for i := 0; i < b.N; i++ {
-				result, err := collection.RunColumnPhysicalQuery(req)
+		cases := []struct {
+			name string
+			req  ColumnPhysicalQueryRequest
+		}{
+			{name: "q1", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}},
+			{name: "q2", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}},
+			{name: "q3", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
+			{name: "q5", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
+		}
+		for _, tc := range cases {
+			b.Run(fmt.Sprintf("%s_rows_%d", tc.name, rows), func(b *testing.B) {
+				collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
+				defer closeFn()
+				preview, err := collection.RunColumnPhysicalQuery(tc.req)
 				if err != nil {
-					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+					b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
 				}
-				if len(result.Groups) == 0 {
-					b.Fatal("empty result")
+				b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+				b.ReportAllocs()
+				b.ResetTimer()
+				var reducedRows int64
+				for i := 0; i < b.N; i++ {
+					result, err := collection.RunColumnPhysicalQuery(tc.req)
+					if err != nil {
+						b.Fatalf("RunColumnPhysicalQuery: %v", err)
+					}
+					if len(result.Groups) == 0 {
+						b.Fatal("empty result")
+					}
+					reducedRows += int64(result.Diagnostics.ReduceRows)
 				}
-				reducedRows += int64(result.Diagnostics.ReduceRows)
-			}
-			if reducedRows > 0 {
-				elapsed := b.Elapsed()
-				b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
-				b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
-			}
-		})
-		b.Run(fmt.Sprintf("q5_rows_%d", rows), func(b *testing.B) {
-			collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
-			defer closeFn()
-			req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}
-			preview, err := collection.RunColumnPhysicalQuery(req)
-			if err != nil {
-				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
-			}
-			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
-			b.ReportAllocs()
-			b.ResetTimer()
-			var reducedRows int64
-			for i := 0; i < b.N; i++ {
-				result, err := collection.RunColumnPhysicalQuery(req)
-				if err != nil {
-					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				if reducedRows > 0 {
+					elapsed := b.Elapsed()
+					b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
+					b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
 				}
-				if len(result.Groups) == 0 {
-					b.Fatal("empty result")
-				}
-				reducedRows += int64(result.Diagnostics.ReduceRows)
-			}
-			if reducedRows > 0 {
-				elapsed := b.Elapsed()
-				b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
-				b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
-			}
-		})
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This is the second #1634 post-V1 optimization PR, chained after #1649. It extends the direct TCPA reduce path from q1/q5 to the remaining low-risk JSONBench reducer shapes q2 and q3.

Changes:
- Adds direct insert-only TCPA reducers for q2 (`group_count_distinct`) and q3 (`hour_count`).
- Keeps q4a/q4b on the existing row-view path; this PR does not implement min/max direct reducers or q4 early-stop behavior.
- Extends direct-path diagnostics/tests so q1/q2/q3/q5 prove `DirectReduceBlocks == DecodedBlocks`, while q4a/q4b remain non-direct.
- Extends the focused adapter benchmark to report q1/q2/q3/q5 package evidence.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64. Base is PR #1649 head `78f3268adad8`; this PR head is `7e8d8fef7`.

Package benchmark command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B' -benchmem -benchtime=20x -count=1
```

Package results:
- q2 8192: `818046 ns/op`, `10.05M rows/s`, `99.55 ns/row`, `7337 B/op`, `83 allocs/op`.
- q3 8192: `426352 ns/op`, `19.33M rows/s`, `51.72 ns/row`, `5981 B/op`, `39 allocs/op`.
- q1/q5 remain covered by the same benchmark: q1 8192 `12.84M rows/s`, `50 allocs/op`; q5 8192 `11.03M rows/s`, `72 allocs/op`.

Routed production serial command:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_q2_q3_serial_20260520 -path-label native-fastpath -column-store-path serial_column_scan -progress=false
```

Routed serial results:
- q2: `8.44M rows/s`, `837.82 MiB/s`, `118.4 ns/row`, `B/read=10404660`, `row_materializations=0`, parity pass.
- q3: `17.78M rows/s`, `1763.91 MiB/s`, `56.3 ns/row`, `B/read=10404660`, `row_materializations=0`, parity pass.
- PR #1649 routed serial reference: q2 `8.42M rows/s`, q3 `16.91M rows/s`.

Routed production parallel command:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_q2_q3_parallel_20260520 -path-label native-fastpath -column-store-path parallel_column_scan -progress=false
```

Routed parallel results:
- q2: `17.36M rows/s`, `1722.27 MiB/s`, `57.6 ns/row`, parity pass.
- q3: `34.17M rows/s`, `3390.28 MiB/s`, `29.3 ns/row`, parity pass.
- PR #1649 routed parallel reference: q2 `15.47M rows/s`, q3 `31.25M rows/s`.

Byte accounting remains stable:
- `retained_payload_bytes=3368750`
- `column_asset_bytes=10404660`
- `manifest_control_bytes=28`
- `command_wal_bytes_before_checkpoint=11172291`
- `db_total_bytes=24119432`

## Granule / ClickHouse Equivalent Comparison

These are context comparisons, not PR gates. Production includes durable TreeDB collection integration, manifest/recovery validation, typed column asset manager reads, planner/query adapter, parity/reporting, and row-oriented TCPA decode. The older granule and ClickHouse comparisons are useful ceilings/baselines, but not apples-to-apples with routed production.

Earlier `experiments/colgranule` JSONBench hot-kernel equivalent from the #1634 latest-head refresh (`/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`):
- q1 encoded reducer: `412.80M rows/s`.
- q2 encoded reducer: `237.61M rows/s`.
- q3 encoded reducer: `191.61M rows/s`.
- q5 encoded reducer: `138.03M rows/s`.
- q5 metadata kernel: `399.71M rows/s`.

Historical local ClickHouse-equivalent comparison from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1,000,000 JSONBench rows against local ClickHouse `26.4.3.1` on Darwin arm64:
- q1 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.004284s`, about `233.43M rows/s`.
- q2 ClickHouse local: `0.027s`, about `37.04M rows/s`; granule column-kernel best `0.038895s`, about `25.71M rows/s`.
- q3 ClickHouse local: `0.014s`, about `71.43M rows/s`; granule column-kernel best `0.006631s`, about `150.81M rows/s`.
- q4 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.009869s`, about `101.33M rows/s`.
- q5 ClickHouse local: `0.013s`, about `76.92M rows/s`; granule column-kernel best `0.010027s`, about `99.73M rows/s`.

Interpretation for this PR: q2/q3 now use the same direct insert-only production path family as q1/q5, but production is still well below the earlier granule hot-kernel and historical ClickHouse-equivalent numbers. The remaining gap is expected while TCPA is row-oriented and production still lacks true vector/block column layout, metadata assets, mark pruning, dictionaries, and locators.

## Throughput Interpretation

The main value of this PR is path consistency and parallel routed throughput for q2/q3, not a claim that production has reached the old analytical-kernel ceiling. q2 still pays distinct-set map work, so serial throughput is essentially flat versus #1649; q3 benefits more because direct hour bucketing avoids row-view value construction. Parallel routed q2/q3 show clearer improvement because each worker now avoids the non-direct row-view reducer path.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery(AdapterExecutesJSONBenchShapesM13B|ParallelMatchesSerialInsertOnlyM14B|AdapterUsesFloorHourForNegativeTimeUSM13B|UsesFloorHourForNegativeTimeUSM13B)' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- Package benchmark `BenchmarkColumnPhysicalQueryAdapterM13B` passed with q1/q2/q3/q5 evidence.
- Routed `serial_column_scan` 100K durable unified-bench passed parity for q1-q5/q5_metadata.
- Routed `parallel_column_scan` 100K durable unified-bench passed parity for q1-q5/q5_metadata.

## Artifacts

- Package benchmark output: `/tmp/gomap_1634_q2_q3_adapter_bench.txt`
- Serial routed artifacts: `/tmp/gomap_1634_q2_q3_serial_20260520`
- Parallel routed artifacts: `/tmp/gomap_1634_q2_q3_parallel_20260520`

## Assumptions / Non-Goals

- This PR intentionally optimizes only insert-only q2/q3 physical query shapes.
- q4a/q4b direct min/max reducers, q4 early-stop behavior, mutation visibility, mark pruning, dictionaries, locators, and real aggregate metadata fast paths remain outside this PR.
- The scratch-pool and typed asset manager behavior comes from #1649; this PR does not change column asset storage or lifecycle.

Fixes part of #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for counting distinct values within grouped queries for more accurate aggregation.

* **Tests**
  * Extended test coverage for distinct-count and time-based grouping query shapes.
  * Updated benchmarks to run multiple query shapes in a shared suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->