### PR TITLE
collections: add column graph physical row reader

### DIFF
--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -9,7 +9,7 @@ import (
 
 const defaultColumnPhysicalRowReaderMaxDecodedBlocks = 4
 
-var errColumnPhysicalRowOrdinalOutOfBounds = errors.New("collections: physical column row ordinal outside row_count")
+var errColumnPhysicalRowOrdinalOutOfBounds = errors.New("physical column row ordinal outside row_count")
 
 type columnPhysicalRowReaderOptions struct {
 	ProjectedColumns  []string

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -9,6 +9,8 @@ import (
 
 const defaultColumnPhysicalRowReaderMaxDecodedBlocks = 4
 
+var errColumnPhysicalRowOrdinalOutOfBounds = errors.New("collections: physical column row ordinal outside row_count")
+
 type columnPhysicalRowReaderOptions struct {
 	ProjectedColumns  []string
 	MaxDecodedBlocks  int
@@ -276,7 +278,7 @@ func (r *columnPhysicalRowReader) buildOrdinalRanges() error {
 func (r *columnPhysicalRowReader) fetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnPhysicalRowReaderRow, error) {
 	rangeIdx := r.rangeIndexForOrdinal(ordinal)
 	if rangeIdx < 0 {
-		return columnPhysicalRowReaderRow{}, fmt.Errorf("collections: physical column row ordinal=%d outside row_count=%d", ordinal, r.totalRows)
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("collections: physical column row ordinal=%d outside row_count=%d: %w", ordinal, r.totalRows, errColumnPhysicalRowOrdinalOutOfBounds)
 	}
 	rowRange := r.ranges[rangeIdx]
 	block, err := r.loadBlock(rowRange)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -758,21 +758,6 @@ func columnManifestPartKeyFromRecordKeyForScan(key []byte) (uint64, uint64, erro
 
 func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string) ([]columnManifestAssetRefForScan, int, error) {
 	refs := make([]columnManifestAssetRefForScan, 0, len(records))
-	mutationParts, err := walkColumnManifestAssetRefsFromRecordsForScan(records, activeGeneration, expectedNamespace, func(ref ColumnAssetRef, operation ColumnPublishOperation) error {
-		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
-		return nil
-	})
-	if err != nil {
-		return nil, 0, err
-	}
-	return refs, mutationParts, nil
-}
-
-func columnManifestMutationPartsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string) (int, error) {
-	return walkColumnManifestAssetRefsFromRecordsForScan(records, activeGeneration, expectedNamespace, nil)
-}
-
-func walkColumnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string, visit func(ColumnAssetRef, ColumnPublishOperation) error) (int, error) {
 	mutationParts := 0
 	for _, record := range records {
 		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) {
@@ -780,39 +765,35 @@ func walkColumnManifestAssetRefsFromRecordsForScan(records []columnManifestRecor
 		}
 		keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
 		// The active manifest root contains the reachable immutable lineage:
 		// the original base parts plus later delta/tombstone parts. Older
 		// generations are therefore live until compaction publishes a root
 		// that omits them; only future-generation records are impossible here.
 		if keyGeneration > activeGeneration {
-			return 0, fmt.Errorf("collections: column manifest part generation=%d is newer than active manifest generation=%d", keyGeneration, activeGeneration)
+			return nil, 0, fmt.Errorf("collections: column manifest part generation=%d is newer than active manifest generation=%d", keyGeneration, activeGeneration)
 		}
 		ref, reason, err := decodeColumnManifestPartRefForScan(record.value, expectedNamespace)
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
 		if ref.Generation != keyGeneration {
-			return 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+			return nil, 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
 		}
 		if ref.PartID != keyPartID {
-			return 0, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
+			return nil, 0, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
 		}
 		operation, ok := columnPhysicalScanOperationFromBytes(reason)
 		if !ok {
-			return 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
+			return nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
-		if visit != nil {
-			if err := visit(ref, operation); err != nil {
-				return 0, err
-			}
-		}
+		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
 		if operation != ColumnPublishOperationInsert {
 			mutationParts++
 		}
 	}
-	return mutationParts, nil
+	return refs, mutationParts, nil
 }
 
 func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (ColumnAssetRef, []byte, error) {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -758,6 +758,21 @@ func columnManifestPartKeyFromRecordKeyForScan(key []byte) (uint64, uint64, erro
 
 func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string) ([]columnManifestAssetRefForScan, int, error) {
 	refs := make([]columnManifestAssetRefForScan, 0, len(records))
+	mutationParts, err := walkColumnManifestAssetRefsFromRecordsForScan(records, activeGeneration, expectedNamespace, func(ref ColumnAssetRef, operation ColumnPublishOperation) error {
+		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return refs, mutationParts, nil
+}
+
+func columnManifestMutationPartsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string) (int, error) {
+	return walkColumnManifestAssetRefsFromRecordsForScan(records, activeGeneration, expectedNamespace, nil)
+}
+
+func walkColumnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, activeGeneration uint64, expectedNamespace string, visit func(ColumnAssetRef, ColumnPublishOperation) error) (int, error) {
 	mutationParts := 0
 	for _, record := range records {
 		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) {
@@ -765,35 +780,39 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, a
 		}
 		keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
 		if err != nil {
-			return nil, 0, err
+			return 0, err
 		}
 		// The active manifest root contains the reachable immutable lineage:
 		// the original base parts plus later delta/tombstone parts. Older
 		// generations are therefore live until compaction publishes a root
 		// that omits them; only future-generation records are impossible here.
 		if keyGeneration > activeGeneration {
-			return nil, 0, fmt.Errorf("collections: column manifest part generation=%d is newer than active manifest generation=%d", keyGeneration, activeGeneration)
+			return 0, fmt.Errorf("collections: column manifest part generation=%d is newer than active manifest generation=%d", keyGeneration, activeGeneration)
 		}
 		ref, reason, err := decodeColumnManifestPartRefForScan(record.value, expectedNamespace)
 		if err != nil {
-			return nil, 0, err
+			return 0, err
 		}
 		if ref.Generation != keyGeneration {
-			return nil, 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+			return 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
 		}
 		if ref.PartID != keyPartID {
-			return nil, 0, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
+			return 0, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
 		}
 		operation, ok := columnPhysicalScanOperationFromBytes(reason)
 		if !ok {
-			return nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
+			return 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
-		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+		if visit != nil {
+			if err := visit(ref, operation); err != nil {
+				return 0, err
+			}
+		}
 		if operation != ColumnPublishOperationInsert {
 			mutationParts++
 		}
 	}
-	return refs, mutationParts, nil
+	return mutationParts, nil
 }
 
 func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (ColumnAssetRef, []byte, error) {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -197,6 +197,9 @@ func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStat
 	return r.reader.Stats()
 }
 
+// FetchRow returns one graph row and performs fail-closed adjacency ordinal
+// validation. Native search uses fetchRowUnchecked and validates each edge once
+// when expanded to avoid duplicate adjacency scans on the hot path.
 func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
 	if r == nil || r.reader == nil {
 		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
@@ -219,6 +222,10 @@ func (r *columnVectorGraphPhysicalRowReader) fetchRowUnchecked(ordinal int, scra
 	return r.graphRowFromPhysicalRowUnchecked(row)
 }
 
+// FetchBatch returns graph rows in the underlying reader's batch order and
+// performs fail-closed adjacency ordinal validation for each row. Native search
+// uses fetchBatchUnchecked for final result fetches after validating expanded
+// edges during traversal.
 func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
 	if r == nil || r.reader == nil {
 		return errors.New("collections: nil column vector graph physical row reader")

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -136,10 +136,6 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 	if err := validateColumnManifestSnapshot(manifest, records, *cfg, *cfg.ActiveManifest, catalog.meta.Name, "column vector graph row reader"); err != nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
 	}
-	mutationParts, err := columnManifestMutationPartsFromRecordsForScan(records, manifest.Generation, cfg.AssetManager.Namespace)
-	if err != nil {
-		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
-	}
 	graphRecord, ok := findColumnVectorGraphManifestRecord(records, def.Name)
 	if !ok {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q has no published graph manifest", def.Name)
@@ -174,7 +170,6 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 			Ref:    graph.AssetRef,
 			Reason: ColumnPublishOperationInsert,
 		}},
-		MutationParts: mutationParts,
 		Diagnostics: columnPhysicalScanDiagnostics{
 			ManifestRoot:               rootID,
 			ManifestGeneration:         cfg.ActiveManifest.Generation,
@@ -182,7 +177,6 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 			AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
 			ManifestRecords:            len(records),
 			AssetRefs:                  1,
-			MutationParts:              mutationParts,
 		},
 		ColumnAssetRootDir: c.db.ColumnAssetRootDir(),
 		AssetNamespace:     graphCfg.AssetManager.Namespace,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -198,6 +198,10 @@ func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStat
 }
 
 func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
+	return r.fetchRow(ordinal, scratch, true)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch, validateAdjacency bool) (columnVectorGraphPhysicalRow, error) {
 	if r == nil || r.reader == nil {
 		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -205,10 +209,14 @@ func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *colu
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	return r.graphRowFromPhysicalRow(row)
+	return r.graphRowFromPhysicalRowWithValidation(row, validateAdjacency)
 }
 
 func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
+	return r.fetchBatch(ordinals, scratch, true, visitor)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, validateAdjacency bool, visitor func(columnVectorGraphPhysicalRow) error) error {
 	if r == nil || r.reader == nil {
 		return errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -216,7 +224,7 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
 	}
 	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
-		graphRow, err := r.graphRowFromPhysicalRow(row)
+		graphRow, err := r.graphRowFromPhysicalRowWithValidation(row, validateAdjacency)
 		if err != nil {
 			return err
 		}
@@ -225,6 +233,10 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 }
 
 func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
+	return r.graphRowFromPhysicalRowWithValidation(row, true)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowWithValidation(row columnPhysicalRowReaderRow, validateAdjacency bool) (columnVectorGraphPhysicalRow, error) {
 	if r == nil {
 		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -251,6 +263,14 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	}
 	if invNorm.Float32 <= 0 || math.IsNaN(float64(invNorm.Float32)) || math.IsInf(float64(invNorm.Float32), 0) {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", r.def.Name, row.Ordinal, invNorm.Float32)
+	}
+	if validateAdjacency {
+		rowCount := r.RowCount()
+		for i, neighbor := range adjacency.AdjacencyList {
+			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
+				return columnVectorGraphPhysicalRow{}, err
+			}
+		}
 	}
 	return columnVectorGraphPhysicalRow{
 		Ordinal:   row.Ordinal,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -198,10 +198,6 @@ func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStat
 }
 
 func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
-	return r.fetchRow(ordinal, scratch, true)
-}
-
-func (r *columnVectorGraphPhysicalRowReader) fetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch, validateAdjacency bool) (columnVectorGraphPhysicalRow, error) {
 	if r == nil || r.reader == nil {
 		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -209,14 +205,21 @@ func (r *columnVectorGraphPhysicalRowReader) fetchRow(ordinal int, scratch *colu
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	return r.graphRowFromPhysicalRowWithValidation(row, validateAdjacency)
+	return r.graphRowFromPhysicalRow(row)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchRowUnchecked(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
+	if r == nil || r.reader == nil {
+		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+	}
+	row, err := r.reader.FetchRow(ordinal, scratch)
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
+	}
+	return r.graphRowFromPhysicalRowUnchecked(row)
 }
 
 func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
-	return r.fetchBatch(ordinals, scratch, true, visitor)
-}
-
-func (r *columnVectorGraphPhysicalRowReader) fetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, validateAdjacency bool, visitor func(columnVectorGraphPhysicalRow) error) error {
 	if r == nil || r.reader == nil {
 		return errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -224,7 +227,23 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatch(ordinals []int, scratch 
 		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
 	}
 	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
-		graphRow, err := r.graphRowFromPhysicalRowWithValidation(row, validateAdjacency)
+		graphRow, err := r.graphRowFromPhysicalRow(row)
+		if err != nil {
+			return err
+		}
+		return visitor(graphRow)
+	})
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
+	if r == nil || r.reader == nil {
+		return errors.New("collections: nil column vector graph physical row reader")
+	}
+	if visitor == nil {
+		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
+	}
+	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
+		graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)
 		if err != nil {
 			return err
 		}
