### PR TITLE
TreeDB column store post-V1: add int64 value sidecar scans

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -203,6 +203,10 @@ func writeColumnDictionaryCodesAssetToManager(rootDir string, cfg ColumnStoreCon
 	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1DictionaryCodes, generation, partID)
 }
 
+func writeColumnInt64ValuesAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
+	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1Int64Values, generation, partID)
+}
+
 func writeColumnAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, kind ColumnAssetKind, generation, partID uint64) (ColumnAssetRef, error) {
 	return writeColumnAssetToManagerSegment(rootDir, cfg, payload, kind, generation, partID, columnAssetM12ASegmentFileID)
 }

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -297,6 +297,19 @@ func (c *Collection) planColumnAssetReachability(ctx context.Context, opts colum
 			input.recoveryRefs++
 		}
 	}
+	for i, valuesRef := range view.Int64Values {
+		if i%columnAssetReachabilityContextCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return columnAssetReachabilityPlanIdentity(input), input.refs, err
+			}
+		}
+		if input.addRef(valuesRef.AssetRef, ColumnAssetReachabilitySourceActiveManifest) {
+			input.activeRefs++
+		}
+		if input.addRef(valuesRef.AssetRef, ColumnAssetReachabilitySourceRecoveryManifest) {
+			input.recoveryRefs++
+		}
+	}
 	if err := input.addRefs(ctx, opts.CandidateRefs, ColumnAssetReachabilitySourceCandidate); err != nil {
 		return columnAssetReachabilityPlanIdentity(input), input.refs, err
 	}
