### PR TITLE
TreeDB column store post-V1: add reusable physical query runner

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,6 +84,20 @@ type ColumnPhysicalQueryResult struct {
 	Diagnostics ColumnPhysicalQueryDiagnostics
 }
 
+// ColumnPhysicalQueryRunner pins one immutable snapshot and reuses direct-query
+// execution state across repeated scans. It is intentionally limited to
+// insert-only direct physical reducers; mutation visibility and planner routing
+// remain owned by RunColumnPhysicalQuery.
+type ColumnPhysicalQueryRunner struct {
+	collection *Collection
+	view       columnPhysicalScanSnapshotView
+	closeView  func()
+	req        ColumnPhysicalQueryRequest
+	exec       *columnPhysicalQueryExecutor
+	readCache  columnPhysicalAssetReadCache
+	closed     bool
+}
+
 var errColumnPhysicalScanCancelled = errors.New("collections: physical column scan cancelled")
 
 // RunColumnPhysicalQuery executes an explicit serial physical column query over
@@ -123,6 +136,95 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 		return c.runColumnPhysicalQueryAggregateMetadataInSnapshotView(view, req)
 	}
 	return c.runColumnPhysicalQueryInSnapshotView(view, req)
+}
+
+// PrepareColumnPhysicalQuery prepares a reusable direct physical query runner
+// over the current recovery-authoritative manifest. The runner pins a snapshot
+// until Close and fail-closes for mutation-bearing manifests or unsupported
+// query shapes rather than silently changing semantics.
+func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (*ColumnPhysicalQueryRunner, error) {
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	if err != nil {
+		if closeView != nil {
+			closeView()
+		}
+		return nil, err
+	}
+	release := true
+	defer func() {
+		if release && closeView != nil {
+			closeView()
+		}
+	}()
+	if view.MutationParts > 0 {
+		return nil, fmt.Errorf("%w: prepared physical column query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
+	}
+	if req.AggregateMetadataName != "" {
+		return nil, fmt.Errorf("%w: prepared physical column query does not support aggregate metadata yet", ErrColumnQueryPlanUnsupported)
+	}
+	exec, err := newColumnPhysicalQueryExecutor(view.Config, req)
+	if err != nil {
+		return nil, err
+	}
+	if !exec.supportsDirectAssetReduce() {
+		return nil, fmt.Errorf("%w: prepared physical column query requires direct asset reducer", ErrColumnQueryPlanUnsupported)
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return nil, err
+	}
+	readCache.returnViews = true
+	release = false
+	return &ColumnPhysicalQueryRunner{
+		collection: c,
+		view:       view,
+		closeView:  closeView,
+		req:        req,
+		exec:       exec,
+		readCache:  readCache,
+	}, nil
+}
+
+// Close releases the pinned snapshot and typed column asset readers owned by
+// the prepared physical query runner.
+func (r *ColumnPhysicalQueryRunner) Close() error {
+	if r == nil || r.closed {
+		return nil
+	}
+	r.closed = true
+	var closeErr error
+	if err := r.readCache.close(); err != nil {
+		closeErr = err
+	}
+	if r.closeView != nil {
+		r.closeView()
+		r.closeView = nil
+	}
+	return closeErr
+}
+
+// Run executes the prepared direct physical query against the pinned snapshot.
+func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
+	if r == nil || r.closed {
+		return ColumnPhysicalQueryResult{}, errors.New("collections: prepared physical column query runner is closed")
+	}
+	r.exec.resetForRun()
+	scanStart := time.Now()
+	diag, err := r.collection.scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(r.view, r.exec, &r.readCache, 0, 0, nil)
+	scanNanos := time.Since(scanStart).Nanoseconds()
+	result := ColumnPhysicalQueryResult{
+		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
+	}
+	result.Diagnostics.DirectReduceBlocks = diag.DecodedBlocks
+	result.Diagnostics.WorkerCount = 1
+	result.Diagnostics.ScanNanos = scanNanos
+	result.Diagnostics.ReduceRows = r.exec.reduceRows
+	if err != nil {
+		return result, err
+	}
+	result.Groups = r.exec.groups()
+	result.Diagnostics.ResultGroups = len(result.Groups)
+	return result, nil
 }
 
 func (c *Collection) runColumnPhysicalQueryAggregateMetadataInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
