### PR TITLE
collections: add physical row reader hot block fast path

### DIFF
--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -64,8 +64,13 @@ type columnPhysicalRowReader struct {
 	maxBlocks  int
 	blocks     map[int]*columnPhysicalRowReaderBlock
 	lru        []int
-	closed     bool
-	stats      columnPhysicalRowReaderStats
+	// lastRange/lastBlock are a one-entry hot path over the existing bounded
+	// block cache. They avoid repeating binary range lookup and map/LRU work
+	// when graph/native readers fetch many rows from the same physical granule.
+	lastRange int
+	lastBlock *columnPhysicalRowReaderBlock
+	closed    bool
+	stats     columnPhysicalRowReaderStats
 }
 
 type columnPhysicalRowReaderRange struct {
@@ -155,6 +160,7 @@ func newColumnPhysicalRowReaderFromSnapshotViewWithClose(view columnPhysicalScan
 		closeView:  closeView,
 		maxBlocks:  maxBlocks,
 		blocks:     make(map[int]*columnPhysicalRowReaderBlock, maxBlocks),
+		lastRange:  -1,
 		stats: columnPhysicalRowReaderStats{
 			Granules: len(view.AssetRefs),
 		},
@@ -180,6 +186,8 @@ func (r *columnPhysicalRowReader) Close() error {
 		delete(r.blocks, key)
 	}
 	r.lru = r.lru[:0]
+	r.lastRange = -1
+	r.lastBlock = nil
 	r.stats.ResidentBytes = 0
 	if r.closeView != nil {
 		r.closeView()
@@ -315,6 +323,16 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 	if ordinal < 0 || ordinal >= r.totalRows {
 		return -1
 	}
+	if r.lastRange >= 0 && r.lastRange < len(r.ranges) {
+		rowRange := r.ranges[r.lastRange]
+		if ordinal >= rowRange.startOrdinal && ordinal < rowRange.startOrdinal+rowRange.rowCount {
+			return r.lastRange
+		}
+	}
+	if len(r.ranges) == 1 {
+		r.lastRange = 0
+		return 0
+	}
 	lo, hi := 0, len(r.ranges)
 	for lo < hi {
 		mid := lo + (hi-lo)/2
@@ -327,6 +345,7 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 			lo = mid + 1
 			continue
 		}
+		r.lastRange = mid
 		return mid
 	}
 	return -1
@@ -334,9 +353,14 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 
 func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRange) (*columnPhysicalRowReaderBlock, error) {
 	assetOrdinal := rowRange.assetOrdinal
+	if block := r.lastBlock; block != nil && block.assetOrdinal == assetOrdinal {
+		r.stats.CacheHits++
+		return block, nil
+	}
 	if block := r.blocks[assetOrdinal]; block != nil {
 		r.stats.CacheHits++
 		r.touchBlock(assetOrdinal)
+		r.lastBlock = block
 		return block, nil
 	}
 	r.stats.CacheMisses++
@@ -379,6 +403,7 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 	r.evictBlocksForInsert()
 	r.blocks[assetOrdinal] = block
 	r.lru = append(r.lru, assetOrdinal)
+	r.lastBlock = block
 	r.stats.DecodedBlocks++
 	r.stats.GranulesTouched++
 	r.stats.PhysicalBytesRead += int64(len(raw))
@@ -409,6 +434,9 @@ func (r *columnPhysicalRowReader) evictBlocksForInsert() {
 		block := r.blocks[evict]
 		delete(r.blocks, evict)
 		if block != nil {
+			if r.lastBlock == block {
+				r.lastBlock = nil
+			}
 			r.stats.ResidentBytes -= block.residentBytes
 			if r.stats.ResidentBytes < 0 {
 				r.stats.ResidentBytes = 0

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -330,6 +330,8 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 		}
 	}
 	if len(r.ranges) == 1 {
+		// Single-range readers are common for column_graph assets; skip binary
+		// search entirely after the bounds check above.
 		r.lastRange = 0
 		return 0
 	}
@@ -355,6 +357,9 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 	assetOrdinal := rowRange.assetOrdinal
 	if block := r.lastBlock; block != nil && block.assetOrdinal == assetOrdinal {
 		r.stats.CacheHits++
+		// lastBlock matches only when this block was the previous access, so it
+		// is already at the LRU tail. Interleaved access changes lastBlock and
+		// falls through to the map path, which refreshes LRU with touchBlock.
 		return block, nil
 	}
 	if block := r.blocks[assetOrdinal]; block != nil {

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -64,13 +64,13 @@ type columnPhysicalRowReader struct {
 	maxBlocks  int
 	blocks     map[int]*columnPhysicalRowReaderBlock
 	lru        []int
-	// lastRange/lastBlock are a one-entry hot path over the existing bounded
+	// lastRangeIndex/lastBlock are a one-entry hot path over the existing bounded
 	// block cache. They avoid repeating binary range lookup and map/LRU work
 	// when graph/native readers fetch many rows from the same physical granule.
-	lastRange int
-	lastBlock *columnPhysicalRowReaderBlock
-	closed    bool
-	stats     columnPhysicalRowReaderStats
+	lastRangeIndex int
+	lastBlock      *columnPhysicalRowReaderBlock
+	closed         bool
+	stats          columnPhysicalRowReaderStats
 }
 
 type columnPhysicalRowReaderRange struct {
@@ -154,13 +154,13 @@ func newColumnPhysicalRowReaderFromSnapshotViewWithClose(view columnPhysicalScan
 		return nil, err
 	}
 	reader := &columnPhysicalRowReader{
-		view:       view,
-		projection: projection,
-		readCache:  readCache,
-		closeView:  closeView,
-		maxBlocks:  maxBlocks,
-		blocks:     make(map[int]*columnPhysicalRowReaderBlock, maxBlocks),
-		lastRange:  -1,
+		view:           view,
+		projection:     projection,
+		readCache:      readCache,
+		closeView:      closeView,
+		maxBlocks:      maxBlocks,
+		blocks:         make(map[int]*columnPhysicalRowReaderBlock, maxBlocks),
+		lastRangeIndex: -1,
 		stats: columnPhysicalRowReaderStats{
 			Granules: len(view.AssetRefs),
 		},
@@ -186,7 +186,7 @@ func (r *columnPhysicalRowReader) Close() error {
 		delete(r.blocks, key)
 	}
 	r.lru = r.lru[:0]
-	r.lastRange = -1
+	r.lastRangeIndex = -1
 	r.lastBlock = nil
 	r.stats.ResidentBytes = 0
 	if r.closeView != nil {
@@ -323,16 +323,16 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 	if ordinal < 0 || ordinal >= r.totalRows {
 		return -1
 	}
-	if r.lastRange >= 0 && r.lastRange < len(r.ranges) {
-		rowRange := r.ranges[r.lastRange]
+	if r.lastRangeIndex >= 0 && r.lastRangeIndex < len(r.ranges) {
+		rowRange := r.ranges[r.lastRangeIndex]
 		if ordinal >= rowRange.startOrdinal && ordinal < rowRange.startOrdinal+rowRange.rowCount {
-			return r.lastRange
+			return r.lastRangeIndex
 		}
 	}
 	if len(r.ranges) == 1 {
 		// Single-range readers are common for column_graph assets; skip binary
 		// search entirely after the bounds check above.
-		r.lastRange = 0
+		r.lastRangeIndex = 0
 		return 0
 	}
 	lo, hi := 0, len(r.ranges)
@@ -347,7 +347,7 @@ func (r *columnPhysicalRowReader) rangeIndexForOrdinal(ordinal int) int {
 			lo = mid + 1
 			continue
 		}
-		r.lastRange = mid
+		r.lastRangeIndex = mid
 		return mid
 	}
 	return -1

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -186,6 +186,46 @@ func TestColumnPhysicalRowReaderHotBlockFastPathInvalidatesOnEvictionV1(t *testi
 	}
 }
 
+func TestColumnPhysicalRowReaderHotBlockFastPathPreservesInterleavedLRUV1(t *testing.T) {
+	normalized := testColumnPhysicalRowReaderConfigV1(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	left := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 1, testColumnPhysicalRowReaderRowsV1(0, 3, normalized))
+	middle := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 2, testColumnPhysicalRowReaderRowsV1(3, 3, normalized))
+	right := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 3, testColumnPhysicalRowReaderRowsV1(6, 3, normalized))
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, normalized, left, middle, right), columnPhysicalRowReaderOptions{
+		ProjectedColumns:  []string{"doc_ordinal"},
+		MaxDecodedBlocks:  2,
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var scratch columnPhysicalRowReaderScratch
+	for _, ordinal := range []int{0, 3, 4, 1, 4, 6} {
+		if _, err := reader.FetchRow(ordinal, &scratch); err != nil {
+			t.Fatalf("FetchRow(%d): %v", ordinal, err)
+		}
+	}
+	if reader.blocks[0] != nil {
+		t.Fatalf("left block survived after interleaved LRU sequence")
+	}
+	if reader.blocks[1] == nil || reader.blocks[2] == nil {
+		t.Fatalf("blocks after interleaved LRU sequence=%v want middle and right", reader.blocks)
+	}
+	row, err := reader.FetchRow(5, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow(5): %v", err)
+	}
+	if len(row.Values) != 1 || row.Values[0].Int64 != 5 {
+		t.Fatalf("row=%+v want doc_ordinal 5", row)
+	}
+	stats := reader.Stats()
+	if stats.CacheMisses != 3 || stats.CacheHits != 4 || stats.BlockEvictions != 1 {
+		t.Fatalf("cache stats=%+v want misses=3 hits=4 evictions=1", stats)
+	}
+}
+
 func TestColumnPhysicalRowReaderRejectsMutationPartsV1(t *testing.T) {
 	normalized := testColumnPhysicalRowReaderConfigV1(t)
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -161,25 +161,16 @@ func TestColumnPhysicalRowReaderHotBlockFastPathInvalidatesOnEvictionV1(t *testi
 		t.Fatalf("warm left block: %v", err)
 	}
 	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-000", 0, []float32{0, 0.25, 0.5, 0.75}, []uint32{0, 1, 2})
-	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 0 {
-		t.Fatalf("lastBlock after left fetch=%+v want asset 0", reader.lastBlock)
-	}
 	row, err = reader.FetchRow(4, &scratch)
 	if err != nil {
 		t.Fatalf("fetch right block: %v", err)
 	}
 	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-004", 4, []float32{4, 4.25, 4.5, 4.75}, []uint32{4, 5, 6})
-	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 1 {
-		t.Fatalf("lastBlock after right fetch=%+v want asset 1", reader.lastBlock)
-	}
 	row, err = reader.FetchRow(1, &scratch)
 	if err != nil {
 		t.Fatalf("refetch evicted left block: %v", err)
 	}
 	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-001", 1, []float32{1, 1.25, 1.5, 1.75}, []uint32{1, 2, 3})
-	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 0 {
-		t.Fatalf("lastBlock after left refetch=%+v want asset 0", reader.lastBlock)
-	}
 	stats := reader.Stats()
 	if stats.CacheMisses != 3 || stats.CacheHits != 0 || stats.BlockEvictions != 2 {
 		t.Fatalf("cache stats=%+v want misses=3 hits=0 evictions=2", stats)
@@ -206,12 +197,6 @@ func TestColumnPhysicalRowReaderHotBlockFastPathPreservesInterleavedLRUV1(t *tes
 		if _, err := reader.FetchRow(ordinal, &scratch); err != nil {
 			t.Fatalf("FetchRow(%d): %v", ordinal, err)
 		}
-	}
-	if reader.blocks[0] != nil {
-		t.Fatalf("left block survived after interleaved LRU sequence")
-	}
-	if reader.blocks[1] == nil || reader.blocks[2] == nil {
-		t.Fatalf("blocks after interleaved LRU sequence=%v want middle and right", reader.blocks)
 	}
 	row, err := reader.FetchRow(5, &scratch)
 	if err != nil {

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -137,6 +137,55 @@ func TestColumnPhysicalRowReaderCachedBlocksOwnRawBytesV1(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalRowReaderHotBlockFastPathInvalidatesOnEvictionV1(t *testing.T) {
+	normalized := testColumnPhysicalRowReaderConfigV1(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	left := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 1, testColumnPhysicalRowReaderRowsV1(0, 4, normalized))
+	right := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 10, 2, testColumnPhysicalRowReaderRowsV1(4, 4, normalized))
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, normalized, left, right), columnPhysicalRowReaderOptions{
+		ProjectedColumns:  []string{"embedding", "neighbors"},
+		MaxDecodedBlocks:  1,
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	scratch := columnPhysicalRowReaderScratch{
+		Values:        make([]columnDeclaredValue, 0, 2),
+		Float32Values: make([]float32, 0, normalized.Columns[1].VectorDims),
+		Uint32Values:  make([]uint32, 0, 4),
+	}
+	row, err := reader.FetchRow(0, &scratch)
+	if err != nil {
+		t.Fatalf("warm left block: %v", err)
+	}
+	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-000", 0, []float32{0, 0.25, 0.5, 0.75}, []uint32{0, 1, 2})
+	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 0 {
+		t.Fatalf("lastBlock after left fetch=%+v want asset 0", reader.lastBlock)
+	}
+	row, err = reader.FetchRow(4, &scratch)
+	if err != nil {
+		t.Fatalf("fetch right block: %v", err)
+	}
+	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-004", 4, []float32{4, 4.25, 4.5, 4.75}, []uint32{4, 5, 6})
+	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 1 {
+		t.Fatalf("lastBlock after right fetch=%+v want asset 1", reader.lastBlock)
+	}
+	row, err = reader.FetchRow(1, &scratch)
+	if err != nil {
+		t.Fatalf("refetch evicted left block: %v", err)
+	}
+	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-001", 1, []float32{1, 1.25, 1.5, 1.75}, []uint32{1, 2, 3})
+	if reader.lastBlock == nil || reader.lastBlock.assetOrdinal != 0 {
+		t.Fatalf("lastBlock after left refetch=%+v want asset 0", reader.lastBlock)
+	}
+	stats := reader.Stats()
+	if stats.CacheMisses != 3 || stats.CacheHits != 0 || stats.BlockEvictions != 2 {
+		t.Fatalf("cache stats=%+v want misses=3 hits=0 evictions=2", stats)
+	}
+}
+
 func TestColumnPhysicalRowReaderRejectsMutationPartsV1(t *testing.T) {
 	normalized := testColumnPhysicalRowReaderConfigV1(t)
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())


### PR DESCRIPTION
## Summary

This is the first M1B follow-up from #1696, stacked on #1703. It keeps the scope deliberately small: generic physical column row-reader hot range/block reuse inside the existing bounded decoded-block cache.

Changes:

- Add a one-entry `lastRange` / `lastBlock` fast path in `columnPhysicalRowReader` so repeated fetches from the same physical granule avoid repeated binary range lookup plus decoded-block map/LRU touch.
- Keep the behavior generic to the physical row reader. No vector-specific cache, no new decoded-block cache tier, no public API/doc materialization/cold-open changes.
- Add a focused eviction test proving the hot block pointer is invalidated when `MaxDecodedBlocks=1` evicts the cached block.

## Benchmark Evidence

Hardware: Apple M3, darwin/arm64. Benchmarks use the same command shape before/after and report median `benchstat` values. All hot-loop rows remain `0 B/op`, `0 allocs/op`.

Before artifact: `/tmp/pr1703_m1b_hot_block_before_20260521_095626/bench.txt`  
After artifact: `/tmp/pr1703_m1b_hot_block_after2_20260521_100000/bench.txt`  
Benchstat: `/tmp/pr1703_m1b_hot_block_after2_20260521_100000/benchstat.txt`

| Benchmark | Before ns/op | Before ops/sec | After ns/op | After ops/sec | Delta | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `ColumnPhysicalRowReaderFetchV1/row_warmed_vector_adjacency` | 238.3 | 4,196,391 | 230.5 | 4,338,395 | -3.27% | 0 B/op, 0 allocs/op |
| `ColumnPhysicalRowReaderFetchV1/batch_warmed_vector_adjacency` | 1,769.0 | 565,291 | 1,724.0 | 580,046 | -2.54% | 0 B/op, 0 allocs/op |
| `ColumnVectorGraphPhysicalRowReaderFetchV2B` | 274.8 | 3,639,010 | 272.0 | 3,676,471 | -1.02% | 0 B/op, 0 allocs/op |
| `ColumnVectorGraphNativeSearchCosineV3` | 63,040.0 | 15,863 | 62,380.0 | 16,031 | -1.05% | 0 B/op, 0 allocs/op |
| `ColumnVectorGraphNativeSearchCosineParallelV3` | 12,170.0 | 82,169 | 12,190.0 | 82,034 | +0.16% | 0 B/op, 0 allocs/op |

Parallel note: one full after-run had environmental outliers; a focused rerun of `BenchmarkColumnVectorGraphNativeSearchCosineParallelV3` produced median `11,843 ns/op` / `84,438 ops/sec`. The full-run median above is the conservative value and is effectively neutral.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalRowReader|TestColumnVectorGraphPhysicalRowReader|TestColumnVectorGraphNative' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.803s

GOWORK=off go test ./TreeDB/collections -run 'Test.*Column.*Vector|Test.*Vector.*Column|TestColumnVectorGraph|TestColumnStore|TestColumnPublish|TestColumnPhysicalRowReader' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 7.230s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnPhysicalRowReader|TestColumnVectorGraph.*Parallel|Test.*NativeReader' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.949s

GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalRowReaderFetchV1|BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B|BenchmarkColumnVectorGraphNativeSearchCosineV3|BenchmarkColumnVectorGraphNativeSearchCosineParallelV3' -benchmem -benchtime=500ms -count=5
# matched the benchmark rows shown above
```

## Review Boundary

This PR intentionally does not include projection decode planning, batch APIs, generic decoded-block caching, public search allocation cleanup, cold-open/load improvements, or document materialization changes. Those remain separate #1696 follow-ups if profiling continues to justify them.
