### PR TITLE
TreeDB column store post-V1: stream dictionary code translation setup

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -45,12 +45,6 @@ type columnDictionaryCodeGroupCountDistinctAsset struct {
 	distinctCodes []uint32
 }
 
-type columnDictionaryCodeGroupCountDistinctPendingAsset struct {
-	group    columnDictionaryCodesAsset
-	distinct columnDictionaryCodesAsset
-	bytes    int64
-}
-
 type columnDictionaryCodeGroupCountOneShotReducer struct {
 	dictionary    []string
 	byValue       map[string]uint32
@@ -123,23 +117,45 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn, err)
 		}
 		scratch = raw
-		decoded, err := decodeColumnDictionaryCodesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		dictCur, cardinality, rowCount, err := decodeColumnDictionaryCodesAssetHeader(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
 		if err != nil {
 			return nil, err
 		}
-		translated := make([]uint32, len(decoded.Codes))
-		for codeIdx, localCode := range decoded.Codes {
-			value := decoded.Dictionary[localCode]
-			globalCode, ok := globalByValue[value]
+		localToGlobal := make([]uint32, cardinality)
+		for localCode := 0; localCode < cardinality; localCode++ {
+			value := dictCur.stringBytes()
+			globalCode, ok := globalByValue[unsafeStringFromBytes(value)]
 			if !ok {
 				if uint64(len(runner.dictionary)) == uint64(^uint32(0)) {
 					return nil, fmt.Errorf("collections: dictionary code query cardinality exceeds uint32")
 				}
 				globalCode = uint32(len(runner.dictionary))
-				globalByValue[value] = globalCode
-				runner.dictionary = append(runner.dictionary, value)
+				key := columnDictionaryCodeOwnedString(value)
+				globalByValue[key] = globalCode
+				runner.dictionary = append(runner.dictionary, key)
 			}
-			translated[codeIdx] = globalCode
+			localToGlobal[localCode] = globalCode
+			if dictCur.err != nil {
+				break
+			}
+		}
+		if dictCur.err != nil {
+			return nil, dictCur.err
+		}
+		cur := manifestCursor{raw: raw, pos: dictCur.pos}
+		translated := make([]uint32, rowCount)
+		for codeIdx := range translated {
+			localCode := cur.u32()
+			if int(localCode) >= len(localToGlobal) {
+				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, localCode, len(localToGlobal))
+			}
+			translated[codeIdx] = localToGlobal[localCode]
+		}
+		if cur.err != nil {
+			return nil, cur.err
+		}
+		if cur.pos != len(raw) {
+			return nil, errors.New("collections: trailing bytes in dictionary codes asset")
 		}
 		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountAsset{
 			codes: translated,
@@ -318,7 +334,6 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	}
 	groupByValue := make(map[string]uint32)
 	distinctByValue := make(map[string]uint32)
-	pending := make([]columnDictionaryCodeGroupCountDistinctPendingAsset, 0, len(view.AssetRefs))
 	var scratch []byte
 	for _, part := range view.AssetRefs {
 		if part.Reason != ColumnPublishOperationInsert {
@@ -338,42 +353,79 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
 		}
 		scratch = groupRaw
-		groupAsset, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		groupCur, groupCardinality, groupRows, err := decodeColumnDictionaryCodesAssetHeader(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
 		if err != nil {
 			return nil, err
 		}
+		groupLocal := make([]uint32, groupCardinality)
+		for localCode := 0; localCode < groupCardinality; localCode++ {
+			value := groupCur.stringBytes()
+			valueKey := unsafeStringFromBytes(value)
+			globalCode, ok := groupByValue[valueKey]
+			if !ok {
+				if uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
+					return nil, fmt.Errorf("collections: dictionary code distinct group cardinality exceeds uint32")
+				}
+				globalCode = uint32(len(runner.groupDict))
+				key := columnDictionaryCodeOwnedString(value)
+				groupByValue[key] = globalCode
+				runner.groupDict = append(runner.groupDict, key)
+			}
+			groupLocal[localCode] = globalCode
+			if groupCur.err != nil {
+				break
+			}
+		}
+		if groupCur.err != nil {
+			return nil, groupCur.err
+		}
+		groupCodeCur := manifestCursor{raw: groupRaw, pos: groupCur.pos}
+		groupCodes := make([]uint32, groupRows)
+		for codeIdx := range groupCodes {
+			groupCode := groupCodeCur.u32()
+			if int(groupCode) >= len(groupLocal) {
+				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, groupCode, len(groupLocal))
+			}
+			groupCodes[codeIdx] = groupLocal[groupCode]
+		}
+		if groupCodeCur.err != nil {
+			return nil, groupCodeCur.err
+		}
+		if groupCodeCur.pos != len(groupRaw) {
+			return nil, errors.New("collections: trailing bytes in dictionary codes asset")
+		}
+
 		distinctRaw, err := readCache.read(distinctSnapshot.AssetRef, scratch)
 		if err != nil {
 			return nil, fmt.Errorf("collections: dictionary codes read generation=%d part_id=%d column=%q: %w", distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn, err)
 		}
 		scratch = distinctRaw
-		distinctAsset, err := decodeColumnDictionaryCodesAsset(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
+		distinctCur, distinctCardinality, distinctRows, err := decodeColumnDictionaryCodesAssetHeader(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
 		if err != nil {
 			return nil, err
 		}
-		if len(groupAsset.Codes) != len(distinctAsset.Codes) {
-			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", len(groupAsset.Codes), len(distinctAsset.Codes))
+		if groupRows != distinctRows {
+			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", groupRows, distinctRows)
 		}
-		for _, value := range groupAsset.Dictionary {
-			_, ok := groupByValue[value]
-			if !ok {
-				if uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
-					return nil, fmt.Errorf("collections: dictionary code distinct group cardinality exceeds uint32")
-				}
-				globalCode := uint32(len(runner.groupDict))
-				groupByValue[value] = globalCode
-				runner.groupDict = append(runner.groupDict, value)
-			}
-		}
-		for _, value := range distinctAsset.Dictionary {
-			_, ok := distinctByValue[value]
+		distinctLocal := make([]uint32, distinctCardinality)
+		for localCode := 0; localCode < distinctCardinality; localCode++ {
+			value := distinctCur.stringBytes()
+			valueKey := unsafeStringFromBytes(value)
+			globalCode, ok := distinctByValue[valueKey]
 			if !ok {
 				if uint64(len(distinctByValue)) == uint64(^uint32(0)) {
 					return nil, fmt.Errorf("collections: dictionary code distinct cardinality exceeds uint32")
 				}
-				globalCode := uint32(len(distinctByValue))
-				distinctByValue[value] = globalCode
+				globalCode = uint32(len(distinctByValue))
+				distinctByValue[columnDictionaryCodeOwnedString(value)] = globalCode
 			}
+			distinctLocal[localCode] = globalCode
+			if distinctCur.err != nil {
+				break
+			}
+		}
+		if distinctCur.err != nil {
+			return nil, distinctCur.err
 		}
 		_, _, ok, err = columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
 		if err != nil {
@@ -382,13 +434,28 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		if !ok {
 			return nil, nil
 		}
-		pending = append(pending, columnDictionaryCodeGroupCountDistinctPendingAsset{
-			group:    groupAsset,
-			distinct: distinctAsset,
-			bytes:    groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length,
+		distinctCodeCur := manifestCursor{raw: distinctRaw, pos: distinctCur.pos}
+		distinctCodes := make([]uint32, distinctRows)
+		for codeIdx := range distinctCodes {
+			distinctCode := distinctCodeCur.u32()
+			if int(distinctCode) >= len(distinctLocal) {
+				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, distinctCode, len(distinctLocal))
+			}
+			distinctCodes[codeIdx] = distinctLocal[distinctCode]
+		}
+		if distinctCodeCur.err != nil {
+			return nil, distinctCodeCur.err
+		}
+		if distinctCodeCur.pos != len(distinctRaw) {
+			return nil, errors.New("collections: trailing bytes in dictionary codes asset")
+		}
+		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountDistinctAsset{
+			groupCodes:    groupCodes,
+			distinctCodes: distinctCodes,
 		})
+		runner.assetBytes += groupSnapshot.AssetRef.Length + distinctSnapshot.AssetRef.Length
 	}
-	if len(pending) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
+	if len(runner.assets) == 0 || len(runner.groupDict) == 0 || len(distinctByValue) == 0 {
 		return nil, nil
 	}
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(len(runner.groupDict), len(distinctByValue))
@@ -401,21 +468,6 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	runner.wordsPerGroup = wordsPerGroup
 	runner.groupCounts = make([]int, len(runner.groupDict))
 	runner.seen = make([]uint64, totalWords)
-	for _, asset := range pending {
-		groupCodes := make([]uint32, len(asset.group.Codes))
-		for codeIdx, localCode := range asset.group.Codes {
-			groupCodes[codeIdx] = groupByValue[asset.group.Dictionary[localCode]]
-		}
-		distinctCodes := make([]uint32, len(asset.distinct.Codes))
-		for codeIdx, localCode := range asset.distinct.Codes {
-			distinctCodes[codeIdx] = distinctByValue[asset.distinct.Dictionary[localCode]]
-		}
-		runner.assets = append(runner.assets, columnDictionaryCodeGroupCountDistinctAsset{
-			groupCodes:    groupCodes,
-			distinctCodes: distinctCodes,
-		})
-		runner.assetBytes += asset.bytes
-	}
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.groupDict))
 	return runner, nil
 }

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -45,6 +45,13 @@ type columnDictionaryCodeGroupCountDistinctAsset struct {
 	distinctCodes []uint32
 }
 
+func columnDictionaryCodeIndex(code uint32, cardinality int) (int, bool) {
+	if uint64(code) >= uint64(cardinality) {
+		return 0, false
+	}
+	return int(code), true
+}
+
 type columnDictionaryCodeGroupCountOneShotReducer struct {
 	dictionary    []string
 	byValue       map[string]uint32
@@ -146,10 +153,11 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 		translated := make([]uint32, rowCount)
 		for codeIdx := range translated {
 			localCode := cur.u32()
-			if int(localCode) >= len(localToGlobal) {
+			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localToGlobal))
+			if !ok {
 				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, localCode, len(localToGlobal))
 			}
-			translated[codeIdx] = localToGlobal[localCode]
+			translated[codeIdx] = localToGlobal[localIdx]
 		}
 		if cur.err != nil {
 			return nil, cur.err
@@ -383,10 +391,11 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		groupCodes := make([]uint32, groupRows)
 		for codeIdx := range groupCodes {
 			groupCode := groupCodeCur.u32()
-			if int(groupCode) >= len(groupLocal) {
+			groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(groupLocal))
+			if !ok {
 				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, groupCode, len(groupLocal))
 			}
-			groupCodes[codeIdx] = groupLocal[groupCode]
+			groupCodes[codeIdx] = groupLocal[groupIdx]
 		}
 		if groupCodeCur.err != nil {
 			return nil, groupCodeCur.err
@@ -438,10 +447,11 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		distinctCodes := make([]uint32, distinctRows)
 		for codeIdx := range distinctCodes {
 			distinctCode := distinctCodeCur.u32()
-			if int(distinctCode) >= len(distinctLocal) {
+			distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, len(distinctLocal))
+			if !ok {
 				return nil, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", codeIdx, distinctCode, len(distinctLocal))
 			}
-			distinctCodes[codeIdx] = distinctLocal[distinctCode]
+			distinctCodes[codeIdx] = distinctLocal[distinctIdx]
 		}
 		if distinctCodeCur.err != nil {
 			return nil, distinctCodeCur.err

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2817,6 +2817,15 @@ func TestColumnDictionaryCodesAssetCodecRejectsCorruptionM1634(t *testing.T) {
 	}
 }
 
+func TestColumnDictionaryCodeIndexRejectsCorruptWideCodeM1634(t *testing.T) {
+	if idx, ok := columnDictionaryCodeIndex(2, 3); !ok || idx != 2 {
+		t.Fatalf("valid code idx=%d ok=%v want idx=2 ok=true", idx, ok)
+	}
+	if _, ok := columnDictionaryCodeIndex(^uint32(0), 3); ok {
+		t.Fatalf("max uint32 code unexpectedly accepted for cardinality 3")
+	}
+}
+
 func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(4, 129)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR keeps the large q1/q2 dictionary-code prepared runner path from #1701, but stops materializing owned decoded `columnDictionaryCodesAsset` payloads before translation. The prepared setup now streams dictionary headers/codes directly from the binary sidecar into the existing translated dense-code arrays.

This is intentionally not the rejected raw one-shot-cap removal. The one-shot-cap experiment cut allocations but regressed 1M q1/q2 throughput badly, so this PR preserves the prepared translated-code/dense-loop shape and removes the avoidable intermediate decode allocation instead.

## Static Analysis Checkpoint

Latest #1701 1M routed `skip_checksums` profiles showed dictionary-code setup as the next visible allocation category after planner manifest string allocation was trimmed. The dominant old source was `decodeColumnDictionaryCodesAsset` / `manifestCursor.string`, not per-row reducer allocation.

Current priority remains large q1-q5 routed evidence first: 8,192-row package benches are useful for TDD/hot-loop ceilings, but next-workload prioritization should come from 100K-1M routed q1-q5 profiles because those expose manifest scale, repeated assets, dictionary/cardinality effects, read-integrity choices, and steady-state scan/reduce behavior.

## Measurement Class

- Measurement class: `routed unified-bench query path`. Primary evidence for this PR; production durable column-store fixture, planner-routed forced `serial_column_scan`, 1M rows, `skip_checksums`.
- Measurement class: `direct package scanner`. Focused 8,192-row adapter context; q1/q2 are mostly unchanged because that size already uses the one-shot path.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Focused hot-runner allocation ceiling; unchanged kernel target remains `0 allocs/op`.
- Measurement class: `experiment/granule baseline`. Historical/context only; not rerun here.
- Measurement class: `historical ClickHouse context`. Historical/context only; not rerun here.

## Performance / Benchmark Evidence

Measurement class: `routed unified-bench query path`. Apple M3, darwin/arm64, head `63faa5481`, 1,000,000 rows, durable profile, forced `serial_column_scan`, `skip_checksums`, artifact `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253`:

```text
q1 0.8 ns/row, 1.329B rows/s, scan 0.410 ms, parity pass
q2 1.0 ns/row, 1.003B rows/s, scan 0.758 ms, parity pass
q3 13.1 ns/row, 76.56M rows/s, scan 12.838 ms, parity pass
q4a 7.2 ns/row, 139.60M rows/s, scan 6.908 ms, parity pass
q4b 7.0 ns/row, 143.41M rows/s, scan 6.698 ms, parity pass
q5 6.9 ns/row, 144.26M rows/s, scan 6.676 ms, parity pass
q5_metadata serial alias 7.1 ns/row, metadata_hits=0, parity pass
```

Allocation profile comparison against #1701 same 1M routed `skip_checksums` shape:

```text
#1701 alloc_objects: ~71,306 total; manifestCursor.string ~65,537; decodeColumnDictionaryCodesAsset path dominant
this PR alloc_objects: ~1,203 total; prepareColumnDictionaryCodeGroupCountDistinctRunner 364; prepareColumnDictionaryCodeGroupCountRunner 287
#1701 alloc_space: ~39.7 MiB total
this PR alloc_space: ~23.18 MiB total
```

Measurement class: `direct package scanner`. Apple M3, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B/(q1|q2)_rows_8192`, `-benchtime=1000x -count=3`: q1 stayed around `5.2-5.6 ns/row`, `~2.8 KiB/op`, `21 allocs/op`; q2 stayed around `6.1-6.4 ns/row`, `~4.1 KiB/op`, `40 allocs/op`. This is expected because the small adapter shape already uses the one-shot path, not the large prepared translation setup changed here.

Measurement class: `prepared hot runner / warmed repeated Run()`. Apple M3, 8,192 rows, `BenchmarkColumnPhysicalQueryRunnerM1634/(q1|q2)_rows_8192`, `-benchtime=1000x -count=3`: q1/q2 hot runners remain `0 allocs/op` with noisy sub-ns to ~1.3 ns/row timing. These numbers exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production q1-q5 snapshot is the fresh 1M artifact above. Routed execution reaches the optimized prepared dictionary-code translation path for large q1/q2 sidecars; q3/q4/q5 are context and are not changed by this PR.

Measurement class: `experiment/granule baseline`. Historical granule context remains the allocation/kernel target: dense encoded kernels were designed for `0 allocs/op`; prior encoded JSONBench context had q1 around `~2.38 ns/row` and q2 around `~4.13 ns/row`. This PR improves production setup allocation for large routed q1/q2, but it does not convert production into the experiment's schema-fixed column-block layout.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench 1M context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. Not same-harness and not rerun for this PR.

## Throughput Interpretation

The useful result is allocation reduction without forcing the slower large one-shot path. A local rejected candidate removed the `3 MiB` dictionary-code one-shot cap and cut allocations further, but regressed 1M q1/q2 to about `46.0 ns/row` and `31.9 ns/row`. This PR keeps q1/q2 near the #1701 large-run throughput while removing most of the owned dictionary decode objects from prepared setup.

This still leaves real post-V1 work: production is not yet a true schema-fixed granule/block kernel, q4/q5 metadata remains scan-backed in this path (`metadata_hits=0`), and future priority should keep using 100K-1M q1-q5 routed profiles before choosing the next center of gravity.

## Apples-to-Apples Limitations

The fresh routed evidence uses `skip_checksums`, durable mode, synthetic JSONBench-shaped fixture, 1M rows, and forced `serial_column_scan`; it is not a strict-read-integrity measurement. Prepared hot-runner numbers are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery` and exclude setup/lifecycle costs. Granule and ClickHouse values are historical context, not same-head/same-harness comparisons.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation)M1634|TestColumnPhysicalQuerySerial(DictionarySidecarParity|SidecarAllocationBudget)M1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySerial(DictionarySidecarParity|DictionaryDistinctOneShotRequiresViewBackedReads)M1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634' -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation)M1634|TestColumnPhysicalQuerySerial(DictionarySidecarParity|DictionaryDistinctOneShotRequiresViewBackedReads)M1634' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `git diff --check`
- `go build -o bin/unified-bench ./cmd/unified_bench`
- 1M routed `unified-bench` profile listed below

## Artifacts

- Routed markdown: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/column_store_results.md`
- Routed HTML: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/column_store_results.html`
- Routed JSON: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/column_store_results.json`
- Benchprof markdown: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/benchprof_results.md`
- Benchprof JSON: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/benchprof_results.json`
- Insights HTML: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/insights.html`
- CPU profile: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_dict_translate_1m_skip_20260521_085253/allocs_column_store_treedb_column_store.pprof`
- Rejected one-shot-cap artifact: `/tmp/gomap_1634_dict_oneshot_1m_skip_20260521_084831`

## Review Fixes

- Addressed Copilot fail-closed review on corrupt `uint32` dictionary codes by using unsigned bounds validation before converting to `int` for slice indexing.
- Added `TestColumnDictionaryCodeIndexRejectsCorruptWideCodeM1634`.
- Reran focused q1/q2 runner/allocation tests, full `go test ./TreeDB/collections -count=1`, full `go test ./cmd/unified_bench -count=1`, and `git diff --check` after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dictionary-encoded query processing for faster, more memory-efficient handling of grouped and distinct counts, reducing intermediate work and streamlining translation of stored codes.
* **Tests**
  * Added a unit test that ensures corrupt or out-of-range encoded values are detected and rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->