### PR TITLE
Add content hash tournament experiment

### DIFF
--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -71,19 +71,44 @@ current checksum slot is already `uint32`-sized. A fast native 32-bit hash could
 be a drop-in format change while gomap does not need backward compatibility for
 persisted checksum values.
 
-## Initial Apple M3 Read
+## Current Apple M3 Read
 
-A short Apple M3 run showed `FarmHash64` as the fastest candidate across the
-four sizes, with `XXH3_64` next and `CRC32C_Castagnoli_TreeDB` around 9-10
-GB/s on larger buffers.
+On the local Apple M3 smoke runs, `FarmHash64` and its seeded 64-bit variants
+are the fastest candidates. The 128-bit farm and `XXH3` variants do not beat
+the 64-bit farm path, and the native 32-bit farm variants do not beat the
+current Go `CRC32C_Castagnoli_TreeDB` path.
 
-In the native 32-bit set, `FarmHash32` and `FarmFingerprint32` are useful
-drop-in-width candidates, but this local run had both around 7.6 GB/s. That is
-slower than Go's `CRC32C_Castagnoli_TreeDB` path on the same machine, so the
-32-bit candidates need target-hardware validation before replacing the current
-TreeDB checksum slot.
+Representative 1 MiB expanded-run results:
 
-Representative top-contender pass:
+```text
+FarmHash64:           ~27.20 GB/s
+FarmHash64Seeded:     ~27.16 GB/s
+FarmHash64TwoSeeds:   ~27.22 GB/s
+FarmFingerprint64:    ~21.33 GB/s
+FarmHash128:          ~19.65 GB/s
+FarmHash128Seeded:    ~19.69 GB/s
+FarmFingerprint128:   ~19.63 GB/s
+XXH3_128:             ~19.13 GB/s
+XXH3_64:              ~18.95 GB/s
+XXHash64:             ~16.88 GB/s
+MapHash_ProcessLocal: ~13.90 GB/s
+CRC32C_Castagnoli:    ~10.64 GB/s
+FarmHash32Seeded:     ~7.71 GB/s
+FarmFingerprint32:    ~7.67 GB/s
+FarmHash32:           ~7.38 GB/s
+```
+
+Practical read from this machine:
+
+- If the checksum field can move to 64 bits, `FarmHash64` is the strongest
+  local candidate to validate on target hardware.
+- If the checksum field must stay `uint32`, benchmark truncating fast 64-bit
+  hashes, such as `uint32(farm.Hash64(data))`, before choosing a native 32-bit
+  hash. The native 32-bit farm variants are slower than CRC32C in this run.
+- `maphash` is not a good persisted checksum default because its seed is
+  process-local unless the format explicitly owns and persists seed semantics.
+
+Earlier short-run top-contender pass:
 
 ```text
 64 KiB:  FarmHash64 ~24.3 GB/s, XXH3 ~15.2 GB/s, CRC32C ~7.6 GB/s

--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -1,0 +1,59 @@
+# Content Hash Tournament
+
+This experiment compares candidate content hash functions for block-sized read
+integrity checks. It includes the current TreeDB-style CRC path:
+
+```go
+crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+```
+
+The benchmark sizes mirror ClickHouse-like compressed block boundaries that are
+useful for reasoning about checksum cost in a read hot path:
+
+- 64 KiB: default lower compression-block threshold.
+- 256 KiB: middle case.
+- 512 KiB: common one-mark scale for wider rows.
+- 1 MiB: default maximum compression block size.
+
+## Run
+
+From this directory:
+
+```sh
+go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=1s -count=3
+```
+
+For a longer run:
+
+```sh
+go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=2s -count=5
+```
+
+## Competitors
+
+- `CRC32C_Castagnoli_TreeDB`: Go `hash/crc32` with `crc32.Castagnoli`.
+- `CRC32_IEEE`: Go `hash/crc32.ChecksumIEEE`.
+- `XXHash64`: `github.com/cespare/xxhash/v2`.
+- `XXH3_64`: `github.com/zeebo/xxh3`.
+- `FarmHash64`: `github.com/dgryski/go-farm`.
+- `MapHash_ProcessLocal`: Go `hash/maphash`.
+- `FNV1a_64`: Go `hash/fnv`.
+- `SHA256`: Go `crypto/sha256`.
+
+## Initial Apple M3 Read
+
+A short Apple M3 run showed `FarmHash64` as the fastest candidate across the
+four sizes, with `XXH3_64` next and `CRC32C_Castagnoli_TreeDB` around 9-10
+GB/s on larger buffers.
+
+Representative top-contender pass:
+
+```text
+64 KiB:  FarmHash64 ~24.3 GB/s, XXH3 ~15.2 GB/s, CRC32C ~7.6 GB/s
+256 KiB: FarmHash64 ~25.8 GB/s, XXH3 ~16.8 GB/s, CRC32C ~9.4 GB/s
+512 KiB: FarmHash64 ~23.9 GB/s, XXH3 ~16.1 GB/s, CRC32C ~9.8 GB/s
+1 MiB:   FarmHash64 ~20.5 GB/s, XXH3 ~15.6 GB/s, CRC32C ~9.3 GB/s
+```
+
+Treat these numbers as local signal only; rerun on target hardware before using
+them to choose an on-disk checksum format.

--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -34,6 +34,8 @@ go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=2s -count=5
 - `CRC32C_Castagnoli_TreeDB`: Go `hash/crc32` with `crc32.Castagnoli`.
 - `CRC32_IEEE`: Go `hash/crc32.ChecksumIEEE`.
 - `CRC32_Koopman`: Go `hash/crc32` with `crc32.Koopman`.
+- `CRC64_ECMA`: Go `hash/crc64` with `crc64.ECMA`.
+- `CRC64_ISO`: Go `hash/crc64` with `crc64.ISO`.
 - `XXHash64`: `github.com/cespare/xxhash/v2`.
 - `XXHash64_Digest`: `github.com/cespare/xxhash/v2` streaming digest.
 - `XXHash64_DigestSeeded`: `github.com/cespare/xxhash/v2` seeded streaming digest.
@@ -96,12 +98,18 @@ CRC32C_Castagnoli:    ~10.64 GB/s
 FarmHash32Seeded:     ~7.71 GB/s
 FarmFingerprint32:    ~7.67 GB/s
 FarmHash32:           ~7.38 GB/s
+SHA256:               ~2.85 GB/s
+CRC64_ECMA:           ~1.99 GB/s
+CRC64_ISO:            ~1.93 GB/s
 ```
 
 Practical read from this machine:
 
 - If the checksum field can move to 64 bits, `FarmHash64` is the strongest
   local candidate to validate on target hardware.
