### PR TITLE
collections: search column graph through native reader

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -125,8 +125,10 @@ func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearch
 
 func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		clear(dst)
 		return make([]columnVectorGraphNativeSearchResult, 0, target)
 	}
+	clear(dst)
 	return dst[:0]
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -65,7 +65,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		return errors.New("collections: column_graph native search requires caller-owned scratch")
 	}
 	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 || efSearch < 0 {
-		return errors.New("collections: column_graph native search received negative sizing input")
+		return fmt.Errorf("collections: column_graph native search received negative sizing input: rowCount=%d dimensions=%d degree=%d topK=%d efSearch=%d", rowCount, dimensions, degree, topK, efSearch)
 	}
 	for _, rowScratch := range []*columnPhysicalRowReaderScratch{&s.scoreScratch, &s.expandScratch, &s.resultScratch} {
 		prepareColumnVectorGraphNativeRowScratch(rowScratch, dimensions, degree)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -6,6 +6,8 @@ import (
 	"math"
 )
 
+const columnVectorGraphNativeFrontierOversizeSlack = 16
+
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
 	EfSearch int
@@ -77,7 +79,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if frontierCap < topK {
 		frontierCap = topK
 	}
-	if cap(s.frontier) < frontierCap || cap(s.frontier) > frontierCap*2+16 {
+	if cap(s.frontier) < frontierCap || cap(s.frontier) > frontierCap*2+columnVectorGraphNativeFrontierOversizeSlack {
 		s.frontier = make([]columnVectorGraphSearchCandidate, 0, frontierCap)
 	} else {
 		s.frontier = s.frontier[:0]
@@ -94,6 +96,11 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		next := make([][]byte, topK)
 		copy(next, s.idBuffers)
 		s.idBuffers = next
+	} else {
+		for i := topK; i < len(s.idBuffers); i++ {
+			s.idBuffers[i] = nil
+		}
+		s.idBuffers = s.idBuffers[:topK]
 	}
 	if cap(s.resultOrder) < topK {
 		s.resultOrder = make([]int, 0, topK)
@@ -235,6 +242,8 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
 	fetchPos := 0
+	// FetchBatch preserves request order today; the ordinal check below fails
+	// closed if that contract changes.
 	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
 		if fetchPos >= n {
 			return fmt.Errorf("collections: column_graph %q result batch returned extra row ordinal=%d", r.def.Name, row.Ordinal)
@@ -320,7 +329,7 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int) {
 	for idx > 0 {
 		parent := (idx - 1) / 2
-		if !columnVectorGraphSearchCandidateLess(s.frontier[idx], s.frontier[parent]) {
+		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
 			return
 		}
 		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
@@ -335,10 +344,10 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
 			return
 		}
 		child := left
-		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateLess(s.frontier[right], s.frontier[left]) {
+		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateBetter(s.frontier[right], s.frontier[left]) {
 			child = right
 		}
-		if !columnVectorGraphSearchCandidateLess(s.frontier[child], s.frontier[idx]) {
+		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
 			return
 		}
 		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
@@ -351,7 +360,7 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 		return
 	}
 	pos := len(s.top)
-	for pos > 0 && columnVectorGraphSearchCandidateLess(candidate, s.top[pos-1]) {
+	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
 		pos--
 	}
 	if pos >= limit {
@@ -364,7 +373,7 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 	s.top[pos] = candidate
 }
 
-func columnVectorGraphSearchCandidateLess(left, right columnVectorGraphSearchCandidate) bool {
+func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchCandidate) bool {
 	if left.score == right.score {
 		return left.ordinal < right.ordinal
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -142,7 +142,7 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 // must be copied before the next SearchCosine call with the same scratch.
 func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
 	if r == nil || r.reader == nil {
-		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: nil column vector graph physical row reader")
+		return nil, columnVectorGraphNativeSearchStats{}, errNilColumnVectorGraphPhysicalRowReader
 	}
 	if len(query) != r.def.Dimensions {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d", r.def.Name, len(query), r.def.Dimensions)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -57,7 +57,6 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
-	resultFetched  []bool
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
@@ -115,9 +114,6 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	}
 	if cap(s.resultOrdinals) < topK {
 		s.resultOrdinals = make([]int, 0, topK)
-	}
-	if cap(s.resultFetched) < topK {
-		s.resultFetched = make([]bool, 0, topK)
 	}
 	return nil
 }
@@ -243,8 +239,6 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	n := len(scratch.top)
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
-	scratch.resultFetched = scratch.resultFetched[:n]
-	clear(scratch.resultFetched)
 	for i := 0; i < n; i++ {
 		scratch.resultOrder[i] = i
 	}
@@ -258,11 +252,12 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 		if resultPos >= n || scratch.resultOrdinals[resultPos] != row.Ordinal {
 			return fmt.Errorf("collections: column_graph %q result batch returned unexpected row ordinal=%d", r.def.Name, row.Ordinal)
 		}
-		if scratch.resultFetched[resultPos] {
+		topIndex := scratch.resultOrder[resultPos]
+		if topIndex < 0 {
 			return fmt.Errorf("collections: column_graph %q result batch returned duplicate row ordinal=%d", r.def.Name, row.Ordinal)
 		}
-		scratch.resultFetched[resultPos] = true
-		topIndex := scratch.resultOrder[resultPos]
+		// Mark fetched in-place to avoid another per-search scratch slice.
+		scratch.resultOrder[resultPos] = ^topIndex
 		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {
 			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
 		}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -48,8 +48,9 @@ type columnVectorGraphNativeSearchResult struct {
 }
 
 type columnVectorGraphSearchCandidate struct {
-	ordinal int
-	score   float64
+	ordinal   int
+	score     float64
+	adjacency []uint32
 }
 
 // columnVectorGraphNativeSearchScratch is caller-owned mutable search state.
@@ -67,6 +68,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
+	adjacencyBuf   []uint32
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
@@ -92,12 +94,20 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if frontierCap < topK {
 		frontierCap = topK
 	}
+	adjacencyCap := 0
+	if frontierCap > 0 && degree > 0 {
+		if frontierCap > math.MaxInt/degree {
+			return fmt.Errorf("collections: column_graph native search adjacency scratch overflows: frontierCap=%d degree=%d", frontierCap, degree)
+		}
+		adjacencyCap = frontierCap * degree
+	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
 	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
+	s.adjacencyBuf = resizeColumnVectorGraphNativeUint32Scratch(s.adjacencyBuf, adjacencyCap)
 	return nil
 }
 
@@ -150,6 +160,13 @@ func resizeColumnVectorGraphNativeUint64Scratch(dst []uint64, target int) []uint
 		return make([]uint64, target)
 	}
 	return dst[:target]
+}
+
+func resizeColumnVectorGraphNativeUint32Scratch(dst []uint32, target int) []uint32 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]uint32, 0, target)
+	}
+	return dst[:0]
 }
 
 func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][]byte {
@@ -249,19 +266,14 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		// Search validates adjacency as edges are expanded; avoid duplicate
-		// full adjacency scans on score/result fetches.
-		row, err := r.fetchRowUnchecked(candidate.ordinal, &scratch.expandScratch)
-		if err != nil {
-			return nil, stats, err
-		}
-		stats.ExpansionFetches++
-		for i, neighbor := range row.Adjacency {
+		// Candidate scoring fetches adjacency once into scratch-owned storage;
+		// expansion validates and consumes that copy without a second row fetch.
+		for i, neighbor := range candidate.adjacency {
 			if stats.Candidates >= uint64(efSearch) {
 				break
 			}
 			stats.Edges++
-			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
+			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, candidate.ordinal, i, neighbor, rowCount); err != nil {
 				return nil, stats, err
 			}
 			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
@@ -362,11 +374,32 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float3
 			return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
 		}
 		stats.Candidates++
-		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
+		candidate := columnVectorGraphSearchCandidate{
+			ordinal:   ordinal,
+			score:     score,
+			adjacency: scratch.copyCandidateAdjacency(row.Adjacency),
+		}
 		scratch.insertTop(topK, candidate)
 		scratch.pushFrontier(candidate)
 	}
 	return nil
+}
+
+func (s *columnVectorGraphNativeSearchScratch) copyCandidateAdjacency(adjacency []uint32) []uint32 {
+	start := len(s.adjacencyBuf)
+	need := start + len(adjacency)
+	if need > cap(s.adjacencyBuf) {
+		nextCap := cap(s.adjacencyBuf) * 2
+		if nextCap < need {
+			nextCap = need
+		}
+		next := make([]uint32, len(s.adjacencyBuf), nextCap)
+		copy(next, s.adjacencyBuf)
+		s.adjacencyBuf = next
+	}
+	s.adjacencyBuf = s.adjacencyBuf[:need]
+	copy(s.adjacencyBuf[start:need], adjacency)
+	return s.adjacencyBuf[start:need]
 }
 
 func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -7,7 +7,12 @@ import (
 	"sort"
 )
 
+// Keep modest frontier overgrowth to avoid realloc churn when callers vary
+// EfSearch slightly, while still releasing oversized scratch after large probes.
 const columnVectorGraphNativeFrontierOversizeSlack = 16
