### PR TITLE
TreeDB column store post-V1: filter query manifest sidecars

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -132,7 +132,7 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 		}
 		return c.runColumnPhysicalQueryWithVisibility(cfg, req)
 	}
-	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
 	if closeView != nil {
 		defer closeView()
 	}
@@ -156,7 +156,7 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 // until Close and fail-closes for mutation-bearing manifests or unsupported
 // query shapes rather than silently changing semantics.
 func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (*ColumnPhysicalQueryRunner, error) {
-	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
 	if err != nil {
 		if closeView != nil {
 			closeView()
@@ -473,7 +473,7 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(
 // Mutation-bearing manifests stay fail-closed until partitioned visibility
 // reconstruction is available.
 func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryRequest, maxWorkers int) (ColumnPhysicalQueryResult, error) {
-	view, closeView, err := c.prepareColumnPhysicalScanSnapshotView()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
 	if closeView != nil {
 		defer closeView()
 	}
@@ -573,6 +573,22 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	result.Diagnostics.ReduceRows = merged.reduceRows
 	result.Diagnostics.ResultGroups = len(result.Groups)
 	return result, nil
+}
+
+func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) columnManifestScanSidecarFilter {
+	if req.AggregateMetadataName != "" {
+		return columnManifestScanSidecarFilter{AggregateMetadata: true}
+	}
+	switch req.Kind {
+	case ColumnPhysicalQueryGroupCount, ColumnPhysicalQueryGroupCountDistinct:
+		return columnManifestScanSidecarFilter{DictionaryCodes: true}
+	case ColumnPhysicalQueryHourCount:
+		return columnManifestScanSidecarFilter{Int64Values: true}
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
+		return columnManifestScanSidecarFilter{DictionaryCodes: true, Int64Values: true}
+	default:
+		return columnManifestScanNoSidecars()
+	}
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 31,
+			maxAllocs: 26,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 50,
+			maxAllocs: 45,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 22,
+			maxAllocs: 14,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 45,
+			maxAllocs: 42,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 45,
+			maxAllocs: 42,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 46,
+			maxAllocs: 43,
 		},
 	}
 	for _, tc := range tests {
@@ -2395,6 +2395,90 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 			}
 			if allocs > maxAllocs {
 				t.Fatalf("%s routed sidecar allocs/run=%.2f want <= %.2f", tc.name, allocs, maxAllocs)
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalQueryManifestSidecarFilterM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(128)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	all, closeAll, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeAll != nil {
+		defer closeAll()
+	}
+	if err != nil {
+		t.Fatalf("prepare full snapshot view: %v", err)
+	}
+	if got, want := len(all.AssetRefs), 1; got != want {
+		t.Fatalf("full asset refs=%d want %d", got, want)
+	}
+	if got, want := len(all.DictionaryCodes), 2; got != want {
+		t.Fatalf("full dictionary sidecars=%d want %d", got, want)
+	}
+	if got, want := len(all.Int64Values), 1; got != want {
+		t.Fatalf("full int64 sidecars=%d want %d", got, want)
+	}
+	if got, want := len(all.AggregateMetadata), 2; got != want {
+		t.Fatalf("full aggregate sidecars=%d want %d", got, want)
+	}
+
+	tests := []struct {
+		name           string
+		req            ColumnPhysicalQueryRequest
+		wantDictionary int
+		wantInt64      int
+		wantAggregate  int
+	}{
+		{
+			name:           "q1_dictionary_only",
+			req:            ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
+			wantDictionary: 2,
+		},
+		{
+			name:           "q2_dictionary_only",
+			req:            ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
+			wantDictionary: 2,
+		},
+		{
+			name:      "q3_int64_only",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
+			wantInt64: 1,
+		},
+		{
+			name:           "q4_dictionary_and_int64",
+			req:            ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
+			wantDictionary: 2,
+			wantInt64:      1,
+		},
+		{
+			name:          "q5_metadata_aggregate_only",
+			req:           ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"},
+			wantAggregate: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			view, closeView, err := collection.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(tc.req))
+			if closeView != nil {
+				defer closeView()
+			}
+			if err != nil {
+				t.Fatalf("prepare filtered snapshot view: %v", err)
+			}
+			if got, want := len(view.AssetRefs), len(all.AssetRefs); got != want {
+				t.Fatalf("filtered asset refs=%d want %d", got, want)
+			}
+			if got := len(view.DictionaryCodes); got != tc.wantDictionary {
+				t.Fatalf("filtered dictionary sidecars=%d want %d", got, tc.wantDictionary)
+			}
+			if got := len(view.Int64Values); got != tc.wantInt64 {
+				t.Fatalf("filtered int64 sidecars=%d want %d", got, tc.wantInt64)
+			}
+			if got := len(view.AggregateMetadata); got != tc.wantAggregate {
+				t.Fatalf("filtered aggregate sidecars=%d want %d", got, tc.wantAggregate)
 			}
 		})
 	}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -88,6 +88,54 @@ type columnManifestAssetRefForScan struct {
 	Reason ColumnPublishOperation
 }
 
