### PR TITLE
TreeDB column store post-V1: add dictionary-code sidecar assets

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -199,6 +199,10 @@ func writeColumnAggregateMetadataAssetToManager(rootDir string, cfg ColumnStoreC
 	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1AggregateMetadata, generation, partID)
 }
 
+func writeColumnDictionaryCodesAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
+	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1DictionaryCodes, generation, partID)
+}
+
 func writeColumnAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, kind ColumnAssetKind, generation, partID uint64) (ColumnAssetRef, error) {
 	return writeColumnAssetToManagerSegment(rootDir, cfg, payload, kind, generation, partID, columnAssetM12ASegmentFileID)
 }

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -284,6 +284,19 @@ func (c *Collection) planColumnAssetReachability(ctx context.Context, opts colum
 			input.recoveryRefs++
 		}
 	}
+	for i, dictionaryRef := range view.DictionaryCodes {
+		if i%columnAssetReachabilityContextCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return columnAssetReachabilityPlanIdentity(input), input.refs, err
+			}
+		}
+		if input.addRef(dictionaryRef.AssetRef, ColumnAssetReachabilitySourceActiveManifest) {
+			input.activeRefs++
+		}
+		if input.addRef(dictionaryRef.AssetRef, ColumnAssetReachabilitySourceRecoveryManifest) {
+			input.recoveryRefs++
+		}
+	}
 	if err := input.addRefs(ctx, opts.CandidateRefs, ColumnAssetReachabilitySourceCandidate); err != nil {
 		return columnAssetReachabilityPlanIdentity(input), input.refs, err
 	}
