### PR TITLE
TreeDB column store post-V1: add dictionary/int64 group sidecar scans

### DIFF
--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -1,0 +1,398 @@
+package collections
+
+import (
+	"fmt"
+	"time"
+)
+
+const columnDictionaryInt64GroupMaxGroups = 1 << 20
+
+type columnDictionaryInt64GroupRunner struct {
+	groupColumn string
+	valueColumn string
+	kind        ColumnPhysicalQueryKind
+	groupDict   []string
+	assets      []columnDictionaryInt64GroupAsset
+	seen        []uint64
+	minValues   []int64
+	maxValues   []int64
+	result      []ColumnPhysicalQueryGroup
+	assetBytes  int64
+}
+
+type columnDictionaryInt64GroupAsset struct {
+	groupCodes []uint32
+	values     []int64
+}
+
+func prepareColumnDictionaryInt64GroupRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryInt64GroupRunner, error) {
+	if req.AggregateMetadataName != "" || !columnDictionaryInt64GroupQueryKind(req.Kind) || req.GroupColumn == "" || req.ValueColumn == "" || view.MutationParts != 0 {
+		return nil, nil
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: dictionary/int64 query missing read cache")
+	}
+	if !columnDictionaryInt64GroupColumnsEligible(view, req) {
+		return nil, nil
+	}
+	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	valueByPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(groupByPart) == 0 || len(valueByPart) == 0 || !columnDictionaryInt64GroupSnapshotsCoverParts(view, groupByPart, valueByPart) {
+		return nil, nil
+	}
+	runner := &columnDictionaryInt64GroupRunner{
+		groupColumn: req.GroupColumn,
+		valueColumn: req.ValueColumn,
+		kind:        req.Kind,
+		assets:      make([]columnDictionaryInt64GroupAsset, 0, len(view.AssetRefs)),
+	}
+	groupByValue := make(map[string]uint32)
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		groupSnapshot := groupByPart[partKey]
+		valueSnapshot := valueByPart[partKey]
+		groupRaw, err := readCache.read(groupSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary/int64 group codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = groupRaw
+		groupAsset, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, readCache.verifyChecksum)
+		if err != nil {
+			return nil, err
+		}
+		valueRaw, err := readCache.read(valueSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary/int64 values read generation=%d part_id=%d column=%q: %w", valueSnapshot.AssetRef.Generation, valueSnapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = valueRaw
+		valueAsset, err := decodeColumnInt64ValuesAsset(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
+		if err != nil {
+			return nil, err
+		}
+		if len(groupAsset.Codes) != len(valueAsset.Values) || len(valueAsset.Values) != valueSnapshot.Rows {
+			return nil, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), len(valueAsset.Values), valueSnapshot.Rows)
+		}
+		groupCodes := make([]uint32, len(groupAsset.Codes))
+		for codeIdx, localCode := range groupAsset.Codes {
+			value := groupAsset.Dictionary[localCode]
+			globalCode, ok := groupByValue[value]
+			if !ok {
+				if len(runner.groupDict) >= columnDictionaryInt64GroupMaxGroups || uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
+					return nil, nil
+				}
+				globalCode = uint32(len(runner.groupDict))
+				groupByValue[value] = globalCode
+				runner.groupDict = append(runner.groupDict, value)
+			}
+			groupCodes[codeIdx] = globalCode
+		}
+		runner.assets = append(runner.assets, columnDictionaryInt64GroupAsset{
+			groupCodes: groupCodes,
+			values:     valueAsset.Values,
+		})
+		runner.assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
+	}
+	if len(runner.assets) == 0 || len(runner.groupDict) == 0 {
+		return nil, nil
+	}
+	runner.initScratch()
+	return runner, nil
+}
+
+func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (ColumnPhysicalQueryResult, bool, error) {
+	if !columnDictionaryInt64GroupQueryKind(req.Kind) || req.GroupColumn == "" || req.ValueColumn == "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if readCache == nil {
+		return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 query missing read cache")
+	}
+	if !columnDictionaryInt64GroupColumnsEligible(view, req) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	valueByPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(groupByPart) == 0 || len(valueByPart) == 0 || !columnDictionaryInt64GroupSnapshotsCoverParts(view, groupByPart, valueByPart) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+
+	start := time.Now()
+	reducer := columnDictionaryInt64GroupOneShotReducer{
+		kind:         req.Kind,
+		groupByValue: make(map[string]uint32),
+	}
+	var scratch []byte
+	assetBytes := int64(0)
+	blocks := 0
+	rows := 0
+	for _, part := range view.AssetRefs {
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		groupSnapshot := groupByPart[partKey]
+		valueSnapshot := valueByPart[partKey]
+		groupRaw, err := readCache.read(groupSnapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 group codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = groupRaw
+		groupAsset, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, readCache.verifyChecksum)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		valueRaw, err := readCache.read(valueSnapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 values read generation=%d part_id=%d column=%q: %w", valueSnapshot.AssetRef.Generation, valueSnapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = valueRaw
+		valueAsset, err := decodeColumnInt64ValuesAsset(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, readCache.verifyChecksum)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		if len(groupAsset.Codes) != len(valueAsset.Values) || len(valueAsset.Values) != valueSnapshot.Rows {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), len(valueAsset.Values), valueSnapshot.Rows)
+		}
+		localToGlobal, ok := reducer.translateDictionary(groupAsset.Dictionary)
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		for rowIdx, localCode := range groupAsset.Codes {
+			reducer.reduceValue(localToGlobal[localCode], valueAsset.Values[rowIdx])
+			rows++
+		}
+		assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
+		blocks++
+	}
+	if blocks == 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	groups := reducer.groups()
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 2
+	diag.ScheduledGranules = blocks
+	diag.DecodedBlocks = blocks
+	diag.DirectReduceBlocks = blocks
+	diag.DictionaryCodeHits = blocks
+	diag.Int64ValueHits = blocks
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(groups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, true, nil
+}
+
+func columnDictionaryInt64GroupQueryKind(kind ColumnPhysicalQueryKind) bool {
+	return kind == ColumnPhysicalQueryGroupMinInt64 ||
+		kind == ColumnPhysicalQueryGroupMaxInt64 ||
+		kind == ColumnPhysicalQueryGroupInt64Span
+}
+
+func columnDictionaryInt64GroupColumnsEligible(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) bool {
+	groupCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.GroupColumn)
+	if !ok || groupCol.ValueType != ColumnStoreValueString || !groupCol.Dictionary {
+		return false
+	}
+	valueCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.ValueColumn)
+	if !ok || valueCol.ValueType != ColumnStoreValueInt64 || valueCol.Nullable {
+		return false
+	}
+	return true
+}
+
+func columnDictionaryInt64GroupSnapshotsCoverParts(view columnPhysicalScanSnapshotView, groupByPart map[[2]uint64]columnManifestDictionaryCodesSnapshot, valueByPart map[[2]uint64]columnManifestInt64ValuesSnapshot) bool {
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return false
+		}
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		if _, ok := groupByPart[partKey]; !ok {
+			return false
+		}
+		if _, ok := valueByPart[partKey]; !ok {
+			return false
+		}
+	}
+	return len(view.AssetRefs) > 0
+}
+
+func (r *columnDictionaryInt64GroupRunner) initScratch() {
+	groups := len(r.groupDict)
+	words := (groups + 63) / 64
+	r.seen = make([]uint64, words)
+	r.minValues = make([]int64, groups)
+	if r.kind == ColumnPhysicalQueryGroupInt64Span {
+		r.maxValues = make([]int64, groups)
+	}
+	r.result = make([]ColumnPhysicalQueryGroup, 0, groups)
+}
+
+func (r *columnDictionaryInt64GroupRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	clear(r.seen)
+	rows := 0
+	for _, asset := range r.assets {
+		for rowIdx, groupCode := range asset.groupCodes {
+			value := asset.values[rowIdx]
+			r.reduceValue(groupCode, value)
+			rows++
+		}
+	}
+	r.result = r.result[:0]
+	for code, key := range r.groupDict {
+		if !r.seenCode(uint32(code)) {
+			continue
+		}
+		value := r.minValues[code]
+		if r.kind == ColumnPhysicalQueryGroupInt64Span {
+			value = r.maxValues[code] - r.minValues[code]
+		}
+		r.result = append(r.result, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.result)
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 2
+	diag.ScheduledGranules = len(r.assets)
+	diag.DecodedBlocks = len(r.assets)
+	diag.DirectReduceBlocks = len(r.assets)
+	diag.DictionaryCodeHits = len(r.assets)
+	diag.Int64ValueHits = len(r.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(r.result)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.result, Diagnostics: diag}
+}
+
+func (r *columnDictionaryInt64GroupRunner) reduceValue(code uint32, value int64) {
+	idx := int(code)
+	word := idx / 64
+	mask := uint64(1) << uint(idx&63)
+	if r.seen[word]&mask == 0 {
+		r.seen[word] |= mask
+		r.minValues[idx] = value
+		if r.kind == ColumnPhysicalQueryGroupInt64Span {
+			r.maxValues[idx] = value
+		}
+		return
+	}
+	switch r.kind {
+	case ColumnPhysicalQueryGroupMinInt64:
+		if value < r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		if value > r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		if value < r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+		if value > r.maxValues[idx] {
+			r.maxValues[idx] = value
+		}
+	}
+}
+
+func (r *columnDictionaryInt64GroupRunner) seenCode(code uint32) bool {
+	idx := int(code)
+	return r.seen[idx/64]&(uint64(1)<<uint(idx&63)) != 0
+}
+
+type columnDictionaryInt64GroupOneShotReducer struct {
+	kind          ColumnPhysicalQueryKind
+	groupByValue  map[string]uint32
+	groupDict     []string
+	localToGlobal []uint32
+	seen          []uint64
+	minValues     []int64
+	maxValues     []int64
+	result        []ColumnPhysicalQueryGroup
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) translateDictionary(dictionary []string) ([]uint32, bool) {
+	if cap(r.localToGlobal) < len(dictionary) {
+		r.localToGlobal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.localToGlobal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		globalCode, ok := r.groupByValue[value]
+		if !ok {
+			if len(r.groupDict) >= columnDictionaryInt64GroupMaxGroups || uint64(len(r.groupDict)) == uint64(^uint32(0)) {
+				return nil, false
+			}
+			globalCode = uint32(len(r.groupDict))
+			r.groupByValue[value] = globalCode
+			r.groupDict = append(r.groupDict, value)
+			r.growScratch(len(r.groupDict))
+		}
+		localToGlobal[localCode] = globalCode
+	}
+	return localToGlobal, true
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) growScratch(groups int) {
+	words := (groups + 63) / 64
+	if len(r.seen) < words {
+		r.seen = append(r.seen, make([]uint64, words-len(r.seen))...)
+	}
+	if len(r.minValues) < groups {
+		r.minValues = append(r.minValues, make([]int64, groups-len(r.minValues))...)
+	}
+	if r.kind == ColumnPhysicalQueryGroupInt64Span && len(r.maxValues) < groups {
+		r.maxValues = append(r.maxValues, make([]int64, groups-len(r.maxValues))...)
+	}
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) reduceValue(code uint32, value int64) {
+	idx := int(code)
+	word := idx / 64
+	mask := uint64(1) << uint(idx&63)
+	if r.seen[word]&mask == 0 {
+		r.seen[word] |= mask
+		r.minValues[idx] = value
+		if r.kind == ColumnPhysicalQueryGroupInt64Span {
+			r.maxValues[idx] = value
+		}
+		return
+	}
+	switch r.kind {
+	case ColumnPhysicalQueryGroupMinInt64:
+		if value < r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		if value > r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		if value < r.minValues[idx] {
+			r.minValues[idx] = value
+		}
+		if value > r.maxValues[idx] {
+			r.maxValues[idx] = value
+		}
+	}
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) groups() []ColumnPhysicalQueryGroup {
+	r.result = r.result[:0]
+	for code, key := range r.groupDict {
+		word := code / 64
+		mask := uint64(1) << uint(code&63)
+		if r.seen[word]&mask == 0 {
+			continue
+		}
+		value := r.minValues[code]
+		if r.kind == ColumnPhysicalQueryGroupInt64Span {
+			value = r.maxValues[code] - r.minValues[code]
+		}
+		r.result = append(r.result, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.result)
+	return r.result
+}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -106,6 +106,7 @@ type ColumnPhysicalQueryRunner struct {
 	dictCount    *columnDictionaryCodeGroupCountRunner
 	dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
 	int64Hour    *columnInt64ValueHourCountRunner
+	dictInt64    *columnDictionaryInt64GroupRunner
 	metadata     *columnAggregateMetadataRunner
 	closed       bool
 }
@@ -214,6 +215,11 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		_ = readCache.close()
 		return nil, err
 	}
+	dictInt64, err := prepareColumnDictionaryInt64GroupRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	release = false
 	return &ColumnPhysicalQueryRunner{
 		collection:   c,
@@ -225,6 +231,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		dictCount:    dictCount,
 		dictDistinct: dictDistinct,
 		int64Hour:    int64Hour,
+		dictInt64:    dictInt64,
 		metadata:     metadata,
 	}, nil
 }
