### PR TITLE
collections: unroll fixed-width physical row decode

### DIFF
--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -730,6 +730,7 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 	}
 	i := base
 	for ; i+4 <= need; i += 4 {
+		_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
 		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
 		dst[i+1] = math.Float32frombits(uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7]))
 		dst[i+2] = math.Float32frombits(uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11]))
@@ -772,6 +773,7 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	}
 	i := base
 	for ; i+4 <= need; i += 4 {
+		_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
 		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
 		dst[i+1] = uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7])
 		dst[i+2] = uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11])

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -728,7 +728,15 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 	if pos < end {
 		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
-	for i := base; i < need; i++ {
+	i := base
+	for ; i+4 <= need; i += 4 {
+		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
+		dst[i+1] = math.Float32frombits(uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7]))
+		dst[i+2] = math.Float32frombits(uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11]))
+		dst[i+3] = math.Float32frombits(uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15]))
+		pos += 16
+	}
+	for ; i < need; i++ {
 		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
 		pos += 4
 	}
@@ -762,7 +770,15 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	if pos < end {
 		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
-	for i := base; i < need; i++ {
+	i := base
+	for ; i+4 <= need; i += 4 {
+		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
+		dst[i+1] = uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7])
+		dst[i+2] = uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11])
+		dst[i+3] = uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15])
+		pos += 16
+	}
+	for ; i < need; i++ {
 		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
 		pos += 4
 	}

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -440,7 +440,7 @@ func TestColumnPhysicalRowReaderScratchAppendFixedWidthSlicesV1(t *testing.T) {
 	})
 
 	t.Run("float32_vector_exact", func(t *testing.T) {
-		values := []float32{1.25, -2.5, 0.75}
+		values := []float32{1.25, -2.5, 0.75, 8.5, -16.25}
 		var b bytes.Buffer
 		writeManifestFloat32Slice(&b, values)
 		cur := manifestCursor{raw: b.Bytes()}
@@ -501,7 +501,7 @@ func TestColumnPhysicalRowReaderScratchAppendFixedWidthSlicesV1(t *testing.T) {
 	})
 
 	t.Run("uint32_slice_exact", func(t *testing.T) {
-		values := []uint32{1, 17, 1024}
+		values := []uint32{1, 17, 1024, math.MaxUint16 + 1, math.MaxUint32}
 		var b bytes.Buffer
 		writeManifestUint32Slice(&b, values)
 		cur := manifestCursor{raw: b.Bytes()}


### PR DESCRIPTION
## Summary

Part of #1696.

This PR keeps the current physical column asset format unchanged and tightens the existing fixed-width decode hot loop:

- unrolls the generic `manifestCursor` fixed-width `[]float32` and `[]uint32` append paths four values at a time;
- keeps the implementation safe Go with the same big-endian on-disk decode semantics;
- extends fixed-width scratch tests so exact decode cases cover the unrolled body plus tail handling.

This is deliberately not the little-endian/vector-format follow-up. It establishes a cleaner measured baseline for the current format before adding opt-in typed little-endian physical column encodings.

## Scope Boundaries

- No vector-specific sidecar or full-index/full-column decoded graph.
- No checksum skipping.
- No cache policy changes.
- No cold open/load or document materialization changes.
- No physical column format change in this PR.

## Benchmark Evidence

Hardware: Apple M3, darwin/arm64.

Primary full matrix command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalRowReaderFetchV1|BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B|BenchmarkColumnVectorGraphNativeSearchCosineV3|BenchmarkColumnVectorGraphNativeSearchCosineParallelV3' -benchmem -benchtime=1s -count=5
```

Parent: `/tmp/pr1707_m1b2_parent_full_rerun_20260521_103308/bench.txt`
After: `/tmp/pr1707_m1b2_fixed_width_final_after_20260521_103207/bench.txt`
Benchstat: `/tmp/pr1707_m1b2_fixed_width_final_after_20260521_103207/benchstat_vs_parent_full.txt`

| Benchmark | Parent | Parent ops/sec | After | After ops/sec | Delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Row warmed vector+adjacency | 230.7 ns/op | 4,334,634 | 207.6 ns/op | 4,816,956 | -10.01% | 0 | 0 |
| Batch warmed vector+adjacency | 1.724 us/op | 580,046 | 1.576 us/op | 634,518 | -8.58% | 0 | 0 |
| V2B physical graph row fetch | 274.4 ns/op | 3,644,315 | 248.7 ns/op | 4,020,909 | -9.37% | 0 | 0 |
| Native search serial | 62.59 us/op | 15,977 | 60.47 us/op | 16,537 | -3.39% | 0 | 0 |

The full-matrix parallel row was noisy in the first run, so I reran parallel search in isolation and sequentially after observing the mixed result.

Parallel isolated command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelV3$' -benchmem -benchtime=500ms -count=12
```

Parent: `/tmp/pr1707_m1b2_parent_parallel_sequential_20260521_103538/bench.txt`
After: `/tmp/pr1707_m1b2_fixed_width_parallel_sequential_20260521_103610/bench.txt`
Benchstat: `/tmp/pr1707_m1b2_fixed_width_parallel_sequential_20260521_103610/benchstat_vs_parent_parallel_sequential.txt`

| Benchmark | Parent | Parent ops/sec | After | After ops/sec | Delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Native search parallel isolated | 11.45 us/op | 87,336 | 11.15 us/op | 89,686 | ~, p=0.078 | 0 | 0 |

Useful accounting stayed unchanged in the warmed hot loop: 128 candidates/search, 1,912 edges/search, 14.94 edges/node, 138 cache hits/search, 0 cache misses/search, 0 decoded blocks/search, 0 physical bytes/search.

## Profile Evidence

Before profile: `/tmp/pr1707_m1b2_fixed_width_before_20260521_102356/cpu_top.txt`
After profile: `/tmp/pr1707_m1b2_fixed_width_unroll_profile_20260521_102822/cpu_top.txt`

| Profile item | Before | After |
| --- | ---: | ---: |
| `appendFloat32SliceWithExpectedLength` flat | 20.55% | 12.83% |
| `readColumnPhysicalRowValuesIntoScratch` cumulative | 27.40% | 20.35% |
| `readSelectedColumnPhysicalValueIntoScratch` cumulative | 23.74% | 15.04% |
| `FetchRow` cumulative | 33.33% | 30.97% |

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalRowReaderScratchAppend|TestColumnPhysicalRowReader|TestColumnVectorGraphPhysicalRowReader|TestColumnVectorGraphNative' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.260s

GOWORK=off go test ./TreeDB/collections -run 'Test.*Column.*Vector|Test.*Vector.*Column|TestColumnVectorGraph|TestColumnStore|TestColumnPublish|TestColumnPhysicalRowReader' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 6.310s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnPhysicalRowReader|TestColumnVectorGraph.*Parallel|Test.*NativeReader' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.912s

git diff --check
# clean
```

@coderabbitai review
@codex review
@copilot review