@@ -316,7 +329,7 @@ func (c *Collection) columnAssetReachabilityOlderSnapshotPinned(planCommitSeq ui
 }
 
 func columnAssetReachabilityInputFromSnapshotView(view columnPhysicalScanSnapshotView, opts columnAssetReachabilityOptionsInternal) columnAssetReachabilityInput {
-	expectedRefs := len(view.AssetRefs) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
+	expectedRefs := len(view.AssetRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
 	input := columnAssetReachabilityInput{
 		rootDir:        view.ColumnAssetRootDir,
 		collection:     view.CollectionName,
@@ -982,7 +995,7 @@ func columnAssetReachabilitySegmentPath(segmentDir, name string) string {
 }
 
 func columnAssetReachabilityRefCanContributeRange(ref ColumnAssetRef, namespace string) bool {
-	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1AggregateMetadata) &&
+	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes) &&
 		ref.Namespace == namespace &&
 		ref.Generation != 0 &&
 		ref.PartID != 0 &&

--- a/TreeDB/collections/column_asset_rewrite.go
+++ b/TreeDB/collections/column_asset_rewrite.go
@@ -444,8 +444,8 @@ func cleanupColumnAssetRewriteCopiedSegment(rootDir string, remap columnAssetRew
 
 func validateColumnAssetRewriteRefKinds(refs []ColumnAssetRef) error {
 	for idx, ref := range refs {
-		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1AggregateMetadata {
-			return fmt.Errorf("collections: column asset rewrite supports only physical part or aggregate metadata refs: ref %d kind %q", idx, ref.Kind)
+		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1AggregateMetadata && ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
+			return fmt.Errorf("collections: column asset rewrite supports only physical part, aggregate metadata, or dictionary code refs: ref %d kind %q", idx, ref.Kind)
 		}
 	}
 	return nil
@@ -476,7 +476,8 @@ func patchColumnAssetRewriteManifestRecordsWithMode(records []columnManifestReco
 		}
 		isPart := bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes)
 		isMetadata := bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes)
-		if !isPart && !isMetadata {
+		isDictionary := bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes)
+		if !isPart && !isMetadata && !isDictionary {
 			continue
 		}
 		oldRef, offsets, err := columnAssetRewriteManifestPartRefForPatch(record.value, expectedNamespace)
@@ -490,7 +491,11 @@ func patchColumnAssetRewriteManifestRecordsWithMode(records []columnManifestReco
 				return nil, 0, err
 			}
 		} else {
-			keyGeneration, keyPartID, _, err = columnManifestAggregateMetadataKeyFromRecordKey(record.key)
+			if isMetadata {
+				keyGeneration, keyPartID, _, err = columnManifestAggregateMetadataKeyFromRecordKey(record.key)
+			} else {
+				keyGeneration, keyPartID, _, err = columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			}
 			if err != nil {
 				return nil, 0, err
 			}
@@ -563,7 +568,7 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: trailing bytes in column manifest part record")
 	}
 	kind := ColumnAssetKind(string(kindBytes))
-	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1AggregateMetadata {
+	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1AggregateMetadata && kind != ColumnAssetKindTCS1DictionaryCodes {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, fmt.Errorf("collections: unsupported column manifest part asset kind %q", string(kindBytes))
 	}
 	if !columnPhysicalBytesEqualString(namespaceBytes, expectedNamespace) {

--- a/TreeDB/collections/column_dictionary_codes_asset.go
+++ b/TreeDB/collections/column_dictionary_codes_asset.go
@@ -202,6 +202,9 @@ func decodeColumnDictionaryCodesAsset(raw []byte, ref ColumnAssetRef, cfg Column
 	if asset.SchemaHash != cfg.SchemaHash {
 		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset schema_hash=%d want %d", asset.SchemaHash, cfg.SchemaHash)
 	}
+	if asset.AppliedCommandLSN > cfg.RecoveryAuthoritativeAppliedCommandLSN {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset applied_command_lsn=%d is newer than recovery applied_command_lsn=%d", asset.AppliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
+	}
 	if expectedColumn != "" && asset.ColumnName != expectedColumn {
 		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset column=%q want %q", asset.ColumnName, expectedColumn)
 	}

--- a/TreeDB/collections/column_dictionary_codes_asset.go
+++ b/TreeDB/collections/column_dictionary_codes_asset.go
@@ -1,0 +1,214 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const (
+	columnDictionaryCodesAssetMagic   = uint32(0x54434443) // TCDC
+	columnDictionaryCodesAssetVersion = uint16(1)
+)
+
+type columnDictionaryCodesAsset struct {
+	Collection        string
+	Namespace         string
+	Generation        uint64
+	PartID            uint64
+	AppliedCommandLSN uint64
+	SchemaHash        uint64
+	ColumnName        string
+	ColumnIndex       int
+	Dictionary        []string
+	Codes             []uint32
+}
+
+func buildColumnDictionaryCodesAssets(cfg ColumnStoreConfig, rows []columnDeclaredRow, collection, namespace string, generation, partID, appliedCommandLSN uint64) ([]columnDictionaryCodesAsset, error) {
+	var assets []columnDictionaryCodesAsset
+	for colIdx, col := range cfg.Columns {
+		if !col.Dictionary || col.ValueType != ColumnStoreValueString {
+			continue
+		}
+		asset, ok, err := buildColumnDictionaryCodesAssetForColumn(cfg, rows, collection, namespace, generation, partID, appliedCommandLSN, colIdx)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			assets = append(assets, asset)
+		}
+	}
+	return assets, nil
+}
+
+func buildColumnDictionaryCodesAssetForColumn(cfg ColumnStoreConfig, rows []columnDeclaredRow, collection, namespace string, generation, partID, appliedCommandLSN uint64, colIdx int) (columnDictionaryCodesAsset, bool, error) {
+	if colIdx < 0 || colIdx >= len(cfg.Columns) {
+		return columnDictionaryCodesAsset{}, false, fmt.Errorf("collections: dictionary code column index=%d outside columns=%d", colIdx, len(cfg.Columns))
+	}
+	col := cfg.Columns[colIdx]
+	if !col.Dictionary || col.ValueType != ColumnStoreValueString {
+		return columnDictionaryCodesAsset{}, false, nil
+	}
+	byValue := make(map[string]uint32)
+	dict := make([]string, 0)
+	codes := make([]uint32, 0, len(rows))
+	for rowIdx, row := range rows {
+		if row.Deleted {
+			return columnDictionaryCodesAsset{}, false, nil
+		}
+		if len(row.Values) != len(cfg.Columns) {
+			return columnDictionaryCodesAsset{}, false, fmt.Errorf("collections: dictionary code row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(cfg.Columns))
+		}
+		value := row.Values[colIdx]
+		if value.Type != ColumnStoreValueString {
+			return columnDictionaryCodesAsset{}, false, fmt.Errorf("collections: dictionary code row[%d] column[%d] type=%q want string", rowIdx, colIdx, value.Type)
+		}
+		if !value.Present || value.Null {
+			return columnDictionaryCodesAsset{}, false, nil
+		}
+		code, ok := byValue[value.String]
+		if !ok {
+			if uint64(len(dict)) == uint64(^uint32(0)) {
+				return columnDictionaryCodesAsset{}, false, errors.New("collections: dictionary code cardinality exceeds uint32")
+			}
+			code = uint32(len(dict))
+			byValue[value.String] = code
+			dict = append(dict, value.String)
+		}
+		codes = append(codes, code)
+	}
+	if len(codes) == 0 {
+		return columnDictionaryCodesAsset{}, false, nil
+	}
+	return columnDictionaryCodesAsset{
+		Collection:        collection,
+		Namespace:         namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		SchemaHash:        cfg.SchemaHash,
+		ColumnName:        col.Name,
+		ColumnIndex:       colIdx,
+		Dictionary:        dict,
+		Codes:             codes,
+	}, true, nil
+}
+
+func encodeColumnDictionaryCodesAsset(asset columnDictionaryCodesAsset) ([]byte, error) {
+	if asset.Collection == "" || asset.Namespace == "" || asset.Generation == 0 || asset.PartID == 0 || asset.ColumnName == "" {
+		return nil, errors.New("collections: dictionary codes asset missing collection, namespace, generation, part_id, or column")
+	}
+	if asset.ColumnIndex < 0 {
+		return nil, errors.New("collections: dictionary codes asset column index is negative")
+	}
+	if len(asset.Dictionary) == 0 || len(asset.Codes) == 0 {
+		return nil, errors.New("collections: dictionary codes asset requires dictionary and codes")
+	}
+	var b bytes.Buffer
+	writeManifestUint32(&b, columnDictionaryCodesAssetMagic)
+	writeManifestUint16(&b, columnDictionaryCodesAssetVersion)
+	writeManifestString(&b, asset.Collection)
+	writeManifestString(&b, asset.Namespace)
+	writeManifestUint64(&b, asset.Generation)
+	writeManifestUint64(&b, asset.PartID)
+	writeManifestUint64(&b, asset.AppliedCommandLSN)
+	writeManifestUint64(&b, asset.SchemaHash)
+	writeManifestString(&b, asset.ColumnName)
+	writeManifestUint64(&b, uint64(asset.ColumnIndex))
+	writeManifestUint64(&b, uint64(len(asset.Dictionary)))
+	writeManifestUint64(&b, uint64(len(asset.Codes)))
+	for _, value := range asset.Dictionary {
+		writeManifestString(&b, value)
+	}
+	for idx, code := range asset.Codes {
+		if int(code) >= len(asset.Dictionary) {
+			return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", idx, code, len(asset.Dictionary))
+		}
+		writeManifestUint32(&b, code)
+	}
+	return b.Bytes(), nil
+}
+
+func decodeColumnDictionaryCodesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, expectedCollection, expectedColumn string) (columnDictionaryCodesAsset, error) {
+	if ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset ref kind=%q want %q", ref.Kind, ColumnAssetKindTCS1DictionaryCodes)
+	}
+	if int64(len(raw)) != ref.Length {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset length=%d does not match ref length=%d", len(raw), ref.Length)
+	}
+	if checksum := page.Checksum(raw); checksum != ref.Checksum {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+	}
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnDictionaryCodesAssetMagic {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: bad dictionary codes asset magic=0x%08x", magic)
+	}
+	if version := cur.u16(); version != columnDictionaryCodesAssetVersion {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: unsupported dictionary codes asset version=%d", version)
+	}
+	asset := columnDictionaryCodesAsset{
+		Collection:        cur.string(),
+		Namespace:         cur.string(),
+		Generation:        cur.u64(),
+		PartID:            cur.u64(),
+		AppliedCommandLSN: cur.u64(),
+		SchemaHash:        cur.u64(),
+		ColumnName:        cur.string(),
+	}
+	columnIndex := cur.u64()
+	cardinality := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return columnDictionaryCodesAsset{}, err
+	}
+	if columnIndex > uint64(maxCollectionInt) || cardinality > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
+		return columnDictionaryCodesAsset{}, errors.New("collections: dictionary codes asset dimensions overflow int")
+	}
+	asset.ColumnIndex = int(columnIndex)
+	asset.Dictionary = make([]string, int(cardinality))
+	for i := range asset.Dictionary {
+		asset.Dictionary[i] = cur.string()
+	}
+	asset.Codes = make([]uint32, int(rowCount))
+	for i := range asset.Codes {
+		code := cur.u32()
+		if int(code) >= len(asset.Dictionary) {
+			return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, code, len(asset.Dictionary))
+		}
+		asset.Codes[i] = code
+	}
+	if cur.err != nil {
+		return columnDictionaryCodesAsset{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return columnDictionaryCodesAsset{}, errors.New("collections: trailing bytes in dictionary codes asset")
+	}
+	if asset.Collection != expectedCollection {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset collection=%q want %q", asset.Collection, expectedCollection)
+	}
+	if cfg.AssetManager == nil {
+		return columnDictionaryCodesAsset{}, errors.New("collections: dictionary codes asset validation requires asset manager")
+	}
+	if asset.Namespace != cfg.AssetManager.Namespace || ref.Namespace != cfg.AssetManager.Namespace {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset namespace=%q ref_namespace=%q want %q", asset.Namespace, ref.Namespace, cfg.AssetManager.Namespace)
+	}
+	if asset.Generation != ref.Generation || asset.PartID != ref.PartID {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset generation/part does not match ref")
+	}
+	if asset.SchemaHash != cfg.SchemaHash {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset schema_hash=%d want %d", asset.SchemaHash, cfg.SchemaHash)
+	}
+	if expectedColumn != "" && asset.ColumnName != expectedColumn {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset column=%q want %q", asset.ColumnName, expectedColumn)
+	}
+	if asset.ColumnIndex < 0 || asset.ColumnIndex >= len(cfg.Columns) {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset column_index=%d outside columns=%d", asset.ColumnIndex, len(cfg.Columns))
+	}
+	col := cfg.Columns[asset.ColumnIndex]
+	if col.Name != asset.ColumnName || col.ValueType != ColumnStoreValueString || !col.Dictionary {
+		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset column %q is not a declared dictionary string column", asset.ColumnName)
+	}
+	return asset, nil
+}