@@ -263,6 +270,9 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.int64Hour != nil {
 		return r.int64Hour.run(r.view, r.req), nil
+	}
+	if r.dictInt64 != nil {
+		return r.dictInt64.run(r.view, r.req), nil
 	}
 	if r.metadata != nil {
 		return r.metadata.run(r.view, r.req), nil
@@ -572,6 +582,9 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 	if result, ok, err := c.runColumnPhysicalQueryInt64ValuesInSnapshotView(view, req); ok {
 		return result, err
 	}
+	if result, ok, err := c.runColumnPhysicalQueryDictionaryInt64InSnapshotView(view, req); ok {
+		return result, err
+	}
 	if result, ok, err := c.runColumnPhysicalQueryDirectInSnapshotView(view, req, 0, 0, nil); ok {
 		if err != nil {
 			if errors.Is(err, errColumnPhysicalQueryNeedsVisibility) {
@@ -656,6 +669,30 @@ func (c *Collection) runColumnPhysicalQueryInt64ValuesInSnapshotView(view column
 	defer func() { _ = readCache.close() }()
 
 	result, ok, err := runColumnInt64ValueHourCountOneShot(view, req, &readCache)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	if !ok {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	result.Diagnostics.SegmentFileCacheHits = readCache.hits
+	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	return result, true, nil
+}
+
+func (c *Collection) runColumnPhysicalQueryDictionaryInt64InSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 ||
+		!columnDictionaryInt64GroupQueryKind(req.Kind) || req.GroupColumn == "" || req.ValueColumn == "" {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+
+	result, ok, err := runColumnDictionaryInt64GroupOneShot(view, req, &readCache)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, true, err
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -364,7 +364,12 @@ func TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B(t *testing.T) {
 			if got, want := parallel.Diagnostics.ScheduledGranules, serial.Diagnostics.ScheduledGranules; got != want {
 				t.Fatalf("parallel scheduled granules=%d want serial %d diagnostics=%+v", got, want, parallel.Diagnostics)
 			}
-			if tc.req.Kind == ColumnPhysicalQueryGroupCount || tc.req.Kind == ColumnPhysicalQueryGroupCountDistinct || tc.req.Kind == ColumnPhysicalQueryHourCount {
+			if tc.req.Kind == ColumnPhysicalQueryGroupCount ||
+				tc.req.Kind == ColumnPhysicalQueryGroupCountDistinct ||
+				tc.req.Kind == ColumnPhysicalQueryHourCount ||
+				tc.req.Kind == ColumnPhysicalQueryGroupMinInt64 ||
+				tc.req.Kind == ColumnPhysicalQueryGroupMaxInt64 ||
+				tc.req.Kind == ColumnPhysicalQueryGroupInt64Span {
 				if serial.Diagnostics.PhysicalBytesScanned <= 0 || serial.Diagnostics.PhysicalBytesScanned >= parallel.Diagnostics.PhysicalBytesScanned {
 					t.Fatalf("serial sidecar bytes=%d want below parallel TCPA bytes=%d serial=%+v parallel=%+v", serial.Diagnostics.PhysicalBytesScanned, parallel.Diagnostics.PhysicalBytesScanned, serial.Diagnostics, parallel.Diagnostics)
 				}
@@ -1354,9 +1359,14 @@ func TestColumnStoreQueryAndReconstructionFailClosedMissingAssetM13C(t *testing.
 
 func TestColumnStoreQueryAndReconstructionFailClosedCorruptAssetM13C(t *testing.T) {
 	dir, ref := prepareColumnPhysicalScannerCorruptionFixtureM13A(t)
+	sidecarRef := columnPhysicalQueryInt64SidecarRefForCorruption(t, dir)
 	assetPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), ref)
 	if err != nil {
 		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	sidecarPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), sidecarRef)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath sidecar: %v", err)
 	}
 	file, err := os.OpenFile(assetPath, os.O_RDWR, 0)
 	if err != nil {
@@ -1368,6 +1378,17 @@ func TestColumnStoreQueryAndReconstructionFailClosedCorruptAssetM13C(t *testing.
 	}
 	if err := file.Close(); err != nil {
 		t.Fatalf("Close corrupt asset: %v", err)
+	}
+	sidecarFile, err := os.OpenFile(sidecarPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile sidecar asset: %v", err)
+	}
+	if _, err := sidecarFile.WriteAt([]byte{0xff}, sidecarRef.Offset); err != nil {
+		_ = sidecarFile.Close()
+		t.Fatalf("corrupt sidecar asset: %v", err)
+	}
+	if err := sidecarFile.Close(); err != nil {
+		t.Fatalf("Close corrupt sidecar asset: %v", err)
 	}
 
 	reopen := openCollectionCommandWALDB(t, dir)
@@ -1383,23 +1404,52 @@ func TestColumnStoreQueryAndReconstructionFailClosedCorruptAssetM13C(t *testing.
 
 func TestColumnStoreQueryAndReconstructionFailClosedTruncatedAssetM13C(t *testing.T) {
 	dir, ref := prepareColumnPhysicalScannerCorruptionFixtureM13A(t)
+	sidecarRef := columnPhysicalQueryInt64SidecarRefForCorruption(t, dir)
 	assetPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), ref)
 	if err != nil {
 		t.Fatalf("columnAssetSegmentPath: %v", err)
 	}
+	sidecarPath, err := columnAssetSegmentPath(backenddb.ColumnAssetRootDirPath(dir), sidecarRef)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath sidecar: %v", err)
+	}
 	if err := os.Truncate(assetPath, ref.Offset+ref.Length-1); err != nil {
 		t.Fatalf("Truncate asset: %v", err)
+	}
+	if err := os.Truncate(sidecarPath, sidecarRef.Offset+sidecarRef.Length-1); err != nil {
+		t.Fatalf("Truncate sidecar asset: %v", err)
 	}
 
 	reopen := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = reopen.Close() }()
 	reopened := openColumnStoreCollectionM10B(t, reopen)
-	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}); !errors.Is(err, io.ErrUnexpectedEOF) {
-		t.Fatalf("RunColumnPhysicalQuery truncated asset err=%v want io.ErrUnexpectedEOF", err)
+	if _, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}); err == nil || (!errors.Is(err, io.ErrUnexpectedEOF) && !strings.Contains(err.Error(), "checksum")) {
+		t.Fatalf("RunColumnPhysicalQuery truncated asset err=%v want fail-closed checksum/EOF failure", err)
 	}
-	if got, err := reopened.Get([]byte("e1")); !errors.Is(err, io.ErrUnexpectedEOF) || got != nil {
-		t.Fatalf("Get truncated asset got=%s err=%v want fail-closed io.ErrUnexpectedEOF", got, err)
+	if got, err := reopened.Get([]byte("e1")); got != nil || err == nil || (!errors.Is(err, io.ErrUnexpectedEOF) && !strings.Contains(err.Error(), "checksum")) {
+		t.Fatalf("Get truncated asset got=%s err=%v want fail-closed checksum/EOF failure", got, err)
 	}
+}
+
+func columnPhysicalQueryInt64SidecarRefForCorruption(t *testing.T, dir string) ColumnAssetRef {
+	t.Helper()
+	db := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = db.Close() }()
+	collection := openColumnStoreCollectionM10B(t, db)
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	for _, ref := range view.Int64Values {
+		if ref.ColumnName == "time_us" {
+			return ref.AssetRef
+		}
+	}
+	t.Fatalf("missing time_us int64 sidecar refs=%+v", view.Int64Values)
+	return ColumnAssetRef{}
 }
 
 func TestColumnPhysicalAssetScanRejectsWrongNamespaceM13C(t *testing.T) {
@@ -2002,6 +2052,85 @@ func TestColumnPhysicalQueryRunnerInt64ValueSidecarParityAndAllocationM1634(t *t
 	}
 }
 
+func TestColumnPhysicalQueryRunnerDictInt64SidecarParityAndAllocationM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
+	tests := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+	}{
+		{
+			name: "q4a",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+		{
+			name: "q4b",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+		{
+			name: "q5",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := columnPhysicalQueryReferenceHashM13B(tc.name, events)
+			runner, err := collection.PrepareColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+			}
+			defer func() {
+				if err := runner.Close(); err != nil {
+					t.Fatalf("runner Close: %v", err)
+				}
+			}()
+			wantGroups := 0
+			for i := 0; i < 3; i++ {
+				result, err := runner.Run()
+				if err != nil {
+					t.Fatalf("runner Run warmup %d: %v", i, err)
+				}
+				if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B(tc.name, result.Groups)); got != wantHash {
+					t.Fatalf("runner %s hash=%d want %d groups=%+v", tc.name, got, wantHash, result.Groups)
+				}
+				if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+					t.Fatalf("runner diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+				}
+				if result.Diagnostics.ProjectedColumns != 2 {
+					t.Fatalf("runner projected columns=%d want did+time_us sidecars", result.Diagnostics.ProjectedColumns)
+				}
+				if result.Diagnostics.DictionaryCodeHits == 0 || result.Diagnostics.DictionaryCodeHits != result.Diagnostics.ScheduledGranules {
+					t.Fatalf("runner dictionary hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.DictionaryCodeHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+				}
+				if result.Diagnostics.Int64ValueHits == 0 || result.Diagnostics.Int64ValueHits != result.Diagnostics.ScheduledGranules {
+					t.Fatalf("runner int64 hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.Int64ValueHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+				}
+				if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+					t.Fatalf("runner physical bytes=%d want sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
+				}
+				if result.Diagnostics.SegmentFileCacheMisses != 0 {
+					t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared sidecar setup", result.Diagnostics)
+				}
+				wantGroups = len(result.Groups)
+			}
+			allocs := testing.AllocsPerRun(20, func() {
+				result, err := runner.Run()
+				if err != nil {
+					panic(fmt.Sprintf("runner Run: %v", err))
+				}
+				if len(result.Groups) != wantGroups {
+					panic(fmt.Sprintf("runner groups=%d want %d", len(result.Groups), wantGroups))
+				}
+			})
+			if allocs != 0 {
+				t.Fatalf("runner %s warmed allocs/run=%.2f want 0", tc.name, allocs)
+			}
+		})
+	}
+}
+
 func TestColumnPhysicalQuerySerialDictionarySidecarParityM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(2048)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
@@ -2086,6 +2215,60 @@ func TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634(t *testing.T) {
 	}
 	if result.Diagnostics.SegmentFileCacheMisses == 0 {
 		t.Fatalf("serial int64 sidecar diagnostics=%+v want one-shot sidecar read misses accounted", result.Diagnostics)
+	}
+}
+
+func TestColumnPhysicalQuerySerialDictInt64SidecarParityM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	tcpBytes := columnPhysicalQueryTCPAAssetBytesM1634(t, collection)
+	tests := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+	}{
+		{
+			name: "q4a",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+		{
+			name: "q4b",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+		{
+			name: "q5",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := columnPhysicalQueryReferenceHashM13B(tc.name, events)
+			result, err := collection.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery: %v", err)
+			}
+			if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B(tc.name, result.Groups)); got != wantHash {
+				t.Fatalf("serial sidecar %s hash=%d want %d groups=%+v", tc.name, got, wantHash, result.Groups)
+			}
+			if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReduceRows != len(events) {
+				t.Fatalf("serial sidecar diagnostics=%+v want direct reduce over %d rows", result.Diagnostics, len(events))
+			}
+			if result.Diagnostics.ProjectedColumns != 2 {
+				t.Fatalf("serial sidecar projected columns=%d want did+time_us sidecars", result.Diagnostics.ProjectedColumns)
+			}
+			if result.Diagnostics.DictionaryCodeHits == 0 || result.Diagnostics.DictionaryCodeHits != result.Diagnostics.ScheduledGranules {
+				t.Fatalf("serial sidecar dictionary hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.DictionaryCodeHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+			}
+			if result.Diagnostics.Int64ValueHits == 0 || result.Diagnostics.Int64ValueHits != result.Diagnostics.ScheduledGranules {
+				t.Fatalf("serial sidecar int64 hits=%d scheduled=%d diagnostics=%+v", result.Diagnostics.Int64ValueHits, result.Diagnostics.ScheduledGranules, result.Diagnostics)
+			}
+			if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned >= tcpBytes {
+				t.Fatalf("serial sidecar physical bytes=%d want dictionary+int64 sidecars below TCPA bytes=%d", result.Diagnostics.PhysicalBytesScanned, tcpBytes)
+			}
+			if result.Diagnostics.SegmentFileCacheMisses == 0 {
+				t.Fatalf("serial sidecar diagnostics=%+v want one-shot sidecar read misses accounted", result.Diagnostics)
+			}
+		})
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1525,6 +1525,15 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 			}
 			continue
 		}
+		if q.Name == columnStoreQueryQ4A || q.Name == columnStoreQueryQ4B || q.Name == columnStoreQueryQ5 || q.Name == columnStoreQueryQ5Metadata {
+			if q.DictionaryCodeHits == 0 || q.Int64ValueHits == 0 {
+				t.Fatalf("query %s dictionary_code_hits=%d int64_value_hits=%d want dictionary+int64 sidecar hits", q.Name, q.DictionaryCodeHits, q.Int64ValueHits)
+			}
+			if !strings.Contains(q.ThroughputInterpretation, "dictionary-code and int64-value sidecar serial path") {
+				t.Fatalf("query %s throughput_interpretation=%q want dictionary+int64 sidecar classification", q.Name, q.ThroughputInterpretation)
+			}
+			continue
+		}
 		if !strings.Contains(q.ThroughputInterpretation, "physical serial scan") {
 			t.Fatalf("query %s throughput_interpretation=%q want serial physical classification", q.Name, q.ThroughputInterpretation)
 		}


### PR DESCRIPTION
Refs #1634

## Benchmark Claim Boundary

This PR extends production sidecar execution for q4/q5-shaped grouped int64 queries. Prepared hot-runner numbers below are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery`; they exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.

Routed `unified-bench` numbers are reported separately. In this PR, forced `serial_column_scan` reaches the new dictionary-code + int64-value sidecar serial path for q4a/q4b/q5 and for `q5_metadata` when it is running as a serial q5 alias rather than the forced aggregate-metadata plan.

## Static Analysis / Priority Checkpoint

The prior #1675 evidence showed q3 moved because production stopped decoding TCPA row records and instead reduced over typed int64 value sidecars. A fresh static pass over the current production path and `experiments/colgranule` kept the same center of gravity: q4/q5 were still downstream of row-record-shaped physical assets, while the experiment kernels use fixed typed vectors/dense reducers.

This PR therefore does not chase another TCPA cursor micro-optimization. It uses the already-published `did` dictionary-code sidecars and `time_us` int64-value sidecars together, translates part-local dictionary codes into one dense query domain at prepare/scan time, and reduces q4a/q4b/q5 over dense `uint32` group codes plus `int64` value arrays.

## What Landed

- Added a production dictionary+int64 group sidecar path for `GroupMinInt64`, `GroupMaxInt64`, and `GroupInt64Span` when complete insert-only sidecars cover every physical part.
- Added a prepared runner path with reusable dense scratch so warmed q4a/q4b/q5 `Run()` calls stay at `0 allocs/op`.
- Added a serial one-shot path used by `RunColumnPhysicalQuery`/forced `serial_column_scan`, with diagnostics reporting both `dictionary_code_hits` and `int64_value_hits`.
- Preserved fail-closed/fallback behavior for aggregate metadata requests, mutation-bearing manifests, unsupported column shapes, missing/incomplete sidecars, excessive cardinality, row-count mismatches, and corrupt/truncated sidecars.
- Strengthened parity, corruption, truncation, allocation, and unified-bench classification tests.

## Measurement Class

- Measurement class: `prepared hot runner / warmed repeated Run()` for `BenchmarkColumnPhysicalQueryRunnerM1634` q4a/q4b/q5.
- Measurement class: `direct package scanner` for `BenchmarkColumnPhysicalQueryAdapterM13B` q4a/q4b/q5/q5_metadata.
- Measurement class: `routed unified-bench query path` for 100K durable forced `serial_column_scan`.
- Measurement class: `experiment/granule baseline` for fresh `experiments/colgranule` q4/q5 context on the same machine.
- Measurement class: `historical ClickHouse context` from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Performance / Benchmark Evidence

Hardware: Apple M3, darwin/arm64.

Measurement class: `prepared hot runner / warmed repeated Run()`.

Current PR, rows 8192, `0 allocs/op`:

- q4a: `19.66-20.17 us/op`, `2.390-2.437 ns/row`, `410-418M rows/s`, `0 allocs/op`.
- q4b: `24.86-25.16 us/op`, `3.024-3.057 ns/row`, `327-331M rows/s`, `0 allocs/op`.
- q5: `21.57-21.87 us/op`, `2.624-2.658 ns/row`, `376-381M rows/s`, `0 allocs/op`.

Base #1675 prepared q4/q5 TCPA context:

- q4a: `613.1 us/op`, `74.82 ns/row`, `13.37M rows/s`, `0 allocs/op`.
- q4b: `697.7 us/op`, `85.15 ns/row`, `11.74M rows/s`, `0 allocs/op`.
- q5: `679.4 us/op`, `82.92 ns/row`, `12.06M rows/s`, `0 allocs/op`.

Measurement class: `direct package scanner`.

Current PR, rows 8192:

- q4a: `104.7-107.2 us/op`, `12.73-13.03 ns/row`, `76.8-78.5M rows/s`, `130 allocs/op`.
- q4b: `108.0-111.6 us/op`, `13.13-13.55 ns/row`, `73.8-76.1M rows/s`, `130 allocs/op`.
- q5: `103.4-104.1 us/op`, `12.54-12.65 ns/row`, `79.0-79.7M rows/s`, `135 allocs/op`.
- q5_metadata adapter metadata path: `24.4-25.3 us/op`, `2.953-3.045 ns/row`, `328-339M rows/s`, `104 allocs/op`.

Base #1675 direct/package q4/q5 TCPA context:

- q4a: `654.4 us/op`, `79.79 ns/row`, `12.53M rows/s`, `128 allocs/op`.
- q4b: `736.4 us/op`, `89.82 ns/row`, `11.13M rows/s`, `128 allocs/op`.
- q5: `711.4 us/op`, `86.77 ns/row`, `11.52M rows/s`, `128 allocs/op`.

Adapter allocation note: this PR improves direct scanner throughput materially but does not claim direct adapter allocation parity. The prepared hot q4/q5 kernels are `0 allocs/op`; direct one-shot allocation remains dominated by sidecar read/decode/setup and result/reporting shape.

Measurement class: `routed unified-bench query path`.

100K durable forced `serial_column_scan`, `column_asset_read_integrity=verify`:

- q1 dictionary sidecar: `2.6 ns/row`, `378.8M rows/s`, `dictionary_code_hits=100`, `row_materializations=0`.
- q2 dictionary sidecar: `2.7 ns/row`, `368.7M rows/s`, `dictionary_code_hits=100`, `row_materializations=0`.
- q3 int64 sidecar: `8.9 ns/row`, `112.2M rows/s`, `int64_value_hits=100`, `row_materializations=0`.
- q4a dictionary+int64 sidecar: `39.8 ns/row`, `25.1M rows/s`, `dictionary_code_hits=100`, `int64_value_hits=100`, `row_materializations=0`.
- q4b dictionary+int64 sidecar: `41.2 ns/row`, `24.3M rows/s`, `dictionary_code_hits=100`, `int64_value_hits=100`, `row_materializations=0`.
- q5 dictionary+int64 sidecar: `40.5 ns/row`, `24.7M rows/s`, `dictionary_code_hits=100`, `int64_value_hits=100`, `row_materializations=0`.
- q5_metadata serial alias: `40.5 ns/row`, `24.7M rows/s`, `dictionary_code_hits=100`, `int64_value_hits=100`, `metadata_hits=0`, `row_materializations=0`.

Byte accounting from the same routed run: `source_document_bytes=9,368,750`, `retained_payload_bytes=3,368,750`, `column_asset_bytes=21,399,500`, `manifest_control_bytes=28`, `command_wal_bytes_before_checkpoint=11,182,573`, `db_total_bytes=35,998,639`.

## End-to-End Comparable Snapshot

Routed production execution now reaches optimized sidecar paths for q1/q2/q3/q4a/q4b/q5 under forced `serial_column_scan`; `q5_metadata` under serial scan is a q5 alias and uses dictionary+int64 sidecars with `metadata_hits=0`. Forced `aggregate_metadata` remains the path for typed aggregate metadata assets.

Measurement class: `experiment/granule baseline`, fresh same-machine context:

- Q4a time-ordered experiment path: `4,820 ns/row`, `207K rows/s`, `2 allocs/op` because it is the early-stop/top-shape fairness path and not comparable to the full grouped sidecar scan.
- Q4b ClickHouse-order row-scan experiment path: `12.48 ns/row`, `80.1M rows/s`, `2 allocs/op`.
- Q5 encoded experiment row-scan path: `7.123 ns/row`, `140.4M rows/s`, `5 allocs/op`.
- Q4b metadata experiment path: `3.321 ns/row`, `301.1M rows/s`, `2 allocs/op`.
- Q5 metadata experiment path: `2.406 ns/row`, `415.6M rows/s`, `2 allocs/op`.

Measurement class: `historical ClickHouse context`: the historical 1M-row JSONBench report in `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` listed local ClickHouse q1/q2/q3/q4/q5 at approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. These are stale context numbers, not same-commit production routed measurements.

## Throughput Interpretation

The prepared q4/q5 hot-runner improvement is representation/kernel-shape driven: the hot loop now scans dense translated group codes and int64 values instead of TCPA row-record values. This is why prepared q4/q5 moves from roughly `75-85 ns/row` to roughly `2.4-3.1 ns/row` while staying at `0 allocs/op`.

The routed 100K production numbers are lower than prepared hot-runner numbers because they include planner/query adapter setup, sidecar reads, decode/checksum/translation, unified-bench parity/reporting, and durable TreeDB lifecycle stages reported separately. Do not read the prepared `ns/row` numbers as end-to-end scan duration.

At this fixture scale, q4/q5 routed serial scans are about `3.8-4.0 ms` for 100K rows, or `~40 ns/row`. The prepared hot loop for 8192 rows is about `20-25 us/op`, or `~2.4-3.1 ns/row`; those are intentionally different measurement classes.

## Apples-to-Apples Limitations

- Prepared hot-runner results exclude read/decode/checksum/translation and all database lifecycle costs.
- Direct/package scanner results include sidecar decode/setup allocations but not the full unified-bench fixture/report lifecycle.
- Routed `unified-bench` results use a 100K synthetic fixture under durable TreeDB integration; the historical ClickHouse context used a 1M JSONBench fixture.
- Experiment q4a is an early-stop/top-shape fairness path and should not be compared directly to production full grouped q4a sidecar scans.
- Production q5_metadata under forced serial scan has `metadata_hits=0`; metadata-only experiment paths are context for future metadata assets, not a claim that this PR implements metadata pruning.
- This PR does not add marks/pruning, schema-fixed column blocks, mutation sidecar visibility, parallel sidecar execution, mmap/read-integrity changes, or routed prepared-session reuse.

## Gate Status / Tests Run

- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery(SerialDictInt64SidecarParity|RunnerDictInt64SidecarParityAndAllocation)M1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnStoreQueryAndReconstructionFailClosed(Corrupt|Truncated)AssetM13C|TestColumnPhysicalQueryParallelMatchesSerialInsertOnlyM14B|TestColumnPhysicalQueryRunnerAggregateMetadataParityAndAllocationM1634' -count=1`
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B' -count=1`
- `git diff --check`

## Artifacts

- Prepared runner benchmark: `/tmp/gomap_1634_dict_int64_group_20260520_233930/prepared_runner_bench.txt`
- Direct/package adapter benchmark: `/tmp/gomap_1634_dict_int64_group_20260520_233930/adapter_bench.txt`
- Base #1675 prepared runner benchmark: `/tmp/gomap_1634_dict_int64_group_20260520_233930/base_1675_prepared_runner_bench.txt`
- Base #1675 adapter benchmark: `/tmp/gomap_1634_dict_int64_group_20260520_233930/base_1675_adapter_bench.txt`
- Fresh granule q4/q5 context: `/tmp/gomap_1634_dict_int64_group_20260520_233930/granule_q4_q5_context.txt`
- Routed production snapshot: `/tmp/gomap_1634_dict_int64_group_routed_20260520_233549/column_store_results.md`
- Routed production HTML: `/tmp/gomap_1634_dict_int64_group_routed_20260520_233549/column_store_results.html`
- Routed production JSON: `/tmp/gomap_1634_dict_int64_group_routed_20260520_233549/column_store_results.json`
- Routed benchprof: `/tmp/gomap_1634_dict_int64_group_routed_20260520_233549/benchprof_results.json`, `/tmp/gomap_1634_dict_int64_group_routed_20260520_233549/benchprof_results.md`

## Assumption Ledger

- The dictionary+int64 group sidecar path is insert-only for this PR; mutation-aware sidecar visibility remains outside this optimization slice.
- The prepared runner owns decoded/translated sidecars and returns runner-owned group storage; callers must copy results if they need them after a later `Run()` or `Close()`.
- Direct one-shot adapter allocation is not the optimized hot-loop target in this PR; it remains a measured setup/decode/reporting cost for future prioritization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dictionary-based int64 group-by physical query execution supporting min/max/span aggregations with optimized asset lookups and diagnostic reporting.

* **Tests**
  * Expanded test coverage including dictionary-int64 sidecar validation, asset corruption/truncation handling, and serial/parallel execution parity checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->