### PR TITLE
TreeDB column store post-V1: reduce manifest scan allocations

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,32 +2334,42 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 24,
+			maxAllocs: 22,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 43,
+			maxAllocs: 41,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 13,
+			maxAllocs: 11,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 39,
+			maxAllocs: 37,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 39,
+			maxAllocs: 37,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 40,
+			maxAllocs: 38,
+		},
+		{
+			name:      "q4b_metadata",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"},
+			maxAllocs: 35,
+		},
+		{
+			name:      "q5_metadata",
+			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"},
+			maxAllocs: 35,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -592,8 +592,8 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 	activeParts := uint64(0)
 	manifestRecords := 0
 	mutationParts := 0
-	refs := make([]columnManifestAssetRefForScan, 0, 8)
-	livePartRows := make(map[[2]uint64]int, 8)
+	var refs []columnManifestAssetRefForScan
+	var livePartRows columnManifestLivePartRowsForScan
 	for iter.Valid() {
 		key := iter.UnsafeKey()
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
@@ -640,10 +640,8 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			if header.expectedParts > 0 && header.expectedParts <= uint64(maxCollectionInt) {
 				expectedParts := int(header.expectedParts)
-				if cap(refs) < expectedParts {
-					refs = make([]columnManifestAssetRefForScan, 0, expectedParts)
-				}
-				livePartRows = make(map[[2]uint64]int, expectedParts)
+				refs = make([]columnManifestAssetRefForScan, 0, expectedParts)
+				livePartRows.initCapacity(expectedParts)
 				if filter.AggregateMetadata {
 					if capacity := columnManifestScanSidecarCapacity(expectedParts, len(cfg.AggregateMetadata)); capacity > 0 {
 						snapshot.AggregateMetadata = make([]columnManifestAggregateMetadataSnapshot, 0, capacity)
@@ -697,7 +695,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			if !ok {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 			}
-			livePartRows[[2]uint64{ref.Generation, ref.PartID}] = rows
+			livePartRows.add(ref.Generation, ref.PartID, rows)
 			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
 			if ref.Generation == snapshot.Generation {
 				activeParts++
@@ -718,14 +716,14 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			preferredName, include := filter.aggregateMetadataNameForScan(name)
 			if !include {
-				if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+				if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
 				break
 			}
-			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredName)
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -743,14 +741,14 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			preferredColumnName, include := filter.dictionaryColumnNameForScan(columnName)
 			if !include {
-				if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+				if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
 				break
 			}
-			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredColumnName)
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredColumnName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -768,14 +766,14 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			preferredColumnName, include := filter.int64ColumnNameForScan(columnName)
 			if !include {
-				if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows); err != nil {
+				if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
 					return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
 				break
 			}
-			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, livePartRows, preferredColumnName)
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredColumnName)
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, err
 			}
@@ -1272,7 +1270,8 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 	}
 
 	refs := make([]columnManifestAssetRefForScan, 0, partRecords)