+- Go's standard-library `CRC64_ECMA` and `CRC64_ISO` provide 64-bit CRC-style
+  checksums, but they are much slower than `CRC32C_Castagnoli_TreeDB` and the
+  fast 64-bit fingerprint hashes on this machine.
 - If the checksum field must stay `uint32`, benchmark truncating fast 64-bit
   hashes, such as `uint32(farm.Hash64(data))`, before choosing a native 32-bit
   hash. The native 32-bit farm variants are slower than CRC32C in this run.

--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -36,15 +36,29 @@ go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=2s -count=5
 - `XXHash64`: `github.com/cespare/xxhash/v2`.
 - `XXH3_64`: `github.com/zeebo/xxh3`.
 - `FarmHash64`: `github.com/dgryski/go-farm`.
+- `FarmHash32`: `github.com/dgryski/go-farm`.
+- `FarmFingerprint32`: `github.com/dgryski/go-farm`.
 - `MapHash_ProcessLocal`: Go `hash/maphash`.
 - `FNV1a_64`: Go `hash/fnv`.
+- `FNV1a_32`: Go `hash/fnv`.
 - `SHA256`: Go `crypto/sha256`.
+
+The native 32-bit entries are included because TreeDB's current checksum slot is
+already `uint32`-sized. A fast native 32-bit hash could be a drop-in format
+change while gomap does not need backward compatibility for persisted checksum
+values.
 
 ## Initial Apple M3 Read
 
 A short Apple M3 run showed `FarmHash64` as the fastest candidate across the
 four sizes, with `XXH3_64` next and `CRC32C_Castagnoli_TreeDB` around 9-10
 GB/s on larger buffers.
