### PR TITLE
TreeDB column store post-V1: add relaxed asset read integrity

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -578,7 +578,15 @@ func readColumnPhysicalAssetFromManager(rootDir string, ref ColumnAssetRef) ([]b
 }
 
 func readColumnPhysicalAssetFromManagerInto(rootDir string, ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	return readColumnPhysicalAssetFromManagerIntoWithIntegrity(rootDir, ref, dst, ColumnAssetReadIntegrityVerify)
+}
+
+func readColumnPhysicalAssetFromManagerIntoWithIntegrity(rootDir string, ref ColumnAssetRef, dst []byte, integrity ColumnAssetReadIntegrity) ([]byte, error) {
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
+		return nil, err
+	}
+	verifyChecksum, err := columnAssetReadIntegrityVerifyChecksum(integrity)
+	if err != nil {
 		return nil, err
 	}
 	if ref.Length > int64(maxCollectionInt) {
@@ -604,34 +612,78 @@ func readColumnPhysicalAssetFromManagerInto(rootDir string, ref ColumnAssetRef, 
 	if n != len(raw) {
 		return nil, io.ErrUnexpectedEOF
 	}
-	if checksum := page.Checksum(raw); checksum != ref.Checksum {
-		return nil, fmt.Errorf("collections: column physical asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+	if verifyChecksum {
+		if checksum := page.Checksum(raw); checksum != ref.Checksum {
+			return nil, fmt.Errorf("collections: column physical asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+		}
 	}
 	return raw, nil
 }
 
+func columnAssetReadIntegrityVerifyChecksum(integrity ColumnAssetReadIntegrity) (bool, error) {
+	switch integrity {
+	case "", ColumnAssetReadIntegrityVerify:
+		return true, nil
+	case ColumnAssetReadIntegritySkipChecksums:
+		return false, nil
+	default:
+		return false, fmt.Errorf("collections: unsupported column asset read integrity %q", integrity)
+	}
+}
+
+func columnAssetReadIntegrityLabel(integrity ColumnAssetReadIntegrity) string {
+	switch integrity {
+	case ColumnAssetReadIntegritySkipChecksums:
+		return string(ColumnAssetReadIntegritySkipChecksums)
+	default:
+		return string(ColumnAssetReadIntegrityVerify)
+	}
+}
+
+func verifyColumnPhysicalAssetReadChecksum(raw []byte, ref ColumnAssetRef, verify bool) error {
+	if !verify {
+		return nil
+	}
+	if checksum := page.Checksum(raw); checksum != ref.Checksum {
+		return fmt.Errorf("collections: column physical asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+	}
+	return nil
+}
+
 type columnPhysicalAssetReadCache struct {
-	namespace  string
-	segmentDir string
-	fileID     uint32
-	file       *os.File
-	files      map[uint32]*os.File
-	scratch    []byte
-	hits       uint64
-	misses     uint64
+	namespace      string
+	segmentDir     string
+	readIntegrity  ColumnAssetReadIntegrity
+	verifyChecksum bool
+	fileID         uint32
+	file           *os.File
+	files          map[uint32]*os.File
+	scratch        []byte
+	hits           uint64
+	misses         uint64
 }
 
 func newColumnPhysicalAssetReadCache(rootDir string, namespace string) (columnPhysicalAssetReadCache, error) {
+	return newColumnPhysicalAssetReadCacheWithIntegrity(rootDir, namespace, ColumnAssetReadIntegrityVerify)
+}
+
+func newColumnPhysicalAssetReadCacheWithIntegrity(rootDir string, namespace string, integrity ColumnAssetReadIntegrity) (columnPhysicalAssetReadCache, error) {
 	if namespace == "" {
 		return columnPhysicalAssetReadCache{}, errors.New("collections: column asset read cache namespace is required")
+	}
+	verifyChecksum, err := columnAssetReadIntegrityVerifyChecksum(integrity)
+	if err != nil {
+		return columnPhysicalAssetReadCache{}, err
 	}
 	managerNamespace, err := columnAssetManagerNamespaceForRoot(rootDir, namespace)
 	if err != nil {
 		return columnPhysicalAssetReadCache{}, err
 	}
 	return columnPhysicalAssetReadCache{
-		namespace:  namespace,
-		segmentDir: managerNamespace.SegmentDir,
+		namespace:      namespace,
+		segmentDir:     managerNamespace.SegmentDir,
+		readIntegrity:  integrity,
+		verifyChecksum: verifyChecksum,
 	}, nil
 }
 
@@ -679,7 +731,7 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 		}
 		dst = c.scratch
 	}
-	return readColumnPhysicalAssetFromFile(file, ref, dst)
+	return readColumnPhysicalAssetFromFileWithChecksum(file, ref, dst, c.verifyChecksum)
 }
 
 func getColumnPhysicalAssetReadScratch(minLen int) []byte {
@@ -738,6 +790,10 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 }
 
 func readColumnPhysicalAssetFromFile(file *os.File, ref ColumnAssetRef, dst []byte) ([]byte, error) {
+	return readColumnPhysicalAssetFromFileWithChecksum(file, ref, dst, true)
+}
+
+func readColumnPhysicalAssetFromFileWithChecksum(file *os.File, ref ColumnAssetRef, dst []byte, verifyChecksum bool) ([]byte, error) {
 	if file == nil {
 		return nil, errors.New("collections: nil column physical asset segment file")
 	}
@@ -755,8 +811,8 @@ func readColumnPhysicalAssetFromFile(file *os.File, ref ColumnAssetRef, dst []by
 	if n != len(raw) {
 		return nil, io.ErrUnexpectedEOF
 	}
-	if checksum := page.Checksum(raw); checksum != ref.Checksum {
-		return nil, fmt.Errorf("collections: column physical asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+	if err := verifyColumnPhysicalAssetReadChecksum(raw, ref, verifyChecksum); err != nil {
+		return nil, err
 	}
 	return raw, nil
 }

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -633,10 +633,12 @@ func columnAssetReadIntegrityVerifyChecksum(integrity ColumnAssetReadIntegrity) 
 
 func columnAssetReadIntegrityLabel(integrity ColumnAssetReadIntegrity) string {
 	switch integrity {
+	case "", ColumnAssetReadIntegrityVerify:
+		return string(ColumnAssetReadIntegrityVerify)
 	case ColumnAssetReadIntegritySkipChecksums:
 		return string(ColumnAssetReadIntegritySkipChecksums)
 	default:
-		return string(ColumnAssetReadIntegrityVerify)
+		return string(integrity)
 	}
 }
 

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -511,6 +511,15 @@ func TestColumnAssetManagerWritesIsolatedSegmentAndValidatesM12A(t *testing.T) {
 	}
 }
 
+func TestColumnAssetReadIntegrityLabelPreservesUnsupportedM1634(t *testing.T) {
+	if got := columnAssetReadIntegrityLabel(""); got != string(ColumnAssetReadIntegrityVerify) {
+		t.Fatalf("empty integrity label=%q want %q", got, ColumnAssetReadIntegrityVerify)
+	}
+	if got := columnAssetReadIntegrityLabel(ColumnAssetReadIntegrity("bad-mode")); got != "bad-mode" {
+		t.Fatalf("unsupported integrity label=%q want raw value", got)
+	}
+}
+
 func TestColumnAssetManagerWriteAllowsZeroChecksumM12A(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -499,6 +499,16 @@ func TestColumnAssetManagerWritesIsolatedSegmentAndValidatesM12A(t *testing.T) {
 	if _, err := readColumnPhysicalAssetFromManager(root, ref); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("read corrupt asset err=%v want checksum failure", err)
 	}
+	relaxedRaw, err := readColumnPhysicalAssetFromManagerIntoWithIntegrity(root, ref, nil, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("relaxed read corrupt asset: %v", err)
+	}
+	if bytes.Equal(relaxedRaw, raw) {
+		t.Fatalf("relaxed read returned uncorrupted payload")
+	}
+	if err := validateColumnPhysicalAssetForManifest(relaxedRaw, ref, *normalized); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("manifest validation err=%v want checksum failure", err)
+	}
 }
 
 func TestColumnAssetManagerWriteAllowsZeroChecksumM12A(t *testing.T) {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -28,11 +28,12 @@ const columnPhysicalQueryHourUS = int64(3_600_000_000)
 // ColumnPhysicalQueryRequest describes one explicit physical column query. It
 // does not invoke planner routing; M14 owns forced/automatic route selection.
 type ColumnPhysicalQueryRequest struct {
-	Kind                  ColumnPhysicalQueryKind
-	GroupColumn           string
-	ValueColumn           string
-	DistinctColumn        string
-	AggregateMetadataName string
+	Kind                     ColumnPhysicalQueryKind
+	GroupColumn              string
+	ValueColumn              string
+	DistinctColumn           string
+	AggregateMetadataName    string
+	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
 }
 
 // ColumnPhysicalQueryGroup is one reduced result row. Count is populated for
@@ -70,6 +71,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	WorkerCount                int
 	SegmentFileCacheHits       uint64
 	SegmentFileCacheMisses     uint64
+	ColumnAssetReadIntegrity   string
 	ScanNanos                  int64
 	VisibilityNanos            int64
 	ReduceNanos                int64
@@ -135,7 +137,7 @@ func (c *Collection) runColumnPhysicalQueryAggregateMetadataInSnapshotView(view 
 	if len(refs) == 0 {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: aggregate metadata %q has no physical asset refs", ErrColumnQueryPlanUnsupported, aggregate.Name)
 	}
-	readCache, err := newColumnPhysicalAssetReadCache(view.ColumnAssetRootDir, view.AssetNamespace)
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
@@ -146,6 +148,7 @@ func (c *Collection) runColumnPhysicalQueryAggregateMetadataInSnapshotView(view 
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ProjectedColumns = 2
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
 	diag.ScheduledGranules = len(refs)
 	for _, metadataRef := range refs {
 		raw, err := readCache.read(metadataRef.AssetRef, rawScratch)
@@ -233,7 +236,8 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
 		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", refRemainder, refModulo)
 	}
 	diag.ProjectedColumns = len(exec.projected)
-	readCache, err := newColumnPhysicalAssetReadCache(view.ColumnAssetRootDir, view.AssetNamespace)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(exec.readIntegrity)
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, exec.readIntegrity)
 	if err != nil {
 		return diag, err
 	}
@@ -338,6 +342,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 					RefOrdinalModulo:    workers,
 					RefOrdinalRemainder: worker,
 					ShouldCancel:        cancel.Load,
+					ReadIntegrity:       req.ColumnAssetReadIntegrity,
 				})
 			}
 			if err != nil {
@@ -398,6 +403,7 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 		ProjectedColumns:  exec.projected,
 		Visitor:           exec.visit,
 		RequireInsertOnly: true,
+		ReadIntegrity:     req.ColumnAssetReadIntegrity,
 	})
 	scanNanos := time.Since(scanStart).Nanoseconds()
 	result := ColumnPhysicalQueryResult{
@@ -422,7 +428,7 @@ func (c *Collection) runColumnPhysicalQueryWithVisibility(cfg ColumnStoreConfig,
 		return ColumnPhysicalQueryResult{}, err
 	}
 	visibilityStart := time.Now()
-	visible, err := c.scanColumnPhysicalVisibleRows(exec.projected)
+	visible, err := c.scanColumnPhysicalVisibleRowsWithReadIntegrity(exec.projected, req.ColumnAssetReadIntegrity)
 	visibilityNanos := time.Since(visibilityStart).Nanoseconds()
 	result := ColumnPhysicalQueryResult{
 		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(visible.Diagnostics),
@@ -501,6 +507,7 @@ func columnPhysicalQueryDiagnosticsFromScan(diag columnPhysicalScanDiagnostics) 
 		PhysicalBytesScanned:       diag.PhysicalBytesScanned,
 		SegmentFileCacheHits:       diag.SegmentFileCacheHits,
 		SegmentFileCacheMisses:     diag.SegmentFileCacheMisses,
+		ColumnAssetReadIntegrity:   diag.ColumnAssetReadIntegrity,
 	}
 }
 
@@ -513,6 +520,10 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 		left.ManifestRecords = right.ManifestRecords
 		left.AssetRefs = right.AssetRefs
 		left.ProjectedColumns = right.ProjectedColumns
+		left.ColumnAssetReadIntegrity = right.ColumnAssetReadIntegrity
+	}
+	if left.ColumnAssetReadIntegrity == "" {
+		left.ColumnAssetReadIntegrity = right.ColumnAssetReadIntegrity
 	}
 	if right.ManifestRecords > left.ManifestRecords {
 		left.ManifestRecords = right.ManifestRecords
@@ -545,6 +556,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 
 type columnPhysicalQueryExecutor struct {
 	kind              ColumnPhysicalQueryKind
+	readIntegrity     ColumnAssetReadIntegrity
 	projected         []string
 	groupIdx          int
 	valueIdx          int
@@ -571,6 +583,7 @@ type columnPhysicalQuerySpan struct {
 func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (*columnPhysicalQueryExecutor, error) {
 	exec := &columnPhysicalQueryExecutor{
 		kind:              req.Kind,
+		readIntegrity:     req.ColumnAssetReadIntegrity,
 		groupIdx:          -1,
 		valueIdx:          -1,
 		distinctIdx:       -1,

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -21,6 +21,7 @@ type columnPhysicalScanRequest struct {
 	RefOrdinalModulo    int
 	RefOrdinalRemainder int
 	ShouldCancel        func() bool
+	ReadIntegrity       ColumnAssetReadIntegrity
 }
 
 type columnPhysicalScanDiagnostics struct {
@@ -39,10 +40,11 @@ type columnPhysicalScanDiagnostics struct {
 	DeletedRows      int
 	ProjectedColumns int
 	// Counts full-document row materialization; M13A emits declared-column row views only.
-	RowMaterializations    int
-	PhysicalBytesScanned   int64
-	SegmentFileCacheHits   uint64
-	SegmentFileCacheMisses uint64
+	RowMaterializations      int
+	PhysicalBytesScanned     int64
+	SegmentFileCacheHits     uint64
+	SegmentFileCacheMisses   uint64
+	ColumnAssetReadIntegrity string
 }
 
 type columnPhysicalScanRowView struct {
@@ -312,11 +314,12 @@ func (c *Collection) scanColumnPhysicalRowsInSnapshotView(
 	if req.RefOrdinalModulo > 0 && (req.RefOrdinalRemainder < 0 || req.RefOrdinalRemainder >= req.RefOrdinalModulo) {
 		return diag, fmt.Errorf("collections: physical column scan ref ordinal remainder=%d outside modulo=%d", req.RefOrdinalRemainder, req.RefOrdinalModulo)
 	}
-	readCache, err := newColumnPhysicalAssetReadCache(view.ColumnAssetRootDir, view.AssetNamespace)
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ReadIntegrity)
 	if err != nil {
 		return diag, err
 	}
 	defer func() { _ = readCache.close() }()
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ReadIntegrity)
 	var rawScratch []byte
 	start, step := columnPhysicalScanRefOrdinalPartition(req)
 	for ordinal := start; ordinal < len(view.AssetRefs); ordinal += step {

--- a/TreeDB/collections/column_physical_visibility.go
+++ b/TreeDB/collections/column_physical_visibility.go
@@ -24,6 +24,10 @@ type columnPhysicalVisibilityResult struct {
 }
 
 func (c *Collection) scanColumnPhysicalVisibleRows(projected []string) (columnPhysicalVisibilityResult, error) {
+	return c.scanColumnPhysicalVisibleRowsWithReadIntegrity(projected, ColumnAssetReadIntegrityVerify)
+}
+
+func (c *Collection) scanColumnPhysicalVisibleRowsWithReadIntegrity(projected []string, readIntegrity ColumnAssetReadIntegrity) (columnPhysicalVisibilityResult, error) {
 	if c == nil {
 		return columnPhysicalVisibilityResult{}, errCollectionNil
 	}
@@ -53,7 +57,7 @@ func (c *Collection) scanColumnPhysicalVisibleRows(projected []string) (columnPh
 	if cfgPtr != nil {
 		cfg = cfgPtr.copy()
 	}
-	return c.scanColumnPhysicalVisibleRowsAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, projected)
+	return c.scanColumnPhysicalVisibleRowsAtSnapshotWithReadIntegrity(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, projected, readIntegrity)
 }
 
 func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshot(
@@ -65,7 +69,20 @@ func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshot(
 	columnStoreEnabled bool,
 	projected []string,
 ) (columnPhysicalVisibilityResult, error) {
-	return c.scanColumnPhysicalVisibleRowsAtSnapshotForTargets(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, nil, projected)
+	return c.scanColumnPhysicalVisibleRowsAtSnapshotWithReadIntegrity(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, projected, ColumnAssetReadIntegrityVerify)
+}
+
+func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshotWithReadIntegrity(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	collectionName string,
+	rootID uint64,
+	cfg ColumnStoreConfig,
+	columnStoreEnabled bool,
+	projected []string,
+	readIntegrity ColumnAssetReadIntegrity,
+) (columnPhysicalVisibilityResult, error) {
+	return c.scanColumnPhysicalVisibleRowsAtSnapshotForTargetsWithReadIntegrity(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, nil, projected, readIntegrity)
 }
 
 func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshotForTargets(
@@ -78,9 +95,24 @@ func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshotForTargets(
 	targets *columnPhysicalVisibilityTargetIDs,
 	projected []string,
 ) (columnPhysicalVisibilityResult, error) {
+	return c.scanColumnPhysicalVisibleRowsAtSnapshotForTargetsWithReadIntegrity(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, targets, projected, ColumnAssetReadIntegrityVerify)
+}
+
+func (c *Collection) scanColumnPhysicalVisibleRowsAtSnapshotForTargetsWithReadIntegrity(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	collectionName string,
+	rootID uint64,
+	cfg ColumnStoreConfig,
+	columnStoreEnabled bool,
+	targets *columnPhysicalVisibilityTargetIDs,
+	projected []string,
+	readIntegrity ColumnAssetReadIntegrity,
+) (columnPhysicalVisibilityResult, error) {
 	var latest columnPhysicalVisibilityIndex
 	diag, err := c.scanColumnPhysicalRowsAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, columnPhysicalScanRequest{
 		ProjectedColumns: projected,
+		ReadIntegrity:    readIntegrity,
 		Visitor: func(row columnPhysicalScanRowView) error {
 			if targets != nil && !targets.contains(row.ID) {
 				return nil

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -116,6 +116,16 @@ const (
 	ColumnStoreProfileBenchmarkRelaxed ColumnStoreProfileSupport = "benchmark-relaxed"
 )
 
+// ColumnAssetReadIntegrity controls hot physical column asset payload checksum
+// verification. It does not change durability, manifest validation, or the
+// checksum fields written into typed column asset refs.
+type ColumnAssetReadIntegrity string
+
+const (
+	ColumnAssetReadIntegrityVerify        ColumnAssetReadIntegrity = "verify"
+	ColumnAssetReadIntegritySkipChecksums ColumnAssetReadIntegrity = "skip_checksums"
+)
+
 type ColumnStoreConfig struct {
 	Enabled                                bool                          `json:"enabled,omitempty"`
 	Columns                                []ColumnStoreColumn           `json:"columns,omitempty"`

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -134,6 +134,7 @@ Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
 - `-treedb-bg-vacuum-interval` TreeDB: background index vacuum interval (0=disabled)
 - `-treedb-bg-vacuum-span-ppm` TreeDB: background index vacuum span ratio threshold (ppm), `0`=default
 - `-treedb-allow-unsafe` TreeDB: allow unsafe durability/integrity options (required for unsafe toggles)
+- `-column-store-asset-read-integrity` column-store typed asset hot-read integrity for `-suite column_store` physical paths (`verify|skip_checksums`). `skip_checksums` requires `-treedb-allow-unsafe`; when unset, `-treedb-disable-read-checksum` also disables typed column-asset hot-read CRC verification for the suite.
 - `-treedb-vlog-dict` TreeDB: value-log dict compression mode (`default|on|off|both`)
 - `-treedb-vlog-rewrite-min-segment-age-ms` TreeDB: minimum source segment age for online generational rewrite (`0`=default)
 - `-treedb-vlog-dict-frame-encode-level` TreeDB: dict frame zstd encoder level (`engine|fastest|default|better|best|all|<int>`)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -75,8 +75,9 @@ var (
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 		columnStoreSuitePathList(columnStoreSuiteExecutableForcedPaths),
 	)
-	columnStoreSuitePathArg    = flag.String("column-store-path", columnStorePathRowStoreBaseline, columnStoreSuitePathUsage)
-	columnStoreSuiteFixtureArg = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
+	columnStoreSuitePathArg               = flag.String("column-store-path", columnStorePathRowStoreBaseline, columnStoreSuitePathUsage)
+	columnStoreSuiteFixtureArg            = flag.String("column-store-fixture", "synthetic", "Fixture for -suite column_store (synthetic; JSONBENCH_DATA mode is reserved for the large local gate)")
+	columnStoreSuiteAssetReadIntegrityArg = flag.String("column-store-asset-read-integrity", string(collections.ColumnAssetReadIntegrityVerify), "Column asset hot-read integrity for -suite column_store physical paths (verify, skip_checksums; skip_checksums is unsafe and requires -treedb-allow-unsafe)")
 
 	columnStoreSuiteAcceptedForcedPaths = []string{
 		columnStorePathRowStoreBaseline,
@@ -102,39 +103,41 @@ var (
 )
 
 type columnStoreSuiteOptions struct {
-	ProfileDir              string
-	ExecutionPath           string
-	ForcedPath              string
-	Fixture                 string
-	RunBenchprof            bool
-	CorruptReferenceForTest string
+	ProfileDir               string
+	ExecutionPath            string
+	ForcedPath               string
+	Fixture                  string
+	ColumnAssetReadIntegrity collections.ColumnAssetReadIntegrity
+	RunBenchprof             bool
+	CorruptReferenceForTest  string
 }
 
 type columnStoreSuiteReport struct {
-	GeneratedAt            string                       `json:"generated_at"`
-	Suite                  string                       `json:"suite"`
-	Profile                string                       `json:"profile"`
-	Fixture                string                       `json:"fixture"`
-	DataDir                string                       `json:"data_dir,omitempty"`
-	PathLabel              string                       `json:"path_label,omitempty"`
-	ForcedPath             string                       `json:"forced_path"`
-	Rows                   int                          `json:"rows"`
-	BatchSize              int                          `json:"batch_size"`
-	Seed                   int64                        `json:"seed"`
-	CacheLabel             string                       `json:"cache_label"`
-	AcceptedForcedPaths    []string                     `json:"accepted_forced_paths"`
-	FailClosedForcedPaths  []string                     `json:"fail_closed_forced_paths"`
-	Stages                 []columnStoreStageMetric     `json:"stages"`
-	Queries                []columnStoreQueryMetric     `json:"queries"`
-	Parity                 map[string]columnStoreParity `json:"parity"`
-	ByteAccounting         columnStoreByteAccounting    `json:"byte_accounting"`
-	Manifest               columnStoreManifestMetric    `json:"manifest"`
-	Artifacts              columnStoreArtifactPaths     `json:"artifacts,omitempty"`
-	ProductionScope        string                       `json:"production_scope"`
-	PhysicalColumnQuery    string                       `json:"physical_column_query"`
-	BenchmarkOnlyRelaxed   bool                         `json:"benchmark_only_relaxed"`
-	StageSeparatedBoundary string                       `json:"stage_separated_boundary"`
-	ProfileFinalizeError   string                       `json:"profile_finalize_error,omitempty"`
+	GeneratedAt              string                       `json:"generated_at"`
+	Suite                    string                       `json:"suite"`
+	Profile                  string                       `json:"profile"`
+	Fixture                  string                       `json:"fixture"`
+	DataDir                  string                       `json:"data_dir,omitempty"`
+	PathLabel                string                       `json:"path_label,omitempty"`
+	ForcedPath               string                       `json:"forced_path"`
+	Rows                     int                          `json:"rows"`
+	BatchSize                int                          `json:"batch_size"`
+	Seed                     int64                        `json:"seed"`
+	CacheLabel               string                       `json:"cache_label"`
+	AcceptedForcedPaths      []string                     `json:"accepted_forced_paths"`
+	FailClosedForcedPaths    []string                     `json:"fail_closed_forced_paths"`
+	Stages                   []columnStoreStageMetric     `json:"stages"`
+	Queries                  []columnStoreQueryMetric     `json:"queries"`
+	Parity                   map[string]columnStoreParity `json:"parity"`
+	ByteAccounting           columnStoreByteAccounting    `json:"byte_accounting"`
+	Manifest                 columnStoreManifestMetric    `json:"manifest"`
+	Artifacts                columnStoreArtifactPaths     `json:"artifacts,omitempty"`
+	ProductionScope          string                       `json:"production_scope"`
+	PhysicalColumnQuery      string                       `json:"physical_column_query"`
+	ColumnAssetReadIntegrity string                       `json:"column_asset_read_integrity"`
+	BenchmarkOnlyRelaxed     bool                         `json:"benchmark_only_relaxed"`
+	StageSeparatedBoundary   string                       `json:"stage_separated_boundary"`
+	ProfileFinalizeError     string                       `json:"profile_finalize_error,omitempty"`
 }
 
 type columnStoreStageMetric struct {
@@ -298,6 +301,10 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if _, err := columnStoreSuitePlanKind(forcedPath); err != nil {
 		return "", err
 	}
+	assetReadIntegrity, err := columnStoreSuiteEffectiveAssetReadIntegrity(opts.ColumnAssetReadIntegrity)
+	if err != nil {
+		return "", err
+	}
 	if err := validateColumnStoreSuiteDBSelection(baseCfg.DBsArg, baseCfg.DBsExcludeArg); err != nil {
 		return "", err
 	}
@@ -426,7 +433,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		}
 		rawHashes[corrupt]++
 	}
-	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(baseCfg, collection, rows, rawHashes, forcedPath)
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(baseCfg, collection, rows, rawHashes, forcedPath, assetReadIntegrity)
 	if err != nil {
 		return "", err
 	}
@@ -501,10 +508,11 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			ManifestRoot:                    manifestIdentity.ManifestRoot,
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
-		ProductionScope:        "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
-		PhysicalColumnQuery:    "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q4b and q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
-		BenchmarkOnlyRelaxed:   false,
-		StageSeparatedBoundary: "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, physical scan/reducer execution, row/B-tree reduce, and parity hash stages are timed separately for the forced execution label; M14B direct physical reducers are fused into scan timing unless visibility reconstruction reports a separate reduce phase",
+		ProductionScope:          "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
+		PhysicalColumnQuery:      "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q4b and q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
+		ColumnAssetReadIntegrity: string(assetReadIntegrity),
+		BenchmarkOnlyRelaxed:     assetReadIntegrity == collections.ColumnAssetReadIntegritySkipChecksums,
+		StageSeparatedBoundary:   "fixture generation, collection create, insert, checkpoint, reopen/recovery, planner, physical scan/reducer execution, row/B-tree reduce, and parity hash stages are timed separately for the forced execution label; M14B direct physical reducers are fused into scan timing unless visibility reconstruction reports a separate reduce phase",
 	}
 	if baseCfg.KeepDir {
 		report.DataDir = dataDir
@@ -547,6 +555,30 @@ func columnStoreSuiteEffectiveProfile(profile string) (string, error) {
 		return "", fmt.Errorf("column_store: profile %q is benchmark-relaxed and unsupported for M11B production column-store writes; use -profile durable", profile)
 	default:
 		return "", fmt.Errorf("column_store: unsupported profile %q; use durable for the M11B production gate", profile)
+	}
+}
+
+func columnStoreSuiteEffectiveAssetReadIntegrity(opt collections.ColumnAssetReadIntegrity) (collections.ColumnAssetReadIntegrity, error) {
+	value := strings.ToLower(strings.TrimSpace(string(opt)))
+	if value == "" {
+		if flagExplicit("column-store-asset-read-integrity") {
+			value = strings.ToLower(strings.TrimSpace(*columnStoreSuiteAssetReadIntegrityArg))
+		} else if *treedbDisableReadChecksum {
+			value = string(collections.ColumnAssetReadIntegritySkipChecksums)
+		} else {
+			value = strings.ToLower(strings.TrimSpace(*columnStoreSuiteAssetReadIntegrityArg))
+		}
+	}
+	switch value {
+	case "", string(collections.ColumnAssetReadIntegrityVerify):
+		return collections.ColumnAssetReadIntegrityVerify, nil
+	case string(collections.ColumnAssetReadIntegritySkipChecksums), "skip-checksums", "none":
+		if !*treedbAllowUnsafe {
+			return "", errors.New("column_store: column asset read integrity skip_checksums requires -treedb-allow-unsafe")
+		}
+		return collections.ColumnAssetReadIntegritySkipChecksums, nil
+	default:
+		return "", fmt.Errorf("column_store: unsupported column asset read integrity %q; use verify or skip_checksums", value)
 	}
 }
 
@@ -920,7 +952,7 @@ func startColumnStoreSuiteRuntimeProfiles(cfg BenchConfig) (func() error, error)
 	return finish, nil
 }
 
-func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
+func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections.Collection, rows int, rawHashes map[string]uint64, path string, assetReadIntegrity collections.ColumnAssetReadIntegrity) ([]columnStoreQueryMetric, map[string]columnStoreParity, error, error) {
 	profileHooks := profileHooksFromConfig(cfg)
 	cleanup := func(paths ...string) {
 		for _, path := range paths {
@@ -974,7 +1006,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 		}
 	}
 
-	queries, parity, runErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, path)
+	queries, parity, runErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, path, assetReadIntegrity)
 
 	if cpuFile != nil {
 		profileHooks.stopCPUProfile()
@@ -1036,7 +1068,7 @@ func runColumnStoreSuiteQueriesProfiled(cfg BenchConfig, collection *collections
 	return queries, parity, runErr, nil
 }
 
-func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, rawHashes map[string]uint64, path string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
+func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, rawHashes map[string]uint64, path string, assetReadIntegrity collections.ColumnAssetReadIntegrity) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
 	path = normalizeColumnStoreSuitePath(path)
 	forceKind, err := columnStoreSuitePlanKind(path)
 	if err != nil {
@@ -1061,7 +1093,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			return nil, nil, fmt.Errorf("column_store: forced path %q unsupported for %s: refusing to route through row store; reason=%s: %w", path, name, reason, collections.ErrColumnQueryPlanUnsupported)
 		}
 
-		exec, err := executeColumnStoreSuiteQueryWithPlan(collection, rows, name, plan)
+		exec, err := executeColumnStoreSuiteQueryWithPlan(collection, rows, name, plan, assetReadIntegrity)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1175,7 +1207,7 @@ func columnStoreSuiteAggregateMetadataName(name string) string {
 	}
 }
 
-func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, rows int, queryName string, plan collections.ColumnQueryPlan) (columnStoreQueryExecution, error) {
+func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, rows int, queryName string, plan collections.ColumnQueryPlan, assetReadIntegrity collections.ColumnAssetReadIntegrity) (columnStoreQueryExecution, error) {
 	switch plan.Kind {
 	case collections.ColumnQueryPlanRowStoreBaseline:
 		scanStart := time.Now()
@@ -1234,13 +1266,13 @@ func executeColumnStoreSuiteQueryWithPlan(collection *collections.Collection, ro
 			ReduceDuration:         reduceElapsed,
 		}, nil
 	case collections.ColumnQueryPlanSerialColumnScan, collections.ColumnQueryPlanAggregateMetadata, collections.ColumnQueryPlanParallelColumnScan:
-		return executeColumnStoreSuitePhysicalQuery(collection, queryName, plan)
+		return executeColumnStoreSuitePhysicalQuery(collection, queryName, plan, assetReadIntegrity)
 	default:
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: executable path %q is not implemented: %w", plan.Kind, collections.ErrColumnQueryPlanUnsupported)
 	}
 }
 
-func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, queryName string, plan collections.ColumnQueryPlan) (columnStoreQueryExecution, error) {
+func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, queryName string, plan collections.ColumnQueryPlan, assetReadIntegrity collections.ColumnAssetReadIntegrity) (columnStoreQueryExecution, error) {
 	req, err := columnStoreSuitePhysicalQueryRequest(queryName)
 	if err != nil {
 		return columnStoreQueryExecution{}, err
@@ -1250,6 +1282,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	} else {
 		req.AggregateMetadataName = ""
 	}
+	req.ColumnAssetReadIntegrity = assetReadIntegrity
 	start := time.Now()
 	var result collections.ColumnPhysicalQueryResult
 	switch plan.Kind {
@@ -1808,6 +1841,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString(fmt.Sprintf("- rows: %s\n", formatInt(report.Rows)))
 	sb.WriteString(fmt.Sprintf("- batchsize: %s\n", formatInt(report.BatchSize)))
 	sb.WriteString(fmt.Sprintf("- forced path: `%s`\n", report.ForcedPath))
+	sb.WriteString(fmt.Sprintf("- column asset read integrity: `%s`\n", report.ColumnAssetReadIntegrity))
 	if report.DataDir != "" {
 		sb.WriteString(fmt.Sprintf("- data-dir: `%s`\n", report.DataDir))
 	}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -49,6 +49,96 @@ func TestColumnStoreSuiteRetainedPayloadRejectsTrailingJSONM13C(t *testing.T) {
 	}
 }
 
+func TestRunColumnStoreSuiteRejectsRelaxedAssetReadIntegrityWithoutUnsafeM1634(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{
+		Keys:      16,
+		BatchSize: 8,
+		DBsArg:    "treedb",
+		Profile:   "durable",
+		Progress:  false,
+		SeedUsed:  1,
+	}
+	prevAllowUnsafe := *treedbAllowUnsafe
+	prevIntegrity := *columnStoreSuiteAssetReadIntegrityArg
+	*treedbAllowUnsafe = false
+	*columnStoreSuiteAssetReadIntegrityArg = "skip_checksums"
+	t.Cleanup(func() {
+		*treedbAllowUnsafe = prevAllowUnsafe
+		*columnStoreSuiteAssetReadIntegrityArg = prevIntegrity
+	})
+	if _, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:    dir,
+		ExecutionPath: "native-fastpath",
+		ForcedPath:    columnStorePathSerialColumnScan,
+	}); err == nil || !strings.Contains(err.Error(), "requires -treedb-allow-unsafe") {
+		t.Fatalf("runColumnStoreSuite relaxed read integrity err=%v want unsafe rejection", err)
+	}
+}
+
+func TestRunColumnStoreSuiteReportsRelaxedAssetReadIntegrityM1634(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{
+		Keys:      16,
+		BatchSize: 8,
+		DBsArg:    "treedb",
+		Profile:   "durable",
+		Progress:  false,
+		SeedUsed:  1,
+	}
+	prevAllowUnsafe := *treedbAllowUnsafe
+	*treedbAllowUnsafe = true
+	t.Cleanup(func() { *treedbAllowUnsafe = prevAllowUnsafe })
+	if _, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:               dir,
+		ExecutionPath:            "native-fastpath",
+		ForcedPath:               columnStorePathSerialColumnScan,
+		ColumnAssetReadIntegrity: collections.ColumnAssetReadIntegritySkipChecksums,
+	}); err != nil {
+		t.Fatalf("runColumnStoreSuite relaxed read integrity: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if err != nil {
+		t.Fatalf("read column_store_results.json: %v", err)
+	}
+	var report columnStoreSuiteReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal column_store_results.json: %v", err)
+	}
+	if got, want := report.ColumnAssetReadIntegrity, string(collections.ColumnAssetReadIntegritySkipChecksums); got != want {
+		t.Fatalf("column_asset_read_integrity=%q want %q", got, want)
+	}
+}
+
+func TestColumnStoreSuiteInheritsTreeDBDisableReadChecksumM1634(t *testing.T) {
+	prevAllowUnsafe := *treedbAllowUnsafe
+	prevDisableReadChecksum := *treedbDisableReadChecksum
+	prevIntegrity := *columnStoreSuiteAssetReadIntegrityArg
+	*treedbAllowUnsafe = true
+	*treedbDisableReadChecksum = true
+	*columnStoreSuiteAssetReadIntegrityArg = string(collections.ColumnAssetReadIntegrityVerify)
+	t.Cleanup(func() {
+		*treedbAllowUnsafe = prevAllowUnsafe
+		*treedbDisableReadChecksum = prevDisableReadChecksum
+		*columnStoreSuiteAssetReadIntegrityArg = prevIntegrity
+	})
+
+	got, err := columnStoreSuiteEffectiveAssetReadIntegrity("")
+	if err != nil {
+		t.Fatalf("columnStoreSuiteEffectiveAssetReadIntegrity: %v", err)
+	}
+	if got != collections.ColumnAssetReadIntegritySkipChecksums {
+		t.Fatalf("column asset read integrity=%q want inherited %q", got, collections.ColumnAssetReadIntegritySkipChecksums)
+	}
+	got, err = columnStoreSuiteEffectiveAssetReadIntegrity(collections.ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		t.Fatalf("explicit verify integrity: %v", err)
+	}
+	if got != collections.ColumnAssetReadIntegrityVerify {
+		t.Fatalf("explicit column asset read integrity=%q want verify override", got)
+	}
+}
+
 func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	dir := t.TempDir()
 	cfg := BenchConfig{
@@ -834,7 +924,7 @@ func TestColumnStoreSuiteCPUProfileStartsAfterProfileBaselinesM11A(t *testing.T)
 		MutexProfile:         filepath.Join(profileTmpDir, "mutex.pprof"),
 		MutexProfileFraction: 1,
 		profileHooks:         profileHooks,
-	}, collection, len(fixture), rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(fixture), rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err != nil {
 		t.Fatalf("profiled queries: %v", err)
 	}
@@ -978,7 +1068,7 @@ func TestColumnStoreSuiteCPUProfileStartFailureRemovesArtifactM11A(t *testing.T)
 	_, _, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
 		CPUProfile:   profilePrefix,
 		profileHooks: profileHooks,
-	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err == nil {
 		t.Fatal("expected CPU profile start failure")
 	}
@@ -1030,7 +1120,7 @@ func TestColumnStoreSuiteHardQueryFailureRemovesCPUArtifactM11A(t *testing.T) {
 	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
 		CPUProfile:   profilePrefix,
 		profileHooks: profileHooks,
-	}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err == nil {
 		t.Fatal("expected hard query error")
 	}
@@ -1062,7 +1152,7 @@ func TestColumnStoreSuiteRuntimeDeltaSkipsEmptyOutputM11A(t *testing.T) {
 	_, _, _, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{
 		BlockProfile: blockPath,
 		profileHooks: profileHooks,
-	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err != nil {
 		t.Fatalf("empty block delta output should be skipped: %v", err)
 	}
@@ -1114,7 +1204,7 @@ func TestColumnStoreSuiteProfiledQueriesSkipWhitespaceOnlyRuntimeProfilePathsM11
 		BlockProfile: " \t ",
 		MutexProfile: " \n ",
 		profileHooks: profileHooks,
-	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err != nil || parityErr != nil {
 		t.Fatalf("whitespace-only runtime profiles should be ignored: err=%v parityErr=%v", err, parityErr)
 	}
@@ -1141,7 +1231,7 @@ func TestColumnStoreSuiteProfiledQueriesTrimAllocsDeltaPathM11A(t *testing.T) {
 		AllocsProfile:     " \t" + allocsPrefix + "\t ",
 		AllocsProfileRate: 1,
 		profileHooks:      profileHooks,
-	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline)
+	}, collection, len(events), rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err != nil || parityErr != nil {
 		t.Fatalf("profiled queries failed: err=%v parityErr=%v", err, parityErr)
 	}
@@ -1248,7 +1338,7 @@ func TestColumnStoreSuiteArtifactsPreserveRuntimeDeltaStatErrorsM11A(t *testing.
 
 func TestColumnStoreSuiteProfiledQueriesReturnHardErrorsSeparatelyM11A(t *testing.T) {
 	collection, events, rawHashes := newColumnStoreSuiteTestCollectionM11A(t, 4, 2)
-	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline)
+	queries, parity, parityErr, err := runColumnStoreSuiteQueriesProfiled(BenchConfig{}, collection, len(events)+1, rawHashes, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 	if err == nil {
 		t.Fatal("expected hard query error")
 	}
@@ -1647,7 +1737,7 @@ func TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reference hashes: %v", err)
 	}
-	queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, "row")
+	queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, "row", collections.ColumnAssetReadIntegrityVerify)
 	if err != nil {
 		t.Fatalf("runColumnStoreSuiteQueries row alias: %v", err)
 	}
@@ -1698,7 +1788,7 @@ func TestColumnStoreSuiteQueriesNormalizeForcedPathAliasesM11B(t *testing.T) {
 		if got != want {
 			t.Fatalf("columnStoreSuitePlanKind(%q)=%q want %q", alias, got, want)
 		}
-		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, alias)
+		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, alias, collections.ColumnAssetReadIntegrityVerify)
 		if err != nil {
 			t.Fatalf("physical alias %q: %v", alias, err)
 		}
@@ -1772,7 +1862,7 @@ func TestColumnStoreSuitePhysicalPathFailsClosedOnMissingAssetsM14B(t *testing.T
 	if err != nil {
 		t.Fatalf("reopen collection after asset removal: %v", err)
 	}
-	_, _, err = runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathSerialColumnScan)
+	_, _, err = runColumnStoreSuiteQueries(collection, rows, rawHashes, columnStorePathSerialColumnScan, collections.ColumnAssetReadIntegrityVerify)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("missing physical assets err=%v want os.ErrNotExist without row fallback", err)
 	}
@@ -2062,26 +2152,34 @@ func TestColumnStoreSuiteREADMEDocumentsCommandM11A(t *testing.T) {
 }
 
 func BenchmarkColumnStoreSuiteRowBaselineQueriesM11B(b *testing.B) {
-	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathRowStoreBaseline)
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathRowStoreBaseline, collections.ColumnAssetReadIntegrityVerify)
 }
 
 func BenchmarkColumnStoreSuiteBTreeIndexBaselineQueriesM11B(b *testing.B) {
-	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathBTreeIndexBaseline)
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathBTreeIndexBaseline, collections.ColumnAssetReadIntegrityVerify)
 }
 
 func BenchmarkColumnStoreSuiteSerialPhysicalQueriesM14C(b *testing.B) {
-	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathSerialColumnScan)
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathSerialColumnScan, collections.ColumnAssetReadIntegrityVerify)
+}
+
+func BenchmarkColumnStoreSuiteSerialPhysicalQueriesSkipChecksumsM1634(b *testing.B) {
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathSerialColumnScan, collections.ColumnAssetReadIntegritySkipChecksums)
 }
 
 func BenchmarkColumnStoreSuiteAggregateMetadataQueriesM14C(b *testing.B) {
-	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathAggregateMetadata)
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathAggregateMetadata, collections.ColumnAssetReadIntegrityVerify)
+}
+
+func BenchmarkColumnStoreSuiteAggregateMetadataQueriesSkipChecksumsM1634(b *testing.B) {
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathAggregateMetadata, collections.ColumnAssetReadIntegritySkipChecksums)
 }
 
 func BenchmarkColumnStoreSuiteParallelPhysicalQueriesM14C(b *testing.B) {
-	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathParallelColumnScan)
+	benchmarkColumnStoreSuiteQueriesM11B(b, columnStorePathParallelColumnScan, collections.ColumnAssetReadIntegrityVerify)
 }
 
