### PR TITLE
TreeDB column store post-V1: stream dictionary scan headers

### DIFF
--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -158,6 +158,10 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 			for localCode := 0; localCode < cardinality; localCode++ {
 				if !reducer.translateDictionaryValue(localToGlobal, localCode, dictCur.stringBytes()) {
 					ok = false
+					break
+				}
+				if dictCur.err != nil {
+					break
 				}
 			}
 			if dictCur.err != nil {

--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -136,18 +136,37 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 		}
 		scratch = groupRaw
 		groupIsView := readCache.lastView
-		groupAsset, groupPayload, err := decodeColumnDictionaryCodesAssetPayload(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
-		if err != nil {
-			return ColumnPhysicalQueryResult{}, true, err
-		}
+		var groupPayload columnDictionaryCodesAssetPayload
 		var groupCodes []uint32
+		var localToGlobal []uint32
+		var ok bool
 		if !groupIsView {
 			decoded, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
 			if err != nil {
 				return ColumnPhysicalQueryResult{}, true, err
 			}
-			groupAsset = decoded
+			groupPayload = columnDictionaryCodesAssetPayload{rowCount: len(decoded.Codes), offset: 0}
 			groupCodes = decoded.Codes
+			localToGlobal, ok = reducer.translateDictionary(decoded.Dictionary)
+		} else {
+			ok = true
+			dictCur, cardinality, rowCount, err := decodeColumnDictionaryCodesAssetHeader(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+			if err != nil {
+				return ColumnPhysicalQueryResult{}, true, err
+			}
+			localToGlobal = reducer.prepareDictionary(cardinality)
+			for localCode := 0; localCode < cardinality; localCode++ {
+				if !reducer.translateDictionaryValue(localToGlobal, localCode, dictCur.stringBytes()) {
+					ok = false
+				}
+			}
+			if dictCur.err != nil {
+				return ColumnPhysicalQueryResult{}, true, dictCur.err
+			}
+			groupPayload = columnDictionaryCodesAssetPayload{rowCount: rowCount, offset: dictCur.pos}
+		}
+		if !ok {
+			return ColumnPhysicalQueryResult{}, false, nil
 		}
 		valueRaw, err := readCache.read(valueSnapshot.AssetRef, scratch)
 		if err != nil {
@@ -160,10 +179,6 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 		}
 		if groupPayload.rowCount != valuePayload.rowCount || valuePayload.rowCount != valueSnapshot.Rows {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", groupPayload.rowCount, valuePayload.rowCount, valueSnapshot.Rows)
-		}
-		localToGlobal, ok := reducer.translateDictionary(groupAsset.Dictionary)
-		if !ok {
-			return ColumnPhysicalQueryResult{}, false, nil
 		}
 		valueCur := manifestCursor{raw: valueRaw, pos: valuePayload.offset}
 		if groupCodes != nil {
@@ -372,6 +387,33 @@ func (r *columnDictionaryInt64GroupOneShotReducer) translateDictionary(dictionar
 		localToGlobal[localCode] = globalCode
 	}
 	return localToGlobal, true
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) prepareDictionary(cardinality int) []uint32 {
+	if cap(r.localToGlobal) < cardinality {
+		r.localToGlobal = make([]uint32, cardinality)
+	}
+	localToGlobal := r.localToGlobal[:cardinality]
+	if len(r.groupDict) == 0 {
+		r.growScratch(cardinality)
+	}
+	return localToGlobal
+}
+
+func (r *columnDictionaryInt64GroupOneShotReducer) translateDictionaryValue(localToGlobal []uint32, localCode int, value []byte) bool {
+	globalCode, ok := r.groupByValue[unsafeStringFromBytes(value)]
+	if !ok {
+		if len(r.groupDict) >= columnDictionaryInt64GroupMaxGroups || uint64(len(r.groupDict)) == uint64(^uint32(0)) {
+			return false
+		}
+		globalCode = uint32(len(r.groupDict))
+		key := columnDictionaryCodeOwnedString(value)
+		r.groupByValue[key] = globalCode
+		r.groupDict = append(r.groupDict, key)
+		r.growScratch(len(r.groupDict))
+	}
+	localToGlobal[localCode] = globalCode
+	return true
 }
 
 func (r *columnDictionaryInt64GroupOneShotReducer) growScratch(groups int) {

--- a/TreeDB/collections/column_dictionary_codes_asset.go
+++ b/TreeDB/collections/column_dictionary_codes_asset.go
@@ -244,3 +244,77 @@ func decodeColumnDictionaryCodesAssetPayload(raw []byte, ref ColumnAssetRef, cfg
 	}
 	return asset, columnDictionaryCodesAssetPayload{rowCount: int(rowCount), offset: cur.pos}, nil
 }
+
+func decodeColumnDictionaryCodesAssetHeader(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig, expectedCollection, expectedColumn string, verifyChecksum bool) (manifestCursor, int, int, error) {
+	if ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset ref kind=%q want %q", ref.Kind, ColumnAssetKindTCS1DictionaryCodes)
+	}
+	if int64(len(raw)) != ref.Length {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset length=%d does not match ref length=%d", len(raw), ref.Length)
+	}
+	if verifyChecksum {
+		if checksum := page.Checksum(raw); checksum != ref.Checksum {
+			return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset checksum=%d does not match ref checksum=%d", checksum, ref.Checksum)
+		}
+	}
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnDictionaryCodesAssetMagic {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: bad dictionary codes asset magic=0x%08x", magic)
+	}
+	if version := cur.u16(); version != columnDictionaryCodesAssetVersion {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: unsupported dictionary codes asset version=%d", version)
+	}
+	collectionBytes := cur.stringBytes()
+	namespaceBytes := cur.stringBytes()
+	generation := cur.u64()
+	partID := cur.u64()
+	appliedCommandLSN := cur.u64()
+	schemaHash := cur.u64()
+	columnNameBytes := cur.stringBytes()
+	columnIndex := cur.u64()
+	cardinality := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return manifestCursor{}, 0, 0, err
+	}
+	if columnIndex > uint64(maxCollectionInt) || cardinality > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
+		return manifestCursor{}, 0, 0, errors.New("collections: dictionary codes asset dimensions overflow int")
+	}
+	if rowCount > uint64((len(raw)-cur.pos)/4) {
+		return manifestCursor{}, 0, 0, errors.New("collections: dictionary codes asset row count exceeds payload bytes")
+	}
+	if !manifestBytesEqualString(collectionBytes, expectedCollection) {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset collection=%q want %q", string(collectionBytes), expectedCollection)
+	}
+	if cfg.AssetManager == nil {
+		return manifestCursor{}, 0, 0, errors.New("collections: dictionary codes asset validation requires asset manager")
+	}
+	if !manifestBytesEqualString(namespaceBytes, cfg.AssetManager.Namespace) || ref.Namespace != cfg.AssetManager.Namespace {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset namespace=%q ref_namespace=%q want %q", string(namespaceBytes), ref.Namespace, cfg.AssetManager.Namespace)
+	}
+	if generation != ref.Generation || partID != ref.PartID {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset generation/part does not match ref")
+	}
+	if schemaHash != cfg.SchemaHash {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset schema_hash=%d want %d", schemaHash, cfg.SchemaHash)
+	}
+	if appliedCommandLSN > cfg.RecoveryAuthoritativeAppliedCommandLSN {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset applied_command_lsn=%d is newer than recovery applied_command_lsn=%d", appliedCommandLSN, cfg.RecoveryAuthoritativeAppliedCommandLSN)
+	}
+	if expectedColumn != "" && !manifestBytesEqualString(columnNameBytes, expectedColumn) {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset column=%q want %q", string(columnNameBytes), expectedColumn)
+	}
+	columnIndexInt := int(columnIndex)
+	if columnIndexInt < 0 || columnIndexInt >= len(cfg.Columns) {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset column_index=%d outside columns=%d", columnIndexInt, len(cfg.Columns))
+	}
+	col := cfg.Columns[columnIndexInt]
+	if !manifestBytesEqualString(columnNameBytes, col.Name) || col.ValueType != ColumnStoreValueString || !col.Dictionary {
+		return manifestCursor{}, 0, 0, fmt.Errorf("collections: dictionary codes asset column %q is not a declared dictionary string column", string(columnNameBytes))
+	}
+	return cur, int(cardinality), int(rowCount), nil
+}
+
+func columnDictionaryCodeOwnedString(value []byte) string {
+	return string(value)
+}

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -238,6 +238,10 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		for localCode := 0; localCode < cardinality; localCode++ {
 			if !reducer.translateDictionaryValue(localToGlobal, localCode, dictCur.stringBytes()) {
 				ok = false
+				break
+			}
+			if dictCur.err != nil {
+				break
 			}
 		}
 		if dictCur.err != nil {
@@ -568,6 +572,10 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		for localCode := 0; localCode < groupCardinality; localCode++ {
 			if !reducer.translateGroupDictionaryValue(localCode, groupCur.stringBytes()) {
 				ok = false
+				break
+			}
+			if groupCur.err != nil {
+				break
 			}
 		}
 		if groupCur.err != nil {
@@ -593,6 +601,10 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		for localCode := 0; localCode < distinctCardinality; localCode++ {
 			if !reducer.translateDistinctDictionaryValue(localCode, distinctCur.stringBytes()) {
 				ok = false
+				break
+			}
+			if distinctCur.err != nil {
+				break
 			}
 		}
 		if distinctCur.err != nil {
@@ -744,26 +756,6 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDic
 	return true
 }
 
-func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDictionary(dictionary []string) ([]uint32, bool) {
-	if cap(r.groupLocal) < len(dictionary) {
-		r.groupLocal = make([]uint32, len(dictionary))
-	}
-	localToGlobal := r.groupLocal[:len(dictionary)]
-	for localCode, value := range dictionary {
-		globalCode, ok := r.groupByValue[value]
-		if !ok {
-			if uint64(len(r.groupDict)) == uint64(^uint32(0)) {
-				return nil, false
-			}
-			globalCode = uint32(len(r.groupDict))
-			r.groupByValue[value] = globalCode
-			r.groupDict = append(r.groupDict, value)
-		}
-		localToGlobal[localCode] = globalCode
-	}
-	return localToGlobal, true
-}
-
 func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) prepareDistinctDictionary(cardinality int) []uint32 {
 	if cap(r.distinctLocal) < cardinality {
 		r.distinctLocal = make([]uint32, cardinality)
@@ -784,47 +776,6 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateDistinct
 	return true
 }
 
-func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateDistinctDictionary(dictionary []string) ([]uint32, bool) {
-	if cap(r.distinctLocal) < len(dictionary) {
-		r.distinctLocal = make([]uint32, len(dictionary))
-	}
-	localToGlobal := r.distinctLocal[:len(dictionary)]
-	for localCode, value := range dictionary {
-		globalCode, ok := r.distinctByValue[value]
-		if !ok {
-			if uint64(len(r.distinctByValue)) == uint64(^uint32(0)) {
-				return nil, false
-			}
-			globalCode = uint32(len(r.distinctByValue))
-			r.distinctByValue[value] = globalCode
-		}
-		localToGlobal[localCode] = globalCode
-	}
-	return localToGlobal, true
-}
-
-func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateKnownGroupDictionary(dictionary []string) []uint32 {
-	if cap(r.groupLocal) < len(dictionary) {
-		r.groupLocal = make([]uint32, len(dictionary))
-	}
-	localToGlobal := r.groupLocal[:len(dictionary)]
-	for localCode, value := range dictionary {
-		localToGlobal[localCode] = r.groupByValue[value]
-	}
-	return localToGlobal
-}
-
-func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateKnownDistinctDictionary(dictionary []string) []uint32 {
-	if cap(r.distinctLocal) < len(dictionary) {
-		r.distinctLocal = make([]uint32, len(dictionary))
-	}
-	localToGlobal := r.distinctLocal[:len(dictionary)]
-	for localCode, value := range dictionary {
-		localToGlobal[localCode] = r.distinctByValue[value]
-	}
-	return localToGlobal
-}
-
 func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (int, error) {
 	rows := 0
 	for _, asset := range r.assets {
@@ -835,6 +786,9 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets(view
 		groupMap := r.prepareGroupDictionary(groupCardinality)
 		for localCode := 0; localCode < groupCardinality; localCode++ {
 			groupMap[localCode] = r.groupByValue[unsafeStringFromBytes(groupDictCur.stringBytes())]
+			if groupDictCur.err != nil {
+				break
+			}
 		}
 		if groupDictCur.err != nil {
 			return 0, groupDictCur.err
@@ -846,6 +800,9 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets(view
 		distinctMap := r.prepareDistinctDictionary(distinctCardinality)
 		for localCode := 0; localCode < distinctCardinality; localCode++ {
 			distinctMap[localCode] = r.distinctByValue[unsafeStringFromBytes(distinctDictCur.stringBytes())]
+			if distinctDictCur.err != nil {
+				break
+			}
 		}
 		if distinctDictCur.err != nil {
 			return 0, distinctDictCur.err

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -61,11 +61,11 @@ type columnDictionaryCodeGroupCountOneShotReducer struct {
 
 type columnDictionaryCodeGroupCountDistinctOneShotAsset struct {
 	groupRaw        []byte
+	groupRef        ColumnAssetRef
 	groupPayload    columnDictionaryCodesAssetPayload
-	groupDictionary []string
 	distinctRaw     []byte
+	distinctRef     ColumnAssetRef
 	distinctPayload columnDictionaryCodesAssetPayload
-	distinctDict    []string
 	bytes           int64
 }
 
@@ -229,16 +229,25 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		if !readCache.lastView {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
-		asset, payload, err := decodeColumnDictionaryCodesAssetPayload(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		dictCur, cardinality, rowCount, err := decodeColumnDictionaryCodesAssetHeader(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, err
 		}
-		localToGlobal, ok := reducer.translateDictionary(asset.Dictionary)
+		localToGlobal := reducer.prepareDictionary(cardinality)
+		ok := true
+		for localCode := 0; localCode < cardinality; localCode++ {
+			if !reducer.translateDictionaryValue(localToGlobal, localCode, dictCur.stringBytes()) {
+				ok = false
+			}
+		}
+		if dictCur.err != nil {
+			return ColumnPhysicalQueryResult{}, true, dictCur.err
+		}
 		if !ok {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
-		cur := manifestCursor{raw: raw, pos: payload.offset}
-		for i := 0; i < payload.rowCount; i++ {
+		cur := manifestCursor{raw: raw, pos: dictCur.pos}
+		for i := 0; i < rowCount; i++ {
 			localCode := cur.u32()
 			if int(localCode) >= len(localToGlobal) {
 				return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
@@ -550,14 +559,24 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		if !readCache.lastView {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
-		groupAsset, groupPayload, err := decodeColumnDictionaryCodesAssetPayload(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		ok := true
+		groupCur, groupCardinality, groupRows, err := decodeColumnDictionaryCodesAssetHeader(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, err
 		}
-		_, ok := reducer.translateGroupDictionary(groupAsset.Dictionary)
+		reducer.prepareGroupDictionary(groupCardinality)
+		for localCode := 0; localCode < groupCardinality; localCode++ {
+			if !reducer.translateGroupDictionaryValue(localCode, groupCur.stringBytes()) {
+				ok = false
+			}
+		}
+		if groupCur.err != nil {
+			return ColumnPhysicalQueryResult{}, true, groupCur.err
+		}
 		if !ok {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
+		groupPayload := columnDictionaryCodesAssetPayload{rowCount: groupRows, offset: groupCur.pos}
 		distinctRaw, err := readCache.read(distinctSnapshot.AssetRef, scratch)
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn, err)
@@ -566,14 +585,23 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		if !readCache.lastView {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
-		distinctAsset, distinctPayload, err := decodeColumnDictionaryCodesAssetPayload(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
+		distinctCur, distinctCardinality, distinctRows, err := decodeColumnDictionaryCodesAssetHeader(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, err
 		}
+		reducer.prepareDistinctDictionary(distinctCardinality)
+		for localCode := 0; localCode < distinctCardinality; localCode++ {
+			if !reducer.translateDistinctDictionaryValue(localCode, distinctCur.stringBytes()) {
+				ok = false
+			}
+		}
+		if distinctCur.err != nil {
+			return ColumnPhysicalQueryResult{}, true, distinctCur.err
+		}
+		distinctPayload := columnDictionaryCodesAssetPayload{rowCount: distinctRows, offset: distinctCur.pos}
 		if groupPayload.rowCount != distinctPayload.rowCount {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", groupPayload.rowCount, distinctPayload.rowCount)
 		}
-		_, ok = reducer.translateDistinctDictionary(distinctAsset.Dictionary)
 		if !ok {
 			return ColumnPhysicalQueryResult{}, false, nil
 		}
@@ -592,11 +620,11 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 		// appending when reads are scratch-backed.
 		reducer.assets = append(reducer.assets, columnDictionaryCodeGroupCountDistinctOneShotAsset{
 			groupRaw:        groupRaw,
+			groupRef:        groupSnapshot.AssetRef,
 			groupPayload:    groupPayload,
-			groupDictionary: groupAsset.Dictionary,
 			distinctRaw:     distinctRaw,
+			distinctRef:     distinctSnapshot.AssetRef,
 			distinctPayload: distinctPayload,
-			distinctDict:    distinctAsset.Dictionary,
 			bytes:           groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length,
 		})
 		reducer.assetBytes += groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length
@@ -614,7 +642,7 @@ func runColumnDictionaryCodeGroupCountDistinctOneShot(view columnPhysicalScanSna
 	reducer.wordsPerGroup = wordsPerGroup
 	reducer.groupCounts = make([]int, len(reducer.groupDict))
 	reducer.seen = make([]uint64, totalWords)
-	rows, err := reducer.reduceAssets()
+	rows, err := reducer.reduceAssets(view, req)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, true, err
 	}
@@ -656,6 +684,29 @@ func (r *columnDictionaryCodeGroupCountOneShotReducer) translateDictionary(dicti
 	return localToGlobal, true
 }
 
+func (r *columnDictionaryCodeGroupCountOneShotReducer) prepareDictionary(cardinality int) []uint32 {
+	if cap(r.localToGlobal) < cardinality {
+		r.localToGlobal = make([]uint32, cardinality)
+	}
+	return r.localToGlobal[:cardinality]
+}
+
+func (r *columnDictionaryCodeGroupCountOneShotReducer) translateDictionaryValue(localToGlobal []uint32, localCode int, value []byte) bool {
+	globalCode, ok := r.byValue[unsafeStringFromBytes(value)]
+	if !ok {
+		if uint64(len(r.dictionary)) == uint64(^uint32(0)) {
+			return false
+		}
+		globalCode = uint32(len(r.dictionary))
+		key := columnDictionaryCodeOwnedString(value)
+		r.byValue[key] = globalCode
+		r.dictionary = append(r.dictionary, key)
+		r.counts = append(r.counts, 0)
+	}
+	localToGlobal[localCode] = globalCode
+	return true
+}
+
 func (r *columnDictionaryCodeGroupCountOneShotReducer) groups() []ColumnPhysicalQueryGroup {
 	r.result = r.result[:0]
 	for code, count := range r.counts {
@@ -669,6 +720,28 @@ func (r *columnDictionaryCodeGroupCountOneShotReducer) groups() []ColumnPhysical
 	}
 	sortColumnPhysicalQueryGroupsByKey(r.result)
 	return r.result
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) prepareGroupDictionary(cardinality int) []uint32 {
+	if cap(r.groupLocal) < cardinality {
+		r.groupLocal = make([]uint32, cardinality)
+	}
+	return r.groupLocal[:cardinality]
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDictionaryValue(localCode int, value []byte) bool {
+	globalCode, ok := r.groupByValue[unsafeStringFromBytes(value)]
+	if !ok {
+		if uint64(len(r.groupDict)) == uint64(^uint32(0)) {
+			return false
+		}
+		globalCode = uint32(len(r.groupDict))
+		key := columnDictionaryCodeOwnedString(value)
+		r.groupByValue[key] = globalCode
+		r.groupDict = append(r.groupDict, key)
+	}
+	r.groupLocal[localCode] = globalCode
+	return true
 }
 
 func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDictionary(dictionary []string) ([]uint32, bool) {
@@ -689,6 +762,26 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateGroupDic
 		localToGlobal[localCode] = globalCode
 	}
 	return localToGlobal, true
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) prepareDistinctDictionary(cardinality int) []uint32 {
+	if cap(r.distinctLocal) < cardinality {
+		r.distinctLocal = make([]uint32, cardinality)
+	}
+	return r.distinctLocal[:cardinality]
+}
+
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateDistinctDictionaryValue(localCode int, value []byte) bool {
+	globalCode, ok := r.distinctByValue[unsafeStringFromBytes(value)]
+	if !ok {
+		if uint64(len(r.distinctByValue)) == uint64(^uint32(0)) {
+			return false
+		}
+		globalCode = uint32(len(r.distinctByValue))
+		r.distinctByValue[columnDictionaryCodeOwnedString(value)] = globalCode
+	}
+	r.distinctLocal[localCode] = globalCode
+	return true
 }
 
 func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateDistinctDictionary(dictionary []string) ([]uint32, bool) {
@@ -732,11 +825,31 @@ func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) translateKnownDis
 	return localToGlobal
 }
 
-func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets() (int, error) {
+func (r *columnDictionaryCodeGroupCountDistinctOneShotReducer) reduceAssets(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (int, error) {
 	rows := 0
 	for _, asset := range r.assets {
-		groupMap := r.translateKnownGroupDictionary(asset.groupDictionary)
-		distinctMap := r.translateKnownDistinctDictionary(asset.distinctDict)
+		groupDictCur, groupCardinality, _, err := decodeColumnDictionaryCodesAssetHeader(asset.groupRaw, asset.groupRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		if err != nil {
+			return 0, err
+		}
+		groupMap := r.prepareGroupDictionary(groupCardinality)
+		for localCode := 0; localCode < groupCardinality; localCode++ {
+			groupMap[localCode] = r.groupByValue[unsafeStringFromBytes(groupDictCur.stringBytes())]
+		}
+		if groupDictCur.err != nil {
+			return 0, groupDictCur.err
+		}
+		distinctDictCur, distinctCardinality, _, err := decodeColumnDictionaryCodesAssetHeader(asset.distinctRaw, asset.distinctRef, view.Config, view.CollectionName, req.DistinctColumn, false)
+		if err != nil {
+			return 0, err
+		}
+		distinctMap := r.prepareDistinctDictionary(distinctCardinality)
+		for localCode := 0; localCode < distinctCardinality; localCode++ {
+			distinctMap[localCode] = r.distinctByValue[unsafeStringFromBytes(distinctDictCur.stringBytes())]
+		}
+		if distinctDictCur.err != nil {
+			return 0, distinctDictCur.err
+		}
 		groupCur := manifestCursor{raw: asset.groupRaw, pos: asset.groupPayload.offset}
 		distinctCur := manifestCursor{raw: asset.distinctRaw, pos: asset.distinctPayload.offset}
 		for i := 0; i < asset.groupPayload.rowCount; i++ {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2339,7 +2339,7 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 51,
+			maxAllocs: 50,
 		},
 		{
 			name:      "q3_int64_values",

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,12 +2334,12 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 34,
+			maxAllocs: 31,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 54,
+			maxAllocs: 51,
 		},
 		{
 			name:      "q3_int64_values",
@@ -2349,17 +2349,17 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 51,
+			maxAllocs: 45,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 51,
+			maxAllocs: 45,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 55,
+			maxAllocs: 46,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## What Landed

This #1634 slice avoids materializing dictionary header `[]string` slices in routed/direct one-shot sidecar scans when the typed column asset read is view-backed. Dictionary-code headers are streamed from the asset bytes, dictionary values are copied only when retained in reducer-owned global dictionaries, and ephemeral map lookups use the existing package-local unsafe string lookup helper without retaining the unsafe view.

The change is intentionally local:

- keeps the current routed serial sidecar path and manifest semantics unchanged;
- keeps prepared hot runners unchanged;
- keeps scratch-backed reads fail-closed to the existing full decode path;
- preserves validation of typed `ColumnAssetRef` kind, namespace, generation/part, schema hash, applied LSN, declared column, row count, and trailing bytes;
- tightens the direct package scanner allocation budget gate for q1/q2/q4/q5.

## Static Analysis / Priority Checkpoint

After #1690, q4/q5 reducer scratch growth was no longer the next local allocation source, but direct package scanner paths still allocated q1/q2/q3/q4/q5 `32/52/20/46/46/47 allocs/op`, well above the granule `0 allocs/op` hot-kernel target. A focused code pass showed the one-shot dictionary sidecar paths still decoded dictionary headers into owned `[]string` slices even when the read cache had a stable asset view and the reducer only needed a transient local-code-to-global-code translation.

This PR targets that measured local setup/decode bucket. It is allocation hygiene inside the current production sidecar representation, not a schema-fixed column-block/dense-kernel conversion and not a claim that row-record/TCPA work closes the granule-kernel gap. The next slice should still start from a fresh static/profile checkpoint and prioritize measured remaining buckets such as manifest/view setup, read-cache/open path work, result construction, or representation/kernel shape.

## Measurement Class

- Primary changed path: measurement class `direct package scanner`; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, asset read/decode, reducer work, and result construction.
- End-to-end comparable snapshot: measurement class `routed unified-bench query path`; the routed production path reaches the changed dictionary header streaming path in this PR for serial physical q1/q2/q4/q5 sidecar scans.
- Prepared hot runner: measurement class `prepared hot runner / warmed repeated Run()` is not used as this PR's evidence. Earlier billion-rows/sec prepared-runner results after `PrepareColumnPhysicalQuery` exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.
- Experiment context: measurement class `experiment/granule baseline`; historical dense-kernel context only, not a routed production measurement.
- ClickHouse context: measurement class `historical ClickHouse context`; historical JSONBench context only, not a same-harness gate.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`.

Apple M3, darwin/arm64, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B`, same-window parent #1690 vs this PR, `-benchtime=1000x -count=6`, head `c54d77cc8`:

```text
allocs/op:
q1 32 -> 31 (-3.12%)
q2 52 -> 50 (-3.85%)
q3 20 -> 20 (unchanged)
q4a 46 -> 45 (-2.17%)
q4b 46 -> 45 (-2.17%)
q5 47 -> 46 (-2.13%)
geomean 38.60 -> 37.74 (-2.25%)

B/op:
q1 4.462 KiB -> 4.400 KiB (-1.39%)
q2 5.829 KiB -> 5.688 KiB (-2.41%)
q3 unchanged
q4a 4.524 KiB -> 4.337 KiB (-4.14%)
q4b 4.524 KiB -> 4.337 KiB (-4.14%)
q5 4.618 KiB -> 4.431 KiB (-4.06%)
geomean 4.503 KiB -> 4.381 KiB (-2.70%)

sec/op geomean: 55.71 us -> 55.91 us (+0.36%)
rows/s geomean: 147.5M -> 147.3M (-0.16%)
```

Representative current direct package scanner results from `/tmp/gomap_1634_dictionary_header_stream_unsafe_lookup_adapter_q1q5_bench.txt`:

| query | ns/row | rows/s | B/op | allocs/op |
|---|---:|---:|---:|---:|
| q1 | 5.25-5.71 | 175.1M-190.5M | ~4.40 KiB | 31 |
| q2 | 5.90-6.35 | 157.4M-169.4M | ~5.69 KiB | 50 |
| q3 | 5.59-5.72 | 174.9M-179.1M | ~3.39 KiB | 20 |
| q4a | 7.79-7.86 | 127.3M-128.4M | ~4.34 KiB | 45 |
| q4b | 8.48-8.52 | 117.3M-117.9M | ~4.34 KiB | 45 |
| q5 | 7.87-8.09 | 123.6M-127.1M | ~4.43 KiB | 46 |

TDD allocation gate: with only the stricter q1/q2/q4/q5 budgets applied, pre-change #1690 would fail q1/q2/q4a/q4b/q5 at `32/52/46/46/47 allocs/op` against new targets `31/50/45/45/46`. After the header-streaming change, the gate passes; observed benchmark allocations are q1/q2/q4a/q4b/q5 `31/50/45/45/46 allocs/op`.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. The routed path reaches the changed dictionary header streaming path in this PR for serial physical q1/q2/q4/q5 sidecar scans.

Apple M3, darwin/arm64, 100K rows, durable profile, forced `serial_column_scan`, `-column-store-asset-read-integrity verify`, artifact `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7`:

| query | rows/s | ns/row | scan ms | dictionary hits | int64 hits | B/read | row materializations | parity |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| q1 | 118.19M | 8.5 | 0.675 | 100 | 0 | 423,600 | 0 | pass |
| q2 | 33.23M | 30.1 | 2.891 | 100 | 0 | 2,335,100 | 0 | pass |
| q3 | 155.08M | 6.4 | 0.515 | 0 | 100 | 811,100 | 0 | pass |
| q4a | 42.83M | 23.4 | 2.168 | 100 | 100 | 2,722,600 | 0 | pass |
| q4b | 44.94M | 22.3 | 2.058 | 100 | 100 | 2,722,600 | 0 | pass |
| q5 | 43.60M | 22.9 | 2.139 | 100 | 100 | 2,722,600 | 0 | pass |
| q5_metadata alias | 46.93M | 21.3 | 1.970 | 100 | 100 | 2,722,600 | 0 | pass |

Byte/accounting snapshot from the same routed run: `source_document_bytes=9,368,750`, `retained_payload_bytes=3,368,750`, `column_asset_bytes=21,399,500`, `manifest_control_bytes=28`, `command_wal_bytes_before_checkpoint=11,182,573`, checkpoint stage `204.728 ms`, `db_total_bytes=35,998,639` across 9 files.

Measurement class: `experiment/granule baseline`. Historical granule context remains q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, q5 metadata `~2.406 ns/row`. This PR does not claim to close the representation/kernel gap; it removes avoidable dictionary header materialization inside the current production sidecar path.

Measurement class: `historical ClickHouse context`. Historical ClickHouse JSONBench context remains 1M q1/q2/q3/q4/q5 at approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is context only, not apples-to-apples with the direct package scanner or 100K routed production run.

Apples-to-apples limitations: the direct package scanner is an 8,192-row package benchmark, the routed snapshot is a 100K durable `unified-bench` run with reporting/parity/lifecycle stages, the granule baseline is an experiment hot-kernel context, and the ClickHouse numbers are historical JSONBench context. The dictionary header allocation reduction is the claim; ClickHouse/granule parity is not.

## Throughput Interpretation

This is an allocation-hygiene PR for dictionary sidecar one-shot scan setup. It does not change sidecar asset layout, planner routing, mark pruning, aggregate metadata semantics, WAL/checkpoint behavior, reopen, mutation handling, or prepared hot-runner behavior.

The direct package scanner numbers include physical query adapter setup and scanner execution. The routed `unified-bench` numbers include planner routing, reporting, durable fixture setup, reopen/recovery, and parity stages as separated by the benchmark report. Prepared hot-runner measurements are not part of this PR's evidence.

Scale note: 100K routed scans here are sub-ms to low-ms scan stages for q1-q5. A `~5-9 ns/row` direct scanner result over 8,192 rows is not a multi-ms scan by itself; larger fixtures are required before fixed setup costs and steady-state scan/reduce slopes are fully separated. Conversely, 1M rows at about `90 ns/row` extrapolates to about `90 ms`.

## Gate Status

- TDD allocation gate would fail on #1690 for q1/q2/q4a/q4b/q5 at `32/52/46/46/47 allocs/op` against tightened `31/50/45/45/46` targets.
- Post-change allocation gate passes with q1/q2/q4a/q4b/q5 targets `31/50/45/45/46`.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuery' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `make unified-bench`
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial_column_scan -column-store-asset-read-integrity verify -progress=false`
- `git diff --check`
- Review-fix head `d956bc83e`: removed dead distinct-reducer translation helpers and added fail-fast cursor-error guards in streaming dictionary decode loops.
- Review-fix validation: `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuery' -count=1`, `go test ./TreeDB/collections -count=1`, `go test ./cmd/unified_bench -count=1`, manual `go build -o /tmp/unified-bench-check ./cmd/unified_bench`, `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B' -benchmem -benchtime=1000x -count=3`, and `git diff --check`.

## Artifacts

- Parent #1690 direct package scanner: `/tmp/gomap_1634_parent1690_samewindow_adapter_q1q5_bench_real.txt`
- Current direct package scanner: `/tmp/gomap_1634_dictionary_header_stream_unsafe_lookup_adapter_q1q5_bench.txt`
- Review-fix direct package scanner: `/tmp/gomap_1634_dictionary_header_stream_reviewfix_adapter_q1q5_bench.txt`
- Benchstat against #1690: `/tmp/gomap_1634_dictionary_header_stream_unsafe_lookup_benchstat.txt`
- Earlier non-unsafe lookup comparison, retained as rejected local variant: `/tmp/gomap_1634_dictionary_header_stream_samewindow_benchstat_real.txt`
- Routed 100K artifact dir: `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7`
- Routed HTML: `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7/column_store_results.html`
- Insights HTML: `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7/insights.html`
- CPU profile: `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_dict_header_stream_routed_100k_heLPr7/allocs_column_store_treedb_column_store.pprof`

## Assumption Ledger

Remaining direct package scanner allocations are still far above the granule `0 allocs/op` hot-kernel target. This PR removes dictionary header materialization when the read cache provides stable views; scratch-backed reads still fall back to the full decode path rather than retaining unsafe bytes. The next #1634 slice should use fresh static/profile evidence to choose between manifest/view setup, read-cache/open path work, result construction, or a larger representation/kernel-shape change.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dictionary-backed query execution to reduce memory allocations and speed up group/distinct counts, yielding more efficient data retrieval.

* **Tests**
  * Adjusted test allocation budgets to match the optimized query paths and ensure stable performance validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


