### PR TITLE
TreeDB column store post-V1: vectorize physical q4 min/max reducers

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -776,8 +776,12 @@ func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCol
 			if err := exec.visitDirectHourCount(value, valueOK); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
 			}
-		case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
-			if err := exec.visitDirectGroupInt64Value(group, groupOK, value, valueOK); err != nil {
+		case ColumnPhysicalQueryGroupMinInt64:
+			if err := exec.visitDirectGroupMinInt64(group, groupOK, value, valueOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		case ColumnPhysicalQueryGroupMaxInt64:
+			if err := exec.visitDirectGroupMaxInt64(group, groupOK, value, valueOK); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
 			}
 		case ColumnPhysicalQueryGroupInt64Span:
@@ -928,7 +932,7 @@ func (e *columnPhysicalQueryExecutor) visitDirectHourCount(value int64, valueOK 
 	return nil
 }
 
-func (e *columnPhysicalQueryExecutor) visitDirectGroupInt64Value(group []byte, groupOK bool, value int64, valueOK bool) error {
+func (e *columnPhysicalQueryExecutor) visitDirectGroupMinInt64(group []byte, groupOK bool, value int64, valueOK bool) error {
 	if !groupOK {
 		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
 	}
@@ -936,17 +940,23 @@ func (e *columnPhysicalQueryExecutor) visitDirectGroupInt64Value(group []byte, g
 		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
 	}
 	key := e.interner.internBytes(group)
-	switch e.kind {
-	case ColumnPhysicalQueryGroupMinInt64:
-		if cur, ok := e.int64Values[key]; !ok || value < cur {
-			e.int64Values[key] = value
-		}
-	case ColumnPhysicalQueryGroupMaxInt64:
-		if cur, ok := e.int64Values[key]; !ok || value > cur {
-			e.int64Values[key] = value
-		}
-	default:
-		return fmt.Errorf("%w: unsupported direct physical column int64 value query kind %q", ErrColumnQueryPlanUnsupported, e.kind)
+	if cur, ok := e.int64Values[key]; !ok || value < cur {
+		e.int64Values[key] = value
+	}
+	e.reduceRows++
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectGroupMaxInt64(group []byte, groupOK bool, value int64, valueOK bool) error {
+	if !groupOK {
+		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
+	}
+	if !valueOK {
+		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
+	}
+	key := e.interner.internBytes(group)
+	if cur, ok := e.int64Values[key]; !ok || value > cur {
+		e.int64Values[key] = value
 	}
 	e.reduceRows++
 	return nil

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -589,7 +589,7 @@ func (e *columnPhysicalQueryExecutor) supportsDirectAssetReduce() bool {
 		return e.groupColumnIdx >= 0 && e.distinctColumnIdx >= 0
 	case ColumnPhysicalQueryHourCount:
 		return e.valueColumnIdx >= 0
-	case ColumnPhysicalQueryGroupInt64Span:
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
 		return e.groupColumnIdx >= 0 && e.valueColumnIdx >= 0
 	default:
 		return false
@@ -776,6 +776,10 @@ func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCol
 			if err := exec.visitDirectHourCount(value, valueOK); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
 			}
+		case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
+			if err := exec.visitDirectGroupInt64Value(group, groupOK, value, valueOK); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
 		case ColumnPhysicalQueryGroupInt64Span:
 			if err := exec.visitDirectGroupInt64Span(group, groupOK, value, valueOK); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
@@ -920,6 +924,30 @@ func (e *columnPhysicalQueryExecutor) visitDirectHourCount(value int64, valueOK 
 		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
 	}
 	e.hourCounts[columnPhysicalQueryUTCHour(value)]++
+	e.reduceRows++
+	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) visitDirectGroupInt64Value(group []byte, groupOK bool, value int64, valueOK bool) error {
+	if !groupOK {
+		return fmt.Errorf("%w: physical column query missing string group value", ErrColumnQueryPlanUnsupported)
+	}
+	if !valueOK {
+		return fmt.Errorf("%w: physical column query missing int64 value", ErrColumnQueryPlanUnsupported)
+	}
+	key := e.interner.internBytes(group)
+	switch e.kind {
+	case ColumnPhysicalQueryGroupMinInt64:
+		if cur, ok := e.int64Values[key]; !ok || value < cur {
+			e.int64Values[key] = value
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		if cur, ok := e.int64Values[key]; !ok || value > cur {
+			e.int64Values[key] = value
+		}
+	default:
+		return fmt.Errorf("%w: unsupported direct physical column int64 value query kind %q", ErrColumnQueryPlanUnsupported, e.kind)
+	}
 	e.reduceRows++
 	return nil
 }

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -53,16 +53,18 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			wantDirect: true,
 		},
 		{
-			name:      "q4a",
-			hashName:  "q4a",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			wantCount: 12,
+			name:       "q4a",
+			hashName:   "q4a",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount:  12,
+			wantDirect: true,
 		},
 		{
-			name:      "q4b",
-			hashName:  "q4b",
-			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			wantCount: 12,
+			name:       "q4b",
+			hashName:   "q4b",
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			wantCount:  12,
+			wantDirect: true,
 		},
 		{
 			name:       "q5",
@@ -283,6 +285,14 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 		{
 			name: "hour_count",
 			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
+		},
+		{
+			name: "min",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+		{
+			name: "max",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
 		},
 		{
 			name: "span",
@@ -1717,6 +1727,8 @@ func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 			{name: "q1", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}},
 			{name: "q2", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}},
 			{name: "q3", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
+			{name: "q4a", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q4b", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"}},
 			{name: "q5", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
 		}
 		for _, tc := range cases {


### PR DESCRIPTION
## Summary

This is the next measured #1634 post-V1 column-store query optimization chunk, chained after #1651. It vectorizes the remaining JSONBench q4 physical reducers over TCPA assets:

- adds direct insert-only physical reducers for q4a `group_min_int64(did, time_us)` and q4b `group_max_int64(did, time_us)`;
- keeps q4 on the same fail-closed direct-reducer support gate as q1/q2/q3/q5;
- extends JSONBench-shaped adapter and parallel-vs-serial tests so q4a/q4b must use direct physical blocks and preserve parity.

This does not add q4 sort-order early-stop, mark pruning, dictionaries, locators, metadata-only paths, mutation visibility fast paths, or GC/rewrite behavior changes.

## Performance / Benchmark Evidence

Apple M3, darwin/arm64, branch `codex/column-store-vectorized-q4-minmax`, head `6a3fd63f1`.

Package adapter benchmark after Copilot hot-loop branch fix:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B' -benchmem -benchtime=20x -count=1 | tee /tmp/gomap_1634_q4_minmax_reviewfix_adapter_bench.txt
```

8192-row package results:

| Query | ns/op | rows/sec | ns/row | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| q1 | 808373 | 10.23M | 97.71 | 5653 | 50 |
| q2 | 1098825 | 8.15M | 122.7 | 6997 | 83 |
| q3 | 427054 | 19.35M | 51.68 | 5981 | 39 |
| q4a | 657042 | 12.52M | 79.86 | 7133 | 72 |
| q4b | 834227 | 11.13M | 89.86 | 7136 | 72 |
| q5 | 739223 | 11.12M | 89.91 | 7341 | 72 |

Routed durable 100K serial:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_q4_minmax_serial_20260520 -path-label native-fastpath -column-store-path serial_column_scan -progress=false
```

- q4a: `9.99M rows/s`, `990.916 MiB/s`, `100.1 ns/row`, parity pass.
- q4b: `10.04M rows/s`, `996.447 MiB/s`, `99.6 ns/row`, parity pass.
- q1/q2/q3/q5 remained in the expected range: `10.18M` / `8.43M` / `18.07M` / `9.51M rows/s`.

Routed durable 100K parallel:

```sh
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/gomap_1634_q4_minmax_parallel_20260520 -path-label native-fastpath -column-store-path parallel_column_scan -progress=false
```

- q4a: `18.91M rows/s`, `1875.886 MiB/s`, `52.9 ns/row`, parity pass.
- q4b: `18.10M rows/s`, `1795.739 MiB/s`, `55.3 ns/row`, parity pass.
- q1/q2/q3/q5 remained in the expected range: `20.30M` / `16.63M` / `35.83M` / `16.81M rows/s`.

Byte accounting stayed stable for both routed runs:

- retained payload bytes: `3368750`.
- column asset bytes: `10404660`.
- manifest/control bytes: `28`.
- command-WAL bytes before checkpoint: `11172291`.
- DB total bytes: `24119432`.
- q4a/q4b row materializations: `0/100000`.
- q4a/q4b scheduled granules: `20`; skipped granules: `0`; metadata hits: `0`.

## Granule / ClickHouse Equivalent Comparison

Historical/stale comparison context is included for interpretation only; this PR does not claim parity with experiment kernels or ClickHouse. Production currently includes durable TreeDB integration, manifest/query adapter, typed asset manager reads, parity/reporting, and scalar TCPA decode/reduce over physical assets. The q4 path here is still a full physical scan over scheduled granules: no sort-order early-stop, mark pruning, dictionary, locator, or metadata fast path is active.

Same-head-family experiment baseline from `/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`:

- q1 encoded reducer: `412.80M rows/s`.
- q2 encoded reducer: `237.61M rows/s`.
- q3 encoded reducer: `191.61M rows/s`.
- q5 encoded reducer: `138.03M rows/s`.
- q4b metadata: `259.71M rows/s`.
- q5 metadata: `399.71M rows/s`.
- q4b row-scan baseline: `87.40M rows/s`.

Historical ClickHouse-equivalent context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`:

| Query | ClickHouse equivalent | Granule best historical |
|---|---:|---:|
| q1 | `0.014s`, about `71.43M rows/s` | `0.004284s`, about `233.43M rows/s` |
| q2 | `0.027s`, about `37.04M rows/s` | `0.038895s`, about `25.71M rows/s` |
| q3 | `0.014s`, about `71.43M rows/s` | `0.006631s`, about `150.81M rows/s` |
| q4 | `0.013s`, about `76.92M rows/s` | `0.009869s`, about `101.33M rows/s` |
| q5 | `0.013s`, about `76.92M rows/s` | `0.010027s`, about `99.73M rows/s` |

The important q4-specific interpretation is that production q4a/q4b now avoids the previous generic row-view reducer path for insert-only physical assets, but it does not yet reproduce the experiment q4 sort-order/early-stop behavior. That remains a separate measured optimization candidate.

## Throughput Interpretation

The local win is reducer-shape work, not storage-lifecycle work. Direct q4 reducers now process the group and int64 value columns in the TCPA block loop and update min/max maps directly. The remaining q4 production gap versus the old experiment kernels is expected to come from scalar TCPA row-view/decode shape, planner/asset-manager/routing overhead, parity/reporting, and missing mark/sort-order pruning. Since `metadata_hits=0` and `skipped_granules=0`, q4 should be read as full-scan physical throughput, not metadata or skip-scan throughput.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery(AdapterExecutesJSONBenchShapesM13B|ParallelMatchesSerialInsertOnlyM14B|AdapterUsesFloorHourForNegativeTimeUSM13B|ValueValidationM13B)' -count=1`: pass.
- `go test ./TreeDB/collections -count=1`: pass.
- `go test ./cmd/unified_bench -count=1`: pass.
- Package benchmark above after review fix: pass, q4a/q4b included.
- Routed durable serial and parallel 100K `unified-bench -suite column_store`: pass with parity.
- CI/reviews: latest-head CI is `CLEAN`; Codex review reports no major issues; CodeRabbit review approves the review-fix commit; zero unresolved review threads.

## Artifacts

- Package benchmark: `/tmp/gomap_1634_q4_minmax_reviewfix_adapter_bench.txt`.
- Serial routed artifacts: `/tmp/gomap_1634_q4_minmax_serial_20260520`.
- Parallel routed artifacts: `/tmp/gomap_1634_q4_minmax_parallel_20260520`.
- Experiment refresh baseline: `/tmp/gomap_1634_refresh_20260520_105442/experiment_colgranule_baseline.txt`.
- Historical ClickHouse comparison: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Assumptions / Non-Goals

- Insert-only direct reducers remain the optimized path; mutation visibility continues to use the existing safe fallback unless explicitly supported by a later measured PR.
- q4 sort-order early-stop, adaptive marks, dictionary/locator pruning, aggregate metadata assets, and prepared/reusable executors remain post-V1 #1634 candidates that need their own measured attribution before implementation.
- This PR does not alter write format, manifest format, GC, rewrite, WAL, or column asset lifecycle behavior.