-func benchmarkColumnStoreSuiteQueriesM11B(b *testing.B, path string) {
+func benchmarkColumnStoreSuiteQueriesM11B(b *testing.B, path string, readIntegrity collections.ColumnAssetReadIntegrity) {
 	const rows = 10_000
 	const batchSize = 1_000
 
@@ -2128,7 +2226,7 @@ func benchmarkColumnStoreSuiteQueriesM11B(b *testing.B, path string) {
 	b.SetBytes(sourceBytes * int64(queryCount))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, path)
+		queries, parity, err := runColumnStoreSuiteQueries(collection, rows, rawHashes, path, readIntegrity)
 		if err != nil {
 			b.Fatalf("queries: %v", err)
 		}


### PR DESCRIPTION
Refs #1634.

## Summary

This PR adds an explicit typed-column-asset hot-read integrity mode for the column-store physical read path:

- default remains `verify`, preserving current checksum validation behavior;
- `skip_checksums` skips hot `ColumnAssetRef` payload CRC validation for typed column asset reads only;
- `skip_checksums` requires `-treedb-allow-unsafe` in `unified-bench` and is reported in JSON/Markdown/HTML artifacts;
- `-treedb-disable-read-checksum` now also applies to column-store typed asset hot reads when no column-specific override is set;
- checksums are still written into refs/metadata, and manifest/reopen/recovery validation remains strict.

This does not change WAL/checkpoint/root durability semantics, physical asset layout, planner routing, mmap behavior, metadata assets, marks, dictionaries, locators, GC/rewrite, or row/leaf value-log read integrity outside the existing TreeDB option.

## Performance / Benchmark Evidence

Machine: Apple M3, darwin/arm64. Head: `e1b5c711a` on `codex/column-store-relaxed-read-integrity`, based on #1660 head `e5beac5a5`.

100K routed production `serial_column_scan`, durable profile, native-fastpath, strict vs inherited `skip_checksums` via `-treedb-disable-read-checksum`:

| query | verify rows/s | skip rows/s | delta | verify ns/row | skip ns/row |
|---|---:|---:|---:|---:|---:|
| q1 | 12.00M | 12.95M | +7.87% | 83.3 | 77.2 |
| q2 | 9.20M | 10.32M | +12.08% | 108.6 | 96.9 |
| q3 | 18.49M | 24.74M | +33.84% | 54.1 | 40.4 |
| q4a | 10.24M | 12.74M | +24.40% | 97.7 | 78.5 |
| q4b | 10.37M | 11.98M | +15.57% | 96.5 | 83.5 |
| q5 | 9.23M | 10.80M | +17.02% | 108.3 | 92.6 |
| q5_metadata alias | 9.25M | 10.77M | +16.47% | 108.1 | 92.8 |

100K routed production `aggregate_metadata`, durable profile:

| query | executed plan | verify rows/s | skip rows/s | delta | metadata hits | bytes/read |
|---|---|---:|---:|---:|---:|---:|
| q1 | serial scan reroute | 11.42M | 13.54M | +18.55% | 0 | 10,404,660 |
| q2 | serial scan reroute | 8.88M | 10.40M | +17.14% | 0 | 10,404,660 |
| q3 | serial scan reroute | 18.11M | 22.92M | +26.59% | 0 | 10,404,660 |
| q4a | serial scan reroute | 10.23M | 11.99M | +17.25% | 0 | 10,404,660 |
| q4b | aggregate metadata | 57.57M | 58.48M | +1.57% | 20 | 801,720 |
| q5 | serial scan reroute | 9.48M | 10.55M | +11.26% | 0 | 10,404,660 |
| q5_metadata | aggregate metadata | 85.61M | 99.59M | +16.32% | 20 | 801,720 |

Package benchmark (`go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueries|SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueries|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=1`):

| benchmark | ns/op | MB/s | rows/op | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| Serial verify | 8,327,192 | 787.55 | 70,000 | 2,745,755 | 29,639 |
| Serial skip | 7,752,983 | 845.88 | 70,000 | 2,747,192 | 29,639 |
| Aggregate verify | 6,820,492 | 961.53 | 70,000 | 3,192,104 | 45,606 |
| Aggregate skip | 6,380,933 | 1027.76 | 70,000 | 3,330,590 | 45,609 |

Byte accounting for representative 100K routed runs remains stable: `retained_payload_bytes=3368750`, `column_asset_bytes=12008100`, `column_asset_store_bytes=12008100`, `manifest_control_bytes=28`, `ordinary_value_vlog_bytes=0`, `leaf_vlog_bytes=2279912`, `command_wal_bytes_before_checkpoint=11172332`, and `db_total_bytes=25985056`.

## Granule / ClickHouse Context

Fresh #1660 same-machine granule-kernel context remains the comparison baseline for this q1-q5 family, not a pass/fail gate for this PR:

| query family | experiment baseline |
|---|---:|
| Q1 encoded reducer | `418.77M rows/s`, `2.388 ns/row`, `2377 B/op`, `5 allocs/op` |
| Q2 encoded reducer | `241.75M rows/s`, `4.136 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q3 encoded reducer | `195.30M rows/s`, `5.120 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q4b ClickHouse-order row scan | `91.46M rows/s`, `10.93 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 encoded reducer | `141.81M rows/s`, `7.052 ns/row`, `2440 B/op`, `5 allocs/op` |
| Q4b metadata | `307.95M rows/s`, `3.247 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 metadata | `420.58M rows/s`, `2.378 ns/row`, `96 B/op`, `2 allocs/op` |

ClickHouse-equivalent context is historical/local from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1M JSONBench rows on local ClickHouse `26.4.3.1` / Darwin arm64:

| query | granule-kernel best | ClickHouse local | kernel / ClickHouse |
|---|---:|---:|---:|
| Q1 | `0.004284s` | `0.014000s` | `0.31x` |
| Q2 | `0.038895s` | `0.027000s` | `1.44x` |
| Q3 | `0.006631s` | `0.014000s` | `0.47x` |
| Q4 | `0.009869s` | `0.013000s` | `0.76x` |
| Q5 | `0.010027s` | `0.013000s` | `0.77x` |

## Throughput Interpretation

Skipping hot typed column-asset CRC is a measured read-path win for full serial physical scans, which confirms checksum validation was a material part of the remaining `pread`/asset-manager overhead. It is not a durability mode: durable still means WAL/checkpoint/root publication ordering, while this flag only weakens hot-read corruption detection after refs and assets have been published.

The metadata path gains less for q4b because it reads only `801,720` bytes through aggregate metadata assets instead of the full `10,404,660` byte TCPA scan. q5_metadata still benefits more because the fixed adapter/reporting cost is lower and the metadata asset read path is more CRC-sensitive in this sample.

The package benchmark allocation counts are unchanged for serial scan and essentially unchanged for aggregate metadata. This PR is a CPU/read-integrity wedge, not an allocation cleanup. The next mmap/view-reader work should compare against this `skip_checksums` mode so it does not attribute CRC cost to `pread`/copy.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnAssetManagerWritesIsolatedSegmentAndValidatesM12A|TestColumnPhysical' -count=1` passed.
- `go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteRejectsRelaxedAssetReadIntegrityWithoutUnsafeM1634|TestRunColumnStoreSuiteReportsRelaxedAssetReadIntegrityM1634|TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A|TestColumnStoreSuitePhysicalForcedPathsProduceNoRowMaterializationM14B' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueries|SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueries|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=1` passed.
- `git diff --check` passed.

## Artifacts

- Serial verify: `/tmp/gomap_1634_relaxed_serial_verify_LcTtPn`
- Serial skip: `/tmp/gomap_1634_relaxed_serial_skip_ae0FwK`
- Aggregate verify: `/tmp/gomap_1634_relaxed_metadata_verify_v2Mz9s`
- Aggregate skip: `/tmp/gomap_1634_relaxed_metadata_skip_cdux08`
- Representative HTML reports:
  - `/tmp/gomap_1634_relaxed_serial_verify_LcTtPn/column_store_results.html`
  - `/tmp/gomap_1634_relaxed_serial_skip_ae0FwK/column_store_results.html`
  - `/tmp/gomap_1634_relaxed_metadata_verify_v2Mz9s/column_store_results.html`
  - `/tmp/gomap_1634_relaxed_metadata_skip_cdux08/column_store_results.html`
