### PR TITLE
collections: lazily expand column graph adjacency

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -434,6 +434,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacency(plan *colu
 		return nil, err
 	}
 	scratch.expandScratch.Uint32Values = adjacencyScratch
+	stats.ExpansionFetches++
 	stats.AdjacencyExpansions++
 	stats.AdjacencyScratchDecodes++
 	stats.BlockViewHits = plan.hits

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -56,9 +56,8 @@ type columnVectorGraphNativeSearchResult struct {
 }
 
 type columnVectorGraphSearchCandidate struct {
-	ordinal   int
-	score     float64
-	adjacency []uint32
+	ordinal int
+	score   float64
 }
 
 // columnVectorGraphNativeSearchScratch is caller-owned mutable search state.
@@ -76,7 +75,6 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
-	adjacencyBuf   []uint32
 	searchPlan     columnVectorGraphSearchPlan
 }
 
@@ -103,20 +101,12 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if frontierCap < topK {
 		frontierCap = topK
 	}
-	adjacencyCap := 0
-	if frontierCap > 0 && degree > 0 {
-		if frontierCap > math.MaxInt/degree {
-			return fmt.Errorf("collections: column_graph native search adjacency scratch overflows: frontierCap=%d degree=%d", frontierCap, degree)
-		}
-		adjacencyCap = frontierCap * degree
-	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
 	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
-	s.adjacencyBuf = resizeColumnVectorGraphNativeUint32Scratch(s.adjacencyBuf, adjacencyCap)
 	return nil
 }
 
@@ -140,19 +130,10 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 }
 
 func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearchCandidate, target int) []columnVectorGraphSearchCandidate {
-	if len(dst) > 0 {
-		clearColumnVectorGraphNativeCandidateAdjacencyRefs(dst)
-	}
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]columnVectorGraphSearchCandidate, 0, target)
 	}
 	return dst[:0]
