### PR TITLE
TreeDB column store post-V1: avoid scan key string materialization

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 71,
+			maxAllocs: 65,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 91,
+			maxAllocs: 85,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 60,
+			maxAllocs: 53,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 94,
+			maxAllocs: 87,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 94,
+			maxAllocs: 87,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 99,
+			maxAllocs: 92,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -614,7 +614,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 				iter.Next()
 				continue
 			}
-			keyGeneration, _, _, err := columnManifestAggregateMetadataKeyFromRecordKey(key)
+			keyGeneration, _, _, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
@@ -642,7 +642,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 				iter.Next()
 				continue
 			}
-			keyGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(key)
+			keyGeneration, _, _, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
@@ -670,7 +670,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 				iter.Next()
 				continue
 			}
-			keyGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(key)
+			keyGeneration, _, _, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
@@ -784,7 +784,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 				active = append(active, record)
 			}
 		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
-			metadataGeneration, _, _, err := columnManifestAggregateMetadataKeyFromRecordKey(record.key)
+			metadataGeneration, _, _, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return nil, err
 			}
@@ -792,7 +792,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 				active = append(active, record)
 			}
 		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
-			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return nil, err
 			}
@@ -800,7 +800,7 @@ func activeColumnManifestRecordsForScan(records []columnManifestRecord, generati
 				active = append(active, record)
 			}
 		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
-			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(record.key)
+			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return nil, err
 			}
@@ -846,7 +846,7 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 			if !sawHeader {
 				continue
 			}
-			metadataGeneration, _, _, err := columnManifestAggregateMetadataKeyFromRecordKey(record.key)
+			metadataGeneration, _, _, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return columnManifestSnapshot{}, err
 			}
@@ -857,7 +857,7 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 			if !sawHeader {
 				continue
 			}
-			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyFromRecordKey(record.key)
+			dictionaryGeneration, _, _, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return columnManifestSnapshot{}, err
 			}
@@ -868,7 +868,7 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 			if !sawHeader {
 				continue
 			}
-			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyFromRecordKey(record.key)
+			valuesGeneration, _, _, err := columnManifestInt64ValuesKeyPartsFromRecordKey(record.key)
 			if err != nil {
 				return columnManifestSnapshot{}, err
 			}


### PR DESCRIPTION
## Benchmark Claim Boundary