+
+In the native 32-bit set, `FarmHash32` and `FarmFingerprint32` are useful
+drop-in-width candidates, but this local run had both around 7.6 GB/s. That is
+slower than Go's `CRC32C_Castagnoli_TreeDB` path on the same machine, so the
+32-bit candidates need target-hardware validation before replacing the current
+TreeDB checksum slot.
 
 Representative top-contender pass:
 

--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -33,20 +33,43 @@ go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=2s -count=5
 
 - `CRC32C_Castagnoli_TreeDB`: Go `hash/crc32` with `crc32.Castagnoli`.
 - `CRC32_IEEE`: Go `hash/crc32.ChecksumIEEE`.
+- `CRC32_Koopman`: Go `hash/crc32` with `crc32.Koopman`.
 - `XXHash64`: `github.com/cespare/xxhash/v2`.
+- `XXHash64_Digest`: `github.com/cespare/xxhash/v2` streaming digest.
+- `XXHash64_DigestSeeded`: `github.com/cespare/xxhash/v2` seeded streaming digest.
 - `XXH3_64`: `github.com/zeebo/xxh3`.
+- `XXH3_64Seeded`: `github.com/zeebo/xxh3`.
+- `XXH3_128`: `github.com/zeebo/xxh3`.
+- `XXH3_128Seeded`: `github.com/zeebo/xxh3`.
+- `XXH3_64_Hasher`: `github.com/zeebo/xxh3` streaming hasher.
+- `XXH3_64_HasherSeeded`: `github.com/zeebo/xxh3` seeded streaming hasher.
+- `XXH3_128_Hasher`: `github.com/zeebo/xxh3` streaming hasher.
+- `XXH3_128_HasherSeeded`: `github.com/zeebo/xxh3` seeded streaming hasher.
 - `FarmHash64`: `github.com/dgryski/go-farm`.
+- `FarmHash64Seeded`: `github.com/dgryski/go-farm`.
+- `FarmHash64TwoSeeds`: `github.com/dgryski/go-farm`.
+- `FarmFingerprint64`: `github.com/dgryski/go-farm`.
+- `FarmHash128`: `github.com/dgryski/go-farm`.
+- `FarmHash128Seeded`: `github.com/dgryski/go-farm`.
+- `FarmFingerprint128`: `github.com/dgryski/go-farm`.
 - `FarmHash32`: `github.com/dgryski/go-farm`.
+- `FarmHash32Seeded`: `github.com/dgryski/go-farm`.
 - `FarmFingerprint32`: `github.com/dgryski/go-farm`.
 - `MapHash_ProcessLocal`: Go `hash/maphash`.
+- `FNV1_64`: Go `hash/fnv`.
 - `FNV1a_64`: Go `hash/fnv`.
+- `FNV1_32`: Go `hash/fnv`.
 - `FNV1a_32`: Go `hash/fnv`.
+- `FNV1_128`: Go `hash/fnv`.
+- `FNV1a_128`: Go `hash/fnv`.
+- `SHA224`: Go `crypto/sha256`.
 - `SHA256`: Go `crypto/sha256`.
 
