### PR TITLE
TreeDB column store post-V1: add mmap direct asset views

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -658,11 +658,18 @@ type columnPhysicalAssetReadCache struct {
 	readIntegrity  ColumnAssetReadIntegrity
 	verifyChecksum bool
 	fileID         uint32
-	file           *os.File
-	files          map[uint32]*os.File
+	file           *columnPhysicalAssetSegmentReader
+	files          map[uint32]*columnPhysicalAssetSegmentReader
 	scratch        []byte
+	returnViews    bool
+	lastView       bool
 	hits           uint64
 	misses         uint64
+}
+
+type columnPhysicalAssetSegmentReader struct {
+	file *os.File
+	mmap []byte
 }
 
 func newColumnPhysicalAssetReadCache(rootDir string, namespace string) (columnPhysicalAssetReadCache, error) {
@@ -696,16 +703,16 @@ func (c *columnPhysicalAssetReadCache) close() error {
 		c.scratch = nil
 	}
 	if c.file != nil {
-		if err := c.file.Close(); err != nil && closeErr == nil {
+		if err := c.file.close(); err != nil && closeErr == nil {
 			closeErr = err
 		}
 		c.file = nil
 	}
-	for fileID, file := range c.files {
-		if file == nil {
+	for fileID, reader := range c.files {
+		if reader == nil {
 			continue
 		}
-		if err := file.Close(); err != nil && closeErr == nil {
+		if err := reader.close(); err != nil && closeErr == nil {
 			closeErr = err
 		}
 		delete(c.files, fileID)
@@ -720,9 +727,24 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 	if ref.Namespace != c.namespace {
 		return nil, fmt.Errorf("collections: column physical asset ref namespace=%q want %q", ref.Namespace, c.namespace)
 	}
-	file, err := c.fileForRef(ref)
+	reader, err := c.fileForRef(ref)
 	if err != nil {
 		return nil, err
+	}
+	if c.lastView {
+		dst = nil
+		c.lastView = false
+	}
+	if c.returnViews {
+		if raw, ok, err := reader.readView(ref); err != nil {
+			return nil, err
+		} else if ok {
+			if err := verifyColumnPhysicalAssetReadChecksum(raw, ref, c.verifyChecksum); err != nil {
+				return nil, err
+			}
+			c.lastView = true
+			return raw, nil
+		}
 	}
 	if ref.Length >= 0 && ref.Length <= int64(maxCollectionInt) && cap(dst) < int(ref.Length) {
 		if cap(c.scratch) < int(ref.Length) {
@@ -733,7 +755,7 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 		}
 		dst = c.scratch
 	}
-	return readColumnPhysicalAssetFromFileWithChecksum(file, ref, dst, c.verifyChecksum)
+	return readColumnPhysicalAssetFromFileWithChecksum(reader.file, ref, dst, c.verifyChecksum)
 }
 
 func getColumnPhysicalAssetReadScratch(minLen int) []byte {
@@ -755,7 +777,7 @@ func putColumnPhysicalAssetReadScratch(scratch []byte) {
 	columnPhysicalAssetReadScratchPool.Put(scratch[:0])
 }
 
-func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File, error) {
+func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*columnPhysicalAssetSegmentReader, error) {
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
 		return nil, err
 	}
@@ -764,9 +786,9 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 		return c.file, nil
 	}
 	if c.files != nil {
-		if file := c.files[ref.FileID]; file != nil {
+		if reader := c.files[ref.FileID]; reader != nil {
 			c.hits++
-			return file, nil
+			return reader, nil
 		}
 	}
 	c.misses++
@@ -774,21 +796,58 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*os.File,
 	if err != nil {
 		return nil, err
 	}
+	reader := &columnPhysicalAssetSegmentReader{file: file}
+	if c.returnViews {
+		if mapped, err := mmapColumnPhysicalAssetFile(file); err == nil {
+			reader.mmap = mapped
+		}
+	}
 	if c.file == nil && c.files == nil {
 		c.fileID = ref.FileID
-		c.file = file
-		return file, nil
+		c.file = reader
+		return reader, nil
 	}
 	if c.files == nil {
-		c.files = make(map[uint32]*os.File, 2)
+		c.files = make(map[uint32]*columnPhysicalAssetSegmentReader, 2)
 		if c.file != nil {
 			c.files[c.fileID] = c.file
 			c.file = nil
 			c.fileID = 0
 		}
 	}
-	c.files[ref.FileID] = file
-	return file, nil
+	c.files[ref.FileID] = reader
+	return reader, nil
+}
+
+func (r *columnPhysicalAssetSegmentReader) close() error {
+	if r == nil {
+		return nil
+	}
+	unmapErr := munmapColumnPhysicalAssetFile(r.mmap)
+	r.mmap = nil
+	var closeErr error
+	if r.file != nil {
+		closeErr = r.file.Close()
+		r.file = nil
+	}
+	return errors.Join(unmapErr, closeErr)
+}
+
+func (r *columnPhysicalAssetSegmentReader) readView(ref ColumnAssetRef) ([]byte, bool, error) {
+	if r == nil || len(r.mmap) == 0 {
+		return nil, false, nil
+	}
+	if ref.Offset < 0 || ref.Length < 0 || ref.Length > int64(maxCollectionInt) {
+		return nil, false, nil
+	}
+	end := ref.Offset + ref.Length
+	if end < ref.Offset {
+		return nil, false, fmt.Errorf("collections: column physical asset offset=%d length=%d overflows", ref.Offset, ref.Length)
+	}
+	if end > int64(len(r.mmap)) {
+		return nil, false, io.ErrUnexpectedEOF
+	}
+	return r.mmap[ref.Offset:end], true, nil
 }
 
 func readColumnPhysicalAssetFromFile(file *os.File, ref ColumnAssetRef, dst []byte) ([]byte, error) {

--- a/TreeDB/collections/column_asset_mmap_fallback.go
+++ b/TreeDB/collections/column_asset_mmap_fallback.go
@@ -1,0 +1,16 @@
+//go:build !(darwin || linux || freebsd || netbsd || openbsd)
+
+package collections
+
+import (
+	"errors"
+	"os"
+)
+
+func mmapColumnPhysicalAssetFile(_ *os.File) ([]byte, error) {
+	return nil, errors.New("collections: column asset mmap is not supported on this platform")
+}
+
+func munmapColumnPhysicalAssetFile(_ []byte) error {
+	return nil
+}

--- a/TreeDB/collections/column_asset_mmap_unix.go
+++ b/TreeDB/collections/column_asset_mmap_unix.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd
+
+package collections
+
+import (
+	"os"
+	"syscall"
+)
+
+func mmapColumnPhysicalAssetFile(file *os.File) ([]byte, error) {
+	if file == nil {
+		return nil, os.ErrInvalid
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+	if size <= 0 || size > int64(maxCollectionInt) {
+		return nil, os.ErrInvalid
+	}
+	return syscall.Mmap(int(file.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func munmapColumnPhysicalAssetFile(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return syscall.Munmap(data)
+}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -520,6 +520,67 @@ func TestColumnAssetReadIntegrityLabelPreservesUnsupportedM1634(t *testing.T) {
 	}
 }
 
+func TestColumnAssetReadCacheViewsRequireExplicitOptInM1634(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	payload := []byte("column-asset-reader-view-payload")
+	ref, err := writeColumnPhysicalAssetToManager(root, *normalized, payload, 7, 3)
+	if err != nil {
+		t.Fatalf("writeColumnPhysicalAssetToManager: %v", err)
+	}
+
+	copyCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new copy read cache: %v", err)
+	}
+	copyRaw, err := copyCache.read(ref, nil)
+	if err != nil {
+		_ = copyCache.close()
+		t.Fatalf("copy cache read: %v", err)
+	}
+	if !bytes.Equal(copyRaw, payload) {
+		_ = copyCache.close()
+		t.Fatalf("copy cache raw=%q want %q", copyRaw, payload)
+	}
+	if copyCache.lastView {
+		_ = copyCache.close()
+		t.Fatalf("copy cache returned an mmap view without opt-in")
+	}
+	if copyCache.file != nil && len(copyCache.file.mmap) != 0 {
+		_ = copyCache.close()
+		t.Fatalf("copy cache mapped segment without opt-in")
+	}
+	if err := copyCache.close(); err != nil {
+		t.Fatalf("copy cache close: %v", err)
+	}
+
+	viewCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new view read cache: %v", err)
+	}
+	viewCache.returnViews = true
+	viewRaw, err := viewCache.read(ref, nil)
+	if err != nil {
+		_ = viewCache.close()
+		t.Fatalf("view cache read: %v", err)
+	}
+	if !bytes.Equal(viewRaw, payload) {
+		_ = viewCache.close()
+		t.Fatalf("view cache raw=%q want %q", viewRaw, payload)
+	}
+	if viewCache.file != nil && len(viewCache.file.mmap) != 0 && !viewCache.lastView {
+		_ = viewCache.close()
+		t.Fatalf("view cache mapped segment but did not report view return")
+	}
+	if err := viewCache.close(); err != nil {
+		t.Fatalf("view cache close: %v", err)
+	}
+}
+
 func TestColumnAssetManagerWriteAllowsZeroChecksumM12A(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -141,6 +141,7 @@ func (c *Collection) runColumnPhysicalQueryAggregateMetadataInSnapshotView(view 
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
+	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 	acc := newColumnPhysicalQueryMetadataAccumulator(req.Kind)
 	var rawScratch []byte
@@ -241,6 +242,7 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
 	if err != nil {
 		return diag, err
 	}
+	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
 	start, step := columnPhysicalScanRefOrdinalPartition(columnPhysicalScanRequest{RefOrdinalModulo: refModulo, RefOrdinalRemainder: refRemainder})


### PR DESCRIPTION
Refs #1634.

## Summary

This PR adds a narrow mmap-backed view path for typed column asset reads in the production physical query path:

- wraps column asset segment files in a session-local reader that can hold an mmap view plus the existing `ReadAt` fallback;
- enables mmap views only for synchronous direct physical reducers and aggregate-metadata reducers that consume bytes before the read cache closes;
- leaves scanner/visibility/reconstruction paths copy-backed so they cannot retain slices into unmapped memory;
- preserves typed isolated `column_assets` ownership and does not store column assets in generic `value_vlog` or `leaf_vlog`;
- preserves checksum semantics from #1661: default `verify` still validates hot reads, `skip_checksums` skips hot typed column-asset payload CRC only when explicitly selected.

This is intentionally not the long-term shared cross-store cache manager. It is a measured, session-local substrate step that removes repeated `pread` copies from the hot direct physical query paths while keeping the existing file/ref/checksum lifecycle.

## Performance / Benchmark Evidence

Machine: Apple M3, darwin/arm64. Head: `2741c1f65` on `codex/column-store-mmap-asset-reader-probe`, based on #1661 head `a113e341f`.

Package benchmark, #1661 baseline vs this PR, both using `skip_checksums`:

Command:

```sh
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=10
benchstat /tmp/mmap_baseline10.txt /tmp/mmap_probe10.txt
```

| benchmark | #1661 sec/op | mmap sec/op | delta | #1661 MB/s | mmap MB/s | B/op delta | allocs/op delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| Serial physical skip | 7.754ms | 7.389ms | -4.70% | 806.6 MiB/s | 846.4 MiB/s | -0.73% | +0.02% |
| Aggregate metadata skip | 6.523ms | 6.288ms | -3.60% | 958.8 MiB/s | 994.6 MiB/s | -0.63% | +0.01% |
| Geomean | 7.112ms | 6.817ms | -4.15% | 879.4 MiB/s | 917.5 MiB/s | -0.68% | +0.02% |

100K routed production `serial_column_scan`, durable profile, `skip_checksums`, native-fastpath:

| query | #1661 rows/s | mmap rows/s | delta | #1661 ns/row | mmap ns/row | parity |
|---|---:|---:|---:|---:|---:|---|
| q1 | 12.63M | 14.59M | +15.59% | 79.2 | 68.5 | pass |
| q2 | 9.81M | 10.54M | +7.49% | 102.0 | 94.9 | pass |
| q3 | 23.37M | 25.85M | +10.63% | 42.8 | 38.7 | pass |
| q4a | 11.79M | 12.48M | +5.86% | 84.8 | 80.1 | pass |
| q4b | 11.71M | 12.82M | +9.54% | 85.4 | 78.0 | pass |
| q5 | 9.96M | 10.89M | +7.45% | 100.4 | 91.9 | pass |
| q5_metadata alias | 10.14M | 10.77M | +6.20% | 98.6 | 92.8 | pass |

100K routed production `aggregate_metadata`, durable profile, `skip_checksums`, native-fastpath:

| query | executed plan | #1661 rows/s | mmap rows/s | delta | metadata hits | bytes/read | parity |
|---|---|---:|---:|---:|---:|---:|---|
| q1 | serial scan reroute | 12.56M | 13.81M | +9.93% | 0 | 10,403,029 | pass |
| q2 | serial scan reroute | 9.89M | 10.42M | +5.43% | 0 | 10,403,029 | pass |
| q3 | serial scan reroute | 23.80M | 26.42M | +11.03% | 0 | 10,403,029 | pass |
| q4a | serial scan reroute | 11.73M | 11.90M | +1.43% | 0 | 10,403,029 | pass |
| q4b | aggregate metadata | 78.38M | 83.22M | +6.18% | 13 | 521,118 | pass |
| q5 | serial scan reroute | 10.07M | 11.08M | +10.01% | 0 | 10,403,029 | pass |
| q5_metadata | aggregate metadata | 115.49M | 112.20M | -2.85% | 13 | 521,118 | pass |

CPU-profile attribution from the representative serial routed runs:

- #1661 baseline profile samples are dominated by `columnPhysicalAssetReadCache.read -> readColumnPhysicalAssetFromFileWithChecksum -> os.File.ReadAt -> syscall.Pread`.
- This PR removes `pread` from the direct physical query profile; samples shift to TCPA cursor/reducer work plus mmap setup/teardown.
- Allocation count is effectively unchanged; this PR is a read-copy/syscall reduction, not an allocation cleanup.

Byte accounting for representative 100K routed runs remains stable: `retained_payload_bytes=3368750`, `column_asset_bytes=11445265`, `column_asset_store_bytes=11445265`, `manifest_control_bytes=28`, `ordinary_value_vlog_bytes=0`, `leaf_vlog_bytes=2272885`, `command_wal_bytes_before_checkpoint=11171437`, and `db_total_bytes=25414300`.

## Granule / ClickHouse Context

Fresh #1660 same-machine granule-kernel context remains the comparison baseline for this q1-q5 family, not a pass/fail gate for this PR:

| query family | experiment baseline |
|---|---:|
| Q1 encoded reducer | `418.77M rows/s`, `2.388 ns/row`, `2377 B/op`, `5 allocs/op` |
| Q2 encoded reducer | `241.75M rows/s`, `4.136 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q3 encoded reducer | `195.30M rows/s`, `5.120 ns/row`, `2424 B/op`, `5 allocs/op` |
| Q4b ClickHouse-order row scan | `91.46M rows/s`, `10.93 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 encoded reducer | `141.81M rows/s`, `7.052 ns/row`, `2440 B/op`, `5 allocs/op` |
| Q4b metadata | `307.95M rows/s`, `3.247 ns/row`, `160 B/op`, `2 allocs/op` |
| Q5 metadata | `420.58M rows/s`, `2.378 ns/row`, `96 B/op`, `2 allocs/op` |

ClickHouse-equivalent context is historical/local from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, generated from 1M JSONBench rows on local ClickHouse `26.4.3.1` / Darwin arm64:

| query | granule-kernel best | ClickHouse local | kernel / ClickHouse |
|---|---:|---:|---:|
| Q1 | `0.004284s` | `0.014000s` | `0.31x` |
| Q2 | `0.038895s` | `0.027000s` | `1.44x` |
| Q3 | `0.006631s` | `0.014000s` | `0.47x` |
| Q4 | `0.009869s` | `0.013000s` | `0.76x` |
| Q5 | `0.010027s` | `0.013000s` | `0.77x` |

## Throughput Interpretation

This confirms that after #1661 removes hot CRC cost, repeated typed asset `pread`/copy is still material for routed direct physical queries. The largest gains are in serial full-scan routes where every scheduled granule reads the full TCPA image; aggregate metadata sees smaller and noisier gains because it reads much less data and is more sensitive to fixed adapter/reporting cost.

The q5_metadata aggregate-metadata sample regressed slightly while q4b aggregate metadata improved. That path reads only `521,118` bytes and is dominated by fixed costs at this fixture size, so this PR does not claim a universal metadata-fast-path speedup. The accepted win is the full direct physical asset scan path and the pprof removal of `pread` from that path.

This is intentionally conservative on safety: mmap views are not returned from row scanner, visibility, or reconstruction paths because those callers can retain row slices beyond the read-cache lifetime. Those paths still use the existing copy-backed `ReadAt` fallback.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysical' -count=1` passed.
- `go test ./TreeDB/collections -run 'TestColumnAssetReadCacheViewsRequireExplicitOptInM1634|TestColumnPhysical|TestColumnAssetManagerWritesIsolatedSegmentAndValidatesM12A' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=10` passed.
- `git diff --check` passed.

## Artifacts

- Package baseline: `/tmp/mmap_baseline10.txt`
- Package mmap: `/tmp/mmap_probe10.txt`
- Serial #1661 baseline: `/tmp/mmap_baseline_unified_seq_20260520_154910`
- Serial mmap: `/tmp/mmap_probe_unified_seq_20260520_154920`
- Aggregate #1661 baseline: `/tmp/mmap_baseline_agg_seq_20260520_154933`
- Aggregate mmap: `/tmp/mmap_probe_agg_seq_20260520_154933`
- Representative HTML reports:
  - `/tmp/mmap_baseline_unified_seq_20260520_154910/column_store_results.html`
  - `/tmp/mmap_probe_unified_seq_20260520_154920/column_store_results.html`
  - `/tmp/mmap_baseline_agg_seq_20260520_154933/column_store_results.html`
  - `/tmp/mmap_probe_agg_seq_20260520_154933/column_store_results.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory-mapped file support for column asset reads to improve performance on supported platforms (Linux, macOS, FreeBSD, OpenBSD, NetBSD)
  * Checksum verification maintained for all read operations
  * Feature is opt-in to maintain backward compatibility with graceful fallback on unsupported platforms

* **Tests**
  * Added test coverage for memory-mapped view read behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->