### PR TITLE
collections: direct-set little-endian vector payloads

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -384,7 +384,9 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 			case ColumnStoreValueString:
 				writeManifestString(&b, value.String)
 			case ColumnStoreValueFloat32Vector:
-				writeManifestFloat32SliceWithEncoding(&b, value.Float32Vector, col.FixedWidthEncoding)
+				if err := writeManifestFloat32SliceWithEncoding(&b, value.Float32Vector, col.FixedWidthEncoding); err != nil {
+					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row value column[%d] float32_vector: %w", colIdx, err)
+				}
 			case ColumnStoreValueAdjacencyList:
 				writeManifestUint32Slice(&b, value.AdjacencyList)
 			default:
@@ -677,26 +679,28 @@ func writeManifestBytes(b *bytes.Buffer, value []byte) {
 }
 
 func writeManifestFloat32Slice(b *bytes.Buffer, values []float32) {
-	writeManifestFloat32SliceWithEncoding(b, values, ColumnFixedWidthEncodingDefault)
+	_ = writeManifestFloat32SliceWithEncoding(b, values, ColumnFixedWidthEncodingDefault)
 }
 
-func writeManifestFloat32SliceWithEncoding(b *bytes.Buffer, values []float32, encoding ColumnFixedWidthEncoding) {
+func writeManifestFloat32SliceWithEncoding(b *bytes.Buffer, values []float32, encoding ColumnFixedWidthEncoding) error {
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
+		return err
+	}
 	writeManifestUint64(b, uint64(len(values)))
 	var buf [4]byte
-	switch encoding {
-	case ColumnFixedWidthEncodingDefault:
-		for _, value := range values {
-			binary.BigEndian.PutUint32(buf[:], math.Float32bits(value))
-			_, _ = b.Write(buf[:])
-		}
-	case ColumnFixedWidthEncodingLittleEndian:
+	if littleEndian {
 		for _, value := range values {
 			binary.LittleEndian.PutUint32(buf[:], math.Float32bits(value))
 			_, _ = b.Write(buf[:])
 		}
-	default:
-		panic(fmt.Sprintf("collections: unsupported fixed_width_encoding %q", encoding))
+		return nil
 	}
+	for _, value := range values {
+		binary.BigEndian.PutUint32(buf[:], math.Float32bits(value))
+		_, _ = b.Write(buf[:])
+	}
+	return nil
 }
 
 func writeManifestUint32Slice(b *bytes.Buffer, values []uint32) {
@@ -782,12 +786,8 @@ func (c *manifestCursor) float32SliceAfterLengthWithEncoding(n uint64, encoding 
 	if !ok {
 		return nil
 	}
-	littleEndian := false
-	switch encoding {
-	case ColumnFixedWidthEncodingDefault:
-	case ColumnFixedWidthEncodingLittleEndian:
-		littleEndian = true
-	default:
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
 		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
 		return nil
 	}

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -683,9 +683,19 @@ func writeManifestFloat32Slice(b *bytes.Buffer, values []float32) {
 func writeManifestFloat32SliceWithEncoding(b *bytes.Buffer, values []float32, encoding ColumnFixedWidthEncoding) {
 	writeManifestUint64(b, uint64(len(values)))
 	var buf [4]byte
-	for _, value := range values {
-		putColumnFixedWidthUint32(buf[:], math.Float32bits(value), encoding)
-		_, _ = b.Write(buf[:])
+	switch encoding {
+	case ColumnFixedWidthEncodingDefault:
+		for _, value := range values {
+			binary.BigEndian.PutUint32(buf[:], math.Float32bits(value))
+			_, _ = b.Write(buf[:])
+		}
+	case ColumnFixedWidthEncodingLittleEndian:
+		for _, value := range values {
+			binary.LittleEndian.PutUint32(buf[:], math.Float32bits(value))
+			_, _ = b.Write(buf[:])
+		}
+	default:
+		panic(fmt.Sprintf("collections: unsupported fixed_width_encoding %q", encoding))
 	}
 }
 
@@ -696,14 +706,6 @@ func writeManifestUint32Slice(b *bytes.Buffer, values []uint32) {
 		binary.BigEndian.PutUint32(buf[:], value)
 		_, _ = b.Write(buf[:])
 	}
-}
-
-func putColumnFixedWidthUint32(dst []byte, value uint32, encoding ColumnFixedWidthEncoding) {
-	if encoding == ColumnFixedWidthEncodingLittleEndian {
-		binary.LittleEndian.PutUint32(dst, value)
-		return
-	}
-	binary.BigEndian.PutUint32(dst, value)
 }
 
 func (c *manifestCursor) bool() bool {
@@ -780,9 +782,24 @@ func (c *manifestCursor) float32SliceAfterLengthWithEncoding(n uint64, encoding 
 	if !ok {
 		return nil
 	}
+	littleEndian := false
+	switch encoding {
+	case ColumnFixedWidthEncodingDefault:
+	case ColumnFixedWidthEncodingLittleEndian:
+		littleEndian = true
+	default:
+		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
+		return nil
+	}
 	out := make([]float32, int(n))
 	for i := range out {
-		out[i] = math.Float32frombits(uint32FromColumnFixedWidth(c.raw[c.pos:], encoding))
+		var bits uint32
+		if littleEndian {
+			bits = binary.LittleEndian.Uint32(c.raw[c.pos:])
+		} else {
+			bits = binary.BigEndian.Uint32(c.raw[c.pos:])
+		}
+		out[i] = math.Float32frombits(bits)
 		c.pos += 4
 	}
 	return out
@@ -803,13 +820,6 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 		c.pos += 4
 	}
 	return out
-}
-
-func uint32FromColumnFixedWidth(raw []byte, encoding ColumnFixedWidthEncoding) uint32 {
-	if encoding == ColumnFixedWidthEncodingLittleEndian {
-		return binary.LittleEndian.Uint32(raw)
-	}
-	return binary.BigEndian.Uint32(raw)
 }
 
 func (c *manifestCursor) skipUint32Slice() uint64 {

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -20,6 +20,7 @@ const (
 	columnPhysicalAssetVersionV2 = uint16(2)
 	columnPhysicalAssetVersionV3 = uint16(3)
 	columnPhysicalAssetVersionV4 = uint16(4)
+	columnPhysicalAssetVersionV5 = uint16(5)
 	columnPhysicalAssetVersion   = columnPhysicalAssetVersionV4
 )
 
@@ -328,8 +329,12 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		}
 	}
 	var b bytes.Buffer
+	version, err := columnPhysicalAssetVersionForColumns(input.Columns)
+	if err != nil {
+		return nil, columnPhysicalAssetSummary{}, err
+	}
 	writeManifestUint32(&b, columnPhysicalAssetMagic)
-	writeManifestUint16(&b, columnPhysicalAssetVersion)
+	writeManifestUint16(&b, version)
 	writeManifestString(&b, input.Collection)
 	writeManifestString(&b, input.Namespace)
 	writeManifestUint64(&b, input.Generation)
@@ -346,6 +351,9 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		writeManifestBool(&b, col.Nullable)
 		writeManifestBool(&b, col.Dictionary)
 		writeManifestUint64(&b, uint64(col.VectorDims))
+		if version >= columnPhysicalAssetVersionV5 {
+			writeManifestString(&b, string(col.FixedWidthEncoding))
+		}
 	}
 	for _, row := range input.Rows {
 		writeManifestBytes(&b, row.ID)
@@ -353,7 +361,8 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		if row.Deleted {
 			continue
 		}
-		for _, value := range row.Values {
+		for colIdx, value := range row.Values {
+			col := input.Columns[colIdx]
 			writeManifestString(&b, string(value.Type))
 			writeManifestBool(&b, value.Null)
 			writeManifestBool(&b, columnDeclaredValuePresentForEncode(value))
@@ -375,7 +384,7 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 			case ColumnStoreValueString:
 				writeManifestString(&b, value.String)
 			case ColumnStoreValueFloat32Vector:
-				writeManifestFloat32Slice(&b, value.Float32Vector)
+				writeManifestFloat32SliceWithEncoding(&b, value.Float32Vector, col.FixedWidthEncoding)
 			case ColumnStoreValueAdjacencyList:
 				writeManifestUint32Slice(&b, value.AdjacencyList)
 			default:
@@ -439,6 +448,15 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 			}
 			asset.Columns[i].VectorDims = int(vectorDims)
 		}
+		if version >= columnPhysicalAssetVersionV5 {
+			asset.Columns[i].FixedWidthEncoding = ColumnFixedWidthEncoding(cur.string())
+			if _, err := normalizeColumnFixedWidthEncoding(asset.Columns[i].FixedWidthEncoding); err != nil {
+				return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset column[%d] fixed_width_encoding: %w", i, err)
+			}
+			if asset.Columns[i].FixedWidthEncoding != ColumnFixedWidthEncodingDefault && !columnStoreValueTypeSupportsFixedWidthEncoding(asset.Columns[i].ValueType) {
+				return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset column[%d] fixed_width_encoding unsupported for value_type %q", i, asset.Columns[i].ValueType)
+			}
+		}
 	}
 	for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
 		row := columnDeclaredRow{
@@ -480,7 +498,7 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 						value.String = cur.string()
 					case ColumnStoreValueFloat32Vector:
 						if version >= columnPhysicalAssetVersionV4 {
-							value.Float32Vector = cur.float32SliceWithExpectedLength(asset.Columns[colIdx].VectorDims)
+							value.Float32Vector = cur.float32SliceWithExpectedLengthAndEncoding(asset.Columns[colIdx].VectorDims, asset.Columns[colIdx].FixedWidthEncoding)
 						} else {
 							value.Float32Vector = cur.float32Slice()
 						}
@@ -592,11 +610,27 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 
 func isSupportedColumnPhysicalAssetVersion(version uint16) bool {
 	switch version {
-	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersion:
+	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersionV4, columnPhysicalAssetVersionV5:
 		return true
 	default:
 		return false
 	}
+}
+
+func columnPhysicalAssetVersionForColumns(columns []ColumnStoreColumn) (uint16, error) {
+	for i, col := range columns {
+		encoding, err := normalizeColumnFixedWidthEncoding(col.FixedWidthEncoding)
+		if err != nil {
+			return 0, fmt.Errorf("collections: column physical asset column[%d] fixed_width_encoding: %w", i, err)
+		}
+		if encoding != ColumnFixedWidthEncodingDefault {
+			if !columnStoreValueTypeSupportsFixedWidthEncoding(col.ValueType) {
+				return 0, fmt.Errorf("collections: column physical asset column[%d] fixed_width_encoding unsupported for value_type %q", i, col.ValueType)
+			}
+			return columnPhysicalAssetVersionV5, nil
+		}
+	}
+	return columnPhysicalAssetVersion, nil
 }
 
 func validateColumnDeclaredPhysicalValueShape(col ColumnStoreColumn, value columnDeclaredValue) error {
@@ -639,10 +673,14 @@ func writeManifestBytes(b *bytes.Buffer, value []byte) {
 }
 
 func writeManifestFloat32Slice(b *bytes.Buffer, values []float32) {
+	writeManifestFloat32SliceWithEncoding(b, values, ColumnFixedWidthEncodingDefault)
+}
+
+func writeManifestFloat32SliceWithEncoding(b *bytes.Buffer, values []float32, encoding ColumnFixedWidthEncoding) {
 	writeManifestUint64(b, uint64(len(values)))
 	var buf [4]byte
 	for _, value := range values {
-		binary.BigEndian.PutUint32(buf[:], math.Float32bits(value))
+		putColumnFixedWidthUint32(buf[:], math.Float32bits(value), encoding)
 		_, _ = b.Write(buf[:])
 	}
 }
@@ -654,6 +692,14 @@ func writeManifestUint32Slice(b *bytes.Buffer, values []uint32) {
 		binary.BigEndian.PutUint32(buf[:], value)
 		_, _ = b.Write(buf[:])
 	}
+}
+
+func putColumnFixedWidthUint32(dst []byte, value uint32, encoding ColumnFixedWidthEncoding) {
+	if encoding == ColumnFixedWidthEncodingLittleEndian {
+		binary.LittleEndian.PutUint32(dst, value)
+		return
+	}
+	binary.BigEndian.PutUint32(dst, value)
 }
 
 func (c *manifestCursor) bool() bool {
@@ -703,6 +749,10 @@ func (c *manifestCursor) float32Slice() []float32 {
 }
 
 func (c *manifestCursor) float32SliceWithExpectedLength(expected int) []float32 {
+	return c.float32SliceWithExpectedLengthAndEncoding(expected, ColumnFixedWidthEncodingDefault)
+}
+
+func (c *manifestCursor) float32SliceWithExpectedLengthAndEncoding(expected int, encoding ColumnFixedWidthEncoding) []float32 {
 	n := c.u64()
 	if c.err != nil {
 		return nil
@@ -711,10 +761,14 @@ func (c *manifestCursor) float32SliceWithExpectedLength(expected int) []float32 
 		c.err = fmt.Errorf("collections: float32_vector length=%d want vector_dims=%d", n, expected)
 		return nil
 	}
-	return c.float32SliceAfterLength(n)
+	return c.float32SliceAfterLengthWithEncoding(n, encoding)
 }
 
 func (c *manifestCursor) float32SliceAfterLength(n uint64) []float32 {
+	return c.float32SliceAfterLengthWithEncoding(n, ColumnFixedWidthEncodingDefault)
+}
+
+func (c *manifestCursor) float32SliceAfterLengthWithEncoding(n uint64, encoding ColumnFixedWidthEncoding) []float32 {
 	if c.err != nil {
 		return nil
 	}
@@ -724,7 +778,7 @@ func (c *manifestCursor) float32SliceAfterLength(n uint64) []float32 {
 	}
 	out := make([]float32, int(n))
 	for i := range out {
-		out[i] = math.Float32frombits(binary.BigEndian.Uint32(c.raw[c.pos:]))
+		out[i] = math.Float32frombits(uint32FromColumnFixedWidth(c.raw[c.pos:], encoding))
 		c.pos += 4
 	}
 	return out
@@ -745,6 +799,13 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 		c.pos += 4
 	}
 	return out
+}
+
+func uint32FromColumnFixedWidth(raw []byte, encoding ColumnFixedWidthEncoding) uint32 {
+	if encoding == ColumnFixedWidthEncodingLittleEndian {
+		return binary.LittleEndian.Uint32(raw)
+	}
+	return binary.BigEndian.Uint32(raw)
 }
 
 func (c *manifestCursor) skipUint32Slice() uint64 {

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -618,6 +618,7 @@ func isSupportedColumnPhysicalAssetVersion(version uint16) bool {
 }
 
 func columnPhysicalAssetVersionForColumns(columns []ColumnStoreColumn) (uint16, error) {
+	requiresV5 := false
 	for i, col := range columns {
 		encoding, err := normalizeColumnFixedWidthEncoding(col.FixedWidthEncoding)
 		if err != nil {
@@ -627,8 +628,11 @@ func columnPhysicalAssetVersionForColumns(columns []ColumnStoreColumn) (uint16, 
 			if !columnStoreValueTypeSupportsFixedWidthEncoding(col.ValueType) {
 				return 0, fmt.Errorf("collections: column physical asset column[%d] fixed_width_encoding unsupported for value_type %q", i, col.ValueType)
 			}
-			return columnPhysicalAssetVersionV5, nil
+			requiresV5 = true
 		}
+	}
+	if requiresV5 {
+		return columnPhysicalAssetVersionV5, nil
 	}
 	return columnPhysicalAssetVersion, nil
 }

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -257,6 +257,182 @@ func TestColumnPhysicalAssetVectorValueTypesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetFloat32VectorLittleEndianRoundTrip(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
+			{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32},
+			{Name: "embedding_neighbors", Path: "embedding_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+		},
+	}
+	normalized, err := normalizeColumnStoreConfig("vectors", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	rows := []columnDeclaredRow{{
+		ID: []byte("v1"),
+		Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{
+				math.Float32frombits(0x3f800000),
+				math.Float32frombits(0xc0200000),
+				math.Float32frombits(0x7fc12345),
+			}},
+			{Type: ColumnStoreValueFloat32, Present: true, Float32: math.Float32frombits(0x3e800000)},
+			{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: []uint32{0x01020304, 0xa0b0c0d0}},
+		},
+	}}
+	encoded, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "vectors",
+		Namespace:         normalized.AssetManager.Namespace,
+		Generation:        2,
+		PartID:            1,
+		AppliedCommandLSN: 9,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        normalized.SchemaHash,
+		Columns:           normalized.Columns,
+		Rows:              rows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset: %v", err)
+	}
+	assertColumnPhysicalAssetFloat32VectorLittleEndianFixture(t, encoded, normalized)
+
+	decoded, err := decodeColumnPhysicalAsset(encoded)
+	if err != nil {
+		t.Fatalf("decodeColumnPhysicalAsset: %v", err)
+	}
+	if got := decoded.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("decoded fixed_width_encoding=%q want little_endian", got)
+	}
+	if got := math.Float32bits(decoded.Rows[0].Values[0].Float32Vector[2]); got != 0x7fc12345 {
+		t.Fatalf("decoded vector nan bits=0x%08x want 0x7fc12345", got)
+	}
+	if got := math.Float32bits(decoded.Rows[0].Values[1].Float32); got != 0x3e800000 {
+		t.Fatalf("decoded scalar bits=0x%08x want 0x3e800000", got)
+	}
+	if got := decoded.Rows[0].Values[2].AdjacencyList; len(got) != 2 || got[0] != 0x01020304 || got[1] != 0xa0b0c0d0 {
+		t.Fatalf("decoded adjacency=%x", got)
+	}
+
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  normalized.AssetManager.Namespace,
+		Generation: 2,
+		PartID:     1,
+		FileID:     columnAssetM12ASegmentFileID,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	if err := validateColumnPhysicalAssetForManifest(encoded, ref, *normalized); err != nil {
+		t.Fatalf("validateColumnPhysicalAssetForManifest: %v", err)
+	}
+	projection, err := newColumnPhysicalScanProjection(*normalized, []string{"embedding", "embedding_inv_norm", "embedding_neighbors"})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	visited := 0
+	_, err = scanColumnPhysicalAssetRows(encoded, ref, "vectors", normalized, projection, func(row columnPhysicalScanRowView) error {
+		visited++
+		if got := math.Float32bits(row.Values[0].Float32Vector[2]); got != 0x7fc12345 {
+			t.Fatalf("scanned vector nan bits=0x%08x want 0x7fc12345", got)
+		}
+		if got := math.Float32bits(row.Values[1].Float32); got != 0x3e800000 {
+			t.Fatalf("scanned scalar bits=0x%08x want 0x3e800000", got)
+		}
+		if got := row.Values[2].AdjacencyList; len(got) != 2 || got[1] != 0xa0b0c0d0 {
+			t.Fatalf("scanned adjacency=%x", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalAssetRows: %v", err)
+	}
+	if visited != 1 {
+		t.Fatalf("visited=%d want 1", visited)
+	}
+
+	mismatch := *normalized
+	mismatch.Columns = append([]ColumnStoreColumn(nil), normalized.Columns...)
+	mismatch.Columns[0].FixedWidthEncoding = ColumnFixedWidthEncodingDefault
+	mismatch.SchemaHash = normalized.SchemaHash
+	if err := validateColumnPhysicalAssetForManifest(encoded, ref, mismatch); err == nil || !strings.Contains(err.Error(), "column[0]") {
+		t.Fatalf("validate metadata mismatch err=%v want column mismatch", err)
+	}
+}
+
+func assertColumnPhysicalAssetFloat32VectorLittleEndianFixture(t *testing.T, encoded []byte, cfg *ColumnStoreConfig) {
+	t.Helper()
+	cur := manifestCursor{raw: encoded}
+	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
+		t.Fatalf("magic=0x%08x want 0x%08x", magic, columnPhysicalAssetMagic)
+	}
+	if version := cur.u16(); version != columnPhysicalAssetVersionV5 {
+		t.Fatalf("version=%d want %d", version, columnPhysicalAssetVersionV5)
+	}
+	_ = cur.stringBytes()
+	_ = cur.stringBytes()
+	_ = cur.u64()
+	_ = cur.u64()
+	_ = cur.u64()
+	_ = cur.stringBytes()
+	_ = cur.u64()
+	columnCount := cur.u64()
+	rowCount := cur.u64()
+	if cur.err != nil {
+		t.Fatalf("header cursor err=%v", cur.err)
+	}
+	if columnCount != uint64(len(cfg.Columns)) || rowCount != 1 {
+		t.Fatalf("column_count=%d row_count=%d", columnCount, rowCount)
+	}
+	for i, col := range cfg.Columns {
+		_ = cur.stringBytes()
+		_ = cur.stringBytes()
+		_ = cur.stringBytes()
+		_ = cur.bool()
+		_ = cur.bool()
+		_ = cur.u64()
+		if got := ColumnFixedWidthEncoding(cur.string()); got != col.FixedWidthEncoding {
+			t.Fatalf("column[%d] fixed_width_encoding=%q want %q", i, got, col.FixedWidthEncoding)
+		}
+	}
+	_ = cur.bytesView()
+	_ = cur.bool()
+	_ = cur.stringBytes()
+	_ = cur.bool()
+	_ = cur.bool()
+	if n := cur.u64(); n != 3 {
+		t.Fatalf("vector length=%d want 3", n)
+	}
+	if got, want := encoded[cur.pos:cur.pos+12], []byte{0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x20, 0xc0, 0x45, 0x23, 0xc1, 0x7f}; !bytes.Equal(got, want) {
+		t.Fatalf("vector payload bytes=% x want % x", got, want)
+	}
+	cur.pos += 12
+	_ = cur.stringBytes()
+	_ = cur.bool()
+	_ = cur.bool()
+	if got, want := encoded[cur.pos:cur.pos+4], []byte{0x3e, 0x80, 0x00, 0x00}; !bytes.Equal(got, want) {
+		t.Fatalf("float32 payload bytes=% x want % x", got, want)
+	}
+	cur.pos += 4
+	_ = cur.stringBytes()
+	_ = cur.bool()
+	_ = cur.bool()
+	if n := cur.u64(); n != 2 {
+		t.Fatalf("adjacency length=%d want 2", n)
+	}
+	if got, want := encoded[cur.pos:cur.pos+8], []byte{0x01, 0x02, 0x03, 0x04, 0xa0, 0xb0, 0xc0, 0xd0}; !bytes.Equal(got, want) {
+		t.Fatalf("adjacency payload bytes=% x want % x", got, want)
+	}
+	cur.pos += 8
+	if cur.err != nil {
+		t.Fatalf("cursor err=%v", cur.err)
+	}
+	if cur.pos != len(encoded) {
+		t.Fatalf("cursor pos=%d len=%d", cur.pos, len(encoded))
+	}
+}
+
 func TestEncodeColumnPhysicalAssetRejectsMismatchedVectorLength(t *testing.T) {
 	cfg := &ColumnStoreConfig{
 		Enabled: true,

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -372,6 +372,18 @@ func TestColumnPhysicalAssetVersionSelectionValidatesAllFixedWidthEncodings(t *t
 	}
 }
 
+func TestColumnPhysicalAssetFloat32SliceRejectsUnsupportedFixedWidthEncoding(t *testing.T) {
+	var b bytes.Buffer
+	writeManifestFloat32Slice(&b, []float32{1})
+	cur := manifestCursor{raw: b.Bytes()}
+	if got := cur.float32SliceWithExpectedLengthAndEncoding(1, ColumnFixedWidthEncoding("future")); got != nil {
+		t.Fatalf("float32SliceWithExpectedLengthAndEncoding got=%v want nil", got)
+	}
+	if cur.err == nil || !strings.Contains(cur.err.Error(), "unsupported fixed_width_encoding") {
+		t.Fatalf("cursor err=%v want unsupported fixed_width_encoding", cur.err)
+	}
+}
+
 func assertColumnPhysicalAssetFloat32VectorLittleEndianFixture(t *testing.T, encoded []byte, cfg *ColumnStoreConfig) {
 	t.Helper()
 	cur := manifestCursor{raw: encoded}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -361,6 +361,17 @@ func TestColumnPhysicalAssetFloat32VectorLittleEndianRoundTrip(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetVersionSelectionValidatesAllFixedWidthEncodings(t *testing.T) {
+	columns := []ColumnStoreColumn{
+		{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
+		{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
+	}
+	_, err := columnPhysicalAssetVersionForColumns(columns)
+	if err == nil || !strings.Contains(err.Error(), "column[1]") || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("columnPhysicalAssetVersionForColumns err=%v want later fixed-width validation failure", err)
+	}
+}
+
 func assertColumnPhysicalAssetFloat32VectorLittleEndianFixture(t *testing.T, encoded []byte, cfg *ColumnStoreConfig) {
 	t.Helper()
 	cur := manifestCursor{raw: encoded}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -384,6 +384,17 @@ func TestColumnPhysicalAssetFloat32SliceRejectsUnsupportedFixedWidthEncoding(t *
 	}
 }
 
+func TestColumnPhysicalAssetFloat32SliceWriteRejectsUnsupportedFixedWidthEncoding(t *testing.T) {
+	var b bytes.Buffer
+	err := writeManifestFloat32SliceWithEncoding(&b, []float32{1}, ColumnFixedWidthEncoding("future"))
+	if err == nil || !strings.Contains(err.Error(), "unsupported fixed_width_encoding") {
+		t.Fatalf("writeManifestFloat32SliceWithEncoding err=%v want unsupported fixed_width_encoding", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("buffer len=%d want 0 after rejected write", b.Len())
+	}
+}
+
 func assertColumnPhysicalAssetFloat32VectorLittleEndianFixture(t *testing.T, encoded []byte, cfg *ColumnStoreConfig) {
 	t.Helper()
 	cur := manifestCursor{raw: encoded}

--- a/TreeDB/collections/column_physical_fixed_width_decode_bench_test.go
+++ b/TreeDB/collections/column_physical_fixed_width_decode_bench_test.go
@@ -121,6 +121,10 @@ func TestColumnPhysicalFixedWidthEndianDecodeBenchHelpersV1(t *testing.T) {
 		}
 	}
 
+	mustPanicColumnPhysicalFixedWidthBenchmark(t, func() {
+		columnPhysicalCopyLittleEndianFloat32Bytes(make([]float32, 1), []byte{1, 2, 3})
+	})
+
 	for _, tc := range []struct {
 		name string
 		fn   func()
@@ -168,6 +172,9 @@ func BenchmarkColumnPhysicalFixedWidthEndianDecodeV1(b *testing.B) {
 			benchmarkFloat32FixedWidthDecodeCopy(b, littleEndianRaw, dims, appendFloat32FixedWidthLittleEndianForBenchmark)
 		})
 		b.Run(fmt.Sprintf("float32_%dd/little_endian_direct_set_copy", dims), func(b *testing.B) {
+			if !columnPhysicalNativeLittleEndian {
+				b.Skip("direct-set copy requires a little-endian host")
+			}
 			benchmarkFloat32FixedWidthDecodeCopy(b, littleEndianRaw, dims, appendFloat32FixedWidthLittleEndianDirectSetForBenchmark)
 		})
 		b.Run(fmt.Sprintf("float32_%dd/little_endian_direct_view_setup", dims), func(b *testing.B) {

--- a/TreeDB/collections/column_physical_fixed_width_decode_bench_test.go
+++ b/TreeDB/collections/column_physical_fixed_width_decode_bench_test.go
@@ -167,6 +167,9 @@ func BenchmarkColumnPhysicalFixedWidthEndianDecodeV1(b *testing.B) {
 		b.Run(fmt.Sprintf("float32_%dd/little_endian_decode_copy", dims), func(b *testing.B) {
 			benchmarkFloat32FixedWidthDecodeCopy(b, littleEndianRaw, dims, appendFloat32FixedWidthLittleEndianForBenchmark)
 		})
+		b.Run(fmt.Sprintf("float32_%dd/little_endian_direct_set_copy", dims), func(b *testing.B) {
+			benchmarkFloat32FixedWidthDecodeCopy(b, littleEndianRaw, dims, appendFloat32FixedWidthLittleEndianDirectSetForBenchmark)
+		})
 		b.Run(fmt.Sprintf("float32_%dd/little_endian_direct_view_setup", dims), func(b *testing.B) {
 			benchmarkFloat32FixedWidthDirectViewSetup(b, littleEndianRaw, dims)
 		})
@@ -396,6 +399,24 @@ func appendFloat32FixedWidthLittleEndianForBenchmark(dst []float32, raw []byte) 
 		dst[i] = math.Float32frombits(uint32(raw[pos]) | uint32(raw[pos+1])<<8 | uint32(raw[pos+2])<<16 | uint32(raw[pos+3])<<24)
 		pos += 4
 	}
+	return dst
+}
+
+func appendFloat32FixedWidthLittleEndianDirectSetForBenchmark(dst []float32, raw []byte) []float32 {
+	requireColumnPhysicalFixedWidth4ForBenchmark(raw)
+	if !columnPhysicalNativeLittleEndian {
+		return appendFloat32FixedWidthLittleEndianForBenchmark(dst, raw)
+	}
+	base := len(dst)
+	need := base + len(raw)/4
+	if cap(dst) < need {
+		next := make([]float32, need)
+		copy(next, dst)
+		dst = next
+	} else {
+		dst = dst[:need]
+	}
+	columnPhysicalCopyLittleEndianFloat32Bytes(dst[base:need], raw)
 	return dst
 }
 

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"unsafe"
 )
 
 const defaultColumnPhysicalRowReaderMaxDecodedBlocks = 4
 
 var errColumnPhysicalRowOrdinalOutOfBounds = errors.New("physical column row ordinal outside row_count")
+
+var columnPhysicalNativeLittleEndian = func() bool {
+	var value uint16 = 1
+	return *(*byte)(unsafe.Pointer(&value)) == 1
+}()
 
 type columnPhysicalRowReaderOptions struct {
 	ProjectedColumns  []string
@@ -737,6 +743,11 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 	if pos < end {
 		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
+	if littleEndian && columnPhysicalNativeLittleEndian {
+		columnPhysicalCopyLittleEndianFloat32Bytes(dst[base:need], raw[pos:end])
+		c.pos = end
+		return dst, nil
+	}
 	i := base
 	if littleEndian {
 		for ; i+4 <= need; i += 4 {
@@ -767,6 +778,17 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 	}
 	c.pos = end
 	return dst, nil
+}
+
+func columnPhysicalCopyLittleEndianFloat32Bytes(dst []float32, raw []byte) {
+	if len(raw) == 0 {
+		return
+	}
+	// raw may be byte-unaligned inside a manifest row. Copying into the aligned
+	// scratch []float32 backing store avoids per-element byte assembly without
+	// changing the row reader's scratch-aliasing contract.
+	dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(raw))
+	copy(dstBytes, raw)
 }
 
 func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -679,7 +679,7 @@ func readSelectedColumnPhysicalValueIntoScratch(cur *manifestCursor, col ColumnS
 	case ColumnStoreValueFloat32Vector:
 		start := len(scratch.Float32Values)
 		var err error
-		scratch.Float32Values, err = cur.appendFloat32SliceWithExpectedLength(scratch.Float32Values, col.VectorDims)
+		scratch.Float32Values, err = cur.appendFloat32SliceWithExpectedLengthAndEncoding(scratch.Float32Values, col.VectorDims, col.FixedWidthEncoding)
 		if err != nil {
 			return err
 		}
@@ -699,6 +699,10 @@ func readSelectedColumnPhysicalValueIntoScratch(cur *manifestCursor, col ColumnS
 }
 
 func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, expected int) ([]float32, error) {
+	return c.appendFloat32SliceWithExpectedLengthAndEncoding(dst, expected, ColumnFixedWidthEncodingDefault)
+}
+
+func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []float32, expected int, encoding ColumnFixedWidthEncoding) ([]float32, error) {
 	n := c.u64()
 	if c.err != nil {
 		return dst, c.err
@@ -729,17 +733,32 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLength(dst []float32, exp
 		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
 	i := base
-	for ; i+4 <= need; i += 4 {
-		_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
-		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
-		dst[i+1] = math.Float32frombits(uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7]))
-		dst[i+2] = math.Float32frombits(uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11]))
-		dst[i+3] = math.Float32frombits(uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15]))
-		pos += 16
-	}
-	for ; i < need; i++ {
-		dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
-		pos += 4
+	if encoding == ColumnFixedWidthEncodingLittleEndian {
+		for ; i+4 <= need; i += 4 {
+			_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
+			dst[i] = math.Float32frombits(uint32(raw[pos]) | uint32(raw[pos+1])<<8 | uint32(raw[pos+2])<<16 | uint32(raw[pos+3])<<24)
+			dst[i+1] = math.Float32frombits(uint32(raw[pos+4]) | uint32(raw[pos+5])<<8 | uint32(raw[pos+6])<<16 | uint32(raw[pos+7])<<24)
+			dst[i+2] = math.Float32frombits(uint32(raw[pos+8]) | uint32(raw[pos+9])<<8 | uint32(raw[pos+10])<<16 | uint32(raw[pos+11])<<24)
+			dst[i+3] = math.Float32frombits(uint32(raw[pos+12]) | uint32(raw[pos+13])<<8 | uint32(raw[pos+14])<<16 | uint32(raw[pos+15])<<24)
+			pos += 16
+		}
+		for ; i < need; i++ {
+			dst[i] = math.Float32frombits(uint32(raw[pos]) | uint32(raw[pos+1])<<8 | uint32(raw[pos+2])<<16 | uint32(raw[pos+3])<<24)
+			pos += 4
+		}
+	} else {
+		for ; i+4 <= need; i += 4 {
+			_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
+			dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
+			dst[i+1] = math.Float32frombits(uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7]))
+			dst[i+2] = math.Float32frombits(uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11]))
+			dst[i+3] = math.Float32frombits(uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15]))
+			pos += 16
+		}
+		for ; i < need; i++ {
+			dst[i] = math.Float32frombits(uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3]))
+			pos += 4
+		}
 	}
 	c.pos = end
 	return dst, nil

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -715,12 +715,8 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 	if !ok {
 		return dst, c.err
 	}