Primary measurement class: `direct package scanner`.
Changed path reaches routed unified-bench: yes; routed serial physical scans exercise the same manifest scan validation/setup path before running q1-q5.
Prepared-runner boundary, if applicable: not applicable; this PR makes no prepared hot-runner or billion-rows/sec claim.
Current routed comparable snapshot: Apple M3, durable, 100K rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG`; q1 `7.5 ns/row`, q2 `40.7`, q3 `5.5`, q4a `28.5`, q4b `28.8`, q5 `29.3`, q5_metadata serial alias `29.4`, all parity pass.
Granule/ClickHouse context: historical granule q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`; historical ClickHouse JSONBench 1M q1/q2/q3/q4/q5 `~0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. These are context only, not an end-to-end parity claim.
Scale note: direct package numbers below are `ns/row` over 8,192-row package benchmark fixtures; routed numbers are `ns/row` over 100K rows. A `90 ns/row` result over 100K rows is about 9 ms, while 1M rows at `90 ns/row` extrapolates to about 90 ms.

## Static Analysis / Priority Checkpoint

After #1686, typed asset namespace path setup no longer appeared as a material allocation source. The next measured local allocation source was manifest key string materialization during scan-time validation: several paths only needed generation/part ids but called helpers that converted the trailing key name bytes into Go strings. This PR removes that local avoidable allocation by using existing `*KeyPartsFromRecordKey` helpers in physical scan validation paths.

This is tactical allocation hygiene inside the current manifest/TCPA-sidecar setup path. It does not change representation shape, does not add mark pruning or metadata fast paths, and does not claim to close the production-vs-granule analytical-kernel gap.

## What Landed

- Replaced unused string-returning manifest key decode calls with byte-slice key-parts helpers in physical scan planner capability validation.
- Applied the same change in active manifest record filtering and scan snapshot validation.
- Tightened the q1-q5 routed sidecar allocation-budget gate by 6-7 allocs/run across the serial sidecar query shapes.
- Preserved fail-closed manifest key prefix/length/generation validation; only unused string construction was removed.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed evidence; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict `verify`.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Not used by this PR; no prepared-runner claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. TDD pre-change allocation gate failed as expected with q1 `67`, q2 `87`, q3 `55`, q4a `89`, q4b `89`, q5 `94` allocs/run against tightened targets `65/85/53/87/87/92`. After the key-parts change, the allocation-budget test passes.

Measurement class: `direct package scanner`. Focused adapter benchmark on Apple M3, darwin/arm64, 8,192 rows, `-benchtime=500x -count=5`, artifact `/tmp/gomap_1634_key_parts_adapter_bench.txt`:

- q1: `4.92-5.84 ns/row`, `171.3-203.2M rows/s`, `62 allocs/op`.
- q2: `5.57-5.71 ns/row`, `175.0-179.5M rows/s`, `82 allocs/op`.
- q3: `5.51-5.59 ns/row`, `178.9-181.6M rows/s`, `50 allocs/op`.
- q4a: `7.58-7.76 ns/row`, `128.9-131.9M rows/s`, `84 allocs/op`.
- q4b: `8.21-8.33 ns/row`, `120.1-121.8M rows/s`, `84 allocs/op`.
- q5: `7.72-7.86 ns/row`, `127.2-129.6M rows/s`, `89 allocs/op`.

Measurement class: `direct package scanner`. Benchstat versus #1686 artifact `/tmp/gomap_1634_namespace_cache_adapter_bench.txt`, written to `/tmp/gomap_1634_key_parts_benchstat.txt`:

```text
allocs/op: q1 67 -> 62 (-7.46%), q2 87 -> 82 (-5.75%), q3 55 -> 50 (-9.09%), q4a 89 -> 84 (-5.62%), q4b 89 -> 84 (-5.62%), q5 94 -> 89 (-5.32%), geomean 78.76 -> 73.65 (-6.49%)
B/op geomean: 7.114 KiB -> 7.067 KiB (-0.66%)
rows/s geomean: 151.0M -> 152.8M (+1.18%)
```

Focused allocation attribution, artifact `/tmp/gomap_1634_key_parts_adapter_allocs_focused_top.txt`, still shows remaining setup allocations in manifest decode/clones, one-shot reducer/result setup, and file-cache opens. This PR removes the local unused string conversion source but does not eliminate manifest decode allocation as a class.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG`:

- q1: `7.5 ns/row`, `133.33M rows/s`, parity pass.
- q2: `40.7 ns/row`, `24.58M rows/s`, parity pass.
- q3: `5.5 ns/row`, `181.68M rows/s`, parity pass.
- q4a: `28.5 ns/row`, `35.13M rows/s`, parity pass.
- q4b: `28.8 ns/row`, `34.77M rows/s`, parity pass.
- q5: `29.3 ns/row`, `34.16M rows/s`, parity pass.
- q5_metadata serial alias: `29.4 ns/row`, `33.97M rows/s`, `metadata_hits=0`.

The routed path reaches the changed manifest scan validation/setup because forced serial physical scans prepare and validate the manifest records before executing q1-q5 sidecar scans. This remains a routed production scan over the current sidecar/TCPA-adjacent physical representation; it is not a prepared hot-runner measurement.

Measurement class: `experiment/granule baseline`. Historical/context values for equivalent JSONBench-shaped hot kernels remain q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded row scan `~12.48 ns/row`, q5 encoded row scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, and q5 metadata `~2.406 ns/row`. These are not durable routed production measurements.

