### PR TITLE
TreeDB column store post-V1: route q4b through aggregate metadata

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -62,9 +62,9 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 		{
 			name:       "q4b",
 			hashName:   "q4b",
-			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			req:        ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"},
 			wantCount:  12,
-			wantDirect: true,
+			wantDirect: false,
 		},
 		{
 			name:       "q5",
@@ -105,7 +105,8 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			if result.Diagnostics.WorkerCount != 1 {
 				t.Fatalf("%s worker count=%d want 1 diagnostics=%+v", tc.name, result.Diagnostics.WorkerCount, result.Diagnostics)
 			}
-			if tc.name != "q5_metadata" && result.Diagnostics.DecodedBlocks == 0 {
+			wantMetadata := tc.name == "q4b" || tc.name == "q5_metadata"
+			if !wantMetadata && result.Diagnostics.DecodedBlocks == 0 {
 				t.Fatalf("%s decoded blocks=0 diagnostics=%+v", tc.name, result.Diagnostics)
 			}
 			if tc.wantDirect && result.Diagnostics.DirectReduceBlocks != result.Diagnostics.DecodedBlocks {
@@ -114,7 +115,7 @@ func TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B(t *testing.T) {
 			if !tc.wantDirect && result.Diagnostics.DirectReduceBlocks != 0 {
 				t.Fatalf("%s direct reduce blocks=%d want zero for non-vectorized shape diagnostics=%+v", tc.name, result.Diagnostics.DirectReduceBlocks, result.Diagnostics)
 			}
-			if tc.name == "q5_metadata" {
+			if wantMetadata {
 				if result.Diagnostics.MetadataHits == 0 {
 					t.Fatalf("%s metadata hits=0 diagnostics=%+v", tc.name, result.Diagnostics)
 				}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -70,7 +70,7 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata executes q5_metadata through typed aggregate metadata assets when available; other queries reroute to serial physical scan)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan; aggregate_metadata executes q4b and q5_metadata through typed aggregate metadata assets when available; other queries reroute to serial physical scan)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 		columnStoreSuitePathList(columnStoreSuiteExecutableForcedPaths),
@@ -502,7 +502,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
 		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
-		PhysicalColumnQuery:    "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
+		PhysicalColumnQuery:    "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q4b and q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
 		BenchmarkOnlyRelaxed:   false,
 		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, physical scan/reducer execution, row/B-tree reduce, and parity hash stages are timed separately for the forced execution label; M14B direct physical reducers are fused into scan timing unless visibility reconstruction reports a separate reduce phase",
 	}
@@ -1140,7 +1140,7 @@ func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.Co
 }
 
 func columnStoreSuitePlanKindForQuery(path, name string, forceKind collections.ColumnQueryPlanKind) collections.ColumnQueryPlanKind {
-	if path == columnStorePathAggregateMetadata && name != columnStoreQueryQ5Metadata {
+	if path == columnStorePathAggregateMetadata && columnStoreSuiteAggregateMetadataName(name) == "" {
 		return collections.ColumnQueryPlanSerialColumnScan
 	}
 	return forceKind
@@ -1165,10 +1165,14 @@ func columnStoreSuiteQueryIndexCandidates(name string) []string {
 }
 
 func columnStoreSuiteAggregateMetadataName(name string) string {
-	if name == columnStoreQueryQ5Metadata {
+	switch name {
+	case columnStoreQueryQ4B:
+		return columnStoreSuiteQ5AggregateMax
+	case columnStoreQueryQ5Metadata:
 		return columnStoreSuiteQ5AggregateMin
+	default:
+		return ""
 	}
-	return ""
 }
 
 func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, rows int, queryName string, plan collections.ColumnQueryPlan) (columnStoreQueryExecution, error) {
@@ -1481,8 +1485,11 @@ func columnStoreQueryAliasOf(name, path string) string {
 }
 
 func columnStoreQueryImplementationNote(name, requestedPath, planPath string) string {
-	if requestedPath == columnStorePathAggregateMetadata && planPath == columnStorePathSerialColumnScan && name != columnStoreQueryQ5Metadata {
+	if requestedPath == columnStorePathAggregateMetadata && planPath == columnStorePathSerialColumnScan && columnStoreSuiteAggregateMetadataName(name) == "" {
 		return "aggregate_metadata_forced_path_rerouted_to_serial_column_scan_no_metadata_asset_for_query_m14b"
+	}
+	if name == columnStoreQueryQ4B && planPath == columnStorePathAggregateMetadata {
+		return "q4b_physical_aggregate_metadata_asset_fast_path"
 	}
 	if name == columnStoreQueryQ5Metadata && planPath == columnStorePathAggregateMetadata {
 		return "q5_metadata_physical_aggregate_metadata_asset_fast_path"

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2008,14 +2008,14 @@ func TestColumnStoreSuiteAggregateMetadataRequestUsesRegisteredNameM11B(t *testi
 	for _, agg := range cfg.AggregateMetadata {
 		registered[agg.Name] = true
 	}
-	name := columnStoreSuiteAggregateMetadataName("q5_metadata")
+	name := columnStoreSuiteAggregateMetadataName(columnStoreQueryQ5Metadata)
 	if name == "" {
 		t.Fatal("q5_metadata did not request aggregate metadata")
 	}
 	if !registered[name] {
 		t.Fatalf("q5_metadata requested aggregate metadata %q outside registered names", name)
 	}
-	name = columnStoreSuiteAggregateMetadataName("q4b")
+	name = columnStoreSuiteAggregateMetadataName(columnStoreQueryQ4B)
 	if name == "" {
 		t.Fatal("q4b did not request aggregate metadata")
 	}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1383,7 +1383,8 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			}
 			queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 			for _, q := range report.Queries {
-				if tc.forcedPath == columnStorePathAggregateMetadata && q.Name != columnStoreQueryQ5Metadata {
+				metadataFastPath := q.Name == columnStoreQueryQ4B || q.Name == columnStoreQueryQ5Metadata
+				if tc.forcedPath == columnStorePathAggregateMetadata && !metadataFastPath {
 					if q.PlanLabel != columnStorePathSerialColumnScan {
 						t.Fatalf("query %s plan_label=%q want %q under aggregate_metadata forced path", q.Name, q.PlanLabel, columnStorePathSerialColumnScan)
 					}
@@ -1412,6 +1413,16 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 				}
 			}
 			if tc.forcedPath == columnStorePathAggregateMetadata {
+				q4b := queryMetrics[columnStoreQueryQ4B]
+				if q4b.PlanLabel != columnStorePathAggregateMetadata {
+					t.Fatalf("q4b plan_label=%q want %q", q4b.PlanLabel, columnStorePathAggregateMetadata)
+				}
+				if q4b.MetadataHits == 0 {
+					t.Fatalf("q4b metadata_hits=0 want aggregate metadata fast path: %+v", q4b)
+				}
+				if !strings.Contains(q4b.ThroughputInterpretation, "metadata-bound") {
+					t.Fatalf("q4b throughput_interpretation=%q want metadata-bound aggregate classification", q4b.ThroughputInterpretation)
+				}
 				interpretation := queryMetrics[columnStoreQueryQ5Metadata].ThroughputInterpretation
 				if queryMetrics[columnStoreQueryQ5Metadata].MetadataHits > 0 {
 					if !strings.Contains(interpretation, "metadata-bound") {
@@ -2003,6 +2014,13 @@ func TestColumnStoreSuiteAggregateMetadataRequestUsesRegisteredNameM11B(t *testi
 	}
 	if !registered[name] {
 		t.Fatalf("q5_metadata requested aggregate metadata %q outside registered names", name)
+	}
+	name = columnStoreSuiteAggregateMetadataName("q4b")
+	if name == "" {
+		t.Fatal("q4b did not request aggregate metadata")
+	}
+	if !registered[name] {
+		t.Fatalf("q4b requested aggregate metadata %q outside registered names", name)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is the fifth #1634 post-V1 optimization PR, chained after #1657. It extends the typed aggregate-metadata asset fast path from `q5_metadata` to JSONBench `q4b` max-by-group:

- Routes forced `aggregate_metadata` `q4b` to the existing typed max-time aggregate metadata asset.
- Keeps q1/q2/q3/q4a/q5 rerouted to serial physical scan when they do not request a supported metadata asset.
- Adds collection-level and unified-bench regressions requiring q4b metadata hits, zero row materializations, zero physical row/block scan on the metadata path, and parity.
- Does not add q4a early-stop, mark pruning, dictionaries, locators, mutation-visible metadata merge, mmap reader reuse, or automatic planner selection.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64. Base PR is #1657 head `c4a526a0`; benchmark head is `caf054753`, with latest review-cleanup head `c89827884`. The cleanup changes only test literals to existing query constants and does not change runtime behavior or benchmark evidence.

Routed durable production runs, 100K rows, batchsize 5000:

```sh
OUT=/tmp/gomap_1634_q4b_metadata_20260520_135417
go build -o "$OUT/unified-bench" ./cmd/unified_bench
"$OUT/unified-bench" -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir "$OUT/routed_100000_aggregate_metadata" -path-label native-fastpath -column-store-path aggregate_metadata -progress=false
"$OUT/unified-bench" -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir "$OUT/routed_100000_serial_column_scan" -path-label native-fastpath -column-store-path serial_column_scan -progress=false
```

Key routed results:

| path | query | rows/s | MiB/s | ns/row | B/read | metadata hits | row materializations | parity |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `aggregate_metadata` | `q4b` | 53.30M | 407.56 | 18.8 | 801,720 | 20 | 0 | pass |
| `serial_column_scan` | `q4b` | 11.01M | 1092.07 | 90.9 | 10,404,660 | 0 | 0 | pass |
| `aggregate_metadata` | `q5_metadata` | 89.79M | 686.49 | 11.1 | 801,720 | 20 | 0 | pass |
| `serial_column_scan` | `q5_metadata` alias | 9.72M | 964.10 | 102.9 | 10,404,660 | 0 | 0 | pass |

Byte accounting for the routed durable runs:

| metric | bytes |
|---|---:|
| source document bytes | 9,368,750 |
| retained payload bytes | 3,368,750 |
| column asset bytes | 12,008,100 |
| manifest/control bytes | 28 |
| ordinary value_vlog bytes | 0 |
| leaf_vlog bytes | 2,279,912 |
| command-WAL bytes before checkpoint | 11,172,333 |
| DB total bytes | 25,985,058 |

## Throughput Interpretation

This is a narrow metadata-path extension, not a new physical encoding or mark-pruning PR. q4b now uses the typed aggregate metadata assets published by #1657, reads ~0.80 MiB of metadata assets instead of ~10.40 MiB of TCPA physical part assets, reports `metadata_hits=20`, and remains parity-passing with zero row materializations.

q4a intentionally remains scan-backed. The old experiment q4a early-stop behavior is not apples-to-apples with this full scheduled-granule q4b metadata path and should stay a separate measured candidate.

## Granule / ClickHouse Equivalent Comparison

Fresh experiment kernel baseline from #1657 on the same machine/commit family:

```sh
GOWORK=off go test ./experiments/colgranule -run '^$' -bench 'BenchmarkJSONBenchEncodedPartQueries|BenchmarkJSONBenchQ4SortOrderFairness|BenchmarkJSONBenchAggregateMetadataQueries' -benchmem -benchtime=20x -count=1
```

| query | experiment/kernel equivalent | rows/s | allocs/op |
|---|---|---:|---:|
| q1 | encoded part reducer | 406.73M | 5 |
| q2 | encoded part reducer | 233.92M | 5 |
| q3 | encoded part reducer | 189.69M | 5 |
| q4b | ClickHouse-order encoded row scan | 87.51M | 2 |
| q5 | encoded row scan | 137.10M | 5 |
| q4b metadata | experiment aggregate metadata | 302.59M | 2 |
| q5 metadata | experiment aggregate metadata | 396.66M | 2 |

Historical local ClickHouse comparison from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` remains a smoke-level column-kernel comparison, not a production TreeDB DB benchmark: q1 ClickHouse local 0.014s (~71.43M rows/s), q2 0.027s (~37.04M), q3 0.014s (~71.43M), q4 0.013s (~76.92M), q5 0.013s (~76.92M). The experiment kernel bests were q1 0.004284s, q2 0.038895s, q3 0.006631s, q4 0.009869s, q5 0.010027s.

## Gate Status

Passed locally:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite(ExecutesForcedAggregateAndParallelPhysicalPathsM14B|AggregateMetadataRequestUsesRegisteredNameM11B)' -count=1
go test ./TreeDB/collections -run 'TestColumnPhysicalQuery(AdapterExecutesJSONBenchShapesM13B|AggregateMetadataRequiresRegisteredAssetM1634|AdapterAppliesMutationVisibilityM13C)|TestColumnQueryPlannerM14BRoutesForcedPhysicalPlansFromManifestCapabilities' -count=1
go test ./cmd/unified_bench -run 'TestColumnStoreSuite(ExecutesForcedAggregateAndParallelPhysicalPathsM14B|QueriesNormalizeForcedPathAliasesM11B|MarkdownRendersThroughputInterpretationM14C|AggregateMetadataRequestUsesRegisteredNameM11B)' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
# review-cleanup head c89827884
go test ./cmd/unified_bench -run 'TestColumnStoreSuiteAggregateMetadataRequestUsesRegisteredNameM11B' -count=1
git diff --check
```

Latest-head CI/reviews are stable at `c898278843b59bc4f82a0256277cac7d237f83fe`: GitHub Actions passed, Codex reported no major issues, CodeRabbit reported no actionable comments, and the Copilot review thread was addressed and resolved.

## Artifacts

- Routed aggregate metadata HTML: `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_aggregate_metadata/column_store_results.html`
- Routed aggregate metadata JSON/MD: `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_aggregate_metadata/column_store_results.json`, `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_aggregate_metadata/column_store_results.md`
- Routed serial HTML: `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_serial_column_scan/column_store_results.html`
- Routed serial JSON/MD: `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_serial_column_scan/column_store_results.json`, `/tmp/gomap_1634_q4b_metadata_20260520_135417/routed_100000_serial_column_scan/column_store_results.md`
- benchprof outputs/profiles are under each routed profile dir.

## Assumptions / Non-Goals

- q4b reuses the existing max-time aggregate metadata asset shape from #1657; this PR does not add a new asset format or storage lifecycle.
- q4a remains intentionally scan-backed because its old experiment early-stop behavior is a different sort-order/mark-pruning candidate.
- Mutation-bearing manifests remain fail-closed for explicit aggregate metadata requests.
- Column assets remain isolated typed column assets under the column asset manager namespace. They are value-log-shaped/segment-log-shaped assets, not generic row value-log entries.

Fixes part of #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests to treat q4b like the existing metadata case, validating aggregate-metadata fast-path behavior, metadata hits, and metadata-bound throughput.

* **Chores**
  * Updated benchmark suite and reporting so aggregate-metadata routing and descriptive notes include q4b and q5_metadata; non-metadata queries now reroute to the serial column scan when no metadata asset is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