@@ -233,10 +252,23 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatch(ordinals []int, scratch 
 }
 
 func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
-	return r.graphRowFromPhysicalRowWithValidation(row, true)
+	graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
+	}
+	rowCount := r.RowCount()
+	for i, neighbor := range graphRow.Adjacency {
+		if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
+			return columnVectorGraphPhysicalRow{}, err
+		}
+	}
+	return graphRow, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowWithValidation(row columnPhysicalRowReaderRow, validateAdjacency bool) (columnVectorGraphPhysicalRow, error) {
+// graphRowFromPhysicalRowUnchecked validates row shape and vector scoring
+// inputs, but intentionally does not scan adjacency bounds. Native search uses
+// this path and validates each edge exactly when it is expanded.
+func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowUnchecked(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
 	if r == nil {
 		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
 	}
@@ -263,14 +295,6 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowWithValidati
 	}
 	if invNorm.Float32 <= 0 || math.IsNaN(float64(invNorm.Float32)) || math.IsInf(float64(invNorm.Float32), 0) {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", r.def.Name, row.Ordinal, invNorm.Float32)
-	}
-	if validateAdjacency {
-		rowCount := r.RowCount()
-		for i, neighbor := range adjacency.AdjacencyList {
-			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
-				return columnVectorGraphPhysicalRow{}, err
-			}
-		}
 	}
 	return columnVectorGraphPhysicalRow{
 		Ordinal:   row.Ordinal,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -70,6 +70,10 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReader(name string, opts co
 	if err != nil {
 		return nil, err
 	}
+	if got, want := reader.RowCount(), graph.RowCount; got != want {
+		_ = reader.Close()
+		return nil, fmt.Errorf("collections: column_graph %q manifest row_count=%d physical_row_count=%d: %w", def.Name, want, got, errColumnVectorGraphManifestMismatch)
+	}
 	return &columnVectorGraphPhysicalRowReader{
 		def:    def,
 		graph:  graph,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -235,6 +235,9 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	if vector.Type != ColumnStoreValueFloat32Vector || invNorm.Type != ColumnStoreValueFloat32 || adjacency.Type != ColumnStoreValueAdjacencyList {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d unexpected graph value types: vector=%q inv_norm=%q adjacency=%q", r.def.Name, row.Ordinal, vector.Type, invNorm.Type, adjacency.Type)
 	}
+	if !vector.Present || !invNorm.Present || !adjacency.Present {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d missing graph value", r.def.Name, row.Ordinal)
+	}
 	if vector.Null || invNorm.Null || adjacency.Null {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d contains null graph value", r.def.Name, row.Ordinal)
 	}

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -1,0 +1,244 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type columnVectorGraphPhysicalRowReaderOptions struct {
+	MaxDecodedBlocks int
+}
+
+// columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
+// column graph asset by ordinal. It is a graph-specific wrapper around the
+// generic physical row reader, not a decoded ColumnVectorGraph.
+type columnVectorGraphPhysicalRowReader struct {
+	def    VectorIndexDefinition
+	graph  columnVectorGraphManifestSnapshot
+	reader *columnPhysicalRowReader
+}
+
+// columnVectorGraphPhysicalRow aliases caller-owned scratch and cached asset
+// bytes. Copy ID, Vector, or Adjacency before the next fetch if retention is
+// required.
+type columnVectorGraphPhysicalRow struct {
+	Ordinal   int
+	RowIndex  int
+	ID        []byte
+	Vector    []float32
+	InvNorm   float32
+	Adjacency []uint32
+}
+
+func (c *Collection) openColumnVectorGraphPhysicalRowReader(name string, opts columnVectorGraphPhysicalRowReaderOptions) (*columnVectorGraphPhysicalRowReader, error) {
+	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotView(name)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(view, columnPhysicalRowReaderOptions{
+		ProjectedColumns: []string{
+			columnVectorGraphVectorColumnName,
+			columnVectorGraphInvNormColumnName,
+			columnVectorGraphAdjacencyColumnName,
+		},
+		MaxDecodedBlocks:  opts.MaxDecodedBlocks,
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &columnVectorGraphPhysicalRowReader{
+		def:    def,
+		graph:  graph,
+		reader: reader,
+	}, nil
+}
+
+func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string) (VectorIndexDefinition, columnVectorGraphManifestSnapshot, columnPhysicalScanSnapshotView, error) {
+	if c == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errCollectionNil
+	}
+	if c.db == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	if catalog == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, name)
+	if !ok {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, ErrIndexNotFound
+	}
+	if def.Strategy != VectorIndexStrategyColumnGraph {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: vector index %q strategy=%q is not column_graph", def.Name, def.Strategy)
+	}
+	cfg := catalog.meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled || cfg.AssetManager == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires physical column asset support")
+	}
+	if cfg.ActiveManifest == nil || cfg.RecoveryAuthoritativeManifest == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires active column manifest")
+	}
+	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+	if rootID == 0 {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph physical row reader missing manifest root %q", collectionColumnManifestRootName(catalog.meta.Name))
+	}
+	if err := validateColumnManifestIdentityAtRoot(snap, rootID, *cfg.ActiveManifest); err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	manifest, err := decodeColumnManifestSnapshotForScan(records)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	if err := validateColumnManifestSnapshot(manifest, records, *cfg, *cfg.ActiveManifest, catalog.meta.Name, "column vector graph row reader"); err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	graphRecord, ok := findColumnVectorGraphManifestRecord(records, def.Name)
+	if !ok {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q has no published graph manifest", def.Name)
+	}
+	graph, err := decodeColumnVectorGraphManifestRecord(graphRecord.value)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	if !columnVectorGraphManifestMatchesDefinition(catalog.meta.Name, graph, def, *cfg, manifest, records) {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q graph manifest does not match vector index definition", def.Name)
+	}
+	if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(catalog.meta.Name, *cfg, def)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	graphCfg.ActiveManifest = cfg.ActiveManifest
+	graphCfg.RecoveryAuthoritativeManifest = cfg.RecoveryAuthoritativeManifest
+	graphCfg.RecoveryAuthoritativeAppliedCommandLSN = cfg.RecoveryAuthoritativeAppliedCommandLSN
+	state := snap.State()
+	if state == nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, backenddb.ErrClosed
+	}
+	view := columnPhysicalScanSnapshotView{
+		CollectionName:     catalog.meta.Name,
+		Config:             graphCfg,
+		ColumnStoreEnabled: true,
+		CommitSeq:          state.CommitSeq,
+		AssetRefs: []columnManifestAssetRefForScan{{
+			Ref:    graph.AssetRef,
+			Reason: ColumnPublishOperationInsert,
+		}},
+		Diagnostics: columnPhysicalScanDiagnostics{
+			ManifestRoot:               rootID,
+			ManifestGeneration:         cfg.ActiveManifest.Generation,
+			RecoveryManifestGeneration: cfg.RecoveryAuthoritativeManifest.Generation,
+			AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
+			ManifestRecords:            len(records),
+			AssetRefs:                  1,
+		},
+		ColumnAssetRootDir: c.db.ColumnAssetRootDir(),
+		AssetNamespace:     graphCfg.AssetManager.Namespace,
+	}
+	return def, graph, view, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) Close() error {
+	if r == nil || r.reader == nil {
+		return nil
+	}
+	return r.reader.Close()
+}
+
+func (r *columnVectorGraphPhysicalRowReader) RowCount() int {
+	if r == nil || r.reader == nil {
+		return 0
+	}
+	return r.reader.RowCount()
+}
+
+func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStats {
+	if r == nil || r.reader == nil {
+		return columnPhysicalRowReaderStats{}
+	}
+	return r.reader.Stats()
+}
+
+func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
+	if r == nil || r.reader == nil {
+		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+	}
+	row, err := r.reader.FetchRow(ordinal, scratch)
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
+	}
+	return r.graphRowFromPhysicalRow(row)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
+	if r == nil || r.reader == nil {
+		return errors.New("collections: nil column vector graph physical row reader")
+	}
+	if visitor == nil {
+		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
+	}
+	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
+		graphRow, err := r.graphRowFromPhysicalRow(row)
+		if err != nil {
+			return err
+		}
+		return visitor(graphRow)
+	})
+}
+
+func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
+	if len(row.ID) == 0 {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d missing document id", r.def.Name, row.Ordinal)
+	}
+	if len(row.Values) != 3 {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d values=%d want 3", r.def.Name, row.Ordinal, len(row.Values))
+	}
+	vector := row.Values[0]
+	invNorm := row.Values[1]
+	adjacency := row.Values[2]
+	if vector.Type != ColumnStoreValueFloat32Vector || invNorm.Type != ColumnStoreValueFloat32 || adjacency.Type != ColumnStoreValueAdjacencyList {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d unexpected graph value types", r.def.Name, row.Ordinal)
+	}
+	if vector.Null || invNorm.Null || adjacency.Null {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d contains null graph value", r.def.Name, row.Ordinal)
+	}
+	if len(vector.Float32Vector) != r.def.Dimensions {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d vector dims=%d want %d", r.def.Name, row.Ordinal, len(vector.Float32Vector), r.def.Dimensions)
+	}
+	if invNorm.Float32 <= 0 || math.IsNaN(float64(invNorm.Float32)) || math.IsInf(float64(invNorm.Float32), 0) {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", r.def.Name, row.Ordinal, invNorm.Float32)
+	}
+	rowCount := r.reader.RowCount()
+	for i, neighbor := range adjacency.AdjacencyList {
+		if uint64(neighbor) >= uint64(rowCount) {
+			return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d", r.def.Name, row.Ordinal, i, neighbor, rowCount)
+		}
+	}
+	return columnVectorGraphPhysicalRow{
+		Ordinal:   row.Ordinal,
+		RowIndex:  row.RowIndex,
+		ID:        row.ID,
+		Vector:    vector.Float32Vector,
+		InvNorm:   invNorm.Float32,
+		Adjacency: adjacency.AdjacencyList,
+	}, nil
+}

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -23,6 +23,8 @@ const (
 	columnVectorGraphPhysicalRowValueCount
 )
 
