### PR TITLE
TreeDB column store post-V1: consolidate dictionary code query arenas

### DIFF
--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -194,10 +194,11 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 			groupCur := manifestCursor{raw: groupRaw, pos: groupPayload.offset}
 			for i := 0; i < groupPayload.rowCount; i++ {
 				localCode := groupCur.u32()
-				if int(localCode) >= len(localToGlobal) {
+				localIdx, ok := columnDictionaryCodeIndex(localCode, len(localToGlobal))
+				if !ok {
 					return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
 				}
-				reducer.reduceValue(localToGlobal[localCode], int64(valueCur.u64()))
+				reducer.reduceValue(localToGlobal[localIdx], int64(valueCur.u64()))
 				rows++
 			}
 			if groupCur.err != nil {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -105,12 +105,19 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 	if len(byPart) == 0 {
 		return nil, nil
 	}
+	if !columnDictionaryCodeSnapshotsCoverParts(view, byPart) {
+		return nil, nil
+	}
+	codeArenaRows := columnDictionaryCodeSnapshotRows(view, byPart)
+	if codeArenaRows == 0 {
+		return nil, nil
+	}
 	globalByValue := make(map[string]uint32)
 	runner := &columnDictionaryCodeGroupCountRunner{
 		column: req.GroupColumn,
 		assets: make([]columnDictionaryCodeGroupCountAsset, 0, len(view.AssetRefs)),
 	}
-	codeArena := make([]uint32, columnDictionaryCodeSnapshotRows(view, byPart))
+	codeArena := make([]uint32, codeArenaRows)
 	codeArenaOffset := 0
 	var localToGlobal []uint32
 	var scratch []byte
@@ -345,6 +352,13 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	if len(groupByPart) == 0 || len(distinctByPart) == 0 {
 		return nil, nil
 	}
+	if !columnDictionaryCodeSnapshotsCoverParts(view, groupByPart) || !columnDictionaryCodeSnapshotsCoverParts(view, distinctByPart) {
+		return nil, nil
+	}
+	codeArenaRows := columnDictionaryCodeSnapshotRows(view, groupByPart)
+	if codeArenaRows == 0 {
+		return nil, nil
+	}
 	runner := &columnDictionaryCodeGroupCountDistinctRunner{
 		groupColumn:    req.GroupColumn,
 		distinctColumn: req.DistinctColumn,
@@ -352,7 +366,6 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	}
 	groupByValue := make(map[string]uint32)
 	distinctByValue := make(map[string]uint32)
-	codeArenaRows := columnDictionaryCodeSnapshotRows(view, groupByPart)
 	groupCodeArena := make([]uint32, codeArenaRows)
 	distinctCodeArena := make([]uint32, codeArenaRows)
 	groupCodeArenaOffset := 0

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -164,7 +164,7 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 		}
 		cur := manifestCursor{raw: raw, pos: dictCur.pos}
 		if rowCount > len(codeArena)-codeArenaOffset {
-			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows generation=%d part_id=%d column=%q", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn)
 		}
 		translated := codeArena[codeArenaOffset : codeArenaOffset+rowCount]
 		codeArenaOffset += rowCount
@@ -294,10 +294,11 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		cur := manifestCursor{raw: raw, pos: dictCur.pos}
 		for i := 0; i < rowCount; i++ {
 			localCode := cur.u32()
-			if int(localCode) >= len(localToGlobal) {
+			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localToGlobal))
+			if !ok {
 				return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
 			}
-			reducer.counts[localToGlobal[localCode]]++
+			reducer.counts[localToGlobal[localIdx]]++
 			rows++
 		}
 		if cur.err != nil {
@@ -422,7 +423,7 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		}
 		groupCodeCur := manifestCursor{raw: groupRaw, pos: groupCur.pos}
 		if groupRows > len(groupCodeArena)-groupCodeArenaOffset {
-			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+			return nil, fmt.Errorf("collections: group dictionary codes asset rows exceed manifest sidecar rows generation=%d part_id=%d column=%q", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn)
 		}
 		groupCodes := groupCodeArena[groupCodeArenaOffset : groupCodeArenaOffset+groupRows]
 		groupCodeArenaOffset += groupRows
