### PR TITLE
TreeDB column store post-V1: stream bounded dictionary scans

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -1,11 +1,19 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
 
-const columnDictionaryCodeDistinctMaxSeenWords = 1 << 20
+const (
+	columnDictionaryCodeDistinctMaxSeenWords = 1 << 20
+	// Keep routed one-shot dictionary scans to small/medium payloads for now.
+	// Larger snapshots use the prepared runner path until routed sessions can
+	// reuse decoded dictionaries without moving setup into every query.
+	columnDictionaryCodeOneShotMaxBytes          = 3 << 20
+	columnDictionaryCodeDistinctOneShotMaxValues = 1 << 16
+)
 
 type columnDictionaryCodeGroupCountRunner struct {
 	column       string
@@ -41,6 +49,38 @@ type columnDictionaryCodeGroupCountDistinctPendingAsset struct {
 	group    columnDictionaryCodesAsset
 	distinct columnDictionaryCodesAsset
 	bytes    int64
+}
+
+type columnDictionaryCodeGroupCountOneShotReducer struct {
+	dictionary    []string
+	byValue       map[string]uint32
+	localToGlobal []uint32
+	counts        []int
+	result        []ColumnPhysicalQueryGroup
+}
+
+type columnDictionaryCodeGroupCountDistinctOneShotAsset struct {
+	groupRaw        []byte
+	groupPayload    columnDictionaryCodesAssetPayload
+	groupDictionary []string
+	distinctRaw     []byte
+	distinctPayload columnDictionaryCodesAssetPayload
+	distinctDict    []string
+	bytes           int64
+}
+
+type columnDictionaryCodeGroupCountDistinctOneShotReducer struct {
+	groupDict       []string
+	groupByValue    map[string]uint32
+	distinctByValue map[string]uint32
+	groupLocal      []uint32
+	distinctLocal   []uint32
+	groupCounts     []int
+	seen            []uint64
+	wordsPerGroup   int
+	assets          []columnDictionaryCodeGroupCountDistinctOneShotAsset
+	result          []ColumnPhysicalQueryGroup
+	assetBytes      int64
 }
 
 func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountRunner, error) {
@@ -148,6 +188,91 @@ func (r *columnDictionaryCodeGroupCountRunner) run(view columnPhysicalScanSnapsh
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
 	diag.ScanNanos = time.Since(start).Nanoseconds()
 	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}
+
+func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (ColumnPhysicalQueryResult, bool, error) {
+	if req.Kind != ColumnPhysicalQueryGroupCount || req.GroupColumn == "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if readCache == nil {
+		return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary code query missing read cache")
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.GroupColumn)
+	if !ok || col.ValueType != ColumnStoreValueString || !col.Dictionary {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	byPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	if len(byPart) == 0 || !columnDictionaryCodeSnapshotsCoverParts(view, byPart) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if bytes := columnDictionaryCodeSnapshotBytes(view, byPart); bytes > columnDictionaryCodeOneShotMaxBytes {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	start := time.Now()
+	reducer := columnDictionaryCodeGroupCountOneShotReducer{
+		dictionary: make([]string, 0, 16),
+		byValue:    make(map[string]uint32, 16),
+		counts:     make([]int, 0, 16),
+		result:     make([]ColumnPhysicalQueryGroup, 0, 16),
+	}
+	var scratch []byte
+	assetBytes := int64(0)
+	blocks := 0
+	rows := 0
+	for _, part := range view.AssetRefs {
+		snapshot := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		raw, err := readCache.read(snapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = raw
+		if !readCache.lastView {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		asset, payload, err := decodeColumnDictionaryCodesAssetPayload(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		localToGlobal, ok := reducer.translateDictionary(asset.Dictionary)
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		cur := manifestCursor{raw: raw, pos: payload.offset}
+		for i := 0; i < payload.rowCount; i++ {
+			localCode := cur.u32()
+			if int(localCode) >= len(localToGlobal) {
+				return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
+			}
+			reducer.counts[localToGlobal[localCode]]++
+			rows++
+		}
+		if cur.err != nil {
+			return ColumnPhysicalQueryResult{}, true, cur.err
+		}
+		if cur.pos != len(raw) {
+			return ColumnPhysicalQueryResult{}, true, errors.New("collections: trailing bytes in dictionary codes asset")
+		}
+		assetBytes += snapshot.AssetRef.Length
+		blocks++
+	}
+	if blocks == 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	groups := reducer.groups()
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 1
+	diag.ScheduledGranules = blocks
+	diag.DecodedBlocks = blocks
+	diag.DirectReduceBlocks = blocks
+	diag.DictionaryCodeHits = blocks
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(groups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, true, nil
 }
 
 func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountDistinctRunner, error) {
@@ -308,6 +433,33 @@ func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, co
 	return byPart
 }
 
+func columnDictionaryCodeSnapshotsCoverParts(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) bool {
+	for _, part := range view.AssetRefs {
+		if part.Reason != ColumnPublishOperationInsert {
+			return false
+		}
+		if _, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]; !ok {
+			return false
+		}
+	}
+	return len(view.AssetRefs) > 0
+}
+
+func columnDictionaryCodeSnapshotBytes(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) int64 {
+	var bytes int64
+	for _, part := range view.AssetRefs {
+		snapshot, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		if !ok {
+			return 0
+		}
+		if snapshot.AssetRef.Length > int64(maxCollectionInt)-bytes {
+			return int64(maxCollectionInt)
+		}
+		bytes += snapshot.AssetRef.Length
+	}
+	return bytes
+}
+
 func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
 	start := time.Now()
 	clear(r.groupCounts)
@@ -349,4 +501,287 @@ func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalSc
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
 	diag.ScanNanos = time.Since(start).Nanoseconds()
 	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}
+
+func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (ColumnPhysicalQueryResult, bool, error) {
+	if req.Kind != ColumnPhysicalQueryGroupCountDistinct || req.GroupColumn == "" || req.DistinctColumn == "" || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if req.GroupColumn == req.DistinctColumn {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if readCache == nil {
+		return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary code distinct query missing read cache")
+	}
+	groupCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.GroupColumn)
+	if !ok || groupCol.ValueType != ColumnStoreValueString || !groupCol.Dictionary {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	distinctCol, _, ok := columnPhysicalQueryDeclaredColumn(view.Config, req.DistinctColumn)
+	if !ok || distinctCol.ValueType != ColumnStoreValueString || !distinctCol.Dictionary {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	distinctByPart := columnDictionaryCodeSnapshotsByPart(view, req.DistinctColumn)
+	if len(groupByPart) == 0 || len(distinctByPart) == 0 || !columnDictionaryCodeSnapshotsCoverParts(view, groupByPart) || !columnDictionaryCodeSnapshotsCoverParts(view, distinctByPart) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if bytes := columnDictionaryCodeSnapshotBytes(view, groupByPart) + columnDictionaryCodeSnapshotBytes(view, distinctByPart); bytes > columnDictionaryCodeOneShotMaxBytes {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	start := time.Now()
+	reducer := columnDictionaryCodeGroupCountDistinctOneShotReducer{
+		groupDict:       make([]string, 0, 16),
+		groupByValue:    make(map[string]uint32, 16),
+		distinctByValue: make(map[string]uint32, 16),
+		assets:          make([]columnDictionaryCodeGroupCountDistinctOneShotAsset, 0, len(view.AssetRefs)),
+		result:          make([]ColumnPhysicalQueryGroup, 0, 16),
+	}
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		groupSnapshot := groupByPart[partKey]
+		distinctSnapshot := distinctByPart[partKey]
+		groupRaw, err := readCache.read(groupSnapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = groupRaw
+		if !readCache.lastView {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		groupAsset, groupPayload, err := decodeColumnDictionaryCodesAssetPayload(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		_, ok := reducer.translateGroupDictionary(groupAsset.Dictionary)
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		distinctRaw, err := readCache.read(distinctSnapshot.AssetRef, scratch)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn, err)
+		}
+		scratch = distinctRaw
+		if !readCache.lastView {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		distinctAsset, distinctPayload, err := decodeColumnDictionaryCodesAssetPayload(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		if groupPayload.rowCount != distinctPayload.rowCount {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", groupPayload.rowCount, distinctPayload.rowCount)
+		}
+		_, ok = reducer.translateDistinctDictionary(distinctAsset.Dictionary)
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		if len(reducer.distinctByValue) > columnDictionaryCodeDistinctOneShotMaxValues {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		_, _, ok, err = columnDictionaryCodeDistinctSeenWords(len(reducer.groupDict), len(reducer.distinctByValue))
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
+		}
+		reducer.assets = append(reducer.assets, columnDictionaryCodeGroupCountDistinctOneShotAsset{
+			groupRaw:        groupRaw,
+			groupPayload:    groupPayload,
+			groupDictionary: groupAsset.Dictionary,
+			distinctRaw:     distinctRaw,
+			distinctPayload: distinctPayload,
+			distinctDict:    distinctAsset.Dictionary,
+			bytes:           groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length,
+		})
+		reducer.assetBytes += groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length
+	}
+	if len(reducer.assets) == 0 || len(reducer.groupDict) == 0 || len(reducer.distinctByValue) == 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(len(reducer.groupDict), len(reducer.distinctByValue))
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	if !ok {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	reducer.wordsPerGroup = wordsPerGroup
+	reducer.groupCounts = make([]int, len(reducer.groupDict))
+	reducer.seen = make([]uint64, totalWords)
+	rows, err := reducer.reduceAssets()
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	groups := reducer.groups()
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = 2
+	diag.ScheduledGranules = len(reducer.assets)
+	diag.DecodedBlocks = len(reducer.assets)
+	diag.DirectReduceBlocks = len(reducer.assets)
+	diag.DictionaryCodeHits = len(reducer.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = reducer.assetBytes
+	diag.ReduceRows = rows
+	diag.ResultGroups = len(groups)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, true, nil
+}
+
+func (r *columnDictionaryCodeGroupCountOneShotReducer) translateDictionary(dictionary []string) ([]uint32, bool) {
+	if cap(r.localToGlobal) < len(dictionary) {
+		r.localToGlobal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.localToGlobal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		globalCode, ok := r.byValue[value]
+		if !ok {
+			if uint64(len(r.dictionary)) == uint64(^uint32(0)) {
+				return nil, false
+			}
+			globalCode = uint32(len(r.dictionary))
+			r.byValue[value] = globalCode
+			r.dictionary = append(r.dictionary, value)
+			r.counts = append(r.counts, 0)
+		}
+		localToGlobal[localCode] = globalCode
+	}
+	return localToGlobal, true
+}
+
+func (r *columnDictionaryCodeGroupCountOneShotReducer) groups() []ColumnPhysicalQueryGroup {
+	r.result = r.result[:0]
+	for code, count := range r.counts {
+		if count == 0 {
+			continue
+		}
+		r.result = append(r.result, ColumnPhysicalQueryGroup{
+			Key:   r.dictionary[code],
+			Count: count,
+		})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.result)
+	return r.result
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDictionary(dictionary []string) ([]uint32, bool) {
+	if cap(r.groupLocal) < len(dictionary) {
+		r.groupLocal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.groupLocal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		globalCode, ok := r.groupByValue[value]
+		if !ok {
+			if uint64(len(r.groupDict)) == uint64(^uint32(0)) {
+				return nil, false
+			}
+			globalCode = uint32(len(r.groupDict))
+			r.groupByValue[value] = globalCode
+			r.groupDict = append(r.groupDict, value)
+		}
+		localToGlobal[localCode] = globalCode
+	}
+	return localToGlobal, true
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateDistinctDictionary(dictionary []string) ([]uint32, bool) {
+	if cap(r.distinctLocal) < len(dictionary) {
+		r.distinctLocal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.distinctLocal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		globalCode, ok := r.distinctByValue[value]
+		if !ok {
+			if uint64(len(r.distinctByValue)) == uint64(^uint32(0)) {
+				return nil, false
+			}
+			globalCode = uint32(len(r.distinctByValue))
+			r.distinctByValue[value] = globalCode
+		}
+		localToGlobal[localCode] = globalCode
+	}
+	return localToGlobal, true
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateKnownGroupDictionary(dictionary []string) []uint32 {
+	if cap(r.groupLocal) < len(dictionary) {
+		r.groupLocal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.groupLocal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		localToGlobal[localCode] = r.groupByValue[value]
+	}
+	return localToGlobal
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateKnownDistinctDictionary(dictionary []string) []uint32 {
+	if cap(r.distinctLocal) < len(dictionary) {
+		r.distinctLocal = make([]uint32, len(dictionary))
+	}
+	localToGlobal := r.distinctLocal[:len(dictionary)]
+	for localCode, value := range dictionary {
+		localToGlobal[localCode] = r.distinctByValue[value]
+	}
+	return localToGlobal
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets() (int, error) {
+	rows := 0
+	for _, asset := range r.assets {
+		groupMap := r.translateKnownGroupDictionary(asset.groupDictionary)
+		distinctMap := r.translateKnownDistinctDictionary(asset.distinctDict)
+		groupCur := manifestCursor{raw: asset.groupRaw, pos: asset.groupPayload.offset}
+		distinctCur := manifestCursor{raw: asset.distinctRaw, pos: asset.distinctPayload.offset}
+		for i := 0; i < asset.groupPayload.rowCount; i++ {
+			groupLocal := groupCur.u32()
+			if int(groupLocal) >= len(groupMap) {
+				return 0, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, groupLocal, len(groupMap))
+			}
+			distinctLocal := distinctCur.u32()
+			if int(distinctLocal) >= len(distinctMap) {
+				return 0, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, distinctLocal, len(distinctMap))
+			}
+			groupCode := groupMap[groupLocal]
+			distinctCode := distinctMap[distinctLocal]
+			seenIdx := int(groupCode)*r.wordsPerGroup + int(distinctCode/64)
+			mask := uint64(1) << (distinctCode & 63)
+			if r.seen[seenIdx]&mask == 0 {
+				r.seen[seenIdx] |= mask
+				r.groupCounts[groupCode]++
+			}
+			rows++
+		}
+		if groupCur.err != nil {
+			return 0, groupCur.err
+		}
+		if distinctCur.err != nil {
+			return 0, distinctCur.err
+		}
+		if groupCur.pos != len(asset.groupRaw) {
+			return 0, errors.New("collections: trailing bytes in dictionary codes asset")
+		}
+		if distinctCur.pos != len(asset.distinctRaw) {
+			return 0, errors.New("collections: trailing bytes in dictionary codes asset")
+		}
+	}
+	return rows, nil
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) groups() []ColumnPhysicalQueryGroup {
+	r.result = r.result[:0]
+	for code, count := range r.groupCounts {
+		if count == 0 {
+			continue
+		}
+		r.result = append(r.result, ColumnPhysicalQueryGroup{
+			Key:   r.groupDict[code],
+			Count: count,
+		})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.result)
+	return r.result
 }

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -587,6 +587,9 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		if !ok {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
+		// groupRaw and distinctRaw are retained for the deferred second pass, so
+		// the path above requires mmap/view-backed reads and falls back before
+		// appending when reads are scratch-backed.
 		reducer.assets = append(reducer.assets, columnDictionaryCodeGroupCountDistinctOneShotAsset{
 			groupRaw:        groupRaw,
 			groupPayload:    groupPayload,

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -632,6 +632,17 @@ func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view co
 	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 
+	if result, ok, err := runColumnDictionaryCodeGroupCountOneShot(view, req, &readCache); ok {
+		result.Diagnostics.SegmentFileCacheHits = readCache.hits
+		result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+		return result, true, err
+	}
+	if result, ok, err := runColumnDictionaryCodeGroupCountDistinctOneShot(view, req, &readCache); ok {
+		result.Diagnostics.SegmentFileCacheHits = readCache.hits
+		result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+		return result, true, err
+	}
+
 	dictCount, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, true, err

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2185,6 +2185,55 @@ func TestColumnPhysicalQuerySerialDictionarySidecarParityM1634(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQuerySerialDictionaryDistinctOneShotRequiresViewBackedReadsM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}
+	copyCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity copy cache: %v", err)
+	}
+	defer func() {
+		if err := copyCache.close(); err != nil {
+			t.Fatalf("copy cache close: %v", err)
+		}
+	}()
+	copyCache.returnViews = false
+	if _, ok, err := runColumnDictionaryCodeGroupCountDistinctOneShot(view, req, &copyCache); err != nil || ok {
+		t.Fatalf("copy-backed one-shot ok=%v err=%v want clean fallback", ok, err)
+	}
+
+	viewCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity view cache: %v", err)
+	}
+	defer func() {
+		if err := viewCache.close(); err != nil {
+			t.Fatalf("view cache close: %v", err)
+		}
+	}()
+	viewCache.returnViews = true
+	result, ok, err := runColumnDictionaryCodeGroupCountDistinctOneShot(view, req, &viewCache)
+	if err != nil {
+		t.Fatalf("view-backed one-shot: %v", err)
+	}
+	if !ok {
+		t.Skip("column asset mmap views are unavailable on this platform")
+	}
+	if got := columnPhysicalQueryHashLinesM13B(columnPhysicalQueryLinesM13B("q2", result.Groups)); got != columnPhysicalQueryReferenceHashM13B("q2", events) {
+		t.Fatalf("view-backed one-shot q2 hash=%d want reference", got)
+	}
+}
+
 func TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(2048)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2283,6 +2283,16 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		maxAllocs float64
 	}{
 		{
+			name:      "q1_dictionary_codes",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+			maxAllocs: 93,
+		},
+		{
+			name:      "q2_dictionary_codes",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+			maxAllocs: 113,
+		},
+		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
 			maxAllocs: 90,


### PR DESCRIPTION
## What landed

This #1634 follow-up keeps the #1677 physical formats and manifest records unchanged, and adds a bounded routed one-shot scanner for small/medium dictionary-code q1/q2 scans:

- streams q1 dictionary-code payloads directly from view-backed `tcs1_dictionary_codes` assets instead of building decoded per-row `[]uint32` code arrays and translated per-row slices;
- streams q2 dictionary-code payloads for bounded small/medium payloads, with dense distinct scratch and no per-row translated sidecar arrays;
- falls back to the existing prepared dictionary runner for large dictionary payloads or high distinct cardinality until routed sessions can reuse decoded dictionaries without moving setup into every query;
- keeps planner semantics, physical asset formats, manifest records, WAL/checkpoint behavior, mutation fail-closed behavior, and prepared hot runners unchanged;
- extends the routed one-shot sidecar allocation-budget regression test to q1/q2;
- adds a regression test proving the deferred q2 one-shot reducer requires mmap/view-backed reads and cleanly falls back for scratch-backed reads instead of retaining reusable read buffers.

This is tactical #1634 work. It is not a schema-fixed column-block format, mark pruning, metadata fast path, routed prepared-session reuse, or mutation support.

## Measurement Class / Claim Boundary

- Measurement class: `direct package scanner` is the primary changed path in this PR. `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection; it includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction. It is not a prepared hot runner.
- Measurement class: `routed unified-bench query path` is the current end-to-end comparable production snapshot for q1-q5 query-stage behavior under durable `unified-bench`. The 1M routed q1/q2 snapshot stays on the existing prepared dictionary path because the new one-shot path is bounded to small/medium dictionary payloads.
- Measurement class: `prepared hot runner / warmed repeated Run()` is unchanged by this PR; #1672/#1676 remain the prepared sidecar hot-loop evidence and exclude sidecar read/decode/checksum/translation, planner routing, unified-bench reporting, writes, WAL/checkpoint, reopen, and mutation handling.
- Measurement class: `experiment/granule baseline` is context only from experiment kernels, not production durable TreeDB routing.
- Measurement class: `historical ClickHouse context` is stale/local context only, not rerun in this PR.

This PR does not report a new prepared hot-runner claim and does not claim end-to-end ClickHouse/granule parity.

## Static Analysis / Priority Checkpoint

After #1677, q3/q4/q5 routed one-shot scans stopped allocating decoded int64 value slices. The latest allocation profile still pointed at dictionary-code payload/materialization and manifest/view setup. The local safe slice was q1/q2 dictionary one-shot setup for small/medium payloads: avoid decoded `Codes` arrays and translated per-row slices where a view-backed payload can be streamed directly.

A 1M routed validation run exposed a scale boundary: q2 with 1M distinct `did` values should not build a fresh one-shot global distinct dictionary inside every routed query. This PR therefore keeps the one-shot scanner bounded by payload size and distinct cardinality, and leaves larger q1/q2 snapshots on the existing prepared runner path until routed prepared-session reuse is implemented.

## Performance / Benchmark Evidence

Local machine: Apple M3, darwin/arm64. Head: `db2a1eea2` (review-fix commit after initial `3930ccc0b`).

Measurement class: `direct package scanner`. Same-machine base #1677 vs this PR, 8,192 rows, `-benchtime=500x -count=5`:

```text
benchstat /tmp/gomap_1634_stream_dict_base_adapter_bench.txt /tmp/gomap_1634_stream_dict_adapter_bench_v3.txt
geomean sec/op: 138.8us -> 46.15us (-66.75%)
geomean ns/row: 16.93ns -> 5.625ns (-66.77%)
geomean rows/s: 59.07M -> 177.8M (+200.95%)
geomean B/op: 99.54Ki -> 10.27Ki (-89.69%)
geomean allocs/op: 102.5 -> 101.5 (-0.98%)
```

Representative current direct package scanner results:

```text
q1 rows_8192: 5.16-5.99 ns/row, 167.1-193.8M rows/s, 9.604 KiB/op, 92 allocs/op
q2 rows_8192: 5.93-6.11 ns/row, 163.7-168.5M rows/s, 10.97 KiB/op, 112 allocs/op
```

Measurement class: `prepared hot runner / warmed repeated Run()`. Prepared q1/q2 runner behavior is unchanged by this PR; the prior #1672 prepared q1/q2 sidecar evidence remains the hot-runner context: q1 about `2.2-2.5B rows/s`, q2 about `1.4-1.5B rows/s`, both `0 allocs/op`, after `PrepareColumnPhysicalQuery`.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production `unified-bench`, Apple M3, durable, 1,000,000 rows, forced `serial_column_scan`, read integrity `verify`:

```text
q1: 0.7 ns/row, 1.376B rows/s, dictionary_code_hits=200, row_materializations=0
q2: 0.9 ns/row, 1.073B rows/s, dictionary_code_hits=200, row_materializations=0
q3: 29.9 ns/row, 33.4M rows/s, int64_value_hits=200, row_materializations=0
q4a: 10.5 ns/row, 95.2M rows/s, dictionary_code_hits=200, int64_value_hits=200, row_materializations=0
q4b: 10.1 ns/row, 98.9M rows/s, dictionary_code_hits=200, int64_value_hits=200, row_materializations=0
q5: 10.5 ns/row, 94.9M rows/s, dictionary_code_hits=200, int64_value_hits=200, row_materializations=0
q5_metadata serial alias: 10.6 ns/row, 94.5M rows/s, metadata_hits=0; this is not the aggregate metadata fast path under this forced label
```

The 1M routed q1/q2 path does not use the new bounded one-shot scanner because dictionary payload bytes exceed the one-shot cap; it uses the existing prepared dictionary path. The direct package scanner evidence above is the changed path for this PR. The q3 number in this single routed run is treated as noisy current context, not as a q3 claim by this PR. Review-fix commit `db2a1eea2` did not change the measured hot path; it documents and tests the existing view-backed-read precondition for deferred q2 one-shot reduction.

Byte/accounting snapshot from the same routed run: `source_document_bytes=93,687,500`, `retained_payload_bytes=33,687,500`, `column_asset_bytes=139,245,400`, `manifest_control_bytes=28`, `command_wal_bytes_before_checkpoint=111,714,123`, checkpoint stage `204.673 ms`, `db_total_bytes=275,586,427`.

Measurement class: `experiment/granule baseline`. Prior fresh granule context remains the allocation/kernel target: dense grouped-code kernels remain `0 allocs/op`; encoded JSONBench context was q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q3 `~5.07 ns/row`, q5 `~7.04 ns/row`, q4b ClickHouse-order `~11.07 ns/row`. These are not apples-to-apples with routed durable production.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` remains stale/local context only: 1M q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`.

## Throughput Interpretation

The package-level win comes from eliminating decoded per-row dictionary-code arrays and translated per-row slices for bounded q1/q2 one-shot scans. The bytes/op reduction is the main signal: q1/q2 direct package scanner B/op drops by about 90%, while allocs/op also move slightly down instead of increasing.

The bounded fallback is intentional. For large routed snapshots, the existing prepared dictionary runner still wins because it keeps setup outside the measured repeated-reduce scan and avoids rebuilding a high-cardinality distinct dictionary inside every one-shot query. The next strategic path for large q1/q2 is routed prepared-session reuse or shared decoded dictionary/cache state, not an unbounded one-shot reducer.

Scale note: the q1/q2 direct package scanner results above are around `5-6 ns/row` for 8,192 rows, not `5-6 ms` scans. The 1M routed snapshot reports separate `ns/row` and scan milliseconds in `column_store_results.md`; compare by measurement class, not by mixing prepared, direct, routed, experiment, and ClickHouse numbers.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerial(DictionarySidecarParity|DictionaryDistinctOneShotRequiresViewBackedReads|SidecarAllocationBudget)M1634|TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test -race ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuerySerialDictionaryDistinctOneShotRequiresViewBackedReadsM1634' -count=1` passed.
- Direct package scanner benchmark and same-machine benchstat passed.
- Routed 1M durable `unified-bench` parity passed for q1-q5 and q5_metadata serial alias.
- `git diff --check` passed.

## Artifacts

- Base #1677 direct package scanner: `/tmp/gomap_1634_stream_dict_base_adapter_bench.txt`
- Current direct package scanner: `/tmp/gomap_1634_stream_dict_adapter_bench_v3.txt`
- Benchstat: `/tmp/gomap_1634_stream_dict_benchstat_q1q2_v3.txt`
- Current routed production 1M markdown: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/column_store_results.md`
- Current routed production 1M HTML: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/column_store_results.html`
- Current routed production 1M JSON: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/column_store_results.json`
- Current routed benchprof JSON/markdown: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/benchprof_results.json`, `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/benchprof_results.md`
- Current routed insights HTML: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/insights.html`
- Current routed CPU profile: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/cpu_column_store_treedb_column_store.pprof`
- Current routed allocs profile: `/tmp/gomap_1634_stream_dict_routed_1m_v3_20260521_011527/allocs_column_store_treedb_column_store.pprof`
- Historical ClickHouse/granule JSONBench comparison: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`

## Assumption Ledger / Remaining Work

- The one-shot dictionary scanner is intentionally bounded to small/medium payloads. Large snapshots remain on the prepared dictionary runner path until routed prepared-session reuse or shared decoded dictionary state lands. Deferred q2 one-shot reduction also requires view-backed asset reads; scratch-backed reads cleanly fall back before raw buffers are retained.
- Mutation-bearing manifests continue to fail closed/fallback through existing behavior; this PR does not enable mutation visibility.
- This does not change physical formats or add schema-fixed column blocks, dictionaries beyond existing sidecars, marks, locators, or metadata fast paths.
- The next #1634 PR should start with a fresh static/profile checkpoint and likely focus on routed prepared-session reuse or a measured q3/checksum regression, not another q1/q2 row-loop tweak.

Refs #1634.

