### PR TITLE
[codex] stage unchanged-index BSON updates behind command WAL

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -924,6 +924,8 @@ type bufferedIndexedCheckpoint struct {
 	uniqueValueMutableRuns map[string]memtable.Table
 	rootRunCount           int
 	indexedDeletesOnly     bool
+	pendingCommandWALFirst uint64
+	pendingCommandWALLast  uint64
 }
 
 type bufferedUniqueValueIndex struct {
@@ -5305,6 +5307,8 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		uniqueValueMutableRuns: cloneMutableRunMap(domain.uniqueValueMutableRuns),
 		rootRunCount:           domain.rootRunCount,
 		indexedDeletesOnly:     domain.indexedDeletesOnly,
+		pendingCommandWALFirst: domain.pendingCommandWALFirst,
+		pendingCommandWALLast:  domain.pendingCommandWALLast,
 	}
 }
 
@@ -5341,6 +5345,13 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.primaryCacheDirty = checkpoint.primaryCacheDirty
 	domain.rootRunCount = checkpoint.rootRunCount
 	domain.indexedDeletesOnly = checkpoint.indexedDeletesOnly
+	domain.pendingCommandWALFirst = checkpoint.pendingCommandWALFirst
+	domain.pendingCommandWALLast = checkpoint.pendingCommandWALLast
+	if collectionCommandWALDomainPendingLocked(domain) {
+		domain.reserveCommandWALCoordinatorOwnerLocked()
+	} else {
+		domain.clearCommandWALCoordinatorOwnerIfNoPendingLocked()
+	}
 	pendingRuns := indexedFlushUnitPendingRootRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.rootRuns)
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, pendingRuns)
 	if checkpoint.primaryRunIndexActive {
@@ -15150,7 +15161,17 @@ func summarizeUpdateBatchSecondaryIndexChanges(runtimes []indexRuntime, updates 
 }
 
 func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
-	return summarizeUpdateBatchSecondaryIndexChanges(runtimes, updates).unique
+	for runtimeIdx := range runtimes {
+		if !runtimes[runtimeIdx].def.unique {
+			continue
+		}
+		for _, update := range updates {
+			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func updateBatchChangesSecondaryIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -13961,7 +13961,12 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	if templateV1CommandWALDocuments != nil {
 		commandWALDocuments = templateV1CommandWALDocuments
 	}
-	secondaryIndexChanges := summarizeUpdateBatchSecondaryIndexChanges(runtimes, changed)
+	var secondaryIndexChanges updateBatchSecondaryIndexChangeSummary
+	if c.commandWALActive(nil) {
+		secondaryIndexChanges = summarizeUpdateBatchSecondaryIndexChanges(runtimes, changed)
+	} else {
+		secondaryIndexChanges.unique = updateBatchChangesSecondaryUniqueIndex(runtimes, changed)
+	}
 	if mode == updateBatchModeNoSecondaryUniqueIndexChanges && secondaryIndexChanges.unique {
 		_ = snap.Close()
 		return nil, errUpdateBatchChangesSecondaryUniqueIndex

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -12746,11 +12746,17 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
 	}
-	if c.commandWALActive(nil) {
-		return false
-	}
 	if !meta.Options.BufferedIndexedWrites {
 		return false
+	}
+	if c.commandWALActive(nil) {
+		return c.canBufferDirectUpdateAck() &&
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			isBSONDocumentFormat(opts.documentFormat) &&
+			structuredBSONSetBatch &&
+			canBuffer &&
+			!updateBatchChangesSecondaryIndex(runtimes, changed) &&
+			!persistIndexStateForOptions(opts)
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
 		if updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
@@ -12830,7 +12836,11 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					results = plan.results
 					return nil
 				}
-				if commandWALBufferedMode && plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && len(plan.commandWALDocuments) > 0 {
+				if commandWALBufferedMode &&
+					plan.directBufferedUpdate != nil &&
+					len(plan.directBufferedUpdate.templateEntries) == 0 &&
+					len(plan.directBufferedUpdate.secondaryRootPlans) == 0 &&
+					len(plan.commandWALDocuments) > 0 {
 					intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
 					if err != nil {
 						return err
@@ -14983,6 +14993,20 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 		if !runtime.def.unique {
 			continue
 		}
+		for _, update := range updates {
+			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func updateBatchChangesSecondaryIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
+	if len(runtimes) == 0 || len(updates) == 0 {
+		return false
+	}
+	for runtimeIdx := range runtimes {
 		for _, update := range updates {
 			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 				return true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -12265,6 +12265,18 @@ type directBufferedUpdatePlan struct {
 	stagedBytes                 int64
 }
 
+func (plan *updateBatchPlan) canStageDirectBufferedUpdateAfterCommandWALAppend() bool {
+	return plan != nil &&
+		plan.directBufferedUpdate != nil &&
+		plan.directBufferedUpdate.stagesOnlyPrimaryRoot()
+}
+
+func (direct *directBufferedUpdatePlan) stagesOnlyPrimaryRoot() bool {
+	return direct != nil &&
+		len(direct.templateEntries) == 0 &&
+		len(direct.secondaryRootPlans) == 0
+}
+
 type directBufferedRootEntry struct {
 	key   []byte
 	value []byte
@@ -12822,7 +12834,7 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, runtimes []indexRuntime, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, secondaryIndexChanges updateBatchSecondaryIndexChangeSummary, changed []preparedBatchUpdate, structuredBSONSetBatch bool) bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
@@ -12846,11 +12858,11 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch &&
 			canBuffer &&
-			!updateBatchChangesSecondaryIndex(runtimes, changed) &&
+			!secondaryIndexChanges.any &&
 			!persistIndexStateForOptions(opts)
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
-		if updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
+		if secondaryIndexChanges.unique {
 			return false
 		}
 		canBuffer = true
@@ -12895,9 +12907,7 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 			err = func() error {
 				var unlockCommandWALRawStage func()
 				if commandWALBufferedMode &&
-					plan.directBufferedUpdate != nil &&
-					len(plan.directBufferedUpdate.templateEntries) == 0 &&
-					len(plan.directBufferedUpdate.secondaryRootPlans) == 0 &&
+					plan.canStageDirectBufferedUpdateAfterCommandWALAppend() &&
 					len(plan.commandWALDocuments) > 0 {
 					intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
 					if err != nil {
@@ -13951,7 +13961,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	if templateV1CommandWALDocuments != nil {
 		commandWALDocuments = templateV1CommandWALDocuments
 	}
-	if mode == updateBatchModeNoSecondaryUniqueIndexChanges && updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
+	secondaryIndexChanges := summarizeUpdateBatchSecondaryIndexChanges(runtimes, changed)
+	if mode == updateBatchModeNoSecondaryUniqueIndexChanges && secondaryIndexChanges.unique {
 		_ = snap.Close()
 		return nil, errUpdateBatchChangesSecondaryUniqueIndex
 	}
@@ -13972,7 +13983,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, runtimes, changed, updateBatchItemsAllHaveBSONSet(items))
+	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, secondaryIndexChanges, changed, updateBatchItemsAllHaveBSONSet(items))
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
@@ -15110,35 +15121,35 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 	return nil
 }
 
-func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
-	if len(runtimes) == 0 || len(updates) == 0 {
-		return false
-	}
-	for runtimeIdx, runtime := range runtimes {
-		if !runtime.def.unique {
-			continue
-		}
-		for _, update := range updates {
-			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
-				return true
-			}
-		}
-	}
-	return false
+type updateBatchSecondaryIndexChangeSummary struct {
+	any    bool
+	unique bool
 }
 
-func updateBatchChangesSecondaryIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
-	if len(runtimes) == 0 || len(updates) == 0 {
-		return false
-	}
+func summarizeUpdateBatchSecondaryIndexChanges(runtimes []indexRuntime, updates []preparedBatchUpdate) updateBatchSecondaryIndexChangeSummary {
+	var summary updateBatchSecondaryIndexChangeSummary
 	for runtimeIdx := range runtimes {
 		for _, update := range updates {
 			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
-				return true
+				summary.any = true
+				if runtimes[runtimeIdx].def.unique {
+					summary.unique = true
+				}
+				if summary.any && summary.unique {
+					return summary
+				}
 			}
 		}
 	}
-	return false
+	return summary
+}
+
+func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
+	return summarizeUpdateBatchSecondaryIndexChanges(runtimes, updates).unique
+}
+
+func updateBatchChangesSecondaryIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
+	return summarizeUpdateBatchSecondaryIndexChanges(runtimes, updates).any
 }
 
 func documentIndexRuntimeChanged(oldState, newState documentIndexState, runtime indexRuntime) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -12762,11 +12762,17 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 			isBSONDocumentFormat(opts.documentFormat) &&
 			structuredBSONSetBatch
 	}
-	if c.commandWALActive(nil) {
-		return false
-	}
 	if !meta.Options.BufferedIndexedWrites {
 		return false
+	}
+	if c.commandWALActive(nil) {
+		return c.canBufferDirectUpdateAck() &&
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
+			isBSONDocumentFormat(opts.documentFormat) &&
+			structuredBSONSetBatch &&
+			canBuffer &&
+			!updateBatchChangesSecondaryIndex(runtimes, changed) &&
+			!persistIndexStateForOptions(opts)
 	}
 	if mode == updateBatchModeAny && collectionMetaHasSecondaryUniqueIndex(meta) {
 		if updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
@@ -12846,7 +12852,11 @@ func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMo
 					results = plan.results
 					return nil
 				}
-				if commandWALBufferedMode && plan.directBufferedUpdate != nil && len(plan.meta.Indexes) == 0 && len(plan.commandWALDocuments) > 0 {
+				if commandWALBufferedMode &&
+					plan.directBufferedUpdate != nil &&
+					len(plan.directBufferedUpdate.templateEntries) == 0 &&
+					len(plan.directBufferedUpdate.secondaryRootPlans) == 0 &&
+					len(plan.commandWALDocuments) > 0 {
 					intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
 					if err != nil {
 						return err
@@ -14999,6 +15009,20 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 		if !runtime.def.unique {
 			continue
 		}
+		for _, update := range updates {
+			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func updateBatchChangesSecondaryIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
+	if len(runtimes) == 0 || len(updates) == 0 {
+		return false
+	}
+	for runtimeIdx := range runtimes {
 		for _, update := range updates {
 			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 				return true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -12839,6 +12839,8 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if c.commandWALActive(nil) {
+		// The mode excludes secondary-unique changes at the planner boundary;
+		// this runtime guard is the authoritative check for all secondary indexes.
 		return c.canBufferDirectUpdateAck() &&
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges &&
 			isBSONDocumentFormat(opts.documentFormat) &&
@@ -14732,6 +14734,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			return false, err
 		}
 	}
+	// Record after staging before any synchronous threshold flush; the flush
+	// clears the pending range after it advances AppliedCommandLSN.
 	if err := recordPendingCommandWAL(); err != nil {
 		return false, err
 	}
@@ -14747,6 +14751,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
 		if err != nil {
+			// The command frame is appended and staged writes are buffered, so a
+			// flush failure is commit-ambiguous and the deferred poison forces recovery.
 			if rollbackOnError {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
@@ -14756,6 +14762,8 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	resetCollectionTables(compactedObsolete)
 	plan.stats.BufferedBatches = 1
+	// If no threshold flush published the range, leave it pending for the next
+	// explicit/background flush. The helper is idempotent if already recorded.
 	if err := recordPendingCommandWAL(); err != nil {
 		return false, err
 	}

--- a/TreeDB/collections/command_wal_pending.go
+++ b/TreeDB/collections/command_wal_pending.go
@@ -385,7 +385,10 @@ func (domain *collectionWriteDomain) recordPendingCommandWALLSNLocked(db *backen
 		if state == nil {
 			return backenddb.ErrClosed
 		}
-		if lsn <= state.AppliedCommandLSN {
+		if lsn < state.AppliedCommandLSN {
+			return fmt.Errorf("%w: pending collection command WAL lsn %d is behind applied %d", backenddb.ErrCommandWALAppliedLSNNonContig, lsn, state.AppliedCommandLSN)
+		}
+		if lsn == state.AppliedCommandLSN {
 			return nil
 		}
 		if lsn != state.AppliedCommandLSN+1 {

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -870,8 +870,14 @@ func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexStagesAfterWALApp
 		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0 before flush", got)
 	}
 	frames := collectionCommandWALFrames(t, dir)
-	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
-		t.Fatalf("command WAL frames=%+v, want one update frame before flush", frames)
+	var updateFrames []commitlog.CommandEnvelope
+	for _, frame := range frames {
+		if frame.Kind == commitlog.CommandKindCollectionUpdateBatchByID {
+			updateFrames = append(updateFrames, frame)
+		}
+	}
+	if len(updateFrames) != 1 {
+		t.Fatalf("command WAL update frames=%+v all frames=%+v, want one update frame before flush", updateFrames, frames)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("Flush: %v", err)

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1819,6 +1819,41 @@ func TestCollectionCommandWALPendingRecordIgnoresAlreadyAppliedLSN(t *testing.T)
 	}
 }
 
+func TestRollbackBufferedIndexedDomainRestoresPendingCommandWAL(t *testing.T) {
+	coord := newCollectionCommandWALCoordinator()
+	domain := &collectionWriteDomain{
+		pendingCommandWALFirst: 1,
+		pendingCommandWALLast:  2,
+	}
+	domain.commandWALCoordinator.Store(coord)
+	domain.reserveCommandWALCoordinatorOwnerLocked()
+	checkpoint := checkpointBufferedIndexedDomain(domain)
+
+	domain.pendingCommandWALLast = 3
+	rollbackBufferedIndexedDomain(domain, checkpoint)
+	if domain.pendingCommandWALFirst != 1 || domain.pendingCommandWALLast != 2 {
+		t.Fatalf("pending command WAL range=[%d,%d], want [1,2]", domain.pendingCommandWALFirst, domain.pendingCommandWALLast)
+	}
+	coord.mu.Lock()
+	if coord.owner != domain {
+		coord.mu.Unlock()
+		t.Fatalf("coordinator owner cleared despite restored pending command WAL")
+	}
+	coord.mu.Unlock()
+
+	emptyCheckpoint := checkpointBufferedIndexedDomain(&collectionWriteDomain{})
+	rollbackBufferedIndexedDomain(domain, emptyCheckpoint)
+	if domain.pendingCommandWALFirst != 0 || domain.pendingCommandWALLast != 0 {
+		t.Fatalf("pending command WAL range=[%d,%d], want empty", domain.pendingCommandWALFirst, domain.pendingCommandWALLast)
+	}
+	coord.mu.Lock()
+	if coord.owner != nil {
+		coord.mu.Unlock()
+		t.Fatalf("coordinator owner retained after pending command WAL rollback")
+	}
+	coord.mu.Unlock()
+}
+
 func TestCollectionCommandWALUpdateBSONSetUniqueIndexReopenRecovery(t *testing.T) {
 	doc1 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}})
 	doc2 := mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}})

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -828,7 +828,7 @@ func TestCollectionCommandWALUpdateBSONSetUniqueIndexChangePublishesAppliedLSN(t
 	}
 }
 
-func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexPublishesAppliedLSN(t *testing.T) {
+func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexStagesAfterWALAppend(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",
 		Options: CollectionOptions{
@@ -865,9 +865,37 @@ func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexPublishesAppliedL
 		t.Fatalf("city=%q want sea", got)
 	}
 	assertCollectionIndexIDs(t, col, "email", "ada@example.test", "u1")
-	if got := d.State().AppliedCommandLSN; got != 1 {
-		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0 before flush", got)
 	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
+		t.Fatalf("command WAL frames=%+v, want one update frame before flush", frames)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	doc, err = reopened.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get reopened doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("reopened city=%q want sea", got)
+	}
+	assertCollectionIndexIDs(t, reopened, "email", "ada@example.test", "u1")
 }
 
 func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing.T) {

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -896,6 +896,9 @@ func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexStagesAfterWALApp
 		t.Fatalf("reopened city=%q want sea", got)
 	}
 	assertCollectionIndexIDs(t, reopened, "email", "ada@example.test", "u1")
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
 }
 
 func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing.T) {

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -843,7 +843,11 @@ func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexStagesAfterWALApp
 		},
 	})
 	d := openCollectionCommandWALDB(t, dir)
-	defer func() { _ = d.Close() }()
+	defer func() {
+		if d != nil {
+			_ = d.Close()
+		}
+	}()
 	col, err := NewCollectionManager(d).OpenCollection("users")
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
@@ -888,6 +892,7 @@ func TestCollectionCommandWALUpdateBSONSetIndexedUnchangedIndexStagesAfterWALApp
 	if err := d.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+	d = nil
 
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1793,15 +1793,18 @@ func TestCollectionCommandWALPendingRecordIgnoresAlreadyAppliedLSN(t *testing.T)
 	})
 	d := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = d.Close() }()