-The native 32-bit entries are included because TreeDB's current checksum slot is
-already `uint32`-sized. A fast native 32-bit hash could be a drop-in format
-change while gomap does not need backward compatibility for persisted checksum
-values.
+The suite includes the native output widths exposed by each package for byte
+slice content hashing. The native 32-bit entries are included because TreeDB's
+current checksum slot is already `uint32`-sized. A fast native 32-bit hash could
+be a drop-in format change while gomap does not need backward compatibility for
+persisted checksum values.
 
 ## Initial Apple M3 Read
 

--- a/experiments/hash_tournament/README.md
+++ b/experiments/hash_tournament/README.md
@@ -4,7 +4,9 @@ This experiment compares candidate content hash functions for block-sized read
 integrity checks. It includes the current TreeDB-style CRC path:
 
 ```go
-crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+crc32.Checksum(data, crc32cTable)
 ```
 
 The benchmark sizes mirror ClickHouse-like compressed block boundaries that are
@@ -94,7 +96,7 @@ XXH3_128:             ~19.13 GB/s
 XXH3_64:              ~18.95 GB/s
 XXHash64:             ~16.88 GB/s
 MapHash_ProcessLocal: ~13.90 GB/s
-CRC32C_Castagnoli:    ~10.64 GB/s
+CRC32C_Castagnoli_TreeDB: ~10.64 GB/s
 FarmHash32Seeded:     ~7.71 GB/s
 FarmFingerprint32:    ~7.67 GB/s
 FarmHash32:           ~7.38 GB/s

--- a/experiments/hash_tournament/go.mod
+++ b/experiments/hash_tournament/go.mod
@@ -1,0 +1,11 @@
+module github.com/snissn/gomap/experiments/hash_tournament
+
+go 1.25
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da
+	github.com/zeebo/xxh3 v1.0.2
+)
+
+require github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/experiments/hash_tournament/go.mod
+++ b/experiments/hash_tournament/go.mod
@@ -1,6 +1,6 @@
 module github.com/snissn/gomap/experiments/hash_tournament
 
-go 1.25
+go 1.23.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/experiments/hash_tournament/go.sum
+++ b/experiments/hash_tournament/go.sum
@@ -1,0 +1,10 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -83,6 +83,20 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/FarmHash32", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= farm.Hash32(data)
+			}
+		})
+
+		b.Run(size.name+"/FarmFingerprint32", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= farm.Fingerprint32(data)
+			}
+		})
+
 		b.Run(size.name+"/MapHash_ProcessLocal", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
@@ -97,6 +111,16 @@ func BenchmarkContentHashTournament(b *testing.B) {
 				h.Reset()
 				_, _ = h.Write(data)
 				sink64 ^= h.Sum64()
+			}
+		})
+
+		b.Run(size.name+"/FNV1a_32", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New32a()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink32 ^= h.Sum32()
 			}
 		})
 

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -27,6 +27,7 @@ var (
 )
 
 const (
+	// Deterministic seeds keep seeded benchmark variants reproducible.
 	seed64A uint64 = 0x9e3779b97f4a7c15
 	seed64B uint64 = 0xbf58476d1ce4e5b9
 	seed32A uint32 = 0x9e3779b9

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 var (
-	crc32cTable = crc32.MakeTable(crc32.Castagnoli)
-	mapSeed     = maphash.MakeSeed()
-	sink64      uint64
-	sink32      uint32
-	sinkBytes   [32]byte
+	crc32cTable  = crc32.MakeTable(crc32.Castagnoli)
+	koopmanTable = crc32.MakeTable(crc32.Koopman)
+	mapSeed      = maphash.MakeSeed()
+	sink64       uint64
+	sink32       uint32
+	sinkByte     byte
+	sinkBytes28  [28]byte
+	sinkBytes    [32]byte
 )
 
 type inputSize struct {
@@ -62,10 +65,37 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/CRC32_Koopman", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= crc32.Checksum(data, koopmanTable)
+			}
+		})
+
 		b.Run(size.name+"/XXHash64", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
 				sink64 ^= xxhash.Sum64(data)
+			}
+		})
+
+		b.Run(size.name+"/XXHash64_Digest", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxhash.New()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
+			}
+		})
+
+		b.Run(size.name+"/XXHash64_DigestSeeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxhash.NewWithSeed(0x9e3779b97f4a7c15)
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
 			}
 		})
 