+var errColumnVectorGraphAdjacencyOrdinalOutOfBounds = errors.New("collections: column_graph adjacency ordinal outside row_count")
+
 // columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
 // column graph asset by ordinal. It is a graph-specific wrapper around the
 // generic physical row reader, not a decoded ColumnVectorGraph.
@@ -223,6 +225,9 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 }
 
 func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
+	if r == nil {
+		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+	}
 	if len(row.ID) == 0 {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d missing document id", r.def.Name, row.Ordinal)
 	}
@@ -247,14 +252,6 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	if invNorm.Float32 <= 0 || math.IsNaN(float64(invNorm.Float32)) || math.IsInf(float64(invNorm.Float32), 0) {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", r.def.Name, row.Ordinal, invNorm.Float32)
 	}
-	rowCount := r.reader.RowCount()
-	// Fail closed if persisted adjacency points outside the immutable graph.
-	// V3 search relies on this validation before expanding neighbor ordinals.
-	for i, neighbor := range adjacency.AdjacencyList {
-		if uint64(neighbor) >= uint64(rowCount) {
-			return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d", r.def.Name, row.Ordinal, i, neighbor, rowCount)
-		}
-	}
 	return columnVectorGraphPhysicalRow{
 		Ordinal:   row.Ordinal,
 		RowIndex:  row.RowIndex,
@@ -263,4 +260,11 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 		InvNorm:   invNorm.Float32,
 		Adjacency: adjacency.AdjacencyList,
 	}, nil
+}
+
+func validateColumnVectorGraphAdjacencyOrdinal(graphName string, ordinal int, adjacencyIndex int, neighbor uint32, rowCount int) error {
+	if uint64(neighbor) >= uint64(rowCount) {
+		return fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", graphName, ordinal, adjacencyIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+	}
+	return nil
 }

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -26,7 +26,7 @@ const (
 var (
 	errColumnVectorGraphAdjacencyOrdinalOutOfBounds = errors.New("column_graph adjacency ordinal outside row_count")
 	errColumnVectorGraphManifestMismatch            = errors.New("column_graph manifest mismatch")
-	errNilColumnVectorGraphPhysicalRowReader        = errors.New("collections: nil column vector graph physical row reader")
+	errNilColumnVectorGraphPhysicalRowReader        = errors.New("nil column vector graph physical row reader")
 )
 
 // columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
@@ -224,7 +224,7 @@ func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *colu
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	return r.graphRowFromPhysicalRow(row)
+	return r.graphRowFromPhysicalRow(row, reader.RowCount())
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchRowUnchecked(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
@@ -251,8 +251,9 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 	if visitor == nil {
 		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
 	}
+	rowCount := reader.RowCount()
 	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
-		graphRow, err := r.graphRowFromPhysicalRow(row)
+		graphRow, err := r.graphRowFromPhysicalRow(row, rowCount)
 		if err != nil {
 			return err
 		}
@@ -277,16 +278,11 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int,
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
-	reader, err := r.rowReader()
-	if err != nil {
-		return columnVectorGraphPhysicalRow{}, err
-	}
+func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow, rowCount int) (columnVectorGraphPhysicalRow, error) {
 	graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	rowCount := reader.totalRows
 	for i, neighbor := range graphRow.Adjacency {
 		if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
 			return columnVectorGraphPhysicalRow{}, err

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -54,7 +54,16 @@ type columnVectorGraphPhysicalRow struct {
 }
 
 func (c *Collection) openColumnVectorGraphPhysicalRowReader(name string, opts columnVectorGraphPhysicalRowReaderOptions) (*columnVectorGraphPhysicalRowReader, error) {
-	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotView(name)
+	snap, err := c.acquireColumnVectorGraphPhysicalRowReaderSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = snap.Close() }()
+	return c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(name, snap, opts)
+}
+
+func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name string, snap *backenddb.Snapshot, opts columnVectorGraphPhysicalRowReaderOptions) (*columnVectorGraphPhysicalRowReader, error) {
+	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(name, snap)
 	if err != nil {
 		return nil, err
 	}
@@ -82,18 +91,38 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReader(name string, opts co
 }
 
 func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string) (VectorIndexDefinition, columnVectorGraphManifestSnapshot, columnPhysicalScanSnapshotView, error) {
+	snap, err := c.acquireColumnVectorGraphPhysicalRowReaderSnapshot()
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
+	defer func() { _ = snap.Close() }()
+	return c.columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(name, snap)
+}
+
+func (c *Collection) acquireColumnVectorGraphPhysicalRowReaderSnapshot() (*backenddb.Snapshot, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	return snap, nil
+}
+
+func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(name string, snap *backenddb.Snapshot) (VectorIndexDefinition, columnVectorGraphManifestSnapshot, columnPhysicalScanSnapshotView, error) {
 	if c == nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errCollectionNil
 	}
 	if c.db == nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errCollectionDBNil
 	}
-	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, backenddb.ErrClosed
 	}
-	defer func() { _ = snap.Close() }()
-
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
@@ -249,7 +278,7 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 		return err
 	}
 	if visitor == nil {
-		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
+		return errors.New("collections: column_graph physical row reader batch visitor is nil")
 	}
 	rowCount := reader.RowCount()
 	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
@@ -267,7 +296,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int,
 		return err
 	}
 	if visitor == nil {
-		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
+		return errors.New("collections: column_graph physical row reader batch visitor is nil")
 	}
 	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
 		graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -136,6 +136,10 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 	if err := validateColumnManifestSnapshot(manifest, records, *cfg, *cfg.ActiveManifest, catalog.meta.Name, "column vector graph row reader"); err != nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
 	}
+	mutationParts, err := columnManifestMutationPartsFromRecordsForScan(records, manifest.Generation, cfg.AssetManager.Namespace)
+	if err != nil {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	}
 	graphRecord, ok := findColumnVectorGraphManifestRecord(records, def.Name)
 	if !ok {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q has no published graph manifest", def.Name)
@@ -170,6 +174,7 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 			Ref:    graph.AssetRef,
 			Reason: ColumnPublishOperationInsert,
 		}},
+		MutationParts: mutationParts,
 		Diagnostics: columnPhysicalScanDiagnostics{
 			ManifestRoot:               rootID,
 			ManifestGeneration:         cfg.ActiveManifest.Generation,
@@ -177,6 +182,7 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 			AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
 			ManifestRecords:            len(records),
 			AssetRefs:                  1,
+			MutationParts:              mutationParts,
 		},
 		ColumnAssetRootDir: c.db.ColumnAssetRootDir(),
 		AssetNamespace:     graphCfg.AssetManager.Namespace,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -105,6 +105,9 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 	if cfg.ActiveManifest == nil || cfg.RecoveryAuthoritativeManifest == nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires active and recovery-authoritative column manifests")
 	}
+	if !columnManifestIdentityValueEqual(*cfg.ActiveManifest, *cfg.RecoveryAuthoritativeManifest) {
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires active recovery-authoritative column manifest")
+	}
 	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	if rootID == 0 {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph physical row reader missing manifest root %q", collectionColumnManifestRootName(catalog.meta.Name))

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -24,9 +24,10 @@ const (
 )
 
 var (
-	errColumnVectorGraphAdjacencyOrdinalOutOfBounds = errors.New("column_graph adjacency ordinal outside row_count")
-	errColumnVectorGraphManifestMismatch            = errors.New("column_graph manifest mismatch")
-	errNilColumnVectorGraphPhysicalRowReader        = errors.New("nil column vector graph physical row reader")
+	errColumnVectorGraphAdjacencyOrdinalOutOfBounds      = errors.New("column_graph adjacency ordinal outside row_count")
+	errColumnVectorGraphManifestMismatch                 = errors.New("column_graph manifest mismatch")
+	errNilColumnVectorGraphPhysicalRowReader             = errors.New("nil column vector graph physical row reader")
+	errColumnVectorGraphPhysicalRowReaderBatchVisitorNil = errors.New("collections: column_graph physical row reader batch visitor is nil")
 )
 
 // columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
@@ -278,7 +279,7 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 		return err
 	}
 	if visitor == nil {
-		return errors.New("collections: column_graph physical row reader batch visitor is nil")
+		return errColumnVectorGraphPhysicalRowReaderBatchVisitorNil
 	}
 	rowCount := reader.RowCount()
 	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