+type columnManifestScanSidecarFilter struct {
+	AggregateMetadata bool
+	DictionaryCodes   bool
+	Int64Values       bool
+}
+
+func columnManifestScanAllSidecars() columnManifestScanSidecarFilter {
+	return columnManifestScanSidecarFilter{
+		AggregateMetadata: true,
+		DictionaryCodes:   true,
+		Int64Values:       true,
+	}
+}
+
+func columnManifestScanNoSidecars() columnManifestScanSidecarFilter {
+	return columnManifestScanSidecarFilter{}
+}
+
+func columnManifestDictionarySidecarColumns(cfg ColumnStoreConfig) int {
+	count := 0
+	for _, col := range cfg.Columns {
+		if col.Dictionary && col.ValueType == ColumnStoreValueString {
+			count++
+		}
+	}
+	return count
+}
+
+func columnManifestInt64SidecarColumns(cfg ColumnStoreConfig) int {
+	count := 0
+	for _, col := range cfg.Columns {
+		if col.ValueType == ColumnStoreValueInt64 {
+			count++
+		}
+	}
+	return count
+}
+
+func columnManifestScanSidecarCapacity(parts, perPart int) int {
+	if parts <= 0 || perPart <= 0 {
+		return 0
+	}
+	if parts > maxCollectionInt/perPart {
+		return 0
+	}
+	return parts * perPart
+}
+
 type columnPhysicalScanSnapshotView struct {
 	CollectionName     string
 	Config             ColumnStoreConfig
@@ -121,6 +169,14 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotView() (columnPhysicalScan
 }
 
 func (c *Collection) prepareColumnPhysicalScanSnapshotViewWithContext(ctx context.Context) (columnPhysicalScanSnapshotView, func(), error) {
+	return c.prepareColumnPhysicalScanSnapshotViewWithContextAndSidecars(ctx, columnManifestScanAllSidecars())
+}
+
+func (c *Collection) prepareColumnPhysicalScanSnapshotViewWithSidecars(filter columnManifestScanSidecarFilter) (columnPhysicalScanSnapshotView, func(), error) {
+	return c.prepareColumnPhysicalScanSnapshotViewWithContextAndSidecars(context.Background(), filter)
+}
+
+func (c *Collection) prepareColumnPhysicalScanSnapshotViewWithContextAndSidecars(ctx context.Context, filter columnManifestScanSidecarFilter) (columnPhysicalScanSnapshotView, func(), error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -164,7 +220,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewWithContext(ctx contex
 		cfg = *cfgPtr
 	}
 
-	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled)
+	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, filter)
 	if err != nil {
 		closeView()
 		return view, nil, err
@@ -199,6 +255,18 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 	rootID uint64,
 	cfg ColumnStoreConfig,
 	columnStoreEnabled bool,
+) (columnPhysicalScanSnapshotView, error) {
+	return c.prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars(snap, catalog, collectionName, rootID, cfg, columnStoreEnabled, columnManifestScanAllSidecars())
+}
+
+func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	collectionName string,
+	rootID uint64,
+	cfg ColumnStoreConfig,
+	columnStoreEnabled bool,
+	filter columnManifestScanSidecarFilter,
 ) (columnPhysicalScanSnapshotView, error) {
 	if c == nil {
 		return columnPhysicalScanSnapshotView{}, errCollectionNil
@@ -252,7 +320,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshot(
 		view.Diagnostics = diag
 		return view, err
 	}
-	manifest, refs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRoot(snap, rootID, cfg, *cfg.ActiveManifest, collectionName)
+	manifest, refs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, cfg, *cfg.ActiveManifest, collectionName, filter)
 	if err != nil {
 		diag.ManifestRecords = manifestRecords
 		view.Diagnostics = diag
@@ -449,6 +517,10 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 }
 
 func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string) (columnManifestSnapshot, []columnManifestAssetRefForScan, int, int, error) {
+	return loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, cfg, identity, collection, columnManifestScanAllSidecars())
+}
+
+func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, filter columnManifestScanSidecarFilter) (columnManifestSnapshot, []columnManifestAssetRefForScan, int, int, error) {
 	iter, err := snap.IteratorAtRoot(rootID, columnManifestHeaderRecordKeyBytes, nil)
 	if err != nil {
 		return columnManifestSnapshot{}, nil, 0, 0, fmt.Errorf("collections: column manifest root %d unreadable: %w", rootID, err)
@@ -508,6 +580,28 @@ func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, roo
 				RowRemainderBytes:  int64(header.rowRemainderBytes),
 				ColumnPayloadBytes: int64(header.columnPayloadBytes),
 			}
+			if header.expectedParts > 0 && header.expectedParts <= uint64(maxCollectionInt) {
+				expectedParts := int(header.expectedParts)
+				if cap(refs) < expectedParts {
+					refs = make([]columnManifestAssetRefForScan, 0, expectedParts)
+				}
+				livePartRows = make(map[[2]uint64]int, expectedParts)
+				if filter.AggregateMetadata {
+					if capacity := columnManifestScanSidecarCapacity(expectedParts, len(cfg.AggregateMetadata)); capacity > 0 {
+						snapshot.AggregateMetadata = make([]columnManifestAggregateMetadataSnapshot, 0, capacity)
+					}
+				}
+				if filter.DictionaryCodes {
+					if capacity := columnManifestScanSidecarCapacity(expectedParts, columnManifestDictionarySidecarColumns(cfg)); capacity > 0 {
+						snapshot.DictionaryCodes = make([]columnManifestDictionaryCodesSnapshot, 0, capacity)
+					}
+				}
+				if filter.Int64Values {
+					if capacity := columnManifestScanSidecarCapacity(expectedParts, columnManifestInt64SidecarColumns(cfg)); capacity > 0 {
+						snapshot.Int64Values = make([]columnManifestInt64ValuesSnapshot, 0, capacity)
+					}
+				}
+			}
 			writeHashBytes(&d, header.collection)
 			writeHashBytes(&d, header.operation)
 			writeHashUint64(&d, header.generation)
@@ -560,6 +654,14 @@ func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, roo
 				iter.Next()
 				continue
 			}
