### PR TITLE
TreeDB column store post-V1: stream scan manifest setup

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 58,
+			maxAllocs: 34,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 78,
+			maxAllocs: 54,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 46,
+			maxAllocs: 22,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 80,
+			maxAllocs: 56,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 80,
+			maxAllocs: 56,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 85,
+			maxAllocs: 61,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -252,21 +252,13 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 		view.Diagnostics = diag
 		return view, err
 	}
-	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	manifest, refs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRoot(snap, rootID, cfg, *cfg.ActiveManifest, collectionName)
 	if err != nil {
+		diag.ManifestRecords = manifestRecords
 		view.Diagnostics = diag
 		return view, err
 	}
-	diag.ManifestRecords = len(records)
-	manifest, refs, mutationParts, err := decodeColumnManifestSnapshotViewForScan(records, cfg.AssetManager.Namespace)
-	if err != nil {
-		view.Diagnostics = diag
-		return view, err
-	}
-	if err := validateColumnManifestSnapshot(manifest, records, cfg, *cfg.ActiveManifest, collectionName, "physical column scan"); err != nil {
-		view.Diagnostics = diag
-		return view, err
-	}
+	diag.ManifestRecords = manifestRecords
 	diag.AssetRefs = len(refs)
 	diag.MutationParts = mutationParts
 	view.AssetRefs = refs
@@ -454,6 +446,171 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 		return nil, err
 	}
 	return records, nil
+}
+
+func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string) (columnManifestSnapshot, []columnManifestAssetRefForScan, int, int, error) {
+	iter, err := snap.IteratorAtRoot(rootID, columnManifestHeaderRecordKeyBytes, nil)
+	if err != nil {
+		return columnManifestSnapshot{}, nil, 0, 0, fmt.Errorf("collections: column manifest root %d unreadable: %w", rootID, err)
+	}
+	defer func() { _ = iter.Close() }()
+
+	var snapshot columnManifestSnapshot
+	var d xxhash.Digest
+	d.Reset()
+	sawHeader := false
+	activeParts := uint64(0)
+	manifestRecords := 0
+	mutationParts := 0
+	refs := make([]columnManifestAssetRefForScan, 0, 8)
+	livePartRows := make(map[[2]uint64]int, 8)
+	for iter.Valid() {
+		key := iter.UnsafeKey()
+		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
+			!bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) &&
+			!bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes) {
+			break
+		}
+		if iter.IsDeleted() {
+			iter.Next()
+			continue
+		}
+		value, _, flags := iter.UnsafeEntry()
+		if flags&node.FlagPointer != 0 {
+			return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest record %q must be inline", key)
+		}
+		manifestRecords++
+
+		switch {
+		case bytes.Equal(key, columnManifestHeaderRecordKeyBytes):
+			if sawHeader {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, errors.New("collections: duplicate column manifest binary header record")
+			}
+			header, err := decodeColumnManifestHeaderRecordForScan(value)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			if err := validateColumnManifestHeaderRecordForScan(header, cfg, identity, collection); err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			operation, _ := columnPhysicalScanOperationFromBytes(header.operation)
+			snapshot = columnManifestSnapshot{
+				Collection:         collection,
+				Operation:          operation,
+				Generation:         header.generation,
+				AppliedCommandLSN:  header.appliedCommandLSN,
+				SchemaHash:         header.schemaHash,
+				ExpectedParts:      header.expectedParts,
+				RowCount:           int(header.rowCount),
+				CommandBytes:       int64(header.commandBytes),
+				RowRemainderBytes:  int64(header.rowRemainderBytes),
+				ColumnPayloadBytes: int64(header.columnPayloadBytes),
+			}
+			writeHashBytes(&d, header.collection)
+			writeHashBytes(&d, header.operation)
+			writeHashUint64(&d, header.generation)
+			writeHashUint64(&d, header.appliedCommandLSN)
+			writeHashUint64(&d, header.schemaHash)
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
+			sawHeader = true
+		case bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(key)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			if keyGeneration > snapshot.Generation {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part generation=%d is newer than header generation=%d", keyGeneration, snapshot.Generation)
+			}
+			ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(value, cfg.AssetManager.Namespace)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			if ref.Kind != ColumnAssetKindTCS1PartImage {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
+			}
+			if ref.Generation != keyGeneration {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+			}
+			if ref.PartID != keyPartID {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
+			}
+			operation, ok := columnPhysicalScanOperationFromBytes(reason)
+			if !ok {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
+			}
+			livePartRows[[2]uint64{ref.Generation, ref.PartID}] = rows
+			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+			if ref.Generation == snapshot.Generation {
+				activeParts++
+			}
+			if operation != ColumnPublishOperationInsert {
+				mutationParts++
+			}
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
+		case bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
+		case bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
+		case bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes):
+			if !sawHeader {
+				iter.Next()
+				continue
+			}
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			snapshot.Int64Values = append(snapshot.Int64Values, values)
+			writeHashBytes(&d, key)
+			writeHashBytes(&d, value)
+		}
+		iter.Next()
+	}
+	if err := iter.Error(); err != nil {
+		return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+	}
+	if !sawHeader {
+		return columnManifestSnapshot{}, nil, 0, manifestRecords, errors.New("collections: column manifest missing binary header record")
+	}
+	if activeParts != snapshot.ExpectedParts {
+		return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: invalid column manifest part count=%d want %d", activeParts, snapshot.ExpectedParts)
+	}
+	checksum := d.Sum64()
+	if checksum == 0 {
+		checksum = 1
+	}
+	if checksum != identity.Checksum {
+		return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: physical column scan manifest checksum=%d want active identity checksum=%d", checksum, identity.Checksum)
+	}
+	return snapshot, refs, mutationParts, manifestRecords, nil
 }
 
 func validateColumnManifestSnapshot(snapshot columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, context string) error {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -94,6 +94,48 @@ func TestColumnManifestScanViewRejectsPreparedAssetByteMismatchM1634(t *testing.
 	}
 }
 