Measurement class: `historical ClickHouse context`. Stale local ClickHouse JSONBench context remains 1M-row q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`.

## Throughput Interpretation

The main result is allocation reduction, not a major throughput change. Direct package scanner allocs/op drop by five allocations for every q1-q5 shape measured, moving the current routed package path closer to the granule `0 allocs/op` target while preserving correctness gates.

The small rows/sec movement is useful but not the claim boundary. This PR does not add schema-fixed column blocks, dictionary/mark/metadata pruning, prepared routed session reuse, or dense block reducers beyond existing sidecar paths. Remaining post-V1 priority should continue to be allocation parity and representation/kernel shape, using fresh static/profile checkpoints for each PR.

## Apples-to-Apples Limitations

- Direct package scanner numbers include `RunColumnPhysicalQuery` setup and result construction; they are not prepared hot-runner kernel numbers.
- Routed `unified-bench` numbers include durable fixture/create/insert/checkpoint/reopen/planner/reporting artifacts separately, but the query rows above are still a 100K synthetic fixture, not the historical 1M ClickHouse JSONBench fixture.
- Granule and ClickHouse values are historical context, not same-commit same-harness reruns.
- `q5_metadata` under forced `serial_column_scan` is a serial alias with `metadata_hits=0`, not a real aggregate metadata fast path.
- This PR optimizes manifest key decode allocation only; it does not alter column asset read integrity, mutation handling, WAL/checkpoint, or GC/rewrite behavior.

## Gate Status

- TDD pre-change allocation gate failed as expected: `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1 -v`.
- Post-change allocation gate passed: `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1 -v`.
- Focused query/manifest tests passed: `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnManifest' -count=1`.
- Full touched package tests passed: `go test ./TreeDB/collections -count=1`.
- Unified-bench package tests passed: `go test ./cmd/unified_bench -count=1`.
- Focused adapter benchmark passed and wrote `/tmp/gomap_1634_key_parts_adapter_bench.txt`.
- Focused allocation profile passed and wrote `/tmp/gomap_1634_key_parts_adapter_allocs.pprof` and `/tmp/gomap_1634_key_parts_adapter_allocs_focused_top.txt`.
- `make unified-bench` passed.
- Routed `unified-bench` snapshot passed and wrote `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG`.
- `git diff --check` passed.

## Artifacts

- Direct package scanner: `/tmp/gomap_1634_key_parts_adapter_bench.txt`.
- Base #1686 direct package scanner: `/tmp/gomap_1634_namespace_cache_adapter_bench.txt`.
- Benchstat: `/tmp/gomap_1634_key_parts_benchstat.txt`.
- Focused allocation profile: `/tmp/gomap_1634_key_parts_adapter_allocs.pprof`.
- Focused allocation top: `/tmp/gomap_1634_key_parts_adapter_allocs_focused_top.txt`.
- Routed production markdown: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/column_store_results.md`.
- Routed production HTML: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/column_store_results.html`.
- Routed production JSON: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/column_store_results.json`.
- Benchprof JSON/markdown: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/benchprof_results.json`, `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/benchprof_results.md`.
- Insights HTML: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/insights.html`.
- CPU profile: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/cpu_column_store_treedb_column_store.pprof`.
- Allocs profile: `/tmp/gomap_1634_key_parts_routed_100k_L3J5KG/allocs_column_store_treedb_column_store.pprof`.

## Assumption Ledger / Remaining Work

- This is local allocation hygiene. The remaining allocation gap is still material: q1-q5 direct package scans are at `50-89 allocs/op`, not the granule hot-kernel target of `0 allocs/op`.
- Remaining measured candidates include manifest decode/clones, result/reducer setup, file-cache/session reuse, and representation/kernel-shape work. The next #1634 PR should start with a fresh static/profile checkpoint before choosing among them.
- No merge is requested by this PR.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Performance**
  * Optimized column manifest scanning and key extraction logic for improved efficiency.
  * Adjusted performance benchmarks to reflect current system behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->