+
+// Default TopK values are small; insertion order avoids sort overhead there.
+// Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
 type columnVectorGraphNativeSearchOptions struct {
@@ -116,12 +121,18 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch, dimensions, degree int) {
 	if cap(s.Values) < 3 {
 		s.Values = make([]columnDeclaredValue, 0, 3)
+	} else {
+		s.Values = s.Values[:0]
 	}
 	if cap(s.Float32Values) < dimensions {
 		s.Float32Values = make([]float32, 0, dimensions)
+	} else {
+		s.Float32Values = s.Float32Values[:0]
 	}
 	if cap(s.Uint32Values) < degree {
 		s.Uint32Values = make([]uint32, 0, degree)
+	} else {
+		s.Uint32Values = s.Uint32Values[:0]
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -50,11 +50,11 @@ type columnVectorGraphNativeSearchScratch struct {
 	resultOrdinals []int
 }
 
-func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK int) error {
+func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
 	if s == nil {
 		return errors.New("collections: column_graph native search requires caller-owned scratch")
 	}
-	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 {
+	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 || efSearch < 0 {
 		return errors.New("collections: column_graph native search received negative sizing input")
 	}
 	for _, rowScratch := range []*columnPhysicalRowReaderScratch{&s.scoreScratch, &s.expandScratch, &s.resultScratch} {
@@ -70,9 +70,17 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		clear(s.visitMarks)
 		s.visitEpoch = 1
 	}
-	s.frontier = s.frontier[:0]
-	if cap(s.frontier) < rowCount {
-		s.frontier = make([]columnVectorGraphSearchCandidate, 0, rowCount)
+	frontierCap := efSearch
+	if frontierCap > rowCount {
+		frontierCap = rowCount
+	}
+	if frontierCap < topK {
+		frontierCap = topK
+	}
+	if cap(s.frontier) < frontierCap || cap(s.frontier) > frontierCap*2+16 {
+		s.frontier = make([]columnVectorGraphSearchCandidate, 0, frontierCap)
+	} else {
+		s.frontier = s.frontier[:0]
 	}
 	s.top = s.top[:0]
 	if cap(s.top) < topK {
@@ -137,7 +145,10 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		topK = rowCount
 	}
 	efSearch := opts.EfSearch
-	if efSearch <= 0 {
+	if efSearch < 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search ef_search cannot be negative")
+	}
+	if efSearch == 0 {
 		efSearch = r.def.EfSearch
 	}
 	if efSearch < topK {
@@ -150,7 +161,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if degree < 0 {
 		degree = 0
 	}
-	if err := scratch.prepare(rowCount, r.def.Dimensions, degree, topK); err != nil {
+	if err := scratch.prepare(rowCount, r.def.Dimensions, degree, topK, efSearch); err != nil {
 		return nil, columnVectorGraphNativeSearchStats{}, err
 	}
 
@@ -179,10 +190,10 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		}
 		stats.ExpansionFetches++
 		for _, neighbor := range row.Adjacency {
-			stats.Edges++
 			if stats.Candidates >= uint64(efSearch) {
 				break
 			}
+			stats.Edges++
 			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -20,6 +20,7 @@ var (
 	errColumnVectorGraphNativeSearchScratchRequired            = errors.New("collections: column_graph native search requires caller-owned scratch")
 	errColumnVectorGraphNativeSearchQueryDimensionMismatch     = errors.New("collections: column_graph native search query dimension mismatch")
 	errColumnVectorGraphNativeSearchQueryNormInvalid           = errors.New("collections: column_graph native search query norm invalid")
+	errColumnVectorGraphNativeSearchTopKNegative               = errors.New("collections: column_graph native search top_k cannot be negative")
 	errColumnVectorGraphNativeSearchEfSearchNegative           = errors.New("collections: column_graph native search ef_search cannot be negative")
 	errColumnVectorGraphNativeSearchCandidateDimensionMismatch = errors.New("collections: column_graph native search candidate dimension mismatch")
 )
@@ -190,7 +191,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	rowCount := r.RowCount()
 	topK := opts.TopK
 	if topK < 0 {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative", r.def.Name)
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative: %w", r.def.Name, errColumnVectorGraphNativeSearchTopKNegative)
 	}
 	efSearch := opts.EfSearch
 	if efSearch < 0 {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -57,6 +57,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
+	resultFetched  []bool
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
@@ -114,6 +115,9 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	}
 	if cap(s.resultOrdinals) < topK {
 		s.resultOrdinals = make([]int, 0, topK)
+	}
+	if cap(s.resultFetched) < topK {
+		s.resultFetched = make([]bool, 0, topK)
 	}
 	return nil
 }
@@ -217,8 +221,8 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			stats.Edges++
-			if uint64(neighbor) >= uint64(rowCount) {
-				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, row.Ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
+				return nil, stats, err
 			}
 			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
 				return nil, stats, err
@@ -239,6 +243,8 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	n := len(scratch.top)
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
+	scratch.resultFetched = scratch.resultFetched[:n]
+	clear(scratch.resultFetched)
 	for i := 0; i < n; i++ {
 		scratch.resultOrder[i] = i
 	}
@@ -246,30 +252,29 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	for fetchPos, topIndex := range scratch.resultOrder {
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
-	fetchPos := 0
-	// FetchBatch preserves request order today; the ordinal check below fails
-	// closed if that contract changes.
+	fetched := 0
 	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
-		if fetchPos >= n {
-			return fmt.Errorf("collections: column_graph %q result batch returned extra row ordinal=%d", r.def.Name, row.Ordinal)
+		resultPos := sort.SearchInts(scratch.resultOrdinals, row.Ordinal)
+		if resultPos >= n || scratch.resultOrdinals[resultPos] != row.Ordinal {
+			return fmt.Errorf("collections: column_graph %q result batch returned unexpected row ordinal=%d", r.def.Name, row.Ordinal)
 		}
-		topIndex := scratch.resultOrder[fetchPos]
-		candidate := scratch.top[topIndex]
-		if row.Ordinal != candidate.ordinal {
-			return fmt.Errorf("collections: column_graph %q result batch row ordinal=%d want %d", r.def.Name, row.Ordinal, candidate.ordinal)
+		if scratch.resultFetched[resultPos] {
+			return fmt.Errorf("collections: column_graph %q result batch returned duplicate row ordinal=%d", r.def.Name, row.Ordinal)
 		}
+		scratch.resultFetched[resultPos] = true
+		topIndex := scratch.resultOrder[resultPos]
 		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {
 			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
 		}
 		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(row.ID)]
 		copy(scratch.idBuffers[topIndex], row.ID)
-		fetchPos++
+		fetched++
 		return nil
 	}); err != nil {
 		return err
 	}
-	if fetchPos != n {
-		return fmt.Errorf("collections: column_graph %q result batch rows=%d want %d", r.def.Name, fetchPos, n)
+	if fetched != n {
+		return fmt.Errorf("collections: column_graph %q result batch rows=%d want %d", r.def.Name, fetched, n)
 	}
 	stats.ResultFetches += uint64(n)
 	for i, candidate := range scratch.top {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -184,7 +184,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		row, err := r.FetchRow(candidate.ordinal, &scratch.expandScratch)
+		// Search validates adjacency as edges are expanded; avoid duplicate
+		// full adjacency scans on score/result fetches.
+		row, err := r.fetchRowUnchecked(candidate.ordinal, &scratch.expandScratch)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -233,7 +235,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
 	fetchPos := 0
-	if err := r.FetchBatch(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
+	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
 		if fetchPos >= n {
 			return fmt.Errorf("collections: column_graph %q result batch returned extra row ordinal=%d", r.def.Name, row.Ordinal)
 		}
@@ -268,7 +270,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 
 func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	if scratch.markVisited(ordinal) {
-		row, err := r.FetchRow(ordinal, &scratch.scoreScratch)
+		row, err := r.fetchRowUnchecked(ordinal, &scratch.scoreScratch)
 		if err != nil {
 			return err
 		}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -102,6 +102,7 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 	if cap(s.Values) < columnVectorGraphPhysicalRowValueCount {
 		s.Values = make([]columnDeclaredValue, 0, columnVectorGraphPhysicalRowValueCount)
 	} else {
+		clear(s.Values)
 		s.Values = s.Values[:0]
 	}
 	if cap(s.Float32Values) < dimensions {
@@ -148,7 +149,10 @@ func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][
 		return next
 	}
 	if len(dst) < target {
-		return dst[:target]
+		oldLen := len(dst)
+		dst = dst[:target]
+		clear(dst[oldLen:target])
+		return dst
 	}
 	for i := target; i < len(dst); i++ {
 		dst[i] = nil

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -16,6 +16,8 @@ const columnVectorGraphNativeScratchOversizeSlack = 16
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
+var errColumnVectorGraphNativeSearchScratchRequired = errors.New("collections: column_graph native search requires caller-owned scratch")
+
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
 	EfSearch int
@@ -62,7 +64,7 @@ type columnVectorGraphNativeSearchScratch struct {
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
 	if s == nil {
-		return errors.New("collections: column_graph native search requires caller-owned scratch")
+		return errColumnVectorGraphNativeSearchScratchRequired
 	}
 	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 || efSearch < 0 {
 		return fmt.Errorf("collections: column_graph native search received negative sizing input: rowCount=%d dimensions=%d degree=%d topK=%d efSearch=%d", rowCount, dimensions, degree, topK, efSearch)
@@ -174,7 +176,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, columnVectorGraphNativeSearchStats{}, nil
 	}
 	if scratch == nil {
-		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search requires caller-owned scratch")
+		return nil, columnVectorGraphNativeSearchStats{}, errColumnVectorGraphNativeSearchScratchRequired
 	}
 	queryInvNorm, err := columnVectorGraphInvNorm(query)
 	if err != nil {
@@ -268,7 +270,11 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	resultPos := 0
 	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
 		if resultPos >= n || scratch.resultOrdinals[resultPos] != row.Ordinal {
-			return fmt.Errorf("collections: column_graph %q result batch returned unexpected or out-of-order row ordinal=%d", r.def.Name, row.Ordinal)
+			expected := -1
+			if resultPos < n {
+				expected = scratch.resultOrdinals[resultPos]
+			}
+			return fmt.Errorf("collections: column_graph %q result batch returned unexpected or out-of-order row ordinal=%d result_pos=%d expected_ordinal=%d", r.def.Name, row.Ordinal, resultPos, expected)
 		}
 		topIndex := scratch.resultOrder[resultPos]
 		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -16,7 +16,13 @@ const columnVectorGraphNativeScratchOversizeSlack = 16
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
-var errColumnVectorGraphNativeSearchScratchRequired = errors.New("collections: column_graph native search requires caller-owned scratch")
+var (
+	errColumnVectorGraphNativeSearchScratchRequired            = errors.New("collections: column_graph native search requires caller-owned scratch")
+	errColumnVectorGraphNativeSearchQueryDimensionMismatch     = errors.New("collections: column_graph native search query dimension mismatch")
+	errColumnVectorGraphNativeSearchQueryNormInvalid           = errors.New("collections: column_graph native search query norm invalid")
+	errColumnVectorGraphNativeSearchEfSearchNegative           = errors.New("collections: column_graph native search ef_search cannot be negative")
+	errColumnVectorGraphNativeSearchCandidateDimensionMismatch = errors.New("collections: column_graph native search candidate dimension mismatch")
+)
 
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
@@ -179,7 +185,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, columnVectorGraphNativeSearchStats{}, errNilColumnVectorGraphPhysicalRowReader
 	}
 	if len(query) != r.def.Dimensions {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d", r.def.Name, len(query), r.def.Dimensions)
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
 	}
 	rowCount := r.RowCount()
 	topK := opts.TopK
@@ -188,17 +194,17 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	efSearch := opts.EfSearch
 	if efSearch < 0 {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative", r.def.Name)
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative: %w", r.def.Name, errColumnVectorGraphNativeSearchEfSearchNegative)
 	}
 	if topK == 0 || rowCount == 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, nil
 	}
 	if scratch == nil {
-		return nil, columnVectorGraphNativeSearchStats{}, errColumnVectorGraphNativeSearchScratchRequired
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
 	}
 	queryInvNorm, err := columnVectorGraphInvNorm(query)
 	if err != nil {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w", r.def.Name, err)
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w: %v", r.def.Name, errColumnVectorGraphNativeSearchQueryNormInvalid, err)
 	}
 	if topK > rowCount {
 		topK = rowCount
@@ -217,7 +223,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		degree = 0
 	}
 	if err := scratch.prepare(rowCount, r.def.Dimensions, degree, topK, efSearch); err != nil {
-		return nil, columnVectorGraphNativeSearchStats{}, err
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search scratch prepare: %w", r.def.Name, err)
 	}
 
 	var stats columnVectorGraphNativeSearchStats
@@ -442,7 +448,7 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {
 	if len(row.Vector) != len(query) {
-		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d", row.Ordinal, len(row.Vector), len(query))
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", row.Ordinal, len(row.Vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
 	var dot float64
 	for i, v := range query {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -7,9 +7,10 @@ import (
 	"sort"
 )
 
-// Keep modest frontier overgrowth to avoid realloc churn when callers vary
-// EfSearch slightly, while still releasing oversized scratch after large probes.
-const columnVectorGraphNativeFrontierOversizeSlack = 16
+// Keep modest scratch overgrowth to avoid realloc churn when callers vary
+// TopK/EfSearch slightly, while still releasing oversized scratch after large
+// probes.
+const columnVectorGraphNativeScratchOversizeSlack = 16
 
 // Default TopK values are small; insertion order avoids sort overhead there.
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
@@ -86,41 +87,18 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if frontierCap < topK {
 		frontierCap = topK
 	}
-	if cap(s.frontier) < frontierCap || cap(s.frontier) > frontierCap*2+columnVectorGraphNativeFrontierOversizeSlack {
-		s.frontier = make([]columnVectorGraphSearchCandidate, 0, frontierCap)
-	} else {
-		s.frontier = s.frontier[:0]
-	}
-	s.top = s.top[:0]
-	if cap(s.top) < topK {
-		s.top = make([]columnVectorGraphSearchCandidate, 0, topK)
-	}
-	s.results = s.results[:0]
-	if cap(s.results) < topK {
-		s.results = make([]columnVectorGraphNativeSearchResult, 0, topK)
-	}
-	if len(s.idBuffers) < topK {
-		next := make([][]byte, topK)
-		copy(next, s.idBuffers)
-		s.idBuffers = next
-	} else {
-		for i := topK; i < len(s.idBuffers); i++ {
-			s.idBuffers[i] = nil
-		}
-		s.idBuffers = s.idBuffers[:topK]
-	}
-	if cap(s.resultOrder) < topK {
-		s.resultOrder = make([]int, 0, topK)
-	}
-	if cap(s.resultOrdinals) < topK {
-		s.resultOrdinals = make([]int, 0, topK)
-	}
+	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
+	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
+	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
+	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
+	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
+	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
 	return nil
 }
 
 func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch, dimensions, degree int) {
-	if cap(s.Values) < 3 {
-		s.Values = make([]columnDeclaredValue, 0, 3)
+	if cap(s.Values) < columnVectorGraphPhysicalRowValueCount {
+		s.Values = make([]columnDeclaredValue, 0, columnVectorGraphPhysicalRowValueCount)
 	} else {
 		s.Values = s.Values[:0]
 	}
@@ -134,6 +112,46 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 	} else {
 		s.Uint32Values = s.Uint32Values[:0]
 	}
+}
+
+func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearchCandidate, target int) []columnVectorGraphSearchCandidate {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]columnVectorGraphSearchCandidate, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]columnVectorGraphNativeSearchResult, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeIntScratch(dst []int, target int) []int {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]int, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][]byte {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		next := make([][]byte, target)
+		copy(next, dst)
+		return next
+	}
+	if len(dst) < target {
+		return dst[:target]
+	}
+	for i := target; i < len(dst); i++ {
+		dst[i] = nil
+	}
+	return dst[:target]
+}
+
+func columnVectorGraphNativeScratchCapOversized(capacity, target int) bool {
+	return capacity > target*2+columnVectorGraphNativeScratchOversizeSlack
 }
 
 // SearchCosine traverses the persisted column graph through the physical row
@@ -247,23 +265,21 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
 	fetched := 0
+	resultPos := 0
 	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
-		resultPos := sort.SearchInts(scratch.resultOrdinals, row.Ordinal)
 		if resultPos >= n || scratch.resultOrdinals[resultPos] != row.Ordinal {
-			return fmt.Errorf("collections: column_graph %q result batch returned unexpected row ordinal=%d", r.def.Name, row.Ordinal)
+			return fmt.Errorf("collections: column_graph %q result batch returned unexpected or out-of-order row ordinal=%d", r.def.Name, row.Ordinal)
 		}
 		topIndex := scratch.resultOrder[resultPos]
-		if topIndex < 0 {
-			return fmt.Errorf("collections: column_graph %q result batch returned duplicate row ordinal=%d", r.def.Name, row.Ordinal)
-		}
-		// Mark fetched in-place to avoid another per-search scratch slice.
-		scratch.resultOrder[resultPos] = ^topIndex
 		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {
+			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
+		} else if columnVectorGraphNativeScratchCapOversized(cap(scratch.idBuffers[topIndex]), len(row.ID)) {
 			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
 		}
 		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(row.ID)]
 		copy(scratch.idBuffers[topIndex], row.ID)
 		fetched++
+		resultPos++
 		return nil
 	}); err != nil {
 		return err

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -161,6 +161,12 @@ func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][
 }
 
 func columnVectorGraphNativeScratchCapOversized(capacity, target int) bool {
+	if target < 0 {
+		return true
+	}
+	if target > (math.MaxInt-columnVectorGraphNativeScratchOversizeSlack)/2 {
+		return false
+	}
 	return capacity > target*2+columnVectorGraphNativeScratchOversizeSlack
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -131,10 +131,19 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 }
 
 func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearchCandidate, target int) []columnVectorGraphSearchCandidate {
+	if len(dst) > 0 {
+		clearColumnVectorGraphNativeCandidateAdjacencyRefs(dst)
+	}
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]columnVectorGraphSearchCandidate, 0, target)
 	}
 	return dst[:0]
+}
+
+func clearColumnVectorGraphNativeCandidateAdjacencyRefs(candidates []columnVectorGraphSearchCandidate) {
+	for i := range candidates {
+		candidates[i].adjacency = nil
+	}
 }
 
 func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {
@@ -419,9 +428,11 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 	if len(s.frontier) == 0 {
 		return columnVectorGraphSearchCandidate{}, false
 	}
+	lastIdx := len(s.frontier) - 1
 	best := s.frontier[0]
-	last := s.frontier[len(s.frontier)-1]
-	s.frontier = s.frontier[:len(s.frontier)-1]
+	last := s.frontier[lastIdx]
+	s.frontier[lastIdx].adjacency = nil
+	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
 		s.frontier[0] = last
 		s.frontierSiftDown(0)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 )
 
 type columnVectorGraphNativeSearchOptions struct {
@@ -194,6 +195,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			stats.Edges++
+			if strconv.IntSize == 32 && neighbor > uint32(1<<31-1) {
+				return nil, stats, fmt.Errorf("collections: column_graph neighbor ordinal %d exceeds int range", neighbor)
+			}
 			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -128,7 +128,9 @@ func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSea
 		clear(dst)
 		return make([]columnVectorGraphNativeSearchResult, 0, target)
 	}
-	clear(dst)
+	if len(dst) > target {
+		clear(dst)
+	}
 	return dst[:0]
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -60,8 +60,10 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	for _, rowScratch := range []*columnPhysicalRowReaderScratch{&s.scoreScratch, &s.expandScratch, &s.resultScratch} {
 		prepareColumnVectorGraphNativeRowScratch(rowScratch, dimensions, degree)
 	}