@@ -210,6 +312,23 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
 	refRemainder int,
 	shouldCancel func() bool,
 ) (columnPhysicalScanDiagnostics, error) {
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, exec.readIntegrity)
+	if err != nil {
+		return view.Diagnostics, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+	return c.scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(view, exec, &readCache, refModulo, refRemainder, shouldCancel)
+}
+
+func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(
+	view columnPhysicalScanSnapshotView,
+	exec *columnPhysicalQueryExecutor,
+	readCache *columnPhysicalAssetReadCache,
+	refModulo int,
+	refRemainder int,
+	shouldCancel func() bool,
+) (columnPhysicalScanDiagnostics, error) {
 	cfg := view.Config
 	diag := view.Diagnostics
 	if c == nil {
@@ -238,12 +357,10 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotView(
 	}
 	diag.ProjectedColumns = len(exec.projected)
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(exec.readIntegrity)
-	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, exec.readIntegrity)
-	if err != nil {
-		return diag, err
+	if readCache == nil {
+		return diag, errors.New("collections: prepared physical column query missing read cache")
 	}
 	readCache.returnViews = true
-	defer func() { _ = readCache.close() }()
 	var rawScratch []byte
 	start, step := columnPhysicalScanRefOrdinalPartition(columnPhysicalScanRequest{RefOrdinalModulo: refModulo, RefOrdinalRemainder: refRemainder})
 	for ordinal := start; ordinal < len(view.AssetRefs); ordinal += step {
@@ -710,6 +827,31 @@ func (e *columnPhysicalQueryExecutor) supportsDirectAssetReduce() bool {
 	}
 }
 
+func (e *columnPhysicalQueryExecutor) resetForRun() {
+	if e == nil {
+		return
+	}
+	e.reduceRows = 0
+	e.resultGroups = e.resultGroups[:0]
+	for idx := range e.hourCounts {
+		e.hourCounts[idx] = 0
+	}
+	for key := range e.counts {
+		delete(e.counts, key)
+	}
+	for _, set := range e.distinct {
+		for key := range set {
+			delete(set, key)
+		}
+	}
+	for key := range e.int64Values {
+		delete(e.int64Values, key)
+	}
+	for key := range e.int64Spans {
+		delete(e.int64Spans, key)
+	}
+}
+
 func (e *columnPhysicalQueryExecutor) visit(row columnPhysicalScanRowView) error {
 	if row.Deleted || row.Operation != ColumnPublishOperationInsert {
 		return fmt.Errorf("%w: operation=%s deleted=%v", errColumnPhysicalQueryNeedsVisibility, row.Operation, row.Deleted)
@@ -1169,10 +1311,19 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	sort.Slice(e.resultGroups, func(i, j int) bool {
-		return e.resultGroups[i].Key < e.resultGroups[j].Key
-	})
+	sortColumnPhysicalQueryGroupsByKey(e.resultGroups)
 	return e.resultGroups
+}
+
+func sortColumnPhysicalQueryGroupsByKey(groups []ColumnPhysicalQueryGroup) {
+	for i := 1; i < len(groups); i++ {
+		group := groups[i]
+		j := i - 1
+		for ; j >= 0 && group.Key < groups[j].Key; j-- {
+			groups[j+1] = groups[j]
+		}
+		groups[j+1] = group
+	}
 }
 
 type columnPhysicalQueryMetadataAccumulator struct {
@@ -1244,7 +1395,7 @@ func (a *columnPhysicalQueryMetadataAccumulator) groups() []ColumnPhysicalQueryG
 			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	sortColumnPhysicalQueryGroupsByKey(out)
 	return out
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -218,9 +218,13 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 		return ColumnPhysicalQueryResult{}, errors.New("collections: prepared physical column query runner is closed")
 	}
 	r.exec.resetForRun()
+	beforeHits := r.readCache.hits
+	beforeMisses := r.readCache.misses
 	scanStart := time.Now()
 	diag, err := r.collection.scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(r.view, r.exec, &r.readCache, 0, 0, nil)
 	scanNanos := time.Since(scanStart).Nanoseconds()
+	diag.SegmentFileCacheHits -= beforeHits
+	diag.SegmentFileCacheMisses -= beforeMisses
 	result := ColumnPhysicalQueryResult{
 		Diagnostics: columnPhysicalQueryDiagnosticsFromScan(diag),
 	}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -1,8 +1,10 @@
 package collections
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -88,6 +90,10 @@ type ColumnPhysicalQueryResult struct {
 // execution state across repeated scans. It is intentionally limited to
 // insert-only direct physical reducers; mutation visibility and planner routing
 // remain owned by RunColumnPhysicalQuery.
+//
+// The runner is not safe for concurrent use; callers must externally
+// synchronize Run and Close. Result groups returned by Run alias runner-owned
+// storage and are valid only until the next Run or Close.
 type ColumnPhysicalQueryRunner struct {
 	collection *Collection
 	view       columnPhysicalScanSnapshotView
@@ -204,6 +210,9 @@ func (r *ColumnPhysicalQueryRunner) Close() error {
 }
 
 // Run executes the prepared direct physical query against the pinned snapshot.
+// The returned Groups slice aliases runner-owned storage to keep hot loops
+// allocation-free; copy Groups before calling Run again or Close if the result
+// must be retained.
 func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	if r == nil || r.closed {
 		return ColumnPhysicalQueryResult{}, errors.New("collections: prepared physical column query runner is closed")
@@ -1316,6 +1325,13 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 }
 
 func sortColumnPhysicalQueryGroupsByKey(groups []ColumnPhysicalQueryGroup) {
+	const insertionSortLimit = 64
+	if len(groups) > insertionSortLimit {
+		slices.SortFunc(groups, func(a, b ColumnPhysicalQueryGroup) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+		return
+	}
 	for i := 1; i < len(groups); i++ {
 		group := groups[i]
 		j := i - 1

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -696,6 +696,7 @@ type columnPhysicalQueryExecutor struct {
 
 	counts       map[string]int
 	distinct     map[string]map[string]struct{}
+	distinctPool []map[string]struct{}
 	hourCounts   [24]int
 	int64Values  map[string]int64
 	int64Spans   map[string]columnPhysicalQuerySpan
@@ -848,10 +849,13 @@ func (e *columnPhysicalQueryExecutor) resetForRun() {
 	for key := range e.counts {
 		delete(e.counts, key)
 	}
-	for _, set := range e.distinct {
-		for key := range set {
-			delete(set, key)
+	e.distinctPool = e.distinctPool[:0]
+	for key, set := range e.distinct {
+		for value := range set {
+			delete(set, value)
 		}
+		e.distinctPool = append(e.distinctPool, set)
+		delete(e.distinct, key)
 	}
 	for key := range e.int64Values {
 		delete(e.int64Values, key)
@@ -886,11 +890,7 @@ func (e *columnPhysicalQueryExecutor) visitValues(values []columnDeclaredValue) 
 		if err != nil {
 			return err
 		}
-		set := e.distinct[key]
-		if set == nil {
-			set = make(map[string]struct{})
-			e.distinct[key] = set
-		}
+		set := e.distinctSetForGroup(key)
 		set[distinct] = struct{}{}
 	case ColumnPhysicalQueryHourCount:
 		value, err := columnPhysicalQueryInt64Value(values[e.valueIdx])
@@ -933,6 +933,21 @@ func (e *columnPhysicalQueryExecutor) visitValues(values []columnDeclaredValue) 
 		e.int64Spans[key] = cur
 	}
 	return nil
+}
+
+func (e *columnPhysicalQueryExecutor) distinctSetForGroup(key string) map[string]struct{} {
+	set := e.distinct[key]
+	if set != nil {
+		return set
+	}
+	if n := len(e.distinctPool); n > 0 {
+		set = e.distinctPool[n-1]
+		e.distinctPool = e.distinctPool[:n-1]
+	} else {
+		set = make(map[string]struct{})
+	}
+	e.distinct[key] = set
+	return set
 }
 
 func reduceColumnPhysicalAssetDirect(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg *ColumnStoreConfig, expectedOperation ColumnPublishOperation, exec *columnPhysicalQueryExecutor) (columnPhysicalAssetScanSummary, error) {
@@ -1194,11 +1209,7 @@ func (e *columnPhysicalQueryExecutor) visitDirectGroupCountDistinct(group []byte
 	}
 	key := e.interner.internBytes(group)
 	distinctKey := e.interner.internBytes(distinct)
-	set := e.distinct[key]
-	if set == nil {
-		set = make(map[string]struct{})
-		e.distinct[key] = set
-	}
+	set := e.distinctSetForGroup(key)
 	set[distinctKey] = struct{}{}
 	e.reduceRows++
 	return nil

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1900,6 +1900,19 @@ func TestColumnPhysicalQueryRunnerFailsClosedForUnsupportedShapeM1634(t *testing
 	}
 }
 
+func TestColumnPhysicalQueryGroupSortHybridM1634(t *testing.T) {
+	groups := make([]ColumnPhysicalQueryGroup, 96)
+	for i := range groups {
+		groups[i] = ColumnPhysicalQueryGroup{Key: fmt.Sprintf("key_%03d", len(groups)-i)}
+	}
+	sortColumnPhysicalQueryGroupsByKey(groups)
+	for i := 1; i < len(groups); i++ {
+		if groups[i-1].Key > groups[i].Key {
+			t.Fatalf("groups not sorted at %d: %q > %q", i, groups[i-1].Key, groups[i].Key)
+		}
+	}
+}
+
 func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 	for _, rows := range []int{1024, 8192} {
 		cases := []struct {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1837,6 +1837,69 @@ func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+	wantHash := columnPhysicalQueryReferenceHashM13B("q1", events)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	defer func() {
+		if err := runner.Close(); err != nil {
+			t.Fatalf("runner Close: %v", err)
+		}
+	}()
+	for i := 0; i < 3; i++ {
+		result, err := runner.Run()
+		if err != nil {
+			t.Fatalf("runner Run warmup %d: %v", i, err)
+		}
+		if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B("q1", result.Groups)); got != wantHash {
+			t.Fatalf("runner q1 hash=%d want %d groups=%+v", got, wantHash, result.Groups)
+		}
+		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+		}
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		result, err := runner.Run()
+		if err != nil {
+			panic(fmt.Sprintf("runner Run: %v", err))
+		}
+		if len(result.Groups) != 4 {
+			panic(fmt.Sprintf("runner groups=%d want 4", len(result.Groups)))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("runner q1 warmed allocs/run=%.2f want 0", allocs)
+	}
+}
+
+func TestColumnPhysicalQueryRunnerFailsClosedForUnsupportedShapeM1634(t *testing.T) {
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
+	defer closeFn()
+	if _, err := collection.PrepareColumnPhysicalQuery(ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupCount,
+		GroupColumn: "payload",
+	}); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("PrepareColumnPhysicalQuery unsupported err=%v want ErrColumnQueryPlanUnsupported", err)
+	}
+
+	mutated, closeMutated, _ := openColumnPhysicalMutationFixtureM13C(t, 128)
+	defer closeMutated()
+	if _, err := mutated.PrepareColumnPhysicalQuery(ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupCount,
+		GroupColumn: "kind",
+	}); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("PrepareColumnPhysicalQuery mutation err=%v want ErrColumnQueryPlanUnsupported", err)
+	}
+}
+
 func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 	for _, rows := range []int{1024, 8192} {
 		cases := []struct {
@@ -1866,6 +1929,56 @@ func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 					result, err := collection.RunColumnPhysicalQuery(tc.req)
 					if err != nil {
 						b.Fatalf("RunColumnPhysicalQuery: %v", err)
+					}
+					if len(result.Groups) == 0 {
+						b.Fatal("empty result")
+					}
+					reducedRows += int64(result.Diagnostics.ReduceRows)
+				}
+				if reducedRows > 0 {
+					elapsed := b.Elapsed()
+					b.ReportMetric(float64(reducedRows)/elapsed.Seconds(), "rows/s")
+					b.ReportMetric(float64(elapsed.Nanoseconds())/float64(reducedRows), "ns/row")
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkColumnPhysicalQueryRunnerM1634(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		cases := []struct {
+			name string
+			req  ColumnPhysicalQueryRequest
+		}{
+			{name: "q1", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}},
+			{name: "q2", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}},
+			{name: "q3", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
+			{name: "q4a", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q4b", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q5", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
+		}
+		for _, tc := range cases {
+			b.Run(fmt.Sprintf("%s_rows_%d", tc.name, rows), func(b *testing.B) {
+				collection, closeFn := openColumnPhysicalQueryFixtureM13B(b, columnPhysicalQueryFixtureEventsM13B(rows))
+				defer closeFn()
+				runner, err := collection.PrepareColumnPhysicalQuery(tc.req)
+				if err != nil {
+					b.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+				}
+				defer func() { _ = runner.Close() }()
+				preview, err := runner.Run()
+				if err != nil {
+					b.Fatalf("preview runner Run: %v", err)
+				}
+				b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+				b.ReportAllocs()
+				b.ResetTimer()
+				var reducedRows int64
+				for i := 0; i < b.N; i++ {
+					result, err := runner.Run()
+					if err != nil {
+						b.Fatalf("runner Run: %v", err)
 					}
 					if len(result.Groups) == 0 {
 						b.Fatal("empty result")

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1913,6 +1913,32 @@ func TestColumnPhysicalQueryGroupSortHybridM1634(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQueryExecutorResetClearsDistinctGroupsM1634(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	exec, err := newColumnPhysicalQueryExecutor(*cfg, ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountDistinct,
+		GroupColumn:    "kind",
+		DistinctColumn: "did",
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalQueryExecutor: %v", err)
+	}
+	if err := exec.visitDirectGroupCountDistinct([]byte("kind_a"), true, []byte("did_a"), true); err != nil {
+		t.Fatalf("visit first distinct: %v", err)
+	}
+	if got := exec.groups(); len(got) != 1 || got[0].Key != "kind_a" || got[0].Count != 1 {
+		t.Fatalf("first groups=%+v want kind_a=1", got)
+	}
+	exec.resetForRun()
+	if err := exec.visitDirectGroupCountDistinct([]byte("kind_b"), true, []byte("did_b"), true); err != nil {
+		t.Fatalf("visit second distinct: %v", err)
+	}
+	got := exec.groups()
+	if len(got) != 1 || got[0].Key != "kind_b" || got[0].Count != 1 {
+		t.Fatalf("second groups=%+v want only kind_b=1", got)
+	}
+}
+
 func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 	for _, rows := range []int{1024, 8192} {
 		cases := []struct {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1864,6 +1864,12 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
 			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
 		}
+		if i == 0 && result.Diagnostics.SegmentFileCacheMisses == 0 {
+			t.Fatalf("first runner diagnostics=%+v want initial segment cache miss", result.Diagnostics)
+		}
+		if i > 0 && result.Diagnostics.SegmentFileCacheMisses != 0 {
+			t.Fatalf("runner diagnostics=%+v want per-run cache misses reset after warmup", result.Diagnostics)
+		}
 	}
 
 	allocs := testing.AllocsPerRun(20, func() {


### PR DESCRIPTION
## What Landed

This PR adds a reusable direct physical column query runner for #1634 allocation-parity work:

- `Collection.PrepareColumnPhysicalQuery(req)` pins the current recovery-authoritative snapshot and prepares one insert-only direct physical query shape.
- `ColumnPhysicalQueryRunner.Run()` reuses the query executor, string interner, result slices, and typed column asset read cache across repeated scans.
- Unsupported shapes, aggregate-metadata requests, and mutation-bearing manifests fail closed instead of silently falling back to planner routing or visibility reconstruction.
- Direct scanner semantics, TCPA asset format, planner routing, visibility overlay, metadata assets, mmap behavior, read-integrity semantics, and GC/rewrite behavior are unchanged.
- Result-group sorting now uses a typed insertion sort helper instead of closure/interface sorting in the hot direct result path.

## Static Reprioritization Checkpoint

The current production physical asset is still TCPA row-record-shaped: scan code reads row id/deleted state and per-declared-column type/null/present/value framing, then reducers use string interning and maps. The old `experiments/colgranule` hot kernels use schema-fixed encoded column granules, low-cardinality `uint32` codes, dense scratch arrays/bitsets, marks, dictionaries, and metadata. This PR does not close that representation gap. Review follow-up at `e4f45c540` also documents runner non-concurrency/result-slice lifetime and switches result sorting to a hybrid path: insertion sort for small zero-allocation result sets and `slices.SortFunc` for larger high-cardinality outputs.

The measured allocation gap after #1668 was still largely avoidable setup/result/reducer state for repeated direct queries: q1-q5 direct adapter benchmarks were at `60-104 allocs/op` on the 8192-row fixture. This PR proves the production direct path can run q1-q5 with `0 allocs/op` when a caller can reuse pinned query state. The next strategic slice should still be dictionary/code projection plus dense reducers, not more TCPA cursor micro-optimization.

## Performance / Benchmark Evidence

Apple M3, darwin/arm64, head `e4f45c540`.

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQuery(AdapterM13B|RunnerM1634)/(q1|q2|q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=100x -count=5
```

Artifact: `/tmp/gomap_1634_runner_vs_adapter_count5_20260520_184552.txt`

Representative current adapter vs prepared runner results at 8192 rows:

| query | regular adapter allocs/op | runner allocs/op | runner rows/s range | runner ns/row range |
|---|---:|---:|---:|---:|
| q1 | 71 | 0 | 13.92M-14.20M | 70.40-71.85 |
| q2 | 104 | 0 | 10.36M-10.76M | 92.93-96.57 |
| q3 | 60 | 0 | 21.18M-22.28M | 44.89-47.21 |
| q4a | 93 | 0 | 13.13M-13.58M | 73.66-76.13 |
| q4b | 93 | 0 | 11.66M-11.83M | 84.56-85.73 |
| q5 | 93 | 0 | 11.98M-12.11M | 82.59-83.48 |

Single-run benchmark artifact with both adapter and runner: `/tmp/gomap_1634_runner_vs_adapter_20260520_184441.txt`.

Review-fix runner benchmark artifact after the hybrid sort/documentation follow-up: `/tmp/gomap_1634_runner_reviewfix_bench_20260520_185436.txt`; q1/q2/q3/q4a/q4b/q5 remain `0 allocs/op` at 8192 rows. Latest distinct-pool/cache-delta review-fix benchmark artifact: `/tmp/gomap_1634_runner_reviewfix2_bench_20260520_190102.txt`; q1/q2/q3/q4a/q4b/q5 remain `0 allocs/op`, including q2 after stale distinct-group correction.

## Throughput Interpretation

This is a warmed prepared-runner result, not the general routed `unified-bench` path. It removes repeated snapshot/view setup, executor allocation, read-cache setup, string re-interning, and result-slice allocation for a pinned insert-only direct query. It is therefore the right comparison for granule-style hot-kernel allocation parity, but not a replacement for routed query evidence.

The old granule hot-kernel comparison remains the allocation target: `/tmp/gomap_1634_granule_hot_kernel_alloc_refresh_20260520_182331.txt` showed `BenchmarkCountUint32CodesGranule`, `BenchmarkAggregateGroupedCountCodes`, `BenchmarkAggregateFilteredGroupedCountCodes`, and locator hot paths at `0 B/op, 0 allocs/op`. This PR reaches the same `0 allocs/op` target for the production prepared direct q1-q5 loop, but production still scans row-record TCPA rather than schema-fixed encoded column blocks.

ClickHouse-equivalent context remains historical/stale comparison context from the JSONBench-shaped column-store evidence. This PR does not add a new ClickHouse run and does not claim ClickHouse-style block/vectorized execution; it only reduces production direct hot-loop allocations.

## Gate Status

Passed locally:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner|TestColumnPhysicalQueryGroupSortHybridM1634|TestColumnPhysicalQueryExecutorResetClearsDistinctGroupsM1634|TestColumnPhysicalQueryAdapterAllocationSlopeM13B' -count=1
go test ./TreeDB/collections -run 'TestColumnPhysicalQuery' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQuery(AdapterM13B|RunnerM1634)/(q1|q2|q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=100x -count=5
```

New tests cover parity, 0-allocation warmed q1 runner behavior, fail-closed unsupported/mutation-bearing manifests, stale distinct-group clearing, and per-run runner segment-cache diagnostics.

## Artifacts

- `/tmp/gomap_1634_runner_vs_adapter_count5_20260520_184552.txt`
- `/tmp/gomap_1634_runner_vs_adapter_20260520_184441.txt`
- `/tmp/gomap_1634_runner_alloc_probe_insertion_20260520_184422.txt`
- `/tmp/gomap_1634_runner_reviewfix_bench_20260520_185436.txt`
- `/tmp/gomap_1634_runner_reviewfix2_bench_20260520_190102.txt`
- Granule hot-kernel allocation context: `/tmp/gomap_1634_granule_hot_kernel_alloc_refresh_20260520_182331.txt`

## Remaining Caveats

- The prepared runner pins a snapshot and is intentionally insert-only/direct-query-only for this PR.
- Mutation visibility, routed planner reuse, aggregate metadata runner reuse, and dictionary/code dense reducers remain future #1634 work.
- This does not change the physical asset representation; the production-vs-experiment kernel gap still points toward dictionary/code projection, dense reducers, real metadata assets, marks, and eventually schema-fixed column-block assets or sidecars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable prepared column query runners for repeated direct column scans.

* **Performance**
  * Minimized per-run memory allocations and enabled executor reuse for faster repeated runs.
  * Improved deterministic group sorting for consistent output and efficiency.

* **Improvements**
  * Better diagnostics (scan timing, cache deltas) and robust, idempotent runner cleanup.
  * Stronger validation/error handling for unsupported query shapes.

* **Tests**
  * Added unit tests and updated benchmarks validating parity, allocations, sorting, and reset behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