@@ -485,7 +486,7 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		}
 		distinctCodeCur := manifestCursor{raw: distinctRaw, pos: distinctCur.pos}
 		if distinctRows > len(distinctCodeArena)-distinctCodeArenaOffset {
-			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+			return nil, fmt.Errorf("collections: distinct dictionary codes asset rows exceed manifest sidecar rows generation=%d part_id=%d column=%q", distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn)
 		}
 		distinctCodes := distinctCodeArena[distinctCodeArenaOffset : distinctCodeArenaOffset+distinctRows]
 		distinctCodeArenaOffset += distinctRows

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -110,6 +110,9 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 		column: req.GroupColumn,
 		assets: make([]columnDictionaryCodeGroupCountAsset, 0, len(view.AssetRefs)),
 	}
+	codeArena := make([]uint32, columnDictionaryCodeSnapshotRows(view, byPart))
+	codeArenaOffset := 0
+	var localToGlobal []uint32
 	var scratch []byte
 	for _, part := range view.AssetRefs {
 		if part.Reason != ColumnPublishOperationInsert {
@@ -128,7 +131,10 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 		if err != nil {
 			return nil, err
 		}
-		localToGlobal := make([]uint32, cardinality)
+		if cap(localToGlobal) < cardinality {
+			localToGlobal = make([]uint32, cardinality)
+		}
+		localToGlobal = localToGlobal[:cardinality]
 		for localCode := 0; localCode < cardinality; localCode++ {
 			value := dictCur.stringBytes()
 			globalCode, ok := globalByValue[unsafeStringFromBytes(value)]
@@ -150,7 +156,11 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 			return nil, dictCur.err
 		}
 		cur := manifestCursor{raw: raw, pos: dictCur.pos}
-		translated := make([]uint32, rowCount)
+		if rowCount > len(codeArena)-codeArenaOffset {
+			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+		}
+		translated := codeArena[codeArenaOffset : codeArenaOffset+rowCount]
+		codeArenaOffset += rowCount
 		for codeIdx := range translated {
 			localCode := cur.u32()
 			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localToGlobal))
@@ -342,6 +352,13 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	}
 	groupByValue := make(map[string]uint32)
 	distinctByValue := make(map[string]uint32)
