### PR TITLE
TreeDB column store post-V1: add dictionary distinct sidecar runner

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const columnDictionaryCodeDistinctMaxSeenWords = 1 << 20
+
 type columnDictionaryCodeGroupCountRunner struct {
 	column       string
 	dictionary   []string
@@ -241,9 +243,12 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	if len(runner.assets) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
 		return nil, nil
 	}
-	wordsPerGroup, totalWords, err := columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
+	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, nil
 	}
 	runner.wordsPerGroup = wordsPerGroup
 	runner.groupCounts = make([]int, len(runner.groupDict))
@@ -252,15 +257,19 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	return runner, nil
 }
 
-func columnDictionaryCodeDistinctSeenWords(groupCount, distinctCount int) (int, int, error) {
+func columnDictionaryCodeDistinctSeenWords(groupCount, distinctCount int) (int, int, bool, error) {
 	if groupCount <= 0 || distinctCount <= 0 {
-		return 0, 0, errors.New("collections: dictionary code distinct query requires non-empty group and distinct dictionaries")
+		return 0, 0, false, errors.New("collections: dictionary code distinct query requires non-empty group and distinct dictionaries")
 	}
 	wordsPerGroup := (distinctCount + 63) / 64
 	if wordsPerGroup != 0 && groupCount > maxCollectionInt/wordsPerGroup {
-		return 0, 0, errors.New("collections: dictionary code distinct bitset dimensions overflow int")
+		return 0, 0, false, nil
 	}
-	return wordsPerGroup, groupCount * wordsPerGroup, nil
+	totalWords := groupCount * wordsPerGroup
+	if totalWords > columnDictionaryCodeDistinctMaxSeenWords {
+		return wordsPerGroup, totalWords, false, nil
+	}
+	return wordsPerGroup, totalWords, true, nil
 }
 
 func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, column string) map[[2]uint64]columnManifestDictionaryCodesSnapshot {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -14,8 +14,25 @@ type columnDictionaryCodeGroupCountRunner struct {
 	assetBytes   int64
 }
 
+type columnDictionaryCodeGroupCountDistinctRunner struct {
+	groupColumn    string
+	distinctColumn string
+	groupDict      []string
+	groupCounts    []int
+	seen           []uint64
+	wordsPerGroup  int
+	assets         []columnDictionaryCodeGroupCountDistinctAsset
+	resultGroups   []ColumnPhysicalQueryGroup
+	assetBytes     int64
+}
+
 type columnDictionaryCodeGroupCountAsset struct {
 	codes []uint32
+}
+
+type columnDictionaryCodeGroupCountDistinctAsset struct {
+	groupCodes    []uint32
+	distinctCodes []uint32
 }
 
 func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountRunner, error) {
@@ -113,6 +130,165 @@ func (r *columnDictionaryCodeGroupCountRunner) run(view columnPhysicalScanSnapsh
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ProjectedColumns = 1
+	diag.ScheduledGranules = len(r.assets)
+	diag.DecodedBlocks = len(r.assets)
+	diag.DirectReduceBlocks = len(r.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(r.resultGroups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}
+
+func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountDistinctRunner, error) {
+	if req.Kind != ColumnPhysicalQueryGroupCountDistinct || req.GroupColumn == "" || req.DistinctColumn == "" || view.MutationParts != 0 {
+		return nil, nil
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: dictionary code distinct query missing read cache")
+	}
+	groupCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.GroupColumn)
+	if !ok || groupCol.ValueType != ColumnStoreValueString || !groupCol.Dictionary {
+		return nil, nil
+	}
+	distinctCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.DistinctColumn)
+	if !ok || distinctCol.ValueType != ColumnStoreValueString || !distinctCol.Dictionary {
+		return nil, nil
+	}
+	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	distinctByPart := columnDictionaryCodeSnapshotsByPart(view, req.DistinctColumn)
+	if len(groupByPart) == 0 || len(distinctByPart) == 0 {
+		return nil, nil
+	}
+	runner := &columnDictionaryCodeGroupCountDistinctRunner{
+		groupColumn:    req.GroupColumn,
+		distinctColumn: req.DistinctColumn,
+		assets:         make([]columnDictionaryCodeGroupCountDistinctAsset, 0, len(view.AssetRefs)),
+	}
+	groupByValue := make(map[string]uint32)
+	distinctByValue := make(map[string]uint32)
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return nil, nil
+		}
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		groupSnapshot, ok := groupByPart[partKey]
+		if !ok {
+			return nil, nil
+		}
+		distinctSnapshot, ok := distinctByPart[partKey]
+		if !ok {
+			return nil, nil
+		}
+		groupRaw, err := readCache.read(groupSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = groupRaw
+		groupAsset, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, readCache.verifyChecksum)
+		if err != nil {
+			return nil, err
+		}
+		distinctRaw, err := readCache.read(distinctSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn, err)
+		}
+		scratch = distinctRaw
+		distinctAsset, err := decodeColumnDictionaryCodesAsset(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, readCache.verifyChecksum)
+		if err != nil {
+			return nil, err
+		}
+		if len(groupAsset.Codes) != len(distinctAsset.Codes) {
+			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", len(groupAsset.Codes), len(distinctAsset.Codes))
+		}
+		groupCodes := make([]uint32, len(groupAsset.Codes))
+		for codeIdx, localCode := range groupAsset.Codes {
+			value := groupAsset.Dictionary[localCode]
+			globalCode, ok := groupByValue[value]
+			if !ok {
+				if uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
+					return nil, fmt.Errorf("collections: dictionary code distinct group cardinality exceeds uint32")
+				}
+				globalCode = uint32(len(runner.groupDict))
+				groupByValue[value] = globalCode
+				runner.groupDict = append(runner.groupDict, value)
+			}
+			groupCodes[codeIdx] = globalCode
+		}
+		distinctCodes := make([]uint32, len(distinctAsset.Codes))
+		for codeIdx, localCode := range distinctAsset.Codes {
+			value := distinctAsset.Dictionary[localCode]
+			globalCode, ok := distinctByValue[value]
+			if !ok {
+				if uint64(len(distinctByValue)) == uint64(^uint32(0)) {
+					return nil, fmt.Errorf("collections: dictionary code distinct cardinality exceeds uint32")
+				}
+				globalCode = uint32(len(distinctByValue))
+				distinctByValue[value] = globalCode
+			}
+			distinctCodes[codeIdx] = globalCode
+		}
+		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountDistinctAsset{
+			groupCodes:    groupCodes,
+			distinctCodes: distinctCodes,
+		})
+		runner.assetBytes += groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length
+	}
+	if len(runner.assets) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
+		return nil, nil
+	}
+	runner.wordsPerGroup = (len(distinctByValue) + 63) / 64
+	runner.groupCounts = make([]int, len(runner.groupDict))
+	runner.seen = make([]uint64, len(runner.groupDict)*runner.wordsPerGroup)
+	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.groupDict))
+	return runner, nil
+}
+
+func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, column string) map[[2]uint64]columnManifestDictionaryCodesSnapshot {
+	byPart := make(map[[2]uint64]columnManifestDictionaryCodesSnapshot, len(view.DictionaryCodes))
+	for _, snapshot := range view.DictionaryCodes {
+		if snapshot.ColumnName != column {
+			continue
+		}
+		byPart[[2]uint64{snapshot.AssetRef.Generation, snapshot.AssetRef.PartID}] = snapshot
+	}
+	return byPart
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	clear(r.groupCounts)
+	clear(r.seen)
+	rows := 0
+	for _, asset := range r.assets {
+		for rowIdx, groupCode := range asset.groupCodes {
+			distinctCode := asset.distinctCodes[rowIdx]
+			seenIdx := int(groupCode)*r.wordsPerGroup + int(distinctCode/64)
+			mask := uint64(1) << (distinctCode & 63)
+			if r.seen[seenIdx]&mask == 0 {
+				r.seen[seenIdx] |= mask
+				r.groupCounts[groupCode]++
+			}
+			rows++
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for code, count := range r.groupCounts {
+		if count == 0 {
+			continue
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{
+			Key:   r.groupDict[code],
+			Count: count,
+		})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 2
 	diag.ScheduledGranules = len(r.assets)
 	diag.DecodedBlocks = len(r.assets)
 	diag.DirectReduceBlocks = len(r.assets)

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -38,6 +38,12 @@ type columnDictionaryCodeGroupCountDistinctAsset struct {
 	distinctCodes []uint32
 }
 
+type columnDictionaryCodeGroupCountDistinctPendingAsset struct {
+	group    columnDictionaryCodesAsset
+	distinct columnDictionaryCodesAsset
+	bytes    int64
+}
+
 func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountRunner, error) {
 	if req.Kind != ColumnPhysicalQueryGroupCount || req.GroupColumn == "" || view.MutationParts != 0 {
 		return nil, nil
@@ -149,6 +155,9 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	if req.Kind != ColumnPhysicalQueryGroupCountDistinct || req.GroupColumn == "" || req.DistinctColumn == "" || view.MutationParts != 0 {
 		return nil, nil
 	}
+	if req.GroupColumn == req.DistinctColumn {
+		return nil, nil
+	}
 	if readCache == nil {
 		return nil, fmt.Errorf("collections: dictionary code distinct query missing read cache")
 	}
@@ -172,6 +181,7 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	}
 	groupByValue := make(map[string]uint32)
 	distinctByValue := make(map[string]uint32)
+	pending := make([]columnDictionaryCodeGroupCountDistinctPendingAsset, 0, len(view.AssetRefs))
 	var scratch []byte
 	for _, part := range view.AssetRefs {
 		if part.Reason != ColumnPublishOperationInsert {
@@ -207,40 +217,41 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		if len(groupAsset.Codes) != len(distinctAsset.Codes) {
 			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", len(groupAsset.Codes), len(distinctAsset.Codes))
 		}
-		groupCodes := make([]uint32, len(groupAsset.Codes))
-		for codeIdx, localCode := range groupAsset.Codes {
-			value := groupAsset.Dictionary[localCode]
-			globalCode, ok := groupByValue[value]
+		for _, value := range groupAsset.Dictionary {
+			_, ok := groupByValue[value]
 			if !ok {
 				if uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
 					return nil, fmt.Errorf("collections: dictionary code distinct group cardinality exceeds uint32")
 				}
-				globalCode = uint32(len(runner.groupDict))
+				globalCode := uint32(len(runner.groupDict))
 				groupByValue[value] = globalCode
 				runner.groupDict = append(runner.groupDict, value)
 			}
-			groupCodes[codeIdx] = globalCode
 		}
-		distinctCodes := make([]uint32, len(distinctAsset.Codes))
-		for codeIdx, localCode := range distinctAsset.Codes {
-			value := distinctAsset.Dictionary[localCode]
-			globalCode, ok := distinctByValue[value]
+		for _, value := range distinctAsset.Dictionary {
+			_, ok := distinctByValue[value]
 			if !ok {
 				if uint64(len(distinctByValue)) == uint64(^uint32(0)) {
 					return nil, fmt.Errorf("collections: dictionary code distinct cardinality exceeds uint32")
 				}
-				globalCode = uint32(len(distinctByValue))
+				globalCode := uint32(len(distinctByValue))
 				distinctByValue[value] = globalCode
 			}
-			distinctCodes[codeIdx] = globalCode
 		}
-		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountDistinctAsset{
-			groupCodes:    groupCodes,
-			distinctCodes: distinctCodes,
+		_, _, ok, err = columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, nil
+		}
+		pending = append(pending, columnDictionaryCodeGroupCountDistinctPendingAsset{
+			group:    groupAsset,
+			distinct: distinctAsset,
+			bytes:    groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length,
 		})
-		runner.assetBytes += groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length
 	}
-	if len(runner.assets) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
+	if len(pending) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
 		return nil, nil
 	}
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
@@ -253,6 +264,21 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	runner.wordsPerGroup = wordsPerGroup
 	runner.groupCounts = make([]int, len(runner.groupDict))
 	runner.seen = make([]uint64, totalWords)
+	for _, asset := range pending {
+		groupCodes := make([]uint32, len(asset.group.Codes))
+		for codeIdx, localCode := range asset.group.Codes {
+			groupCodes[codeIdx] = groupByValue[asset.group.Dictionary[localCode]]
+		}
+		distinctCodes := make([]uint32, len(asset.distinct.Codes))
+		for codeIdx, localCode := range asset.distinct.Codes {
+			distinctCodes[codeIdx] = distinctByValue[asset.distinct.Dictionary[localCode]]
+		}
+		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountDistinctAsset{
+			groupCodes:    groupCodes,
+			distinctCodes: distinctCodes,
+		})
+		runner.assetBytes += asset.bytes
+	}
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.groupDict))
 	return runner, nil
 }

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -240,11 +241,26 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	if len(runner.assets) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
 		return nil, nil
 	}
