### PR TITLE
TreeDB column store post-V1: trim planner manifest allocations

### DIFF
--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -862,7 +862,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 	d.Reset()
 	sawHeader := false
 	activeParts := uint64(0)
-	livePartNamespaces := make(map[[2]uint64]string)
+	var livePartRows columnManifestLivePartRowsForScan
 	for iter.Valid() {
 		key := iter.UnsafeKey()
 		if !bytes.Equal(key, columnManifestHeaderRecordKeyBytes) &&
@@ -896,6 +896,9 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if err := validateColumnManifestHeaderRecordForScan(header, cfg, identity, collection); err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
+			if header.expectedParts > 0 && header.expectedParts <= uint64(maxCollectionInt) {
+				livePartRows.initCapacity(int(header.expectedParts))
+			}
 			writeHashBytes(&d, header.collection)
 			writeHashBytes(&d, header.operation)
 			writeHashUint64(&d, header.generation)
@@ -916,9 +919,12 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if keyGeneration > header.generation {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest part generation=%d is newer than header generation=%d", keyGeneration, header.generation)
 			}
-			ref, reason, err := decodeColumnManifestPartRefForScan(value, cfg.AssetManager.Namespace)
+			ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(value, cfg.AssetManager.Namespace)
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
+			}
+			if ref.Kind != ColumnAssetKindTCS1PartImage {
+				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 			}
 			if ref.Generation != keyGeneration {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
@@ -946,7 +952,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
-			livePartNamespaces[[2]uint64{ref.Generation, ref.PartID}] = ref.Namespace
+			livePartRows.add(ref.Generation, ref.PartID, rows)
 			if keyGeneration == header.generation {
 				activeParts++
 			}
@@ -962,19 +968,8 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if keyGeneration > header.generation {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d is newer than header generation=%d", keyGeneration, header.generation)
 			}
-			metadata, err := decodeColumnManifestAggregateMetadataRecord(key, value)
-			if err != nil {
+			if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, header.generation, &livePartRows); err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
-			}
-			if metadata.AssetRef.Namespace != cfg.AssetManager.Namespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest aggregate metadata namespace=%q want %q", metadata.AssetRef.Namespace, cfg.AssetManager.Namespace)
-			}
-			partNamespace, ok := livePartNamespaces[[2]uint64{metadata.AssetRef.Generation, metadata.AssetRef.PartID}]
-			if !ok {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest aggregate metadata generation=%d part_id=%d has no matching live part record", metadata.AssetRef.Generation, metadata.AssetRef.PartID)
-			}
-			if metadata.AssetRef.Namespace != partNamespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest aggregate metadata namespace=%q does not match part namespace=%q", metadata.AssetRef.Namespace, partNamespace)
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
@@ -990,19 +985,8 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if keyGeneration > header.generation {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d is newer than header generation=%d", keyGeneration, header.generation)
 			}
-			dictionary, err := decodeColumnManifestDictionaryCodesRecord(key, value)
-			if err != nil {
+			if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, header.generation, &livePartRows); err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
-			}
-			if dictionary.AssetRef.Namespace != cfg.AssetManager.Namespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes namespace=%q want %q", dictionary.AssetRef.Namespace, cfg.AssetManager.Namespace)
-			}
-			partNamespace, ok := livePartNamespaces[[2]uint64{dictionary.AssetRef.Generation, dictionary.AssetRef.PartID}]
-			if !ok {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes generation=%d part_id=%d has no matching live part record", dictionary.AssetRef.Generation, dictionary.AssetRef.PartID)
-			}
-			if dictionary.AssetRef.Namespace != partNamespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest dictionary codes namespace=%q does not match part namespace=%q", dictionary.AssetRef.Namespace, partNamespace)
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
@@ -1018,19 +1002,8 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if keyGeneration > header.generation {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values generation=%d is newer than header generation=%d", keyGeneration, header.generation)
 			}
-			values, err := decodeColumnManifestInt64ValuesRecord(key, value)
-			if err != nil {
+			if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, header.generation, &livePartRows); err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
-			}
-			if values.AssetRef.Namespace != cfg.AssetManager.Namespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values namespace=%q want %q", values.AssetRef.Namespace, cfg.AssetManager.Namespace)
-			}
-			partNamespace, ok := livePartNamespaces[[2]uint64{values.AssetRef.Generation, values.AssetRef.PartID}]
-			if !ok {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values generation=%d part_id=%d has no matching live part record", values.AssetRef.Generation, values.AssetRef.PartID)
-			}
-			if values.AssetRef.Namespace != partNamespace {
-				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: column manifest int64 values namespace=%q does not match part namespace=%q", values.AssetRef.Namespace, partNamespace)
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)

