### PR TITLE
Stabilize column row blocks and fixed-width decode

### DIFF
--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -343,9 +343,25 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 	if assetOrdinal < 0 || assetOrdinal >= len(r.view.AssetRefs) {
 		return nil, fmt.Errorf("collections: physical column row reader asset ordinal=%d outside refs=%d", assetOrdinal, len(r.view.AssetRefs))
 	}
-	raw, err := r.readCache.read(rowRange.ref, nil)
+	var dst []byte
+	if rowRange.ref.Length >= 0 && rowRange.ref.Length <= int64(maxCollectionInt) {
+		dst = make([]byte, int(rowRange.ref.Length))
+	}
+	// Cached blocks must own stable bytes. The asset read cache reuses scratch
+	// for syscall reads, so storing that scratch would let later cache misses
+	// corrupt already-indexed row offsets.
+	raw, err := r.readCache.read(rowRange.ref, dst)
 	if err != nil {
 		return nil, fmt.Errorf("collections: physical column row reader read generation=%d part_id=%d: %w", rowRange.ref.Generation, rowRange.ref.PartID, err)
+	}
+	if dst != nil {
+		if len(raw) != len(dst) {
+			return nil, fmt.Errorf("collections: physical column row reader read generation=%d part_id=%d length=%d want %d", rowRange.ref.Generation, rowRange.ref.PartID, len(raw), len(dst))
+		}
+		if len(raw) > 0 && &raw[0] != &dst[0] {
+			copy(dst, raw)
+			raw = dst
+		}
 	}
 	rowOffsets, err := indexColumnPhysicalAssetReaderRows(raw, rowRange.version, rowRange.rowsOffset, rowRange.header, &r.view.Config)
 	if err != nil {
@@ -657,7 +673,8 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 		c.err = fmt.Errorf("collections: float32_vector length=%d want vector_dims=%d", n, expected)
 		return dst, c.err
 	}
-	if _, ok := c.fixedWidthSliceByteLen(n, 4, "float32_vector"); !ok {
+	byteLen, ok := c.fixedWidthSliceByteLen(n, 4, "float32_vector")
+	if !ok {
 		return dst, c.err
 	}
 	base := len(dst)
@@ -669,10 +686,19 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 	} else {
 		dst = dst[:need]
 	}
-	for i := base; i < need; i++ {
-		dst[i] = math.Float32frombits(binaryBigEndianUint32(c.raw[c.pos:]))
-		c.pos += 4
+	// Keep cursor state out of the per-element loop; vector search decodes
+	// these fixed-width slices for every candidate row fetch.
+	pos := c.pos
+	end := pos + int(byteLen)
+	raw := c.raw
+	if pos < end {
+		_ = raw[end-1]
 	}
+	for i := base; i < need; i++ {
+		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
+		pos += 4
+	}
+	c.pos = end
 	return dst, nil
 }
 
@@ -681,7 +707,8 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	if c.err != nil {
 		return dst, c.err
 	}
-	if _, ok := c.fixedWidthSliceByteLen(n, 4, "uint32 slice"); !ok {
+	byteLen, ok := c.fixedWidthSliceByteLen(n, 4, "uint32 slice")
+	if !ok {
 		return dst, c.err
 	}
 	base := len(dst)
@@ -693,13 +720,18 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	} else {
 		dst = dst[:need]
 	}
-	for i := base; i < need; i++ {
-		dst[i] = binaryBigEndianUint32(c.raw[c.pos:])
-		c.pos += 4
+	// Keep cursor state out of the per-element loop; vector search decodes
+	// these fixed-width slices for every candidate row fetch.
+	pos := c.pos
+	end := pos + int(byteLen)
+	raw := c.raw
+	if pos < end {
+		_ = raw[end-1]
 	}
+	for i := base; i < need; i++ {
+		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
+		pos += 4
+	}
+	c.pos = end
 	return dst, nil
-}
-
-func binaryBigEndianUint32(b []byte) uint32 {
-	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
 }

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -349,7 +349,8 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 	}
 	// Cached blocks must own stable bytes. The asset read cache reuses scratch
 	// for syscall reads, so storing that scratch would let later cache misses
