### PR TITLE
TreeDB column store post-V1: cache asset namespace paths

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -55,6 +55,8 @@ var columnAssetVerifiedChecksumCache = struct {
 	entries [columnAssetVerifiedChecksumCacheSlots]columnAssetVerifiedChecksumEntry
 }{}
 
+var columnAssetManagerNamespacePathCaches [columnAssetSegmentWriteLockStripes]columnAssetManagerNamespacePathCache
+
 type columnAssetVerifiedChecksumEntry struct {
 	key   columnAssetVerifiedChecksumKey
 	valid bool
@@ -78,6 +80,14 @@ type columnAssetSegmentAllocationCache struct {
 	valid      bool
 }
 
+type columnAssetManagerNamespacePathCache struct {
+	sync.Mutex
+	rootDir   string
+	namespace string
+	value     columnAssetManagerNamespace
+	valid     bool
+}
+
 type columnAssetManagerNamespace struct {
 	ManagerRootDir string
 	RootDir        string
@@ -93,13 +103,21 @@ func columnAssetManagerNamespaceForRoot(rootDir, namespace string) (columnAssetM
 	if rootDir == "" {
 		return columnAssetManagerNamespace{}, errors.New("collections: column asset manager root dir is required")
 	}
+	cache := &columnAssetManagerNamespacePathCaches[columnAssetNamespacePathCacheIndex(rootDir, namespace)]
+	cache.Lock()
+	if cache.valid && cache.rootDir == rootDir && cache.namespace == namespace {
+		value := cache.value
+		cache.Unlock()
+		return value, nil
+	}
+	cache.Unlock()
 	cleanNamespace, err := cleanColumnAssetNamespace(namespace)
 	if err != nil {
 		return columnAssetManagerNamespace{}, err
 	}
 	namespaceRoot := filepath.Join(rootDir, filepath.FromSlash(cleanNamespace))
 	assetDir := filepath.Join(namespaceRoot, columnAssetManagerAssetsDirName)
-	return columnAssetManagerNamespace{
+	value := columnAssetManagerNamespace{
 		ManagerRootDir: rootDir,
 		RootDir:        namespaceRoot,
 		AssetDir:       assetDir,
@@ -108,7 +126,33 @@ func columnAssetManagerNamespaceForRoot(rootDir, namespace string) (columnAssetM
 		PreparedDir:    filepath.Join(namespaceRoot, columnAssetManagerPreparedDirName),
 		QuarantineDir:  filepath.Join(namespaceRoot, columnAssetManagerQuarantineDirName),
 		TempDir:        filepath.Join(namespaceRoot, columnAssetManagerTempDirName),
-	}, nil
+	}
+	cache.Lock()
+	cache.rootDir = rootDir
+	cache.namespace = namespace
+	cache.value = value
+	cache.valid = true
+	cache.Unlock()
+	return value, nil
+}
+
+func columnAssetNamespacePathCacheIndex(rootDir, namespace string) uint64 {
+	const (
+		fnvOffset64 = 14695981039346656037
+		fnvPrime64  = 1099511628211
+	)
+	hash := uint64(fnvOffset64)
+	for i := 0; i < len(rootDir); i++ {
+		hash ^= uint64(rootDir[i])
+		hash *= fnvPrime64
+	}
+	hash ^= '/'
+	hash *= fnvPrime64
+	for i := 0; i < len(namespace); i++ {
+		hash ^= uint64(namespace[i])
+		hash *= fnvPrime64
+	}
+	return hash % uint64(len(columnAssetManagerNamespacePathCaches))
 }
 
 func cleanColumnAssetNamespace(namespace string) (string, error) {

--- a/TreeDB/collections/column_asset_manager_test.go
+++ b/TreeDB/collections/column_asset_manager_test.go
@@ -1,0 +1,30 @@
+package collections
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestColumnAssetManagerNamespaceForRootCachedM1634(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "column_assets")
+	namespaceName := "events/column-assets"
+	first, err := columnAssetManagerNamespaceForRoot(root, namespaceName)
+	if err != nil {
+		t.Fatalf("columnAssetManagerNamespaceForRoot first: %v", err)
+	}
+	if first.ManagerRootDir != root || first.RootDir == "" || first.SegmentDir == "" {
+		t.Fatalf("unexpected namespace paths: %+v", first)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := columnAssetManagerNamespaceForRoot(root, namespaceName)
+		if err != nil {
+			t.Fatalf("columnAssetManagerNamespaceForRoot cached: %v", err)
+		}
+		if got != first {
+			t.Fatalf("cached namespace mismatch got=%+v want=%+v", got, first)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("cached namespace path allocs/run=%0.2f want 0", allocs)
+	}
+}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 79,
+			maxAllocs: 71,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 99,
+			maxAllocs: 91,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 68,
+			maxAllocs: 60,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 102,
+			maxAllocs: 94,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 102,
+			maxAllocs: 94,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 107,
+			maxAllocs: 99,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Static Analysis / Priority Checkpoint

After #1685, the latest focused allocation profile still showed repeated one-shot typed column asset namespace/path setup in routed package scans. `columnAssetManagerNamespaceForRoot` accounted for `49,296` cumulative focused allocation objects, and `filepath.Join` accounted for `51,252` focused allocation objects in `/tmp/gomap_1634_post1685_adapter_allocs_top.txt`. This PR targets only that measured setup source by adding a bounded process-local namespace path cache for the isolated typed `column_assets/` namespace.

This is local allocation hygiene for the current routed/direct package path. It does not change physical asset representation, planner routing, prepared runners, read-integrity/checksum policy, mutation handling, marks, locators, dictionaries, schema-fixed blocks, or reducer/kernel shape. It should not be read as closing the production-vs-experiment analytical-kernel gap.

## What Landed

- Adds a bounded striped cache for `columnAssetManagerNamespaceForRoot(rootDir, namespace)` so repeated hot reads reuse already-validated namespace path derivations without rebuilding the same `filepath.Join` tree.
- Keeps namespace validation fail-closed on cache misses and does not change the isolated typed `column_assets/` physical namespace contract.
- Adds a TDD allocation test proving warmed namespace resolution is `0 allocs/op`.
- Tightens the #1634 routed sidecar allocation-budget test by 8 allocs/run across q1-q5 shapes.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed path; `RunColumnPhysicalQuery` one-shot package adapter over q1-q5 at 8,192 rows.
- Measurement class: `routed unified-bench query path`. Current 100K durable forced `serial_column_scan` snapshot included for end-to-end comparable context.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. Focused adapter benchmark on Apple M3, darwin/arm64, 8,192 rows, `-benchtime=500x -count=5`, artifact `/tmp/gomap_1634_namespace_cache_adapter_bench.txt`:

| query | throughput | allocs |
|---|---:|---:|
| q1 rows 8192 | `4.96-5.82 ns/row`, `171.9-201.5M rows/s`, `~6.68 KiB/op` | `67 allocs/op` |
| q2 rows 8192 | `5.64-5.79 ns/row`, `172.7-177.2M rows/s`, `~8.05 KiB/op` | `87 allocs/op` |
| q3 rows 8192 | `5.43-5.51 ns/row`, `181.4-184.1M rows/s`, `~5.61 KiB/op` | `55 allocs/op` |
| q4a rows 8192 | `7.75-7.84 ns/row`, `127.6-129.0M rows/s`, `~7.46 KiB/op` | `89 allocs/op` |
| q4b rows 8192 | `8.41-8.54 ns/row`, `117.0-118.9M rows/s`, `~7.46 KiB/op` | `89 allocs/op` |
| q5 rows 8192 | `7.97-8.08 ns/row`, `123.8-125.5M rows/s`, `~7.71 KiB/op` | `94 allocs/op` |

Benchstat versus #1685 artifact `/tmp/gomap_1634_cached_asset_root_adapter_bench.txt`, written to `/tmp/gomap_1634_namespace_cache_benchstat.txt`:

allocs/op:
- q1 `75 -> 67` (`-10.67%`)
- q2 `95 -> 87` (`-8.42%`)
- q3 `63 -> 55` (`-12.70%`)
- q4a `97 -> 89` (`-8.25%`)
- q4b `97 -> 89` (`-8.25%`)
- q5 `102 -> 94` (`-7.84%`)
- geomean `86.91 -> 78.76` (`-9.37%`)

B/op geomean improved `8.283 KiB -> 7.114 KiB` (`-14.11%`). rows/s geomean improved `142.2M -> 151.0M` (`+6.22%`).

Measurement class: `direct package scanner`. Focused allocation profile after the change, artifact `/tmp/gomap_1634_namespace_cache_adapter_allocs_top.txt`, no longer shows `columnAssetManagerNamespaceForRoot` in the focused allocation table. `filepath.Join` dropped from `51,252` to `8,202` focused allocation objects. `RunColumnPhysicalQuery` cumulative focused allocation objects dropped from `465,933` to `417,791` in comparable profiles. Remaining focused allocation is still dominated by manifest decode/clones and one-shot reducer/result setup.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot on Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp`:

| query | rows/s | ns/row | notes |
|---|---:|---:|---|
| q1 | `129.06M` | `7.7` | dictionary-code sidecar path, 100 hits, 0 row materializations |
| q2 | `24.24M` | `41.3` | dictionary-code sidecar path, 100 hits, 0 row materializations |
| q3 | `189.30M` | `5.3` | int64-value sidecar path, 100 hits, 0 row materializations |
| q4a | `33.65M` | `29.7` | dictionary+int64 sidecar path, 100/100 hits, 0 row materializations |
| q4b | `34.70M` | `28.8` | dictionary+int64 sidecar path, 100/100 hits, 0 row materializations |
| q5 | `32.99M` | `30.3` | dictionary+int64 sidecar path, 100/100 hits, 0 row materializations |
| q5_metadata serial alias | `33.32M` | `30.0` | serial physical q5 alias; `metadata_hits=0` |

This routed path reaches the changed namespace-path setup because every routed physical query constructs typed column asset read caches for the isolated `column_assets/` namespace. It is still a routed production measurement, not a prepared hot-runner measurement. It includes planner/setup, manifest/view prep, typed asset reads, read-integrity verification, reducer execution, parity, and reporting boundaries as emitted by `unified-bench`.

Byte accounting from the routed snapshot: `source_document_bytes=9368750`, `retained_payload_bytes=3368750`, `column_asset_bytes=21399500`, `column_asset_store_bytes=21399500`, `manifest_control_bytes=28`, `ordinary_value_vlog_bytes=0`, `leaf_vlog_bytes=2367565`, `command_wal_bytes_before_checkpoint=11182573`, `total_reconstructable_bytes=24768278`, `db_total_bytes=35998639 across 9 files`.

Measurement class: `prepared hot runner / warmed repeated Run()`. Not changed by this PR; no prepared-runner table is included and no billion-rows/sec claim is made.

Measurement class: `experiment/granule baseline`. Prior #1634 granule context remains the allocation/kernel target: equivalent dense hot kernels target `0 allocs/op`. Historical/context values for equivalent JSONBench-shaped hot kernels remain q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded row scan `~12.48 ns/row`, q5 encoded row scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, and q5 metadata `~2.406 ns/row`. These are not durable routed production measurements. This PR reduces routed package scanner allocations but does not move those paths to zero or convert the format into schema-fixed granule blocks.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context remains `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`; stale local 1M-row ClickHouse q1/q2/q3/q4/q5 numbers are approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. These are contextual and not apples-to-apples with this routed 100K durable TreeDB run.

## Throughput Interpretation

This PR removes repeated namespace validation/path-construction allocation from hot one-shot typed asset read-cache setup. The measured win is 8 fewer allocations per direct package query and lower bytes/op across q1-q5. The production-vs-granule gap remains centered on allocation-free hot kernels, routed/session reuse, dense code/block representation, marks/pruning, and metadata/locator assets rather than namespace-path caching.

The `ns/row` and `scan ms` values are different scales: the current 100K routed scans are single-digit to low-double-digit milliseconds by query, while 1M rows at `~90 ns/row` would extrapolate to about `90 ms`. This PR reports both where relevant and does not phrase ns/row as total scan time.

## Apples-to-Apples Limitations

- The package scanner benchmark isolates repeated one-shot physical query execution in-process; it is not a full durable ingest/reopen/planner/reporting benchmark.
- The routed snapshot is useful comparable context but this PR should not be judged by routed throughput deltas because the changed allocation source is small and setup-heavy.
- Prepared runners are unchanged; this PR makes no prepared hot-runner throughput claim.
- Granule and ClickHouse numbers are historical/contextual unless explicitly rerun in a future PR; they are included as actual values above for scale/context, not as gates for this allocation-hygiene PR.

## Gate Status

- `go test ./TreeDB/collections -run TestColumnAssetManagerNamespaceForRootCachedM1634 -count=1 -v` passed.
- `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1 -v` passed.
- `go test ./TreeDB/collections -run 'TestColumnAssetManagerNamespaceForRootCachedM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634' -count=1 -v` passed.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `git diff --check` passed.
- `make unified-bench` passed.
- Focused adapter benchmark and allocation profile passed.
- Routed `unified-bench` 100K durable forced `serial_column_scan` snapshot passed with parity.

## Artifacts

- Direct package scanner benchmark: `/tmp/gomap_1634_namespace_cache_adapter_bench.txt`.
- Benchstat vs #1685: `/tmp/gomap_1634_namespace_cache_benchstat.txt`.
- Allocation profile: `/tmp/gomap_1634_namespace_cache_adapter_allocs.pprof`.
- Allocation profile top: `/tmp/gomap_1634_namespace_cache_adapter_allocs_top.txt`.
- Routed snapshot dir: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp`.
- Routed markdown: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/column_store_results.md`.
- Routed HTML: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/column_store_results.html`.
- Routed JSON: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/column_store_results.json`.
- Benchprof JSON: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/benchprof_results.json`.
- Benchprof markdown: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/benchprof_results.md`.
- Insights HTML: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/insights.html`.
- CPU profile: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/cpu_column_store_treedb_column_store.pprof`.
- Allocs profile: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/allocs_column_store_treedb_column_store.pprof`.
- Trace: `/tmp/gomap_1634_namespace_cache_routed_100k.5ctZZp/trace.out`.

## Assumption Ledger / Remaining Work

- This is not a zero-allocation hot-kernel PR. Direct package scanner paths still allocate well above the granule target.
- The namespace-path cache is bounded and process-local; it avoids repeated path derivation but does not change durable refs, asset ownership, checksums, pin/zombie/rewrite semantics, or GC reachability.
- The next #1634 slice should start with another static/profile checkpoint and prioritize measured manifest decode/clones, one-shot reducer/result setup, routed/session reuse, or representation/kernel-shape work. Do not continue path-cache micro-optimization unless fresh profiles show a specific remaining path setup hotspot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added caching for namespace path computations, eliminating redundant recomputation on repeated operations with the same inputs.

* **Tests**
  * Added test coverage for namespace caching stability and zero-allocation performance on cached calls.
  * Optimized allocation budgets for serial sidecar query performance tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->