### PR TITLE
TreeDB column store post-V1: add slope benchmark harness

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -212,15 +212,14 @@ counters used by raw-engine review gates.
 ## Column Store Suite
 
 Use `column_store` as the canonical native TreeDB column-store benchmark entry
-point. M11B measures the production column-enabled collection manifest/control
-path, planner diagnostics, and executable row-store / B-tree baseline labels
-with a durable command-WAL profile and a deterministic JSONBench-shaped fixture.
+point. It measures the production column-enabled collection manifest/control
+path, durable command-WAL publication, isolated physical column assets, planner
+diagnostics, parity, byte accounting, and executable row-store / B-tree /
+physical-column labels with a deterministic JSONBench-shaped fixture.
 `-profile balanced` is accepted as a `durable` alias for the column store suite
 so the unified-bench default still exercises the durable gate. The runnable
-execution labels are `row_store_baseline` and `b_tree_index_baseline`; physical
-column labels (`serial_column_scan`, `aggregate_metadata`,
-`parallel_column_scan`) still fail closed through the planner because durable
-physical column assets/scanners are not implemented yet.
+execution labels are `row_store_baseline`, `b_tree_index_baseline`,
+`serial_column_scan`, `aggregate_metadata`, and `parallel_column_scan`.
 
 ```bash
 OUT=$(mktemp -d /tmp/gomap_column_store_profiles_XXXXXX)
@@ -255,8 +254,26 @@ explicitly and include the fail-closed evidence. The suite reports measured
 assets are published, plus explicit `column_asset_store_bytes`,
 `ordinary_value_vlog_bytes`, and `leaf_vlog_bytes` splits so M12+ evidence does
 not confuse typed column assets with row value-log or leaf-log storage.
-`retained_payload_bytes` equals the source JSONBench payload until
-retained-payload stripping lands.
+`retained_payload_bytes` reports the row/remainder payload for the selected
+path; physical paths that strip declared columns into column assets should
+report less retained payload than the source JSONBench document bytes.
+
+For post-V1 production-vs-experiment attribution, use the slope harness:
+
+```bash
+RUN_DIR=/tmp/treedb_column_store_slope_$(date +%Y%m%d_%H%M%S) \
+  KEYCOUNTS=10000,100000,500000 \
+  ROUTED_PATHS=serial_column_scan,aggregate_metadata,parallel_column_scan \
+  scripts/treedb_column_store_slope_profile.sh
+```
+
+The harness builds `unified-bench`, runs routed production `column_store` cases
+into per-keycount/per-path profile directories, captures direct production
+package benchmarks for the TCPA asset scanner / collection scanner / query
+adapter, captures the older `experiments/colgranule` encoded-kernel baselines,
+and writes `summary.tsv` plus `summary.md`. Use the generated HTML reports for
+review and keep ClickHouse-equivalent JSONBench context tied to
+`experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.
 
 ## Notes
 