--- a/TreeDB/collections/column_dictionary_codes_asset.go
+++ b/TreeDB/collections/column_dictionary_codes_asset.go
@@ -131,15 +131,17 @@ func encodeColumnDictionaryCodesAsset(asset columnDictionaryCodesAsset) ([]byte,
 	return b.Bytes(), nil
 }
 
-func decodeColumnDictionaryCodesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, expectedCollection, expectedColumn string) (columnDictionaryCodesAsset, error) {
+func decodeColumnDictionaryCodesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, expectedCollection, expectedColumn string, verifyChecksum bool) (columnDictionaryCodesAsset, error) {
 	if ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
 		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset ref kind=%q want %q", ref.Kind, ColumnAssetKindTCS1DictionaryCodes)
 	}
 	if int64(len(raw)) != ref.Length {
 		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset length=%d does not match ref length=%d", len(raw), ref.Length)
 	}
-	if checksum := page.Checksum(raw); checksum != ref.Checksum {
-		return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+	if verifyChecksum {
+		if checksum := page.Checksum(raw); checksum != ref.Checksum {
+			return columnDictionaryCodesAsset{}, fmt.Errorf("collections: dictionary codes asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+		}
 	}
 	cur := manifestCursor{raw: raw}
 	if magic := cur.u32(); magic != columnDictionaryCodesAssetMagic {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -1,0 +1,126 @@
+package collections
+
+import (
+	"fmt"
+	"time"
+)
+
+type columnDictionaryCodeGroupCountRunner struct {
+	column       string
+	dictionary   []string
+	counts       []int
+	assets       []columnDictionaryCodeGroupCountAsset
+	resultGroups []ColumnPhysicalQueryGroup
+	assetBytes   int64
+}
+
+type columnDictionaryCodeGroupCountAsset struct {
+	codes []uint32
+}
+
+func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountRunner, error) {
+	if req.Kind != ColumnPhysicalQueryGroupCount || req.GroupColumn == "" || view.MutationParts != 0 {
+		return nil, nil
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: dictionary code query missing read cache")
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.GroupColumn)
+	if !ok || col.ValueType != ColumnStoreValueString || !col.Dictionary {
+		return nil, nil
+	}
+	byPart := make(map[[2]uint64]columnManifestDictionaryCodesSnapshot, len(view.DictionaryCodes))
+	for _, snapshot := range view.DictionaryCodes {
+		if snapshot.ColumnName != req.GroupColumn {
+			continue
+		}
+		byPart[[2]uint64{snapshot.AssetRef.Generation, snapshot.AssetRef.PartID}] = snapshot
+	}
+	if len(byPart) == 0 {
+		return nil, nil
+	}
+	globalByValue := make(map[string]uint32)
+	runner := &columnDictionaryCodeGroupCountRunner{
+		column: req.GroupColumn,
+		assets: make([]columnDictionaryCodeGroupCountAsset, 0, len(view.AssetRefs)),
+	}
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return nil, nil
+		}
+		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		if !ok {
+			return nil, nil
+		}
+		raw, err := readCache.read(snapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = raw
+		decoded, err := decodeColumnDictionaryCodesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn)
+		if err != nil {
+			return nil, err
+		}
+		translated := make([]uint32, len(decoded.Codes))
+		for codeIdx, localCode := range decoded.Codes {
+			value := decoded.Dictionary[localCode]
+			globalCode, ok := globalByValue[value]
+			if !ok {
+				if uint64(len(runner.dictionary)) == uint64(^uint32(0)) {
+					return nil, fmt.Errorf("collections: dictionary code query cardinality exceeds uint32")
+				}
+				globalCode = uint32(len(runner.dictionary))
+				globalByValue[value] = globalCode
+				runner.dictionary = append(runner.dictionary, value)
+			}
+			translated[codeIdx] = globalCode
+		}
+		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountAsset{
+			codes: translated,
+		})
+		runner.assetBytes += snapshot.AssetRef.Length
+	}
+	if len(runner.assets) == 0 || len(runner.dictionary) == 0 {
+		return nil, nil
+	}
+	runner.counts = make([]int, len(runner.dictionary))
+	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.dictionary))
+	return runner, nil
+}
+
+func (r *columnDictionaryCodeGroupCountRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	clear(r.counts)
+	rows := 0
+	for _, asset := range r.assets {
+		for _, code := range asset.codes {
+			r.counts[code]++
+			rows++
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for code, count := range r.counts {
+		if count == 0 {
+			continue
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{
+			Key:   r.dictionary[code],
+			Count: count,
+		})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 1
+	diag.ScheduledGranules = len(r.assets)
+	diag.DecodedBlocks = len(r.assets)
+	diag.DirectReduceBlocks = len(r.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(r.resultGroups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -58,7 +58,7 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn, err)
 		}
 		scratch = raw
-		decoded, err := decodeColumnDictionaryCodesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn)
+		decoded, err := decodeColumnDictionaryCodesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, readCache.verifyChecksum)
 		if err != nil {
 			return nil, err
 		}

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -17,6 +17,7 @@ const (
 	columnManifestHeaderRecordKey               = "\x01column-manifest/v1/header"
 	columnManifestPartRecordPrefix              = "\x02column-manifest/v1/part/"
 	columnManifestAggregateMetadataRecordPrefix = "\x03column-manifest/v1/aggregate/"
+	columnManifestDictionaryCodesRecordPrefix   = "\x04column-manifest/v1/dictionary/"
 
 	columnManifestHeaderMagic   = uint32(0x54434d48) // TCMH
 	columnManifestPartMagic     = uint32(0x54434d50) // TCMP
@@ -28,6 +29,7 @@ var (
 	columnManifestHeaderRecordKeyBytes               = []byte(columnManifestHeaderRecordKey)
 	columnManifestPartRecordPrefixBytes              = []byte(columnManifestPartRecordPrefix)
 	columnManifestAggregateMetadataRecordPrefixBytes = []byte(columnManifestAggregateMetadataRecordPrefix)
+	columnManifestDictionaryCodesRecordPrefixBytes   = []byte(columnManifestDictionaryCodesRecordPrefix)
 )
 
 type columnManifestRecord struct {
@@ -48,6 +50,7 @@ type columnManifestSnapshot struct {
 	ColumnPayloadBytes int64
 	Parts              []columnManifestPartSnapshot
 	AggregateMetadata  []columnManifestAggregateMetadataSnapshot
+	DictionaryCodes    []columnManifestDictionaryCodesSnapshot
 }
 
 type columnManifestPartSnapshot struct {
@@ -67,6 +70,14 @@ type columnManifestAggregateMetadataSnapshot struct {
 	GenerationID uint64
 }
 
+type columnManifestDictionaryCodesSnapshot struct {
+	AssetRef     ColumnAssetRef
+	ColumnName   string
+	Bytes        int64
+	PublishID    uint64
+	GenerationID uint64
+}
+
 func columnManifestPartRecordKey(generation, partID uint64) []byte {
 	key := make([]byte, len(columnManifestPartRecordPrefix)+16)
 	copy(key, columnManifestPartRecordPrefix)
@@ -81,6 +92,15 @@ func columnManifestAggregateMetadataRecordKey(generation, partID uint64, name st
 	binary.BigEndian.PutUint64(key[len(columnManifestAggregateMetadataRecordPrefix):], generation)
 	binary.BigEndian.PutUint64(key[len(columnManifestAggregateMetadataRecordPrefix)+8:], partID)
 	copy(key[len(columnManifestAggregateMetadataRecordPrefix)+16:], name)
+	return key
+}
+
+func columnManifestDictionaryCodesRecordKey(generation, partID uint64, columnName string) []byte {
+	key := make([]byte, len(columnManifestDictionaryCodesRecordPrefix)+16+len(columnName))
+	copy(key, columnManifestDictionaryCodesRecordPrefix)
+	binary.BigEndian.PutUint64(key[len(columnManifestDictionaryCodesRecordPrefix):], generation)
+	binary.BigEndian.PutUint64(key[len(columnManifestDictionaryCodesRecordPrefix)+8:], partID)
+	copy(key[len(columnManifestDictionaryCodesRecordPrefix)+16:], columnName)
 	return key
 }
 
@@ -123,12 +143,22 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 		if err != nil {
 			return ColumnPublishManifestEncodeResult{}, err
 		}
-		if asset.Ref.Kind == ColumnAssetKindTCS1AggregateMetadata {
+		switch asset.Ref.Kind {
+		case ColumnAssetKindTCS1AggregateMetadata:
 			if asset.Reason == "" {
 				return ColumnPublishManifestEncodeResult{}, errors.New("collections: aggregate metadata manifest record requires aggregate name")
 			}
 			records = append(records, columnManifestRecord{
 				key:   columnManifestAggregateMetadataRecordKey(asset.Ref.Generation, asset.Ref.PartID, asset.Reason),
+				value: partValue,
+			})
+			continue
+		case ColumnAssetKindTCS1DictionaryCodes:
+			if asset.Reason == "" {
+				return ColumnPublishManifestEncodeResult{}, errors.New("collections: dictionary codes manifest record requires column name")
+			}
+			records = append(records, columnManifestRecord{
+				key:   columnManifestDictionaryCodesRecordKey(asset.Ref.Generation, asset.Ref.PartID, asset.Reason),
 				value: partValue,
 			})
 			continue
@@ -159,7 +189,9 @@ func retainedColumnManifestRecordsForWrite(records []columnManifestRecord, gener
 	}
 	retained := make([]columnManifestRecord, 0, len(records))
 	for _, record := range records {
-		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) && !bytes.HasPrefix(record.key, []byte(columnManifestAggregateMetadataRecordPrefix)) {
+		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) &&
+			!bytes.HasPrefix(record.key, []byte(columnManifestAggregateMetadataRecordPrefix)) &&
+			!bytes.HasPrefix(record.key, []byte(columnManifestDictionaryCodesRecordPrefix)) {
 			continue
 		}
 		part, err := decodeColumnManifestPartRecord(record.value)
@@ -230,6 +262,7 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 	var snapshot columnManifestSnapshot
 	var parts []columnManifestPartSnapshot
 	var metadata []columnManifestAggregateMetadataSnapshot
+	var dictionaries []columnManifestDictionaryCodesSnapshot
 	sawHeader := false
 	for _, record := range records {
 		switch {
@@ -255,6 +288,12 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 				return columnManifestSnapshot{}, err
 			}
 			metadata = append(metadata, aggregate)
+		case bytes.HasPrefix(record.key, []byte(columnManifestDictionaryCodesRecordPrefix)):
+			dictionary, err := decodeColumnManifestDictionaryCodesRecord(record.key, record.value)
+			if err != nil {
+				return columnManifestSnapshot{}, err
+			}
+			dictionaries = append(dictionaries, dictionary)
 		}
 	}
 	if !sawHeader {
@@ -287,10 +326,50 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 		}
 		snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
 	}
+	for _, dictionary := range dictionaries {
+		if dictionary.AssetRef.Generation > snapshot.Generation {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", dictionary.AssetRef.Generation, snapshot.Generation)
+		}
+		partNamespace, ok := livePartNamespaces[[2]uint64{dictionary.AssetRef.Generation, dictionary.AssetRef.PartID}]
+		if !ok {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", dictionary.AssetRef.Generation, dictionary.AssetRef.PartID)
+		}
+		if dictionary.AssetRef.Namespace != partNamespace {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes namespace=%q does not match part namespace=%q", dictionary.AssetRef.Namespace, partNamespace)
+		}
+		snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
+	}
 	if uint64(len(snapshot.Parts)) != snapshot.ExpectedParts {
 		return columnManifestSnapshot{}, fmt.Errorf("collections: invalid column manifest part count=%d want %d", len(snapshot.Parts), snapshot.ExpectedParts)
 	}
 	return snapshot, nil
+}
+
+func decodeColumnManifestDictionaryCodesRecord(key, raw []byte) (columnManifestDictionaryCodesSnapshot, error) {
+	generation, partID, columnName, err := columnManifestDictionaryCodesKeyFromRecordKey(key)
+	if err != nil {
+		return columnManifestDictionaryCodesSnapshot{}, err
+	}
+	part, err := decodeColumnManifestPartRecord(raw)
+	if err != nil {
+		return columnManifestDictionaryCodesSnapshot{}, err
+	}
+	if part.AssetRef.Kind != ColumnAssetKindTCS1DictionaryCodes {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes asset kind=%q want %q", part.AssetRef.Kind, ColumnAssetKindTCS1DictionaryCodes)
+	}
+	if part.AssetRef.Generation != generation || part.AssetRef.PartID != partID {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key generation/part does not match ref")
+	}
+	if part.Reason != columnName {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", columnName, part.Reason)
+	}
+	return columnManifestDictionaryCodesSnapshot{
+		AssetRef:     part.AssetRef,
+		ColumnName:   columnName,
+		Bytes:        part.Bytes,
+		PublishID:    part.PublishID,
+		GenerationID: part.GenerationID,
+	}, nil
 }
 
 func decodeColumnManifestAggregateMetadataRecord(key, raw []byte) (columnManifestAggregateMetadataSnapshot, error) {
@@ -443,6 +522,14 @@ func enumerateColumnManifestAssetRefs(iter iterator.UnsafeIterator) ([]ColumnAss
 		return nil, err
 	}
 	refs = append(refs, metadataRefs...)
+	dictionaryRefs, err := enumerateColumnManifestAssetRefsForPrefix(iter, columnManifestDictionaryCodesRecordPrefixBytes, func(key, value []byte) (ColumnAssetRef, error) {
+		dictionary, err := decodeColumnManifestDictionaryCodesRecord(key, value)
+		return dictionary.AssetRef, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	refs = append(refs, dictionaryRefs...)
 	return refs, iter.Error()
 }
 
@@ -482,6 +569,18 @@ func columnManifestAggregateMetadataKeyFromRecordKey(key []byte) (uint64, uint64
 	return binary.BigEndian.Uint64(key[len(columnManifestAggregateMetadataRecordPrefix):]),
 		binary.BigEndian.Uint64(key[len(columnManifestAggregateMetadataRecordPrefix)+8:]),
 		string(key[len(columnManifestAggregateMetadataRecordPrefix)+16:]), nil
+}
+
+func columnManifestDictionaryCodesKeyFromRecordKey(key []byte) (uint64, uint64, string, error) {
+	if !bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
+		return 0, 0, "", fmt.Errorf("collections: column manifest dictionary codes key %q missing prefix", string(key))
+	}
+	if len(key) <= len(columnManifestDictionaryCodesRecordPrefix)+16 {
+		return 0, 0, "", fmt.Errorf("collections: column manifest dictionary codes key length=%d too short", len(key))
+	}
+	return binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix):]),
+		binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix)+8:]),
+		string(key[len(columnManifestDictionaryCodesRecordPrefix)+16:]), nil
 }
 
 func columnManifestRootRecordIterator(identityRecord [columnManifestIdentityRecordSize]byte, records []columnManifestRecord) *systemTargetIterator {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -101,6 +101,7 @@ type ColumnPhysicalQueryRunner struct {
 	req        ColumnPhysicalQueryRequest
 	exec       *columnPhysicalQueryExecutor
 	readCache  columnPhysicalAssetReadCache
+	dictCount  *columnDictionaryCodeGroupCountRunner
 	closed     bool
 }
 
@@ -180,6 +181,11 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		return nil, err
 	}
 	readCache.returnViews = true