-	if len(s.visitMarks) < rowCount {
+	if cap(s.visitMarks) < rowCount {
 		s.visitMarks = make([]uint64, rowCount)
+	} else {
+		s.visitMarks = s.visitMarks[:rowCount]
 	}
 	s.visitEpoch++
 	if s.visitEpoch == 0 {
@@ -116,22 +118,20 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if len(query) != r.def.Dimensions {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d", r.def.Name, len(query), r.def.Dimensions)
 	}
-	queryInvNorm, err := columnVectorGraphInvNorm(query)
-	if err != nil {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w", r.def.Name, err)
-	}
 	rowCount := r.RowCount()
 	topK := opts.TopK
 	if topK < 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search top_k cannot be negative")
 	}
 	if topK == 0 || rowCount == 0 {
-		if scratch != nil {
-			if err := scratch.prepare(rowCount, r.def.Dimensions, r.def.M, 0); err != nil {
-				return nil, columnVectorGraphNativeSearchStats{}, err
-			}
-		}
 		return nil, columnVectorGraphNativeSearchStats{}, nil
+	}
+	if scratch == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search requires caller-owned scratch")
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w", r.def.Name, err)
 	}
 	if topK > rowCount {
 		topK = rowCount

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -79,11 +79,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	for _, rowScratch := range []*columnPhysicalRowReaderScratch{&s.scoreScratch, &s.expandScratch, &s.resultScratch} {
 		prepareColumnVectorGraphNativeRowScratch(rowScratch, dimensions, degree)
 	}
-	if cap(s.visitMarks) < rowCount {
-		s.visitMarks = make([]uint64, rowCount)
-	} else {
-		s.visitMarks = s.visitMarks[:rowCount]
-	}
+	s.visitMarks = resizeColumnVectorGraphNativeUint64Scratch(s.visitMarks, rowCount)
 	s.visitEpoch++
 	if s.visitEpoch == 0 {
 		clear(s.visitMarks)
@@ -149,6 +145,13 @@ func resizeColumnVectorGraphNativeIntScratch(dst []int, target int) []int {
 	return dst[:0]
 }
 
+func resizeColumnVectorGraphNativeUint64Scratch(dst []uint64, target int) []uint64 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]uint64, target)
+	}
+	return dst[:target]
+}
+
 func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][]byte {
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		next := make([][]byte, target)
@@ -205,7 +208,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	queryInvNorm, err := columnVectorGraphInvNorm(query)
 	if err != nil {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w: %v", r.def.Name, errColumnVectorGraphNativeSearchQueryNormInvalid, err)
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w: %w", r.def.Name, errColumnVectorGraphNativeSearchQueryNormInvalid, err)
 	}
 	if topK > rowCount {
 		topK = rowCount

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1,0 +1,235 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+type columnVectorGraphNativeSearchOptions struct {
+	TopK     int
+	EfSearch int
+}
+
+type columnVectorGraphNativeSearchStats struct {
+	Candidates       uint64
+	Edges            uint64
+	CandidateFetches uint64
+	ResultFetches    uint64
+}
+
+// columnVectorGraphNativeSearchResult aliases buffers owned by the search
+// scratch. Copy ID before the next search with the same scratch if retention is
+// required.
+type columnVectorGraphNativeSearchResult struct {
+	Ordinal int
+	ID      []byte
+	Score   float64
+}
+
+type columnVectorGraphSearchCandidate struct {
+	ordinal int
+	score   float64
+}
+
+// columnVectorGraphNativeSearchScratch is caller-owned mutable search state.
+// It is not concurrency-safe. Parallel searches over immutable graph assets are
+// valid with one reader and one scratch per worker.
+type columnVectorGraphNativeSearchScratch struct {
+	rowScratch columnPhysicalRowReaderScratch
+	visitMarks []uint64
+	visitEpoch uint64
+	queue      []int
+	top        []columnVectorGraphSearchCandidate
+	results    []columnVectorGraphNativeSearchResult
+	idBuffers  [][]byte
+}
+
+func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK int) error {
+	if s == nil {
+		return errors.New("collections: column_graph native search requires caller-owned scratch")
+	}
+	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 {
+		return errors.New("collections: column_graph native search received negative sizing input")
+	}
+	if cap(s.rowScratch.Values) < 3 {
+		s.rowScratch.Values = make([]columnDeclaredValue, 0, 3)
+	}
+	if cap(s.rowScratch.Float32Values) < dimensions {
+		s.rowScratch.Float32Values = make([]float32, 0, dimensions)
+	}
+	if cap(s.rowScratch.Uint32Values) < degree {
+		s.rowScratch.Uint32Values = make([]uint32, 0, degree)
+	}
+	if len(s.visitMarks) < rowCount {
+		s.visitMarks = make([]uint64, rowCount)
+	}
+	s.visitEpoch++
+	if s.visitEpoch == 0 {
+		clear(s.visitMarks)
+		s.visitEpoch = 1
+	}
+	s.queue = s.queue[:0]
+	if cap(s.queue) < rowCount {
+		s.queue = make([]int, 0, rowCount)
+	}
+	s.top = s.top[:0]
+	if cap(s.top) < topK {
+		s.top = make([]columnVectorGraphSearchCandidate, 0, topK)
+	}
+	s.results = s.results[:0]
+	if cap(s.results) < topK {
+		s.results = make([]columnVectorGraphNativeSearchResult, 0, topK)
+	}
+	if len(s.idBuffers) < topK {
+		next := make([][]byte, topK)
+		copy(next, s.idBuffers)
+		s.idBuffers = next
+	}
+	return nil
+}
+
+// SearchCosine traverses the persisted column graph through the physical row
+// reader. It fetches only graph rows: document materialization stays outside
+// this kernel.
+func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	if r == nil || r.reader == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: nil column vector graph physical row reader")
+	}
+	if len(query) != r.def.Dimensions {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d", r.def.Name, len(query), r.def.Dimensions)
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w", r.def.Name, err)
+	}
+	rowCount := r.RowCount()
+	topK := opts.TopK
+	if topK < 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search top_k cannot be negative")
+	}
+	if topK == 0 || rowCount == 0 {
+		if scratch != nil {
+			if err := scratch.prepare(rowCount, r.def.Dimensions, r.def.M, 0); err != nil {
+				return nil, columnVectorGraphNativeSearchStats{}, err
+			}
+		}
+		return nil, columnVectorGraphNativeSearchStats{}, nil
+	}
+	if topK > rowCount {
+		topK = rowCount
+	}
+	efSearch := opts.EfSearch
+	if efSearch <= 0 {
+		efSearch = r.def.EfSearch
+	}
+	if efSearch < topK {
+		efSearch = topK
+	}
+	if efSearch > rowCount {
+		efSearch = rowCount
+	}
+	degree := r.def.M
+	if degree < 0 {
+		degree = 0
+	}
+	if err := scratch.prepare(rowCount, r.def.Dimensions, degree, topK); err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, err
+	}
+
+	scratch.markAndEnqueue(0)
+	var stats columnVectorGraphNativeSearchStats
+	nextSeed := 0
+	for head := 0; stats.Candidates < uint64(efSearch); {
+		if head >= len(scratch.queue) {
+			for nextSeed < rowCount && scratch.visitMarks[nextSeed] == scratch.visitEpoch {
+				nextSeed++
+			}
+			if nextSeed >= rowCount {
+				break
+			}
+			scratch.markAndEnqueue(nextSeed)
+			continue
+		}
+		ordinal := scratch.queue[head]
+		head++
+		row, err := r.FetchRow(ordinal, &scratch.rowScratch)
+		if err != nil {
+			return nil, stats, err
+		}
+		stats.CandidateFetches++
+		stats.Candidates++
+		score := columnVectorGraphNativeCosineScore(query, queryInvNorm, row)
+		if math.IsNaN(score) {
+			return nil, stats, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is NaN", r.def.Name, ordinal)
+		}
+		scratch.insertTop(topK, columnVectorGraphSearchCandidate{ordinal: ordinal, score: score})
+		for _, neighbor := range row.Adjacency {
+			stats.Edges++
+			scratch.markAndEnqueue(int(neighbor))
+		}
+	}
+
+	if len(scratch.top) == 0 {
+		return scratch.results, stats, nil
+	}
+	for i, candidate := range scratch.top {
+		row, err := r.FetchRow(candidate.ordinal, &scratch.rowScratch)
+		if err != nil {
+			return nil, stats, err
+		}
+		stats.ResultFetches++
+		if cap(scratch.idBuffers[i]) < len(row.ID) {
+			scratch.idBuffers[i] = make([]byte, len(row.ID))
+		}
+		scratch.idBuffers[i] = scratch.idBuffers[i][:len(row.ID)]
+		copy(scratch.idBuffers[i], row.ID)
+		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
+			Ordinal: candidate.ordinal,
+			ID:      scratch.idBuffers[i],
+			Score:   candidate.score,
+		})
+	}
+	return scratch.results, stats, nil
+}
+
+func (s *columnVectorGraphNativeSearchScratch) markAndEnqueue(ordinal int) {
+	if ordinal < 0 || ordinal >= len(s.visitMarks) || s.visitMarks[ordinal] == s.visitEpoch {
+		return
+	}
+	s.visitMarks[ordinal] = s.visitEpoch
+	s.queue = append(s.queue, ordinal)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {
+	if limit <= 0 {
+		return
+	}
+	pos := len(s.top)
+	for pos > 0 && columnVectorGraphSearchCandidateLess(candidate, s.top[pos-1]) {
+		pos--
+	}
+	if pos >= limit {
+		return
+	}
+	if len(s.top) < limit {
+		s.top = append(s.top, columnVectorGraphSearchCandidate{})
+	}
+	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
+	s.top[pos] = candidate
+}
+
+func columnVectorGraphSearchCandidateLess(left, right columnVectorGraphSearchCandidate) bool {
+	if left.score == right.score {
+		return left.ordinal < right.ordinal
+	}
+	return left.score > right.score
+}
+
+func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) float64 {
+	var dot float64
+	for i, v := range query {
+		dot += float64(v) * float64(row.Vector[i])
+	}
+	return dot * float64(queryInvNorm) * float64(row.InvNorm)
+}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -312,8 +312,8 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float3
 		if err != nil {
 			return err
 		}
-		if math.IsNaN(score) {
-			return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is NaN", r.def.Name, ordinal)
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
 		}
 		stats.Candidates++
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -180,6 +180,10 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if topK < 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative", r.def.Name)
 	}
+	efSearch := opts.EfSearch
+	if efSearch < 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative", r.def.Name)
+	}
 	if topK == 0 || rowCount == 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, nil
 	}
@@ -192,10 +196,6 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	if topK > rowCount {
 		topK = rowCount
-	}
-	efSearch := opts.EfSearch
-	if efSearch < 0 {
-		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative", r.def.Name)
 	}
 	if efSearch == 0 {
 		efSearch = r.def.EfSearch

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -15,6 +15,7 @@ type columnVectorGraphNativeSearchStats struct {
 	Candidates       uint64
 	Edges            uint64
 	CandidateFetches uint64
+	ExpansionFetches uint64
 	ResultFetches    uint64
 }
 
@@ -36,13 +37,17 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	rowScratch columnPhysicalRowReaderScratch
-	visitMarks []uint64
-	visitEpoch uint64
-	queue      []int
-	top        []columnVectorGraphSearchCandidate
-	results    []columnVectorGraphNativeSearchResult
-	idBuffers  [][]byte
+	scoreScratch   columnPhysicalRowReaderScratch
+	expandScratch  columnPhysicalRowReaderScratch
+	resultScratch  columnPhysicalRowReaderScratch
+	visitMarks     []uint64
+	visitEpoch     uint64
+	frontier       []columnVectorGraphSearchCandidate
+	top            []columnVectorGraphSearchCandidate
+	results        []columnVectorGraphNativeSearchResult
+	idBuffers      [][]byte
+	resultOrder    []int
+	resultOrdinals []int
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK int) error {
@@ -52,14 +57,8 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if rowCount < 0 || dimensions < 0 || degree < 0 || topK < 0 {
 		return errors.New("collections: column_graph native search received negative sizing input")
 	}
-	if cap(s.rowScratch.Values) < 3 {
-		s.rowScratch.Values = make([]columnDeclaredValue, 0, 3)
-	}
-	if cap(s.rowScratch.Float32Values) < dimensions {
-		s.rowScratch.Float32Values = make([]float32, 0, dimensions)
-	}
-	if cap(s.rowScratch.Uint32Values) < degree {
-		s.rowScratch.Uint32Values = make([]uint32, 0, degree)
+	for _, rowScratch := range []*columnPhysicalRowReaderScratch{&s.scoreScratch, &s.expandScratch, &s.resultScratch} {
+		prepareColumnVectorGraphNativeRowScratch(rowScratch, dimensions, degree)
 	}
 	if len(s.visitMarks) < rowCount {
 		s.visitMarks = make([]uint64, rowCount)
@@ -69,9 +68,9 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		clear(s.visitMarks)
 		s.visitEpoch = 1
 	}
-	s.queue = s.queue[:0]
-	if cap(s.queue) < rowCount {
-		s.queue = make([]int, 0, rowCount)
+	s.frontier = s.frontier[:0]
+	if cap(s.frontier) < rowCount {
+		s.frontier = make([]columnVectorGraphSearchCandidate, 0, rowCount)
 	}
 	s.top = s.top[:0]
 	if cap(s.top) < topK {
@@ -86,7 +85,25 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		copy(next, s.idBuffers)
 		s.idBuffers = next
 	}
+	if cap(s.resultOrder) < topK {
+		s.resultOrder = make([]int, 0, topK)
+	}
+	if cap(s.resultOrdinals) < topK {
+		s.resultOrdinals = make([]int, 0, topK)
+	}
 	return nil
+}
+
+func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch, dimensions, degree int) {
+	if cap(s.Values) < 3 {
+		s.Values = make([]columnDeclaredValue, 0, 3)
+	}
+	if cap(s.Float32Values) < dimensions {
+		s.Float32Values = make([]float32, 0, dimensions)
+	}
+	if cap(s.Uint32Values) < degree {
+		s.Uint32Values = make([]uint32, 0, degree)
+	}
 }
 
 // SearchCosine traverses the persisted column graph through the physical row
@@ -137,68 +154,180 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, columnVectorGraphNativeSearchStats{}, err
 	}
 
-	scratch.markAndEnqueue(0)
 	var stats columnVectorGraphNativeSearchStats
+	if err := r.scoreAndPushFrontier(query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
+		return nil, stats, err
+	}
 	nextSeed := 0
