### PR TITLE
collections: score native vector search through block views

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -32,7 +32,34 @@ type columnVectorGraphAdjacencySpan struct {
 }
 
 type columnVectorGraphSearchPlan struct {
-	reader *columnVectorGraphPhysicalRowReader
+	reader     *columnVectorGraphPhysicalRowReader
+	blockViews map[int]*columnVectorGraphBlockView
+	hits       uint64
+	misses     uint64
+	builds     uint64
+}
+
+func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
+	if s == nil {
+		return nil, errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if _, err := reader.rowReader(); err != nil {
+		return nil, err
+	}
+	plan := &s.searchPlan
+	if plan.reader != reader {
+		for k := range plan.blockViews {
+			delete(plan.blockViews, k)
+		}
+		plan.reader = reader
+	}
+	plan.hits = 0
+	plan.misses = 0
+	plan.builds = 0
+	return plan, nil
 }
 
 type columnVectorGraphBlockView struct {
@@ -97,11 +124,33 @@ func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int)
 	if assetOrdinal < 0 || assetOrdinal >= len(reader.ranges) {
 		return nil, fmt.Errorf("collections: column_graph block view asset ordinal=%d outside ranges=%d", assetOrdinal, len(reader.ranges))
 	}
+	if p.blockViews != nil {
+		if view := p.blockViews[assetOrdinal]; view != nil {
+			p.hits++
+			return view, nil
+		}
+	}
+	p.misses++
 	block, err := reader.loadBlock(reader.ranges[assetOrdinal])
 	if err != nil {
 		return nil, err
 	}