+	dictCount, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	release = false
 	return &ColumnPhysicalQueryRunner{
 		collection: c,
@@ -188,6 +194,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		req:        req,
 		exec:       exec,
 		readCache:  readCache,
+		dictCount:  dictCount,
 	}, nil
 }
 
@@ -216,6 +223,9 @@ func (r *ColumnPhysicalQueryRunner) Close() error {
 func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	if r == nil || r.closed {
 		return ColumnPhysicalQueryResult{}, errors.New("collections: prepared physical column query runner is closed")
+	}
+	if r.dictCount != nil {
+		return r.dictCount.run(r.view, r.req), nil
 	}
 	r.exec.resetForRun()
 	beforeHits := r.readCache.hits

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1969,7 +1969,7 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 		Length:     int64(len(raw)),
 		Checksum:   page.Checksum(raw),
 	}
-	decoded, err := decodeColumnDictionaryCodesAsset(raw, ref, *normalized, "events", "kind")
+	decoded, err := decodeColumnDictionaryCodesAsset(raw, ref, *normalized, "events", "kind", true)
 	if err != nil {
 		t.Fatalf("decodeColumnDictionaryCodesAsset: %v", err)
 	}
@@ -1982,20 +1982,25 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 
 	corrupt := append([]byte(nil), raw...)
 	corrupt[len(corrupt)-1] ^= 0xff
