### PR TITLE
TreeDB column store post-V1: trim mmap reader allocation

### DIFF
--- a/TreeDB/collections/column_asset_mmap_unix.go
+++ b/TreeDB/collections/column_asset_mmap_unix.go
@@ -11,11 +11,11 @@ func mmapColumnPhysicalAssetFile(file *os.File) ([]byte, error) {
 	if file == nil {
 		return nil, os.ErrInvalid
 	}
-	info, err := file.Stat()
-	if err != nil {
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(int(file.Fd()), &stat); err != nil {
 		return nil, err
 	}
-	size := info.Size()
+	size := stat.Size
 	if size <= 0 || size > int64(maxCollectionInt) {
 		return nil, os.ErrInvalid
 	}

--- a/TreeDB/collections/column_asset_mmap_unix.go
+++ b/TreeDB/collections/column_asset_mmap_unix.go
@@ -11,15 +11,22 @@ func mmapColumnPhysicalAssetFile(file *os.File) ([]byte, error) {
 	if file == nil {
 		return nil, os.ErrInvalid
 	}
+	fd := int(file.Fd())
 	var stat syscall.Stat_t
-	if err := syscall.Fstat(int(file.Fd()), &stat); err != nil {
-		return nil, err
+	for {
+		err := syscall.Fstat(fd, &stat)
+		if err == nil {
+			break
+		}
+		if err != syscall.EINTR {
+			return nil, err
+		}
 	}
 	size := stat.Size
 	if size <= 0 || size > int64(maxCollectionInt) {
 		return nil, os.ErrInvalid
 	}
-	return syscall.Mmap(int(file.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+	return syscall.Mmap(fd, 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
 }
 
 func munmapColumnPhysicalAssetFile(data []byte) error {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2334,42 +2334,42 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 		{
 			name:      "q1_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"},
-			maxAllocs: 22,
+			maxAllocs: 21,
 		},
 		{
 			name:      "q2_dictionary_codes",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"},
-			maxAllocs: 41,
+			maxAllocs: 40,
 		},
 		{
 			name:      "q3_int64_values",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"},
-			maxAllocs: 11,
+			maxAllocs: 10,
 		},
 		{
 			name:      "q4a_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 37,
+			maxAllocs: 36,
 		},
 		{
 			name:      "q4b_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 37,
+			maxAllocs: 36,
 		},
 		{
 			name:      "q5_dictionary_int64",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"},
-			maxAllocs: 38,
+			maxAllocs: 37,
 		},
 		{
 			name:      "q4b_metadata",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "max_time_us"},
-			maxAllocs: 35,
+			maxAllocs: 34,
 		},
 		{
 			name:      "q5_metadata",
 			req:       ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"},
-			maxAllocs: 35,
+			maxAllocs: 34,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Avoids one per-scan allocation in mmap-backed typed column asset reads by using `syscall.Fstat` instead of `os.File.Stat` when sizing the asset file.
- Tightens the #1634 serial sidecar allocation budget by 1 alloc/op for q1/q2/q3/q4/q5 and scan-backed metadata aliases.
- Keeps the physical format, manifest format, read-integrity modes, planner routing, prepared runners, WAL/checkpoint behavior, mutation handling, and GC/rewrite behavior unchanged.

Refs #1634.

## Benchmark Claim Boundary

Primary measurement class: `direct package scanner`.

This is a tactical allocation-cleanup PR inside the current typed column asset mmap reader. It removes an avoidable `os.FileInfo` allocation from one-shot mmap-backed scans. It does not claim end-to-end routed throughput improvement, ClickHouse parity, granule-kernel parity, prepared-runner improvement, or a representation/kernel-shape change.

Changed path reaches routed `unified-bench`: yes, routed serial physical scans use the same typed column asset mmap reader, but the routed 100K snapshot is reported as parity/context only because routed query timings are noisy at this scale and include fixture/planner/reporting/lifecycle overhead outside this local allocation change.

## Static Analysis Checkpoint

Before implementation, the latest #1634 priority still pointed at representation/kernel shape as the main production-vs-granule gap. I tested two local reader/setup hypotheses first:

- q3 copy-backed reads instead of mmap: no win versus the clean #1695 baseline, reverted.
- Removing one-shot sidecar snapshot lookup setup: no allocation win, reverted.

A focused exact allocation profile then showed `mmapColumnPhysicalAssetFile` allocating through `file.Stat()` on each mmap-backed one-shot read. Replacing that call with `syscall.Fstat` is a bounded local cleanup: it reduces allocation pressure without changing the broader roadmap. The remaining gap remains dense/schema-fixed representation, zero-alloc reducers, metadata/mark fast paths, and routed/session reuse where measured.

## Measurement Class

- Measurement class: `direct package scanner`. Primary changed evidence; `BenchmarkColumnPhysicalQueryAdapterM13B` repeatedly calls `Collection.RunColumnPhysicalQuery` over an already-open collection and includes package scan setup, manifest/view prep, read-cache setup, asset read/decode, reducer work, and result construction.
- Measurement class: `routed unified-bench query path`. Current end-to-end comparable production snapshot; durable `-suite column_store`, forced `serial_column_scan`, 100K rows, strict default read integrity.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only from prior #1634 evidence; not rerun for this PR.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Local machine: Apple M3, darwin/arm64. Current head: `ae72af461`.

Measurement class: `direct package scanner`. Exact q3 allocation profile before/after the change, `GODEBUG=memprofilerate=1`, 8,192 rows, `-benchtime=200x`:

```text
before: q3 1897 B/op, 11 allocs/op; mmapColumnPhysicalAssetFile cumulative allocation 41.52 KiB, dominated by file.Stat()
after:  q3 1689 B/op, 10 allocs/op; mmapColumnPhysicalAssetFile cumulative allocation 288 B, from syscall.Mmap bookkeeping
```

Measurement class: `direct package scanner`. Same-machine #1695 baseline artifact `/tmp/gomap_1634_manifest_alloc_adapter_bench.txt` compared with current artifact `/tmp/gomap_1634_mmap_fstat_adapter_all_bench.txt`, 8,192 rows, current `-benchtime=1000x -count=5`:

```text
q1:            22 -> 21 allocs/op, ~3034 -> ~2825 B/op
q2:            41 -> 40 allocs/op, ~4353 -> ~4145 B/op
q3:            11 -> 10 allocs/op, ~1889 -> ~1681 B/op
q4a:           37 -> 36 allocs/op, ~3097 -> ~2889 B/op
q4b:           37 -> 36 allocs/op, ~3097 -> ~2889 B/op
q4b_metadata: 35 -> 34 allocs/op, ~3137 -> ~2929 B/op
q5:            38 -> 37 allocs/op, ~3193 -> ~2985 B/op
q5_metadata:  35 -> 34 allocs/op, ~3377 -> ~3169 B/op
```

Representative current direct package scanner timing from `/tmp/gomap_1634_mmap_fstat_adapter_all_bench.txt`:

```text
q1 rows 8192:  ~4.95-5.29 ns/row, 21 allocs/op
q2 rows 8192:  ~5.76-5.87 ns/row, 40 allocs/op
q3 rows 8192:  ~5.49-5.55 ns/row, 10 allocs/op
q4a rows 8192: ~7.59-7.69 ns/row, 36 allocs/op
q4b rows 8192: ~8.16-8.31 ns/row, 36 allocs/op
q5 rows 8192:  ~7.53-7.70 ns/row, 37 allocs/op
q4b_metadata rows 8192: ~2.48-2.54 ns/row, 34 allocs/op
q5_metadata rows 8192:  ~2.48-2.51 ns/row, 34 allocs/op
```

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production snapshot, Apple M3, durable profile, 100,000 rows, forced `serial_column_scan`, artifact `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT`:

```text
q1: 8.7 ns/row, 115.4M rows/s
q2: 26.8 ns/row, 37.3M rows/s
q3: 5.7 ns/row, 175.7M rows/s
q4a: 21.5 ns/row, 46.5M rows/s
q4b: 21.5 ns/row, 46.5M rows/s
q5: 22.0 ns/row, 45.4M rows/s
q5_metadata serial alias: 21.7 ns/row, 46.1M rows/s, metadata_hits=0
```

All q1-q5 parity checks passed, row materializations stayed at `0`, scheduled granules were `100`, skipped granules were `0`. Byte/accounting snapshot: `source_document_bytes=9368750`, `retained_payload_bytes=3368750`, `column_asset_bytes=21399500`, `manifest_control_bytes=28`, `ordinary_value_vlog_bytes=0`, `leaf_vlog_bytes=2367565`, `command_wal_bytes_before_checkpoint=11182573`, `db_total_bytes=35998639`.

The current routed q1 sample is slower than the #1695 routed context (`6.4 ns/row`), while q2/q4a are slightly better and q3/q4b/q5 are roughly unchanged. This PR therefore does not claim a routed throughput win; the routed run is included for parity, accounting, and current end-to-end context.

Measurement class: `prepared hot runner / warmed repeated Run()`. Unchanged by this PR. No prepared-runner measurement is claimed.

Measurement class: `experiment/granule baseline`. Prior #1634 context remains the allocation/kernel target: granule q1 around `2.38 ns/row`, q2 around `4.13 ns/row`, q4b encoded around `12.48 ns/row`, q5 encoded around `7.123 ns/row`, q4b metadata around `3.321 ns/row`, q5 metadata around `2.406 ns/row`, with `0 allocs/op` hot-kernel target. These are not apples-to-apples with routed durable production or this one-shot package scanner.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: 1M q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. This was not rerun for this PR and is not same-harness or same-lifecycle evidence.

Scale note: these direct package scanner results are reported in `ns/row` over 8,192-row benchmark fixtures; the routed snapshot is over 100K rows. A result around `90 ns/row` would be about `9 ms` over 100K rows and about `90 ms` over 1M rows.

## Throughput Interpretation

The measured win is one allocation and about 208 B/op removed from each mmap-backed one-shot direct package scan. The root cause was `os.File.Stat()` materializing `os.FileInfo`; `syscall.Fstat` provides the size without that allocation.

This is useful hygiene toward the granule-style allocation target, but it is intentionally not the center of the post-V1 optimization roadmap. The remaining production-vs-experiment gap still requires representation/kernel-shape work, prepared/session reuse where measured, metadata/mark/dictionary/locator fast paths, and continued allocation-led static checkpoints.

## Gate Status

- `git diff --check` passed.
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuerySerial(Int64ValueSidecarParity|DictionarySidecarParity|DictInt64SidecarParity)M1634' -count=1` passed.
- `go test ./TreeDB/collections -count=1` passed in the pre-commit validation for this change.
- `go test ./cmd/unified_bench -count=1` passed in the pre-commit validation for this change.
- Review fix for Copilot EINTR concern: `syscall.Fstat` now retries `EINTR` and reuses the fd for `Fstat` and `Mmap`.
- `GOOS=linux go test -c ./TreeDB/collections -o /tmp/gomap_collections_linux.test` passed, covering the Unix `syscall.Stat_t.Size` build on Linux.
- A mistaken `GOOS=linux go test ./TreeDB/collections -run '^$' -count=0` attempted to execute the Linux test binary on macOS and failed with `exec format error`; the compile-only command above is the valid cross-platform check.
- Focused direct package scanner benchmark passed: `/tmp/gomap_1634_mmap_fstat_adapter_all_bench.txt`.
- Routed `unified-bench` 100K snapshot passed parity: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT`.

## Artifacts

- Exact pre-change q3 allocation profile: `/tmp/gomap_1634_q3_exact_allocs.pprof`.
- Exact post-change q3 allocation profile: `/tmp/gomap_1634_mmap_fstat_q3_exact_allocs.pprof`.
- #1695 direct package scanner baseline: `/tmp/gomap_1634_manifest_alloc_adapter_bench.txt`.
- Current direct package scanner: `/tmp/gomap_1634_mmap_fstat_adapter_all_bench.txt`.
- Benchstat: `/tmp/gomap_1634_mmap_fstat_all_benchstat.txt`.
- Routed production markdown: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/column_store_results.md`.
- Routed production HTML: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/column_store_results.html`.
- Routed production JSON: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/column_store_results.json`.
- Routed benchprof markdown/json: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/benchprof_results.md`, `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/benchprof_results.json`.
- Routed insights HTML: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/insights.html`.
- Routed CPU/alloc profiles: `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/cpu_column_store_treedb_column_store.pprof`, `/tmp/gomap_1634_mmap_fstat_routed_100k_Dr9wfT/allocs_column_store_treedb_column_store.pprof`.

## Assumption Ledger / Remaining Work

- This PR assumes Unix `syscall.Fstat` is acceptable for the existing Unix mmap file; non-Unix builds keep their existing non-mmap behavior.
- The change does not alter read-integrity behavior or skip checksums.
- The change does not reduce result construction, manifest/view setup, dictionary translation, row-record framing, or routed reporting allocations.
- The next #1634 PR still needs a fresh static/profile checkpoint before choosing the next slice; do not use this cleanup to reprioritize away from representation/kernel-shape and allocation-parity work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file handling resilience with improved interrupt error management in column asset operations.

* **Tests**
  * Optimized memory allocation expectations to reflect improved efficiency in query execution tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->