### PR TITLE
TreeDB column store post-V1: route serial dictionary sidecars

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -58,6 +58,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	DecodedBlocks              int
 	DirectReduceBlocks         int
 	MetadataHits               int
+	DictionaryCodeHits         int
 	ScheduledGranules          int
 	SkippedGranules            int
 	RowsScanned                int
@@ -554,6 +555,9 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if result, ok, err := c.runColumnPhysicalQueryDictionaryCodesInSnapshotView(view, req); ok {
+		return result, err
+	}
 	if result, ok, err := c.runColumnPhysicalQueryDirectInSnapshotView(view, req, 0, 0, nil); ok {
 		if err != nil {
 			if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
@@ -588,6 +592,41 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 	result.Groups = exec.groups()
 	result.Diagnostics.ResultGroups = len(result.Groups)
 	return result, nil
+}
+
+func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+
+	dictCount, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	dictDistinct, err := prepareColumnDictionaryCodeGroupCountDistinctRunner(view, req, &readCache)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	if dictCount == nil && dictDistinct == nil {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+
+	var result ColumnPhysicalQueryResult
+	if dictCount != nil {
+		result = dictCount.run(view, req)
+	} else {
+		result = dictDistinct.run(view, req)
+	}
+	result.Diagnostics.SegmentFileCacheHits = readCache.hits
+	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	result.Diagnostics.DictionaryCodeHits = result.Diagnostics.DecodedBlocks
+	return result, true, nil
 }
 
 var errColumnPhysicalQueryNeedsVisibility = errors.New("collections: physical column query requires mutation visibility overlay")
@@ -710,6 +749,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.DecodedBlocks += right.DecodedBlocks
 	left.DirectReduceBlocks += right.DirectReduceBlocks
 	left.MetadataHits += right.MetadataHits
+	left.DictionaryCodeHits += right.DictionaryCodeHits
 	left.ScheduledGranules += right.ScheduledGranules
 	left.SkippedGranules += right.SkippedGranules
 	left.RowsScanned += right.RowsScanned

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -364,7 +364,11 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if got, want := parallel.Diagnostics.ScheduledGranules, serial.Diagnostics.ScheduledGranules; got != want {
 				t.Fatalf("parallel scheduled granules=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)
 			}
-			if parallel.Diagnostics.PhysicalBytesScanned != serial.Diagnostics.PhysicalBytesScanned {
+			if tc.req.Kind == ColumnPhysicalQueryGroupCount || tc.req.Kind == ColumnPhysicalQueryGroupCountDistinct {
+				if serial.Diagnostics.PhysicalBytesScanned <= 0 || serial.Diagnostics.PhysicalBytesScanned >= parallel.Diagnostics.PhysicalBytesScanned {
+					t.Fatalf("serial dictionary-sidecar bytes=%d want below parallel TCPA bytes=%d serial=%+v parallel=%+v", serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics, parallel.Diagnostics)
+				}
+			} else if parallel.Diagnostics.PhysicalBytesScanned != serial.Diagnostics.PhysicalBytesScanned {
 				t.Fatalf("parallel bytes=%d want serial %d diagnostics=%+v", parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics)
 			}
 			overPartitioned, err := reopened.RunColumnPhysicalQueryParallel(tc.req, 128)
@@ -1369,7 +1373,7 @@ func TestColumnStoreQueryAndReconstructionFailClosedCorruptAssetM13C(t *testing.
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()
 	reopened := openColumnStoreCollectionM10B(t, reopen)
-	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}); err == nil || !strings.Contains(err.Error(), "checksum") {
+	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("RunColumnPhysicalQuery corrupt asset err=%v want checksum failure", err)
 	}
 	if got, err := reopened.Get([]byte("e1")); err == nil || !strings.Contains(err.Error(), "checksum") || got != nil {
@@ -1390,7 +1394,7 @@ func TestColumnStoreQueryAndReconstructionFailClosedTruncatedAssetM13C(t *testin
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()
 	reopened := openColumnStoreCollectionM10B(t, reopen)
-	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("RunColumnPhysicalQuery truncated asset err=%v want io.ErrUnexpectedEOF", err)
 	}
 	if got, err := reopened.Get([]byte("e1")); !errors.Is(err, io.ErrUnexpectedEOF) || got != nil {
@@ -1843,10 +1847,7 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 	defer closeFn()
 	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
 	wantHash := columnPhysicalQueryReferenceHashM13B("q1", events)
-	tcpResult, err := collection.RunColumnPhysicalQuery(req)
-	if err != nil {
-		t.Fatalf("RunColumnPhysicalQuery TCPA baseline: %v", err)
-	}
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
 
 	runner, err := collection.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -1868,8 +1869,8 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
 			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
 		}
-		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpResult.Diagnostics.PhysicalBytesScanned {
-			t.Fatalf("runner physical bytes=%d want dictionary-code sidecar below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpResult.Diagnostics.PhysicalBytesScanned)
+		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+			t.Fatalf("runner physical bytes=%d want dictionary-code sidecar below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
 		}
 		if result.Diagnostics.SegmentFileCacheMisses != 0 {
 			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
@@ -1896,10 +1897,7 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 	defer closeFn()
 	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}
 	wantHash := columnPhysicalQueryReferenceHashM13B("q2", events)
-	tcpResult, err := collection.RunColumnPhysicalQuery(req)
-	if err != nil {
-		t.Fatalf("RunColumnPhysicalQuery TCPA baseline: %v", err)
-	}
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
 
 	runner, err := collection.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -1924,8 +1922,8 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 		if result.Diagnostics.ProjectedColumns != 2 {
 			t.Fatalf("runner projected columns=%d want kind+did sidecars", result.Diagnostics.ProjectedColumns)
 		}
-		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpResult.Diagnostics.PhysicalBytesScanned {
-			t.Fatalf("runner physical bytes=%d want dictionary-code sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpResult.Diagnostics.PhysicalBytesScanned)
+		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+			t.Fatalf("runner physical bytes=%d want dictionary-code sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
 		}
 		if result.Diagnostics.SegmentFileCacheMisses != 0 {
 			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
@@ -1943,6 +1941,59 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 	})
 	if allocs != 0 {
 		t.Fatalf("runner q2 warmed allocs/run=%.2f want 0", allocs)
+	}
+}
+
+func TestColumnPhysicalQuerySerialDictionarySidecarParityM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
+	tests := []struct {
+		name             string
+		hashName         string
+		req              ColumnPhysicalQueryRequest
+		projectedColumns int
+	}{
+		{
+			name:             "q1",
+			hashName:         "q1",
+			req:              ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+			projectedColumns: 1,
+		},
+		{
+			name:             "q2",
+			hashName:         "q2",
+			req:              ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+			projectedColumns: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := columnPhysicalQueryReferenceHashM13B(tc.hashName, events)
+			result, err := collection.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery: %v", err)
+			}
+			if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B(tc.hashName, result.Groups)); got != wantHash {
+				t.Fatalf("serial sidecar %s hash=%d want %d groups=%+v", tc.name, got, wantHash, result.Groups)
+			}
+			if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+				t.Fatalf("serial sidecar diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+			}
+			if result.Diagnostics.ProjectedColumns != tc.projectedColumns {
+				t.Fatalf("serial sidecar projected columns=%d want %d", result.Diagnostics.ProjectedColumns, tc.projectedColumns)
+			}
+			if result.Diagnostics.DictionaryCodeHits == 0 || result.Diagnostics.DictionaryCodeHits != result.Diagnostics.ScheduledGranules {
+				t.Fatalf("serial sidecar dictionary hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.DictionaryCodeHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+			}
+			if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+				t.Fatalf("serial sidecar physical bytes=%d want dictionary-code sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
+			}
+			if result.Diagnostics.SegmentFileCacheMisses == 0 {
+				t.Fatalf("serial sidecar diagnostics=%+v want one-shot sidecar read misses accounted", result.Diagnostics)
+			}
+		})
 	}
 }
 
@@ -2198,6 +2249,25 @@ func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T)
 	if _, _, ok, err := columnDictionaryCodeDistinctSeenWords(columnDictionaryCodeDistinctMaxSeenWords+1, 1); err != nil || ok {
 		t.Fatalf("oversized bitset ok=%v err=%v want clean fallback", ok, err)
 	}
+}
+
+func columnPhysicalQueryTCPAAssetBytesM1634(tb testing.TB, collection *Collection) int64 {
+	tb.Helper()
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		tb.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	var bytes int64
+	for _, ref := range view.AssetRefs {
+		bytes += ref.Ref.Length
+	}
+	if bytes <= 0 {
+		tb.Fatalf("TCPA asset bytes=%d want positive", bytes)
+	}
+	return bytes
 }
 
 func TestColumnPhysicalQueryRunnerFailsClosedForUnsupportedShapeM1634(t *testing.T) {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -168,6 +168,7 @@ type columnStoreQueryMetric struct {
 	RawHash                  uint64  `json:"raw_hash"`
 	ProductionHash           uint64  `json:"production_hash"`
 	MetadataHits             int     `json:"metadata_hits"`
+	DictionaryCodeHits       int     `json:"dictionary_code_hits"`
 	SkippedGranules          int     `json:"skipped_granules"`
 	ScheduledGranules        int     `json:"scheduled_granules"`
 	WorkerCount              int     `json:"worker_count"`
@@ -201,6 +202,7 @@ type columnStoreQueryExecution struct {
 	RowMaterializations    int
 	ResultCount            int
 	MetadataHits           int
+	DictionaryCodeHits     int
 	SkippedGranules        int
 	ScheduledGranules      int
 	WorkerCount            int
@@ -1141,6 +1143,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			RawHash:                rawHash,
 			ProductionHash:         hash,
 			MetadataHits:           exec.MetadataHits,
+			DictionaryCodeHits:     exec.DictionaryCodeHits,
 			SkippedGranules:        exec.SkippedGranules,
 			ScheduledGranules:      exec.ScheduledGranules,
 			WorkerCount:            exec.WorkerCount,
@@ -1344,6 +1347,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		RowMaterializations:    diag.RowMaterializations,
 		ResultCount:            resultCount,
 		MetadataHits:           diag.MetadataHits,
+		DictionaryCodeHits:     diag.DictionaryCodeHits,
 		SkippedGranules:        diag.SkippedGranules,
 		ScheduledGranules:      diag.ScheduledGranules,
 		WorkerCount:            workers,
@@ -1686,6 +1690,9 @@ func columnStoreQueryThroughputInterpretation(q columnStoreQueryMetric) string {
 	case columnStorePathBTreeIndexBaseline:
 		return "decode-bound B-tree baseline: full unbounded secondary-index walk plus JSON row materialization before reduction; " + markPruning + evidence
 	case columnStorePathSerialColumnScan:
+		if q.DictionaryCodeHits > 0 {
+			return fmt.Sprintf("dictionary-code sidecar serial path: %d sidecar hits avoid full TCPA row-record scan for declared dictionary columns; setup/read/decode still occurs in this routed measurement; %s%s", q.DictionaryCodeHits, markPruning, evidence)
+		}
 		return "physical serial scan: TCPA decode plus reducer aggregation over declared columns; memory-bandwidth bound on asset bytes when cache-warm; " + markPruning + evidence
 	case columnStorePathAggregateMetadata:
 		if q.MetadataHits > 0 {
@@ -1716,7 +1723,7 @@ func columnStoreQueryInterpretationEvidence(q columnStoreQueryMetric) string {
 	if rowsProcessedOK {
 		rowsProcessedText = strconv.Itoa(rowsProcessed)
 	}
-	return fmt.Sprintf("; effective_rows_processed=%s row_materializations=%s bytes_read=%d metadata_hits=%d scheduled_granules=%d skipped_granules=%d", rowsProcessedText, rowMaterializations, q.BytesRead, q.MetadataHits, q.ScheduledGranules, q.SkippedGranules)
+	return fmt.Sprintf("; effective_rows_processed=%s row_materializations=%s bytes_read=%d metadata_hits=%d dictionary_code_hits=%d scheduled_granules=%d skipped_granules=%d", rowsProcessedText, rowMaterializations, q.BytesRead, q.MetadataHits, q.DictionaryCodeHits, q.ScheduledGranules, q.SkippedGranules)
 }
 
 func populateColumnStoreThroughputInterpretations(queries []columnStoreQueryMetric) {
@@ -2020,8 +2027,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|\n")
 	for _, q := range report.Queries {
 		parity := "pass"
 		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
@@ -2035,8 +2042,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 		if note != "" {
 			noteCell = markdownCodeTableText(note)
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.PlanLabel), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.PlanLabel), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1507,6 +1507,15 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 		if q.BytesRead <= 0 || q.RowsPerSecond <= 0 || q.NsPerRow <= 0 {
 			t.Fatalf("query %s missing physical throughput metrics: %+v", q.Name, q)
 		}
+		if q.Name == columnStoreQueryQ1 || q.Name == columnStoreQueryQ2 {
+			if q.DictionaryCodeHits == 0 {
+				t.Fatalf("query %s dictionary_code_hits=%d want sidecar hits", q.Name, q.DictionaryCodeHits)
+			}
+			if !strings.Contains(q.ThroughputInterpretation, "dictionary-code sidecar serial path") {
+				t.Fatalf("query %s throughput_interpretation=%q want dictionary sidecar classification", q.Name, q.ThroughputInterpretation)
+			}
+			continue
+		}
 		if !strings.Contains(q.ThroughputInterpretation, "physical serial scan") {
 			t.Fatalf("query %s throughput_interpretation=%q want serial physical classification", q.Name, q.ThroughputInterpretation)
 		}


### PR DESCRIPTION
## Benchmark Claim Boundary

Measurement class: `routed unified-bench query path` is the primary changed path in this PR. q1/q2 now route through dictionary-code sidecars under `serial_column_scan`, so these measurements include normal routed query execution and one-shot sidecar setup for the benchmark query stage. They still do not include writes, WAL/checkpoint, reopen, or mutation handling as part of the query rows/sec number.

Prepared hot-runner evidence, direct/package scanner evidence, experiment/granule baselines, and historical ClickHouse context are separate measurement classes. Do not compare them as if they were the same end-to-end boundary.

## What Landed

This PR makes the existing dictionary-code sidecar representation reachable from normal serial physical query execution for the supported insert-only q1/q2 shapes:

- `RunColumnPhysicalQuery` now tries dictionary-code sidecar runners for `GroupCount(kind)` and `GroupCountDistinct(kind,did)` before falling back to TCPA row-record scans.
- Unsupported shapes, aggregate metadata requests, and mutation-bearing views still fall through to the existing physical path or fail closed under existing rules.
- Diagnostics and unified-bench reports now expose `dictionary_code_hits` so routed benchmark output cannot be mistaken for TCPA row-record scans.
- Corruption/truncation tests were adjusted to use q3 TCPA scans so fail-closed asset validation still exercises TCPA bytes after q1 can bypass unused TCPA assets.

This is a tactical #1634 optimization: it routes existing sidecar assets through serial production execution. It does not add mark pruning, real vectorized column-block storage for q3/q4/q5, or a reusable prepared executor for routed queries.

## Static Analysis / Priority Checkpoint

The latest static pass confirms the next high-value work is representation/kernel shape, not more TCPA cursor shaving. Before this PR, q1/q2 sidecars existed only behind `PrepareColumnPhysicalQuery`; routed serial production still decoded row-record-shaped TCPA assets. This PR moves q1/q2 onto dictionary-code sidecars in the routed serial path while leaving q3/q4/q5 as TCPA scans.

Remaining priority after this PR: push more shapes toward schema-fixed blocks, dictionary/code reducers, metadata assets, marks/pruning, and allocator discipline. Mmap/pread/shared reader work remains useful only if fresh profiles show asset-manager/read-copy overhead dominating after representation costs are removed.

## Measurement Class

- prepared hot runner / warmed repeated `Run()`: not changed by this PR; prior prepared sidecar runner evidence remains a separate measurement class.
- routed `unified-bench` query path: changed for q1/q2 under `-column-store-path serial_column_scan`; this includes planner/routing, one-shot sidecar setup, sidecar read/decode/checksum/translation, unified-bench reporting, and parity timing boundaries.
- direct package scanner: `BenchmarkColumnPhysicalQueryAdapterM13B` shows package-level adapter behavior without full unified-bench fixture/report orchestration.
- experiment/granule baseline: fresh `experiments/colgranule` dense-code kernel numbers are included only as context for allocator/kernel-shape parity, not as production routed numbers.
- historical ClickHouse context: local JSONBench ClickHouse report remains historical context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

Do not read the q1/q2 routed rows/sec as a full database write/reopen/mutation throughput number. The query rows include the routed query stage only; writes, WAL/checkpoint, reopen, and mutation handling are reported separately or out of scope for this PR's query rows/sec.

## Performance / Benchmark Evidence

Same-machine base snapshot from #1673, routed production `unified-bench`, 100K rows, durable, `serial_column_scan`:

| query | base plan behavior | rows/s | ns/row | scan ms | bytes/read |
|---|---|---:|---:|---:|---:|
| q1 | TCPA row-record scan | 11.28M | 88.6 | 8.708 | 10,423,300 |
| q2 | TCPA row-record scan | 8.86M | 112.9 | 11.177 | 10,423,300 |
| q3 | TCPA row-record scan | 18.61M | 53.7 | 5.238 | 10,423,300 |
| q4a | TCPA row-record scan | 9.97M | 100.3 | 9.837 | 10,423,300 |
| q4b | TCPA row-record scan | 10.34M | 96.7 | 9.515 | 10,423,300 |
| q5 | TCPA row-record scan | 9.34M | 107.1 | 10.562 | 10,423,300 |

This PR, routed production `unified-bench`, same command shape and fixture scale:

| query | current plan behavior | rows/s | ns/row | scan ms | dictionary code hits | bytes/read |
|---|---|---:|---:|---:|---:|---:|
| q1 | dictionary-code sidecar serial path | 518.47M | 1.9 | 0.045 | 100 | 423,600 |
| q2 | dictionary-code sidecar serial path | 561.53M | 1.8 | 0.069 | 100 | 2,335,100 |
| q3 | TCPA row-record scan | 17.22M | 58.1 | 5.698 | 0 | 10,423,300 |
| q4a | TCPA row-record scan | 10.28M | 97.2 | 9.569 | 0 | 10,423,300 |
| q4b | TCPA row-record scan | 10.16M | 98.4 | 9.681 | 0 | 10,423,300 |
| q5 | TCPA row-record scan | 9.40M | 106.4 | 10.486 | 0 | 10,423,300 |

Direct package scanner / adapter, 8,192 rows, `-benchtime=200x -count=3`:

| query | ns/row range | rows/s range | B/op | allocs/op |
|---|---:|---:|---:|---:|
| q1 | 12.78-13.44 | 74.4M-78.2M | 73,201-73,202 | 87 |
| q2 | 22.41-24.93 | 40.1M-44.6M | 139,913-139,947 | 110 |
| q3 | 51.38-51.88 | 19.3M-19.5M | 10,865 | 86 |
| q4a | 77.31-78.17 | 12.8M-12.9M | 12,033 | 119 |
| q4b | 88.74-89.04 | 11.2M-11.3M | 12,033 | 119 |
| q5 | 85.95-90.81 | 11.0M-11.6M | 12,225 | 119 |
| q4b_metadata | 2.922-3.007 | 332.6M-342.2M | 9,121 | 95 |
| q5_metadata | 2.912-2.965 | 337.3M-343.4M | 9,345-9,361 | 95 |

Fresh experiment/granule context, Apple M3, same repo worktree:

| benchmark | ns/row | rows/s | allocs/op |
|---|---:|---:|---:|
| `BenchmarkCountUint32CodesGranule` uncompressed | 2.201 | 454.33M | 0 |
| `BenchmarkAggregateGroupedCountCodes/encoded_kernel` | 2.069 | 483.33M | 0 |
| `BenchmarkAggregateFilteredGroupedCountCodes` | 0.5152 | 1.94B | 0 |
| `BenchmarkJSONBenchEncodedPartQueries/Q1_grouped_count` | 2.392 | 418.05M | 5 |
| `BenchmarkJSONBenchEncodedPartQueries/Q2_group_count_distinct` | 4.159 | 240.46M | 5 |
| `BenchmarkJSONBenchEncodedPartQueries/Q3_hourly_grouped_count` | 5.128 | 195.00M | 5 |
| `BenchmarkJSONBenchEncodedPartQueries/Q5_span_by_user` | 7.412 | 134.91M | 5 |

Historical ClickHouse JSONBench context from the experiment report: Q1 0.014s, Q2 0.027s, Q3 0.014s, Q4 0.013s, Q5 0.013s on 1M local rows. That is not an apples-to-apples comparison with this 100K synthetic production fixture; it remains context for the post-V1 target shape.

## End-to-End Comparable Snapshot

Current routed production snapshot is the `unified-bench` durable 100K serial run above. For q1/q2, the routed path now uses the optimized dictionary sidecar path; q3/q4/q5 still use existing TCPA physical row-record scans. Direct/package evidence is shown separately from routed production evidence. Granule and ClickHouse numbers are context only and have different fixture/data/model boundaries.

Scale note: q1/q2 scan times here are sub-ms on 100K rows because they read compact sidecar bytes. The older q1/q2 base measurements were about 89-113 ns/row, which would extrapolate to about 89-113 ms at 1M rows, not 89-113 ms for this 100K routed fixture.

## Throughput Interpretation

This PR confirms the static diagnosis: for low-cardinality q1/q2 shapes, representation matters more than TCPA cursor micro-optimizations. Avoiding full TCPA row-record framing drops routed bytes/read from 10.4 MB to 0.42 MB for q1 and 2.34 MB for q2, and routes the normal serial production query path through dictionary-code assets.

The residual caveat is allocation parity. Prepared hot runners can target zero allocations, and the granule kernels were designed around 0 allocs/op. The one-shot production adapter still allocates in sidecar prepare/global dictionary translation/result setup. That is acceptable for this PR because it removes the larger representation bottleneck from routed q1/q2, but #1634 should continue to prioritize allocator discipline in future reusable/prepared routed execution work.

## Gate Status

- [x] q1/q2 serial `RunColumnPhysicalQuery` uses dictionary-code sidecars and reports `dictionary_code_hits`.
- [x] q1/q2 parity hashes match row/reference expectations.
- [x] q1/q2 remain fail-closed for unsupported sidecar shapes by falling back only when safe.
- [x] q3/q4/q5 continue to use the existing TCPA physical path.
- [x] Corrupt/truncated asset tests still exercise fail-closed TCPA validation through q3.
- [x] Unified-bench reports distinguish dictionary sidecar serial path from TCPA serial scan.

## Tests Run

```sh
go test ./cmd/unified_bench -run 'TestColumnStoreSuite' -count=1
go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnDictionary' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
```

## Artifacts

- Base routed production snapshot: `/tmp/gomap_1634_serial_dict_base_routed_20260520_212150/unified_bench_stdout.md`
- Current routed production snapshot: `/tmp/gomap_1634_serial_dict_routed_20260520_212125/column_store_results.md`
- Current routed HTML: `/tmp/gomap_1634_serial_dict_routed_20260520_212125/column_store_results.html`
- Current routed benchprof JSON/MD: `/tmp/gomap_1634_serial_dict_routed_20260520_212125/benchprof_results.json`, `/tmp/gomap_1634_serial_dict_routed_20260520_212125/benchprof_results.md`
- Direct/package adapter benchmark: `/tmp/gomap_1634_serial_dict_sidecars_adapter_20260520_212108.txt`
- Fresh granule dense-code baseline: `/tmp/gomap_1634_serial_dict_granule_baseline_20260520_212201.txt`
- Fresh granule JSONBench kernel baseline: `/tmp/gomap_1634_serial_dict_granule_jsonbench_20260520_212210.txt`
- Historical ClickHouse context: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`

## Assumption Ledger

- This PR assumes insert-only views without mutation overlays for dictionary sidecar serial routing; mutation-bearing views continue through existing paths.
- q1/q2 are the only routed serial shapes changed here.
- `dictionary_code_hits` counts decoded sidecar blocks/granules, not row count.
- Sidecar routed scan timing is query-stage timing, not write/WAL/checkpoint/reopen timing.
- Future #1634 PRs should re-run the static priority checkpoint and keep optimization candidates tied to measured overhead categories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dictionary code hit diagnostics to track query optimization performance and effectiveness.

* **Tests**
  * Introduced new parity test for dictionary-based query execution validation.
  * Updated test assertions to verify diagnostic data collection accuracy.

* **Chores**
  * Enhanced benchmarking suite to report dictionary code hit statistics in metrics and reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