+			if !filter.AggregateMetadata {
+				if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+				}
+				writeHashBytes(&d, key)
+				writeHashBytes(&d, value)
+				break
+			}
 			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
@@ -572,6 +674,14 @@ func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, roo
 				iter.Next()
 				continue
 			}
+			if !filter.DictionaryCodes {
+				if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+				}
+				writeHashBytes(&d, key)
+				writeHashBytes(&d, value)
+				break
+			}
 			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
@@ -583,6 +693,14 @@ func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, roo
 			if !sawHeader {
 				iter.Next()
 				continue
+			}
+			if !filter.Int64Values {
+				if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+				}
+				writeHashBytes(&d, key)
+				writeHashBytes(&d, value)
+				break
 			}
 			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
 			if err != nil {
@@ -1182,6 +1300,33 @@ func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expecte
 	}, nil
 }
 
+func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
+	if err != nil {
+		return err
+	}
+	ref, _, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return err
+	}
+	if ref.Kind != ColumnAssetKindTCS1AggregateMetadata {
+		return fmt.Errorf("collections: column manifest aggregate metadata asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1AggregateMetadata)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return fmt.Errorf("collections: column manifest aggregate metadata key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+		return fmt.Errorf("collections: column manifest aggregate metadata generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if !bytes.Equal(name, reason) {
+		return fmt.Errorf("collections: column manifest aggregate metadata key name=%q does not match record name=%q", string(name), string(reason))
+	}
+	return nil
+}
+
 func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestDictionaryCodesSnapshot, error) {
 	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 	if err != nil {
@@ -1213,6 +1358,33 @@ func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedN
 		PublishID:    publishID,
 		GenerationID: generationID,
 	}, nil
+}
+
+func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return err
+	}
+	ref, _, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return err
+	}
+	if ref.Kind != ColumnAssetKindTCS1DictionaryCodes {
+		return fmt.Errorf("collections: column manifest dictionary codes asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1DictionaryCodes)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return fmt.Errorf("collections: column manifest dictionary codes key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+		return fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if !bytes.Equal(columnName, reason) {
+		return fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", string(columnName), string(reason))
+	}
+	return nil
 }
 
 func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestInt64ValuesSnapshot, error) {
@@ -1251,6 +1423,37 @@ func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNames
 		PublishID:    publishID,
 		GenerationID: generationID,
 	}, nil
