### PR TITLE
TreeDB column store post-V1: skip unused dictionary setup

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -622,7 +622,8 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 }
 
 func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
-	if req.AggregateMetadataName != "" || view.MutationParts != 0 {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 ||
+		(req.Kind != ColumnPhysicalQueryGroupCount && req.Kind != ColumnPhysicalQueryGroupCountDistinct) {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2344,22 +2344,22 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 90,
+			maxAllocs: 82,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 124,
+			maxAllocs: 116,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 124,
+			maxAllocs: 116,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 129,
+			maxAllocs: 121,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Skips the dictionary-code sidecar query path for query kinds it cannot serve. Before this PR, q3/q4/q5 entered `runColumnPhysicalQueryDictionaryCodesInSnapshotView`, built a typed asset read cache, and only then fell through to the int64 or dictionary+int64 sidecar paths. The dictionary-code path is only valid for q1/q2 (`GroupCount` and `GroupCountDistinct`), so q3/q4/q5 now fail closed before paying that setup cost.

Static checkpoint before implementation: after #1680, the next measured local allocation slice was not another checksum mode or representation change. Focused allocation profiles showed q3/q4/q5 still paying an unused dictionary-code setup attempt before their real sidecar reducers. This PR removes that local setup overhead. It is tactical allocator hygiene, not a schema-fixed column-block/dense-reducer change and not a granule-parity claim.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed path; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction. It is not a prepared hot runner.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict `verify`.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR. No prepared-runner or billion-rows/sec claim is made here.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. TDD allocation gate before the code change failed with the tightened budgets, proving the old q3/q4/q5 path still allocated through the unused dictionary setup:

```text
q3_int64_values allocs/run=88.00 want <=82.00
q4a_dictionary_int64 allocs/run=122.00 want <=116.00
q4b_dictionary_int64 allocs/run=122.00 want <=116.00
q5_dictionary_int64 allocs/run=127.00 want <=121.00
```

After the guard, the same allocation-budget test passes. Focused adapter benchmark on Apple M3, darwin/arm64, 8,192 rows, `-benchtime=500x -count=5`, artifact `/tmp/gomap_1634_kind_guard_adapter_bench.txt`:

```text
q3 rows_8192: 80 allocs/op, ~8.74 KiB/op, 6.27-7.01 ns/row, 142.6-159.4M rows/s
q4a rows_8192: 114 allocs/op, ~10.65 KiB/op, 8.41-8.72 ns/row, 114.7-118.9M rows/s
q4b rows_8192: 114 allocs/op, ~10.65 KiB/op, 9.09-9.76 ns/row, 102.4-110.0M rows/s
q5 rows_8192: 119 allocs/op, ~10.88 KiB/op, 8.53-9.82 ns/row, 101.8-117.3M rows/s
```

Compared to the measured failing pre-patch allocation counts, this removes 8 allocs/op from q3/q4a/q4b/q5 in the routed one-shot package path. Throughput movement is not claimed as the primary win because this is a small setup-allocation guard and local noise is larger than the code change.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot, Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB`:

```text
q1: 7.9 ns/row, 125.96M rows/s, dictionary_code_hits=100, row_materializations=0
q2: 43.6 ns/row, 22.94M rows/s, dictionary_code_hits=100, row_materializations=0
q3: 6.2 ns/row, 161.96M rows/s, int64_value_hits=100, row_materializations=0
q4a: 28.9 ns/row, 34.66M rows/s, dictionary_code_hits=100, int64_value_hits=100, row_materializations=0
q4b: 29.5 ns/row, 33.84M rows/s, dictionary_code_hits=100, int64_value_hits=100, row_materializations=0
q5: 30.4 ns/row, 32.91M rows/s, dictionary_code_hits=100, int64_value_hits=100, row_materializations=0
q5_metadata serial alias: 30.9 ns/row, 32.41M rows/s, metadata_hits=0
```

The routed path reaches this PR's guard because it calls `RunColumnPhysicalQuery` with q3/q4/q5 shapes before entering their real int64/dictionary+int64 sidecar paths. The guard only removes unused setup; it does not alter physical assets, decoded representations, reducer shape, WAL/checkpoint, reopen, mutation handling, or planner routing.

Measurement class: `prepared hot runner / warmed repeated Run()`. No prepared hot-runner behavior changes in this PR. Prior #1672/#1673/#1676 prepared sidecar/metadata runners remain the 0 allocs/op hot-loop evidence.

Measurement class: `experiment/granule baseline`. Prior #1634 context remains the allocation/kernel target: granule dense-code/block kernels were built for 0 hot-kernel allocations. This PR moves a routed package path down by 8 allocs/op but does not close the remaining gap to equivalent granule zero-allocation kernels.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench context remains `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`, with 1M q1/q2/q3/q4/q5 around `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is stale context, not a same-commit apples-to-apples comparison.

Scale note: the routed snapshot above reports `ns/row` for 100K rows. For example, `30 ns/row` over 100K rows is about a 3 ms query-stage scan, not 30 ms; 1M rows at `30 ns/row` would extrapolate to about 30 ms.

## Throughput Interpretation

This is an allocation/setup cleanup in the current routed direct package path. q3/q4/q5 still use the existing int64 or dictionary+int64 sidecar one-shot reducers; they are still not prepared hot runners and still do not have schema-fixed column-block/dense-reducer granule parity. The expected value is fewer avoidable heap allocations before the real reducer path, not a material change to analytical-kernel shape.

The remaining center of gravity for #1634 is still representation/kernel shape, routed/session reuse, and allocation cleanup in manifest/view/result setup. Do not treat this PR as evidence that TCPA/sidecar cursor micro-optimization alone can close the production-vs-experiment gap.

## Apples-to-Apples Limitations

- The direct package scanner benchmark is not a prepared hot runner and includes package-level setup/read/decode/result construction.
- The routed snapshot is 100K rows, strict `verify`, forced `serial_column_scan`; it is useful for current end-to-end context but not a 1M latest-head slope run.
- The experiment/granule and ClickHouse numbers are historical context unless explicitly rerun on the same fixture and commit family.
- `q5_metadata` under forced `serial_column_scan` is a serial q5 alias with `metadata_hits=0`, not the aggregate metadata fast path.
- This PR does not address remaining allocations from manifest/view setup, dictionary materialization, result construction, or routed reporting.

## Gate Status

- TDD pre-change allocation gate failed with the tightened q3/q4/q5 budgets.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634' -count=1 -v` passed after the guard.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuerySerial(DictionarySidecarParity|DictionaryInt64SidecarParity|Int64ValueSidecarParity)M1634|TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/(q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=500x -count=5` passed.
- `make unified-bench` passed.
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir /tmp/gomap_1634_kind_guard_routed_100k_QqlHjB -path-label native-fastpath -column-store-path serial_column_scan -progress=false` passed.
- `git diff --check` passed.

## Artifacts

- Direct package scanner benchmark: `/tmp/gomap_1634_kind_guard_adapter_bench.txt`.
- Routed production markdown/html/json: `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/column_store_results.md`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/column_store_results.html`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/column_store_results.json`.
- Routed benchprof markdown/json: `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/benchprof_results.md`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/benchprof_results.json`.
- Routed insights markdown/html/json: `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/insights.md`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/insights.html`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/insights.json`.
- Routed CPU/alloc profiles: `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/cpu_column_store_treedb_column_store.pprof`, `/tmp/gomap_1634_kind_guard_routed_100k_QqlHjB/allocs_column_store_treedb_column_store.pprof`.
- Historical ClickHouse/granule JSONBench comparison: `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`.

## Assumption Ledger / Remaining Work

- This is a tactical allocation cleanup only. It does not make q3/q4/q5 prepared hot runners or schema-fixed column-block reducers.
- Routed q3/q4/q5 still allocate well above the granule hot-kernel target; remaining allocations need separate measured work.
- Next #1634 slice should start with another static/profile checkpoint and likely target manifest/view/result setup allocation or representation/kernel shape, not more unsupported-path setup cleanup unless profiles identify it.

Refs #1634.