--- a/TreeDB/collections/column_query_plan_test.go
+++ b/TreeDB/collections/column_query_plan_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"fmt"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1607,6 +1608,45 @@ func BenchmarkColumnQueryPlannerCapabilitiesM14A(b *testing.B) {
 }
 
 var columnQueryPlannerBenchSinkM14A int
+
+func TestColumnQueryPlannerCapabilitiesAllocationBudgetM1634(t *testing.T) {
+	reopened, closeFn := openColumnPhysicalQueryFixtureM13B(t, columnPhysicalQueryFixtureEventsM13B(1024))
+	defer closeFn()
+	req := ColumnQueryPlanRequest{
+		Name:             "m1634_insert",
+		ProjectedColumns: []string{"time_us", "kind", "did"},
+		ForceKind:        ColumnQueryPlanSerialColumnScan,
+		Capabilities: ColumnQueryPlannerCapabilities{
+			SerialColumnScan:   true,
+			AggregateMetadata:  true,
+			ParallelColumnScan: true,
+			MaxParallelWorkers: 4,
+		},
+	}
+	plan, err := reopened.PlanColumnQuery(req)
+	if err != nil {
+		t.Fatalf("PlanColumnQuery preview: %v", err)
+	}
+	if !plan.Supported || plan.Kind != ColumnQueryPlanSerialColumnScan || plan.Diagnostics.PhysicalAssetCount == 0 {
+		t.Fatalf("unexpected plan: %+v", plan)
+	}
+	allocs := testing.AllocsPerRun(50, func() {
+		plan, err := reopened.PlanColumnQuery(req)
+		if err != nil {
+			panic(fmt.Sprintf("PlanColumnQuery: %v", err))
+		}
+		if !plan.Supported || plan.Kind != ColumnQueryPlanSerialColumnScan || plan.Diagnostics.PhysicalAssetCount == 0 {
+			panic(fmt.Sprintf("unexpected plan: %+v", plan))
+		}
+	})
+	maxAllocs := 12.0
+	if runtime.GOOS == "windows" || collectionsRaceEnabled {
+		maxAllocs += 16
+	}
+	if allocs > maxAllocs {
+		t.Fatalf("planner capability allocs/run=%.2f want <= %.2f", allocs, maxAllocs)
+	}
+}
 
 func equalInts(left, right []int) bool {
 	return slices.Equal(left, right)


### PR DESCRIPTION
## Summary

This is a tactical #1634 follow-on PR on top of #1699. It removes avoidable allocation from the production column query planner capability scan by validating manifest sidecar refs with scan-specific cursor validators instead of decoding owned string records during forced physical planning.

The changed path is planner/manifest validation, not the analytical reducer hot kernel. It does not claim to close the production-vs-experiment representation gap; it makes the routed production path cheaper while preserving fail-closed manifest validation.

## Static Analysis Checkpoint

Current production routed q1-q5 is now dominated by sidecar/block decode and reducer setup rather than the older TCPA row-record path or checksum verification when `skip_checksums` / relaxed read integrity is used. A same-head 1M profile on #1699 still showed `manifestCursor.string` as the largest allocation-object source in routed sidecar runs. This PR targets the planner-capability portion of that string materialization with a local scan-specific validator change.

This remains below the main #1634 center of gravity: dictionary/code projection, dense reducers, real metadata/mark fast paths, and schema-fixed column block layout are still the higher-leverage paths for closing the old `experiments/colgranule` gap. Future priority-setting should continue to use 100K-1M routed q1-q5 profiles, not only one-granule package benches.

## Measurement Class

- Measurement class: `direct package scanner / planner microbench`. `BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024` repeatedly exercises planner capability manifest scanning over an already-open physical fixture.
- Measurement class: `routed unified-bench query path`. `unified-bench -suite column_store` over 1M rows, durable profile, forced `serial_column_scan`, production collection manifest/control plane, isolated physical column assets, planner routing, sidecar reads/decodes, reducers, parity/reporting, and profiles.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Not changed by this PR; no prepared-runner or billion-rows/sec claim is made.
- Measurement class: `experiment/granule baseline`. Historical/context only; not rerun for this PR. The old granule path remains a true schema-fixed encoded block/kernel baseline with 0-hot-kernel-allocation intent.
- Measurement class: `historical ClickHouse context`. Historical JSONBench context only; not rerun for this PR.

## Performance / Benchmark Evidence

Focused planner allocation gate:

```text
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8  1000  3273 ns/op  2 B/op  0 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8  1000  2306 ns/op  1 B/op  0 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8  1000  2198 ns/op  1 B/op  0 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8  1000  2546 ns/op  1 B/op  0 allocs/op
BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024-8  1000  2857 ns/op  1 B/op  0 allocs/op
```

Prior same-benchmark baseline from the #1699 head family was about `2.6-7.2 us/op`, `~297-298 B/op`, `15 allocs/op`; the new path is `0 allocs/op` in the focused planner capability benchmark.

1M routed production snapshot, Apple M3, durable profile, forced `serial_column_scan`, `skip_checksums`, artifact `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654`:

```text
q1   0.7 ns/row   1.429B rows/s   scan 0.429 ms   parity pass
q2   1.0 ns/row   1.051B rows/s   scan 0.714 ms   parity pass
q3   37.0 ns/row  26.998M rows/s  scan 36.784 ms  parity pass
q4a  7.1 ns/row   141.319M rows/s scan 6.797 ms   parity pass
q4b  6.6 ns/row   150.819M rows/s scan 6.369 ms   parity pass
q5   6.7 ns/row   150.065M rows/s scan 6.390 ms   parity pass
q5_metadata serial alias 6.7 ns/row, metadata_hits=0, parity pass
```

Same-head routed allocation profile comparison:

```text
#1699 skip_checksums 1M: ~100,073 alloc objects; manifestCursor.string ~98,305 objects
this PR skip_checksums 1M: ~71,306 alloc objects; manifestCursor.string ~65,537 objects
```

The remaining routed allocation space is dominated by dictionary-code asset decode/setup and group-count runner setup, not the planner capability scan changed here.

## End-to-End Comparable Snapshot

Current routed production snapshot is fresh on this branch at 1M rows and includes planner routing, sidecar reads, decode, reducers, parity/reporting, and profile artifact emission. The routed path uses production sidecar physical query execution, not the prepared hot-runner-only path.

Granule/experiment comparison is historical/contextual for this PR: `experiments/colgranule` used schema-fixed encoded column blocks, low-cardinality dictionary codes, dense reducers, and 0-hot-kernel-allocation goals. Those numbers are not apples-to-apples with routed production because they do not include durable TreeDB collection integration, manifest/recovery validation, typed asset manager reads, planner routing, parity/reporting, WAL/checkpoint, or reopen semantics.

ClickHouse comparison is also historical/contextual for the JSONBench-shaped q1-q5 family. This PR does not rerun ClickHouse and does not claim ClickHouse parity.

## Throughput Interpretation

The focused planner capability benchmark proves the local allocation fix directly. The 1M routed profile proves the change is visible in realistic q1-q5 profiling scale and confirms the next larger allocation target moved to dictionary-code decode/setup. Because this PR changes planner validation, query scan-time throughput may vary with normal profile noise; the durable production evidence should be interpreted primarily as allocation attribution and parity preservation, not as a reducer/kernel throughput breakthrough.

## Apples-to-Apples Limitations

- The 1M routed run uses `skip_checksums`, so it should not be compared directly with strict read-integrity runs without labeling the integrity mode.
- The routed run includes production fixture/load/checkpoint/reopen/planner/parity/reporting boundaries; granule hot kernels and prepared runners do not.
- The `q5_metadata` row in this forced serial snapshot is still a serial alias with `metadata_hits=0`; it is not a metadata-only fast path claim.
- 100K/1M routed profiles should drive roadmap priority; one-granule package benches remain local TDD/allocation evidence.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnQueryPlannerCapabilitiesAllocationBudgetM1634|TestColumnManifestPlannerCapabilitiesReject(PartIDKeyMismatch|OrphanAggregateMetadata|ActivePartCountMismatch|ChecksumMismatch|HeaderOperation)M' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQuerySerial(Int64ValueSidecarParity|DictionarySidecarParity|DictInt64SidecarParity)M1634' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnQueryPlannerCapabilitiesM14A/insert_manifest_rows_1024$' -benchmem -benchtime=1000x -count=5`
- `go build -o bin/unified-bench ./cmd/unified_bench`
- `./bin/unified-bench -suite column_store -dbs treedb -profile durable -keys 1000000 -batchsize 5000 -profile-dir /tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654 -path-label native-fastpath -column-store-path serial_column_scan -column-store-asset-read-integrity skip_checksums -treedb-allow-unsafe -progress=false`
- `git diff --check`

## Artifacts

- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/column_store_results.md`
- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/column_store_results.html`
- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/benchprof_results.md`
- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/insights.html`
- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/cpu_column_store_treedb_column_store.pprof`
- `/tmp/gomap_1634_planner_alloc_1m_skip_20260521_083654/allocs_column_store_treedb_column_store.pprof`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal query plan validation logic
* **Tests**
  * Added allocation budget testing for query planning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->