@@ -296,7 +297,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int,
 		return err
 	}
 	if visitor == nil {
-		return errors.New("collections: column_graph physical row reader batch visitor is nil")
+		return errColumnVectorGraphPhysicalRowReaderBatchVisitorNil
 	}
 	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
 		graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -103,7 +103,7 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires physical column asset support")
 	}
 	if cfg.ActiveManifest == nil || cfg.RecoveryAuthoritativeManifest == nil {
-		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires active column manifest")
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, errors.New("collections: column_graph physical row reader requires active and recovery-authoritative column manifests")
 	}
 	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	if rootID == 0 {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -23,7 +23,11 @@ const (
 	columnVectorGraphPhysicalRowValueCount
 )
 
-var errColumnVectorGraphAdjacencyOrdinalOutOfBounds = errors.New("collections: column_graph adjacency ordinal outside row_count")
+var (
+	errColumnVectorGraphAdjacencyOrdinalOutOfBounds = errors.New("column_graph adjacency ordinal outside row_count")
+	errColumnVectorGraphManifestMismatch            = errors.New("column_graph manifest mismatch")
+	errNilColumnVectorGraphPhysicalRowReader        = errors.New("collections: nil column vector graph physical row reader")
+)
 
 // columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
 // column graph asset by ordinal. It is a graph-specific wrapper around the
@@ -137,7 +141,7 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string)
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
 	}
 	if !columnVectorGraphManifestMatchesDefinition(catalog.meta.Name, graph, def, *cfg, manifest, records) {
-		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q graph manifest does not match vector index definition", def.Name)
+		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q graph manifest does not match vector index definition: %w", def.Name, errColumnVectorGraphManifestMismatch)
 	}
 	if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
@@ -197,14 +201,22 @@ func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStat
 	return r.reader.Stats()
 }
 
+func (r *columnVectorGraphPhysicalRowReader) rowReader() (*columnPhysicalRowReader, error) {
+	if r == nil || r.reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	return r.reader, nil
+}
+
 // FetchRow returns one graph row and performs fail-closed adjacency ordinal
 // validation. Native search uses fetchRowUnchecked and validates each edge once
 // when expanded to avoid duplicate adjacency scans on the hot path.
 func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
-	if r == nil || r.reader == nil {
-		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+	reader, err := r.rowReader()
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
 	}
