### PR TITLE
collections: materialize native vector top-k IDs from block views

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -309,13 +309,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
-	if err := r.fetchTopSearchResults(scratch, &stats); err != nil {
+	if err := r.fetchTopSearchResults(plan, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	return scratch.results, stats, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	n := len(scratch.top)
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
@@ -326,34 +326,28 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(scratch *colu
 	for fetchPos, topIndex := range scratch.resultOrder {
 		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
 	}
-	fetched := 0
-	resultPos := 0
-	if err := r.fetchBatchUnchecked(scratch.resultOrdinals, &scratch.resultScratch, func(row columnVectorGraphPhysicalRow) error {
-		if resultPos >= n || scratch.resultOrdinals[resultPos] != row.Ordinal {
-			expected := -1
-			if resultPos < n {
-				expected = scratch.resultOrdinals[resultPos]
-			}
-			return fmt.Errorf("collections: column_graph %q result batch returned unexpected or out-of-order row ordinal=%d result_pos=%d expected_ordinal=%d", r.def.Name, row.Ordinal, resultPos, expected)
+	for resultPos, topIndex := range scratch.resultOrder {
+		ordinal := scratch.resultOrdinals[resultPos]
+		view, ref, err := plan.blockViewForOrdinal(ordinal)
+		if err != nil {
+			return err
 		}
-		topIndex := scratch.resultOrder[resultPos]
-		if cap(scratch.idBuffers[topIndex]) < len(row.ID) {
-			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
-		} else if columnVectorGraphNativeScratchCapOversized(cap(scratch.idBuffers[topIndex]), len(row.ID)) {
-			scratch.idBuffers[topIndex] = make([]byte, len(row.ID))
+		id, err := view.id(ref.rowIndex)
+		if err != nil {
+			return err
 		}
-		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(row.ID)]
-		copy(scratch.idBuffers[topIndex], row.ID)
-		fetched++
-		resultPos++
-		return nil
-	}); err != nil {
-		return err
-	}
-	if fetched != n {
-		return fmt.Errorf("collections: column_graph %q result batch rows=%d want %d", r.def.Name, fetched, n)
+		if cap(scratch.idBuffers[topIndex]) < len(id) {
+			scratch.idBuffers[topIndex] = make([]byte, len(id))
+		} else if columnVectorGraphNativeScratchCapOversized(cap(scratch.idBuffers[topIndex]), len(id)) {
+			scratch.idBuffers[topIndex] = make([]byte, len(id))
+		}
+		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(id)]
+		copy(scratch.idBuffers[topIndex], id)
 	}
 	stats.ResultFetches += uint64(n)
+	stats.BlockViewHits = plan.hits
+	stats.BlockViewMisses = plan.misses
+	stats.BlockViewBuilds = plan.builds
 	for i, candidate := range scratch.top {
 		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
 			Ordinal: candidate.ordinal,

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -83,11 +83,8 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 		t.Fatalf("stats=%+v want candidate/result fetches without duplicate expansion row fetches", stats)
 	}
 	readerStats := reader.Stats()
-	if readerStats.BatchFetches == 0 {
-		t.Fatalf("reader stats=%+v want batched top-k result fetch", readerStats)
-	}
-	if gotRows, wantRows := readerStats.RowsFetched, stats.ResultFetches; gotRows != wantRows {
-		t.Fatalf("reader rows_fetched=%d want top-k result fetches=%d stats=%+v", gotRows, wantRows, stats)
+	if readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {
+		t.Fatalf("reader stats=%+v want no generic row fetches for scoring or result IDs", readerStats)
 	}
 }
 
@@ -118,8 +115,8 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != 0 {
 		t.Fatalf("stats=%+v want four scored candidates without duplicate expansion row fetches", stats)
 	}
-	if readerStats := reader.Stats(); readerStats.RowsFetched != stats.ResultFetches {
-		t.Fatalf("reader rows_fetched=%d want top-k result fetches stats=%+v", readerStats.RowsFetched, stats)
+	if readerStats := reader.Stats(); readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {
+		t.Fatalf("reader stats=%+v want no generic row fetches for scoring or result IDs stats=%+v", readerStats, stats)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR is the fourth implementation step after #1718/#1720/#1721/#1722 for the column_graph native block-oriented search planner.

It moves final top-k ID materialization onto the planner/block-view path. Native graph search no longer uses the generic physical row reader for candidate scoring, adjacency expansion, or final result IDs.

Scope boundary:

- Top-k IDs are copied from `columnVectorGraphBlockView.id` after sorting result ordinals for locality.
- Result score ordering is preserved.
- Public API document materialization remains outside the graph traversal/top-k ID path and is still only performed when requested.
- Does not change adjacency physical encoding; adjacency direct views remain a possible follow-on.

## What Changed

- `fetchTopSearchResults` now receives the search plan.
- Final result IDs resolve ordinal -> block view -> row index and copy only final top-k IDs.
- Existing generic result batch fetch is removed from the native search kernel.
- Tests now assert no generic row fetches are used for scoring or result IDs in native search.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 16.954s
```

Benchmark smoke on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 12235 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 3169 ns/op, 50 B/op, 0 allocs/op
```

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | result_fetches/search | block_view_hits/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 12,235 | 81,733 | 0 | 0 | 128 | 10 | 177 | 612 | 0 | 0 |
| Parallel production 8192 | 3,169 | 315,557 | 50 | 0 | 128 | 10 | 177 | 612 | 0 | 0 |

## Before / After Evidence

Against #1722 smoke on the same Apple M3 machine:

| Benchmark | #1722 ns/op | This PR ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 12,912 | 12,235 | 81,733 | -5.2% |
| Parallel production 8192 | 3,471 | 3,169 | 315,557 | -8.7% |

Against the clean post-SIMD baseline from `/tmp/pr1713_native_hot_profile_20260521_172315`:

| Benchmark | baseline ns/op | This PR ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 30,035 | 12,235 | 81,733 | -59.3% |
| Parallel production 8192 | 7,072 | 3,169 | 315,557 | -55.2% |

## Throughput Notes

The warmed production benchmark reports `decoded_blocks/search=0`, `physical_B/search=0`, and no generic row-reader cache hits for the native search kernel. Candidate scoring, lazy adjacency expansion, and final ID copy all flow through cached block views.

## Stack

- Depends on #1722.
- Optional next PR: physical encoding extension for direct invNorm/adjacency views if profiles show adjacency decode remains material.
