### PR TITLE
collections: add column graph manifest asset seam

### DIFF
--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -428,7 +428,7 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 	records := make([]columnManifestRecord, 0, 8)
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) && !bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) {
+		if !columnManifestRecordKeyKnownForScan(key) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -510,7 +510,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 	activeParts := uint64(0)
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) && !bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) {
+		if !columnManifestRecordKeyKnownForScan(key) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -589,6 +589,11 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			writeHashBytes(&d, value)
 			if keyGeneration == header.generation {
 				activeParts++
+			}
+		case bytes.HasPrefix(key, columnManifestVectorGraphRecordPrefixBytes):
+			if sawHeader {
+				writeHashBytes(&d, key)
+				writeHashBytes(&d, value)
 			}
 		}
 		iter.Next()
@@ -671,6 +676,8 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 	for _, record := range records {
 		switch {
 		case bytes.Equal(record.key, columnManifestHeaderRecordKeyBytes):
+			active = append(active, record)
+		case bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes):
 			active = append(active, record)
 		case bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes):
 			partGeneration, err := columnManifestPartGenerationFromRecordKeyForScan(record.key)

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -379,7 +379,7 @@ func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg
 		status.RebuildNeeded = true
 		return status, nil
 	}
-	if !columnVectorGraphManifestMatchesDefinition(c.meta.Name, graph, def, *cfg) {
+	if !columnVectorGraphManifestMatchesDefinition(c.meta.Name, graph, def, *cfg, manifest, records) {
 		status.State = VectorIndexStateColumnGraphRebuildNeeded
 		status.Reason = VectorIndexReasonColumnGraphAssetMismatch
 		status.RebuildNeeded = true
@@ -396,11 +396,15 @@ func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg
 	return status, nil
 }
 
-func columnVectorGraphManifestMatchesDefinition(collection string, graph columnVectorGraphManifestSnapshot, def VectorIndexDefinition, cfg ColumnStoreConfig) bool {
+func columnVectorGraphManifestMatchesDefinition(collection string, graph columnVectorGraphManifestSnapshot, def VectorIndexDefinition, cfg ColumnStoreConfig, manifest columnManifestSnapshot, records []columnManifestRecord) bool {
 	if cfg.ActiveManifest == nil {
 		return false
 	}
 	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(collection, cfg, def)
+	if err != nil {
+		return false
+	}
+	baseChecksum, err := columnVectorGraphBaseManifestChecksum(manifest, records, cfg)
 	if err != nil {
 		return false
 	}
@@ -413,10 +417,32 @@ func columnVectorGraphManifestMatchesDefinition(collection string, graph columnV
 		graph.EfConstruction == def.EfConstruction &&
 		graph.EfSearch == def.EfSearch &&
 		graph.BaseManifestGeneration == cfg.ActiveManifest.Generation &&
+		graph.BaseManifestChecksum == baseChecksum &&
 		graph.BaseSchemaHash == cfg.SchemaHash &&
 		graph.GraphSchemaHash == graphCfg.SchemaHash &&
 		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
 		graph.AssetRef.Generation == graph.BaseManifestGeneration
+}
+
+func columnVectorGraphBaseManifestChecksum(manifest columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig) (uint64, error) {
+	activeRecords, err := activeColumnManifestRecordsForScan(records, manifest.Generation)
+	if err != nil {
+		return 0, err
+	}
+	baseRecords := activeRecords[:0]
+	for _, record := range activeRecords {
+		if bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes) {
+			continue
+		}
+		baseRecords = append(baseRecords, record)
+	}
+	sortColumnManifestRecords(baseRecords)
+	return checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+		Collection:        manifest.Collection,
+		ColumnStore:       cfg,
+		Operation:         manifest.Operation,
+		AppliedCommandLSN: manifest.AppliedCommandLSN,
+	}, manifest.Generation, baseRecords), nil
 }
 
 func validateColumnVectorGraphAssetRefAvailable(rootDir string, ref ColumnAssetRef) error {

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -1,0 +1,444 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+)
+
+const (
+	columnManifestVectorGraphRecordPrefix = "\x03column-manifest/v1/vector-graph/"
+	columnManifestVectorGraphMagic        = uint32(0x54434d47) // TCMG
+
+	columnVectorGraphVectorColumnName    = "vector"
+	columnVectorGraphInvNormColumnName   = "inv_norm"
+	columnVectorGraphAdjacencyColumnName = "adjacency"
+)
+
+var columnManifestVectorGraphRecordPrefixBytes = []byte(columnManifestVectorGraphRecordPrefix)
+
+type columnVectorGraphManifestSnapshot struct {
+	IndexName              string
+	Field                  string
+	Metric                 VectorMetric
+	Encoding               VectorIndexEncoding
+	Dimensions             int
+	M                      int
+	EfConstruction         int
+	EfSearch               int
+	BaseManifestGeneration uint64
+	BaseManifestChecksum   uint64
+	BaseSchemaHash         uint64
+	GraphSchemaHash        uint64
+	RowCount               int
+	AssetRef               ColumnAssetRef
+	AssetBytes             int64
+}
+
+type columnVectorGraphAssetRow struct {
+	ID        []byte
+	Vector    []float32
+	InvNorm   float32
+	Adjacency []uint32
+}
+
+type columnVectorGraphPreparedPhysicalAsset struct {
+	AssetRootDir string
+	Config       ColumnStoreConfig
+	Ref          ColumnAssetRef
+	Bytes        int64
+	RowCount     int
+}
+
+func columnVectorGraphManifestRecordKey(indexName string) []byte {
+	key := make([]byte, len(columnManifestVectorGraphRecordPrefix)+len(indexName))
+	copy(key, columnManifestVectorGraphRecordPrefix)
+	copy(key[len(columnManifestVectorGraphRecordPrefix):], indexName)
+	return key
+}
+
+func columnManifestRecordKeyKnownForScan(key []byte) bool {
+	return bytes.Equal(key, columnManifestHeaderRecordKeyBytes) ||
+		bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) ||
+		bytes.HasPrefix(key, columnManifestVectorGraphRecordPrefixBytes)
+}
+
+func findColumnVectorGraphManifestRecord(records []columnManifestRecord, indexName string) (columnManifestRecord, bool) {
+	key := columnVectorGraphManifestRecordKey(indexName)
+	for _, record := range records {
+		if bytes.Equal(record.key, key) {
+			return record, true
+		}
+	}
+	return columnManifestRecord{}, false
+}
+
+func encodeColumnVectorGraphManifestRecord(snapshot columnVectorGraphManifestSnapshot) ([]byte, error) {
+	if err := validateColumnVectorGraphManifestSnapshot(snapshot); err != nil {
+		return nil, err
+	}
+	var b bytes.Buffer
+	writeManifestUint32(&b, columnManifestVectorGraphMagic)
+	writeManifestUint16(&b, columnManifestRecordVersion)
+	writeManifestString(&b, snapshot.IndexName)
+	writeManifestString(&b, snapshot.Field)
+	writeManifestString(&b, string(snapshot.Metric))
+	writeManifestString(&b, string(snapshot.Encoding))
+	writeManifestUint64(&b, uint64(snapshot.Dimensions))
+	writeManifestUint64(&b, uint64(snapshot.M))
+	writeManifestUint64(&b, uint64(snapshot.EfConstruction))
+	writeManifestUint64(&b, uint64(snapshot.EfSearch))
+	writeManifestUint64(&b, snapshot.BaseManifestGeneration)
+	writeManifestUint64(&b, snapshot.BaseManifestChecksum)
+	writeManifestUint64(&b, snapshot.BaseSchemaHash)
+	writeManifestUint64(&b, snapshot.GraphSchemaHash)
+	writeManifestUint64(&b, uint64(snapshot.RowCount))
+	writeManifestString(&b, string(snapshot.AssetRef.Kind))
+	writeManifestString(&b, snapshot.AssetRef.Namespace)
+	writeManifestUint64(&b, snapshot.AssetRef.Generation)
+	writeManifestUint64(&b, snapshot.AssetRef.PartID)
+	writeManifestUint64(&b, uint64(snapshot.AssetRef.FileID))
+	writeManifestUint64(&b, uint64(snapshot.AssetRef.Offset))
+	writeManifestUint64(&b, uint64(snapshot.AssetRef.Length))
+	writeManifestUint64(&b, uint64(snapshot.AssetRef.Checksum))
+	writeManifestUint64(&b, uint64(snapshot.AssetBytes))
+	return b.Bytes(), nil
+}
+
+func decodeColumnVectorGraphManifestRecord(raw []byte) (columnVectorGraphManifestSnapshot, error) {
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnManifestVectorGraphMagic {
+		return columnVectorGraphManifestSnapshot{}, fmt.Errorf("collections: bad column vector graph manifest magic=0x%08x", magic)
+	}
+	if version := cur.u16(); version != columnManifestRecordVersion {
+		return columnVectorGraphManifestSnapshot{}, fmt.Errorf("collections: unsupported column vector graph manifest version=%d", version)
+	}
+	snapshot := columnVectorGraphManifestSnapshot{
+		IndexName:              cur.string(),
+		Field:                  cur.string(),
+		Metric:                 VectorMetric(cur.string()),
+		Encoding:               VectorIndexEncoding(cur.string()),
+		Dimensions:             int(cur.u64()),
+		M:                      int(cur.u64()),
+		EfConstruction:         int(cur.u64()),
+		EfSearch:               int(cur.u64()),
+		BaseManifestGeneration: cur.u64(),
+		BaseManifestChecksum:   cur.u64(),
+		BaseSchemaHash:         cur.u64(),
+		GraphSchemaHash:        cur.u64(),
+		RowCount:               int(cur.u64()),
+	}
+	snapshot.AssetRef = ColumnAssetRef{
+		Kind:       ColumnAssetKind(cur.string()),
+		Namespace:  cur.string(),
+		Generation: cur.u64(),
+		PartID:     cur.u64(),
+	}
+	fileID64 := cur.u64()
+	offset64 := cur.u64()
+	length64 := cur.u64()
+	checksum64 := cur.u64()
+	assetBytes64 := cur.u64()
+	if err := cur.err; err != nil {
+		return columnVectorGraphManifestSnapshot{}, err
+	}
+	if snapshot.Dimensions < 0 || snapshot.M < 0 || snapshot.EfConstruction < 0 || snapshot.EfSearch < 0 || snapshot.RowCount < 0 {
+		return columnVectorGraphManifestSnapshot{}, errors.New("collections: column vector graph manifest integer overflow")
+	}
+	if fileID64 > uint64(math.MaxUint32) {
+		return columnVectorGraphManifestSnapshot{}, errors.New("collections: column vector graph manifest file_id overflows uint32")
+	}
+	if checksum64 > uint64(math.MaxUint32) {
+		return columnVectorGraphManifestSnapshot{}, errors.New("collections: column vector graph manifest checksum overflows uint32")
+	}
+	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) || assetBytes64 > uint64(math.MaxInt64) {
+		return columnVectorGraphManifestSnapshot{}, errors.New("collections: column vector graph manifest offsets or byte counts overflow int64")
+	}
+	snapshot.AssetRef.FileID = uint32(fileID64)
+	snapshot.AssetRef.Offset = int64(offset64)
+	snapshot.AssetRef.Length = int64(length64)
+	snapshot.AssetRef.Checksum = uint32(checksum64)
+	snapshot.AssetBytes = int64(assetBytes64)
+	if cur.pos != len(raw) {
+		return columnVectorGraphManifestSnapshot{}, errors.New("collections: trailing bytes in column vector graph manifest record")
+	}
+	if err := validateColumnVectorGraphManifestSnapshot(snapshot); err != nil {
+		return columnVectorGraphManifestSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func validateColumnVectorGraphManifestSnapshot(snapshot columnVectorGraphManifestSnapshot) error {
+	if err := ValidateIndexName(snapshot.IndexName); err != nil {
+		return fmt.Errorf("collections: invalid column vector graph manifest index name: %w", err)
+	}
+	if err := ValidateIndexPath(snapshot.Field); err != nil {
+		return fmt.Errorf("collections: invalid column vector graph manifest field: %w", err)
+	}
+	if metric, err := normalizeVectorMetric(snapshot.Metric); err != nil || metric != snapshot.Metric {
+		if err == nil {
+			err = fmt.Errorf("unsupported metric %q", snapshot.Metric)
+		}
+		return fmt.Errorf("collections: invalid column vector graph manifest metric: %w", err)
+	}
+	if encoding, err := normalizeVectorIndexEncoding(snapshot.Encoding); err != nil || encoding != snapshot.Encoding {
+		if err == nil {
+			err = fmt.Errorf("unsupported encoding %q", snapshot.Encoding)
+		}
+		return fmt.Errorf("collections: invalid column vector graph manifest encoding: %w", err)
+	}
+	if snapshot.Dimensions <= 0 {
+		return errors.New("collections: column vector graph manifest dimensions must be positive")
+	}
+	if snapshot.M <= 0 || snapshot.EfConstruction <= 0 || snapshot.EfSearch <= 0 {
+		return errors.New("collections: column vector graph manifest graph parameters must be positive")
+	}
+	if snapshot.BaseManifestGeneration == 0 || snapshot.BaseManifestChecksum == 0 || snapshot.BaseSchemaHash == 0 || snapshot.GraphSchemaHash == 0 {
+		return errors.New("collections: column vector graph manifest missing base or graph identity")
+	}
+	if snapshot.RowCount <= 0 {
+		return errors.New("collections: column vector graph manifest row count must be positive")
+	}
+	if err := validateColumnAssetRefForPlan(snapshot.AssetRef); err != nil {
+		return err
+	}
+	if snapshot.AssetBytes <= 0 {
+		return errors.New("collections: column vector graph manifest asset bytes must be positive")
+	}
+	if snapshot.AssetBytes != snapshot.AssetRef.Length {
+		return fmt.Errorf("collections: column vector graph manifest asset bytes=%d does not match ref length=%d", snapshot.AssetBytes, snapshot.AssetRef.Length)
+	}
+	return nil
+}
+
+func columnVectorGraphPhysicalColumnStoreConfig(collection string, base ColumnStoreConfig, def VectorIndexDefinition) (ColumnStoreConfig, error) {
+	normalizedDef, err := normalizeVectorIndexDefinition(def)
+	if err != nil {
+		return ColumnStoreConfig{}, err
+	}
+	if normalizedDef.Strategy != VectorIndexStrategyColumnGraph {
+		return ColumnStoreConfig{}, fmt.Errorf("collections: vector index %q strategy=%q is not column_graph", normalizedDef.Name, normalizedDef.Strategy)
+	}
+	if !base.Enabled {
+		return ColumnStoreConfig{}, errors.New("collections: column vector graph physical config requires enabled base column_store")
+	}
+	if base.AssetManager == nil {
+		return ColumnStoreConfig{}, errors.New("collections: column vector graph physical config requires base asset manager")
+	}
+	cfg, err := normalizeColumnStoreConfig(collection, &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: columnVectorGraphVectorColumnName, Path: normalizedDef.Field, ValueType: ColumnStoreValueFloat32Vector, VectorDims: normalizedDef.Dimensions},
+			{Name: columnVectorGraphInvNormColumnName, Path: normalizedDef.Field + "_inv_norm", ValueType: ColumnStoreValueFloat32},
+			{Name: columnVectorGraphAdjacencyColumnName, Path: normalizedDef.Field + "_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+		},
+		RetainedPayload: ColumnRetainedPayloadNone,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		AssetManager: &ColumnAssetManagerConfig{
+			Kind:      base.AssetManager.Kind,
+			Namespace: base.AssetManager.Namespace + "/vector_graph/" + normalizedDef.Name,
+		},
+	})
+	if err != nil {
+		return ColumnStoreConfig{}, err
+	}
+	return *cfg, nil
+}
+
+func prepareColumnVectorGraphPhysicalAsset(assetRootDir, collection string, base ColumnStoreConfig, def VectorIndexDefinition, generation, partID, appliedCommandLSN uint64, rows []columnVectorGraphAssetRow) (columnVectorGraphPreparedPhysicalAsset, error) {
+	if assetRootDir == "" {
+		return columnVectorGraphPreparedPhysicalAsset{}, errors.New("collections: column vector graph physical asset requires asset root dir")
+	}
+	normalizedDef, err := normalizeVectorIndexDefinition(def)
+	if err != nil {
+		return columnVectorGraphPreparedPhysicalAsset{}, err
+	}
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(collection, base, def)
+	if err != nil {
+		return columnVectorGraphPreparedPhysicalAsset{}, err
+	}
+	if len(rows) == 0 {
+		return columnVectorGraphPreparedPhysicalAsset{}, errors.New("collections: column vector graph physical asset requires rows")
+	}
+	declared := make([]columnDeclaredRow, len(rows))
+	for i, row := range rows {
+		if len(row.ID) == 0 {
+			return columnVectorGraphPreparedPhysicalAsset{}, fmt.Errorf("collections: column vector graph row[%d] missing document id", i)
+		}
+		if len(row.Vector) != normalizedDef.Dimensions {
+			return columnVectorGraphPreparedPhysicalAsset{}, fmt.Errorf("collections: column vector graph row[%d] vector dims=%d want %d", i, len(row.Vector), normalizedDef.Dimensions)
+		}
+		declared[i] = columnDeclaredRow{
+			ID: bytes.Clone(row.ID),
+			Values: []columnDeclaredValue{
+				{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: append([]float32(nil), row.Vector...)},
+				{Type: ColumnStoreValueFloat32, Present: true, Float32: row.InvNorm},
+				{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: append([]uint32(nil), row.Adjacency...)},
+			},
+		}
+	}
+	encoded, summary, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        collection,
+		Namespace:         graphCfg.AssetManager.Namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        graphCfg.SchemaHash,
+		Columns:           graphCfg.Columns,
+		Rows:              declared,
+	})
+	if err != nil {
+		return columnVectorGraphPreparedPhysicalAsset{}, err
+	}
+	ref, err := writeColumnPhysicalAssetToManager(assetRootDir, graphCfg, encoded, generation, partID)
+	if err != nil {
+		return columnVectorGraphPreparedPhysicalAsset{}, err
+	}
+	return columnVectorGraphPreparedPhysicalAsset{
+		AssetRootDir: assetRootDir,
+		Config:       graphCfg,
+		Ref:          ref,
+		Bytes:        summary.PayloadBytes,
+		RowCount:     summary.RowCount,
+	}, nil
+}
+
+func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg *ColumnStoreConfig) (VectorIndexStatus, error) {
+	status := VectorIndexStatus{
+		Name:     def.Name,
+		Strategy: def.Strategy,
+	}
+	if cfg == nil || !cfg.Enabled || cfg.AssetManager == nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonPhysicalColumnAssetSupportMissing
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	if cfg.ActiveManifest == nil || cfg.RecoveryAuthoritativeManifest == nil {
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphRebuildNeeded
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return VectorIndexStatus{}, errors.New("collections: collection db is closed")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return VectorIndexStatus{}, err
+	}
+	if catalog == nil {
+		return VectorIndexStatus{}, errCollectionNotFound
+	}
+	rootID := catalog.rootID(collectionColumnManifestRootName(c.meta.Name))
+	if rootID == 0 {
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphRebuildNeeded
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	if err := validateColumnManifestIdentityAtRoot(snap, rootID, *cfg.ActiveManifest); err != nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonColumnGraphCorrupt
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	if err != nil {
+		return VectorIndexStatus{}, err
+	}
+	manifest, err := decodeColumnManifestSnapshotForScan(records)
+	if err != nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonColumnGraphCorrupt
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	if err := validateColumnManifestSnapshot(manifest, records, *cfg, *cfg.ActiveManifest, c.meta.Name, "column vector graph status"); err != nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonColumnGraphCorrupt
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	graphRecord, ok := findColumnVectorGraphManifestRecord(records, def.Name)
+	if !ok {
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphRebuildNeeded
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	graph, err := decodeColumnVectorGraphManifestRecord(graphRecord.value)
+	if err != nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonColumnGraphCorrupt
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	if !columnVectorGraphManifestMatchesDefinition(c.meta.Name, graph, def, *cfg) {
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphAssetMismatch
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
+		status.State = VectorIndexStateColumnGraphUnavailable
+		status.Reason = VectorIndexReasonColumnGraphCorrupt
+		status.RebuildNeeded = true
+		return status, nil
+	}
+	status.State = VectorIndexStateColumnGraphLoaded
+	status.Loaded = true
+	return status, nil
+}
+
+func columnVectorGraphManifestMatchesDefinition(collection string, graph columnVectorGraphManifestSnapshot, def VectorIndexDefinition, cfg ColumnStoreConfig) bool {
+	if cfg.ActiveManifest == nil {
+		return false
+	}
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(collection, cfg, def)
+	if err != nil {
+		return false
+	}
+	return graph.IndexName == def.Name &&
+		graph.Field == def.Field &&
+		graph.Metric == def.Metric &&
+		graph.Encoding == def.Encoding &&
+		graph.Dimensions == def.Dimensions &&
+		graph.M == def.M &&
+		graph.EfConstruction == def.EfConstruction &&
+		graph.EfSearch == def.EfSearch &&
+		graph.BaseManifestGeneration == cfg.ActiveManifest.Generation &&
+		graph.BaseSchemaHash == cfg.SchemaHash &&
+		graph.GraphSchemaHash == graphCfg.SchemaHash &&
+		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
+		graph.AssetRef.Generation == graph.BaseManifestGeneration
+}
+
+func validateColumnVectorGraphAssetRefAvailable(rootDir string, ref ColumnAssetRef) error {
+	if err := validateColumnAssetRefForPlan(ref); err != nil {
+		return err
+	}
+	path, err := columnAssetSegmentPath(rootDir, ref)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("collections: column vector graph asset segment %q is a directory", path)
+	}
+	if ref.Offset < 0 || ref.Length <= 0 || ref.Offset > math.MaxInt64-ref.Length {
+		return fmt.Errorf("collections: invalid column vector graph asset range offset=%d length=%d", ref.Offset, ref.Length)
+	}
+	if info.Size() < ref.Offset+ref.Length {
+		return fmt.Errorf("collections: column vector graph asset segment size=%d shorter than ref end=%d", info.Size(), ref.Offset+ref.Length)
+	}
+	return nil
+}

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -313,6 +313,11 @@ func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg
 		Name:     def.Name,
 		Strategy: def.Strategy,
 	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return VectorIndexStatus{}, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
 	if cfg == nil || !cfg.Enabled || cfg.AssetManager == nil {
 		status.State = VectorIndexStateColumnGraphUnavailable
 		status.Reason = VectorIndexReasonPhysicalColumnAssetSupportMissing
@@ -331,11 +336,6 @@ func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg
 		status.RebuildNeeded = true
 		return status, nil
 	}
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return VectorIndexStatus{}, backenddb.ErrClosed
-	}
-	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		return VectorIndexStatus{}, err

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 const (
@@ -323,9 +325,15 @@ func (c *Collection) columnGraphVectorIndexStatus(def VectorIndexDefinition, cfg
 		status.RebuildNeeded = true
 		return status, nil
 	}
+	if !columnManifestIdentityValueEqual(*cfg.ActiveManifest, *cfg.RecoveryAuthoritativeManifest) {
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphRebuildNeeded
+		status.RebuildNeeded = true
+		return status, nil
+	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return VectorIndexStatus{}, errors.New("collections: collection db is closed")
+		return VectorIndexStatus{}, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -162,9 +163,13 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
 	}
 	var ids []string
+	var vectors [][]float32
+	var invNorms []float32
 	var neighbors [][]uint32
 	summary, err := scanColumnPhysicalAssetRows(raw, prepared.Ref, "docs", &prepared.Config, projection, func(row columnPhysicalScanRowView) error {
 		ids = append(ids, string(row.ID))
+		vectors = append(vectors, append([]float32(nil), row.Values[0].Float32Vector...))
+		invNorms = append(invNorms, row.Values[1].Float32)
 		neighbors = append(neighbors, append([]uint32(nil), row.Values[2].AdjacencyList...))
 		return nil
 	})
@@ -176,6 +181,15 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 	}
 	if got := neighbors[1]; len(got) != 2 || got[0] != 0 || got[1] != 2 {
 		t.Fatalf("row1 neighbors=%v", got)
+	}
+	if got := vectors[0]; len(got) != 3 || got[0] != 1 || got[1] != 0 || got[2] != 0 {
+		t.Fatalf("row0 vector=%v", got)
+	}
+	if got := vectors[1]; len(got) != 3 || got[0] != 0 || got[1] != 1 || got[2] != 0 {
+		t.Fatalf("row1 vector=%v", got)
+	}
+	if got := invNorms[2]; got != 1 {
+		t.Fatalf("row2 inv_norm=%v want 1", got)
 	}
 }
 