-	row, err := r.reader.FetchRow(ordinal, scratch)
+	row, err := reader.FetchRow(ordinal, scratch)
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
@@ -212,10 +224,11 @@ func (r *columnVectorGraphPhysicalRowReader) FetchRow(ordinal int, scratch *colu
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchRowUnchecked(ordinal int, scratch *columnPhysicalRowReaderScratch) (columnVectorGraphPhysicalRow, error) {
-	if r == nil || r.reader == nil {
-		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+	reader, err := r.rowReader()
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
 	}
-	row, err := r.reader.FetchRow(ordinal, scratch)
+	row, err := reader.FetchRow(ordinal, scratch)
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
@@ -227,13 +240,14 @@ func (r *columnVectorGraphPhysicalRowReader) fetchRowUnchecked(ordinal int, scra
 // uses fetchBatchUnchecked for final result fetches after validating expanded
 // edges during traversal.
 func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
-	if r == nil || r.reader == nil {
-		return errors.New("collections: nil column vector graph physical row reader")
+	reader, err := r.rowReader()
+	if err != nil {
+		return err
 	}
 	if visitor == nil {
 		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
 	}
-	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
+	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
 		graphRow, err := r.graphRowFromPhysicalRow(row)
 		if err != nil {
 			return err
@@ -243,13 +257,14 @@ func (r *columnVectorGraphPhysicalRowReader) FetchBatch(ordinals []int, scratch 
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int, scratch *columnPhysicalRowReaderScratch, visitor func(columnVectorGraphPhysicalRow) error) error {
-	if r == nil || r.reader == nil {
-		return errors.New("collections: nil column vector graph physical row reader")
+	reader, err := r.rowReader()
+	if err != nil {
+		return err
 	}
 	if visitor == nil {
 		return errors.New("collections: column vector graph physical row reader batch visitor is nil")
 	}
-	return r.reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
+	return reader.FetchBatch(ordinals, scratch, func(row columnPhysicalRowReaderRow) error {
 		graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)
 		if err != nil {
 			return err
@@ -263,7 +278,7 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	rowCount := r.RowCount()
+	rowCount := r.reader.totalRows
 	for i, neighbor := range graphRow.Adjacency {
 		if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
 			return columnVectorGraphPhysicalRow{}, err

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -274,11 +274,15 @@ func (r *columnVectorGraphPhysicalRowReader) fetchBatchUnchecked(ordinals []int,
 }
 
 func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
+	reader, err := r.rowReader()
+	if err != nil {
+		return columnVectorGraphPhysicalRow{}, err
+	}
 	graphRow, err := r.graphRowFromPhysicalRowUnchecked(row)
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	rowCount := r.reader.totalRows
+	rowCount := reader.totalRows
 	for i, neighbor := range graphRow.Adjacency {
 		if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
 			return columnVectorGraphPhysicalRow{}, err
@@ -292,7 +296,7 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 // this path and validates each edge exactly when it is expanded.
 func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowUnchecked(row columnPhysicalRowReaderRow) (columnVectorGraphPhysicalRow, error) {
 	if r == nil {
-		return columnVectorGraphPhysicalRow{}, errors.New("collections: nil column vector graph physical row reader")
+		return columnVectorGraphPhysicalRow{}, errNilColumnVectorGraphPhysicalRowReader
 	}
 	if len(row.ID) == 0 {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d missing document id", r.def.Name, row.Ordinal)

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -9,12 +9,26 @@ import (
 )
 
 type columnVectorGraphPhysicalRowReaderOptions struct {
+	// MaxDecodedBlocks is the maximum number of decoded column blocks retained
+	// in the reader cache. Zero uses the underlying row reader default.
 	MaxDecodedBlocks int
 }
+
+const (
+	// These positions must match the ProjectedColumns order in
+	// openColumnVectorGraphPhysicalRowReader.
+	columnVectorGraphPhysicalRowValueVector = iota
+	columnVectorGraphPhysicalRowValueInvNorm
+	columnVectorGraphPhysicalRowValueAdjacency
+	columnVectorGraphPhysicalRowValueCount
+)
 
 // columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
 // column graph asset by ordinal. It is a graph-specific wrapper around the
 // generic physical row reader, not a decoded ColumnVectorGraph.
+//
+// The reader is not concurrency-safe. Parallel native search uses one reader
+// and one scratch per worker over immutable physical graph assets.
 type columnVectorGraphPhysicalRowReader struct {
 	def    VectorIndexDefinition
 	graph  columnVectorGraphManifestSnapshot
@@ -209,14 +223,14 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	if len(row.ID) == 0 {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d missing document id", r.def.Name, row.Ordinal)
 	}
-	if len(row.Values) != 3 {
-		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d values=%d want 3", r.def.Name, row.Ordinal, len(row.Values))
+	if len(row.Values) != columnVectorGraphPhysicalRowValueCount {
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d values=%d want %d", r.def.Name, row.Ordinal, len(row.Values), columnVectorGraphPhysicalRowValueCount)
 	}
-	vector := row.Values[0]
-	invNorm := row.Values[1]
-	adjacency := row.Values[2]
+	vector := row.Values[columnVectorGraphPhysicalRowValueVector]
+	invNorm := row.Values[columnVectorGraphPhysicalRowValueInvNorm]
+	adjacency := row.Values[columnVectorGraphPhysicalRowValueAdjacency]
 	if vector.Type != ColumnStoreValueFloat32Vector || invNorm.Type != ColumnStoreValueFloat32 || adjacency.Type != ColumnStoreValueAdjacencyList {
-		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d unexpected graph value types", r.def.Name, row.Ordinal)
+		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d unexpected graph value types: vector=%q inv_norm=%q adjacency=%q", r.def.Name, row.Ordinal, vector.Type, invNorm.Type, adjacency.Type)
 	}
 	if vector.Null || invNorm.Null || adjacency.Null {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d contains null graph value", r.def.Name, row.Ordinal)
@@ -228,6 +242,8 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", r.def.Name, row.Ordinal, invNorm.Float32)
 	}
 	rowCount := r.reader.RowCount()
+	// Fail closed if persisted adjacency points outside the immutable graph.
+	// V3 search relies on this validation before expanding neighbor ordinals.
 	for i, neighbor := range adjacency.AdjacencyList {
 		if uint64(neighbor) >= uint64(rowCount) {
 			return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d", r.def.Name, row.Ordinal, i, neighbor, rowCount)

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -68,9 +68,6 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if stats.RowFetches != 1 || stats.BatchFetches != 1 || stats.RowsFetched != 3 {
 		t.Fatalf("stats=%+v want one row fetch, one batch fetch, three fetched rows", stats)
 	}
-	if stats.CacheMisses == 0 || stats.CacheHits == 0 || stats.BlockEvictions != 0 {
-		t.Fatalf("cache stats=%+v want cache activity with no evictions", stats)
-	}
 }
 
 func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testing.T) {
@@ -367,7 +364,7 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, r
 		Name: "docs",
 		Options: CollectionOptions{
 			DocumentFormat: DocumentFormatJSON,
-			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(3),
+			ColumnStore:    baseCfg,
 		},
 		VectorIndexes: []VectorIndexDefinition{def},
 	}

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -210,6 +210,19 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsManifestRowCountMismatchV2B(t 
 	}
 }
 
+func TestColumnVectorGraphPhysicalRowReaderRejectsMutationManifestPartsV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithMutationPartV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+
+	_, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if !errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want visibility-required mutation-part failure", err)
+	}
+}
+
 func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -394,6 +407,33 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithManifestRowsV2B(tb testi
 
 func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(tb testing.TB, rows []columnVectorGraphAssetRow, manifestRows int, mutateMeta func(CollectionMeta) CollectionMeta) (*backenddb.DB, *Collection, VectorIndexDefinition) {
 	tb.Helper()
+	return publishColumnVectorGraphPhysicalReaderTestAssetWithMetaManifestRowsAndBaseAssetsV2B(tb, rows, manifestRows, mutateMeta, nil)
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetWithMutationPartV2B(tb testing.TB, rows []columnVectorGraphAssetRow) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	return publishColumnVectorGraphPhysicalReaderTestAssetWithMetaManifestRowsAndBaseAssetsV2B(tb, rows, len(rows), nil, func(baseCfg ColumnStoreConfig) []ColumnPreparedAsset {
+		return []ColumnPreparedAsset{{
+			Ref: ColumnAssetRef{
+				Kind:       ColumnAssetKindTCS1PartImage,
+				Namespace:  baseCfg.AssetManager.Namespace,
+				Generation: 2,
+				PartID:     99,
+				FileID:     99,
+				Offset:     0,
+				Length:     1,
+				Checksum:   99,
+			},
+			Bytes:        1,
+			PublishID:    99,
+			GenerationID: 2,
+			Reason:       string(ColumnPublishOperationUpdate),
+		}}
+	})
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaManifestRowsAndBaseAssetsV2B(tb testing.TB, rows []columnVectorGraphAssetRow, manifestRows int, mutateMeta func(CollectionMeta) CollectionMeta, baseAssets func(ColumnStoreConfig) []ColumnPreparedAsset) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
 	if err != nil {
 		tb.Fatalf("open db: %v", err)
@@ -409,8 +449,12 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(t
 		_ = d.Close()
 		tb.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
 	}
+	var assets []ColumnPreparedAsset
+	if baseAssets != nil {
+		assets = baseAssets(*baseCfg)
+	}
 	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
-	records, manifestIdentity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, manifestRows)
+	records, manifestIdentity := testColumnGraphManifestRecordsWithBaseAssetsV2B(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, manifestRows, assets)
 	meta := CollectionMeta{
 		Name: "docs",
 		Options: CollectionOptions{
@@ -429,6 +473,77 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(t
 		tb.Fatalf("OpenCollection: %v", err)
 	}
 	return d, col, def
+}
+
+func testColumnGraphManifestRecordsWithBaseAssetsV2B(tb testing.TB, baseCfg ColumnStoreConfig, def VectorIndexDefinition, identity ColumnManifestIdentity, ref ColumnAssetRef, assetBytes int64, rows int, assets []ColumnPreparedAsset) ([]columnManifestRecord, ColumnManifestIdentity) {
+	tb.Helper()
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig("docs", baseCfg, def)
+	if err != nil {
+		tb.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
+	}
+	operation := ColumnPublishOperationInsert
+	if len(assets) != 0 {
+		operation = ColumnPublishOperationUpdate
+	}
+	var payloadBytes int64
+	for _, asset := range assets {
+		payloadBytes += asset.Bytes
+	}
+	input := ColumnPublishManifestEncodeInput{
+		Collection:        "docs",
+		ColumnStore:       baseCfg,
+		Operation:         operation,
+		AppliedCommandLSN: 1,
+		Prepared: ColumnPublishPreparedAssets{
+			Assets:             append([]ColumnPreparedAsset(nil), assets...),
+			RowCount:           rows,
+			ColumnPayloadBytes: payloadBytes,
+		},
+	}
+	header, err := encodeColumnManifestHeaderRecord(input, identity.Generation)
+	if err != nil {
+		tb.Fatalf("encodeColumnManifestHeaderRecord: %v", err)
+	}
+	baseRecords := []columnManifestRecord{
+		{key: []byte(columnManifestHeaderRecordKey), value: header},
+	}
+	for _, asset := range assets {
+		value, err := encodeColumnManifestPartRecord(asset)
+		if err != nil {
+			tb.Fatalf("encodeColumnManifestPartRecord: %v", err)
+		}
+		baseRecords = append(baseRecords, columnManifestRecord{
+			key:   columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID),
+			value: value,
+		})
+	}
+	sortColumnManifestRecords(baseRecords)
+	baseChecksum := checksumColumnManifestRecords(input, identity.Generation, baseRecords)
+	record := columnVectorGraphManifestSnapshot{
+		IndexName:              def.Name,
+		Field:                  def.Field,
+		Metric:                 def.Metric,
+		Encoding:               def.Encoding,
+		Dimensions:             def.Dimensions,
+		M:                      def.M,
+		EfConstruction:         def.EfConstruction,
+		EfSearch:               def.EfSearch,
+		BaseManifestGeneration: identity.Generation,
+		BaseManifestChecksum:   baseChecksum,
+		BaseSchemaHash:         baseCfg.SchemaHash,
+		GraphSchemaHash:        graphCfg.SchemaHash,
+		RowCount:               rows,
+		AssetRef:               ref,
+		AssetBytes:             assetBytes,
+	}
+	encoded, err := encodeColumnVectorGraphManifestRecord(record)
+	if err != nil {
+		tb.Fatalf("encodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	records := append(baseRecords, columnManifestRecord{key: columnVectorGraphManifestRecordKey(def.Name), value: encoded})
+	sortColumnManifestRecords(records)
+	identity.Checksum = checksumColumnManifestRecords(input, identity.Generation, records)
+	return records, identity
 }
 
 func assertColumnVectorGraphPhysicalRowV2B(tb testing.TB, row columnVectorGraphPhysicalRow, id string, ordinal, rowIndex int, vector []float32, invNorm float32, adjacency []uint32) {

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -124,7 +124,8 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *test
 
 func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testing.T) {
 	reader := &columnVectorGraphPhysicalRowReader{
-		def: VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},
+		def:    VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},
+		reader: &columnPhysicalRowReader{totalRows: 8},
 	}
 	row := func(vector []float32, invNorm float32) columnPhysicalRowReaderRow {
 		return columnPhysicalRowReaderRow{
@@ -167,6 +168,15 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 			}
 		})
 	}
+	t.Run("nil underlying reader", func(t *testing.T) {
+		nilReader := &columnVectorGraphPhysicalRowReader{
+			def: VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},
+		}
+		_, err := nilReader.graphRowFromPhysicalRow(row([]float32{1, 0, 0}, 1))
+		if !errors.Is(err, errNilColumnVectorGraphPhysicalRowReader) {
+			t.Fatalf("graphRowFromPhysicalRow err=%v want nil-reader sentinel", err)
+		}
+	})
 }
 
 func TestColumnVectorGraphPhysicalRowReaderRejectsDefinitionMismatchV2B(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -51,7 +51,7 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if err != nil {
 		t.Fatalf("FetchRow(1): %v", err)
 	}
-	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-b", 1, []float32{0, 1, 0}, 1, []uint32{0, 2})
+	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-b", 1, 1, []float32{0, 1, 0}, 1, []uint32{0, 2})
 
 	var batchIDs []string
 	if err := reader.FetchBatch([]int{2, 0}, &scratch, func(row columnVectorGraphPhysicalRow) error {
@@ -295,10 +295,13 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, r
 	return d, col, def
 }
 
-func assertColumnVectorGraphPhysicalRowV2B(tb testing.TB, row columnVectorGraphPhysicalRow, id string, ordinal int, vector []float32, invNorm float32, adjacency []uint32) {
+func assertColumnVectorGraphPhysicalRowV2B(tb testing.TB, row columnVectorGraphPhysicalRow, id string, ordinal, rowIndex int, vector []float32, invNorm float32, adjacency []uint32) {
 	tb.Helper()
 	if string(row.ID) != id || row.Ordinal != ordinal {
 		tb.Fatalf("row id=%q ordinal=%d want id=%q ordinal=%d", string(row.ID), row.Ordinal, id, ordinal)
+	}
+	if row.RowIndex != rowIndex {
+		tb.Fatalf("row index=%d want %d", row.RowIndex, rowIndex)
 	}
 	if len(row.Vector) != len(vector) {
 		tb.Fatalf("vector len=%d want %d", len(row.Vector), len(vector))

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -197,6 +197,19 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsDefinitionMismatchV2B(t *testi
 	}
 }
 
+func TestColumnVectorGraphPhysicalRowReaderRejectsManifestRowCountMismatchV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithManifestRowsV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	}, 3)
+	defer func() { _ = d.Close() }()
+
+	_, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if !errors.Is(err, errColumnVectorGraphManifestMismatch) || !strings.Contains(err.Error(), "manifest row_count=3 physical_row_count=2") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want row_count manifest mismatch", err)
+	}
+}
+
 func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -371,6 +384,16 @@ func publishColumnVectorGraphPhysicalReaderTestAssetV2B(tb testing.TB, rows []co
 
 func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, rows []columnVectorGraphAssetRow, mutateMeta func(CollectionMeta) CollectionMeta) (*backenddb.DB, *Collection, VectorIndexDefinition) {
 	tb.Helper()
+	return publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(tb, rows, len(rows), mutateMeta)
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetWithManifestRowsV2B(tb testing.TB, rows []columnVectorGraphAssetRow, manifestRows int) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	return publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(tb, rows, manifestRows, nil)
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaAndManifestRowsV2B(tb testing.TB, rows []columnVectorGraphAssetRow, manifestRows int, mutateMeta func(CollectionMeta) CollectionMeta) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
 	if err != nil {
 		tb.Fatalf("open db: %v", err)
@@ -387,7 +410,7 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, r
 		tb.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
 	}
 	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
-	records, manifestIdentity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	records, manifestIdentity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, manifestRows)
 	meta := CollectionMeta{
 		Name: "docs",
 		Options: CollectionOptions{

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -94,21 +94,13 @@ func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testin
 	}
 }
 
-func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *testing.T) {
-	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
-		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
-		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
-	})
-	defer func() { _ = d.Close() }()
-	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err != nil {
-		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+func TestColumnVectorGraphAdjacencyBoundsRejectsBadOrdinalV2B(t *testing.T) {
+	err := validateColumnVectorGraphAdjacencyOrdinal("embedding_graph", 7, 0, 2, 2)
+	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
+		t.Fatalf("validateColumnVectorGraphAdjacencyOrdinal err=%v want adjacency bounds sentinel", err)
 	}
-	defer func() { _ = reader.Close() }()
-	var scratch columnPhysicalRowReaderScratch
-	_, err = reader.FetchRow(0, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "adjacency[0]=2 outside row_count=2") {
-		t.Fatalf("FetchRow err=%v want adjacency bounds failure", err)
+	if err := validateColumnVectorGraphAdjacencyOrdinal("embedding_graph", 7, 0, 1, 2); err != nil {
+		t.Fatalf("validateColumnVectorGraphAdjacencyOrdinal valid edge err=%v", err)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -133,6 +133,14 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 			t.Fatalf("graphRowFromPhysicalRow err=%v want vector dims failure", err)
 		}
 	})
+	t.Run("missing projected value", func(t *testing.T) {
+		missing := row([]float32{1, 0, 0}, 1)
+		missing.Values[columnVectorGraphPhysicalRowValueVector].Present = false
+		_, err := reader.graphRowFromPhysicalRow(missing)
+		if err == nil || !strings.Contains(err.Error(), "missing graph value") {
+			t.Fatalf("graphRowFromPhysicalRow err=%v want missing value failure", err)
+		}
+	})
 	for _, tc := range []struct {
 		name string
 		inv  float32

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -67,8 +68,8 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if stats.RowFetches != 1 || stats.BatchFetches != 1 || stats.RowsFetched != 3 {
 		t.Fatalf("stats=%+v want one row fetch, one batch fetch, three fetched rows", stats)
 	}
-	if stats.CacheMisses != 1 || stats.CacheHits != 2 || stats.BlockEvictions != 0 {
-		t.Fatalf("cache stats=%+v want one graph block miss, two hits, no evictions", stats)
+	if stats.CacheMisses == 0 || stats.CacheHits == 0 || stats.BlockEvictions != 0 {
+		t.Fatalf("cache stats=%+v want cache activity with no evictions", stats)
 	}
 }
 
@@ -91,7 +92,7 @@ func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testin
 	}
 	var scratch columnPhysicalRowReaderScratch
 	_, err = reader.FetchRow(0, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "outside row_count=0") {
+	if !errors.Is(err, errColumnPhysicalRowOrdinalOutOfBounds) {
 		t.Fatalf("FetchRow empty err=%v want row_count bounds", err)
 	}
 }
@@ -111,6 +112,45 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *test
 	_, err = reader.FetchRow(0, &scratch)
 	if err == nil || !strings.Contains(err.Error(), "adjacency[0]=2 outside row_count=2") {
 		t.Fatalf("FetchRow err=%v want adjacency bounds failure", err)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testing.T) {
+	reader := &columnVectorGraphPhysicalRowReader{
+		def: VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},
+	}
+	row := func(vector []float32, invNorm float32) columnPhysicalRowReaderRow {
+		return columnPhysicalRowReaderRow{
+			Ordinal: 7,
+			ID:      []byte("doc-bad"),
+			Values: []columnDeclaredValue{
+				{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: vector},
+				{Type: ColumnStoreValueFloat32, Present: true, Float32: invNorm},
+				{Type: ColumnStoreValueAdjacencyList, Present: true},
+			},
+		}
+	}
+	t.Run("vector dims", func(t *testing.T) {
+		_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0}, 1))
+		if err == nil || !strings.Contains(err.Error(), "vector dims=2 want 3") {
+			t.Fatalf("graphRowFromPhysicalRow err=%v want vector dims failure", err)
+		}
+	})
+	for _, tc := range []struct {
+		name string
+		inv  float32
+	}{
+		{name: "zero", inv: 0},
+		{name: "nan", inv: float32(math.NaN())},
+		{name: "positive infinity", inv: float32(math.Inf(1))},
+		{name: "negative infinity", inv: float32(math.Inf(-1))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0, 0}, tc.inv))
+			if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
+				t.Fatalf("graphRowFromPhysicalRow err=%v want invalid inv_norm failure", err)
+			}
+		})
 	}
 }
 
