### PR TITLE
collections: add column graph block view foundation

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -1,0 +1,361 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"unsafe"
+)
+
+var errColumnVectorGraphBlockViewRowOutOfBounds = errors.New("column_graph block view row outside block")
+
+type columnVectorGraphOrdinalRef struct {
+	assetOrdinal int
+	rowIndex     int
+}
+
+type columnVectorGraphByteSpan struct {
+	start int
+	end   int
+}
+
+type columnVectorGraphVectorSpan struct {
+	start int
+	end   int
+	dims  int
+}
+
+type columnVectorGraphAdjacencySpan struct {
+	start int
+	end   int
+	count int
+}
+
+type columnVectorGraphSearchPlan struct {
+	reader *columnVectorGraphPhysicalRowReader
+}
+
+type columnVectorGraphBlockView struct {
+	reader       *columnVectorGraphPhysicalRowReader
+	block        *columnPhysicalRowReaderBlock
+	idSpans      []columnVectorGraphByteSpan
+	vectorSpans  []columnVectorGraphVectorSpan
+	invNorms     []float32
+	adjSpans     []columnVectorGraphAdjacencySpan
+	rowValidated []bool
+}
+
+func newColumnVectorGraphSearchPlan(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
+	if reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if _, err := reader.rowReader(); err != nil {
+		return nil, err
+	}
+	return &columnVectorGraphSearchPlan{reader: reader}, nil
+}
+
+func (p *columnVectorGraphSearchPlan) ordinalRef(ordinal int) (columnVectorGraphOrdinalRef, error) {
+	if p == nil || p.reader == nil {
+		return columnVectorGraphOrdinalRef{}, errNilColumnVectorGraphPhysicalRowReader
+	}
+	reader, err := p.reader.rowReader()
+	if err != nil {
+		return columnVectorGraphOrdinalRef{}, err
+	}
+	rangeIdx := reader.rangeIndexForOrdinal(ordinal)
+	if rangeIdx < 0 {
+		return columnVectorGraphOrdinalRef{}, fmt.Errorf("collections: physical column row ordinal=%d outside row_count=%d: %w", ordinal, reader.totalRows, errColumnPhysicalRowOrdinalOutOfBounds)
+	}
+	rowRange := reader.ranges[rangeIdx]
+	return columnVectorGraphOrdinalRef{
+		assetOrdinal: rowRange.assetOrdinal,
+		rowIndex:     ordinal - rowRange.startOrdinal,
+	}, nil
+}
+
+func (p *columnVectorGraphSearchPlan) blockViewForOrdinal(ordinal int) (*columnVectorGraphBlockView, columnVectorGraphOrdinalRef, error) {
+	ref, err := p.ordinalRef(ordinal)
+	if err != nil {
+		return nil, columnVectorGraphOrdinalRef{}, err
+	}
+	view, err := p.blockViewForAssetOrdinal(ref.assetOrdinal)
+	if err != nil {
+		return nil, columnVectorGraphOrdinalRef{}, err
+	}
+	return view, ref, nil
+}
+
+func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int) (*columnVectorGraphBlockView, error) {
+	if p == nil || p.reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	reader, err := p.reader.rowReader()
+	if err != nil {
+		return nil, err
+	}
+	if assetOrdinal < 0 || assetOrdinal >= len(reader.ranges) {
+		return nil, fmt.Errorf("collections: column_graph block view asset ordinal=%d outside ranges=%d", assetOrdinal, len(reader.ranges))
+	}
+	block, err := reader.loadBlock(reader.ranges[assetOrdinal])
+	if err != nil {
+		return nil, err
+	}
+	return newColumnVectorGraphBlockView(p.reader, block)
+}
+
+func newColumnVectorGraphBlockView(reader *columnVectorGraphPhysicalRowReader, block *columnPhysicalRowReaderBlock) (*columnVectorGraphBlockView, error) {
+	if reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if block == nil {
+		return nil, errors.New("collections: column_graph block view requires block")
+	}
+	rows := len(block.rowOffsets)
+	view := &columnVectorGraphBlockView{
+		reader:       reader,
+		block:        block,
+		idSpans:      make([]columnVectorGraphByteSpan, rows),
+		vectorSpans:  make([]columnVectorGraphVectorSpan, rows),
+		invNorms:     make([]float32, rows),
+		adjSpans:     make([]columnVectorGraphAdjacencySpan, rows),
+		rowValidated: make([]bool, rows),
+	}
+	for rowIndex := 0; rowIndex < rows; rowIndex++ {
+		if err := view.indexRow(rowIndex); err != nil {
+			return nil, err
+		}
+	}
+	return view, nil
+}
+
+func (v *columnVectorGraphBlockView) indexRow(rowIndex int) error {
+	cur := manifestCursor{raw: v.block.raw, pos: v.block.rowOffsets[rowIndex]}
+	idStart, idEnd, err := columnVectorGraphReadBytesSpan(&cur)
+	if err != nil {
+		return err
+	}
+	deleted := false
+	if v.block.version >= columnPhysicalAssetVersionV2 {
+		deleted = cur.bool()
+	}
+	if cur.err != nil {
+		return cur.err
+	}
+	ordinal := v.ordinalForRowIndex(rowIndex)
+	if len(v.block.raw[idStart:idEnd]) == 0 {
+		return fmt.Errorf("collections: column_graph %q ordinal=%d missing document id", v.reader.def.Name, ordinal)
+	}
+	if deleted {
+		if v.block.header.Operation != ColumnPublishOperationDelete {
+			return fmt.Errorf("column physical asset %s row[%d] is marked deleted", v.block.header.Operation, rowIndex)
+		}
+		return fmt.Errorf("collections: column_graph %q ordinal=%d row is deleted", v.reader.def.Name, ordinal)
+	}
+	if v.block.header.Operation == ColumnPublishOperationDelete {
+		return fmt.Errorf("column physical asset delete row[%d] is not marked deleted", rowIndex)
+	}
+	v.idSpans[rowIndex] = columnVectorGraphByteSpan{start: idStart, end: idEnd}
+
+	vectorSpan, err := v.indexVector(&cur, ordinal)
+	if err != nil {
+		return fmt.Errorf("row[%d]: %w", rowIndex, err)
+	}
+	invNorm, err := v.indexInvNorm(&cur, ordinal)
+	if err != nil {
+		return fmt.Errorf("row[%d]: %w", rowIndex, err)
+	}
+	adjSpan, err := v.indexAdjacency(&cur, ordinal)
+	if err != nil {
+		return fmt.Errorf("row[%d]: %w", rowIndex, err)
+	}
+	if cur.err != nil {
+		return cur.err
+	}
+	v.vectorSpans[rowIndex] = vectorSpan
+	v.invNorms[rowIndex] = invNorm
+	v.adjSpans[rowIndex] = adjSpan
+	v.rowValidated[rowIndex] = true
+	return nil
+}
+
+func (v *columnVectorGraphBlockView) ordinalForRowIndex(rowIndex int) int {
+	if v == nil || v.reader == nil || v.reader.reader == nil || v.block == nil {
+		return rowIndex
+	}
+	assetOrdinal := v.block.assetOrdinal
+	if assetOrdinal < 0 || assetOrdinal >= len(v.reader.reader.ranges) {
+		return rowIndex
+	}
+	return v.reader.reader.ranges[assetOrdinal].startOrdinal + rowIndex
+}
+
+func (v *columnVectorGraphBlockView) indexVector(cur *manifestCursor, ordinal int) (columnVectorGraphVectorSpan, error) {
+	if err := v.readGraphHeader(cur, v.block.version, ordinal, 0, ColumnStoreValueFloat32Vector); err != nil {
+		return columnVectorGraphVectorSpan{}, err
+	}
+	n := cur.u64()
+	if cur.err != nil {
+		return columnVectorGraphVectorSpan{}, cur.err
+	}
+	if n != uint64(v.reader.def.Dimensions) {
+		return columnVectorGraphVectorSpan{}, fmt.Errorf("collections: column_graph %q ordinal=%d vector dims=%d want %d", v.reader.def.Name, ordinal, n, v.reader.def.Dimensions)
+	}
+	byteLen, ok := cur.fixedWidthSliceByteLen(n, 4, "float32_vector")
+	if !ok {
+		return columnVectorGraphVectorSpan{}, cur.err
+	}
+	start := cur.pos
+	cur.pos += int(byteLen)
+	return columnVectorGraphVectorSpan{start: start, end: cur.pos, dims: int(n)}, nil
+}
+
+func (v *columnVectorGraphBlockView) indexInvNorm(cur *manifestCursor, ordinal int) (float32, error) {
+	if err := v.readGraphHeader(cur, v.block.version, ordinal, 1, ColumnStoreValueFloat32); err != nil {
+		return 0, err
+	}
+	invNorm := math.Float32frombits(cur.u32())
+	if cur.err != nil {
+		return 0, cur.err
+	}
+	if invNorm <= 0 || math.IsNaN(float64(invNorm)) || math.IsInf(float64(invNorm), 0) {
+		return 0, fmt.Errorf("collections: column_graph %q ordinal=%d invalid inv_norm=%v", v.reader.def.Name, ordinal, invNorm)
+	}
+	return invNorm, nil
+}
+
+func (v *columnVectorGraphBlockView) indexAdjacency(cur *manifestCursor, ordinal int) (columnVectorGraphAdjacencySpan, error) {
+	if err := v.readGraphHeader(cur, v.block.version, ordinal, 2, ColumnStoreValueAdjacencyList); err != nil {
+		return columnVectorGraphAdjacencySpan{}, err
+	}
+	n := cur.u64()
+	if cur.err != nil {
+		return columnVectorGraphAdjacencySpan{}, cur.err
+	}
+	byteLen, ok := cur.fixedWidthSliceByteLen(n, 4, "uint32 slice")
+	if !ok {
+		return columnVectorGraphAdjacencySpan{}, cur.err
+	}
+	start := cur.pos
+	cur.pos += int(byteLen)
+	return columnVectorGraphAdjacencySpan{start: start, end: cur.pos, count: int(n)}, nil
+}
+
+func (v *columnVectorGraphBlockView) readGraphHeader(cur *manifestCursor, version uint16, ordinal, colIdx int, want ColumnStoreValueType) error {
+	typeBytes := cur.stringBytes()
+	if cur.err != nil {
+		return cur.err
+	}
+	if !columnPhysicalBytesEqualString(typeBytes, string(want)) {
+		return fmt.Errorf("column[%d] type=%q want %q", colIdx, string(typeBytes), want)
+	}
+	null := cur.bool()
+	if cur.err != nil {
+		return cur.err
+	}
+	present := true
+	if version >= columnPhysicalAssetVersionV3 {
+		present = cur.bool()
+		if cur.err != nil {
+			return cur.err
+		}
+	}
+	if !present {
+		return fmt.Errorf("collections: column_graph %q ordinal=%d missing graph value", v.reader.def.Name, ordinal)
+	}
+	if null {
+		return fmt.Errorf("collections: column_graph %q ordinal=%d contains null graph value", v.reader.def.Name, ordinal)
+	}
+	return nil
+}
+
+func (v *columnVectorGraphBlockView) checkRowIndex(rowIndex int) error {
+	if v == nil || v.block == nil || rowIndex < 0 || rowIndex >= len(v.rowValidated) || !v.rowValidated[rowIndex] {
+		return errColumnVectorGraphBlockViewRowOutOfBounds
+	}
+	return nil
+}
+
+func (v *columnVectorGraphBlockView) id(rowIndex int) ([]byte, error) {
+	if err := v.checkRowIndex(rowIndex); err != nil {
+		return nil, err
+	}
+	span := v.idSpans[rowIndex]
+	return v.block.raw[span.start:span.end], nil
+}
+
+func (v *columnVectorGraphBlockView) vector(rowIndex int, scratch []float32) ([]float32, []float32, error) {
+	if err := v.checkRowIndex(rowIndex); err != nil {
+		return nil, scratch, err
+	}
+	span := v.vectorSpans[rowIndex]
+	if span.dims == 0 {
+		return nil, scratch, nil
+	}
+	if columnPhysicalNativeLittleEndian {
+		raw := v.block.raw[span.start:span.end]
+		vector := unsafe.Slice((*float32)(unsafe.Pointer(unsafe.SliceData(raw))), span.dims)
+		return vector, scratch, nil
+	}
+	base := len(scratch)
+	need := base + span.dims
+	if cap(scratch) < need {
+		next := make([]float32, need)
+		copy(next, scratch)
+		scratch = next
+	} else {
+		scratch = scratch[:need]
+	}
+	pos := span.start
+	for i := base; i < need; i++ {
+		scratch[i] = math.Float32frombits(uint32(v.block.raw[pos]) | uint32(v.block.raw[pos+1])<<8 | uint32(v.block.raw[pos+2])<<16 | uint32(v.block.raw[pos+3])<<24)
+		pos += 4
+	}
+	return scratch[base:], scratch, nil
+}
+
+func (v *columnVectorGraphBlockView) invNorm(rowIndex int) (float32, error) {
+	if err := v.checkRowIndex(rowIndex); err != nil {
+		return 0, err
+	}
+	return v.invNorms[rowIndex], nil
+}
+
+func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) ([]uint32, []uint32, error) {
+	if err := v.checkRowIndex(rowIndex); err != nil {
+		return nil, scratch, err
+	}
+	span := v.adjSpans[rowIndex]
+	base := len(scratch)
+	need := base + span.count
+	if cap(scratch) < need {
+		next := make([]uint32, need)
+		copy(next, scratch)
+		scratch = next
+	} else {
+		scratch = scratch[:need]
+	}
+	pos := span.start
+	for i := base; i < need; i++ {
+		scratch[i] = uint32(v.block.raw[pos])<<24 | uint32(v.block.raw[pos+1])<<16 | uint32(v.block.raw[pos+2])<<8 | uint32(v.block.raw[pos+3])
+		pos += 4
+	}
+	return scratch[base:], scratch, nil
+}
+
+func columnVectorGraphReadBytesSpan(cur *manifestCursor) (int, int, error) {
+	if cur.err != nil {
+		return 0, 0, cur.err
+	}
+	n := cur.u64()
+	if cur.err != nil {
+		return 0, 0, cur.err
+	}
+	if n > uint64(len(cur.raw)-cur.pos) {
+		cur.err = errors.New("collections: short column binary bytes")
+		return 0, 0, cur.err
+	}
+	start := cur.pos
+	cur.pos += int(n)
+	return start, cur.pos, nil
+}

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -94,6 +94,9 @@ func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int)
 	if err != nil {
 		return nil, err
 	}