-	runner.wordsPerGroup = (len(distinctByValue) + 63) / 64
+	wordsPerGroup, totalWords, err := columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
+	if err != nil {
+		return nil, err
+	}
+	runner.wordsPerGroup = wordsPerGroup
 	runner.groupCounts = make([]int, len(runner.groupDict))
-	runner.seen = make([]uint64, len(runner.groupDict)*runner.wordsPerGroup)
+	runner.seen = make([]uint64, totalWords)
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.groupDict))
 	return runner, nil
+}
+
+func columnDictionaryCodeDistinctSeenWords(groupCount, distinctCount int) (int, int, error) {
+	if groupCount <= 0 || distinctCount <= 0 {
+		return 0, 0, errors.New("collections: dictionary code distinct query requires non-empty group and distinct dictionaries")
+	}
+	wordsPerGroup := (distinctCount + 63) / 64
+	if wordsPerGroup != 0 && groupCount > maxCollectionInt/wordsPerGroup {
+		return 0, 0, errors.New("collections: dictionary code distinct bitset dimensions overflow int")
+	}
+	return wordsPerGroup, groupCount * wordsPerGroup, nil
 }
 
 func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, column string) map[[2]uint64]columnManifestDictionaryCodesSnapshot {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )
@@ -285,7 +284,7 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 
 func columnDictionaryCodeDistinctSeenWords(groupCount, distinctCount int) (int, int, bool, error) {
 	if groupCount <= 0 || distinctCount <= 0 {
-		return 0, 0, false, errors.New("collections: dictionary code distinct query requires non-empty group and distinct dictionaries")
+		return 0, 0, false, nil
 	}
 	wordsPerGroup := (distinctCount + 63) / 64
 	if wordsPerGroup != 0 && groupCount > maxCollectionInt/wordsPerGroup {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -95,14 +95,15 @@ type ColumnPhysicalQueryResult struct {
 // synchronize Run and Close. Result groups returned by Run alias runner-owned
 // storage and are valid only until the next Run or Close.
 type ColumnPhysicalQueryRunner struct {
-	collection *Collection
-	view       columnPhysicalScanSnapshotView
-	closeView  func()
-	req        ColumnPhysicalQueryRequest
-	exec       *columnPhysicalQueryExecutor
-	readCache  columnPhysicalAssetReadCache
-	dictCount  *columnDictionaryCodeGroupCountRunner
-	closed     bool
+	collection   *Collection
+	view         columnPhysicalScanSnapshotView
+	closeView    func()
+	req          ColumnPhysicalQueryRequest
+	exec         *columnPhysicalQueryExecutor
+	readCache    columnPhysicalAssetReadCache
+	dictCount    *columnDictionaryCodeGroupCountRunner
+	dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
+	closed       bool
 }
 
 var errColumnPhysicalScanCancelled = errors.New("collections: physical column scan cancelled")
@@ -186,15 +187,21 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		_ = readCache.close()
 		return nil, err
 	}
+	dictDistinct, err := prepareColumnDictionaryCodeGroupCountDistinctRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	release = false
 	return &ColumnPhysicalQueryRunner{
-		collection: c,
-		view:       view,
-		closeView:  closeView,
-		req:        req,
-		exec:       exec,
-		readCache:  readCache,
-		dictCount:  dictCount,
+		collection:   c,
+		view:         view,
+		closeView:    closeView,
+		req:          req,
+		exec:         exec,
+		readCache:    readCache,
+		dictCount:    dictCount,
+		dictDistinct: dictDistinct,
 	}, nil
 }
 
@@ -226,6 +233,9 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.dictCount != nil {
 		return r.dictCount.run(r.view, r.req), nil
+	}
+	if r.dictDistinct != nil {
+		return r.dictDistinct.run(r.view, r.req), nil
 	}
 	r.exec.resetForRun()
 	beforeHits := r.readCache.hits

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1890,6 +1890,62 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}
+	wantHash := columnPhysicalQueryReferenceHashM13B("q2", events)
+	tcpResult, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery TCPA baseline: %v", err)
+	}
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	defer func() {
+		if err := runner.Close(); err != nil {
+			t.Fatalf("runner Close: %v", err)
+		}
+	}()
+	for i := 0; i < 3; i++ {
+		result, err := runner.Run()
+		if err != nil {
+			t.Fatalf("runner Run warmup %d: %v", i, err)
+		}
+		if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B("q2", result.Groups)); got != wantHash {
+			t.Fatalf("runner q2 hash=%d want %d groups=%+v", got, wantHash, result.Groups)
+		}
+		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+		}
+		if result.Diagnostics.ProjectedColumns != 2 {
+			t.Fatalf("runner projected columns=%d want kind+did sidecars", result.Diagnostics.ProjectedColumns)
+		}
+		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpResult.Diagnostics.PhysicalBytesScanned {
+			t.Fatalf("runner physical bytes=%d want dictionary-code sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpResult.Diagnostics.PhysicalBytesScanned)
+		}
+		if result.Diagnostics.SegmentFileCacheMisses != 0 {
+			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
+		}
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		result, err := runner.Run()
+		if err != nil {
+			panic(fmt.Sprintf("runner Run: %v", err))
+		}
+		if len(result.Groups) != 4 {
+			panic(fmt.Sprintf("runner groups=%d want 4", len(result.Groups)))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("runner q2 warmed allocs/run=%.2f want 0", allocs)
+	}
+}
+
 func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.T) {
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
 	defer closeFn()

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1946,6 +1946,40 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 	}
 }
 
