### PR TITLE
TreeDB column store post-V1: add prepared aggregate metadata runner

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_query.go
+++ b/TreeDB/collections/column_aggregate_metadata_query.go
@@ -1,0 +1,139 @@
+package collections
+
+import (
+	"fmt"
+	"time"
+)
+
+type columnAggregateMetadataRunnerEntry struct {
+	groupCode int
+	count     int
+	min       int64
+	max       int64
+}
+
+type columnAggregateMetadataRunner struct {
+	kind                     ColumnPhysicalQueryKind
+	assetBytes               int64
+	metadataHits             int
+	rows                     int
+	scheduledGranules        int
+	groupKeys                []string
+	entries                  []columnAggregateMetadataRunnerEntry
+	present                  []bool
+	mins                     []int64
+	maxs                     []int64
+	resultGroups             []ColumnPhysicalQueryGroup
+	columnAssetReadIntegrity string
+}
+
+func prepareColumnAggregateMetadataRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnAggregateMetadataRunner, error) {
+	if view.MutationParts != 0 {
+		return nil, fmt.Errorf("%w: prepared aggregate metadata query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: prepared aggregate metadata query requires read cache")
+	}
+	aggregate, ok := columnPhysicalQueryAggregateMetadataConfig(view.Config, req)
+	if !ok {
+		return nil, fmt.Errorf("%w: aggregate metadata %q does not match physical query shape", ErrColumnQueryPlanUnsupported, req.AggregateMetadataName)
+	}
+	refs := columnPhysicalQueryAggregateMetadataRefs(view.AggregateMetadata, aggregate.Name)
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	runner := &columnAggregateMetadataRunner{
+		kind:                     req.Kind,
+		scheduledGranules:        len(refs),
+		columnAssetReadIntegrity: columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity),
+	}
+	groupCodes := make(map[string]int)
+	var rawScratch []byte
+	for _, metadataRef := range refs {
+		raw, err := readCache.read(metadataRef.AssetRef, rawScratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: aggregate metadata read %q generation=%d part_id=%d: %w", metadataRef.Name, metadataRef.AssetRef.Generation, metadataRef.AssetRef.PartID, err)
+		}
+		rawScratch = raw
+		runner.assetBytes += int64(len(raw))
+		asset, err := decodeColumnAggregateMetadataAsset(raw, metadataRef.AssetRef, view.Config, view.CollectionName, aggregate.Name)
+		if err != nil {
+			return nil, err
+		}
+		if asset.GroupColumn != req.GroupColumn || asset.ValueColumn != req.ValueColumn {
+			return nil, fmt.Errorf("%w: aggregate metadata %q columns %s/%s do not match query %s/%s", ErrColumnQueryPlanUnsupported, aggregate.Name, asset.GroupColumn, asset.ValueColumn, req.GroupColumn, req.ValueColumn)
+		}
+		runner.metadataHits++
+		for _, entry := range asset.Entries {
+			code, ok := groupCodes[entry.Group]
+			if !ok {
+				code = len(runner.groupKeys)
+				groupCodes[entry.Group] = code
+				runner.groupKeys = append(runner.groupKeys, entry.Group)
+			}
+			runner.entries = append(runner.entries, columnAggregateMetadataRunnerEntry{
+				groupCode: code,
+				count:     entry.Count,
+				min:       entry.Min,
+				max:       entry.Max,
+			})
+			runner.rows += entry.Count
+		}
+	}
+	groupCount := len(runner.groupKeys)
+	runner.present = make([]bool, groupCount)
+	runner.mins = make([]int64, groupCount)
+	runner.maxs = make([]int64, groupCount)
+	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, groupCount)
+	return runner, nil
+}
+
+func (r *columnAggregateMetadataRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	for i := range r.present {
+		r.present[i] = false
+	}
+	for _, entry := range r.entries {
+		code := entry.groupCode
+		if !r.present[code] {
+			r.present[code] = true
+			r.mins[code] = entry.min
+			r.maxs[code] = entry.max
+			continue
+		}
+		if entry.min < r.mins[code] {
+			r.mins[code] = entry.min
+		}
+		if entry.max > r.maxs[code] {
+			r.maxs[code] = entry.max
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for code, key := range r.groupKeys {
+		if !r.present[code] {
+			continue
+		}
+		group := ColumnPhysicalQueryGroup{Key: key}
+		switch r.kind {
+		case ColumnPhysicalQueryGroupMinInt64:
+			group.Int64 = r.mins[code]
+		case ColumnPhysicalQueryGroupMaxInt64:
+			group.Int64 = r.maxs[code]
+		case ColumnPhysicalQueryGroupInt64Span:
+			group.Int64 = r.maxs[code] - r.mins[code]
+		}
+		r.resultGroups = append(r.resultGroups, group)
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 2
+	diag.MetadataHits = r.metadataHits
+	diag.ScheduledGranules = r.scheduledGranules
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = r.rows
+	diag.ResultGroups = len(r.resultGroups)
+	diag.ColumnAssetReadIntegrity = r.columnAssetReadIntegrity
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -103,6 +103,7 @@ type ColumnPhysicalQueryRunner struct {
 	readCache    columnPhysicalAssetReadCache
 	dictCount    *columnDictionaryCodeGroupCountRunner
 	dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
+	metadata     *columnAggregateMetadataRunner
 	closed       bool
 }
 
@@ -167,21 +168,34 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	if view.MutationParts > 0 {
 		return nil, fmt.Errorf("%w: prepared physical column query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
 	}
-	if req.AggregateMetadataName != "" {
-		return nil, fmt.Errorf("%w: prepared physical column query does not support aggregate metadata yet", ErrColumnQueryPlanUnsupported)
-	}
-	exec, err := newColumnPhysicalQueryExecutor(view.Config, req)
-	if err != nil {
-		return nil, err
-	}
-	if !exec.supportsDirectAssetReduce() {
-		return nil, fmt.Errorf("%w: prepared physical column query requires direct asset reducer", ErrColumnQueryPlanUnsupported)
-	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
 		return nil, err
 	}
 	readCache.returnViews = true
+	var metadata *columnAggregateMetadataRunner
+	var exec *columnPhysicalQueryExecutor
+	if req.AggregateMetadataName != "" {
+		metadata, err = prepareColumnAggregateMetadataRunner(view, req, &readCache)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		if metadata == nil {
+			_ = readCache.close()
+			return nil, fmt.Errorf("%w: prepared aggregate metadata query requires metadata assets", ErrColumnQueryPlanUnsupported)
+		}
+	} else {
+		exec, err = newColumnPhysicalQueryExecutor(view.Config, req)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		if !exec.supportsDirectAssetReduce() {
+			_ = readCache.close()
+			return nil, fmt.Errorf("%w: prepared physical column query requires direct asset reducer", ErrColumnQueryPlanUnsupported)
+		}
+	}
 	dictCount, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
 	if err != nil {
 		_ = readCache.close()
@@ -202,6 +216,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		readCache:    readCache,
 		dictCount:    dictCount,
 		dictDistinct: dictDistinct,
+		metadata:     metadata,
 	}, nil
 }
 
@@ -236,6 +251,9 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.dictDistinct != nil {
 		return r.dictDistinct.run(r.view, r.req), nil
+	}
+	if r.metadata != nil {
+		return r.metadata.run(r.view, r.req), nil
 	}
 	r.exec.resetForRun()
 	beforeHits := r.readCache.hits

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1977,6 +1977,82 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634(t *t
 	}
 }
 
+func TestColumnPhysicalQueryRunnerAggregateMetadataParityAndAllocationM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	tests := []struct {
+		name     string
+		hashName string
+		req      ColumnPhysicalQueryRequest
+	}{
+		{
+			name:     "q4b",
+			hashName: "q4b",
+			req:      ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"},
+		},
+		{
+			name:     "q5_metadata",
+			hashName: "q5",
+			req:      ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := columnPhysicalQueryReferenceHashM13B(tc.hashName, events)
+			baseline, err := collection.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery baseline: %v", err)
+			}
+			if baseline.Diagnostics.MetadataHits == 0 || baseline.Diagnostics.RowsScanned != 0 || baseline.Diagnostics.DecodedBlocks != 0 {
+				t.Fatalf("baseline diagnostics=%+v want metadata-only path", baseline.Diagnostics)
+			}
+			runner, err := collection.PrepareColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+			}
+			defer func() {
+				if err := runner.Close(); err != nil {
+					t.Fatalf("runner Close: %v", err)
+				}
+			}()
+			for i := 0; i < 3; i++ {
+				result, err := runner.Run()
+				if err != nil {
+					t.Fatalf("runner Run warmup %d: %v", i, err)
+				}
+				if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B(tc.name, result.Groups)); got != wantHash {
+					t.Fatalf("runner %s hash=%d want %d groups=%+v", tc.name, got, wantHash, result.Groups)
+				}
+				if result.Diagnostics.MetadataHits == 0 || result.Diagnostics.RowsScanned != 0 || result.Diagnostics.DecodedBlocks != 0 {
+					t.Fatalf("runner diagnostics=%+v want metadata-only hot path", result.Diagnostics)
+				}
+				if result.Diagnostics.SegmentFileCacheMisses != 0 {
+					t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after metadata prepare", result.Diagnostics)
+				}
+				if result.Diagnostics.ReduceRows != len(events) {
+					t.Fatalf("runner reduce rows=%d want %d diagnostics=%+v", result.Diagnostics.ReduceRows, len(events), result.Diagnostics)
+				}
+				if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned != baseline.Diagnostics.PhysicalBytesScanned {
+					t.Fatalf("runner physical bytes=%d want metadata bytes=%d", result.Diagnostics.PhysicalBytesScanned, baseline.Diagnostics.PhysicalBytesScanned)
+				}
+			}
+			allocs := testing.AllocsPerRun(20, func() {
+				result, err := runner.Run()
+				if err != nil {
+					panic(fmt.Sprintf("runner Run: %v", err))
+				}
+				if len(result.Groups) == 0 {
+					panic("empty metadata result")
+				}
+			})
+			if allocs != 0 {
+				t.Fatalf("runner %s warmed allocs/run=%.2f want 0", tc.name, allocs)
+			}
+		})
+	}
+}
+
 func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.T) {
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
 	defer closeFn()
@@ -2194,7 +2270,9 @@ func BenchmarkColumnPhysicalQueryAdapterM13B(b *testing.B) {
 			{name: "q3", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
 			{name: "q4a", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
 			{name: "q4b", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q4b_metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"}},
 			{name: "q5", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q5_metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}},
 		}
 		for _, tc := range cases {
 			b.Run(fmt.Sprintf("%s_rows_%d", tc.name, rows), func(b *testing.B) {
@@ -2239,7 +2317,9 @@ func BenchmarkColumnPhysicalQueryRunnerM1634(b *testing.B) {
 			{name: "q3", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
 			{name: "q4a", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
 			{name: "q4b", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q4b_metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"}},
 			{name: "q5", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
+			{name: "q5_metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}},
 		}
 		for _, tc := range cases {
 			b.Run(fmt.Sprintf("%s_rows_%d", tc.name, rows), func(b *testing.B) {


### PR DESCRIPTION
## Benchmark Claim Boundary

Measurement class: `prepared hot runner / warmed repeated Run()` is the primary changed path in this PR. The q4b_metadata/q5_metadata billion-rows/sec numbers are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery`; they do not include metadata asset read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, or mutation handling. Routed production execution is unchanged by this PR, so these numbers must not be read as end-to-end routed TreeDB query throughput or ClickHouse parity.

The routed `unified-bench` aggregate-metadata snapshot remains the end-to-end comparable production evidence and is reported separately from the prepared hot-runner evidence.

## What Landed

This #1634 follow-on PR adds a prepared hot-runner path for insert-only aggregate metadata queries after `PrepareColumnPhysicalQuery`.

- Decodes typed aggregate metadata assets during prepare and stores dense group-coded metadata entries in runner-owned state.
- Supports q4b-style grouped max and q5_metadata-style grouped span over existing aggregate metadata assets.
- Keeps forced/routed `unified-bench` behavior unchanged; this PR changes the prepared hot-runner path, not planner routing.
- Keeps mutation-bearing manifests fail-closed for prepared physical runners.
- Adds explicit q4b_metadata/q5_metadata benchmark cases beside existing q4b/q5 TCPA row-record scanner cases.

## Measurement Class

- Primary changed path: prepared hot runner / warmed repeated `Run()` after `PrepareColumnPhysicalQuery`.
- Current end-to-end comparable snapshot: routed `unified-bench` query path with forced `aggregate_metadata`.
- Direct package scanner context: `BenchmarkColumnPhysicalQueryAdapterM13B` for current non-prepared direct adapter behavior.
- Experiment/granule baseline: historical `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` encoded-kernel context.
- Historical ClickHouse context: local ClickHouse JSONBench numbers from the same report.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64.

Prepared hot runner / warmed repeated `Run()` after prepare:

```text
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryRunnerM1634/(q4b|q4b_metadata|q5|q5_metadata)_rows_8192$' -benchmem -benchtime=1000x -count=3

q4b TCPA row-record scanner:       ~692.8-699.8 us/op, ~84.6-85.4 ns/row, 0 allocs/op
q4b_metadata prepared metadata:    ~213.4-218.7 ns/op, ~0.022 ns/row, 0 allocs/op
q5 TCPA row-record scanner:        ~672.5-804.3 us/op, ~82.1-98.2 ns/row, 0 allocs/op
q5_metadata prepared metadata:     ~217.0-229.3 ns/op, ~0.022 ns/row, 0 allocs/op
```

Direct package scanner / non-prepared adapter context:

```text
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/(q4b|q4b_metadata|q5|q5_metadata)_rows_8192$' -benchmem -benchtime=200x -count=3

q4b TCPA row-record scanner:       ~743.5-762.0 us/op, ~90.7-93.0 ns/row, 111 allocs/op
q4b_metadata adapter metadata:     ~23.9-24.4 us/op, ~2.90-2.96 ns/row, 95 allocs/op
q5 TCPA row-record scanner:        ~711.8-733.1 us/op, ~86.8-89.5 ns/row, 111 allocs/op
q5_metadata adapter metadata:      ~24.1-24.5 us/op, ~2.92-2.96 ns/row, 95 allocs/op
```

Routed `unified-bench` end-to-end comparable snapshot, forced `aggregate_metadata`, durable, 100K rows:

```text
./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir /tmp/gomap_1634_metadata_routed_20260520_205938 -path-label native-fastpath -column-store-path aggregate_metadata -progress=false -format markdown

q1 serial reroute:        11.08M rows/s, 90.2 ns/row, 8.851 ms scan, parity pass
q2 serial reroute:         8.40M rows/s, 119.1 ns/row, 11.750 ms scan, parity pass
q3 serial reroute:        18.08M rows/s, 55.3 ns/row, 5.407 ms scan, parity pass
q4a serial reroute:        9.73M rows/s, 102.7 ns/row, 10.108 ms scan, parity pass
q4b aggregate_metadata:   21.29M rows/s, 47.0 ns/row, 4.535 ms scan, 100 metadata hits, parity pass
q5 serial reroute:         9.07M rows/s, 110.3 ns/row, 10.869 ms scan, parity pass
q5_metadata:              21.48M rows/s, 46.6 ns/row, 4.507 ms scan, 100 metadata hits, parity pass
```

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. The 100K durable forced `aggregate_metadata` run above is the current end-to-end comparable snapshot for this PR. It includes durable collection setup, insert, checkpoint, reopen/recovery, planner diagnostics, physical query execution, parity hashing, and reporting. In that routed path, q4b/q5_metadata use aggregate metadata assets, while q1/q2/q3/q4a/q5 reroute to serial physical scans for this forced label.

Measurement class: `prepared hot runner / warmed repeated Run()`. The q4b_metadata/q5_metadata billion-rows/sec figures are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery`; they exclude sidecar read/decode/checksum/translation, planner routing, unified-bench reporting, writes, WAL/checkpoint, reopen, and mutation handling.

Measurement class: `experiment/granule baseline` and `historical ClickHouse context`. The granule and ClickHouse numbers from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` remain historical and not apples-to-apples with this synthetic 100K production fixture: granule Q4 was 0.009869s and Q5 was 0.010027s over 1M JSONBench rows; local ClickHouse Q4/Q5 were 0.013s each. Those are encoded-kernel/SQL context numbers, not prepared hot-runner measurements.

Scale note: q4b_metadata/q5_metadata at about `0.022 ns/row` are prepared metadata hot-loop measurements over already-prepared entries, not routed scan durations. Routed production results should be interpreted by row count: about `90 ns/row` over 100K rows is about 9 ms, while 1M rows at `90 ns/row` extrapolates to about 90 ms.

## Throughput Interpretation

The prepared metadata win is a representation/metadata hot-loop result, while the routed `unified-bench` snapshot remains the production comparable number. This PR intentionally does not route `unified-bench` through `PrepareColumnPhysicalQuery`, so the PR does not claim that the prepared hot-runner throughput is the current end-to-end production query throughput.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunnerAggregateMetadataParityAndAllocationM1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation|DistinctSidecarSkipsIdenticalColumns|AggregateMetadataParityAndAllocation)M1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnAggregateMetadata|TestColumnDictionary' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `git diff --check`

## Artifacts

- Routed column-store results: `/tmp/gomap_1634_metadata_routed_20260520_205938/column_store_results.md`
- Routed column-store HTML: `/tmp/gomap_1634_metadata_routed_20260520_205938/column_store_results.html`
- Routed insights: `/tmp/gomap_1634_metadata_routed_20260520_205938/insights.md`
- Routed insights HTML: `/tmp/gomap_1634_metadata_routed_20260520_205938/insights.html`
- Benchprof results: `/tmp/gomap_1634_metadata_routed_20260520_205938/benchprof_results.md`
- CPU profile: `/tmp/gomap_1634_metadata_routed_20260520_205938/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_metadata_routed_20260520_205938/allocs_column_store_treedb_column_store.pprof`

## Assumption Ledger

- This PR intentionally does not route `unified-bench` through `PrepareColumnPhysicalQuery`; prepared-runner adoption remains a separate measured optimization decision.
- This PR does not change aggregate metadata asset encoding or GC/rewrite reachability.
- Mutation-bearing manifests remain unsupported for prepared physical runners and continue to fail closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prepared queries now support aggregate-metadata operations, enabling efficient batch processing of statistical calculations (min/max/count).

* **Tests**
  * Added comprehensive test coverage validating query execution parity and performance across aggregate-metadata query patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