+	codeArenaRows := columnDictionaryCodeSnapshotRows(view, groupByPart)
+	groupCodeArena := make([]uint32, codeArenaRows)
+	distinctCodeArena := make([]uint32, codeArenaRows)
+	groupCodeArenaOffset := 0
+	distinctCodeArenaOffset := 0
+	var groupLocal []uint32
+	var distinctLocal []uint32
 	var scratch []byte
 	for _, part := range view.AssetRefs {
 		if part.Reason != ColumnPublishOperationInsert {
@@ -365,7 +382,10 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		if err != nil {
 			return nil, err
 		}
-		groupLocal := make([]uint32, groupCardinality)
+		if cap(groupLocal) < groupCardinality {
+			groupLocal = make([]uint32, groupCardinality)
+		}
+		groupLocal = groupLocal[:groupCardinality]
 		for localCode := 0; localCode < groupCardinality; localCode++ {
 			value := groupCur.stringBytes()
 			valueKey := unsafeStringFromBytes(value)
@@ -388,7 +408,11 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 			return nil, groupCur.err
 		}
 		groupCodeCur := manifestCursor{raw: groupRaw, pos: groupCur.pos}
-		groupCodes := make([]uint32, groupRows)
+		if groupRows > len(groupCodeArena)-groupCodeArenaOffset {
+			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+		}
+		groupCodes := groupCodeArena[groupCodeArenaOffset : groupCodeArenaOffset+groupRows]
+		groupCodeArenaOffset += groupRows
 		for codeIdx := range groupCodes {
 			groupCode := groupCodeCur.u32()
 			groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(groupLocal))
@@ -416,7 +440,10 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		if groupRows != distinctRows {
 			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", groupRows, distinctRows)
 		}
-		distinctLocal := make([]uint32, distinctCardinality)
+		if cap(distinctLocal) < distinctCardinality {
+			distinctLocal = make([]uint32, distinctCardinality)
+		}
+		distinctLocal = distinctLocal[:distinctCardinality]
 		for localCode := 0; localCode < distinctCardinality; localCode++ {
 			value := distinctCur.stringBytes()
 			valueKey := unsafeStringFromBytes(value)
@@ -444,7 +471,11 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 			return nil, nil
 		}
 		distinctCodeCur := manifestCursor{raw: distinctRaw, pos: distinctCur.pos}
-		distinctCodes := make([]uint32, distinctRows)
+		if distinctRows > len(distinctCodeArena)-distinctCodeArenaOffset {
+			return nil, fmt.Errorf("collections: dictionary codes asset rows exceed manifest sidecar rows")
+		}
+		distinctCodes := distinctCodeArena[distinctCodeArenaOffset : distinctCodeArenaOffset+distinctRows]
+		distinctCodeArenaOffset += distinctRows
 		for codeIdx := range distinctCodes {
 			distinctCode := distinctCodeCur.u32()
 			distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, len(distinctLocal))
@@ -506,6 +537,21 @@ func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, co
 		byPart[[2]uint64{snapshot.AssetRef.Generation, snapshot.AssetRef.PartID}] = snapshot
 	}
 	return byPart
+}
+
+func columnDictionaryCodeSnapshotRows(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) int {
+	rows := 0
+	for _, part := range view.AssetRefs {
+		_, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
+		if !ok {
+			return 0
+		}
+		if part.Rows > maxCollectionInt-rows {
+			return 0
+		}
+		rows += part.Rows
+	}
+	return rows
 }
 
 func columnDictionaryCodeSnapshotsCoverParts(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) bool {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -138,6 +138,9 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 		if err != nil {
 			return nil, err
 		}
+		if rowCount != part.Rows {
+			return nil, fmt.Errorf("collections: dictionary codes asset row count=%d want manifest rows=%d generation=%d part_id=%d column=%q", rowCount, part.Rows, snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.GroupColumn)
+		}
 		if cap(localToGlobal) < cardinality {
 			localToGlobal = make([]uint32, cardinality)
 		}
@@ -396,6 +399,9 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		if err != nil {
 			return nil, err
 		}
+		if groupRows != part.Rows {
+			return nil, fmt.Errorf("collections: group dictionary codes asset row count=%d want manifest rows=%d generation=%d part_id=%d column=%q", groupRows, part.Rows, groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn)
+		}
 		if cap(groupLocal) < groupCardinality {
 			groupLocal = make([]uint32, groupCardinality)
 		}
@@ -450,6 +456,9 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 		distinctCur, distinctCardinality, distinctRows, err := decodeColumnDictionaryCodesAssetHeader(distinctRaw, distinctSnapshot.AssetRef, view.Config, view.CollectionName, req.DistinctColumn, false)
 		if err != nil {
 			return nil, err
+		}
+		if distinctRows != part.Rows {
+			return nil, fmt.Errorf("collections: distinct dictionary codes asset row count=%d want manifest rows=%d generation=%d part_id=%d column=%q", distinctRows, part.Rows, distinctSnapshot.AssetRef.Generation, distinctSnapshot.AssetRef.PartID, req.DistinctColumn)
 		}
 		if groupRows != distinctRows {
 			return nil, fmt.Errorf("collections: dictionary code distinct row count mismatch group=%d distinct=%d", groupRows, distinctRows)

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -108,8 +108,8 @@ func prepareColumnDictionaryCodeGroupCountRunner(view columnPhysicalScanSnapshot
 	if !columnDictionaryCodeSnapshotsCoverParts(view, byPart) {
 		return nil, nil
 	}
-	codeArenaRows := columnDictionaryCodeSnapshotRows(view, byPart)
-	if codeArenaRows == 0 {
+	codeArenaRows, ok := columnDictionaryCodeSnapshotRows(view, byPart)
+	if !ok || codeArenaRows == 0 {
 		return nil, nil
 	}
 	globalByValue := make(map[string]uint32)
@@ -355,8 +355,8 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	if !columnDictionaryCodeSnapshotsCoverParts(view, groupByPart) || !columnDictionaryCodeSnapshotsCoverParts(view, distinctByPart) {
 		return nil, nil
 	}
-	codeArenaRows := columnDictionaryCodeSnapshotRows(view, groupByPart)
-	if codeArenaRows == 0 {
+	codeArenaRows, ok := columnDictionaryCodeSnapshotRows(view, groupByPart)
+	if !ok || codeArenaRows == 0 {
 		return nil, nil
 	}
 	runner := &columnDictionaryCodeGroupCountDistinctRunner{
@@ -552,19 +552,19 @@ func columnDictionaryCodeSnapshotsByPart(view columnPhysicalScanSnapshotView, co
 	return byPart
 }
 
-func columnDictionaryCodeSnapshotRows(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) int {
+func columnDictionaryCodeSnapshotRows(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) (int, bool) {
 	rows := 0
 	for _, part := range view.AssetRefs {
 		_, ok := byPart[[2]uint64{part.Ref.Generation, part.Ref.PartID}]
 		if !ok {
-			return 0
+			return 0, false
 		}
 		if part.Rows > maxCollectionInt-rows {
-			return 0
+			return 0, false
 		}
 		rows += part.Rows
 	}
-	return rows
+	return rows, true
 }
 
 func columnDictionaryCodeSnapshotsCoverParts(view columnPhysicalScanSnapshotView, byPart map[[2]uint64]columnManifestDictionaryCodesSnapshot) bool {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2846,6 +2846,33 @@ func TestColumnDictionaryCodeSnapshotRowsM1634(t *testing.T) {
 	}
 }
 
+func TestColumnDictionaryCodePreparedRunnersFallbackOnMixedSidecarCoverageM1634(t *testing.T) {
+	normalized, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	ns := normalized.AssetManager.Namespace
+	view := columnPhysicalScanSnapshotView{
+		CollectionName: "events",
+		Config:         *normalized,
+		AssetRefs: []columnManifestAssetRefForScan{
+			{Ref: ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, Namespace: ns, Generation: 2, PartID: 1}, Reason: ColumnPublishOperationInsert, Rows: 3},
+			{Ref: ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, Namespace: ns, Generation: 2, PartID: 2}, Reason: ColumnPublishOperationInsert, Rows: 5},
+		},
+		DictionaryCodes: []columnManifestDictionaryCodesSnapshot{
+			{ColumnName: "kind", AssetRef: ColumnAssetRef{Kind: ColumnAssetKindTCS1DictionaryCodes, Namespace: ns, Generation: 2, PartID: 1}},
+			{ColumnName: "did", AssetRef: ColumnAssetRef{Kind: ColumnAssetKindTCS1DictionaryCodes, Namespace: ns, Generation: 2, PartID: 1}},
+		},
+	}
+	readCache := &columnPhysicalAssetReadCache{namespace: ns}
+	if runner, err := prepareColumnDictionaryCodeGroupCountRunner(view, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}, readCache); err != nil || runner != nil {
+		t.Fatalf("group-count runner=%T err=%v want clean fallback", runner, err)
+	}
+	if runner, err := prepareColumnDictionaryCodeGroupCountDistinctRunner(view, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}, readCache); err != nil || runner != nil {
+		t.Fatalf("group-count-distinct runner=%T err=%v want clean fallback", runner, err)
+	}
+}
+
 func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(4, 129)
 	if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2879,6 +2879,39 @@ func TestColumnDictionaryCodePreparedRunnersFallbackOnMixedSidecarCoverageM1634(
 	}
 }
 
+func TestColumnDictionaryCodePreparedRunnersRejectManifestRowMismatchM1634(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(2048)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotView()
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotView: %v", err)
+	}
+	if len(view.AssetRefs) == 0 {
+		t.Fatal("fixture produced no physical asset refs")
+	}
+	view.AssetRefs[0].Rows++
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity: %v", err)
+	}
+	defer func() {
+		if err := readCache.close(); err != nil {
+			t.Fatalf("read cache close: %v", err)
+		}
+	}()
+	if _, err := prepareColumnDictionaryCodeGroupCountRunner(view, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}, &readCache); err == nil || !strings.Contains(err.Error(), "want manifest rows") {
+		t.Fatalf("group-count err=%v want manifest row mismatch", err)
+	}
+	if _, err := prepareColumnDictionaryCodeGroupCountDistinctRunner(view, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "kind", DistinctColumn: "did"}, &readCache); err == nil || !strings.Contains(err.Error(), "want manifest rows") {
+		t.Fatalf("group-count-distinct err=%v want manifest row mismatch", err)
+	}
+}
+
 func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(4, 129)
 	if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2826,6 +2826,26 @@ func TestColumnDictionaryCodeIndexRejectsCorruptWideCodeM1634(t *testing.T) {
 	}
 }
 