+func TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(128)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "kind"}
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	defer func() {
+		if err := runner.Close(); err != nil {
+			t.Fatalf("runner Close: %v", err)
+		}
+	}()
+	if runner.dictDistinct != nil {
+		t.Fatal("identical group/distinct columns used dictionary distinct sidecar; want direct fallback")
+	}
+	result, err := runner.Run()
+	if err != nil {
+		t.Fatalf("runner Run: %v", err)
+	}
+	want := []string{"q2:kind_00=1", "q2:kind_01=1", "q2:kind_02=1", "q2:kind_03=1"}
+	if got := columnPhysicalQueryLinesM13B("q2", result.Groups); !equalStringSets(got, want) {
+		t.Fatalf("runner q2 identical-column lines=%v want %v", got, want)
+	}
+	if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+		t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+	}
+	if result.Diagnostics.ProjectedColumns != 1 {
+		t.Fatalf("runner projected columns=%d want direct fallback projection for kind/kind", result.Diagnostics.ProjectedColumns)
+	}
+}
+
 func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.T) {
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
 	defer closeFn()

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1961,9 +1961,6 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634(t *t
 			t.Fatalf("runner Close: %v", err)
 		}
 	}()
-	if runner.dictDistinct != nil {
-		t.Fatal("identical group/distinct columns used dictionary distinct sidecar; want direct fallback")
-	}
 	result, err := runner.Run()
 	if err != nil {
 		t.Fatalf("runner Run: %v", err)
@@ -2112,6 +2109,12 @@ func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T)
 	}
 	if wordsPerGroup != 3 || totalWords != 12 {
 		t.Fatalf("wordsPerGroup=%d totalWords=%d want 3/12", wordsPerGroup, totalWords)
+	}
+	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(0, 1); err != nil || ok {
+		t.Fatalf("empty group ok=%v err=%v want clean fallback", ok, err)
+	}
+	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(1, 0); err != nil || ok {
+		t.Fatalf("empty distinct ok=%v err=%v want clean fallback", ok, err)
 	}
 	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(maxCollectionInt, 65); err != nil || ok {
 		t.Fatalf("overflow ok=%v err=%v want clean fallback", ok, err)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2069,15 +2069,21 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 }
 
 func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