-	for head := 0; stats.Candidates < uint64(efSearch); {
-		if head >= len(scratch.queue) {
+	for stats.Candidates < uint64(efSearch) {
+		candidate, ok := scratch.popFrontier()
+		if !ok {
 			for nextSeed < rowCount && scratch.visitMarks[nextSeed] == scratch.visitEpoch {
 				nextSeed++
 			}
 			if nextSeed >= rowCount {
 				break
 			}
-			scratch.markAndEnqueue(nextSeed)
+			if err := r.scoreAndPushFrontier(query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
+				return nil, stats, err
+			}
 			continue
 		}
-		ordinal := scratch.queue[head]
-		head++
-		row, err := r.FetchRow(ordinal, &scratch.rowScratch)
+		row, err := r.FetchRow(candidate.ordinal, &scratch.expandScratch)
 		if err != nil {
 			return nil, stats, err
 		}
-		stats.CandidateFetches++
-		stats.Candidates++
-		score := columnVectorGraphNativeCosineScore(query, queryInvNorm, row)
-		if math.IsNaN(score) {
-			return nil, stats, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is NaN", r.def.Name, ordinal)
-		}
-		scratch.insertTop(topK, columnVectorGraphSearchCandidate{ordinal: ordinal, score: score})
+		stats.ExpansionFetches++
 		for _, neighbor := range row.Adjacency {
 			stats.Edges++
-			scratch.markAndEnqueue(int(neighbor))
+			if stats.Candidates >= uint64(efSearch) {
+				break
+			}
+			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
+				return nil, stats, err
+			}
 		}
 	}
 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
+	if err := r.fetchTopSearchResults(scratch, &stats); err != nil {
+		return nil, stats, err
+	}
+	return scratch.results, stats, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	n := len(scratch.top)
+	scratch.resultOrder = scratch.resultOrder[:n]
+	scratch.resultOrdinals = scratch.resultOrdinals[:n]
+	for i := 0; i < n; i++ {
+		scratch.resultOrder[i] = i
+	}
+	for i := 1; i < n; i++ {
+		order := scratch.resultOrder[i]
+		ordinal := scratch.top[order].ordinal
+		j := i - 1
+		for j >= 0 && scratch.top[scratch.resultOrder[j]].ordinal > ordinal {
+			scratch.resultOrder[j+1] = scratch.resultOrder[j]
+			j--
+		}
+		scratch.resultOrder[j+1] = order
+	}
+	for fetchPos, topIndex := range scratch.resultOrder {
+		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
+	}
+	fetchPos := 0
+	if err := r.FetchBatch(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
+		if fetchPos >= n {
+			return fmt.Errorf("collections: column_graph %q result batch returned extra row ordinal=%d", r.def.Name, row.Ordinal)
+		}
+		topIndex := scratch.resultOrder[fetchPos]
+		candidate := scratch.top[topIndex]
+		if row.Ordinal != candidate.ordinal {
+			return fmt.Errorf("collections: column_graph %q result batch row ordinal=%d want %d", r.def.Name, row.Ordinal, candidate.ordinal)
+		}
+		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {
+			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
+		}
+		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(row.ID)]
+		copy(scratch.idBuffers[topIndex], row.ID)
+		fetchPos++
+		return nil
+	}); err != nil {
+		return err
+	}
+	if fetchPos != n {
+		return fmt.Errorf("collections: column_graph %q result batch rows=%d want %d", r.def.Name, fetchPos, n)
+	}
+	stats.ResultFetches += uint64(n)
 	for i, candidate := range scratch.top {
-		row, err := r.FetchRow(candidate.ordinal, &scratch.rowScratch)
-		if err != nil {
-			return nil, stats, err
-		}
-		stats.ResultFetches++
-		if cap(scratch.idBuffers[i]) < len(row.ID) {
-			scratch.idBuffers[i] = make([]byte, len(row.ID))
-		}
-		scratch.idBuffers[i] = scratch.idBuffers[i][:len(row.ID)]
-		copy(scratch.idBuffers[i], row.ID)
 		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
 			Ordinal: candidate.ordinal,
 			ID:      scratch.idBuffers[i],
 			Score:   candidate.score,
 		})
 	}
-	return scratch.results, stats, nil
+	return nil
 }
 
-func (s *columnVectorGraphNativeSearchScratch) markAndEnqueue(ordinal int) {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if scratch.markVisited(ordinal) {
+		row, err := r.FetchRow(ordinal, &scratch.scoreScratch)
+		if err != nil {
+			return err
+		}
+		stats.CandidateFetches++
+		score, err := columnVectorGraphNativeCosineScore(query, queryInvNorm, row)
+		if err != nil {
+			return err
+		}
+		if math.IsNaN(score) {
+			return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is NaN", r.def.Name, ordinal)
+		}
+		stats.Candidates++
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
+		scratch.insertTop(topK, candidate)
+		scratch.pushFrontier(candidate)
+	}
+	return nil
+}
+
+func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {
 	if ordinal < 0 || ordinal >= len(s.visitMarks) || s.visitMarks[ordinal] == s.visitEpoch {
-		return
+		return false
 	}
 	s.visitMarks[ordinal] = s.visitEpoch
-	s.queue = append(s.queue, ordinal)
+	return true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate) {
+	s.frontier = append(s.frontier, candidate)
+	s.frontierSiftUp(len(s.frontier) - 1)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphSearchCandidate, bool) {
+	if len(s.frontier) == 0 {
+		return columnVectorGraphSearchCandidate{}, false
+	}
+	best := s.frontier[0]
+	last := s.frontier[len(s.frontier)-1]
+	s.frontier = s.frontier[:len(s.frontier)-1]
+	if len(s.frontier) > 0 {
+		s.frontier[0] = last
+		s.frontierSiftDown(0)
+	}
+	return best, true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int) {
+	for idx > 0 {
+		parent := (idx - 1) / 2
+		if !columnVectorGraphSearchCandidateLess(s.frontier[idx], s.frontier[parent]) {
+			return
+		}
+		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
+		idx = parent
+	}
+}
+
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
+	for {
+		left := idx*2 + 1
+		if left >= len(s.frontier) {
+			return
+		}
+		child := left
+		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateLess(s.frontier[right], s.frontier[left]) {
+			child = right
+		}
+		if !columnVectorGraphSearchCandidateLess(s.frontier[child], s.frontier[idx]) {
+			return
+		}
+		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
+		idx = child
+	}
 }
 
 func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {
@@ -226,10 +355,13 @@ func columnVectorGraphSearchCandidateLess(left, right columnVectorGraphSearchCan
 	return left.score > right.score
 }
 
-func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) float64 {
+func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {
+	if len(row.Vector) != len(query) {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d", row.Ordinal, len(row.Vector), len(query))
+	}
 	var dot float64
 	for i, v := range query {
 		dot += float64(v) * float64(row.Vector[i])
 	}
-	return dot * float64(queryInvNorm) * float64(row.InvNorm)
+	return dot * float64(queryInvNorm) * float64(row.InvNorm), nil
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -20,8 +20,8 @@ type columnVectorGraphNativeSearchStats struct {
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
-// scratch. Copy ID before the next search with the same scratch if retention is
-// required.
+// scratch. Callers must copy the returned result slice and any retained result
+// IDs before the next search with the same scratch.
 type columnVectorGraphNativeSearchResult struct {
 	Ordinal int
 	ID      []byte

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 )
 
 type columnVectorGraphNativeSearchOptions struct {
@@ -190,13 +189,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			return nil, stats, err
 		}
 		stats.ExpansionFetches++
-		for _, neighbor := range row.Adjacency {
+		for i, neighbor := range row.Adjacency {
 			if stats.Candidates >= uint64(efSearch) {
 				break
 			}
 			stats.Edges++
-			if strconv.IntSize == 32 && neighbor > uint32(1<<31-1) {
-				return nil, stats, fmt.Errorf("collections: column_graph neighbor ordinal %d exceeds int range", neighbor)
+			if uint64(neighbor) >= uint64(rowCount) {
+				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, row.Ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
 				return nil, stats, err

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -129,7 +129,7 @@ func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSea
 		clear(dst)
 		return make([]columnVectorGraphNativeSearchResult, 0, target)
 	}
-	if len(dst) > target {
+	if len(dst) > 0 {
 		clear(dst)
 	}
 	return dst[:0]
@@ -178,7 +178,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	rowCount := r.RowCount()
 	topK := opts.TopK
 	if topK < 0 {
-		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search top_k cannot be negative")
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative", r.def.Name)
 	}
 	if topK == 0 || rowCount == 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, nil
@@ -195,7 +195,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	efSearch := opts.EfSearch
 	if efSearch < 0 {
-		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: column_graph native search ef_search cannot be negative")
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative", r.def.Name)
 	}
 	if efSearch == 0 {
 		efSearch = r.def.EfSearch

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 )
 
 const columnVectorGraphNativeFrontierOversizeSlack = 16
+const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
@@ -125,7 +127,8 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 
 // SearchCosine traverses the persisted column graph through the physical row
 // reader. It fetches only graph rows: document materialization stays outside
-// this kernel.
+// this kernel. Returned results and result IDs alias scratch-owned buffers and
+// must be copied before the next SearchCosine call with the same scratch.
 func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
 	if r == nil || r.reader == nil {
 		return nil, columnVectorGraphNativeSearchStats{}, errors.New("collections: nil column vector graph physical row reader")
@@ -228,16 +231,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	for i := 0; i < n; i++ {
 		scratch.resultOrder[i] = i
 	}
-	for i := 1; i < n; i++ {
-		order := scratch.resultOrder[i]
-		ordinal := scratch.top[order].ordinal
-		j := i - 1
-		for j >= 0 && scratch.top[scratch.resultOrder[j]].ordinal > ordinal {
-			scratch.resultOrder[j+1] = scratch.resultOrder[j]
-			j--
-		}
-		scratch.resultOrder[j+1] = order
-	}
+	sortColumnVectorGraphResultOrderByOrdinal(scratch.resultOrder, scratch.top)
 	for fetchPos, topIndex := range scratch.resultOrder {
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
@@ -275,6 +269,25 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 		})
 	}
 	return nil
+}
+
+func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGraphSearchCandidate) {
+	if len(order) <= columnVectorGraphNativeResultOrderInsertionSortLimit {
+		for i := 1; i < len(order); i++ {
+			item := order[i]
+			ordinal := top[item].ordinal
+			j := i - 1
+			for j >= 0 && top[order[j]].ordinal > ordinal {
+				order[j+1] = order[j]
+				j--
+			}
+			order[j+1] = item
+		}
+		return
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return top[order[i]].ordinal < top[order[j]].ordinal
+	})
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 )
 
+const columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 = 8
+
 func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -295,6 +297,52 @@ func TestColumnVectorGraphNativeSearchScratchClearsResultAliasesV3(t *testing.T)
 	}
 }
 
+func TestColumnVectorGraphNativeSearchScratchClearsRowValueAliasesV3(t *testing.T) {
+	var scratch columnVectorGraphNativeSearchScratch
+	staleBytes := []byte("stale-bytes")
+	staleVector := []float32{1, 2, 3}
+	staleAdjacency := []uint32{4, 5}
+	scratch.scoreScratch.Values = make([]columnDeclaredValue, 1, columnVectorGraphPhysicalRowValueCount)
+	scratch.scoreScratch.Values[0] = columnDeclaredValue{
+		Type:          ColumnStoreValueString,
+		Present:       true,
+		String:        "stale-string",
+		StringBytes:   staleBytes,
+		Float32Vector: staleVector,
+		AdjacencyList: staleAdjacency,
+	}
+	oldValues := scratch.scoreScratch.Values
+	if err := scratch.prepare(1, 3, 2, 1, 1); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if len(scratch.scoreScratch.Values) != 0 {
+		t.Fatalf("prepared row values len=%d want zero", len(scratch.scoreScratch.Values))
+	}
+	for i, value := range oldValues {
+		if value.String != "" || value.StringBytes != nil || value.Float32Vector != nil || value.AdjacencyList != nil {
+			t.Fatalf("old row value[%d] retained aliases: string=%q bytes=%v vector=%v adjacency=%v", i, value.String, value.StringBytes, value.Float32Vector, value.AdjacencyList)
+		}
+	}
+}
+
+func TestColumnVectorGraphNativeSearchScratchClearsIDBufferGrowthAliasesV3(t *testing.T) {
+	stale := []byte("stale-doc")
+	dst := make([][]byte, 1, 4)
+	expanded := dst[:4]
+	expanded[2] = stale
+	dst = expanded[:1]
+
+	dst = resizeColumnVectorGraphNativeIDBuffersScratch(dst, 3)
+	if len(dst) != 3 {
+		t.Fatalf("id buffers len=%d want 3", len(dst))
+	}
+	for i := 1; i < len(dst); i++ {
+		if dst[i] != nil {
+			t.Fatalf("newly exposed id buffer[%d] retained alias %q", i, string(dst[i]))
+		}
+	}
+}
+
 func TestColumnVectorGraphNativeSearchDoesNotFetchDocumentsV3(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -520,6 +568,11 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 		scratch columnVectorGraphNativeSearchScratch
 	}
 	workers := runtime.GOMAXPROCS(0)
+	if workers > columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 {
+		workers = columnVectorGraphNativeSearchParallelBenchMaxWorkersV3
+	}
+	previousGOMAXPROCS := runtime.GOMAXPROCS(workers)
+	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
 	benchWorkers := make([]*searchWorker, workers)
 	query := append([]float32(nil), input[37].vector...)
 	for i := range benchWorkers {
@@ -594,6 +647,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
 	}
+	b.ReportMetric(float64(workers), "parallel_workers")
 	columnPhysicalScanBenchSum += sink.Load()
 	var stats columnPhysicalRowReaderStats
 	for _, worker := range benchWorkers {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -146,15 +145,15 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
 	_, _, err = reader.SearchCosine([]float32{1, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "query dims=2 want 3") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
 		t.Fatalf("SearchCosine dim err=%v want dimension failure", err)
 	}
 	_, _, err = reader.SearchCosine([]float32{0, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "query norm") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryNormInvalid) {
 		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
 	}
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: -1}, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchEfSearchNegative) {
 		t.Fatalf("SearchCosine ef_search err=%v want negative ef_search failure", err)
 	}
 }
@@ -184,12 +183,12 @@ func TestColumnVectorGraphNativeSearchRequiresScratchV3(t *testing.T) {
 		t.Fatalf("zero top_k results=%v stats=%+v want empty", got, stats)
 	}
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: -1}, nil)
-	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchEfSearchNegative) {
 		t.Fatalf("SearchCosine zero top_k ef_search err=%v want negative ef_search failure", err)
 	}
 
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, nil)
-	if err == nil || !strings.Contains(err.Error(), "requires caller-owned scratch") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchScratchRequired) {
 		t.Fatalf("SearchCosine err=%v want caller-owned scratch failure", err)
 	}
 }
@@ -200,7 +199,7 @@ func TestColumnVectorGraphNativeCosineScoreRejectsMalformedRowV3(t *testing.T) {
 		Vector:  []float32{1},
 		InvNorm: 1,
 	})
-	if err == nil || !strings.Contains(err.Error(), "ordinal=7 vector dims=1 want 2") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchCandidateDimensionMismatch) {
 		t.Fatalf("columnVectorGraphNativeCosineScore err=%v want dimension failure", err)
 	}
 }