@@ -228,7 +268,7 @@ func BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B(b *testing.B) {
 	baseStats := reader.Stats()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ordinal := (i * 131) & (rows - 1)
+		ordinal := (i * 131) % rows
 		row, err := reader.FetchRow(ordinal, &scratch)
 		if err != nil {
 			b.Fatalf("FetchRow(%d): %v", ordinal, err)
@@ -274,7 +314,7 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, r
 		tb.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
 	}
 	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
-	records, identity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	records, manifestIdentity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
 	meta := CollectionMeta{
 		Name: "docs",
 		Options: CollectionOptions{
@@ -286,7 +326,7 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, r
 	if mutateMeta != nil {
 		meta = mutateMeta(meta)
 	}
-	publishColumnGraphCatalogForTestV2A(tb, d, meta, identity, records)
+	publishColumnGraphCatalogForTestV2A(tb, d, meta, manifestIdentity, records)
 	col, err := NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
 		_ = d.Close()

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -210,17 +210,28 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsManifestRowCountMismatchV2B(t 
 	}
 }
 
-func TestColumnVectorGraphPhysicalRowReaderRejectsMutationManifestPartsV2B(t *testing.T) {
+func TestColumnVectorGraphPhysicalRowReaderAllowsBaseMutationManifestPartsV2B(t *testing.T) {
 	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithMutationPartV2B(t, []columnVectorGraphAssetRow{
 		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
 		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
 	})
 	defer func() { _ = d.Close() }()
 
-	_, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if !errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
-		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want visibility-required mutation-part failure", err)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
+	defer func() { _ = reader.Close() }()
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 3),
+		Float32Values: make([]float32, 0, def.Dimensions),
+		Uint32Values:  make([]uint32, 0, def.M),
+	}
+	row, err := reader.FetchRow(0, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow: %v", err)
+	}
+	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-a", 0, 0, []float32{1, 0, 0}, 1, []uint32{1})
 }
 
 func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -199,6 +199,54 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *
 	}
 }
 
+func TestColumnVectorGraphPhysicalRowReaderRejectsNonRecoveryAuthoritativeManifestV2B(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	badCatalog := catalog.copy()
+	badMeta := copyCollectionMeta(badCatalog.meta)
+	badCfg := badMeta.Options.ColumnStore.copy()
+	recovery := *badCfg.RecoveryAuthoritativeManifest
+	recovery.Checksum++
+	badCfg.RecoveryAuthoritativeManifest = &recovery
+	badMeta.Options.ColumnStore = &badCfg
+	badCatalog.meta = badMeta
+	systemRoot := snapshotSystemRoot(snap)
+	commitSeq := snapshotCommitSeq(snap)
+	if err := snap.Close(); err != nil {
+		t.Fatalf("close snapshot: %v", err)
+	}
+
+	col.catalogMu.Lock()
+	col.catalog = badCatalog
+	col.catalogSystemRoot = systemRoot
+	col.catalogCommitSeq = commitSeq
+	col.catalogMu.Unlock()
+
+	_, err = col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err == nil || !strings.Contains(err.Error(), "active recovery-authoritative column manifest") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want recovery-authoritative manifest failure", err)
+	}
+}
+
 func TestColumnVectorGraphPhysicalRowReaderWarmScratchHotFetchZeroAllocsV2B(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -104,6 +104,24 @@ func TestColumnVectorGraphAdjacencyBoundsRejectsBadOrdinalV2B(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnPhysicalRowReaderScratch
+	_, err = reader.FetchRow(0, &scratch)
+	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
+		t.Fatalf("FetchRow err=%v want adjacency bounds sentinel", err)
+	}
+}
+
 func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testing.T) {
 	reader := &columnVectorGraphPhysicalRowReader{
 		def: VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -122,6 +122,77 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *test
 	}
 }
 
+func TestColumnVectorGraphPhysicalRowReaderUncheckedSkipsAdjacencyBoundsV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnPhysicalRowReaderScratch
+	_, err = reader.FetchRow(0, &scratch)
+	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
+		t.Fatalf("FetchRow err=%v want adjacency bounds sentinel", err)
+	}
+	row, err := reader.fetchRowUnchecked(0, &scratch)
+	if err != nil {
+		t.Fatalf("fetchRowUnchecked: %v", err)
+	}
+	if !slices.Equal(row.Adjacency, []uint32{2}) {
+		t.Fatalf("unchecked adjacency=%v want invalid edge retained for search-time validation", row.Adjacency)
+	}
+	var batchRows int
+	err = reader.fetchBatchUnchecked([]int{0}, &scratch, func(row columnVectorGraphPhysicalRow) error {
+		if !slices.Equal(row.Adjacency, []uint32{2}) {
+			t.Fatalf("unchecked batch adjacency=%v want invalid edge retained", row.Adjacency)
+		}
+		batchRows++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("fetchBatchUnchecked: %v", err)
+	}
+	if batchRows != 1 {
+		t.Fatalf("unchecked batch rows=%d want 1", batchRows)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderUncheckedPreservesValidationV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 0, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnPhysicalRowReaderScratch
+	_, err = reader.fetchRowUnchecked(0, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
+		t.Fatalf("fetchRowUnchecked err=%v want inv_norm validation failure", err)
+	}
+	err = reader.fetchBatchUnchecked([]int{0}, &scratch, func(columnVectorGraphPhysicalRow) error {
+		t.Fatal("visitor should not run for invalid graph row")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
+		t.Fatalf("fetchBatchUnchecked err=%v want inv_norm validation failure", err)
+	}
+	err = reader.fetchBatchUnchecked([]int{0}, &scratch, nil)
+	if !errors.Is(err, errColumnVectorGraphPhysicalRowReaderBatchVisitorNil) {
+		t.Fatalf("fetchBatchUnchecked nil visitor err=%v want sentinel", err)
+	}
+	err = reader.FetchBatch([]int{0}, &scratch, nil)
+	if !errors.Is(err, errColumnVectorGraphPhysicalRowReaderBatchVisitorNil) {
+		t.Fatalf("FetchBatch nil visitor err=%v want sentinel", err)
+	}
+}
+
 func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testing.T) {
 	reader := &columnVectorGraphPhysicalRowReader{
 		def:    VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -182,7 +182,7 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsDefinitionMismatchV2B(t *testi
 	defer func() { _ = d.Close() }()
 
 	_, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err == nil || !strings.Contains(err.Error(), "graph manifest does not match vector index definition") {
+	if !errors.Is(err, errColumnVectorGraphManifestMismatch) {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want manifest mismatch", err)
 	}
 }
@@ -209,7 +209,7 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *
 		t.Fatalf("status=%+v want stale graph mismatch", status)
 	}
 	_, err = col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err == nil || !strings.Contains(err.Error(), "graph manifest does not match vector index definition") {
+	if !errors.Is(err, errColumnVectorGraphManifestMismatch) {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want stale graph mismatch", err)
 	}
 }

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -2,8 +2,8 @@ package collections
 
 import (
 	"errors"
-	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 
@@ -139,7 +139,7 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 		}
 	}
 	t.Run("vector dims", func(t *testing.T) {
-		_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0}, 1))
+		_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0}, 1), reader.RowCount())
 		if err == nil || !strings.Contains(err.Error(), "vector dims=2 want 3") {
 			t.Fatalf("graphRowFromPhysicalRow err=%v want vector dims failure", err)
 		}