-	if err := d.PublishCommandWALAppliedLSN(1, []backenddb.CommandWALLSNRange{{First: 1, Last: 1}}, false); err != nil {
+	if err := d.PublishCommandWALAppliedLSN(2, []backenddb.CommandWALLSNRange{{First: 1, Last: 2}}, false); err != nil {
 		t.Fatalf("PublishCommandWALAppliedLSN: %v", err)
 	}
 	domain := &collectionWriteDomain{}
-	if err := domain.recordPendingCommandWALLSNLocked(d, 1); err != nil {
+	if err := domain.recordPendingCommandWALLSNLocked(d, 2); err != nil {
 		t.Fatalf("recordPendingCommandWALLSNLocked already applied: %v", err)
 	}
 	if domain.pendingCommandWALFirst != 0 || domain.pendingCommandWALLast != 0 {
 		t.Fatalf("pending command WAL range=[%d,%d], want empty", domain.pendingCommandWALFirst, domain.pendingCommandWALLast)
+	}
+	if err := domain.recordPendingCommandWALLSNLocked(d, 1); !errors.Is(err, backenddb.ErrCommandWALAppliedLSNNonContig) {
+		t.Fatalf("recordPendingCommandWALLSNLocked stale error=%v, want ErrCommandWALAppliedLSNNonContig", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is stacked on #1662. It extends the command-WAL fast ACK path from no-index BSON `$set` updates to indexed BSON `$set` updates when secondary index values are provably unchanged.

- allows the direct buffered update plan in command-WAL mode only when the update is BSON `$set`, can be buffered, changes no secondary index values, and does not need persisted index-state roots
- stages the primary overlay after the command WAL append instead of publishing the primary root before ACK for unchanged-index updates
- keeps secondary-index-changing and unique-index-changing updates on the synchronous publish path
- extends command-WAL collection coverage to prove staged indexed updates remain visible, preserve index lookups, publish on flush, persist applied LSN, and survive reopen

## Benchmark proof

Base binary: #1662 head `2631cef`.
After binary: this PR head `29e2112`.
Artifacts: `/tmp/mongo_wal_current_heads_bench_20260520_165242`.

Command shape for each run:

```sh
/tmp/mongo_gateway_bench_* \
  -target treedb \
  -treedb-profile durable \
  -treedb-document-format bson \
  -secondary-indexes {1,2} \
  -documents 20000 \
  -batch-size 1000 \
  -reads 0 \
  -range-reads 0 \
  -updates 2000 \
  -concurrent-writers 32 \
  -concurrent-writes 20000 \
  -deletes 0 \
  -treedb-maintenance none \
  -format json \
  -treedb-command-wal
```

Three-rep averages:

| indexes | phase | before ops/s | after ops/s | speedup | before mean us | after mean us | latency reduction |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `id_update_set` | 7,729.50 | 12,068.40 | 1.56x | 128.20 | 77.28 | 39.7% |
| 1 | `concurrent_id_update_set_w32` | 11,865.84 | 90,088.76 | 7.59x | 2,696.27 | 284.96 | 89.4% |
| 2 | `id_update_set` | 7,150.56 | 11,273.37 | 1.58x | 138.64 | 82.22 | 40.7% |
| 2 | `concurrent_id_update_set_w32` | 11,190.58 | 91,538.65 | 8.18x | 2,857.93 | 287.10 | 90.0% |

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWAL(UpdateBSONSetNoIndexStagesAfterWALAppend|UpdateBSONSetNoopFlushesStagedUpdate|UpdateBSONSetNoIndexInterleavedCollectionsDrainOwner|PendingFirstLSNRequiresAppliedNext|UpdateBSONSetIndexedUnchangedIndexStagesAfterWALAppend|UpdateBSONSetUniqueIndexChangePublishesAppliedLSN|UpdateBSONSetUniqueIndexReopenRecovery)' -count=1 -v
GOWORK=off go test ./cmd/mongo_gateway_bench -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/db -run 'TestCommandWAL|TestPublishCommandWAL' -count=1
git diff --check
codex review --base codex/mongo-command-wal-noindex-update
```

Local Codex review of the stacked diff found no actionable issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secondary index handling during buffered write operations with refined change detection
  * Enhanced error reporting for ambiguous commit scenarios in buffered updates

* **Tests**
  * Expanded validation of staging semantics and data persistence across flush operations
  * Added verification of secondary index correctness after database restart

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->