@@ -227,7 +226,7 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 		t.Fatalf("empty search results=%v stats=%+v want empty", got, stats)
 	}
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: -1}, &scratch)
-	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+	if !errors.Is(err, errColumnVectorGraphNativeSearchEfSearchNegative) {
 		t.Fatalf("SearchCosine empty ef_search err=%v want negative ef_search failure", err)
 	}
 	got, stats, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: 10}, nil)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -269,6 +269,15 @@ func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeScratchCapOversizedOverflowSafeV3(t *testing.T) {
+	if !columnVectorGraphNativeScratchCapOversized(64, 1) {
+		t.Fatalf("expected oversized scratch cap for small target")
+	}
+	if columnVectorGraphNativeScratchCapOversized(math.MaxInt, math.MaxInt/2+1) {
+		t.Fatalf("overflow-sized target must not wrap oversized threshold")
+	}
+}
+
 func TestColumnVectorGraphNativeSearchScratchClearsResultAliasesV3(t *testing.T) {
 	var scratch columnVectorGraphNativeSearchScratch
 	oldID := []byte("old-doc")
@@ -452,6 +461,9 @@ func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
 		got, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch)
 		if err != nil {
 			t.Fatalf("SearchCosine: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("SearchCosine returned no results")
 		}
 		columnPhysicalScanBenchSum += int64(got[0].Ordinal)
 	})

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -457,16 +457,25 @@ func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
 	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch); err != nil {
 		t.Fatalf("warm SearchCosine: %v", err)
 	}
+	var hotErr error
 	allocs := testing.AllocsPerRun(1000, func() {
+		if hotErr != nil {
+			return
+		}
 		got, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch)
 		if err != nil {
-			t.Fatalf("SearchCosine: %v", err)
+			hotErr = err
+			return
 		}
 		if len(got) == 0 {
-			t.Fatalf("SearchCosine returned no results")
+			hotErr = errors.New("SearchCosine returned no results")
+			return
 		}
 		columnPhysicalScanBenchSum += int64(got[0].Ordinal)
 	})
+	if hotErr != nil {
+		t.Fatalf("SearchCosine: %v", hotErr)
+	}
 	if allocs != 0 {
 		t.Fatalf("hot SearchCosine allocs=%v want zero", allocs)
 	}
@@ -571,6 +580,9 @@ func BenchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B) {
 		if err != nil {
 			b.Fatalf("SearchCosine: %v", err)
 		}
+		if len(got) == 0 {
+			b.Fatalf("SearchCosine returned no results")
+		}
 		columnPhysicalScanBenchSum += int64(got[0].Ordinal)
 		searchStats.Candidates += stats.Candidates
 		searchStats.Edges += stats.Edges
@@ -663,6 +675,10 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 			got, stats, err := worker.reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &worker.scratch)
 			if err != nil {
 				recordParallelErr("SearchCosine: %v", err)
+				continue
+			}
+			if len(got) == 0 {
+				recordParallelErr("SearchCosine returned no results")
 				continue
 			}
 			localSink += int64(got[0].Ordinal)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -231,14 +231,14 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 
 func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	var scratch columnVectorGraphNativeSearchScratch
-	if err := scratch.prepare(10, 3, 2, 1, 4); err != nil {
+	if err := scratch.prepare(64, 3, 2, 64, 64); err != nil {
 		t.Fatalf("prepare large: %v", err)
 	}
-	if len(scratch.visitMarks) != 10 {
-		t.Fatalf("large visitMarks len=%d want 10", len(scratch.visitMarks))
+	if len(scratch.visitMarks) != 64 {
+		t.Fatalf("large visitMarks len=%d want 64", len(scratch.visitMarks))
 	}
-	if cap(scratch.frontier) > 4 {
-		t.Fatalf("frontier cap=%d want bounded by ef_search", cap(scratch.frontier))
+	if cap(scratch.frontier) < 64 || cap(scratch.top) < 64 || cap(scratch.results) < 64 || cap(scratch.idBuffers) < 64 || cap(scratch.resultOrder) < 64 || cap(scratch.resultOrdinals) < 64 {
+		t.Fatalf("large scratch caps frontier=%d top=%d results=%d idBuffers=%d resultOrder=%d resultOrdinals=%d want at least 64", cap(scratch.frontier), cap(scratch.top), cap(scratch.results), cap(scratch.idBuffers), cap(scratch.resultOrder), cap(scratch.resultOrdinals))
 	}
 	if err := scratch.prepare(1, 3, 2, 1, 1); err != nil {
 		t.Fatalf("prepare small: %v", err)
@@ -248,6 +248,14 @@ func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	}
 	if scratch.markVisited(5) {
 		t.Fatalf("markVisited accepted stale ordinal outside current row count")
+	}
+	if cap(scratch.frontier) > 1+columnVectorGraphNativeScratchOversizeSlack ||
+		cap(scratch.top) > 1+columnVectorGraphNativeScratchOversizeSlack ||
+		cap(scratch.results) > 1+columnVectorGraphNativeScratchOversizeSlack ||
+		cap(scratch.idBuffers) > 1+columnVectorGraphNativeScratchOversizeSlack ||
+		cap(scratch.resultOrder) > 1+columnVectorGraphNativeScratchOversizeSlack ||
+		cap(scratch.resultOrdinals) > 1+columnVectorGraphNativeScratchOversizeSlack {
+		t.Fatalf("small scratch retained oversized caps frontier=%d top=%d results=%d idBuffers=%d resultOrder=%d resultOrdinals=%d", cap(scratch.frontier), cap(scratch.top), cap(scratch.results), cap(scratch.idBuffers), cap(scratch.resultOrder), cap(scratch.resultOrdinals))
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -152,6 +152,9 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryNormInvalid) {
 		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
 	}
+	if !errors.Is(err, errColumnVectorGraphInvNormNormInvalid) {
+		t.Fatalf("SearchCosine zero err=%v want underlying inv_norm failure", err)
+	}
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: -1, EfSearch: 1}, &scratch)
 	if !errors.Is(err, errColumnVectorGraphNativeSearchTopKNegative) {
 		t.Fatalf("SearchCosine top_k err=%v want negative top_k failure", err)
@@ -258,6 +261,9 @@ func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	}
 	if len(scratch.visitMarks) != 1 {
 		t.Fatalf("small visitMarks len=%d want 1", len(scratch.visitMarks))
+	}
+	if cap(scratch.visitMarks) > 1+columnVectorGraphNativeScratchOversizeSlack {
+		t.Fatalf("small visitMarks retained oversized cap=%d", cap(scratch.visitMarks))
 	}
 	if scratch.markVisited(5) {
 		t.Fatalf("markVisited accepted stale ordinal outside current row count")

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -131,6 +131,37 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchRequiresScratchV3(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 0, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: 1}, nil)
+	if err != nil {
+		t.Fatalf("SearchCosine zero top_k with nil scratch: %v", err)
+	}
+	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
+		t.Fatalf("zero top_k results=%v stats=%+v want empty", got, stats)
+	}
+
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires caller-owned scratch") {
+		t.Fatalf("SearchCosine err=%v want caller-owned scratch failure", err)
+	}
+}
+
 func TestColumnVectorGraphNativeCosineScoreRejectsMalformedRowV3(t *testing.T) {
 	_, err := columnVectorGraphNativeCosineScore([]float32{1, 0}, 1, columnVectorGraphPhysicalRow{
 		Ordinal: 7,
@@ -162,6 +193,32 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 	}
 	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
 		t.Fatalf("empty search results=%v stats=%+v want empty", got, stats)
+	}
+	got, stats, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: 10}, nil)
+	if err != nil {
+		t.Fatalf("SearchCosine zero top_k with nil scratch: %v", err)
+	}
+	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
+		t.Fatalf("zero top_k results=%v stats=%+v want empty", got, stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
+	var scratch columnVectorGraphNativeSearchScratch
+	if err := scratch.prepare(10, 3, 2, 1); err != nil {
+		t.Fatalf("prepare large: %v", err)
+	}
+	if len(scratch.visitMarks) != 10 {
+		t.Fatalf("large visitMarks len=%d want 10", len(scratch.visitMarks))
+	}
+	if err := scratch.prepare(1, 3, 2, 1); err != nil {
+		t.Fatalf("prepare small: %v", err)
+	}
+	if len(scratch.visitMarks) != 1 {
+		t.Fatalf("small visitMarks len=%d want 1", len(scratch.visitMarks))
+	}
+	if scratch.markVisited(5) {
+		t.Fatalf("markVisited accepted stale ordinal outside current row count")
 	}
 }
 
@@ -379,27 +436,32 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 		b.Fatalf("RebuildVectorIndex: %v", err)
 	}
 	assertColumnGraphRebuildLoadedStatusV2A(b, status, def.Name)
+	type searchWorker struct {
+		reader  *columnVectorGraphPhysicalRowReader
+		scratch columnVectorGraphNativeSearchScratch
+	}
 	workers := runtime.GOMAXPROCS(0)
-	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
-	scratches := make([]columnVectorGraphNativeSearchScratch, workers)
+	benchWorkers := make([]*searchWorker, workers)
+	var workerPool sync.Pool
 	query := append([]float32(nil), input[37].vector...)
-	for i := range readers {
+	for i := range benchWorkers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 		if err != nil {
 			b.Fatalf("open reader %d: %v", i, err)
 		}
 		defer func() { _ = reader.Close() }()
-		readers[i] = reader
-		if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratches[i]); err != nil {
+		worker := &searchWorker{reader: reader}
+		if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &worker.scratch); err != nil {
 			b.Fatalf("warm reader %d SearchCosine: %v", i, err)
 		}
+		benchWorkers[i] = worker
+		workerPool.Put(worker)
 	}
 	var baseStats columnPhysicalRowReaderStats
-	for _, reader := range readers {
-		baseStats = addColumnPhysicalRowReaderStatsV3(baseStats, reader.Stats())
+	for _, worker := range benchWorkers {
+		baseStats = addColumnPhysicalRowReaderStatsV3(baseStats, worker.reader.Stats())
 	}
 
-	var nextWorker atomic.Uint32
 	var sink atomic.Int64
 	var totalCandidates atomic.Uint64
 	var totalEdges atomic.Uint64
@@ -409,19 +471,16 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
-		// testing.B.RunParallel starts GOMAXPROCS workers by default. Keep the
-		// prewarmed reader/scratch arrays sized to that value and do not raise
-		// parallelism here; each worker owns exactly one reader and scratch.
-		worker := int(nextWorker.Add(1)) - 1
-		if worker < 0 || worker >= len(readers) {
-			b.Fatalf("parallel worker=%d outside prewarmed readers=%d", worker, len(readers))
+		value := workerPool.Get()
+		if value == nil {
+			b.Fatalf("parallel worker requested more than %d prewarmed readers/scratches", workers)
 		}
-		reader := readers[worker]
-		scratch := &scratches[worker]
+		worker := value.(*searchWorker)
+		defer workerPool.Put(worker)
 		for pb.Next() {
-			got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, scratch)
+			got, stats, err := worker.reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &worker.scratch)
 			if err != nil {
-				b.Fatalf("SearchCosine worker=%d: %v", worker, err)
+				b.Fatalf("SearchCosine: %v", err)
 			}
 			sink.Add(int64(got[0].Ordinal))
 			totalCandidates.Add(stats.Candidates)
@@ -434,8 +493,8 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	b.StopTimer()
 	columnPhysicalScanBenchSum += sink.Load()
 	var stats columnPhysicalRowReaderStats
-	for _, reader := range readers {
-		stats = addColumnPhysicalRowReaderStatsV3(stats, reader.Stats())
+	for _, worker := range benchWorkers {
+		stats = addColumnPhysicalRowReaderStatsV3(stats, worker.reader.Stats())
 	}
 	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, columnVectorGraphNativeSearchStats{
 		Candidates:       totalCandidates.Load(),

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -152,6 +152,10 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryNormInvalid) {
 		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
 	}
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: -1, EfSearch: 1}, &scratch)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchTopKNegative) {
+		t.Fatalf("SearchCosine top_k err=%v want negative top_k failure", err)
+	}
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: -1}, &scratch)
 	if !errors.Is(err, errColumnVectorGraphNativeSearchEfSearchNegative) {
 		t.Fatalf("SearchCosine ef_search err=%v want negative ef_search failure", err)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -580,7 +580,7 @@ func exactColumnGraphTopKForTest(tb testing.TB, rows []columnGraphRebuildInputRo
 
 func insertColumnGraphTopForTest(top []columnVectorGraphSearchCandidate, limit int, candidate columnVectorGraphSearchCandidate) []columnVectorGraphSearchCandidate {
 	pos := len(top)
-	for pos > 0 && columnVectorGraphSearchCandidateLess(candidate, top[pos-1]) {
+	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, top[pos-1]) {
 		pos--
 	}
 	if pos >= limit {
@@ -630,15 +630,29 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
 	b.ReportMetric(float64(searchStats.ExpansionFetches)/float64(n), "expansion_fetches/search")
 	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
-	b.ReportMetric(float64(stats.CacheHits-baseStats.CacheHits)/float64(n), "cache_hits/search")
-	b.ReportMetric(float64(stats.CacheMisses-baseStats.CacheMisses)/float64(n), "cache_misses/search")
-	b.ReportMetric(float64(stats.DecodedBlocks-baseStats.DecodedBlocks)/float64(n), "decoded_blocks/search")
-	b.ReportMetric(float64(stats.GranulesTouched-baseStats.GranulesTouched)/float64(n), "granules_touched/search")
-	b.ReportMetric(float64(stats.PhysicalBytesRead-baseStats.PhysicalBytesRead)/float64(n), "physical_B/search")
+	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheHits, baseStats.CacheHits))/float64(n), "cache_hits/search")
+	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheMisses, baseStats.CacheMisses))/float64(n), "cache_misses/search")
+	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.DecodedBlocks, baseStats.DecodedBlocks))/float64(n), "decoded_blocks/search")
+	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.GranulesTouched, baseStats.GranulesTouched))/float64(n), "granules_touched/search")
+	b.ReportMetric(float64(deltaColumnGraphNativeBenchBytesV3(stats.PhysicalBytesRead, baseStats.PhysicalBytesRead))/float64(n), "physical_B/search")
 	b.ReportMetric(float64(stats.MaxResidentBytes), "max_resident_B")
 	if stats.Rows > 0 {
 		b.ReportMetric(float64(stats.OpenPhysicalBytesRead)/float64(stats.Rows), "asset_B/row")
 	}
