### PR TITLE
TreeDB column store post-V1: reduce parity line allocations

### DIFF
--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"hash/fnv"
 	"html"
 	"math"
 	"math/rand"
@@ -193,6 +192,8 @@ type columnStoreParity struct {
 
 type columnStoreQueryExecution struct {
 	Lines                  []string
+	ProductionHash         uint64
+	ProductionHashKnown    bool
 	RowsProcessed          int
 	RowsProcessedKnown     bool
 	BytesRead              int64
@@ -207,6 +208,7 @@ type columnStoreQueryExecution struct {
 	ScanDuration           time.Duration
 	ReduceDuration         time.Duration
 	AdapterDuration        time.Duration
+	ParityHashDuration     time.Duration
 }
 
 type columnStoreByteAccounting struct {
@@ -1098,9 +1100,16 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			return nil, nil, err
 		}
 		planLabel := string(plan.Kind)
-		parityHashStart := time.Now()
-		hash := columnStoreHashLines(exec.Lines)
-		parityHashElapsed := time.Since(parityHashStart)
+		var hash uint64
+		var parityHashElapsed time.Duration
+		if exec.ProductionHashKnown {
+			hash = exec.ProductionHash
+			parityHashElapsed = exec.ParityHashDuration
+		} else {
+			parityHashStart := time.Now()
+			hash = columnStoreHashLines(exec.Lines)
+			parityHashElapsed = time.Since(parityHashStart)
+		}
 		elapsed := plannerElapsed + exec.ScanDuration + exec.ReduceDuration + exec.AdapterDuration + parityHashElapsed
 		rawHash := rawHashes[name]
 		pass := rawHash == hash
@@ -1301,11 +1310,11 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	if err != nil {
 		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s: %w", queryName, plan.Kind, err)
 	}
-	adapterStart := time.Now()
-	lines, err := columnStoreSuitePhysicalQueryLines(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
-	adapterElapsed := time.Since(adapterStart)
+	parityHashStart := time.Now()
+	productionHash, resultCount, err := columnStoreSuiteHashPhysicalQueryGroups(columnStoreQueryHashLineName(queryName), queryName, result.Groups)
+	parityHashElapsed := time.Since(parityHashStart)
 	if err != nil {
-		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s line mapping: %w", queryName, plan.Kind, err)
+		return columnStoreQueryExecution{}, fmt.Errorf("column_store: physical query %s via %s parity hash: %w", queryName, plan.Kind, err)
 	}
 	diag := result.Diagnostics
 	workers := diag.WorkerCount
@@ -1324,12 +1333,13 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		reduceDuration = time.Duration(diag.ReduceNanos)
 	}
 	return columnStoreQueryExecution{
-		Lines:                  lines,
+		ProductionHash:         productionHash,
+		ProductionHashKnown:    true,
 		RowsProcessed:          diag.ReduceRows,
 		RowsProcessedKnown:     true,
 		BytesRead:              diag.PhysicalBytesScanned,
 		RowMaterializations:    diag.RowMaterializations,
-		ResultCount:            len(lines),
+		ResultCount:            resultCount,
 		MetadataHits:           diag.MetadataHits,
 		SkippedGranules:        diag.SkippedGranules,
 		ScheduledGranules:      diag.ScheduledGranules,
@@ -1338,7 +1348,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		SegmentFileCacheMisses: diag.SegmentFileCacheMisses,
 		ScanDuration:           scanDuration,
 		ReduceDuration:         reduceDuration,
-		AdapterDuration:        adapterElapsed,
+		ParityHashDuration:     parityHashElapsed,
 	}, nil
 }
 
@@ -1376,6 +1386,34 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 		return nil, fmt.Errorf("column_store: unsupported physical query line mapping %q", queryName)
 	}
 	return lines, nil