+	if reader.closed {
+		return nil, errors.New("collections: physical column row reader is closed")
+	}
 	if assetOrdinal < 0 || assetOrdinal >= len(reader.ranges) {
 		return nil, fmt.Errorf("collections: column_graph block view asset ordinal=%d outside ranges=%d", assetOrdinal, len(reader.ranges))
 	}

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -336,6 +336,8 @@ func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) (
 	} else {
 		scratch = scratch[:need]
 	}
+	// Adjacency uses the current big-endian row-record payload encoding; dense
+	// little-endian adjacency blocks are a later format-level optimization.
 	pos := span.start
 	for i := base; i < need; i++ {
 		scratch[i] = uint32(v.block.raw[pos])<<24 | uint32(v.block.raw[pos+1])<<16 | uint32(v.block.raw[pos+2])<<8 | uint32(v.block.raw[pos+3])

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"unsafe"
 )
 
 var errColumnVectorGraphBlockViewRowOutOfBounds = errors.New("column_graph block view row outside block")
@@ -295,11 +294,6 @@ func (v *columnVectorGraphBlockView) vector(rowIndex int, scratch []float32) ([]
 	if span.dims == 0 {
 		return nil, scratch, nil
 	}
-	if columnPhysicalNativeLittleEndian {
-		raw := v.block.raw[span.start:span.end]
-		vector := unsafe.Slice((*float32)(unsafe.Pointer(unsafe.SliceData(raw))), span.dims)
-		return vector, scratch, nil
-	}
 	base := len(scratch)
 	need := base + span.dims
 	if cap(scratch) < need {
@@ -308,6 +302,10 @@ func (v *columnVectorGraphBlockView) vector(rowIndex int, scratch []float32) ([]
 		scratch = next
 	} else {
 		scratch = scratch[:need]
+	}
+	if columnPhysicalNativeLittleEndian {
+		columnPhysicalCopyLittleEndianFloat32Bytes(scratch[base:need], v.block.raw[span.start:span.end])
+		return scratch[base:need], scratch, nil
 	}
 	pos := span.start
 	for i := base; i < need; i++ {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -72,8 +72,8 @@ func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
 	if !slices.Equal(vector, []float32{0, 1, 0}) {
 		t.Fatalf("vector=%v want [0 1 0]", vector)
 	}
-	if columnPhysicalNativeLittleEndian && len(vector) > 0 && len(vectorScratch) == 0 {
-		t.Fatalf("little-endian vector used no scratch; want aligned scratch copy")
+	if len(vectorScratch) > 0 && !slices.Equal(vector, vectorScratch) {
+		t.Fatalf("vectorScratch=%v want it to mirror vector=%v when scratch is used", vectorScratch, vector)
 	}
 	invNorm, err := view.invNorm(ref.rowIndex)
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -1,0 +1,116 @@
+package collections
+
+import (
+	"errors"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestColumnVectorGraphSearchPlanOrdinalRefV1(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	plan, err := newColumnVectorGraphSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("newColumnVectorGraphSearchPlan: %v", err)
+	}
+	ref, err := plan.ordinalRef(1)
+	if err != nil {
+		t.Fatalf("ordinalRef: %v", err)
+	}
+	if ref.assetOrdinal != 0 || ref.rowIndex != 1 {
+		t.Fatalf("ordinalRef={asset:%d row:%d} want {asset:0 row:1}", ref.assetOrdinal, ref.rowIndex)
+	}
+	_, err = plan.ordinalRef(2)
+	if !errors.Is(err, errColumnPhysicalRowOrdinalOutOfBounds) {
+		t.Fatalf("ordinalRef out-of-bounds err=%v want row bounds", err)
+	}
+}
+
+func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	plan, err := newColumnVectorGraphSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("newColumnVectorGraphSearchPlan: %v", err)
+	}
+	view, ref, err := plan.blockViewForOrdinal(1)
+	if err != nil {
+		t.Fatalf("blockViewForOrdinal: %v", err)
+	}
+	if ref.rowIndex != 1 {
+		t.Fatalf("rowIndex=%d want 1", ref.rowIndex)
+	}
+	id, err := view.id(ref.rowIndex)
+	if err != nil {
+		t.Fatalf("id: %v", err)
+	}
+	if string(id) != "doc-b" {
+		t.Fatalf("id=%q want doc-b", string(id))
+	}
+	vector, vectorScratch, err := view.vector(ref.rowIndex, nil)
+	if err != nil {
+		t.Fatalf("vector: %v", err)
+	}
+	if !slices.Equal(vector, []float32{0, 1, 0}) {
+		t.Fatalf("vector=%v want [0 1 0]", vector)
+	}
+	if columnPhysicalNativeLittleEndian && len(vector) > 0 && len(vectorScratch) != 0 {
+		t.Fatalf("little-endian vector used scratch len=%d; want direct typed view", len(vectorScratch))
+	}
+	invNorm, err := view.invNorm(ref.rowIndex)
+	if err != nil {
+		t.Fatalf("invNorm: %v", err)
+	}
+	if math.Abs(float64(invNorm-1)) > 1e-6 {
+		t.Fatalf("invNorm=%v want 1", invNorm)
+	}
+	adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, nil)
+	if err != nil {
+		t.Fatalf("adjacency: %v", err)
+	}
+	if !slices.Equal(adjacency, []uint32{0}) || !slices.Equal(adjacencyScratch, []uint32{0}) {
+		t.Fatalf("adjacency=%v scratch=%v want [0]", adjacency, adjacencyScratch)
+	}
+	stats := reader.Stats()
+	if stats.RowFetches != 0 || stats.RowsFetched != 0 {
+		t.Fatalf("stats after block-view access=%+v want no generic row fetch/materialization", stats)
+	}
+}
+
+func TestColumnVectorGraphBlockViewRejectsMalformedRowsV1(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 0, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	plan, err := newColumnVectorGraphSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("newColumnVectorGraphSearchPlan: %v", err)
+	}
+	_, _, err = plan.blockViewForOrdinal(0)
+	if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
+		t.Fatalf("blockViewForOrdinal err=%v want invalid inv_norm", err)
+	}
+}

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -72,8 +72,8 @@ func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
 	if !slices.Equal(vector, []float32{0, 1, 0}) {
 		t.Fatalf("vector=%v want [0 1 0]", vector)
 	}
