### PR TITLE
V6: add column graph native reader evidence

### DIFF
--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -920,10 +920,13 @@ func BenchmarkSearchVectorIndexColumnGraphNativeReaderV4(b *testing.B) {
 		EfSearch:         efSearch,
 		MaxDecodedBlocks: 1,
 	}
-	if _, err := col.SearchVectorIndex(opts); err != nil {
+	warm, err := col.SearchVectorIndex(opts)
+	if err != nil {
 		b.Fatalf("warm SearchVectorIndex: %v", err)
 	}
-	var stats VectorIndexSearchStats
+	// Sample deterministic telemetry before the timed loop so reporting does not
+	// add per-iteration work to the public one-shot search benchmark.
+	stats := warm.Stats
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -932,15 +935,9 @@ func BenchmarkSearchVectorIndexColumnGraphNativeReaderV4(b *testing.B) {
 			b.Fatalf("SearchVectorIndex: %v", err)
 		}
 		vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
-		stats.Candidates += got.Stats.Candidates
-		stats.Edges += got.Stats.Edges
-		stats.CandidateFetches += got.Stats.CandidateFetches
-		stats.ExpansionFetches += got.Stats.ExpansionFetches
-		stats.ResultFetches += got.Stats.ResultFetches
-		stats.DocumentsFetched += got.Stats.DocumentsFetched
 	}
 	b.StopTimer()
-	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats)
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
 }
 
 func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4(b *testing.B) {
@@ -974,7 +971,13 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4(b *testing.B) {
 	if _, err := searcher.Search(opts); err != nil {
 		b.Fatalf("warm Search: %v", err)
 	}
-	var stats VectorIndexSearchStats
+	measuredStats, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("measure Search stats: %v", err)
+	}
+	// The steady-state benchmark times only Search. Metrics come from a warmed
+	// pre-timer search so telemetry accumulation cannot hide throughput drift.
+	stats := measuredStats.Stats
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -983,15 +986,9 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4(b *testing.B) {
 			b.Fatalf("Search: %v", err)
 		}
 		vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
-		stats.Candidates += got.Stats.Candidates
-		stats.Edges += got.Stats.Edges
-		stats.CandidateFetches += got.Stats.CandidateFetches
-		stats.ExpansionFetches += got.Stats.ExpansionFetches
-		stats.ResultFetches += got.Stats.ResultFetches
-		stats.DocumentsFetched += got.Stats.DocumentsFetched
 	}
 	b.StopTimer()
-	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats)
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
 }
 
 func BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4(b *testing.B) {
@@ -1017,10 +1014,13 @@ func BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4(b *testing
 		IncludeDocuments: true,
 		MaxDecodedBlocks: 1,
 	}
-	if _, err := col.SearchVectorIndex(opts); err != nil {
+	warm, err := col.SearchVectorIndex(opts)
+	if err != nil {
 		b.Fatalf("warm SearchVectorIndex: %v", err)
 	}
-	var stats VectorIndexSearchStats
+	// Document materialization remains in the timed loop; metric collection does
+	// not, so allocs/op reflects the public API path instead of test bookkeeping.
+	stats := warm.Stats
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1029,31 +1029,97 @@ func BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4(b *testing
 			b.Fatalf("SearchVectorIndex: %v", err)
 		}
 		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
-		stats.Candidates += got.Stats.Candidates
-		stats.Edges += got.Stats.Edges
-		stats.CandidateFetches += got.Stats.CandidateFetches
-		stats.ExpansionFetches += got.Stats.ExpansionFetches
-		stats.ResultFetches += got.Stats.ResultFetches
-		stats.DocumentsFetched += got.Stats.DocumentsFetched
 	}
 	b.StopTimer()
-	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats)
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
 }
 