@@ -147,7 +147,7 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 	t.Run("missing projected value", func(t *testing.T) {
 		missing := row([]float32{1, 0, 0}, 1)
 		missing.Values[columnVectorGraphPhysicalRowValueVector].Present = false
-		_, err := reader.graphRowFromPhysicalRow(missing)
+		_, err := reader.graphRowFromPhysicalRow(missing, reader.RowCount())
 		if err == nil || !strings.Contains(err.Error(), "missing graph value") {
 			t.Fatalf("graphRowFromPhysicalRow err=%v want missing value failure", err)
 		}
@@ -162,7 +162,7 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 		{name: "negative infinity", inv: float32(math.Inf(-1))},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0, 0}, tc.inv))
+			_, err := reader.graphRowFromPhysicalRow(row([]float32{1, 0, 0}, tc.inv), reader.RowCount())
 			if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
 				t.Fatalf("graphRowFromPhysicalRow err=%v want invalid inv_norm failure", err)
 			}
@@ -172,9 +172,9 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B(t *testi
 		nilReader := &columnVectorGraphPhysicalRowReader{
 			def: VectorIndexDefinition{Name: "embedding_graph", Dimensions: 3},
 		}
-		_, err := nilReader.graphRowFromPhysicalRow(row([]float32{1, 0, 0}, 1))
+		_, err := nilReader.FetchRow(0, nil)
 		if !errors.Is(err, errNilColumnVectorGraphPhysicalRowReader) {
-			t.Fatalf("graphRowFromPhysicalRow err=%v want nil-reader sentinel", err)
+			t.Fatalf("FetchRow err=%v want nil-reader sentinel", err)
 		}
 	})
 }