-	if _, err := decodeColumnDictionaryCodesAsset(corrupt, ref, *normalized, "events", "kind"); err == nil || !strings.Contains(err.Error(), "checksum") {
+	if _, err := decodeColumnDictionaryCodesAsset(corrupt, ref, *normalized, "events", "kind", true); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("checksum corruption err=%v want checksum failure", err)
+	}
+	mismatchedChecksumRef := ref
+	mismatchedChecksumRef.Checksum ^= 1
+	if _, err := decodeColumnDictionaryCodesAsset(raw, mismatchedChecksumRef, *normalized, "events", "kind", false); err != nil {
+		t.Fatalf("skip-checksum decode err=%v want valid raw bytes to decode despite ref checksum mismatch", err)
 	}
 
 	badCode := append([]byte(nil), raw...)
 	badCode[len(badCode)-1] = 9
 	badRef := ref
 	badRef.Checksum = page.Checksum(badCode)
-	if _, err := decodeColumnDictionaryCodesAsset(badCode, badRef, *normalized, "events", "kind"); err == nil || !strings.Contains(err.Error(), "outside cardinality") {
+	if _, err := decodeColumnDictionaryCodesAsset(badCode, badRef, *normalized, "events", "kind", true); err == nil || !strings.Contains(err.Error(), "outside cardinality") {
 		t.Fatalf("bad code err=%v want outside cardinality failure", err)
 	}
 
 	wrongColumnRef := ref
-	if _, err := decodeColumnDictionaryCodesAsset(raw, wrongColumnRef, *normalized, "events", "did"); err == nil || !strings.Contains(err.Error(), "column=") {
+	if _, err := decodeColumnDictionaryCodesAsset(raw, wrongColumnRef, *normalized, "events", "did", true); err == nil || !strings.Contains(err.Error(), "column=") {
 		t.Fatalf("wrong column err=%v want column validation failure", err)
 	}
 }

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1843,6 +1843,10 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 	defer closeFn()
 	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
 	wantHash := columnPhysicalQueryReferenceHashM13B("q1", events)
+	tcpResult, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery TCPA baseline: %v", err)
+	}
 
 	runner, err := collection.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -1864,11 +1868,11 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
 			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
 		}
