### PR TITLE
TreeDB column store post-V1: trim dict-int64 scan scratch allocs

### DIFF
--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -355,6 +355,9 @@ func (r *columnDictionaryInt64GroupOneShotReducer) translateDictionary(dictionar
 		r.localToGlobal = make([]uint32, len(dictionary))
 	}
 	localToGlobal := r.localToGlobal[:len(dictionary)]
+	if len(r.groupDict) == 0 {
+		r.growScratch(len(dictionary))
+	}
 	for localCode, value := range dictionary {
 		globalCode, ok := r.groupByValue[value]
 		if !ok {
@@ -372,16 +375,54 @@ func (r *columnDictionaryInt64GroupOneShotReducer) translateDictionary(dictionar
 }
 
 func (r *columnDictionaryInt64GroupOneShotReducer) growScratch(groups int) {
+	if groups > columnDictionaryInt64GroupMaxGroups {
+		groups = columnDictionaryInt64GroupMaxGroups
+	}
 	words := (groups + 63) / 64
 	if len(r.seen) < words {
-		r.seen = append(r.seen, make([]uint64, words-len(r.seen))...)
+		if cap(r.seen) < words {
+			next := make([]uint64, words, columnDictionaryInt64GroupNextScratchCap(cap(r.seen), words))
+			copy(next, r.seen)
+			r.seen = next
+		} else {
+			r.seen = r.seen[:words]
+		}
 	}
 	if len(r.minValues) < groups {
-		r.minValues = append(r.minValues, make([]int64, groups-len(r.minValues))...)
+		if cap(r.minValues) < groups {
+			next := make([]int64, groups, columnDictionaryInt64GroupNextScratchCap(cap(r.minValues), groups))
+			copy(next, r.minValues)
+			r.minValues = next
+		} else {
+			r.minValues = r.minValues[:groups]
+		}
 	}
 	if r.kind == ColumnPhysicalQueryGroupInt64Span && len(r.maxValues) < groups {
-		r.maxValues = append(r.maxValues, make([]int64, groups-len(r.maxValues))...)
+		if cap(r.maxValues) < groups {
+			next := make([]int64, groups, columnDictionaryInt64GroupNextScratchCap(cap(r.maxValues), groups))
+			copy(next, r.maxValues)
+			r.maxValues = next
+		} else {
+			r.maxValues = r.maxValues[:groups]
+		}
 	}
+	if cap(r.result) < groups {
+		r.result = make([]ColumnPhysicalQueryGroup, 0, columnDictionaryInt64GroupNextScratchCap(cap(r.result), groups))
+	}
+}
+
+func columnDictionaryInt64GroupNextScratchCap(current, required int) int {
+	next := current * 2
+	if next < 4 {
+		next = 4
+	}
+	if next < required {
+		next = required
+	}
+	if next > columnDictionaryInt64GroupMaxGroups {
+		next = columnDictionaryInt64GroupMaxGroups
+	}
+	return next
 }
 
 func (r *columnDictionaryInt64GroupOneShotReducer) reduceValue(code uint32, value int64) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2349,17 +2349,17 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 56,
+			maxAllocs: 51,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 56,
+			maxAllocs: 51,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 61,
+			maxAllocs: 55,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## What Landed

This #1634 slice trims avoidable q4/q5 dictionary+int64 one-shot reducer allocations by changing reducer scratch growth from `append(make(...))` per discovered group to bounded scratch growth with reusable capacity.

The change is intentionally local:
- keeps the current routed serial sidecar path and manifest semantics unchanged;
- keeps q1/q2/q3 behavior unchanged;
- preserves fail-closed cardinality limits for dictionary+int64 grouped reducers;
- tightens the q4a/q4b/q5 allocation budget gate.

## Static Analysis / Priority Checkpoint

After #1689, fresh allocation evidence still showed runtime buckets in `RunColumnPhysicalQuery`, including manifest view setup, read-cache file/path work, and q4/q5 dictionary+int64 reducer translation. The q4/q5 reducer had a small local allocation issue: `growScratch` appended a freshly allocated zero slice while discovering each new dictionary group. That is tactical allocation hygiene, not a representation change and not a claim that TCPA/sidecar cursor work closes the granule-kernel gap.

This PR targets that measured local bucket because it is small, safe, and moves q4/q5 direct package scans closer to the granule `0 allocs/op` hot-kernel goal without changing query routing or asset format. The next slice should still start from a fresh static/profile checkpoint and may need to target manifest/view setup, read-cache/open work, or representation/kernel shape rather than more q4/q5 scratch tuning.

## Measurement Class

- Primary changed path: measurement class `direct package scanner`; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, asset read/decode, reducer work, and result construction.
- End-to-end comparable snapshot: measurement class `routed unified-bench query path`; the routed production path reaches the changed q4/q5 dictionary+int64 reducer setup in this PR.
- Prepared hot runner: measurement class `prepared hot runner / warmed repeated Run()` is not used as this PR's evidence. Earlier billion-rows/sec prepared-runner results after `PrepareColumnPhysicalQuery` exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.
- Experiment context: measurement class `experiment/granule baseline`; historical dense-kernel context only, not a routed production measurement.
- ClickHouse context: measurement class `historical ClickHouse context`; historical JSONBench context only, not a same-harness gate.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`.

Apple M3, darwin/arm64, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B`, `-benchtime=1000x -count=6`, head `ae6b7ab80`:

| query | ns/row | rows/s | B/op | allocs/op |
|---|---:|---:|---:|---:|
| q1 | 4.77-6.00 | 166.6M-209.6M | ~4.46 KiB | 32 |
| q2 | 5.50-5.62 | 178.0M-181.8M | ~5.83 KiB | 52 |
| q3 | 5.30-5.47 | 182.8M-188.6M | ~3.39 KiB | 20 |
| q4a | 7.52-7.69 | 130.1M-132.9M | ~4.52 KiB | 46 |
| q4b | 8.26-8.46 | 118.2M-121.0M | ~4.52 KiB | 46 |
| q5 | 7.72-7.89 | 126.8M-129.6M | ~4.62 KiB | 47 |

Benchstat against #1689 direct package scanner artifact `/tmp/gomap_1634_stream_manifest_adapter_bench_count8.txt`:

```text
q4a allocs/op: 54 -> 46 (-14.81%)
q4b allocs/op: 54 -> 46 (-14.81%)
q5  allocs/op: 59 -> 47 (-20.34%)
q4a B/op: ~5.24 KiB -> ~4.52 KiB (-13.71%)
q4b B/op: ~5.24 KiB -> ~4.52 KiB (-13.71%)
q5  B/op: ~5.49 KiB -> ~4.62 KiB (-15.81%)
common q1-q5 alloc geomean: 42.30 -> 38.60 (-8.73%)
common q1-q5 B/op geomean: 4.868 KiB -> 4.503 KiB (-7.49%)
```

Timing is neutral-to-slightly-better at this fixture scale: q4b improved by ~2.35%, q5 by ~1.57%, q4a was within the same range/noise, and q1/q2/q3 were unchanged as expected.

TDD allocation gate: with only the stricter q4/q5 budgets applied, pre-change #1689 failed at q4a/q4b/q5 `54/54/59 allocs/run` against new targets `51/51/55`. After the scratch change, the allocation-budget test passes; observed benchmark allocations are q4a/q4b/q5 `46/46/47 allocs/op`.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. The routed path reaches the changed q4/q5 dictionary+int64 reducer setup in this PR.

Apple M3, darwin/arm64, 100K rows, durable profile, forced `serial_column_scan`, `-column-store-asset-read-integrity verify`, artifact `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN`:

| query | rows/s | ns/row | scan ms | row materializations | parity |
|---|---:|---:|---:|---:|---|
| q1 | 158.84M | 6.3 | 0.464 | 0 | pass |
| q2 | 25.06M | 39.9 | 3.878 | 0 | pass |
| q3 | 186.58M | 5.4 | 0.414 | 0 | pass |
| q4a | 32.08M | 31.2 | 2.966 | 0 | pass |
| q4b | 34.59M | 28.9 | 2.741 | 0 | pass |
| q5 | 33.71M | 29.7 | 2.820 | 0 | pass |
| q5_metadata alias | 33.42M | 29.9 | 2.842 | 0 | pass |

Measurement class: `experiment/granule baseline`. Historical granule context remains q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, q5 metadata `~2.406 ns/row`. This PR does not claim to close the representation/kernel gap; it removes avoidable reducer scratch allocation inside the current production sidecar path.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context remains 1M q1/q2/q3/q4/q5 at approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is context only, not an apples-to-apples comparison with the direct package scanner or 100K routed production run.

Apples-to-apples limitations: the direct package scanner is an 8,192-row package benchmark, the routed snapshot is a 100K durable `unified-bench` run with reporting/parity/lifecycle stages, the granule baseline is an experiment hot-kernel context, and the ClickHouse numbers are historical JSONBench context. The q4/q5 allocation reduction is the claim; ClickHouse/granule parity is not.

## Throughput Interpretation

This is an allocation-hygiene PR for q4/q5 dictionary+int64 reducer setup. It does not change sidecar asset layout, planner routing, mark pruning, aggregate metadata semantics, WAL/checkpoint behavior, reopen, mutation handling, or prepared hot-runner behavior.

The direct package scanner numbers include physical query adapter setup and scanner execution. The routed `unified-bench` numbers include planner routing, reporting, durable fixture setup, reopen/recovery, and parity stages as separated by the benchmark report. Prepared hot-runner measurements are not part of this PR's evidence.

Scale note: 100K routed scans here are sub-ms to low-ms scan stages for q1-q5. A `~7-8 ns/row` direct scanner result over 8,192 rows is not a multi-ms scan by itself; larger fixtures are required before fixed setup costs and steady-state scan/reduce slopes are fully separated. Conversely, 1M rows at about `90 ns/row` extrapolates to about `90 ms`.

## Gate Status

- TDD allocation gate failed before implementation for q4a/q4b/q5 at `54/54/59 allocs/run` against tightened `51/51/55` targets.
- Post-change allocation gate passes with q4a/q4b/q5 targets `51/51/55`.
- `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1 -v`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuery' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `make unified-bench`
- `git diff --check`

## Artifacts

- Direct package scanner q1-q5 benchmark: `/tmp/gomap_1634_dict_int64_scratch_adapter_q1q5_bench_v3.txt`
- Benchstat against #1689: `/tmp/gomap_1634_dict_int64_scratch_benchstat_v3.txt`
- Earlier q4/q5 focused benchmark: `/tmp/gomap_1634_dict_int64_scratch_adapter_bench.txt`
- Routed 100K artifact dir: `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN`
- Routed HTML: `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN/column_store_results.html`
- Insights HTML: `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN/insights.html`
- CPU profile: `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_dict_int64_scratch_routed_100k_psGjNN/allocs_column_store_treedb_column_store.pprof`

## Assumption Ledger

Remaining q4/q5 direct package scanner allocations are still far above the granule `0 allocs/op` hot-kernel target. This PR removes a local scratch-growth allocation source; the next #1634 slice should use fresh static/profile evidence to choose between manifest/view setup, read-cache/open path work, result construction, or a larger representation/kernel-shape change.

Refs #1634.