-	return newColumnVectorGraphBlockView(p.reader, block)
+	view, err := newColumnVectorGraphBlockView(p.reader, block)
+	if err != nil {
+		return nil, err
+	}
+	p.builds++
+	if p.blockViews == nil {
+		p.blockViews = make(map[int]*columnVectorGraphBlockView, reader.maxBlocks)
+	}
+	if reader.maxBlocks > 0 && len(p.blockViews) >= reader.maxBlocks {
+		for existing := range p.blockViews {
+			delete(p.blockViews, existing)
+			break
+		}
+	}
+	p.blockViews[assetOrdinal] = view
+	return view, nil
 }
 
 func newColumnVectorGraphBlockView(reader *columnVectorGraphPhysicalRowReader, block *columnPhysicalRowReaderBlock) (*columnVectorGraphBlockView, error) {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -116,6 +116,30 @@ func TestColumnVectorGraphBlockViewRejectsClosedReaderV1(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphBlockViewRejectsClosedReaderWithCachedViewV1(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	plan, err := newColumnVectorGraphSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("newColumnVectorGraphSearchPlan: %v", err)
+	}
+	if _, _, err := plan.blockViewForOrdinal(0); err != nil {
+		t.Fatalf("prime cached blockViewForOrdinal: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, _, err := plan.blockViewForOrdinal(0); err == nil || !strings.Contains(err.Error(), "physical column row reader is closed") {
+		t.Fatalf("cached blockViewForOrdinal after close err=%v want closed reader", err)
+	}
+}
+
 func TestColumnVectorGraphBlockViewRejectsMalformedRowsV1(t *testing.T) {
 	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, []columnVectorGraphAssetRow{
 		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 0, Adjacency: []uint32{0}},

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -36,6 +36,11 @@ type columnVectorGraphNativeSearchStats struct {
 	CandidateFetches uint64
 	ExpansionFetches uint64
 	ResultFetches    uint64
+	ScoreBatches     uint64
+	OrdinalsGrouped  uint64
+	BlockViewHits    uint64
+	BlockViewMisses  uint64
+	BlockViewBuilds  uint64
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -69,6 +74,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	resultOrder    []int
 	resultOrdinals []int
 	adjacencyBuf   []uint32
+	searchPlan     columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
@@ -257,7 +263,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 
 	var stats columnVectorGraphNativeSearchStats
-	if err := r.scoreAndPushFrontier(query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
+	plan, err := scratch.prepareSearchPlan(r)
+	if err != nil {
+		return nil, stats, err
+	}
+	if err := r.scoreAndPushFrontier(plan, query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
@@ -270,7 +280,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			if nextSeed >= rowCount {
 				break
 			}
-			if err := r.scoreAndPushFrontier(query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontier(plan, query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 			continue
@@ -285,7 +295,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, candidate.ordinal, i, neighbor, rowCount); err != nil {
 				return nil, stats, err
 			}
-			if err := r.scoreAndPushFrontier(query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontier(plan, query, queryInvNorm, int(neighbor), topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -368,14 +378,35 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	if scratch.markVisited(ordinal) {
-		row, err := r.fetchNativeRowUnchecked(ordinal, &scratch.scoreScratch)
+		view, ref, err := plan.blockViewForOrdinal(ordinal)
 		if err != nil {
 			return err
 		}
+		stats.ScoreBatches++
+		stats.OrdinalsGrouped++
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+		scratch.scoreScratch.Float32Values = scratch.scoreScratch.Float32Values[:0]
+		vector, vectorScratch, err := view.vector(ref.rowIndex, scratch.scoreScratch.Float32Values)
+		if err != nil {
+			return err
+		}
+		scratch.scoreScratch.Float32Values = vectorScratch
+		invNorm, err := view.invNorm(ref.rowIndex)
+		if err != nil {
+			return err
+		}
+		scratch.scoreScratch.Uint32Values = scratch.scoreScratch.Uint32Values[:0]
+		adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, scratch.scoreScratch.Uint32Values)
+		if err != nil {
+			return err
+		}
+		scratch.scoreScratch.Uint32Values = adjacencyScratch
 		stats.CandidateFetches++
-		score, err := columnVectorGraphNativeCosineScore(query, queryInvNorm, row)
+		score, err := columnVectorGraphNativeCosineScore(query, queryInvNorm, columnVectorGraphPhysicalRow{Ordinal: ordinal, Vector: vector, InvNorm: invNorm})
 		if err != nil {
 			return err
 		}
@@ -386,7 +417,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(query []float3
 		candidate := columnVectorGraphSearchCandidate{
 			ordinal:   ordinal,
 			score:     score,
-			adjacency: scratch.copyCandidateAdjacency(row.Adjacency),
+			adjacency: scratch.copyCandidateAdjacency(adjacency),
 		}
 		scratch.insertTop(topK, candidate)
 		scratch.pushFrontier(candidate)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -79,15 +79,15 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if stats.Candidates != uint64(len(rows)) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
-	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ExpansionFetches != 0 || stats.ResultFetches != uint64(len(got)) {
+	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ScoreBatches != uint64(len(rows)) || stats.ExpansionFetches != 0 || stats.ResultFetches != uint64(len(got)) {
 		t.Fatalf("stats=%+v want candidate/result fetches without duplicate expansion row fetches", stats)
 	}
 	readerStats := reader.Stats()
 	if readerStats.BatchFetches == 0 {
 		t.Fatalf("reader stats=%+v want batched top-k result fetch", readerStats)
 	}
-	if gotRows, wantRows := readerStats.RowsFetched, stats.CandidateFetches+stats.ResultFetches; gotRows != wantRows {
-		t.Fatalf("reader rows_fetched=%d want candidate+result fetches=%d stats=%+v", gotRows, wantRows, stats)
+	if gotRows, wantRows := readerStats.RowsFetched, stats.ResultFetches; gotRows != wantRows {
+		t.Fatalf("reader rows_fetched=%d want top-k result fetches=%d stats=%+v", gotRows, wantRows, stats)
 	}
 }
 
@@ -115,11 +115,11 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ExpansionFetches != 0 {
+	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != 0 {
 		t.Fatalf("stats=%+v want four scored candidates without duplicate expansion row fetches", stats)
 	}
-	if readerStats := reader.Stats(); readerStats.RowsFetched != stats.CandidateFetches+stats.ResultFetches {
-		t.Fatalf("reader rows_fetched=%d want candidate+result fetches stats=%+v", readerStats.RowsFetched, stats)
+	if readerStats := reader.Stats(); readerStats.RowsFetched != stats.ResultFetches {
+		t.Fatalf("reader rows_fetched=%d want top-k result fetches stats=%+v", readerStats.RowsFetched, stats)
 	}
 }
 
@@ -694,6 +694,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.CandidateFetches += stats.CandidateFetches
 		searchStats.ExpansionFetches += stats.ExpansionFetches
 		searchStats.ResultFetches += stats.ResultFetches
+		searchStats.ScoreBatches += stats.ScoreBatches
+		searchStats.OrdinalsGrouped += stats.OrdinalsGrouped
+		searchStats.BlockViewHits += stats.BlockViewHits
+		searchStats.BlockViewMisses += stats.BlockViewMisses
+		searchStats.BlockViewBuilds += stats.BlockViewBuilds
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -755,6 +760,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalCandidateFetches atomic.Uint64
 	var totalExpansionFetches atomic.Uint64
 	var totalResultFetches atomic.Uint64
+	var totalScoreBatches atomic.Uint64
+	var totalOrdinalsGrouped atomic.Uint64
+	var totalBlockViewHits atomic.Uint64
+	var totalBlockViewMisses atomic.Uint64
+	var totalBlockViewBuilds atomic.Uint64
 	var nextWorker atomic.Uint64
 	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
@@ -789,6 +799,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.CandidateFetches += stats.CandidateFetches
 			localStats.ExpansionFetches += stats.ExpansionFetches
 			localStats.ResultFetches += stats.ResultFetches
+			localStats.ScoreBatches += stats.ScoreBatches
+			localStats.OrdinalsGrouped += stats.OrdinalsGrouped
+			localStats.BlockViewHits += stats.BlockViewHits
+			localStats.BlockViewMisses += stats.BlockViewMisses
+			localStats.BlockViewBuilds += stats.BlockViewBuilds
 		}
 		sink.Add(localSink)
 		totalCandidates.Add(localStats.Candidates)
@@ -796,6 +811,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalCandidateFetches.Add(localStats.CandidateFetches)
 		totalExpansionFetches.Add(localStats.ExpansionFetches)
 		totalResultFetches.Add(localStats.ResultFetches)
+		totalScoreBatches.Add(localStats.ScoreBatches)
+		totalOrdinalsGrouped.Add(localStats.OrdinalsGrouped)
+		totalBlockViewHits.Add(localStats.BlockViewHits)
+		totalBlockViewMisses.Add(localStats.BlockViewMisses)
+		totalBlockViewBuilds.Add(localStats.BlockViewBuilds)
 	})
 	b.StopTimer()
 	reportColumnGraphNativeSearchBenchShapeMetricsV3(b, shape)
@@ -814,6 +834,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		CandidateFetches: totalCandidateFetches.Load(),
 		ExpansionFetches: totalExpansionFetches.Load(),
 		ResultFetches:    totalResultFetches.Load(),
+		ScoreBatches:     totalScoreBatches.Load(),
+		OrdinalsGrouped:  totalOrdinalsGrouped.Load(),
+		BlockViewHits:    totalBlockViewHits.Load(),
+		BlockViewMisses:  totalBlockViewMisses.Load(),
+		BlockViewBuilds:  totalBlockViewBuilds.Load(),
 	})
 }
 
@@ -980,6 +1005,11 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 		b.ReportMetric(float64(searchStats.Edges)/float64(searchStats.Candidates), "edges/node")
 	}
 	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
+	b.ReportMetric(float64(searchStats.ScoreBatches)/float64(n), "score_batches/search")
+	b.ReportMetric(float64(searchStats.OrdinalsGrouped)/float64(n), "ordinals_grouped/search")
+	b.ReportMetric(float64(searchStats.BlockViewHits)/float64(n), "block_view_hits/search")
+	b.ReportMetric(float64(searchStats.BlockViewMisses)/float64(n), "block_view_misses/search")
+	b.ReportMetric(float64(searchStats.BlockViewBuilds)/float64(n), "block_view_builds/search")
 	b.ReportMetric(float64(searchStats.ExpansionFetches)/float64(n), "expansion_fetches/search")
 	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
 	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheHits, baseStats.CacheHits))/float64(n), "cache_hits/search")

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -314,11 +314,11 @@ func TestOpenVectorIndexSearcherReusesNativeReaderV4(t *testing.T) {
 	if second.Stats.OpenGranulesRead != first.Stats.OpenGranulesRead || second.Stats.OpenPhysicalBytesRead != first.Stats.OpenPhysicalBytesRead {
 		t.Fatalf("open stats changed first=(%d,%d) second=(%d,%d); want stable bound-reader setup telemetry", first.Stats.OpenGranulesRead, first.Stats.OpenPhysicalBytesRead, second.Stats.OpenGranulesRead, second.Stats.OpenPhysicalBytesRead)
 	}
-	// Physical read/cache counters may be zero when the segment cache is warm;
-	// logical fetch/search counters prove the bound reader is reused without
-	// depending on cold-cache telemetry.
-	if first.Stats.RowFetches == 0 || second.Stats.RowFetches == 0 {
-		t.Fatalf("row fetch stats first=%d second=%d want non-zero per-search deltas", first.Stats.RowFetches, second.Stats.RowFetches)
+	// Physical read/cache counters and generic row fetches may be zero when the
+	// planner-backed segment/block cache is warm; logical candidate counters prove
+	// the bound reader is reused without depending on cold-cache telemetry.
+	if first.Stats.CandidateFetches == 0 || second.Stats.CandidateFetches == 0 {
+		t.Fatalf("candidate fetch stats first=%d second=%d want non-zero per-search deltas", first.Stats.CandidateFetches, second.Stats.CandidateFetches)
 	}
 	if first.Stats.Candidates == 0 || second.Stats.Candidates == 0 {
 		t.Fatalf("candidate stats first=%d second=%d want non-zero searches", first.Stats.Candidates, second.Stats.Candidates)


### PR DESCRIPTION
## Summary

This PR is the second implementation step after #1718/#1720 for the column_graph native block-oriented search planner.

It switches candidate scoring in `SearchCosine` from per-candidate native row fetch/decode to the search-plan/block-view path introduced in #1720.

Scope boundary:

- Uses `columnVectorGraphSearchPlan` from search scratch so warmed searches reuse bounded block views without allocations.
- Scores candidates through `columnVectorGraphBlockView.vector` and `invNorm`.
- Keeps current eager adjacency copy behavior for frontier candidates; lazy adjacency is the next stacked PR.
- Keeps final top-k ID materialization on the existing batch fetch path; grouped top-k materialization is a later stacked PR.
- Does not merge earlier PRs.

## What Changed

- `SearchCosine` prepares a scratch-owned search plan.
- Candidate scoring resolves ordinal -> block view -> row index.
- Candidate vector scoring uses direct typed vector spans from the block view on little-endian hosts.
- Adds planner accounting:
  - `score_batches/search`
  - `ordinals_grouped/search`
  - `block_view_hits/search`
  - `block_view_misses/search`
  - `block_view_builds/search`
- Updates tests that previously expected generic row-reader `RowsFetched` to include candidate scoring. Candidate scoring is no longer a generic row fetch; final result ID fetches still use the existing result path in this PR.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 16.791s
```

Benchmark smoke on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 13685 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 4135 ns/op, 14 B/op, 0 allocs/op
```

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | score_batches/search | block_view_hits/search | block_view_builds/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 13,685 | 73,073 | 0 | 0 | 128 | 128 | 128 | 0 | 612 | 0 | 0 |
| Parallel production 8192 | 4,135 | 241,838 | 14 | 0 | 128 | 128 | 128 | 0 | 612 | 0 | 0 |

## Before / After Evidence

Against #1720 smoke on the same Apple M3 machine:

| Benchmark | #1720 ns/op | This PR ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 21,497 | 13,685 | 73,073 | -36.3% |
| Parallel production 8192 | 4,919 | 4,135 | 241,838 | -15.9% |

## Throughput Notes

The warmed production benchmark now reports `block_view_hits/search=128`, `block_view_builds/search=0`, `decoded_blocks/search=0`, and `physical_B/search=0`. This shows the hot scoring path is using the scratch-owned block view cache rather than generic row materialization or physical rereads.

## Stack

- Depends on #1720.
- Next planned PR: lazy adjacency expansion so scoring no longer copies adjacency into every frontier candidate.