+}
+
+func validateColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
+	if err != nil {
+		return err
+	}
+	ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(raw, expectedNamespace)
+	if err != nil {
+		return err
+	}
+	if ref.Kind != ColumnAssetKindTCS1Int64Values {
+		return fmt.Errorf("collections: column manifest int64 values asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1Int64Values)
+	}
+	if ref.Generation != generation || ref.PartID != partID {
+		return fmt.Errorf("collections: column manifest int64 values key generation/part does not match ref")
+	}
+	if ref.Generation > activeGeneration {
+		return fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
+	}
+	partRows, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]
+	if !ok {
+		return fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
+	}
+	if rows != partRows {
+		return fmt.Errorf("collections: column manifest int64 values rows=%d does not match part rows=%d", rows, partRows)
+	}
+	if !bytes.Equal(columnName, reason) {
+		return fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", string(columnName), string(reason))
+	}
+	return nil
 }
 
 func columnManifestPartGenerationFromRecordKeyForScan(key []byte) (uint64, error) {

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -849,6 +849,46 @@ func TestColumnManifestPlannerCapabilitiesRejectOrphanAggregateMetadataM1634(t *
 	}
 }
 
+func TestColumnManifestSnapshotSidecarFilterStillValidatesSkippedRecordsM1634(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	cfg, input, _, asset := columnManifestPlannerOnePartFixtureM14A(t)
+	dictionary := asset
+	dictionary.Ref.Kind = ColumnAssetKindTCS1DictionaryCodes
+	dictionary.Ref.PartID = asset.Ref.PartID + 1
+	dictionary.Ref.Offset += dictionary.Ref.Length
+	dictionary.Ref.Length = 256
+	dictionary.Bytes = dictionary.Ref.Length
+	dictionary.Reason = "kind"
+	input.Prepared.Assets = []ColumnPreparedAsset{asset, dictionary}
+	manifest, err := encodeColumnManifestForWrite(input)
+	if err != nil {
+		t.Fatalf("encodeColumnManifestForWrite: %v", err)
+	}
+	rootID := publishColumnManifestRecordsForScanTestM13A(t, d, manifest.Identity, manifest.Records)
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	_, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRootWithSidecars(
+		snap,
+		rootID,
+		*cfg,
+		manifest.Identity,
+		"events",
+		columnManifestScanSidecarFilter{Int64Values: true},
+	)
+	if err == nil || !strings.Contains(err.Error(), "matching live part") {
+		t.Fatalf("loadColumnManifestSnapshotViewForScanFromRootWithSidecars err=%v want skipped sidecar validation failure", err)
+	}
+}
+
 func TestColumnManifestPlannerCapabilitiesRejectActivePartCountMismatchM14A(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
 	if err != nil {


### PR DESCRIPTION
## Summary

This #1634 slice filters column-manifest sidecar materialization by physical query shape. The manifest loader still reads and checksums every record and still validates skipped sidecar records fail-closed, but it no longer allocates aggregate/dictionary/int64 sidecar snapshot slices that the current query cannot use.

Primary changed path: direct package scanner and routed serial physical query setup. This is allocation hygiene in the current production sidecar path; it is not a representation/kernel-shape change and does not claim to close the production-vs-granule analytical-kernel gap.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed evidence; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict `verify`.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Static Checkpoint

After #1691, the remaining local allocation source in `RunColumnPhysicalQuery` was not another dictionary-header hot-loop issue. Package profiles showed repeated manifest/view setup still materialized every registered sidecar family even when the query needed only one subset:

- q1/q2 need dictionary-code sidecars.
- q3 needs int64-value sidecars.
- q4/q5 need dictionary-code plus int64-value sidecars.
- aggregate-metadata requests need aggregate metadata sidecars.
- the parallel direct TCPA path does not need sidecar lists.

This PR makes sidecar materialization request-aware while preserving full manifest checksum coverage and semantic validation for skipped sidecar records.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. Same-machine #1691 baseline vs this PR on Apple M3, darwin/arm64, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B`, `-benchtime=1000x -count=5` for this PR and the pre-PR checkpoint for #1691:

```text
geomean sec/op:     42.65us -> 43.19us (+1.28%, timing neutral/noisy)
geomean ns/row:     5.201ns -> 5.265ns (+1.24%, timing neutral/noisy)
geomean rows/s:     192.3M  -> 189.9M  (-1.22%, timing neutral/noisy)
geomean B/op:       4.406Ki -> 4.073Ki (-7.54%)
geomean allocs/op:  39.21   -> 34.24   (-12.68%)
```

Per-query allocation movement:

```text
q1:           31 -> 26 allocs/op
q2:           50 -> 45 allocs/op
q3:           20 -> 14 allocs/op
q4a:          45 -> 42 allocs/op
q4b:          45 -> 42 allocs/op
q4b_metadata: 44 -> 39 allocs/op
q5:           46 -> 43 allocs/op
q5_metadata:  44 -> 39 allocs/op
```

Representative current direct package scanner numbers:

```text
q1:           5.03-5.14 ns/row, 194.7-199.0M rows/s, 4097-4098 B/op, 26 allocs/op
q2:           5.81-5.90 ns/row, 169.6-172.3M rows/s, 5417 B/op, 45 allocs/op
q3:           5.59-5.73 ns/row, 174.5-178.8M rows/s, 2953 B/op, 14 allocs/op
q4a:          7.67-7.83 ns/row, 127.7-130.3M rows/s, 4169 B/op, 42 allocs/op
q4b:          8.28-8.58 ns/row, 116.5-120.8M rows/s, 4169 B/op, 42 allocs/op
q4b_metadata: 2.60-2.68 ns/row, 372.8-384.1M rows/s, 4225 B/op, 39 allocs/op
q5:           7.73-8.11 ns/row, 123.3-129.4M rows/s, 4265-4272 B/op, 43 allocs/op
q5_metadata:  2.53-2.67 ns/row, 374.4-395.1M rows/s, 4449-4465 B/op, 39 allocs/op
```

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current production snapshot on Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF`:

```text
q1:          8.6 ns/row, 116.16M rows/s, scan 0.686 ms, dictionary_code_hits=100, int64_value_hits=0
q2:         29.5 ns/row,  33.90M rows/s, scan 2.821 ms, dictionary_code_hits=100, int64_value_hits=0
q3:          6.3 ns/row, 159.67M rows/s, scan 0.506 ms, dictionary_code_hits=0,   int64_value_hits=100
q4a:        21.5 ns/row,  46.57M rows/s, scan 1.991 ms, dictionary_code_hits=100, int64_value_hits=100
q4b:        21.5 ns/row,  46.46M rows/s, scan 1.982 ms, dictionary_code_hits=100, int64_value_hits=100
q5:         21.3 ns/row,  46.91M rows/s, scan 1.982 ms, dictionary_code_hits=100, int64_value_hits=100
q5_metadata serial alias: 21.0 ns/row, 47.61M rows/s, scan 1.953 ms, metadata_hits=0 under forced serial label
```

Routed execution reaches the changed path because `serial_column_scan` uses `RunColumnPhysicalQuery`, which now requests only the sidecar families required by the query. All parity checks passed and row materializations remained zero.

Routed byte/accounting snapshot from the same run:

```text
source_document_bytes=9,368,750
retained_payload_bytes=3,368,750
column_asset_bytes=21,399,500
column_asset_store_bytes=21,399,500
manifest_control_bytes=28
ordinary_value_vlog_bytes=0
leaf_vlog_bytes=2,367,565
command_wal_bytes_before_checkpoint=11,182,572
checkpoint=205.010 ms
reopen_recovery=99.084 ms
db_total_bytes=35,998,637 across 9 files
```

Measurement class: `experiment/granule baseline`. Historical granule context remains q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, q5 metadata `~2.406 ns/row`, with `0 allocs/op` as the hot-kernel target. This PR moves production allocation counts downward but does not change the row/sidecar representation into the granule dense block kernel.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench context remains stale/context-only from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: 1M q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is not a same-harness or same-lifecycle production comparison.

Scale note: the routed 100K scan durations above are sub-ms to low-ms; the `ns/row` numbers are per-row rates. Do not read `21 ns/row` as `21 ms` unless the row count makes that conversion true.

## Throughput Interpretation

This is a local allocation reduction in manifest-sidecar setup. The timing effect is expected to be small/noisy because the query still reads and validates the same manifest records, reads the same physical sidecar assets, and runs the same reducers.

The allocation win comes from avoiding unused sidecar snapshot slice growth and string/snapshot construction by query shape. Skipped sidecar records are still decoded enough to validate namespace, kind, generation, part id, live-part reachability, row count where applicable, and key/reason consistency; they still contribute to the manifest checksum.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnManifestSnapshotSidecarFilterStillValidatesSkippedRecordsM1634|TestColumnPhysicalQueryManifestSidecarFilterM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQueryParallel' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/q[1-5].*rows_8192' -benchmem -benchtime=1000x -count=5`
- `make unified-bench`
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial_column_scan -column-store-asset-read-integrity verify -progress=false`
- `git diff --check`

## Artifacts

- Direct package scanner current: `/tmp/gomap_1634_manifest_filter_adapter_q1q5_bench_final.txt`
- Direct package scanner baseline: `/tmp/gomap_1691_next_checkpoint_adapter_q1q5.txt`
- Benchstat: `/tmp/gomap_1634_manifest_filter_benchstat_vs_1691_final.txt`
- Routed production markdown: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/column_store_results.md`
- Routed production HTML: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/column_store_results.html`
- Routed production JSON: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/column_store_results.json`
- Routed benchprof markdown/json: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/benchprof_results.md`, `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/benchprof_results.json`
- Routed insights HTML: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/insights.html`
- Routed CPU profile: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/cpu_column_store_treedb_column_store.pprof`
- Routed allocs profile: `/tmp/gomap_1634_manifest_filter_routed_100k_jVBUGF/allocs_column_store_treedb_column_store.pprof`

## Assumptions / Caveats

- The parallel physical path requests no manifest sidecar materialization because it scans TCPA part-image refs directly; focused parallel tests cover this.
- This PR intentionally preserves full sidecar validation for skipped records, so it does not optimize away manifest safety checks.
- This is not a prepared-runner PR and makes no billion-rows/sec claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized column physical query execution by selectively loading only required metadata sidecars based on query type and requirements
  * Improved parallel query performance with streamlined sidecar allocation and reduced memory overhead
  * Enhanced memory efficiency during manifest snapshot preparation across different query scenarios

* **Tests**
  * Added comprehensive test coverage for manifest-driven metadata filtering and validation mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->