+func TestColumnManifestScanLoaderRejectsChecksumMismatchM1634(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	cfg, _, manifest, _ := columnManifestPlannerOnePartFixtureM14A(t)
+	active := manifest.Identity
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &active
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+
+	tampered := cloneColumnManifestRecords(manifest.Records)
+	tamperedCount := 0
+	for i := range tampered {
+		if bytes.HasPrefix(tampered[i].key, columnManifestPartRecordPrefixBytes) {
+			badRecord := bytes.Clone(tampered[i].value)
+			bytesOffset := columnManifestPartRecordBytesOffsetForScanTestM1634(t, badRecord)
+			publishIDOffset := bytesOffset + 8
+			publishID := binary.BigEndian.Uint64(badRecord[publishIDOffset:])
+			binary.BigEndian.PutUint64(badRecord[publishIDOffset:], publishID+1)
+			tampered[i].value = badRecord
+			tamperedCount++
+			break
+		}
+	}
+	if tamperedCount != 1 {
+		t.Fatalf("tampered manifest part records=%d want 1", tamperedCount)
+	}
+	rootID := publishColumnManifestRecordsForScanTestM13A(t, d, manifest.Identity, tampered)
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	_, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRoot(snap, rootID, *cfg, manifest.Identity, "events")
+	if err == nil || !strings.Contains(err.Error(), "physical column scan manifest checksum") {
+		t.Fatalf("loadColumnManifestSnapshotViewForScanFromRoot err=%v want checksum mismatch", err)
+	}
+}
+
 func columnManifestPartRecordBytesOffsetForScanTestM1634(t testing.TB, raw []byte) int {
 	t.Helper()
 	cur := manifestCursor{raw: raw}


### PR DESCRIPTION
## What Landed

This #1634 slice streams the physical scan manifest view directly from the snapshot iterator instead of first cloning every inline manifest key/value into `[]columnManifestRecord` and then materializing a second active-record slice for checksum validation.

The new scan loader:
- preserves fail-closed header, generation, namespace, part/ref, sidecar, active-part count, and checksum validation;
- hashes active manifest records while iterating the manifest root;
- builds the physical scan view refs/sidecars directly from unsafe iterator bytes without retaining them;
- keeps publish/rewrite paths on the existing owned-record loader.

Regression coverage adds a scan-loader checksum-mismatch test, and the routed q1-q5 allocation budget is tightened to the new lower ceiling.

## Measurement Class

- Primary changed path: measurement class `direct package scanner`; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, asset read/decode, reducer work, and result construction.
- End-to-end comparable snapshot: measurement class `routed unified-bench query path`; the routed production path reaches the changed scan manifest setup in this PR.
- Prepared hot runner: measurement class `prepared hot runner / warmed repeated Run()` is not used as #1689 evidence. Earlier billion-rows/sec prepared-runner results after `PrepareColumnPhysicalQuery` exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.
- Experiment context: measurement class `experiment/granule baseline`; historical dense-kernel context only, not a routed production measurement.
- ClickHouse context: measurement class `historical ClickHouse context`; historical JSONBench context only, not a same-harness gate.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`.

Apple M3, darwin/arm64, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B`, `-benchtime=1000x -count=8`, head `1dce9cb61`:

| query | ns/row | rows/s | B/op | allocs/op |
|---|---:|---:|---:|---:|
| q1 | 4.81-5.52 | 181.1M-207.7M | ~4.46 KiB | 32 |
| q2 | 5.45-5.64 | 177.3M-183.4M | ~5.83 KiB | 52 |
| q3 | 5.24-5.47 | 182.9M-190.9M | ~3.39 KiB | 20 |
| q4a | 7.55-7.83 | 127.7M-132.4M | ~5.24 KiB | 54 |
| q4b | 8.36-8.61 | 116.1M-119.6M | ~5.24 KiB | 54 |
| q5 | 7.86-8.19 | 122.1M-127.2M | ~5.49 KiB | 59 |

Compared with #1688's direct package scanner artifact, common q1-q5 allocation counts move from `48/68/36/70/70/75` to `32/52/20/54/54/59 allocs/op`. Common-shape B/op geomean moves from about `5.95 KiB/op` to `4.87 KiB/op`. Timing is effectively neutral at this fixture scale: q1/q2/q3 are in the same ~5 ns/row band, q4/q5 remain ~7.5-8.6 ns/row, and run-to-run noise is larger than this setup-only change.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. The routed path reaches the changed scan manifest setup in this PR.

Apple M3, darwin/arm64, 100K rows, durable profile, forced `serial_column_scan`, `-column-store-asset-read-integrity verify`, artifact `/tmp/gomap_1634_stream_manifest_routed_100k_kNKp94`:

| query | rows/s | ns/row | scan ms | row materializations | parity |
|---|---:|---:|---:|---:|---|
| q1 | 135.62M | 7.4 | 0.591 | 0 | pass |
| q2 | 24.59M | 40.7 | 3.955 | 0 | pass |
| q3 | 177.02M | 5.6 | 0.452 | 0 | pass |
| q4a | 34.89M | 28.7 | 2.716 | 0 | pass |
| q4b | 35.41M | 28.2 | 2.674 | 0 | pass |
| q5 | 33.44M | 29.9 | 2.820 | 0 | pass |
| q5_metadata alias | 33.85M | 29.5 | 2.810 | 0 | pass |

Measurement class: `experiment/granule baseline`. Historical granule context remains the same stale/reference context used by #1688: q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, q5 metadata `~2.406 ns/row`. This PR does not claim to close the representation/kernel gap; it removes production scan-setup allocation from manifest loading.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context remains 1M q1/q2/q3/q4/q5 at approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is context only, not an apples-to-apples comparison with the direct package scanner or 100K routed production run.

Apples-to-apples limitations: the direct package scanner is an 8,192-row package benchmark, the routed snapshot is a 100K durable `unified-bench` run with reporting/parity/lifecycle stages, the granule baseline is an experiment hot-kernel context, and the ClickHouse numbers are historical JSONBench context. The direct scanner allocation reduction is the claim; ClickHouse/granule parity is not.

## Throughput Interpretation

This is a setup-allocation PR, not a new analytical-kernel path. It does not change sidecar asset layout, dictionary-code reducers, mark pruning, aggregate metadata semantics, WAL/checkpoint behavior, or mutation visibility.

The direct package scanner numbers include physical query adapter setup and scanner execution. The routed `unified-bench` numbers include planner routing, reporting, durable fixture setup, reopen/recovery, and parity stages as separated by the benchmark report. Prepared hot-runner measurements are not part of this PR's evidence.

Scale note: 100K routed scans here are sub-ms to low-ms scan stages for q1-q5. A `~5 ns/row` direct scanner result over 8,192 rows is not a multi-ms scan by itself; larger fixtures are required before fixed setup costs and steady-state scan/reduce slopes are fully separated. Conversely, 1M rows at about `90 ns/row` extrapolates to about `90 ms`.

## Gate Status

- TDD allocation gate failed before implementation at q1/q2/q3/q4a/q4b/q5 `48/68/36/70/70/75 allocs/run` against tightened targets.
- Post-change allocation gate passes with strict targets `34/54/22/56/56/61`.
- `go test ./TreeDB/collections -run 'TestColumnManifestScanLoaderRejectsChecksumMismatchM1634|TestColumnManifestScanViewRejectsPreparedAssetByteMismatchM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuery|TestColumnManifest|TestColumnPhysicalScan' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `make unified-bench`
- `git diff --check`

## Artifacts

- Direct package scanner count-8 benchmark: `/tmp/gomap_1634_stream_manifest_adapter_bench_count8.txt`
- Direct package scanner count-5 benchmark: `/tmp/gomap_1634_stream_manifest_adapter_bench.txt`
- Benchstat against #1688 artifact: `/tmp/gomap_1634_stream_manifest_benchstat.txt`
- Routed 100K artifact dir: `/tmp/gomap_1634_stream_manifest_routed_100k_kNKp94`
- Routed HTML: `/tmp/gomap_1634_stream_manifest_routed_100k_kNKp94/column_store_results.html`
- Insights HTML: `/tmp/gomap_1634_stream_manifest_routed_100k_kNKp94/insights.html`

## Assumption Ledger

The scan loader still allocates result/sidecar slices and reducer outputs. Remaining allocation work should be selected from fresh profiles after this PR, with the larger representation/kernel gap still owned by #1634 follow-up evidence rather than this tactical manifest setup slice.

Refs #1634.