-		if i == 0 && result.Diagnostics.SegmentFileCacheMisses == 0 {
-			t.Fatalf("first runner diagnostics=%+v want initial segment cache miss", result.Diagnostics)
+		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpResult.Diagnostics.PhysicalBytesScanned {
+			t.Fatalf("runner physical bytes=%d want dictionary-code sidecar below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpResult.Diagnostics.PhysicalBytesScanned)
 		}
-		if i > 0 && result.Diagnostics.SegmentFileCacheMisses != 0 {
-			t.Fatalf("runner diagnostics=%+v want per-run cache misses reset after warmup", result.Diagnostics)
+		if result.Diagnostics.SegmentFileCacheMisses != 0 {
+			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
 		}
 	}
 
@@ -1883,6 +1887,116 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("runner q1 warmed allocs/run=%.2f want 0", allocs)
+	}
+}
+
+func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.T) {
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
+	defer closeFn()
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	if len(view.AssetRefs) != 1 {
+		t.Fatalf("asset refs=%d want 1 physical part", len(view.AssetRefs))
+	}
+	if len(view.DictionaryCodes) != 2 {
+		t.Fatalf("dictionary code refs=%d want kind+did sidecars", len(view.DictionaryCodes))
+	}
+	byColumn := make(map[string]ColumnAssetRef, len(view.DictionaryCodes))
+	for _, sidecar := range view.DictionaryCodes {
+		byColumn[sidecar.ColumnName] = sidecar.AssetRef
+		if sidecar.AssetRef.Kind != ColumnAssetKindTCS1DictionaryCodes {
+			t.Fatalf("dictionary sidecar kind=%q want %q", sidecar.AssetRef.Kind, ColumnAssetKindTCS1DictionaryCodes)
+		}
+		if sidecar.AssetRef.Generation != view.AssetRefs[0].Ref.Generation || sidecar.AssetRef.PartID != view.AssetRefs[0].Ref.PartID {
+			t.Fatalf("dictionary sidecar ref=%+v want same generation/part as %+v", sidecar.AssetRef, view.AssetRefs[0].Ref)
+		}
+	}
+	if byColumn["kind"].Length == 0 || byColumn["did"].Length == 0 {
+		t.Fatalf("dictionary sidecars missing expected columns: %+v", byColumn)
+	}
+}
+
+func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
+	normalized, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	rows := []columnDeclaredRow{
+		{ID: []byte("e1"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+			{Type: ColumnStoreValueString, Present: true, String: "share"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_a"},
+		}},
+		{ID: []byte("e2"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 2},
+			{Type: ColumnStoreValueString, Present: true, String: "like"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_b"},
+		}},
+		{ID: []byte("e3"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 3},
+			{Type: ColumnStoreValueString, Present: true, String: "share"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_c"},
+		}},
+	}
+	assets, err := buildColumnDictionaryCodesAssets(*normalized, rows, "events", normalized.AssetManager.Namespace, 7, 3, 42)
+	if err != nil {
+		t.Fatalf("buildColumnDictionaryCodesAssets: %v", err)
+	}
+	var kindAsset columnDictionaryCodesAsset
+	for _, asset := range assets {
+		if asset.ColumnName == "kind" {
+			kindAsset = asset
+			break
+		}
+	}
+	if kindAsset.ColumnName == "" {
+		t.Fatalf("missing kind dictionary asset: %+v", assets)
+	}
+	raw, err := encodeColumnDictionaryCodesAsset(kindAsset)
+	if err != nil {
+		t.Fatalf("encodeColumnDictionaryCodesAsset: %v", err)
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1DictionaryCodes,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: kindAsset.Generation,
+		PartID:     kindAsset.PartID,
+		Length:     int64(len(raw)),
+		Checksum:   page.Checksum(raw),
+	}
+	decoded, err := decodeColumnDictionaryCodesAsset(raw, ref, *normalized, "events", "kind")
+	if err != nil {
+		t.Fatalf("decodeColumnDictionaryCodesAsset: %v", err)
+	}
+	if got, want := decoded.Dictionary, []string{"share", "like"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("dictionary=%v want %v", got, want)
+	}
+	if got, want := decoded.Codes, []uint32{0, 1, 0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("codes=%v want %v", got, want)
+	}
+
+	corrupt := append([]byte(nil), raw...)
+	corrupt[len(corrupt)-1] ^= 0xff
+	if _, err := decodeColumnDictionaryCodesAsset(corrupt, ref, *normalized, "events", "kind"); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("checksum corruption err=%v want checksum failure", err)
+	}
+
+	badCode := append([]byte(nil), raw...)
+	badCode[len(badCode)-1] = 9
+	badRef := ref
+	badRef.Checksum = page.Checksum(badCode)
+	if _, err := decodeColumnDictionaryCodesAsset(badCode, badRef, *normalized, "events", "kind"); err == nil || !strings.Contains(err.Error(), "outside cardinality") {
+		t.Fatalf("bad code err=%v want outside cardinality failure", err)
+	}
+
+	wrongColumnRef := ref
+	if _, err := decodeColumnDictionaryCodesAsset(raw, wrongColumnRef, *normalized, "events", "did"); err == nil || !strings.Contains(err.Error(), "column=") {
+		t.Fatalf("wrong column err=%v want column validation failure", err)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1926,6 +1926,7 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeColumnStoreConfig: %v", err)
 	}