-func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorIndexSearchStats) {
+func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderSetupV6(b *testing.B) {
+	const (
+		rows = 1024
+		dims = 128
+		m    = 16
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	statsSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		b.Fatalf("stats OpenVectorIndexSearcher: %v", err)
+	}
+	readerStats := statsSearcher.reader.Stats()
+	stats := VectorIndexSearchStats{
+		OpenGranulesRead:      uint64(readerStats.OpenGranulesRead),
+		OpenPhysicalBytesRead: readerStats.OpenPhysicalBytesRead,
+		MaxResidentBytes:      readerStats.MaxResidentBytes,
+	}
+	if err := statsSearcher.Close(); err != nil {
+		b.Fatalf("Close stats searcher: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+			IndexName:        def.Name,
+			MaxDecodedBlocks: 1,
+		})
+		if err != nil {
+			b.Fatalf("OpenVectorIndexSearcher: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += searcher.reader.RowCount()
+		if err := searcher.Close(); err != nil {
+			b.Fatalf("Close searcher: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
+}
+
+func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorIndexSearchStats, includeOpenPerOp bool) {
 	b.Helper()
 	if n <= 0 {
 		return
 	}
-	b.ReportMetric(float64(stats.Candidates)/float64(n), "candidates/search")
-	b.ReportMetric(float64(stats.Edges)/float64(n), "edges/search")
+	// Callers pass one representative search/setup sample captured outside the
+	// timer; these labels are intentionally per-search or per-open, not averaged
+	// over b.N. Keep aggregation out of the hot benchmark loop.
+	b.ReportMetric(float64(stats.Candidates), "candidates/search")
+	b.ReportMetric(float64(stats.Edges), "edges/search")
 	if stats.Candidates > 0 {
 		b.ReportMetric(float64(stats.Edges)/float64(stats.Candidates), "edges/node")
 	}
-	b.ReportMetric(float64(stats.CandidateFetches)/float64(n), "candidate_fetches/search")
-	b.ReportMetric(float64(stats.ExpansionFetches)/float64(n), "expansion_fetches/search")
-	b.ReportMetric(float64(stats.ResultFetches)/float64(n), "result_fetches/search")
-	b.ReportMetric(float64(stats.DocumentsFetched)/float64(n), "docs_fetched/search")
+	b.ReportMetric(float64(stats.CandidateFetches), "candidate_fetches/search")
+	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")
+	b.ReportMetric(float64(stats.ResultFetches), "result_fetches/search")
+	b.ReportMetric(float64(stats.RowFetches), "row_fetches/search")
+	b.ReportMetric(float64(stats.BatchFetches), "batch_fetches/search")
+	b.ReportMetric(float64(stats.RowsFetched), "rows_fetched/search")
+	b.ReportMetric(float64(stats.CacheHits), "cache_hits/search")
+	b.ReportMetric(float64(stats.CacheMisses), "cache_misses/search")
+	if cacheLookups := stats.CacheHits + stats.CacheMisses; cacheLookups > 0 {
+		b.ReportMetric(float64(stats.CacheHits)/float64(cacheLookups), "cache_hit_ratio")
+	}
+	b.ReportMetric(float64(stats.DecodedBlocks), "decoded_blocks/search")
+	b.ReportMetric(float64(stats.GranulesTouched), "granules_touched/search")
+	b.ReportMetric(float64(stats.PhysicalBytesRead), "physical_B/search")
+	b.ReportMetric(float64(stats.MaxResidentBytes), "max_resident_B")
+	if includeOpenPerOp {
+		b.ReportMetric(float64(stats.OpenGranulesRead), "open_granules/op")
+		b.ReportMetric(float64(stats.OpenPhysicalBytesRead), "open_physical_B/op")
+	}
+	if stats.OpenGranulesRead > 0 {
+		b.ReportMetric(float64(stats.OpenGranulesRead), "max_open_granules")
+	}
+	if stats.OpenPhysicalBytesRead > 0 {
+		b.ReportMetric(float64(stats.OpenPhysicalBytesRead), "max_open_physical_B")
+	}
+	b.ReportMetric(float64(stats.DocumentsFetched), "docs_fetched/search")
 }
 
 var vectorSearchBenchSinkOrdinalV4 int

--- a/TreeDB/docs/column_graph_native_vector_search_test.go
+++ b/TreeDB/docs/column_graph_native_vector_search_test.go
@@ -1,0 +1,68 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocs_ColumnGraphNativeVectorSearchGuide(t *testing.T) {
+	treeRoot, repoRoot := repoRoots(t)
+	guidePath := filepath.Join(treeRoot, "docs", "spec", "column-graph-native-vector-search.md")
+	content, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("read guide: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"`column_graph_native_reader`",
+		"must not materialize a full decoded `ColumnVectorGraph` copy",
+		"OpenVectorIndexSearcher",
+		"SearchVectorIndex",
+		"BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderSetupV6",
+		"BenchmarkColumnVectorGraphNativeSearchCosineParallelV3",
+		"row_fetches/search",
+		"cache_hit_ratio",
+		"open_physical_B/op",
+		"docs_fetched/search",
+		"scripts/treedb_column_graph_glove_demo.sh --run",
+		"not vendor the dataset",
+		"one searcher per concurrent worker",
+		"document-fetch-free",
+	}
+	for _, needle := range required {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("guide missing %q", needle)
+		}
+	}
+	forbidden := []string{
+		"decoded path is native",
+		"decoded `ColumnVectorGraph` path is native",
+		"SearchVectorIndex is the steady-state path",
+	}
+	for _, needle := range forbidden {
+		if strings.Contains(text, needle) {
+			t.Fatalf("guide contains misleading phrase %q", needle)
+		}
+	}
+
+	scriptPath := filepath.Join(repoRoot, "scripts", "treedb_column_graph_glove_demo.sh")
+	script, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read dataset script: %v", err)
+	}
+	scriptText := string(script)
+	scriptRequired := []string{
+		"dry_run=true",
+		"https://nlp.stanford.edu/data/glove.6B.zip",
+		"go run ./cmd/treedb_column_graph_demo",
+		"-glove",
+		"-max-decoded-blocks",
+	}
+	for _, needle := range scriptRequired {
+		if !strings.Contains(scriptText, needle) {
+			t.Fatalf("dataset script missing %q", needle)
+		}
+	}
+}

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -89,6 +89,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     distributed/Raft behavior remains target behavior until cluster mode lands.
 - `TreeDB/docs/spec/verification.md`
   - invariants mapped to tests and benchmark harnesses.
+- `TreeDB/docs/spec/column-graph-native-vector-search.md`
+  - user-facing quickstart, benchmark matrix, demo, and caveats for explicit
+    `column_graph` vector indexes that search through the native physical column
+    row reader.
 
 ## Target Gates (Normative Target, Not Current Behavior)
 

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -1,0 +1,195 @@
+# Column Graph Native Vector Search
+
+This guide covers the `column_graph` vector-index path that searches persisted
+TreeDB column assets through the physical column row reader.
+
+## What Path Runs
+
+`column_graph` is distinct from two older/comparator paths:
+
+- Native runtime vector indexes are the legacy collection vector path and do not
+  use physical column graph assets.
+- Decoded `ColumnVectorGraph` benchmarks fully load vector, invNorm, and
+  adjacency columns into Go slices, then search that in-memory graph. That path
+  remains useful as an oracle and throughput ceiling.
+- `column_graph_native_reader` opens the collection manifest/root snapshot,
+  uses the physical column row reader/cache for vector, invNorm, adjacency, and
+  doc-id rows, and fetches full documents only after top-k when callers request
+  materialized documents.
+
+The native-reader path must not materialize a full decoded `ColumnVectorGraph` copy as its search substrate.
+
+## Quickstart
+
+Declare a collection with JSON documents, physical column storage for the vector
+field, and an explicit `column_graph` vector index:
+
+```go
+meta := &collections.CollectionMeta{
+    Name: "docs",
+    Options: collections.CollectionOptions{
+        DocumentFormat: collections.DocumentFormatJSON,
+        ColumnStore: &collections.ColumnStoreConfig{
+            Enabled: true,
+            Columns: []collections.ColumnStoreColumn{
+                {Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
+                {Name: "did", Path: "did", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+                {Name: "embedding", Path: "embedding", ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: 128},
+            },
+            SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
+        },
+    },
+    VectorIndexes: []collections.VectorIndexDefinition{{
+        Name:       "embedding_graph",
+        Field:      "embedding",
+        Metric:     collections.VectorMetricCosine,
+        Dimensions: 128,
+        M:          16,
+        Strategy:   collections.VectorIndexStrategyColumnGraph,
+    }},
+}
+```
+
+Then load documents, build the graph, close/reopen, and search through a reusable
+searcher for steady-state queries:
+
+```go
+_, _ = collections.NewCollectionManager(db).CreateCollection(meta)
+col, _ := collections.NewCollectionManager(db).OpenCollection("docs")
+_, _ = col.InsertBatch(ids, docs)
+status, _ := col.RebuildVectorIndex("embedding_graph")
+
+searcher, _ := col.OpenVectorIndexSearcher(collections.VectorIndexSearcherOptions{
+    IndexName:        "embedding_graph",
+    MaxDecodedBlocks: 4,
+})
+defer searcher.Close()
+
+response, _ := searcher.Search(collections.VectorIndexSearcherSearchOptions{
+    Query:    query,
+    TopK:     10,
+    EfSearch: 128,
+})
+fmt.Println(status.State, response.Path, response.Stats.RowFetches)
+```
+
+Use `SearchVectorIndex` for one-shot calls. It opens and closes the native reader
+per call, so it measures setup/open cost in addition to graph search. Use
+`OpenVectorIndexSearcher` when benchmarking or serving steady-state query load.
+
+## Demo
+
+Run a synthetic close/reopen demo:
+
+```sh
+GOWORK=off go run ./cmd/treedb_column_graph_demo \
+  -dir /tmp/treedb-column-graph-demo \
+  -reset \
+  -rows 1024 \
+  -dims 128 \
+  -degree 16 \
+  -top-k 10 \
+  -ef-search 128 \
+  -max-decoded-blocks 4
+```
+
+Representative output shape:
+
+```text
+TreeDB column_graph native-reader demo
+db_dir=/tmp/treedb-column-graph-demo rows=1024 dims=128 degree=16 top_k=10 ef_search=128
+rebuild status=column_graph_loaded loaded=true reason=
+search path=column_graph_native_reader status=column_graph_loaded loaded=true results=10 include_docs=false
+stats candidates=... edges=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0
+result[0] id=doc-000000 ordinal=0 score=1.000000
+```
+
+Run an opt-in real public dataset smoke using GloVe 6B 50d:
+
+```sh
+scripts/treedb_column_graph_glove_demo.sh
+scripts/treedb_column_graph_glove_demo.sh --run
+```
+
+The script defaults to dry-run mode. It does not vendor the dataset into the
+repository. With `--run`, it downloads GloVe into
+`$HOME/.cache/treedb-column-graph/glove`, loads a configurable row subset, builds
+the index, reopens the DB, and prints native-reader search status and accounting.
+
+## Benchmark Commands
+
+CI-safe smoke:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run 'TestColumnVectorGraphNativeSearch|TestSearchVectorIndexColumnGraph|TestOpenVectorIndexSearcher' \
+  -count=1
+```
+
+Focused benchmark matrix:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+The expected categories are:
+
+- `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderSetupV6`: cold
+  native-reader setup/open. It does not search.
+- `BenchmarkColumnVectorGraphNativeSearchCosineV3`: lower-level native reader
+  graph traversal, vector scoring, and top-k over the physical row reader.
+- `BenchmarkColumnVectorGraphNativeSearchCosineParallelV3`: real
+  `b.RunParallel`; workers use local scratch and readers.
+- `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4`: public reusable
+  searcher steady-state query. Setup/open is outside the timed loop.
+- `BenchmarkSearchVectorIndexColumnGraphNativeReaderV4`: public one-shot search.
+  Setup/open is inside each timed operation.
+- `BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4`: public
+  one-shot search plus post-top-k document materialization.
+
+Report and compare:
+
+- searches/s or ns/op,
+- `B/op` and `allocs/op`,
+- candidates/search and edges/search,
+- row_fetches/search, batch_fetches/search, rows_fetched/search,
+- cache_hits/search, cache_misses/search, cache_hit_ratio,
+- decoded_blocks/search, granules_touched/search, physical_B/search,
+- max_resident_B,
+- open_granules/op and open_physical_B/op for setup/one-shot paths,
+- docs_fetched/search only for materializing public API benchmarks.
+
+## Best Practices
+
+- Use `column_graph` explicitly. Existing native runtime vector indexes remain a
+  separate path.
+- Batch inserts, then call `RebuildVectorIndex` before serving column graph
+  queries.
+- Reopen or checkpoint in validation flows when proving durable root/manifest
+  discovery.
+- Prefer `OpenVectorIndexSearcher` for steady-state query throughput.
+- Keep one searcher per concurrent worker. Searchers and scratch are not
+  concurrency-safe; the persisted graph snapshot is immutable.
+- Tune `MaxDecodedBlocks` as bounded cache capacity. It must not become an
+  unbounded decoded graph copy.
+- Request documents only when needed. Graph traversal/scoring should remain
+  document-fetch-free; document fetch belongs after top-k.
+- Treat update/delete support according to current status. Unsupported mutation
+  visibility must return rebuild-needed or unsupported-visibility status rather
+  than stale results.
+
+## Caveats
+
+- The current V6 evidence is correctness and product-path evidence over
+  CI-sized fixtures. Larger public dataset runs are opt-in and should be
+  reported separately with hardware labels.
+- Generic column-store reader/cache improvements from #1621/#1634 may change
+  absolute throughput. PR-local changes should still avoid avoidable CPU,
+  memcopies, allocation churn, repeated setup, or hidden full decode.
+- Decoded `ColumnVectorGraph` numbers are ceiling/comparator numbers, not proof
+  that native-reader search is using a fully decoded in-memory graph.

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -305,8 +305,11 @@ func loadGloveRows(path string, limit int) ([]demoRow, int, error) {
 		vector := make([]float32, dims)
 		for i := 0; i < dims; i++ {
 			value, err := strconv.ParseFloat(fields[i+1], 32)
-			if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+			if err != nil {
 				return nil, 0, fmt.Errorf("GloVe row %q dim %d parse: %w", fields[0], i, err)
+			}
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return nil, 0, fmt.Errorf("GloVe row %q dim %d has non-finite value %g", fields[0], i, value)
 			}
 			vector[i] = float32(value)
 		}

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const defaultIndexName = "embedding_graph"
+
+type demoConfig struct {
+	Dir              string
+	Reset            bool
+	Rows             int
+	Dims             int
+	Degree           int
+	TopK             int
+	EfSearch         int
+	MaxDecodedBlocks int
+	IncludeDocs      bool
+	GlovePath        string
+}
+
+type demoRow struct {
+	ID     string
+	Label  string
+	Vector []float32
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb column_graph demo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	if cfg.TopK < 0 || cfg.EfSearch < 0 || cfg.MaxDecodedBlocks < 0 {
+		return errors.New("top-k, ef-search, and max-decoded-blocks must be non-negative")
+	}
+	if cfg.Rows <= 0 {
+		return errors.New("rows must be positive")
+	}
+	if cfg.Degree < 0 {
+		return errors.New("degree must be non-negative")
+	}
+
+	cleanup := func() {}
+	if cfg.Dir == "" {
+		dir, err := os.MkdirTemp("", "treedb-column-graph-demo-*")
+		if err != nil {
+			return err
+		}
+		cfg.Dir = dir
+		cleanup = func() { _ = os.RemoveAll(dir) }
+	}
+	defer cleanup()
+	if cfg.Reset {
+		if err := os.RemoveAll(cfg.Dir); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
+		return err
+	}
+
+	rows, dims, err := loadDemoRows(cfg)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return errors.New("dataset is empty")
+	}
+	query := append([]float32(nil), rows[0].Vector...)
+	if cfg.TopK == 0 {
+		cfg.TopK = min(10, len(rows))
+	}
+	if cfg.EfSearch == 0 {
+		cfg.EfSearch = 128
+	}
+	if cfg.TopK > len(rows) {
+		cfg.TopK = len(rows)
+	}
+
+	if err := backenddb.SaveFormatConfig(cfg.Dir, backenddb.FormatConfig{
+		RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1},
+	}); err != nil {
+		return err
+	}
+	db, err := backenddb.Open(backenddb.Options{Dir: cfg.Dir, DisableBackgroundPrune: true})
+	if err != nil {
+		return err
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(demoCollectionMeta(dims, cfg.Degree)); err != nil {
+		_ = db.Close()
+		return err
+	}
+	col, err := manager.OpenCollection("docs")
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
+	if err := insertDemoRows(col, rows); err != nil {
+		_ = db.Close()
+		return err
+	}
+	status, err := col.RebuildVectorIndex(defaultIndexName)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
+	if !status.Loaded {
+		_ = db.Close()
+		return fmt.Errorf("rebuild status=%+v, want loaded column_graph", status)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return err
+	}
+	if err := db.Close(); err != nil {
+		return err
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: cfg.Dir, DisableBackgroundPrune: true})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := collections.NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		return err
+	}
+	searcher, err := reopenedCol.OpenVectorIndexSearcher(collections.VectorIndexSearcherOptions{
+		IndexName:        defaultIndexName,
+		MaxDecodedBlocks: cfg.MaxDecodedBlocks,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = searcher.Close() }()
+	got, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{
+		Query:            query,
+		TopK:             cfg.TopK,
+		EfSearch:         cfg.EfSearch,
+		IncludeDocuments: cfg.IncludeDocs,
+	})
+	if err != nil {
+		return err
+	}
+	if len(got.Results) == 0 {
+		return errors.New("search returned no results")
+	}
+
+	fmt.Fprintf(stdout, "TreeDB column_graph native-reader demo\n")
+	fmt.Fprintf(stdout, "db_dir=%s rows=%d dims=%d degree=%d top_k=%d ef_search=%d\n", cfg.Dir, len(rows), dims, cfg.Degree, cfg.TopK, cfg.EfSearch)
+	fmt.Fprintf(stdout, "rebuild status=%s loaded=%t reason=%s\n", status.State, status.Loaded, status.Reason)
+	fmt.Fprintf(stdout, "search path=%s status=%s loaded=%t results=%d include_docs=%t\n", got.Path, got.Status.State, got.Status.Loaded, len(got.Results), cfg.IncludeDocs)
+	fmt.Fprintf(stdout, "stats candidates=%d edges=%d row_fetches=%d cache_hits=%d cache_misses=%d decoded_blocks=%d granules_touched=%d physical_B=%d max_resident_B=%d docs_fetched=%d\n",
+		got.Stats.Candidates,
+		got.Stats.Edges,
+		got.Stats.RowFetches,
+		got.Stats.CacheHits,
+		got.Stats.CacheMisses,
+		got.Stats.DecodedBlocks,
+		got.Stats.GranulesTouched,
+		got.Stats.PhysicalBytesRead,
+		got.Stats.MaxResidentBytes,
+		got.Stats.DocumentsFetched,
+	)
+	for i, result := range got.Results {
+		if i >= 5 {
+			break
+		}
+		fmt.Fprintf(stdout, "result[%d] id=%s ordinal=%d score=%.6f", i, result.ID, result.Ordinal, result.Score)
+		if cfg.IncludeDocs {
+			fmt.Fprintf(stdout, " document_B=%d", len(result.Document))
+		}
+		fmt.Fprintln(stdout)
+	}
+	_, _ = fmt.Fprintln(stderr, "tip: use OpenVectorIndexSearcher for steady-state queries; SearchVectorIndex is a one-shot path that pays open/setup per call.")
+	return nil
+}
+
+func parseConfig(args []string) (demoConfig, error) {
+	cfg := demoConfig{
+		Rows:             256,
+		Dims:             32,
+		Degree:           16,
+		TopK:             10,
+		EfSearch:         128,
+		MaxDecodedBlocks: 4,
+	}
+	fs := flag.NewFlagSet("treedb_column_graph_demo", flag.ContinueOnError)
+	fs.StringVar(&cfg.Dir, "dir", cfg.Dir, "TreeDB directory; empty uses a temporary directory")
+	fs.BoolVar(&cfg.Reset, "reset", cfg.Reset, "delete -dir before loading")
+	fs.IntVar(&cfg.Rows, "rows", cfg.Rows, "rows to load from the selected dataset")
+	fs.IntVar(&cfg.Dims, "dims", cfg.Dims, "synthetic vector dimensions; ignored for GloVe input after inference")
+	fs.IntVar(&cfg.Degree, "degree", cfg.Degree, "graph out-degree used by RebuildVectorIndex")
+	fs.IntVar(&cfg.TopK, "top-k", cfg.TopK, "number of nearest results")
+	fs.IntVar(&cfg.EfSearch, "ef-search", cfg.EfSearch, "graph search exploration bound")
+	fs.IntVar(&cfg.MaxDecodedBlocks, "max-decoded-blocks", cfg.MaxDecodedBlocks, "bounded physical column decoded-block cache size")
+	fs.BoolVar(&cfg.IncludeDocs, "include-docs", cfg.IncludeDocs, "materialize full documents after top-k")
+	fs.StringVar(&cfg.GlovePath, "glove", cfg.GlovePath, "optional GloVe text file to load as a real public embedding dataset")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	return cfg, nil
+}
+
+func demoCollectionMeta(dims, degree int) *collections.CollectionMeta {
+	return &collections.CollectionMeta{
+		Name: "docs",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatJSON,
+			ColumnStore: &collections.ColumnStoreConfig{
+				Enabled: true,
+				Columns: []collections.ColumnStoreColumn{
+					{Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
+					{Name: "kind", Path: "kind", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+					{Name: "did", Path: "did", ValueType: collections.ColumnStoreValueString, Dictionary: true},
+					{Name: "label", Path: "label", ValueType: collections.ColumnStoreValueString, Dictionary: true, Nullable: true},
+					{Name: "embedding", Path: "embedding", ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: dims},
+				},
+				SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
+			},
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:       defaultIndexName,
+			Field:      "embedding",
+			Metric:     collections.VectorMetricCosine,
+			Dimensions: dims,
+			M:          degree,
+			EfSearch:   128,
+			Encoding:   collections.VectorIndexEncodingFloat32,
+			Strategy:   collections.VectorIndexStrategyColumnGraph,
+		}},
+	}
+}
+
+func loadDemoRows(cfg demoConfig) ([]demoRow, int, error) {
+	if cfg.GlovePath != "" {
+		return loadGloveRows(cfg.GlovePath, cfg.Rows)
+	}
+	if cfg.Dims <= 0 {
+		return nil, 0, errors.New("dims must be positive")
+	}
+	rows := make([]demoRow, cfg.Rows)
+	for i := range rows {
+		vector := make([]float32, cfg.Dims)
+		for j := range vector {
+			vector[j] = float32(((i+3)*(j+5))%23+1) / 23
+		}
+		rows[i] = demoRow{
+			ID:     fmt.Sprintf("doc-%06d", i),
+			Label:  fmt.Sprintf("synthetic-%06d", i),
+			Vector: vector,
+		}
+	}
+	return rows, cfg.Dims, nil
+}
+
+func loadGloveRows(path string, limit int) ([]demoRow, int, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	rows := make([]demoRow, 0, limit)
+	dims := 0
+	for scanner.Scan() {
+		if len(rows) >= limit {
+			break
+		}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		if dims == 0 {
+			dims = len(fields) - 1
+		}
+		if len(fields)-1 != dims {
+			return nil, 0, fmt.Errorf("GloVe row %q has %d dims, want %d", fields[0], len(fields)-1, dims)
+		}
+		vector := make([]float32, dims)
+		for i := 0; i < dims; i++ {
+			value, err := strconv.ParseFloat(fields[i+1], 32)
+			if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+				return nil, 0, fmt.Errorf("GloVe row %q dim %d parse: %w", fields[0], i, err)
+			}
+			vector[i] = float32(value)
+		}
+		rows = append(rows, demoRow{
+			ID:     fmt.Sprintf("glove-%06d", len(rows)),
+			Label:  fields[0],
+			Vector: vector,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, 0, err
+	}
+	return rows, dims, nil
+}
+
+func insertDemoRows(col *collections.Collection, rows []demoRow) error {
+	ids := make([][]byte, len(rows))
+	docs := make([][]byte, len(rows))
+	for i, row := range rows {
+		raw, err := json.Marshal(map[string]any{
+			"time_us":   int64(i + 1),
+			"kind":      "vector",
+			"did":       row.ID,
+			"label":     row.Label,
+			"embedding": row.Vector,
+		})
+		if err != nil {
+			return err
+		}
+		ids[i] = []byte(row.ID)
+		docs[i] = raw
+	}
+	_, err := col.InsertBatch(ids, docs)
+	return err
+}

--- a/cmd/treedb_column_graph_demo/main_test.go
+++ b/cmd/treedb_column_graph_demo/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestColumnGraphDemoRunsCloseReopenNativeReaderPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "db")
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"-dir", dir,
+		"-reset",
+		"-rows", "64",
+		"-dims", "8",
+		"-degree", "4",
+		"-top-k", "3",
+		"-ef-search", "32",
+		"-max-decoded-blocks", "1",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run demo: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	required := []string{
+		"TreeDB column_graph native-reader demo",
+		"rebuild status=column_graph_loaded loaded=true",
+		"search path=column_graph_native_reader status=column_graph_loaded loaded=true",
+		"stats candidates=",
+		"row_fetches=",
+		"decoded_blocks=",
+		"max_resident_B=",
+		"result[0] id=doc-000000 ordinal=0",
+	}
+	for _, needle := range required {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("demo output missing %q\nstdout:\n%s\nstderr:\n%s", needle, out, stderr.String())
+		}
+	}
+	if !strings.Contains(stderr.String(), "OpenVectorIndexSearcher") {
+		t.Fatalf("demo stderr missing steady-state searcher tip: %s", stderr.String())
+	}
+}

--- a/cmd/treedb_column_graph_demo/main_test.go
+++ b/cmd/treedb_column_graph_demo/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -41,5 +42,39 @@ func TestColumnGraphDemoRunsCloseReopenNativeReaderPath(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "OpenVectorIndexSearcher") {
 		t.Fatalf("demo stderr missing steady-state searcher tip: %s", stderr.String())
+	}
+}
+
+func TestLoadGloveRowsRejectsInvalidNumericValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "parse error",
+			content: "bad 0.1 nope\n",
+			want:    `GloVe row "bad" dim 1 parse`,
+		},
+		{
+			name:    "non finite",
+			content: "bad 0.1 NaN\n",
+			want:    `GloVe row "bad" dim 1 has non-finite value`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "glove.txt")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			_, _, err := loadGloveRows(path, 1)
+			if err == nil {
+				t.Fatal("loadGloveRows succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not contain %q", err, tt.want)
+			}
+		})
 	}
 }

--- a/scripts/treedb_column_graph_glove_demo.sh
+++ b/scripts/treedb_column_graph_glove_demo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/treedb_column_graph_glove_demo.sh [--run]
+
+Opt-in real-dataset smoke for TreeDB column_graph native-reader search.
+By default this is a dry run: it prints the download and benchmark command and
+does not fetch data. Pass --run to download GloVe 6B 50d if missing, build a
+temporary TreeDB column_graph index, reopen it, and run the demo search path.
+
+Environment:
+  DATA_DIR   cache directory, default: $HOME/.cache/treedb-column-graph/glove
+  DB_DIR     TreeDB demo directory, default: /tmp/treedb-column-graph-glove-db
+  ROWS       number of GloVe rows to load, default: 10000
+  TOPK       search TopK, default: 10
+  EF_SEARCH  graph search ef_search, default: 128
+USAGE
+}
+
+run=false
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+if [[ "${1:-}" == "--run" ]]; then
+  run=true
+elif [[ $# -gt 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+DATA_DIR="${DATA_DIR:-$HOME/.cache/treedb-column-graph/glove}"
+DB_DIR="${DB_DIR:-/tmp/treedb-column-graph-glove-db}"
+ROWS="${ROWS:-10000}"
+TOPK="${TOPK:-10}"
+EF_SEARCH="${EF_SEARCH:-128}"
+ZIP_URL="${GLOVE_ZIP_URL:-https://nlp.stanford.edu/data/glove.6B.zip}"
+ZIP_PATH="$DATA_DIR/glove.6B.zip"
+GLOVE_PATH="$DATA_DIR/glove.6B.50d.txt"
+
+cat <<EOF
+dataset=GloVe 6B 50d
+url=$ZIP_URL
+cache=$DATA_DIR
+glove_file=$GLOVE_PATH
+db_dir=$DB_DIR
+rows=$ROWS top_k=$TOPK ef_search=$EF_SEARCH
+EOF
+
+if [[ "$run" != true ]]; then
+  cat <<EOF
+dry_run=true
+to_run:
+  scripts/treedb_column_graph_glove_demo.sh --run
+EOF
+  exit 0
+fi
+
+mkdir -p "$DATA_DIR"
+if [[ ! -f "$GLOVE_PATH" ]]; then
+  if [[ ! -f "$ZIP_PATH" ]]; then
+    curl -L "$ZIP_URL" -o "$ZIP_PATH"
+  fi
+  unzip -p "$ZIP_PATH" glove.6B.50d.txt > "$GLOVE_PATH"
+fi
+
+GOWORK="${GOWORK:-off}" go run ./cmd/treedb_column_graph_demo \
+  -dir "$DB_DIR" \
+  -reset \
+  -glove "$GLOVE_PATH" \
+  -rows "$ROWS" \
+  -top-k "$TOPK" \
+  -ef-search "$EF_SEARCH" \
+  -max-decoded-blocks "${MAX_DECODED_BLOCKS:-4}"


### PR DESCRIPTION
## Summary

This V6 closeout PR adds PR-ready benchmark evidence, docs, and a runnable demo for the explicit `column_graph` native-reader path built in the #1646 reconstruction stack.

It does not change runtime search behavior. The code changes are benchmark/reporting, docs, demo, and an opt-in public-dataset script.

## Copied/Adapted From Old Stack

- Copied: no old-stack runtime search code copied.
- Adapted: existing V4 public benchmark harness and V3 native-reader benchmark labels; benchmark metric reporting now exposes reader/cache/open accounting without putting telemetry aggregation in timed search loops.
- Oracle/comparator only: decoded `ColumnVectorGraph` remains a separately labeled comparator/ceiling path and is not used by the demo as the native product path.
- Quarantined/not copied: Deep1B/geometric codec experiments, dynamic overlay work, decoded full-graph product claims, and sidecar/vector-only persistence paths.

## Path Identity

- Native reader: `column_graph_native_reader`; public reusable searcher and one-shot public API paths search through the physical column row reader/cache.
- Decoded comparator: lower-level decoded `ColumnVectorGraph` comparator remains separate and unchanged.
- Legacy/native vector index: unchanged unless a collection explicitly selects `VectorIndexStrategyColumnGraph`.
- Unsupported/fail-closed: unchanged from V5; docs state stale/mutation caveats and rebuild-needed behavior.

## Base And Dependency State

- Base branch: `codex/column-graph-native-v5-mutation-staleness`
- Base commit after latest restack: `d562660a3`
- #1621/#1634 assumptions: use the existing generic physical column row reader/cache and stats surfaces; do not add vector-specific storage/caching shortcuts.
- Missing generic column-store primitives: larger production-scale reader/cache tuning and sustained dataset evidence remain outside this V6 closeout.

## Evidence

- Tests: docs guide validation, demo close/reopen native-reader path, existing focused collection vector/native-reader tests.
- Benchmarks: cold/open setup, reusable steady-state public search, one-shot public search, public search plus post-top-k document materialization, serial native-reader kernel, parallel native-reader kernel.
- Status/fallback proof: demo/test assert `search path=column_graph_native_reader` and `column_graph_loaded` after close/reopen.
- Performance attribution: runtime search code is untouched. Benchmark stats are sampled before timed loops so telemetry reporting does not depress throughput or add hot-loop allocations.
- Local regressions found/fixed: removed benchmark per-iteration stats accumulation from the timed loop before publishing this PR, specifically to avoid measurement-induced CPU/allocation drift.

## Test Plan Start

- Milestone tasks targeted: V6 benchmark/docs/demo closeout.
- Tests to add before or with implementation: demo close/reopen test, docs/wording test, dataset script dry-run validation.
- Existing tests to preserve: focused `TestSearchVectorIndexColumnGraph`, `TestOpenVectorIndexSearcher`, `TestColumnVectorGraphNativeSearch` coverage.
- #1646 test-list changes made before implementation: already present on the issue; this PR implements the V6 test/demo/docs items without changing milestone scope.

## Performance Plan Start

- Relevant benchmarks/metrics for this PR: public native-reader setup/search/materialization benchmarks plus lower-level serial/parallel native-reader kernel benchmarks.
- Baseline/comparator command: V5 public-path benchmark from `codex/column-graph-native-v5-mutation-staleness`, same Apple M3 hardware, same benchmark shape.
- Expected setup/search/materialization boundary: setup/open measured separately; reusable search has setup outside timer; one-shot public path intentionally includes open/setup; document benchmark intentionally fetches docs after top-k.
- Upstream costs explicitly out of scope: generic #1621/#1634 reader/cache internals and future larger dataset tuning.
- Local performance risks to watch: benchmark instrumentation in timed loops, repeated setup hidden in steady-state search, added memcopies/allocations from docs/demo changes, misleading labels.

## Test Plan Close

- Additional tests found during implementation/review: added docs checks to prevent wording that equates decoded comparator search with native column-store search.
- Tests added or changed: `cmd/treedb_column_graph_demo` demo test; focused GloVe parse/non-finite rejection test; `TreeDB/docs` guide/script validation; benchmark reporting comments to keep telemetry out of hot timed loops.
- Failing tests fixed: none after final pass.
- #1646 test-list changes made at close: none required; the issue already contains V6 benchmark/docs/demo and throughput-drift requirements.
- Residual untested gaps: the opt-in GloVe script is dry-run validated in CI-safe form; full dataset download/run is intentionally manual.

## Performance Plan Close

Hardware: Apple M3, darwin/arm64.

Focused validation commands:

```sh
GOWORK=off go test ./cmd/treedb_column_graph_demo -count=1
GOWORK=off go test ./TreeDB/docs -run 'TestDocs_ColumnGraphNative' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexColumnGraph|TestOpenVectorIndexSearcher|TestColumnVectorGraphNativeSearch' -count=1
scripts/treedb_column_graph_glove_demo.sh
GOWORK=off go run ./cmd/treedb_column_graph_demo -dir /tmp/treedb-column-graph-demo-v6 -reset -rows 128 -dims 16 -degree 8 -top-k 5 -ef-search 64 -max-decoded-blocks 2
```

All passed locally. Demo output includes:

```text
search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false
stats candidates=64 edges=436 row_fetches=64 cache_hits=68 cache_misses=1 decoded_blocks=1 granules_touched=1 physical_B=25912 max_resident_B=26936 docs_fetched=0
```

Benchmark commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' -benchmem -benchtime=500ms -count=5
benchstat /tmp/column_graph_v5_full_bench_now_d562.txt /tmp/column_graph_v6_full_bench_restack_4eac.txt
```

Representative latest-head results on `4eac16e1c`:

| Category | Median latency | Approx throughput | Allocations | Key accounting |
| --- | ---: | ---: | ---: | --- |
| Native-reader kernel serial | 66.45 us/op | 15.0k searches/s | 0 B/op, 0 allocs/op | 128 candidates, 1,912 edges, 0 physical_B/search |
| Native-reader kernel parallel | 11.95 us/op | 83.7k searches/s total | 0 B/op, 0 allocs/op | real parallel benchmark, 8 workers |
| Public reusable searcher | 66.24 us/op | 15.1k searches/s | 784 B/op, 2 allocs/op | 128 row_fetches/search, 0 physical_B/search after warm cache |
| Public one-shot `SearchVectorIndex` | 357.1 us/op | 2.8k searches/s | 1.37 MiB/op, 121 allocs/op | includes open/setup, 694,584 open_physical_B/op |
| Public one-shot plus docs | 3.394 ms/op | 295 searches/s | 12.83 MiB/op, 11.2k allocs/op | includes 10 docs fetched after top-k |
| Native-reader setup/open | 134.3 us/op | 7.4k opens/s | 690.8 KiB/op, 87 allocs/op | open only, no search |

Same-time V5-parent-to-V6-current `benchstat` on comparable public/hot paths:

```text
ColumnVectorGraphNativeSearchCosineV3:             65.91us -> 66.45us (~), 0 B/op and 0 allocs/op unchanged
ColumnVectorGraphNativeSearchCosineParallelV3:     12.20us -> 11.95us (~), 0 B/op and 0 allocs/op unchanged
SearchVectorIndexColumnGraphNativeReaderV4:        356.4us -> 357.1us (~), B/op and allocs/op unchanged
OpenVectorIndexSearcherColumnGraphNativeReaderV4:  66.56us -> 66.24us (~), 784 B/op and 2 allocs/op unchanged
SearchVectorIndex...WithDocumentsV4:               3.408ms -> 3.394ms (~), B/op and allocs/op unchanged
```

Benchmark sample note: n=5 output still prints benchstat's `need >= 6 samples` warning for confidence intervals; the comparison is sufficient here as PR-local drift evidence, not a final performance claim.

Review-resolution throughput closeout: the latest restack merged the current V5 parent (`d562660a3`) into V6 and did not change runtime search behavior. Same-time V5-vs-V6 comparison shows no statistically meaningful slowdown on comparable kernel, reusable-searcher, one-shot, or document-materialization paths; operation counts, `B/op`, and `allocs/op` are unchanged. Older faster V6 numbers from the previous parent are superseded by the current restacked evidence and are not being treated as the new baseline.

## AI Review Loop

- Latest head after restack: `4eac16e1c`.
- Codex latest-head review: no major issues on `4eac16e1c` at 2026-05-21T13:27:09Z.
- Copilot latest-head review: requested after the final restack push; no Copilot comments or review threads were posted.
- CodeRabbit latest-head review: acknowledged latest restack/throughput evidence and posted no actionable comments on `4eac16e1c`; status is success.
- Review comments/threads resolved or explicitly dismissed: unresolved review-thread count is zero after latest-head check.
- CI: all GitHub checks passed on `4eac16e1c`; merge state is `CLEAN`.

Refs #1646.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI demo for column-graph native vector search workflows.
  * Added a GloVe-backed demo script with an opt-in smoke-run mode.

* **Documentation**
  * Published column-graph native vector search quickstart, benchmarks, demo steps, and guidance.

* **Tests**
  * Added docs and demo validation tests.
  * Updated vector-index benchmarks to report warm-started search metrics and added a benchmark for searcher setup/open behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