@@ -76,6 +106,71 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/XXH3_64Seeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= xxh3.HashSeed(data, 0x9e3779b97f4a7c15)
+			}
+		})
+
+		b.Run(size.name+"/XXH3_128", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sum := xxh3.Hash128(data)
+				sink64 ^= sum.Lo ^ sum.Hi
+			}
+		})
+
+		b.Run(size.name+"/XXH3_128Seeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sum := xxh3.Hash128Seed(data, 0x9e3779b97f4a7c15)
+				sink64 ^= sum.Lo ^ sum.Hi
+			}
+		})
+
+		b.Run(size.name+"/XXH3_64_Hasher", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxh3.New()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
+			}
+		})
+
+		b.Run(size.name+"/XXH3_64_HasherSeeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxh3.NewSeed(0x9e3779b97f4a7c15)
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
+			}
+		})
+
+		b.Run(size.name+"/XXH3_128_Hasher", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxh3.New()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sum := h.Sum128()
+				sink64 ^= sum.Lo ^ sum.Hi
+			}
+		})
+
+		b.Run(size.name+"/XXH3_128_HasherSeeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := xxh3.NewSeed(0x9e3779b97f4a7c15)
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sum := h.Sum128()
+				sink64 ^= sum.Lo ^ sum.Hi
+			}
+		})
+
 		b.Run(size.name+"/FarmHash64", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
@@ -83,10 +178,62 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/FarmHash64Seeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= farm.Hash64WithSeed(data, 0x9e3779b97f4a7c15)
+			}
+		})
+
+		b.Run(size.name+"/FarmHash64TwoSeeds", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= farm.Hash64WithSeeds(data, 0x9e3779b97f4a7c15, 0xbf58476d1ce4e5b9)
+			}
+		})
+
+		b.Run(size.name+"/FarmFingerprint64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= farm.Fingerprint64(data)
+			}
+		})
+
+		b.Run(size.name+"/FarmHash128", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				lo, hi := farm.Hash128(data)
+				sink64 ^= lo ^ hi
+			}
+		})
+
+		b.Run(size.name+"/FarmHash128Seeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				lo, hi := farm.Hash128WithSeed(data, 0x9e3779b97f4a7c15, 0xbf58476d1ce4e5b9)
+				sink64 ^= lo ^ hi
+			}
+		})
+
+		b.Run(size.name+"/FarmFingerprint128", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				lo, hi := farm.Fingerprint128(data)
+				sink64 ^= lo ^ hi
+			}
+		})
+
 		b.Run(size.name+"/FarmHash32", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
 				sink32 ^= farm.Hash32(data)
+			}
+		})
+
+		b.Run(size.name+"/FarmHash32Seeded", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= farm.Hash32WithSeed(data, 0x9e3779b9)
 			}
 		})
 
@@ -104,6 +251,16 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/FNV1_64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New64()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
+			}
+		})
+
 		b.Run(size.name+"/FNV1a_64", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New64a()
@@ -114,6 +271,16 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			}
 		})
 
+		b.Run(size.name+"/FNV1_32", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New32()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink32 ^= h.Sum32()
+			}
+		})
+
 		b.Run(size.name+"/FNV1a_32", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New32a()
@@ -121,6 +288,37 @@ func BenchmarkContentHashTournament(b *testing.B) {
 				h.Reset()
 				_, _ = h.Write(data)
 				sink32 ^= h.Sum32()
+			}
+		})
+
+		b.Run(size.name+"/FNV1_128", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New128()
+			sum := make([]byte, 0, h.Size())
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sum = h.Sum(sum[:0])
+				sinkByte ^= sum[0]
+			}
+		})
+
+		b.Run(size.name+"/FNV1a_128", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New128a()
+			sum := make([]byte, 0, h.Size())
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sum = h.Sum(sum[:0])
+				sinkByte ^= sum[0]
+			}
+		})
+
+		b.Run(size.name+"/SHA224", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sinkBytes28 = sha256.Sum224(data)
 			}
 		})
 

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -26,6 +26,12 @@ var (
 	sinkBytes    [32]byte
 )
 
