### PR TITLE
TreeDB column store post-V1: use scan-specific manifest view decode

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 65,
+			maxAllocs: 58,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 85,
+			maxAllocs: 78,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 53,
+			maxAllocs: 46,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 87,
+			maxAllocs: 80,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 87,
+			maxAllocs: 80,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 92,
+			maxAllocs: 85,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1226,6 +1226,12 @@ func decodeColumnManifestPartFieldsForScan(raw []byte, expectedNamespace string)
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
 		return ColumnAssetRef{}, 0, 0, 0, 0, nil, err
 	}
+	if bytes64 == 0 {
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: column prepared asset bytes=0 must be positive")
+	}
+	if int64(bytes64) != ref.Length {
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, fmt.Errorf("collections: column prepared asset bytes=%d does not match ref length=%d", bytes64, ref.Length)
+	}
 	return ref, int(rows64), int64(bytes64), publishID, generationID, reason, nil
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -258,17 +258,12 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 		return view, err
 	}
 	diag.ManifestRecords = len(records)
-	manifest, err := decodeColumnManifestRecords(records)
+	manifest, refs, mutationParts, err := decodeColumnManifestSnapshotViewForScan(records, cfg.AssetManager.Namespace)
 	if err != nil {
 		view.Diagnostics = diag
 		return view, err
 	}
 	if err := validateColumnManifestSnapshot(manifest, records, cfg, *cfg.ActiveManifest, collectionName, "physical column scan"); err != nil {
-		view.Diagnostics = diag
-		return view, err
-	}
-	refs, mutationParts, err := columnManifestAssetRefsFromRecordsForScan(records, manifest.Generation, cfg.AssetManager.Namespace)
-	if err != nil {
 		view.Diagnostics = diag
 		return view, err
 	}
@@ -886,6 +881,221 @@ func decodeColumnManifestSnapshotForScan(records []columnManifestRecord) (column
 	return snapshot, nil
 }
 