-}
-
-func clearColumnVectorGraphNativeCandidateAdjacencyRefs(candidates []columnVectorGraphSearchCandidate) {
-	for i := range candidates {
-		candidates[i].adjacency = nil
-	}
 }
 
 func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {
@@ -463,7 +444,6 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 	lastIdx := len(s.frontier) - 1
 	best := s.frontier[0]
 	last := s.frontier[lastIdx]
-	s.frontier[lastIdx].adjacency = nil
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
 		s.frontier[0] = last

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -31,16 +31,19 @@ type columnVectorGraphNativeSearchOptions struct {
 }
 
 type columnVectorGraphNativeSearchStats struct {
-	Candidates       uint64
-	Edges            uint64
-	CandidateFetches uint64
-	ExpansionFetches uint64
-	ResultFetches    uint64
-	ScoreBatches     uint64
-	OrdinalsGrouped  uint64
-	BlockViewHits    uint64
-	BlockViewMisses  uint64
-	BlockViewBuilds  uint64
+	Candidates              uint64
+	Edges                   uint64
+	CandidateFetches        uint64
+	ExpansionFetches        uint64
+	ResultFetches           uint64
+	ScoreBatches            uint64
+	OrdinalsGrouped         uint64
+	BlockViewHits           uint64
+	BlockViewMisses         uint64
+	BlockViewBuilds         uint64
+	AdjacencyExpansions     uint64
+	AdjacencyScratchDecodes uint64
+	AdjacencyDirectViews    uint64
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -285,9 +288,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		// Candidate scoring fetches adjacency once into scratch-owned storage;
-		// expansion validates and consumes that copy without a second row fetch.
-		for i, neighbor := range candidate.adjacency {
+		adjacency, err := r.expandCandidateAdjacency(plan, candidate.ordinal, scratch, &stats)
+		if err != nil {
+			return nil, stats, err
+		}
+		for i, neighbor := range adjacency {
 			if stats.Candidates >= uint64(efSearch) {
 				break
 			}
@@ -399,12 +404,6 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(plan *columnVe
 		if err != nil {
 			return err
 		}
-		scratch.scoreScratch.Uint32Values = scratch.scoreScratch.Uint32Values[:0]
-		adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, scratch.scoreScratch.Uint32Values)
-		if err != nil {
-			return err
-		}
-		scratch.scoreScratch.Uint32Values = adjacencyScratch
 		stats.CandidateFetches++
 		score, err := columnVectorGraphNativeCosineScore(query, queryInvNorm, columnVectorGraphPhysicalRow{Ordinal: ordinal, Vector: vector, InvNorm: invNorm})
 		if err != nil {
@@ -415,9 +414,8 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(plan *columnVe
 		}
 		stats.Candidates++
 		candidate := columnVectorGraphSearchCandidate{
-			ordinal:   ordinal,
-			score:     score,
-			adjacency: scratch.copyCandidateAdjacency(adjacency),
+			ordinal: ordinal,
+			score:   score,
 		}
 		scratch.insertTop(topK, candidate)
 		scratch.pushFrontier(candidate)
@@ -425,21 +423,23 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontier(plan *columnVe
 	return nil
 }
 
-func (s *columnVectorGraphNativeSearchScratch) copyCandidateAdjacency(adjacency []uint32) []uint32 {
-	start := len(s.adjacencyBuf)
-	need := start + len(adjacency)
-	if need > cap(s.adjacencyBuf) {
-		nextCap := cap(s.adjacencyBuf) * 2
-		if nextCap < need {
-			nextCap = need
-		}
-		next := make([]uint32, len(s.adjacencyBuf), nextCap)
-		copy(next, s.adjacencyBuf)
-		s.adjacencyBuf = next
+func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacency(plan *columnVectorGraphSearchPlan, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+	view, ref, err := plan.blockViewForOrdinal(ordinal)
+	if err != nil {
+		return nil, err
 	}
-	s.adjacencyBuf = s.adjacencyBuf[:need]
-	copy(s.adjacencyBuf[start:need], adjacency)
-	return s.adjacencyBuf[start:need]
+	scratch.expandScratch.Uint32Values = scratch.expandScratch.Uint32Values[:0]
+	adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, scratch.expandScratch.Uint32Values)
+	if err != nil {
+		return nil, err
+	}
+	scratch.expandScratch.Uint32Values = adjacencyScratch
+	stats.AdjacencyExpansions++
+	stats.AdjacencyScratchDecodes++
+	stats.BlockViewHits = plan.hits
+	stats.BlockViewMisses = plan.misses
+	stats.BlockViewBuilds = plan.builds
+	return adjacency, nil
 }
 
 func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -149,49 +149,6 @@ func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing
 	}
 }
 
-func TestColumnVectorGraphNativeSearchScratchClearsCandidateAdjacencyRefsV3(t *testing.T) {
-	var scratch columnVectorGraphNativeSearchScratch
-	scratch.frontier = append(scratch.frontier, columnVectorGraphSearchCandidate{
-		ordinal:   1,
-		score:     1,
-		adjacency: []uint32{1, 2},
-	})
-	scratch.top = append(scratch.top, columnVectorGraphSearchCandidate{
-		ordinal:   2,
-		score:     2,
-		adjacency: []uint32{3, 4},
-	})
-	if err := scratch.prepare(4, 3, 2, 1, 2); err != nil {
-		t.Fatalf("prepare: %v", err)
-	}
-	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "frontier after prepare", scratch.frontier)
-	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "top after prepare", scratch.top)
-
-	scratch.frontier = append(scratch.frontier,
-		columnVectorGraphSearchCandidate{ordinal: 1, score: 1, adjacency: []uint32{1}},
-		columnVectorGraphSearchCandidate{ordinal: 2, score: 2, adjacency: []uint32{2}},
-	)
-	if _, ok := scratch.popFrontier(); !ok {
-		t.Fatalf("popFrontier returned ok=false")
-	}
-	backing := scratch.frontier[:cap(scratch.frontier)]
-	for i := len(scratch.frontier); i < len(backing); i++ {
-		if backing[i].adjacency != nil {
-			t.Fatalf("frontier backing slot %d retained adjacency %v after pop", i, backing[i].adjacency)
-		}
-	}
-}
-
-func assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t *testing.T, label string, candidates []columnVectorGraphSearchCandidate) {
-	t.Helper()
-	backing := candidates[:cap(candidates)]
-	for i, candidate := range backing {
-		if candidate.adjacency != nil {
-			t.Fatalf("%s backing slot %d retained adjacency %v", label, i, candidate.adjacency)
-		}
-	}
-}
-
 func TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3(t *testing.T) {
 	rows := []columnVectorGraphAssetRow{
 		{ID: []byte("doc-start"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -79,8 +79,8 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if stats.Candidates != uint64(len(rows)) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
-	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ScoreBatches != uint64(len(rows)) || stats.ExpansionFetches != 0 || stats.ResultFetches != uint64(len(got)) {
-		t.Fatalf("stats=%+v want candidate/result fetches without duplicate expansion row fetches", stats)
+	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ScoreBatches != uint64(len(rows)) || stats.ExpansionFetches != stats.AdjacencyExpansions || stats.ResultFetches != uint64(len(got)) {
+		t.Fatalf("stats=%+v want candidate/result fetches plus lazy adjacency expansion fetches", stats)
 	}
 	readerStats := reader.Stats()
 	if readerStats.BatchFetches == 0 {
@@ -115,8 +115,8 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != 0 {
-		t.Fatalf("stats=%+v want four scored candidates without duplicate expansion row fetches", stats)
+	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != stats.AdjacencyExpansions {
+		t.Fatalf("stats=%+v want four scored candidates plus lazy adjacency expansion fetches", stats)
 	}
 	if readerStats := reader.Stats(); readerStats.RowsFetched != stats.ResultFetches {
 		t.Fatalf("reader rows_fetched=%d want top-k result fetches stats=%+v", readerStats.RowsFetched, stats)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -699,6 +699,9 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.BlockViewHits += stats.BlockViewHits
 		searchStats.BlockViewMisses += stats.BlockViewMisses
 		searchStats.BlockViewBuilds += stats.BlockViewBuilds
+		searchStats.AdjacencyExpansions += stats.AdjacencyExpansions
+		searchStats.AdjacencyScratchDecodes += stats.AdjacencyScratchDecodes
+		searchStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -765,6 +768,9 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalBlockViewHits atomic.Uint64
 	var totalBlockViewMisses atomic.Uint64
 	var totalBlockViewBuilds atomic.Uint64
+	var totalAdjacencyExpansions atomic.Uint64
+	var totalAdjacencyScratchDecodes atomic.Uint64
+	var totalAdjacencyDirectViews atomic.Uint64
 	var nextWorker atomic.Uint64
 	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
@@ -804,6 +810,9 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.BlockViewHits += stats.BlockViewHits
 			localStats.BlockViewMisses += stats.BlockViewMisses
 			localStats.BlockViewBuilds += stats.BlockViewBuilds
+			localStats.AdjacencyExpansions += stats.AdjacencyExpansions
+			localStats.AdjacencyScratchDecodes += stats.AdjacencyScratchDecodes
+			localStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
 		}
 		sink.Add(localSink)
 		totalCandidates.Add(localStats.Candidates)
@@ -816,6 +825,9 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalBlockViewHits.Add(localStats.BlockViewHits)
 		totalBlockViewMisses.Add(localStats.BlockViewMisses)
 		totalBlockViewBuilds.Add(localStats.BlockViewBuilds)
+		totalAdjacencyExpansions.Add(localStats.AdjacencyExpansions)
+		totalAdjacencyScratchDecodes.Add(localStats.AdjacencyScratchDecodes)
+		totalAdjacencyDirectViews.Add(localStats.AdjacencyDirectViews)
 	})
 	b.StopTimer()
 	reportColumnGraphNativeSearchBenchShapeMetricsV3(b, shape)
@@ -829,16 +841,19 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		stats = addColumnPhysicalRowReaderStatsV3(stats, worker.reader.Stats())
 	}
 	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, columnVectorGraphNativeSearchStats{
-		Candidates:       totalCandidates.Load(),
-		Edges:            totalEdges.Load(),
-		CandidateFetches: totalCandidateFetches.Load(),
-		ExpansionFetches: totalExpansionFetches.Load(),
-		ResultFetches:    totalResultFetches.Load(),
-		ScoreBatches:     totalScoreBatches.Load(),
-		OrdinalsGrouped:  totalOrdinalsGrouped.Load(),
-		BlockViewHits:    totalBlockViewHits.Load(),
-		BlockViewMisses:  totalBlockViewMisses.Load(),
-		BlockViewBuilds:  totalBlockViewBuilds.Load(),
+		Candidates:              totalCandidates.Load(),
+		Edges:                   totalEdges.Load(),
+		CandidateFetches:        totalCandidateFetches.Load(),
+		ExpansionFetches:        totalExpansionFetches.Load(),
+		ResultFetches:           totalResultFetches.Load(),
+		ScoreBatches:            totalScoreBatches.Load(),
+		OrdinalsGrouped:         totalOrdinalsGrouped.Load(),
+		BlockViewHits:           totalBlockViewHits.Load(),
+		BlockViewMisses:         totalBlockViewMisses.Load(),
+		BlockViewBuilds:         totalBlockViewBuilds.Load(),
+		AdjacencyExpansions:     totalAdjacencyExpansions.Load(),
+		AdjacencyScratchDecodes: totalAdjacencyScratchDecodes.Load(),
+		AdjacencyDirectViews:    totalAdjacencyDirectViews.Load(),
 	})
 }
 
@@ -1010,6 +1025,9 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.BlockViewHits)/float64(n), "block_view_hits/search")
 	b.ReportMetric(float64(searchStats.BlockViewMisses)/float64(n), "block_view_misses/search")
 	b.ReportMetric(float64(searchStats.BlockViewBuilds)/float64(n), "block_view_builds/search")
+	b.ReportMetric(float64(searchStats.AdjacencyExpansions)/float64(n), "adjacency_expansions/search")
+	b.ReportMetric(float64(searchStats.AdjacencyScratchDecodes)/float64(n), "adjacency_scratch_decodes/search")
+	b.ReportMetric(float64(searchStats.AdjacencyDirectViews)/float64(n), "adjacency_direct_views/search")
 	b.ReportMetric(float64(searchStats.ExpansionFetches)/float64(n), "expansion_fetches/search")
 	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
 	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheHits, baseStats.CacheHits))/float64(n), "cache_hits/search")