+const (
+	seed64A uint64 = 0x9e3779b97f4a7c15
+	seed64B uint64 = 0xbf58476d1ce4e5b9
+	seed32A uint32 = 0x9e3779b9
+)
+
 type inputSize struct {
 	name string
 	n    int
@@ -40,7 +46,7 @@ var inputSizes = []inputSize{
 
 func makeInput(n int) []byte {
 	data := make([]byte, n)
-	var x uint64 = 0x9e3779b97f4a7c15
+	x := seed64A
 	for i := range data {
 		x ^= x << 7
 		x ^= x >> 9
@@ -99,6 +105,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/XXHash64_Digest", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := xxhash.New()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -108,7 +115,8 @@ func BenchmarkContentHashTournament(b *testing.B) {
 
 		b.Run(size.name+"/XXHash64_DigestSeeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
-			h := xxhash.NewWithSeed(0x9e3779b97f4a7c15)
+			h := xxhash.NewWithSeed(seed64A)
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -126,7 +134,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/XXH3_64Seeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				sink64 ^= xxh3.HashSeed(data, 0x9e3779b97f4a7c15)
+				sink64 ^= xxh3.HashSeed(data, seed64A)
 			}
 		})
 
@@ -141,7 +149,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/XXH3_128Seeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				sum := xxh3.Hash128Seed(data, 0x9e3779b97f4a7c15)
+				sum := xxh3.Hash128Seed(data, seed64A)
 				sink64 ^= sum.Lo ^ sum.Hi
 			}
 		})
@@ -149,6 +157,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/XXH3_64_Hasher", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := xxh3.New()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -158,7 +167,8 @@ func BenchmarkContentHashTournament(b *testing.B) {
 
 		b.Run(size.name+"/XXH3_64_HasherSeeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
-			h := xxh3.NewSeed(0x9e3779b97f4a7c15)
+			h := xxh3.NewSeed(seed64A)
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -169,6 +179,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/XXH3_128_Hasher", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := xxh3.New()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -179,7 +190,8 @@ func BenchmarkContentHashTournament(b *testing.B) {
 
 		b.Run(size.name+"/XXH3_128_HasherSeeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
-			h := xxh3.NewSeed(0x9e3779b97f4a7c15)
+			h := xxh3.NewSeed(seed64A)
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -198,14 +210,14 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FarmHash64Seeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				sink64 ^= farm.Hash64WithSeed(data, 0x9e3779b97f4a7c15)
+				sink64 ^= farm.Hash64WithSeed(data, seed64A)
 			}
 		})
 
 		b.Run(size.name+"/FarmHash64TwoSeeds", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				sink64 ^= farm.Hash64WithSeeds(data, 0x9e3779b97f4a7c15, 0xbf58476d1ce4e5b9)
+				sink64 ^= farm.Hash64WithSeeds(data, seed64A, seed64B)
 			}
 		})
 
@@ -227,7 +239,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FarmHash128Seeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				lo, hi := farm.Hash128WithSeed(data, 0x9e3779b97f4a7c15, 0xbf58476d1ce4e5b9)
+				lo, hi := farm.Hash128WithSeed(data, seed64A, seed64B)
 				sink64 ^= lo ^ hi
 			}
 		})
@@ -250,7 +262,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FarmHash32Seeded", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
-				sink32 ^= farm.Hash32WithSeed(data, 0x9e3779b9)
+				sink32 ^= farm.Hash32WithSeed(data, seed32A)
 			}
 		})
 