@@ -232,6 +246,42 @@ func TestColumnGraphVectorIndexStatusUsesPublishedPhysicalManifestV2A(t *testing
 	}
 }
 
+func TestColumnGraphVectorIndexStatusClosedDBReturnsErrClosedV2A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(d.ColumnAssetRootDir(), "docs", *baseCfg, def, 2, 1, 1, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+	})
+	if err != nil {
+		t.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
+	meta := CollectionMeta{
+		Name:          "docs",
+		Options:       CollectionOptions{ColumnStore: testColumnGraphBaseColumnStoreConfigV2A()},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	records, identity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	publishColumnGraphCatalogForTestV2A(t, d, meta, identity, records)
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	if _, err := col.VectorIndexStatus(def.Name); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("VectorIndexStatus closed err=%v want ErrClosed", err)
+	}
+}
+
 func TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAssetV2A(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})
@@ -275,6 +325,27 @@ func TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAssetV2A(t 
 		}
 		if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
 			t.Fatalf("status=%+v want mismatch rebuild-needed", status)
+		}
+	})
+
+	t.Run("active_recovery_manifest_mismatch", func(t *testing.T) {
+		records, goodIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+		publishColumnGraphCatalogForTestV2A(t, d, meta, goodIdentity, records)
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			t.Fatalf("open collection: %v", err)
+		}
+		currentMeta := col.Meta()
+		badCfg := *currentMeta.Options.ColumnStore
+		recoveryIdentity := *badCfg.RecoveryAuthoritativeManifest
+		recoveryIdentity.Checksum++
+		badCfg.RecoveryAuthoritativeManifest = &recoveryIdentity
+		status, err := col.columnGraphVectorIndexStatus(def, &badCfg)
+		if err != nil {
+			t.Fatalf("columnGraphVectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphRebuildNeeded || !status.RebuildNeeded || status.Loaded {
+			t.Fatalf("status=%+v want manifest mismatch rebuild-needed", status)
 		}
 	})
 