+}
+
+func deltaColumnGraphNativeBenchCounterV3(current, base uint64) uint64 {
+	if current < base {
+		return 0
+	}
+	return current - base
+}
+
+func deltaColumnGraphNativeBenchBytesV3(current, base int64) int64 {
+	if current < base {
+		return 0
+	}
+	return current - base
 }
 
 func addColumnPhysicalRowReaderStatsV3(left, right columnPhysicalRowReaderStats) columnPhysicalRowReaderStats {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -259,6 +259,42 @@ func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchScratchClearsResultAliasesV3(t *testing.T) {
+	var scratch columnVectorGraphNativeSearchScratch
+	oldID := []byte("old-doc")
+	scratch.results = append(scratch.results,
+		columnVectorGraphNativeSearchResult{Ordinal: 7, ID: oldID, Score: 1},
+		columnVectorGraphNativeSearchResult{Ordinal: 8, ID: oldID, Score: 0.5},
+	)
+	oldResults := scratch.results
+	if err := scratch.prepare(1, 3, 2, 1, 1); err != nil {
+		t.Fatalf("prepare small: %v", err)
+	}
+	if len(scratch.results) != 0 {
+		t.Fatalf("prepared results len=%d want zero", len(scratch.results))
+	}
+	for i, result := range oldResults {
+		if result.ID != nil {
+			t.Fatalf("old result[%d] retained ID alias %q", i, string(result.ID))
+		}
+	}
+	scratch.results = make([]columnVectorGraphNativeSearchResult, 2, 64)
+	scratch.results[0].ID = oldID
+	scratch.results[1].ID = oldID
+	oldResults = scratch.results
+	if err := scratch.prepare(1, 3, 2, 1, 1); err != nil {
+		t.Fatalf("prepare oversized: %v", err)
+	}
+	if cap(scratch.results) > 1+columnVectorGraphNativeScratchOversizeSlack {
+		t.Fatalf("oversized prepared results cap=%d want bounded", cap(scratch.results))
+	}
+	for i, result := range oldResults {
+		if result.ID != nil {
+			t.Fatalf("oversized old result[%d] retained ID alias %q", i, string(result.ID))
+		}
+	}
+}
+
 func TestColumnVectorGraphNativeSearchDoesNotFetchDocumentsV3(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1,0 +1,488 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{1, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := []float32{0, 0.2, 1}
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	want := exactColumnGraphTopKForTest(t, rows, query, 2)
+	assertColumnGraphNativeSearchResultsV3(t, got, want)
+	if stats.Candidates != uint64(len(rows)) {
+		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
+	}
+	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ResultFetches != uint64(len(got)) {
+		t.Fatalf("stats=%+v want graph traversal row fetch accounting", stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 0, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnVectorGraphNativeSearchScratch
+	_, _, err = reader.SearchCosine([]float32{1, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "query dims=2 want 3") {
+		t.Fatalf("SearchCosine dim err=%v want dimension failure", err)
+	}
+	_, _, err = reader.SearchCosine([]float32{0, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "query norm") {
+		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, nil)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex empty collection: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 10}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine empty: %v", err)
+	}
+	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
+		t.Fatalf("empty search results=%v stats=%+v want empty", got, stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchDoesNotFetchDocumentsV3(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnVectorGraphNativeSearchScratch
+	got, _, err := reader.SearchCosine([]float32{0, 0, 1}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: len(rows)}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || string(got[0].ID) != "doc-c" {
+		t.Fatalf("results=%+v want doc-c", got)
+	}
+	// This kernel has no collection/document handle and returns only IDs,
+	// ordinals, and scores from physical graph rows. Document materialization
+	// belongs above this layer after top-k selection.
+}
+
+func TestColumnVectorGraphNativeSearchContinuesAcrossDisconnectedComponentsV3(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1},
+		{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{0, 0, 1}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: len(rows)}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || string(got[0].ID) != "doc-c" {
+		t.Fatalf("results=%+v want doc-c after disconnected traversal", got)
+	}
+	if stats.Candidates != uint64(len(rows)) || stats.Edges != 0 {
+		t.Fatalf("stats=%+v want all disconnected rows searched without edges", stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
+	const (
+		rows = 32
+		dims = 16
+		m    = 8
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[7].vector...)
+	var scratch columnVectorGraphNativeSearchScratch
+	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch); err != nil {
+		t.Fatalf("warm SearchCosine: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch)
+		if err != nil {
+			t.Fatalf("SearchCosine: %v", err)
+		}
+		columnPhysicalScanBenchSum += int64(got[0].Ordinal)
+	})
+	if allocs != 0 {
+		t.Fatalf("hot SearchCosine allocs=%v want zero", allocs)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchParallelReadersV3(t *testing.T) {
+	const (
+		rows = 128
+		dims = 32
+		m    = 16
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	query := append([]float32(nil), input[17].vector...)
+	workers := runtime.GOMAXPROCS(0)
+	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+	for i := range readers {
+		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+		if err != nil {
+			t.Fatalf("open reader %d: %v", i, err)
+		}
+		defer func() { _ = reader.Close() }()
+		readers[i] = reader
+	}
+	want, _, err := readers[0].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		t.Fatalf("baseline SearchCosine: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan string, len(readers))
+	for worker := range readers {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var scratch columnVectorGraphNativeSearchScratch
+			for i := 0; i < 100; i++ {
+				got, _, err := readers[worker].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &scratch)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d SearchCosine: %v", worker, err)
+					return
+				}
+				if mismatch := columnGraphNativeSearchResultsMismatchV3(got, want); mismatch != "" {
+					errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B) {
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(b, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	var scratch columnVectorGraphNativeSearchScratch
+	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratch); err != nil {
+		b.Fatalf("warm SearchCosine: %v", err)
+	}
+	baseStats := reader.Stats()
+	var searchStats columnVectorGraphNativeSearchStats
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratch)
+		if err != nil {
+			b.Fatalf("SearchCosine: %v", err)
+		}
+		columnPhysicalScanBenchSum += int64(got[0].Ordinal)
+		searchStats.Candidates += stats.Candidates
+		searchStats.Edges += stats.Edges
+		searchStats.CandidateFetches += stats.CandidateFetches
+		searchStats.ResultFetches += stats.ResultFetches
+	}
+	b.StopTimer()
+	stats := reader.Stats()
+	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, searchStats)
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(b, status, def.Name)
+	workers := runtime.GOMAXPROCS(0)
+	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+	scratches := make([]columnVectorGraphNativeSearchScratch, workers)
+	query := append([]float32(nil), input[37].vector...)
+	for i := range readers {
+		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+		if err != nil {
+			b.Fatalf("open reader %d: %v", i, err)
+		}
+		defer func() { _ = reader.Close() }()
+		readers[i] = reader
+		if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratches[i]); err != nil {
+			b.Fatalf("warm reader %d SearchCosine: %v", i, err)
+		}
+	}
+	var baseStats columnPhysicalRowReaderStats
+	for _, reader := range readers {
+		baseStats = addColumnPhysicalRowReaderStatsV3(baseStats, reader.Stats())
+	}
+
+	var nextWorker atomic.Uint32
+	var sink atomic.Int64
+	var totalCandidates atomic.Uint64
+	var totalEdges atomic.Uint64
+	var totalCandidateFetches atomic.Uint64
+	var totalResultFetches atomic.Uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		worker := int(nextWorker.Add(1)) - 1
+		if worker < 0 || worker >= len(readers) {
+			b.Fatalf("parallel worker=%d outside prewarmed readers=%d", worker, len(readers))
+		}
+		reader := readers[worker]
+		scratch := &scratches[worker]
+		for pb.Next() {
+			got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, scratch)
+			if err != nil {
+				b.Fatalf("SearchCosine worker=%d: %v", worker, err)
+			}
+			sink.Add(int64(got[0].Ordinal))
+			totalCandidates.Add(stats.Candidates)
+			totalEdges.Add(stats.Edges)
+			totalCandidateFetches.Add(stats.CandidateFetches)
+			totalResultFetches.Add(stats.ResultFetches)
+		}
+	})
+	b.StopTimer()
+	columnPhysicalScanBenchSum += sink.Load()
+	var stats columnPhysicalRowReaderStats
+	for _, reader := range readers {
+		stats = addColumnPhysicalRowReaderStatsV3(stats, reader.Stats())
+	}
+	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, columnVectorGraphNativeSearchStats{
+		Candidates:       totalCandidates.Load(),
+		Edges:            totalEdges.Load(),
+		CandidateFetches: totalCandidateFetches.Load(),
+		ResultFetches:    totalResultFetches.Load(),
+	})
+}
+
+func exactColumnGraphTopKForTest(tb testing.TB, rows []columnGraphRebuildInputRowV2A, query []float32, topK int) []columnVectorGraphNativeSearchResult {
+	tb.Helper()
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		tb.Fatalf("columnVectorGraphInvNorm query: %v", err)
+	}
+	var top []columnVectorGraphSearchCandidate
+	for ordinal, row := range rows {
+		invNorm, err := columnVectorGraphInvNorm(row.vector)
+		if err != nil {
+			tb.Fatalf("columnVectorGraphInvNorm row %d: %v", ordinal, err)
+		}
+		var dot float64
+		for i, v := range query {
+			dot += float64(v) * float64(row.vector[i])
+		}
+		score := dot * float64(queryInvNorm) * float64(invNorm)
+		top = insertColumnGraphTopForTest(top, topK, columnVectorGraphSearchCandidate{ordinal: ordinal, score: score})
+	}
+	out := make([]columnVectorGraphNativeSearchResult, len(top))
+	for i, candidate := range top {
+		out[i] = columnVectorGraphNativeSearchResult{
+			Ordinal: candidate.ordinal,
+			ID:      []byte(rows[candidate.ordinal].id),
+			Score:   candidate.score,
+		}
+	}
+	return out
+}
+
+func insertColumnGraphTopForTest(top []columnVectorGraphSearchCandidate, limit int, candidate columnVectorGraphSearchCandidate) []columnVectorGraphSearchCandidate {
+	pos := len(top)
+	for pos > 0 && columnVectorGraphSearchCandidateLess(candidate, top[pos-1]) {
+		pos--
+	}
+	if pos >= limit {
+		return top
+	}
+	if len(top) < limit {
+		top = append(top, columnVectorGraphSearchCandidate{})
+	}
+	copy(top[pos+1:], top[pos:len(top)-1])
+	top[pos] = candidate
+	return top
+}
+
+func assertColumnGraphNativeSearchResultsV3(tb testing.TB, got, want []columnVectorGraphNativeSearchResult) {
+	tb.Helper()
+	if mismatch := columnGraphNativeSearchResultsMismatchV3(got, want); mismatch != "" {
+		tb.Fatal(mismatch)
+	}
+}
+
+func columnGraphNativeSearchResultsMismatchV3(got, want []columnVectorGraphNativeSearchResult) string {
+	if len(got) != len(want) {
+		return fmt.Sprintf("results len=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].Ordinal != want[i].Ordinal || string(got[i].ID) != string(want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+			return fmt.Sprintf("result[%d]=%s want %s", i, columnGraphNativeSearchResultStringV3(got[i]), columnGraphNativeSearchResultStringV3(want[i]))
+		}
+	}
+	return ""
+}
+
+func columnGraphNativeSearchResultStringV3(result columnVectorGraphNativeSearchResult) string {
+	return fmt.Sprintf("{ordinal:%d id:%q score:%.9f}", result.Ordinal, string(result.ID), result.Score)
+}
+
+func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats, stats columnPhysicalRowReaderStats, searchStats columnVectorGraphNativeSearchStats) {
+	b.Helper()
+	if n <= 0 {
+		return
+	}
+	b.ReportMetric(float64(searchStats.Candidates)/float64(n), "candidates/search")
+	b.ReportMetric(float64(searchStats.Edges)/float64(n), "edges/search")
+	if searchStats.Candidates > 0 {
+		b.ReportMetric(float64(searchStats.Edges)/float64(searchStats.Candidates), "edges/node")
+	}
+	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
+	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
+	b.ReportMetric(float64(stats.CacheHits-baseStats.CacheHits)/float64(n), "cache_hits/search")
+	b.ReportMetric(float64(stats.CacheMisses-baseStats.CacheMisses)/float64(n), "cache_misses/search")
+	b.ReportMetric(float64(stats.DecodedBlocks-baseStats.DecodedBlocks)/float64(n), "decoded_blocks/search")
+	b.ReportMetric(float64(stats.GranulesTouched-baseStats.GranulesTouched)/float64(n), "granules_touched/search")
+	b.ReportMetric(float64(stats.PhysicalBytesRead-baseStats.PhysicalBytesRead)/float64(n), "physical_B/search")
+	b.ReportMetric(float64(stats.MaxResidentBytes), "max_resident_B")
+	if stats.Rows > 0 {
+		b.ReportMetric(float64(stats.OpenPhysicalBytesRead)/float64(stats.Rows), "asset_B/row")
+	}
+}
+
+func addColumnPhysicalRowReaderStatsV3(left, right columnPhysicalRowReaderStats) columnPhysicalRowReaderStats {
+	left.Rows += right.Rows
+	left.Granules += right.Granules
+	left.OpenGranulesRead += right.OpenGranulesRead
+	left.OpenPhysicalBytesRead += right.OpenPhysicalBytesRead
+	left.OpenSegmentCacheHits += right.OpenSegmentCacheHits
+	left.OpenSegmentCacheMisses += right.OpenSegmentCacheMisses
+	left.RowFetches += right.RowFetches
+	left.BatchFetches += right.BatchFetches
+	left.RowsFetched += right.RowsFetched
+	left.CacheHits += right.CacheHits
+	left.CacheMisses += right.CacheMisses
+	left.DecodedBlocks += right.DecodedBlocks
+	left.BlockEvictions += right.BlockEvictions
+	left.GranulesTouched += right.GranulesTouched
+	left.PhysicalBytesRead += right.PhysicalBytesRead
+	left.ResidentBytes += right.ResidentBytes
+	if right.MaxResidentBytes > left.MaxResidentBytes {
+		left.MaxResidentBytes = right.MaxResidentBytes
+	}
+	left.SegmentFileCacheHits += right.SegmentFileCacheHits
+	left.SegmentFileCacheMisses += right.SegmentFileCacheMisses
+	return left
+}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -29,7 +29,7 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	query := []float32{0, 0.2, 1}
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
@@ -63,7 +63,7 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 4}, &scratch)
@@ -92,7 +92,7 @@ func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 
 	var scratch columnVectorGraphNativeSearchScratch
 	got, _, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 3}, &scratch)
@@ -119,7 +119,7 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
 	_, _, err = reader.SearchCosine([]float32{1, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
 	if err == nil || !strings.Contains(err.Error(), "query dims=2 want 3") {
@@ -150,7 +150,7 @@ func TestColumnVectorGraphNativeSearchRequiresScratchV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 
 	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: 1}, nil)
 	if err != nil {
@@ -189,7 +189,7 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 10}, &scratch)
 	if err != nil {
@@ -246,7 +246,7 @@ func TestColumnVectorGraphNativeSearchDoesNotFetchDocumentsV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
 	got, _, err := reader.SearchCosine([]float32{0, 0, 1}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: len(rows)}, &scratch)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestColumnVectorGraphNativeSearchContinuesAcrossDisconnectedComponentsV3(t 
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine([]float32{0, 0, 1}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: len(rows)}, &scratch)
 	if err != nil {
@@ -304,7 +304,7 @@ func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	query := append([]float32(nil), input[7].vector...)
 	var scratch columnVectorGraphNativeSearchScratch
 	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch); err != nil {
@@ -344,7 +344,7 @@ func TestColumnVectorGraphNativeSearchParallelReadersV3(t *testing.T) {
 		if err != nil {
 			t.Fatalf("open reader %d: %v", i, err)
 		}
-		defer func() { _ = reader.Close() }()
+		defer reader.Close()
 		readers[i] = reader
 	}
 	want, _, err := readers[0].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &columnVectorGraphNativeSearchScratch{})