--- a/scripts/treedb_column_store_slope_profile.sh
+++ b/scripts/treedb_column_store_slope_profile.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/treedb_column_store_slope_$(date +%Y%m%d_%H%M%S)}"
+KEYCOUNTS="${KEYCOUNTS:-10000,100000,500000}"
+ROUTED_PATHS="${ROUTED_PATHS:-serial_column_scan,aggregate_metadata,parallel_column_scan}"
+PROFILE="${PROFILE:-durable}"
+BATCHSIZE="${BATCHSIZE:-5000}"
+PATH_LABEL="${PATH_LABEL:-native-fastpath}"
+RUN_ROUTED="${RUN_ROUTED:-true}"
+RUN_DIRECT="${RUN_DIRECT:-true}"
+RUN_EXPERIMENT="${RUN_EXPERIMENT:-true}"
+DIRECT_BENCHTIME="${DIRECT_BENCHTIME:-20x}"
+DIRECT_COUNT="${DIRECT_COUNT:-1}"
+EXPERIMENT_BENCHTIME="${EXPERIMENT_BENCHTIME:-20x}"
+EXPERIMENT_COUNT="${EXPERIMENT_COUNT:-1}"
+
+mkdir -p "$RUN_DIR"
+
+is_true() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		1|true|yes|y|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+split_words() {
+	printf '%s' "$1" | tr ',' ' '
+}
+
+slug() {
+	printf '%s' "$1" | tr -c '[:alnum:]_=-' '_'
+}
+
+write_index() {
+	cat >"$RUN_DIR/README.md" <<EOF
+# TreeDB Column Store Slope Profile
+
+- worktree: \`$ROOT\`
+- branch: \`$(git rev-parse --abbrev-ref HEAD)\`
+- commit: \`$(git rev-parse HEAD)\`
+- generated_at: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
+- keycounts: \`$KEYCOUNTS\`
+- routed paths: \`$ROUTED_PATHS\`
+- profile: \`$PROFILE\`
+- batchsize: \`$BATCHSIZE\`
+- execution path label: \`$PATH_LABEL\`
+- direct package benchmarks: \`$RUN_DIRECT\`
+- experiment kernel benchmarks: \`$RUN_EXPERIMENT\`
+
+This bundle separates fixed setup/reporting cost from steady-state scan/reduce
+throughput for the production column-store path. Routed production runs use
+\`unified-bench -suite column_store\` and write the normal JSON/Markdown/HTML,
+benchprof, pprof, and trace artifacts below \`routed/keys_<n>/<path>/\`.
+
+Companion artifacts:
+
+- \`production_package_bench.txt\` captures direct TCPA asset scan, collection
+  scanner, and physical query adapter package benchmarks.
+- \`experiment_colgranule_baseline.txt\` captures the older
+  \`experiments/colgranule\` encoded/block reducer and metadata baselines.
+- \`summary.tsv\` contains one row per routed production query.
+- \`summary.md\` is the review-facing rollup.
+- \`experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md\` remains the local
+  ClickHouse-equivalent context for JSONBench-shaped query and storage
+  comparisons; copy exact ClickHouse numbers into PR descriptions only when the
+  relevant query family is discussed.
+
+The slope bundle is attribution evidence, not an automatic optimization gate.
+Use it to classify planner/setup overhead, typed asset-manager/read overhead,
+TCPA row-view decode, reducer shape, reporting/parity overhead, and missing
+metadata/mark/dictionary/locator fast paths.
+EOF
+}
+
+run_routed_case() {
+	local keys=$1
+	local path=$2
+	local safe_path
+	safe_path=$(slug "$path")
+	local dir="$RUN_DIR/routed/keys_${keys}/${safe_path}"
+
+	mkdir -p "$dir"
+	echo "running routed column_store keys=$keys path=$path into: $dir"
+	"$RUN_DIR/unified-bench" \
+		-suite column_store \
+		-dbs treedb \
+		-profile "$PROFILE" \
+		-keys "$keys" \
+		-batchsize "$BATCHSIZE" \
+		-profile-dir "$dir" \
+		-path-label "$PATH_LABEL" \
+		-column-store-path "$path" \
+		-progress=false \
+		2>&1 | tee "$dir/run.log"
+}
+
+write_routed_summary() {
+	python3 - "$RUN_DIR" <<'PY'
+import csv
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+rows = []
+for report_path in sorted(root.glob("routed/keys_*/*/column_store_results.json")):
+    with report_path.open("r", encoding="utf-8") as f:
+        report = json.load(f)
+    for q in report.get("queries", []):
+        rows.append({
+            "keys": report.get("rows", 0),
+            "forced_path": report.get("forced_path", ""),
+            "query": q.get("name", ""),
+            "plan_label": q.get("plan_label", ""),
+            "rows_per_second": q.get("rows_per_second", 0),
+            "mib_per_second": q.get("mib_per_second", 0),
+            "ns_per_row": q.get("ns_per_row", 0),
+            "bytes_read": q.get("bytes_read", 0),
+            "row_materializations": q.get("row_materializations", 0),
+            "metadata_hits": q.get("metadata_hits", 0),
+            "scheduled_granules": q.get("scheduled_granules", 0),
+            "skipped_granules": q.get("skipped_granules", 0),
+            "worker_count": q.get("worker_count", 0),
+            "segment_file_cache_hits": q.get("segment_file_cache_hits", 0),
+            "segment_file_cache_misses": q.get("segment_file_cache_misses", 0),
+            "parity": report.get("parity", {}).get(q.get("name", ""), {}).get("pass", False),
+            "html": str(report_path.with_name("column_store_results.html")),
+        })
+
+summary_tsv = root / "summary.tsv"
+with summary_tsv.open("w", encoding="utf-8", newline="") as f:
+    fieldnames = [
+        "keys", "forced_path", "query", "plan_label", "rows_per_second",
+        "mib_per_second", "ns_per_row", "bytes_read", "row_materializations",
+        "metadata_hits", "scheduled_granules", "skipped_granules",
+        "worker_count", "segment_file_cache_hits", "segment_file_cache_misses",
+        "parity", "html",
+    ]
+    writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+    writer.writeheader()
+    writer.writerows(rows)
+
+summary_md = root / "summary.md"
+with summary_md.open("w", encoding="utf-8") as f:
+    f.write("# TreeDB Column Store Slope Summary\n\n")
+    f.write(f"- routed query rows: `{len(rows)}`\n")
+    f.write(f"- summary TSV: `{summary_tsv}`\n")
+    f.write(f"- direct package benchmark: `{root / 'production_package_bench.txt'}`\n")
+    f.write(f"- experiment baseline: `{root / 'experiment_colgranule_baseline.txt'}`\n\n")
+    f.write("| keys | path | query | rows/s | ns/row | MiB/s | bytes | mat | meta | sched/skip | workers | cache hit/miss | parity |\n")
+    f.write("|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n")
+    for r in rows:
+        f.write(
+            f"| {r['keys']} | `{r['forced_path']}` | `{r['query']}` | "
+            f"{float(r['rows_per_second']):.2f} | {float(r['ns_per_row']):.2f} | "
+            f"{float(r['mib_per_second']):.2f} | {r['bytes_read']} | "
+            f"{r['row_materializations']} | {r['metadata_hits']} | "
+            f"{r['scheduled_granules']}/{r['skipped_granules']} | {r['worker_count']} | "
+            f"{r['segment_file_cache_hits']}/{r['segment_file_cache_misses']} | {r['parity']} |\n"
+        )
+PY
+}
+
+write_index
+
+if is_true "$RUN_ROUTED"; then
+	echo "building unified-bench"
+	go build -o "$RUN_DIR/unified-bench" ./cmd/unified_bench
+	for keys in $(split_words "$KEYCOUNTS"); do
+		for path in $(split_words "$ROUTED_PATHS"); do
+			run_routed_case "$keys" "$path"
+		done
+	done
+	write_routed_summary
+fi
+
+if is_true "$RUN_DIRECT"; then
+	echo "running direct package scanner/query benchmarks"
+	go test ./TreeDB/collections \
+		-run '^$' \
+		-bench 'BenchmarkColumnPhysical(AssetSerialScan|CollectionSerialScan)M13A|BenchmarkColumnPhysicalQuery(AdapterM13B|VisibilityM13C)' \
+		-benchmem \
+		-benchtime="$DIRECT_BENCHTIME" \
+		-count="$DIRECT_COUNT" \
+		2>&1 | tee "$RUN_DIR/production_package_bench.txt"
+fi
+
+if is_true "$RUN_EXPERIMENT"; then
+	echo "running experiment colgranule kernel baselines"
+	GOWORK=off go test ./experiments/colgranule \
+		-run '^$' \
+		-bench 'BenchmarkJSONBenchEncodedPartQueries|BenchmarkJSONBenchQ4SortOrderFairness|BenchmarkJSONBenchAggregateMetadataQueries' \
+		-benchmem \
+		-benchtime="$EXPERIMENT_BENCHTIME" \
+		-count="$EXPERIMENT_COUNT" \
+		2>&1 | tee "$RUN_DIR/experiment_colgranule_baseline.txt"
+fi
+
+echo "column store slope bundle: $RUN_DIR"
+echo "bundle index: $RUN_DIR/README.md"
+if [[ -s "$RUN_DIR/summary.md" ]]; then
+	echo "summary: $RUN_DIR/summary.md"
+fi


### PR DESCRIPTION
## Summary

Adds a reusable post-V1 column-store slope benchmark harness so #1634 can separate fixed setup/reporting cost from steady-state physical scan/reduce throughput before selecting more optimization PRs.

This PR is measurement infrastructure only. It does not change query execution behavior, planner routing, physical asset format, GC/rewrite behavior, or column asset lifecycle semantics.

Changes:
- Adds `scripts/treedb_column_store_slope_profile.sh`.
- Runs routed production `unified-bench -suite column_store` across key-count slopes and forced paths.
- Captures direct production package benchmarks for TCPA asset scanner, collection scanner, query adapter, and mutation-visible query path.
- Captures fresh `experiments/colgranule` encoded/block reducer and metadata baselines.
- Writes `README.md`, `summary.tsv`, and `summary.md` into the artifact bundle.
- Documents the harness in `cmd/unified_bench/README.md`, including HTML artifact expectations and ClickHouse-equivalent JSONBench context.

## Performance / Benchmark Evidence

Primary run on Apple M3, darwin/arm64, branch `codex/column-store-slope-bench`, commit `e5beac5a5`:

```bash
OUT=/tmp/gomap_1634_slope_bench_$(date +%Y%m%d_%H%M%S)
RUN_DIR="$OUT" \
  KEYCOUNTS=10000,100000 \
  ROUTED_PATHS=serial_column_scan,aggregate_metadata,parallel_column_scan \
  BATCHSIZE=5000 \
  DIRECT_BENCHTIME=10x \
  EXPERIMENT_BENCHTIME=10x \
  scripts/treedb_column_store_slope_profile.sh
```

Artifact root: `/tmp/gomap_1634_slope_bench_20260520_144816`.

Routed production 100K durable highlights:

| path | query | rows/s | ns/row | MiB/s | bytes/read | metadata_hits | row_materializations | parity |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `serial_column_scan` | q1 | 11.43M | 87.5 | 1133.68 | 10404660 | 0 | 0 | pass |
| `serial_column_scan` | q2 | 9.23M | 108.4 | 915.53 | 10404660 | 0 | 0 | pass |
| `serial_column_scan` | q3 | 18.93M | 52.8 | 1878.67 | 10404660 | 0 | 0 | pass |
| `serial_column_scan` | q4a | 10.32M | 96.9 | 1023.78 | 10404660 | 0 | 0 | pass |
| `serial_column_scan` | q4b | 10.87M | 92.0 | 1078.40 | 10404660 | 0 | 0 | pass |
| `serial_column_scan` | q5 | 9.99M | 100.1 | 991.35 | 10404660 | 0 | 0 | pass |
| `aggregate_metadata` | q4b | 60.57M | 16.5 | 463.14 | 801720 | 20 | 0 | pass |
| `aggregate_metadata` | q5_metadata | 95.52M | 10.5 | 730.32 | 801720 | 20 | 0 | pass |
| `parallel_column_scan` | q1 | 21.69M | 46.1 | 2151.86 | 10404660 | 0 | 0 | pass |
| `parallel_column_scan` | q5 | 18.05M | 55.4 | 1790.90 | 10404660 | 0 | 0 | pass |

Routed production 10K durable highlights:

| path | query | rows/s | ns/row | MiB/s | bytes/read | metadata_hits | row_materializations | parity |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `serial_column_scan` | q1 | 7.45M | 134.1 | 739.72 | 1040466 | 0 | 0 | pass |
| `serial_column_scan` | q5 | 6.24M | 160.2 | 619.49 | 1040466 | 0 | 0 | pass |
| `aggregate_metadata` | q4b | 26.66M | 37.5 | 203.84 | 80172 | 2 | 0 | pass |
| `aggregate_metadata` | q5_metadata | 29.15M | 34.3 | 222.88 | 80172 | 2 | 0 | pass |
| `parallel_column_scan` | q1 | 12.72M | 78.6 | 1262.49 | 1040466 | 0 | 0 | pass |
| `parallel_column_scan` | q5 | 8.41M | 118.9 | 834.42 | 1040466 | 0 | 0 | pass |

Direct production package benchmarks from the same bundle:

| benchmark | result |
|---|---:|
| `BenchmarkColumnPhysicalAssetSerialScanM13A/rows_1024` | `87875 ns/op`, `1202.90 MB/s`, `0 B/op`, `0 allocs/op` |
| `BenchmarkColumnPhysicalAssetSerialScanM13A/rows_8192` | `381017 ns/op`, `2215.15 MB/s`, `0 B/op`, `0 allocs/op` |
| `BenchmarkColumnPhysicalCollectionSerialScanM13A` | `96125 ns/op`, `1099.66 MB/s`, `5328 B/op`, `53 allocs/op` |
| `BenchmarkColumnPhysicalQueryAdapterM13B/q1_rows_8192` | `12.77M rows/s`, `78.33 ns/row`, `7715 B/op`, `73 allocs/op` |
| `BenchmarkColumnPhysicalQueryAdapterM13B/q5_rows_8192` | `11.93M rows/s`, `83.81 ns/row`, `9403 B/op`, `95 allocs/op` |
| `BenchmarkColumnPhysicalQueryVisibilityM13C/q1_rows_8192` | `105957 rows/s`, `9438 ns/row`, `8454962 B/op`, `14647 allocs/op` |

Fresh `experiments/colgranule` granule-kernel baseline from the same bundle:

| query family | experiment baseline |
|---|---:|
| Q1 encoded reducer | `418.77M rows/s`, `2.388 ns/row`, `2377 B/op`, `5 allocs/op` |
| Q2 encoded reducer | `241.75M rows/s`, `4.136 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q3 encoded reducer | `195.30M rows/s`, `5.120 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q4b ClickHouse-order row scan | `91.46M rows/s`, `10.93 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 encoded reducer | `141.81M rows/s`, `7.052 ns/row`, `2440 B/op`, `5 allocs/op` |
| Q4b metadata | `307.95M rows/s`, `3.247 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 metadata | `420.58M rows/s`, `2.378 ns/row`, `96 B/op`, `2 allocs/op` |

ClickHouse-equivalent context is from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1M JSONBench rows on local ClickHouse `26.4.3.1` / Darwin arm64. It is historical/local context, not rerun by this PR:

| query | granule-kernel best | ClickHouse local | kernel / ClickHouse |
|---|---:|---:|---:|
| Q1 | `0.004284s` | `0.014000s` | `0.31x` |
| Q2 | `0.038895s` | `0.027000s` | `1.44x` |
| Q3 | `0.006631s` | `0.014000s` | `0.47x` |
| Q4 | `0.009869s` | `0.013000s` | `0.76x` |
| Q5 | `0.010027s` | `0.013000s` | `0.77x` |

## Throughput Interpretation

The new harness makes the current attribution boundary explicit:
- Direct TCPA asset scan is still zero-allocation and reaches `2.2 GB/s` on the 8192-row package benchmark.
- Routed production query paths are much slower than `experiments/colgranule` kernels because they include durable TreeDB integration, planner/query adapter setup, manifest/recovery validation, typed asset-manager reads, row-view decode, parity/reporting, and current reducer shape.
- The 10K-to-100K slope separates fixed setup/reporting effects from steady-state throughput; serial q1 improves from `7.45M` to `11.43M rows/s`, while metadata q5 improves from `29.15M` to `95.52M rows/s` as fixed costs amortize.
- The mutation-visible package benchmark remains intentionally called out separately because it is allocation-heavy and not representative of insert-only direct physical scan throughput.
- The ClickHouse table is context for the JSONBench query family. It is not an apples-to-apples production TreeDB database benchmark and should not be used as a pass/fail gate for this harness PR.

## Gate Status

No runtime behavior changed. This PR adds repeatable evidence collection for future #1634 decisions.

Validated locally:
- `bash -n scripts/treedb_column_store_slope_profile.sh`
- `go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuitePhysicalForcedPathsProduceNoRowMaterializationM14B|TestColumnStoreSuiteAggregateMetadataReportsMetadataHitsM1634' -count=1`
- `go test ./cmd/unified_bench -count=1`
- Smoke slope run: `/tmp/gomap_1634_slope_smoke_20260520_144701`
- Full slope run: `/tmp/gomap_1634_slope_bench_20260520_144816`
- `git diff --check HEAD~1..HEAD`

## Artifacts

Primary artifact root: `/tmp/gomap_1634_slope_bench_20260520_144816`.

Review-facing rollups:
- `/tmp/gomap_1634_slope_bench_20260520_144816/README.md`
- `/tmp/gomap_1634_slope_bench_20260520_144816/summary.md`
- `/tmp/gomap_1634_slope_bench_20260520_144816/summary.tsv`
- `/tmp/gomap_1634_slope_bench_20260520_144816/production_package_bench.txt`
- `/tmp/gomap_1634_slope_bench_20260520_144816/experiment_colgranule_baseline.txt`

Representative routed HTML reports:
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_100000/serial_column_scan/column_store_results.html`
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_100000/aggregate_metadata/column_store_results.html`
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_100000/parallel_column_scan/column_store_results.html`
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_10000/serial_column_scan/column_store_results.html`
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_10000/aggregate_metadata/column_store_results.html`
- `/tmp/gomap_1634_slope_bench_20260520_144816/routed/keys_10000/parallel_column_scan/column_store_results.html`

Smoke artifact root: `/tmp/gomap_1634_slope_smoke_20260520_144701`.