-	wordsPerGroup, totalWords, err := columnDictionaryCodeDistinctSeenWords(4, 129)
+	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(4, 129)
 	if err != nil {
 		t.Fatalf("columnDictionaryCodeDistinctSeenWords normal: %v", err)
+	}
+	if !ok {
+		t.Fatal("columnDictionaryCodeDistinctSeenWords normal ok=false want true")
 	}
 	if wordsPerGroup != 3 || totalWords != 12 {
 		t.Fatalf("wordsPerGroup=%d totalWords=%d want 3/12", wordsPerGroup, totalWords)
 	}
-	if _, _, err := columnDictionaryCodeDistinctSeenWords(maxCollectionInt, 65); err == nil || !strings.Contains(err.Error(), "overflow") {
-		t.Fatalf("overflow err=%v want overflow failure", err)
+	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(maxCollectionInt, 65); err != nil || ok {
+		t.Fatalf("overflow ok=%v err=%v want clean fallback", ok, err)
+	}
+	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(columnDictionaryCodeDistinctMaxSeenWords+1, 1); err != nil || ok {
+		t.Fatalf("oversized bitset ok=%v err=%v want clean fallback", ok, err)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2068,6 +2068,19 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 	}
 }
 
+func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
+	wordsPerGroup, totalWords, err := columnDictionaryCodeDistinctSeenWords(4, 129)
+	if err != nil {
+		t.Fatalf("columnDictionaryCodeDistinctSeenWords normal: %v", err)
+	}
+	if wordsPerGroup != 3 || totalWords != 12 {
+		t.Fatalf("wordsPerGroup=%d totalWords=%d want 3/12", wordsPerGroup, totalWords)
+	}
+	if _, _, err := columnDictionaryCodeDistinctSeenWords(maxCollectionInt, 65); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("overflow err=%v want overflow failure", err)
+	}
+}
+
 func TestColumnPhysicalQueryRunnerFailsClosedForUnsupportedShapeM1634(t *testing.T) {
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
 	defer closeFn()


### PR DESCRIPTION
## Benchmark Claim Boundary

Measurement class: `prepared hot runner / warmed repeated Run()` is the primary changed path in this PR. The billion-rows/sec q1/q2 numbers are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery`; they do not include sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, or mutation handling. Routed production execution is unchanged by this PR, so these numbers must not be read as end-to-end routed TreeDB query throughput or ClickHouse parity.

The end-to-end comparable snapshot section below is therefore intentionally separate from the prepared-runner evidence. It identifies the routed production boundary and the available historical granule/ClickHouse context, with apples-to-apples limitations called out explicitly.

Benchmark wording backfill: this PR follows the #1634 standing convention for prepared-runner PRs. Any billion-rows/sec number in this body is only a prepared hot-runner result unless the same paragraph says `routed unified-bench query path`; routed production was not changed by #1672 and is not implied by the prepared q1/q2 rows/sec.

## Static Analysis / Priority Checkpoint

After #1671, production q1 has a prepared direct dictionary-code sidecar path matching the granule hot-kernel allocation target. q2 was the next measured representation gap: it still used the prepared TCPA row-record reducer, interning `kind`/`did` strings and maintaining per-group distinct maps. That shape is tactical zero-allocation after #1670, but it remains row-record representation work rather than granule-style dense code execution.

This PR extends the #1671 representation step to q2. It consumes the already-published `kind` and `did` dictionary-code sidecars, pretranslates part-local codes to global code domains during prepare, and runs the hot q2 reducer over dense `uint32` code arrays plus reusable bitset/count scratch. It does not change routed planner execution, mutation visibility, TCPA fallback/parity, marks, metadata, locators, or schema-fixed column-block assets.

## What Landed

- Adds a prepared direct `GroupCountDistinct(kind,did)` dictionary-sidecar runner.
- Requires complete insert-only sidecar coverage for both group and distinct columns; otherwise the prepared runner keeps existing fail-closed/fallback behavior.
- Uses reusable dense bitset/count state to count distinct `did` codes per `kind` group without hot-run maps, string interning, segment reads, or heap allocation.
- Keeps q1 dictionary sidecar behavior from #1671 unchanged and leaves q3/q4/q5 on the existing prepared TCPA runner.
- Adds q2 parity/allocation tests that verify reference hash parity, `0 allocs/op`, sidecar physical bytes below TCPA bytes, and no hot segment cache misses after prepare.

## Measurement Class

- Primary changed path: measurement class `prepared hot runner / warmed repeated Run()` after `PrepareColumnPhysicalQuery`.
- End-to-end comparable snapshot: measurement class `routed unified-bench query path`; this PR does not change routed execution and current routed production does not call the prepared q2 sidecar runner.
- Direct package scanner context: not the changed path in this PR; prior adapter/TCPA numbers are context only.
- Experiment/granule baseline: measurement class `experiment/granule baseline`, used for allocation and dense-code kernel context.
- ClickHouse context: measurement class `historical ClickHouse context`, used only as JSONBench family context.


## Performance / Benchmark Evidence

Local machine: Apple M3, darwin/arm64. Latest review-fix head: `ce7d8dc24`.

Measurement class: `prepared hot runner / warmed repeated Run()`. These billion-rows/sec numbers are measured after `PrepareColumnPhysicalQuery`; they exclude sidecar read/decode/checksum/translation, planner routing, unified-bench reporting, writes, WAL/checkpoint, reopen, and mutation handling.

Prepared hot-runner artifact `/tmp/gomap_1634_dict_distinct_runner_bench_20260520_195451.txt`:

| Shape | Current prepared result | Allocations | Interpretation |
|---|---:|---:|---|
| q1 rows 8192 | mostly 4.3-4.6 us/op, ~2.40-2.43B rows/s | 0 allocs/op | Existing #1671 dictionary-code sidecar count path |
| q2 rows 8192 | 5.69-6.15 us/op, ~1.44-1.45B rows/s | 0 allocs/op | New dictionary-code sidecar dense distinct path |
| q3 rows 8192 | 0.385-0.465 ms/op, ~17.65-21.34M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q4a rows 8192 | 0.617-0.646 ms/op, ~12.72-13.30M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q4b rows 8192 | 0.707-0.813 ms/op, ~10.09-11.59M rows/s | 0 allocs/op | Existing prepared TCPA path |
| q5 rows 8192 | 0.684-0.702 ms/op, ~11.67-11.98M rows/s | 0 allocs/op | Existing prepared TCPA path |





Measurement class: `prepared hot runner / warmed repeated Run()`. Second review-fix benchmark after adding the hard bitset cap/fallback, artifact `/tmp/gomap_1634_dict_distinct_reviewfix2_bench_20260520_201038.txt`:

- q1 rows 8192: 3.33-3.38 us/op, ~2.45-2.49B rows/s, 0 allocs/op.
- q2 rows 8192: 5.58-5.76 us/op, ~1.44-1.48B rows/s, 0 allocs/op.

Measurement class: `prepared hot runner / warmed repeated Run()`. Third review-fix benchmark after skipping identical-column sidecars and moving cardinality/budget checks before translated per-row sidecar arrays, artifact `/tmp/gomap_1634_dict_distinct_reviewfix3_bench_20260520_202249.txt`:

- q1 rows 8192: 3.48-3.54 us/op, ~2.35-2.41B rows/s, 0 allocs/op.
- q2 rows 8192: 6.37-12.59 us/op, ~0.66-1.30B rows/s, 0 allocs/op. The slower first q2 sample is treated as local noise/outlier; the important gate for this review fix is preserved zero hot-run allocation and fallback correctness.

Measurement class: `prepared hot runner / warmed repeated Run()`. Fourth review-fix benchmark after clean empty-cardinality fallback and observable-only identical-column test assertions, artifact `/tmp/gomap_1634_dict_distinct_reviewfix4_bench_20260520_203501.txt`:

- q1 rows 8192: 4.05-5.81 us/op, ~2.21-2.44B rows/s by benchmark-reported ns/row, 0 allocs/op.
- q2 rows 8192: 5.95-8.27 us/op, ~1.40-1.45B rows/s by benchmark-reported ns/row, 0 allocs/op.

Measurement class: `prepared hot runner / warmed repeated Run()`. Review-fix benchmark after the guarded bitset allocation check, artifact `/tmp/gomap_1634_dict_distinct_reviewfix_bench_20260520_200239.txt`:

- q1 rows 8192: 3.77-4.22 us/op, ~1.97-2.21B rows/s, 0 allocs/op.
- q2 rows 8192: 5.64-5.77 us/op, ~1.43-1.47B rows/s, 0 allocs/op.

Measurement class: `prepared hot runner / warmed repeated Run()`. Comparison to #1671 prepared baseline:

- #1671 q2 prepared TCPA path was ~0.762-0.785 ms/op, ~10.45-10.76M rows/s, `0 allocs/op`.
- This PR's q2 sidecar path is ~5.69-6.15 us/op, ~1.44-1.45B rows/s, `0 allocs/op`.
- The win is representation/kernel shape, not another TCPA cursor micro-optimization.

Measurement class: `experiment/granule baseline`. Fresh granule allocation context from #1671 artifact `/tmp/gomap_1634_dict_sidecar_granule_baseline_20260520_192323.txt` remains the target:

- `BenchmarkCountUint32CodesGranule`: 396-512M rows/s, 0 B/op, 0 allocs/op.
- `BenchmarkAggregateGroupedCountCodes/encoded_kernel`: 498M rows/s, 0 B/op, 0 allocs/op.
- `BenchmarkAggregateFilteredGroupedCountCodes`: 1.88B rows/s, 0 B/op, 0 allocs/op.

Measurement class: `historical ClickHouse context`. Historical ClickHouse-equivalent JSONBench context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`:

- ClickHouse local 1M-row JSONBench q1/q2/q3/q4/q5: 0.014s/0.027s/0.014s/0.013s/0.013s.
- Old granule best kernels: q1 0.004284s, q2 0.038895s, q3 0.006631s, q4 0.009869s, q5 0.010027s.
- These remain context, not an end-to-end parity claim; this PR proves the q2 prepared production kernel now has granule-style code/dense allocation behavior.


## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. This PR does not change routed planner execution, and routed execution at this PR does not call this prepared q2 sidecar runner. No new routed `unified-bench` q1-q5 rerun is claimed for #1672 itself. Current-best routed context at benchmark-wording backfill time comes from the later #1683 stack snapshot, Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_manifest_decoder_routed_100k_uOb9WP`: q1 `9.0 ns/row`, `111.03M rows/s`; q2 `41.7 ns/row`, `23.96M rows/s`; q3 `5.4 ns/row`, `183.70M rows/s`; q4a `29.1 ns/row`, `34.34M rows/s`; q4b `29.3 ns/row`, `34.08M rows/s`; q5 `29.6 ns/row`, `33.78M rows/s`; q5_metadata serial alias `30.2 ns/row`, `33.10M rows/s`, `metadata_hits=0`. This is stale relative to #1672's head and later than #1672 in the stack, but it is the newest named routed comparable artifact available in the #1634 tracker. The prepared q2 `~1.4B rows/s` number is therefore not an end-to-end routed scan time, not a ClickHouse parity claim, and not a measurement of writes, WAL/checkpoint, reopen, mutation handling, or unified-bench reporting.

Measurement class: `prepared hot runner / warmed repeated Run()`. The changed q2 shape is measured above at 8192 rows with repeated `Run()` after prepare, including `0 allocs/op` but excluding prepare/setup and end-to-end database work.

Measurement class: `experiment/granule baseline`. The granule numbers above are kernel/context baselines for allocation and representation shape; they are not production TreeDB routed measurements.

Measurement class: `historical ClickHouse context`. The ClickHouse JSONBench numbers above are stale/historical context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, not a same-commit or same-harness gate.

Scale note: q2 at ~5.69-6.15 us for 8192 rows is a prepared hot-runner measurement. Do not extrapolate it as an end-to-end routed scan time. Conversely, routed production results reported in `ns/row` should be converted by row count: about `90 ns/row` over 100K rows is about 9 ms, while 1M rows at `90 ns/row` extrapolates to about 90 ms.

## Throughput Interpretation

The q2 number is a `prepared hot runner / warmed repeated Run()` measurement. Sidecars are read, decoded, checksummed according to the selected read-integrity mode, and translated during `PrepareColumnPhysicalQuery`; repeated `Run` calls count cached code arrays through reusable bitsets. The q2 billion-rows/sec figures therefore do not include sidecar read/decode/checksum/translation, planner routing, unified-bench reporting, writes, WAL/checkpoint, reopen, or mutation handling. Routed planner execution is not changed here.

This materially supports the current #1634 diagnosis: the large gap is representation and kernel shape. Moving q2 from TCPA row records/string maps to dictionary-code sidecars produces an order-of-magnitude-plus throughput improvement while preserving `0 allocs/op`.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation)M1634' -count=1` passed.
- Guarded dense bitset allocation against group-cardinality by distinct-cardinality overflow and added a focused overflow test.
- Added a bounded dense bitset budget; high-cardinality dictionary shapes fall back to the existing prepared TCPA reducer rather than allocating/clearing an oversized bitmap.
- Skips identical group/distinct columns because that shape has a direct linear answer but would make the dense sidecar bitset quadratic.
- Performs distinct sidecar cardinality/budget checks before materializing translated per-row sidecar arrays, so oversized shapes fall back before paying the sidecar memory cost.
- Treats empty cardinality as clean fallback and keeps the identical-column fallback test on observable output/diagnostics instead of internal runner fields.
- Verified the scratch-buffer review concern is not valid for current code because `decodeColumnDictionaryCodesAsset` copies dictionary strings and code slices.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634' -count=1` passed.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634|TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634|TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryRunnerM1634/(q1|q2|q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=1000x -count=5` passed.
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryRunnerM1634/(q1|q2)_rows_8192$' -benchmem -benchtime=1000x -count=3` passed.
- `git diff --check` passed.

## Artifacts

- Prepared runner q1-q5: `/tmp/gomap_1634_dict_distinct_runner_bench_20260520_195451.txt`.
- Review-fix q1/q2: `/tmp/gomap_1634_dict_distinct_reviewfix_bench_20260520_200239.txt`.
- Review-fix q1/q2 with hard bitset cap: `/tmp/gomap_1634_dict_distinct_reviewfix2_bench_20260520_201038.txt`.
- Review-fix q1/q2 with early fallback and identical-column skip: `/tmp/gomap_1634_dict_distinct_reviewfix3_bench_20260520_202249.txt`.
- Review-fix q1/q2 with clean fallback and observable-only test assertion: `/tmp/gomap_1634_dict_distinct_reviewfix4_bench_20260520_203501.txt`.
- Prior #1671 q1/q2 review-fix baseline: `/tmp/gomap_1634_dict_sidecar_reviewfix_runner_bench_20260520_193419.txt`.
- Fresh granule allocation context: `/tmp/gomap_1634_dict_sidecar_granule_baseline_20260520_192323.txt`.
- Historical ClickHouse/granule JSONBench comparison: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Assumption Ledger / Remaining Work

- This is prepared direct execution only. Routed planner/session reuse remains separate work.
- Dictionary sidecar execution remains insert-only; mutation-bearing manifests fail closed to the existing prepared-runner behavior.
- q3/q4/q5 still scan TCPA row-record assets in prepared mode. The next priority should be based on a fresh static/profile checkpoint, likely aggregate metadata or schema-fixed/time/code sidecars rather than row-cursor shaving.
- This does not replace TCPA physical parts or claim final ClickHouse/granule end-to-end parity.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct-aware group-count execution that deduplicates distinct values per group and returns sorted group counts.

* **Bug Fixes**
  * Improved validation and overflow handling for distinct-count sizing; oversized or invalid sizing now falls back cleanly.
  * Added fallback to direct execution when group and distinct columns are identical.

* **Tests**
  * Added tests for parity with baseline, diagnostics (ProjectedColumns = 2 and 1), allocation behavior, and overflow rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