@@ -400,7 +400,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B) {
 	if err != nil {
 		b.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 	query := append([]float32(nil), input[37].vector...)
 	var scratch columnVectorGraphNativeSearchScratch
 	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratch); err != nil {
@@ -456,7 +456,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 		if err != nil {
 			b.Fatalf("open reader %d: %v", i, err)
 		}
-		defer func() { _ = reader.Close() }()
+		defer reader.Close()
 		worker := &searchWorker{reader: reader}
 		if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &worker.scratch); err != nil {
 			b.Fatalf("warm reader %d SearchCosine: %v", i, err)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -183,6 +183,10 @@ func TestColumnVectorGraphNativeSearchRequiresScratchV3(t *testing.T) {
 	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
 		t.Fatalf("zero top_k results=%v stats=%+v want empty", got, stats)
 	}
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: -1}, nil)
+	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+		t.Fatalf("SearchCosine zero top_k ef_search err=%v want negative ef_search failure", err)
+	}
 
 	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, nil)
 	if err == nil || !strings.Contains(err.Error(), "requires caller-owned scratch") {
@@ -221,6 +225,10 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 	}
 	if len(got) != 0 || stats != (columnVectorGraphNativeSearchStats{}) {
 		t.Fatalf("empty search results=%v stats=%+v want empty", got, stats)
+	}
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: -1}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+		t.Fatalf("SearchCosine empty ef_search err=%v want negative ef_search failure", err)
 	}
 	got, stats, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 0, EfSearch: 10}, nil)
 	if err != nil {
@@ -471,8 +479,8 @@ func TestColumnVectorGraphNativeSearchParallelReadersV3(t *testing.T) {
 	if workers < 2 {
 		workers = 2
 	}
-	if workers > 8 {
-		workers = 8
+	if workers > columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 {
+		workers = columnVectorGraphNativeSearchParallelBenchMaxWorkersV3
 	}
 	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
 	for i := range readers {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -129,6 +129,10 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "query norm") {
 		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
 	}
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: -1}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "ef_search cannot be negative") {
+		t.Fatalf("SearchCosine ef_search err=%v want negative ef_search failure", err)
+	}
 }
 
 func TestColumnVectorGraphNativeSearchRequiresScratchV3(t *testing.T) {
@@ -205,13 +209,16 @@ func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 
 func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	var scratch columnVectorGraphNativeSearchScratch
-	if err := scratch.prepare(10, 3, 2, 1); err != nil {
+	if err := scratch.prepare(10, 3, 2, 1, 4); err != nil {
 		t.Fatalf("prepare large: %v", err)
 	}
 	if len(scratch.visitMarks) != 10 {
 		t.Fatalf("large visitMarks len=%d want 10", len(scratch.visitMarks))
 	}
-	if err := scratch.prepare(1, 3, 2, 1); err != nil {
+	if cap(scratch.frontier) > 4 {
+		t.Fatalf("frontier cap=%d want bounded by ef_search", cap(scratch.frontier))
+	}
+	if err := scratch.prepare(1, 3, 2, 1, 1); err != nil {
 		t.Fatalf("prepare small: %v", err)
 	}
 	if len(scratch.visitMarks) != 1 {
@@ -463,6 +470,13 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	}
 
 	var sink atomic.Int64
+	var firstErr atomic.Value
+	var failed atomic.Bool
+	recordParallelErr := func(format string, args ...any) {
+		if failed.CompareAndSwap(false, true) {
+			firstErr.Store(fmt.Sprintf(format, args...))
+		}
+	}
 	var totalCandidates atomic.Uint64
 	var totalEdges atomic.Uint64
 	var totalCandidateFetches atomic.Uint64
@@ -473,14 +487,21 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		value := workerPool.Get()
 		if value == nil {
-			b.Fatalf("parallel worker requested more than %d prewarmed readers/scratches", workers)
+			recordParallelErr("parallel worker requested more than %d prewarmed readers/scratches", workers)
+			for pb.Next() {
+			}
+			return
 		}
 		worker := value.(*searchWorker)
 		defer workerPool.Put(worker)
 		for pb.Next() {
+			if failed.Load() {
+				continue
+			}
 			got, stats, err := worker.reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &worker.scratch)
 			if err != nil {
-				b.Fatalf("SearchCosine: %v", err)
+				recordParallelErr("SearchCosine: %v", err)
+				continue
 			}
 			sink.Add(int64(got[0].Ordinal))
 			totalCandidates.Add(stats.Candidates)
@@ -491,6 +512,9 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 		}
 	})
 	b.StopTimer()
+	if errValue := firstErr.Load(); errValue != nil {
+		b.Fatalf("%s", errValue.(string))
+	}
 	columnPhysicalScanBenchSum += sink.Load()
 	var stats columnPhysicalRowReaderStats
 	for _, worker := range benchWorkers {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -114,6 +114,49 @@ func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing
 	}
 }
 
+func TestColumnVectorGraphNativeSearchScratchClearsCandidateAdjacencyRefsV3(t *testing.T) {
+	var scratch columnVectorGraphNativeSearchScratch
+	scratch.frontier = append(scratch.frontier, columnVectorGraphSearchCandidate{
+		ordinal:   1,
+		score:     1,
+		adjacency: []uint32{1, 2},
+	})
+	scratch.top = append(scratch.top, columnVectorGraphSearchCandidate{
+		ordinal:   2,
+		score:     2,
+		adjacency: []uint32{3, 4},
+	})
+	if err := scratch.prepare(4, 3, 2, 1, 2); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "frontier after prepare", scratch.frontier)
+	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "top after prepare", scratch.top)
+
+	scratch.frontier = append(scratch.frontier,
+		columnVectorGraphSearchCandidate{ordinal: 1, score: 1, adjacency: []uint32{1}},
+		columnVectorGraphSearchCandidate{ordinal: 2, score: 2, adjacency: []uint32{2}},
+	)
+	if _, ok := scratch.popFrontier(); !ok {
+		t.Fatalf("popFrontier returned ok=false")
+	}
+	backing := scratch.frontier[:cap(scratch.frontier)]
+	for i := len(scratch.frontier); i < len(backing); i++ {
+		if backing[i].adjacency != nil {
+			t.Fatalf("frontier backing slot %d retained adjacency %v after pop", i, backing[i].adjacency)
+		}
+	}
+}
+
+func assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t *testing.T, label string, candidates []columnVectorGraphSearchCandidate) {
+	t.Helper()
+	backing := candidates[:cap(candidates)]
+	for i, candidate := range backing {
+		if candidate.adjacency != nil {
+			t.Fatalf("%s backing slot %d retained adjacency %v", label, i, candidate.adjacency)
+		}
+	}
+}
+
 func TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3(t *testing.T) {
 	rows := []columnVectorGraphAssetRow{
 		{ID: []byte("doc-start"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -502,6 +503,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	var totalExpansionFetches atomic.Uint64
 	var totalResultFetches atomic.Uint64
 	var nextWorker atomic.Uint64
+	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -606,7 +608,7 @@ func columnGraphNativeSearchResultsMismatchV3(got, want []columnVectorGraphNativ
 		return fmt.Sprintf("results len=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
 	}
 	for i := range want {
-		if got[i].Ordinal != want[i].Ordinal || string(got[i].ID) != string(want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
 			return fmt.Sprintf("result[%d]=%s want %s", i, columnGraphNativeSearchResultStringV3(got[i]), columnGraphNativeSearchResultStringV3(want[i]))
 		}
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -280,6 +280,22 @@ func TestColumnVectorGraphNativeSearchScratchClearsResultAliasesV3(t *testing.T)
 			t.Fatalf("old result[%d] retained ID alias %q", i, string(result.ID))
 		}
 	}
+	scratch.results = append(scratch.results,
+		columnVectorGraphNativeSearchResult{Ordinal: 9, ID: oldID, Score: 1},
+		columnVectorGraphNativeSearchResult{Ordinal: 10, ID: oldID, Score: 0.5},
+	)
+	oldResults = scratch.results
+	if err := scratch.prepare(2, 3, 2, 2, 2); err != nil {
+		t.Fatalf("prepare same target: %v", err)
+	}
+	if len(scratch.results) != 0 {
+		t.Fatalf("prepared same-target results len=%d want zero", len(scratch.results))
+	}
+	for i, result := range oldResults {
+		if result.ID != nil {
+			t.Fatalf("same-target old result[%d] retained ID alias %q", i, string(result.ID))
+		}
+	}
 	scratch.results = make([]columnVectorGraphNativeSearchResult, 2, 64)
 	scratch.results[0].ID = oldID
 	scratch.results[1].ID = oldID

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
@@ -101,6 +102,26 @@ func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing
 	}
 	if len(got) != 1 || got[0].Ordinal != 2 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want scoring fetches not to mutate expansion adjacency", got)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
+		{ID: []byte("doc-other"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 2}, &scratch)
+	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
+		t.Fatalf("SearchCosine err=%v want adjacency bounds sentinel", err)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -449,7 +449,6 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	}
 	workers := runtime.GOMAXPROCS(0)
 	benchWorkers := make([]*searchWorker, workers)
-	var workerPool sync.Pool
 	query := append([]float32(nil), input[37].vector...)
 	for i := range benchWorkers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
@@ -462,7 +461,6 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 			b.Fatalf("warm reader %d SearchCosine: %v", i, err)
 		}
 		benchWorkers[i] = worker
-		workerPool.Put(worker)
 	}
 	var baseStats columnPhysicalRowReaderStats
 	for _, worker := range benchWorkers {
@@ -482,18 +480,18 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	var totalCandidateFetches atomic.Uint64
 	var totalExpansionFetches atomic.Uint64
 	var totalResultFetches atomic.Uint64
+	var nextWorker atomic.Uint64
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
-		value := workerPool.Get()
-		if value == nil {
+		workerIndex := int(nextWorker.Add(1)) - 1
+		if workerIndex < 0 || workerIndex >= len(benchWorkers) {
 			recordParallelErr("parallel worker requested more than %d prewarmed readers/scratches", workers)
 			for pb.Next() {
 			}
 			return
 		}
-		worker := value.(*searchWorker)
-		defer workerPool.Put(worker)
+		worker := benchWorkers[workerIndex]
 		for pb.Next() {
 			if failed.Load() {
 				continue

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -41,8 +41,66 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if stats.Candidates != uint64(len(rows)) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
-	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ResultFetches != uint64(len(got)) {
+	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ExpansionFetches == 0 || stats.ResultFetches != uint64(len(got)) {
 		t.Fatalf("stats=%+v want graph traversal row fetch accounting", stats)
+	}
+	if readerStats := reader.Stats(); readerStats.BatchFetches == 0 {
+		t.Fatalf("reader stats=%+v want batched top-k result fetch", readerStats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+		{ID: []byte("doc-low"), Vector: []float32{-1, 0, 0}, InvNorm: 1, Adjacency: []uint32{3}},
+		{ID: []byte("doc-bridge"), Vector: []float32{0.8, 0.6, 0}, InvNorm: 1, Adjacency: []uint32{4}},
+		{ID: []byte("doc-mid"), Vector: []float32{0.5, 0.8660254, 0}, InvNorm: 1},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 4}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
+	}
+	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ExpansionFetches == 0 {
+		t.Fatalf("stats=%+v want four scored candidates with expansion fetch accounting", stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+		{ID: []byte("doc-low"), Vector: []float32{-1, 0, 0}, InvNorm: 1, Adjacency: []uint32{4, 4}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+		{ID: []byte("doc-unused"), Vector: []float32{0, 0, 1}, InvNorm: 1},
+		{ID: []byte("doc-bad"), Vector: []float32{-0.9, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, _, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 3}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 2 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v want scoring fetches not to mutate expansion adjacency", got)
 	}
 }
 
@@ -70,6 +128,17 @@ func TestColumnVectorGraphNativeSearchRejectsBadQueryV3(t *testing.T) {
 	_, _, err = reader.SearchCosine([]float32{0, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 1}, &scratch)
 	if err == nil || !strings.Contains(err.Error(), "query norm") {
 		t.Fatalf("SearchCosine zero err=%v want norm failure", err)
+	}
+}
+
+func TestColumnVectorGraphNativeCosineScoreRejectsMalformedRowV3(t *testing.T) {
+	_, err := columnVectorGraphNativeCosineScore([]float32{1, 0}, 1, columnVectorGraphPhysicalRow{
+		Ordinal: 7,
+		Vector:  []float32{1},
+		InvNorm: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ordinal=7 vector dims=1 want 2") {
+		t.Fatalf("columnVectorGraphNativeCosineScore err=%v want dimension failure", err)
 	}
 }
 
@@ -286,6 +355,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B) {
 		searchStats.Candidates += stats.Candidates
 		searchStats.Edges += stats.Edges
 		searchStats.CandidateFetches += stats.CandidateFetches
+		searchStats.ExpansionFetches += stats.ExpansionFetches
 		searchStats.ResultFetches += stats.ResultFetches
 	}
 	b.StopTimer()
@@ -334,10 +404,14 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 	var totalCandidates atomic.Uint64
 	var totalEdges atomic.Uint64
 	var totalCandidateFetches atomic.Uint64
+	var totalExpansionFetches atomic.Uint64
 	var totalResultFetches atomic.Uint64
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
+		// testing.B.RunParallel starts GOMAXPROCS workers by default. Keep the
+		// prewarmed reader/scratch arrays sized to that value and do not raise
+		// parallelism here; each worker owns exactly one reader and scratch.
 		worker := int(nextWorker.Add(1)) - 1
 		if worker < 0 || worker >= len(readers) {
 			b.Fatalf("parallel worker=%d outside prewarmed readers=%d", worker, len(readers))
@@ -353,6 +427,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 			totalCandidates.Add(stats.Candidates)
 			totalEdges.Add(stats.Edges)
 			totalCandidateFetches.Add(stats.CandidateFetches)
+			totalExpansionFetches.Add(stats.ExpansionFetches)
 			totalResultFetches.Add(stats.ResultFetches)
 		}
 	})
@@ -366,6 +441,7 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 		Candidates:       totalCandidates.Load(),
 		Edges:            totalEdges.Load(),
 		CandidateFetches: totalCandidateFetches.Load(),
+		ExpansionFetches: totalExpansionFetches.Load(),
 		ResultFetches:    totalResultFetches.Load(),
 	})
 }
@@ -450,6 +526,7 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 		b.ReportMetric(float64(searchStats.Edges)/float64(searchStats.Candidates), "edges/node")
 	}
 	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
+	b.ReportMetric(float64(searchStats.ExpansionFetches)/float64(n), "expansion_fetches/search")
 	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
 	b.ReportMetric(float64(stats.CacheHits-baseStats.CacheHits)/float64(n), "cache_hits/search")
 	b.ReportMetric(float64(stats.CacheMisses-baseStats.CacheMisses)/float64(n), "cache_misses/search")

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -368,6 +368,12 @@ func TestColumnVectorGraphNativeSearchParallelReadersV3(t *testing.T) {
 	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
 	query := append([]float32(nil), input[17].vector...)
 	workers := runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 2
+	}
+	if workers > 8 {
+		workers = 8
+	}
 	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
 	for i := range readers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
@@ -523,6 +529,8 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 			return
 		}
 		worker := benchWorkers[workerIndex]