-	// corrupt already-indexed row offsets.
+	// corrupt already-indexed row offsets. Malformed lengths skip the owned
+	// destination and are rejected by the read/index checks below.
 	raw, err := r.readCache.read(rowRange.ref, dst)
 	if err != nil {
 		return nil, fmt.Errorf("collections: physical column row reader read generation=%d part_id=%d: %w", rowRange.ref.Generation, rowRange.ref.PartID, err)
@@ -692,7 +693,7 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 	end := pos + int(byteLen)
 	raw := c.raw
 	if pos < end {
-		_ = raw[end-1]
+		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
 	for i := base; i < need; i++ {
 		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
@@ -726,7 +727,7 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	end := pos + int(byteLen)
 	raw := c.raw
 	if pos < end {
-		_ = raw[end-1]
+		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
 	for i := base; i < need; i++ {
 		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -102,6 +102,41 @@ func TestColumnPhysicalRowReaderBatchFetchReusesCachedBlockV1(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalRowReaderCachedBlocksOwnRawBytesV1(t *testing.T) {
+	normalized := testColumnPhysicalRowReaderConfigV1(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	left := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 1, testColumnPhysicalRowReaderRowsV1(0, 4, normalized))
+	right := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 2, testColumnPhysicalRowReaderRowsV1(4, 4, normalized))
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, normalized, left, right), columnPhysicalRowReaderOptions{
+		ProjectedColumns:  []string{"embedding", "neighbors"},
+		MaxDecodedBlocks:  2,
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 2),
+		Float32Values: make([]float32, 0, normalized.Columns[1].VectorDims),
+		Uint32Values:  make([]uint32, 0, 4),
+	}
+	if _, err := reader.FetchRow(0, &scratch); err != nil {
+		t.Fatalf("warm left block: %v", err)
+	}
+	if _, err := reader.FetchRow(4, &scratch); err != nil {
+		t.Fatalf("warm right block: %v", err)
+	}
+	row, err := reader.FetchRow(1, &scratch)
+	if err != nil {
+		t.Fatalf("refetch left block: %v", err)
+	}
+	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-001", 1, []float32{1, 1.25, 1.5, 1.75}, []uint32{1, 2, 3})
+	if stats := reader.Stats(); stats.CacheMisses != 2 || stats.CacheHits != 1 || stats.BlockEvictions != 0 {
+		t.Fatalf("cache stats=%+v want cached left block to survive right-block load", stats)
+	}
+}
+
 func TestColumnPhysicalRowReaderRejectsMutationPartsV1(t *testing.T) {
 	normalized := testColumnPhysicalRowReaderConfigV1(t)
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
@@ -313,6 +348,117 @@ func TestColumnPhysicalRowReaderWarmScratchHotFetchZeroAllocsV1(t *testing.T) {
 	if allocs != 0 {
 		t.Fatalf("hot FetchRow allocs=%v want zero", allocs)
 	}
+}
+
+func TestColumnPhysicalRowReaderScratchAppendFixedWidthSlicesV1(t *testing.T) {
+	t.Run("float32_vector_empty", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestFloat32Slice(&b, nil)
+		cur := manifestCursor{raw: b.Bytes()}
+		dst := []float32{42}
+		got, err := cur.appendFloat32SliceWithExpectedLength(dst, 0)
+		if err != nil {
+			t.Fatalf("appendFloat32SliceWithExpectedLength: %v", err)
+		}
+		if len(got) != 1 || got[0] != 42 || cur.pos != len(cur.raw) {
+			t.Fatalf("got=%v pos=%d len=%d", got, cur.pos, len(cur.raw))
+		}
+	})
+
+	t.Run("float32_vector_exact", func(t *testing.T) {
+		values := []float32{1.25, -2.5, 0.75}
+		var b bytes.Buffer
+		writeManifestFloat32Slice(&b, values)
+		cur := manifestCursor{raw: b.Bytes()}
+		dst := []float32{99}
+		got, err := cur.appendFloat32SliceWithExpectedLength(dst, len(values))
+		if err != nil {
+			t.Fatalf("appendFloat32SliceWithExpectedLength: %v", err)
+		}
+		if len(got) != 1+len(values) || got[0] != 99 || cur.pos != len(cur.raw) {
+			t.Fatalf("got=%v pos=%d len=%d", got, cur.pos, len(cur.raw))
+		}
+		for i, want := range values {
+			if got[i+1] != want {
+				t.Fatalf("got[%d]=%v want %v", i+1, got[i+1], want)
+			}
+		}
+	})
+
+	t.Run("float32_vector_wrong_length", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestFloat32Slice(&b, []float32{1, 2})
+		cur := manifestCursor{raw: b.Bytes()}
+		got, err := cur.appendFloat32SliceWithExpectedLength([]float32{7}, 3)
+		if err == nil || !strings.Contains(err.Error(), "length=2 want vector_dims=3") {
+			t.Fatalf("appendFloat32SliceWithExpectedLength err=%v want length mismatch", err)
+		}
+		if fmt.Sprint(got) != "[7]" {
+			t.Fatalf("got=%v want original dst", got)
+		}
+	})
+
+	t.Run("float32_vector_truncated", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestUint64(&b, 2)
+		writeManifestUint32(&b, math.Float32bits(1.5))
+		cur := manifestCursor{raw: b.Bytes()}
+		got, err := cur.appendFloat32SliceWithExpectedLength([]float32{7}, 2)
+		if err == nil || !strings.Contains(err.Error(), "short column binary float32_vector") {
+			t.Fatalf("appendFloat32SliceWithExpectedLength err=%v want short binary", err)
+		}
+		if fmt.Sprint(got) != "[7]" {
+			t.Fatalf("got=%v want original dst", got)
+		}
+	})
+
+	t.Run("uint32_slice_empty", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestUint32Slice(&b, nil)
+		cur := manifestCursor{raw: b.Bytes()}
+		dst := []uint32{42}
+		got, err := cur.appendUint32Slice(dst)
+		if err != nil {
+			t.Fatalf("appendUint32Slice: %v", err)
+		}
+		if len(got) != 1 || got[0] != 42 || cur.pos != len(cur.raw) {
+			t.Fatalf("got=%v pos=%d len=%d", got, cur.pos, len(cur.raw))
+		}
+	})
+
+	t.Run("uint32_slice_exact", func(t *testing.T) {
+		values := []uint32{1, 17, 1024}
+		var b bytes.Buffer
+		writeManifestUint32Slice(&b, values)
+		cur := manifestCursor{raw: b.Bytes()}
+		dst := []uint32{99}
+		got, err := cur.appendUint32Slice(dst)
+		if err != nil {
+			t.Fatalf("appendUint32Slice: %v", err)
+		}
+		if len(got) != 1+len(values) || got[0] != 99 || cur.pos != len(cur.raw) {
+			t.Fatalf("got=%v pos=%d len=%d", got, cur.pos, len(cur.raw))
+		}
+		for i, want := range values {
+			if got[i+1] != want {
+				t.Fatalf("got[%d]=%v want %v", i+1, got[i+1], want)
+			}
+		}
+	})
+
+	t.Run("uint32_slice_truncated", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestUint64(&b, 2)
+		writeManifestUint32(&b, 1)
+		cur := manifestCursor{raw: b.Bytes()}
+		got, err := cur.appendUint32Slice([]uint32{7})
+		if err == nil || !strings.Contains(err.Error(), "short column binary uint32 slice") {
+			t.Fatalf("appendUint32Slice err=%v want short binary", err)
+		}
+		if fmt.Sprint(got) != "[7]" {
+			t.Fatalf("got=%v want original dst", got)
+		}
+	})
 }
 
 func TestColumnPhysicalRowReaderScratchAppendRejectsWrappedFixedWidthSliceLengthsV1(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked on #1700 / `codex/column-graph-native-1699-integration` for #1696 M1.

This PR keeps the first M1 slice intentionally small:

- fixes generic physical row-reader cached block ownership so multi-granule warmed readers do not keep raw bytes backed by the reusable asset read-cache scratch buffer;
- keeps fixed-width `float32` vector and `uint32` adjacency decode cursor state out of the per-element loop;
- adds focused tests for cached-block byte ownership and fixed-width slice decode success/failure cases.

Non-goals: no decoded-block cache, no vector-specific cache, no search frontier rewrite, no cold open/load/doc-materialization optimization.

Reviewability boundary: this PR should stop at this two-file M1 slice. Additional typed-reader work, row lookup/fetch improvements, decoded-block reuse, or prepared/public allocation cleanup should be separate stacked PRs under #1696 M1B/M2/M3 once this PR is stable.

## Correctness / Reviewability

Pre-change baseline found `BenchmarkColumnPhysicalRowReaderFetchV1/{row_warmed_vector_adjacency,batch_warmed_vector_adjacency}` failing with `collections: short column binary bytes`. The underlying issue was that cached row blocks could retain bytes backed by `columnPhysicalAssetReadCache` scratch, then a later cache miss could overwrite those bytes while row offsets still pointed into the old block.

This PR makes cached blocks own stable bytes on load and adds `TestColumnPhysicalRowReaderCachedBlocksOwnRawBytesV1` to lock that down.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalRowReader|TestColumnVectorGraphPhysicalRowReader|TestColumnVectorGraphNative' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.198s

GOWORK=off go test ./TreeDB/collections -run 'Test.*Column.*Vector|Test.*Vector.*Column|TestColumnVectorGraph|TestColumnStore|TestColumnPublish' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 9.575s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnPhysicalRowReader|TestColumnVectorGraph.*Parallel|Test.*NativeReader' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.935s
```

## Benchmarks

Hardware: Apple M3, darwin/arm64.

Before artifact: `/tmp/pr1701_m1_decode_before_20260521_091051`  
Final hot artifact: `/tmp/pr1701_m1_decode_final_hot_20260521_092012`  
Profile artifact: `/tmp/pr1701_m1_decode_profile_20260521_092134`

Command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^Benchmark(ColumnVectorGraphPhysicalRowReaderFetchV2B|ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3)$' \
  -benchmem -benchtime=500ms -count=10
```

Before used the M1 baseline artifact. `BenchmarkColumnPhysicalRowReaderFetchV1` failed before this PR, so the before/after table below uses the graph-native benchmarks that completed both before and after.

| Benchmark | Before ns/op | Before ops/sec | After ns/op | After ops/sec | Delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `ColumnVectorGraphPhysicalRowReaderFetchV2B` | 297.9 | 3,356,831 | 282.1 | 3,544,842 | -5.29% | 0 | 0 |
| `ColumnVectorGraphNativeSearchCosineV3` | 65,690 | 15,223 | 62,840 | 15,913 | -4.33% | 0 | 0 |
| `ColumnVectorGraphNativeSearchCosineParallelV3` | 12,710 | 78,678 | 11,270 | 88,731 | -11.38% | 0 | 0 |

Useful unchanged metrics:

| Metric | Value |
| --- | ---: |
| candidates/search | 128 |
| edges/search | 1,912 |
| edges/node | 14.94 |
| cache hits/search | 138 |
| physical bytes/search | 0 |
| open physical bytes | 694,584 |
| resident bytes | 702,776 |

Generic row-reader benchmark now passes after the cached-block ownership fix:

| Benchmark | Final ns/op | Final ops/sec | Notes | B/op | allocs/op |
| --- | ---: | ---: | --- | ---: | ---: |
| `ColumnPhysicalRowReaderFetchV1/row_warmed_vector_adjacency` | 235.4 | 4,248,088 | 1 cache hit/op, 0 misses | 0 | 0 |
| `ColumnPhysicalRowReaderFetchV1/batch_warmed_vector_adjacency` | 1,763 | 567,215 | 8 rows/op; about 4.54M rows/sec | 0 | 0 |

Profile note: package-level `go test` profiles are still setup-noisy (`runtime.madvise`, JSON/setup frames). The timed benchmark remains `0 B/op`, `0 allocs/op`; search-path samples still show fixed-width vector decode, row fetch/decode, and native cosine scoring as the relevant remaining M1/M1B areas.