+	normalized.RecoveryAuthoritativeAppliedCommandLSN = 42
 	rows := []columnDeclaredRow{
 		{ID: []byte("e1"), Values: []columnDeclaredValue{
 			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
@@ -2002,6 +2003,12 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 	wrongColumnRef := ref
 	if _, err := decodeColumnDictionaryCodesAsset(raw, wrongColumnRef, *normalized, "events", "did", true); err == nil || !strings.Contains(err.Error(), "column=") {
 		t.Fatalf("wrong column err=%v want column validation failure", err)
+	}
+
+	futureLSNCfg := *normalized
+	futureLSNCfg.RecoveryAuthoritativeAppliedCommandLSN = 41
+	if _, err := decodeColumnDictionaryCodesAsset(raw, ref, futureLSNCfg, "events", "kind", true); err == nil || !strings.Contains(err.Error(), "newer than recovery") {
+		t.Fatalf("future lsn err=%v want recovery-authoritative LSN failure", err)
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -95,6 +95,7 @@ type columnPhysicalScanSnapshotView struct {
 	CommitSeq          uint64
 	AssetRefs          []columnManifestAssetRefForScan
 	AggregateMetadata  []columnManifestAggregateMetadataSnapshot
+	DictionaryCodes    []columnManifestDictionaryCodesSnapshot
 	MutationParts      int
 	Diagnostics        columnPhysicalScanDiagnostics
 	ColumnAssetRootDir string
@@ -274,6 +275,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 	diag.MutationParts = mutationParts
 	view.AssetRefs = refs
 	view.AggregateMetadata = manifest.AggregateMetadata
+	view.DictionaryCodes = manifest.DictionaryCodes
 	view.MutationParts = mutationParts
 	view.Diagnostics = diag
 	return view, nil
@@ -435,7 +437,8 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 		key := iter.UnsafeKey()
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
 			!bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) &&
-			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) {
+			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -520,7 +523,8 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 		key := iter.UnsafeKey()
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
 			!bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) &&
-			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) {
+			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -629,6 +633,34 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
+		case bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			keyGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(key)
+			if err != nil {
+				return columnManifestPlannerCapabilitiesForScan{}, err
+			}
+			if keyGeneration > header.generation {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", keyGeneration, header.generation)
+			}
+			dictionary, err := decodeColumnManifestDictionaryCodesRecord(key, value)
+			if err != nil {
+				return columnManifestPlannerCapabilitiesForScan{}, err
+			}
+			if dictionary.AssetRef.Namespace != cfg.AssetManager.Namespace {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes namespace=%q want %q", dictionary.AssetRef.Namespace, cfg.AssetManager.Namespace)
+			}
+			partNamespace, ok := livePartNamespaces[[2]uint64{dictionary.AssetRef.Generation, dictionary.AssetRef.PartID}]
+			if !ok {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", dictionary.AssetRef.Generation, dictionary.AssetRef.PartID)
+			}
+			if dictionary.AssetRef.Namespace != partNamespace {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes namespace=%q does not match part namespace=%q", dictionary.AssetRef.Namespace, partNamespace)
+			}
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
 		}
 		iter.Next()
 	}
@@ -727,6 +759,14 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 			if metadataGeneration <= generation {
 				active = append(active, record)
 			}
+		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
+			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			if err != nil {
+				return nil, err
+			}
+			if dictionaryGeneration <= generation {
+				active = append(active, record)
+			}
 		}
 	}
 	return active, nil
@@ -772,6 +812,17 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 			}
 			if metadataGeneration > snapshot.Generation {
 				return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", metadataGeneration, snapshot.Generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
+			if !sawHeader {
+				continue
+			}
+			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			if err != nil {
+				return columnManifestSnapshot{}, err
+			}
+			if dictionaryGeneration > snapshot.Generation {
+				return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", dictionaryGeneration, snapshot.Generation)
 			}
 		}
 	}

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -43,6 +43,9 @@ const (
 	// ColumnAssetKindTCS1AggregateMetadata references grouped aggregate metadata
 	// stored as a typed column asset beside physical part images.
 	ColumnAssetKindTCS1AggregateMetadata ColumnAssetKind = "tcs1_aggregate_metadata"
+	// ColumnAssetKindTCS1DictionaryCodes references low-cardinality dictionary
+	// codes derived from one declared dictionary string column in a TCS1 part.
+	ColumnAssetKindTCS1DictionaryCodes ColumnAssetKind = "tcs1_dictionary_codes"
 )
 
 // ColumnAssetRef is the durable typed address of a column-asset-manager-owned