-	livePartRows := make(map[[2]uint64]int, partRecords)
+	var livePartRows columnManifestLivePartRowsForScan
+	livePartRows.initCapacity(partRecords)
 	mutationParts := 0
 	activeParts := 0
 	for _, record := range records {
@@ -1303,7 +1302,7 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 		if !ok {
 			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
-		livePartRows[[2]uint64{ref.Generation, ref.PartID}] = rows
+		livePartRows.add(ref.Generation, ref.PartID, rows)
 		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
 		if ref.Generation == snapshot.Generation {
 			activeParts++
@@ -1315,19 +1314,19 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 	for _, record := range records {
 		switch {
 		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
-			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
+			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, &livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
 			snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
 		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
-			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
+			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, &livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
 			snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
 		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
-			values, err := decodeColumnManifestInt64ValuesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, livePartRows, "")
+			values, err := decodeColumnManifestInt64ValuesRecordForScan(record.key, record.value, expectedNamespace, snapshot.Generation, &livePartRows, "")
 			if err != nil {
 				return columnManifestSnapshot{}, nil, 0, err
 			}
@@ -1340,7 +1339,49 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 	return snapshot, refs, mutationParts, nil
 }
 
-func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredName string) (columnManifestAggregateMetadataSnapshot, error) {
+type columnManifestLivePartRowsForScan struct {
+	inlineKey  [2]uint64
+	inlineRows int
+	inlineSet  bool
+	rows       map[[2]uint64]int
+}
+
+func (r *columnManifestLivePartRowsForScan) initCapacity(parts int) {
+	if parts > 1 {
+		r.rows = make(map[[2]uint64]int, parts)
+	}
+}
+
+func (r *columnManifestLivePartRowsForScan) add(generation, partID uint64, rows int) {
+	key := [2]uint64{generation, partID}
+	if r.rows != nil {
+		r.rows[key] = rows
+		return
+	}
+	if !r.inlineSet || r.inlineKey == key {
+		r.inlineKey = key
+		r.inlineRows = rows
+		r.inlineSet = true
+		return
+	}
+	r.rows = make(map[[2]uint64]int, 2)
+	r.rows[r.inlineKey] = r.inlineRows
+	r.rows[key] = rows
+}
+
+func (r *columnManifestLivePartRowsForScan) get(generation, partID uint64) (int, bool) {
+	key := [2]uint64{generation, partID}
+	if r.rows != nil {
+		rows, ok := r.rows[key]
+		return rows, ok
+	}
+	if r.inlineSet && r.inlineKey == key {
+		return r.inlineRows, true
+	}
+	return 0, false
+}
+
+func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan, preferredName string) (columnManifestAggregateMetadataSnapshot, error) {
 	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestAggregateMetadataSnapshot{}, err
@@ -1358,7 +1399,7 @@ func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expecte
 	if ref.Generation > activeGeneration {
 		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+	if _, ok := livePartRows.get(ref.Generation, ref.PartID); !ok {
 		return columnManifestAggregateMetadataSnapshot{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}
 	if !bytes.Equal(name, reason) {
@@ -1376,7 +1417,7 @@ func decodeColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expecte
 	}, nil
 }
 
-func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan) error {
 	generation, partID, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 	if err != nil {
 		return err
@@ -1394,7 +1435,7 @@ func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expec
 	if ref.Generation > activeGeneration {
 		return fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+	if _, ok := livePartRows.get(ref.Generation, ref.PartID); !ok {
 		return fmt.Errorf("collections: column manifest aggregate metadata generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}
 	if !bytes.Equal(name, reason) {
@@ -1403,7 +1444,7 @@ func validateColumnManifestAggregateMetadataRecordForScan(key, raw []byte, expec
 	return nil
 }
 
-func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredColumnName string) (columnManifestDictionaryCodesSnapshot, error) {
+func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan, preferredColumnName string) (columnManifestDictionaryCodesSnapshot, error) {
 	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestDictionaryCodesSnapshot{}, err
@@ -1421,7 +1462,7 @@ func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedN
 	if ref.Generation > activeGeneration {
 		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+	if _, ok := livePartRows.get(ref.Generation, ref.PartID); !ok {
 		return columnManifestDictionaryCodesSnapshot{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}
 	if !bytes.Equal(columnName, reason) {
@@ -1439,7 +1480,7 @@ func decodeColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedN
 	}, nil
 }
 
-func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan) error {
 	generation, partID, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return err
@@ -1457,7 +1498,7 @@ func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expecte
 	if ref.Generation > activeGeneration {
 		return fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	if _, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]; !ok {
+	if _, ok := livePartRows.get(ref.Generation, ref.PartID); !ok {
 		return fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}
 	if !bytes.Equal(columnName, reason) {
@@ -1466,7 +1507,7 @@ func validateColumnManifestDictionaryCodesRecordForScan(key, raw []byte, expecte
 	return nil
 }
 
-func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int, preferredColumnName string) (columnManifestInt64ValuesSnapshot, error) {
+func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan, preferredColumnName string) (columnManifestInt64ValuesSnapshot, error) {
 	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return columnManifestInt64ValuesSnapshot{}, err
@@ -1484,7 +1525,7 @@ func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNames
 	if ref.Generation > activeGeneration {
 		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	partRows, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]
+	partRows, ok := livePartRows.get(ref.Generation, ref.PartID)
 	if !ok {
 		return columnManifestInt64ValuesSnapshot{}, fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}
@@ -1507,7 +1548,7 @@ func decodeColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNames
 	}, nil
 }
 
-func validateColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows map[[2]uint64]int) error {
+func validateColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNamespace string, activeGeneration uint64, livePartRows *columnManifestLivePartRowsForScan) error {
 	generation, partID, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 	if err != nil {
 		return err
@@ -1525,7 +1566,7 @@ func validateColumnManifestInt64ValuesRecordForScan(key, raw []byte, expectedNam
 	if ref.Generation > activeGeneration {
 		return fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", ref.Generation, activeGeneration)
 	}
-	partRows, ok := livePartRows[[2]uint64{ref.Generation, ref.PartID}]
+	partRows, ok := livePartRows.get(ref.Generation, ref.PartID)
 	if !ok {
 		return fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", ref.Generation, ref.PartID)
 	}


### PR DESCRIPTION
## Summary

This #1634 slice removes avoidable manifest snapshot allocation from the routed/direct column-store query setup path. The manifest sidecar validators now use a tiny inline live-part row table for the common single-part case and only allocate the map when a manifest actually has multiple live parts.

This is tactical allocation hygiene inside the current sidecar/TCPA production path. It does not claim to close the remaining production-vs-granule representation gap; that still requires schema-fixed column blocks, dense reducers, marks/metadata, and broader routed/session reuse work.

## Measurement Class

Primary measurement class: `direct package scanner`.

Changed path reaches routed unified-bench: yes, through manifest snapshot/view setup before physical sidecar query execution. Routed gains are setup-allocation hygiene, not a new query kernel.

Prepared-runner boundary: no prepared hot-runner claim is made by this PR. Existing prepared hot-runner evidence remains context only and excludes sidecar read/decode/checksum/translation, planner routing, unified-bench reporting, writes, WAL/checkpoint, reopen, and mutation handling.

## Static Analysis Checkpoint

After #1694, requested-name sidecar filtering stopped materializing unused sidecars, but the one-shot direct/routed scan still allocated a map for live part row validation even when the manifest had exactly one live part. The current synthetic fixture and most small direct scanner benches are single-part. A map is still needed for multi-part manifests, but the common single-part validation path can be represented inline without changing manifest validation, checksum contribution, fail-closed behavior, or GC/ref visibility.

Allocation parity with the old granule kernels remains a priority. This PR moves direct one-shot q1-q5 sidecar paths two allocs/op closer to the `0 allocs/op` granule hot-kernel target, while leaving the larger representation/kernel-shape work for later #1634 PRs.

## Performance / Benchmark Evidence

Measurement class: `direct package scanner`. Apple M3, darwin/arm64, 8,192 rows, `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/q[1-5].*rows_8192' -benchmem -benchtime=1000x -count=1`:

```text
q1:          5.158 ns/row, 193.9M rows/s, 3034 B/op, 22 allocs/op
q2:          5.813 ns/row, 172.0M rows/s, 4353 B/op, 41 allocs/op
q3:          5.589 ns/row, 178.9M rows/s, 1889 B/op, 11 allocs/op
q4a:         7.636 ns/row, 131.0M rows/s, 3097 B/op, 37 allocs/op
q4b:         9.599 ns/row, 104.2M rows/s, 3097 B/op, 37 allocs/op
q4b_metadata: 2.539 ns/row, 393.9M rows/s, 3137 B/op, 35 allocs/op
q5:          7.697 ns/row, 129.9M rows/s, 3193 B/op, 38 allocs/op
q5_metadata: 2.625 ns/row, 380.9M rows/s, 3377 B/op, 35 allocs/op
```

TDD allocation gates now enforce the reduced budgets in `TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634`: q1 `24 -> 22`, q2 `43 -> 41`, q3 `13 -> 11`, q4a/q4b `39 -> 37`, q5 `40 -> 38`, plus new metadata-path budgets at `35 allocs/op`.

Measurement class: `routed unified-bench query path`. Current production comparable snapshot, Apple M3, durable profile, 100,000 rows, forced `serial_column_scan`, strict `verify`, artifact `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G`:

```text
q1:  6.4 ns/row, 155.2M rows/s, parity pass, row_materializations=0
q2: 28.1 ns/row,  35.6M rows/s, parity pass, row_materializations=0
q3:  5.7 ns/row, 176.3M rows/s, parity pass, row_materializations=0
q4a: 22.3 ns/row, 44.8M rows/s, parity pass, row_materializations=0
q4b: 21.5 ns/row, 46.5M rows/s, parity pass, row_materializations=0
q5: 21.8 ns/row, 45.9M rows/s, parity pass, row_materializations=0
q5_metadata serial alias: 21.8 ns/row, 45.8M rows/s, metadata_hits=0, parity pass
```

Routed byte/accounting snapshot from the same run: `source_document_bytes=9,368,750`, `retained_payload_bytes=3,368,750`, `column_asset_bytes=21,399,500`, `manifest_control_bytes=28`, `ordinary_value_vlog_bytes=0`, `leaf_vlog_bytes=2,367,565`, `command_wal_bytes_before_checkpoint=11,182,572`, `db_total_bytes=35,998,637`.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot is the 100K durable run above. The routed path reaches this optimization through manifest snapshot/view setup before direct sidecar execution.

Measurement class: `direct package scanner`. Current direct numbers are the package benchmark above; they include package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction. They are not prepared hot-runner measurements.

Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no billion-rows/sec prepared-runner claim is made here.

Measurement class: `experiment/granule baseline`. Historical/current-best #1634 context remains that the granule hot kernels targeted `0 allocs/op`; encoded granule context includes q1 around `~2.38 ns/row`, q2 around `~4.13 ns/row`, q4b encoded row scan around `~12.48 ns/row`, q5 encoded row scan around `~7.123 ns/row`, q4b metadata around `~3.321 ns/row`, and q5 metadata around `~2.406 ns/row`. These are not durable routed production measurements.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md` remains approximately 1M q1/q2/q3/q4/q5 `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This is stale/contextual and not a same-harness lifecycle comparison.

Scale note: the routed values above are `ns/row` on 100K rows, so q5 at `21.8 ns/row` is about a `2.18 ms` query-stage scan, not a `21.8 ms` scan.

## Throughput Interpretation

This PR reduces setup allocation in the production manifest/view path without changing sidecar encoding, reducer shape, read-integrity policy, WAL/checkpoint, or reopen behavior. The direct package scanner allocation drop is the meaningful signal. Routed q1-q5 remains in the expected 100K single-digit/low-double-digit `ns/row` range and should be interpreted as current end-to-end context, not as a new analytical-kernel breakthrough.

The remaining gap to granule is still dominated by representation/kernel shape and routed/session setup: production still uses typed sidecar assets and manifest/view setup, while granule kernels use schema-fixed dense column blocks and zero-allocation hot loops.

## Apples-to-Apples Limitations

The direct package scanner is not full fixture/create/checkpoint/reopen/reporting and is not a prepared hot runner. The routed 100K snapshot includes durable TreeDB lifecycle and reporting but is smaller than the historical 1M ClickHouse/granule context. The granule and ClickHouse values are historical/contextual and should not be read as same-commit parity gates.

## Validation

- `go test ./TreeDB/collections -run TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634 -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQueryAdapterM13B/q[1-5].*rows_8192' -benchmem -benchtime=1000x -count=1`
- `go build -o ./bin/unified-bench ./cmd/unified_bench`
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir /tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G -path-label native-fastpath -column-store-path serial_column_scan -progress=false`
- `git diff --check`

## Artifacts

- Direct package scanner output: `/tmp/gomap_1634_manifest_alloc_adapter_bench.txt`
- Routed production markdown: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/column_store_results.md`
- Routed production HTML: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/column_store_results.html`
- Routed production JSON: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/column_store_results.json`
- Benchprof JSON/markdown: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/benchprof_results.json`, `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/benchprof_results.md`
- Insights HTML: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/insights.html`
- CPU profile: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_manifest_alloc_routed_100k_8ye53G/allocs_column_store_treedb_column_store.pprof`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced memory efficiency in column manifest tracking during physical scans through optimized data structure handling.

* **Tests**
  * Updated allocation budgets for query execution paths and expanded test coverage with additional metadata test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->