### PR TITLE
collections: fail closed stale column graph visibility

### DIFF
--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -487,19 +487,7 @@ func columnVectorGraphManifestMatchStatus(collection string, graph columnVectorG
 	if err != nil {
 		return columnVectorGraphManifestMatchMismatch
 	}
-	if !(graph.IndexName == def.Name &&
-		graph.Field == def.Field &&
-		graph.Metric == def.Metric &&
-		graph.Encoding == def.Encoding &&
-		graph.Dimensions == def.Dimensions &&
-		graph.M == def.M &&
-		graph.EfConstruction == def.EfConstruction &&
-		graph.EfSearch == def.EfSearch &&
-		graph.BaseSchemaHash == cfg.SchemaHash &&
-		graph.GraphSchemaHash == graphCfg.SchemaHash &&
-		graph.AssetRef.Kind == ColumnAssetKindTCS1PartImage &&
-		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
-		graph.AssetRef.Generation == graph.BaseManifestGeneration) {
+	if !columnVectorGraphCoreParametersMatch(&graph, &def, &cfg, &graphCfg) {
 		return columnVectorGraphManifestMatchMismatch
 	}
 	if graph.BaseManifestGeneration != cfg.ActiveManifest.Generation {
@@ -509,6 +497,30 @@ func columnVectorGraphManifestMatchStatus(collection string, graph columnVectorG
 		return columnVectorGraphManifestMatchMismatch
 	}
 	return columnVectorGraphManifestMatchLoaded
+}
+
+func columnVectorGraphCoreParametersMatch(graph *columnVectorGraphManifestSnapshot, def *VectorIndexDefinition, cfg *ColumnStoreConfig, graphCfg *ColumnStoreConfig) bool {
+	return columnVectorGraphDefinitionParametersMatch(graph, def) &&
+		columnVectorGraphAssetParametersMatch(graph, cfg, graphCfg)
+}
+
+func columnVectorGraphDefinitionParametersMatch(graph *columnVectorGraphManifestSnapshot, def *VectorIndexDefinition) bool {
+	return graph.IndexName == def.Name &&
+		graph.Field == def.Field &&
+		graph.Metric == def.Metric &&
+		graph.Encoding == def.Encoding &&
+		graph.Dimensions == def.Dimensions &&
+		graph.M == def.M &&
+		graph.EfConstruction == def.EfConstruction &&
+		graph.EfSearch == def.EfSearch
+}
+
+func columnVectorGraphAssetParametersMatch(graph *columnVectorGraphManifestSnapshot, cfg *ColumnStoreConfig, graphCfg *ColumnStoreConfig) bool {
+	return graph.BaseSchemaHash == cfg.SchemaHash &&
+		graph.GraphSchemaHash == graphCfg.SchemaHash &&
+		graph.AssetRef.Kind == ColumnAssetKindTCS1PartImage &&
+		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
+		graph.AssetRef.Generation == graph.BaseManifestGeneration
 }
 
 func columnVectorGraphBaseManifestChecksum(manifest columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig) (uint64, error) {

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -439,7 +439,14 @@ func (c *Collection) columnGraphVectorIndexStatusAtSnapshot(name string, snap *b
 		status.RebuildNeeded = true
 		return status, nil
 	}
-	if !columnVectorGraphManifestMatchesDefinition(catalog.meta.Name, graph, def, *cfg, manifest, records) {
+	switch columnVectorGraphManifestMatchStatus(catalog.meta.Name, graph, def, *cfg, manifest, records) {
+	case columnVectorGraphManifestMatchLoaded:
+	case columnVectorGraphManifestMatchUnsupportedVisibility:
+		status.State = VectorIndexStateColumnGraphRebuildNeeded
+		status.Reason = VectorIndexReasonColumnGraphUnsupportedVisibility
+		status.RebuildNeeded = true
+		return status, nil
+	default:
 		status.State = VectorIndexStateColumnGraphRebuildNeeded
 		status.Reason = VectorIndexReasonColumnGraphAssetMismatch
 		status.RebuildNeeded = true
@@ -456,19 +463,31 @@ func (c *Collection) columnGraphVectorIndexStatusAtSnapshot(name string, snap *b
 	return status, nil
 }
 
+type columnVectorGraphManifestMatch uint8
+
+const (
+	columnVectorGraphManifestMatchMismatch columnVectorGraphManifestMatch = iota
+	columnVectorGraphManifestMatchLoaded
+	columnVectorGraphManifestMatchUnsupportedVisibility
+)
+
 func columnVectorGraphManifestMatchesDefinition(collection string, graph columnVectorGraphManifestSnapshot, def VectorIndexDefinition, cfg ColumnStoreConfig, manifest columnManifestSnapshot, records []columnManifestRecord) bool {
+	return columnVectorGraphManifestMatchStatus(collection, graph, def, cfg, manifest, records) == columnVectorGraphManifestMatchLoaded
+}
+
+func columnVectorGraphManifestMatchStatus(collection string, graph columnVectorGraphManifestSnapshot, def VectorIndexDefinition, cfg ColumnStoreConfig, manifest columnManifestSnapshot, records []columnManifestRecord) columnVectorGraphManifestMatch {
 	if cfg.ActiveManifest == nil {
-		return false
+		return columnVectorGraphManifestMatchMismatch
 	}
 	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(collection, cfg, def)
 	if err != nil {
-		return false
+		return columnVectorGraphManifestMatchMismatch
 	}
 	baseChecksum, err := columnVectorGraphBaseManifestChecksum(manifest, records, cfg)
 	if err != nil {
-		return false
+		return columnVectorGraphManifestMatchMismatch
 	}
-	return graph.IndexName == def.Name &&
+	if !(graph.IndexName == def.Name &&
 		graph.Field == def.Field &&
 		graph.Metric == def.Metric &&
 		graph.Encoding == def.Encoding &&
@@ -476,13 +495,20 @@ func columnVectorGraphManifestMatchesDefinition(collection string, graph columnV
 		graph.M == def.M &&
 		graph.EfConstruction == def.EfConstruction &&
 		graph.EfSearch == def.EfSearch &&
-		graph.BaseManifestGeneration == cfg.ActiveManifest.Generation &&
-		graph.BaseManifestChecksum == baseChecksum &&
 		graph.BaseSchemaHash == cfg.SchemaHash &&
 		graph.GraphSchemaHash == graphCfg.SchemaHash &&
 		graph.AssetRef.Kind == ColumnAssetKindTCS1PartImage &&
 		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
-		graph.AssetRef.Generation == graph.BaseManifestGeneration
+		graph.AssetRef.Generation == graph.BaseManifestGeneration) {
+		return columnVectorGraphManifestMatchMismatch
+	}
+	if graph.BaseManifestGeneration != cfg.ActiveManifest.Generation {
+		return columnVectorGraphManifestMatchUnsupportedVisibility
+	}
+	if graph.BaseManifestChecksum != baseChecksum {
+		return columnVectorGraphManifestMatchMismatch
+	}
+	return columnVectorGraphManifestMatchLoaded
 }
 
 func columnVectorGraphBaseManifestChecksum(manifest columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig) (uint64, error) {

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -323,8 +323,8 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutationV2B(t *
 	if err != nil {
 		t.Fatalf("VectorIndexStatus: %v", err)
 	}
-	if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphAssetMismatch || !status.RebuildNeeded {
-		t.Fatalf("status=%+v want stale graph mismatch", status)
+	if status.State != VectorIndexStateColumnGraphRebuildNeeded || status.Reason != VectorIndexReasonColumnGraphUnsupportedVisibility || !status.RebuildNeeded {
+		t.Fatalf("status=%+v want stale graph unsupported visibility", status)
 	}
 	_, err = col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if !errors.Is(err, errColumnVectorGraphManifestMismatch) {

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -53,6 +53,7 @@ const (
 	VectorIndexReasonPhysicalColumnAssetSupportMissing VectorIndexReason = "physical_column_asset_support_missing"
 	VectorIndexReasonColumnGraphAssetMismatch          VectorIndexReason = "column_graph_asset_mismatch"
 	VectorIndexReasonColumnGraphCorrupt                VectorIndexReason = "column_graph_corrupt"
+	VectorIndexReasonColumnGraphUnsupportedVisibility  VectorIndexReason = "column_graph_unsupported_visibility"
 	VectorIndexReasonColumnGraphUnsupportedMetric      VectorIndexReason = "column_graph_unsupported_metric"
 	VectorIndexReasonUnsupportedStrategy               VectorIndexReason = "unsupported_vector_index_strategy"
 )

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -289,9 +289,9 @@ func TestColumnGraphRebuildVectorIndexMarksStaleAfterMutationV2A(t *testing.T) {
 		t.Fatalf("status after mutation=%+v, want stale/rebuild-needed", status)
 	}
 	switch status.Reason {
-	case VectorIndexReasonColumnGraphRebuildNeeded, VectorIndexReasonColumnGraphAssetMismatch:
+	case VectorIndexReasonColumnGraphRebuildNeeded, VectorIndexReasonColumnGraphAssetMismatch, VectorIndexReasonColumnGraphUnsupportedVisibility:
 	default:
-		t.Fatalf("status reason after mutation=%q, want rebuild-needed or asset-mismatch", status.Reason)
+		t.Fatalf("status reason after mutation=%q, want rebuild-needed, asset-mismatch, or unsupported visibility", status.Reason)
 	}
 }
 

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -480,6 +480,185 @@ func TestSearchVectorIndexColumnGraphStaleAfterMutationV4(t *testing.T) {
 	if got.Status.State != VectorIndexStateColumnGraphRebuildNeeded || !got.Status.RebuildNeeded {
 		t.Fatalf("status=%+v want stale graph to require rebuild", got.Status)
 	}
+	if got.Status.Reason != VectorIndexReasonColumnGraphUnsupportedVisibility {
+		t.Fatalf("status reason=%q want %q", got.Status.Reason, VectorIndexReasonColumnGraphUnsupportedVisibility)
+	}
+}
+
+func TestSearchVectorIndexColumnGraphMutationMatrixFailsClosedV5(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(testing.TB, *Collection)
+		query  []float32
+	}{
+		{
+			name: "insert_after_build",
+			mutate: func(tb testing.TB, col *Collection) {
+				insertColumnGraphRebuildRowsV2A(tb, col, []columnGraphRebuildInputRowV2A{
+					{id: "doc-c", vector: []float32{0, 0, 1}},
+				})
+			},
+			query: []float32{0, 0, 1},
+		},
+		{
+			name: "vector_update",
+			mutate: func(tb testing.TB, col *Collection) {
+				updateColumnGraphRebuildJSONDocumentV5(tb, col, "doc-a", []float32{0, 0, 1}, "vector-updated")
+			},
+			query: []float32{0, 0, 1},
+		},
+		{
+			name: "non_vector_payload_update",
+			mutate: func(tb testing.TB, col *Collection) {
+				updateColumnGraphRebuildJSONDocumentV5(tb, col, "doc-a", []float32{1, 0, 0}, "payload-updated")
+			},
+			query: []float32{1, 0, 0},
+		},
+		{
+			name: "delete",
+			mutate: func(tb testing.TB, col *Collection) {
+				deleted, err := col.DeleteDocument([]byte("doc-a"))
+				if err != nil {
+					tb.Fatalf("DeleteDocument: %v", err)
+				}
+				if !deleted {
+					tb.Fatalf("DeleteDocument deleted=false want true")
+				}
+			},
+			query: []float32{1, 0, 0},
+		},
+		{
+			name: "mixed_sequential_batch",
+			mutate: func(tb testing.TB, col *Collection) {
+				insertColumnGraphRebuildRowsV2A(tb, col, []columnGraphRebuildInputRowV2A{
+					{id: "doc-c", vector: []float32{0, 0, 1}},
+				})
+				updateColumnGraphRebuildJSONDocumentV5(tb, col, "doc-b", []float32{1, 0, 0}, "vector-updated")
+				deleted, err := col.DeleteDocument([]byte("doc-a"))
+				if err != nil {
+					tb.Fatalf("DeleteDocument: %v", err)
+				}
+				if !deleted {
+					tb.Fatalf("DeleteDocument deleted=false want true")
+				}
+			},
+			query: []float32{1, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := []columnGraphRebuildInputRowV2A{
+				{id: "doc-a", vector: []float32{1, 0, 0}},
+				{id: "doc-b", vector: []float32{0, 1, 0}},
+			}
+			_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+			defer func() { _ = d.Close() }()
+			status, err := col.RebuildVectorIndex(def.Name)
+			if err != nil {
+				t.Fatalf("RebuildVectorIndex: %v", err)
+			}
+			assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+
+			tt.mutate(t, col)
+
+			assertColumnGraphUnsupportedVisibilityStatusV5(t, col, def.Name)
+			got, err := col.SearchVectorIndex(VectorIndexSearchOptions{
+				IndexName:        def.Name,
+				Query:            tt.query,
+				TopK:             2,
+				EfSearch:         len(rows) + 1,
+				IncludeDocuments: true,
+				MaxDecodedBlocks: 1,
+			})
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !errors.Is(err, errColumnVectorGraphManifestMismatch) {
+				t.Fatalf("SearchVectorIndex err=%v want unavailable stale manifest mismatch", err)
+			}
+			if got.Path != "" || len(got.Results) != 0 || got.Stats.DocumentsFetched != 0 {
+				t.Fatalf("response path=%q results=%d docs=%d want no search results before rebuild", got.Path, len(got.Results), got.Stats.DocumentsFetched)
+			}
+			assertColumnGraphUnsupportedVisibilitySearchStatusV5(t, got.Status, def.Name)
+		})
+	}
+}
+
+func TestSearchVectorIndexColumnGraphMutationStaleStatusSurvivesReopenV5(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	dir, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	updateColumnGraphRebuildJSONDocumentV5(t, col, "doc-a", []float32{0, 0, 1}, "vector-updated")
+	assertColumnGraphUnsupportedVisibilityStatusV5(t, col, def.Name)
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	assertColumnGraphUnsupportedVisibilityStatusV5(t, reopenedCol, def.Name)
+	got, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            []float32{0, 0, 1},
+		TopK:             1,
+		EfSearch:         len(rows),
+		MaxDecodedBlocks: 1,
+	})
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !errors.Is(err, errColumnVectorGraphManifestMismatch) {
+		t.Fatalf("SearchVectorIndex reopen err=%v want unavailable stale manifest mismatch", err)
+	}
+	assertColumnGraphUnsupportedVisibilitySearchStatusV5(t, got.Status, def.Name)
+}
+
+func TestSearchVectorIndexColumnGraphSnapshotBoundSearcherSurvivesLaterMutationV5(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	updateColumnGraphRebuildJSONDocumentV5(t, col, "doc-a", []float32{0, 0, 1}, "vector-updated")
+	assertColumnGraphUnsupportedVisibilityStatusV5(t, col, def.Name)
+
+	got, err := searcher.Search(VectorIndexSearcherSearchOptions{
+		Query:            []float32{1, 0, 0},
+		TopK:             1,
+		EfSearch:         len(rows),
+		IncludeDocuments: true,
+	})
+	if err != nil {
+		t.Fatalf("snapshot-bound Search: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 1)
+	if string(got.Results[0].ID) != "doc-a" ||
+		!bytes.Contains(got.Results[0].Document, []byte(`"did":"doc-a"`)) ||
+		bytes.Contains(got.Results[0].Document, []byte(`"note":"vector-updated"`)) {
+		t.Fatalf("snapshot result id=%q doc=%s want old consistent generation", got.Results[0].ID, got.Results[0].Document)
+	}
 }
 
 func TestSearchVectorIndexNativeRuntimeDoesNotFallbackToColumnGraphV4(t *testing.T) {
@@ -671,6 +850,51 @@ func assertVectorIndexSearchResultsV4(tb testing.TB, got []VectorIndexSearchResu
 		if wantDocs && len(got[i].Document) == 0 {
 			tb.Fatalf("result[%d] missing materialized document", i)
 		}
+	}
+}
+
+func assertColumnGraphUnsupportedVisibilityStatusV5(tb testing.TB, col *Collection, name string) {
+	tb.Helper()
+	status, err := col.VectorIndexStatus(name)
+	if err != nil {
+		tb.Fatalf("VectorIndexStatus: %v", err)
+	}
+	assertColumnGraphUnsupportedVisibilitySearchStatusV5(tb, status, name)
+}
+
+func assertColumnGraphUnsupportedVisibilitySearchStatusV5(tb testing.TB, status VectorIndexStatus, name string) {
+	tb.Helper()
+	if status.Name != name || status.Strategy != VectorIndexStrategyColumnGraph {
+		tb.Fatalf("status=%+v want column_graph index %q", status, name)
+	}
+	if status.State != VectorIndexStateColumnGraphRebuildNeeded ||
+		status.Reason != VectorIndexReasonColumnGraphUnsupportedVisibility ||
+		!status.RebuildNeeded ||
+		status.Loaded {
+		tb.Fatalf("status=%+v want rebuild-needed unsupported visibility", status)
+	}
+}
+
+func updateColumnGraphRebuildJSONDocumentV5(tb testing.TB, col *Collection, id string, vector []float32, note string) {
+	tb.Helper()
+	replacement, err := json.Marshal(map[string]any{
+		"time_us":   int64(100),
+		"kind":      "vector",
+		"did":       id,
+		"embedding": vector,
+		"note":      note,
+	})
+	if err != nil {
+		tb.Fatalf("json.Marshal replacement: %v", err)
+	}
+	matched, modified, err := col.Update([]byte(id), func(current []byte) ([]byte, bool, error) {
+		return replacement, true, nil
+	})
+	if err != nil {
+		tb.Fatalf("Update %q: %v", id, err)
+	}
+	if !matched || !modified {
+		tb.Fatalf("Update %q matched=%t modified=%t want true/true", id, matched, modified)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is the V5 mutation/staleness PR for #1646, chained on top of #1669.

- Adds the public/status reason `column_graph_unsupported_visibility`.
- Classifies a column_graph manifest whose graph was built for an older base manifest generation as unsupported mutation visibility, not a generic asset mismatch.
- Keeps row-reader open/search fail-closed before any stale results are returned.
- Adds V5 mutation matrix, reopen persistence, and snapshot-bound searcher consistency tests.

## Copied/Adapted From Old Stack

- Copied: none.
- Adapted: existing V2A/V2B/V4 test helpers for building/rebuilding column_graph fixtures and public search assertions.
- Oracle/comparator only: none.
- Quarantined/not copied: decoded `ColumnVectorGraph` loader/search, dynamic overlay code, Deep1B/geometric experiments.

## Path Identity

- Native reader: unchanged hot path, `column_graph_native_reader` over the physical row reader.
- Decoded comparator: not used by this PR.
- Legacy/native vector index: unchanged.
- Unsupported/fail-closed: mutation-bearing current manifests whose graph record points at an older base generation now report `column_graph_rebuild_needed` / `column_graph_unsupported_visibility`.

## Base And Dependency State

- Base branch: `codex/column-graph-native-v4-public-api` (#1669).
- Base commit: `6aadcc9fc895b8227645cf29422b24efbaadce34`.
- #1621/#1634 assumptions: generic physical column row reader/cache and manifest/root publication APIs from the current native stack remain the substrate.
- Missing generic column-store primitives: mutation/tombstone visibility APIs that would let native graph search serve post-build inserts/updates/deletes without rebuild.

## Evidence

- Tests: new V5 mutation matrix covers insert after build, vector update, non-vector payload update, delete, and mixed sequential mutation.
- Tests: close/reopen preserves unsupported-visibility stale status.
- Tests: snapshot-bound searcher opened before a later mutation continues to see one old consistent generation.
- Status/fallback proof: public one-shot search returns `ErrVectorIndexSearchUnavailable`, wraps `errColumnVectorGraphManifestMismatch`, returns no path/results/doc fetches, and reports `column_graph_rebuild_needed` / `column_graph_unsupported_visibility`.
- Performance attribution: code change is in manifest/status classification, not traversal/scoring/fetch/cache. Hot search benchmarks are unchanged within noise and remain zero-alloc.
- Review-resolution attribution: the CodeRabbit readability fix touches status/open classification only. The helper was checked with compiler diagnostics and a same-machine status benchmark A/B before push so the review cleanup did not silently add CPU or allocations.
- Local regressions found/fixed: initial helper shape was rejected before commit because it was a worse compiler shape; the committed split-helper form keeps allocation count stable and improves the focused status benchmark in the same-machine comparison.

## Test Plan Start

- Milestone tasks targeted: V5 fail-closed mutation/staleness handling before overlay/visibility support exists.
- Tests to add before or with implementation: mutation matrix, close/reopen stale status, snapshot-bound searcher consistency, existing stale-row-reader expectation.
- Existing tests to preserve: V2A/V2B/V3/V4 vector and column graph tests, especially asset mismatch/corruption tests and native reader search benchmarks.
- #1646 test-list changes made before implementation: added explicit V5 requirement that unsupported mutation visibility reports `column_graph_rebuild_needed` / `column_graph_unsupported_visibility` before returning results.

## Performance Plan Start

- Relevant benchmarks/metrics for this PR: row fetch, V3 serial native search, V3 parallel native search, V4 one-shot public search, status lookup.
- Baseline/comparator command: same focused benchmark shapes used in #1667/#1669 PR-head evidence on Apple M3.
- Expected setup/search/materialization boundary: status classification is setup/open/status only; no new work should enter hot traversal/scoring.
- Upstream costs explicitly out of scope: one-shot public open/load/setup allocation cost and document materialization cost.
- Local performance risks to watch: accidental classification work inside search loop, new row-reader fetches, extra manifest opens per candidate, extra allocations, or result copies before top-k.

## Test Plan Close

- Additional tests found during implementation/review: older V2A/V2B stale-status tests needed to recognize the more precise unsupported-visibility reason.
- Tests added or changed: V5 mutation matrix, V5 reopen stale status, V5 snapshot-bound searcher consistency, existing V4 stale search reason assertion, existing V2B/V2A stale status expectations.
- Failing tests fixed: `TestColumnGraphRebuildVectorIndexMarksStaleAfterMutationV2A` was updated to allow the new precise reason.
- #1646 test-list changes made at close: same explicit unsupported-visibility requirement recorded on the issue.
- Residual untested gaps: full concurrent readers plus writer/rebuild loop remains a follow-up once generic mutation visibility/maintenance exists; this PR proves fail-closed behavior and snapshot consistency.

## Performance Plan Close

Commands run on Apple M3:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexColumnGraph(Mutation|Stale|Snapshot)|TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutation|TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAsset' -count=1
GOWORK=off go test ./TreeDB/collections -run 'Test.*Vector|TestColumnVectorGraph' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestSearchVectorIndexColumnGraph(MutationMatrixFailsClosed|SnapshotBoundSearcherSurvivesLaterMutation)V5' -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'Benchmark(ColumnVectorGraphPhysicalRowReaderFetchV2B|ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|SearchVectorIndexColumnGraphNativeReaderV4)$' -benchmem -benchtime=500ms -count=5
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnGraphVectorIndexStatusLoadedV2A' -benchmem -benchtime=500ms -count=5
```

Representative benchmark medians:

| Benchmark | Median | Throughput | Allocations | Notes |
| --- | ---: | ---: | ---: | --- |
| `BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B` | 296.0 ns/op | ~3.38M fetches/s | 0 B/op, 0 allocs/op | warmed fetch/cache path |
| `BenchmarkColumnVectorGraphNativeSearchCosineV3` | 65,526 ns/op | ~15.3k searches/s | 0 B/op, 0 allocs/op | 128 candidates, 1912 edges, no physical reads/search |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelV3` | 11,676 ns/op | ~85.6k searches/s | 0 B/op, 0 allocs/op | real `b.RunParallel`, 8 workers |
| `BenchmarkSearchVectorIndexColumnGraphNativeReaderV4` | 347,596 ns/op | ~2.88k searches/s | ~1.439 MB/op, 121 allocs/op | one-shot public setup/open/load/search, no docs |
| `BenchmarkColumnGraphVectorIndexStatusLoadedV2A` | 6,441 ns/op | ~155k status/s | ~4.3 KB/op, 45 allocs/op | status/open classification path |

Review-resolution benchmark after CodeRabbit helper cleanup (`e500915b5`), same Apple M3, sequential before/after against pre-review-fix head `488ba7037`:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnGraphVectorIndexStatusLoadedV2A' -benchmem -benchtime=500ms -count=10
benchstat /tmp/column_graph_status_before_1679.txt /tmp/column_graph_status_after_1679_helper.txt
```

`benchstat` result:

| Benchmark | Before | After | Delta | Allocations |
| --- | ---: | ---: | ---: | ---: |
| `BenchmarkColumnGraphVectorIndexStatusLoadedV2A` | 6.782 us/op | 6.573 us/op | -3.07% | 45 allocs/op -> 45 allocs/op |

Review fix path classification: status/open classification only. It does not touch hot traversal/scoring, row fetch, batch fetch, cache/decode reuse, or public materialization. No hot-search benchmark reset is needed for this review cleanup.

Local slow/heavy code found and fixed: the first extracted-helper form was not kept because compiler diagnostics showed a worse helper shape. The committed helper split keeps allocations unchanged and avoids accepting a review-clean but slower local shape. This PR does not add hot search CPU, memcopies, allocations, row fetches, or result copies.

Remaining upstream or deferred costs: one-shot public search still pays current setup/open/load allocations; mutation maintenance without rebuild waits for generic column-store visibility APIs.

## Latest Restack Evidence
Restacked on #1669 head `66e848623` / #1667 head `92f507fa1` / #1664 head `de67e6e7b` / #1658 head `10a95c2b3`; latest head is `d562660a3`.

Validation:
```sh
git diff --check
GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexColumnGraph(Mutation|Stale|Snapshot)|TestColumnVectorGraphPhysicalRowReaderRejectsStaleGraphAfterMutation|TestColumnGraphVectorIndexStatusFailsClosedOnMissingOrMismatchedAsset' -count=1
```
Result: passed locally.

Benchmark command:
```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'Benchmark(ColumnVectorGraphPhysicalRowReaderFetchV2B|ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|SearchVectorIndexColumnGraphNativeReaderV4|ColumnGraphVectorIndexStatusLoadedV2A)$' -benchmem -benchtime=500ms -count=5
```

Current-head medians from this run:
```text
Status loaded:                  6,824 ns/op       4,318 B/op     45 allocs/op
Physical row-reader fetch:        306.6 ns/op         0 B/op      0 allocs/op
Kernel serial native search:   66,572 ns/op           0 B/op      0 allocs/op
Kernel parallel native search: 12,392 ns/op           0 B/op      0 allocs/op
One-shot public search:       375,634 ns/op   1,438,790 B/op    121 allocs/op
```

Interpretation: V5 restack changed parent setup/reachability code only; mutation/staleness status code still does not enter traversal/scoring. Hot row fetch and native search remain zero-allocation with no physical reads or decoded blocks in the timed loop. Public one-shot search remains slower than the earlier pre-restack PR body because it counts setup/open/load per op; that is recorded separately from the kernel/reusable hot path.

## AI Review Loop

- Review-resolution throughput guard: any human/Codex/Copilot/CodeRabbit fix must classify the touched path before final review. Docs/status/test-only fixes do not reset the search baseline. Any fix touching hot search, row/batch fetch, cache/decode reuse, or public materialization must rerun the matching focused benchmark on the same hardware/command shape and compare against the medians above before being treated as review-ready.
- Codex latest-head review: passed on `e500915b5` with no major issues.
- Copilot latest-head review: requested by PR comment after `e500915b5`; no final Copilot review artifact is visible in `gh pr view` yet, only the request/comment reaction.
- CodeRabbit latest-head review: prior readability thread is marked resolved/addressed in `e500915`; latest CodeRabbit status is success/skipped with no new actionable comments.
- Review comments/threads resolved or explicitly dismissed: all review threads are resolved; no unresolved review threads remain.
- Re-requested after final meaningful push: yes, Codex/Copilot/CodeRabbit comments posted after `e500915b5`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector index manifest validation to detect and report an "unsupported visibility" stale status after incompatible column-graph changes.
  * Search now fail-closes when the column-graph becomes stale, returning no results and an unavailable error tied to the manifest mismatch.
  * Stale "unsupported visibility" status now persists across checkpoints/reopen.

* **Tests**
  * Added extensive mutation and snapshot tests covering fail-closed behavior, persistence of stale status, and snapshot-bound search semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