+func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, expectedNamespace string) (columnManifestSnapshot, []columnManifestAssetRefForScan, int, error) {
+	var snapshot columnManifestSnapshot
+	sawHeader := false
+	partRecords := 0
+	metadataRecords := 0
+	dictionaryRecords := 0
+	int64ValueRecords := 0
+	for _, record := range records {
+		switch {
+		case bytes.Equal(record.key, columnManifestHeaderRecordKeyBytes):
+			if sawHeader {
+				return columnManifestSnapshot{}, nil, 0, errors.New("collections: duplicate column manifest binary header record")
+			}
+			header, err := decodeColumnManifestHeaderRecord(record.value)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, err
+			}
+			snapshot = header
+			sawHeader = true
+		case bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes):
+			partRecords++
+		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
+			metadataRecords++
+		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
+			dictionaryRecords++
+		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
+			int64ValueRecords++
+		}
+	}
+	if !sawHeader {
+		return columnManifestSnapshot{}, nil, 0, errors.New("collections: column manifest missing binary header record")
+	}
+	if metadataRecords > 0 {
+		snapshot.AggregateMetadata = make([]columnManifestAggregateMetadataSnapshot, 0, metadataRecords)
+	}
+	if dictionaryRecords > 0 {
+		snapshot.DictionaryCodes = make([]columnManifestDictionaryCodesSnapshot, 0, dictionaryRecords)
+	}
+	if int64ValueRecords > 0 {
+		snapshot.Int64Values = make([]columnManifestInt64ValuesSnapshot, 0, int64ValueRecords)
+	}
+
+	refs := make([]columnManifestAssetRefForScan, 0, partRecords)
+	livePartRows := make(map[[2]uint64]int, partRecords)
+	mutationParts := 0
+	activeParts := 0
+	for _, record := range records {
+		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) {
+			continue
+		}
+		keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
+		if err != nil {
+			return columnManifestSnapshot{}, nil, 0, err
+		}
+		if keyGeneration > snapshot.Generation {
+			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: column manifest part generation=%d is newer than header generation=%d", keyGeneration, snapshot.Generation)
+		}
+		ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(record.value, expectedNamespace)
+		if err != nil {
+			return columnManifestSnapshot{}, nil, 0, err
+		}
+		if ref.Kind != ColumnAssetKindTCS1PartImage {
+			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
+		}
+		if ref.Generation != keyGeneration {
+			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+		}
+		if ref.PartID != keyPartID {
+			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
+		}
+		operation, ok := columnPhysicalScanOperationFromBytes(reason)
+		if !ok {
+			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
+		}
+		livePartRows[[2]uint64{ref.Generation, ref.PartID}] = rows
+		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+		if ref.Generation == snapshot.Generation {
+			activeParts++
+		}
+		if operation != ColumnPublishOperationInsert {
+			mutationParts++
+		}
+	}
+	for _, record := range records {
+		switch {
+		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, err
+			}
+			snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
+		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, err
+			}
+			snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
+		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, err
+			}
+			snapshot.Int64Values = append(snapshot.Int64Values, values)
+		}
+	}
+	if uint64(activeParts) != snapshot.ExpectedParts {
+		return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: invalid column manifest part count=%d want %d", activeParts, snapshot.ExpectedParts)
+	}
+	return snapshot, refs, mutationParts, nil
+}
+
+func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestAggregateMetadataSnapshot, error) {
+	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
+	if err != nil {
+		return columnManifestAggregateMetadataSnapshot{}, err
+	}
+	ref, _, bytesValue, publishID, generationID, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return columnManifestAggregateMetadataSnapshot{}, err
+	}
+	if ref.Kind != ColumnAssetKindTCS1AggregateMetadata {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1AggregateMetadata)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if !bytes.Equal(name, reason) {
+		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key name=%q does not match record name=%q", string(name), string(reason))
+	}
+	return columnManifestAggregateMetadataSnapshot{
+		AssetRef:     ref,
+		Name:         string(name),
+		Bytes:        bytesValue,
+		PublishID:    publishID,
+		GenerationID: generationID,
+	}, nil
+}
+
+func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestDictionaryCodesSnapshot, error) {
+	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return columnManifestDictionaryCodesSnapshot{}, err
+	}
+	ref, _, bytesValue, publishID, generationID, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return columnManifestDictionaryCodesSnapshot{}, err
+	}
+	if ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1DictionaryCodes)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if !bytes.Equal(columnName, reason) {
+		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", string(columnName), string(reason))
+	}
+	return columnManifestDictionaryCodesSnapshot{
+		AssetRef:     ref,
+		ColumnName:   string(columnName),
+		Bytes:        bytesValue,
+		PublishID:    publishID,
+		GenerationID: generationID,
+	}, nil
+}
+
+func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestInt64ValuesSnapshot, error) {
+	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return columnManifestInt64ValuesSnapshot{}, err
+	}
+	ref, rows, bytesValue, publishID, generationID, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return columnManifestInt64ValuesSnapshot{}, err
+	}
+	if ref.Kind != ColumnAssetKindTCS1Int64Values {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1Int64Values)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	partRows, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]
+	if !ok {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if rows != partRows {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values rows=%d does not match part rows=%d", rows, partRows)
+	}
+	if !bytes.Equal(columnName, reason) {
+		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", string(columnName), string(reason))
+	}
+	return columnManifestInt64ValuesSnapshot{
+		AssetRef:     ref,
+		ColumnName:   string(columnName),
+		Rows:         rows,
+		Bytes:        bytesValue,
+		PublishID:    publishID,
+		GenerationID: generationID,
+	}, nil
+}
+
 func columnManifestPartGenerationFromRecordKeyForScan(key []byte) (uint64, error) {
 	generation, _, err := columnManifestPartKeyFromRecordKeyForScan(key)
 	return generation, err
@@ -943,13 +1153,24 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, a
 }
 
 func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (ColumnAssetRef, []byte, error) {
+	ref, _, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return ColumnAssetRef{}, nil, err
+	}
+	if ref.Kind != ColumnAssetKindTCS1PartImage {
+		return ColumnAssetRef{}, nil, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
+	}
+	return ref, reason, nil
+}
+
+func decodeColumnManifestPartFieldsForScan(raw []byte, expectedNamespace string) (ColumnAssetRef, int, int64, uint64, uint64, []byte, error) {
 	cur := manifestCursor{raw: raw}
 	if magic := cur.u32(); magic != columnManifestPartMagic {
-		return ColumnAssetRef{}, nil, fmt.Errorf("collections: bad column manifest part magic=0x%08x", magic)
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, fmt.Errorf("collections: bad column manifest part magic=0x%08x", magic)
 	}
 	version := cur.u16()
 	if version != columnManifestRecordVersion && version != columnManifestRecordVersionV1 {
-		return ColumnAssetRef{}, nil, fmt.Errorf("collections: unsupported column manifest part version=%d", version)
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, fmt.Errorf("collections: unsupported column manifest part version=%d", version)
 	}
 	kindBytes := cur.stringBytes()
 	namespaceBytes := cur.stringBytes()
@@ -963,36 +1184,37 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 	if version >= columnManifestRecordVersion {
 		rows64 = cur.u64()
 	}
-	_ = cur.u64() // bytes; scan only needs the durable asset ref.
-	_ = cur.u64() // publish_id
-	_ = cur.u64() // generation_id
+	bytes64 := cur.u64()
+	publishID := cur.u64()
+	generationID := cur.u64()
 	reason := cur.stringBytes()
 	if err := cur.err; err != nil {
-		return ColumnAssetRef{}, nil, err
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, err
 	}
 	if cur.pos != len(raw) {
-		return ColumnAssetRef{}, nil, errors.New("collections: trailing bytes in column manifest part record")
-	}
-	if !columnPhysicalBytesEqualString(kindBytes, string(ColumnAssetKindTCS1PartImage)) {
-		return ColumnAssetRef{}, nil, fmt.Errorf("collections: unsupported column manifest part asset kind %q", string(kindBytes))
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: trailing bytes in column manifest part record")
 	}
 	if !columnPhysicalBytesEqualString(namespaceBytes, expectedNamespace) {
-		return ColumnAssetRef{}, nil, fmt.Errorf("collections: column manifest part namespace=%q want %q", string(namespaceBytes), expectedNamespace)
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, fmt.Errorf("collections: column manifest part namespace=%q want %q", string(namespaceBytes), expectedNamespace)
 	}
 	if fileID64 > uint64(math.MaxUint32) {
-		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part file_id overflows uint32")
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: column manifest part file_id overflows uint32")
 	}
 	if checksum64 > uint64(math.MaxUint32) {
-		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part checksum overflows uint32")
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: column manifest part checksum overflows uint32")
 	}
 	if rows64 > uint64(maxCollectionInt) {
-		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part rows overflows int")
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: column manifest part rows overflows int")
 	}
-	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) {
-		return ColumnAssetRef{}, nil, errors.New("collections: column manifest part offsets or byte counts overflow int64")
+	if offset64 > uint64(math.MaxInt64) || length64 > uint64(math.MaxInt64) || bytes64 > uint64(math.MaxInt64) {
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, errors.New("collections: column manifest part offsets or byte counts overflow int64")
+	}
+	kind, ok := columnAssetKindFromBytesForScan(kindBytes)
+	if !ok {
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, fmt.Errorf("collections: unsupported column manifest part asset kind %q", string(kindBytes))
 	}
 	ref := ColumnAssetRef{
-		Kind:       ColumnAssetKindTCS1PartImage,
+		Kind:       kind,
 		Namespace:  expectedNamespace,
 		Generation: generation,
 		PartID:     partID,
@@ -1002,9 +1224,24 @@ func decodeColumnManifestPartRefForScan(raw []byte, expectedNamespace string) (C
 		Checksum:   uint32(checksum64),
 	}
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
-		return ColumnAssetRef{}, nil, err
+		return ColumnAssetRef{}, 0, 0, 0, 0, nil, err
 	}
-	return ref, reason, nil
+	return ref, int(rows64), int64(bytes64), publishID, generationID, reason, nil
+}
+
+func columnAssetKindFromBytesForScan(raw []byte) (ColumnAssetKind, bool) {
+	switch {
+	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1PartImage)):
+		return ColumnAssetKindTCS1PartImage, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1AggregateMetadata)):
+		return ColumnAssetKindTCS1AggregateMetadata, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1DictionaryCodes)):
+		return ColumnAssetKindTCS1DictionaryCodes, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1Int64Values)):
+		return ColumnAssetKindTCS1Int64Values, true
+	default:
+		return "", false
+	}
 }
 
 func scanColumnPhysicalAssetRows(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg *ColumnStoreConfig, projection columnPhysicalScanProjection, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"os"
 	"strings"
@@ -69,6 +70,52 @@ func TestColumnManifestAssetRefsRejectPartIDKeyMismatchM13C(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "key part_id") {
 		t.Fatalf("columnManifestAssetRefsFromRecordsForScan err=%v want key part_id mismatch", err)
 	}
+}
+
+func TestColumnManifestScanViewRejectsPreparedAssetByteMismatchM1634(t *testing.T) {
+	_, _, manifest, asset := columnManifestPlannerOnePartFixtureM14A(t)
+	tampered := cloneColumnManifestRecords(manifest.Records)
+	replaced := false
+	for i := range tampered {
+		if bytes.Equal(tampered[i].key, columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID)) {
+			badRecord := bytes.Clone(tampered[i].value)
+			pos := columnManifestPartRecordBytesOffsetForScanTestM1634(t, badRecord)
+			binary.BigEndian.PutUint64(badRecord[pos:], uint64(asset.Ref.Length+1))
+			tampered[i].value = badRecord
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		t.Fatal("manifest part record not found")
+	}
+	if _, _, _, err := decodeColumnManifestSnapshotViewForScan(tampered, asset.Ref.Namespace); err == nil || !strings.Contains(err.Error(), "does not match ref length") {
+		t.Fatalf("decodeColumnManifestSnapshotViewForScan err=%v want byte/ref length mismatch", err)
+	}
+}
+
+func columnManifestPartRecordBytesOffsetForScanTestM1634(t testing.TB, raw []byte) int {
+	t.Helper()
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnManifestPartMagic {
+		t.Fatalf("bad part magic=0x%08x", magic)
+	}
+	version := cur.u16()
+	cur.skipStringBytes() // kind
+	cur.skipStringBytes() // namespace
+	_ = cur.u64()         // generation
+	_ = cur.u64()         // part_id
+	_ = cur.u64()         // file_id
+	_ = cur.u64()         // offset
+	_ = cur.u64()         // length
+	_ = cur.u64()         // checksum
+	if version >= columnManifestRecordVersion {
+		_ = cur.u64() // rows
+	}
+	if cur.err != nil {
+		t.Fatalf("decode part prefix: %v", cur.err)
+	}
+	return cur.pos
 }
 
 func columnManifestAssetRefFilterTestAssetM13C(generation, partID uint64, reason ColumnPublishOperation) ColumnPreparedAsset {


### PR DESCRIPTION
## Benchmark Claim Boundary

This PR is a #1634 post-V1 allocation-hygiene slice. It does not claim final analytical-kernel parity with `experiments/colgranule` or ClickHouse, and it does not change the physical asset format, planner routing, WAL/checkpoint behavior, mutation visibility, mark pruning, dictionaries, or metadata fast paths.

Billion-rows/sec prepared-runner claims are not part of this PR. All primary measurements below are either `direct package scanner` one-shot adapter benchmarks or the routed `unified-bench` production query path.

## Static Analysis / Priority Checkpoint

After #1687, focused allocation profiles no longer pointed at scan-time manifest key string materialization. The next local allocation source was full manifest value decode in physical query preparation: `decodeColumnManifestRecords` built full `columnManifestPartSnapshot` values and materialized part kind/namespace/reason strings even though the scan path immediately re-decoded the same part records as typed refs/operation bytes.

This PR adds a scan-specific manifest view decoder for physical scan/query preparation. It preserves fail-closed header, generation, namespace, kind, key/ref, sidecar, row-count, checksum, and identity validation, but avoids constructing full part snapshots and discarded part strings on hot routed scans.

## What Landed

- `prepareColumnPhysicalScanSnapshotViewAtSnapshot` now uses a scan-specific manifest decoder that returns the header snapshot, typed scan refs, mutation count, and sidecar snapshots in one scan-oriented pass.
- Ordinary TCS1 part records are decoded through byte-backed fields and `ColumnPublishOperation` parsing instead of full string materialization.
- Sidecar records still validate key/ref/name/kind/generation/part/row-count relationships and materialize only the sidecar names required by query planning.
- The #1634 routed sidecar allocation gate was tightened again for q1-q5.

## Measurement Class

- Primary local allocation evidence: `direct package scanner`.
- End-to-end comparable snapshot: routed `unified-bench` query path.
- Historical/context baselines: `experiment/granule baseline` and `historical ClickHouse context`.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. TDD allocation gate before implementation failed as expected:

- q1 `62 allocs/run` wanted `<=58`
- q2 `82 allocs/run` wanted `<=78`
- q3 `50 allocs/run` wanted `<=46`
- q4a `84 allocs/run` wanted `<=80`
- q4b `84 allocs/run` wanted `<=80`
- q5 `89 allocs/run` wanted `<=85`

After implementation, the tightened allocation gate passes.

Measurement class: `direct package scanner`. Focused adapter benchmark on Apple M3, darwin/arm64, 8,192 rows, `-benchtime=500x -count=5`, artifact `/tmp/gomap_1634_scan_manifest_view_adapter_bench.txt`:

- q1: `5.004-5.604 ns/row`, `178.4-199.8M rows/s`, `48 allocs/op`
- q2: `5.633-5.776 ns/row`, `173.1-177.5M rows/s`, `68 allocs/op`
- q3: `5.452-5.842 ns/row`, `171.2-183.4M rows/s`, `36 allocs/op`
- q4a: `7.399-7.583 ns/row`, `131.9-135.1M rows/s`, `70 allocs/op`
- q4b: `8.150-8.654 ns/row`, `115.6-122.7M rows/s`, `70 allocs/op`
- q5: `7.700-7.892 ns/row`, `126.7-129.9M rows/s`, `75 allocs/op`

Benchstat versus #1687 artifact `/tmp/gomap_1634_key_parts_adapter_bench.txt`, written to `/tmp/gomap_1634_scan_manifest_view_benchstat.txt`:

- allocs/op q1 `62 -> 48` (`-22.58%`), q2 `82 -> 68` (`-17.07%`), q3 `50 -> 36` (`-28.00%`), q4a `84 -> 70` (`-16.67%`), q4b `84 -> 70` (`-16.67%`), q5 `89 -> 75` (`-15.73%`)
- common q1-q5 geomean allocs/op `73.65 -> 59.42` (`-19.58%`)
- B/op improved roughly 1 KiB/op per query shape, common q1-q5 geomean `7.067 KiB -> 5.953 KiB` (`-14.28%`)
- rows/s was effectively neutral: q4a improved modestly, other q1-q5 shapes were within run noise

Focused allocation profile after this PR, artifact `/tmp/gomap_1634_scan_manifest_view_adapter_allocs_focused_top.txt`, no longer shows `manifestCursor.string` as the dominant scan-setup bucket. Remaining local buckets include manifest record `bytes.Clone`, scan-view maps/slices, metadata accumulator/result setup, reducer scratch/result setup, and segment file path/open work.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot on Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_scan_manifest_view_routed_100k_3AruHV`:

- q1: `8.3 ns/row`, `120.51M rows/s`, parity pass
- q2: `40.9 ns/row`, `24.46M rows/s`, parity pass
- q3: `6.3 ns/row`, `159.39M rows/s`, parity pass
- q4a: `28.7 ns/row`, `34.85M rows/s`, parity pass
- q4b: `28.5 ns/row`, `35.05M rows/s`, parity pass
- q5: `29.1 ns/row`, `34.36M rows/s`, parity pass
- q5_metadata serial alias: `29.2 ns/row`, `34.24M rows/s`, `metadata_hits=0`, parity pass

The routed path reaches the changed scan setup, but it is still the production routed query path over current sidecar assets and includes planner/setup/reporting boundaries that direct package scanner benchmarks do not.

## Granule / ClickHouse Context

Measurement class: `experiment/granule baseline`. Historical/context values remain q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded row scan `~12.48 ns/row`, q5 encoded row scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, and q5 metadata `~2.406 ns/row`. These are not durable routed production measurements.

Measurement class: `historical ClickHouse context`. Stale local ClickHouse JSONBench context remains 1M-row q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`.

Apples-to-apples limitation: this PR removes local manifest setup allocations in the current production sidecar path. It does not change the larger representation/kernel gap versus granule: production still lacks true schema-fixed column blocks for all hot paths, full dense reducer coverage, mark pruning, and metadata-only aggregate hits for this routed serial alias.

Scale note: 100K routed scans are usually single-digit/low-double-digit ms; ns/row values are not scan-ms values. For example, 1M rows at `~90 ns/row` extrapolates to `~90 ms`, while this 100K snapshot reports q1 at `8.3 ns/row` and scan time `0.663 ms`.

## Gate Status

- `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1 -v` failed before implementation with the tightened budgets and passed after implementation.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuery|TestColumnManifest|TestColumnPhysicalScan' -count=1` passed.
- Review-fix regression coverage added: `TestColumnManifestScanViewRejectsPreparedAssetByteMismatchM1634` mutates the encoded manifest part bytes field directly and verifies the scan-specific decoder still rejects `Bytes != Ref.Length`.
- `go test ./TreeDB/collections -count=1` passed.
- `go test ./cmd/unified_bench -count=1` passed.
- `make unified-bench` passed.
- `git diff --check` passed.

## Artifacts

- Direct package scanner benchmark: `/tmp/gomap_1634_scan_manifest_view_adapter_bench.txt`
- Previous #1687 direct benchmark baseline: `/tmp/gomap_1634_key_parts_adapter_bench.txt`
- Benchstat: `/tmp/gomap_1634_scan_manifest_view_benchstat.txt`
- Focused allocation benchmark/profile: `/tmp/gomap_1634_scan_manifest_view_adapter_allocs_bench.txt`, `/tmp/gomap_1634_scan_manifest_view_adapter_allocs.pprof`
- Focused allocation top: `/tmp/gomap_1634_scan_manifest_view_adapter_allocs_focused_top.txt`
- Routed snapshot directory: `/tmp/gomap_1634_scan_manifest_view_routed_100k_3AruHV`
- Routed HTML artifacts: `/tmp/gomap_1634_scan_manifest_view_routed_100k_3AruHV/column_store_results.html`, `/tmp/gomap_1634_scan_manifest_view_routed_100k_3AruHV/insights.html`

## Assumption Ledger / Remaining Work

- This PR intentionally keeps publish/recovery/maintenance manifest decode unchanged; it only specializes the physical scan/query preparation view.
- Remaining one-shot direct scanner allocations are still far above the granule hot-kernel `0 allocs/op` target: q1-q5 are now `36-75 allocs/op`.
- Next priority should start with another static/profile checkpoint. Likely candidates are manifest record clone avoidance or prepared/cached manifest views, reducer/result setup reuse, file/session reuse, and representation/kernel-shape work. Do not keep optimizing scan manifest decode unless fresh evidence identifies another local scan-decode hotspot.

Fixes part of #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tuned allocation budgets for column query performance tests.
  * Added a new test that detects and rejects manifest/asset byte-length mismatches to prevent corrupted-scan results.

* **Refactor**
  * Consolidated manifest decoding for physical scans and strengthened validation checks to improve data integrity and reduce memory overhead during scans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