@@ -898,7 +901,7 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 
 func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	switch ref.Kind {
-	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1AggregateMetadata:
+	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes:
 	default:
 		if ref.Kind == "" {
 			return errors.New("collections: column asset ref kind is required")

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -522,6 +522,31 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		Reason:       string(input.operation),
 	}}
 	if hookInput.Operation == ColumnPublishOperationInsert {
+		dictionaryAssets, err := buildColumnDictionaryCodesAssets(hookInput.ColumnStore, rows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
+		if err != nil {
+			return ColumnPublishPreparedAssets{}, err
+		}
+		for _, dictionary := range dictionaryAssets {
+			encodedDictionary, err := encodeColumnDictionaryCodesAsset(dictionary)
+			if err != nil {
+				return ColumnPublishPreparedAssets{}, err
+			}
+			dictionaryRef, err := writeColumnDictionaryCodesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedDictionary, generation, partID)
+			if err != nil {
+				return ColumnPublishPreparedAssets{}, err
+			}
+			if dictionaryRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || dictionaryRef.Kind != ColumnAssetKindTCS1DictionaryCodes ||
+				dictionaryRef.Generation != generation || dictionaryRef.PartID != partID || dictionaryRef.Length != int64(len(encodedDictionary)) {
+				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid dictionary codes asset ref %+v", dictionaryRef)
+			}
+			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
+				Ref:          dictionaryRef,
+				Bytes:        dictionaryRef.Length,
+				PublishID:    hookInput.AppliedCommandLSN,
+				GenerationID: generation,
+				Reason:       dictionary.ColumnName,
+			})
+		}
 		for _, aggregate := range hookInput.ColumnStore.AggregateMetadata {
 			metadata, ok, err := buildColumnAggregateMetadataAsset(hookInput.ColumnStore, rows, aggregate, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
 			if err != nil {


### PR DESCRIPTION
## Static Analysis / Priority Checkpoint

The current production-vs-experiment gap is still mostly representation and kernel shape, not another TCPA cursor micro-optimization. Production TCPA assets are row-record-shaped: each scan walks row id/deleted state, declared-column framing, present/null/type metadata, and string bytes. The old `experiments/colgranule` kernels are closer to ClickHouse-style analytical execution: schema-fixed blocks, low-cardinality dictionary codes, dense arrays/bitsets, and reusable scratch.

This PR takes the first production step toward that representation: it publishes typed dictionary-code sidecar assets for declared low-cardinality string columns and lets a prepared direct q1 group-count runner reduce over cached `uint32` codes with no per-run segment read and no heap allocation. It is intentionally tactical and narrow: q2-q5 still use the prepared TCPA runner from #1670, routed planner execution is unchanged, and the TCPA part image remains the canonical physical part for fallback/parity.

## What Landed

- Adds a new typed column asset kind, `tcs1_dictionary_codes`, owned by the isolated column asset manager namespace.
- Publishes immutable dictionary-code sidecars for complete insert-only declared dictionary string columns, currently `kind` and `did` in the JSONBench-shaped config.
- Extends binary manifest records, scan snapshot loading, reachability/GC enumeration, and rewrite/remap validation so dictionary sidecars are first-class durable column asset refs.
- Adds a prepared direct q1 `GroupCount(kind)` runner that loads/validates sidecars at prepare time, translates local codes to a global dictionary, and runs a zero-allocation dense count loop.
- Keeps fail-closed fallback behavior: missing/incomplete sidecars, mutation parts, unsupported columns, or unsupported query shapes continue through existing unsupported/fallback paths rather than silently changing semantics.

## Performance / Benchmark Evidence

Local machine: Apple M3, darwin/arm64. Latest review-fix head: `297bf7da9`.

Allocation parity is an explicit gate for this PR. The granule experiment hot kernels were built around `0 allocs/op`; this PR treats the equivalent prepared direct q1 dictionary-code hot loop the same way, and keeps routed/adapter allocations reported separately so integration/reporting overhead is not confused with kernel allocation.

Prepared direct runner benchmark, artifact `/tmp/gomap_1634_dict_sidecar_runner_bench_20260520_192129.txt`:

| Shape | Current prepared result | Allocations | Interpretation |
|---|---:|---:|---|
| q1 rows 8192 | 3.76-3.91 us/op, 2.41-2.43B rows/s | 0 allocs/op | New dictionary-code sidecar dense hot loop |
| q2 rows 8192 | 0.77-1.02 ms/op, 8.06-10.59M rows/s | 0 allocs/op | Existing prepared TCPA path from #1670 |
| q3 rows 8192 | 0.38-0.59 ms/op, 14.00-21.52M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q4a rows 8192 | 0.62-0.78 ms/op, 10.53-13.23M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q4b rows 8192 | 0.70-0.98 ms/op, 8.37-11.66M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q5 rows 8192 | 0.68-0.89 ms/op, 9.25-11.98M rows/s | 0 allocs/op | Existing prepared TCPA path |


Review-fix benchmark after honoring sidecar read-integrity mode, artifact `/tmp/gomap_1634_dict_sidecar_reviewfix_runner_bench_20260520_193419.txt`:

- q1 rows 8192: 3.58-4.08 us/op, 2.25-2.60B rows/s, 0 allocs/op.
- q2 rows 8192: 0.762-0.785 ms/op, 10.45-10.76M rows/s, 0 allocs/op.

Routed/adapter context, artifact `/tmp/gomap_1634_dict_sidecar_adapter_bench_20260520_192145.txt`:

- q1 rows 8192: 643-678 us/op, 12.5-12.8M rows/s, ~9.4 KiB/op, 89 allocs/op.
- q2 rows 8192: 829-837 us/op, ~9.87-9.89M rows/s, ~10.7 KiB/op, 122 allocs/op.
- q3/q4/q5 remain in the same routed TCPA range and still allocate in the adapter path.

Fresh granule allocation context, artifact `/tmp/gomap_1634_dict_sidecar_granule_baseline_20260520_192323.txt`:

- `BenchmarkCountUint32CodesGranule`: 396-512M rows/s, 0 B/op, 0 allocs/op.
- `BenchmarkAggregateGroupedCountCodes/encoded_kernel`: 498M rows/s, 0 B/op, 0 allocs/op.
- `BenchmarkAggregateFilteredGroupedCountCodes`: 1.88B rows/s, 0 B/op, 0 allocs/op.

Historical ClickHouse-equivalent JSONBench context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`:

- ClickHouse local 1M-row JSONBench: q1 0.014s, q2 0.027s, q3 0.014s, q4 0.013s, q5 0.013s on Darwin arm64 with ClickHouse 26.4.3.1.
- The old granule best kernels in that report were q1 0.004284s, q2 0.038895s, q3 0.006631s, q4 0.009869s, q5 0.010027s.
- This PR should be compared to those as representation-direction evidence only. It does not claim routed 1M-row ClickHouse parity; it proves the first production dictionary-code hot loop can match the granule allocation target.

## Throughput Interpretation

The q1 number is a prepared direct sidecar hot-loop measurement, not routed end-to-end query throughput. Sidecar bytes are read and checksummed during `PrepareColumnPhysicalQuery`; repeated `Run` calls count cached `uint32` code slices and emit from cached dictionary strings. That is the intended shape for granule-style allocation parity, but it must not be confused with the regular planner/adapter path.

The big remaining gap is now explicit: q1 can be made zero-allocation and dense when production has dictionary-code representation. q2-q5 already have zero-allocation prepared execution from #1670, but still scan TCPA row records. The next measured slices should extend dictionary/dense reducers to q2 where distinct maps dominate, then evaluate schema-fixed column-block or richer sidecar assets if profiles confirm row-record TCPA remains the throughput ceiling.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634|TestColumnPhysicalQueryRunnerParityAndAllocationM1634|TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634|TestColumnAssetReachabilityPlanProtectsActiveManifestRefsM15A|TestColumnAssetGCDryRunReportsReclaimableButDoesNotDeleteM15B|TestColumnAssetRewriteRemapsManifestRefsOutOfMixedSegmentM15C' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed before the initial push and after the read-integrity review fix.
- `go test ./cmd/unified_bench -count=1` passed before the initial push and after the read-integrity review fix.
- `git diff --check` passed before the initial push and after the read-integrity review fix.
- Prepared q1-q5 package benchmark passed with `0 allocs/op` for every prepared shape; q1 uses the new dictionary-code sidecar path.
- Review-fix prepared q1/q2 benchmark passed with `0 allocs/op` after `skip_checksums` sidecar decode was corrected.
- AppliedCommandLSN sidecar validation now matches aggregate metadata recovery-authoritative LSN fail-closed checks.

## Artifacts

- Prepared runner q1-q5: `/tmp/gomap_1634_dict_sidecar_runner_bench_20260520_192129.txt`.
- Review-fix prepared q1/q2: `/tmp/gomap_1634_dict_sidecar_reviewfix_runner_bench_20260520_193419.txt`.
- Routed adapter q1-q5 context: `/tmp/gomap_1634_dict_sidecar_adapter_bench_20260520_192145.txt`.
- Fresh granule allocation context: `/tmp/gomap_1634_dict_sidecar_granule_baseline_20260520_192323.txt`.
- Historical ClickHouse/granule JSONBench comparison: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Assumption Ledger / Remaining Work

- Dictionary sidecars are insert-only in this PR. Mutation-bearing manifests fail closed for the sidecar runner and remain on the existing physical query path.
- q1 is the only sidecar-consuming query shape in this PR. `did` sidecars are published and lifecycle-managed now so q2/dense distinct work can be a focused follow-up.
- Sidecar decode follows the requested read-integrity mode at prepare time: strict mode validates checksums, while `skip_checksums` avoids duplicate hot-read checksum work after the read cache applies the selected integrity mode. It also rejects sidecars with AppliedCommandLSN newer than the recovery-authoritative LSN, matching aggregate metadata fail-closed validation. Hot repeated runs do not reread or revalidate sidecar bytes.
- Routed planner execution is unchanged; if a future PR wires prepared sessions into routed query execution, it needs separate adapter allocation evidence.
- This does not replace TCPA part images or claim the final schema-fixed column-block format.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dictionary-code assets to store low-cardinality string columns and a dictionary-backed query path for grouped counts.

* **Tests**
  * Added tests for query parity, manifest reachability of dictionary sidecars, and asset codec corruption/validation scenarios.

* **Chores**
  * Integrated dictionary-code assets into publishing, manifest encoding/decoding, reachability/planning, and physical scan preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