+		var localSink int64
+		var localStats columnVectorGraphNativeSearchStats
 		for pb.Next() {
 			if failed.Load() {
 				continue
@@ -532,13 +540,19 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 				recordParallelErr("SearchCosine: %v", err)
 				continue
 			}
-			sink.Add(int64(got[0].Ordinal))
-			totalCandidates.Add(stats.Candidates)
-			totalEdges.Add(stats.Edges)
-			totalCandidateFetches.Add(stats.CandidateFetches)
-			totalExpansionFetches.Add(stats.ExpansionFetches)
-			totalResultFetches.Add(stats.ResultFetches)
+			localSink += int64(got[0].Ordinal)
+			localStats.Candidates += stats.Candidates
+			localStats.Edges += stats.Edges
+			localStats.CandidateFetches += stats.CandidateFetches
+			localStats.ExpansionFetches += stats.ExpansionFetches
+			localStats.ResultFetches += stats.ResultFetches
 		}
+		sink.Add(localSink)
+		totalCandidates.Add(localStats.Candidates)
+		totalEdges.Add(localStats.Edges)
+		totalCandidateFetches.Add(localStats.CandidateFetches)
+		totalExpansionFetches.Add(localStats.ExpansionFetches)
+		totalResultFetches.Add(localStats.ResultFetches)
 	})
 	b.StopTimer()
 	if errValue := firstErr.Load(); errValue != nil {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -44,11 +44,15 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if stats.Candidates != uint64(len(rows)) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
-	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ExpansionFetches == 0 || stats.ResultFetches != uint64(len(got)) {
-		t.Fatalf("stats=%+v want graph traversal row fetch accounting", stats)
+	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ExpansionFetches != 0 || stats.ResultFetches != uint64(len(got)) {
+		t.Fatalf("stats=%+v want candidate/result fetches without duplicate expansion row fetches", stats)
 	}
-	if readerStats := reader.Stats(); readerStats.BatchFetches == 0 {
+	readerStats := reader.Stats()
+	if readerStats.BatchFetches == 0 {
 		t.Fatalf("reader stats=%+v want batched top-k result fetch", readerStats)
+	}
+	if gotRows, wantRows := readerStats.RowsFetched, stats.CandidateFetches+stats.ResultFetches; gotRows != wantRows {
+		t.Fatalf("reader rows_fetched=%d want candidate+result fetches=%d stats=%+v", gotRows, wantRows, stats)
 	}
 }
 
@@ -76,8 +80,11 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ExpansionFetches == 0 {
-		t.Fatalf("stats=%+v want four scored candidates with expansion fetch accounting", stats)
+	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ExpansionFetches != 0 {
+		t.Fatalf("stats=%+v want four scored candidates without duplicate expansion row fetches", stats)
+	}
+	if readerStats := reader.Stats(); readerStats.RowsFetched != stats.CandidateFetches+stats.ResultFetches {
+		t.Fatalf("reader rows_fetched=%d want candidate+result fetches stats=%+v", readerStats.RowsFetched, stats)
 	}
 }
 

--- a/TreeDB/collections/vector_index_rebuild.go
+++ b/TreeDB/collections/vector_index_rebuild.go
@@ -13,6 +13,13 @@ import (
 
 const columnVectorGraphNeighborInsertionLimit = 32
 
+var (
+	errColumnVectorGraphInvNormEmpty          = errors.New("collections: column_graph vector is empty")
+	errColumnVectorGraphInvNormValueNotFinite = errors.New("collections: column_graph vector value is not finite")
+	errColumnVectorGraphInvNormNormInvalid    = errors.New("collections: column_graph vector norm must be finite and non-zero")
+	errColumnVectorGraphInvNormOutOfRange     = errors.New("collections: column_graph vector inverse norm must be finite and fit float32")
+)
+
 // RebuildVectorIndex rebuilds the named vector index through the collection
 // product lifecycle. V2A only builds and publishes physical column graph assets;
 // it does not load or search a decoded in-memory graph.
@@ -403,22 +410,22 @@ func (c *Collection) columnVectorGraphRowsFromCatalogSnapshot(snap *backenddb.Sn
 
 func columnVectorGraphInvNorm(vector []float32) (float32, error) {
 	if len(vector) == 0 {
-		return 0, errors.New("empty vector")
+		return 0, errColumnVectorGraphInvNormEmpty
 	}
 	var sum float64
 	for i, v := range vector {
 		f := float64(v)
 		if math.IsNaN(f) || math.IsInf(f, 0) {
-			return 0, fmt.Errorf("vector[%d] is not finite", i)
+			return 0, fmt.Errorf("vector[%d] is not finite: %w", i, errColumnVectorGraphInvNormValueNotFinite)
 		}
 		sum += f * f
 	}
 	if sum == 0 || math.IsNaN(sum) || math.IsInf(sum, 0) {
-		return 0, errors.New("vector norm must be finite and non-zero")
+		return 0, errColumnVectorGraphInvNormNormInvalid
 	}
 	invNorm := 1 / math.Sqrt(sum)
 	if invNorm > math.MaxFloat32 || math.IsNaN(invNorm) || math.IsInf(invNorm, 0) {
-		return 0, errors.New("vector inverse norm must be finite and fit float32")
+		return 0, errColumnVectorGraphInvNormOutOfRange
 	}
 	return float32(invNorm), nil
 }


### PR DESCRIPTION
## Summary

Adds the V3 native reader search kernel for #1646.

This PR does **not** use the decoded `ColumnVectorGraph` full in-memory graph as the search substrate. Search runs over the physical column graph row reader introduced by V2B: vector, invNorm, adjacency, and doc ID are fetched by ordinal through the column-store row reader/cache boundary.

Stack position:

- Base PR: #1664 (`codex/column-graph-native-v2b-ordinal-reader`)
- This PR: V3 native reader search kernel
- Follow-up: V4 public collection/vector-index routing and materialized document results

## What Changed

- Added `columnVectorGraphPhysicalRowReader.SearchCosine`.
- Added worker-local `columnVectorGraphNativeSearchScratch` for the best-first frontier, visited stamps, top-k candidates, row scratch, reusable result ID buffers, and candidate adjacency copies.
- Kept traversal/scoring/top-k document-fetch-free; the kernel returns IDs, ordinals, and scores only.
- Avoided duplicate expansion row fetches by copying each scored candidate's adjacency into warmed scratch once and consuming that copy during expansion.
- Clears candidate adjacency slice headers when candidate scratch is reused or frontier slots are retired, so long-lived scratch does not retain old adjacency buffers after growth/shrink cycles.
- Handles disconnected graph components by seeding the next unvisited ordinal when the current frontier drains before `EfSearch` is reached.
- Added serial and real `b.RunParallel` benchmarks using warmed worker-local scratch/readers.

## Required PR Sections

Copied/Adapted From Old Stack:

- Copied: no old-stack product search code copied.
- Adapted: benchmark shape and zero-allocation scratch discipline from the decoded comparator workstream.
- Oracle/comparator only: decoded `ColumnVectorGraph` remains a conceptual parity/ceiling comparator, not this PR's substrate.
- Quarantined/not copied: public API routing, document materialization, dynamic overlays, and codec/large-dataset experiments.

Path Identity:

- Native reader: `columnVectorGraphPhysicalRowReader.SearchCosine` over physical column graph rows.
- Decoded comparator: not used as the search substrate in this PR.
- Legacy/native vector index: not used.
- Unsupported/fail-closed: public routing remains for V4.

Base And Dependency State:

- Base branch: `codex/column-graph-native-v2b-ordinal-reader` / PR #1664.
- Base commit at latest restack: `8c688b93a`.
- #1621/#1634 assumptions: physical row reader/cache APIs are stable enough for correctness; broader column-store optimization remains upstream.
- Missing generic column-store primitives: public API routing/status, mutation visibility/staleness, and larger benchmark/docs/demo closeout remain later milestones.

## Test Plan Start / Close

Start phase: checked #1646 V3 requirements before implementation. The ticket already required parity/correctness, no full-document fetch in traversal/scoring, race-clean concurrent reader proof, and serial/parallel native-search benchmarks.

Close phase additions implemented in this PR:

- Cosine top-k correctness against a test oracle over deterministic vectors.
- Best-first traversal test.
- Bad query validation for dimension mismatch and zero-norm query.
- Empty graph behavior.
- No-document-fetch kernel test at the reader/search layer.
- Disconnected component traversal test proving `EfSearch` is not accidentally limited to the first component.
- Stable adjacency scratch test proving scoring fetches do not mutate expansion adjacency.
- Candidate scratch retention test proving reused/retired candidate slots do not keep old adjacency slice headers alive.
- Warmed scratch zero-allocation guard.
- Concurrent reader/scratch sanity test, race-tested locally.
- Review-resolution regression guard: duplicate expansion row fetches were identified as local overhead and removed.

## Performance Plan Close

Relevant path: hot native search/traversal/scoring, row fetch/cache, top-k result production. Setup/build/open/warm are outside the timed loop. Full document fetch is outside this PR.

Hardware: Apple M3, darwin/arm64.

Dataset shape: 1,024 rows, 128 dims, degree 16, `TopK=10`, `EfSearch=128`.

Latest-head representative output after the candidate-adjacency retention fix:

```text
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       median 298.5 ns/op   0 B/op  0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8            median 65484 ns/op  128 candidates/search  1912 edges/search  138 cache_hits/search  0 expansion_fetches/search  0 physical_B/search  0 B/op  0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8    median 11597 ns/op  128 candidates/search  1912 edges/search  138 cache_hits/search  8 parallel_workers  0 physical_B/search  0 B/op  0 allocs/op
```

Median latest-head throughput:

- Serial native reader search: ~15.27k searches/s.
- Parallel native reader search: ~86.23k searches/s total.

Review-resolution performance attribution:

- Initial PR-head evidence at `68fc396fd`: serial median ~56.23 µs/search; parallel median ~10.17 µs/search; 0 B/op, 0 allocs/op.
- Review-resolved head before duplicate-fetch cleanup at `313fb94a2`: serial median ~95.48 µs/search; parallel median ~16.68 µs/search; 0 B/op, 0 allocs/op.
- After duplicate-fetch cleanup at `4571f2840`: serial median ~65.46 µs/search; parallel median ~11.51 µs/search; 0 B/op, 0 allocs/op.
- Latest head after candidate-adjacency retention cleanup at `1be88a58b`: serial median ~65.48 µs/search; parallel median ~11.60 µs/search; 0 B/op, 0 allocs/op.
- Local regression fixed: best-first review cleanup had introduced separate score and expansion row fetch/decode work. The latest code keeps best-first correctness but stores candidate adjacency in warmed scratch, so expansion does not re-fetch rows.
- Current review fix cost: clearing only adjacency slice headers prevents scratch retention without adding hot-loop allocations; measured throughput remains in the same band as the duplicate-fetch cleanup.
- Remaining gap vs the original PR-head benchmark is attributed to correctness-oriented best-first frontier / validation / scratch bookkeeping versus the original FIFO traversal. No hot-loop allocations remain.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearch' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.931s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchParallelReadersV3|TestColumnVectorGraphNativeSearch' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.989s

GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(V3|ParallelV3)|BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B' -benchmem -benchtime=500ms -count=5
# BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       median 298.5 ns/op  0 B/op  0 allocs/op
# BenchmarkColumnVectorGraphNativeSearchCosineV3-8            median 65484 ns/op  0 B/op  0 allocs/op
# BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8    median 11597 ns/op  0 B/op  0 allocs/op

git diff --check
# clean
```

## Latest Restack Evidence
Restacked on #1664 head `de67e6e7b` / #1658 head `10a95c2b3`; latest head is `92f507fa1`.

Validation:
```sh
git diff --check
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearch' -count=1
```
Result: passed locally.

Benchmark command:
```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(V3|ParallelV3)|BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B' -benchmem -benchtime=500ms -count=5
```

Current-head representative output:
```text
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       1969629   301.2 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       1994545   300.7 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       2003167   302.2 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       1993381   304.5 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B-8       1992585   303.9 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8               9064   66645 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   0 expansion_fetches/search   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8               8896   67191 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   0 expansion_fetches/search   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8               8935   66408 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   0 expansion_fetches/search   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8               8836   67319 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   0 expansion_fetches/search   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineV3-8               8840   65980 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   0 expansion_fetches/search   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8      50338   12212 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   8 parallel_workers   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8      51016   12388 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   8 parallel_workers   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8      50623   12017 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   8 parallel_workers   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8      41064   12561 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   8 parallel_workers   0 physical_B/search   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelV3-8      51075   12160 ns/op   128 candidates/search   1912 edges/search   138 cache_hits/search   8 parallel_workers   0 physical_B/search   0 B/op   0 allocs/op
```

Interpretation: restack diff only brought in parent reachability/setup pruning and did not modify the native search kernel or hot row-fetch code. Hot search remains 0 B/op and 0 allocs/op with no physical reads or decoded blocks in the timed loop. The current absolute medians are slightly slower than the prior PR-body run, but no local search-code CPU/copy/allocation change was introduced by this restack.

## AI Review Loop

Latest meaningful push: `1be88a58b`.

- Codex: current-head clean comment at 2026-05-21 11:17 UTC: "Didn't find any major issues."
- CodeRabbit: current-head review/check clean after latest-head request at 2026-05-21 11:14 UTC.
- Copilot: latest formal review is on an older head; a latest-head comment request was posted. Direct GitHub reviewer request for `copilot-pull-request-reviewer` was not accepted by the API because GitHub reports it is not a collaborator reviewer for this repo.
- Review comments/threads: stale outdated threads resolved; candidate-adjacency retention feedback addressed in latest head.

