### PR TITLE
collections: add vector index metadata seam

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	collectionMetaVersion        = 2
+	collectionMetaVersion        = 3
 	maxCollectionMutationRetries = 64
 	// Bound stale buffered-read replans so a writer under constant buffered
 	// pressure eventually falls back to a publish boundary or outer retry.

--- a/TreeDB/collections/vector_index_metadata_test.go
+++ b/TreeDB/collections/vector_index_metadata_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -8,6 +9,32 @@ import (
 )
 
 var vectorIndexStatusBenchSink VectorIndexStatus
+
+func TestColumnGraphVectorIndexMetadataUsesCollectionMetaVersionV2A(t *testing.T) {
+	raw, err := encodeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		VectorIndexes: []VectorIndexDefinition{{
+			Name:       "embedding_graph",
+			Field:      "embedding",
+			Metric:     VectorMetricCosine,
+			Dimensions: 3,
+			Strategy:   VectorIndexStrategyColumnGraph,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("encodeCollectionMeta: %v", err)
+	}
+	var disk collectionMetaDisk
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		t.Fatalf("unmarshal collectionMetaDisk: %v", err)
+	}
+	if disk.Version != 3 {
+		t.Fatalf("collection metadata version=%d want 3 after adding durable vector_indexes", disk.Version)
+	}
+	if len(disk.VectorIndexes) != 1 || disk.VectorIndexes[0].Name != "embedding_graph" {
+		t.Fatalf("encoded vector indexes=%+v", disk.VectorIndexes)
+	}
+}
 
 func TestColumnGraphVectorIndexMetadataCreateStatusDropReopenV2A(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What this PR does

First #1646 V2A seam slice. This adds collection metadata/status plumbing for vector indexes so later PRs can build and publish physical `column_graph` assets through the normal collection root/manifest lifecycle.

- Adds `CollectionMeta.VectorIndexes` and durable JSON metadata encoding/decoding.
- Adds `VectorIndexDefinition`, metric/encoding/strategy enums, `CreateVectorIndex`, `DropVectorIndex`, and `VectorIndexStatus`.
- Adds explicit `column_graph` statuses for rebuild-needed and physical column asset support missing.
- Preserves scalar index behavior and keeps scalar `DropIndex` from dropping vector index metadata.

## Hard boundary

This PR does not implement graph build, graph search, or any decoded in-memory `ColumnVectorGraph` persistence path. `column_graph` currently reports `column_graph_rebuild_needed` when column-store support is configured and `physical_column_asset_support_missing` when it is not. Later V2A PRs must publish real vector/invNorm/adjacency graph column assets and graph metadata through the physical column-store path.

No sidecar vector index format is added. No document fetch/search path is added.

## Start/close test plan

Start-phase tests added before implementation:

- `TestColumnGraphVectorIndexMetadataCreateStatusDropReopenV2A`
- `TestColumnGraphVectorIndexStatusReportsMissingPhysicalSupportV2A`
- `TestScalarIndexMutationPreservesVectorIndexMetadataV2A`
- `TestVectorIndexMetadataValidationV2A`

Close-phase review checked that the tests cover metadata normalization, durable reopen, defensive copies, drop behavior, duplicate/invalid definitions, and explicit no-asset status.

## Performance evidence

This PR only adds a metadata/status seam. The relevant local perf guard is the status call path:

```text
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkVectorIndexStatusV2A' -benchmem -benchtime=500ms -count=5

goos: darwin
goarch: arm64
pkg: github.com/snissn/gomap/TreeDB/collections
cpu: Apple M3
BenchmarkVectorIndexStatusV2A-8    21622144    27.83 ns/op    0 B/op    0 allocs/op
BenchmarkVectorIndexStatusV2A-8    21327014    27.91 ns/op    0 B/op    0 allocs/op
BenchmarkVectorIndexStatusV2A-8    19894970    27.67 ns/op    0 B/op    0 allocs/op
BenchmarkVectorIndexStatusV2A-8    21545210    27.74 ns/op    0 B/op    0 allocs/op
BenchmarkVectorIndexStatusV2A-8    21545694    27.72 ns/op    0 B/op    0 allocs/op
```

## Validation

```text
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphVectorIndex|TestVectorIndexMetadataValidation|TestScalarIndexMutationPreservesVectorIndexMetadata' -count=1
ok  github.com/snissn/gomap/TreeDB/collections  0.607s

GOWORK=off go test ./TreeDB/collections -run 'Test.*Vector|Test.*Column.*|TestCollectionMeta|TestCollectionCreateIndex|TestCollectionDropIndex' -count=1
ok  github.com/snissn/gomap/TreeDB/collections  7.133s

GOWORK=off go test ./TreeDB/collections -count=1
ok  github.com/snissn/gomap/TreeDB/collections  10.728s

git diff --check
```

## AI review requirement

After CI starts on this head, request Codex, Copilot, and CodeRabbit review. Iterate until latest-head findings are fixed or explicitly dismissed and review threads are resolved.