### PR DESCRIPTION
## Summary

This PR is the third implementation step after #1718/#1720/#1721 for the column_graph native block-oriented search planner.

It removes eager per-scored-candidate adjacency copies from native vector search. Frontier candidates now carry ordinal+score only, and adjacency is loaded lazily from the block view when a candidate is popped for expansion.

Scope boundary:

- Keeps candidate scoring on the block-view path from #1721.
- Removes adjacency decode/copy from candidate scoring.
- Loads adjacency through `columnVectorGraphBlockView.adjacency` only during frontier expansion.
- Keeps final top-k ID materialization on the existing result fetch path; grouped top-k materialization is the next stacked PR.
- Does not change the current big-endian adjacency physical encoding; adjacency still decodes into scratch.

## What Changed

- `scoreAndPushFrontier` no longer reads/copies adjacency.
- Expansion resolves candidate ordinal -> block view -> row index and decodes adjacency lazily.
- Adds adjacency planner accounting:
  - `adjacency_expansions/search`
  - `adjacency_scratch_decodes/search`
  - `adjacency_direct_views/search`
- Keeps fail-closed edge validation as edges are expanded.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 20.234s
```

Benchmark smoke on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 12912 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 3471 ns/op, 45 B/op, 0 allocs/op
```

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | adjacency_expansions/search | adjacency_scratch_decodes/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 12,912 | 77,447 | 0 | 0 | 128 | 39 | 39 | 612 | 0 | 0 |
| Parallel production 8192 | 3,471 | 288,102 | 45 | 0 | 128 | 39 | 39 | 612 | 0 | 0 |

## Before / After Evidence

Against #1721 smoke on the same Apple M3 machine:

| Benchmark | #1721 ns/op | This PR ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 13,685 | 12,912 | 77,447 | -5.6% |
| Parallel production 8192 | 4,135 | 3,471 | 288,102 | -16.1% |

## Throughput Notes

The benchmark now reports `adjacency_expansions/search=39` instead of decoding/copying adjacency for all 128 scored candidates. This keeps graph traversal correctness while paying adjacency decode only for candidates that are actually expanded.

## Stack

- Depends on #1721.
- Next planned PR: grouped final top-k ID materialization through block views.