-	if columnPhysicalNativeLittleEndian && len(vector) > 0 && len(vectorScratch) != 0 {
-		t.Fatalf("little-endian vector used scratch len=%d; want direct typed view", len(vectorScratch))
+	if columnPhysicalNativeLittleEndian && len(vector) > 0 && len(vectorScratch) == 0 {
+		t.Fatalf("little-endian vector used no scratch; want aligned scratch copy")
 	}
 	invNorm, err := view.invNorm(ref.rowIndex)
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -95,6 +95,27 @@ func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphBlockViewRejectsClosedReaderV1(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	plan, err := newColumnVectorGraphSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("newColumnVectorGraphSearchPlan: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, _, err := plan.blockViewForOrdinal(0); err == nil || !strings.Contains(err.Error(), "physical column row reader is closed") {
+		t.Fatalf("blockViewForOrdinal after close err=%v want closed reader", err)
+	}
+}
+
 func TestColumnVectorGraphBlockViewRejectsMalformedRowsV1(t *testing.T) {
 	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
 		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 0, Adjacency: []uint32{0}},


### PR DESCRIPTION
## Summary

This PR is the first implementation step after #1718 for the column_graph native block-oriented search planner.

It adds internal planner/block-view foundations without switching the production search loop yet.

Scope boundary:

- Adds `columnVectorGraphSearchPlan` and `columnVectorGraphBlockView` internals.
- Maps global ordinals to physical asset/block-local row indexes.
- Indexes graph row spans once per loaded block view.
- Exposes graph-native accessors for ID, vector, invNorm, and adjacency.
- Uses direct typed vector views over little-endian physical graph payload bytes on little-endian hosts.
- Keeps adjacency scratch-backed for the current big-endian adjacency encoding.
- Does not merge or retarget earlier PRs.
- Does not yet switch `SearchCosine` to batched scoring; that is the next stacked PR.

## What Changed

- Added `TreeDB/collections/column_vector_graph_block_view.go`.
- Added block-view tests for:
  - ordinal mapping,
  - direct vector access/correctness,
  - malformed row validation,
  - no generic row fetch/materialization accounting during block-view access.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnVectorGraph(SearchPlan|BlockView)'
# ok github.com/snissn/gomap/TreeDB/collections 0.648s

go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 16.687s

go test ./TreeDB/docs
# ok github.com/snissn/gomap/TreeDB/docs 0.727s
```

Benchmark smoke on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 21497 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 4919 ns/op, 44 B/op, 0 allocs/op
```

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 21,497 | 46,518 | 0 | 0 | 128 | 612 | 0 | 0 |
| Parallel production 8192 | 4,919 | 203,293 | 44 | 0 | 128 | 612 | 0 | 0 |

## Throughput Notes

This PR is foundation-only, so the production search loop is intentionally unchanged. The benchmark smoke is included to show no regression in the current native hot path while adding the block-view types that the next PR will use for grouped scoring.

## Stack

- Depends on #1718.
- Next planned PR: search scoring through planner/block batches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a block-scoped read view for column-vector-graph data to enable efficient, on-block access to IDs, vectors, inverse norms, and adjacency lists.

* **Bug Fixes / Validation**
  * Enforced strict validation for vector dimensions, inverse norms, IDs and deletion markers; rejects malformed or inconsistent rows.

* **Tests**
  * Added comprehensive unit tests covering mapping, accessors, error handling, and reader-state behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->