### PR TITLE
TreeDB column store post-V1: filter sidecars by requested name

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -577,15 +577,17 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 
 func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) columnManifestScanSidecarFilter {
 	if req.AggregateMetadataName != "" {
-		return columnManifestScanSidecarFilter{AggregateMetadata: true}
+		return columnManifestScanSidecarFilter{AggregateMetadata: true, AggregateMetadataName: req.AggregateMetadataName}
 	}
 	switch req.Kind {
-	case ColumnPhysicalQueryGroupCount, ColumnPhysicalQueryGroupCountDistinct:
-		return columnManifestScanSidecarFilter{DictionaryCodes: true}
+	case ColumnPhysicalQueryGroupCount:
+		return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn}
+	case ColumnPhysicalQueryGroupCountDistinct:
+		return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, DictionaryColumn2: req.DistinctColumn}
 	case ColumnPhysicalQueryHourCount:
-		return columnManifestScanSidecarFilter{Int64Values: true}
+		return columnManifestScanSidecarFilter{Int64Values: true, Int64Column: req.ValueColumn}
 	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
-		return columnManifestScanSidecarFilter{DictionaryCodes: true, Int64Values: true}
+		return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, Int64Values: true, Int64Column: req.ValueColumn}
 	default:
 		return columnManifestScanNoSidecars()
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,32 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 26,
+			maxAllocs: 24,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 45,
+			maxAllocs: 43,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 14,
+			maxAllocs: 13,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 42,
+			maxAllocs: 39,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 42,
+			maxAllocs: 39,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 43,
+			maxAllocs: 40,
 		},
 	}
 	for _, tc := range tests {
@@ -2435,7 +2435,7 @@ func TestColumnPhysicalQueryManifestSidecarFilterM1634(t *testing.T) {
 		{
 			name:           "q1_dictionary_only",
 			req:            ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			wantDictionary: 2,
+			wantDictionary: 1,
 		},
 		{
 			name:           "q2_dictionary_only",
@@ -2450,13 +2450,13 @@ func TestColumnPhysicalQueryManifestSidecarFilterM1634(t *testing.T) {
 		{
 			name:           "q4_dictionary_and_int64",
 			req:            ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			wantDictionary: 2,
+			wantDictionary: 1,
 			wantInt64:      1,
 		},
 		{
 			name:          "q5_metadata_aggregate_only",
 			req:           ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"},
-			wantAggregate: 2,
+			wantAggregate: 1,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -89,9 +89,13 @@ type columnManifestAssetRefForScan struct {
 }
 
 type columnManifestScanSidecarFilter struct {
-	AggregateMetadata bool
-	DictionaryCodes   bool
-	Int64Values       bool
+	AggregateMetadata     bool
+	AggregateMetadataName string
+	DictionaryCodes       bool
+	DictionaryColumn      string
+	DictionaryColumn2     string
+	Int64Values           bool
+	Int64Column           string
 }
 
 func columnManifestScanAllSidecars() columnManifestScanSidecarFilter {
@@ -104,6 +108,60 @@ func columnManifestScanAllSidecars() columnManifestScanSidecarFilter {
 
 func columnManifestScanNoSidecars() columnManifestScanSidecarFilter {
 	return columnManifestScanSidecarFilter{}
+}
+
+func (f columnManifestScanSidecarFilter) aggregateMetadataNameForScan(name []byte) (string, bool) {
+	if !f.AggregateMetadata {
+		return "", false
+	}
+	if f.AggregateMetadataName == "" {
+		return "", true
+	}
+	if columnManifestBytesEqualString(name, f.AggregateMetadataName) {
+		return f.AggregateMetadataName, true
+	}
+	return "", false
+}
+
+func (f columnManifestScanSidecarFilter) dictionaryColumnNameForScan(columnName []byte) (string, bool) {
+	if !f.DictionaryCodes {
+		return "", false
+	}
+	if f.DictionaryColumn == "" && f.DictionaryColumn2 == "" {
+		return "", true
+	}
+	if columnManifestBytesEqualString(columnName, f.DictionaryColumn) {
+		return f.DictionaryColumn, true
+	}
+	if f.DictionaryColumn2 != "" && columnManifestBytesEqualString(columnName, f.DictionaryColumn2) {
+		return f.DictionaryColumn2, true
+	}
+	return "", false
+}
+
+func (f columnManifestScanSidecarFilter) int64ColumnNameForScan(columnName []byte) (string, bool) {
+	if !f.Int64Values {
+		return "", false
+	}
+	if f.Int64Column == "" {
+		return "", true
+	}
+	if columnManifestBytesEqualString(columnName, f.Int64Column) {
+		return f.Int64Column, true
+	}
+	return "", false
+}
+
+func columnManifestBytesEqualString(raw []byte, value string) bool {
+	if len(raw) != len(value) {
+		return false
+	}
+	for i, b := range raw {
+		if b != value[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func columnManifestDictionarySidecarColumns(cfg ColumnStoreConfig) int {
@@ -654,7 +712,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				iter.Next()
 				continue
 			}
-			if !filter.AggregateMetadata {
+			_, _, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			preferredName, include := filter.aggregateMetadataNameForScan(name)
+			if !include {
 				if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
@@ -662,7 +725,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				writeHashBytes(&d, value)
 				break
 			}
-			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -674,7 +737,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				iter.Next()
 				continue
 			}
-			if !filter.DictionaryCodes {
+			_, _, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			preferredColumnName, include := filter.dictionaryColumnNameForScan(columnName)
+			if !include {
 				if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
@@ -682,7 +750,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				writeHashBytes(&d, value)
 				break
 			}
-			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredColumnName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -694,7 +762,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				iter.Next()
 				continue
 			}
-			if !filter.Int64Values {
+			_, _, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
+			if err != nil {
+				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
+			}
+			preferredColumnName, include := filter.int64ColumnNameForScan(columnName)
+			if !include {
 				if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
@@ -702,7 +775,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				writeHashBytes(&d, value)
 				break
 			}
-			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows)
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredColumnName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -1242,19 +1315,19 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 	for _, record := range records {
 		switch {
 		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
-			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
 			snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
 		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
-			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
 			snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
 		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
-			values, err := decodeColumnManifestInt64ValuesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows)
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
@@ -1267,7 +1340,7 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 	return snapshot, refs, mutationParts, nil
 }
 
-func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestAggregateMetadataSnapshot, error) {
+func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredName string) (columnManifestAggregateMetadataSnapshot, error) {
 	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestAggregateMetadataSnapshot{}, err
@@ -1291,9 +1364,12 @@ func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expecte
 	if !bytes.Equal(name, reason) {
 		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata key name=%q does not match record name=%q", string(name), string(reason))
 	}
+	if preferredName == "" {
+		preferredName = string(name)
+	}
 	return columnManifestAggregateMetadataSnapshot{
 		AssetRef:     ref,
-		Name:         string(name),
+		Name:         preferredName,
 		Bytes:        bytesValue,
 		PublishID:    publishID,
 		GenerationID: generationID,
@@ -1327,7 +1403,7 @@ func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expec
 	return nil
 }
 
-func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestDictionaryCodesSnapshot, error) {
+func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredColumnName string) (columnManifestDictionaryCodesSnapshot, error) {
 	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestDictionaryCodesSnapshot{}, err
@@ -1351,9 +1427,12 @@ func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedN
 	if !bytes.Equal(columnName, reason) {
 		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes key column=%q does not match record column=%q", string(columnName), string(reason))
 	}
+	if preferredColumnName == "" {
+		preferredColumnName = string(columnName)
+	}
 	return columnManifestDictionaryCodesSnapshot{
 		AssetRef:     ref,
-		ColumnName:   string(columnName),
+		ColumnName:   preferredColumnName,
 		Bytes:        bytesValue,
 		PublishID:    publishID,
 		GenerationID: generationID,
@@ -1387,7 +1466,7 @@ func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expecte
 	return nil
 }
 
-func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) (columnManifestInt64ValuesSnapshot, error) {
+func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredColumnName string) (columnManifestInt64ValuesSnapshot, error) {
 	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestInt64ValuesSnapshot{}, err
@@ -1415,9 +1494,12 @@ func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNames
 	if !bytes.Equal(columnName, reason) {
 		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values key column=%q does not match record column=%q", string(columnName), string(reason))
 	}
+	if preferredColumnName == "" {
+		preferredColumnName = string(columnName)
+	}
 	return columnManifestInt64ValuesSnapshot{
 		AssetRef:     ref,
-		ColumnName:   string(columnName),
+		ColumnName:   preferredColumnName,
 		Rows:         rows,
 		Bytes:        bytesValue,
 		PublishID:    publishID,


### PR DESCRIPTION
## Summary

This #1634 slice tightens #1693's manifest sidecar filtering from family-level selection to requested-name selection. The loader still reads, validates, and checksums skipped sidecar records, but it no longer materializes sidecar snapshots for unrequested dictionary columns, int64 columns, or aggregate metadata names.

Primary changed path: direct package scanner and routed serial physical query setup. This is allocation hygiene in the current production sidecar path; it is not a schema-fixed column-block/dense-kernel conversion and does not claim to close the production-vs-granule analytical-kernel gap.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed evidence; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict `verify`.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Static Checkpoint

After #1693, manifest loading stopped materializing whole unused sidecar families, but q1/q4/q5 and aggregate-metadata requests still materialized sidecars within the requested family that the query could not use. The focused code pass showed avoidable snapshot/name allocations for:

- q1 loading both dictionary-code columns when it only needs `kind`.
- q4/q5 loading both dictionary-code columns when they only need the requested group column plus `time_us` values.
- aggregate metadata requests loading every aggregate metadata record when they only need the requested metadata name.

This PR keeps the full manifest checksum/validation boundary intact while making sidecar snapshot materialization specific to the requested column/name.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. Same-machine #1693 baseline vs this PR on Apple M3, darwin/arm64, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B`, `-benchtime=1000x -count=5`:

```text
geomean sec/op:     43.19us -> 42.90us (-0.67%, timing neutral/noisy)
geomean ns/row:     5.265ns -> 5.230ns (-0.67%, timing neutral/noisy)
geomean rows/s:     189.9M  -> 191.2M  (+0.68%, timing neutral/noisy)
geomean B/op:       4.073Ki -> 4.057Ki (-0.40%)
geomean allocs/op:  34.24   -> 32.06   (-6.36%)
```

Per-query allocation movement:

```text
q1:           26 -> 24 allocs/op
q2:           45 -> 43 allocs/op
q3:           14 -> 13 allocs/op
q4a:          42 -> 39 allocs/op
q4b:          42 -> 39 allocs/op
q4b_metadata: 39 -> 37 allocs/op
q5:           43 -> 40 allocs/op
q5_metadata:  39 -> 37 allocs/op
```

Representative current direct package scanner numbers:

```text
q1:           4.97-5.69 ns/row, 175.6-201.1M rows/s, 4089-4096 B/op, 24 allocs/op
q2:           5.82-5.86 ns/row, 170.6-171.9M rows/s, 5409 B/op, 43 allocs/op
q3:           5.56-8.42 ns/row, 118.8-179.9M rows/s, 2945 B/op, 13 allocs/op
q4a:          7.76-9.02 ns/row, 110.9-128.9M rows/s, 4153-4160 B/op, 39 allocs/op
q4b:          8.30-9.50 ns/row, 105.3-120.5M rows/s, 4153-4160 B/op, 39 allocs/op
q4b_metadata: 2.56-2.63 ns/row, 380.3-390.9M rows/s, 4193 B/op, 37 allocs/op
q5:           7.59-7.97 ns/row, 125.5-131.7M rows/s, 4249 B/op, 40 allocs/op
q5_metadata:  2.54-2.61 ns/row, 383.4-393.8M rows/s, 4417-4433 B/op, 37 allocs/op
```

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Routed execution reaches the changed path because forced `serial_column_scan` calls `RunColumnPhysicalQuery`, which now requests only the sidecar names/columns required by the query. Current production snapshot on Apple M3, durable, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS`:

```text
q1:          8.9 ns/row, 112.33M rows/s, scan 0.713 ms, dictionary_code_hits=100, int64_value_hits=0
q2:         28.6 ns/row,  35.00M rows/s, scan 2.739 ms, dictionary_code_hits=100, int64_value_hits=0
q3:          5.7 ns/row, 175.68M rows/s, scan 0.446 ms, dictionary_code_hits=0,   int64_value_hits=100
q4a:        22.5 ns/row,  44.54M rows/s, scan 2.084 ms, dictionary_code_hits=100, int64_value_hits=100
q4b:        22.1 ns/row,  45.16M rows/s, scan 2.049 ms, dictionary_code_hits=100, int64_value_hits=100
q5:         22.4 ns/row,  44.61M rows/s, scan 2.084 ms, dictionary_code_hits=100, int64_value_hits=100
q5_metadata serial alias: 21.7 ns/row, 46.01M rows/s, scan 2.013 ms, metadata_hits=0 under forced serial label
```

All routed q1-q5 parity checks passed and row materializations remained zero.

Routed byte/accounting snapshot from the same run:

```text
source_document_bytes=9,368,750
retained_payload_bytes=3,368,750
column_asset_bytes=21,399,500
column_asset_store_bytes=21,399,500
manifest_control_bytes=28
ordinary_value_vlog_bytes=0
leaf_vlog_bytes=2,367,565
command_wal_bytes_before_checkpoint=11,182,572
checkpoint=203.090 ms
reopen_recovery=96.684 ms
db_total_bytes=35,998,637 across 9 files
```

Measurement class: `experiment/granule baseline`. Historical granule context remains q1 `~2.38 ns/row`, q2 `~4.13 ns/row`, q4b encoded scan `~12.48 ns/row`, q5 encoded scan `~7.123 ns/row`, q4b metadata `~3.321 ns/row`, q5 metadata `~2.406 ns/row`, with `0 allocs/op` as the hot-kernel target. This PR moves production allocation counts downward but does not change the production representation into the granule dense block kernel.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench context remains stale/context-only from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: 1M q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is not a same-harness or same-lifecycle production comparison.

Scale note: the routed 100K scan durations above are sub-ms to low-ms; the `ns/row` numbers are per-row rates. Do not read `22 ns/row` as `22 ms` unless the row count makes that conversion true. At 100K rows, `22 ns/row` is about `2.2 ms`; at 1M rows it would extrapolate to about `22 ms`.

## Throughput Interpretation

The direct allocation win comes from two places: avoiding snapshot slice growth for unrequested sidecar names and reusing request-owned column/name strings for included sidecars when the manifest key matches the request. Skipped sidecar records are still validated for namespace, kind, generation, part id, row count where applicable, key/reason consistency, live-part reachability, and checksum contribution.

The timing effect is expected to be small because the manifest cursor still visits every relevant record and the query still reads the same physical sidecar assets it actually needs. This is therefore a measured allocation hygiene PR, not a throughput headline PR.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnManifestSnapshotSidecarFilterStillValidatesSkippedRecordsM1634|TestColumnPhysicalQueryManifestSidecarFilterM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuerySerial(Int64SidecarParity|DictionaryInt64SidecarParity|DictionarySidecarParity)M1634|TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation)M1634' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/q[1-5].*rows_8192' -benchmem -benchtime=1000x -count=5`
- `benchstat /tmp/gomap_1634_manifest_filter_adapter_q1q5_bench_final.txt /tmp/gomap_1634_sidecar_name_filter_adapter_q1q5_final.txt`
- `make unified-bench`
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial_column_scan -column-store-asset-read-integrity verify -progress=false`
- `git diff --check`

## Artifacts

- Direct package scanner current: `/tmp/gomap_1634_sidecar_name_filter_adapter_q1q5_final.txt`
- Direct package scanner baseline: `/tmp/gomap_1634_manifest_filter_adapter_q1q5_bench_final.txt`
- Benchstat: `/tmp/gomap_1634_sidecar_name_filter_benchstat_vs_1693_final.txt`
- Routed production markdown: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/column_store_results.md`
- Routed production HTML: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/column_store_results.html`
- Routed production JSON: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/column_store_results.json`
- Routed benchprof markdown/json: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/benchprof_results.md`, `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/benchprof_results.json`
- Routed insights HTML: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/insights.html`
- Routed CPU profile: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/cpu_column_store_treedb_column_store.pprof`
- Routed allocs profile: `/tmp/gomap_1634_sidecar_name_filter_routed_100k_SvC6wS/allocs_column_store_treedb_column_store.pprof`

## Assumptions / Caveats

- This PR intentionally preserves full validation for skipped sidecar records, so it does not optimize away manifest safety checks.
- This PR does not change prepared runners, schema-fixed dense block layout, mark pruning, aggregate metadata routing, WAL/checkpoint behavior, reopen, mutation handling, or GC/rewrite behavior.
- Remaining direct package scanner allocations are still above the granule `0 allocs/op` hot-kernel target. The next #1634 slice should start with another static/profile checkpoint before choosing between manifest/view setup, result construction, routed/session reuse, or representation/kernel-shape work.

Refs #1634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal query processing logic to improve performance and filtering accuracy.

* **Tests**
  * Updated performance allocation and filtering expectations in query tests to reflect optimizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->