@@ -329,7 +342,7 @@ func (c *Collection) columnAssetReachabilityOlderSnapshotPinned(planCommitSeq ui
 }
 
 func columnAssetReachabilityInputFromSnapshotView(view columnPhysicalScanSnapshotView, opts columnAssetReachabilityOptionsInternal) columnAssetReachabilityInput {
-	expectedRefs := len(view.AssetRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
+	expectedRefs := len(view.AssetRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(view.Int64Values) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
 	input := columnAssetReachabilityInput{
 		rootDir:        view.ColumnAssetRootDir,
 		collection:     view.CollectionName,
@@ -995,7 +1008,7 @@ func columnAssetReachabilitySegmentPath(segmentDir, name string) string {
 }
 
 func columnAssetReachabilityRefCanContributeRange(ref ColumnAssetRef, namespace string) bool {
-	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes) &&
+	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes || ref.Kind == ColumnAssetKindTCS1Int64Values) &&
 		ref.Namespace == namespace &&
 		ref.Generation != 0 &&
 		ref.PartID != 0 &&

--- a/TreeDB/collections/column_asset_rewrite.go
+++ b/TreeDB/collections/column_asset_rewrite.go
@@ -545,7 +545,8 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 	if magic := cur.u32(); magic != columnManifestPartMagic {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, fmt.Errorf("collections: bad column manifest part magic=0x%08x", magic)
 	}
-	if version := cur.u16(); version != columnManifestRecordVersion {
+	version := cur.u16()
+	if version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, fmt.Errorf("collections: unsupported column manifest part version=%d", version)
 	}
 	kindBytes := cur.stringBytes()
@@ -560,7 +561,10 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 	length64 := cur.u64()
 	offsets.checksum = cur.pos
 	checksum64 := cur.u64()
-	rows64 := cur.u64()
+	rows64 := uint64(0)
+	if version >= columnManifestRecordVersion {
+		rows64 = cur.u64()
+	}
 	bytes64 := cur.u64()
 	_ = cur.u64() // publish_id; rewrite preserves the original field bytes.
 	_ = cur.u64() // generation_id; rewrite preserves the original field bytes.

--- a/TreeDB/collections/column_asset_rewrite.go
+++ b/TreeDB/collections/column_asset_rewrite.go
@@ -444,8 +444,8 @@ func cleanupColumnAssetRewriteCopiedSegment(rootDir string, remap columnAssetRew
 
 func validateColumnAssetRewriteRefKinds(refs []ColumnAssetRef) error {
 	for idx, ref := range refs {
-		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1AggregateMetadata && ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
-			return fmt.Errorf("collections: column asset rewrite supports only physical part, aggregate metadata, or dictionary code refs: ref %d kind %q", idx, ref.Kind)
+		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1AggregateMetadata && ref.Kind != ColumnAssetKindTCS1DictionaryCodes && ref.Kind != ColumnAssetKindTCS1Int64Values {
+			return fmt.Errorf("collections: column asset rewrite supports only physical part, aggregate metadata, dictionary code, or int64 value refs: ref %d kind %q", idx, ref.Kind)
 		}
 	}
 	return nil
@@ -477,7 +477,8 @@ func patchColumnAssetRewriteManifestRecordsWithMode(records []columnManifestReco
 		isPart := bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes)
 		isMetadata := bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes)
 		isDictionary := bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes)
-		if !isPart && !isMetadata && !isDictionary {
+		isInt64Values := bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes)
+		if !isPart && !isMetadata && !isDictionary && !isInt64Values {
 			continue
 		}
 		oldRef, offsets, err := columnAssetRewriteManifestPartRefForPatch(record.value, expectedNamespace)
@@ -493,8 +494,10 @@ func patchColumnAssetRewriteManifestRecordsWithMode(records []columnManifestReco
 		} else {
 			if isMetadata {
 				keyGeneration, keyPartID, _, err = columnManifestAggregateMetadataKeyFromRecordKey(record.key)
-			} else {
+			} else if isDictionary {
 				keyGeneration, keyPartID, _, err = columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			} else {
+				keyGeneration, keyPartID, _, err = columnManifestInt64ValuesKeyFromRecordKey(record.key)
 			}
 			if err != nil {
 				return nil, 0, err
@@ -557,6 +560,7 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 	length64 := cur.u64()
 	offsets.checksum = cur.pos
 	checksum64 := cur.u64()
+	rows64 := cur.u64()
 	bytes64 := cur.u64()
 	_ = cur.u64() // publish_id; rewrite preserves the original field bytes.
 	_ = cur.u64() // generation_id; rewrite preserves the original field bytes.
@@ -568,7 +572,7 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: trailing bytes in column manifest part record")
 	}
 	kind := ColumnAssetKind(string(kindBytes))
-	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1AggregateMetadata && kind != ColumnAssetKindTCS1DictionaryCodes {
+	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1AggregateMetadata && kind != ColumnAssetKindTCS1DictionaryCodes && kind != ColumnAssetKindTCS1Int64Values {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, fmt.Errorf("collections: unsupported column manifest part asset kind %q", string(kindBytes))
 	}
 	if !columnPhysicalBytesEqualString(namespaceBytes, expectedNamespace) {
@@ -579,6 +583,9 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 	}
 	if checksum64 > uint64(math.MaxUint32) {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: column manifest part checksum overflows uint32")
+	}
+	if rows64 > uint64(maxCollectionInt) {
+		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: column manifest part rows overflows int")
 	}
 	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) || bytes64 > uint64(math.MaxInt64) {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: column manifest part offsets or byte counts overflow int64")
@@ -593,7 +600,7 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 		Length:     int64(length64),
 		Checksum:   uint32(checksum64),
 	}
-	if err := validateColumnPreparedAssetForPlan(ColumnPreparedAsset{Ref: ref, Bytes: int64(bytes64)}); err != nil {
+	if err := validateColumnPreparedAssetForPlan(ColumnPreparedAsset{Ref: ref, Rows: int(rows64), Bytes: int64(bytes64)}); err != nil {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, err
 	}
 	return ref, offsets, nil

--- a/TreeDB/collections/column_int64_query.go
+++ b/TreeDB/collections/column_int64_query.go
@@ -1,0 +1,119 @@
+package collections
+
+import (
+	"fmt"
+	"time"
+)
+
+type columnInt64ValueHourCountRunner struct {
+	column       string
+	assets       []columnInt64ValueHourCountAsset
+	counts       [24]int
+	resultGroups []ColumnPhysicalQueryGroup
+	assetBytes   int64
+}
+
+type columnInt64ValueHourCountAsset struct {
+	values []int64
+}
+
+func prepareColumnInt64ValueHourCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnInt64ValueHourCountRunner, error) {
+	if req.Kind != ColumnPhysicalQueryHourCount || req.ValueColumn == "" || view.MutationParts != 0 {
+		return nil, nil
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: int64 values query missing read cache")
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
+	if !ok || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return nil, nil
+	}
+	byPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(byPart) == 0 {
+		return nil, nil
+	}
+	runner := &columnInt64ValueHourCountRunner{
+		column: req.ValueColumn,
+		assets: make([]columnInt64ValueHourCountAsset, 0, len(view.AssetRefs)),
+	}
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return nil, nil
+		}
+		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		if !ok {
+			return nil, nil
+		}
+		raw, err := readCache.read(snapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = raw
+		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
+		if err != nil {
+			return nil, err
+		}
+		if len(decoded.Values) != snapshot.Rows {
+			return nil, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
+		}
+		runner.assets = append(runner.assets, columnInt64ValueHourCountAsset{
+			values: decoded.Values,
+		})
+		runner.assetBytes += snapshot.AssetRef.Length
+	}
+	if len(runner.assets) == 0 {
+		return nil, nil
+	}
+	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, 24)
+	return runner, nil
+}
+
+func columnInt64ValueSnapshotsByPart(view columnPhysicalScanSnapshotView, column string) map[[2]uint64]columnManifestInt64ValuesSnapshot {
+	byPart := make(map[[2]uint64]columnManifestInt64ValuesSnapshot, len(view.Int64Values))
+	for _, snapshot := range view.Int64Values {
+		if snapshot.ColumnName != column {
+			continue
+		}
+		byPart[[2]uint64{snapshot.AssetRef.Generation, snapshot.AssetRef.PartID}] = snapshot
+	}
+	return byPart
+}
+
+func (r *columnInt64ValueHourCountRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	for idx := range r.counts {
+		r.counts[idx] = 0
+	}
+	rows := 0
+	for _, asset := range r.assets {
+		for _, value := range asset.values {
+			r.counts[columnPhysicalQueryUTCHour(value)]++
+			rows++
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for hour, count := range r.counts {
+		if count == 0 {
+			continue
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{
+			Key:   columnPhysicalQueryHourKey(hour),
+			Count: count,
+		})
+	}
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 1
+	diag.ScheduledGranules = len(r.assets)
+	diag.DecodedBlocks = len(r.assets)
+	diag.DirectReduceBlocks = len(r.assets)
+	diag.Int64ValueHits = len(r.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(r.resultGroups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}

--- a/TreeDB/collections/column_int64_query.go
+++ b/TreeDB/collections/column_int64_query.go
@@ -32,19 +32,16 @@ func prepareColumnInt64ValueHourCountRunner(view columnPhysicalScanSnapshotView,
 	if len(byPart) == 0 {
 		return nil, nil
 	}
+	if !columnInt64ValueSnapshotsCoverParts(view, byPart) {
+		return nil, nil
+	}
 	runner := &columnInt64ValueHourCountRunner{
 		column: req.ValueColumn,
 		assets: make([]columnInt64ValueHourCountAsset, 0, len(view.AssetRefs)),
 	}
 	var scratch []byte
 	for _, part := range view.AssetRefs {
-		if part.Reason != ColumnPublishOperationInsert {
-			return nil, nil
-		}
-		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
-		if !ok {
-			return nil, nil
-		}
+		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
 		raw, err := readCache.read(snapshot.AssetRef, scratch)
 		if err != nil {
 			return nil, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
@@ -67,6 +64,18 @@ func prepareColumnInt64ValueHourCountRunner(view columnPhysicalScanSnapshotView,
 	}
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, 24)
 	return runner, nil
+}
+
+func columnInt64ValueSnapshotsCoverParts(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestInt64ValuesSnapshot) bool {
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return false
+		}
+		if _, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]; !ok {
+			return false
+		}
+	}
+	return len(view.AssetRefs) > 0
 }
 
 func columnInt64ValueSnapshotsByPart(view columnPhysicalScanSnapshotView, column string) map[[2]uint64]columnManifestInt64ValuesSnapshot {
@@ -95,6 +104,9 @@ func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, re
 	if len(byPart) == 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
+	if !columnInt64ValueSnapshotsCoverParts(view, byPart) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
 
 	start := time.Now()
 	var counts [24]int
@@ -103,13 +115,7 @@ func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, re
 	blocks := 0
 	var scratch []byte
 	for _, part := range view.AssetRefs {
-		if part.Reason != ColumnPublishOperationInsert {
-			return ColumnPhysicalQueryResult{}, false, nil
-		}
-		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
-		if !ok {
-			return ColumnPhysicalQueryResult{}, false, nil
-		}
+		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
 		raw, err := readCache.read(snapshot.AssetRef, scratch)
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)

--- a/TreeDB/collections/column_int64_query.go
+++ b/TreeDB/collections/column_int64_query.go
@@ -24,44 +24,23 @@ func prepareColumnInt64ValueHourCountRunner(view columnPhysicalScanSnapshotView,
 	if readCache == nil {
 		return nil, fmt.Errorf("collections: int64 values query missing read cache")
 	}
-	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
-	if !ok || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
-		return nil, nil
-	}
-	byPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
-	if len(byPart) == 0 {
-		return nil, nil
-	}
-	if !columnInt64ValueSnapshotsCoverParts(view, byPart) {
-		return nil, nil
-	}
 	runner := &columnInt64ValueHourCountRunner{
-		column: req.ValueColumn,
 		assets: make([]columnInt64ValueHourCountAsset, 0, len(view.AssetRefs)),
 	}
-	var scratch []byte
-	for _, part := range view.AssetRefs {
-		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
-		raw, err := readCache.read(snapshot.AssetRef, scratch)
-		if err != nil {
-			return nil, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
-		}
-		scratch = raw
-		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
-		if err != nil {
-			return nil, err
-		}
-		if len(decoded.Values) != snapshot.Rows {
-			return nil, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
-		}
+	assetBytes, blocks, ok, err := visitColumnInt64ValueHourCountAssets(view, req, readCache, func(snapshot columnManifestInt64ValuesSnapshot, decoded columnInt64ValuesAsset) error {
 		runner.assets = append(runner.assets, columnInt64ValueHourCountAsset{
 			values: decoded.Values,
 		})
-		runner.assetBytes += snapshot.AssetRef.Length
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	if len(runner.assets) == 0 {
+	if !ok || blocks == 0 {
 		return nil, nil
 	}
+	runner.column = req.ValueColumn
+	runner.assetBytes = assetBytes
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, 24)
 	return runner, nil
 }
@@ -96,46 +75,21 @@ func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, re
 	if readCache == nil {
 		return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values query missing read cache")
 	}
-	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
-	if !ok || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
-		return ColumnPhysicalQueryResult{}, false, nil
-	}
-	byPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
-	if len(byPart) == 0 {
-		return ColumnPhysicalQueryResult{}, false, nil
-	}
-	if !columnInt64ValueSnapshotsCoverParts(view, byPart) {
-		return ColumnPhysicalQueryResult{}, false, nil
-	}
 
 	start := time.Now()
 	var counts [24]int
 	rows := 0
-	assetBytes := int64(0)
-	blocks := 0
-	var scratch []byte
-	for _, part := range view.AssetRefs {
-		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
-		raw, err := readCache.read(snapshot.AssetRef, scratch)
-		if err != nil {
-			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
-		}
-		scratch = raw
-		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
-		if err != nil {
-			return ColumnPhysicalQueryResult{}, true, err
-		}
-		if len(decoded.Values) != snapshot.Rows {
-			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
-		}
+	assetBytes, blocks, ok, err := visitColumnInt64ValueHourCountAssets(view, req, readCache, func(snapshot columnManifestInt64ValuesSnapshot, decoded columnInt64ValuesAsset) error {
 		for _, value := range decoded.Values {
 			counts[columnPhysicalQueryUTCHour(value)]++
 			rows++
 		}
-		assetBytes += snapshot.AssetRef.Length
-		blocks++
+		return nil
+	})
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
 	}
-	if blocks == 0 {
+	if !ok || blocks == 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	groups := make([]ColumnPhysicalQueryGroup, 0, 24)
@@ -162,6 +116,44 @@ func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, re
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
 	diag.ScanNanos = time.Since(start).Nanoseconds()
 	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, true, nil
+}
+
+func visitColumnInt64ValueHourCountAssets(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, visit func(columnManifestInt64ValuesSnapshot, columnInt64ValuesAsset) error) (int64, int, bool, error) {
+	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
+	if !ok || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return 0, 0, false, nil
+	}
+	byPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(byPart) == 0 {
+		return 0, 0, false, nil
+	}
+	if !columnInt64ValueSnapshotsCoverParts(view, byPart) {
+		return 0, 0, false, nil
+	}
+	var scratch []byte
+	assetBytes := int64(0)
+	blocks := 0
+	for _, part := range view.AssetRefs {
+		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		raw, err := readCache.read(snapshot.AssetRef, scratch)
+		if err != nil {
+			return 0, 0, true, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = raw
+		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
+		if err != nil {
+			return 0, 0, true, err
+		}
+		if len(decoded.Values) != snapshot.Rows {
+			return 0, 0, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
+		}
+		if err := visit(snapshot, decoded); err != nil {
+			return 0, 0, true, err
+		}
+		assetBytes += snapshot.AssetRef.Length
+		blocks++
+	}
+	return assetBytes, blocks, true, nil
 }
 
 func (r *columnInt64ValueHourCountRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {

--- a/TreeDB/collections/column_int64_query.go
+++ b/TreeDB/collections/column_int64_query.go
@@ -80,6 +80,84 @@ func columnInt64ValueSnapshotsByPart(view columnPhysicalScanSnapshotView, column
 	return byPart
 }
 
+func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (ColumnPhysicalQueryResult, bool, error) {
+	if req.Kind != ColumnPhysicalQueryHourCount || req.ValueColumn == "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if readCache == nil {
+		return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values query missing read cache")
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
+	if !ok || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	byPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(byPart) == 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+
+	start := time.Now()
+	var counts [24]int
+	rows := 0
+	assetBytes := int64(0)
+	blocks := 0
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		raw, err := readCache.read(snapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = raw
+		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		if len(decoded.Values) != snapshot.Rows {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
+		}
+		for _, value := range decoded.Values {
+			counts[columnPhysicalQueryUTCHour(value)]++
+			rows++
+		}
+		assetBytes += snapshot.AssetRef.Length
+		blocks++
+	}
+	if blocks == 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	groups := make([]ColumnPhysicalQueryGroup, 0, 24)
+	for hour, count := range counts {
+		if count == 0 {
+			continue
+		}
+		groups = append(groups, ColumnPhysicalQueryGroup{
+			Key:   columnPhysicalQueryHourKey(hour),
+			Count: count,
+		})
+	}
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 1
+	diag.ScheduledGranules = blocks
+	diag.DecodedBlocks = blocks
+	diag.DirectReduceBlocks = blocks
+	diag.Int64ValueHits = blocks
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(groups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, true, nil
+}
+
 func (r *columnInt64ValueHourCountRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
 	start := time.Now()
 	for idx := range r.counts {

--- a/TreeDB/collections/column_int64_values_asset.go
+++ b/TreeDB/collections/column_int64_values_asset.go
@@ -147,6 +147,9 @@ func decodeColumnInt64ValuesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStor
 	if columnIndex > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
 		return columnInt64ValuesAsset{}, errors.New("collections: int64 values asset dimensions overflow int")
 	}
+	if rowCount > uint64((len(raw)-cur.pos)/8) {
+		return columnInt64ValuesAsset{}, errors.New("collections: int64 values asset row count exceeds payload bytes")
+	}
 	asset.ColumnIndex = int(columnIndex)
 	asset.Values = make([]int64, int(rowCount))
 	for i := range asset.Values {

--- a/TreeDB/collections/column_int64_values_asset.go
+++ b/TreeDB/collections/column_int64_values_asset.go
@@ -1,0 +1,190 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const (
+	columnInt64ValuesAssetMagic   = uint32(0x54434938) // TCI8
+	columnInt64ValuesAssetVersion = uint16(1)
+)
+
+type columnInt64ValuesAsset struct {
+	Collection        string
+	Namespace         string
+	Generation        uint64
+	PartID            uint64
+	AppliedCommandLSN uint64
+	SchemaHash        uint64
+	ColumnName        string
+	ColumnIndex       int
+	Values            []int64
+}
+
+func buildColumnInt64ValuesAssets(cfg ColumnStoreConfig, rows []columnDeclaredRow, collection, namespace string, generation, partID, appliedCommandLSN uint64) ([]columnInt64ValuesAsset, error) {
+	var assets []columnInt64ValuesAsset
+	for colIdx, col := range cfg.Columns {
+		if col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+			continue
+		}
+		asset, ok, err := buildColumnInt64ValuesAssetForColumn(cfg, rows, collection, namespace, generation, partID, appliedCommandLSN, colIdx)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			assets = append(assets, asset)
+		}
+	}
+	return assets, nil
+}
+
+func buildColumnInt64ValuesAssetForColumn(cfg ColumnStoreConfig, rows []columnDeclaredRow, collection, namespace string, generation, partID, appliedCommandLSN uint64, colIdx int) (columnInt64ValuesAsset, bool, error) {
+	if colIdx < 0 || colIdx >= len(cfg.Columns) {
+		return columnInt64ValuesAsset{}, false, fmt.Errorf("collections: int64 values column index=%d outside columns=%d", colIdx, len(cfg.Columns))
+	}
+	col := cfg.Columns[colIdx]
+	if col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return columnInt64ValuesAsset{}, false, nil
+	}
+	values := make([]int64, 0, len(rows))
+	for rowIdx, row := range rows {
+		if row.Deleted {
+			return columnInt64ValuesAsset{}, false, nil
+		}
+		if len(row.Values) != len(cfg.Columns) {
+			return columnInt64ValuesAsset{}, false, fmt.Errorf("collections: int64 values row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(cfg.Columns))
+		}
+		value := row.Values[colIdx]
+		if value.Type != ColumnStoreValueInt64 {
+			return columnInt64ValuesAsset{}, false, fmt.Errorf("collections: int64 values row[%d] column[%d] type=%q want int64", rowIdx, colIdx, value.Type)
+		}
+		if !value.Present || value.Null {
+			return columnInt64ValuesAsset{}, false, nil
+		}
+		values = append(values, value.Int64)
+	}
+	if len(values) == 0 {
+		return columnInt64ValuesAsset{}, false, nil
+	}
+	return columnInt64ValuesAsset{
+		Collection:        collection,
+		Namespace:         namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		SchemaHash:        cfg.SchemaHash,
+		ColumnName:        col.Name,
+		ColumnIndex:       colIdx,
+		Values:            values,
+	}, true, nil
+}
+
+func encodeColumnInt64ValuesAsset(asset columnInt64ValuesAsset) ([]byte, error) {
+	if asset.Collection == "" || asset.Namespace == "" || asset.Generation == 0 || asset.PartID == 0 || asset.ColumnName == "" {
+		return nil, errors.New("collections: int64 values asset missing collection, namespace, generation, part_id, or column")
+	}
+	if asset.ColumnIndex < 0 {
+		return nil, errors.New("collections: int64 values asset column index is negative")
+	}
+	if len(asset.Values) == 0 {
+		return nil, errors.New("collections: int64 values asset requires values")
+	}
+	var b bytes.Buffer
+	writeManifestUint32(&b, columnInt64ValuesAssetMagic)
+	writeManifestUint16(&b, columnInt64ValuesAssetVersion)
+	writeManifestString(&b, asset.Collection)
+	writeManifestString(&b, asset.Namespace)
+	writeManifestUint64(&b, asset.Generation)
+	writeManifestUint64(&b, asset.PartID)
+	writeManifestUint64(&b, asset.AppliedCommandLSN)
+	writeManifestUint64(&b, asset.SchemaHash)
+	writeManifestString(&b, asset.ColumnName)
+	writeManifestUint64(&b, uint64(asset.ColumnIndex))
+	writeManifestUint64(&b, uint64(len(asset.Values)))
+	for _, value := range asset.Values {
+		writeManifestUint64(&b, uint64(value))
+	}
+	return b.Bytes(), nil
+}
+
+func decodeColumnInt64ValuesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, expectedCollection, expectedColumn string, verifyChecksum bool) (columnInt64ValuesAsset, error) {
+	if ref.Kind != ColumnAssetKindTCS1Int64Values {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset ref kind=%q want %q", ref.Kind, ColumnAssetKindTCS1Int64Values)
+	}
+	if int64(len(raw)) != ref.Length {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset length=%d does not match ref length=%d", len(raw), ref.Length)
+	}
+	if verifyChecksum {
+		if checksum := page.Checksum(raw); checksum != ref.Checksum {
+			return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+		}
+	}
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnInt64ValuesAssetMagic {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: bad int64 values asset magic=0x%08x", magic)
+	}
+	if version := cur.u16(); version != columnInt64ValuesAssetVersion {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: unsupported int64 values asset version=%d", version)
+	}
+	asset := columnInt64ValuesAsset{
+		Collection:        cur.string(),
+		Namespace:         cur.string(),
+		Generation:        cur.u64(),
+		PartID:            cur.u64(),
+		AppliedCommandLSN: cur.u64(),
+		SchemaHash:        cur.u64(),
+		ColumnName:        cur.string(),
+	}
+	columnIndex := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return columnInt64ValuesAsset{}, err
+	}
+	if columnIndex > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
+		return columnInt64ValuesAsset{}, errors.New("collections: int64 values asset dimensions overflow int")
+	}
+	asset.ColumnIndex = int(columnIndex)
+	asset.Values = make([]int64, int(rowCount))
+	for i := range asset.Values {
+		asset.Values[i] = int64(cur.u64())
+	}
+	if cur.err != nil {
+		return columnInt64ValuesAsset{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return columnInt64ValuesAsset{}, errors.New("collections: trailing bytes in int64 values asset")
+	}
+	if asset.Collection != expectedCollection {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset collection=%q want %q", asset.Collection, expectedCollection)
+	}
+	if cfg.AssetManager == nil {
+		return columnInt64ValuesAsset{}, errors.New("collections: int64 values asset validation requires asset manager")
+	}
+	if asset.Namespace != cfg.AssetManager.Namespace || ref.Namespace != cfg.AssetManager.Namespace {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset namespace=%q ref_namespace=%q want %q", asset.Namespace, ref.Namespace, cfg.AssetManager.Namespace)
+	}
+	if asset.Generation != ref.Generation || asset.PartID != ref.PartID {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset generation/part does not match ref")
+	}
+	if asset.SchemaHash != cfg.SchemaHash {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset schema_hash=%d want %d", asset.SchemaHash, cfg.SchemaHash)
+	}
+	if asset.AppliedCommandLSN > cfg.RecoveryAuthoritativeAppliedCommandLSN {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset applied_command_lsn=%d is newer than recovery applied_command_lsn=%d", asset.AppliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
+	}
+	if expectedColumn != "" && asset.ColumnName != expectedColumn {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset column=%q want %q", asset.ColumnName, expectedColumn)
+	}
+	if asset.ColumnIndex < 0 || asset.ColumnIndex >= len(cfg.Columns) {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset column_index=%d outside columns=%d", asset.ColumnIndex, len(cfg.Columns))
+	}
+	col := cfg.Columns[asset.ColumnIndex]
+	if col.Name != asset.ColumnName || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return columnInt64ValuesAsset{}, fmt.Errorf("collections: int64 values asset column %q is not a non-null declared int64 column", asset.ColumnName)
+	}
+	return asset, nil
+}

--- a/TreeDB/collections/column_int64_values_asset.go
+++ b/TreeDB/collections/column_int64_values_asset.go
@@ -50,7 +50,6 @@ func buildColumnInt64ValuesAssetForColumn(cfg ColumnStoreConfig, rows []columnDe
 	if col.ValueType != ColumnStoreValueInt64 || col.Nullable {
 		return columnInt64ValuesAsset{}, false, nil
 	}
-	values := make([]int64, 0, len(rows))
 	for rowIdx, row := range rows {
 		if row.Deleted {
 			return columnInt64ValuesAsset{}, false, nil
@@ -65,10 +64,13 @@ func buildColumnInt64ValuesAssetForColumn(cfg ColumnStoreConfig, rows []columnDe
 		if !value.Present || value.Null {
 			return columnInt64ValuesAsset{}, false, nil
 		}
-		values = append(values, value.Int64)
 	}
-	if len(values) == 0 {
+	if len(rows) == 0 {
 		return columnInt64ValuesAsset{}, false, nil
+	}
+	values := make([]int64, len(rows))
+	for rowIdx, row := range rows {
+		values[rowIdx] = row.Values[colIdx].Int64
 	}
 	return columnInt64ValuesAsset{
 		Collection:        collection,

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -22,7 +22,7 @@ const (
 
 	columnManifestHeaderMagic   = uint32(0x54434d48) // TCMH
 	columnManifestPartMagic     = uint32(0x54434d50) // TCMP
-	columnManifestRecordVersion = uint16(1)
+	columnManifestRecordVersion = uint16(2)
 )
 
 var (

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// Manifest record keys keep their v1 keyspace names for stable ordering and
+	// prefix scans; columnManifestRecordVersion versions the binary values.
 	columnManifestHeaderRecordKey               = "\x01column-manifest/v1/header"
 	columnManifestPartRecordPrefix              = "\x02column-manifest/v1/part/"
 	columnManifestAggregateMetadataRecordPrefix = "\x03column-manifest/v1/aggregate/"

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -18,6 +18,7 @@ const (
 	columnManifestPartRecordPrefix              = "\x02column-manifest/v1/part/"
 	columnManifestAggregateMetadataRecordPrefix = "\x03column-manifest/v1/aggregate/"
 	columnManifestDictionaryCodesRecordPrefix   = "\x04column-manifest/v1/dictionary/"
+	columnManifestInt64ValuesRecordPrefix       = "\x05column-manifest/v1/int64/"
 
 	columnManifestHeaderMagic   = uint32(0x54434d48) // TCMH
 	columnManifestPartMagic     = uint32(0x54434d50) // TCMP
@@ -30,6 +31,7 @@ var (
 	columnManifestPartRecordPrefixBytes              = []byte(columnManifestPartRecordPrefix)
 	columnManifestAggregateMetadataRecordPrefixBytes = []byte(columnManifestAggregateMetadataRecordPrefix)
 	columnManifestDictionaryCodesRecordPrefixBytes   = []byte(columnManifestDictionaryCodesRecordPrefix)
+	columnManifestInt64ValuesRecordPrefixBytes       = []byte(columnManifestInt64ValuesRecordPrefix)
 )
 
 type columnManifestRecord struct {
@@ -51,6 +53,7 @@ type columnManifestSnapshot struct {
 	Parts              []columnManifestPartSnapshot
 	AggregateMetadata  []columnManifestAggregateMetadataSnapshot
 	DictionaryCodes    []columnManifestDictionaryCodesSnapshot
+	Int64Values        []columnManifestInt64ValuesSnapshot
 }
 
 type columnManifestPartSnapshot struct {
@@ -73,6 +76,15 @@ type columnManifestAggregateMetadataSnapshot struct {
 type columnManifestDictionaryCodesSnapshot struct {
 	AssetRef     ColumnAssetRef
 	ColumnName   string
+	Bytes        int64
+	PublishID    uint64
+	GenerationID uint64
+}
+
+type columnManifestInt64ValuesSnapshot struct {
+	AssetRef     ColumnAssetRef
+	ColumnName   string
+	Rows         int
 	Bytes        int64
 	PublishID    uint64
 	GenerationID uint64
@@ -101,6 +113,15 @@ func columnManifestDictionaryCodesRecordKey(generation, partID uint64, columnNam
 	binary.BigEndian.PutUint64(key[len(columnManifestDictionaryCodesRecordPrefix):], generation)
 	binary.BigEndian.PutUint64(key[len(columnManifestDictionaryCodesRecordPrefix)+8:], partID)
 	copy(key[len(columnManifestDictionaryCodesRecordPrefix)+16:], columnName)
+	return key
+}
+
+func columnManifestInt64ValuesRecordKey(generation, partID uint64, columnName string) []byte {
+	key := make([]byte, len(columnManifestInt64ValuesRecordPrefix)+16+len(columnName))
+	copy(key, columnManifestInt64ValuesRecordPrefix)
+	binary.BigEndian.PutUint64(key[len(columnManifestInt64ValuesRecordPrefix):], generation)
+	binary.BigEndian.PutUint64(key[len(columnManifestInt64ValuesRecordPrefix)+8:], partID)
+	copy(key[len(columnManifestInt64ValuesRecordPrefix)+16:], columnName)
 	return key
 }
 
@@ -162,6 +183,15 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 				value: partValue,
 			})
 			continue
+		case ColumnAssetKindTCS1Int64Values:
+			if asset.Reason == "" {
+				return ColumnPublishManifestEncodeResult{}, errors.New("collections: int64 values manifest record requires column name")
+			}
+			records = append(records, columnManifestRecord{
+				key:   columnManifestInt64ValuesRecordKey(asset.Ref.Generation, asset.Ref.PartID, asset.Reason),
+				value: partValue,
+			})
+			continue
 		}
 		records = append(records, columnManifestRecord{
 			key:   columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID),
@@ -191,7 +221,8 @@ func retainedColumnManifestRecordsForWrite(records []columnManifestRecord, gener
 	for _, record := range records {
 		if !bytes.HasPrefix(record.key, []byte(columnManifestPartRecordPrefix)) &&
 			!bytes.HasPrefix(record.key, []byte(columnManifestAggregateMetadataRecordPrefix)) &&
-			!bytes.HasPrefix(record.key, []byte(columnManifestDictionaryCodesRecordPrefix)) {
+			!bytes.HasPrefix(record.key, []byte(columnManifestDictionaryCodesRecordPrefix)) &&
+			!bytes.HasPrefix(record.key, []byte(columnManifestInt64ValuesRecordPrefix)) {
 			continue
 		}
 		part, err := decodeColumnManifestPartRecord(record.value)
@@ -251,6 +282,7 @@ func encodeColumnManifestPartRecord(asset ColumnPreparedAsset) ([]byte, error) {
 	writeManifestUint64(&b, uint64(asset.Ref.Offset))
 	writeManifestUint64(&b, uint64(asset.Ref.Length))
 	writeManifestUint64(&b, uint64(asset.Ref.Checksum))
+	writeManifestUint64(&b, uint64(asset.Rows))
 	writeManifestUint64(&b, uint64(asset.Bytes))
 	writeManifestUint64(&b, asset.PublishID)
 	writeManifestUint64(&b, asset.GenerationID)
@@ -263,6 +295,7 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 	var parts []columnManifestPartSnapshot
 	var metadata []columnManifestAggregateMetadataSnapshot
 	var dictionaries []columnManifestDictionaryCodesSnapshot
+	var int64Values []columnManifestInt64ValuesSnapshot
 	sawHeader := false
 	for _, record := range records {
 		switch {
@@ -294,6 +327,12 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 				return columnManifestSnapshot{}, err
 			}
 			dictionaries = append(dictionaries, dictionary)
+		case bytes.HasPrefix(record.key, []byte(columnManifestInt64ValuesRecordPrefix)):
+			values, err := decodeColumnManifestInt64ValuesRecord(record.key, record.value)
+			if err != nil {
+				return columnManifestSnapshot{}, err
+			}
+			int64Values = append(int64Values, values)
 		}
 	}
 	if !sawHeader {
@@ -308,9 +347,11 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 		}
 	}
 	livePartNamespaces := make(map[[2]uint64]string, len(parts))
+	livePartRows := make(map[[2]uint64]int, len(parts))
 	for _, part := range parts {
 		if part.AssetRef.Generation <= snapshot.Generation {
 			livePartNamespaces[[2]uint64{part.AssetRef.Generation, part.AssetRef.PartID}] = part.AssetRef.Namespace
+			livePartRows[[2]uint64{part.AssetRef.Generation, part.AssetRef.PartID}] = part.Rows
 		}
 	}
 	for _, aggregate := range metadata {
@@ -339,6 +380,24 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 		}
 		snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
 	}
+	for _, values := range int64Values {
+		if values.AssetRef.Generation > snapshot.Generation {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", values.AssetRef.Generation, snapshot.Generation)
+		}
+		partKey := [2]uint64{values.AssetRef.Generation, values.AssetRef.PartID}
+		partNamespace, ok := livePartNamespaces[partKey]
+		if !ok {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", values.AssetRef.Generation, values.AssetRef.PartID)
+		}
+		if values.AssetRef.Namespace != partNamespace {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest int64 values namespace=%q does not match part namespace=%q", values.AssetRef.Namespace, partNamespace)
+		}
+		partRows := livePartRows[partKey]
+		if values.Rows != partRows {
+			return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest int64 values rows=%d does not match part rows=%d", values.Rows, partRows)
+		}
+		snapshot.Int64Values = append(snapshot.Int64Values, values)
+	}
 	if uint64(len(snapshot.Parts)) != snapshot.ExpectedParts {
 		return columnManifestSnapshot{}, fmt.Errorf("collections: invalid column manifest part count=%d want %d", len(snapshot.Parts), snapshot.ExpectedParts)
 	}
@@ -366,6 +425,34 @@ func decodeColumnManifestDictionaryCodesRecord(key, raw []byte) (columnManifestD
 	return columnManifestDictionaryCodesSnapshot{
 		AssetRef:     part.AssetRef,
 		ColumnName:   columnName,
+		Bytes:        part.Bytes,
+		PublishID:    part.PublishID,
+		GenerationID: part.GenerationID,
+	}, nil
+}
+
+func decodeColumnManifestInt64ValuesRecord(key, raw []byte) (columnManifestInt64ValuesSnapshot, error) {
+	generation, partID, columnName, err := columnManifestInt64ValuesKeyFromRecordKey(key)
+	if err != nil {
+		return columnManifestInt64ValuesSnapshot{}, err
+	}
+	part, err := decodeColumnManifestPartRecord(raw)
+	if err != nil {
+		return columnManifestInt64ValuesSnapshot{}, err
+	}
+	if part.AssetRef.Kind != ColumnAssetKindTCS1Int64Values {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values asset kind=%q want %q", part.AssetRef.Kind, ColumnAssetKindTCS1Int64Values)
+	}
+	if part.AssetRef.Generation != generation || part.AssetRef.PartID != partID {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key generation/part does not match ref")
+	}
+	if part.Reason != columnName {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", columnName, part.Reason)
+	}
+	return columnManifestInt64ValuesSnapshot{
+		AssetRef:     part.AssetRef,
+		ColumnName:   columnName,
+		Rows:         part.Rows,
 		Bytes:        part.Bytes,
 		PublishID:    part.PublishID,
 		GenerationID: part.GenerationID,
@@ -459,6 +546,7 @@ func decodeColumnManifestPartRecord(raw []byte) (columnManifestPartSnapshot, err
 	offset64 := cur.u64()
 	length64 := cur.u64()
 	checksum64 := cur.u64()
+	rows64 := cur.u64()
 	bytes64 := cur.u64()
 	publishID := cur.u64()
 	generationID := cur.u64()
@@ -471,6 +559,9 @@ func decodeColumnManifestPartRecord(raw []byte) (columnManifestPartSnapshot, err
 	}
 	if checksum64 > uint64(math.MaxUint32) {
 		return columnManifestPartSnapshot{}, errors.New("collections: column manifest part checksum overflows uint32")
+	}
+	if rows64 > uint64(maxCollectionInt) {
+		return columnManifestPartSnapshot{}, errors.New("collections: column manifest part rows overflows int")
 	}
 	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) || bytes64 > uint64(math.MaxInt64) {
 		return columnManifestPartSnapshot{}, errors.New("collections: column manifest part offsets or byte counts overflow int64")
@@ -488,12 +579,13 @@ func decodeColumnManifestPartRecord(raw []byte) (columnManifestPartSnapshot, err
 		Length:     int64(length64),
 		Checksum:   uint32(checksum64),
 	}
-	asset := ColumnPreparedAsset{Ref: ref, Bytes: int64(bytes64), PublishID: publishID, GenerationID: generationID, Reason: reason}
+	asset := ColumnPreparedAsset{Ref: ref, Rows: int(rows64), Bytes: int64(bytes64), PublishID: publishID, GenerationID: generationID, Reason: reason}
 	if err := validateColumnPreparedAssetForPlan(asset); err != nil {
 		return columnManifestPartSnapshot{}, err
 	}
 	return columnManifestPartSnapshot{
 		AssetRef:     ref,
+		Rows:         int(rows64),
 		Bytes:        int64(bytes64),
 		PublishID:    publishID,
 		GenerationID: generationID,
@@ -530,6 +622,14 @@ func enumerateColumnManifestAssetRefs(iter iterator.UnsafeIterator) ([]ColumnAss
 		return nil, err
 	}
 	refs = append(refs, dictionaryRefs...)
+	int64Refs, err := enumerateColumnManifestAssetRefsForPrefix(iter, columnManifestInt64ValuesRecordPrefixBytes, func(key, value []byte) (ColumnAssetRef, error) {
+		values, err := decodeColumnManifestInt64ValuesRecord(key, value)
+		return values.AssetRef, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	refs = append(refs, int64Refs...)
 	return refs, iter.Error()
 }
 
@@ -581,6 +681,18 @@ func columnManifestDictionaryCodesKeyFromRecordKey(key []byte) (uint64, uint64, 
 	return binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix):]),
 		binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix)+8:]),
 		string(key[len(columnManifestDictionaryCodesRecordPrefix)+16:]), nil
+}
+
+func columnManifestInt64ValuesKeyFromRecordKey(key []byte) (uint64, uint64, string, error) {
+	if !bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes) {
+		return 0, 0, "", fmt.Errorf("collections: column manifest int64 values key %q missing prefix", string(key))
+	}
+	if len(key) <= len(columnManifestInt64ValuesRecordPrefix)+16 {
+		return 0, 0, "", fmt.Errorf("collections: column manifest int64 values key length=%d too short", len(key))
+	}
+	return binary.BigEndian.Uint64(key[len(columnManifestInt64ValuesRecordPrefix):]),
+		binary.BigEndian.Uint64(key[len(columnManifestInt64ValuesRecordPrefix)+8:]),
+		string(key[len(columnManifestInt64ValuesRecordPrefix)+16:]), nil
 }
 
 func columnManifestRootRecordIterator(identityRecord [columnManifestIdentityRecordSize]byte, records []columnManifestRecord) *systemTargetIterator {

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -20,9 +20,10 @@ const (
 	columnManifestDictionaryCodesRecordPrefix   = "\x04column-manifest/v1/dictionary/"
 	columnManifestInt64ValuesRecordPrefix       = "\x05column-manifest/v1/int64/"
 
-	columnManifestHeaderMagic   = uint32(0x54434d48) // TCMH
-	columnManifestPartMagic     = uint32(0x54434d50) // TCMP
-	columnManifestRecordVersion = uint16(2)
+	columnManifestHeaderMagic     = uint32(0x54434d48) // TCMH
+	columnManifestPartMagic       = uint32(0x54434d50) // TCMP
+	columnManifestRecordVersionV1 = uint16(1)
+	columnManifestRecordVersion   = uint16(2)
 )
 
 var (
@@ -491,7 +492,7 @@ func decodeColumnManifestHeaderRecord(raw []byte) (columnManifestSnapshot, error
 	if magic := cur.u32(); magic != columnManifestHeaderMagic {
 		return columnManifestSnapshot{}, fmt.Errorf("collections: bad column manifest header magic=0x%08x", magic)
 	}
-	if version := cur.u16(); version != columnManifestRecordVersion {
+	if version := cur.u16(); version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
 		return columnManifestSnapshot{}, fmt.Errorf("collections: unsupported column manifest header version=%d", version)
 	}
 	collection := cur.string()
@@ -535,7 +536,8 @@ func decodeColumnManifestPartRecord(raw []byte) (columnManifestPartSnapshot, err
 	if magic := cur.u32(); magic != columnManifestPartMagic {
 		return columnManifestPartSnapshot{}, fmt.Errorf("collections: bad column manifest part magic=0x%08x", magic)
 	}
-	if version := cur.u16(); version != columnManifestRecordVersion {
+	version := cur.u16()
+	if version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
 		return columnManifestPartSnapshot{}, fmt.Errorf("collections: unsupported column manifest part version=%d", version)
 	}
 	kind := ColumnAssetKind(cur.string())
@@ -546,7 +548,10 @@ func decodeColumnManifestPartRecord(raw []byte) (columnManifestPartSnapshot, err
 	offset64 := cur.u64()
 	length64 := cur.u64()
 	checksum64 := cur.u64()
-	rows64 := cur.u64()
+	rows64 := uint64(0)
+	if version >= columnManifestRecordVersion {
+		rows64 = cur.u64()
+	}
 	bytes64 := cur.u64()
 	publishID := cur.u64()
 	generationID := cur.u64()

--- a/TreeDB/collections/column_manifest_format_test.go
+++ b/TreeDB/collections/column_manifest_format_test.go
@@ -1,0 +1,96 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestColumnManifestRecordDecodeAcceptsV1CompatibilityM1634(t *testing.T) {
+	header := mustEncodeColumnManifestHeaderRecordVersionM1634(t, 1)
+	decodedHeader, err := decodeColumnManifestHeaderRecord(header)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestHeaderRecord v1: %v", err)
+	}
+	if decodedHeader.Generation != 7 || decodedHeader.ExpectedParts != 1 {
+		t.Fatalf("unexpected v1 header: %+v", decodedHeader)
+	}
+
+	asset := ColumnPreparedAsset{
+		Ref: ColumnAssetRef{
+			Kind:       ColumnAssetKindTCS1PartImage,
+			Namespace:  "events_column_assets",
+			Generation: 7,
+			PartID:     3,
+			FileID:     1,
+			Offset:     16,
+			Length:     128,
+			Checksum:   99,
+		},
+		Rows:         42,
+		Bytes:        128,
+		PublishID:    11,
+		GenerationID: 7,
+		Reason:       string(ColumnPublishOperationInsert),
+	}
+	part := mustEncodeColumnManifestPartRecordVersionM1634(t, asset, 1)
+	decodedPart, err := decodeColumnManifestPartRecord(part)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestPartRecord v1: %v", err)
+	}
+	if decodedPart.AssetRef != asset.Ref || decodedPart.Rows != 0 || decodedPart.Bytes != asset.Bytes || decodedPart.Reason != asset.Reason {
+		t.Fatalf("unexpected v1 part decode: %+v", decodedPart)
+	}
+
+	records := []columnManifestRecord{
+		{key: []byte(columnManifestHeaderRecordKey), value: header},
+		{key: columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID), value: part},
+	}
+	snapshot, err := decodeColumnManifestRecords(records)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestRecords v1: %v", err)
+	}
+	if len(snapshot.Parts) != 1 || snapshot.Parts[0].Rows != 0 {
+		t.Fatalf("unexpected v1 snapshot parts: %+v", snapshot.Parts)
+	}
+}
+
+func mustEncodeColumnManifestHeaderRecordVersionM1634(t *testing.T, version uint16) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	writeManifestUint32(&b, columnManifestHeaderMagic)
+	writeManifestUint16(&b, version)
+	writeManifestString(&b, "events")
+	writeManifestString(&b, string(ColumnPublishOperationInsert))
+	writeManifestUint64(&b, 7)
+	writeManifestUint64(&b, 123)
+	writeManifestUint64(&b, 456)
+	writeManifestUint64(&b, 42)
+	writeManifestUint64(&b, 100)
+	writeManifestUint64(&b, 20)
+	writeManifestUint64(&b, 80)
+	writeManifestUint64(&b, 1)
+	return b.Bytes()
+}
+
+func mustEncodeColumnManifestPartRecordVersionM1634(t *testing.T, asset ColumnPreparedAsset, version uint16) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	writeManifestUint32(&b, columnManifestPartMagic)
+	writeManifestUint16(&b, version)
+	writeManifestString(&b, string(asset.Ref.Kind))
+	writeManifestString(&b, asset.Ref.Namespace)
+	writeManifestUint64(&b, asset.Ref.Generation)
+	writeManifestUint64(&b, asset.Ref.PartID)
+	writeManifestUint64(&b, uint64(asset.Ref.FileID))
+	writeManifestUint64(&b, uint64(asset.Ref.Offset))
+	writeManifestUint64(&b, uint64(asset.Ref.Length))
+	writeManifestUint64(&b, uint64(asset.Ref.Checksum))
+	if version >= columnManifestRecordVersion {
+		writeManifestUint64(&b, uint64(asset.Rows))
+	}
+	writeManifestUint64(&b, uint64(asset.Bytes))
+	writeManifestUint64(&b, asset.PublishID)
+	writeManifestUint64(&b, asset.GenerationID)
+	writeManifestString(&b, asset.Reason)
+	return b.Bytes()
+}

--- a/TreeDB/collections/column_manifest_format_test.go
+++ b/TreeDB/collections/column_manifest_format_test.go
@@ -52,6 +52,28 @@ func TestColumnManifestRecordDecodeAcceptsV1CompatibilityM1634(t *testing.T) {
 	if len(snapshot.Parts) != 1 || snapshot.Parts[0].Rows != 0 {
 		t.Fatalf("unexpected v1 snapshot parts: %+v", snapshot.Parts)
 	}
+
+	scanHeader, err := decodeColumnManifestHeaderRecordForScan(header)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestHeaderRecordForScan v1: %v", err)
+	}
+	if scanHeader.generation != 7 || scanHeader.expectedParts != 1 {
+		t.Fatalf("unexpected v1 scan header: %+v", scanHeader)
+	}
+	scanRef, reason, err := decodeColumnManifestPartRefForScan(part, asset.Ref.Namespace)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestPartRefForScan v1: %v", err)
+	}
+	if scanRef != asset.Ref || string(reason) != asset.Reason {
+		t.Fatalf("unexpected v1 scan part: ref=%+v reason=%q", scanRef, string(reason))
+	}
+	rewriteRef, _, err := columnAssetRewriteManifestPartRefForPatch(part, asset.Ref.Namespace)
+	if err != nil {
+		t.Fatalf("columnAssetRewriteManifestPartRefForPatch v1: %v", err)
+	}
+	if rewriteRef != asset.Ref {
+		t.Fatalf("unexpected v1 rewrite ref: %+v", rewriteRef)
+	}
 }
 
 func mustEncodeColumnManifestHeaderRecordVersionM1634(t *testing.T, version uint16) []byte {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -59,6 +59,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	DirectReduceBlocks         int
 	MetadataHits               int
 	DictionaryCodeHits         int
+	Int64ValueHits             int
 	ScheduledGranules          int
 	SkippedGranules            int
 	RowsScanned                int
@@ -104,6 +105,7 @@ type ColumnPhysicalQueryRunner struct {
 	readCache    columnPhysicalAssetReadCache
 	dictCount    *columnDictionaryCodeGroupCountRunner
 	dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
+	int64Hour    *columnInt64ValueHourCountRunner
 	metadata     *columnAggregateMetadataRunner
 	closed       bool
 }
@@ -207,6 +209,11 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		_ = readCache.close()
 		return nil, err
 	}
+	int64Hour, err := prepareColumnInt64ValueHourCountRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	release = false
 	return &ColumnPhysicalQueryRunner{
 		collection:   c,
@@ -217,6 +224,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		readCache:    readCache,
 		dictCount:    dictCount,
 		dictDistinct: dictDistinct,
+		int64Hour:    int64Hour,
 		metadata:     metadata,
 	}, nil
 }
@@ -252,6 +260,9 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.dictDistinct != nil {
 		return r.dictDistinct.run(r.view, r.req), nil
+	}
+	if r.int64Hour != nil {
+		return r.int64Hour.run(r.view, r.req), nil
 	}
 	if r.metadata != nil {
 		return r.metadata.run(r.view, r.req), nil
@@ -558,6 +569,9 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 	if result, ok, err := c.runColumnPhysicalQueryDictionaryCodesInSnapshotView(view, req); ok {
 		return result, err
 	}
+	if result, ok, err := c.runColumnPhysicalQueryInt64ValuesInSnapshotView(view, req); ok {
+		return result, err
+	}
 	if result, ok, err := c.runColumnPhysicalQueryDirectInSnapshotView(view, req, 0, 0, nil); ok {
 		if err != nil {
 			if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
@@ -626,6 +640,31 @@ func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view co
 	result.Diagnostics.SegmentFileCacheHits = readCache.hits
 	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
 	result.Diagnostics.DictionaryCodeHits = result.Diagnostics.DecodedBlocks
+	return result, true, nil
+}
+
+func (c *Collection) runColumnPhysicalQueryInt64ValuesInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+
+	hour, err := prepareColumnInt64ValueHourCountRunner(view, req, &readCache)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	if hour == nil {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	result := hour.run(view, req)
+	result.Diagnostics.SegmentFileCacheHits = readCache.hits
+	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	result.Diagnostics.Int64ValueHits = result.Diagnostics.DecodedBlocks
 	return result, true, nil
 }
 
@@ -750,6 +789,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.DirectReduceBlocks += right.DirectReduceBlocks
 	left.MetadataHits += right.MetadataHits
 	left.DictionaryCodeHits += right.DictionaryCodeHits
+	left.Int64ValueHits += right.Int64ValueHits
 	left.ScheduledGranules += right.ScheduledGranules
 	left.SkippedGranules += right.SkippedGranules
 	left.RowsScanned += right.RowsScanned

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -654,17 +654,15 @@ func (c *Collection) runColumnPhysicalQueryInt64ValuesInSnapshotView(view column
 	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 
-	hour, err := prepareColumnInt64ValueHourCountRunner(view, req, &readCache)
+	result, ok, err := runColumnInt64ValueHourCountOneShot(view, req, &readCache)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, true, err
 	}
-	if hour == nil {
+	if !ok {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	result := hour.run(view, req)
 	result.Diagnostics.SegmentFileCacheHits = readCache.hits
 	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
-	result.Diagnostics.Int64ValueHits = result.Diagnostics.DecodedBlocks
 	return result, true, nil
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -644,7 +644,8 @@ func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view co
 }
 
 func (c *Collection) runColumnPhysicalQueryInt64ValuesInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
-	if req.AggregateMetadataName != "" || view.MutationParts != 0 {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 ||
+		req.Kind != ColumnPhysicalQueryHourCount || req.ValueColumn == "" {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -364,9 +364,9 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if got, want := parallel.Diagnostics.ScheduledGranules, serial.Diagnostics.ScheduledGranules; got != want {
 				t.Fatalf("parallel scheduled granules=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)
 			}
-			if tc.req.Kind == ColumnPhysicalQueryGroupCount || tc.req.Kind == ColumnPhysicalQueryGroupCountDistinct {
+			if tc.req.Kind == ColumnPhysicalQueryGroupCount || tc.req.Kind == ColumnPhysicalQueryGroupCountDistinct || tc.req.Kind == ColumnPhysicalQueryHourCount {
 				if serial.Diagnostics.PhysicalBytesScanned <= 0 || serial.Diagnostics.PhysicalBytesScanned >= parallel.Diagnostics.PhysicalBytesScanned {
-					t.Fatalf("serial dictionary-sidecar bytes=%d want below parallel TCPA bytes=%d serial=%+v parallel=%+v", serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics, parallel.Diagnostics)
+					t.Fatalf("serial sidecar bytes=%d want below parallel TCPA bytes=%d serial=%+v parallel=%+v", serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics, parallel.Diagnostics)
 				}
 			} else if parallel.Diagnostics.PhysicalBytesScanned != serial.Diagnostics.PhysicalBytesScanned {
 				t.Fatalf("parallel bytes=%d want serial %d diagnostics=%+v", parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics)
@@ -1373,7 +1373,7 @@ func TestColumnStoreQueryAndReconstructionFailClosedCorruptAssetM13C(t *testing.
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()
 	reopened := openColumnStoreCollectionM10B(t, reopen)
-	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}); err == nil || !strings.Contains(err.Error(), "checksum") {
+	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("RunColumnPhysicalQuery corrupt asset err=%v want checksum failure", err)
 	}
 	if got, err := reopened.Get([]byte("e1")); err == nil || !strings.Contains(err.Error(), "checksum") || got != nil {
@@ -1394,7 +1394,7 @@ func TestColumnStoreQueryAndReconstructionFailClosedTruncatedAssetM13C(t *testin
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()
 	reopened := openColumnStoreCollectionM10B(t, reopen)
-	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("RunColumnPhysicalQuery truncated asset err=%v want io.ErrUnexpectedEOF", err)
 	}
 	if got, err := reopened.Get([]byte("e1")); !errors.Is(err, io.ErrUnexpectedEOF) || got != nil {
@@ -1997,6 +1997,40 @@ func TestColumnPhysicalQuerySerialDictionarySidecarParityM1634(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
+	wantHash := columnPhysicalQueryReferenceHashM13B("q3", events)
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}
+	result, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery: %v", err)
+	}
+	if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B("q3", result.Groups)); got != wantHash {
+		t.Fatalf("serial int64 sidecar q3 hash=%d want %d groups=%+v", got, wantHash, result.Groups)
+	}
+	if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+		t.Fatalf("serial int64 sidecar diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+	}
+	if result.Diagnostics.ProjectedColumns != 1 {
+		t.Fatalf("serial int64 sidecar projected columns=%d want 1", result.Diagnostics.ProjectedColumns)
+	}
+	if result.Diagnostics.Int64ValueHits == 0 || result.Diagnostics.Int64ValueHits != result.Diagnostics.ScheduledGranules {
+		t.Fatalf("serial int64 sidecar hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.Int64ValueHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+	}
+	if result.Diagnostics.DictionaryCodeHits != 0 {
+		t.Fatalf("serial int64 sidecar dictionary hits=%d want 0 diagnostics=%+v", result.Diagnostics.DictionaryCodeHits, result.Diagnostics)
+	}
+	if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+		t.Fatalf("serial int64 sidecar physical bytes=%d want int64 sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
+	}
+	if result.Diagnostics.SegmentFileCacheMisses == 0 {
+		t.Fatalf("serial int64 sidecar diagnostics=%+v want one-shot sidecar read misses accounted", result.Diagnostics)
+	}
+}
+
 func TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(128)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
@@ -2105,7 +2139,8 @@ func TestColumnPhysicalQueryRunnerAggregateMetadataParityAndAllocationM1634(t *t
 }
 
 func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.T) {
-	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(128))
+	events := columnPhysicalQueryFixtureEventsM13B(128)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
 	defer closeFn()
 	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
 	if closeView != nil {
@@ -2120,6 +2155,9 @@ func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.
 	if len(view.DictionaryCodes) != 2 {
 		t.Fatalf("dictionary code refs=%d want kind+did sidecars", len(view.DictionaryCodes))
 	}
+	if len(view.Int64Values) != 1 {
+		t.Fatalf("int64 value refs=%d want time_us sidecar", len(view.Int64Values))
+	}
 	byColumn := make(map[string]ColumnAssetRef, len(view.DictionaryCodes))
 	for _, sidecar := range view.DictionaryCodes {
 		byColumn[sidecar.ColumnName] = sidecar.AssetRef
@@ -2132,6 +2170,88 @@ func TestColumnPhysicalQueryDictionaryCodesAreManifestReachableM1634(t *testing.
 	}
 	if byColumn["kind"].Length == 0 || byColumn["did"].Length == 0 {
 		t.Fatalf("dictionary sidecars missing expected columns: %+v", byColumn)
+	}
+	if view.Int64Values[0].ColumnName != "time_us" || view.Int64Values[0].AssetRef.Kind != ColumnAssetKindTCS1Int64Values {
+		t.Fatalf("int64 sidecar=%+v want time_us %q", view.Int64Values[0], ColumnAssetKindTCS1Int64Values)
+	}
+	if view.Int64Values[0].Rows != len(events) {
+		t.Fatalf("int64 sidecar rows=%d want %d", view.Int64Values[0].Rows, len(events))
+	}
+	if view.Int64Values[0].AssetRef.Generation != view.AssetRefs[0].Ref.Generation || view.Int64Values[0].AssetRef.PartID != view.AssetRefs[0].Ref.PartID {
+		t.Fatalf("int64 sidecar ref=%+v want same generation/part as %+v", view.Int64Values[0].AssetRef, view.AssetRefs[0].Ref)
+	}
+}
+
+func TestColumnInt64ValuesAssetCodecRejectsCorruptionM1634(t *testing.T) {
+	normalized, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	normalized.RecoveryAuthoritativeAppliedCommandLSN = 42
+	rows := []columnDeclaredRow{
+		{ID: []byte("e1"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+			{Type: ColumnStoreValueString, Present: true, String: "share"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_a"},
+		}},
+		{ID: []byte("e2"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: -2},
+			{Type: ColumnStoreValueString, Present: true, String: "like"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_b"},
+		}},
+		{ID: []byte("e3"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 3},
+			{Type: ColumnStoreValueString, Present: true, String: "share"},
+			{Type: ColumnStoreValueString, Present: true, String: "did_c"},
+		}},
+	}
+	assets, err := buildColumnInt64ValuesAssets(*normalized, rows, "events", normalized.AssetManager.Namespace, 7, 3, 42)
+	if err != nil {
+		t.Fatalf("buildColumnInt64ValuesAssets: %v", err)
+	}
+	if len(assets) != 1 || assets[0].ColumnName != "time_us" {
+		t.Fatalf("assets=%+v want one time_us int64 sidecar", assets)
+	}
+	raw, err := encodeColumnInt64ValuesAsset(assets[0])
+	if err != nil {
+		t.Fatalf("encodeColumnInt64ValuesAsset: %v", err)
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1Int64Values,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: assets[0].Generation,
+		PartID:     assets[0].PartID,
+		Length:     int64(len(raw)),
+		Checksum:   page.Checksum(raw),
+	}
+	decoded, err := decodeColumnInt64ValuesAsset(raw, ref, *normalized, "events", "time_us", true)
+	if err != nil {
+		t.Fatalf("decodeColumnInt64ValuesAsset: %v", err)
+	}
+	if got, want := decoded.Values, []int64{1, -2, 3}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("values=%v want %v", got, want)
+	}
+
+	corrupt := append([]byte(nil), raw...)
+	corrupt[len(corrupt)-1] ^= 0xff
+	if _, err := decodeColumnInt64ValuesAsset(corrupt, ref, *normalized, "events", "time_us", true); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("checksum corruption err=%v want checksum failure", err)
+	}
+	mismatchedChecksumRef := ref
+	mismatchedChecksumRef.Checksum ^= 1
+	if _, err := decodeColumnInt64ValuesAsset(raw, mismatchedChecksumRef, *normalized, "events", "time_us", false); err != nil {
+		t.Fatalf("skip-checksum decode err=%v want valid raw bytes to decode despite ref checksum mismatch", err)
+	}
+
+	wrongColumnRef := ref
+	if _, err := decodeColumnInt64ValuesAsset(raw, wrongColumnRef, *normalized, "events", "kind", true); err == nil || !strings.Contains(err.Error(), "column=") {
+		t.Fatalf("wrong column err=%v want column validation failure", err)
+	}
+
+	futureLSNCfg := *normalized
+	futureLSNCfg.RecoveryAuthoritativeAppliedCommandLSN = 41
+	if _, err := decodeColumnInt64ValuesAsset(raw, ref, futureLSNCfg, "events", "time_us", true); err == nil || !strings.Contains(err.Error(), "newer than recovery") {
+		t.Fatalf("future lsn err=%v want recovery-authoritative LSN failure", err)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1944,6 +1944,64 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 	}
 }
 
+func TestColumnPhysicalQueryRunnerInt64ValueSidecarParityAndAllocationM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}
+	wantHash := columnPhysicalQueryReferenceHashM13B("q3", events)
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	defer func() {
+		if err := runner.Close(); err != nil {
+			t.Fatalf("runner Close: %v", err)
+		}
+	}()
+	wantGroups := 0
+	for i := 0; i < 3; i++ {
+		result, err := runner.Run()
+		if err != nil {
+			t.Fatalf("runner Run warmup %d: %v", i, err)
+		}
+		if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B("q3", result.Groups)); got != wantHash {
+			t.Fatalf("runner q3 hash=%d want %d groups=%+v", got, wantHash, result.Groups)
+		}
+		if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+			t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+		}
+		if result.Diagnostics.ProjectedColumns != 1 {
+			t.Fatalf("runner projected columns=%d want time_us sidecar", result.Diagnostics.ProjectedColumns)
+		}
+		if result.Diagnostics.Int64ValueHits == 0 || result.Diagnostics.Int64ValueHits != result.Diagnostics.ScheduledGranules {
+			t.Fatalf("runner int64 hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.Int64ValueHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+		}
+		if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+			t.Fatalf("runner physical bytes=%d want int64 sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
+		}
+		if result.Diagnostics.SegmentFileCacheMisses != 0 {
+			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared int64 sidecar setup", result.Diagnostics)
+		}
+		wantGroups = len(result.Groups)
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		result, err := runner.Run()
+		if err != nil {
+			panic(fmt.Sprintf("runner Run: %v", err))
+		}
+		if len(result.Groups) != wantGroups {
+			panic(fmt.Sprintf("runner groups=%d want %d", len(result.Groups), wantGroups))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("runner q3 warmed allocs/run=%.2f want 0", allocs)
+	}
+}
+
 func TestColumnPhysicalQuerySerialDictionarySidecarParityM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(2048)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
@@ -2230,6 +2288,14 @@ func TestColumnInt64ValuesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 	}
 	if got, want := decoded.Values, []int64{1, -2, 3}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("values=%v want %v", got, want)
+	}
+
+	truncated := append([]byte(nil), raw[:len(raw)-8]...)
+	truncatedRef := ref
+	truncatedRef.Length = int64(len(truncated))
+	truncatedRef.Checksum = page.Checksum(truncated)
+	if _, err := decodeColumnInt64ValuesAsset(truncated, truncatedRef, *normalized, "events", "time_us", true); err == nil || !strings.Contains(err.Error(), "row count exceeds payload bytes") {
+		t.Fatalf("truncated payload err=%v want row-count payload validation failure", err)
 	}
 
 	corrupt := append([]byte(nil), raw...)

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -96,6 +96,7 @@ type columnPhysicalScanSnapshotView struct {
 	AssetRefs          []columnManifestAssetRefForScan
 	AggregateMetadata  []columnManifestAggregateMetadataSnapshot
 	DictionaryCodes    []columnManifestDictionaryCodesSnapshot
+	Int64Values        []columnManifestInt64ValuesSnapshot
 	MutationParts      int
 	Diagnostics        columnPhysicalScanDiagnostics
 	ColumnAssetRootDir string
@@ -276,6 +277,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 	view.AssetRefs = refs
 	view.AggregateMetadata = manifest.AggregateMetadata
 	view.DictionaryCodes = manifest.DictionaryCodes
+	view.Int64Values = manifest.Int64Values
 	view.MutationParts = mutationParts
 	view.Diagnostics = diag
 	return view, nil
@@ -438,7 +440,8 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
 			!bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) &&
 			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) &&
-			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
+			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -524,7 +527,8 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
 			!bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) &&
 			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) &&
-			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
+			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes) {
 			break
 		}
 		if iter.IsDeleted() {
@@ -661,6 +665,34 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
+		case bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			keyGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(key)
+			if err != nil {
+				return columnManifestPlannerCapabilitiesForScan{}, err
+			}
+			if keyGeneration > header.generation {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", keyGeneration, header.generation)
+			}
+			values, err := decodeColumnManifestInt64ValuesRecord(key, value)
+			if err != nil {
+				return columnManifestPlannerCapabilitiesForScan{}, err
+			}
+			if values.AssetRef.Namespace != cfg.AssetManager.Namespace {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values namespace=%q want %q", values.AssetRef.Namespace, cfg.AssetManager.Namespace)
+			}
+			partNamespace, ok := livePartNamespaces[[2]uint64{values.AssetRef.Generation, values.AssetRef.PartID}]
+			if !ok {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", values.AssetRef.Generation, values.AssetRef.PartID)
+			}
+			if values.AssetRef.Namespace != partNamespace {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values namespace=%q does not match part namespace=%q", values.AssetRef.Namespace, partNamespace)
+			}
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
 		}
 		iter.Next()
 	}
@@ -767,6 +799,14 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 			if dictionaryGeneration <= generation {
 				active = append(active, record)
 			}
+		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
+			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(record.key)
+			if err != nil {
+				return nil, err
+			}
+			if valuesGeneration <= generation {
+				active = append(active, record)
+			}
 		}
 	}
 	return active, nil
@@ -823,6 +863,17 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 			}
 			if dictionaryGeneration > snapshot.Generation {
 				return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", dictionaryGeneration, snapshot.Generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
+			if !sawHeader {
+				continue
+			}
+			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(record.key)
+			if err != nil {
+				return columnManifestSnapshot{}, err
+			}
+			if valuesGeneration > snapshot.Generation {
+				return columnManifestSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", valuesGeneration, snapshot.Generation)
 			}
 		}
 	}
@@ -907,6 +958,7 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 	offset64 := cur.u64()
 	length64 := cur.u64()
 	checksum64 := cur.u64()
+	rows64 := cur.u64()
 	_ = cur.u64() // bytes; scan only needs the durable asset ref.
 	_ = cur.u64() // publish_id
 	_ = cur.u64() // generation_id
@@ -928,6 +980,9 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 	}
 	if checksum64 > uint64(math.MaxUint32) {
 		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part checksum overflows uint32")
+	}
+	if rows64 > uint64(maxCollectionInt) {
+		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part rows overflows int")
 	}
 	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) {
 		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part offsets or byte counts overflow int64")

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -720,7 +720,7 @@ func decodeColumnManifestHeaderRecordForScan(raw []byte) (columnManifestHeaderRe
 	if magic := cur.u32(); magic != columnManifestHeaderMagic {
 		return columnManifestHeaderRecordForScan{}, fmt.Errorf("collections: bad column manifest header magic=0x%08x", magic)
 	}
-	if version := cur.u16(); version != columnManifestRecordVersion {
+	if version := cur.u16(); version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
 		return columnManifestHeaderRecordForScan{}, fmt.Errorf("collections: unsupported column manifest header version=%d", version)
 	}
 	header := columnManifestHeaderRecordForScan{
@@ -947,7 +947,8 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 	if magic := cur.u32(); magic != columnManifestPartMagic {
 		return ColumnAssetRef{}, nil, fmt.Errorf("collections: bad column manifest part magic=0x%08x", magic)
 	}
-	if version := cur.u16(); version != columnManifestRecordVersion {
+	version := cur.u16()
+	if version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
 		return ColumnAssetRef{}, nil, fmt.Errorf("collections: unsupported column manifest part version=%d", version)
 	}
 	kindBytes := cur.stringBytes()
@@ -958,7 +959,10 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 	offset64 := cur.u64()
 	length64 := cur.u64()
 	checksum64 := cur.u64()
-	rows64 := cur.u64()
+	rows64 := uint64(0)
+	if version >= columnManifestRecordVersion {
+		rows64 = cur.u64()
+	}
 	_ = cur.u64() // bytes; scan only needs the durable asset ref.
 	_ = cur.u64() // publish_id
 	_ = cur.u64() // generation_id

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -46,6 +46,9 @@ const (
 	// ColumnAssetKindTCS1DictionaryCodes references low-cardinality dictionary
 	// codes derived from one declared dictionary string column in a TCS1 part.
 	ColumnAssetKindTCS1DictionaryCodes ColumnAssetKind = "tcs1_dictionary_codes"
+	// ColumnAssetKindTCS1Int64Values references dense int64 values derived from
+	// one non-null declared int64 column in a TCS1 part.
+	ColumnAssetKindTCS1Int64Values ColumnAssetKind = "tcs1_int64_values"
 )
 
 // ColumnAssetRef is the durable typed address of a column-asset-manager-owned
@@ -65,6 +68,7 @@ type ColumnAssetRef struct {
 // ColumnPreparedAsset describes an immutable asset staged for manifest publish.
 type ColumnPreparedAsset struct {
 	Ref          ColumnAssetRef
+	Rows         int
 	Bytes        int64
 	PublishID    uint64
 	GenerationID uint64
@@ -872,6 +876,7 @@ func validateColumnPublishClosureMatchesPrepared(prepared ColumnPublishPreparedA
 
 type columnPreparedAssetMatchKey struct {
 	Ref          ColumnAssetRef
+	Rows         int
 	Bytes        int64
 	PublishID    uint64
 	GenerationID uint64
@@ -880,6 +885,7 @@ type columnPreparedAssetMatchKey struct {
 func columnPreparedAssetMatchKeyOf(asset ColumnPreparedAsset) columnPreparedAssetMatchKey {
 	return columnPreparedAssetMatchKey{
 		Ref:          asset.Ref,
+		Rows:         asset.Rows,
 		Bytes:        asset.Bytes,
 		PublishID:    asset.PublishID,
 		GenerationID: asset.GenerationID,
@@ -889,6 +895,9 @@ func columnPreparedAssetMatchKeyOf(asset ColumnPreparedAsset) columnPreparedAsse
 func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 	if err := validateColumnAssetRefForPlan(asset.Ref); err != nil {
 		return err
+	}
+	if asset.Rows < 0 {
+		return fmt.Errorf("collections: column prepared asset rows=%d cannot be negative", asset.Rows)
 	}
 	if asset.Bytes <= 0 {
 		return fmt.Errorf("collections: column prepared asset bytes=%d must be positive", asset.Bytes)
@@ -901,7 +910,7 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 
 func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	switch ref.Kind {
-	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes:
+	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values:
 	default:
 		if ref.Kind == "" {
 			return errors.New("collections: column asset ref kind is required")

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -516,6 +516,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	prepared.ColumnPayloadBytes = summary.PayloadBytes
 	prepared.Assets = []ColumnPreparedAsset{{
 		Ref:          ref,
+		Rows:         summary.RowCount,
 		Bytes:        ref.Length,
 		PublishID:    hookInput.AppliedCommandLSN,
 		GenerationID: generation,
@@ -541,10 +542,37 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
 				Ref:          dictionaryRef,
+				Rows:         summary.RowCount,
 				Bytes:        dictionaryRef.Length,
 				PublishID:    hookInput.AppliedCommandLSN,
 				GenerationID: generation,
 				Reason:       dictionary.ColumnName,
+			})
+		}
+		int64Assets, err := buildColumnInt64ValuesAssets(hookInput.ColumnStore, rows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
+		if err != nil {
+			return ColumnPublishPreparedAssets{}, err
+		}
+		for _, values := range int64Assets {
+			encodedValues, err := encodeColumnInt64ValuesAsset(values)
+			if err != nil {
+				return ColumnPublishPreparedAssets{}, err
+			}
+			valuesRef, err := writeColumnInt64ValuesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedValues, generation, partID)
+			if err != nil {
+				return ColumnPublishPreparedAssets{}, err
+			}
+			if valuesRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || valuesRef.Kind != ColumnAssetKindTCS1Int64Values ||
+				valuesRef.Generation != generation || valuesRef.PartID != partID || valuesRef.Length != int64(len(encodedValues)) {
+				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid int64 values asset ref %+v", valuesRef)
+			}
+			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
+				Ref:          valuesRef,
+				Rows:         summary.RowCount,
+				Bytes:        valuesRef.Length,
+				PublishID:    hookInput.AppliedCommandLSN,
+				GenerationID: generation,
+				Reason:       values.ColumnName,
 			})
 		}
 		for _, aggregate := range hookInput.ColumnStore.AggregateMetadata {
@@ -569,6 +597,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
 				Ref:          metadataRef,
+				Rows:         summary.RowCount,
 				Bytes:        metadataRef.Length,
 				PublishID:    hookInput.AppliedCommandLSN,
 				GenerationID: generation,

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -1694,6 +1694,9 @@ func columnStoreQueryThroughputInterpretation(q columnStoreQueryMetric) string {
 	case columnStorePathBTreeIndexBaseline:
 		return "decode-bound B-tree baseline: full unbounded secondary-index walk plus JSON row materialization before reduction; " + markPruning + evidence
 	case columnStorePathSerialColumnScan:
+		if q.DictionaryCodeHits > 0 && q.Int64ValueHits > 0 {
+			return fmt.Sprintf("dictionary-code and int64-value sidecar serial path: dictionary_hits=%d int64_hits=%d avoid full TCPA row-record scan for covered declared columns; setup/read/decode still occurs in this routed measurement; %s%s", q.DictionaryCodeHits, q.Int64ValueHits, markPruning, evidence)
+		}
 		if q.DictionaryCodeHits > 0 {
 			return fmt.Sprintf("dictionary-code sidecar serial path: %d sidecar hits avoid full TCPA row-record scan for declared dictionary columns; setup/read/decode still occurs in this routed measurement; %s%s", q.DictionaryCodeHits, markPruning, evidence)
 		}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -169,6 +169,7 @@ type columnStoreQueryMetric struct {
 	ProductionHash           uint64  `json:"production_hash"`
 	MetadataHits             int     `json:"metadata_hits"`
 	DictionaryCodeHits       int     `json:"dictionary_code_hits"`
+	Int64ValueHits           int     `json:"int64_value_hits"`
 	SkippedGranules          int     `json:"skipped_granules"`
 	ScheduledGranules        int     `json:"scheduled_granules"`
 	WorkerCount              int     `json:"worker_count"`
@@ -203,6 +204,7 @@ type columnStoreQueryExecution struct {
 	ResultCount            int
 	MetadataHits           int
 	DictionaryCodeHits     int
+	Int64ValueHits         int
 	SkippedGranules        int
 	ScheduledGranules      int
 	WorkerCount            int
@@ -1144,6 +1146,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			ProductionHash:         hash,
 			MetadataHits:           exec.MetadataHits,
 			DictionaryCodeHits:     exec.DictionaryCodeHits,
+			Int64ValueHits:         exec.Int64ValueHits,
 			SkippedGranules:        exec.SkippedGranules,
 			ScheduledGranules:      exec.ScheduledGranules,
 			WorkerCount:            exec.WorkerCount,
@@ -1348,6 +1351,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		ResultCount:            resultCount,
 		MetadataHits:           diag.MetadataHits,
 		DictionaryCodeHits:     diag.DictionaryCodeHits,
+		Int64ValueHits:         diag.Int64ValueHits,
 		SkippedGranules:        diag.SkippedGranules,
 		ScheduledGranules:      diag.ScheduledGranules,
 		WorkerCount:            workers,
@@ -1693,6 +1697,9 @@ func columnStoreQueryThroughputInterpretation(q columnStoreQueryMetric) string {
 		if q.DictionaryCodeHits > 0 {
 			return fmt.Sprintf("dictionary-code sidecar serial path: %d sidecar hits avoid full TCPA row-record scan for declared dictionary columns; setup/read/decode still occurs in this routed measurement; %s%s", q.DictionaryCodeHits, markPruning, evidence)
 		}
+		if q.Int64ValueHits > 0 {
+			return fmt.Sprintf("int64-value sidecar serial path: %d sidecar hits avoid full TCPA row-record scan for declared int64 columns; setup/read/decode still occurs in this routed measurement; %s%s", q.Int64ValueHits, markPruning, evidence)
+		}
 		return "physical serial scan: TCPA decode plus reducer aggregation over declared columns; memory-bandwidth bound on asset bytes when cache-warm; " + markPruning + evidence
 	case columnStorePathAggregateMetadata:
 		if q.MetadataHits > 0 {
@@ -1723,7 +1730,7 @@ func columnStoreQueryInterpretationEvidence(q columnStoreQueryMetric) string {
 	if rowsProcessedOK {
 		rowsProcessedText = strconv.Itoa(rowsProcessed)
 	}
-	return fmt.Sprintf("; effective_rows_processed=%s row_materializations=%s bytes_read=%d metadata_hits=%d dictionary_code_hits=%d scheduled_granules=%d skipped_granules=%d", rowsProcessedText, rowMaterializations, q.BytesRead, q.MetadataHits, q.DictionaryCodeHits, q.ScheduledGranules, q.SkippedGranules)
+	return fmt.Sprintf("; effective_rows_processed=%s row_materializations=%s bytes_read=%d metadata_hits=%d dictionary_code_hits=%d int64_value_hits=%d scheduled_granules=%d skipped_granules=%d", rowsProcessedText, rowMaterializations, q.BytesRead, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.ScheduledGranules, q.SkippedGranules)
 }
 
 func populateColumnStoreThroughputInterpretations(queries []columnStoreQueryMetric) {
@@ -2027,8 +2034,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|\n")
+	sb.WriteString("| query | plan | rows/s | MiB/s | ns/row | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|\n")
 	for _, q := range report.Queries {
 		parity := "pass"
 		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
@@ -2042,8 +2049,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 		if note != "" {
 			noteCell = markdownCodeTableText(note)
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.PlanLabel), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.PlanLabel), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1516,6 +1516,15 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 			}
 			continue
 		}
+		if q.Name == columnStoreQueryQ3 {
+			if q.Int64ValueHits == 0 {
+				t.Fatalf("query %s int64_value_hits=%d want sidecar hits", q.Name, q.Int64ValueHits)
+			}
+			if !strings.Contains(q.ThroughputInterpretation, "int64-value sidecar serial path") {
+				t.Fatalf("query %s throughput_interpretation=%q want int64 sidecar classification", q.Name, q.ThroughputInterpretation)
+			}
+			continue
+		}
 		if !strings.Contains(q.ThroughputInterpretation, "physical serial scan") {
 			t.Fatalf("query %s throughput_interpretation=%q want serial physical classification", q.Name, q.ThroughputInterpretation)
 		}


### PR DESCRIPTION
## Benchmark Claim Boundary

Measurement class: `prepared hot runner / warmed repeated Run()` numbers below are repeated `Run()` calls after `PrepareColumnPhysicalQuery`. They do not include sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, or mutation handling.

Measurement class: `routed unified-bench query path` numbers below are durable production collection runs through `unified-bench -suite column_store` with `-column-store-path serial_column_scan`; q3 now reaches the int64-value sidecar path and q4/q5 remain TCPA row-record scans.

## Static Analysis / Priority Checkpoint

This PR follows the current #1634 priority read: the largest gap versus `experiments/colgranule` is representation and kernel shape, not another local TCPA cursor skip. Production q3 previously decoded row-record-shaped TCPA assets for a single non-null int64 column. This PR adds a typed dense int64 sidecar for non-null declared int64 columns and routes q3 `HourCount(time_us)` over that dense sidecar when the manifest is insert-only and fully covered.

This is still tactical, not the final schema-fixed column-block format. It proves the next representation lever for q3 while preserving the typed column-asset-manager lifecycle, manifest reachability, rewrite/remap, reopen validation, and routed reporting boundaries.

## What Landed

- Added `tcs1_int64_values` typed column asset refs and immutable dense int64 sidecar assets for non-null declared int64 columns.
- Published int64 sidecars beside existing TCPA part images, dictionary code sidecars, and aggregate metadata assets for insert batches.
- Extended binary manifest records, scan snapshots, reachability, GC/rewrite ref validation, and manifest rewrite patching so int64 sidecars are first-class durable refs.
- Added q3 serial/prepared execution over dense int64 sidecars, with full manifest part coverage required and fail-closed row-count validation against manifest part rows.
- Added `int64_value_hits` reporting to `unified-bench` and throughput interpretation text that distinguishes q3 sidecar scans from q4/q5 TCPA scans.

## Measurement Class

- Measurement class: `prepared hot runner / warmed repeated Run()` for `BenchmarkColumnPhysicalQueryRunnerM1634`.
- Measurement class: `direct package scanner` for `BenchmarkColumnPhysicalQueryAdapterM13B`.
- Measurement class: `routed unified-bench query path` for durable 100K `unified-bench -suite column_store`.
- Measurement class: `experiment/granule baseline` for fresh `experiments/colgranule` dense-code and encoded JSONBench runs on this machine.
- Measurement class: `historical ClickHouse context` from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64.

Measurement class: `prepared hot runner / warmed repeated Run()`. Prepared hot runner, 8,192 rows, `-benchtime=1000x -count=3`:

- q1 dictionary sidecar: `0.403-0.442 ns/row`, `2.26-2.48B rows/s`, `0 allocs/op`.
- q2 dictionary sidecar: `0.666-0.678 ns/row`, `1.48-1.50B rows/s`, `0 allocs/op`.
- q3 int64 sidecar: `1.182-1.192 ns/row`, `839-846M rows/s`, `0 allocs/op`.
- q4a TCPA row-record: `73.95-82.56 ns/row`, `12.1-13.5M rows/s`, `0 allocs/op`.
- q4b TCPA row-record: `84.32-89.12 ns/row`, `11.2-11.9M rows/s`, `0 allocs/op`.
- q5 TCPA row-record: `82.10-86.10 ns/row`, `11.6-12.2M rows/s`, `0 allocs/op`.

Measurement class: `direct package scanner`. Direct package scanner / adapter, 8,192 rows, `-benchtime=200x -count=3`:

- Initial q3 int64 sidecar snapshot: `8.179-8.324 ns/row`, `120-122M rows/s`, `75,817 B/op`, `94 allocs/op`.
- Review-fix q3 int64 sidecar snapshot after changing one-shot execution to stream sidecars per part instead of retaining all decoded sidecars: `8.427-13.15 ns/row`, `76.0-118.7M rows/s`, `75,505-75,507 B/op`, `92 allocs/op`; one sample was a noisy outlier, but allocation pressure moved down and peak retention is bounded by part rather than total rows.
- Final review-fix q3 benchmark after prevalidating full sidecar coverage, guarding truncated payload row-count allocation, and adding prepared q3 hot-path coverage: direct/package q3 `8.642-8.976 ns/row`, `111.4-115.7M rows/s`, `75,499-75,500 B/op`, `92 allocs/op`; prepared q3 `1.220-1.316 ns/row`, `759.9-819.7M rows/s`, `0 allocs/op`.
- Latest review-followup q3 benchmark after adding v1/v2 manifest decode compatibility across full decode, scan-time, and rewrite patch paths, sharing the int64 sidecar read/decode iterator, and gating q3 before opening the read cache: direct/package q3 `8.465-8.599 ns/row`, `116.3-118.1M rows/s`, `75,499-75,500 B/op`, `92 allocs/op`; prepared q3 `1.190-1.197 ns/row`, `835.3-840.3M rows/s`, `0 allocs/op`.
- q1/q2 dictionary sidecar context: q1 `12.99-13.34 ns/row`, `96 allocs/op`; q2 `22.59-22.74 ns/row`, `119 allocs/op`.
- q4/q5 TCPA context: q4a `78.21-78.31 ns/row`, q4b `89.08-90.11 ns/row`, q5 `86.94-87.57 ns/row`, each `136 allocs/op`.

Measurement class: `routed unified-bench query path`. Routed production `unified-bench`, durable 100K fixture, `serial_column_scan`, read integrity `verify`:

- Initial routed q3 snapshot retained decoded sidecars across the routed run: q3 `2.7 ns/row`, `374.2M rows/s`, `811,100 B/read`, `int64_value_hits=100`.
- Review-fix routed snapshot streams int64 sidecars per part to avoid O(total rows) decoded-sidecar retention: q1 `2.4 ns/row`, `424.4M rows/s`, `423,600 B/read`, `dictionary_code_hits=100`; q2 `2.1 ns/row`, `481.3M rows/s`, `2,335,100 B/read`, `dictionary_code_hits=100`; q3 `8.8 ns/row`, `113.9M rows/s`, `811,100 B/read`, `int64_value_hits=100`.
- Review-fix q4/q5 routed TCPA row-record context: q4a `102.6 ns/row`, q4b `97.1 ns/row`, q5 `107.5 ns/row`, q5_metadata `110.7 ns/row`.
- Review-fix byte accounting: `source_document_bytes=9,368,750`, `retained_payload_bytes=3,368,750`, `column_asset_bytes=21,399,500`, `manifest_control_bytes=28`, `command_wal_bytes_before_checkpoint=11,182,573`, `db_total_bytes=35,998,639`.

## End-to-End Comparable Snapshot

Current routed production reaches the optimized path for q3: `int64_value_hits=100` under `serial_column_scan`. It also reaches the prior q1/q2 dictionary sidecar paths. q4/q5 still use existing TCPA row-record scans except the older aggregate metadata shapes. The latest review-fix routed evidence uses part-streamed q3 sidecars, so its q3 number is lower throughput than the initial retaining snapshot but has the intended bounded-retention execution shape.

Experiment/granule baseline, fresh same-machine context:

- Dense code kernels remain `0 allocs/op`: count codes `2.317-2.438 ns/row`, grouped count `1.949 ns/row`, filtered grouped count `0.4910 ns/row`.
- Encoded JSONBench q3: `5.074 ns/row`, `197.1M rows/s`, `5 allocs/op`.
- Encoded JSONBench context: q1 `2.376 ns/row`, q2 `4.129 ns/row`, q5 `7.035 ns/row`, q4b ClickHouse-order `11.07 ns/row`.

Historical ClickHouse context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: local ClickHouse 1M q1/q2/q3/q4/q5 was approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`; old granule best kernels were q1 `0.004284s`, q2 `0.038895s`, q3 `0.006631s`, q4 `0.009869s`, q5 `0.010027s`. This is historical context only, not an apples-to-apples routed production run.

Scale note: the latest routed q3 measurement here is a 100K-row scan at `8.8 ns/row`, about `0.878 ms` scan time in the report. Do not read `8.8 ns/row` as `8.8 ms` unless the row count makes that true; lifecycle stages are reported separately. As a scale check, 1M rows at `8.8 ns/row` extrapolates to about `8.8 ms`, while 1M rows at `90 ns/row` extrapolates to about `90 ms`.

## Throughput Interpretation

The q3 win comes from avoiding TCPA row-record framing for a single int64 column and running a dense `[24]int` hour reducer over typed sidecar values. This is representation/kernel-shape work, not mmap/pread/checksum work.

Prepared q3 now has granule-style hot-loop allocation behavior at `0 allocs/op`. The direct package and routed measurements still allocate for setup, decoding/translation, manifest/read-cache work, and reporting boundaries; those are intentionally outside the prepared hot-loop claim. The review-fix one-shot/routed path intentionally trades some q3 throughput for bounded decoded-sidecar retention by streaming per part.

q4/q5 remain bounded by TCPA row-record decode until future PRs add real aggregate metadata, mark pruning, or schema-fixed column-block sidecars for those shapes.

## Gate Status

- q3 parity passes against the JSONBench-shaped reference hash.
- q3 serial path reports `int64_value_hits` and `row_materializations=0`.
- Prepared q3 hot runner is `0 allocs/op` and now has explicit prepared-runner parity/allocation test coverage.
- Manifest binary decoding accepts v1 and v2 records across full decode, scan-time, and rewrite patch paths; new writes remain v2 so legacy v1 part records decode with missing row counts as zero instead of failing open.
- Int64 sidecar refs are manifest-enumerable, reachability/GC-visible, and rewrite/remap-compatible.
- Sidecar decode validates kind, namespace, generation/part, schema hash, recovery LSN, checksum when enabled, expected column, declared non-null int64 type, and row-count agreement with the manifest part.

## Tests Run

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnDictionary|TestColumnInt64|TestColumnManifest|TestColumnAssetRewrite' -count=1`
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner(Int64ValueSidecarParityAndAllocation|DistinctSidecarParityAndAllocation|ParityAndAllocation)M1634|TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634|TestColumnInt64ValuesAssetCodecRejectsCorruptionM1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnManifestRecordDecodeAcceptsV1CompatibilityM1634|TestColumnPhysicalQueryRunnerInt64ValueSidecarParityAndAllocationM1634|TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634|TestColumnInt64ValuesAssetCodecRejectsCorruptionM1634' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `git diff --check`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/(q1|q2|q3|q4a|q4b|q4b_metadata|q5|q5_metadata)_rows_8192$' -benchmem -benchtime=200x -count=3`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryRunnerM1634/(q1|q2|q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=1000x -count=3`
- `/tmp/gomap_1634_int64_unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial_column_scan -progress=false -format markdown`
- `GOWORK=off go test ./experiments/colgranule -run '^$' -bench 'BenchmarkCountUint32CodesGranule|BenchmarkAggregateGroupedCountCodes|BenchmarkAggregateFilteredGroupedCountCodes|BenchmarkJSONBenchEncodedPartQueries/(Q1|Q2|Q3|Q4b_clickhouse_order|Q5)$' -benchmem -benchtime=100x -count=1`

## Artifacts

- Initial direct/package adapter benchmark: `/tmp/gomap_1634_int64_sidecar_adapter_20260520_220136.txt`
- Review-fix direct/package adapter benchmark: `/tmp/gomap_1634_int64_sidecar_adapter_reviewfix_20260520_221721.txt`
- Final review-fix q3 direct/prepared benchmark: `/tmp/gomap_1634_int64_sidecar_reviewfix2_bench_20260520_222317.txt`
- Latest review-followup q3 direct/prepared benchmark: `/tmp/gomap_1634_int64_sidecar_reviewfix3_bench_20260520_223939.txt`
- Prepared runner benchmark: `/tmp/gomap_1634_int64_sidecar_runner_20260520_220147.txt`
- Initial routed production snapshot: `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/column_store_results.md`
- Review-fix routed production snapshot: `/tmp/gomap_1634_int64_sidecar_routed_reviewfix_20260520_221740/column_store_results.md`
- Review-fix routed production HTML: `/tmp/gomap_1634_int64_sidecar_routed_reviewfix_20260520_221740/column_store_results.html`
- Review-fix routed production JSON: `/tmp/gomap_1634_int64_sidecar_routed_reviewfix_20260520_221740/column_store_results.json`
- Routed production HTML: `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/column_store_results.html`
- Routed production JSON: `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/column_store_results.json`
- Routed benchprof JSON/MD: `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/benchprof_results.json`, `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/benchprof_results.md`
- Routed profiles: `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/cpu_column_store_treedb_column_store.pprof`, `/tmp/gomap_1634_int64_sidecar_routed_20260520_220207/allocs_column_store_treedb_column_store.pprof`
- Fresh granule dense-code baseline: `/tmp/gomap_1634_int64_sidecar_granule_20260520_215610.txt`
- Fresh granule JSONBench baseline: `/tmp/gomap_1634_int64_sidecar_granule_jsonbench_20260520_215626.txt`

## Assumption Ledger

- Int64 sidecars are insert-only for this PR; mutation visibility still falls back/fails closed rather than using the sidecar path.
- Only non-null declared int64 columns are sidecar-eligible.
- This PR does not add mark pruning, mmap reader changes, real q4/q5 metadata fast paths, or a full schema-fixed column-block format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for int64-value column assets and hour-count queries on non-nullable int64 columns
  * Query diagnostics now include int64-value hit counts

* **Improvements**
  * Manifest, publish and scan flows updated to account for int64-value sidecars and row counts
  * Encoding/decoding and validation strengthened for int64-value assets
  * Benchmarks and reporting include int64-value metrics

* **Tests**
  * Added tests for int64-value asset codec, query parity, diagnostics, and manifest decoding compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