-	littleEndian := false
-	switch encoding {
-	case ColumnFixedWidthEncodingDefault:
-	case ColumnFixedWidthEncodingLittleEndian:
-		littleEndian = true
-	default:
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
 		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
 		return dst, c.err
 	}

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -781,13 +781,17 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 }
 
 func columnPhysicalCopyLittleEndianFloat32Bytes(dst []float32, raw []byte) {
-	if len(raw) == 0 {
+	dstByteLen := len(dst) * 4
+	if len(raw) != dstByteLen {
+		panic("collections: invalid little-endian float32_vector direct-copy length")
+	}
+	if dstByteLen == 0 {
 		return
 	}
 	// raw may be byte-unaligned inside a manifest row. Copying into the aligned
 	// scratch []float32 backing store avoids per-element byte assembly without
 	// changing the row reader's scratch-aliasing contract.
-	dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(raw))
+	dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), dstByteLen)
 	copy(dstBytes, raw)
 }
 

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -715,6 +715,15 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 	if !ok {
 		return dst, c.err
 	}
+	littleEndian := false
+	switch encoding {
+	case ColumnFixedWidthEncodingDefault:
+	case ColumnFixedWidthEncodingLittleEndian:
+		littleEndian = true
+	default:
+		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
+		return dst, c.err
+	}
 	base := len(dst)
 	need := base + int(n)
 	if cap(dst) < need {
@@ -733,7 +742,7 @@ func (c *manifestCursor) appendFloat32SliceWithExpectedLengthAndEncoding(dst []f
 		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
 	}
 	i := base
-	if encoding == ColumnFixedWidthEncodingLittleEndian {
+	if littleEndian {
 		for ; i+4 <= need; i += 4 {
 			_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
 			dst[i] = math.Float32frombits(uint32(raw[pos]) | uint32(raw[pos+1])<<8 | uint32(raw[pos+2])<<16 | uint32(raw[pos+3])<<24)

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -84,6 +84,17 @@ func TestColumnPhysicalRowReaderFetchesLittleEndianFixedWidthRowsV1(t *testing.T
 		t.Fatalf("FetchRow(2): %v", err)
 	}
 	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-002", 2, []float32{2, 2.25, 2.5, 2.75}, []uint32{2, 3, 4})
+
+	if _, err := reader.FetchRow(2, &scratch); err != nil {
+		t.Fatalf("warm FetchRow(2): %v", err)
+	}
+	if allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := reader.FetchRow(2, &scratch); err != nil {
+			t.Fatalf("FetchRow(2): %v", err)
+		}
+	}); allocs != 0 {
+		t.Fatalf("little-endian hot FetchRow allocs=%v want zero", allocs)
+	}
 }
 
 func TestColumnPhysicalRowReaderBatchFetchReusesCachedBlockV1(t *testing.T) {

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -512,6 +512,19 @@ func TestColumnPhysicalRowReaderScratchAppendFixedWidthSlicesV1(t *testing.T) {
 		}
 	})
 