@@ -446,12 +517,14 @@ func testColumnVectorGraphManifestRecordV2A(tb testing.TB, baseCfg *ColumnStoreC
 		EfConstruction:         def.EfConstruction,
 		EfSearch:               def.EfSearch,
 		BaseManifestGeneration: identity.Generation,
-		BaseManifestChecksum:   identity.Checksum,
-		BaseSchemaHash:         baseCfg.SchemaHash,
-		GraphSchemaHash:        graphCfg.SchemaHash,
-		RowCount:               1,
-		AssetRef:               ref,
-		AssetBytes:             ref.Length,
+		// Callers must pass the base-only identity; manifest identities that
+		// already include graph records have a different checksum.
+		BaseManifestChecksum: identity.Checksum,
+		BaseSchemaHash:       baseCfg.SchemaHash,
+		GraphSchemaHash:      graphCfg.SchemaHash,
+		RowCount:             1,
+		AssetRef:             ref,
+		AssetBytes:           ref.Length,
 	}
 	encoded, err := encodeColumnVectorGraphManifestRecord(record)
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -1,0 +1,499 @@
+package collections
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestColumnVectorGraphManifestRecordRoundTripV2A(t *testing.T) {
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig("docs", *baseCfg, def)
+	if err != nil {
+		t.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
+	}
+	record := columnVectorGraphManifestSnapshot{
+		IndexName:              def.Name,
+		Field:                  def.Field,
+		Metric:                 def.Metric,
+		Encoding:               def.Encoding,
+		Dimensions:             def.Dimensions,
+		M:                      def.M,
+		EfConstruction:         def.EfConstruction,
+		EfSearch:               def.EfSearch,
+		BaseManifestGeneration: 11,
+		BaseManifestChecksum:   0xabcddcba,
+		BaseSchemaHash:         baseCfg.SchemaHash,
+		GraphSchemaHash:        graphCfg.SchemaHash,
+		RowCount:               3,
+		AssetRef: ColumnAssetRef{
+			Kind:       ColumnAssetKindTCS1PartImage,
+			Namespace:  graphCfg.AssetManager.Namespace,
+			Generation: 11,
+			PartID:     7,
+			FileID:     1,
+			Offset:     128,
+			Length:     4096,
+			Checksum:   0xfeedbeef,
+		},
+		AssetBytes: 4096,
+	}
+	encoded, err := encodeColumnVectorGraphManifestRecord(record)
+	if err != nil {
+		t.Fatalf("encodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	decoded, err := decodeColumnVectorGraphManifestRecord(encoded)
+	if err != nil {
+		t.Fatalf("decodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	if decoded != record {
+		t.Fatalf("decoded=%+v want %+v", decoded, record)
+	}
+	if key := columnVectorGraphManifestRecordKey(def.Name); !bytes.HasPrefix(key, columnManifestVectorGraphRecordPrefixBytes) {
+		t.Fatalf("graph record key %q missing graph prefix", key)
+	}
+
+	corrupt := append([]byte(nil), encoded...)
+	corrupt = append(corrupt, 0)
+	if _, err := decodeColumnVectorGraphManifestRecord(corrupt); err == nil || !strings.Contains(err.Error(), "trailing") {
+		t.Fatalf("decode corrupt err=%v want trailing-bytes failure", err)
+	}
+}
+
+func TestColumnVectorGraphManifestRecordsParticipateInIdentityWithoutRowLaneCountsV2A(t *testing.T) {
+	cfg, input, manifest, asset := makeColumnManifestWithPartForGraphTestV2A(t)
+	graphRecord := testColumnVectorGraphManifestRecordV2A(t, cfg, testColumnGraphVectorIndexDefinitionV2A(), manifest.Identity, asset.Ref)
+	withGraph := cloneColumnManifestRecords(manifest.Records)
+	withGraph = append(withGraph, graphRecord)
+	sortColumnManifestRecords(withGraph)
+	withGraphIdentity := manifest.Identity
+	withGraphIdentity.Checksum = checksumColumnManifestRecords(input, manifest.Identity.Generation, withGraph)
+
+	withoutGraphChecksum := checksumColumnManifestRecords(input, manifest.Identity.Generation, manifest.Records)
+	if withGraphIdentity.Checksum == withoutGraphChecksum {
+		t.Fatalf("graph manifest record did not change identity checksum=%d", withGraphIdentity.Checksum)
+	}
+
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	rootID := publishColumnManifestRecordsForScanTestM13A(t, d, withGraphIdentity, withGraph)
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("missing snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	caps, err := loadColumnManifestPlannerCapabilitiesForScan(snap, rootID, *cfg, withGraphIdentity, "events")
+	if err != nil {
+		t.Fatalf("loadColumnManifestPlannerCapabilitiesForScan: %v", err)
+	}
+	if caps.PhysicalAssetCount != 1 || caps.MutationParts != 0 {
+		t.Fatalf("planner caps=%+v want only the row-lane part counted", caps)
+	}
+}
+
+func makeColumnManifestWithPartForGraphTestV2A(tb testing.TB) (*ColumnStoreConfig, ColumnPublishManifestEncodeInput, ColumnPublishManifestEncodeResult, ColumnPreparedAsset) {
+	tb.Helper()
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		tb.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	asset := testColumnPublishPreparedAssetM10A()
+	asset.Ref.Generation = 1
+	asset.Ref.PartID = 1
+	asset.GenerationID = 1
+	asset.Reason = string(ColumnPublishOperationInsert)
+	input := ColumnPublishManifestEncodeInput{
+		Collection:        "events",
+		ColumnStore:       *cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			Assets:             []ColumnPreparedAsset{asset},
+			RowCount:           1,
+			ColumnPayloadBytes: asset.Bytes,
+		},
+	}
+	manifest, err := encodeColumnManifestForWrite(input)
+	if err != nil {
+		tb.Fatalf("encodeColumnManifestForWrite: %v", err)
+	}
+	return cfg, input, manifest, asset
+}
+
+func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(t.TempDir(), "docs", *baseCfg, def, 12, 4, 88, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0, 2}},
+		{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1, Adjacency: []uint32{0, 1}},
+	})
+	if err != nil {
+		t.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	raw, err := readColumnPhysicalAssetFromManager(prepared.AssetRootDir, prepared.Ref)
+	if err != nil {
+		t.Fatalf("read graph asset: %v", err)
+	}
+	if err := validateColumnPhysicalAssetForManifest(raw, prepared.Ref, prepared.Config); err != nil {
+		t.Fatalf("validate graph asset: %v", err)
+	}
+	projection, err := newColumnPhysicalScanProjection(prepared.Config, []string{
+		columnVectorGraphVectorColumnName,
+		columnVectorGraphInvNormColumnName,
+		columnVectorGraphAdjacencyColumnName,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	var ids []string
+	var neighbors [][]uint32
+	summary, err := scanColumnPhysicalAssetRows(raw, prepared.Ref, "docs", &prepared.Config, projection, func(row columnPhysicalScanRowView) error {
+		ids = append(ids, string(row.ID))
+		neighbors = append(neighbors, append([]uint32(nil), row.Values[2].AdjacencyList...))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalAssetRows: %v", err)
+	}
+	if summary.rows != 3 || strings.Join(ids, ",") != "doc-a,doc-b,doc-c" {
+		t.Fatalf("summary=%+v ids=%v", summary, ids)
+	}
+	if got := neighbors[1]; len(got) != 2 || got[0] != 0 || got[1] != 2 {
+		t.Fatalf("row1 neighbors=%v", got)
+	}
+}
+
+func TestColumnGraphVectorIndexStatusUsesPublishedPhysicalManifestV2A(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(d.ColumnAssetRootDir(), "docs", *baseCfg, def, 2, 1, 1, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	if err != nil {
+		t.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
+	meta := CollectionMeta{
+		Name:    "docs",
+		Options: CollectionOptions{ColumnStore: testColumnGraphBaseColumnStoreConfigV2A()},
+		VectorIndexes: []VectorIndexDefinition{
+			def,
+		},
+	}
+	manifestRecords, identity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	publishColumnGraphCatalogForTestV2A(t, d, meta, identity, manifestRecords)
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopenedDB, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopenedDB.Close() }()
+	col, err := NewCollectionManager(reopenedDB).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	status, err := col.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	if status.State != VectorIndexStateColumnGraphLoaded || !status.Loaded || status.RebuildNeeded || status.Reason != "" {
+		t.Fatalf("status=%+v want loaded column graph", status)
+	}
+}
+
+func TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAssetV2A(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(d.ColumnAssetRootDir(), "docs", *baseCfg, def, 2, 1, 1, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	if err != nil {
+		t.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
+	meta := CollectionMeta{
+		Name:          "docs",
+		Options:       CollectionOptions{ColumnStore: testColumnGraphBaseColumnStoreConfigV2A()},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+
+	t.Run("mismatched_base_manifest", func(t *testing.T) {
+		mismatchDef := def
+		mismatchDef.Dimensions = 4
+		mismatchMeta := meta
+		mismatchMeta.VectorIndexes = []VectorIndexDefinition{mismatchDef}
+		records, goodIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+		publishColumnGraphCatalogForTestV2A(t, d, mismatchMeta, goodIdentity, records)
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			t.Fatalf("open collection: %v", err)
+		}
+		status, err := col.VectorIndexStatus(def.Name)
+		if err != nil {
+			t.Fatalf("VectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
+			t.Fatalf("status=%+v want mismatch rebuild-needed", status)
+		}
+	})
+
+	t.Run("asset_generation_mismatch", func(t *testing.T) {
+		badRef := prepared.Ref
+		badRef.Generation++
+		records, badIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, badRef, prepared.Bytes, prepared.RowCount)
+		publishColumnGraphCatalogForTestV2A(t, d, meta, badIdentity, records)
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			t.Fatalf("open collection: %v", err)
+		}
+		status, err := col.VectorIndexStatus(def.Name)
+		if err != nil {
+			t.Fatalf("VectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
+			t.Fatalf("status=%+v want asset-generation mismatch rebuild-needed", status)
+		}
+	})
+
+	t.Run("missing_asset", func(t *testing.T) {
+		records, goodIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+		publishColumnGraphCatalogForTestV2A(t, d, meta, goodIdentity, records)
+		path, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), prepared.Ref)
+		if err != nil {
+			t.Fatalf("columnAssetSegmentPath: %v", err)
+		}
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("remove graph asset: %v", err)
+		}
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			t.Fatalf("open collection: %v", err)
+		}
+		status, err := col.VectorIndexStatus(def.Name)
+		if err != nil {
+			t.Fatalf("VectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphUnavailable || status.Reason != VectorIndexReasonColumnGraphCorrupt || !status.RebuildNeeded || status.Loaded {
+			t.Fatalf("status=%+v want corrupt unavailable", status)
+		}
+	})
+}
+
+func BenchmarkColumnGraphVectorIndexStatusLoadedV2A(b *testing.B) {
+	dir := b.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		b.Fatalf("normalize base column store: %v", err)
+	}
+	def := testColumnGraphVectorIndexDefinitionV2A()
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(d.ColumnAssetRootDir(), "docs", *baseCfg, def, 2, 1, 1, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	if err != nil {
+		b.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
+	meta := CollectionMeta{
+		Name:          "docs",
+		Options:       CollectionOptions{ColumnStore: testColumnGraphBaseColumnStoreConfigV2A()},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	manifestRecords, identity := testColumnGraphManifestRecordsV2A(b, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	publishColumnGraphCatalogForTestV2A(b, d, meta, identity, manifestRecords)
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(prepared.RowCount), "graph_rows")
+	b.ReportMetric(float64(prepared.Bytes)/float64(prepared.RowCount), "asset_B/row")
+	for i := 0; i < b.N; i++ {
+		status, err := col.VectorIndexStatus(def.Name)
+		if err != nil {
+			b.Fatalf("VectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphLoaded || !status.Loaded || status.RebuildNeeded {
+			b.Fatalf("status=%+v want loaded", status)
+		}
+		vectorIndexStatusBenchSink = status
+	}
+}
+
+func testColumnGraphBaseColumnStoreConfigV2A() *ColumnStoreConfig {
+	return &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString},
+		},
+	}
+}
+
+func testColumnGraphVectorIndexDefinitionV2A() VectorIndexDefinition {
+	def, err := normalizeVectorIndexDefinition(VectorIndexDefinition{
+		Name:       "embedding_graph",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 3,
+		Strategy:   VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return def
+}
+
+func testColumnVectorGraphManifestRecordV2A(tb testing.TB, baseCfg *ColumnStoreConfig, def VectorIndexDefinition, identity ColumnManifestIdentity, ref ColumnAssetRef) columnManifestRecord {
+	tb.Helper()
+	records, _ := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, ref, ref.Length, 1)
+	for _, record := range records {
+		if bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes) {
+			return record
+		}
+	}
+	tb.Fatal("missing graph manifest record")
+	return columnManifestRecord{}
+}
+
+func testColumnGraphManifestRecordsV2A(tb testing.TB, baseCfg ColumnStoreConfig, def VectorIndexDefinition, identity ColumnManifestIdentity, ref ColumnAssetRef, assetBytes int64, rows int) ([]columnManifestRecord, ColumnManifestIdentity) {
+	tb.Helper()
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig("docs", baseCfg, def)
+	if err != nil {
+		tb.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
+	}
+	input := ColumnPublishManifestEncodeInput{
+		Collection:        "docs",
+		ColumnStore:       baseCfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			RowCount:           0,
+			ColumnPayloadBytes: 0,
+		},
+	}
+	header, err := encodeColumnManifestHeaderRecord(input, identity.Generation)
+	if err != nil {
+		tb.Fatalf("encodeColumnManifestHeaderRecord: %v", err)
+	}
+	record := columnVectorGraphManifestSnapshot{
+		IndexName:              def.Name,
+		Field:                  def.Field,
+		Metric:                 def.Metric,
+		Encoding:               def.Encoding,
+		Dimensions:             def.Dimensions,
+		M:                      def.M,
+		EfConstruction:         def.EfConstruction,
+		EfSearch:               def.EfSearch,
+		BaseManifestGeneration: identity.Generation,
+		BaseManifestChecksum:   identity.Checksum,
+		BaseSchemaHash:         baseCfg.SchemaHash,
+		GraphSchemaHash:        graphCfg.SchemaHash,
+		RowCount:               rows,
+		AssetRef:               ref,
+		AssetBytes:             assetBytes,
+	}
+	encoded, err := encodeColumnVectorGraphManifestRecord(record)
+	if err != nil {
+		tb.Fatalf("encodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	records := []columnManifestRecord{
+		{key: []byte(columnManifestHeaderRecordKey), value: header},
+		{key: columnVectorGraphManifestRecordKey(def.Name), value: encoded},
+	}
+	sortColumnManifestRecords(records)
+	identity.Checksum = checksumColumnManifestRecords(input, identity.Generation, records)
+	return records, identity
+}
+
+func publishColumnGraphCatalogForTestV2A(tb testing.TB, d *backenddb.DB, meta CollectionMeta, identity ColumnManifestIdentity, records []columnManifestRecord) uint64 {
+	tb.Helper()
+	normalized, err := normalizeCollectionMeta(meta)
+	if err != nil {
+		tb.Fatalf("normalize meta: %v", err)
+	}
+	cfg := normalized.Options.ColumnStore
+	cfg.ActiveManifest = &identity
+	cfg.RecoveryAuthoritativeManifest = &identity
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	normalized.Options.ColumnStore = cfg
+	normalized, err = normalizeCollectionMeta(normalized)
+	if err != nil {
+		tb.Fatalf("normalize active meta: %v", err)
+	}
+	encoded, err := encodeCollectionMeta(normalized)
+	if err != nil {
+		tb.Fatalf("encode meta: %v", err)
+	}
+	rootName := collectionColumnManifestRootName(normalized.Name)
+	manifestIter := columnManifestRootRecordIterator(encodeColumnManifestIdentityRecordArray(identity), records)
+	defer func() { _ = manifestIter.Close() }()
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{
+		Iter: manifestIter,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		current := d.AcquireSnapshot()
+		if current == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		return buildSystemTargetIterator(current, map[string][]byte{
+			systemCollectionMetaKey(normalized.Name): encoded,
+			systemCollectionRootKey(rootName):        encodeRootID(rootIDs[0]),
+		})
+	})
+	if err != nil {
+		tb.Fatalf("publish column graph manifest root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		tb.Fatalf("unexpected root IDs: %v", rootIDs)
+	}
+	return rootIDs[0]
+}

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -296,6 +296,44 @@ func TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAssetV2A(t 
 		}
 	})
 
+	t.Run("base_manifest_checksum_mismatch", func(t *testing.T) {
+		records, goodIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+		for i := range records {
+			if !bytes.HasPrefix(records[i].key, columnManifestVectorGraphRecordPrefixBytes) {
+				continue
+			}
+			graph, err := decodeColumnVectorGraphManifestRecord(records[i].value)
+			if err != nil {
+				t.Fatalf("decode graph record: %v", err)
+			}
+			graph.BaseManifestChecksum++
+			records[i].value, err = encodeColumnVectorGraphManifestRecord(graph)
+			if err != nil {
+				t.Fatalf("encode graph record: %v", err)
+			}
+		}
+		sortColumnManifestRecords(records)
+		badIdentity := goodIdentity
+		badIdentity.Checksum = checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+			Collection:        "docs",
+			ColumnStore:       *baseCfg,
+			Operation:         ColumnPublishOperationInsert,
+			AppliedCommandLSN: 1,
+		}, badIdentity.Generation, records)
+		publishColumnGraphCatalogForTestV2A(t, d, meta, badIdentity, records)
+		col, err := NewCollectionManager(d).OpenCollection("docs")
+		if err != nil {
+			t.Fatalf("open collection: %v", err)
+		}
+		status, err := col.VectorIndexStatus(def.Name)
+		if err != nil {
+			t.Fatalf("VectorIndexStatus: %v", err)
+		}
+		if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
+			t.Fatalf("status=%+v want checksum mismatch rebuild-needed", status)
+		}
+	})
+
 	t.Run("missing_asset", func(t *testing.T) {
 		records, goodIdentity := testColumnGraphManifestRecordsV2A(t, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
 		publishColumnGraphCatalogForTestV2A(t, d, meta, goodIdentity, records)
@@ -394,14 +432,32 @@ func testColumnGraphVectorIndexDefinitionV2A() VectorIndexDefinition {
 
 func testColumnVectorGraphManifestRecordV2A(tb testing.TB, baseCfg *ColumnStoreConfig, def VectorIndexDefinition, identity ColumnManifestIdentity, ref ColumnAssetRef) columnManifestRecord {
 	tb.Helper()
-	records, _ := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, ref, ref.Length, 1)
-	for _, record := range records {
-		if bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes) {
-			return record
-		}
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig("events", *baseCfg, def)
+	if err != nil {
+		tb.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
 	}
-	tb.Fatal("missing graph manifest record")
-	return columnManifestRecord{}
+	record := columnVectorGraphManifestSnapshot{
+		IndexName:              def.Name,
+		Field:                  def.Field,
+		Metric:                 def.Metric,
+		Encoding:               def.Encoding,
+		Dimensions:             def.Dimensions,
+		M:                      def.M,
+		EfConstruction:         def.EfConstruction,
+		EfSearch:               def.EfSearch,
+		BaseManifestGeneration: identity.Generation,
+		BaseManifestChecksum:   identity.Checksum,
+		BaseSchemaHash:         baseCfg.SchemaHash,
+		GraphSchemaHash:        graphCfg.SchemaHash,
+		RowCount:               1,
+		AssetRef:               ref,
+		AssetBytes:             ref.Length,
+	}
+	encoded, err := encodeColumnVectorGraphManifestRecord(record)
+	if err != nil {
+		tb.Fatalf("encodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	return columnManifestRecord{key: columnVectorGraphManifestRecordKey(def.Name), value: encoded}
 }
 
 func testColumnGraphManifestRecordsV2A(tb testing.TB, baseCfg ColumnStoreConfig, def VectorIndexDefinition, identity ColumnManifestIdentity, ref ColumnAssetRef, assetBytes int64, rows int) ([]columnManifestRecord, ColumnManifestIdentity) {
@@ -424,6 +480,11 @@ func testColumnGraphManifestRecordsV2A(tb testing.TB, baseCfg ColumnStoreConfig,
 	if err != nil {
 		tb.Fatalf("encodeColumnManifestHeaderRecord: %v", err)
 	}
+	baseRecords := []columnManifestRecord{
+		{key: []byte(columnManifestHeaderRecordKey), value: header},
+	}
+	sortColumnManifestRecords(baseRecords)
+	baseChecksum := checksumColumnManifestRecords(input, identity.Generation, baseRecords)
 	record := columnVectorGraphManifestSnapshot{
 		IndexName:              def.Name,
 		Field:                  def.Field,
@@ -434,7 +495,7 @@ func testColumnGraphManifestRecordsV2A(tb testing.TB, baseCfg ColumnStoreConfig,
 		EfConstruction:         def.EfConstruction,
 		EfSearch:               def.EfSearch,
 		BaseManifestGeneration: identity.Generation,
-		BaseManifestChecksum:   identity.Checksum,
+		BaseManifestChecksum:   baseChecksum,
 		BaseSchemaHash:         baseCfg.SchemaHash,
 		GraphSchemaHash:        graphCfg.SchemaHash,
 		RowCount:               rows,

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -282,6 +282,31 @@ func TestColumnGraphVectorIndexStatusClosedDBReturnsErrClosedV2A(t *testing.T) {
 	}
 }
 
+func TestColumnGraphVectorIndexStatusClosedDBBeforeEarlyStatusV2A(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	meta := CollectionMeta{
+		Name:          "docs",
+		Options:       CollectionOptions{ColumnStore: &ColumnStoreConfig{}},
+		VectorIndexes: []VectorIndexDefinition{testColumnGraphVectorIndexDefinitionV2A()},
+	}
+	if _, err := NewCollectionManager(d).CreateCollection(&meta); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	if _, err := col.columnGraphVectorIndexStatus(meta.VectorIndexes[0], nil); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("columnGraphVectorIndexStatus closed unsupported err=%v want ErrClosed", err)
+	}
+}
+
 func TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAssetV2A(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -231,16 +231,7 @@ func (c *Collection) VectorIndexStatus(name string) (VectorIndexStatus, error) {
 		return status, nil
 	case VectorIndexStrategyColumnGraph:
 		cfg := c.meta.Options.ColumnStore
-		if cfg == nil || !cfg.Enabled {
-			status.State = VectorIndexStateColumnGraphUnavailable
-			status.Reason = VectorIndexReasonPhysicalColumnAssetSupportMissing
-			status.RebuildNeeded = true
-			return status, nil
-		}
-		status.State = VectorIndexStateColumnGraphRebuildNeeded
-		status.Reason = VectorIndexReasonColumnGraphRebuildNeeded
-		status.RebuildNeeded = true
-		return status, nil
+		return c.columnGraphVectorIndexStatus(def, cfg)
 	default:
 		return VectorIndexStatus{}, fmt.Errorf("collections: unsupported vector index strategy %q", def.Strategy)
 	}


### PR DESCRIPTION
## Stack

Chained on #1652 (`codex/column-graph-native-v2a-build-publish`). This is a narrow V2A slice for #1646.

## What this PR does

- Adds a `column_graph` manifest record type under the real column manifest root for vector graph asset metadata.
- Adds a graph-shaped physical column asset seam using the existing TCS physical asset encoder for `vector`, `inv_norm`, and `adjacency` columns.
- Makes graph manifest records participate in manifest identity/checksum while not counting them as row-lane physical assets or mutation parts.
- Updates `VectorIndexStatus` so `column_graph` can report `column_graph_loaded` only when collection metadata, active column manifest identity, graph record schema, asset namespace/generation, and segment availability are consistent.
- Adds fail-closed status coverage for mismatched definitions, mismatched graph asset generation, missing graph records, and removed asset segments.

## Correct hard boundary

This PR still does not implement TreeDB column-store-native vector search. It does not add graph traversal, public rebuild, document materialization, a decoded in-memory `ColumnVectorGraph`, or a vector-only sidecar format.

The new status path validates manifest metadata and segment/ref availability only. It intentionally does not read/decode the full graph asset in `VectorIndexStatus`; full graph loading/search belongs in later #1646 slices using the generic row-reader/cache APIs.

## Tests

Start/close TDD checklist for this slice:

- Graph manifest record round-trip and corrupt trailing-byte rejection.
- Graph manifest records affect manifest identity checksum.
- Graph manifest records do not inflate row-lane physical-asset or mutation-part planner counts.
- Real graph-shaped physical TCS asset round-trip for `[]float32` vectors, `float32` invNorm, and `[]uint32` adjacency.
- Reopen/status test proves collection metadata plus durable manifest root can report `column_graph_loaded`.
- Fallback/status tests prove mismatch and missing segment cases fail closed instead of silently reporting loaded.

Validation run locally:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraph|TestColumnGraphVectorIndexStatus' -count=1\n# ok github.com/snissn/gomap/TreeDB/collections 0.693s\n\nGOWORK=off go test ./TreeDB/collections -run 'Test.*Vector|Test.*Column.*' -count=1\n# ok github.com/snissn/gomap/TreeDB/collections 6.836s\n\nGOWORK=off go test ./TreeDB/collections -count=1\n# ok github.com/snissn/gomap/TreeDB/collections 10.362s\n\ngit diff --check\n```\n\n## Benchmarks\n\nHardware: Apple M3, darwin/arm64. These are status-path benchmarks, not search benchmarks. The loaded path measures manifest/root metadata validation plus graph asset segment availability for an already published graph asset.\n\n```sh\nGOWORK=off go test ./TreeDB/collections -run '^$' -bench 'Benchmark(VectorIndexStatusV2A|ColumnGraphVectorIndexStatusLoadedV2A)' -benchmem -benchtime=500ms -count=5\n```\n\nResults:\n\n```text\nBenchmarkColumnGraphVectorIndexStatusLoadedV2A-8    74674  6973 ns/op  285.5 asset_B/row  2.000 graph_rows  4608 B/op  44 allocs/op\nBenchmarkColumnGraphVectorIndexStatusLoadedV2A-8    87058  6982 ns/op  285.5 asset_B/row  2.000 graph_rows  4591 B/op  44 allocs/op\nBenchmarkColumnGraphVectorIndexStatusLoadedV2A-8    85263  7110 ns/op  285.5 asset_B/row  2.000 graph_rows  4607 B/op  44 allocs/op\nBenchmarkColumnGraphVectorIndexStatusLoadedV2A-8    86350  6927 ns/op  285.5 asset_B/row  2.000 graph_rows  4608 B/op  44 allocs/op\nBenchmarkColumnGraphVectorIndexStatusLoadedV2A-8    86922  6926 ns/op  285.5 asset_B/row  2.000 graph_rows  4608 B/op  44 allocs/op\n\nBenchmarkVectorIndexStatusV2A-8                  15910880  38.03 ns/op  0 B/op  0 allocs/op\nBenchmarkVectorIndexStatusV2A-8                  15703156  38.16 ns/op  0 B/op  0 allocs/op\nBenchmarkVectorIndexStatusV2A-8                  15732958  38.11 ns/op  0 B/op  0 allocs/op\nBenchmarkVectorIndexStatusV2A-8                  15139328  38.65 ns/op  0 B/op  0 allocs/op\nBenchmarkVectorIndexStatusV2A-8                  15809460  38.13 ns/op  0 B/op  0 allocs/op\n```\n\nInterpretation: the missing/rebuild-needed status path remains zero-alloc and sub-40 ns. The loaded graph status path is several microseconds and allocates because it currently acquires a snapshot, loads manifest records, validates metadata, and stats the segment. That cost is outside the future search hot path and does not decode the graph asset.\n\n## Review gates\n\nBefore this PR is considered ready, latest-head CI plus Codex, Copilot, and CodeRabbit reviews should be clean or have each finding fixed/explicitly resolved. Do not merge from this PR.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a "column graph" vector index strategy with manifest handling, physical asset publishing/validation, and status reporting.

* **Bug Fixes**
  * Manifest scanning and active-record handling now correctly include vector-graph records and incorporate them into manifest identity checks.

* **Tests**
  * Added end-to-end tests and a benchmark covering manifest round-trip, physical asset round-trip, and index status under success and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->