+}
+
+func columnStoreSuiteHashPhysicalQueryGroups(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) (uint64, int, error) {
+	hash := columnStoreFNV64Offset
+	switch queryName {
+	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
+		for _, group := range groups {
+			hash = columnStoreHashPhysicalQueryGroup(hash, prefix, group.Key, int64(group.Count))
+		}
+	case columnStoreQueryQ4A, columnStoreQueryQ4B, columnStoreQueryQ5, columnStoreQueryQ5Metadata:
+		for _, group := range groups {
+			hash = columnStoreHashPhysicalQueryGroup(hash, prefix, group.Key, group.Int64)
+		}
+	default:
+		return 0, 0, fmt.Errorf("column_store: unsupported physical query hash mapping %q", queryName)
+	}
+	return hash, len(groups), nil
+}
+
+func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value int64) uint64 {
+	const maxInt64DecimalLen = 20 // len("-9223372036854775808")
+	var num [maxInt64DecimalLen]byte
+	hash = columnStoreHashString(hash, prefix)
+	hash = columnStoreHashByte(hash, ':')
+	hash = columnStoreHashString(hash, key)
+	hash = columnStoreHashByte(hash, '=')
+	hash = columnStoreHashBytes(hash, strconv.AppendInt(num[:0], value, 10))
+	return columnStoreHashByte(hash, 0)
 }
 
 func columnStoreSuiteFormatPhysicalQueryLine(prefix, key string, value int64) string {
@@ -1620,12 +1658,36 @@ func columnStoreQueryHash(name string, events []columnStoreDecodedEvent) (uint64
 
 func columnStoreHashLines(lines []string) uint64 {
 	sort.Strings(lines)
-	h := fnv.New64a()
+	hash := columnStoreFNV64Offset
 	for _, line := range lines {
-		_, _ = h.Write([]byte(line))
-		_, _ = h.Write([]byte{0})
+		hash = columnStoreHashString(hash, line)
+		hash = columnStoreHashByte(hash, 0)
 	}
-	return h.Sum64()
+	return hash
+}
+
+const (
+	columnStoreFNV64Offset uint64 = 14695981039346656037
+	columnStoreFNV64Prime  uint64 = 1099511628211
+)
+
+func columnStoreHashString(hash uint64, value string) uint64 {
+	for i := 0; i < len(value); i++ {
+		hash = columnStoreHashByte(hash, value[i])
+	}
+	return hash
+}
+
+func columnStoreHashBytes(hash uint64, value []byte) uint64 {
+	for _, b := range value {
+		hash = columnStoreHashByte(hash, b)
+	}
+	return hash
+}
+
+func columnStoreHashByte(hash uint64, value byte) uint64 {
+	hash ^= uint64(value)
+	return hash * columnStoreFNV64Prime
 }
 
 func columnStoreQueryHashLineName(name string) string {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1389,6 +1389,7 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 }
 
 func columnStoreSuiteHashPhysicalQueryGroups(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) (uint64, int, error) {
+	columnStoreSuiteSortPhysicalQueryGroups(queryName, groups)
 	hash := columnStoreFNV64Offset
 	switch queryName {
 	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
@@ -1403,6 +1404,31 @@ func columnStoreSuiteHashPhysicalQueryGroups(prefix, queryName string, groups []
 		return 0, 0, fmt.Errorf("column_store: unsupported physical query hash mapping %q", queryName)
 	}
 	return hash, len(groups), nil
+}
+
+func columnStoreSuiteSortPhysicalQueryGroups(queryName string, groups []collections.ColumnPhysicalQueryGroup) {
+	for i := 1; i < len(groups); i++ {
+		group := groups[i]
+		j := i - 1
+		for ; j >= 0 && columnStoreSuitePhysicalQueryGroupLess(queryName, group, groups[j]); j-- {
+			groups[j+1] = groups[j]
+		}
+		groups[j+1] = group
+	}
+}
+
+func columnStoreSuitePhysicalQueryGroupLess(queryName string, left, right collections.ColumnPhysicalQueryGroup) bool {
+	if left.Key != right.Key {
+		return left.Key < right.Key
+	}
+	switch queryName {
+	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
+		return left.Count < right.Count
+	case columnStoreQueryQ4A, columnStoreQueryQ4B, columnStoreQueryQ5, columnStoreQueryQ5Metadata:
+		return left.Int64 < right.Int64
+	default:
+		return false
+	}
 }
 
 func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value int64) uint64 {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -209,7 +209,9 @@ type columnStoreQueryExecution struct {
 	ScanDuration           time.Duration
 	ReduceDuration         time.Duration
 	AdapterDuration        time.Duration
-	ParityHashDuration     time.Duration
+	// Set when ProductionHashKnown is true. Fallback line-hash timing is
+	// measured at the call site because it is derived from Lines, not execution.
+	ParityHashDuration time.Duration
 }
 
 type columnStoreByteAccounting struct {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1379,8 +1379,9 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 }
 
 func columnStoreSuiteFormatPhysicalQueryLine(prefix, key string, value int64) string {
+	const maxInt64DecimalLen = 20 // len("-9223372036854775808")
 	var b strings.Builder
-	var num [20]byte
+	var num [maxInt64DecimalLen]byte
 	b.Grow(len(prefix) + 1 + len(key) + 1 + len(num))
 	b.WriteString(prefix)
 	b.WriteByte(':')

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -23,27 +23,28 @@ import (
 )
 
 const (
-	columnStorePathRowStoreBaseline   = "row_store_baseline"
-	columnStorePathBTreeIndexBaseline = "b_tree_index_baseline"
-	columnStorePathSerialColumnScan   = "serial_column_scan"
-	columnStorePathAggregateMetadata  = "aggregate_metadata"
-	columnStorePathParallelColumnScan = "parallel_column_scan"
-	columnStoreSuiteBenchTestName     = "column_store"
-	columnStoreSuiteBenchDBName       = "treedb_column_store"
-	columnStoreSuiteBenchDisplayName  = "TreeDB Column Store"
-	columnStoreSuitePathCanonicalHelp = "row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan"
-	columnStoreQueryQ1                = "q1"
-	columnStoreQueryQ2                = "q2"
-	columnStoreQueryQ3                = "q3"
-	columnStoreQueryQ4A               = "q4a"
-	columnStoreQueryQ4B               = "q4b"
-	columnStoreQueryQ5                = "q5"
-	columnStoreQueryQ5Metadata        = "q5_metadata"
-	columnStoreSuiteBenchMetricPrefix = "column_store_"
-	columnStoreSuiteAliasFullScanQ1   = "alias_full_scan_from_" + columnStoreQueryQ1
-	columnStoreSuiteAliasPrefixQ4A    = "alias_prefix_scan_from_" + columnStoreQueryQ4A
-	columnStoreSuiteQ5AggregateMin    = "q5_did_time_span_min"
-	columnStoreSuiteQ5AggregateMax    = "q5_did_time_span_max"
+	columnStorePathRowStoreBaseline    = "row_store_baseline"
+	columnStorePathBTreeIndexBaseline  = "b_tree_index_baseline"
+	columnStorePathSerialColumnScan    = "serial_column_scan"
+	columnStorePathAggregateMetadata   = "aggregate_metadata"
+	columnStorePathParallelColumnScan  = "parallel_column_scan"
+	columnStoreSuiteBenchTestName      = "column_store"
+	columnStoreSuiteBenchDBName        = "treedb_column_store"
+	columnStoreSuiteBenchDisplayName   = "TreeDB Column Store"
+	columnStoreSuitePathCanonicalHelp  = "row_store_baseline, b_tree_index_baseline, serial_column_scan, aggregate_metadata, parallel_column_scan"
+	columnStoreQueryQ1                 = "q1"
+	columnStoreQueryQ2                 = "q2"
+	columnStoreQueryQ3                 = "q3"
+	columnStoreQueryQ4A                = "q4a"
+	columnStoreQueryQ4B                = "q4b"
+	columnStoreQueryQ5                 = "q5"
+	columnStoreQueryQ5Metadata         = "q5_metadata"
+	columnStoreSuiteBenchMetricPrefix  = "column_store_"
+	columnStoreSuiteAliasFullScanQ1    = "alias_full_scan_from_" + columnStoreQueryQ1
+	columnStoreSuiteAliasPrefixQ4A     = "alias_prefix_scan_from_" + columnStoreQueryQ4A
+	columnStoreSuiteQ5AggregateMin     = "q5_did_time_span_min"
+	columnStoreSuiteQ5AggregateMax     = "q5_did_time_span_max"
+	columnStoreSuiteMaxInt64DecimalLen = 20 // len("-9223372036854775808")
 )
 
 type columnStoreSuitePathAlias struct {
@@ -1432,8 +1433,7 @@ func columnStoreSuitePhysicalQueryGroupLess(queryName string, left, right collec
 }
 
 func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value int64) uint64 {
-	const maxInt64DecimalLen = 20 // len("-9223372036854775808")
-	var num [maxInt64DecimalLen]byte
+	var num [columnStoreSuiteMaxInt64DecimalLen]byte
 	hash = columnStoreHashString(hash, prefix)
 	hash = columnStoreHashByte(hash, ':')
 	hash = columnStoreHashString(hash, key)
@@ -1443,9 +1443,8 @@ func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value in
 }
 
 func columnStoreSuiteFormatPhysicalQueryLine(prefix, key string, value int64) string {
-	const maxInt64DecimalLen = 20 // len("-9223372036854775808")
 	var b strings.Builder
-	var num [maxInt64DecimalLen]byte
+	var num [columnStoreSuiteMaxInt64DecimalLen]byte
 	b.Grow(len(prefix) + 1 + len(key) + 1 + len(num))
 	b.WriteString(prefix)
 	b.WriteByte(':')

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1366,16 +1366,28 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 	switch queryName {
 	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
 		for _, group := range groups {
-			lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, group.Key, group.Count))
+			lines = append(lines, columnStoreSuiteFormatPhysicalQueryLine(prefix, group.Key, int64(group.Count)))
 		}
 	case columnStoreQueryQ4A, columnStoreQueryQ4B, columnStoreQueryQ5, columnStoreQueryQ5Metadata:
 		for _, group := range groups {
-			lines = append(lines, fmt.Sprintf("%s:%s=%d", prefix, group.Key, group.Int64))
+			lines = append(lines, columnStoreSuiteFormatPhysicalQueryLine(prefix, group.Key, group.Int64))
 		}
 	default:
 		return nil, fmt.Errorf("column_store: unsupported physical query line mapping %q", queryName)
 	}
 	return lines, nil
+}
+
+func columnStoreSuiteFormatPhysicalQueryLine(prefix, key string, value int64) string {
+	var b strings.Builder
+	var num [20]byte
+	b.Grow(len(prefix) + 1 + len(key) + 1 + len(num))
+	b.WriteString(prefix)
+	b.WriteByte(':')
+	b.WriteString(key)
+	b.WriteByte('=')
+	b.Write(strconv.AppendInt(num[:0], value, 10))
+	return b.String()
 }
 
 func scanColumnStoreSuiteEvents(collection *collections.Collection, rows int) ([]columnStoreDecodedEvent, int, int64, error) {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1391,10 +1391,10 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 	return lines, nil
 }
 
+// columnStoreSuiteHashPhysicalQueryGroups sorts groups in-place before hashing.
+// The caller passes a result slice that is no longer used for ordered reporting
+// after hashing; mutating it here avoids copying on the hot parity path.
 func columnStoreSuiteHashPhysicalQueryGroups(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) (uint64, int, error) {
-	// The caller passes a result slice that is no longer used for ordered
-	// reporting after hashing; sort it in-place to avoid copying on the hot
-	// parity path.
 	columnStoreSuiteSortPhysicalQueryGroups(queryName, groups)
 	hash := columnStoreFNV64Offset
 	switch queryName {
@@ -1432,42 +1432,60 @@ func columnStoreSuitePhysicalQueryGroupLess(queryName string, left, right collec
 	default:
 		return false
 	}
+	if cmp := columnStoreSuitePhysicalQueryLineKeyPrefixCompare(left.Key, right.Key); cmp != 0 {
+		return cmp < 0
+	}
 	var leftNum [columnStoreSuiteMaxInt64DecimalLen]byte
 	var rightNum [columnStoreSuiteMaxInt64DecimalLen]byte
-	return columnStoreSuitePhysicalQueryLineSuffixLess(
-		left.Key,
+	return columnStoreSuiteBytesLess(
 		strconv.AppendInt(leftNum[:0], leftValue, 10),
-		right.Key,
 		strconv.AppendInt(rightNum[:0], rightValue, 10),
 	)
 }
 
-func columnStoreSuitePhysicalQueryLineSuffixLess(leftKey string, leftValue []byte, rightKey string, rightValue []byte) bool {
+func columnStoreSuitePhysicalQueryLineKeyPrefixCompare(leftKey, rightKey string) int {
 	for idx := 0; ; idx++ {
-		leftByte, leftOK := columnStoreSuitePhysicalQueryLineSuffixByte(leftKey, leftValue, idx)
-		rightByte, rightOK := columnStoreSuitePhysicalQueryLineSuffixByte(rightKey, rightValue, idx)
+		leftByte, leftOK := columnStoreSuitePhysicalQueryLineKeyPrefixByte(leftKey, idx)
+		rightByte, rightOK := columnStoreSuitePhysicalQueryLineKeyPrefixByte(rightKey, idx)
 		if !leftOK || !rightOK {
-			return !leftOK && rightOK
+			if leftOK == rightOK {
+				return 0
+			}
+			if leftOK {
+				return 1
+			}
+			return -1
 		}
 		if leftByte != rightByte {
-			return leftByte < rightByte
+			if leftByte < rightByte {
+				return -1
+			}
+			return 1
 		}
 	}
 }
 
-func columnStoreSuitePhysicalQueryLineSuffixByte(key string, value []byte, idx int) (byte, bool) {
+func columnStoreSuitePhysicalQueryLineKeyPrefixByte(key string, idx int) (byte, bool) {
 	if idx < len(key) {
 		return key[idx], true
 	}
-	idx -= len(key)
-	if idx == 0 {
+	if idx == len(key) {
 		return '=', true
 	}
-	idx--
-	if idx < len(value) {
-		return value[idx], true
-	}
 	return 0, false
+}
+
+func columnStoreSuiteBytesLess(left, right []byte) bool {
+	for idx := 0; ; idx++ {
+		leftOK := idx < len(left)
+		rightOK := idx < len(right)
+		if !leftOK || !rightOK {
+			return !leftOK && rightOK
+		}
+		if left[idx] != right[idx] {
+			return left[idx] < right[idx]
+		}
+	}
 }
 
 func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value int64) uint64 {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1390,6 +1390,9 @@ func columnStoreSuitePhysicalQueryLines(prefix, queryName string, groups []colle
 }
 
 func columnStoreSuiteHashPhysicalQueryGroups(prefix, queryName string, groups []collections.ColumnPhysicalQueryGroup) (uint64, int, error) {
+	// The caller passes a result slice that is no longer used for ordered
+	// reporting after hashing; sort it in-place to avoid copying on the hot
+	// parity path.
 	columnStoreSuiteSortPhysicalQueryGroups(queryName, groups)
 	hash := columnStoreFNV64Offset
 	switch queryName {
@@ -1419,17 +1422,50 @@ func columnStoreSuiteSortPhysicalQueryGroups(queryName string, groups []collecti
 }
 
 func columnStoreSuitePhysicalQueryGroupLess(queryName string, left, right collections.ColumnPhysicalQueryGroup) bool {
-	if left.Key != right.Key {
-		return left.Key < right.Key
-	}
+	leftValue, rightValue := left.Int64, right.Int64
 	switch queryName {
 	case columnStoreQueryQ1, columnStoreQueryQ2, columnStoreQueryQ3:
-		return left.Count < right.Count
+		leftValue, rightValue = int64(left.Count), int64(right.Count)
 	case columnStoreQueryQ4A, columnStoreQueryQ4B, columnStoreQueryQ5, columnStoreQueryQ5Metadata:
-		return left.Int64 < right.Int64
 	default:
 		return false
 	}
+	var leftNum [columnStoreSuiteMaxInt64DecimalLen]byte
+	var rightNum [columnStoreSuiteMaxInt64DecimalLen]byte
+	return columnStoreSuitePhysicalQueryLineSuffixLess(
+		left.Key,
+		strconv.AppendInt(leftNum[:0], leftValue, 10),
+		right.Key,
+		strconv.AppendInt(rightNum[:0], rightValue, 10),
+	)
+}
+
+func columnStoreSuitePhysicalQueryLineSuffixLess(leftKey string, leftValue []byte, rightKey string, rightValue []byte) bool {
+	for idx := 0; ; idx++ {
+		leftByte, leftOK := columnStoreSuitePhysicalQueryLineSuffixByte(leftKey, leftValue, idx)
+		rightByte, rightOK := columnStoreSuitePhysicalQueryLineSuffixByte(rightKey, rightValue, idx)
+		if !leftOK || !rightOK {
+			return !leftOK && rightOK
+		}
+		if leftByte != rightByte {
+			return leftByte < rightByte
+		}
+	}
+}
+
+func columnStoreSuitePhysicalQueryLineSuffixByte(key string, value []byte, idx int) (byte, bool) {
+	if idx < len(key) {
+		return key[idx], true
+	}
+	idx -= len(key)
+	if idx == 0 {
+		return '=', true
+	}
+	idx--
+	if idx < len(value) {
+		return value[idx], true
+	}
+	return 0, false
 }
 
 func columnStoreHashPhysicalQueryGroup(hash uint64, prefix, key string, value int64) uint64 {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -171,12 +171,14 @@ func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lines, err := columnStoreSuitePhysicalQueryLines(tt.prefix, tt.queryName, tt.groups)
+			groupsForLines := append([]collections.ColumnPhysicalQueryGroup(nil), tt.groups...)
+			lines, err := columnStoreSuitePhysicalQueryLines(tt.prefix, tt.queryName, groupsForLines)
 			if err != nil {
 				t.Fatalf("columnStoreSuitePhysicalQueryLines: %v", err)
 			}
 			want := columnStoreHashLines(lines)
-			got, count, err := columnStoreSuiteHashPhysicalQueryGroups(tt.prefix, tt.queryName, tt.groups)
+			groupsForHash := append([]collections.ColumnPhysicalQueryGroup(nil), tt.groups...)
+			got, count, err := columnStoreSuiteHashPhysicalQueryGroups(tt.prefix, tt.queryName, groupsForHash)
 			if err != nil {
 				t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups: %v", err)
 			}

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -120,6 +120,8 @@ func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
 	}{
 		{name: "count", prefix: "q1", key: "share", value: 12, want: "q1:share=12"},
 		{name: "negative", prefix: "q4a", key: "d000001", value: -42, want: "q4a:d000001=-42"},
+		{name: "min_int64", prefix: "q4a", key: "d000002", value: -1 << 63, want: "q4a:d000002=-9223372036854775808"},
+		{name: "max_int64", prefix: "q4b", key: "d000003", value: 1<<63 - 1, want: "q4b:d000003=9223372036854775807"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -110,6 +110,26 @@ func TestRunColumnStoreSuiteReportsRelaxedAssetReadIntegrityM1634(t *testing.T) 
 	}
 }
 
+func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		key    string
+		value  int64
+		want   string
+	}{
+		{name: "count", prefix: "q1", key: "share", value: 12, want: "q1:share=12"},
+		{name: "negative", prefix: "q4a", key: "d000001", value: -42, want: "q4a:d000001=-42"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := columnStoreSuiteFormatPhysicalQueryLine(tt.prefix, tt.key, tt.value); got != tt.want {
+				t.Fatalf("columnStoreSuiteFormatPhysicalQueryLine=%q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestColumnStoreSuiteInheritsTreeDBDisableReadChecksumM1634(t *testing.T) {
 	prevAllowUnsafe := *treedbAllowUnsafe
 	prevDisableReadChecksum := *treedbDisableReadChecksum

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -134,8 +134,8 @@ func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
 
 func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.T) {
 	groups := []collections.ColumnPhysicalQueryGroup{
-		{Key: "app.bsky.feed.like", Count: 12},
 		{Key: "app.bsky.feed.post", Count: 34},
+		{Key: "app.bsky.feed.like", Count: 12},
 		{Key: "app.bsky.graph.follow", Count: 56},
 	}
 	lines, err := columnStoreSuitePhysicalQueryLines("q1", columnStoreQueryQ1, groups)
@@ -155,8 +155,8 @@ func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.
 	}
 
 	spanGroups := []collections.ColumnPhysicalQueryGroup{
-		{Key: "d000001", Int64: -1 << 63},
 		{Key: "d000002", Int64: 1<<63 - 1},
+		{Key: "d000001", Int64: -1 << 63},
 	}
 	lines, err = columnStoreSuitePhysicalQueryLines("q5", columnStoreQueryQ5, spanGroups)
 	if err != nil {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -124,6 +124,7 @@ func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
 		{name: "max_int64", prefix: "q4b", key: "d000003", value: 1<<63 - 1, want: "q4b:d000003=9223372036854775807"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := columnStoreSuiteFormatPhysicalQueryLine(tt.prefix, tt.key, tt.value); got != tt.want {
 				t.Fatalf("columnStoreSuiteFormatPhysicalQueryLine=%q want %q", got, tt.want)
@@ -170,6 +171,7 @@ func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			groupsForLines := append([]collections.ColumnPhysicalQueryGroup(nil), tt.groups...)
 			lines, err := columnStoreSuitePhysicalQueryLines(tt.prefix, tt.queryName, groupsForLines)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -133,45 +133,60 @@ func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
 }
 
 func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.T) {
-	groups := []collections.ColumnPhysicalQueryGroup{
-		{Key: "app.bsky.feed.post", Count: 34},
-		{Key: "app.bsky.feed.like", Count: 12},
-		{Key: "app.bsky.graph.follow", Count: 56},
+	tests := []struct {
+		name      string
+		prefix    string
+		queryName string
+		groups    []collections.ColumnPhysicalQueryGroup
+	}{
+		{
+			name:      "q1_unsorted",
+			prefix:    "q1",
+			queryName: columnStoreQueryQ1,
+			groups: []collections.ColumnPhysicalQueryGroup{
+				{Key: "app.bsky.feed.post", Count: 34},
+				{Key: "app.bsky.feed.like", Count: 12},
+				{Key: "app.bsky.graph.follow", Count: 56},
+			},
+		},
+		{
+			name:      "q1_prefix_key_and_decimal_lexical_order",
+			prefix:    "q1",
+			queryName: columnStoreQueryQ1,
+			groups: []collections.ColumnPhysicalQueryGroup{
+				{Key: "a", Count: 2},
+				{Key: "a.b", Count: 1},
+				{Key: "a", Count: 10},
+			},
+		},
+		{
+			name:      "q5_unsorted_boundaries",
+			prefix:    "q5",
+			queryName: columnStoreQueryQ5,
+			groups: []collections.ColumnPhysicalQueryGroup{
+				{Key: "d000002", Int64: 1<<63 - 1},
+				{Key: "d000001", Int64: -1 << 63},
+			},
+		},
 	}
-	lines, err := columnStoreSuitePhysicalQueryLines("q1", columnStoreQueryQ1, groups)
-	if err != nil {
-		t.Fatalf("columnStoreSuitePhysicalQueryLines: %v", err)
-	}
-	want := columnStoreHashLines(lines)
-	got, count, err := columnStoreSuiteHashPhysicalQueryGroups("q1", columnStoreQueryQ1, groups)
-	if err != nil {
-		t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups: %v", err)
-	}
-	if count != len(groups) {
-		t.Fatalf("result count=%d want %d", count, len(groups))
-	}
-	if got != want {
-		t.Fatalf("direct hash=%016x want line hash=%016x", got, want)
-	}
-
-	spanGroups := []collections.ColumnPhysicalQueryGroup{
-		{Key: "d000002", Int64: 1<<63 - 1},
-		{Key: "d000001", Int64: -1 << 63},
-	}
-	lines, err = columnStoreSuitePhysicalQueryLines("q5", columnStoreQueryQ5, spanGroups)
-	if err != nil {
-		t.Fatalf("columnStoreSuitePhysicalQueryLines q5: %v", err)
-	}
-	want = columnStoreHashLines(lines)
-	got, count, err = columnStoreSuiteHashPhysicalQueryGroups("q5", columnStoreQueryQ5, spanGroups)
-	if err != nil {
-		t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups q5: %v", err)
-	}
-	if count != len(spanGroups) {
-		t.Fatalf("q5 result count=%d want %d", count, len(spanGroups))
-	}
-	if got != want {
-		t.Fatalf("q5 direct hash=%016x want line hash=%016x", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines, err := columnStoreSuitePhysicalQueryLines(tt.prefix, tt.queryName, tt.groups)
+			if err != nil {
+				t.Fatalf("columnStoreSuitePhysicalQueryLines: %v", err)
+			}
+			want := columnStoreHashLines(lines)
+			got, count, err := columnStoreSuiteHashPhysicalQueryGroups(tt.prefix, tt.queryName, tt.groups)
+			if err != nil {
+				t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups: %v", err)
+			}
+			if count != len(tt.groups) {
+				t.Fatalf("result count=%d want %d", count, len(tt.groups))
+			}
+			if got != want {
+				t.Fatalf("direct hash=%016x want line hash=%016x", got, want)
+			}
+		})
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -132,6 +132,49 @@ func TestColumnStoreSuiteFormatPhysicalQueryLineM1634(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634(t *testing.T) {
+	groups := []collections.ColumnPhysicalQueryGroup{
+		{Key: "app.bsky.feed.like", Count: 12},
+		{Key: "app.bsky.feed.post", Count: 34},
+		{Key: "app.bsky.graph.follow", Count: 56},
+	}
+	lines, err := columnStoreSuitePhysicalQueryLines("q1", columnStoreQueryQ1, groups)
+	if err != nil {
+		t.Fatalf("columnStoreSuitePhysicalQueryLines: %v", err)
+	}
+	want := columnStoreHashLines(lines)
+	got, count, err := columnStoreSuiteHashPhysicalQueryGroups("q1", columnStoreQueryQ1, groups)
+	if err != nil {
+		t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups: %v", err)
+	}
+	if count != len(groups) {
+		t.Fatalf("result count=%d want %d", count, len(groups))
+	}
+	if got != want {
+		t.Fatalf("direct hash=%016x want line hash=%016x", got, want)
+	}
+
+	spanGroups := []collections.ColumnPhysicalQueryGroup{
+		{Key: "d000001", Int64: -1 << 63},
+		{Key: "d000002", Int64: 1<<63 - 1},
+	}
+	lines, err = columnStoreSuitePhysicalQueryLines("q5", columnStoreQueryQ5, spanGroups)
+	if err != nil {
+		t.Fatalf("columnStoreSuitePhysicalQueryLines q5: %v", err)
+	}
+	want = columnStoreHashLines(lines)
+	got, count, err = columnStoreSuiteHashPhysicalQueryGroups("q5", columnStoreQueryQ5, spanGroups)
+	if err != nil {
+		t.Fatalf("columnStoreSuiteHashPhysicalQueryGroups q5: %v", err)
+	}
+	if count != len(spanGroups) {
+		t.Fatalf("q5 result count=%d want %d", count, len(spanGroups))
+	}
+	if got != want {
+		t.Fatalf("q5 direct hash=%016x want line hash=%016x", got, want)
+	}
+}
+
 func TestColumnStoreSuiteInheritsTreeDBDisableReadChecksumM1634(t *testing.T) {
 	prevAllowUnsafe := *treedbAllowUnsafe
 	prevDisableReadChecksum := *treedbDisableReadChecksum


### PR DESCRIPTION
## Summary

This is a narrow #1634 harness/reporting allocation cleanup on top of #1665. It removes avoidable q1-q5 physical parity/result-line heap work by replacing the original `fmt.Sprintf` line formatting and then hashing physical query groups directly instead of materializing strings only to hash them. It adds direct formatter coverage plus direct-hash equivalence coverage, including `MinInt64`/`MaxInt64` boundary cases for the fixed decimal scratch buffer.

No engine, planner, storage, durability, read-integrity, mmap, asset-manager, query routing, physical asset layout, metadata asset, mark, dictionary, locator, visibility, GC, or rewrite behavior changes in this PR.

Review follow-up through `a272a0363`: direct physical parity hashing now canonicalizes group order before hashing so the direct hash remains equivalent to the prior line-hash semantics even if a physical query returns unsorted groups. The helper uses an in-place typed insertion sort over the small result-group slice instead of `sort.Slice` or a copied slice, because the `sort.Slice` variant was measured to add about 20 allocations/op across the package q1-q5 benchmark. The latest fix compares the virtual `key=value` suffix byte-by-byte, so prefix keys such as `a`/`a.b` and duplicate-key decimal values such as `10`/`2` preserve exact `sort.Strings(formattedLines)` ordering without allocating formatted strings.

## Static Reprioritization Checkpoint

Static pass after #1661/#1663/#1665: the next large gap to the old `experiments/colgranule` kernels is not primarily another TCPA cursor branch. Production still scans row-record-shaped physical assets: row id/deleted state, every declared column's type/null/present framing, selected string bytes interned into Go maps, and skipped unselected values. The experiment path is closer to ClickHouse-style analytical execution: schema-fixed per-column blocks/granules, low-cardinality `uint32` codes, dense arrays/bitsets/reusable scratch, sort-key marks, dictionaries, locators, and metadata assets.

This PR is therefore tactical. It reduces parity/reporting adapter allocation overhead visible in current routed-suite/package measurements. It does not move production toward experiment-kernel throughput by itself. The next high-value #1634 direction should prioritize measured dictionary/code projection plus dense-code reducers, real metadata-only q4/q5 assets, mark/pruning evidence, and eventually a schema-fixed column-block asset or sidecar layout if the dense-code prototype confirms representation is the limiter. Shared mmap/segment-reader work remains useful infrastructure, but should not dominate unless fresh profiles show asset-manager/read-copy/open-cache overhead re-emerging.

Source evidence used for this checkpoint:

- `experiments/colgranule/part.go`: `ColumnPart` stores columns, granules, marks, locators, aggregate metadata, and low-cardinality code column definitions.
- `experiments/colgranule/aggregate.go` and `jsonbench_part_queries.go`: experiment reducers use dense code/count/bitset scratch over encoded granules.
- `TreeDB/collections/column_physical_asset.go`: production TCPA writes row records with per-row id/deleted state and per-value type/null/present/value framing.
- `TreeDB/collections/column_physical_scan.go` and `column_physical_query.go`: production direct query path still walks every row and declared column, then interns string groups into maps.

## Performance / Benchmark Evidence

Apple M3, darwin/arm64, current branch `codex/column-store-parity-line-format-allocs`, latest head `a272a0363`, compared against #1665 baseline `/tmp/direct_decode_specialization_cmd_bench10_relaxed_doc_head.txt`.

Package benchmark command:

```sh
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=10
```

Current artifact: `/tmp/parity_direct_hash_allocs_cmd_bench10.txt`.

Review-fix allocation checks: `/tmp/parity_direct_hash_order_const_cmd_bench5.txt` validates the first canonical hash ordering fix and shared scratch constant, and `/tmp/parity_direct_hash_line_equiv_cmd_bench5.txt` validates the latest line-equivalent comparator fix. Serial physical remains around `13.10K allocs/op`; aggregate metadata remains around `29.07K allocs/op`.

Residual direct-query allocation refresh artifact: `/tmp/gomap_1668_query_alloc_profile_20260520_180040`. Timed `BenchmarkColumnPhysicalQueryAdapterM13B` q1-q5 at 8192 rows reports q1 `74 allocs/op`, q2 `107 allocs/op`, q3 `63 allocs/op`, and q4a/q4b/q5 `96 allocs/op`. The generated memprofile is setup-heavy because it includes fixture/open/insert allocations outside the timed benchmark region; the per-subbenchmark `allocs/op` numbers are the query allocation signal.

Latest-head allocation parity refresh after the doc-only review follow-up: `/tmp/gomap_1634_alloc_parity_refresh_20260520_182320` reports production direct q1/q2/q3/q4a/q4b/q5 at 8192 rows as `74`/`107`/`63`/`96`/`96`/`96 allocs/op`. The paired hot-kernel granule refresh `/tmp/gomap_1634_granule_hot_kernel_alloc_refresh_20260520_182331.txt` confirms the old granule target for the equivalent inner kernels: `BenchmarkCountUint32CodesGranule`, `BenchmarkAggregateGroupedCountCodes`, `BenchmarkAggregateFilteredGroupedCountCodes`, and locator hot paths report `0 B/op, 0 allocs/op`.

Results:

- `SerialPhysicalQueriesSkipChecksums`: `7.173 ms/op` to `6.637 ms/op` (`-7.46%`), `872.0 MiB/s` to `942.3 MiB/s`, `2.601 MiB/op` to `2.262 MiB/op`, `29.64K allocs/op` to `13.10K allocs/op` (`-55.80%`).
- `AggregateMetadataQueriesSkipChecksums`: `6.052 ms/op` to `5.582 ms/op` (`-7.77%`), `1.009 GiB/s` to `1.094 GiB/s`, `3.026 MiB/op` to `2.688 MiB/op`, `45.61K allocs/op` to `29.07K allocs/op` (`-36.27%`).
- Geomean: `-7.62% sec/op`, `+8.25% throughput`, `-12.11% B/op`, `-46.93% allocs/op`.

Routed 100K durable `skip_checksums` context artifact root, captured before the direct-hash commit and retained as engine/HTML context because scanner/reducer behavior is unchanged: `/tmp/gomap_1634_parity_line_format_20260520_173535`.

Representative HTML reports:

- `/tmp/gomap_1634_parity_line_format_20260520_173535/routed_100000_serial_column_scan/column_store_results.html`
- `/tmp/gomap_1634_parity_line_format_20260520_173535/routed_100000_aggregate_metadata/column_store_results.html`

Routed serial q1/q2/q3/q4a/q4b/q5/q5_metadata: `15.71M` / `10.80M` / `28.64M` / `12.45M` / `12.28M` / `11.02M` / `10.90M rows/s`; all parity pass, `row_materializations=0`, `bytes_read=10404660`, segment cache hits/misses `19/1`.

Routed aggregate q1/q2/q3/q4a/q5: `15.80M` / `10.80M` / `29.11M` / `13.05M` / `11.69M rows/s`; q4b aggregate metadata `67.79M rows/s`, q5_metadata aggregate metadata `113.31M rows/s`, `metadata_hits=20`, `bytes_read=801720`; all parity pass.

## Throughput Interpretation

The win is in benchmark/reporting parity-line allocation overhead after physical query execution. Direct scanner semantics, bytes read, physical asset format, and reducer logic are unchanged. Do not interpret this as production reaching the experiment granule-kernel ceiling.

Allocation parity remains a first-class #1634 priority. The old granule kernels were designed for zero hot-kernel allocations, so the target for equivalent direct q1-q5 hot-kernel shapes is 0 allocs/op. This PR removes one avoidable reporting/parity allocation source, but it does not satisfy that target: current production routed/package paths still allocate materially more than the granule equivalents. The residual allocation ledger after this PR is therefore explicit: remaining allocations are expected to come from row-record string interning/maps, routed-suite/reporting integration, and other production adapter state until dictionary/code projection plus dense reducers replace the string-map reducer shape. Future #1634 PRs should keep reporting allocs/op beside throughput and prefer low-risk local allocation reductions when they do not distract from the representation/kernel-shape plan.

Best available stale comparison context from the prior #1634 slope/refresh runs:

- Experiment encoded q1/q2/q3/q5 reducers: about `414.32M` / `237.43M` / `192.13M` / `140.22M rows/s` from `/tmp/gomap_1634_after_mmap_refresh_20260520_160708/experiment_colgranule_baseline.txt`.
- Experiment q4b ClickHouse-order row scan: about `90.21M rows/s`.
- Experiment q4b/q5 metadata: about `302.36M` / `423.85M rows/s`.
- Historical ClickHouse-equivalent local context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: ClickHouse `26.4.3.1`, 1M JSONBench rows, q1/q2/q3/q4/q5 `0.014s` / `0.027s` / `0.014s` / `0.013s` / `0.013s`; experiment column-kernel best `0.004284s` / `0.038895s` / `0.006631s` / `0.009869s` / `0.010027s`. This is context only, not an apples-to-apples routed production gate.

## Gate Status

Passed locally:

```sh
go test ./cmd/unified_bench -run 'TestColumnStoreSuiteFormatPhysicalQueryLineM1634|TestColumnStoreSuiteHashPhysicalQueryGroupsMatchesLineHashM1634|TestRunColumnStoreSuiteReportsRelaxedAssetReadIntegrityM1634' -count=1
go test ./cmd/unified_bench -run TestColumnStoreSuiteFormatPhysicalQueryLineM1634 -count=1
go test ./cmd/unified_bench -count=1
git diff --check
go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysicalQueriesSkipChecksums|AggregateMetadataQueriesSkipChecksums)' -benchmem -benchtime=5x -count=10
```

## Artifacts

- Package benchmark current: `/tmp/parity_direct_hash_allocs_cmd_bench10.txt`
- Review-fix package benchmark: `/tmp/parity_direct_hash_order_const_cmd_bench5.txt`
- Line-equivalent review-fix package benchmark: `/tmp/parity_direct_hash_line_equiv_cmd_bench5.txt`
- Latest comparator review-fix package benchmark: `/tmp/parity_direct_hash_reviewfix_b914_followup_cmd_bench5.txt`
- Latest-head allocation parity refresh: `/tmp/gomap_1634_alloc_parity_refresh_20260520_182320`
- Latest-head granule hot-kernel allocation refresh: `/tmp/gomap_1634_granule_hot_kernel_alloc_refresh_20260520_182331.txt`; latest head doc-only, test-isolation, loop-shadow, in-place mutation, and comparator review follow-ups were validated with targeted unified-bench tests, full `cmd/unified_bench`, package benchmarks, and `git diff --check`
- Package benchmark baseline: `/tmp/direct_decode_specialization_cmd_bench10_relaxed_doc_head.txt`
- Routed artifact root: `/tmp/gomap_1634_parity_line_format_20260520_173535`
- Routed serial HTML: `/tmp/gomap_1634_parity_line_format_20260520_173535/routed_100000_serial_column_scan/column_store_results.html`
- Routed aggregate HTML: `/tmp/gomap_1634_parity_line_format_20260520_173535/routed_100000_aggregate_metadata/column_store_results.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated physical-query group/line formatting into a shared, builder-based implementation for deterministic, faster output.

* **Improvements**
  * Parity verification now records and reuses production hash and timing to reduce redundant recomputation and improve parity timing accuracy.
  * Replaced external hash dependency with an internal 64-bit hash implementation for parity calculations.

* **Tests**
  * Added unit tests validating formatting and hash consistency across positive, negative, and boundary numeric cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->