+	t.Run("float32_vector_unsupported_encoding", func(t *testing.T) {
+		var b bytes.Buffer
+		writeManifestFloat32Slice(&b, []float32{1})
+		cur := manifestCursor{raw: b.Bytes()}
+		got, err := cur.appendFloat32SliceWithExpectedLengthAndEncoding([]float32{7}, 1, ColumnFixedWidthEncoding("future"))
+		if err == nil || !strings.Contains(err.Error(), "unsupported fixed_width_encoding") {
+			t.Fatalf("appendFloat32SliceWithExpectedLengthAndEncoding err=%v want unsupported fixed_width_encoding", err)
+		}
+		if fmt.Sprint(got) != "[7]" {
+			t.Fatalf("got=%v want original dst", got)
+		}
+	})
+
 	t.Run("float32_vector_wrong_length", func(t *testing.T) {
 		var b bytes.Buffer
 		writeManifestFloat32Slice(&b, []float32{1, 2})

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -63,6 +63,29 @@ func TestColumnPhysicalRowReaderFetchesRowsWithBoundedCacheV1(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalRowReaderFetchesLittleEndianFixedWidthRowsV1(t *testing.T) {
+	normalized := testColumnPhysicalRowReaderConfigV1(t)
+	normalized.Columns[1].FixedWidthEncoding = ColumnFixedWidthEncodingLittleEndian
+	normalized.SchemaHash = hashColumnStoreSchema(normalized)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	ref := writeColumnPhysicalRowReaderAssetForTestV1(t, root, normalized, 7, 1, testColumnPhysicalRowReaderRowsV1(0, 3, normalized))
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, normalized, ref), columnPhysicalRowReaderOptions{
+		ProjectedColumns:  []string{"embedding", "neighbors"},
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var scratch columnPhysicalRowReaderScratch
+	row, err := reader.FetchRow(2, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow(2): %v", err)
+	}
+	assertColumnPhysicalRowReaderVectorRowV1(t, row, "doc-002", 2, []float32{2, 2.25, 2.5, 2.75}, []uint32{2, 3, 4})
+}
+
 func TestColumnPhysicalRowReaderBatchFetchReusesCachedBlockV1(t *testing.T) {
 	normalized := testColumnPhysicalRowReaderConfigV1(t)
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
@@ -455,6 +478,25 @@ func TestColumnPhysicalRowReaderScratchAppendFixedWidthSlicesV1(t *testing.T) {
 		for i, want := range values {
 			if got[i+1] != want {
 				t.Fatalf("got[%d]=%v want %v", i+1, got[i+1], want)
+			}
+		}
+	})
+
+	t.Run("float32_vector_little_endian_exact", func(t *testing.T) {
+		values := []float32{math.Float32frombits(0x3f800000), math.Float32frombits(0x7fc12345), math.Float32frombits(0xc0200000)}
+		var b bytes.Buffer
+		writeManifestFloat32SliceWithEncoding(&b, values, ColumnFixedWidthEncodingLittleEndian)
+		cur := manifestCursor{raw: b.Bytes()}
+		got, err := cur.appendFloat32SliceWithExpectedLengthAndEncoding([]float32{99}, len(values), ColumnFixedWidthEncodingLittleEndian)
+		if err != nil {
+			t.Fatalf("appendFloat32SliceWithExpectedLengthAndEncoding: %v", err)
+		}
+		if len(got) != 1+len(values) || got[0] != 99 || cur.pos != len(cur.raw) {
+			t.Fatalf("got=%v pos=%d len=%d", got, cur.pos, len(cur.raw))
+		}
+		for i, want := range values {
+			if math.Float32bits(got[i+1]) != math.Float32bits(want) {
+				t.Fatalf("got[%d] bits=0x%08x want 0x%08x", i+1, math.Float32bits(got[i+1]), math.Float32bits(want))
 			}
 		}
 	})

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1822,6 +1822,16 @@ func parseColumnPhysicalAssetScanHeader(raw []byte, ref ColumnAssetRef, expected
 			}
 			vectorDims = int(rawVectorDims)
 		}
+		fixedWidthEncoding := ColumnFixedWidthEncodingDefault
+		if version >= columnPhysicalAssetVersionV5 {
+			fixedWidthEncoding = ColumnFixedWidthEncoding(string(cur.stringBytes()))
+			if _, err := normalizeColumnFixedWidthEncoding(fixedWidthEncoding); err != nil {
+				return columnPhysicalAssetScanHeader{}, 0, 0, fmt.Errorf("column physical asset column[%d] fixed_width_encoding: %w", colIdx, err)
+			}
+			if fixedWidthEncoding != ColumnFixedWidthEncodingDefault && !columnStoreValueTypeSupportsFixedWidthEncoding(ColumnStoreValueType(string(valueType))) {
+				return columnPhysicalAssetScanHeader{}, 0, 0, fmt.Errorf("column physical asset column[%d] fixed_width_encoding unsupported for value_type %q", colIdx, string(valueType))
+			}
+		}
 		if cur.err != nil {
 			return columnPhysicalAssetScanHeader{}, 0, 0, cur.err
 		}
@@ -1831,9 +1841,10 @@ func parseColumnPhysicalAssetScanHeader(raw []byte, ref ColumnAssetRef, expected
 			!columnPhysicalBytesEqualString(valueType, string(want.ValueType)) ||
 			nullable != want.Nullable ||
 			dictionary != want.Dictionary ||
-			vectorDims != want.VectorDims {
-			return columnPhysicalAssetScanHeader{}, 0, 0, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t VectorDims:%d} want %+v",
-				colIdx, string(name), string(path), string(valueType), nullable, dictionary, vectorDims, want)
+			vectorDims != want.VectorDims ||
+			fixedWidthEncoding != want.FixedWidthEncoding {
+			return columnPhysicalAssetScanHeader{}, 0, 0, fmt.Errorf("column physical asset column[%d]={Name:%q Path:%q ValueType:%q Nullable:%t Dictionary:%t VectorDims:%d FixedWidthEncoding:%q} want %+v",
+				colIdx, string(name), string(path), string(valueType), nullable, dictionary, vectorDims, fixedWidthEncoding, want)
 		}
 	}
 	return header, version, cur.pos, nil
@@ -2012,7 +2023,7 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			}
 		case ColumnStoreValueFloat32Vector:
 			if selected {
-				value := cur.float32SliceWithExpectedLength(col.VectorDims)
+				value := cur.float32SliceWithExpectedLengthAndEncoding(col.VectorDims, col.FixedWidthEncoding)
 				if cur.err != nil {
 					return cur.err
 				}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -592,6 +592,14 @@ func normalizeColumnFixedWidthEncoding(encoding ColumnFixedWidthEncoding) (Colum
 	}
 }
 
