### PR TITLE
[codex] stage no-index BSON updates behind command WAL

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -111,6 +111,8 @@ var (
 	)
 )
 
+var testBeforeCommandWALBufferedUpdateStageLock func()
+
 // CommitAmbiguousError reports that a collection mutation reached its logical
 // commit point before a later visibility, flush, checkpoint, response, or
 // bookkeeping step failed. The operation may already be visible or recoverable;
@@ -12844,6 +12846,9 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					}
 					plan.bufferedCommandWALIntent = intent
 					if c.db != nil {
+						if testBeforeCommandWALBufferedUpdateStageLock != nil {
+							testBeforeCommandWALBufferedUpdateStageLock()
+						}
 						unlockCommandWALRawStage = c.db.LockCommandWALStaging()
 						defer unlockCommandWALRawStage()
 					}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -978,7 +978,7 @@ type collectionWriteDomain struct {
 	baseSystemRoot           uint64
 	primaryRoot              uint64
 	storagePolicy            backenddb.OrderedRootStoragePolicy
-	commandWALCoordinator    *collectionCommandWALCoordinator
+	commandWALCoordinator    atomic.Pointer[collectionCommandWALCoordinator]
 	table                    memtable.Table
 	indexedPublishingUnits   []indexedFlushUnit
 	indexedFlushUnits        []indexedFlushUnit
@@ -2448,15 +2448,15 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 		m.domains = make(map[string]*collectionWriteDomain)
 	}
 	if domain := m.domains[name]; domain != nil {
-		if domain.commandWALCoordinator == nil {
-			domain.commandWALCoordinator = m.commandWALCoordinator
+		if domain.commandWALCoordinator.Load() == nil {
+			domain.commandWALCoordinator.Store(m.commandWALCoordinator)
 		}
 		return domain
 	}
 	domain := &collectionWriteDomain{
-		commandWALCoordinator: m.commandWALCoordinator,
-		updateCombineShards:   defaultCollectionUpdateCombineShards,
+		updateCombineShards: defaultCollectionUpdateCombineShards,
 	}
+	domain.commandWALCoordinator.Store(m.commandWALCoordinator)
 	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
 	m.domains[name] = domain
 	return domain
@@ -7749,6 +7749,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.mutableBytes = 0
 	if commandWALAppliedLSN != 0 {
 		domain.clearPendingCommandWALThroughLocked(commandWALAppliedLSN)
+		domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
 	}
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1155,10 +1155,12 @@ func (m *CollectionManager) SetUpdateBatchDetailedStatsEnabled(enabled bool) {
 
 func (m *CollectionManager) closeForBackend() error {
 	m.closing.Store(true)
-	if m.commandWALRawUnregister != nil {
-		m.commandWALRawUnregister()
-		m.commandWALRawUnregister = nil
-	}
+	defer func() {
+		if m.commandWALRawUnregister != nil {
+			m.commandWALRawUnregister()
+			m.commandWALRawUnregister = nil
+		}
+	}()
 	m.stopUpdateCombiners()
 	return m.FlushAll()
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -155,6 +155,17 @@ func (e *CommitAmbiguousError) Is(target error) bool {
 	return target == ErrCommitAmbiguous
 }
 
+func commandWALBufferedUpdateCommitAmbiguous(err error) error {
+	if err == nil {
+		return nil
+	}
+	var ambiguous *CommitAmbiguousError
+	if errors.As(err, &ambiguous) {
+		return err
+	}
+	return &CommitAmbiguousError{Operation: "command WAL buffered update", Err: err}
+}
+
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
 // non-empty and unique within the batch. Update receives the current stored
 // document bytes and returns the replacement document bytes in the same format
@@ -2242,7 +2253,7 @@ func setTestBeforeCommandWALBufferedUpdateStageLockForTest(fn func()) func() {
 	}
 	testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Store(next)
 	return func() {
-		testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Store(prev)
+		testBeforeCommandWALBufferedUpdateStageLockHook.ptr.CompareAndSwap(next, prev)
 	}
 }
 
@@ -14393,6 +14404,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	defer func() {
 		if err != nil && commandWALStageAppended && c.db != nil {
 			c.db.MarkCommandWALIntentRecoveryRequired(commandWALStageIntent)
+			err = commandWALBufferedUpdateCommitAmbiguous(err)
 		}
 	}()
 	appendCommandWALBeforeStage := func() error {
@@ -14570,7 +14582,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		plan.stats.BufferStageRootAppend += overlayAppendDuration
 		if err == nil && buffered && plan.bufferedCommandWALLSN != 0 {
 			if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
-				return false, &CommitAmbiguousError{Operation: "command WAL buffered update", Err: err}
+				return false, commandWALBufferedUpdateCommitAmbiguous(err)
 			}
 		}
 		return buffered, err
@@ -14712,7 +14724,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	plan.stats.BufferedBatches = 1
 	if plan.bufferedCommandWALLSN != 0 {
 		if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
-			return false, &CommitAmbiguousError{Operation: "command WAL buffered update", Err: err}
+			return false, commandWALBufferedUpdateCommitAmbiguous(err)
 		}
 	}
 	return true, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -294,6 +294,7 @@ type CollectionManager struct {
 	closeUnregister          func()
 	closing                  atomic.Bool
 	updateBatchDetailedStats atomic.Bool
+	commandWALCoordinator    *collectionCommandWALCoordinator
 	domainMu                 sync.RWMutex
 	domains                  map[string]*collectionWriteDomain
 }
@@ -964,6 +965,7 @@ type collectionWriteDomain struct {
 	baseSystemRoot           uint64
 	primaryRoot              uint64
 	storagePolicy            backenddb.OrderedRootStoragePolicy
+	commandWALCoordinator    *collectionCommandWALCoordinator
 	table                    memtable.Table
 	indexedPublishingUnits   []indexedFlushUnit
 	indexedFlushUnits        []indexedFlushUnit
@@ -1114,6 +1116,7 @@ type collectionWriteDomain struct {
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
 	manager := &CollectionManager{db: database}
 	if database != nil {
+		manager.commandWALCoordinator = collectionCommandWALCoordinatorForDB(database)
 		manager.closeUnregister = database.RegisterCloseHook(manager.closeForBackend)
 	}
 	return manager
@@ -2399,9 +2402,15 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 		m.domains = make(map[string]*collectionWriteDomain)
 	}
 	if domain := m.domains[name]; domain != nil {
+		if domain.commandWALCoordinator == nil {
+			domain.commandWALCoordinator = m.commandWALCoordinator
+		}
 		return domain
 	}
-	domain := &collectionWriteDomain{updateCombineShards: defaultCollectionUpdateCombineShards}
+	domain := &collectionWriteDomain{
+		commandWALCoordinator: m.commandWALCoordinator,
+		updateCombineShards:   defaultCollectionUpdateCombineShards,
+	}
 	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
 	m.domains[name] = domain
 	return domain
@@ -2610,7 +2619,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 		}
 		if commandWALIntent != nil {
-			if err := m.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+			if err := m.publishCommandWALNoop(commandWALIntent, false); err != nil {
 				return nil, err
 			}
 		}
@@ -2646,7 +2655,10 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		if err != nil {
 			return nil, err
 		}
-		_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(nil, intent, buildSystemDelta)
+		err = m.withCommandWALPublishCoordinator(func() error {
+			_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(nil, intent, buildSystemDelta)
+			return err
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -8524,8 +8536,11 @@ func (c *Collection) insertBatchOnceWithLockState(
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if commandWALIntent != nil {
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		err = c.withCommandWALPublishCoordinator(func() error {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			})
+			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -8963,8 +8978,11 @@ func (c *Collection) insertBatchNoIndex(
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if commandWALIntent != nil {
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+		err = c.withCommandWALPublishCoordinator(func() error {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+			})
+			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -9145,7 +9163,7 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 	if primaryRoot == 0 {
 		_ = snap.Close()
 		if commandWALIntent != nil {
-			if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+			if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 				return 0, err
 			}
 		}
@@ -9198,7 +9216,7 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 	if len(existing) == 0 {
 		_ = snap.Close()
 		if commandWALIntent != nil {
-			if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+			if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 				return 0, err
 			}
 		}
@@ -9283,8 +9301,11 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if commandWALIntent != nil {
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		err = c.withCommandWALPublishCoordinator(func() error {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			})
+			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -9352,7 +9373,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 		if alreadyDeleted {
 			_ = snap.Close()
 			if commandWALIntent != nil {
-				if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+				if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 					return false, err
 				}
 			}
@@ -9363,7 +9384,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		_ = snap.Close()
 		if commandWALIntent != nil {
-			if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+			if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 				return false, err
 			}
 		}
@@ -9376,7 +9397,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 	if entry.Flags&node.FlagTombstone != 0 {
 		_ = snap.Close()
 		if commandWALIntent != nil {
-			if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+			if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 				return false, err
 			}
 		}
@@ -9469,8 +9490,11 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if commandWALIntent != nil {
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		err = c.withCommandWALPublishCoordinator(func() error {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			})
+			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -12799,7 +12823,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 						if err != nil {
 							return err
 						}
-						if err := c.db.PublishCommandWALNoop(intent, false); err != nil {
+						if err := c.publishCommandWALNoop(intent, false); err != nil {
 							return err
 						}
 					}
@@ -12812,6 +12836,11 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 						return err
 					}
 					plan.bufferedCommandWALIntent = intent
+					unlockCommandWALStage, err := c.lockCommandWALStageCoordinator()
+					if err != nil {
+						return err
+					}
+					defer unlockCommandWALStage()
 				}
 				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
 				if bufferErr != nil {
@@ -12918,7 +12947,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 						return err
 					}
 				}
-				if err := c.db.PublishCommandWALNoop(commandWALIntent, false); err != nil {
+				if err := c.publishCommandWALNoop(commandWALIntent, false); err != nil {
 					return err
 				}
 			}
@@ -14147,8 +14176,11 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan, command
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if commandWALIntent != nil {
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder(ordered, preflight, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
+		err = c.withCommandWALPublishCoordinator(func() error {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder(ordered, preflight, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
+			})
+			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -111,7 +111,10 @@ var (
 	)
 )
 
-var testBeforeCommandWALBufferedUpdateStageLock func()
+var testBeforeCommandWALBufferedUpdateStageLockHook struct {
+	mu sync.Mutex
+	fn func()
+}
 
 // CommitAmbiguousError reports that a collection mutation reached its logical
 // commit point before a later visibility, flush, checkpoint, response, or
@@ -2223,6 +2226,27 @@ func runCollectionWaitIndexedAsyncFlushHook() {
 	collectionWaitIndexedAsyncFlushHook.mu.Lock()
 	fn := collectionWaitIndexedAsyncFlushHook.fn
 	collectionWaitIndexedAsyncFlushHook.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func setTestBeforeCommandWALBufferedUpdateStageLockForTest(fn func()) func() {
+	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
+	prev := testBeforeCommandWALBufferedUpdateStageLockHook.fn
+	testBeforeCommandWALBufferedUpdateStageLockHook.fn = fn
+	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
+	return func() {
+		testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
+		testBeforeCommandWALBufferedUpdateStageLockHook.fn = prev
+		testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
+	}
+}
+
+func runTestBeforeCommandWALBufferedUpdateStageLockHook() {
+	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
+	fn := testBeforeCommandWALBufferedUpdateStageLockHook.fn
+	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
 	if fn != nil {
 		fn()
 	}
@@ -12846,9 +12870,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					}
 					plan.bufferedCommandWALIntent = intent
 					if c.db != nil {
-						if testBeforeCommandWALBufferedUpdateStageLock != nil {
-							testBeforeCommandWALBufferedUpdateStageLock()
-						}
+						runTestBeforeCommandWALBufferedUpdateStageLockHook()
 						unlockCommandWALRawStage = c.db.LockCommandWALStaging()
 						defer unlockCommandWALRawStage()
 					}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -295,8 +295,13 @@ type CollectionManager struct {
 	closing                  atomic.Bool
 	updateBatchDetailedStats atomic.Bool
 	commandWALCoordinator    *collectionCommandWALCoordinator
+	commandWALRawUnregister  func()
 	domainMu                 sync.RWMutex
 	domains                  map[string]*collectionWriteDomain
+}
+
+type collectionManagerOptions struct {
+	registerBackendHooks bool
 }
 
 type Collection struct {
@@ -982,20 +987,21 @@ type collectionWriteDomain struct {
 	primaryIDIndex           *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
-	primaryRunIndex        *bufferedPrimaryRunIndex
-	uniqueValueRuns        map[string][]memtable.Table
-	uniqueValueMutableRuns map[string]memtable.Table
-	uniqueValueIndex       map[string]*bufferedUniqueValueIndex
-	count                  int
-	bufferedBytes          int64
-	mutableCount           int
-	mutableBytes           int64
-	rootRunCount           int
-	writeGeneration        uint64
-	primaryWriteIndex      *bufferedPrimaryWriteIndex
-	indexedDeletesOnly     bool
-	pendingCommandWALFirst uint64
-	pendingCommandWALLast  uint64
+	primaryRunIndex             *bufferedPrimaryRunIndex
+	uniqueValueRuns             map[string][]memtable.Table
+	uniqueValueMutableRuns      map[string]memtable.Table
+	uniqueValueIndex            map[string]*bufferedUniqueValueIndex
+	count                       int
+	bufferedBytes               int64
+	mutableCount                int
+	mutableBytes                int64
+	rootRunCount                int
+	writeGeneration             uint64
+	primaryWriteIndex           *bufferedPrimaryWriteIndex
+	indexedDeletesOnly          bool
+	pendingCommandWALFirst      uint64
+	pendingCommandWALLast       uint64
+	commandWALStageReservations atomic.Int32
 
 	mutationLockCalls                  atomic.Uint64
 	mutationLockWaitTotalNs            atomic.Uint64
@@ -1114,10 +1120,17 @@ type collectionWriteDomain struct {
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
+	return newCollectionManager(database, collectionManagerOptions{registerBackendHooks: true})
+}
+
+func newCollectionManager(database *backenddb.DB, opts collectionManagerOptions) *CollectionManager {
 	manager := &CollectionManager{db: database}
 	if database != nil {
 		manager.commandWALCoordinator = collectionCommandWALCoordinatorForDB(database)
-		manager.closeUnregister = database.RegisterCloseHook(manager.closeForBackend)
+		if opts.registerBackendHooks {
+			manager.commandWALRawUnregister = database.RegisterCommandWALRawPublishBarrier(manager.flushPendingCommandWALBeforeRawPublish)
+			manager.closeUnregister = database.RegisterCloseHook(manager.closeForBackend)
+		}
 	}
 	return manager
 }
@@ -1142,6 +1155,10 @@ func (m *CollectionManager) SetUpdateBatchDetailedStatsEnabled(enabled bool) {
 
 func (m *CollectionManager) closeForBackend() error {
 	m.closing.Store(true)
+	if m.commandWALRawUnregister != nil {
+		m.commandWALRawUnregister()
+		m.commandWALRawUnregister = nil
+	}
 	m.stopUpdateCombiners()
 	return m.FlushAll()
 }
@@ -2501,7 +2518,9 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	if hasBufferedIndexedRootRuns(domain) {
 		domain.observeIndexedFlushForcedDrain()
 	}
-	return collection.flushBufferedWritesLocked(domain)
+	err := collection.flushBufferedWritesLocked(domain)
+	domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
+	return err
 }
 
 func flushCollectionWriteDomainAsync(db *backenddb.DB, domain *collectionWriteDomain) error {
@@ -3627,7 +3646,9 @@ func (c *Collection) flushBufferedNoIndex() error {
 	if hasBufferedIndexedPendingWrites(domain) {
 		return nil
 	}
-	return c.flushBufferedNoIndexLocked(domain)
+	err := c.flushBufferedNoIndexLocked(domain)
+	domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
+	return err
 }
 
 func (c *Collection) flushBufferedWrites() error {
@@ -3646,6 +3667,7 @@ func (c *Collection) flushBufferedWrites() error {
 			domain.observeIndexedFlushForcedDrain()
 		}
 		err := c.flushBufferedWritesLocked(domain)
+		domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
 		domain.mu.Unlock()
 		return err
 	}
@@ -12811,108 +12833,122 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 				replan = true
 				return nil
 			}
-			err = c.withMutationLock(func() error {
-				if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
-					if plan.bufferedReadBlocked && useBufferedRead {
-						if err := c.flushBufferedWrites(); err != nil {
-							return err
-						}
-						useBufferedRead = false
-						replan = true
-						return nil
-					}
-					if plan.bufferedBase && !c.bufferedUpdateBatchPlanStillCurrent(plan) {
-						if useBufferedRead {
-							// A buffered snapshot can go stale while update callbacks run
-							// before the mutation lock. Replan against the newer buffered
-							// domain instead of turning that race into a publish boundary.
-							return replanBufferedRead()
-						}
-						return ErrConcurrentMutation
-					}
-					if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
-						return err
-					}
-					c.meta = plan.meta
-					if commandWALBufferedMode {
-						intent, err := c.newCollectionUpdateCommandWALIntent(nil, nil)
-						if err != nil {
-							return err
-						}
-						if err := c.publishCommandWALNoop(intent, false); err != nil {
-							return err
-						}
-					}
-					results = plan.results
-					return nil
-				}
+			err = func() error {
+				var unlockCommandWALRawStage func()
 				if commandWALBufferedMode && plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && len(plan.commandWALDocuments) > 0 {
 					intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
 					if err != nil {
 						return err
 					}
 					plan.bufferedCommandWALIntent = intent
-					unlockCommandWALStage, err := c.lockCommandWALStageCoordinator()
-					if err != nil {
+					if c.db != nil {
+						unlockCommandWALRawStage = c.db.LockCommandWALStaging()
+						defer unlockCommandWALRawStage()
+					}
+					if err := c.drainCommandWALStageCoordinatorBeforeMutation(); err != nil {
 						return err
 					}
-					defer unlockCommandWALStage()
 				}
-				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
-				if bufferErr != nil {
-					if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
-						if commandWALBufferedMode && plan.bufferedCommandWALLSN != 0 {
-							return &CommitAmbiguousError{Operation: "command WAL buffered update", Err: bufferErr}
-						}
-						if !isConcurrentRootModification(bufferErr) && plan.bufferedBase && c.bufferedUpdateBatchPlanCanStillRead(plan) {
-							// The buffered domain moved between planning and staging. Keep
-							// the update in the buffered layer by replanning with a fresh
-							// buffered snapshot.
-							return replanBufferedRead()
-						}
-						if err := c.flushBufferedWrites(); err != nil {
+				return c.withMutationLock(func() error {
+					var unlockCommandWALStage func()
+					if plan.bufferedCommandWALIntent != nil {
+						var err error
+						unlockCommandWALStage, err = c.lockCommandWALStageCoordinator()
+						if err != nil {
 							return err
+						}
+						defer unlockCommandWALStage()
+					}
+					if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
+						if plan.bufferedReadBlocked && useBufferedRead {
+							if err := c.flushBufferedWrites(); err != nil {
+								return err
+							}
+							useBufferedRead = false
+							replan = true
+							return nil
+						}
+						if plan.bufferedBase && !c.bufferedUpdateBatchPlanStillCurrent(plan) {
+							if useBufferedRead {
+								// A buffered snapshot can go stale while update callbacks run
+								// before the mutation lock. Replan against the newer buffered
+								// domain instead of turning that race into a publish boundary.
+								return replanBufferedRead()
+							}
+							return ErrConcurrentMutation
+						}
+						if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
+							return err
+						}
+						c.meta = plan.meta
+						if commandWALBufferedMode {
+							intent, err := c.newCollectionUpdateCommandWALIntent(nil, nil)
+							if err != nil {
+								return err
+							}
+							if err := c.publishCommandWALNoop(intent, false); err != nil {
+								return err
+							}
+						}
+						results = plan.results
+						return nil
+					}
+					buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
+					if bufferErr != nil {
+						if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
+							if commandWALBufferedMode && plan.bufferedCommandWALLSN != 0 {
+								return &CommitAmbiguousError{Operation: "command WAL buffered update", Err: bufferErr}
+							}
+							if !isConcurrentRootModification(bufferErr) && plan.bufferedBase && c.bufferedUpdateBatchPlanCanStillRead(plan) {
+								// The buffered domain moved between planning and staging. Keep
+								// the update in the buffered layer by replanning with a fresh
+								// buffered snapshot.
+								return replanBufferedRead()
+							}
+							if err := c.flushBufferedWrites(); err != nil {
+								return err
+							}
+							useBufferedRead = false
+							replan = true
+							return nil
+						}
+						return bufferErr
+					}
+					if buffered {
+						c.meta = plan.meta
+						results = plan.results
+						return nil
+					}
+					if plan.directBufferedUpdate != nil {
+						if !c.canBufferDirectUpdateAck() {
+							if err := c.flushBufferedWrites(); err != nil {
+								return err
+							}
 						}
 						useBufferedRead = false
 						replan = true
 						return nil
 					}
-					return bufferErr
-				}
-				if buffered {
-					c.meta = plan.meta
-					results = plan.results
-					return nil
-				}
-				if plan.directBufferedUpdate != nil {
-					if !c.canBufferDirectUpdateAck() {
-						if err := c.flushBufferedWrites(); err != nil {
+					if err := c.flushBufferedWrites(); err != nil {
+						return err
+					}
+					if useBufferedRead {
+						useBufferedRead = false
+						replan = true
+						return nil
+					}
+					var publishErr error
+					publishIntent := commandWALIntent
+					if publishIntent == nil && c.commandWALActive(nil) && len(plan.commandWALDocuments) > 0 {
+						publishIntent, err = c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
+						if err != nil {
 							return err
 						}
 					}
-					useBufferedRead = false
-					replan = true
-					return nil
-				}
-				if err := c.flushBufferedWrites(); err != nil {
-					return err
-				}
-				if useBufferedRead {
-					useBufferedRead = false
-					replan = true
-					return nil
-				}
-				var publishErr error
-				publishIntent := commandWALIntent
-				if publishIntent == nil && c.commandWALActive(nil) && len(plan.commandWALDocuments) > 0 {
-					publishIntent, err = c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
-					if err != nil {
-						return err
-					}
-				}
-				results, publishErr = c.publishUpdateBatchPlanLocked(plan, publishIntent)
-				return publishErr
-			})
+					results, publishErr = c.publishUpdateBatchPlanLocked(plan, publishIntent)
+					return publishErr
+				})
+			}()
 			primaryOnlyNoPublish := len(plan.meta.Indexes) == 0 && len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil
 			stats := plan.stats
 			plan.close()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -14486,7 +14486,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		plan.stats.BufferStagePrimaryAppend += overlayAppendDuration
 		plan.stats.BufferStageRootAppend += overlayAppendDuration
 		if err == nil && buffered && plan.bufferedCommandWALLSN != 0 {
-			if err := domain.recordPendingCommandWALLSNLocked(plan.bufferedCommandWALLSN); err != nil {
+			if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
 				return false, err
 			}
 		}
@@ -14628,7 +14628,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	resetCollectionTables(compactedObsolete)
 	plan.stats.BufferedBatches = 1
 	if plan.bufferedCommandWALLSN != 0 {
-		if err := domain.recordPendingCommandWALLSNLocked(plan.bufferedCommandWALLSN); err != nil {
+		if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
 			return false, err
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -112,7 +112,8 @@ var (
 )
 
 var testBeforeCommandWALBufferedUpdateStageLockHook struct {
-	ptr atomic.Pointer[testCommandWALBufferedUpdateStageLockHook]
+	installMu sync.Mutex
+	ptr       atomic.Pointer[testCommandWALBufferedUpdateStageLockHook]
 }
 
 type testCommandWALBufferedUpdateStageLockHook struct {
@@ -2246,14 +2247,19 @@ func runCollectionWaitIndexedAsyncFlushHook() {
 }
 
 func setTestBeforeCommandWALBufferedUpdateStageLockForTest(fn func()) func() {
+	testBeforeCommandWALBufferedUpdateStageLockHook.installMu.Lock()
 	prev := testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Load()
 	var next *testCommandWALBufferedUpdateStageLockHook
 	if fn != nil {
 		next = &testCommandWALBufferedUpdateStageLockHook{fn: fn}
 	}
 	testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Store(next)
+	var once sync.Once
 	return func() {
-		testBeforeCommandWALBufferedUpdateStageLockHook.ptr.CompareAndSwap(next, prev)
+		once.Do(func() {
+			testBeforeCommandWALBufferedUpdateStageLockHook.ptr.CompareAndSwap(next, prev)
+			testBeforeCommandWALBufferedUpdateStageLockHook.installMu.Unlock()
+		})
 	}
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -112,7 +112,10 @@ var (
 )
 
 var testBeforeCommandWALBufferedUpdateStageLockHook struct {
-	mu sync.Mutex
+	ptr atomic.Pointer[testCommandWALBufferedUpdateStageLockHook]
+}
+
+type testCommandWALBufferedUpdateStageLockHook struct {
 	fn func()
 }
 
@@ -2232,23 +2235,21 @@ func runCollectionWaitIndexedAsyncFlushHook() {
 }
 
 func setTestBeforeCommandWALBufferedUpdateStageLockForTest(fn func()) func() {
-	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
-	prev := testBeforeCommandWALBufferedUpdateStageLockHook.fn
-	testBeforeCommandWALBufferedUpdateStageLockHook.fn = fn
-	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
+	prev := testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Load()
+	var next *testCommandWALBufferedUpdateStageLockHook
+	if fn != nil {
+		next = &testCommandWALBufferedUpdateStageLockHook{fn: fn}
+	}
+	testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Store(next)
 	return func() {
-		testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
-		testBeforeCommandWALBufferedUpdateStageLockHook.fn = prev
-		testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
+		testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Store(prev)
 	}
 }
 
 func runTestBeforeCommandWALBufferedUpdateStageLockHook() {
-	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Lock()
-	fn := testBeforeCommandWALBufferedUpdateStageLockHook.fn
-	testBeforeCommandWALBufferedUpdateStageLockHook.mu.Unlock()
-	if fn != nil {
-		fn()
+	hook := testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Load()
+	if hook != nil && hook.fn != nil {
+		hook.fn()
 	}
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -992,6 +992,8 @@ type collectionWriteDomain struct {
 	writeGeneration        uint64
 	primaryWriteIndex      *bufferedPrimaryWriteIndex
 	indexedDeletesOnly     bool
+	pendingCommandWALFirst uint64
+	pendingCommandWALLast  uint64
 
 	mutationLockCalls                  atomic.Uint64
 	mutationLockWaitTotalNs            atomic.Uint64
@@ -3299,6 +3301,9 @@ func (c *Collection) canBufferNoIndexInsertBatchAck() bool {
 func (c *Collection) canBufferDirectUpdateAck() bool {
 	if c == nil || c.db == nil || c.writeDomain == nil {
 		return false
+	}
+	if c.db.CommandWALEnabled() {
+		return c.db.DurabilityMode() != backenddb.DurabilityWALOffRelaxed
 	}
 	switch c.db.DurabilityMode() {
 	case backenddb.DurabilityWALOffRelaxed, backenddb.DurabilityWALOnRelaxed:
@@ -7565,6 +7570,10 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	var rootOverlayFilters map[string]collectionRootOverlayFilter
+	commandWALIntent, commandWALAppliedLSN, err := domain.pendingCommandWALCoverageIntentLocked(c.db)
+	if err != nil {
+		return err
+	}
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
 		materializeStart := time.Now()
 		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
@@ -7580,9 +7589,15 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-		})
+		if commandWALIntent != nil {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+			})
+		} else {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+			})
+		}
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if err == nil {
@@ -7598,9 +7613,15 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-		})
+		if commandWALIntent != nil {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			})
+		} else {
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			})
+		}
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if err == nil {
@@ -7647,6 +7668,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.bufferedBytes = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
+	if commandWALAppliedLSN != 0 {
+		domain.clearPendingCommandWALThroughLocked(commandWALAppliedLSN)
+	}
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldUnits)
@@ -12106,6 +12130,8 @@ type updateBatchPlan struct {
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
 	commandWALDocuments         []commitlog.CollectionDocument
+	bufferedCommandWALIntent    *backenddb.CommandWALIntent
+	bufferedCommandWALLSN       uint64
 	directBufferedUpdate        *directBufferedUpdatePlan
 	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
@@ -12687,9 +12713,6 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
-	if c.commandWALActive(nil) {
-		return false
-	}
 	if len(changed) == 0 {
 		return false
 	}
@@ -12698,6 +12721,9 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
+	}
+	if c.commandWALActive(nil) {
+		return false
 	}
 	if !meta.Options.BufferedIndexedWrites {
 		return false
@@ -12715,7 +12741,8 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 }
 
 func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMode, commandWALIntent *backenddb.CommandWALIntent) ([]UpdateBatchResult, error) {
-	if !c.commandWALActive(commandWALIntent) && c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
+	commandWALBufferedMode := c.commandWALActive(commandWALIntent) && commandWALIntent == nil && mode != updateBatchModeAny
+	if (!c.commandWALActive(commandWALIntent) || commandWALBufferedMode) && (c.shouldPlanUpdateBatchWithBufferedWrites(mode) || commandWALBufferedMode) {
 		useBufferedRead := true
 		bufferedReadReplans := 0
 		for {
@@ -12767,12 +12794,31 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 						return err
 					}
 					c.meta = plan.meta
+					if commandWALBufferedMode {
+						intent, err := c.newCollectionUpdateCommandWALIntent(nil, nil)
+						if err != nil {
+							return err
+						}
+						if err := c.db.PublishCommandWALNoop(intent, false); err != nil {
+							return err
+						}
+					}
 					results = plan.results
 					return nil
+				}
+				if commandWALBufferedMode && plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && len(plan.commandWALDocuments) > 0 {
+					intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
+					if err != nil {
+						return err
+					}
+					plan.bufferedCommandWALIntent = intent
 				}
 				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
 				if bufferErr != nil {
 					if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
+						if commandWALBufferedMode && plan.bufferedCommandWALLSN != 0 {
+							return &CommitAmbiguousError{Operation: "command WAL buffered update", Err: bufferErr}
+						}
 						if !isConcurrentRootModification(bufferErr) && plan.bufferedBase && c.bufferedUpdateBatchPlanCanStillRead(plan) {
 							// The buffered domain moved between planning and staging. Keep
 							// the update in the buffered layer by replanning with a fresh
@@ -12812,7 +12858,14 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					return nil
 				}
 				var publishErr error
-				results, publishErr = c.publishUpdateBatchPlanLocked(plan, nil)
+				publishIntent := commandWALIntent
+				if publishIntent == nil && c.commandWALActive(nil) && len(plan.commandWALDocuments) > 0 {
+					publishIntent, err = c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
+					if err != nil {
+						return err
+					}
+				}
+				results, publishErr = c.publishUpdateBatchPlanLocked(plan, publishIntent)
 				return publishErr
 			})
 			primaryOnlyNoPublish := len(plan.meta.Indexes) == 0 && len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil
@@ -14216,9 +14269,31 @@ func (c *Collection) stageDirectPrimaryOverlayLocked(domain *collectionWriteDoma
 	return true, nil
 }
 
-func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
+func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (buffered bool, err error) {
 	if c == nil || plan == nil || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.primaryEntries) == 0 {
 		return false, nil
+	}
+	commandWALStageIntent := plan.bufferedCommandWALIntent
+	commandWALStageAppended := false
+	defer func() {
+		if err != nil && commandWALStageAppended && c.db != nil {
+			c.db.MarkCommandWALIntentRecoveryRequired(commandWALStageIntent)
+		}
+	}()
+	appendCommandWALBeforeStage := func() error {
+		if commandWALStageIntent == nil || plan.bufferedCommandWALLSN != 0 {
+			return nil
+		}
+		if c.db == nil {
+			return errCollectionDBNil
+		}
+		lsn, appendErr := c.db.AppendCommandWALIntent(commandWALStageIntent, false)
+		if appendErr != nil {
+			return appendErr
+		}
+		plan.bufferedCommandWALLSN = lsn
+		commandWALStageAppended = lsn != 0
+		return nil
 	}
 	direct := plan.directBufferedUpdate
 	detailedStats := c.updateBatchDetailedStatsEnabled()
@@ -14369,12 +14444,20 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if !primaryOnlyDirectUpdate {
 		overlayWouldFlush = shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, 0)
 	}
+	if err := appendCommandWALBeforeStage(); err != nil {
+		return false, err
+	}
 	if canStageDirectPrimaryOverlay(plan, direct, primaryOnlyDirectUpdate, shouldAutoFlushAfterAdding || overlayWouldFlush) {
 		overlayAppendStart := updateBatchStatsNow(detailedStats)
 		buffered, err := c.stageDirectPrimaryOverlayLocked(domain, plan, modifiedCount)
 		overlayAppendDuration := updateBatchStatsSince(detailedStats, overlayAppendStart)
 		plan.stats.BufferStagePrimaryAppend += overlayAppendDuration
 		plan.stats.BufferStageRootAppend += overlayAppendDuration
+		if err == nil && buffered && plan.bufferedCommandWALLSN != 0 {
+			if err := domain.recordPendingCommandWALLSNLocked(plan.bufferedCommandWALLSN); err != nil {
+				return false, err
+			}
+		}
 		return buffered, err
 	}
 	materializePrimaryOverlayLocked(domain)
@@ -14512,11 +14595,19 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	resetCollectionTables(compactedObsolete)
 	plan.stats.BufferedBatches = 1
+	if plan.bufferedCommandWALLSN != 0 {
+		if err := domain.recordPendingCommandWALLSNLocked(plan.bufferedCommandWALLSN); err != nil {
+			return false, err
+		}
+	}
 	return true, nil
 }
 
 func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
 	if c == nil || plan == nil {
+		return false, nil
+	}
+	if c.commandWALActive(nil) && plan.bufferedCommandWALIntent == nil {
 		return false, nil
 	}
 	if plan.directBufferedUpdate != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7582,9 +7582,19 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	var rootOverlayFilters map[string]collectionRootOverlayFilter
-	commandWALIntent, commandWALAppliedLSN, err := domain.pendingCommandWALCoverageIntentLocked(c.db)
-	if err != nil {
-		return err
+	var commandWALAppliedLSN uint64
+	publishWithCommandWALCoordinator := func(fn func(*backenddb.CommandWALIntent) error) error {
+		unlock, err := c.lockCommandWALFlushPublishCoordinator(domain)
+		if err != nil {
+			return err
+		}
+		defer unlock()
+		commandWALIntent, appliedLSN, err := domain.pendingCommandWALCoverageIntentLocked(c.db)
+		if err != nil {
+			return err
+		}
+		commandWALAppliedLSN = appliedLSN
+		return fn(commandWALIntent)
 	}
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
 		materializeStart := time.Now()
@@ -7601,15 +7611,18 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		if commandWALIntent != nil {
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-			})
-		} else {
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-			})
-		}
+		err = publishWithCommandWALCoordinator(func(commandWALIntent *backenddb.CommandWALIntent) error {
+			if commandWALIntent != nil {
+				newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+					return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+				})
+			} else {
+				newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+					return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+				})
+			}
+			return err
+		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if err == nil {
@@ -7625,15 +7638,18 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		if commandWALIntent != nil {
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-			})
-		} else {
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-			})
-		}
+		err = publishWithCommandWALCoordinator(func(commandWALIntent *backenddb.CommandWALIntent) error {
+			if commandWALIntent != nil {
+				newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+					return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+				})
+			} else {
+				newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+					return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+				})
+			}
+			return err
+		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if err == nil {
@@ -14487,7 +14503,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		plan.stats.BufferStageRootAppend += overlayAppendDuration
 		if err == nil && buffered && plan.bufferedCommandWALLSN != 0 {
 			if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
-				return false, err
+				return false, &CommitAmbiguousError{Operation: "command WAL buffered update", Err: err}
 			}
 		}
 		return buffered, err