@@ -271,6 +283,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FNV1_64", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New64()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -281,6 +294,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FNV1a_64", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New64a()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -291,6 +305,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FNV1_32", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New32()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -301,6 +316,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 		b.Run(size.name+"/FNV1a_32", func(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New32a()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -312,6 +328,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New128()
 			sum := make([]byte, 0, h.Size())
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)
@@ -324,6 +341,7 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			h := fnv.New128a()
 			sum := make([]byte, 0, h.Size())
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.Reset()
 				_, _ = h.Write(data)

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -32,11 +32,13 @@ const (
 	seed32A uint32 = 0x9e3779b9
 )
 
+// inputSize names one payload length used by the benchmark matrix.
 type inputSize struct {
 	name string
 	n    int
 }
 
+// inputSizes covers the block sizes used by the content hash tournament.
 var inputSizes = []inputSize{
 	{name: "64KiB_ClickHouseMinCompressBlock", n: 64 << 10},
 	{name: "256KiB_Middle", n: 256 << 10},
@@ -44,6 +46,7 @@ var inputSizes = []inputSize{
 	{name: "1MiB_ClickHouseMaxCompressBlock", n: 1 << 20},
 }
 
+// makeInput builds deterministic pseudo-random input data for each benchmark size.
 func makeInput(n int) []byte {
 	data := make([]byte, n)
 	x := seed64A
@@ -56,6 +59,7 @@ func makeInput(n int) []byte {
 	return data
 }
 
+// BenchmarkContentHashTournament compares content hash throughput across block-sized inputs.
 func BenchmarkContentHashTournament(b *testing.B) {
 	for _, size := range inputSizes {
 		data := makeInput(size.n)

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -3,6 +3,7 @@ package hashtournament
 import (
 	"crypto/sha256"
 	"hash/crc32"
+	"hash/crc64"
 	"hash/fnv"
 	"hash/maphash"
 	"testing"
@@ -15,6 +16,8 @@ import (
 var (
 	crc32cTable  = crc32.MakeTable(crc32.Castagnoli)
 	koopmanTable = crc32.MakeTable(crc32.Koopman)
+	crc64ECMA    = crc64.MakeTable(crc64.ECMA)
+	crc64ISO     = crc64.MakeTable(crc64.ISO)
 	mapSeed      = maphash.MakeSeed()
 	sink64       uint64
 	sink32       uint32
@@ -69,6 +72,20 @@ func BenchmarkContentHashTournament(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for i := 0; i < b.N; i++ {
 				sink32 ^= crc32.Checksum(data, koopmanTable)
+			}
+		})
+
+		b.Run(size.name+"/CRC64_ECMA", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= crc64.Checksum(data, crc64ECMA)
+			}
+		})
+
+		b.Run(size.name+"/CRC64_ISO", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= crc64.Checksum(data, crc64ISO)
 			}
 		})
 

--- a/experiments/hash_tournament/hash_tournament_test.go
+++ b/experiments/hash_tournament/hash_tournament_test.go
@@ -1,0 +1,110 @@
+package hashtournament
+
+import (
+	"crypto/sha256"
+	"hash/crc32"
+	"hash/fnv"
+	"hash/maphash"
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	farm "github.com/dgryski/go-farm"
+	"github.com/zeebo/xxh3"
+)
+
+var (
+	crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+	mapSeed     = maphash.MakeSeed()
+	sink64      uint64
+	sink32      uint32
+	sinkBytes   [32]byte
+)
+
+type inputSize struct {
+	name string
+	n    int
+}
+
+var inputSizes = []inputSize{
+	{name: "64KiB_ClickHouseMinCompressBlock", n: 64 << 10},
+	{name: "256KiB_Middle", n: 256 << 10},
+	{name: "512KiB_WideRowsOneMark", n: 512 << 10},
+	{name: "1MiB_ClickHouseMaxCompressBlock", n: 1 << 20},
+}
+
+func makeInput(n int) []byte {
+	data := make([]byte, n)
+	var x uint64 = 0x9e3779b97f4a7c15
+	for i := range data {
+		x ^= x << 7
+		x ^= x >> 9
+		x ^= x << 8
+		data[i] = byte(x)
+	}
+	return data
+}
+
+func BenchmarkContentHashTournament(b *testing.B) {
+	for _, size := range inputSizes {
+		data := makeInput(size.n)
+
+		b.Run(size.name+"/CRC32C_Castagnoli_TreeDB", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= crc32.Checksum(data, crc32cTable)
+			}
+		})
+
+		b.Run(size.name+"/CRC32_IEEE", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink32 ^= crc32.ChecksumIEEE(data)
+			}
+		})
+
+		b.Run(size.name+"/XXHash64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= xxhash.Sum64(data)
+			}
+		})
+
+		b.Run(size.name+"/XXH3_64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= xxh3.Hash(data)
+			}
+		})
+
+		b.Run(size.name+"/FarmHash64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= farm.Hash64(data)
+			}
+		})
+
+		b.Run(size.name+"/MapHash_ProcessLocal", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sink64 ^= maphash.Bytes(mapSeed, data)
+			}
+		})
+
+		b.Run(size.name+"/FNV1a_64", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			h := fnv.New64a()
+			for i := 0; i < b.N; i++ {
+				h.Reset()
+				_, _ = h.Write(data)
+				sink64 ^= h.Sum64()
+			}
+		})
+
+		b.Run(size.name+"/SHA256", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				sinkBytes = sha256.Sum256(data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a standalone Go benchmark experiment for comparing content hash candidates at ClickHouse-style compressed-block sizes: 64 KiB, 256 KiB, 512 KiB, and 1 MiB. The tournament now covers the byte-slice-compatible output widths exposed by the selected libraries, including CRC32 variants, CRC64 variants, xxhash, xxh3 64/128-bit variants, go-farm 32/64/128-bit variants, maphash, FNV 32/64/128-bit variants, SHA-224, and SHA-256.

Current Apple M3 read:
- `FarmHash64` and its seeded 64-bit variants are the fastest local candidates, around 27 GB/s at 1 MiB.
- 128-bit candidates did not win: farm 128-bit and `XXH3_128` were around 19 GB/s at 1 MiB.
- Native 32-bit farm candidates were slower than the current Go CRC32C path in this run, around 7.4-7.7 GB/s versus CRC32C around 10.2-10.6 GB/s at 1 MiB.
- Go standard-library CRC64 was not competitive here: `CRC64_ECMA`/`CRC64_ISO` were around 1.9-2.0 GB/s at 1 MiB.

Practical conclusion:
- If gomap can store a 64-bit checksum, validate `FarmHash64` on target hardware first.
- If gomap must keep a `uint32` checksum slot, benchmark truncating fast 64-bit hashes such as `uint32(farm.Hash64(data))` before choosing a native 32-bit hash.
- CRC64 gives 64-bit CRC-style structure, but Go standard-library CRC64 is much slower than CRC32C and the fast 64-bit fingerprint hashes on this machine.
- Avoid `maphash` for persisted checksums unless the on-disk format explicitly owns and persists seed semantics.

Validation:
- `go test -run '^$' -bench BenchmarkContentHashTournament -benchtime=100ms -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive benchmark suite that measures and compares many hashing implementations across multiple payload sizes, producing reproducible per-size throughput sub-benchmarks.

* **Documentation**
  * Added a README for the “Content Hash Tournament” experiment with run commands, competitor descriptions, guidance on checksum formats and block-size choices, representative Apple M3 sample results, and a note to rerun on target hardware.

* **Chores**
  * Added a standalone module setup for the new experiment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->