+func columnFixedWidthEncodingIsLittleEndian(encoding ColumnFixedWidthEncoding) (bool, error) {
+	normalized, err := normalizeColumnFixedWidthEncoding(encoding)
+	if err != nil {
+		return false, err
+	}
+	return normalized == ColumnFixedWidthEncodingLittleEndian, nil
+}
+
 func columnStoreValueTypeSupportsFixedWidthEncoding(valueType ColumnStoreValueType) bool {
 	switch valueType {
 	case ColumnStoreValueFloat32Vector:

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -60,6 +60,15 @@ const (
 	ColumnStoreValueAdjacencyList ColumnStoreValueType = "adjacency_list"
 )
 
+type ColumnFixedWidthEncoding string
+
+const (
+	// Empty means the current compatibility encoding: manifest-style big-endian
+	// fixed-width element bytes inside the physical part image.
+	ColumnFixedWidthEncodingDefault      ColumnFixedWidthEncoding = ""
+	ColumnFixedWidthEncodingLittleEndian ColumnFixedWidthEncoding = "little_endian"
+)
+
 type ColumnSortDirection string
 
 const (
@@ -159,12 +168,13 @@ type ColumnStoreConfig struct {
 }
 
 type ColumnStoreColumn struct {
-	Name       string               `json:"name"`
-	Path       string               `json:"path"`
-	ValueType  ColumnStoreValueType `json:"value_type"`
-	Nullable   bool                 `json:"nullable,omitempty"`
-	Dictionary bool                 `json:"dictionary,omitempty"`
-	VectorDims int                  `json:"vector_dims,omitempty"`
+	Name               string                   `json:"name"`
+	Path               string                   `json:"path"`
+	ValueType          ColumnStoreValueType     `json:"value_type"`
+	Nullable           bool                     `json:"nullable,omitempty"`
+	Dictionary         bool                     `json:"dictionary,omitempty"`
+	VectorDims         int                      `json:"vector_dims,omitempty"`
+	FixedWidthEncoding ColumnFixedWidthEncoding `json:"fixed_width_encoding,omitempty"`
 }
 
 type ColumnSortKey struct {
@@ -416,6 +426,13 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		if err != nil {
 			return fmt.Errorf("collections: invalid column %q value_type: %w", col.Name, err)
 		}
+		fixedWidthEncoding, err := normalizeColumnFixedWidthEncoding(col.FixedWidthEncoding)
+		if err != nil {
+			return fmt.Errorf("collections: invalid column %q fixed_width_encoding: %w", col.Name, err)
+		}
+		if fixedWidthEncoding != ColumnFixedWidthEncodingDefault && !columnStoreValueTypeSupportsFixedWidthEncoding(valueType) {
+			return fmt.Errorf("collections: invalid column %q fixed_width_encoding: unsupported for value_type %q", col.Name, valueType)
+		}
 		if valueType == ColumnStoreValueFloat32Vector {
 			if col.VectorDims <= 0 {
 				return fmt.Errorf("collections: invalid column %q vector_dims: must be positive", col.Name)
@@ -563,6 +580,24 @@ func normalizeColumnStoreValueType(valueType ColumnStoreValueType) (ColumnStoreV
 		return "", errors.New("value_type is required")
 	default:
 		return "", fmt.Errorf("unsupported value_type %q", valueType)
+	}
+}
+
+func normalizeColumnFixedWidthEncoding(encoding ColumnFixedWidthEncoding) (ColumnFixedWidthEncoding, error) {
+	switch encoding {
+	case ColumnFixedWidthEncodingDefault, ColumnFixedWidthEncodingLittleEndian:
+		return encoding, nil
+	default:
+		return "", fmt.Errorf("unsupported fixed_width_encoding %q", encoding)
+	}
+}
+
+func columnStoreValueTypeSupportsFixedWidthEncoding(valueType ColumnStoreValueType) bool {
+	switch valueType {
+	case ColumnStoreValueFloat32Vector:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -906,6 +941,9 @@ func hashColumnStoreSchema(cfg *ColumnStoreConfig) uint64 {
 		writeHashBool(&d, col.Dictionary)
 		if col.ValueType == ColumnStoreValueFloat32Vector {
 			writeHashInt(&d, col.VectorDims)
+		}
+		if col.FixedWidthEncoding != ColumnFixedWidthEncodingDefault {
+			writeHashString(&d, string(col.FixedWidthEncoding))
 		}
 	}
 	for _, sortKey := range cfg.SortKey {

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -408,6 +408,38 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			want: "dictionary",
 		},
 		{
+			name: "unknown fixed width encoding rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, VectorDims: 128, FixedWidthEncoding: "native"}},
+			},
+			want: "fixed_width_encoding",
+		},
+		{
+			name: "string fixed width encoding rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian}},
+			},
+			want: "fixed_width_encoding",
+		},
+		{
+			name: "float32 fixed width encoding rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "embedding_inv_norm", Path: "embedding_inv_norm", ValueType: ColumnStoreValueFloat32, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian}},
+			},
+			want: "fixed_width_encoding",
+		},
+		{
+			name: "adjacency fixed width encoding rejected",
+			cfg: &ColumnStoreConfig{
+				Enabled: true,
+				Columns: []ColumnStoreColumn{{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian}},
+			},
+			want: "fixed_width_encoding",
+		},
+		{
 			name: "unsupported locator",
 			cfg: &ColumnStoreConfig{
 				Enabled: true,

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -235,7 +235,7 @@ func columnVectorGraphPhysicalColumnStoreConfig(collection string, base ColumnSt
 	cfg, err := normalizeColumnStoreConfig(collection, &ColumnStoreConfig{
 		Enabled: true,
 		Columns: []ColumnStoreColumn{
-			{Name: columnVectorGraphVectorColumnName, Path: normalizedDef.Field, ValueType: ColumnStoreValueFloat32Vector, VectorDims: normalizedDef.Dimensions},
+			{Name: columnVectorGraphVectorColumnName, Path: normalizedDef.Field, ValueType: ColumnStoreValueFloat32Vector, VectorDims: normalizedDef.Dimensions, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
 			{Name: columnVectorGraphInvNormColumnName, Path: normalizedDef.Field + "_inv_norm", ValueType: ColumnStoreValueFloat32},
 			{Name: columnVectorGraphAdjacencyColumnName, Path: normalizedDef.Field + "_neighbors", ValueType: ColumnStoreValueAdjacencyList},
 		},

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -69,6 +69,29 @@ func TestColumnVectorGraphManifestRecordRoundTripV2A(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphPhysicalConfigUsesLittleEndianVectorOnlyM1C(t *testing.T) {
+	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
+	if err != nil {
+		t.Fatalf("normalize base column store: %v", err)
+	}
+	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig("docs", *baseCfg, testColumnGraphVectorIndexDefinitionV2A())
+	if err != nil {
+		t.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
+	}
+	if len(graphCfg.Columns) != 3 {
+		t.Fatalf("graph columns=%d want 3", len(graphCfg.Columns))
+	}
+	if got := graphCfg.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("vector fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
+	}
+	if got := graphCfg.Columns[1].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+		t.Fatalf("inv_norm fixed_width_encoding=%q want default", got)
+	}
+	if got := graphCfg.Columns[2].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+		t.Fatalf("adjacency fixed_width_encoding=%q want default", got)
+	}
+}
+
 func TestColumnVectorGraphPhysicalAssetWriteRejectsInvalidInputBeforeSegmentAllocationV2A(t *testing.T) {
 	baseCfg, err := normalizeColumnStoreConfig("docs", testColumnGraphBaseColumnStoreConfigV2A())
 	if err != nil {
@@ -184,6 +207,22 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 	if err := validateColumnPhysicalAssetForManifest(raw, prepared.Ref, prepared.Config); err != nil {
 		t.Fatalf("validate graph asset: %v", err)
 	}
+	if got := columnVectorGraphPhysicalAssetVersionForTestM1C(raw); got != columnPhysicalAssetVersionV5 {
+		t.Fatalf("graph physical asset version=%d want %d", got, columnPhysicalAssetVersionV5)
+	}
+	decoded, err := decodeColumnPhysicalAsset(raw)
+	if err != nil {
+		t.Fatalf("decode graph asset: %v", err)
+	}
+	if got := decoded.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("decoded vector fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
+	}
+	if got := decoded.Columns[1].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+		t.Fatalf("decoded inv_norm fixed_width_encoding=%q want default", got)
+	}
+	if got := decoded.Columns[2].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+		t.Fatalf("decoded adjacency fixed_width_encoding=%q want default", got)
+	}
 	projection, err := newColumnPhysicalScanProjection(prepared.Config, []string{
 		columnVectorGraphVectorColumnName,
 		columnVectorGraphInvNormColumnName,
@@ -221,6 +260,12 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 	if got := invNorms[2]; got != 1 {
 		t.Fatalf("row2 inv_norm=%v want 1", got)
 	}
+}
+
+func columnVectorGraphPhysicalAssetVersionForTestM1C(raw []byte) uint16 {
+	cur := manifestCursor{raw: raw}
+	_ = cur.u32()
+	return cur.u16()
 }
 
 func TestColumnGraphVectorIndexStatusUsesPublishedPhysicalManifestV2A(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -81,13 +81,16 @@ func TestColumnVectorGraphPhysicalConfigUsesLittleEndianVectorOnlyM1C(t *testing
 	if len(graphCfg.Columns) != 3 {
 		t.Fatalf("graph columns=%d want 3", len(graphCfg.Columns))
 	}
-	if got := graphCfg.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+	vectorCol := columnVectorGraphPhysicalColumnForTestM1C(t, graphCfg.Columns, columnVectorGraphVectorColumnName)
+	if got := vectorCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
 		t.Fatalf("vector fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
 	}
-	if got := graphCfg.Columns[1].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+	invNormCol := columnVectorGraphPhysicalColumnForTestM1C(t, graphCfg.Columns, columnVectorGraphInvNormColumnName)
+	if got := invNormCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
 		t.Fatalf("inv_norm fixed_width_encoding=%q want default", got)
 	}
-	if got := graphCfg.Columns[2].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+	adjacencyCol := columnVectorGraphPhysicalColumnForTestM1C(t, graphCfg.Columns, columnVectorGraphAdjacencyColumnName)
+	if got := adjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
 		t.Fatalf("adjacency fixed_width_encoding=%q want default", got)
 	}
 }
@@ -207,20 +210,23 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 	if err := validateColumnPhysicalAssetForManifest(raw, prepared.Ref, prepared.Config); err != nil {
 		t.Fatalf("validate graph asset: %v", err)
 	}
-	if got := columnVectorGraphPhysicalAssetVersionForTestM1C(raw); got != columnPhysicalAssetVersionV5 {
+	if got := columnVectorGraphPhysicalAssetVersionForTestM1C(t, raw); got != columnPhysicalAssetVersionV5 {
 		t.Fatalf("graph physical asset version=%d want %d", got, columnPhysicalAssetVersionV5)
 	}
 	decoded, err := decodeColumnPhysicalAsset(raw)
 	if err != nil {
 		t.Fatalf("decode graph asset: %v", err)
 	}
-	if got := decoded.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+	decodedVectorCol := columnVectorGraphPhysicalColumnForTestM1C(t, decoded.Columns, columnVectorGraphVectorColumnName)
+	if got := decodedVectorCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
 		t.Fatalf("decoded vector fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
 	}
-	if got := decoded.Columns[1].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+	decodedInvNormCol := columnVectorGraphPhysicalColumnForTestM1C(t, decoded.Columns, columnVectorGraphInvNormColumnName)
+	if got := decodedInvNormCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
 		t.Fatalf("decoded inv_norm fixed_width_encoding=%q want default", got)
 	}
-	if got := decoded.Columns[2].FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
+	decodedAdjacencyCol := columnVectorGraphPhysicalColumnForTestM1C(t, decoded.Columns, columnVectorGraphAdjacencyColumnName)
+	if got := decodedAdjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
 		t.Fatalf("decoded adjacency fixed_width_encoding=%q want default", got)
 	}
 	projection, err := newColumnPhysicalScanProjection(prepared.Config, []string{
@@ -262,10 +268,28 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 	}
 }
 
-func columnVectorGraphPhysicalAssetVersionForTestM1C(raw []byte) uint16 {
+func columnVectorGraphPhysicalColumnForTestM1C(tb testing.TB, columns []ColumnStoreColumn, name string) ColumnStoreColumn {
+	tb.Helper()
+	for _, col := range columns {
+		if col.Name == name {
+			return col
+		}
+	}
+	tb.Fatalf("missing graph physical column %q in %+v", name, columns)
+	return ColumnStoreColumn{}
+}
+
+func columnVectorGraphPhysicalAssetVersionForTestM1C(tb testing.TB, raw []byte) uint16 {
+	tb.Helper()
 	cur := manifestCursor{raw: raw}
-	_ = cur.u32()
-	return cur.u16()
+	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
+		tb.Fatalf("graph physical asset magic=0x%08x want 0x%08x", magic, columnPhysicalAssetMagic)
+	}
+	version := cur.u16()
+	if cur.err != nil {
+		tb.Fatalf("read graph physical asset header: %v", cur.err)
+	}
+	return version
 }
 
 func TestColumnGraphVectorIndexStatusUsesPublishedPhysicalManifestV2A(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR is the next small #1696 stacked step on top of #1712.

It optimizes the `float32_vector` materialization path for explicitly little-endian physical column payloads on little-endian hosts by copying the persisted IEEE-754 bytes directly into the existing row-reader scratch `[]float32` backing store.

Scope boundary:

- Keeps physical column/granule integrity on the existing CRC32C path.
- Does not introduce FarmHash or any checksum/hash changes.
- Does not alias raw asset bytes into returned vectors; the existing scratch-lifetime contract remains intact.
- Does not change scalar fixed-width payloads or adjacency payloads.
- Falls back to the existing per-element decode path when payload encoding/host endian do not match the fast path.

## What Changed

- Added a guarded little-endian-host fast path in `appendFloat32SliceWithExpectedLengthAndEncoding`.
- Added a benchmark case for `float32` little-endian direct-set copy evidence.
- Preserved the existing unsupported encoding and big-endian decode behavior.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalRowReaderFetchesLittleEndianFixedWidthRowsV1|TestManifestCursorReadsColumnPhysicalValuesV1|TestColumnPhysicalAssetFloat32VectorLittleEndianRoundTrip|TestColumnVectorGraphPhysicalConfigUsesLittleEndianVectorOnlyM1C|TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3|TestVectorIndexSearchColumnGraphPreparedSearchCosineV4' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.632s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 14.939s

GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnPhysicalRowReaderFetchesLittleEndianFixedWidthRowsV1|TestColumnVectorGraphNativeSearchParallelReadersV3|TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.909s

GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalFixedWidthEndianDecodeV1|BenchmarkColumnPhysicalRowReaderFetchV1|BenchmarkColumnVectorGraphNativeSearchCosine(Parallel)?V3|BenchmarkSearchVectorIndexColumnGraphNativeReaderV4|BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4' -benchmem -benchtime=500ms -count=3
# ok github.com/snissn/gomap/TreeDB/collections 60.795s
```

Hardware: Apple M3, darwin/arm64.

| Benchmark | median ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_96d/big_endian_decode_copy` | 69.110 | 14,469,686 | 0 | 0 |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_96d/little_endian_decode_copy` | 69.210 | 14,448,779 | 0 | 0 |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_96d/little_endian_direct_set_copy` | 6.381 | 156,715,248 | 0 | 0 |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_128d/big_endian_decode_copy` | 92.670 | 10,790,979 | 0 | 0 |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_128d/little_endian_decode_copy` | 91.500 | 10,928,962 | 0 | 0 |
| `ColumnPhysicalFixedWidthEndianDecodeV1/float32_128d/little_endian_direct_set_copy` | 7.613 | 131,354,262 | 0 | 0 |
| `ColumnPhysicalRowReaderFetchV1/row_warmed_vector_adjacency` | 202.700 | 4,933,399 | 0 | 0 |
| `ColumnPhysicalRowReaderFetchV1/batch_warmed_vector_adjacency` | 1546.000 | 646,831 | 0 | 0 |
| `ColumnVectorGraphNativeSearchCosineV3` | 49,137.000 | 20,351 | 0 | 0 |
| `ColumnVectorGraphNativeSearchCosineParallelV3` | 8,945.000 | 111,794 | 0 | 0 |
| `SearchVectorIndexColumnGraphNativeReaderV4` | 369,414.000 | 2,707 | 741,072 | 109 |
| `OpenVectorIndexSearcherColumnGraphNativeReaderV4` | 49,680.000 | 20,129 | 784 | 2 |

Before/after against #1712 baseline on the same machine:

| Benchmark | #1712 median ns/op | M1D median ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| `ColumnVectorGraphNativeSearchCosineV3` | 61,373.000 | 49,137.000 | 20,351 | -19.9% |
| `ColumnVectorGraphNativeSearchCosineParallelV3` | 11,620.000 | 8,945.000 | 111,794 | -23.0% |
| `OpenVectorIndexSearcherColumnGraphNativeReaderV4` | 61,063.000 | 49,680.000 | 20,129 | -18.6% |
| `SearchVectorIndexColumnGraphNativeReaderV4` | 387,780.000 | 369,414.000 | 2,707 | -4.7% |

## Notes

The row-reader scratch result remains invalid after the next fetch or reader close. This PR only changes how little-endian vector bytes populate that scratch slice; it does not change reader lifetime, index semantics, or asset checksums.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized float32 vector decoding performance on little-endian platforms through direct byte-to-slice copy operations.

* **Tests**
  * Added comprehensive benchmark tests for float32 fixed-width encoding scenarios, including little-endian direct set operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->