@@ -335,13 +335,21 @@ func TestColumnVectorGraphPhysicalRowReaderWarmScratchHotFetchZeroAllocsV2B(t *t
 	if _, err := reader.FetchRow(1, &scratch); err != nil {
 		t.Fatalf("warm FetchRow: %v", err)
 	}
+	var fetchErr error
 	allocs := testing.AllocsPerRun(1000, func() {
+		if fetchErr != nil {
+			return
+		}
 		row, err := reader.FetchRow(1, &scratch)
 		if err != nil {
-			t.Fatalf("FetchRow: %v", err)
+			fetchErr = err
+			return
 		}
 		columnPhysicalScanBenchSum += int64(row.Adjacency[0])
 	})
+	if fetchErr != nil {
+		t.Fatalf("FetchRow: %v", fetchErr)
+	}
 	if allocs != 0 {
 		t.Fatalf("hot FetchRow allocs=%v want zero", allocs)
 	}
@@ -576,7 +584,7 @@ func assertColumnVectorGraphPhysicalRowV2B(tb testing.TB, row columnVectorGraphP
 	if math.Abs(float64(row.InvNorm-invNorm)) > 1e-6 {
 		tb.Fatalf("invNorm=%v want %v", row.InvNorm, invNorm)
 	}
-	if got, want := fmt.Sprint(row.Adjacency), fmt.Sprint(adjacency); got != want {
-		tb.Fatalf("adjacency=%s want %s", got, want)
+	if !slices.Equal(row.Adjacency, adjacency) {
+		tb.Fatalf("adjacency=%v want %v", row.Adjacency, adjacency)
 	}
 }

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -1,0 +1,317 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	dir, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	reader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if got, want := reader.RowCount(), len(rows); got != want {
+		t.Fatalf("RowCount=%d want %d", got, want)
+	}
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 3),
+		Float32Values: make([]float32, 0, def.Dimensions),
+		Uint32Values:  make([]uint32, 0, def.M),
+	}
+	row, err := reader.FetchRow(1, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow(1): %v", err)
+	}
+	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-b", 1, []float32{0, 1, 0}, 1, []uint32{0, 2})
+
+	var batchIDs []string
+	if err := reader.FetchBatch([]int{2, 0}, &scratch, func(row columnVectorGraphPhysicalRow) error {
+		batchIDs = append(batchIDs, string(row.ID))
+		return nil
+	}); err != nil {
+		t.Fatalf("FetchBatch: %v", err)
+	}
+	if got, want := strings.Join(batchIDs, ","), "doc-c,doc-a"; got != want {
+		t.Fatalf("batch IDs=%q want %q", got, want)
+	}
+	stats := reader.Stats()
+	if stats.RowFetches != 1 || stats.BatchFetches != 1 || stats.RowsFetched != 3 {
+		t.Fatalf("stats=%+v want one row fetch, one batch fetch, three fetched rows", stats)
+	}
+	if stats.CacheMisses != 1 || stats.CacheHits != 2 || stats.BlockEvictions != 0 {
+		t.Fatalf("cache stats=%+v want one graph block miss, two hits, no evictions", stats)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testing.T) {
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, nil)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex empty collection: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if got := reader.RowCount(); got != 0 {
+		t.Fatalf("RowCount=%d want 0", got)
+	}
+	var scratch columnPhysicalRowReaderScratch
+	_, err = reader.FetchRow(0, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "outside row_count=0") {
+		t.Fatalf("FetchRow empty err=%v want row_count bounds", err)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderRejectsBadAdjacencyOrdinalV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnPhysicalRowReaderScratch
+	_, err = reader.FetchRow(0, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "adjacency[0]=2 outside row_count=2") {
+		t.Fatalf("FetchRow err=%v want adjacency bounds failure", err)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderRejectsDefinitionMismatchV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	}, func(meta CollectionMeta) CollectionMeta {
+		mismatched := columnGraphRebuildVectorIndexDefinitionV2A(3, 2)
+		mismatched.Dimensions = 4
+		meta.VectorIndexes = []VectorIndexDefinition{mismatched}
+		return meta
+	})
+	defer func() { _ = d.Close() }()
+
+	_, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err == nil || !strings.Contains(err.Error(), "graph manifest does not match vector index definition") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want manifest mismatch", err)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	insertColumnGraphRebuildRowsV2A(t, col, []columnGraphRebuildInputRowV2A{{id: "doc-c", vector: []float32{0, 0, 1}}})
+
+	status, err = col.VectorIndexStatus(def.Name)
+	if err != nil {
+		t.Fatalf("VectorIndexStatus: %v", err)
+	}
+	if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
+		t.Fatalf("status=%+v want stale graph mismatch", status)
+	}
+	_, err = col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err == nil || !strings.Contains(err.Error(), "graph manifest does not match vector index definition") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want stale graph mismatch", err)
+	}
+}
+
+func TestColumnVectorGraphPhysicalRowReaderWarmScratchHotFetchZeroAllocsV2B(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 3),
+		Float32Values: make([]float32, 0, def.Dimensions),
+		Uint32Values:  make([]uint32, 0, def.M),
+	}
+	if _, err := reader.FetchRow(1, &scratch); err != nil {
+		t.Fatalf("warm FetchRow: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		row, err := reader.FetchRow(1, &scratch)
+		if err != nil {
+			t.Fatalf("FetchRow: %v", err)
+		}
+		columnPhysicalScanBenchSum += int64(row.Adjacency[0])
+	})
+	if allocs != 0 {
+		t.Fatalf("hot FetchRow allocs=%v want zero", allocs)
+	}
+}
+
+func BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B(b *testing.B) {
+	const (
+		rows = 1024
+		dims = 128
+		m    = 16
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(b, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 3),
+		Float32Values: make([]float32, 0, dims),
+		Uint32Values:  make([]uint32, 0, m),
+	}
+	if _, err := reader.FetchRow(0, &scratch); err != nil {
+		b.Fatalf("warm FetchRow: %v", err)
+	}
+	b.ReportAllocs()
+	baseStats := reader.Stats()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ordinal := (i * 131) & (rows - 1)
+		row, err := reader.FetchRow(ordinal, &scratch)
+		if err != nil {
+			b.Fatalf("FetchRow(%d): %v", ordinal, err)
+		}
+		columnPhysicalScanBenchSum += int64(row.Adjacency[0])
+	}
+	b.StopTimer()
+	stats := reader.Stats()
+	b.ReportMetric(float64(baseStats.Rows), "graph_rows")
+	b.ReportMetric(float64(baseStats.Granules), "graph_granules")
+	b.ReportMetric(float64(baseStats.OpenPhysicalBytesRead), "open_physical_B")
+	if baseStats.Rows > 0 {
+		b.ReportMetric(float64(baseStats.OpenPhysicalBytesRead)/float64(baseStats.Rows), "asset_B/row")
+	}
+	b.ReportMetric(float64(stats.CacheHits-baseStats.CacheHits)/float64(b.N), "cache_hits/op")
+	b.ReportMetric(float64(stats.CacheMisses-baseStats.CacheMisses)/float64(b.N), "cache_misses/op")
+	b.ReportMetric(float64(stats.DecodedBlocks-baseStats.DecodedBlocks)/float64(b.N), "decoded_blocks/op")
+	b.ReportMetric(float64(stats.GranulesTouched-baseStats.GranulesTouched)/float64(b.N), "granules_touched/op")
+	b.ReportMetric(float64(stats.PhysicalBytesRead-baseStats.PhysicalBytesRead)/float64(b.N), "physical_B/op")
+	b.ReportMetric(float64(stats.MaxResidentBytes), "max_resident_B")
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetV2B(tb testing.TB, rows []columnVectorGraphAssetRow) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	return publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb, rows, nil)
+}
+
+func publishColumnVectorGraphPhysicalReaderTestAssetWithMetaV2B(tb testing.TB, rows []columnVectorGraphAssetRow, mutateMeta func(CollectionMeta) CollectionMeta) (*backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	baseCfg, err := normalizeColumnStoreConfig("docs", columnGraphRebuildColumnStoreConfigV2A(3))
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	def := columnGraphRebuildVectorIndexDefinitionV2A(3, 2)
+	prepared, err := prepareColumnVectorGraphPhysicalAsset(d.ColumnAssetRootDir(), "docs", *baseCfg, def, 2, 1, 1, rows)
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("prepareColumnVectorGraphPhysicalAsset: %v", err)
+	}
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
+	records, identity := testColumnGraphManifestRecordsV2A(tb, *baseCfg, def, identity, prepared.Ref, prepared.Bytes, prepared.RowCount)
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(3),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	if mutateMeta != nil {
+		meta = mutateMeta(meta)
+	}
+	publishColumnGraphCatalogForTestV2A(tb, d, meta, identity, records)
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	return d, col, def
+}
+
+func assertColumnVectorGraphPhysicalRowV2B(tb testing.TB, row columnVectorGraphPhysicalRow, id string, ordinal int, vector []float32, invNorm float32, adjacency []uint32) {
+	tb.Helper()
+	if string(row.ID) != id || row.Ordinal != ordinal {
+		tb.Fatalf("row id=%q ordinal=%d want id=%q ordinal=%d", string(row.ID), row.Ordinal, id, ordinal)
+	}
+	if len(row.Vector) != len(vector) {
+		tb.Fatalf("vector len=%d want %d", len(row.Vector), len(vector))
+	}
+	for i := range vector {
+		if math.Abs(float64(row.Vector[i]-vector[i])) > 1e-6 {
+			tb.Fatalf("vector[%d]=%v want %v", i, row.Vector[i], vector[i])
+		}
+	}
+	if math.Abs(float64(row.InvNorm-invNorm)) > 1e-6 {
+		tb.Fatalf("invNorm=%v want %v", row.InvNorm, invNorm)
+	}
+	if got, want := fmt.Sprint(row.Adjacency), fmt.Sprint(adjacency); got != want {
+		tb.Fatalf("adjacency=%s want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
This is the next stacked #1646 V2B PR on top of #1658.

It adds the graph-specific ordinal reader seam for explicit `column_graph` vector indexes:
- Opens the published physical column graph asset from the normal collection/root/manifest state.
- Fetches vector, invNorm, adjacency, and document ID by graph ordinal through the generic `columnPhysicalRowReader`.
- Supports row and batch fetch with caller-owned scratch and bounded decoded-block cache accounting.
- Validates graph manifest/schema identity, physical asset availability, vector dimensions, and finite positive invNorm during row fetch. Adjacency ordinal bounds remain fail-closed through a shared validation helper, but are not scanned on every warmed row fetch; V3 validates edges when expanding them during search.

Hard boundary: this PR still does not implement graph traversal/search and still does not route public vector search. It is the V2B ordinal row-fetch seam that V3 native search will consume. It does not materialize a decoded `ColumnVectorGraph`.

Current physical graph limitation: #1658 publishes one graph physical asset for the rebuilt graph. The wrapper uses the generic ordinal/range/cache reader, but the current graph manifest has a single graph asset ref. Multi-granule graph publication remains future build/publish work, not hidden in this reader.

## Contract Details
- Explicit `column_graph` indexes only.
- Existing native/runtime vector index behavior is unchanged.
- Reader opens only if active collection metadata, active column manifest identity, graph manifest metadata, and physical graph asset all agree.
- Stale graph manifests after mutation fail closed instead of returning rows from the old graph.
- Returned ID/vector/adjacency values alias cached asset bytes or caller-owned scratch. Retain by copying before the next fetch.
- Reader/scratch is not concurrency-safe. Future parallel search must use worker-local reader/scratch or synchronization at the native search layer.

## Copied/Adapted From Old Stack
No old-stack vector-search code copied. This PR adds a small wrapper around the generic physical row reader built in the current #1646 stack.

## Tests
- `TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B`
- `TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B`
- `TestColumnVectorGraphAdjacencyBoundsRejectsBadOrdinalV2B`
- `TestColumnVectorGraphPhysicalRowReaderRejectsDefinitionMismatchV2B`
- `TestColumnVectorGraphPhysicalRowReaderRejectsMalformedGraphRowsV2B`
- `TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B`
- `TestColumnVectorGraphPhysicalRowReaderWarmScratchHotFetchZeroAllocsV2B`

## Validation
Latest local validation for head `c4b010873` after restacking on #1658 head `e64beffe0`:

```sh
git diff --check
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPhysicalRowReader|TestColumnGraphAdjacencyBounds|TestColumnPhysicalRowReader|TestColumnGraphVectorIndexStatus|TestColumnGraphRebuildManifestRecordsPrunesDroppedVectorGraphsV2A' -count=1
GOWORK=off go test ./TreeDB/collections -run 'Test.*Vector|TestColumnVectorGraph|TestColumnStore|TestColumnPublish' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

All passed locally.

## Benchmark Evidence
Hardware: Apple M3, darwin/arm64

Command:
```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B' -benchmem -benchtime=500ms -count=5
```

Output captured on head `c4b010873` after restacking on #1658 head `e64beffe0`:
```text
goos: darwin
goarch: arm64
pkg: github.com/snissn/gomap/TreeDB/collections
cpu: Apple M3
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   	 2018973	       298.0 ns/op	       678.3 asset_B/row	         1.000 cache_hits/op	         0 cache_misses/op	         0 decoded_blocks/op	         0 granules_touched/op	         1.000 graph_granules	      1024 graph_rows	    702776 max_resident_B	    694584 open_physical_B	         0 physical_B/op	       0 B/op	       0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   	 2024961	       297.2 ns/op	       678.3 asset_B/row	         1.000 cache_hits/op	         0 cache_misses/op	         0 decoded_blocks/op	         0 granules_touched/op	         1.000 graph_granules	      1024 graph_rows	    702776 max_resident_B	    694584 open_physical_B	         0 physical_B/op	       0 B/op	       0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   	 2011298	       301.3 ns/op	       678.3 asset_B/row	         1.000 cache_hits/op	         0 cache_misses/op	         0 decoded_blocks/op	         0 granules_touched/op	         1.000 graph_granules	      1024 graph_rows	    702776 max_resident_B	    694584 open_physical_B	         0 physical_B/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/snissn/gomap/TreeDB/collections	6.521s
```

Interpretation:
- Timed scope is warmed ordinal row fetch only: vector + invNorm + adjacency + doc ID decode from the physical column graph asset via generic row-reader cache, including default adjacency ordinal fail-closed validation.
- Setup/open physical bytes are reported separately as `open_physical_B`; after warming, hot fetch reports 0 `physical_B/op`, 0 decoded blocks/op, 0 granules touched/op, 0 B/op, and 0 allocs/op.
- This is not search QPS. V3 measures native graph traversal/search and uses the internal unchecked conversion path plus expansion-time edge validation so search does not duplicate adjacency scans on score/result fetches.

## Latest Restack Evidence
Restacked on #1658 head `10a95c2b3`; latest head is `de67e6e7b`.

Validation:
```sh
git diff --check
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPhysicalRowReader|TestColumnGraphAdjacencyBounds|TestColumnPhysicalRowReader|TestColumnGraphVectorIndexStatus|TestColumnGraphRebuildManifestRecordsPrunesDroppedVectorGraphsV2A|TestColumnGraphReachabilityPrunesDroppedVectorIndexGraphRefV2A' -count=1
```
Result: passed locally.

Benchmark command:
```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B' -benchmem -benchtime=500ms -count=5
```

Current-head output:
```text
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   2019489   298.2 ns/op   678.3 asset_B/row   1.000 cache_hits/op   0 cache_misses/op   0 decoded_blocks/op   0 granules_touched/op   1.000 graph_granules   1024 graph_rows   702776 max_resident_B   694584 open_physical_B   0 physical_B/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   1988271   301.8 ns/op   678.3 asset_B/row   1.000 cache_hits/op   0 cache_misses/op   0 decoded_blocks/op   0 granules_touched/op   1.000 graph_granules   1024 graph_rows   702776 max_resident_B   694584 open_physical_B   0 physical_B/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   1984004   298.7 ns/op   678.3 asset_B/row   1.000 cache_hits/op   0 cache_misses/op   0 decoded_blocks/op   0 granules_touched/op   1.000 graph_granules   1024 graph_rows   702776 max_resident_B   694584 open_physical_B   0 physical_B/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   1990756   303.4 ns/op   678.3 asset_B/row   1.000 cache_hits/op   0 cache_misses/op   0 decoded_blocks/op   0 granules_touched/op   1.000 graph_granules   1024 graph_rows   702776 max_resident_B   694584 open_physical_B   0 physical_B/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8   2011293   303.7 ns/op   678.3 asset_B/row   1.000 cache_hits/op   0 cache_misses/op   0 decoded_blocks/op   0 granules_touched/op   1.000 graph_granules   1024 graph_rows   702776 max_resident_B   694584 open_physical_B   0 physical_B/op   0 B/op   0 allocs/op
```

Interpretation: warmed ordinal row fetch remains zero-allocation and within the prior 297-301 ns/op envelope except normal local variance at ~303 ns/op. The restack only brings in #1658 reachability/setup pruning; it does not add hot row-fetch CPU, memcopy, physical reads, decoded blocks, or allocations.

## AI Review Loop
Requested on initial head `d8848190a`: Codex (`@codex review`), CodeRabbit (`@coderabbitai review`), and Copilot PR review.

Restacked on #1658 head `e64beffe0` and pushed latest head `c4b010873`. Reviews are being re-requested on the latest head and will be iterated until latest-head reviews are quiet or any remaining finding is explicitly dismissed.

Do not merge.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, wrapped error returned for out-of-range physical row ordinals with improved diagnostic details.

* **New Features**
  * Added vector-graph row reader with end-to-end validation of IDs, vectors, inverse-norms and adjacency.
  * Dual fetch modes: validated (safe) and optimized (unchecked) paths for different performance needs.

* **Tests**
  * Comprehensive test/benchmark suite covering fetching, validation, edge cases, mutation/staleness checks, and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