+func TestColumnDictionaryCodeSnapshotRowsM1634(t *testing.T) {
+	view := columnPhysicalScanSnapshotView{
+		AssetRefs: []columnManifestAssetRefForScan{
+			{Ref: ColumnAssetRef{Generation: 2, PartID: 1}, Rows: 3},
+			{Ref: ColumnAssetRef{Generation: 2, PartID: 2}, Rows: 5},
+		},
+	}
+	byPart := map[[2]uint64]columnManifestDictionaryCodesSnapshot{
+		{2, 1}: {AssetRef: ColumnAssetRef{Generation: 2, PartID: 1}},
+		{2, 2}: {AssetRef: ColumnAssetRef{Generation: 2, PartID: 2}},
+	}
+	if rows := columnDictionaryCodeSnapshotRows(view, byPart); rows != 8 {
+		t.Fatalf("rows=%d want 8", rows)
+	}
+	delete(byPart, [2]uint64{2, 2})
+	if rows := columnDictionaryCodeSnapshotRows(view, byPart); rows != 0 {
+		t.Fatalf("missing part rows=%d want 0", rows)
+	}
+}
+
 func TestColumnDictionaryCodeDistinctSeenWordsRejectsOverflowM1634(t *testing.T) {
 	wordsPerGroup, totalWords, ok, err := columnDictionaryCodeDistinctSeenWords(4, 129)
 	if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2837,12 +2837,18 @@ func TestColumnDictionaryCodeSnapshotRowsM1634(t *testing.T) {
 		{2, 1}: {AssetRef: ColumnAssetRef{Generation: 2, PartID: 1}},
 		{2, 2}: {AssetRef: ColumnAssetRef{Generation: 2, PartID: 2}},
 	}
-	if rows := columnDictionaryCodeSnapshotRows(view, byPart); rows != 8 {
-		t.Fatalf("rows=%d want 8", rows)
+	if rows, ok := columnDictionaryCodeSnapshotRows(view, byPart); rows != 8 || !ok {
+		t.Fatalf("rows=%d ok=%v want 8/true", rows, ok)
 	}
 	delete(byPart, [2]uint64{2, 2})
-	if rows := columnDictionaryCodeSnapshotRows(view, byPart); rows != 0 {
-		t.Fatalf("missing part rows=%d want 0", rows)
+	if rows, ok := columnDictionaryCodeSnapshotRows(view, byPart); rows != 0 || ok {
+		t.Fatalf("missing part rows=%d ok=%v want 0/false", rows, ok)
+	}
+	byPart[[2]uint64{2, 2}] = columnManifestDictionaryCodesSnapshot{AssetRef: ColumnAssetRef{Generation: 2, PartID: 2}}
+	view.AssetRefs[0].Rows = maxCollectionInt
+	view.AssetRefs[1].Rows = 1
+	if rows, ok := columnDictionaryCodeSnapshotRows(view, byPart); rows != 0 || ok {
+		t.Fatalf("overflow rows=%d ok=%v want 0/false", rows, ok)
 	}
 }
 

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -86,6 +86,7 @@ type columnPhysicalAssetScanHeader struct {
 type columnManifestAssetRefForScan struct {
 	Ref    ColumnAssetRef
 	Reason ColumnPublishOperation
+	Rows   int
 }
 
 type columnManifestScanSidecarFilter struct {
@@ -696,7 +697,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				return columnManifestSnapshot{}, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 			}
 			livePartRows.add(ref.Generation, ref.PartID, rows)
-			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
 			if ref.Generation == snapshot.Generation {
 				activeParts++
 			}
@@ -1276,7 +1277,7 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
 		livePartRows.add(ref.Generation, ref.PartID, rows)
-		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
 		if ref.Generation == snapshot.Generation {
 			activeParts++
 		}
@@ -1586,9 +1587,12 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, a
 		if keyGeneration > activeGeneration {
 			return nil, 0, fmt.Errorf("collections: column manifest part generation=%d is newer than active manifest generation=%d", keyGeneration, activeGeneration)
 		}
-		ref, reason, err := decodeColumnManifestPartRefForScan(record.value, expectedNamespace)
+		ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(record.value, expectedNamespace)
 		if err != nil {
 			return nil, 0, err
+		}
+		if ref.Kind != ColumnAssetKindTCS1PartImage {
+			return nil, 0, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 		}
 		if ref.Generation != keyGeneration {
 			return nil, 0, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
@@ -1600,7 +1604,7 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, a
 		if !ok {
 			return nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
-		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation})
+		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
 		if operation != ColumnPublishOperationInsert {
 			mutationParts++
 		}


### PR DESCRIPTION
## Summary

This PR keeps the #1702 prepared dictionary-code runner path for large q1/q2 scans, but consolidates its per-part translated-code buffers into exact manifest-row arenas. It also reuses per-part local translation scratch and applies the shared unsigned dictionary-code bounds helper to the dictionary+int64 q4/q5 one-shot loop.

This is intentionally based on the latest 1M routed profile, not the 8,192-row package shape. The small adapter benchmarks still use the one-shot path for q1/q2, so they are useful for parity/allocation guardrails but not for prioritizing this change.

Large-fixture priority note: the roadmap signal for this PR is the 1M routed q1-q5 CPU/allocation profile. The 8,192-row package and prepared-runner benches below are local proof and allocation ceilings; they are not used here to choose the optimization stream because they exercise a different q1/q2 path at this scale.

## Static Analysis Checkpoint

Latest #1702 1M routed `skip_checksums` evidence showed the q1/q2 prepared dictionary-code setup remained the largest query-path allocation category after streaming dictionary-code decode was added. The visible allocations were not per-row reducer allocations; they were setup buffers: per-part translated `[]uint32` code arrays and per-part local dictionary translation arrays.

A first local q4/q5 scratch pre-grow idea was rejected before commit because the 1M profile did not support it: it did not improve q4/q5 and increased sampled `growScratch` objects. The committed implementation instead targets the measured q1/q2 prepared setup category and keeps q4/q5 changes to the fail-closed code-index guard.

## Measurement Class

- Measurement class: `routed unified-bench query path`. Primary evidence for this PR; production durable column-store fixture, planner-routed forced `serial_column_scan`, 1M rows, `skip_checksums`.
- Measurement class: `direct package scanner`. Focused 8,192-row adapter context; q1/q2 are expected to be mostly unchanged because that size still uses one-shot execution.
- Measurement class: `prepared hot runner / warmed repeated Run()`. Focused hot-runner allocation ceiling; unchanged kernel target remains `0 allocs/op`.
- Measurement class: `experiment/granule baseline`. Historical/context only; not rerun here.
- Measurement class: `historical ClickHouse context`. Historical/context only; not rerun here.

## Performance / Benchmark Evidence

Measurement class: `routed unified-bench query path`. Apple M3, darwin/arm64, head `695cb35c5`, 1,000,000 rows, durable profile, forced `serial_column_scan`, `skip_checksums`, artifact `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618`:

```text
q1 0.7 ns/row, 1.442B rows/s, scan 0.427 ms, parity pass
q2 0.9 ns/row, 1.142B rows/s, scan 0.651 ms, parity pass
q3 39.4 ns/row, 25.40M rows/s, scan 39.149 ms, parity pass
q4a 7.4 ns/row, 136.04M rows/s, scan 7.092 ms, parity pass
q4b 6.9 ns/row, 145.19M rows/s, scan 6.647 ms, parity pass
q5 7.3 ns/row, 137.22M rows/s, scan 7.055 ms, parity pass
q5_metadata serial alias 7.2 ns/row, metadata_hits=0, parity pass
```

Allocation profile comparison against #1702 same 1M routed `skip_checksums` shape, filtering out profile/report writer frames for the query-path interpretation:

```text
#1702 query-path alloc_objects: ~1,143 shown after runtime/pprof+compress+profile-writer filters; RunColumnPhysicalQuery cum ~1,063
this PR query-path alloc_objects: ~212 shown after the same filters; RunColumnPhysicalQuery cum ~132
#1702 total alloc_space: ~23.18 MiB
this PR total alloc_space: ~22.20 MiB
#1702 q1/q2 prepared dictionary setup objects: prepareColumnDictionaryCodeGroupCountRunner 287, prepareColumnDictionaryCodeGroupCountDistinctRunner 364
this PR q1/q2 prepared dictionary setup objects: prepareColumnDictionaryCodeGroupCountRunner ~1, prepareColumnDictionaryCodeGroupCountDistinctRunner ~2 in the filtered profile
```

Latest-head review-fix rerun on head `96cf9b2a4`, same machine and shape, artifact `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900`: q1 `0.7 ns/row`, `1.491B rows/s`, scan `0.411 ms`; q2 `1.1 ns/row`, `929.33M rows/s`, scan `0.833 ms`; q3 `62.2 ns/row`, `16.07M rows/s`, scan `61.967 ms`; q4a `7.4 ns/row`, `134.76M rows/s`; q4b `7.2 ns/row`, `138.05M rows/s`; q5 `7.5 ns/row`, `132.81M rows/s`; q5_metadata serial alias `7.3 ns/row`, `metadata_hits=0`; all parity passed and row materializations remained zero. The latest alloc profile keeps the same attribution: alloc-space is dominated by prepared q1/q2 code arenas (`~7.83 MiB` distinct, `~3.91 MiB` q1), while real query-path alloc objects are low after excluding profile/report writer noise (`loadColumnManifestSnapshotViewForScanFromRootWithSidecars` `114` objects; `RunColumnPhysicalQuery` cumulative `172` objects).

Measurement class: `direct package scanner`. Apple M3, 8,192 rows, `BenchmarkColumnPhysicalQueryAdapterM13B/(q1|q2)_rows_8192`, `-benchtime=1000x -count=3`: q1 stayed at `21 allocs/op`, `~2.84 KiB/op`, `4.96-5.17 ns/row`; q2 stayed at `40 allocs/op`, `~4.16 KiB/op`, `5.80-5.88 ns/row`. This is expected because the small adapter shape uses the one-shot path rather than the large prepared translation setup changed here.

Measurement class: `prepared hot runner / warmed repeated Run()`. Apple M3, 8,192 rows, `BenchmarkColumnPhysicalQueryRunnerM1634/(q1|q2)_rows_8192`, `-benchtime=1000x -count=3`: q1/q2 hot runners remain `0 allocs/op`; q1 was `~0.408-0.416 ns/row`, q2 was `~0.702-0.719 ns/row`. These measurements exclude sidecar read/decode/checksum/translation, planner routing, `unified-bench` reporting, writes, WAL/checkpoint, reopen, and mutation handling.

## End-to-End Comparable Snapshot

Measurement class: `routed unified-bench query path`. Current routed production q1-q5 snapshot is the fresh 1M artifact above. Routed execution reaches the optimized prepared dictionary-code arena setup for large q1/q2 sidecars; q3/q4/q5 are context and are not expected to improve from this PR.

Measurement class: `experiment/granule baseline`. Historical granule context remains the allocation/kernel target: dense encoded kernels were designed for `0 allocs/op`; prior encoded JSONBench context had q1 around `~2.38 ns/row` and q2 around `~4.13 ns/row`. This PR removes production setup allocation in the routed prepared path, but it does not convert production into the experiment's schema-fixed column-block layout.

Measurement class: `historical ClickHouse context`. Historical local ClickHouse JSONBench 1M context from `experiments/colgranule/JSONBENCH_COMPARISON_REPORT.md`: q1/q2/q3/q4/q5 approximately `0.014s / 0.027s / 0.014s / 0.013s / 0.013s`. Not same-harness and not rerun for this PR.

## Throughput Interpretation

The useful result is allocation consolidation in a large-routed path without giving up the fast prepared translated-code runner. q1/q2 throughput stays in the same high-throughput band as #1702, while query-path allocation objects fall by roughly 80%+ under the same 1M routed profile shape.

The q3 scan time in this single run is noisy and not attributed to this change; q3 does not use the changed dictionary-code prepared arena path. The priority signal for this PR is the allocation profile and q1/q2 prepared setup category.

## Apples-to-Apples Limitations

The fresh routed evidence uses `skip_checksums`, durable mode, synthetic JSONBench-shaped fixture, 1M rows, and forced `serial_column_scan`; it is not a strict-read-integrity measurement. Prepared hot-runner numbers are warmed repeated `Run()` measurements after `PrepareColumnPhysicalQuery` and exclude setup/lifecycle costs. Granule and ClickHouse values are historical context, not same-head/same-harness comparisons.

## Gate Status

- `go test ./TreeDB/collections -run 'TestColumnDictionaryCode(IndexRejectsCorruptWideCode|SnapshotRows)M1634|TestColumnPhysicalQueryRunner(ParityAndAllocation|DistinctSidecarParityAndAllocation)M1634|TestColumnPhysicalQuerySerial(DictionarySidecarParity|SidecarAllocationBudget)M1634' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `git diff --check`
- `go build -o bin/unified-bench ./cmd/unified_bench`
- 1M routed `unified-bench` profile listed below

## Artifacts

- Routed markdown: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/column_store_results.md`
- Routed HTML: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/column_store_results.html`
- Routed JSON: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/column_store_results.json`
- Benchprof markdown: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/benchprof_results.md`
- Benchprof JSON: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/benchprof_results.json`
- Insights HTML: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/insights.html`
- CPU profile: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/cpu_column_store_treedb_column_store.pprof`
- Allocs profile: `/tmp/gomap_1634_dict_code_exact_arena_1m_skip_20260521_092618/allocs_column_store_treedb_column_store.pprof`
- Latest-head routed markdown: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/column_store_results.md`
- Latest-head routed HTML: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/column_store_results.html`
- Latest-head routed JSON: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/column_store_results.json`
- Latest-head benchprof markdown: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/benchprof_results.md`
- Latest-head benchprof JSON: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/benchprof_results.json`
- Latest-head insights HTML: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/insights.html`
- Latest-head CPU profile: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/cpu_column_store_treedb_column_store.pprof`
- Latest-head allocs profile: `/tmp/gomap_1634_dict_code_exact_arena_latest_1m_skip_20260521_095900/allocs_column_store_treedb_column_store.pprof`
- Rejected scratch pre-grow artifact: `/tmp/gomap_1634_dict_int64_pregrow_1m_skip_20260521_092006`
- Rejected generic grow-arena artifact: `/tmp/gomap_1634_dict_code_arena_1m_skip_20260521_092300`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation and explicit errors for decoded dictionary codes to prevent out-of-range failures and manifest row mismatches.
  * Query planning now cleanly falls back when dictionary sidecar coverage is incomplete.

* **Refactor**
  * Reduced memory allocations by using shared arenas for decoded dictionary codes and added safer bounds/capacity checks.
  * Scan planning now records per-part row counts from manifests.

* **Tests**
  * Added unit tests for dictionary-row counting, overflow safety, fallback behavior, and manifest row mismatch detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