@@ -14629,7 +14645,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	plan.stats.BufferedBatches = 1
 	if plan.bufferedCommandWALLSN != 0 {
 		if err := domain.recordPendingCommandWALLSNLocked(c.db, plan.bufferedCommandWALLSN); err != nil {
-			return false, err
+			return false, &CommitAmbiguousError{Operation: "command WAL buffered update", Err: err}
 		}
 	}
 	return true, nil

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -50,8 +50,9 @@ var bsonSetBatchDocumentIDHashSeed = maphash.MakeSeed()
 // slices until UpdateBSONSet returns.
 //
 // For no-index collections, this path may stage buffered root runs in WAL-off
-// relaxed and WAL-on relaxed modes; when staged, crash-recoverability is
-// deferred until Flush/Close publishes the buffered runs.
+// relaxed and WAL-on relaxed modes. In command-WAL durable modes, staged
+// updates append their deterministic command frame before returning, and
+// Flush/Close later publishes the covered roots.
 func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bool, bool, error) {
 	if err := validateCollectionUpdateDocumentInput(c, documentID); err != nil {
 		return false, false, err
@@ -95,10 +96,10 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	}
 	items := []updateBatchItem{newBSONSetUpdateBatchItem(documentID, spec)}
 	mode := updateBatchModeNoSecondaryUniqueIndexChanges
-	if c.commandWALActive(nil) {
-		mode = updateBatchModeAny
-	}
 	results, batched, err := c.updateBatchOwnedItems(items, mode)
+	if c.commandWALActive(nil) && ((err == nil && !batched) || errors.Is(err, errUpdateBatchChangesSecondaryUniqueIndex)) {
+		results, batched, err = c.updateBatchOwnedItems(items, updateBatchModeAny)
+	}
 	if !batched && err == nil {
 		if c.commandWALActive(nil) {
 			return false, false, errors.New("collections: command WAL BSON $set fallback unexpectedly unbatched")

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -98,6 +98,8 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	mode := updateBatchModeNoSecondaryUniqueIndexChanges
 	results, batched, err := c.updateBatchOwnedItems(items, mode)
 	if c.commandWALActive(nil) && err == nil && !batched {
+		// Keep the common no-index direct buffered command-WAL fast path narrow.
+		// Indexed/unique cases that cannot use it fall back to ordinary command-WAL semantics.
 		results, batched, err = c.updateBatchOwnedItems(items, updateBatchModeAny)
 	}
 	if !batched && err == nil {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -97,7 +97,7 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	items := []updateBatchItem{newBSONSetUpdateBatchItem(documentID, spec)}
 	mode := updateBatchModeNoSecondaryUniqueIndexChanges
 	results, batched, err := c.updateBatchOwnedItems(items, mode)
-	if c.commandWALActive(nil) && ((err == nil && !batched) || errors.Is(err, errUpdateBatchChangesSecondaryUniqueIndex)) {
+	if c.commandWALActive(nil) && err == nil && !batched {
 		results, batched, err = c.updateBatchOwnedItems(items, updateBatchModeAny)
 	}
 	if !batched && err == nil {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -98,8 +98,10 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	mode := updateBatchModeNoSecondaryUniqueIndexChanges
 	results, batched, err := c.updateBatchOwnedItems(items, mode)
 	if c.commandWALActive(nil) && err == nil && !batched {
-		// Keep the common no-index direct buffered command-WAL fast path narrow.
-		// Indexed/unique cases that cannot use it fall back to ordinary command-WAL semantics.
+		// updateBatchOwnedItems reports batched=false for this mode only after a
+		// planning-time secondary/unique-index rejection, before staging or
+		// publishing any write. Retrying in ordinary command-WAL mode therefore
+		// cannot double-apply the update.
 		results, batched, err = c.updateBatchOwnedItems(items, updateBatchModeAny)
 	}
 	if !batched && err == nil {

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -50,7 +50,7 @@ var bsonSetBatchDocumentIDHashSeed = maphash.MakeSeed()
 // slices until UpdateBSONSet returns.
 //
 // For no-index collections, this path may stage buffered root runs in WAL-off
-// relaxed and WAL-on relaxed modes. In command-WAL durable modes, staged
+// relaxed and WAL-on relaxed modes. In command-WAL (WAL-on) modes, staged
 // updates append their deterministic command frame before returning, and
 // Flush/Close later publishes the covered roots.
 func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bool, bool, error) {

--- a/TreeDB/collections/command_wal.go
+++ b/TreeDB/collections/command_wal.go
@@ -31,6 +31,10 @@ func RegisterCommandWALReplayHandlers() {
 	})
 }
 
+func newCommandWALReplayCollectionManager(db *backenddb.DB) *CollectionManager {
+	return newCollectionManager(db, collectionManagerOptions{})
+}
+
 func (c *Collection) commandWALActive(intent *backenddb.CommandWALIntent) bool {
 	return intent != nil || (c != nil && c.db != nil && c.db.CommandWALEnabled())
 }
@@ -200,7 +204,7 @@ func replayCollectionInsertBatchByIDCommandWAL(db *backenddb.DB, env commitlog.C
 	if len(payload.Documents) == 0 {
 		return db.PublishCommandWALNoop(backenddb.NewCommandWALReplayIntent(env), false)
 	}
-	manager := NewCollectionManager(db)
+	manager := newCommandWALReplayCollectionManager(db)
 	collection, err := manager.OpenCollection(payload.Collection)
 	if err != nil {
 		return err
@@ -220,7 +224,7 @@ func replayCollectionDeleteBatchByIDCommandWAL(db *backenddb.DB, env commitlog.C
 	if err != nil {
 		return err
 	}
-	manager := NewCollectionManager(db)
+	manager := newCommandWALReplayCollectionManager(db)
 	collection, err := manager.OpenCollection(payload.Collection)
 	if err != nil {
 		return err
@@ -237,7 +241,7 @@ func replayCollectionUpdateBatchByIDCommandWAL(db *backenddb.DB, env commitlog.C
 	if len(payload.Documents) == 0 {
 		return db.PublishCommandWALNoop(backenddb.NewCommandWALReplayIntent(env), false)
 	}
-	manager := NewCollectionManager(db)
+	manager := newCommandWALReplayCollectionManager(db)
 	collection, err := manager.OpenCollection(payload.Collection)
 	if err != nil {
 		return err
@@ -273,7 +277,7 @@ func replayCatalogCreateCollectionCommandWAL(db *backenddb.DB, env commitlog.Com
 	if meta.Name != payload.Collection {
 		return fmt.Errorf("collections: catalog create payload collection %q does not match metadata name %q", payload.Collection, meta.Name)
 	}
-	_, err = NewCollectionManager(db).createCollectionWithCommandWALIntent(meta, backenddb.NewCommandWALReplayIntent(env))
+	_, err = newCommandWALReplayCollectionManager(db).createCollectionWithCommandWALIntent(meta, backenddb.NewCommandWALReplayIntent(env))
 	return err
 }
 

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -440,6 +440,7 @@ func (domain *collectionWriteDomain) clearPendingCommandWALThroughLocked(lsn uin
 	if lsn >= last {
 		domain.pendingCommandWALFirst = 0
 		domain.pendingCommandWALLast = 0
+		domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
 		return
 	}
 	domain.pendingCommandWALFirst = lsn + 1

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -2,9 +2,190 @@ package collections
 
 import (
 	"fmt"
+	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
+
+type collectionCommandWALCoordinator struct {
+	mu    sync.Mutex
+	owner *collectionWriteDomain
+}
+
+var collectionCommandWALCoordinators sync.Map
+
+func collectionCommandWALCoordinatorForDB(db *backenddb.DB) *collectionCommandWALCoordinator {
+	if db == nil {
+		return nil
+	}
+	if existing, ok := collectionCommandWALCoordinators.Load(db); ok {
+		return existing.(*collectionCommandWALCoordinator)
+	}
+	coord := &collectionCommandWALCoordinator{}
+	actual, loaded := collectionCommandWALCoordinators.LoadOrStore(db, coord)
+	if !loaded {
+		db.RegisterCloseHook(func() error {
+			collectionCommandWALCoordinators.Delete(db)
+			return nil
+		})
+		return coord
+	}
+	return actual.(*collectionCommandWALCoordinator)
+}
+
+func (domain *collectionWriteDomain) commandWALCoordinatorForDomain(db *backenddb.DB) *collectionCommandWALCoordinator {
+	if domain == nil {
+		return nil
+	}
+	if domain.commandWALCoordinator != nil {
+		return domain.commandWALCoordinator
+	}
+	return collectionCommandWALCoordinatorForDB(db)
+}
+
+func collectionCommandWALDomainHasPending(domain *collectionWriteDomain) bool {
+	if domain == nil {
+		return false
+	}
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	return domain.pendingCommandWALFirst != 0 && domain.pendingCommandWALLast != 0
+}
+
+func (c *Collection) lockCommandWALStageCoordinator() (func(), error) {
+	if c == nil || c.db == nil || !c.db.CommandWALEnabled() || c.writeDomain == nil {
+		return func() {}, nil
+	}
+	domain := c.writeDomain
+	coord := domain.commandWALCoordinatorForDomain(c.db)
+	if coord == nil {
+		return func() {}, nil
+	}
+	for {
+		coord.mu.Lock()
+		owner := coord.owner
+		if owner == nil || owner == domain {
+			return coord.mu.Unlock, nil
+		}
+		if !collectionCommandWALDomainHasPending(owner) {
+			coord.owner = nil
+			coord.mu.Unlock()
+			continue
+		}
+		coord.mu.Unlock()
+		if err := flushCollectionWriteDomain(c.db, owner); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (c *Collection) lockCommandWALPublishCoordinator() (func(), error) {
+	if c == nil || c.db == nil || !c.db.CommandWALEnabled() || c.writeDomain == nil {
+		return func() {}, nil
+	}
+	domain := c.writeDomain
+	coord := domain.commandWALCoordinatorForDomain(c.db)
+	if coord == nil {
+		return func() {}, nil
+	}
+	for {
+		coord.mu.Lock()
+		owner := coord.owner
+		if owner == nil {
+			return coord.mu.Unlock, nil
+		}
+		if !collectionCommandWALDomainHasPending(owner) {
+			coord.owner = nil
+			coord.mu.Unlock()
+			continue
+		}
+		coord.mu.Unlock()
+		if owner == domain {
+			if err := c.flushBufferedWrites(); err != nil {
+				return nil, err
+			}
+		} else if err := flushCollectionWriteDomain(c.db, owner); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (c *Collection) publishCommandWALNoop(intent *backenddb.CommandWALIntent, sync bool) error {
+	if c == nil || c.db == nil {
+		return errCollectionDBNil
+	}
+	unlock, err := c.lockCommandWALPublishCoordinator()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return c.db.PublishCommandWALNoop(intent, sync)
+}
+
+func (m *CollectionManager) lockCommandWALPublishCoordinator() (func(), error) {
+	if m == nil || m.db == nil || !m.db.CommandWALEnabled() {
+		return func() {}, nil
+	}
+	coord := m.commandWALCoordinator
+	if coord == nil {
+		coord = collectionCommandWALCoordinatorForDB(m.db)
+	}
+	if coord == nil {
+		return func() {}, nil
+	}
+	for {
+		coord.mu.Lock()
+		owner := coord.owner
+		if owner == nil {
+			return coord.mu.Unlock, nil
+		}
+		if !collectionCommandWALDomainHasPending(owner) {
+			coord.owner = nil
+			coord.mu.Unlock()
+			continue
+		}
+		coord.mu.Unlock()
+		if err := flushCollectionWriteDomain(m.db, owner); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (m *CollectionManager) publishCommandWALNoop(intent *backenddb.CommandWALIntent, sync bool) error {
+	if m == nil || m.db == nil {
+		return errCollectionDBNil
+	}
+	unlock, err := m.lockCommandWALPublishCoordinator()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return m.db.PublishCommandWALNoop(intent, sync)
+}
+
+func (m *CollectionManager) withCommandWALPublishCoordinator(fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	unlock, err := m.lockCommandWALPublishCoordinator()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return fn()
+}
+
+func (c *Collection) withCommandWALPublishCoordinator(fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	unlock, err := c.lockCommandWALPublishCoordinator()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return fn()
+}
 
 func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(lsn uint64) error {
 	if domain == nil || lsn == 0 {
@@ -13,12 +194,18 @@ func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(lsn uint64
 	if domain.pendingCommandWALFirst == 0 {
 		domain.pendingCommandWALFirst = lsn
 		domain.pendingCommandWALLast = lsn
+		if domain.commandWALCoordinator != nil {
+			domain.commandWALCoordinator.owner = domain
+		}
 		return nil
 	}
 	if lsn != domain.pendingCommandWALLast+1 {
 		return fmt.Errorf("%w: pending collection command WAL range [%d,%d] cannot cover interleaved lsn %d", backenddb.ErrCommandWALAppliedLSNNonContig, domain.pendingCommandWALFirst, domain.pendingCommandWALLast, lsn)
 	}
 	domain.pendingCommandWALLast = lsn
+	if domain.commandWALCoordinator != nil {
+		domain.commandWALCoordinator.owner = domain
+	}
 	return nil
 }
 

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -57,10 +57,17 @@ func (domain *collectionWriteDomain) commandWALCoordinatorForDomain(db *backendd
 	if domain == nil {
 		return nil
 	}
-	if domain.commandWALCoordinator != nil {
-		return domain.commandWALCoordinator
+	if coord := domain.commandWALCoordinator.Load(); coord != nil {
+		return coord
 	}
-	return collectionCommandWALCoordinatorForDB(db)
+	coord := collectionCommandWALCoordinatorForDB(db)
+	if coord == nil {
+		return nil
+	}
+	if domain.commandWALCoordinator.CompareAndSwap(nil, coord) {
+		return coord
+	}
+	return domain.commandWALCoordinator.Load()
 }
 
 func collectionCommandWALDomainPendingLocked(domain *collectionWriteDomain) bool {
@@ -75,10 +82,13 @@ func collectionCommandWALDomainStageReserved(domain *collectionWriteDomain) bool
 }
 
 func (domain *collectionWriteDomain) reserveCommandWALCoordinatorOwnerLocked() {
-	if domain == nil || domain.commandWALCoordinator == nil {
+	if domain == nil {
 		return
 	}
-	coord := domain.commandWALCoordinator
+	coord := domain.commandWALCoordinator.Load()
+	if coord == nil {
+		return
+	}
 	coord.mu.Lock()
 	coord.owner = domain
 	if cond := coord.condLocked(); cond != nil {
@@ -88,10 +98,13 @@ func (domain *collectionWriteDomain) reserveCommandWALCoordinatorOwnerLocked() {
 }
 
 func (domain *collectionWriteDomain) clearCommandWALCoordinatorOwnerIfNoPendingLocked() {
-	if domain == nil || domain.commandWALCoordinator == nil || collectionCommandWALDomainPendingLocked(domain) {
+	if domain == nil || collectionCommandWALDomainPendingLocked(domain) {
 		return
 	}
-	coord := domain.commandWALCoordinator
+	coord := domain.commandWALCoordinator.Load()
+	if coord == nil {
+		return
+	}
 	coord.mu.Lock()
 	if collectionCommandWALDomainStageReserved(domain) {
 		coord.mu.Unlock()
@@ -180,10 +193,13 @@ func (c *Collection) drainCommandWALStageCoordinatorBeforeMutation() error {
 }
 
 func (domain *collectionWriteDomain) finishCommandWALStageReservation() {
-	if domain == nil || domain.commandWALCoordinator == nil {
+	if domain == nil {
 		return
 	}
-	coord := domain.commandWALCoordinator
+	coord := domain.commandWALCoordinator.Load()
+	if coord == nil {
+		return
+	}
 	coord.mu.Lock()
 	if next := domain.commandWALStageReservations.Add(-1); next < 0 {
 		domain.commandWALStageReservations.Store(0)

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -110,6 +110,32 @@ func (c *Collection) lockCommandWALPublishCoordinator() (func(), error) {
 	}
 }
 
+func (c *Collection) lockCommandWALFlushPublishCoordinator(domain *collectionWriteDomain) (func(), error) {
+	if c == nil || c.db == nil || !c.db.CommandWALEnabled() || domain == nil {
+		return func() {}, nil
+	}
+	coord := domain.commandWALCoordinatorForDomain(c.db)
+	if coord == nil {
+		return func() {}, nil
+	}
+	for {
+		coord.mu.Lock()
+		owner := coord.owner
+		if owner == nil || owner == domain {
+			return coord.mu.Unlock, nil
+		}
+		if !collectionCommandWALDomainHasPending(owner) {
+			coord.owner = nil
+			coord.mu.Unlock()
+			continue
+		}
+		coord.mu.Unlock()
+		if err := flushCollectionWriteDomain(c.db, owner); err != nil {
+			return nil, err
+		}
+	}
+}
+
 func (c *Collection) publishCommandWALNoop(intent *backenddb.CommandWALIntent, sync bool) error {
 	if c == nil || c.db == nil {
 		return errCollectionDBNil

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -25,10 +25,13 @@ func collectionCommandWALCoordinatorForDB(db *backenddb.DB) *collectionCommandWA
 	coord := newCollectionCommandWALCoordinator()
 	actual, loaded := collectionCommandWALCoordinators.LoadOrStore(db, coord)
 	if !loaded {
-		db.RegisterCloseHook(func() error {
+		if _, ok := db.RegisterCloseHookIfOpen(func() error {
 			collectionCommandWALCoordinators.Delete(db)
 			return nil
-		})
+		}); !ok {
+			collectionCommandWALCoordinators.Delete(db)
+			return nil
+		}
 		return coord
 	}
 	return actual.(*collectionCommandWALCoordinator)

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -19,22 +19,22 @@ func collectionCommandWALCoordinatorForDB(db *backenddb.DB) *collectionCommandWA
 	if db == nil {
 		return nil
 	}
-	if existing, ok := collectionCommandWALCoordinators.Load(db); ok {
-		return existing.(*collectionCommandWALCoordinator)
-	}
 	coord := newCollectionCommandWALCoordinator()
-	actual, loaded := collectionCommandWALCoordinators.LoadOrStore(db, coord)
-	if !loaded {
-		if _, ok := db.RegisterCloseHookIfOpen(func() error {
-			collectionCommandWALCoordinators.Delete(db)
-			return nil
-		}); !ok {
-			collectionCommandWALCoordinators.Delete(db)
-			return nil
-		}
-		return coord
+	var actual any
+	var loaded bool
+	if _, ok := db.RegisterCloseHookIfOpenAfter(func() bool {
+		actual, loaded = collectionCommandWALCoordinators.LoadOrStore(db, coord)
+		return !loaded
+	}, func() error {
+		collectionCommandWALCoordinators.Delete(db)
+		return nil
+	}); !ok {
+		return nil
 	}
-	return actual.(*collectionCommandWALCoordinator)
+	if loaded {
+		return actual.(*collectionCommandWALCoordinator)
+	}
+	return coord
 }
 
 func newCollectionCommandWALCoordinator() *collectionCommandWALCoordinator {

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -147,9 +147,12 @@ func (c *Collection) lockCommandWALStageCoordinator() (func(), error) {
 				cond.Broadcast()
 			}
 			coord.mu.Unlock()
+			var unlockOnce sync.Once
 			return func() {
-				domain.finishCommandWALStageReservation()
-				domain.clearCommandWALCoordinatorOwnerIfNoPending()
+				unlockOnce.Do(func() {
+					domain.finishCommandWALStageReservation()
+					domain.clearCommandWALCoordinatorOwnerIfNoPending()
+				})
 			}, nil
 		}
 		if collectionCommandWALDomainStageReserved(owner) {
@@ -201,13 +204,14 @@ func (domain *collectionWriteDomain) finishCommandWALStageReservation() {
 		return
 	}
 	coord.mu.Lock()
+	defer coord.mu.Unlock()
 	if next := domain.commandWALStageReservations.Add(-1); next < 0 {
 		domain.commandWALStageReservations.Store(0)
+		panic("collections: command WAL stage reservation underflow")
 	}
 	if cond := coord.condLocked(); cond != nil {
 		cond.Broadcast()
 	}
-	coord.mu.Unlock()
 }
 
 func (coord *collectionCommandWALCoordinator) waitForCommandWALStageReservationLocked(owner *collectionWriteDomain) {

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -1,0 +1,67 @@
+package collections
+
+import (
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(lsn uint64) error {
+	if domain == nil || lsn == 0 {
+		return nil
+	}
+	if domain.pendingCommandWALFirst == 0 {
+		domain.pendingCommandWALFirst = lsn
+		domain.pendingCommandWALLast = lsn
+		return nil
+	}
+	if lsn != domain.pendingCommandWALLast+1 {
+		return fmt.Errorf("%w: pending collection command WAL range [%d,%d] cannot cover interleaved lsn %d", backenddb.ErrCommandWALAppliedLSNNonContig, domain.pendingCommandWALFirst, domain.pendingCommandWALLast, lsn)
+	}
+	domain.pendingCommandWALLast = lsn
+	return nil
+}
+
+func (domain *collectionWriteDomain) pendingCommandWALCoverageIntentLocked(db *backenddb.DB) (*backenddb.CommandWALIntent, uint64, error) {
+	if domain == nil || db == nil || !db.CommandWALEnabled() {
+		return nil, 0, nil
+	}
+	first, last := domain.pendingCommandWALFirst, domain.pendingCommandWALLast
+	if first == 0 || last == 0 {
+		return nil, 0, nil
+	}
+	state := db.State()
+	if state == nil {
+		return nil, 0, backenddb.ErrClosed
+	}
+	current := state.AppliedCommandLSN
+	if last <= current {
+		domain.clearPendingCommandWALThroughLocked(current)
+		return nil, 0, nil
+	}
+	if first > current+1 {
+		return nil, 0, fmt.Errorf("%w: pending collection command WAL starts at %d after applied %d", backenddb.ErrCommandWALAppliedLSNNonContig, first, current)
+	}
+	applied := last
+	intent, err := backenddb.NewCommandWALCoverageIntent(applied, backenddb.CommandWALLSNRange{First: current + 1, Last: applied})
+	if err != nil {
+		return nil, 0, err
+	}
+	return intent, applied, nil
+}
+
+func (domain *collectionWriteDomain) clearPendingCommandWALThroughLocked(lsn uint64) {
+	if domain == nil || lsn == 0 {
+		return
+	}
+	first, last := domain.pendingCommandWALFirst, domain.pendingCommandWALLast
+	if first == 0 || last == 0 || lsn < first {
+		return
+	}
+	if lsn >= last {
+		domain.pendingCommandWALFirst = 0
+		domain.pendingCommandWALLast = 0
+		return
+	}
+	domain.pendingCommandWALFirst = lsn + 1
+}

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -9,6 +9,7 @@ import (
 
 type collectionCommandWALCoordinator struct {
 	mu    sync.Mutex
+	cond  *sync.Cond
 	owner *collectionWriteDomain
 }
 
@@ -21,7 +22,7 @@ func collectionCommandWALCoordinatorForDB(db *backenddb.DB) *collectionCommandWA
 	if existing, ok := collectionCommandWALCoordinators.Load(db); ok {
 		return existing.(*collectionCommandWALCoordinator)
 	}
-	coord := &collectionCommandWALCoordinator{}
+	coord := newCollectionCommandWALCoordinator()
 	actual, loaded := collectionCommandWALCoordinators.LoadOrStore(db, coord)
 	if !loaded {
 		db.RegisterCloseHook(func() error {
@@ -31,6 +32,22 @@ func collectionCommandWALCoordinatorForDB(db *backenddb.DB) *collectionCommandWA
 		return coord
 	}
 	return actual.(*collectionCommandWALCoordinator)
+}
+
+func newCollectionCommandWALCoordinator() *collectionCommandWALCoordinator {
+	coord := &collectionCommandWALCoordinator{}
+	coord.cond = sync.NewCond(&coord.mu)
+	return coord
+}
+
+func (coord *collectionCommandWALCoordinator) condLocked() *sync.Cond {
+	if coord == nil {
+		return nil
+	}
+	if coord.cond == nil {
+		coord.cond = sync.NewCond(&coord.mu)
+	}
+	return coord.cond
 }
 
 func (domain *collectionWriteDomain) commandWALCoordinatorForDomain(db *backenddb.DB) *collectionCommandWALCoordinator {
@@ -43,13 +60,56 @@ func (domain *collectionWriteDomain) commandWALCoordinatorForDomain(db *backendd
 	return collectionCommandWALCoordinatorForDB(db)
 }
 
-func collectionCommandWALDomainHasPending(domain *collectionWriteDomain) bool {
+func collectionCommandWALDomainPendingLocked(domain *collectionWriteDomain) bool {
 	if domain == nil {
 		return false
 	}
-	domain.mu.RLock()
-	defer domain.mu.RUnlock()
 	return domain.pendingCommandWALFirst != 0 && domain.pendingCommandWALLast != 0
+}
+
+func collectionCommandWALDomainStageReserved(domain *collectionWriteDomain) bool {
+	return domain != nil && domain.commandWALStageReservations.Load() > 0
+}
+
+func (domain *collectionWriteDomain) reserveCommandWALCoordinatorOwnerLocked() {
+	if domain == nil || domain.commandWALCoordinator == nil {
+		return
+	}
+	coord := domain.commandWALCoordinator
+	coord.mu.Lock()
+	coord.owner = domain
+	if cond := coord.condLocked(); cond != nil {
+		cond.Broadcast()
+	}
+	coord.mu.Unlock()
+}
+
+func (domain *collectionWriteDomain) clearCommandWALCoordinatorOwnerIfNoPendingLocked() {
+	if domain == nil || domain.commandWALCoordinator == nil || collectionCommandWALDomainPendingLocked(domain) {
+		return
+	}
+	coord := domain.commandWALCoordinator
+	coord.mu.Lock()
+	if collectionCommandWALDomainStageReserved(domain) {
+		coord.mu.Unlock()
+		return
+	}
+	if coord.owner == domain {
+		coord.owner = nil
+		if cond := coord.condLocked(); cond != nil {
+			cond.Broadcast()
+		}
+	}
+	coord.mu.Unlock()
+}
+
+func (domain *collectionWriteDomain) clearCommandWALCoordinatorOwnerIfNoPending() {
+	if domain == nil {
+		return
+	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
 }
 
 func (c *Collection) lockCommandWALStageCoordinator() (func(), error) {
@@ -65,10 +125,19 @@ func (c *Collection) lockCommandWALStageCoordinator() (func(), error) {
 		coord.mu.Lock()
 		owner := coord.owner
 		if owner == nil || owner == domain {
-			return coord.mu.Unlock, nil
+			domain.commandWALStageReservations.Add(1)
+			coord.owner = domain
+			if cond := coord.condLocked(); cond != nil {
+				cond.Broadcast()
+			}
+			coord.mu.Unlock()
+			return func() {
+				domain.finishCommandWALStageReservation()
+				domain.clearCommandWALCoordinatorOwnerIfNoPending()
+			}, nil
 		}
-		if !collectionCommandWALDomainHasPending(owner) {
-			coord.owner = nil
+		if collectionCommandWALDomainStageReserved(owner) {
+			coord.waitForCommandWALStageReservationLocked(owner)
 			coord.mu.Unlock()
 			continue
 		}
@@ -76,6 +145,62 @@ func (c *Collection) lockCommandWALStageCoordinator() (func(), error) {
 		if err := flushCollectionWriteDomain(c.db, owner); err != nil {
 			return nil, err
 		}
+	}
+}
+
+func (c *Collection) drainCommandWALStageCoordinatorBeforeMutation() error {
+	if c == nil || c.db == nil || !c.db.CommandWALEnabled() || c.writeDomain == nil {
+		return nil
+	}
+	domain := c.writeDomain
+	coord := domain.commandWALCoordinatorForDomain(c.db)
+	if coord == nil {
+		return nil
+	}
+	for {
+		coord.mu.Lock()
+		owner := coord.owner
+		if owner == nil || owner == domain {
+			coord.mu.Unlock()
+			return nil
+		}
+		if collectionCommandWALDomainStageReserved(owner) {
+			coord.waitForCommandWALStageReservationLocked(owner)
+			coord.mu.Unlock()
+			continue
+		}
+		coord.mu.Unlock()
+		if err := flushCollectionWriteDomain(c.db, owner); err != nil {
+			return err
+		}
+	}
+}
+
+func (domain *collectionWriteDomain) finishCommandWALStageReservation() {
+	if domain == nil || domain.commandWALCoordinator == nil {
+		return
+	}
+	coord := domain.commandWALCoordinator
+	coord.mu.Lock()
+	if next := domain.commandWALStageReservations.Add(-1); next < 0 {
+		domain.commandWALStageReservations.Store(0)
+	}
+	if cond := coord.condLocked(); cond != nil {
+		cond.Broadcast()
+	}
+	coord.mu.Unlock()
+}
+
+func (coord *collectionCommandWALCoordinator) waitForCommandWALStageReservationLocked(owner *collectionWriteDomain) {
+	if coord == nil || owner == nil {
+		return
+	}
+	cond := coord.condLocked()
+	if cond == nil {
+		return
+	}
+	for coord.owner == owner && collectionCommandWALDomainStageReserved(owner) {
+		cond.Wait()
 	}
 }
 
@@ -94,8 +219,8 @@ func (c *Collection) lockCommandWALPublishCoordinator() (func(), error) {
 		if owner == nil {
 			return coord.mu.Unlock, nil
 		}
-		if !collectionCommandWALDomainHasPending(owner) {
-			coord.owner = nil
+		if collectionCommandWALDomainStageReserved(owner) {
+			coord.waitForCommandWALStageReservationLocked(owner)
 			coord.mu.Unlock()
 			continue
 		}
@@ -124,8 +249,8 @@ func (c *Collection) lockCommandWALFlushPublishCoordinator(domain *collectionWri
 		if owner == nil || owner == domain {
 			return coord.mu.Unlock, nil
 		}
-		if !collectionCommandWALDomainHasPending(owner) {
-			coord.owner = nil
+		if collectionCommandWALDomainStageReserved(owner) {
+			coord.waitForCommandWALStageReservationLocked(owner)
 			coord.mu.Unlock()
 			continue
 		}
@@ -165,8 +290,8 @@ func (m *CollectionManager) lockCommandWALPublishCoordinator() (func(), error) {
 		if owner == nil {
 			return coord.mu.Unlock, nil
 		}
-		if !collectionCommandWALDomainHasPending(owner) {
-			coord.owner = nil
+		if collectionCommandWALDomainStageReserved(owner) {
+			coord.waitForCommandWALStageReservationLocked(owner)
 			coord.mu.Unlock()
 			continue
 		}
@@ -187,6 +312,18 @@ func (m *CollectionManager) publishCommandWALNoop(intent *backenddb.CommandWALIn
 	}
 	defer unlock()
 	return m.db.PublishCommandWALNoop(intent, sync)
+}
+
+func (m *CollectionManager) flushPendingCommandWALBeforeRawPublish() error {
+	if m == nil || m.db == nil || !m.db.CommandWALEnabled() {
+		return nil
+	}
+	unlock, err := m.lockCommandWALPublishCoordinator()
+	if err != nil {
+		return err
+	}
+	unlock()
+	return nil
 }
 
 func (m *CollectionManager) withCommandWALPublishCoordinator(fn func() error) error {
@@ -230,18 +367,14 @@ func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(db *backen
 		}
 		domain.pendingCommandWALFirst = lsn
 		domain.pendingCommandWALLast = lsn
-		if domain.commandWALCoordinator != nil {
-			domain.commandWALCoordinator.owner = domain
-		}
+		domain.reserveCommandWALCoordinatorOwnerLocked()
 		return nil
 	}
 	if lsn != domain.pendingCommandWALLast+1 {
 		return fmt.Errorf("%w: pending collection command WAL range [%d,%d] cannot cover interleaved lsn %d", backenddb.ErrCommandWALAppliedLSNNonContig, domain.pendingCommandWALFirst, domain.pendingCommandWALLast, lsn)
 	}
 	domain.pendingCommandWALLast = lsn
-	if domain.commandWALCoordinator != nil {
-		domain.commandWALCoordinator.owner = domain
-	}
+	domain.reserveCommandWALCoordinatorOwnerLocked()
 	return nil
 }
 

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -187,11 +187,21 @@ func (c *Collection) withCommandWALPublishCoordinator(fn func() error) error {
 	return fn()
 }
 
-func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(lsn uint64) error {
+func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(db *backenddb.DB, lsn uint64) error {
 	if domain == nil || lsn == 0 {
 		return nil
 	}
 	if domain.pendingCommandWALFirst == 0 {
+		if db == nil {
+			return backenddb.ErrClosed
+		}
+		state := db.State()
+		if state == nil {
+			return backenddb.ErrClosed
+		}
+		if lsn != state.AppliedCommandLSN+1 {
+			return fmt.Errorf("%w: pending collection command WAL starts at %d after applied %d", backenddb.ErrCommandWALAppliedLSNNonContig, lsn, state.AppliedCommandLSN)
+		}
 		domain.pendingCommandWALFirst = lsn
 		domain.pendingCommandWALLast = lsn
 		if domain.commandWALCoordinator != nil {

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1163,8 +1163,18 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish(t *te
 	var launchSecond atomic.Bool
 	var launchedSecond atomic.Bool
 	secondStarted := make(chan struct{})
+	secondStagingAttempted := make(chan struct{})
 	secondDone := make(chan error, 1)
+	var signalSecondStaging sync.Once
 	var col *Collection
+	restoreStageLockHook := setTestBeforeCommandWALBufferedUpdateStageLockForTest(func() {
+		if launchedSecond.Load() {
+			signalSecondStaging.Do(func() {
+				close(secondStagingAttempted)
+			})
+		}
+	})
+	defer restoreStageLockHook()
 	unregister := d.RegisterCommandWALRawPublishBarrier(func() error {
 		if !launchSecond.Load() || !launchedSecond.CompareAndSwap(false, true) {
 			return nil
@@ -1178,8 +1188,17 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish(t *te
 			secondDone <- err
 		}()
 		<-secondStarted
-		time.Sleep(200 * time.Millisecond)
-		return nil
+		select {
+		case <-secondStagingAttempted:
+			return nil
+		case err := <-secondDone:
+			if err != nil {
+				return err
+			}
+			return errors.New("second collection update completed before command WAL staging lock")
+		case <-time.After(2 * time.Second):
+			return errors.New("second collection update did not reach command WAL staging lock")
+		}
 	})
 	defer unregister()
 

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -828,6 +828,126 @@ func TestCollectionCommandWALUpdateBSONSetUniqueIndexChangePublishesAppliedLSN(t
 	}
 }
 
+func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexPublishesAppliedLSN(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "email", Value: "ada@example.test"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+	assertCollectionIndexIDs(t, col, "email", "ada@example.test", "u1")
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	}
+}
+
+func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	col, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get staged doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		_ = d.Close()
+		t.Fatalf("staged city=%q want sea", got)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0 before flush", got)
+	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
+		_ = d.Close()
+		t.Fatalf("command WAL frames=%+v, want one update frame before flush", frames)
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	doc, err = reopened.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get reopened doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("reopened city=%q want sea", got)
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetUniqueIndexReopenRecovery(t *testing.T) {
 	doc1 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}})
 	doc2 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}})

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -948,6 +948,145 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing
 	}
 }
 
+func TestCollectionCommandWALUpdateBSONSetNoopFlushesStagedUpdate(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet staged: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("staged UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0", got)
+	}
+	matched, modified, err = col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet noop: %v", err)
+	}
+	if !matched || modified {
+		t.Fatalf("noop UpdateBSONSet matched=%t modified=%t, want true/false", matched, modified)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after noop=%d, want 2", got)
+	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 2 {
+		t.Fatalf("command WAL frame count=%d, want 2", len(frames))
+	}
+}
+
+func TestCollectionCommandWALUpdateBSONSetNoIndexInterleavedCollectionsDrainOwner(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "a",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("a1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "b",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("CreateCollection b: %v", err)
+	}
+	a, err := mgr.OpenCollection("a")
+	if err != nil {
+		t.Fatalf("OpenCollection a: %v", err)
+	}
+	b, err := mgr.OpenCollection("b")
+	if err != nil {
+		t.Fatalf("OpenCollection b: %v", err)
+	}
+	if _, err := b.Insert([]byte("b1"), mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}})); err != nil {
+		t.Fatalf("Insert b1: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after setup=%d, want 2", got)
+	}
+	if _, _, err := a.UpdateBSONSet([]byte("a1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet a1 first: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after staged a=%d, want 2", got)
+	}
+	if _, _, err := b.UpdateBSONSet([]byte("b1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "bos"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet b1: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 3 {
+		t.Fatalf("AppliedCommandLSN after switching to b=%d, want 3", got)
+	}
+	if _, _, err := a.UpdateBSONSet([]byte("a1"), []BSONSetField{{
+		Key:   "state",
+		Value: mustBSONRawValue(t, "wa"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet a1 second: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 4 {
+		t.Fatalf("AppliedCommandLSN after switching back to a=%d, want 4", got)
+	}
+	if err := a.Flush(); err != nil {
+		t.Fatalf("Flush a: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 5 {
+		t.Fatalf("AppliedCommandLSN after final flush=%d, want 5", got)
+	}
+	doc, err := a.Get([]byte("a1"))
+	if err != nil {
+		t.Fatalf("Get a1: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("a.city=%q want sea", got)
+	}
+	if got := bson.Raw(doc).Lookup("state").StringValue(); got != "wa" {
+		t.Fatalf("a.state=%q want wa", got)
+	}
+	doc, err = b.Get([]byte("b1"))
+	if err != nil {
+		t.Fatalf("Get b1: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "bos" {
+		t.Fatalf("b.city=%q want bos", got)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetUniqueIndexReopenRecovery(t *testing.T) {
 	doc1 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}})
 	doc2 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}})

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1062,14 +1062,12 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish(
 	attempting := make(chan struct{})
 	stagingAttempted := make(chan struct{})
 	var signalStagingAttempt sync.Once
-	testBeforeCommandWALBufferedUpdateStageLock = func() {
+	restoreStageLockHook := setTestBeforeCommandWALBufferedUpdateStageLockForTest(func() {
 		signalStagingAttempt.Do(func() {
 			close(stagingAttempted)
 		})
-	}
-	defer func() {
-		testBeforeCommandWALBufferedUpdateStageLock = nil
-	}()
+	})
+	defer restoreStageLockHook()
 	done := make(chan error, 1)
 	unregister := d.RegisterCommandWALRawPublishBarrier(func() error {
 		go func() {

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1590,6 +1590,87 @@ func TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDraini
 	}
 }
 
+func TestCollectionCommandWALThresholdFlushClearsCoordinatorOwner(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "email", Value: "ada@example.test"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after threshold flush=%d, want 1", got)
+	}
+	coord := mgr.commandWALCoordinator
+	if coord == nil {
+		t.Fatalf("missing command WAL coordinator")
+	}
+	coord.mu.Lock()
+	owner := coord.owner
+	coord.mu.Unlock()
+	if owner != nil {
+		t.Fatalf("coordinator owner after threshold flush=%p, want nil", owner)
+	}
+}
+
+func TestCollectionCommandWALStageCoordinatorPinsFallbackToDomain(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	domain := &collectionWriteDomain{}
+	col := &Collection{db: d, writeDomain: domain}
+
+	unlock, err := col.lockCommandWALStageCoordinator()
+	if err != nil {
+		t.Fatalf("lockCommandWALStageCoordinator: %v", err)
+	}
+	coord := domain.commandWALCoordinator.Load()
+	if coord == nil {
+		t.Fatalf("fallback coordinator was not pinned to domain")
+	}
+	if got := domain.commandWALStageReservations.Load(); got != 1 {
+		t.Fatalf("stage reservations before unlock=%d, want 1", got)
+	}
+	unlock()
+	if got := domain.commandWALStageReservations.Load(); got != 0 {
+		t.Fatalf("stage reservations after unlock=%d, want 0", got)
+	}
+	coord.mu.Lock()
+	owner := coord.owner
+	coord.mu.Unlock()
+	if owner != nil {
+		t.Fatalf("coordinator owner after unlock=%p, want nil", owner)
+	}
+}
+
 func TestCollectionCommandWALPublishWaitsForStageReservation(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1059,6 +1060,16 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish(
 	}
 
 	attempting := make(chan struct{})
+	stagingAttempted := make(chan struct{})
+	var signalStagingAttempt sync.Once
+	testBeforeCommandWALBufferedUpdateStageLock = func() {
+		signalStagingAttempt.Do(func() {
+			close(stagingAttempted)
+		})
+	}
+	defer func() {
+		testBeforeCommandWALBufferedUpdateStageLock = nil
+	}()
 	done := make(chan error, 1)
 	unregister := d.RegisterCommandWALRawPublishBarrier(func() error {
 		go func() {
@@ -1074,12 +1085,22 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish(
 		}()
 		<-attempting
 		select {
+		case <-stagingAttempted:
+		case updateErr := <-done:
+			if updateErr != nil {
+				return updateErr
+			}
+			return errors.New("collection update completed before command WAL staging lock")
+		case <-time.After(2 * time.Second):
+			return errors.New("collection update did not reach command WAL staging lock")
+		}
+		select {
 		case updateErr := <-done:
 			if updateErr != nil {
 				return updateErr
 			}
 			return errors.New("collection update completed while raw command WAL publish was open")
-		case <-time.After(25 * time.Millisecond):
+		default:
 			return nil
 		}
 	})

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1514,6 +1514,7 @@ func TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDraini
 	coordAvailable := make(chan struct{})
 	go func() {
 		coord.mu.Lock()
+		_ = coord.owner
 		coord.mu.Unlock()
 		close(coordAvailable)
 	}()

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1307,13 +1307,16 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation(t 
 	defer releaseMutation()
 
 	updateDone := make(chan error, 1)
+	updateStarted := make(chan struct{})
 	go func() {
+		close(updateStarted)
 		_, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
 			Key:   "city",
 			Value: mustBSONRawValue(t, "sea"),
 		}})
 		updateDone <- err
 	}()
+	<-updateStarted
 
 	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
@@ -1333,9 +1336,12 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation(t 
 		t.Fatalf("newCollectionUpdateCommandWALIntent: %v", err)
 	}
 	publishDone := make(chan error, 1)
+	publishStarted := make(chan struct{})
 	go func() {
+		close(publishStarted)
 		publishDone <- col.publishCommandWALNoop(intent, false)
 	}()
+	<-publishStarted
 	select {
 	case err := <-publishDone:
 		if err != nil {
@@ -1547,14 +1553,16 @@ func TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDraini
 
 	col.writeDomain.mu.Lock()
 	drainDone := make(chan error, 1)
+	drainStarted := make(chan struct{})
 	go func() {
+		close(drainStarted)
 		unlock, lockErr := mgr.lockCommandWALPublishCoordinator()
 		if lockErr == nil {
 			unlock()
 		}
 		drainDone <- lockErr
 	}()
-	time.Sleep(25 * time.Millisecond)
+	<-drainStarted
 	select {
 	case err := <-drainDone:
 		col.writeDomain.mu.Unlock()
@@ -1701,9 +1709,12 @@ func TestCollectionCommandWALPublishWaitsForStageReservation(t *testing.T) {
 		t.Fatalf("newCollectionUpdateCommandWALIntent: %v", err)
 	}
 	publishDone := make(chan error, 1)
+	publishStarted := make(chan struct{})
 	go func() {
+		close(publishStarted)
 		publishDone <- col.publishCommandWALNoop(intent, false)
 	}()
+	<-publishStarted
 	select {
 	case err := <-publishDone:
 		t.Fatalf("publish completed while staged owner had no pending LSN: %v", err)

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1226,6 +1226,19 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish(t *te
 	}
 }
 
+func TestCollectionCommandWALCoordinatorNotStoredAfterCloseHooksDrained(t *testing.T) {
+	d := &backenddb.DB{}
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	if coord := collectionCommandWALCoordinatorForDB(d); coord != nil {
+		t.Fatalf("collectionCommandWALCoordinatorForDB after close hooks drained returned non-nil coordinator")
+	}
+	if _, ok := collectionCommandWALCoordinators.Load(d); ok {
+		t.Fatalf("collection command WAL coordinator stored after close hooks drained")
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -948,6 +948,373 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing
 	}
 }
 
+func TestCollectionCommandWALUpdateBSONSetNoIndexDrainsBeforeRawKVCommandWAL(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0 before raw write", got)
+	}
+	if err := d.Set([]byte("raw"), []byte("v")); err != nil {
+		_ = d.Close()
+		t.Fatalf("raw Set after staged collection update: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after raw write=%d, want staged update and raw frame applied", got)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get staged doc after raw write: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		_ = d.Close()
+		t.Fatalf("city after raw write=%q want sea", got)
+	}
+	raw, err := d.Get([]byte("raw"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get raw key: %v", err)
+	}
+	if !bytes.Equal(raw, []byte("v")) {
+		_ = d.Close()
+		t.Fatalf("raw key=%q, want v", raw)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	doc, err = reopened.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get reopened doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("reopened city=%q want sea", got)
+	}
+	raw, err = reopen.Get([]byte("raw"))
+	if err != nil {
+		t.Fatalf("Get reopened raw key: %v", err)
+	}
+	if !bytes.Equal(raw, []byte("v")) {
+		t.Fatalf("reopened raw key=%q, want v", raw)
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 2", got)
+	}
+}
+
+func TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+
+	attempting := make(chan struct{})
+	done := make(chan error, 1)
+	unregister := d.RegisterCommandWALRawPublishBarrier(func() error {
+		go func() {
+			close(attempting)
+			matched, modified, updateErr := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+				Key:   "city",
+				Value: mustBSONRawValue(t, "sea"),
+			}})
+			if updateErr == nil && (!matched || !modified) {
+				updateErr = errors.New("UpdateBSONSet matched/modified false")
+			}
+			done <- updateErr
+		}()
+		<-attempting
+		select {
+		case updateErr := <-done:
+			if updateErr != nil {
+				return updateErr
+			}
+			return errors.New("collection update completed while raw command WAL publish was open")
+		case <-time.After(25 * time.Millisecond):
+			return nil
+		}
+	})
+	defer unregister()
+
+	if err := d.Set([]byte("raw"), []byte("v")); err != nil {
+		t.Fatalf("raw Set while collection update is waiting: %v", err)
+	}
+	select {
+	case updateErr := <-done:
+		if updateErr != nil {
+			t.Fatalf("UpdateBSONSet after raw publish: %v", updateErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("UpdateBSONSet did not complete after raw publish")
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after raw publish and staged update=%d, want 1", got)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get updated doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city after update=%q want sea", got)
+	}
+	raw, err := d.Get([]byte("raw"))
+	if err != nil {
+		t.Fatalf("Get raw key: %v", err)
+	}
+	if !bytes.Equal(raw, []byte("v")) {
+		t.Fatalf("raw key=%q, want v", raw)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush staged update: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 2", got)
+	}
+}
+
+func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "city", Value: "hnl"}, {Key: "state", Value: "hi"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	closeDB := true
+	defer func() {
+		if closeDB {
+			_ = d.Close()
+		}
+	}()
+
+	var launchSecond atomic.Bool
+	var launchedSecond atomic.Bool
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	var col *Collection
+	unregister := d.RegisterCommandWALRawPublishBarrier(func() error {
+		if !launchSecond.Load() || !launchedSecond.CompareAndSwap(false, true) {
+			return nil
+		}
+		go func() {
+			close(secondStarted)
+			_, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+				Key:   "state",
+				Value: mustBSONRawValue(t, "wa"),
+			}})
+			secondDone <- err
+		}()
+		<-secondStarted
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	})
+	defer unregister()
+
+	mgr := NewCollectionManager(d)
+	var err error
+	col, err = mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("first UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("first UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after first update=%d, want 0", got)
+	}
+
+	launchSecond.Store(true)
+	rawDone := make(chan error, 1)
+	go func() {
+		rawDone <- d.Set([]byte("raw"), []byte("v"))
+	}()
+	select {
+	case err := <-rawDone:
+		if err != nil {
+			t.Fatalf("raw Set: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		closeDB = false
+		t.Fatalf("raw Set did not complete")
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("second UpdateBSONSet: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		closeDB = false
+		t.Fatalf("second UpdateBSONSet did not complete")
+	}
+	raw, err := d.Get([]byte("raw"))
+	if err != nil {
+		t.Fatalf("Get raw key: %v", err)
+	}
+	if string(raw) != "v" {
+		t.Fatalf("raw key=%q, want v", raw)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q, want sea", got)
+	}
+	if got := bson.Raw(doc).Lookup("state").StringValue(); got != "wa" {
+		t.Fatalf("state=%q, want wa", got)
+	}
+}
+
+func TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "city", Value: "hnl"}, {Key: "state", Value: "hi"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+
+	unlockMutation := col.lockMutation()
+	mutationLocked := true
+	releaseMutation := func() {
+		if mutationLocked {
+			unlockMutation.Unlock()
+			mutationLocked = false
+		}
+	}
+	defer releaseMutation()
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, "sea"),
+		}})
+		updateDone <- err
+	}()
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-updateDone:
+			t.Fatalf("UpdateBSONSet completed while mutation lock was held: %v", err)
+		default:
+		}
+		if collectionCommandWALDomainStageReserved(col.writeDomain) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	intent, err := col.newCollectionUpdateCommandWALIntent(nil, nil)
+	if err != nil {
+		t.Fatalf("newCollectionUpdateCommandWALIntent: %v", err)
+	}
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- col.publishCommandWALNoop(intent, false)
+	}()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish no-op while mutation lock held: %v", err)
+		}
+	case <-time.After(time.Second):
+		releaseMutation()
+		t.Fatalf("publish no-op waited on a pre-mutation stage reservation")
+	}
+
+	releaseMutation()
+	select {
+	case err := <-updateDone:
+		if err != nil {
+			t.Fatalf("UpdateBSONSet after mutation release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("UpdateBSONSet did not complete after mutation release")
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN before flushing staged update=%d, want 1", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush staged update: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after flushing staged update=%d, want 2", got)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetNoopFlushesStagedUpdate(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",
@@ -1084,6 +1451,146 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexInterleavedCollectionsDrainOwne
 	}
 	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "bos" {
 		t.Fatalf("b.city=%q want bos", got)
+	}
+}
+
+func TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}}); err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0", got)
+	}
+
+	coord := mgr.commandWALCoordinator
+	if coord == nil {
+		t.Fatalf("missing command WAL coordinator")
+	}
+	coord.mu.Lock()
+	if coord.owner != col.writeDomain {
+		coord.mu.Unlock()
+		t.Fatalf("coordinator owner=%p, want collection write domain %p", coord.owner, col.writeDomain)
+	}
+	coord.mu.Unlock()
+
+	col.writeDomain.mu.Lock()
+	drainDone := make(chan error, 1)
+	go func() {
+		unlock, lockErr := mgr.lockCommandWALPublishCoordinator()
+		if lockErr == nil {
+			unlock()
+		}
+		drainDone <- lockErr
+	}()
+	time.Sleep(25 * time.Millisecond)
+	select {
+	case err := <-drainDone:
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("owner drain completed while owner domain lock was held: %v", err)
+	default:
+	}
+
+	coordAvailable := make(chan struct{})
+	go func() {
+		coord.mu.Lock()
+		coord.mu.Unlock()
+		close(coordAvailable)
+	}()
+	select {
+	case <-coordAvailable:
+	case <-time.After(250 * time.Millisecond):
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("publish coordinator stayed locked while waiting for owner domain")
+	}
+
+	col.writeDomain.mu.Unlock()
+	select {
+	case err := <-drainDone:
+		if err != nil {
+			t.Fatalf("owner drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("owner drain did not complete after owner domain unlocked")
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after owner drain=%d, want 1", got)
+	}
+}
+
+func TestCollectionCommandWALPublishWaitsForStageReservation(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	unlockStage, err := col.lockCommandWALStageCoordinator()
+	if err != nil {
+		t.Fatalf("lockCommandWALStageCoordinator: %v", err)
+	}
+	releaseStage := func() {
+		if unlockStage != nil {
+			unlockStage()
+			unlockStage = nil
+		}
+	}
+	defer releaseStage()
+
+	intent, err := col.newCollectionUpdateCommandWALIntent(nil, nil)
+	if err != nil {
+		t.Fatalf("newCollectionUpdateCommandWALIntent: %v", err)
+	}
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- col.publishCommandWALNoop(intent, false)
+	}()
+	select {
+	case err := <-publishDone:
+		t.Fatalf("publish completed while staged owner had no pending LSN: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN before releasing stage reservation=%d, want 0", got)
+	}
+
+	releaseStage()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish after stage release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("publish did not complete after stage reservation release")
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after publish=%d, want 1", got)
 	}
 }
 
@@ -1290,6 +1797,34 @@ func TestCollectionCommandWALCreateCollectionPublishesAppliedLSN(t *testing.T) {
 	}
 	if got := reopen.State().AppliedCommandLSN; got != 1 {
 		t.Fatalf("reopen AppliedCommandLSN=%d, want 1", got)
+	}
+}
+
+func TestCollectionCommandWALReplayManagerDoesNotRegisterBackendHooks(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+
+	replayManager := newCommandWALReplayCollectionManager(d)
+	if replayManager.commandWALCoordinator == nil {
+		t.Fatalf("replay manager missing command WAL coordinator")
+	}
+	if replayManager.commandWALRawUnregister != nil {
+		t.Fatalf("replay manager registered raw publish barrier")
+	}
+	if replayManager.closeUnregister != nil {
+		t.Fatalf("replay manager registered close hook")
+	}
+
+	liveManager := NewCollectionManager(d)
+	if liveManager.commandWALRawUnregister == nil {
+		t.Fatalf("live manager missing raw publish barrier")
+	}
+	if liveManager.closeUnregister == nil {
+		t.Fatalf("live manager missing close hook")
 	}
 }
 

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1087,6 +1087,21 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexInterleavedCollectionsDrainOwne
 	}
 }
 
+func TestCollectionCommandWALPendingFirstLSNRequiresAppliedNext(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	domain := &collectionWriteDomain{}
+	if err := domain.recordPendingCommandWALLSNLocked(d, 2); !errors.Is(err, backenddb.ErrCommandWALAppliedLSNNonContig) {
+		t.Fatalf("recordPendingCommandWALLSNLocked error=%v, want ErrCommandWALAppliedLSNNonContig", err)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetUniqueIndexReopenRecovery(t *testing.T) {
 	doc1 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}})
 	doc2 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}})

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -218,6 +218,11 @@ func (b *Batch) write(sync bool) error {
 	}
 	intent := b.commandWALPublishIntent
 	if !b.physicalOnly && b.db.commandWAL {
+		unlockRawPublish := b.db.lockCommandWALRawPublish()
+		defer unlockRawPublish()
+		if err := b.db.runCommandWALRawPublishBarriers(); err != nil {
+			return err
+		}
 		var err error
 		intent, err = b.db.prepareRawKVCommandWALIntent(b)
 		if err != nil {

--- a/TreeDB/db/close_hooks_test.go
+++ b/TreeDB/db/close_hooks_test.go
@@ -84,3 +84,34 @@ func TestRegisterCloseHookIfOpenAfterSetupRunsUnderAcceptedRegistration(t *testi
 		t.Fatalf("setup ran after close hooks drained")
 	}
 }
+
+func TestRegisterCloseHookIfOpenAfterSetupCanDeclineHook(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	setupRan := false
+	hookRan := false
+	unregister, ok := d.RegisterCloseHookIfOpenAfter(func() bool {
+		setupRan = true
+		return false
+	}, func() error {
+		hookRan = true
+		return nil
+	})
+	if !ok {
+		t.Fatalf("RegisterCloseHookIfOpenAfter rejected open DB")
+	}
+	unregister()
+	if !setupRan {
+		t.Fatalf("setup did not run")
+	}
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	if hookRan {
+		t.Fatalf("close hook ran after setup declined registration")
+	}
+}

--- a/TreeDB/db/close_hooks_test.go
+++ b/TreeDB/db/close_hooks_test.go
@@ -38,3 +38,49 @@ func TestRegisterCloseHookAfterRunCloseHooksIsIgnored(t *testing.T) {
 		t.Fatalf("close hook ran %d times after second drain, want 1", ran)
 	}
 }
+
+func TestRegisterCloseHookIfOpenAfterSetupRunsUnderAcceptedRegistration(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	published := false
+	hookRan := false
+	if _, ok := d.RegisterCloseHookIfOpenAfter(func() bool {
+		published = true
+		return true
+	}, func() error {
+		if !published {
+			t.Fatalf("close hook ran before setup published state")
+		}
+		hookRan = true
+		return nil
+	}); !ok {
+		t.Fatalf("RegisterCloseHookIfOpenAfter rejected open DB")
+	}
+	if !published {
+		t.Fatalf("setup did not run for accepted close hook registration")
+	}
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	if !hookRan {
+		t.Fatalf("close hook did not run")
+	}
+
+	lateSetupRan := false
+	if _, ok := d.RegisterCloseHookIfOpenAfter(func() bool {
+		lateSetupRan = true
+		return true
+	}, func() error {
+		t.Fatalf("late close hook ran after hook drain")
+		return nil
+	}); ok {
+		t.Fatalf("RegisterCloseHookIfOpenAfter accepted drained DB")
+	}
+	if lateSetupRan {
+		t.Fatalf("setup ran after close hooks drained")
+	}
+}

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -15,7 +15,7 @@ type commandWALRawBarrier struct {
 // command executors use this to drain already-appended staged command frames so
 // raw KV publishes cannot create AppliedCommandLSN gaps.
 func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
-	if db == nil || hook == nil {
+	if db == nil || hook == nil || !db.commandWAL {
 		return func() {}
 	}
 	db.closeHooksMu.Lock()

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -8,6 +8,7 @@ import (
 type commandWALRawBarrier struct {
 	id   uint64
 	hook func() error
+	wg   sync.WaitGroup
 }
 
 // RegisterCommandWALRawPublishBarrier registers a callback that raw command-WAL
@@ -26,24 +27,30 @@ func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 	db.commandWALRawBarrierMu.Lock()
 	db.commandWALRawBarrierNextID++
 	id := db.commandWALRawBarrierNextID
-	db.commandWALRawBarriers = append(db.commandWALRawBarriers, commandWALRawBarrier{id: id, hook: hook})
+	barrier := &commandWALRawBarrier{id: id, hook: hook}
+	db.commandWALRawBarriers = append(db.commandWALRawBarriers, barrier)
 	db.commandWALRawBarrierMu.Unlock()
 	db.closeHooksMu.Unlock()
 
 	var once sync.Once
 	return func() {
 		once.Do(func() {
+			var removed *commandWALRawBarrier
 			db.commandWALRawBarrierMu.Lock()
 			for i := range db.commandWALRawBarriers {
-				if db.commandWALRawBarriers[i].id == id {
+				if db.commandWALRawBarriers[i] != nil && db.commandWALRawBarriers[i].id == id {
+					removed = db.commandWALRawBarriers[i]
 					copy(db.commandWALRawBarriers[i:], db.commandWALRawBarriers[i+1:])
 					last := len(db.commandWALRawBarriers) - 1
-					db.commandWALRawBarriers[last] = commandWALRawBarrier{}
+					db.commandWALRawBarriers[last] = nil
 					db.commandWALRawBarriers = db.commandWALRawBarriers[:last]
 					break
 				}
 			}
 			db.commandWALRawBarrierMu.Unlock()
+			if removed != nil {
+				removed.wg.Wait()
+			}
 		})
 	}
 }
@@ -56,19 +63,23 @@ func (db *DB) runCommandWALRawPublishBarriers() error {
 		return err
 	}
 	db.commandWALRawBarrierMu.Lock()
-	hooks := make([]func() error, 0, len(db.commandWALRawBarriers))
+	barriers := make([]*commandWALRawBarrier, 0, len(db.commandWALRawBarriers))
 	for _, barrier := range db.commandWALRawBarriers {
-		if barrier.hook != nil {
-			hooks = append(hooks, barrier.hook)
+		if barrier != nil && barrier.hook != nil {
+			barrier.wg.Add(1)
+			barriers = append(barriers, barrier)
 		}
 	}
 	db.commandWALRawBarrierMu.Unlock()
 
 	var errs []error
-	for _, hook := range hooks {
-		if err := hook(); err != nil {
-			errs = append(errs, err)
-		}
+	for _, barrier := range barriers {
+		func() {
+			defer barrier.wg.Done()
+			if err := barrier.hook(); err != nil {
+				errs = append(errs, err)
+			}
+		}()
 	}
 	return errors.Join(errs...)
 }

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"errors"
+	"sync"
+)
+
+// RegisterCommandWALRawPublishBarrier registers a callback that raw command-WAL
+// writers must run before appending a new raw KV command frame. Higher-level
+// command executors use this to drain already-appended staged command frames so
+// raw KV publishes cannot create AppliedCommandLSN gaps.
+func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
+	if db == nil || hook == nil {
+		return func() {}
+	}
+	db.commandWALRawBarrierMu.Lock()
+	idx := len(db.commandWALRawBarriers)
+	db.commandWALRawBarriers = append(db.commandWALRawBarriers, hook)
+	db.commandWALRawBarrierMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			db.commandWALRawBarrierMu.Lock()
+			if idx >= 0 && idx < len(db.commandWALRawBarriers) && db.commandWALRawBarriers[idx] != nil {
+				db.commandWALRawBarriers[idx] = nil
+			}
+			db.commandWALRawBarrierMu.Unlock()
+		})
+	}
+}
+
+func (db *DB) runCommandWALRawPublishBarriers() error {
+	if db == nil || !db.commandWAL {
+		return nil
+	}
+	if err := db.commandWALPoisonedError(); err != nil {
+		return err
+	}
+	db.commandWALRawBarrierMu.Lock()
+	hooks := append([]func() error(nil), db.commandWALRawBarriers...)
+	db.commandWALRawBarrierMu.Unlock()
+
+	var errs []error
+	for _, hook := range hooks {
+		if hook == nil {
+			continue
+		}
+		if err := hook(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (db *DB) lockCommandWALRawPublish() func() {
+	if db == nil || !db.commandWAL {
+		return func() {}
+	}
+	db.commandWALRawPublishMu.Lock()
+	return db.commandWALRawPublishMu.Unlock
+}
+
+// LockCommandWALStaging prevents a raw command-WAL publish from starting while
+// a higher-level command has appended a frame but not yet made it publishable.
+func (db *DB) LockCommandWALStaging() func() {
+	if db == nil || !db.commandWAL {
+		return func() {}
+	}
+	db.commandWALRawPublishMu.RLock()
+	return db.commandWALRawPublishMu.RUnlock
+}

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -14,7 +14,9 @@ type commandWALRawBarrier struct {
 // RegisterCommandWALRawPublishBarrier registers a callback that raw command-WAL
 // writers must run before appending a new raw KV command frame. Higher-level
 // command executors use this to drain already-appended staged command frames so
-// raw KV publishes cannot create AppliedCommandLSN gaps.
+// raw KV publishes cannot create AppliedCommandLSN gaps. Hooks run while the raw
+// publish mutex is held, so they must not append raw command-WAL frames, take a
+// staging lock, or call paths that may do either.
 func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 	if db == nil || hook == nil || !db.commandWAL {
 		return func() {}

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -18,11 +18,17 @@ func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 	if db == nil || hook == nil {
 		return func() {}
 	}
+	db.closeHooksMu.Lock()
+	if !db.acceptingCloseHooksLocked() {
+		db.closeHooksMu.Unlock()
+		return func() {}
+	}
 	db.commandWALRawBarrierMu.Lock()
 	db.commandWALRawBarrierNextID++
 	id := db.commandWALRawBarrierNextID
 	db.commandWALRawBarriers = append(db.commandWALRawBarriers, commandWALRawBarrier{id: id, hook: hook})
 	db.commandWALRawBarrierMu.Unlock()
+	db.closeHooksMu.Unlock()
 
 	var once sync.Once
 	return func() {

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -6,9 +6,11 @@ import (
 )
 
 type commandWALRawBarrier struct {
-	id   uint64
-	hook func() error
-	wg   sync.WaitGroup
+	id     uint64
+	hook   func() error
+	active bool
+	mu     sync.Mutex
+	wg     sync.WaitGroup
 }
 
 // RegisterCommandWALRawPublishBarrier registers a callback that raw command-WAL
@@ -29,7 +31,7 @@ func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 	db.commandWALRawBarrierMu.Lock()
 	db.commandWALRawBarrierNextID++
 	id := db.commandWALRawBarrierNextID
-	barrier := &commandWALRawBarrier{id: id, hook: hook}
+	barrier := &commandWALRawBarrier{id: id, hook: hook, active: true}
 	db.commandWALRawBarriers = append(db.commandWALRawBarriers, barrier)
 	db.commandWALRawBarrierMu.Unlock()
 	db.closeHooksMu.Unlock()
@@ -51,6 +53,9 @@ func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 			}
 			db.commandWALRawBarrierMu.Unlock()
 			if removed != nil {
+				removed.mu.Lock()
+				removed.active = false
+				removed.mu.Unlock()
 				removed.wg.Wait()
 			}
 		})
@@ -68,7 +73,6 @@ func (db *DB) runCommandWALRawPublishBarriers() error {
 	barriers := make([]*commandWALRawBarrier, 0, len(db.commandWALRawBarriers))
 	for _, barrier := range db.commandWALRawBarriers {
 		if barrier != nil && barrier.hook != nil {
-			barrier.wg.Add(1)
 			barriers = append(barriers, barrier)
 		}
 	}
@@ -76,9 +80,17 @@ func (db *DB) runCommandWALRawPublishBarriers() error {
 
 	var errs []error
 	for _, barrier := range barriers {
+		barrier.mu.Lock()
+		if !barrier.active || barrier.hook == nil {
+			barrier.mu.Unlock()
+			continue
+		}
+		hook := barrier.hook
+		barrier.wg.Add(1)
+		barrier.mu.Unlock()
 		func() {
 			defer barrier.wg.Done()
-			if err := barrier.hook(); err != nil {
+			if err := hook(); err != nil {
 				errs = append(errs, err)
 			}
 		}()

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 )
 
+type commandWALRawBarrier struct {
+	id   uint64
+	hook func() error
+}
+
 // RegisterCommandWALRawPublishBarrier registers a callback that raw command-WAL
 // writers must run before appending a new raw KV command frame. Higher-level
 // command executors use this to drain already-appended staged command frames so
@@ -14,16 +19,23 @@ func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 		return func() {}
 	}
 	db.commandWALRawBarrierMu.Lock()
-	idx := len(db.commandWALRawBarriers)
-	db.commandWALRawBarriers = append(db.commandWALRawBarriers, hook)
+	db.commandWALRawBarrierNextID++
+	id := db.commandWALRawBarrierNextID
+	db.commandWALRawBarriers = append(db.commandWALRawBarriers, commandWALRawBarrier{id: id, hook: hook})
 	db.commandWALRawBarrierMu.Unlock()
 
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			db.commandWALRawBarrierMu.Lock()
-			if idx >= 0 && idx < len(db.commandWALRawBarriers) && db.commandWALRawBarriers[idx] != nil {
-				db.commandWALRawBarriers[idx] = nil
+			for i := range db.commandWALRawBarriers {
+				if db.commandWALRawBarriers[i].id == id {
+					copy(db.commandWALRawBarriers[i:], db.commandWALRawBarriers[i+1:])
+					last := len(db.commandWALRawBarriers) - 1
+					db.commandWALRawBarriers[last] = commandWALRawBarrier{}
+					db.commandWALRawBarriers = db.commandWALRawBarriers[:last]
+					break
+				}
 			}
 			db.commandWALRawBarrierMu.Unlock()
 		})
@@ -38,14 +50,16 @@ func (db *DB) runCommandWALRawPublishBarriers() error {
 		return err
 	}
 	db.commandWALRawBarrierMu.Lock()
-	hooks := append([]func() error(nil), db.commandWALRawBarriers...)
+	hooks := make([]func() error, 0, len(db.commandWALRawBarriers))
+	for _, barrier := range db.commandWALRawBarriers {
+		if barrier.hook != nil {
+			hooks = append(hooks, barrier.hook)
+		}
+	}
 	db.commandWALRawBarrierMu.Unlock()
 
 	var errs []error
 	for _, hook := range hooks {
-		if hook == nil {
-			continue
-		}
 		if err := hook(); err != nil {
 			errs = append(errs, err)
 		}

--- a/TreeDB/db/command_wal_barrier.go
+++ b/TreeDB/db/command_wal_barrier.go
@@ -18,7 +18,8 @@ type commandWALRawBarrier struct {
 // command executors use this to drain already-appended staged command frames so
 // raw KV publishes cannot create AppliedCommandLSN gaps. Hooks run while the raw
 // publish mutex is held, so they must not append raw command-WAL frames, take a
-// staging lock, or call paths that may do either.
+// staging lock, or call paths that may do either. The returned unregister
+// function waits for in-flight hooks and must not be called from the hook itself.
 func (db *DB) RegisterCommandWALRawPublishBarrier(hook func() error) func() {
 	if db == nil || hook == nil || !db.commandWAL {
 		return func() {}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -336,6 +336,11 @@ func (db *DB) AppendCommandWALPayload(kind commitlog.CommandKind, scope commitlo
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
+	unlockRawPublish := db.lockCommandWALRawPublish()
+	defer unlockRawPublish()
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		return 0, err
+	}
 	intent := commandWALBatchIntent{
 		kind:          kind,
 		scope:         scope,
@@ -357,6 +362,11 @@ func (db *DB) AppendRawKVSingleCommandWAL(op commitlog.RawKVOperation, sync bool
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	unlockRawPublish := db.lockCommandWALRawPublish()
+	defer unlockRawPublish()
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		return 0, err
 	}
 	if op.Op == commitlog.RawKVOpSetRID {
 		return 0, fmt.Errorf("%w: public single-op command WAL cannot carry external refs", ErrCommandWALUnsupported)
@@ -396,6 +406,11 @@ func (db *DB) AppendRawKVPointCommandWALTrusted(op commitlog.RawKVOp, key, value
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	unlockRawPublish := db.lockCommandWALRawPublish()
+	defer unlockRawPublish()
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		return 0, err
 	}
 	if db.commandJournal == nil {
 		return 0, fmt.Errorf("treedb: command wal journal unavailable")
@@ -442,6 +457,11 @@ func (db *DB) appendRawKVBatchPayloadCommandWAL(payload []byte, sync bool, trust
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	unlockRawPublish := db.lockCommandWALRawPublish()
+	defer unlockRawPublish()
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		return 0, err
 	}
 	if db.commandJournal == nil {
 		return 0, fmt.Errorf("treedb: command wal journal unavailable")

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -114,6 +114,22 @@ func NewCommandWALReplayIntent(env commitlog.CommandEnvelope) *CommandWALIntent 
 	}}
 }
 
+// NewCommandWALCoverageIntent returns an intent for publishing roots that
+// already reflect an appended contiguous command-WAL range. It does not append a
+// new command frame when used with the ordered-root command-WAL publish APIs.
+func NewCommandWALCoverageIntent(appliedLSN uint64, covered CommandWALLSNRange) (*CommandWALIntent, error) {
+	if appliedLSN == 0 {
+		return nil, fmt.Errorf("%w: applied lsn is zero", ErrCommandWALAppliedLSNNonContig)
+	}
+	if covered.First == 0 || covered.Last < covered.First || covered.Last != appliedLSN {
+		return nil, fmt.Errorf("%w: invalid coverage range [%d,%d] for applied %d", ErrCommandWALAppliedLSNNonContig, covered.First, covered.Last, appliedLSN)
+	}
+	return &CommandWALIntent{inner: commandWALBatchIntent{
+		lsn:          appliedLSN,
+		coveredRange: [1]CommandWALLSNRange{covered},
+	}}, nil
+}
+
 func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, error) {
 	if db == nil || !db.commandWAL {
 		return nil, nil
@@ -602,6 +618,14 @@ func (db *DB) poisonCommandWALAfterPublicPostAppendFailure(intent *CommandWALInt
 		return
 	}
 	db.poisonCommandWALAfterPostAppendFailure(&intent.inner)
+}
+
+// MarkCommandWALIntentRecoveryRequired fails this open handle closed after a
+// command frame was appended but the caller could not make the corresponding
+// mutation visible in memory or durable roots. Reopen recovery may apply the
+// frame, so retrying on the same handle can create command-WAL gaps.
+func (db *DB) MarkCommandWALIntentRecoveryRequired(intent *CommandWALIntent) {
+	db.poisonCommandWALAfterPublicPostAppendFailure(intent)
 }
 
 func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map[uint64]page.ValuePtr, inlineAppender *replayInlineAppender, ensureReplayRIDMap commandWALReplayRIDMapFunc, ensureReplayLogSupport commandWALReplayLogSupportFunc) error {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -645,6 +645,9 @@ func (db *DB) poisonCommandWALAfterPublicPostAppendFailure(intent *CommandWALInt
 // mutation visible in memory or durable roots. Reopen recovery may apply the
 // frame, so retrying on the same handle can create command-WAL gaps.
 func (db *DB) MarkCommandWALIntentRecoveryRequired(intent *CommandWALIntent) {
+	if db == nil || intent == nil {
+		return
+	}
 	db.poisonCommandWALAfterPublicPostAppendFailure(intent)
 }
 

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -336,11 +336,6 @@ func (db *DB) AppendCommandWALPayload(kind commitlog.CommandKind, scope commitlo
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
-	unlockRawPublish := db.lockCommandWALRawPublish()
-	defer unlockRawPublish()
-	if err := db.runCommandWALRawPublishBarriers(); err != nil {
-		return 0, err
-	}
 	intent := commandWALBatchIntent{
 		kind:          kind,
 		scope:         scope,

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -635,10 +635,11 @@ func (db *DB) poisonCommandWALAfterPublicPostAppendFailure(intent *CommandWALInt
 	db.poisonCommandWALAfterPostAppendFailure(&intent.inner)
 }
 
-// MarkCommandWALIntentRecoveryRequired fails this open handle closed after a
-// command frame was appended but the caller could not make the corresponding
-// mutation visible in memory or durable roots. Reopen recovery may apply the
-// frame, so retrying on the same handle can create command-WAL gaps.
+// MarkCommandWALIntentRecoveryRequired marks this open handle as requiring
+// recovery after a command frame was appended but the caller could not make
+// the corresponding mutation visible in memory or durable roots. Reopen
+// recovery may apply the frame, so retrying on the same handle can create
+// command-WAL gaps.
 func (db *DB) MarkCommandWALIntentRecoveryRequired(intent *CommandWALIntent) {
 	if db == nil || intent == nil {
 		return

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
@@ -797,6 +798,54 @@ func TestCommandWALRawPublishBarrierUnregisterCompacts(t *testing.T) {
 	unregisterSecond()
 	if got := len(db.commandWALRawBarriers); got != 0 {
 		t.Fatalf("barrier count after unregister second=%d, want 0", got)
+	}
+}
+
+func TestCommandWALRawPublishBarrierUnregisterWaitsForInFlight(t *testing.T) {
+	db := &DB{commandWAL: true}
+	barrierEntered := make(chan struct{})
+	releaseBarrier := make(chan struct{})
+	unregisterReturned := make(chan struct{})
+	runDone := make(chan error, 1)
+
+	unregister := db.RegisterCommandWALRawPublishBarrier(func() error {
+		close(barrierEntered)
+		<-releaseBarrier
+		return nil
+	})
+	go func() {
+		runDone <- db.runCommandWALRawPublishBarriers()
+	}()
+	select {
+	case <-barrierEntered:
+	case <-time.After(time.Second):
+		t.Fatalf("raw publish barrier did not start")
+	}
+	go func() {
+		unregister()
+		close(unregisterReturned)
+	}()
+	select {
+	case <-unregisterReturned:
+		t.Fatalf("unregister returned before in-flight barrier completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseBarrier)
+	select {
+	case <-unregisterReturned:
+	case <-time.After(time.Second):
+		t.Fatalf("unregister did not return after in-flight barrier completed")
+	}
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("runCommandWALRawPublishBarriers: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("runCommandWALRawPublishBarriers did not finish")
+	}
+	if got := len(db.commandWALRawBarriers); got != 0 {
+		t.Fatalf("barrier count after unregister=%d, want 0", got)
 	}
 }
 

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -731,6 +731,75 @@ func TestCommandWALRawPublishBarriersSkippedAfterPoison(t *testing.T) {
 	}
 }
 
+func TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	barrierErr := errors.New("raw publish barrier ran")
+	var barrierCalled atomic.Bool
+	unregister := db.RegisterCommandWALRawPublishBarrier(func() error {
+		barrierCalled.Store(true)
+		return barrierErr
+	})
+	defer unregister()
+
+	payload, err := commitlog.EncodeCollectionUpdateBatchByIDPayload("users", []commitlog.CollectionDocument{{
+		ID:       []byte("u1"),
+		Document: []byte(`{"city":"sea"}`),
+	}})
+	if err != nil {
+		t.Fatalf("EncodeCollectionUpdateBatchByIDPayload: %v", err)
+	}
+	lsn, err := db.AppendCommandWALPayload(
+		commitlog.CommandKindCollectionUpdateBatchByID,
+		commitlog.CommandScopeCollection,
+		commitlog.PayloadFormatCollectionUpdateBatchByIDV1,
+		payload,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("AppendCommandWALPayload error=%v", err)
+	}
+	if lsn == 0 {
+		t.Fatalf("AppendCommandWALPayload lsn=0, want assigned LSN")
+	}
+	if barrierCalled.Load() {
+		t.Fatalf("higher-level command WAL payload append ran raw publish barrier")
+	}
+}
+
+func TestCommandWALRawPublishBarrierUnregisterCompacts(t *testing.T) {
+	db := &DB{commandWAL: true}
+	var calls []int
+	unregisterFirst := db.RegisterCommandWALRawPublishBarrier(func() error {
+		calls = append(calls, 1)
+		return nil
+	})
+	unregisterSecond := db.RegisterCommandWALRawPublishBarrier(func() error {
+		calls = append(calls, 2)
+		return nil
+	})
+
+	unregisterFirst()
+	unregisterFirst()
+	if got := len(db.commandWALRawBarriers); got != 1 {
+		t.Fatalf("barrier count after unregister=%d, want 1", got)
+	}
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		t.Fatalf("runCommandWALRawPublishBarriers: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != 2 {
+		t.Fatalf("barrier calls=%v, want only second barrier", calls)
+	}
+
+	unregisterSecond()
+	if got := len(db.commandWALRawBarriers); got != 0 {
+		t.Fatalf("barrier count after unregister second=%d, want 0", got)
+	}
+}
+
 func TestMarkCommandWALIntentRecoveryRequiredNilNoop(t *testing.T) {
 	db := &DB{}
 	db.MarkCommandWALIntentRecoveryRequired(nil)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -731,6 +731,12 @@ func TestCommandWALRawPublishBarriersSkippedAfterPoison(t *testing.T) {
 	}
 }
 
+func TestMarkCommandWALIntentRecoveryRequiredNilNoop(t *testing.T) {
+	db := &DB{}
+	db.MarkCommandWALIntentRecoveryRequired(nil)
+	(*DB)(nil).MarkCommandWALIntentRecoveryRequired(nil)
+}
+
 func TestCommandWALFinalizeFailurePoisonsOpenHandle(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -800,6 +800,26 @@ func TestCommandWALRawPublishBarrierUnregisterCompacts(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawPublishBarrierNoopWhenDisabled(t *testing.T) {
+	db := &DB{}
+	var called atomic.Bool
+	unregister := db.RegisterCommandWALRawPublishBarrier(func() error {
+		called.Store(true)
+		return nil
+	})
+	unregister()
+	if got := len(db.commandWALRawBarriers); got != 0 {
+		t.Fatalf("barrier count with command WAL disabled=%d, want 0", got)
+	}
+	db.commandWAL = true
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		t.Fatalf("runCommandWALRawPublishBarriers: %v", err)
+	}
+	if called.Load() {
+		t.Fatalf("disabled command WAL raw publish barrier was registered")
+	}
+}
+
 func TestCommandWALRawPublishBarrierRejectsCloseHookDrainedDB(t *testing.T) {
 	db := &DB{commandWAL: true}
 	if err := db.RunCloseHooks(); err != nil {

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -700,6 +700,37 @@ func TestCommandWALPublishReadyReportsPoisonedHandle(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawPublishBarriersSkippedAfterPoison(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	db.testFailCommandWALFlush.Store(true)
+	lsn, err := db.AppendRawKVPointCommandWALTrusted(commitlog.RawKVOpSet, []byte("k"), []byte("v"), false)
+	if !errors.Is(err, errTestCommandWALFlushFailpoint) {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted error=%v, want command WAL flush failpoint", err)
+	}
+	if lsn != 1 {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted lsn=%d, want allocated LSN 1 on post-append flush failure", lsn)
+	}
+	db.testFailCommandWALFlush.Store(false)
+
+	var barrierCalled atomic.Bool
+	unregister := db.RegisterCommandWALRawPublishBarrier(func() error {
+		barrierCalled.Store(true)
+		return nil
+	})
+	defer unregister()
+	_, err = db.AppendRawKVPointCommandWALTrusted(commitlog.RawKVOpSet, []byte("after"), []byte("poison"), false)
+	if !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted after poison error=%v, want ErrRecoveryRequired", err)
+	}
+	if barrierCalled.Load() {
+		t.Fatalf("raw publish barrier ran after command WAL handle was poisoned")
+	}
+}
+
 func TestCommandWALFinalizeFailurePoisonsOpenHandle(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -800,6 +800,28 @@ func TestCommandWALRawPublishBarrierUnregisterCompacts(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawPublishBarrierRejectsCloseHookDrainedDB(t *testing.T) {
+	db := &DB{commandWAL: true}
+	if err := db.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	var called atomic.Bool
+	unregister := db.RegisterCommandWALRawPublishBarrier(func() error {
+		called.Store(true)
+		return nil
+	})
+	unregister()
+	if got := len(db.commandWALRawBarriers); got != 0 {
+		t.Fatalf("barrier count after late register=%d, want 0", got)
+	}
+	if err := db.runCommandWALRawPublishBarriers(); err != nil {
+		t.Fatalf("runCommandWALRawPublishBarriers: %v", err)
+	}
+	if called.Load() {
+		t.Fatalf("late raw publish barrier ran after close hooks drained")
+	}
+}
+
 func TestMarkCommandWALIntentRecoveryRequiredNilNoop(t *testing.T) {
 	db := &DB{}
 	db.MarkCommandWALIntentRecoveryRequired(nil)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -805,6 +805,7 @@ func TestCommandWALRawPublishBarrierUnregisterWaitsForInFlight(t *testing.T) {
 	db := &DB{commandWAL: true}
 	barrierEntered := make(chan struct{})
 	releaseBarrier := make(chan struct{})
+	unregisterStarted := make(chan struct{})
 	unregisterReturned := make(chan struct{})
 	runDone := make(chan error, 1)
 
@@ -822,9 +823,15 @@ func TestCommandWALRawPublishBarrierUnregisterWaitsForInFlight(t *testing.T) {
 		t.Fatalf("raw publish barrier did not start")
 	}
 	go func() {
+		close(unregisterStarted)
 		unregister()
 		close(unregisterReturned)
 	}()
+	select {
+	case <-unregisterStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("unregister goroutine did not start")
+	}
 	select {
 	case <-unregisterReturned:
 		t.Fatalf("unregister returned before in-flight barrier completed")

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -258,21 +258,22 @@ type DB struct {
 	// reopening the DB. After an append reached the journal but flush/sync or
 	// root publication failed, continuing on the same handle could create an
 	// unrecoverable LSN gap.
-	commandWALFlushPoisoned   atomic.Bool
-	commandWALStatsMu         sync.Mutex
-	commandWALRequiredFeature bool
-	commandWALRequiredErr     string
-	commandWALStatsAppliedLSN uint64
-	commandWALStatsSummary    commandWALStatsSummary
-	commandWALStatsOK         bool
-	commandWALLiveAccepted    atomic.Uint64
-	commandWALLiveAcceptedMax atomic.Uint64
-	commandWALLiveCovered     atomic.Uint64
-	commandWALLiveCoveredMax  atomic.Uint64
-	commandWALRawPublishMu    sync.RWMutex
-	commandWALRawBarrierMu    sync.Mutex
-	commandWALRawBarriers     []func() error
-	closing                   atomic.Bool
+	commandWALFlushPoisoned    atomic.Bool
+	commandWALStatsMu          sync.Mutex
+	commandWALRequiredFeature  bool
+	commandWALRequiredErr      string
+	commandWALStatsAppliedLSN  uint64
+	commandWALStatsSummary     commandWALStatsSummary
+	commandWALStatsOK          bool
+	commandWALLiveAccepted     atomic.Uint64
+	commandWALLiveAcceptedMax  atomic.Uint64
+	commandWALLiveCovered      atomic.Uint64
+	commandWALLiveCoveredMax   atomic.Uint64
+	commandWALRawPublishMu     sync.RWMutex
+	commandWALRawBarrierMu     sync.Mutex
+	commandWALRawBarrierNextID uint64
+	commandWALRawBarriers      []commandWALRawBarrier
+	closing                    atomic.Bool
 }
 
 type valueLogRewriteLiveBytesKey struct {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -269,6 +269,9 @@ type DB struct {
 	commandWALLiveAcceptedMax atomic.Uint64
 	commandWALLiveCovered     atomic.Uint64
 	commandWALLiveCoveredMax  atomic.Uint64
+	commandWALRawPublishMu    sync.RWMutex
+	commandWALRawBarrierMu    sync.Mutex
+	commandWALRawBarriers     []func() error
 	closing                   atomic.Bool
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1670,9 +1670,11 @@ func (db *DB) RegisterCloseHookIfOpen(hook func() error) (func(), bool) {
 }
 
 // RegisterCloseHookIfOpenAfter runs setup while close-hook registration is
-// serialized with RunCloseHooks, then registers hook if setup returns true.
-// Callers can use setup to publish state that hook owns without exposing that
-// state after close-hook draining has begun.
+// serialized with RunCloseHooks, then registers hook if setup returns true. The
+// returned bool reports that the DB was still accepting close-hook registration
+// and setup, if any, ran inside that accepted registration window. If setup
+// returns false, no hook is retained even though the registration window was
+// accepted.
 func (db *DB) RegisterCloseHookIfOpenAfter(setup func() bool, hook func() error) (func(), bool) {
 	if db == nil || hook == nil {
 		return func() {}, false

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1680,17 +1680,15 @@ func (db *DB) RegisterCloseHookIfOpenAfter(setup func() bool, hook func() error)
 		return func() {}, false
 	}
 	db.closeHooksMu.Lock()
+	defer db.closeHooksMu.Unlock()
 	if !db.acceptingCloseHooksLocked() {
-		db.closeHooksMu.Unlock()
 		return func() {}, false
 	}
 	if setup != nil && !setup() {
-		db.closeHooksMu.Unlock()
 		return func() {}, true
 	}
 	idx := len(db.closeHooks)
 	db.closeHooks = append(db.closeHooks, hook)
-	db.closeHooksMu.Unlock()
 
 	var once sync.Once
 	return func() {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1651,16 +1651,28 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	return db, nil
 }
 
+func (db *DB) acceptingCloseHooksLocked() bool {
+	return db != nil && !db.closeHooksClosed && !db.closing.Load()
+}
+
 // RegisterCloseHook registers a callback that runs before Close marks the DB as
 // closing, while normal write/publish APIs are still available.
 func (db *DB) RegisterCloseHook(hook func() error) func() {
+	unregister, _ := db.RegisterCloseHookIfOpen(hook)
+	return unregister
+}
+
+// RegisterCloseHookIfOpen is like RegisterCloseHook, but also reports whether
+// the hook was retained. Callers that attach external state to the hook can use
+// this to avoid leaks when registration races DB close.
+func (db *DB) RegisterCloseHookIfOpen(hook func() error) (func(), bool) {
 	if db == nil || hook == nil {
-		return func() {}
+		return func() {}, false
 	}
 	db.closeHooksMu.Lock()
-	if db.closeHooksClosed || db.closing.Load() {
+	if !db.acceptingCloseHooksLocked() {
 		db.closeHooksMu.Unlock()
-		return func() {}
+		return func() {}, false
 	}
 	idx := len(db.closeHooks)
 	db.closeHooks = append(db.closeHooks, hook)
@@ -1675,7 +1687,7 @@ func (db *DB) RegisterCloseHook(hook func() error) func() {
 			}
 			db.closeHooksMu.Unlock()
 		})
-	}
+	}, true
 }
 
 // RunCloseHooks runs and clears registered close hooks. Wrappers that own a

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1666,6 +1666,14 @@ func (db *DB) RegisterCloseHook(hook func() error) func() {
 // the hook was retained. Callers that attach external state to the hook can use
 // this to avoid leaks when registration races DB close.
 func (db *DB) RegisterCloseHookIfOpen(hook func() error) (func(), bool) {
+	return db.RegisterCloseHookIfOpenAfter(nil, hook)
+}
+
+// RegisterCloseHookIfOpenAfter runs setup while close-hook registration is
+// serialized with RunCloseHooks, then registers hook if setup returns true.
+// Callers can use setup to publish state that hook owns without exposing that
+// state after close-hook draining has begun.
+func (db *DB) RegisterCloseHookIfOpenAfter(setup func() bool, hook func() error) (func(), bool) {
 	if db == nil || hook == nil {
 		return func() {}, false
 	}
@@ -1673,6 +1681,10 @@ func (db *DB) RegisterCloseHookIfOpen(hook func() error) (func(), bool) {
 	if !db.acceptingCloseHooksLocked() {
 		db.closeHooksMu.Unlock()
 		return func() {}, false
+	}
+	if setup != nil && !setup() {
+		db.closeHooksMu.Unlock()
+		return func() {}, true
 	}
 	idx := len(db.closeHooks)
 	db.closeHooks = append(db.closeHooks, hook)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -272,7 +272,7 @@ type DB struct {
 	commandWALRawPublishMu     sync.RWMutex
 	commandWALRawBarrierMu     sync.Mutex
 	commandWALRawBarrierNextID uint64
-	commandWALRawBarriers      []commandWALRawBarrier
+	commandWALRawBarriers      []*commandWALRawBarrier
 	closing                    atomic.Bool
 }
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -87,6 +87,7 @@ type config struct {
 	SecondaryIndexes                              int
 	ClientMode                                    string
 	TreeDBProfile                                 treedb.Profile
+	TreeDBCommandWAL                              bool
 	TreeDBDocumentFormat                          collections.DocumentFormat
 	TreeDBDataRootStorage                         collections.RootStoragePolicy
 	TreeDBIndexStateRootStorage                   collections.RootStoragePolicy
@@ -143,6 +144,7 @@ type benchmarkResult struct {
 	RangeIndex         bool `json:"range_index"`
 
 	TreeDBProfile                                 string              `json:"treedb_profile,omitempty"`
+	TreeDBCommandWAL                              bool                `json:"treedb_command_wal"`
 	TreeDBDocumentFormat                          string              `json:"treedb_document_format,omitempty"`
 	TreeDBDataRootStorage                         string              `json:"treedb_data_root_storage,omitempty"`
 	TreeDBIndexStateRootStorage                   string              `json:"treedb_index_state_root_storage,omitempty"`
@@ -522,6 +524,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-find-raw, driver-command, driver-command-raw, driver-unack, direct, raw-wire, raw-wire-tcp, raw-wire-tcp-pipeline, native-wire-inproc, or native-wire-tcp; direct/raw/native-wire modes are TreeDB-only")
 	fs.IntVar(&cfg.RawWireTCPPipelineDepth, "raw-wire-tcp-pipeline-depth", cfg.RawWireTCPPipelineDepth, "number of raw-wire TCP find requests to pipeline on one connection when -client-mode raw-wire-tcp-pipeline")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
+	fs.BoolVar(&cfg.TreeDBCommandWAL, "treedb-command-wal", false, "enable TreeDB command-WAL mode for -target treedb")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1/collections-v1, or bson")
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexStateRootStorage, "treedb-index-state-root-storage", treeDBIndexStateRootStorage, "TreeDB collection index-state root storage for -target treedb: default, fast, or compressed")
@@ -994,6 +997,7 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 	}
 
 	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.CommandWAL = cfg.TreeDBCommandWAL
 	opts.IndexOuterLeavesInValueLog = true
 	opts.IndexInternalBaseDelta = false
 	open := treedb.OpenBackend
@@ -1047,6 +1051,7 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	}
 
 	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.CommandWAL = cfg.TreeDBCommandWAL
 	opts.IndexOuterLeavesInValueLog = true
 	opts.IndexInternalBaseDelta = false
 	open := treedb.OpenBackend
@@ -1481,6 +1486,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 			result.TreeDBDir = target.treedbDir
 		}
 		result.TreeDBProfile = string(cfg.TreeDBProfile)
+		result.TreeDBCommandWAL = cfg.TreeDBCommandWAL
 		result.TreeDBDocumentFormat = string(cfg.TreeDBDocumentFormat)
 		result.TreeDBDataRootStorage = string(cfg.TreeDBDataRootStorage)
 		result.TreeDBIndexStateRootStorage = string(cfg.TreeDBIndexStateRootStorage)
@@ -1755,6 +1761,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 		RangeIndex:                             cfg.RangeIndex,
 		PrebuildDocuments:                      cfg.PrebuildDocuments,
 		TreeDBProfile:                          string(cfg.TreeDBProfile),
+		TreeDBCommandWAL:                       cfg.TreeDBCommandWAL,
 		TreeDBDocumentFormat:                   string(cfg.TreeDBDocumentFormat),
 		TreeDBDataRootStorage:                  string(cfg.TreeDBDataRootStorage),
 		TreeDBIndexStateRootStorage:            string(cfg.TreeDBIndexStateRootStorage),
@@ -5914,8 +5921,8 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s read_state=%s\n",
-				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
+			fmt.Fprintf(out, "treedb_profile=%s command_wal=%t document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s read_state=%s\n",
+				result.TreeDBProfile, result.TreeDBCommandWAL, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
 				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
 				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -5959,9 +5959,7 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
 				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
 		}
-		if result.TreeDBCommandWAL {
-			fmt.Fprintf(out, "treedb_command_wal=true\n")
-		}
+		fmt.Fprintf(out, "treedb_command_wal=%t\n", result.TreeDBCommandWAL)
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
 		}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -144,7 +144,7 @@ type benchmarkResult struct {
 	RangeIndex         bool `json:"range_index"`
 
 	TreeDBProfile                                 string              `json:"treedb_profile,omitempty"`
-	TreeDBCommandWAL                              bool                `json:"treedb_command_wal"`
+	TreeDBCommandWAL                              bool                `json:"treedb_command_wal,omitempty"`
 	TreeDBDocumentFormat                          string              `json:"treedb_document_format,omitempty"`
 	TreeDBDataRootStorage                         string              `json:"treedb_data_root_storage,omitempty"`
 	TreeDBIndexStateRootStorage                   string              `json:"treedb_index_state_root_storage,omitempty"`

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -5968,7 +5968,7 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
 				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
 		}
-		fmt.Fprintf(out, "treedb_command_wal=%t\n", result.TreeDBCommandWAL)
+		fmt.Fprintf(out, "command_wal=%t\n", result.TreeDBCommandWAL)
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
 		}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -721,6 +721,9 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.TreeDBProfile = profile
+	if err := validateTreeDBCommandWALProfile(cfg.TreeDBCommandWAL, cfg.TreeDBProfile); err != nil {
+		return config{}, err
+	}
 	documentFormat, err := parseTreeDBDocumentFormat(treeDBDocumentFormat)
 	if err != nil {
 		return config{}, err
@@ -765,6 +768,17 @@ func parseTreeDBProfile(raw string) (treedb.Profile, error) {
 	default:
 		return "", fmt.Errorf("unknown treedb-profile %q", raw)
 	}
+}
+
+func validateTreeDBCommandWALProfile(commandWAL bool, profile treedb.Profile) error {
+	if !commandWAL {
+		return nil
+	}
+	opts := treedb.OptionsFor(profile, "")
+	if opts.Durability == backenddb.DurabilityWALOffRelaxed {
+		return fmt.Errorf("treedb-command-wal requires a WAL-on treedb-profile; got %q (use %q or %q)", profile, treedb.ProfileWALOnFast, treedb.ProfileDurable)
+	}
+	return nil
 }
 
 func parseTreeDBDocumentFormat(raw string) (collections.DocumentFormat, error) {
@@ -996,10 +1010,13 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 		}
 	}
 
-	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
-	opts.CommandWAL = cfg.TreeDBCommandWAL
-	opts.IndexOuterLeavesInValueLog = true
-	opts.IndexInternalBaseDelta = false
+	opts, err := treeDBBenchmarkOptions(cfg, dir)
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
 	open := treedb.OpenBackend
 	if opts.IndexOuterLeavesInValueLog {
 		open = treedb.OpenBackendWithCachedLeafLog
@@ -1034,6 +1051,17 @@ func openTreeDBDirectTarget(ctx context.Context, cfg config) (*benchTarget, erro
 	}, nil
 }
 
+func treeDBBenchmarkOptions(cfg config, dir string) (treedb.Options, error) {
+	if err := validateTreeDBCommandWALProfile(cfg.TreeDBCommandWAL, cfg.TreeDBProfile); err != nil {
+		return treedb.Options{}, err
+	}
+	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
+	opts.CommandWAL = cfg.TreeDBCommandWAL
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	return opts, nil
+}
+
 func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	dir := cfg.TreeDBDir
 	removeDir := false
@@ -1050,10 +1078,13 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		}
 	}
 
-	opts := treedb.OptionsFor(cfg.TreeDBProfile, dir)
-	opts.CommandWAL = cfg.TreeDBCommandWAL
-	opts.IndexOuterLeavesInValueLog = true
-	opts.IndexInternalBaseDelta = false
+	opts, err := treeDBBenchmarkOptions(cfg, dir)
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
 	open := treedb.OpenBackend
 	if opts.IndexOuterLeavesInValueLog {
 		open = treedb.OpenBackendWithCachedLeafLog

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -748,6 +748,12 @@ func parseConfig(args []string) (config, error) {
 	if err != nil {
 		return config{}, err
 	}
+	if cfg.Target == "treedb" && cfg.TreeDBCommandWAL && maintenance == treeDBMaintenanceFull {
+		if seenFlags["treedb-maintenance"] {
+			return config{}, errors.New("treedb-command-wal does not support -treedb-maintenance full; use checkpoint or none")
+		}
+		maintenance = treeDBMaintenanceCheckpoint
+	}
 	cfg.TreeDBMaintenance = maintenance
 	if cfg.Deletes > cfg.Documents {
 		return config{}, errors.New("deletes cannot exceed documents")

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -144,7 +144,7 @@ type benchmarkResult struct {
 	RangeIndex         bool `json:"range_index"`
 
 	TreeDBProfile                                 string              `json:"treedb_profile,omitempty"`
-	TreeDBCommandWAL                              bool                `json:"treedb_command_wal,omitempty"`
+	TreeDBCommandWAL                              bool                `json:"treedb_command_wal"`
 	TreeDBDocumentFormat                          string              `json:"treedb_document_format,omitempty"`
 	TreeDBDataRootStorage                         string              `json:"treedb_data_root_storage,omitempty"`
 	TreeDBIndexStateRootStorage                   string              `json:"treedb_index_state_root_storage,omitempty"`
@@ -5952,12 +5952,15 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s command_wal=%t document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s read_state=%s\n",
-				result.TreeDBProfile, result.TreeDBCommandWAL, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
+			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s read_state=%s\n",
+				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
 				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
 				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
 				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
+		}
+		if result.TreeDBCommandWAL {
+			fmt.Fprintf(out, "treedb_command_wal=true\n")
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -573,6 +573,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.Target != "treedb" && cfg.Target != "mongo" {
 		return config{}, fmt.Errorf("unknown target %q", cfg.Target)
 	}
+	if cfg.Target != "treedb" && cfg.TreeDBCommandWAL {
+		return config{}, errors.New("treedb-command-wal is only supported with -target treedb")
+	}
 	clientMode, err := parseClientMode(cfg.ClientMode)
 	if err != nil {
 		return config{}, err

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -5968,7 +5968,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
 				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
 		}
-		fmt.Fprintf(out, "command_wal=%t\n", result.TreeDBCommandWAL)
+		if result.Target == "treedb" || result.TreeDBProfile != "" {
+			fmt.Fprintf(out, "command_wal=%t\n", result.TreeDBCommandWAL)
+		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
 		}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -5969,7 +5969,7 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode, result.TreeDBReadState)
 		}
 		if result.Target == "treedb" || result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "command_wal=%t\n", result.TreeDBCommandWAL)
+			fmt.Fprintf(out, "treedb_command_wal=%t\n", result.TreeDBCommandWAL)
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2563,10 +2563,11 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	}
 
 	out.Reset()
-	result.Target = "mongo"
-	result.TreeDBProfile = ""
-	result.TreeDBCommandWAL = true
-	if err := writeResult(&out, "text", result); err != nil {
+	mongoResult := *result
+	mongoResult.Target = "mongo"
+	mongoResult.TreeDBProfile = ""
+	mongoResult.TreeDBCommandWAL = true
+	if err := writeResult(&out, "text", &mongoResult); err != nil {
 		t.Fatalf("writeResult mongo text: %v", err)
 	}
 	if strings.Contains(out.String(), "treedb_command_wal=") {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1213,6 +1213,9 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if !cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=false want true")
 	}
+	if _, err := parseConfig([]string{"-target", "mongo", "-treedb-command-wal"}); err == nil || !strings.Contains(err.Error(), "treedb-command-wal is only supported with -target treedb") {
+		t.Fatalf("parse mongo command WAL error=%v, want target error", err)
+	}
 	if cfg.TreeDBMaintenance != treeDBMaintenanceCheckpoint {
 		t.Fatalf("TreeDBMaintenance=%q want %q", cfg.TreeDBMaintenance, treeDBMaintenanceCheckpoint)
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2578,8 +2578,13 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	if err := writeResult(&out, "json", result); err != nil {
 		t.Fatalf("writeResult json without command WAL: %v", err)
 	}
-	if !strings.Contains(out.String(), `"treedb_command_wal": false`) {
-		t.Fatalf("json missing explicit false treedb_command_wal field: %s", out.String())
+	var decodedMap map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decodedMap); err != nil {
+		t.Fatalf("unmarshal json result without command WAL: %v", err)
+	}
+	got, ok := decodedMap["treedb_command_wal"]
+	if !ok || got != false {
+		t.Fatalf("json treedb_command_wal=%v present=%t, want false and present", got, ok)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1213,6 +1213,15 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if !cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=false want true")
 	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(treedb.ProfileDurable)}); err != nil {
+		t.Fatalf("parse durable command WAL config: %v", err)
+	}
+	for _, profile := range []treedb.Profile{treedb.ProfileFast, treedb.ProfileBench} {
+		_, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(profile)})
+		if err == nil || !strings.Contains(err.Error(), "treedb-command-wal requires a WAL-on treedb-profile") {
+			t.Fatalf("parse command WAL profile %q error=%v, want WAL-on profile error", profile, err)
+		}
+	}
 }
 
 func TestParseConfigProfileOptions(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1213,6 +1213,15 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if !cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=false want true")
 	}
+	if cfg.TreeDBMaintenance != treeDBMaintenanceCheckpoint {
+		t.Fatalf("TreeDBMaintenance=%q want %q", cfg.TreeDBMaintenance, treeDBMaintenanceCheckpoint)
+	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-maintenance", treeDBMaintenanceFull}); err == nil || !strings.Contains(err.Error(), "treedb-command-wal does not support -treedb-maintenance full") {
+		t.Fatalf("parse explicit full maintenance error=%v, want command WAL maintenance error", err)
+	}
+	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-maintenance", treeDBMaintenanceNone}); err != nil {
+		t.Fatalf("parse command WAL none maintenance: %v", err)
+	}
 	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(treedb.ProfileDurable)}); err != nil {
 		t.Fatalf("parse durable command WAL config: %v", err)
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2550,7 +2550,7 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	}
 	text := out.String()
 	for _, want := range []string{
-		"command_wal=true",
+		"treedb_command_wal=true",
 		"buffered_indexed_max_docs=1234",
 		"buffered_indexed_max_bytes=5678",
 		"buffered_indexed_max_root_runs=90",
@@ -2569,8 +2569,8 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	if err := writeResult(&out, "text", result); err != nil {
 		t.Fatalf("writeResult mongo text: %v", err)
 	}
-	if strings.Contains(out.String(), "command_wal=") {
-		t.Fatalf("mongo text output included TreeDB command_wal line: %q", out.String())
+	if strings.Contains(out.String(), "treedb_command_wal=") {
+		t.Fatalf("mongo text output included TreeDB command WAL line: %q", out.String())
 	}
 
 	out.Reset()

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2572,6 +2572,15 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 			decoded.TreeDBBufferedIndexedAsyncFlush,
 			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
 	}
+
+	result.TreeDBCommandWAL = false
+	out.Reset()
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json without command WAL: %v", err)
+	}
+	if strings.Contains(out.String(), "treedb_command_wal") {
+		t.Fatalf("json includes false treedb_command_wal field: %s", out.String())
+	}
 }
 
 func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1082,6 +1082,9 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	if cfg.TreeDBProfile != treedb.ProfileWALOnFast {
 		t.Fatalf("TreeDBProfile=%q want %q", cfg.TreeDBProfile, treedb.ProfileWALOnFast)
 	}
+	if cfg.TreeDBCommandWAL {
+		t.Fatal("TreeDBCommandWAL=true want false by default")
+	}
 	if got := string(cfg.TreeDBDocumentFormat); got != "template-v1" {
 		t.Fatalf("TreeDBDocumentFormat=%q want template-v1", got)
 	}
@@ -1199,6 +1202,16 @@ func TestParseConfigAcceptsTreeDBBSONDocumentFormat(t *testing.T) {
 	}
 	if got := string(cfg.TreeDBDocumentFormat); got != "bson" {
 		t.Fatalf("TreeDBDocumentFormat=%q want bson", got)
+	}
+}
+
+func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
+	cfg, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal"})
+	if err != nil {
+		t.Fatalf("parse command WAL flag: %v", err)
+	}
+	if !cfg.TreeDBCommandWAL {
+		t.Fatal("TreeDBCommandWAL=false want true")
 	}
 }
 
@@ -2498,6 +2511,7 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		Collection:                             "docs",
 		Documents:                              1,
 		TreeDBProfile:                          "wal_on_fast",
+		TreeDBCommandWAL:                       true,
 		TreeDBDocumentFormat:                   "bson",
 		TreeDBDataRootStorage:                  "compressed",
 		TreeDBIndexStateRootStorage:            "compressed",
@@ -2515,6 +2529,7 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	}
 	text := out.String()
 	for _, want := range []string{
+		"command_wal=true",
 		"buffered_indexed_max_docs=1234",
 		"buffered_indexed_max_bytes=5678",
 		"buffered_indexed_max_root_runs=90",
@@ -2537,12 +2552,14 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	if decoded.TreeDBBufferedIndexedWriteMaxDocuments != 1234 ||
 		decoded.TreeDBBufferedIndexedWriteMaxBytes != 5678 ||
 		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 ||
+		!decoded.TreeDBCommandWAL ||
 		!decoded.TreeDBBufferedIndexedAsyncFlush ||
 		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
-		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d want 1234/5678/90/true/3",
+		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d commandWAL=%t async=%t asyncMax=%d want 1234/5678/90/true/true/3",
 			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
 			decoded.TreeDBBufferedIndexedWriteMaxBytes,
 			decoded.TreeDBBufferedIndexedWriteMaxRootRuns,
+			decoded.TreeDBCommandWAL,
 			decoded.TreeDBBufferedIndexedAsyncFlush,
 			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2563,6 +2563,17 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	}
 
 	out.Reset()
+	result.Target = "mongo"
+	result.TreeDBProfile = ""
+	result.TreeDBCommandWAL = true
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult mongo text: %v", err)
+	}
+	if strings.Contains(out.String(), "command_wal=") {
+		t.Fatalf("mongo text output included TreeDB command_wal line: %q", out.String())
+	}
+
+	out.Reset()
 	if err := writeResult(&out, "json", result); err != nil {
 		t.Fatalf("writeResult json: %v", err)
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2578,8 +2578,8 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	if err := writeResult(&out, "json", result); err != nil {
 		t.Fatalf("writeResult json without command WAL: %v", err)
 	}
-	if strings.Contains(out.String(), "treedb_command_wal") {
-		t.Fatalf("json includes false treedb_command_wal field: %s", out.String())
+	if !strings.Contains(out.String(), `"treedb_command_wal": false`) {
+		t.Fatalf("json missing explicit false treedb_command_wal field: %s", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR makes durable command-WAL mode useful for Mongo-style no-index BSON `$set` update-one workloads by allowing the gateway write to ACK after the deterministic command WAL frame is appended and staged, while deferring primary-root publication until `Flush`/`Close`.

- adds collection command-WAL coverage intents for already-appended staged writes
- tracks pending collection command-WAL LSN ranges in the write domain and publishes coverage when buffered roots flush
- coordinates staged command-WAL ownership across collections so applied LSN ranges stay contiguous
- adds raw KV publish barriers plus raw-publish/stage exclusion so raw command WAL cannot create gaps around staged collection frames
- keeps raw-publish barriers scoped to raw KV command writers so higher-level collection command appends cannot self-deadlock with staging
- treats post-append/post-stage bookkeeping failures as commit-ambiguous and hardens replay/poison edge cases
- adds `-treedb-command-wal` to `mongo_gateway_bench`

## Benchmark proof

Base binary: `origin/main` at `a174be33`.
Benchmarked after binary: PR implementation commit `82c7be721`.
Current PR head: `85cdc9a6c`.
Artifacts: `/tmp/mongo_wal_pr1662_bench_tcyYIn`.

The post-benchmark commits address review findings in lock scope, barrier unregister cleanup, close-time barrier/coordinator lifetime, benchmark output metadata/reporting, command-WAL maintenance defaults, close-hook/BSON fallback contract notes, command-WAL target validation, inactive-barrier registration, synchronized raw-publish test coverage, lock-free unset test-hook access, deterministic raw-publish staging regression test coverage, text-output key stability, recovery doc wording, threshold-flush coordinator-owner release, fallback coordinator pinning, in-flight raw-publish barrier unregister waits, idempotent stage-unlock cleanup, raw barrier hook contract docs, TreeDB-only command-WAL text metadata, deterministic start signals in concurrency probes, CAS and serialized test-hook cleanup, post-append commit-ambiguous wrapping, helper-level pending owner clearing, close-hook deferred unlock, `treedb_command_wal` text metadata naming, per-entered-hook raw barrier wait accounting, mongo-output test copy isolation, and raw-barrier unregister contract documentation. They do not change the measured no-index BSON id-update semantics or command-WAL algorithm, so the benchmark was not rerun for those follow-ups.

Command shape for the baseline uses the same durable BSON workload without `-treedb-command-wal` because that flag is introduced by this PR. The after run adds `-treedb-command-wal`:

```sh
/tmp/mongo_gateway_bench_pr1662_* \
  -target treedb \
  -treedb-profile durable \
  -treedb-document-format bson \
  -secondary-indexes 0 \
  -documents 20000 \
  -batch-size 1000 \
  -reads 0 \
  -range-reads 0 \
  -updates 2000 \
  -concurrent-writers 32 \
  -concurrent-writes 20000 \
  -deletes 0 \
  -treedb-maintenance none \
  -format json \
  [-treedb-command-wal]
```

Five-rep averages:

| indexes | phase | before ops/s | after ops/s | speedup | before mean us | after mean us | latency reduction |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 | `id_update_set` | 8,201.34 | 11,623.41 | 1.42x | 120.75 | 81.29 | 32.7% |
| 0 | `concurrent_id_update_set_w32` | 14,394.00 | 84,017.46 | 5.84x | 2,223.17 | 325.40 | 85.4% |

## Validation

```sh
GOWORK=off go test ./TreeDB/db -run 'TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers|TestCommandWALRawPublishBarrierUnregisterCompacts|TestMarkCommandWALIntentRecoveryRequiredNilNoop|TestCommandWALRawPublishBarriersSkippedAfterPoison' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionManagerCloseForBackend|TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestParseConfigAcceptsTreeDBCommandWAL|TestWriteResultKeepsTextHeaderStableForIndexedUpdateKnob' -count=1
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestWriteResultKeepsTextHeaderStableForIndexedUpdateKnob' -count=1
GOWORK=off go test ./cmd/mongo_gateway_bench -count=1
git diff --check
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALRawPublishBarrierRejectsCloseHookDrainedDB|TestCommandWALRawPublishBarrierUnregisterCompacts|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers|TestCommandWALRawPublishBarriersSkippedAfterPoison' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALCoordinatorNotStoredAfterCloseHooksDrained|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|TestCollectionManagerCloseForBackend' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestRegisterCloseHookAfterRunCloseHooksIsIgnored|TestRegisterCloseHookIfOpenAfterSetupRunsUnderAcceptedRegistration|TestCommandWALRawPublishBarrierRejectsCloseHookDrainedDB|TestCommandWALRawPublishBarrierUnregisterCompacts|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers|TestCommandWALRawPublishBarriersSkippedAfterPoison' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALCoordinatorNotStoredAfterCloseHooksDrained|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|TestCollectionManagerCloseForBackend' -count=1
git diff --check
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestParseConfigAcceptsTreeDBCommandWAL' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestRegisterCloseHookIfOpenAfterSetupCanDeclineHook|TestRegisterCloseHookIfOpenAfterSetupRunsUnderAcceptedRegistration|TestRegisterCloseHookAfterRunCloseHooksIsIgnored|TestCommandWALRawPublishBarrierRejectsCloseHookDrainedDB' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetUniqueIndexChangePublishesAppliedLSN|TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexPublishesAppliedLSN|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
git diff --check
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALRawPublishBarrier(NoopWhenDisabled|UnregisterCompacts|RejectsCloseHookDrainedDB)|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers' -count=1
GOWORK=off go test ./cmd/mongo_gateway_bench -run TestParseConfigAcceptsTreeDBCommandWAL -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish' -count=1
GOWORK=off go test ./TreeDB/collections -run CommandWAL -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish' -count=1
git diff --check
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestParseConfigAcceptsTreeDBCommandWAL|TestWriteResultKeepsTextHeaderStableForIndexedUpdateKnob' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALRawPublishBarrier(NoopWhenDisabled|UnregisterCompacts|RejectsCloseHookDrainedDB)|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers' -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
git diff --check
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALThresholdFlushClearsCoordinatorOwner|TestCollectionCommandWALStageCoordinatorPinsFallbackToDomain|TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner|TestCollectionCommandWALPublishWaitsForStageReservation|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALRawPublishBarrierUnregisterWaitsForInFlight|TestCommandWALRawPublishBarrier(NoopWhenDisabled|UnregisterCompacts|RejectsCloseHookDrainedDB)|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers' -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionCommandWALThresholdFlushClearsCoordinatorOwner|TestCollectionCommandWALStageCoordinatorPinsFallbackToDomain|TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner|TestCollectionCommandWALPublishWaitsForStageReservation|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
git diff --check
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestParseConfigAcceptsTreeDBCommandWAL|TestWriteResultKeepsTextHeaderStableForIndexedUpdateKnob' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation|TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner|TestCollectionCommandWALPublishWaitsForStageReservation|TestCollectionCommandWALThresholdFlushClearsCoordinatorOwner|TestCollectionCommandWALStageCoordinatorPinsFallbackToDomain|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALRawPublishBarrierUnregisterWaitsForInFlight|TestCommandWALRawPublishBarrier(NoopWhenDisabled|UnregisterCompacts|RejectsCloseHookDrainedDB)|TestAppendCommandWALPayloadDoesNotRunRawPublishBarriers' -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotReserveBeforeMutation|TestCollectionCommandWALPublishCoordinatorDoesNotHoldCoordinatorWhileDrainingOwner|TestCollectionCommandWALPublishWaitsForStageReservation|TestCollectionCommandWALThresholdFlushClearsCoordinatorOwner|TestCollectionCommandWALStageCoordinatorPinsFallbackToDomain|TestCollectionCommandWALUpdateBSONSetNoIndexDoesNotDeadlockRawPublish|TestCollectionCommandWALUpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  - Coordinated staging, flush and publish flows for Command-WAL to improve durability ordering, recovery, and reduce deadlocks
  - New raw-publish barrier and locking to serialize raw vs staged writes and close/race windows
  - Buffered updates now track Command-WAL intents and surface commit-ambiguous outcomes on staging/LSN failures

* **Testing**
  - Extensive new tests for concurrency, ordering, lifecycle and recovery around staged vs raw publish interactions

* **Benchmarks**
  - New CLI flag to enable Command-WAL (default false); reported in outputs and validated against compatible profiles/maintenance modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->










