### PR TITLE
TreeDB column store post-V1: avoid manifest key allocations

### DIFF
--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -427,7 +427,7 @@ func decodeColumnManifestRecords(records []columnManifestRecord) (columnManifest
 }
 
 func decodeColumnManifestDictionaryCodesRecord(key, raw []byte) (columnManifestDictionaryCodesSnapshot, error) {
-	generation, partID, columnName, err := columnManifestDictionaryCodesKeyFromRecordKey(key)
+	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestDictionaryCodesSnapshot{}, err
 	}
@@ -441,12 +441,12 @@ func decodeColumnManifestDictionaryCodesRecord(key, raw []byte) (columnManifestD
 	if part.AssetRef.Generation != generation || part.AssetRef.PartID != partID {
 		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key generation/part does not match ref")
 	}
-	if part.Reason != columnName {
-		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", columnName, part.Reason)
+	if !manifestBytesEqualString(columnName, part.Reason) {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", string(columnName), part.Reason)
 	}
 	return columnManifestDictionaryCodesSnapshot{
 		AssetRef:     part.AssetRef,
-		ColumnName:   columnName,
+		ColumnName:   part.Reason,
 		Bytes:        part.Bytes,
 		PublishID:    part.PublishID,
 		GenerationID: part.GenerationID,
@@ -454,7 +454,7 @@ func decodeColumnManifestDictionaryCodesRecord(key, raw []byte) (columnManifestD
 }
 
 func decodeColumnManifestInt64ValuesRecord(key, raw []byte) (columnManifestInt64ValuesSnapshot, error) {
-	generation, partID, columnName, err := columnManifestInt64ValuesKeyFromRecordKey(key)
+	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestInt64ValuesSnapshot{}, err
 	}
@@ -468,12 +468,12 @@ func decodeColumnManifestInt64ValuesRecord(key, raw []byte) (columnManifestInt64
 	if part.AssetRef.Generation != generation || part.AssetRef.PartID != partID {
 		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key generation/part does not match ref")
 	}
-	if part.Reason != columnName {
-		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", columnName, part.Reason)
+	if !manifestBytesEqualString(columnName, part.Reason) {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", string(columnName), part.Reason)
 	}
 	return columnManifestInt64ValuesSnapshot{
 		AssetRef:     part.AssetRef,
-		ColumnName:   columnName,
+		ColumnName:   part.Reason,
 		Rows:         part.Rows,
 		Bytes:        part.Bytes,
 		PublishID:    part.PublishID,
@@ -482,7 +482,7 @@ func decodeColumnManifestInt64ValuesRecord(key, raw []byte) (columnManifestInt64
 }
 
 func decodeColumnManifestAggregateMetadataRecord(key, raw []byte) (columnManifestAggregateMetadataSnapshot, error) {
-	generation, partID, name, err := columnManifestAggregateMetadataKeyFromRecordKey(key)
+	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestAggregateMetadataSnapshot{}, err
 	}
@@ -496,12 +496,12 @@ func decodeColumnManifestAggregateMetadataRecord(key, raw []byte) (columnManifes
 	if part.AssetRef.Generation != generation || part.AssetRef.PartID != partID {
 		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key generation/part does not match ref")
 	}
-	if part.Reason != name {
-		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key name=%q does not match record name=%q", name, part.Reason)
+	if !manifestBytesEqualString(name, part.Reason) {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key name=%q does not match record name=%q", string(name), part.Reason)
 	}
 	return columnManifestAggregateMetadataSnapshot{
 		AssetRef:     part.AssetRef,
-		Name:         name,
+		Name:         part.Reason,
 		Bytes:        part.Bytes,
 		PublishID:    part.PublishID,
 		GenerationID: part.GenerationID,
@@ -686,39 +686,63 @@ func enumerateColumnManifestAssetRefsForPrefix(iter iterator.UnsafeIterator, pre
 }
 
 func columnManifestAggregateMetadataKeyFromRecordKey(key []byte) (uint64, uint64, string, error) {
+	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	return generation, partID, string(name), nil
+}
+
+func columnManifestAggregateMetadataKeyPartsFromRecordKey(key []byte) (uint64, uint64, []byte, error) {
 	if !bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) {
-		return 0, 0, "", fmt.Errorf("collections: column manifest aggregate metadata key %q missing prefix", string(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest aggregate metadata key %q missing prefix", string(key))
 	}
 	if len(key) <= len(columnManifestAggregateMetadataRecordPrefix)+16 {
-		return 0, 0, "", fmt.Errorf("collections: column manifest aggregate metadata key length=%d too short", len(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest aggregate metadata key length=%d too short", len(key))
 	}
 	return binary.BigEndian.Uint64(key[len(columnManifestAggregateMetadataRecordPrefix):]),
 		binary.BigEndian.Uint64(key[len(columnManifestAggregateMetadataRecordPrefix)+8:]),
-		string(key[len(columnManifestAggregateMetadataRecordPrefix)+16:]), nil
+		key[len(columnManifestAggregateMetadataRecordPrefix)+16:], nil
 }
 
 func columnManifestDictionaryCodesKeyFromRecordKey(key []byte) (uint64, uint64, string, error) {
+	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	return generation, partID, string(columnName), nil
+}
+
+func columnManifestDictionaryCodesKeyPartsFromRecordKey(key []byte) (uint64, uint64, []byte, error) {
 	if !bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) {
-		return 0, 0, "", fmt.Errorf("collections: column manifest dictionary codes key %q missing prefix", string(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest dictionary codes key %q missing prefix", string(key))
 	}
 	if len(key) <= len(columnManifestDictionaryCodesRecordPrefix)+16 {
-		return 0, 0, "", fmt.Errorf("collections: column manifest dictionary codes key length=%d too short", len(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest dictionary codes key length=%d too short", len(key))
 	}
 	return binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix):]),
 		binary.BigEndian.Uint64(key[len(columnManifestDictionaryCodesRecordPrefix)+8:]),
-		string(key[len(columnManifestDictionaryCodesRecordPrefix)+16:]), nil
+		key[len(columnManifestDictionaryCodesRecordPrefix)+16:], nil
 }
 
 func columnManifestInt64ValuesKeyFromRecordKey(key []byte) (uint64, uint64, string, error) {
+	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	return generation, partID, string(columnName), nil
+}
+
+func columnManifestInt64ValuesKeyPartsFromRecordKey(key []byte) (uint64, uint64, []byte, error) {
 	if !bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes) {
-		return 0, 0, "", fmt.Errorf("collections: column manifest int64 values key %q missing prefix", string(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest int64 values key %q missing prefix", string(key))
 	}
 	if len(key) <= len(columnManifestInt64ValuesRecordPrefix)+16 {
-		return 0, 0, "", fmt.Errorf("collections: column manifest int64 values key length=%d too short", len(key))
+		return 0, 0, nil, fmt.Errorf("collections: column manifest int64 values key length=%d too short", len(key))
 	}
 	return binary.BigEndian.Uint64(key[len(columnManifestInt64ValuesRecordPrefix):]),
 		binary.BigEndian.Uint64(key[len(columnManifestInt64ValuesRecordPrefix)+8:]),
-		string(key[len(columnManifestInt64ValuesRecordPrefix)+16:]), nil
+		key[len(columnManifestInt64ValuesRecordPrefix)+16:], nil
 }
 
 func columnManifestRootRecordIterator(identityRecord [columnManifestIdentityRecordSize]byte, records []columnManifestRecord) *systemTargetIterator {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 87,
+			maxAllocs: 83,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 107,
+			maxAllocs: 103,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 76,
+			maxAllocs: 72,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 110,
+			maxAllocs: 106,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 110,
+			maxAllocs: 106,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 115,
+			maxAllocs: 111,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Static Analysis / Priority Checkpoint

After #1683, focused allocation profiles still showed manifest sidecar key suffix materialization as a small but repeated setup cost in routed one-shot `RunColumnPhysicalQuery` calls. The bounded local slice here is to avoid allocating string copies for sidecar record-key names during manifest decode when the decoded record payload already owns the logical name in `part.Reason`.

This is tactical allocation hygiene in manifest/view setup. It does not change physical asset representation, routed planner behavior, prepared runners, read-integrity/checksum policy, mutation handling, marks, locators, dictionaries, schema-fixed blocks, or reducer/kernel shape. It should not be read as closing the production-vs-experiment analytical-kernel gap.

## What Landed

- Adds byte-slice key-part helpers for aggregate metadata, dictionary-code, and int64-value manifest sidecar record keys.
- Decodes sidecar records by comparing the record-key suffix bytes to the already-decoded payload reason, then reuses that owned reason string in the snapshot.
- Keeps the existing string-returning key helpers for compatibility with scan/rewrite callers and tests.
- Tightens the #1634 routed sidecar allocation-budget test by 4 allocs/run for q1-q5 shapes.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed evidence; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict `verify`.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Local machine: Apple M3, darwin/arm64. Head: `abd0a9908`.

Measurement class: `direct package scanner`. TDD pre-change allocation gate failed with tightened q1/q2 budgets: q1 reported `84 allocs/run` with budget `<=83`, q2 reported `104 allocs/run` with budget `<=103`. After the manifest key decode change, the tightened allocation-budget test passes for q1/q2/q3/q4a/q4b/q5 with budgets `83/103/72/106/106/111`.

Measurement class: `direct package scanner`. Focused adapter benchmark, Apple M3, 8,192 rows, `-benchtime=500x -count=5`, artifact `/tmp/gomap_1634_manifest_key_decode_adapter_bench.txt`:

| Shape | Current result | Allocations |
|---|---:|---:|
| q1 rows 8192 | `5.63-5.92 ns/row`, `169.0-177.7M rows/s`, `~8.34 KiB/op` | `79 allocs/op` |
| q2 rows 8192 | `6.32-6.64 ns/row`, `150.6-158.3M rows/s`, `~9.71 KiB/op` | `99 allocs/op` |
| q3 rows 8192 | `6.31-6.50 ns/row`, `153.9-158.5M rows/s`, `~7.27 KiB/op` | `67 allocs/op` |
| q4a rows 8192 | `8.26-9.04 ns/row`, `110.7-121.0M rows/s`, `~9.15 KiB/op` | `101 allocs/op` |
| q4b rows 8192 | `9.37-10.25 ns/row`, `97.5-106.7M rows/s`, `~9.15 KiB/op` | `101 allocs/op` |
| q5 rows 8192 | `9.04-9.57 ns/row`, `104.5-110.6M rows/s`, `~9.36 KiB/op` | `106 allocs/op` |

Measurement class: `direct package scanner`. Same-machine benchstat against #1683 artifact `/tmp/gomap_1634_manifest_decoder_adapter_bench.txt`, current artifact `/tmp/gomap_1634_manifest_key_decode_adapter_bench.txt`:

```text
allocs/op:
q1 84 -> 79 (-5.95%)
q2 104 -> 99 (-4.81%)
q3 72 -> 67 (-6.94%)
q4a 106 -> 101 (-4.72%)
q4b 106 -> 101 (-4.72%)
q5 111 -> 106 (-4.50%)
geomean 96.04 -> 90.97 (-5.28%)

B/op geomean 8.837 KiB -> 8.790 KiB (-0.53%)
sec/op geomean 59.68 us -> 62.44 us (+4.61%)
```

The time result is mixed and should not be interpreted as a throughput win. q1/q2 improve in this sample, q3 is not significant, and q4/q5 are slower in the 5-sample run. This PR is justified by the measured allocation reduction and lower manifest setup heap churn, not by improved wall-clock query time.

Measurement class: `direct package scanner`. Focused allocation profile after the change, artifact `/tmp/gomap_1634_manifest_key_decode_adapter_allocs_top.txt`, shows `decodeColumnManifestRecords` at `24,120` flat allocation objects over the profiled run. Remaining focused allocation is dominated by manifest cursor string decode/clones, dictionary-int64 reducer setup, path/file-cache setup, result construction, and compatibility string helper callers outside this decode path.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot, Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp`:

| Query | ns/row | rows/s | Notes |
|---|---:|---:|---|
| q1 | `10.0` | `100.46M` | dictionary-code sidecar hits=100, row materializations=0 |
| q2 | `48.9` | `20.43M` | dictionary-code sidecar hits=100, row materializations=0 |
| q3 | `6.2` | `161.67M` | int64-value sidecar hits=100, row materializations=0 |
| q4a | `33.0` | `30.34M` | dictionary-code hits=100, int64-value hits=100 |
| q4b | `32.2` | `31.01M` | dictionary-code hits=100, int64-value hits=100 |
| q5 | `33.2` | `30.08M` | dictionary-code hits=100, int64-value hits=100 |
| q5_metadata serial alias | `33.8` | `29.59M` | serial physical alias; `metadata_hits=0` |

This routed path reaches the changed manifest decode path because every routed `RunColumnPhysicalQuery` prepares a snapshot view before physical sidecar execution. It is still a routed production measurement, not a prepared hot-runner measurement. It includes planner/setup, manifest/view prep, typed asset reads, read-integrity verification, reducer execution, parity, and reporting boundaries as emitted by `unified-bench`.

Measurement class: `prepared hot runner / warmed repeated Run()`. Not changed by this PR; no prepared-runner table is included and no billion-rows/sec claim is made.

Measurement class: `experiment/granule baseline`. Prior #1634 granule context remains the allocation/kernel target: equivalent dense hot kernels target `0 allocs/op`. Historical/context values for equivalent JSONBench-shaped hot kernels remain q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded row scan `~12.48 ns/row`, q5 encoded row scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, and q5 metadata `~2.406 ns/row`. These are not durable routed production measurements. This PR reduces routed package scanner allocations but does not move those paths to zero or convert the format into schema-fixed granule blocks.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context remains `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`; stale local 1M-row ClickHouse q1/q2/q3/q4/q5 numbers are approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. These are contextual and not apples-to-apples with this routed 100K durable TreeDB run.

Scale note: the routed table reports `ns/row` plus row count. For 100K rows, `10 ns/row` is about `1 ms`; `33 ns/row` is about `3.3 ms`. Do not read direct package-scanner `ns/row` or prepared-runner `ns/row` as full database lifecycle time.

## Throughput Interpretation

This PR removes a small per-run manifest setup allocation source by avoiding sidecar key suffix string materialization in decode paths. It is deliberately not a representation/kernel-shape PR. The production-vs-granule gap remains centered on allocation-free hot kernels, routed/session reuse, dense code/block representation, marks/pruning, and metadata/locator assets rather than another row-cursor or manifest-key micro-optimization.

## Apples-to-Apples Limitations

- The direct package scanner benchmark is over 8,192 rows and repeatedly calls `RunColumnPhysicalQuery` over an already-open collection; it is not a full `unified-bench` run.
- The routed snapshot is 100K rows, durable profile, strict `verify`, forced serial physical path. It includes more setup/reporting than direct package scanner results.
- The routed snapshot is useful comparable context but this PR should not be judged by routed throughput deltas because the changed allocation source is small and setup-heavy.
- Granule and ClickHouse numbers are historical/contextual unless explicitly rerun in a future PR; they are included as actual values above for scale/context, not as gates for this allocation-hygiene PR.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnManifestRecordDecodeAcceptsV1CompatibilityM1634|TestColumnPhysicalQueryAdapterExecutesJSONBenchShapesM13B' -count=1 -v` passed.
- `go test ./TreeDB/collections -run 'TestColumnManifest|TestColumnPhysicalQuery|TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634|TestColumnPhysicalAsset|TestColumnAssetRewrite' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/(q1|q2|q3|q4a|q4b|q5)_rows_8192$' -benchmem -benchtime=500x -count=5` passed.
- Focused allocation-profile benchmark with `-memprofile /tmp/gomap_1634_manifest_key_decode_adapter_allocs.pprof -memprofilerate=1` passed.
- `make unified-bench` passed.
- Routed `unified-bench -suite column_store ... -keys 100000 ... -column-store-path serial_column_scan` passed with q1-q5 parity.
- `git diff --check` passed.

## Artifacts

- Direct package scanner benchmark: `/tmp/gomap_1634_manifest_key_decode_adapter_bench.txt`.
- Benchstat: `/tmp/gomap_1634_manifest_key_decode_benchstat.txt`.
- Allocation profile benchmark output: `/tmp/gomap_1634_manifest_key_decode_adapter_memprofile_bench.txt`.
- Allocation profile: `/tmp/gomap_1634_manifest_key_decode_adapter_allocs.pprof`.
- Allocation profile top: `/tmp/gomap_1634_manifest_key_decode_adapter_allocs_top.txt`.
- Routed production markdown: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/column_store_results.md`.
- Routed production HTML: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/column_store_results.html`.
- Routed production JSON: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/column_store_results.json`.
- Benchprof JSON/markdown: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/benchprof_results.json`, `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/benchprof_results.md`.
- Insights HTML: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/insights.html`.
- CPU profile: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/cpu_column_store_treedb_column_store.pprof`.
- Allocs profile: `/tmp/gomap_1634_manifest_key_decode_routed_100k_rerun_QNJAfp/allocs_column_store_treedb_column_store.pprof`.

## Assumption Ledger / Remaining Work

- Existing string-returning manifest key helpers remain for compatibility and still allocate when called by scan/rewrite helper paths. This PR only removes the decode-path sidecar key string allocation where the payload reason can be reused safely.
- This is not a zero-allocation hot-kernel PR. Direct package scanner paths still allocate well above the granule target.
- The next #1634 slice should start with another static/profile checkpoint and prioritize a measured allocation source or representation/kernel-shape work. Do not continue manifest-key micro-optimization unless fresh profiles show it is still material.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal validation logic for manifest key parsing and comparison.

* **Chores**
  * Optimized memory allocation budgets for query performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
