### PR TITLE
TreeDB column store post-V1: specialize direct row decode

### DIFF
--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -665,3 +665,29 @@ func (c *manifestCursor) stringBytes() []byte {
 	c.pos += int(n)
 	return value
 }
+
+func (c *manifestCursor) skip(n uint64) {
+	if c.err != nil {
+		return
+	}
+	if n > uint64(len(c.raw)-c.pos) {
+		c.err = errors.New("collections: short column manifest record")
+		return
+	}
+	c.pos += int(n)
+}
+
+func (c *manifestCursor) skipStringBytes() {
+	if c.err != nil {
+		return
+	}
+	n := c.u64()
+	if c.err != nil {
+		return
+	}
+	if n > uint64(len(c.raw)-c.pos) {
+		c.err = errors.New("collections: short column manifest string")
+		return
+	}
+	c.pos += int(n)
+}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -978,7 +978,7 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 		switch col.ValueType {
 		case ColumnStoreValueBool:
 			// Bool is not a supported direct query group/value/distinct type.
-			cur.skip(1)
+			_ = cur.bool()
 		case ColumnStoreValueInt64:
 			if selectedValue {
 				v := int64(cur.u64())

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -977,6 +977,7 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 		}
 		switch col.ValueType {
 		case ColumnStoreValueBool:
+			// Bool is not a supported direct query group/value/distinct type.
 			cur.skip(1)
 		case ColumnStoreValueInt64:
 			if selectedValue {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -924,12 +924,26 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 	var value int64
 	var valueOK bool
 	for colIdx, col := range cfg.Columns {
-		typeBytes := cur.stringBytes()
-		if cur.err != nil {
-			return nil, false, nil, false, 0, false, cur.err
-		}
-		if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
-			return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
+		selectedGroup := colIdx == exec.groupColumnIdx
+		selectedValue := colIdx == exec.valueColumnIdx
+		selectedDistinct := colIdx == exec.distinctColumnIdx
+		selected := selectedGroup || selectedValue || selectedDistinct
+		if selected && exec.readIntegrity != ColumnAssetReadIntegritySkipChecksums {
+			typeBytes := cur.stringBytes()
+			if cur.err != nil {
+				return nil, false, nil, false, 0, false, cur.err
+			}
+			if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
+				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
+			}
+		} else {
+			// Header/schema validation and asset checksums already cover the redundant
+			// per-value type tag. Unsafe checksum-skipping reads also skip selected
+			// type tags and rely on the already-validated asset header/schema.
+			cur.skipStringBytes()
+			if cur.err != nil {
+				return nil, false, nil, false, 0, false, cur.err
+			}
 		}
 		null := cur.bool()
 		if cur.err != nil {
@@ -942,9 +956,6 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 				return nil, false, nil, false, 0, false, cur.err
 			}
 		}
-		selectedGroup := colIdx == exec.groupColumnIdx
-		selectedValue := colIdx == exec.valueColumnIdx
-		selectedDistinct := colIdx == exec.distinctColumnIdx
 		if !present {
 			if !null {
 				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] absent value is not null", colIdx)
@@ -968,24 +979,30 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 		}
 		switch col.ValueType {
 		case ColumnStoreValueBool:
-			_ = cur.bool()
+			cur.skip(1)
 		case ColumnStoreValueInt64:
-			v := int64(cur.u64())
 			if selectedValue {
+				v := int64(cur.u64())
 				value = v
 				valueOK = true
+			} else {
+				cur.skip(8)
 			}
 		case ColumnStoreValueDouble:
-			_ = cur.u64()
+			cur.skip(8)
 		case ColumnStoreValueString:
-			v := cur.stringBytes()
-			if selectedGroup {
-				group = v
-				groupOK = true
-			}
-			if selectedDistinct {
-				distinct = v
-				distinctOK = true
+			if selectedGroup || selectedDistinct {
+				v := cur.stringBytes()
+				if selectedGroup {
+					group = v
+					groupOK = true
+				}
+				if selectedDistinct {
+					distinct = v
+					distinctOK = true
+				}
+			} else {
+				cur.skipStringBytes()
 			}
 		default:
 			return nil, false, nil, false, 0, false, fmt.Errorf("unsupported column physical value type %q", col.ValueType)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -927,8 +927,7 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 		selectedGroup := colIdx == exec.groupColumnIdx
 		selectedValue := colIdx == exec.valueColumnIdx
 		selectedDistinct := colIdx == exec.distinctColumnIdx
-		selected := selectedGroup || selectedValue || selectedDistinct
-		if selected && exec.readIntegrity != ColumnAssetReadIntegritySkipChecksums {
+		if exec.readIntegrity != ColumnAssetReadIntegritySkipChecksums {
 			typeBytes := cur.stringBytes()
 			if cur.err != nil {
 				return nil, false, nil, false, 0, false, cur.err
@@ -937,9 +936,8 @@ func scanColumnPhysicalDirectQueryRowValues(cur *manifestCursor, version uint16,
 				return nil, false, nil, false, 0, false, fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), col.ValueType)
 			}
 		} else {
-			// Header/schema validation and asset checksums already cover the redundant
-			// per-value type tag. Unsafe checksum-skipping reads also skip selected
-			// type tags and rely on the already-validated asset header/schema.
+			// Unsafe checksum-skipping reads also skip redundant per-value type
+			// tags and rely on the already-validated asset header/schema.
 			cur.skipStringBytes()
 			if cur.err != nil {
 				return nil, false, nil, false, 0, false, cur.err

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1511,6 +1511,9 @@ func TestColumnPhysicalDirectQueryValidatesUnselectedTypeTags(t *testing.T) {
 	if summary.rows != 1 || relaxedExec.reduceRows != 1 {
 		t.Fatalf("reduce relaxed summary rows=%d reduceRows=%d want 1", summary.rows, relaxedExec.reduceRows)
 	}
+	if got, want := columnPhysicalQueryLinesM13B("q1", relaxedExec.groups()), []string{"q1:share=1"}; !equalStringSets(got, want) {
+		t.Fatalf("reduce relaxed groups=%v want %v", got, want)
+	}
 }
 
 func equalStringSets(got, want []string) bool {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1437,6 +1437,78 @@ func TestColumnPhysicalAssetScanRejectsWrongNamespaceM13C(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalDirectQueryValidatesUnselectedTypeTags(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+
+	var raw bytes.Buffer
+	writeManifestUint32(&raw, columnPhysicalAssetMagic)
+	writeManifestUint16(&raw, columnPhysicalAssetVersion)
+	writeManifestString(&raw, "events")
+	writeManifestString(&raw, normalized.AssetManager.Namespace)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 1)
+	writeManifestUint64(&raw, 1)
+	writeManifestString(&raw, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&raw, normalized.SchemaHash)
+	writeManifestUint64(&raw, uint64(len(normalized.Columns)))
+	writeManifestUint64(&raw, 1)
+	for _, col := range normalized.Columns {
+		writeManifestString(&raw, col.Name)
+		writeManifestString(&raw, col.Path)
+		writeManifestString(&raw, string(col.ValueType))
+		writeManifestBool(&raw, col.Nullable)
+		writeManifestBool(&raw, col.Dictionary)
+	}
+	writeManifestBytes(&raw, []byte("e1"))
+	writeManifestBool(&raw, false)
+	writeManifestString(&raw, string(ColumnStoreValueString))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestUint64(&raw, 7)
+	writeManifestString(&raw, string(ColumnStoreValueString))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestString(&raw, "share")
+	writeManifestString(&raw, string(ColumnStoreValueString))
+	writeManifestBool(&raw, false)
+	writeManifestBool(&raw, true)
+	writeManifestString(&raw, "did:1")
+	encoded := raw.Bytes()
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 1,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+
+	verifyExec, err := newColumnPhysicalQueryExecutor(*normalized, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalQueryExecutor verify: %v", err)
+	}
+	if _, err := reduceColumnPhysicalAssetDirect(encoded, ref, "events", normalized, ColumnPublishOperationInsert, verifyExec); err == nil || !strings.Contains(err.Error(), `column[0] type="string" want "int64"`) {
+		t.Fatalf("reduce verify err=%v want unselected type-tag failure", err)
+	}
+
+	relaxedExec, err := newColumnPhysicalQueryExecutor(*normalized, ColumnPhysicalQueryRequest{
+		Kind:                     ColumnPhysicalQueryGroupCount,
+		GroupColumn:              "kind",
+		ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalQueryExecutor relaxed: %v", err)
+	}
+	if _, err := reduceColumnPhysicalAssetDirect(encoded, ref, "events", normalized, ColumnPublishOperationInsert, relaxedExec); err != nil {
+		t.Fatalf("reduce relaxed: %v", err)
+	}
+}
+
 func equalStringSets(got, want []string) bool {
 	if len(got) != len(want) {
 		return false

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1504,8 +1504,12 @@ func TestColumnPhysicalDirectQueryValidatesUnselectedTypeTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newColumnPhysicalQueryExecutor relaxed: %v", err)
 	}
-	if _, err := reduceColumnPhysicalAssetDirect(encoded, ref, "events", normalized, ColumnPublishOperationInsert, relaxedExec); err != nil {
+	summary, err := reduceColumnPhysicalAssetDirect(encoded, ref, "events", normalized, ColumnPublishOperationInsert, relaxedExec)
+	if err != nil {
 		t.Fatalf("reduce relaxed: %v", err)
+	}
+	if summary.rows != 1 || relaxedExec.reduceRows != 1 {
+		t.Fatalf("reduce relaxed summary rows=%d reduceRows=%d want 1", summary.rows, relaxedExec.reduceRows)
 	}
 }
 

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -116,13 +116,17 @@ const (
 	ColumnStoreProfileBenchmarkRelaxed ColumnStoreProfileSupport = "benchmark-relaxed"
 )
 
-// ColumnAssetReadIntegrity controls hot physical column asset payload checksum
-// verification. It does not change durability, manifest validation, or the
+// ColumnAssetReadIntegrity controls hot physical column asset read validation.
+// It does not change durability, manifest/header/schema validation, or the
 // checksum fields written into typed column asset refs.
 type ColumnAssetReadIntegrity string
 
 const (
-	ColumnAssetReadIntegrityVerify        ColumnAssetReadIntegrity = "verify"
+	ColumnAssetReadIntegrityVerify ColumnAssetReadIntegrity = "verify"
+	// ColumnAssetReadIntegritySkipChecksums is an unsafe relaxed hot-read mode
+	// for benchmark/performance attribution. It skips per-read payload checksum
+	// verification and may skip redundant per-row tags after the asset header and
+	// schema have been validated.
 	ColumnAssetReadIntegritySkipChecksums ColumnAssetReadIntegrity = "skip_checksums"
 )
 


### PR DESCRIPTION
## Summary

This is the next measured #1634 optimization on top of #1663.

It specializes the insert-only direct physical query row decoder used by q1-q5 scan reducers:

- default verify mode validates every per-row type tag, including unselected columns, so malformed-but-checksummed assets still fail closed
- unselected columns skip value payload decode instead of decoding values the reducer will not use
- unsafe `ColumnAssetReadIntegritySkipChecksums` reads also skip redundant per-value type tags and rely on the already validated asset header/schema plus the documented relaxed-integrity contract
- no planner routing, asset format, metadata, marks, dictionaries, locators, visibility overlay, GC/rewrite, or mmap lifecycle behavior changes

Column assets remain typed isolated `column_assets` assets. This PR does not move column payloads into ordinary `value_vlog` or `leaf_vlog` storage.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64.
Base: #1663 head `2741c1f65` (`codex/column-store-mmap-asset-reader-probe`).
Head: `23fc85577`.
Profile: durable TreeDB, `ColumnAssetReadIntegritySkipChecksums` where noted.

Package suite benchmark, #1663 baseline `/tmp/mmap_probe10.txt` versus this PR `/tmp/direct_decode_specialization_cmd_bench10_relaxed_doc_head.txt`:

```text
BenchmarkColumnStoreSuiteSerialPhysicalQueriesSkipChecksumsM1634
  7.389 ms/op -> 7.173 ms/op, -2.93%, 846.4 MiB/s -> 872.0 MiB/s, allocations unchanged
BenchmarkColumnStoreSuiteAggregateMetadataQueriesSkipChecksumsM1634
  6.288 ms/op -> 6.052 ms/op, -3.76%, 994.6 MiB/s -> 1033.5 MiB/s, allocations unchanged
Geomean
  -3.35% sec/op, +3.46% throughput, allocations unchanged
```

Latest-head read-only attribution refresh before this PR:

- `/tmp/gomap_1634_after_mmap_refresh_20260520_160708`
- `/tmp/gomap_1634_after_mmap_refresh_large_20260520_160937`

The 500K refresh showed the post-mmap direct-scan CPU profile dominated by generic row-value decode:

```text
serial 500K CPU: encoding/binary.bigEndian.Uint64 76.92%, columnPhysicalBytesEqualString 19.23%
aggregate 500K CPU: encoding/binary.bigEndian.Uint64 66.67%, manifestCursor.bool 16.67%, columnPhysicalBytesEqualString 11.11%
```

This PR keeps that optimization target local: it removes unneeded value payload decode from unselected columns while preserving verify-mode type-tag validation. The current-head package rerun shows a clear local decode improvement in this harness, with no allocation-count change. It is still scoped to the direct row decoder and does not claim to close the broader production-vs-experiment gap.

Stale routed 100K durable `skip_checksums` spot check from the pre-review head, artifact root `/tmp/gomap_1634_direct_decode_skip_probe_100k_20260520_161252`:

```text
serial q1/q2/q3/q4a/q4b/q5: 14.51M / 10.78M / 28.30M / 12.44M / 12.41M / 10.91M rows/s
parallel q1/q2/q3/q4a/q4b/q5: 26.50M / 20.53M / 52.78M / 22.01M / 22.33M / 20.16M rows/s
aggregate_metadata q5_metadata: 102.23M rows/s, metadata_hits=20
```

A stale 500K routed spot check is under `/tmp/gomap_1634_direct_decode_skip_probe_20260520_161148`. Those routed runs are retained for context; the current-head package benchmark above is the authoritative post-review performance check.

## Granule / ClickHouse Context

Fresh same-machine experiment kernel context from `/tmp/gomap_1634_after_mmap_refresh_20260520_160708/experiment_colgranule_baseline.txt`:

```text
experiments/colgranule encoded q1/q2/q3/q5: 414.32M / 237.43M / 192.13M / 140.22M rows/s
experiments/colgranule q4b ClickHouse-order row scan: 90.21M rows/s
experiments/colgranule q4b/q5 metadata: 302.36M / 423.85M rows/s
```

ClickHouse-equivalent context remains the historical/local JSONBench comparison in `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` for ClickHouse `26.4.3.1`. Those numbers are context for attribution, not an apples-to-apples gate for this PR, because production TreeDB still includes durable integration, manifest/query adapter, typed asset-manager reads, parity/reporting, and current TCPA row-view shape.

## Throughput Interpretation

This PR is a local scan/reducer decode cleanup after #1661/#1663 removed hot checksum validation and `pread` from the dominant direct-view path. It preserves fail-closed verify semantics and leaves unsafe relaxed integrity explicit.

The remaining production-vs-experiment gap is still mostly format/reducer shape and missing higher-level skip/metadata/dictionary/locator paths. Direct TCPA scanner micro-optimization is still not the first target because direct asset scan remains zero-allocation and very fast; the measured overhead is in routed physical query decode/reduction and metadata setup/reporting around it.

## Gate Status

Passed locally:

```text
go test ./TreeDB/collections -run 'TestColumnPhysicalDirectQueryValidatesUnselectedTypeTags|TestColumnPhysicalQuery|TestColumnPhysicalAsset|TestColumnAssetReadCache' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=10
git diff --check
```

## Artifacts

- Latest-head 10K/100K refresh: `/tmp/gomap_1634_after_mmap_refresh_20260520_160708`
- Latest-head 500K refresh: `/tmp/gomap_1634_after_mmap_refresh_large_20260520_160937`
- Current-head package benchmark comparison: `/tmp/direct_decode_specialization_cmd_bench10_relaxed_doc_head.txt`
- Stale routed 100K spot check: `/tmp/gomap_1634_direct_decode_skip_probe_100k_20260520_161252`
- Stale routed 500K spot check: `/tmp/gomap_1634_direct_decode_skip_probe_20260520_161148`
- HTML reports are present in each routed artifact directory as `column_store_results.html`.


